### PR TITLE
fix(claude-oauth): support subscription models with identity prefix a…

### DIFF
--- a/src/llms/extension/anthropic_oauth.py
+++ b/src/llms/extension/anthropic_oauth.py
@@ -1,8 +1,14 @@
 """ChatAnthropic variant that uses OAuth Bearer auth (auth_token) instead of API key (X-Api-Key)."""
 
+from functools import cached_property
 from typing import Any
 
+import anthropic
 from langchain_anthropic import ChatAnthropic
+from langchain_core.language_models import LanguageModelInput
+
+# Required by Anthropic's API for OAuth subscription tokens to access Sonnet/Opus.
+_CLAUDE_CODE_IDENTITY = "You are Claude Code, Anthropic's official CLI for Claude."
 
 
 class ChatAnthropicOAuth(ChatAnthropic):
@@ -13,7 +19,10 @@ class ChatAnthropicOAuth(ChatAnthropic):
       - ``auth_token`` → ``Authorization: Bearer`` header  (OAuth tokens)
 
     LangChain's ``ChatAnthropic`` only passes ``api_key``.  This subclass
-    intercepts ``_client_params`` so the OAuth token goes through ``auth_token``.
+    intercepts ``_client_params`` so the OAuth token goes through ``auth_token``,
+    nulls out ``api_key`` on the constructed client to prevent the SDK from
+    falling back to the ``ANTHROPIC_API_KEY`` environment variable, and prepends
+    the Claude Code identity to the system prompt (required for Sonnet/Opus access).
     """
 
     @property
@@ -24,3 +33,36 @@ class ChatAnthropicOAuth(ChatAnthropic):
         params["api_key"] = None
         params["auth_token"] = token
         return params
+
+    @cached_property
+    def _client(self) -> anthropic.Client:
+        client = super()._client
+        # The SDK constructor replaces api_key=None with ANTHROPIC_API_KEY env var.
+        # Null it out so auth_headers only sends Authorization: Bearer, not X-Api-Key.
+        client.api_key = None
+        return client
+
+    @cached_property
+    def _async_client(self) -> anthropic.AsyncClient:
+        client = super()._async_client
+        client.api_key = None
+        return client
+
+    def _get_request_payload(
+        self,
+        input_: LanguageModelInput,
+        *,
+        stop: list[str] | None = None,
+        **kwargs: dict,
+    ) -> dict:
+        payload = super()._get_request_payload(input_, stop=stop, **kwargs)
+        # Prepend Claude Code identity — required for Sonnet/Opus with OAuth tokens.
+        system = payload.get("system")
+        identity_block = {"type": "text", "text": _CLAUDE_CODE_IDENTITY}
+        if isinstance(system, list):
+            payload["system"] = [identity_block, *system]
+        elif isinstance(system, str) and system:
+            payload["system"] = [identity_block, {"type": "text", "text": system}]
+        else:
+            payload["system"] = [identity_block]
+        return payload

--- a/src/llms/llm.py
+++ b/src/llms/llm.py
@@ -182,11 +182,16 @@ class LLM:
 
         # Optional default headers from provider config, with model-level beta merging
         self.default_headers = self.provider_info.get("default_headers")
-        additional_betas = model_info.get("additional_betas")
-        if additional_betas and self.default_headers:
-            existing = self.default_headers.get("anthropic-beta", "")
-            merged = ",".join(filter(None, [existing, *additional_betas]))
-            self.default_headers = {**self.default_headers, "anthropic-beta": merged}
+        self._merge_additional_betas(model_info.get("additional_betas"))
+
+    def _merge_additional_betas(self, additional_betas: list[str] | None) -> None:
+        """Merge model-level additional_betas into the anthropic-beta header."""
+        if not additional_betas:
+            return
+        existing_headers = self.default_headers or {}
+        existing = existing_headers.get("anthropic-beta", "")
+        merged = ",".join(filter(None, [existing, *additional_betas]))
+        self.default_headers = {**existing_headers, "anthropic-beta": merged}
 
     @classmethod
     def from_custom_config(
@@ -248,6 +253,7 @@ class LLM:
             else False
         )
         instance.default_headers = instance.provider_info.get("default_headers")
+        instance._merge_additional_betas(config.get("additional_betas"))
         return instance.get_llm()
 
     def get_llm(self):

--- a/src/llms/llm.py
+++ b/src/llms/llm.py
@@ -180,8 +180,13 @@ class LLM:
         self.use_response_api = self.provider_info.get("use_response_api", False) if self.sdk in ("openai", "codex") else False
         self.use_previous_response_id = self.provider_info.get("use_previous_response_id", False) if self.sdk == "openai" else False
 
-        # Optional default headers from provider config
+        # Optional default headers from provider config, with model-level beta merging
         self.default_headers = self.provider_info.get("default_headers")
+        additional_betas = model_info.get("additional_betas")
+        if additional_betas and self.default_headers:
+            existing = self.default_headers.get("anthropic-beta", "")
+            merged = ",".join(filter(None, [existing, *additional_betas]))
+            self.default_headers = {**self.default_headers, "anthropic-beta": merged}
 
     @classmethod
     def from_custom_config(

--- a/src/llms/manifest/models.json
+++ b/src/llms/manifest/models.json
@@ -146,7 +146,9 @@
       "use_previous_response_id": false,
       "extra_body": {
         "provider": {
-          "order": ["Groq"],
+          "order": [
+            "Groq"
+          ],
           "allow_fallbacks": true
         }
       }
@@ -160,7 +162,9 @@
       "use_previous_response_id": false,
       "extra_body": {
         "provider": {
-          "order": ["DeepInfra"],
+          "order": [
+            "DeepInfra"
+          ],
           "allow_fallbacks": false
         }
       }
@@ -174,7 +178,9 @@
       "use_previous_response_id": false,
       "extra_body": {
         "provider": {
-          "order": ["DeepInfra"],
+          "order": [
+            "DeepInfra"
+          ],
           "allow_fallbacks": false
         }
       }
@@ -188,7 +194,9 @@
       "use_previous_response_id": false,
       "extra_body": {
         "provider": {
-          "order": ["Groq"],
+          "order": [
+            "Groq"
+          ],
           "allow_fallbacks": true
         }
       }
@@ -202,7 +210,9 @@
       "use_previous_response_id": false
     },
     "extra_body": {
-      "thinking": {"type": "enabled"}
+      "thinking": {
+        "type": "enabled"
+      }
     }
   },
   "doubao-seed-2.0-lite": {
@@ -213,7 +223,9 @@
       "use_previous_response_id": false
     },
     "extra_body": {
-      "thinking": {"type": "enabled"}
+      "thinking": {
+        "type": "enabled"
+      }
     }
   },
   "doubao-seed-2.0-mini": {
@@ -224,7 +236,9 @@
       "use_previous_response_id": false
     },
     "extra_body": {
-      "thinking": {"type": "enabled"}
+      "thinking": {
+        "type": "enabled"
+      }
     }
   },
   "doubao-seed-2.0-code": {
@@ -235,7 +249,9 @@
       "use_previous_response_id": false
     },
     "extra_body": {
-      "thinking": {"type": "enabled"}
+      "thinking": {
+        "type": "enabled"
+      }
     }
   },
   "doubao-seed-2.0-pro-anthropic": {
@@ -285,6 +301,28 @@
   "glm-5": {
     "model_id": "glm-5",
     "provider": "z-ai",
+    "visible": true,
+    "parameters": {
+      "max_tokens": 128000,
+      "thinking": {
+        "type": "enabled"
+      }
+    }
+  },
+  "glm-5-turbo": {
+    "model_id": "glm-5-turbo",
+    "provider": "z-ai",
+    "visible": true,
+    "parameters": {
+      "max_tokens": 128000,
+      "thinking": {
+        "type": "enabled"
+      }
+    }
+  },
+  "glm-5-turbo-cn": {
+    "model_id": "glm-5-turbo",
+    "provider": "z-ai-cn",
     "visible": true,
     "parameters": {
       "max_tokens": 128000,
@@ -380,7 +418,6 @@
       "enable_thinking": true
     }
   },
-
   "kimi-k2.5": {
     "model_id": "kimi-for-coding",
     "provider": "moonshot",
@@ -400,13 +437,15 @@
         "effort": "medium",
         "summary": "auto"
       },
-      "include": ["reasoning.encrypted_content"],
+      "include": [
+        "reasoning.encrypted_content"
+      ],
       "store": false,
       "model_kwargs": {
         "instructions": "You are a helpful AI assistant."
       }
     }
-},
+  },
   "gpt-5.2-oauth": {
     "model_id": "gpt-5.2",
     "provider": "codex-oauth",
@@ -416,13 +455,15 @@
         "effort": "medium",
         "summary": "auto"
       },
-      "include": ["reasoning.encrypted_content"],
+      "include": [
+        "reasoning.encrypted_content"
+      ],
       "store": false,
       "model_kwargs": {
         "instructions": "You are a helpful AI assistant."
       }
     }
-},
+  },
   "gpt-5.3-codex-oauth": {
     "model_id": "gpt-5.3-codex",
     "provider": "codex-oauth",
@@ -432,13 +473,15 @@
         "effort": "medium",
         "summary": "auto"
       },
-      "include": ["reasoning.encrypted_content"],
+      "include": [
+        "reasoning.encrypted_content"
+      ],
       "store": false,
       "model_kwargs": {
         "instructions": "You are a helpful AI assistant."
       }
     }
-},
+  },
   "gpt-5.1-codex-max-oauth": {
     "model_id": "gpt-5.1-codex-max",
     "provider": "codex-oauth",
@@ -448,13 +491,15 @@
         "effort": "medium",
         "summary": "auto"
       },
-      "include": ["reasoning.encrypted_content"],
+      "include": [
+        "reasoning.encrypted_content"
+      ],
       "store": false,
       "model_kwargs": {
         "instructions": "You are a helpful AI assistant."
       }
     }
-},
+  },
   "gpt-5.3-codex-spark-oauth": {
     "model_id": "gpt-5.3-codex-spark",
     "provider": "codex-oauth",
@@ -464,13 +509,15 @@
         "effort": "medium",
         "summary": "auto"
       },
-      "include": ["reasoning.encrypted_content"],
+      "include": [
+        "reasoning.encrypted_content"
+      ],
       "store": false,
       "model_kwargs": {
         "instructions": "You are a helpful AI assistant."
       }
     }
-},
+  },
   "gpt-5.4-oauth": {
     "model_id": "gpt-5.4",
     "provider": "codex-oauth",
@@ -480,14 +527,16 @@
         "effort": "medium",
         "summary": "auto"
       },
-      "include": ["reasoning.encrypted_content"],
+      "include": [
+        "reasoning.encrypted_content"
+      ],
       "store": false,
       "model_kwargs": {
         "instructions": "You are a helpful AI assistant."
       }
     }
-},
-"claude-sonnet-4-6-oauth": {
+  },
+  "claude-sonnet-4-6-oauth": {
     "model_id": "claude-sonnet-4-6",
     "provider": "claude-oauth",
     "visible": true,
@@ -521,25 +570,56 @@
       }
     }
   },
-"embedding-small": {
-  "model_id": "text-embedding-3-small",
-  "provider": "openai",
-  "parameters": {
-    "dimensions": 1536
+  "embedding-small": {
+    "model_id": "text-embedding-3-small",
+    "provider": "openai",
+    "parameters": {
+      "dimensions": 1536
+    }
+  },
+  "embedding-large": {
+    "model_id": "text-embedding-3-large",
+    "provider": "openai",
+    "parameters": {
+      "dimensions": 3072
+    }
+  },
+  "embedding-cn": {
+    "model_id": "text-embedding-v4",
+    "provider": "dashscope",
+    "parameters": {
+      "dimensions": 1536
+    }
+  },
+  "claude-opus-4-6-oauth-1m": {
+    "model_id": "claude-opus-4-6",
+    "provider": "claude-oauth",
+    "visible": true,
+    "parameters": {
+      "thinking": {
+        "type": "adaptive"
+      },
+      "output_config": {
+        "effort": "medium"
+      }
+    },
+    "context_window": 1000000,
+    "additional_betas": [
+      "context-1m-2025-08-07"
+    ]
+  },
+  "claude-sonnet-4-6-oauth-1m": {
+    "model_id": "claude-sonnet-4-6",
+    "provider": "claude-oauth",
+    "visible": true,
+    "parameters": {
+      "thinking": {
+        "type": "adaptive"
+      }
+    },
+    "context_window": 1000000,
+    "additional_betas": [
+      "context-1m-2025-08-07"
+    ]
   }
-},
-"embedding-large": {
-  "model_id": "text-embedding-3-large",
-  "provider": "openai",
-  "parameters": {
-    "dimensions": 3072
-  }
-},
-"embedding-cn": {
-  "model_id": "text-embedding-v4",
-  "provider": "dashscope",
-  "parameters": {
-    "dimensions": 1536
-  }
-}
 }

--- a/src/llms/manifest/providers.json
+++ b/src/llms/manifest/providers.json
@@ -45,11 +45,13 @@
         "name": "GPT-5 Mini",
         "is_reasoning": true,
         "description": "Smaller, faster GPT-5 variant",
-        "alias": ["gpt-5-mini-2025-08-07"],
+        "alias": [
+          "gpt-5-mini-2025-08-07"
+        ],
         "pricing": {
           "input": 0.25,
           "cached_input": 0.025,
-          "output": 2.00,
+          "output": 2.0,
           "unit": "per_1m_tokens"
         }
       },
@@ -58,11 +60,13 @@
         "name": "GPT-5 Nano",
         "is_reasoning": true,
         "description": "Smallest, fastest GPT-5 variant",
-        "alias": ["gpt-5-nano-2025-08-07"],
+        "alias": [
+          "gpt-5-nano-2025-08-07"
+        ],
         "pricing": {
           "input": 0.05,
           "cached_input": 0.005,
-          "output": 0.40,
+          "output": 0.4,
           "unit": "per_1m_tokens"
         }
       },
@@ -74,7 +78,7 @@
         "pricing": {
           "input": 1.25,
           "cached_input": 0.13,
-          "output": 10.00,
+          "output": 10.0,
           "unit": "per_1m_tokens"
         }
       },
@@ -86,7 +90,7 @@
         "pricing": {
           "input": 0.25,
           "cached_input": 0.03,
-          "output": 2.00,
+          "output": 2.0,
           "unit": "per_1m_tokens"
         }
       },
@@ -95,11 +99,13 @@
         "name": "GPT-5.1",
         "is_reasoning": true,
         "description": "The best model for coding and agentic tasks with configurable reasoning effort",
-        "alias": ["gpt-5.1"],
+        "alias": [
+          "gpt-5.1"
+        ],
         "pricing": {
           "input": 1.25,
           "cached_input": 0.13,
-          "output": 10.00,
+          "output": 10.0,
           "unit": "per_1m_tokens"
         }
       },
@@ -108,11 +114,13 @@
         "name": "GPT-5.2",
         "is_reasoning": true,
         "description": "The best model for coding and agentic tasks with configurable reasoning effort",
-        "alias": ["gpt-5.2"],
+        "alias": [
+          "gpt-5.2"
+        ],
         "pricing": {
           "input": 1.75,
           "cached_input": 0.175,
-          "output": 14.00,
+          "output": 14.0,
           "unit": "per_1m_tokens"
         }
       },
@@ -123,12 +131,26 @@
         "description": "OpenAI's latest and most capable reasoning model with tiered pricing",
         "pricing": {
           "input_tiers": [
-            {"max_tokens": 272000, "rate": 2.50, "cached_input": 0.25},
-            {"max_tokens": null, "rate": 5.00, "cached_input": 0.50}
+            {
+              "max_tokens": 272000,
+              "rate": 2.5,
+              "cached_input": 0.25
+            },
+            {
+              "max_tokens": null,
+              "rate": 5.0,
+              "cached_input": 0.5
+            }
           ],
           "output_tiers": [
-            {"max_tokens": 272000, "rate": 15.00},
-            {"max_tokens": null, "rate": 22.50}
+            {
+              "max_tokens": 272000,
+              "rate": 15.0
+            },
+            {
+              "max_tokens": null,
+              "rate": 22.5
+            }
           ],
           "output_pricing_mode": "input_dependent",
           "unit": "per_1m_tokens"
@@ -136,17 +158,19 @@
       }
     ],
     "anthropic": [
-        {
-          "id": "claude-opus-4-6",
+      {
+        "id": "claude-opus-4-6",
         "name": "Claude 4.6 Opus",
         "is_reasoning": true,
         "description": "Claude 4.6 Opus model",
-        "alias": ["claude-opus-4.6"],
+        "alias": [
+          "claude-opus-4.6"
+        ],
         "pricing": {
-          "input": 5.00,
-          "cached_input": 0.50,
+          "input": 5.0,
+          "cached_input": 0.5,
           "cache_5m": 6.25,
-          "output": 25.00,
+          "output": 25.0,
           "unit": "per_1m_tokens"
         }
       },
@@ -155,19 +179,35 @@
         "name": "Claude 4.6 Sonnet",
         "is_reasoning": true,
         "description": "Claude 4.6 Sonnet model",
-        "alias": ["claude-sonnet-4.6"],
+        "alias": [
+          "claude-sonnet-4.6"
+        ],
         "pricing": {
           "input_tiers": [
-            {"max_tokens": 200000, "rate": 3.00, "cached_input": 0.30},
-            {"max_tokens": null, "rate": 6.00, "cached_input": 0.60}
+            {
+              "max_tokens": 200000,
+              "rate": 3.0,
+              "cached_input": 0.3
+            },
+            {
+              "max_tokens": null,
+              "rate": 6.0,
+              "cached_input": 0.6
+            }
           ],
           "output_tiers": [
-            {"max_tokens": 200000, "rate": 15.00},
-            {"max_tokens": null, "rate": 22.50}
+            {
+              "max_tokens": 200000,
+              "rate": 15.0
+            },
+            {
+              "max_tokens": null,
+              "rate": 22.5
+            }
           ],
           "output_pricing_mode": "input_dependent",
           "cache_5m": 3.75,
-          "cache_1h": 7.50,
+          "cache_1h": 7.5,
           "unit": "per_1m_tokens"
         }
       },
@@ -176,12 +216,14 @@
         "name": "Claude 4.5 Haiku",
         "is_reasoning": true,
         "description": "Fast and cost-efficient model",
-        "alias": ["claude-haiku-4.5"],
+        "alias": [
+          "claude-haiku-4.5"
+        ],
         "pricing": {
-          "input": 0.80,
+          "input": 0.8,
           "cached_input": 0.08,
-          "cache_5m": 1.00,
-          "output": 4.00,
+          "cache_5m": 1.0,
+          "output": 4.0,
           "unit": "per_1m_tokens"
         }
       }
@@ -192,12 +234,14 @@
         "name": "Claude 4.6 Opus",
         "is_reasoning": true,
         "description": "Claude 4.6 Opus model",
-        "alias": ["claude-opus-4.6"],
+        "alias": [
+          "claude-opus-4.6"
+        ],
         "pricing": {
-          "input": 5.00,
-          "cached_input": 0.50,
+          "input": 5.0,
+          "cached_input": 0.5,
           "cache_5m": 6.25,
-          "output": 25.00,
+          "output": 25.0,
           "unit": "per_1m_tokens"
         }
       },
@@ -206,19 +250,35 @@
         "name": "Claude 4.6 Sonnet",
         "is_reasoning": true,
         "description": "Claude 4.6 Sonnet model",
-        "alias": ["claude-sonnet-4.6"],
+        "alias": [
+          "claude-sonnet-4.6"
+        ],
         "pricing": {
           "input_tiers": [
-            {"max_tokens": 200000, "rate": 3.00, "cached_input": 0.30},
-            {"max_tokens": null, "rate": 6.00, "cached_input": 0.60}
+            {
+              "max_tokens": 200000,
+              "rate": 3.0,
+              "cached_input": 0.3
+            },
+            {
+              "max_tokens": null,
+              "rate": 6.0,
+              "cached_input": 0.6
+            }
           ],
           "output_tiers": [
-            {"max_tokens": 200000, "rate": 15.00},
-            {"max_tokens": null, "rate": 22.50}
+            {
+              "max_tokens": 200000,
+              "rate": 15.0
+            },
+            {
+              "max_tokens": null,
+              "rate": 22.5
+            }
           ],
           "output_pricing_mode": "input_dependent",
           "cache_5m": 3.75,
-          "cache_1h": 7.50,
+          "cache_1h": 7.5,
           "unit": "per_1m_tokens"
         }
       },
@@ -227,12 +287,14 @@
         "name": "Claude 4.5 Haiku",
         "is_reasoning": true,
         "description": "Fast and cost-efficient model",
-        "alias": ["claude-haiku-4.5"],
+        "alias": [
+          "claude-haiku-4.5"
+        ],
         "pricing": {
-          "input": 0.80,
+          "input": 0.8,
           "cached_input": 0.08,
-          "cache_5m": 1.00,
-          "output": 4.00,
+          "cache_5m": 1.0,
+          "output": 4.0,
           "unit": "per_1m_tokens"
         }
       }
@@ -246,8 +308,8 @@
         "pricing": {
           "input": 0.25,
           "cached_input": 0.025,
-          "output": 1.50,
-          "cache_storage": 1.00,
+          "output": 1.5,
+          "cache_storage": 1.0,
           "unit": "per_1m_tokens"
         }
       },
@@ -257,8 +319,8 @@
         "description": "Designed for speed and efficiency, effective for quick interactive responses and high throughput image generation",
         "pricing": {
           "input": 0.25,
-          "output": 1.50,
-          "output_image": 60.00,
+          "output": 1.5,
+          "output_image": 60.0,
           "unit": "per_1m_tokens"
         }
       },
@@ -268,10 +330,10 @@
         "is_reasoning": true,
         "description": "Google's fast and cost-efficient model with thinking capabilities",
         "pricing": {
-          "input": 0.50,
+          "input": 0.5,
           "cached_input": 0.05,
-          "output": 3.00,
-          "storage": 1.00,
+          "output": 3.0,
+          "storage": 1.0,
           "unit": "per_1m_tokens"
         }
       },
@@ -282,23 +344,35 @@
         "description": "Google's latest performance, intelligence, and usability improvements for multimodal understanding, agentic capabilities, and vibe-coding",
         "pricing": {
           "input_tiers": [
-            {"max_tokens": 200000, "rate": 2.00, "cached_input": 0.20},
-            {"max_tokens": null, "rate": 4.00, "cached_input": 0.40}
+            {
+              "max_tokens": 200000,
+              "rate": 2.0,
+              "cached_input": 0.2
+            },
+            {
+              "max_tokens": null,
+              "rate": 4.0,
+              "cached_input": 0.4
+            }
           ],
           "output_tiers": [
-            {"max_tokens": 200000, "rate": 12.00},
-            {"max_tokens": null, "rate": 18.00}
+            {
+              "max_tokens": 200000,
+              "rate": 12.0
+            },
+            {
+              "max_tokens": null,
+              "rate": 18.0
+            }
           ],
           "output_pricing_mode": "input_dependent",
-          "cache_storage": 4.50,
+          "cache_storage": 4.5,
           "unit": "per_1m_tokens"
         }
       }
     ],
-    "lm-studio": [
-    ],
-    "openrouter": [
-    ],
+    "lm-studio": [],
+    "openrouter": [],
     "deepseek": [
       {
         "id": "deepseek-reasoner",
@@ -313,8 +387,7 @@
         }
       }
     ],
-    "vllm": [
-    ],
+    "vllm": [],
     "z-ai": [
       {
         "id": "glm-4.7",
@@ -322,9 +395,9 @@
         "is_reasoning": false,
         "description": "Z.AI's GLM-4.7 model with prompt caching support",
         "pricing": {
-          "input": 0.60,
+          "input": 0.6,
           "cached_input": 0.11,
-          "output": 2.20,
+          "output": 2.2,
           "unit": "per_1m_tokens"
         }
       }
@@ -337,12 +410,26 @@
         "description": "Z.AI's latest GLM-5 model with input-dependent tiered pricing",
         "pricing": {
           "input_tiers": [
-            {"max_tokens": 32000, "rate": 0.55, "cached_input": 0.14},
-            {"max_tokens": null, "rate": 0.83, "cached_input": 0.21}
+            {
+              "max_tokens": 32000,
+              "rate": 0.55,
+              "cached_input": 0.14
+            },
+            {
+              "max_tokens": null,
+              "rate": 0.83,
+              "cached_input": 0.21
+            }
           ],
           "output_tiers": [
-            {"max_tokens": 32000, "rate": 2.48},
-            {"max_tokens": null, "rate": 3.03}
+            {
+              "max_tokens": 32000,
+              "rate": 2.48
+            },
+            {
+              "max_tokens": null,
+              "rate": 3.03
+            }
           ],
           "output_pricing_mode": "input_dependent",
           "unit": "per_1m_tokens"
@@ -368,7 +455,7 @@
               "input_max": 32000,
               "output_max": null,
               "input": 0.43,
-              "output": 2.00,
+              "output": 2.0,
               "cached_input": 0.086
             },
             {
@@ -387,12 +474,15 @@
       {
         "id": "minimax-m2.5",
         "name": "MiniMax-M2.5",
-        "alias": ["MiniMax-M2.5", "minimax-m2.5"],
+        "alias": [
+          "MiniMax-M2.5",
+          "minimax-m2.5"
+        ],
         "is_reasoning": false,
         "description": "MiniMax's M2.5 model for commercial use",
         "pricing": {
-          "input": 0.30,
-          "output": 1.20,
+          "input": 0.3,
+          "output": 1.2,
           "cached_input": 0.03,
           "cache_storage": 0.375,
           "unit": "per_1m_tokens"
@@ -401,12 +491,14 @@
       {
         "id": "minimax-m2.5-highspeed",
         "name": "MiniMax-M2.5-Highspeed",
-        "alias": ["MiniMax-M2.5-highspeed"],
+        "alias": [
+          "MiniMax-M2.5-highspeed"
+        ],
         "is_reasoning": false,
         "description": "MiniMax's M2.5 Highspeed model with faster inference and higher output pricing",
         "pricing": {
-          "input": 0.60,
-          "output": 2.40,
+          "input": 0.6,
+          "output": 2.4,
           "cached_input": 0.03,
           "cache_storage": 0.375,
           "unit": "per_1m_tokens"
@@ -421,14 +513,35 @@
         "description": "Doubao Seed 2.0 Pro - high-capability model with tiered pricing",
         "pricing": {
           "input_tiers": [
-            {"max_tokens": 32000, "rate": 3.2, "cached_input": 0.64},
-            {"max_tokens": 128000, "rate": 4.8, "cached_input": 0.64},
-            {"max_tokens": 256000, "rate": 9.6, "cached_input": 0.64}
+            {
+              "max_tokens": 32000,
+              "rate": 3.2,
+              "cached_input": 0.64
+            },
+            {
+              "max_tokens": 128000,
+              "rate": 4.8,
+              "cached_input": 0.64
+            },
+            {
+              "max_tokens": 256000,
+              "rate": 9.6,
+              "cached_input": 0.64
+            }
           ],
           "output_tiers": [
-            {"max_tokens": 32000, "rate": 16.0},
-            {"max_tokens": 128000, "rate": 24.0},
-            {"max_tokens": 256000, "rate": 48.0}
+            {
+              "max_tokens": 32000,
+              "rate": 16.0
+            },
+            {
+              "max_tokens": 128000,
+              "rate": 24.0
+            },
+            {
+              "max_tokens": 256000,
+              "rate": 48.0
+            }
           ],
           "output_pricing_mode": "input_dependent",
           "cache_storage": 0.017,
@@ -442,14 +555,35 @@
         "description": "Doubao Seed 2.0 Lite - balanced performance and cost",
         "pricing": {
           "input_tiers": [
-            {"max_tokens": 32000, "rate": 0.6, "cached_input": 0.12},
-            {"max_tokens": 128000, "rate": 0.9, "cached_input": 0.12},
-            {"max_tokens": 256000, "rate": 1.8, "cached_input": 0.12}
+            {
+              "max_tokens": 32000,
+              "rate": 0.6,
+              "cached_input": 0.12
+            },
+            {
+              "max_tokens": 128000,
+              "rate": 0.9,
+              "cached_input": 0.12
+            },
+            {
+              "max_tokens": 256000,
+              "rate": 1.8,
+              "cached_input": 0.12
+            }
           ],
           "output_tiers": [
-            {"max_tokens": 32000, "rate": 3.6},
-            {"max_tokens": 128000, "rate": 5.4},
-            {"max_tokens": 256000, "rate": 10.8}
+            {
+              "max_tokens": 32000,
+              "rate": 3.6
+            },
+            {
+              "max_tokens": 128000,
+              "rate": 5.4
+            },
+            {
+              "max_tokens": 256000,
+              "rate": 10.8
+            }
           ],
           "output_pricing_mode": "input_dependent",
           "cache_storage": 0.017,
@@ -463,14 +597,35 @@
         "description": "Doubao Seed 2.0 Mini - lightweight and cost-efficient",
         "pricing": {
           "input_tiers": [
-            {"max_tokens": 32000, "rate": 0.2, "cached_input": 0.04},
-            {"max_tokens": 128000, "rate": 0.4, "cached_input": 0.04},
-            {"max_tokens": 256000, "rate": 0.8, "cached_input": 0.04}
+            {
+              "max_tokens": 32000,
+              "rate": 0.2,
+              "cached_input": 0.04
+            },
+            {
+              "max_tokens": 128000,
+              "rate": 0.4,
+              "cached_input": 0.04
+            },
+            {
+              "max_tokens": 256000,
+              "rate": 0.8,
+              "cached_input": 0.04
+            }
           ],
           "output_tiers": [
-            {"max_tokens": 32000, "rate": 2.0},
-            {"max_tokens": 128000, "rate": 4.0},
-            {"max_tokens": 256000, "rate": 8.0}
+            {
+              "max_tokens": 32000,
+              "rate": 2.0
+            },
+            {
+              "max_tokens": 128000,
+              "rate": 4.0
+            },
+            {
+              "max_tokens": 256000,
+              "rate": 8.0
+            }
           ],
           "output_pricing_mode": "input_dependent",
           "cache_storage": 0.017,
@@ -484,14 +639,35 @@
         "description": "Doubao Seed 2.0 Code - optimized for coding tasks",
         "pricing": {
           "input_tiers": [
-            {"max_tokens": 32000, "rate": 3.2, "cached_input": 0.64},
-            {"max_tokens": 128000, "rate": 4.8, "cached_input": 0.64},
-            {"max_tokens": 256000, "rate": 9.6, "cached_input": 0.64}
+            {
+              "max_tokens": 32000,
+              "rate": 3.2,
+              "cached_input": 0.64
+            },
+            {
+              "max_tokens": 128000,
+              "rate": 4.8,
+              "cached_input": 0.64
+            },
+            {
+              "max_tokens": 256000,
+              "rate": 9.6,
+              "cached_input": 0.64
+            }
           ],
           "output_tiers": [
-            {"max_tokens": 32000, "rate": 16.0},
-            {"max_tokens": 128000, "rate": 24.0},
-            {"max_tokens": 256000, "rate": 48.0}
+            {
+              "max_tokens": 32000,
+              "rate": 16.0
+            },
+            {
+              "max_tokens": 128000,
+              "rate": 24.0
+            },
+            {
+              "max_tokens": 256000,
+              "rate": 48.0
+            }
           ],
           "output_pricing_mode": "input_dependent",
           "cache_storage": 0.017,
@@ -509,14 +685,35 @@
         "max_output": 65536,
         "pricing": {
           "input_tiers": [
-            {"max_tokens": 128000, "rate": 0.115, "cached_input": 0.023},
-            {"max_tokens": 256000, "rate": 0.287, "cached_input": 0.057},
-            {"max_tokens": 1000000, "rate": 0.573, "cached_input": 0.115}
+            {
+              "max_tokens": 128000,
+              "rate": 0.115,
+              "cached_input": 0.023
+            },
+            {
+              "max_tokens": 256000,
+              "rate": 0.287,
+              "cached_input": 0.057
+            },
+            {
+              "max_tokens": 1000000,
+              "rate": 0.573,
+              "cached_input": 0.115
+            }
           ],
           "output_tiers": [
-            {"max_tokens": 128000, "rate": 0.688},
-            {"max_tokens": 256000, "rate": 1.72},
-            {"max_tokens": 1000000, "rate": 3.44}
+            {
+              "max_tokens": 128000,
+              "rate": 0.688
+            },
+            {
+              "max_tokens": 256000,
+              "rate": 1.72
+            },
+            {
+              "max_tokens": 1000000,
+              "rate": 3.44
+            }
           ],
           "output_pricing_mode": "input_dependent",
           "unit": "per_1m_tokens"
@@ -526,19 +723,40 @@
         "id": "qwen3.5-flash",
         "name": "Qwen3.5 Flash",
         "is_reasoning": true,
-        "description": "Alibaba's Qwen3.5 Flash — fastest and most cost-efficient in the series, 1M context",
+        "description": "Alibaba's Qwen3.5 Flash \u2014 fastest and most cost-efficient in the series, 1M context",
         "context_window": 1000000,
         "max_output": 65536,
         "pricing": {
           "input_tiers": [
-            {"max_tokens": 128000, "rate": 0.029, "cached_input": 0.006},
-            {"max_tokens": 256000, "rate": 0.115, "cached_input": 0.023},
-            {"max_tokens": 1000000, "rate": 0.172, "cached_input": 0.034}
+            {
+              "max_tokens": 128000,
+              "rate": 0.029,
+              "cached_input": 0.006
+            },
+            {
+              "max_tokens": 256000,
+              "rate": 0.115,
+              "cached_input": 0.023
+            },
+            {
+              "max_tokens": 1000000,
+              "rate": 0.172,
+              "cached_input": 0.034
+            }
           ],
           "output_tiers": [
-            {"max_tokens": 128000, "rate": 0.287},
-            {"max_tokens": 256000, "rate": 1.147},
-            {"max_tokens": 1000000, "rate": 1.72}
+            {
+              "max_tokens": 128000,
+              "rate": 0.287
+            },
+            {
+              "max_tokens": 256000,
+              "rate": 1.147
+            },
+            {
+              "max_tokens": 1000000,
+              "rate": 1.72
+            }
           ],
           "output_pricing_mode": "input_dependent",
           "unit": "per_1m_tokens"
@@ -553,12 +771,24 @@
         "max_output": 65536,
         "pricing": {
           "input_tiers": [
-            {"max_tokens": 128000, "rate": 0.172},
-            {"max_tokens": 256000, "rate": 0.43}
+            {
+              "max_tokens": 128000,
+              "rate": 0.172
+            },
+            {
+              "max_tokens": 256000,
+              "rate": 0.43
+            }
           ],
           "output_tiers": [
-            {"max_tokens": 128000, "rate": 1.032},
-            {"max_tokens": 256000, "rate": 2.58}
+            {
+              "max_tokens": 128000,
+              "rate": 1.032
+            },
+            {
+              "max_tokens": 256000,
+              "rate": 2.58
+            }
           ],
           "output_pricing_mode": "input_dependent",
           "unit": "per_1m_tokens"
@@ -573,12 +803,24 @@
         "max_output": 65536,
         "pricing": {
           "input_tiers": [
-            {"max_tokens": 128000, "rate": 0.115},
-            {"max_tokens": 256000, "rate": 0.287}
+            {
+              "max_tokens": 128000,
+              "rate": 0.115
+            },
+            {
+              "max_tokens": 256000,
+              "rate": 0.287
+            }
           ],
           "output_tiers": [
-            {"max_tokens": 128000, "rate": 0.917},
-            {"max_tokens": 256000, "rate": 2.293}
+            {
+              "max_tokens": 128000,
+              "rate": 0.917
+            },
+            {
+              "max_tokens": 256000,
+              "rate": 2.293
+            }
           ],
           "output_pricing_mode": "input_dependent",
           "unit": "per_1m_tokens"
@@ -593,12 +835,24 @@
         "max_output": 65536,
         "pricing": {
           "input_tiers": [
-            {"max_tokens": 128000, "rate": 0.086},
-            {"max_tokens": 256000, "rate": 0.258}
+            {
+              "max_tokens": 128000,
+              "rate": 0.086
+            },
+            {
+              "max_tokens": 256000,
+              "rate": 0.258
+            }
           ],
           "output_tiers": [
-            {"max_tokens": 128000, "rate": 0.688},
-            {"max_tokens": 256000, "rate": 2.064}
+            {
+              "max_tokens": 128000,
+              "rate": 0.688
+            },
+            {
+              "max_tokens": 256000,
+              "rate": 2.064
+            }
           ],
           "output_pricing_mode": "input_dependent",
           "unit": "per_1m_tokens"
@@ -613,12 +867,24 @@
         "max_output": 65536,
         "pricing": {
           "input_tiers": [
-            {"max_tokens": 128000, "rate": 0.057},
-            {"max_tokens": 256000, "rate": 0.229}
+            {
+              "max_tokens": 128000,
+              "rate": 0.057
+            },
+            {
+              "max_tokens": 256000,
+              "rate": 0.229
+            }
           ],
           "output_tiers": [
-            {"max_tokens": 128000, "rate": 0.459},
-            {"max_tokens": 256000, "rate": 1.835}
+            {
+              "max_tokens": 128000,
+              "rate": 0.459
+            },
+            {
+              "max_tokens": 256000,
+              "rate": 1.835
+            }
           ],
           "output_pricing_mode": "input_dependent",
           "unit": "per_1m_tokens"
@@ -630,17 +896,29 @@
         "id": "qwen3.5-plus",
         "name": "Qwen3.5 Plus (SG)",
         "is_reasoning": true,
-        "description": "Alibaba's Qwen3.5 Plus model — Singapore international region",
+        "description": "Alibaba's Qwen3.5 Plus model \u2014 Singapore international region",
         "context_window": 1000000,
         "max_output": 65536,
         "pricing": {
           "input_tiers": [
-            {"max_tokens": 256000, "rate": 0.421},
-            {"max_tokens": 1000000, "rate": 0.526}
+            {
+              "max_tokens": 256000,
+              "rate": 0.421
+            },
+            {
+              "max_tokens": 1000000,
+              "rate": 0.526
+            }
           ],
           "output_tiers": [
-            {"max_tokens": 256000, "rate": 2.524},
-            {"max_tokens": 1000000, "rate": 3.156}
+            {
+              "max_tokens": 256000,
+              "rate": 2.524
+            },
+            {
+              "max_tokens": 1000000,
+              "rate": 3.156
+            }
           ],
           "output_pricing_mode": "input_dependent",
           "unit": "per_1m_tokens"
@@ -650,17 +928,29 @@
         "id": "qwen3.5-flash",
         "name": "Qwen3.5 Flash (SG)",
         "is_reasoning": true,
-        "description": "Alibaba's Qwen3.5 Flash — Singapore international region",
+        "description": "Alibaba's Qwen3.5 Flash \u2014 Singapore international region",
         "context_window": 1000000,
         "max_output": 65536,
         "pricing": {
           "input_tiers": [
-            {"max_tokens": 256000, "rate": 0.053},
-            {"max_tokens": 1000000, "rate": 0.263}
+            {
+              "max_tokens": 256000,
+              "rate": 0.053
+            },
+            {
+              "max_tokens": 1000000,
+              "rate": 0.263
+            }
           ],
           "output_tiers": [
-            {"max_tokens": 256000, "rate": 0.421},
-            {"max_tokens": 1000000, "rate": 2.103}
+            {
+              "max_tokens": 256000,
+              "rate": 0.421
+            },
+            {
+              "max_tokens": 1000000,
+              "rate": 2.103
+            }
           ],
           "output_pricing_mode": "input_dependent",
           "unit": "per_1m_tokens"
@@ -678,7 +968,7 @@
         "pricing": {
           "input": 0.075,
           "cached_input": 0.0375,
-          "output": 0.30,
+          "output": 0.3,
           "unit": "per_1m_tokens"
         }
       },
@@ -692,7 +982,7 @@
         "pricing": {
           "input": 0.15,
           "cached_input": 0.075,
-          "output": 0.60,
+          "output": 0.6,
           "unit": "per_1m_tokens"
         }
       },
@@ -706,7 +996,7 @@
         "pricing": {
           "input": 0.075,
           "cached_input": 0.037,
-          "output": 0.30,
+          "output": 0.3,
           "unit": "per_1m_tokens"
         }
       }
@@ -719,9 +1009,9 @@
         "description": "Moonshot AI's Kimi model optimized for coding tasks",
         "context_window": 262144,
         "pricing": {
-          "input": 0.60,
-          "cached_input": 0.10,
-          "output": 3.00,
+          "input": 0.6,
+          "cached_input": 0.1,
+          "output": 3.0,
           "unit": "per_1m_tokens"
         }
       },
@@ -732,9 +1022,9 @@
         "description": "Moonshot AI's Kimi K2.5 multi-modal model with extended context",
         "context_window": 262144,
         "pricing": {
-          "input": 0.60,
-          "cached_input": 0.10,
-          "output": 3.00,
+          "input": 0.6,
+          "cached_input": 0.1,
+          "output": 3.0,
           "unit": "per_1m_tokens"
         }
       }
@@ -945,7 +1235,9 @@
       "auth_type": "oauth",
       "display_name": "Claude (OAuth)",
       "default_headers": {
-        "anthropic-beta": "oauth-2025-04-20"
+        "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14",
+        "user-agent": "claude-cli/2.1.77",
+        "x-app": "cli"
       }
     },
     "deepinfra": {

--- a/src/server/services/claude_oauth.py
+++ b/src/server/services/claude_oauth.py
@@ -5,10 +5,10 @@ Handles the OAuth 2.0 PKCE flow for connecting Claude models via users'
 existing Anthropic subscriptions. Unlike Codex (device code flow), Anthropic
 uses a hosted callback page where the user copies a code#state string.
 
-Protocol details (discovered from @mariozechner/pi-ai 0.54.0):
+Protocol details (discovered from @mariozechner/pi-ai 0.58.0):
 - Authorize URL: https://claude.ai/oauth/authorize
-- Token URL: https://console.anthropic.com/v1/oauth/token
-- Redirect URI: https://console.anthropic.com/oauth/code/callback (hosted)
+- Token URL: https://platform.claude.com/v1/oauth/token
+- Redirect URI: https://platform.claude.com/oauth/code/callback (hosted)
 - PKCE: S256, state = verifier
 - Token exchange: Content-Type: application/json (not form-urlencoded)
 - Extra authorize param: code=true
@@ -36,9 +36,9 @@ logger = logging.getLogger(__name__)
 CLAUDE_PROVIDER = "claude-oauth"
 CLAUDE_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
 CLAUDE_AUTHORIZE_URL = "https://claude.ai/oauth/authorize"
-CLAUDE_TOKEN_URL = "https://api.anthropic.com/v1/oauth/token"
-CLAUDE_REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback"
-CLAUDE_SCOPES = "org:create_api_key user:profile user:inference"
+CLAUDE_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
+CLAUDE_REDIRECT_URI = "https://platform.claude.com/oauth/code/callback"
+CLAUDE_SCOPES = "org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload"
 
 
 # --- PKCE ---
@@ -92,7 +92,7 @@ def parse_callback_input(raw: str) -> tuple[str, str]:
     """Parse various callback input formats into (code, state).
 
     Supported formats:
-    - Full URL: https://console.anthropic.com/oauth/code/callback?code=X&state=Y
+    - Full URL: https://platform.claude.com/oauth/code/callback?code=X&state=Y
     - code#state
     - Just the code (state derived from context)
 


### PR DESCRIPTION
## Summary

Fixes Claude OAuth to fully support subscription-based accounts (Max/Pro plans). Three root causes prevented Sonnet/Opus from working with OAuth tokens:

1. The Anthropic SDK silently fell back to `ANTHROPIC_API_KEY` even when an OAuth token was provided.
2. Subscription OAuth tokens require the system prompt to begin with the Claude Code identity string to unlock Sonnet/Opus access.
3. OAuth endpoints migrated from `console.anthropic.com` to `platform.claude.com` (protocol v0.58.0).

This PR also adds 1M context window variants for Opus and Sonnet OAuth models via the `context-1m-2025-08-07` beta header.

## Changes

- **`anthropic_oauth.py`**: Override `_client`/`_async_client` to null out `api_key` post-construction (stops `ANTHROPIC_API_KEY` fallback); prepend Claude Code identity block in `_get_request_payload` (required for subscription Sonnet/Opus)
- **`llm.py`**: Merge model-level `additional_betas` into provider `anthropic-beta` header at construction time
- **`claude_oauth.py`**: Token URL + redirect URI updated to `platform.claude.com`; add `user:sessions:claude_code`, `user:mcp_servers`, `user:file_upload` scopes; bump to v0.58.0
- **`providers.json`**: Expand `anthropic-beta` for `claude-oauth` (add `claude-code-20250219`, `interleaved-thinking-2025-05-14`, `fine-grained-tool-streaming-2025-05-14`); add `User-Agent: claude-cli/2.1.77`
- **`models.json`**: Add `claude-opus-4-6-oauth-1m` and `claude-sonnet-4-6-oauth-1m` (1M context via beta); add `glm-5-turbo` and `glm-5-turbo-cn`; JSON formatting cleanup

## Test Plan

- [ ] Authenticate via OAuth PKCE flow with a Claude Max/Pro subscription
- [ ] Verify Sonnet/Opus requests succeed (identity prefix accepted, no `X-Api-Key` header leaking)
- [ ] Verify 1M context models include the `context-1m-2025-08-07` beta header
- [ ] Confirm OAuth callback parsing works with new `platform.claude.com` redirect URI