### PR TITLE
Update permission configuration in stealth-agent repository

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,7 +19,7 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       issues: write
       id-token: write
@@ -46,6 +46,11 @@ jobs:
           # Optional: Add allowed tools for Claude
           allowed_tools: |
             Bash(git mv:*)
+            Bash(cp:*)
+            Bash(mv:*)
+            Bash(mkdir:*)
+            Bash(rm:*)
+            Bash(rsync:*)
 
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md


### PR DESCRIPTION
- Change contents permission from read to write
- Add allowed_tools for file/directory operations:
  - cp, mv, mkdir, rm, rsync (for directory rename operations)

This addresses the permission issues reported in issue #1 where Claude couldn't perform directory rename operations.