### PR TITLE
feat: Chat agent improvements - SSE adaptation, file panel, and UI en…

### DIFF
--- a/web/FRONTEND_SSE_ADAPTATION_CHANGELOG.md
+++ b/web/FRONTEND_SSE_ADAPTATION_CHANGELOG.md
@@ -1,0 +1,116 @@
+# Frontend SSE Adaptation Changelog
+
+This document summarizes the frontend changes made to adapt to the backend chat SSE event stream updates.
+
+## 1. Tool Name Changes (snake_case → PascalCase)
+
+**File:** `src/pages/ChatAgent/components/ToolCallMessageContent.jsx`
+
+- **Change:** Updated `FILE_TOOLS` constant to include both PascalCase (new) and snake_case (legacy) tool names for backward compatibility.
+- **New tool names:** `Read`, `Write`, `Edit`, `Save`, `ExecuteCode`, `Glob`, `Grep`, `WebFetch`, `WebSearch`
+- **Legacy names retained:** `read_file`, `write_file`, `edit_file`, `save_file` (for older history)
+- **Why:** Backend now uses LangChain SDK convention (PascalCase). FILE_TOOLS is used to detect file-related tools for opening in the file panel.
+
+---
+
+## 2. Subagent Event Detection
+
+**Files:** `hooks/utils/streamEventHandlers.js`, `hooks/utils/historyEventHandlers.js`
+
+### `isSubagentEvent` / `isSubagentHistoryEvent`
+
+- **Old logic:** `event.agent.startsWith('tools:')`
+- **New logic:** Subagent if `agent` contains `:` AND does NOT start with `model:` AND is NOT `"tools"`.
+- **Rationale:** Backend convention:
+  - Main agent: `agent.startsWith("model:")`
+  - Tool node: `agent === "tools"`
+  - Subagent: `agent` = `"{type}:{uuid4}"` (e.g., `"research:550e8400-..."`)
+
+---
+
+## 3. Subagent Status Event Handling
+
+**File:** `hooks/utils/streamEventHandlers.js` – `handleSubagentStatus`
+
+### Preferred Format (from BackgroundTaskRegistry)
+
+- `active_tasks`: Array of objects with `id` (display_id), `agent_id` (stable UUID), `description`, `type`, `tool_calls`, `current_tool`
+- `completed_tasks`: Array of display_id strings (`"Task-1"`, `"Task-2"`)
+
+### Fallback Format (legacy)
+
+- `active_subagents` / `completed_subagents`: Arrays of `agent_id` strings
+
+### Key Changes
+
+- Uses `agent_id` as the primary key for cards (not `id`/display_id).
+- Passes `displayIdToAgentIdMap` to resolve `completed_tasks` display IDs to `agent_id`s.
+- Calls `updateSubagentCard(agentId, {...})` with `agentId` as the card key.
+- Stores `displayId` for human-readable UI when available.
+
+---
+
+## 4. Agent ID as Primary Identifier
+
+**Files:** `hooks/useChatMessages.js`, `hooks/useFloatingCards.js`, `components/ChatView.jsx`
+
+### Refactoring
+
+- **`agent_id`** (format `{type}:{uuid4}`) is the stable identifier for subagent cards and event routing.
+- **`display_id`** (`"Task-1"`, `"Task-2"`) is used only for UI display.
+- Card IDs: `subagent-${agentId}` (e.g., `subagent-research:550e8400-...`).
+
+### Mappings
+
+- `agentToTaskMapRef`: Maps `agent_id` → `agent_id`.
+- `toolCallIdToTaskIdMapRef`: Maps tool call IDs (from main agent’s `task` tool) → `agent_id`.
+- `displayIdToAgentIdMapRef`: Maps display_id → `agent_id` for resolving `completed_tasks`.
+
+### New Helpers
+
+- `resolveSubagentIdToAgentId(subagentId)`: Resolves tool call ID or legacy ID to stable `agent_id`.
+- `getSubagentHistory(subagentId)`: Returns history including `agentId` for card operations.
+
+---
+
+## 5. History Loading
+
+**File:** `hooks/useChatMessages.js`
+
+### Subagent Status in History
+
+- Handles both preferred and fallback formats.
+- Uses `task.agent_id` or `task.agent` for identity.
+- Stores subagent history keyed by `agent_id`.
+
+### Order-Based Matching
+
+- `historyPendingAgentIdsRef`: Holds `agent_id`s from `subagent_status`.
+- `historyPendingTaskToolCallIdsRef`: Holds tool call IDs from `task` tool calls.
+- Order-based matching builds `toolCallIdToTaskIdMapRef` so segments and history resolve to the correct `agent_id`.
+
+---
+
+## 6. ChatView and Floating Cards
+
+**File:** `components/ChatView.jsx`
+
+- `onOpenSubagentTask`: Uses `resolveSubagentIdToAgentId` to convert segment `subagentId` (possibly a tool call ID) to `agent_id` before calling `updateSubagentCard` and `setSelectedAgentId`.
+- Agent panel: Uses `displayId` when available for tab labels (e.g., `"Task-1"`).
+
+**File:** `hooks/useFloatingCards.js`
+
+- `updateSubagentCard(agentId, ...)`: First parameter is `agent_id`, not display_id.
+- Stores `agentId` and `displayId` in `subagentData` for UI and routing.
+
+---
+
+## Summary
+
+| Area | Old | New |
+|------|-----|-----|
+| Tool names | snake_case | PascalCase (with legacy fallback) |
+| Subagent detection | `agent.startsWith('tools:')` | `agent` contains `:` and not `model:` and not `tools` |
+| Subagent identity | display_id (`"Task-1"`) | `agent_id` (`"type:uuid4"`) |
+| Card key | task ID / display ID | `agent_id` |
+| `subagent_status` | `active_subagents` / `completed_subagents` | `active_tasks` / `completed_tasks` (preferred) with fallback |

--- a/web/src/pages/ChatAgent/components/AgentTabBar.jsx
+++ b/web/src/pages/ChatAgent/components/AgentTabBar.jsx
@@ -206,7 +206,7 @@ function AgentTabBar({ agents, selectedAgentId, onSelectAgent, onRemoveAgent }) 
                         isActive && "agent-tab-active-pulse"
                       )}
                       style={{
-                        backgroundColor: 'rgba(255, 255, 255, 0.1)',
+                        backgroundColor: isActive ? 'rgba(15, 237, 190, 0.25)' : 'rgba(255, 255, 255, 0.1)',
                       }}
                     >
                       <img

--- a/web/src/pages/ChatAgent/components/FilePanel.jsx
+++ b/web/src/pages/ChatAgent/components/FilePanel.jsx
@@ -31,7 +31,7 @@ function FilePanel({ workspaceId, onClose, targetFile, onTargetFileHandled }) {
     setLoading(true);
     setError(null);
     try {
-      const data = await listWorkspaceFiles(workspaceId, 'results');
+      const data = await listWorkspaceFiles(workspaceId, '.');
       setFiles(data.files || []);
     } catch (err) {
       console.error('[FilePanel] Failed to list files:', err);

--- a/web/src/pages/ChatAgent/components/ToolCallMessageContent.jsx
+++ b/web/src/pages/ChatAgent/components/ToolCallMessageContent.jsx
@@ -1,13 +1,17 @@
 import { ChevronDown, ChevronUp, Loader2, Wrench } from 'lucide-react';
 import { useState } from 'react';
 
-// File-related tool names that support opening in the file panel
-const FILE_TOOLS = ['write_file', 'edit_file', 'read_file', 'save_file'];
+/**
+ * File-related tool names that support opening in the file panel.
+ * Backend uses PascalCase (LangChain SDK convention). Include both for backward compatibility
+ * with older history that may have snake_case tool names.
+ */
+const FILE_TOOLS = ['Write', 'Edit', 'Read', 'Save', 'write_file', 'edit_file', 'read_file', 'save_file'];
 
 function getFilePathFromToolCall(toolCall) {
   if (!toolCall?.args) return null;
   const args = toolCall.args;
-  return args.file_path || args.path || args.filename || null;
+  return args.file_path || args.filePath || args.path || args.filename || null;
 }
 
 /**
@@ -17,14 +21,14 @@ function getFilePathFromToolCall(toolCall) {
  * 
  * Features:
  * - Shows an icon indicating tool call status (loading when in progress, finished when complete)
- * - Displays tool name (e.g., "write_file")
+ * - Displays tool name (e.g., "Write", "Read")
  * - For file tools: clicking opens the file in the right panel via onOpenFile callback
  * - For non-file tools: clicking toggles visibility of tool call details
  * - Displays tool_calls and tool_call_result with different visual styles
  * 
  * @param {Object} props
  * @param {string} props.toolCallId - Unique identifier for this tool call
- * @param {string} props.toolName - Name of the tool (e.g., "write_file")
+ * @param {string} props.toolName - Name of the tool (e.g., "Write", "Read")
  * @param {Object} props.toolCall - Complete tool_calls event data
  * @param {Object} props.toolCallResult - tool_call_result event data
  * @param {boolean} props.isInProgress - Whether tool call is currently in progress

--- a/web/src/pages/ChatAgent/hooks/useFloatingCards.js
+++ b/web/src/pages/ChatAgent/hooks/useFloatingCards.js
@@ -244,11 +244,11 @@ export function useFloatingCards(initialCards = {}) {
   /**
    * Update or create subagent floating card
    * Called when subagent status is detected/updated during live streaming
-   * @param {string} taskId - Task ID (e.g., "Task-1")
-   * @param {Object} subagentDataUpdate - Partial subagent data to merge { taskId, description, type, toolCalls, currentTool, status, messages }
+   * @param {string} agentId - Stable agent identity (format: "type:uuid", e.g., "research:550e8400-...")
+   * @param {Object} subagentDataUpdate - Partial subagent data to merge { agentId, displayId, taskId, description, type, toolCalls, currentTool, status, messages }
    */
-  const updateSubagentCard = (taskId, subagentDataUpdate) => {
-    const cardId = `subagent-${taskId}`;
+  const updateSubagentCard = (agentId, subagentDataUpdate) => {
+    const cardId = `subagent-${agentId}`;
     
     setFloatingCards((prev) => {
       // Calculate default position closer to the center of the window
@@ -285,7 +285,7 @@ export function useFloatingCards(initialCards = {}) {
         if (isCurrentlyInactive && !isBeingReactivated) {
           if (process.env.NODE_ENV === 'development') {
             console.log('[updateSubagentCard] Skipping update to inactive card:', {
-              taskId,
+              agentId,
               cardId,
               reason: 'Card is inactive and not being reactivated',
             });
@@ -323,7 +323,7 @@ export function useFloatingCards(initialCards = {}) {
                   // Explicit status update (e.g., 'completed' from subagent_status)
                   if (process.env.NODE_ENV === 'development') {
                     console.log('[updateSubagentCard] Status update:', {
-                      taskId,
+                      agentId,
                       newStatus,
                       previousStatus: existingStatus,
                       willUpdate: newStatus !== existingStatus,
@@ -337,7 +337,7 @@ export function useFloatingCards(initialCards = {}) {
                 const preservedStatus = existingStatus || 'active';
                 if (process.env.NODE_ENV === 'development' && existingStatus === 'completed') {
                   console.log('[updateSubagentCard] Preserving completed status:', {
-                    taskId,
+                    agentId,
                     preservedStatus,
                   });
                 }
@@ -386,7 +386,7 @@ export function useFloatingCards(initialCards = {}) {
           // If no card exists, it means this task is from history and hasn't been opened yet
           if (process.env.NODE_ENV === 'development') {
             console.log('[updateSubagentCard] Skipping creation of new card for completed task from live streaming:', {
-              taskId,
+              agentId,
               cardId,
               reason: 'Completed tasks from live streaming should only update existing cards, not create new ones',
               isActive: subagentDataUpdate.isActive,
@@ -411,7 +411,8 @@ export function useFloatingCards(initialCards = {}) {
             minimizeOrder: null,
             hasUnreadUpdate: false,
             subagentData: {
-              taskId: taskId,
+              agentId: agentId,
+              taskId: agentId,
               description: '',
               type: 'general-purpose',
               toolCalls: 0,


### PR DESCRIPTION
…hancements

- Adapt frontend to backend SSE: PascalCase tool names, agent_id for subagents
- Director card: show all content; main chat shows text-only
- Subagent cards: pass onOpenFile so file tool chunks open files in file panel
- Tool call: add filePath fallback for path extraction
- Agent tab bar: light green background for actively running agent icons
- File panel: list all workspace files from root instead of results/ only
- Auto-scroll Director and subagent panels when new messages arrive