### PR TITLE
Feat/preview urls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,6 +93,10 @@ AUTH_USER_ID=local-dev-user
 # Encryption key for API keys stored at rest (any random string works)
 BYOK_ENCRYPTION_KEY=langalpha-local-dev-encryption-key
 
+# Public base URL of this server (used in agent-generated URLs like preview links)
+# Set to your public-facing URL in production (e.g. https://app.example.com)
+# SERVER_BASE_URL=http://localhost:8000
+
 # =============================================================================
 # Infrastructure — controls whether Docker Compose starts PostgreSQL and Redis
 # =============================================================================

--- a/src/config/env.py
+++ b/src/config/env.py
@@ -24,6 +24,9 @@ GINLIX_DATA_WS_URL: str = os.getenv("GINLIX_DATA_WS_URL", "") or (
 )
 GINLIX_DATA_ENABLED: bool = bool(GINLIX_DATA_URL)
 
+# Public base URL of this server (used in agent-generated URLs like preview links)
+SERVER_BASE_URL: str = os.getenv("SERVER_BASE_URL", "http://localhost:8000")
+
 # Automation webhook delivery (ginlix-integration)
 AUTOMATION_WEBHOOK_URL: str = os.getenv("AUTOMATION_WEBHOOK_URL", "")
 AUTOMATION_WEBHOOK_SECRET: str = os.getenv("AUTOMATION_WEBHOOK_SECRET", "")

--- a/src/ptc_agent/agent/agent.py
+++ b/src/ptc_agent/agent/agent.py
@@ -313,7 +313,8 @@ class PTCAgent:
         bash_output_tool = create_bash_output_tool(sandbox)
 
         # Create the preview URL tool for sandbox service previews
-        preview_url_tool = create_preview_url_tool(sandbox)
+        workspace_id = getattr(session, "conversation_id", "") if session else ""
+        preview_url_tool = create_preview_url_tool(sandbox, workspace_id=workspace_id)
 
         # Start with base tools
         tools: list[Any] = [execute_code_tool, bash_tool, bash_output_tool, preview_url_tool, TodoWrite]

--- a/src/ptc_agent/agent/agent.py
+++ b/src/ptc_agent/agent/agent.py
@@ -66,6 +66,7 @@ from ptc_agent.agent.subagents import (
     create_subagents,
 )
 from ptc_agent.agent.tools import (
+    create_bash_output_tool,
     create_execute_bash_tool,
     create_execute_code_tool,
     create_filesystem_tools,
@@ -309,12 +310,13 @@ class PTCAgent:
 
         # Create the Bash tool for shell command execution
         bash_tool = create_execute_bash_tool(sandbox, thread_id=short_thread_id)
+        bash_output_tool = create_bash_output_tool(sandbox)
 
         # Create the preview URL tool for sandbox service previews
         preview_url_tool = create_preview_url_tool(sandbox)
 
         # Start with base tools
-        tools: list[Any] = [execute_code_tool, bash_tool, preview_url_tool, TodoWrite]
+        tools: list[Any] = [execute_code_tool, bash_tool, bash_output_tool, preview_url_tool, TodoWrite]
 
         # Create backend for SkillsMiddleware and LargeResultEvictionMiddleware
         backend = SandboxBackend(sandbox, operation_callback=operation_callback)

--- a/src/ptc_agent/agent/agent.py
+++ b/src/ptc_agent/agent/agent.py
@@ -71,6 +71,7 @@ from ptc_agent.agent.tools import (
     create_filesystem_tools,
     create_glob_tool,
     create_grep_tool,
+    create_preview_url_tool,
     TodoWrite,
 )
 from src.tools.search import get_web_search_tool
@@ -309,8 +310,11 @@ class PTCAgent:
         # Create the Bash tool for shell command execution
         bash_tool = create_execute_bash_tool(sandbox, thread_id=short_thread_id)
 
+        # Create the preview URL tool for sandbox service previews
+        preview_url_tool = create_preview_url_tool(sandbox)
+
         # Start with base tools
-        tools: list[Any] = [execute_code_tool, bash_tool, TodoWrite]
+        tools: list[Any] = [execute_code_tool, bash_tool, preview_url_tool, TodoWrite]
 
         # Create backend for SkillsMiddleware and LargeResultEvictionMiddleware
         backend = SandboxBackend(sandbox, operation_callback=operation_callback)

--- a/src/ptc_agent/agent/agent.py
+++ b/src/ptc_agent/agent/agent.py
@@ -261,6 +261,7 @@ class PTCAgent:
         thread_id: str | None = None,
         on_agent_md_write: Any | None = None,
         store: Any | None = None,
+        on_signed_url: Any | None = None,
     ) -> Any:
         """Create a deepagent with PTC pattern capabilities.
 
@@ -288,6 +289,8 @@ class PTCAgent:
                 First 8 chars used as thread directory name in .agent/threads/{id}/.
             on_agent_md_write: Optional callback invoked when agent.md is written/edited.
                 Used to invalidate Session's agent.md cache.
+            on_signed_url: Optional async callback(sandbox_id, port, url) to cache
+                signed preview URLs. Injected from the server layer.
 
         Returns:
             Configured BackgroundSubagentOrchestrator wrapping the deepagent
@@ -314,7 +317,7 @@ class PTCAgent:
 
         # Create the preview URL tool for sandbox service previews
         workspace_id = getattr(session, "conversation_id", "") if session else ""
-        preview_url_tool = create_preview_url_tool(sandbox, workspace_id=workspace_id)
+        preview_url_tool = create_preview_url_tool(sandbox, workspace_id=workspace_id, on_signed_url=on_signed_url)
 
         # Start with base tools
         tools: list[Any] = [execute_code_tool, bash_tool, bash_output_tool, preview_url_tool, TodoWrite]

--- a/src/ptc_agent/agent/graph.py
+++ b/src/ptc_agent/agent/graph.py
@@ -92,6 +92,7 @@ async def build_ptc_graph(
     checkpointer: Any | None = None,
     background_registry: Any | None = None,
     store: Any | None = None,
+    on_signed_url: Any | None = None,
 ) -> Any:
     """
     Build a compiled LangGraph for a specific conversation.
@@ -108,6 +109,7 @@ async def build_ptc_graph(
         operation_callback: Optional callback for file operation logging
         checkpointer: Optional LangGraph checkpointer for state persistence (e.g., AsyncPostgresSaver)
         background_registry: Optional shared registry for background subagent tasks
+        on_signed_url: Optional async callback(sandbox_id, port, url) to cache signed preview URLs
 
     Returns:
         Compiled StateGraph compatible with LangGraph streaming
@@ -151,6 +153,7 @@ async def build_ptc_graph(
         checkpointer=checkpointer,
         background_registry=background_registry,
         store=store,
+        on_signed_url=on_signed_url,
     )
 
     logger.info(
@@ -175,6 +178,7 @@ async def build_ptc_graph_with_session(
     plan_mode: bool = False,
     thread_id: str | None = None,
     store: Any | None = None,
+    on_signed_url: Any | None = None,
 ) -> Any:
     """
     Build a compiled LangGraph using a provided session.
@@ -191,6 +195,7 @@ async def build_ptc_graph_with_session(
         background_registry: Optional shared registry for background subagent tasks
         user_id: Optional user ID for fetching user profile to inject into system prompt
         plan_mode: If True, enables submit_plan tool for plan review workflow
+        on_signed_url: Optional async callback(sandbox_id, port, url) to cache signed preview URLs
 
     Returns:
         Compiled StateGraph compatible with LangGraph streaming
@@ -239,6 +244,7 @@ async def build_ptc_graph_with_session(
         thread_id=thread_id,
         on_agent_md_write=session.invalidate_agent_md,
         store=store,
+        on_signed_url=on_signed_url,
     )
 
     logger.info(

--- a/src/ptc_agent/agent/tools/__init__.py
+++ b/src/ptc_agent/agent/tools/__init__.py
@@ -21,6 +21,7 @@ from typing import Any
 from langchain_core.tools import BaseTool
 
 from .bash import create_execute_bash_tool
+from .bash_output import create_bash_output_tool
 from .code_execution import create_execute_code_tool
 from .file_ops import create_filesystem_tools
 from .glob import create_glob_tool
@@ -48,6 +49,7 @@ from .todo import (
 __all__ = [
     # Bash
     "create_execute_bash_tool",
+    "create_bash_output_tool",
     # Code execution
     "create_execute_code_tool",
     # Filesystem

--- a/src/ptc_agent/agent/tools/__init__.py
+++ b/src/ptc_agent/agent/tools/__init__.py
@@ -25,6 +25,7 @@ from .code_execution import create_execute_code_tool
 from .file_ops import create_filesystem_tools
 from .glob import create_glob_tool
 from .grep import create_grep_tool
+from .preview_url import create_preview_url_tool
 from .think import think_tool
 
 # Todo tracking
@@ -54,6 +55,8 @@ __all__ = [
     # Search
     "create_glob_tool",
     "create_grep_tool",
+    # Preview URL
+    "create_preview_url_tool",
     # Helper
     "get_all_tools",
     # Research

--- a/src/ptc_agent/agent/tools/bash_output.py
+++ b/src/ptc_agent/agent/tools/bash_output.py
@@ -1,0 +1,63 @@
+"""Get output and status of background bash commands."""
+
+from typing import Any
+
+import structlog
+from langchain_core.tools import BaseTool, tool
+
+logger = structlog.get_logger(__name__)
+
+
+def create_bash_output_tool(sandbox: Any) -> BaseTool:
+    """Factory function to create BashOutput tool with injected dependencies.
+
+    Args:
+        sandbox: PTCSandbox instance for querying background command output
+
+    Returns:
+        Configured BashOutput tool function
+    """
+
+    @tool
+    async def BashOutput(command_id: str) -> str:
+        """Get the output and status of a background bash command.
+
+        Use this to check on commands started with run_in_background=True.
+        To stop a background command, use the Bash tool (e.g. pkill -f '...').
+
+        Args:
+            command_id: The command_id returned when the background command was started
+
+        Returns:
+            Status and output of the background command
+        """
+        try:
+            result = await sandbox.get_background_command_status(command_id)
+
+            is_running = result["is_running"]
+            exit_code = result["exit_code"]
+            stdout = result.get("stdout", "")
+            stderr = result.get("stderr", "")
+
+            # Format status line
+            if is_running:
+                status = "RUNNING"
+            elif exit_code == 0:
+                status = "COMPLETED (success)"
+            else:
+                status = f"COMPLETED (exit code {exit_code})"
+
+            parts = [f"Status: {status}"]
+            if stdout:
+                parts.append(f"Output:\n{stdout}")
+            if stderr:
+                parts.append(f"Errors:\n{stderr}")
+
+            return "\n".join(parts)
+
+        except Exception as e:
+            error_msg = f"Failed to get background command output: {e!s}"
+            logger.error(error_msg, command_id=command_id, exc_info=True)
+            return f"ERROR: {error_msg}"
+
+    return BashOutput

--- a/src/ptc_agent/agent/tools/preview_url.py
+++ b/src/ptc_agent/agent/tools/preview_url.py
@@ -8,11 +8,12 @@ from langchain_core.tools import BaseTool, tool
 logger = structlog.get_logger(__name__)
 
 
-def create_preview_url_tool(sandbox: Any) -> BaseTool:
+def create_preview_url_tool(sandbox: Any, *, workspace_id: str = "") -> BaseTool:
     """Factory function to create GetPreviewUrl tool with injected dependencies.
 
     Args:
         sandbox: PTCSandbox instance for preview URL generation
+        workspace_id: Workspace ID for preview URL generation
 
     Returns:
         Configured GetPreviewUrl tool function
@@ -45,21 +46,39 @@ def create_preview_url_tool(sandbox: Any) -> BaseTool:
         except Exception:
             writer = None
 
+        if not workspace_id:
+            return "ERROR: No workspace ID available — cannot generate preview URL", {}
+
         try:
+            # Start the server process and wait for it to be ready
             preview_info = await sandbox.start_and_get_preview_url(command, port)
-            url = preview_info.url
             display_title = title or f"Port {port}"
+
+            # Cache the fresh signed URL in Redis so frontend resolves it instantly
+            try:
+                from src.server.app.workspace_sandbox import (
+                    _set_cached_signed_url,
+                )
+                await _set_cached_signed_url(sandbox.sandbox_id, port, preview_info.url)
+            except ImportError:
+                pass  # Server layer not available (e.g. CLI context)
+            except Exception:
+                logger.debug("Failed to cache signed URL for port %s", port, exc_info=True)
 
             logger.info(
                 "Generated preview URL",
                 port=port,
                 title=display_title,
-                url=url[:80],
+                workspace_id=workspace_id,
             )
+
+            # Stable URL: {base}/api/v1/preview/{workspace_id}/{port}
+            from src.config.env import SERVER_BASE_URL
+
+            stable_url = f"{SERVER_BASE_URL.rstrip('/')}/api/v1/preview/{workspace_id}/{port}"
 
             artifact = {
                 "type": "preview_url",
-                "url": url,
                 "port": port,
                 "title": display_title,
                 "command": command,
@@ -73,7 +92,7 @@ def create_preview_url_tool(sandbox: Any) -> BaseTool:
                     "payload": artifact,
                 })
 
-            content = f"Preview URL for {display_title}: {url}"
+            content = f"Preview URL for {display_title}: {stable_url}"
             return content, artifact
 
         except NotImplementedError:

--- a/src/ptc_agent/agent/tools/preview_url.py
+++ b/src/ptc_agent/agent/tools/preview_url.py
@@ -21,15 +21,18 @@ def create_preview_url_tool(sandbox: Any) -> BaseTool:
     @tool(response_format="content_and_artifact")
     async def GetPreviewUrl(
         port: int,
+        command: str,
         title: str | None = None,
     ) -> tuple[str, dict[str, Any]]:
         """Get a preview URL for a service running on the given port in the sandbox.
 
-        Use this after starting a web server or frontend dev server in the background
-        to generate a URL that the user can view in the preview panel.
+        This tool starts the given command in the background AND generates a preview URL.
+        Always provide the command used to start the server — it will be persisted so the
+        server can be restarted automatically when the user reopens the preview later.
 
         Args:
             port: Port number (3000-9999) the service is listening on
+            command: The shell command to start the server (e.g. "python -m http.server 8080")
             title: Optional display title for the preview (default: "Port {port}")
 
         Returns:
@@ -43,7 +46,7 @@ def create_preview_url_tool(sandbox: Any) -> BaseTool:
             writer = None
 
         try:
-            preview_info = await sandbox.get_preview_url(port, expires_in=3600)
+            preview_info = await sandbox.start_and_get_preview_url(command, port)
             url = preview_info.url
             display_title = title or f"Port {port}"
 
@@ -59,6 +62,7 @@ def create_preview_url_tool(sandbox: Any) -> BaseTool:
                 "url": url,
                 "port": port,
                 "title": display_title,
+                "command": command,
             }
 
             # Emit SSE artifact so the frontend auto-opens the preview panel
@@ -66,11 +70,7 @@ def create_preview_url_tool(sandbox: Any) -> BaseTool:
                 writer({
                     "artifact_type": "preview_url",
                     "artifact_id": f"preview_{port}",
-                    "payload": {
-                        "url": url,
-                        "port": port,
-                        "title": display_title,
-                    },
+                    "payload": artifact,
                 })
 
             content = f"Preview URL for {display_title}: {url}"

--- a/src/ptc_agent/agent/tools/preview_url.py
+++ b/src/ptc_agent/agent/tools/preview_url.py
@@ -18,11 +18,11 @@ def create_preview_url_tool(sandbox: Any) -> BaseTool:
         Configured GetPreviewUrl tool function
     """
 
-    @tool
+    @tool(response_format="content_and_artifact")
     async def GetPreviewUrl(
         port: int,
         title: str | None = None,
-    ) -> str:
+    ) -> tuple[str, dict[str, Any]]:
         """Get a preview URL for a service running on the given port in the sandbox.
 
         Use this after starting a web server or frontend dev server in the background
@@ -54,7 +54,14 @@ def create_preview_url_tool(sandbox: Any) -> BaseTool:
                 url=url[:80],
             )
 
-            # Emit SSE artifact so the frontend can open the preview panel
+            artifact = {
+                "type": "preview_url",
+                "url": url,
+                "port": port,
+                "title": display_title,
+            }
+
+            # Emit SSE artifact so the frontend auto-opens the preview panel
             if writer:
                 writer({
                     "artifact_type": "preview_url",
@@ -66,13 +73,17 @@ def create_preview_url_tool(sandbox: Any) -> BaseTool:
                     },
                 })
 
-            return f"Preview URL for {display_title}: {url}"
+            content = f"Preview URL for {display_title}: {url}"
+            return content, artifact
 
         except NotImplementedError:
-            return "ERROR: Preview URLs are not supported by the current sandbox provider"
+            return (
+                "ERROR: Preview URLs are not supported by the current sandbox provider",
+                {},
+            )
         except Exception as e:
             error_msg = f"Failed to generate preview URL for port {port}: {e!s}"
             logger.error(error_msg, port=port, error=str(e), exc_info=True)
-            return f"ERROR: {error_msg}"
+            return f"ERROR: {error_msg}", {}
 
     return GetPreviewUrl

--- a/src/ptc_agent/agent/tools/preview_url.py
+++ b/src/ptc_agent/agent/tools/preview_url.py
@@ -1,0 +1,78 @@
+"""Get preview URLs for services running in the sandbox."""
+
+from typing import Any
+
+import structlog
+from langchain_core.tools import BaseTool, tool
+
+logger = structlog.get_logger(__name__)
+
+
+def create_preview_url_tool(sandbox: Any) -> BaseTool:
+    """Factory function to create GetPreviewUrl tool with injected dependencies.
+
+    Args:
+        sandbox: PTCSandbox instance for preview URL generation
+
+    Returns:
+        Configured GetPreviewUrl tool function
+    """
+
+    @tool
+    async def GetPreviewUrl(
+        port: int,
+        title: str | None = None,
+    ) -> str:
+        """Get a preview URL for a service running on the given port in the sandbox.
+
+        Use this after starting a web server or frontend dev server in the background
+        to generate a URL that the user can view in the preview panel.
+
+        Args:
+            port: Port number (3000-9999) the service is listening on
+            title: Optional display title for the preview (default: "Port {port}")
+
+        Returns:
+            The signed preview URL that can be used to access the service
+        """
+        try:
+            from langgraph.config import get_stream_writer
+
+            writer = get_stream_writer()
+        except Exception:
+            writer = None
+
+        try:
+            preview_info = await sandbox.get_preview_url(port, expires_in=3600)
+            url = preview_info.url
+            display_title = title or f"Port {port}"
+
+            logger.info(
+                "Generated preview URL",
+                port=port,
+                title=display_title,
+                url=url[:80],
+            )
+
+            # Emit SSE artifact so the frontend can open the preview panel
+            if writer:
+                writer({
+                    "artifact_type": "preview_url",
+                    "artifact_id": f"preview_{port}",
+                    "payload": {
+                        "url": url,
+                        "port": port,
+                        "title": display_title,
+                    },
+                })
+
+            return f"Preview URL for {display_title}: {url}"
+
+        except NotImplementedError:
+            return "ERROR: Preview URLs are not supported by the current sandbox provider"
+        except Exception as e:
+            error_msg = f"Failed to generate preview URL for port {port}: {e!s}"
+            logger.error(error_msg, port=port, error=str(e), exc_info=True)
+            return f"ERROR: {error_msg}"
+
+    return GetPreviewUrl

--- a/src/ptc_agent/agent/tools/preview_url.py
+++ b/src/ptc_agent/agent/tools/preview_url.py
@@ -1,5 +1,6 @@
 """Get preview URLs for services running in the sandbox."""
 
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 import structlog
@@ -7,13 +8,22 @@ from langchain_core.tools import BaseTool, tool
 
 logger = structlog.get_logger(__name__)
 
+# Callback signature: (sandbox_id, port, signed_url) -> None
+OnSignedUrl = Callable[[str, int, str], Awaitable[None]]
 
-def create_preview_url_tool(sandbox: Any, *, workspace_id: str = "") -> BaseTool:
+
+def create_preview_url_tool(
+    sandbox: Any,
+    *,
+    workspace_id: str = "",
+    on_signed_url: OnSignedUrl | None = None,
+) -> BaseTool:
     """Factory function to create GetPreviewUrl tool with injected dependencies.
 
     Args:
         sandbox: PTCSandbox instance for preview URL generation
         workspace_id: Workspace ID for preview URL generation
+        on_signed_url: Optional async callback to cache signed URLs
 
     Returns:
         Configured GetPreviewUrl tool function
@@ -54,16 +64,12 @@ def create_preview_url_tool(sandbox: Any, *, workspace_id: str = "") -> BaseTool
             preview_info = await sandbox.start_and_get_preview_url(command, port)
             display_title = title or f"Port {port}"
 
-            # Cache the fresh signed URL in Redis so frontend resolves it instantly
-            try:
-                from src.server.app.workspace_sandbox import (
-                    _set_cached_signed_url,
-                )
-                await _set_cached_signed_url(sandbox.sandbox_id, port, preview_info.url)
-            except ImportError:
-                pass  # Server layer not available (e.g. CLI context)
-            except Exception:
-                logger.debug("Failed to cache signed URL for port %s", port, exc_info=True)
+            # Cache the fresh signed URL so frontend resolves it instantly
+            if on_signed_url:
+                try:
+                    await on_signed_url(sandbox.sandbox_id, port, preview_info.url)
+                except Exception:
+                    logger.debug("Failed to cache signed URL for port %s", port, exc_info=True)
 
             logger.info(
                 "Generated preview URL",

--- a/src/ptc_agent/core/sandbox/providers/daytona.py
+++ b/src/ptc_agent/core/sandbox/providers/daytona.py
@@ -260,10 +260,29 @@ class DaytonaRuntime(SandboxRuntime):
 
     # -- Preview URLs --
 
-    async def get_preview_url(self, port: int, expires_in: int = 86400) -> PreviewInfo:
-        """Get a signed preview URL for a service running on the given port."""
+    async def get_preview_url(self, port: int, expires_in: int = 3600) -> PreviewInfo:
+        """Get a signed preview URL for a service running on the given port.
+
+        Daytona returns the base URL and token separately. For iframe use the
+        token must be embedded as a query parameter since iframes cannot set
+        custom headers.
+        """
         result = await self._sandbox.create_signed_preview_url(port, expires_in)
-        return PreviewInfo(url=result.url, token=result.token)
+        url = result.url
+        # Embed token in URL if not already present (required for iframe access)
+        if result.token and "token=" not in url:
+            sep = "&" if "?" in url else "?"
+            url = f"{url}{sep}token={result.token}"
+        return PreviewInfo(url=url, token=result.token)
+
+    async def get_preview_link(self, port: int) -> PreviewInfo:
+        """Get a standard (non-signed) preview URL with header-based auth token."""
+        result = await self._sandbox.get_preview_link(port)
+        return PreviewInfo(
+            url=result.url,
+            token=result.token,
+            auth_headers={"X-Daytona-Preview-Token": result.token},
+        )
 
     # -- Capabilities & metadata --
 

--- a/src/ptc_agent/core/sandbox/providers/daytona.py
+++ b/src/ptc_agent/core/sandbox/providers/daytona.py
@@ -65,6 +65,15 @@ class DaytonaRuntime(SandboxRuntime):
         return self._sandbox.id
 
     @property
+    def proxy_domain(self) -> str | None:
+        from urllib.parse import urlparse
+
+        url = getattr(self._sandbox, "toolbox_proxy_url", None)
+        if not url:
+            return None
+        return urlparse(url).hostname
+
+    @property
     def working_dir(self) -> str:
         """Return cached working dir, or Daytona default if not yet fetched."""
         return self._working_dir or self._default_working_dir
@@ -251,7 +260,7 @@ class DaytonaRuntime(SandboxRuntime):
 
     # -- Preview URLs --
 
-    async def get_preview_url(self, port: int, expires_in: int = 3600) -> PreviewInfo:
+    async def get_preview_url(self, port: int, expires_in: int = 86400) -> PreviewInfo:
         """Get a signed preview URL for a service running on the given port."""
         result = await self._sandbox.create_signed_preview_url(port, expires_in)
         return PreviewInfo(url=result.url, token=result.token)

--- a/src/ptc_agent/core/sandbox/providers/daytona.py
+++ b/src/ptc_agent/core/sandbox/providers/daytona.py
@@ -13,7 +13,7 @@ from daytona_sdk.common.daytona import (
     CreateSandboxFromSnapshotParams,
     Image,
 )
-from daytona_sdk.common.process import CodeRunParams
+from daytona_sdk.common.process import CodeRunParams, SessionExecuteRequest
 from daytona_sdk.common.snapshot import CreateSnapshotParams
 
 from ptc_agent.config.core import DaytonaConfig
@@ -26,6 +26,7 @@ from ptc_agent.core.sandbox.runtime import (
     RuntimeState,
     SandboxProvider,
     SandboxRuntime,
+    SessionCommandResult,
 )
 
 logger = structlog.get_logger(__name__)
@@ -191,6 +192,63 @@ class DaytonaRuntime(SandboxRuntime):
             return [vars(f) for f in result]
         return result
 
+    # -- Sessions (background processes) --
+
+    async def create_session(self, session_id: str) -> None:
+        await self._sandbox.process.create_session(session_id)
+
+    async def session_execute(
+        self,
+        session_id: str,
+        command: str,
+        *,
+        run_async: bool = False,
+        timeout: int | None = None,
+    ) -> SessionCommandResult:
+        req = SessionExecuteRequest(command=command, run_async=run_async)
+        result = await self._sandbox.process.execute_session_command(
+            session_id, req, timeout=timeout
+        )
+        return SessionCommandResult(
+            cmd_id=result.cmd_id,
+            exit_code=result.exit_code,
+            stdout=result.stdout or "",
+            stderr=result.stderr or "",
+        )
+
+    async def session_command_status(
+        self, session_id: str, command_id: str
+    ) -> SessionCommandResult:
+        cmd = await self._sandbox.process.get_session_command(
+            session_id, command_id
+        )
+        return SessionCommandResult(
+            cmd_id=cmd.id,
+            exit_code=cmd.exit_code,
+            stdout="",
+            stderr="",
+        )
+
+    async def session_command_logs(
+        self, session_id: str, command_id: str
+    ) -> SessionCommandResult:
+        # Get status for exit_code
+        cmd = await self._sandbox.process.get_session_command(
+            session_id, command_id
+        )
+        logs = await self._sandbox.process.get_session_command_logs(
+            session_id, command_id
+        )
+        return SessionCommandResult(
+            cmd_id=command_id,
+            exit_code=cmd.exit_code,
+            stdout=logs.stdout or "",
+            stderr=logs.stderr or "",
+        )
+
+    async def delete_session(self, session_id: str) -> None:
+        await self._sandbox.process.delete_session(session_id)
+
     # -- Preview URLs --
 
     async def get_preview_url(self, port: int, expires_in: int = 3600) -> PreviewInfo:
@@ -202,7 +260,7 @@ class DaytonaRuntime(SandboxRuntime):
 
     @property
     def capabilities(self) -> set[str]:
-        return {"exec", "code_run", "file_io", "archive", "snapshot", "preview_url"}
+        return {"exec", "code_run", "file_io", "archive", "snapshot", "preview_url", "sessions"}
 
     async def archive(self) -> None:
         await self._sandbox.archive()

--- a/src/ptc_agent/core/sandbox/providers/daytona.py
+++ b/src/ptc_agent/core/sandbox/providers/daytona.py
@@ -225,28 +225,15 @@ class DaytonaRuntime(SandboxRuntime):
             stderr=result.stderr or "",
         )
 
-    async def session_command_status(
-        self, session_id: str, command_id: str
-    ) -> SessionCommandResult:
-        cmd = await self._sandbox.process.get_session_command(
-            session_id, command_id
-        )
-        return SessionCommandResult(
-            cmd_id=cmd.id,
-            exit_code=cmd.exit_code,
-            stdout="",
-            stderr="",
-        )
 
     async def session_command_logs(
         self, session_id: str, command_id: str
     ) -> SessionCommandResult:
-        # Get status for exit_code
-        cmd = await self._sandbox.process.get_session_command(
-            session_id, command_id
-        )
-        logs = await self._sandbox.process.get_session_command_logs(
-            session_id, command_id
+        cmd, logs = await asyncio.gather(
+            self._sandbox.process.get_session_command(session_id, command_id),
+            self._sandbox.process.get_session_command_logs(
+                session_id, command_id
+            ),
         )
         return SessionCommandResult(
             cmd_id=command_id,

--- a/src/ptc_agent/core/sandbox/providers/daytona.py
+++ b/src/ptc_agent/core/sandbox/providers/daytona.py
@@ -22,6 +22,7 @@ from ptc_agent.core.sandbox.runtime import (
     Artifact,
     CodeRunResult,
     ExecResult,
+    PreviewInfo,
     RuntimeState,
     SandboxProvider,
     SandboxRuntime,
@@ -190,11 +191,18 @@ class DaytonaRuntime(SandboxRuntime):
             return [vars(f) for f in result]
         return result
 
+    # -- Preview URLs --
+
+    async def get_preview_url(self, port: int, expires_in: int = 3600) -> PreviewInfo:
+        """Get a signed preview URL for a service running on the given port."""
+        result = await self._sandbox.create_signed_preview_url(port, expires_in)
+        return PreviewInfo(url=result.url, token=result.token)
+
     # -- Capabilities & metadata --
 
     @property
     def capabilities(self) -> set[str]:
-        return {"exec", "code_run", "file_io", "archive", "snapshot"}
+        return {"exec", "code_run", "file_io", "archive", "snapshot", "preview_url"}
 
     async def archive(self) -> None:
         await self._sandbox.archive()

--- a/src/ptc_agent/core/sandbox/ptc_sandbox.py
+++ b/src/ptc_agent/core/sandbox/ptc_sandbox.py
@@ -487,6 +487,9 @@ class PTCSandbox:
         """
         logger.info("Reconnecting to stopped sandbox", sandbox_id=sandbox_id)
 
+        # Clear stale background session — Daytona sessions don't survive stop/start
+        self._bg_session_id = None
+
         # Get the existing sandbox via provider
         try:
             self.runtime = await self._runtime_call(
@@ -2053,6 +2056,13 @@ class PTCSandbox:
                 charts=[],
             )
 
+    @property
+    def proxy_domain(self) -> str | None:
+        """Hostname of the sandbox proxy, or None if unavailable."""
+        if self.runtime is None:
+            return None
+        return self.runtime.proxy_domain
+
     async def get_preview_url(self, port: int, expires_in: int = 3600) -> PreviewInfo:
         """Get a signed preview URL for a service running on the given port.
 
@@ -2071,6 +2081,54 @@ class PTCSandbox:
             expires_in,
             retry_policy=RetryPolicy.SAFE,
         )
+
+    async def start_preview_server(self, command: str) -> str:
+        """Start a command in background for preview URL serving.
+
+        Fire-and-forget: starts the command via the background session.
+        If the port is already in use (server already running), the command
+        fails silently in the background — existing server keeps serving.
+
+        Returns:
+            The command ID from the session.
+        """
+        session_id = await self._ensure_bg_session()
+        assert self.runtime is not None
+        result = await self._runtime_call(
+            self.runtime.session_execute,
+            session_id,
+            command,
+            run_async=True,
+            retry_policy=RetryPolicy.UNSAFE,
+            total_timeout=30,
+        )
+        logger.info(
+            "Preview server command started",
+            cmd_id=result.cmd_id,
+            session_id=session_id,
+        )
+        return result.cmd_id
+
+    async def start_and_get_preview_url(
+        self,
+        command: str,
+        port: int,
+        *,
+        expires_in: int = 3600,
+        startup_delay: float = 2.0,
+    ) -> PreviewInfo:
+        """Start a server command in background and return a signed preview URL.
+
+        Combines start_preview_server + sleep + get_preview_url into a single call.
+        If the server command fails (e.g. port already in use), the preview URL
+        is still generated — the existing server keeps serving.
+        """
+        try:
+            await self.start_preview_server(command)
+        except Exception as e:
+            logger.warning("Failed to start preview server", command=command, error=str(e))
+        await asyncio.sleep(startup_delay)
+        return await self.get_preview_url(port, expires_in=expires_in)
 
     async def _ensure_bg_session(self) -> str:
         """Lazily create a background session for long-running commands."""

--- a/src/ptc_agent/core/sandbox/ptc_sandbox.py
+++ b/src/ptc_agent/core/sandbox/ptc_sandbox.py
@@ -157,6 +157,9 @@ class PTCSandbox:
         # Track whether disabled tool modules have been pruned (only needed once)
         self._disabled_modules_pruned = False
 
+        # Cached standard preview link info per port (avoids repeated Daytona API calls)
+        self._preview_link_cache: dict[int, PreviewInfo] = {}
+
         logger.info("Initialized PTCSandbox")
 
     @property
@@ -487,8 +490,9 @@ class PTCSandbox:
         """
         logger.info("Reconnecting to stopped sandbox", sandbox_id=sandbox_id)
 
-        # Clear stale background session — Daytona sessions don't survive stop/start
+        # Clear stale state — sessions and preview links don't survive stop/start
         self._bg_session_id = None
+        self._preview_link_cache.clear()
 
         # Get the existing sandbox via provider
         try:
@@ -2081,6 +2085,25 @@ class PTCSandbox:
             expires_in,
             retry_policy=RetryPolicy.SAFE,
         )
+
+    async def get_preview_link(self, port: int) -> PreviewInfo:
+        """Get a standard preview URL with header-based auth token.
+
+        Results are cached per-port since the standard URL doesn't change
+        while the sandbox is running. Cache is cleared on sandbox restart.
+        """
+        cached = self._preview_link_cache.get(port)
+        if cached is not None:
+            return cached
+        await self._wait_ready()
+        assert self.runtime is not None
+        result = await self._runtime_call(
+            self.runtime.get_preview_link,
+            port,
+            retry_policy=RetryPolicy.SAFE,
+        )
+        self._preview_link_cache[port] = result
+        return result
 
     async def start_preview_server(self, command: str) -> str:
         """Start a command in background for preview URL serving.

--- a/src/ptc_agent/core/sandbox/ptc_sandbox.py
+++ b/src/ptc_agent/core/sandbox/ptc_sandbox.py
@@ -24,6 +24,7 @@ from ptc_agent.core.sandbox.runtime import (
     RuntimeState,
     SandboxRuntime,
     SandboxTransientError,
+    SessionCommandResult,
 )
 
 from ..mcp_registry import MCPRegistry
@@ -141,6 +142,9 @@ class PTCSandbox:
 
         # Track per-thread code dirs that have been created (avoids repeated mkdir)
         self._thread_dirs_created: set[str] = set()
+
+        # Background session for long-running commands (lazy-created)
+        self._bg_session_id: str | None = None
 
         # Lazy initialization support
         self._ready_event: asyncio.Event | None = None
@@ -2068,6 +2072,68 @@ class PTCSandbox:
             retry_policy=RetryPolicy.SAFE,
         )
 
+    async def _ensure_bg_session(self) -> str:
+        """Lazily create a background session for long-running commands."""
+        if self._bg_session_id is not None:
+            return self._bg_session_id
+
+        await self._wait_ready()
+        assert self.runtime is not None
+        session_id = f"bg-{self.runtime.id[:12]}"
+        try:
+            await self._runtime_call(
+                self.runtime.create_session,
+                session_id,
+                retry_policy=RetryPolicy.SAFE,
+            )
+        except Exception as e:
+            # Session may already exist from a previous sandbox reconnect
+            if "already exists" in str(e).lower():
+                logger.debug("Background session already exists", session_id=session_id)
+            else:
+                raise
+        self._bg_session_id = session_id
+        logger.info("Background session ready", session_id=session_id)
+        return session_id
+
+    async def get_background_command_status(self, cmd_id: str) -> dict[str, Any]:
+        """Get status and logs for a background command.
+
+        Args:
+            cmd_id: Command ID returned when the background command was started.
+
+        Returns:
+            Dict with keys: success, is_running, exit_code, stdout, stderr, cmd_id.
+        """
+        await self._wait_ready()
+        assert self.runtime is not None
+
+        if not self._bg_session_id:
+            return {
+                "success": False,
+                "is_running": False,
+                "exit_code": None,
+                "stdout": "",
+                "stderr": "No background session exists",
+                "cmd_id": cmd_id,
+            }
+
+        result: SessionCommandResult = await self._runtime_call(
+            self.runtime.session_command_logs,
+            self._bg_session_id,
+            cmd_id,
+            retry_policy=RetryPolicy.SAFE,
+        )
+        is_running = result.exit_code is None
+        return {
+            "success": not is_running and result.exit_code == 0,
+            "is_running": is_running,
+            "exit_code": result.exit_code,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+            "cmd_id": cmd_id,
+        }
+
     async def execute_bash_command(
         self,
         command: str,
@@ -2155,31 +2221,30 @@ class PTCSandbox:
                     error=str(upload_err),
                 )
 
-            # Background execution: launch with nohup and return PID immediately
+            # Background execution via Daytona session
             if background:
-                bg_log = f"/tmp/.bg_{bash_id}.log"
-                # Escape single quotes for safe embedding in bash -c '...'
-                escaped_command = full_command.replace("'", "'\\''")
-                bg_command = (
-                    f"nohup bash -c '{escaped_command}' > {bg_log} 2>&1 & echo $!"
-                )
+                session_id = await self._ensure_bg_session()
                 assert self.runtime is not None
-                exec_result = await self._runtime_call(
-                    self.runtime.exec,
-                    bg_command,
-                    timeout=10,
+                result = await self._runtime_call(
+                    self.runtime.session_execute,
+                    session_id,
+                    full_command,
+                    run_async=True,
                     retry_policy=RetryPolicy.UNSAFE,
-                    total_timeout=40,
+                    total_timeout=30,
                 )
-                pid = exec_result.stdout.strip()
                 logger.info(
-                    "Background process started",
+                    "Background command started",
                     bash_id=bash_id,
-                    pid=pid,
+                    cmd_id=result.cmd_id,
+                    session_id=session_id,
                 )
                 return {
                     "success": True,
-                    "stdout": f"Background process started (PID: {pid})\nLog file: {bg_log}",
+                    "stdout": (
+                        f"Background command started (command_id: {result.cmd_id})\n"
+                        f"Use BashOutput tool with command_id=\"{result.cmd_id}\" to check output and status."
+                    ),
                     "stderr": "",
                     "exit_code": 0,
                     "bash_id": bash_id,
@@ -2848,6 +2913,18 @@ class PTCSandbox:
 
         try:
             if self.runtime:
+                # Clean up background session if one was created
+                if self._bg_session_id:
+                    try:
+                        await self._runtime_call(
+                            self.runtime.delete_session,
+                            self._bg_session_id,
+                            retry_policy=RetryPolicy.SAFE,
+                        )
+                    except Exception as e:
+                        logger.debug("Failed to delete background session", error=str(e))
+                    self._bg_session_id = None
+
                 try:
                     await self._runtime_call(
                         self.runtime.delete,

--- a/src/ptc_agent/core/sandbox/ptc_sandbox.py
+++ b/src/ptc_agent/core/sandbox/ptc_sandbox.py
@@ -20,6 +20,7 @@ from ptc_agent.core.sandbox._defaults import DEFAULT_DEPENDENCIES, SNAPSHOT_PYTH
 from ptc_agent.core.sandbox.providers import create_provider
 from ptc_agent.core.sandbox.retry import RetryPolicy, async_retry_with_backoff
 from ptc_agent.core.sandbox.runtime import (
+    PreviewInfo,
     RuntimeState,
     SandboxRuntime,
     SandboxTransientError,
@@ -2048,6 +2049,25 @@ class PTCSandbox:
                 charts=[],
             )
 
+    async def get_preview_url(self, port: int, expires_in: int = 3600) -> PreviewInfo:
+        """Get a signed preview URL for a service running on the given port.
+
+        Args:
+            port: Port number (3000-9999) the service is listening on.
+            expires_in: URL expiry in seconds (default: 3600 = 1 hour).
+
+        Returns:
+            PreviewInfo with url and token.
+        """
+        await self._wait_ready()
+        assert self.runtime is not None
+        return await self._runtime_call(
+            self.runtime.get_preview_url,
+            port,
+            expires_in,
+            retry_policy=RetryPolicy.SAFE,
+        )
+
     async def execute_bash_command(
         self,
         command: str,
@@ -2063,7 +2083,7 @@ class PTCSandbox:
             command: Bash command to execute
             working_dir: Working directory for command execution (default: sandbox working dir)
             timeout: Maximum execution time in seconds (default: 60)
-            background: Run command in background (not fully implemented yet)
+            background: Run command in background
             thread_id: Optional thread ID (first 8 chars) for thread-scoped script storage
 
         Returns:
@@ -2134,6 +2154,37 @@ class PTCSandbox:
                     bash_id=bash_id,
                     error=str(upload_err),
                 )
+
+            # Background execution: launch with nohup and return PID immediately
+            if background:
+                bg_log = f"/tmp/.bg_{bash_id}.log"
+                # Escape single quotes for safe embedding in bash -c '...'
+                escaped_command = full_command.replace("'", "'\\''")
+                bg_command = (
+                    f"nohup bash -c '{escaped_command}' > {bg_log} 2>&1 & echo $!"
+                )
+                assert self.runtime is not None
+                exec_result = await self._runtime_call(
+                    self.runtime.exec,
+                    bg_command,
+                    timeout=10,
+                    retry_policy=RetryPolicy.UNSAFE,
+                    total_timeout=40,
+                )
+                pid = exec_result.stdout.strip()
+                logger.info(
+                    "Background process started",
+                    bash_id=bash_id,
+                    pid=pid,
+                )
+                return {
+                    "success": True,
+                    "stdout": f"Background process started (PID: {pid})\nLog file: {bg_log}",
+                    "stderr": "",
+                    "exit_code": 0,
+                    "bash_id": bash_id,
+                    "command_hash": command_hash,
+                }
 
             # Execute directly via process.exec — no file upload dependency
             assert self.runtime is not None

--- a/src/ptc_agent/core/sandbox/runtime.py
+++ b/src/ptc_agent/core/sandbox/runtime.py
@@ -90,6 +90,11 @@ class SandboxRuntime(ABC):
         """Default working directory inside the sandbox (sync, may return cached/default)."""
         ...
 
+    @property
+    def proxy_domain(self) -> str | None:
+        """Hostname of the sandbox proxy (e.g. 'abc123.daytonaproxy1.example.com'). None if unsupported."""
+        return None
+
     async def fetch_working_dir(self) -> str:
         """Fetch and cache the working directory (async). Override if working_dir requires I/O."""
         return self.working_dir
@@ -205,7 +210,7 @@ class SandboxRuntime(ABC):
     async def delete_session(self, session_id: str) -> None:
         """Delete a session. Default is no-op for providers without session support."""
 
-    async def get_preview_url(self, port: int, expires_in: int = 3600) -> PreviewInfo:
+    async def get_preview_url(self, port: int, expires_in: int = 86400) -> PreviewInfo:
         """Get a signed preview URL for a service running on the given port.
 
         Not all providers support this; the default raises NotImplementedError.

--- a/src/ptc_agent/core/sandbox/runtime.py
+++ b/src/ptc_agent/core/sandbox/runtime.py
@@ -40,6 +40,7 @@ class PreviewInfo:
 
     url: str
     token: str
+    auth_headers: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass
@@ -92,7 +93,7 @@ class SandboxRuntime(ABC):
 
     @property
     def proxy_domain(self) -> str | None:
-        """Hostname of the sandbox proxy (e.g. 'abc123.daytonaproxy1.example.com'). None if unsupported."""
+        """Hostname of the sandbox proxy (e.g. 'sandbox-abc123.proxy.example.com'). None if unsupported."""
         return None
 
     async def fetch_working_dir(self) -> str:
@@ -210,12 +211,21 @@ class SandboxRuntime(ABC):
     async def delete_session(self, session_id: str) -> None:
         """Delete a session. Default is no-op for providers without session support."""
 
-    async def get_preview_url(self, port: int, expires_in: int = 86400) -> PreviewInfo:
+    async def get_preview_url(self, port: int, expires_in: int = 3600) -> PreviewInfo:
         """Get a signed preview URL for a service running on the given port.
 
         Not all providers support this; the default raises NotImplementedError.
         """
         raise NotImplementedError("Preview URLs not supported by this runtime")
+
+    async def get_preview_link(self, port: int) -> PreviewInfo:
+        """Get a standard (non-signed) preview URL for a service running on the given port.
+
+        Returns PreviewInfo with ``auth_headers`` populated for authenticated
+        requests. Unlike signed URLs, this token resets on sandbox restart.
+        Used for health checks.
+        """
+        raise NotImplementedError("Preview links not supported by this runtime")
 
     async def get_metadata(self) -> dict[str, Any]:
         """Return provider-specific metadata about the runtime."""

--- a/src/ptc_agent/core/sandbox/runtime.py
+++ b/src/ptc_agent/core/sandbox/runtime.py
@@ -43,6 +43,16 @@ class PreviewInfo:
 
 
 @dataclass
+class SessionCommandResult:
+    """Result of a command executed in a background session."""
+
+    cmd_id: str
+    exit_code: int | None  # None = still running
+    stdout: str
+    stderr: str
+
+
+@dataclass
 class Artifact:
     """An artifact produced by code execution (e.g. a chart image)."""
 
@@ -162,6 +172,38 @@ class SandboxRuntime(ABC):
         Not all providers support this; the default raises NotImplementedError.
         """
         raise NotImplementedError
+
+    # -- Sessions (background processes) --
+
+    async def create_session(self, session_id: str) -> None:
+        """Create a named session for background command execution."""
+        raise NotImplementedError("Sessions not supported by this runtime")
+
+    async def session_execute(
+        self,
+        session_id: str,
+        command: str,
+        *,
+        run_async: bool = False,
+        timeout: int | None = None,
+    ) -> SessionCommandResult:
+        """Execute a command in a session. Use run_async=True for background execution."""
+        raise NotImplementedError("Sessions not supported by this runtime")
+
+    async def session_command_status(
+        self, session_id: str, command_id: str
+    ) -> SessionCommandResult:
+        """Get the status and exit code of a session command."""
+        raise NotImplementedError("Sessions not supported by this runtime")
+
+    async def session_command_logs(
+        self, session_id: str, command_id: str
+    ) -> SessionCommandResult:
+        """Get stdout/stderr logs of a session command."""
+        raise NotImplementedError("Sessions not supported by this runtime")
+
+    async def delete_session(self, session_id: str) -> None:
+        """Delete a session. Default is no-op for providers without session support."""
 
     async def get_preview_url(self, port: int, expires_in: int = 3600) -> PreviewInfo:
         """Get a signed preview URL for a service running on the given port.

--- a/src/ptc_agent/core/sandbox/runtime.py
+++ b/src/ptc_agent/core/sandbox/runtime.py
@@ -196,12 +196,6 @@ class SandboxRuntime(ABC):
         """Execute a command in a session. Use run_async=True for background execution."""
         raise NotImplementedError("Sessions not supported by this runtime")
 
-    async def session_command_status(
-        self, session_id: str, command_id: str
-    ) -> SessionCommandResult:
-        """Get the status and exit code of a session command."""
-        raise NotImplementedError("Sessions not supported by this runtime")
-
     async def session_command_logs(
         self, session_id: str, command_id: str
     ) -> SessionCommandResult:

--- a/src/ptc_agent/core/sandbox/runtime.py
+++ b/src/ptc_agent/core/sandbox/runtime.py
@@ -35,6 +35,14 @@ class ExecResult:
 
 
 @dataclass
+class PreviewInfo:
+    """Preview URL info for a service running in the sandbox."""
+
+    url: str
+    token: str
+
+
+@dataclass
 class Artifact:
     """An artifact produced by code execution (e.g. a chart image)."""
 
@@ -154,6 +162,13 @@ class SandboxRuntime(ABC):
         Not all providers support this; the default raises NotImplementedError.
         """
         raise NotImplementedError
+
+    async def get_preview_url(self, port: int, expires_in: int = 3600) -> PreviewInfo:
+        """Get a signed preview URL for a service running on the given port.
+
+        Not all providers support this; the default raises NotImplementedError.
+        """
+        raise NotImplementedError("Preview URLs not supported by this runtime")
 
     async def get_metadata(self) -> dict[str, Any]:
         """Return provider-specific metadata about the runtime."""

--- a/src/server/app/setup.py
+++ b/src/server/app/setup.py
@@ -409,6 +409,7 @@ from src.server.app.utilities import health_router
 from src.server.app.workspaces import router as workspaces_router
 from src.server.app.workspace_files import router as workspace_files_router
 from src.server.app.workspace_sandbox import router as workspace_sandbox_router
+from src.server.app.workspace_sandbox import preview_redirect_router
 from src.server.app.market_data import router as market_data_router
 from src.server.app.users import router as users_router
 from src.server.app.watchlist import router as watchlist_router
@@ -482,6 +483,9 @@ app.include_router(
 )  # /api/v1/public/* - Public shared thread access (no auth)
 app.include_router(skills_router)  # /api/v1/skills - Available agent skills
 app.include_router(health_router)  # /health - Health check
+app.include_router(
+    preview_redirect_router
+)  # /api/v1/preview/{workspace_id}/{port} - Unauthenticated preview URL redirect
 
 app.include_router(
     market_data_ws_router

--- a/src/server/app/workspace_sandbox.py
+++ b/src/server/app/workspace_sandbox.py
@@ -15,7 +15,10 @@ import json
 import logging
 import re
 import shlex
+import time
 from typing import Any
+
+import httpx
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
@@ -445,33 +448,41 @@ async def install_sandbox_packages(
         )
 
 
+class PreviewUrlRequest(BaseModel):
+    port: int = Field(..., ge=3000, le=9999)
+    command: str | None = None
+    expires_in: int = Field(default=3600, ge=60, le=86400)
+
+
 class PreviewUrlResponse(BaseModel):
     url: str
     port: int
     expires_in: int
 
 
-@router.get("/{workspace_id}/sandbox/preview-url")
+@router.post("/{workspace_id}/sandbox/preview-url")
 async def get_sandbox_preview_url(
     workspace_id: str,
     x_user_id: CurrentUserId,
-    port: int,
-    expires_in: int = 3600,
+    body: PreviewUrlRequest,
 ) -> PreviewUrlResponse:
-    """Get a signed preview URL for a service running in the workspace sandbox."""
-    if not (3000 <= port <= 9999):
-        raise HTTPException(
-            status_code=400, detail="Port must be between 3000 and 9999"
-        )
+    """Get a signed preview URL for a service running in the workspace sandbox.
 
+    If command is provided, starts the server process in background before generating the URL.
+    """
     _session, sandbox = await _get_sandbox(workspace_id, x_user_id)
 
     try:
-        preview_info = await sandbox.get_preview_url(port, expires_in=expires_in)
+        if body.command:
+            preview_info = await sandbox.start_and_get_preview_url(
+                body.command, body.port, expires_in=body.expires_in,
+            )
+        else:
+            preview_info = await sandbox.get_preview_url(body.port, expires_in=body.expires_in)
         return PreviewUrlResponse(
             url=preview_info.url,
-            port=port,
-            expires_in=expires_in,
+            port=body.port,
+            expires_in=body.expires_in,
         )
     except NotImplementedError:
         raise HTTPException(
@@ -482,8 +493,52 @@ async def get_sandbox_preview_url(
         logger.exception(
             "Failed to get preview URL for workspace %s port %d",
             workspace_id,
-            port,
+            body.port,
         )
-        raise HTTPException(
-            status_code=500, detail=f"Failed to generate preview URL: {e}"
-        ) from None
+        raise HTTPException(status_code=500, detail=str(e)) from None
+
+
+class PreviewHealthRequest(BaseModel):
+    url: str
+
+
+class PreviewHealthResponse(BaseModel):
+    reachable: bool
+    checked_at: int
+
+
+@router.post("/{workspace_id}/sandbox/preview-health")
+async def check_preview_health(
+    workspace_id: str,
+    x_user_id: CurrentUserId,
+    body: PreviewHealthRequest,
+) -> PreviewHealthResponse:
+    """Check if a preview URL is still reachable."""
+    from urllib.parse import urlparse
+
+    _session, sandbox = await _get_sandbox(workspace_id, x_user_id)
+
+    # Validate URL scheme and domain
+    parsed = urlparse(body.url)
+    if parsed.scheme not in ("http", "https"):
+        raise HTTPException(status_code=400, detail="Invalid URL scheme")
+
+    proxy_host = getattr(sandbox, "proxy_domain", None)
+    if not proxy_host or "." not in proxy_host:
+        raise HTTPException(status_code=501, detail="Preview health checks not supported")
+
+    # Extract shared domain suffix (toolbox: {sandbox_id}.{domain}, preview: {port}-{token}.{domain})
+    proxy_suffix = proxy_host.split(".", 1)[1]
+    if not parsed.hostname or not parsed.hostname.endswith(proxy_suffix):
+        raise HTTPException(status_code=400, detail="Invalid preview URL for this workspace")
+
+    checked_at = int(time.time())
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.head(body.url, follow_redirects=False)
+            return PreviewHealthResponse(
+                reachable=200 <= resp.status_code < 400,
+                checked_at=checked_at,
+            )
+    except Exception:
+        return PreviewHealthResponse(reachable=False, checked_at=checked_at)

--- a/src/server/app/workspace_sandbox.py
+++ b/src/server/app/workspace_sandbox.py
@@ -75,7 +75,7 @@ async def _delete_cached_signed_url(sandbox_id: str, port: int) -> None:
 async def _check_signed_url_healthy(signed_url: str) -> bool:
     """HEAD-check the actual signed URL the iframe would load."""
     try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
+        async with httpx.AsyncClient(timeout=2.0) as client:
             resp = await client.head(signed_url, follow_redirects=True)
             return 200 <= resp.status_code < 400
     except Exception:

--- a/src/server/app/workspace_sandbox.py
+++ b/src/server/app/workspace_sandbox.py
@@ -20,17 +20,66 @@ from typing import Any
 
 import httpx
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Path as PathParam, Response
+from fastapi.responses import RedirectResponse
 from pydantic import BaseModel, Field
 
 from src.server.utils.api import CurrentUserId, require_workspace_owner
 from src.server.database.workspace import get_workspace as db_get_workspace
 from src.server.services.workspace_manager import WorkspaceManager
 from src.ptc_agent.core.sandbox import PTCSandbox
+from src.utils.cache.redis_cache import get_cache_client
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/workspaces", tags=["Workspace Sandbox"])
+
+_SIGNED_URL_TTL = 3000  # 50 min (signed URLs expire in 1h)
+
+
+def _preview_cache_key(sandbox_id: str, port: int) -> str:
+    """Redis key for cached signed preview URL."""
+    return f"preview:signed_url:{sandbox_id}:{port}"
+
+
+async def _get_cached_signed_url(sandbox_id: str, port: int) -> str | None:
+    """Get cached signed URL from Redis."""
+    cache = get_cache_client()
+    return await cache.get(_preview_cache_key(sandbox_id, port))
+
+
+async def _set_cached_signed_url(
+    sandbox_id: str, port: int, url: str, *, expires_in: int | None = None,
+) -> None:
+    """Cache a signed URL in Redis with TTL.
+
+    Args:
+        expires_in: Actual signed URL expiry in seconds. When provided the
+            cache TTL is set to ``expires_in - 600`` (10 min safety margin),
+            clamped to [60, _SIGNED_URL_TTL]. Falls back to _SIGNED_URL_TTL.
+    """
+    if expires_in is not None:
+        ttl = max(60, min(expires_in - 600, _SIGNED_URL_TTL))
+    else:
+        ttl = _SIGNED_URL_TTL
+    cache = get_cache_client()
+    await cache.set(_preview_cache_key(sandbox_id, port), url, ttl=ttl)
+
+
+async def _delete_cached_signed_url(sandbox_id: str, port: int) -> None:
+    """Delete a cached signed URL from Redis."""
+    cache = get_cache_client()
+    await cache.delete(_preview_cache_key(sandbox_id, port))
+
+
+async def _check_signed_url_healthy(signed_url: str) -> bool:
+    """HEAD-check the actual signed URL the iframe would load."""
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.head(signed_url, follow_redirects=True)
+            return 200 <= resp.status_code < 400
+    except Exception:
+        return False
 
 # Regex for validating package names (allows version specifiers)
 _PACKAGE_NAME_RE = re.compile(r"^[a-zA-Z0-9._-]+([<>=!~]+.*)?$")
@@ -451,6 +500,7 @@ async def install_sandbox_packages(
 class PreviewUrlRequest(BaseModel):
     port: int = Field(..., ge=3000, le=9999)
     command: str | None = None
+    force: bool = False
     expires_in: int = Field(default=3600, ge=60, le=86400)
 
 
@@ -477,13 +527,49 @@ async def get_sandbox_preview_url(
             preview_info = await sandbox.start_and_get_preview_url(
                 body.command, body.port, expires_in=body.expires_in,
             )
-        else:
-            preview_info = await sandbox.get_preview_url(body.port, expires_in=body.expires_in)
+            await _set_cached_signed_url(
+                sandbox.sandbox_id, body.port, preview_info.url,
+                expires_in=body.expires_in,
+            )
+            return PreviewUrlResponse(
+                url=preview_info.url,
+                port=body.port,
+                expires_in=body.expires_in,
+            )
+
+        # No command — try cache (unless force=True)
+        if body.force:
+            await _delete_cached_signed_url(sandbox.sandbox_id, body.port)
+        cached_url = None if body.force else await _get_cached_signed_url(sandbox.sandbox_id, body.port)
+        if cached_url and await _check_signed_url_healthy(cached_url):
+            return PreviewUrlResponse(
+                url=cached_url,
+                port=body.port,
+                expires_in=body.expires_in,
+            )
+
+        # Stale or missing — get a fresh signed URL from the provider
+        await _delete_cached_signed_url(sandbox.sandbox_id, body.port)
+        preview_info = await sandbox.get_preview_url(
+            body.port, expires_in=body.expires_in,
+        )
+
+        # A freshly-generated signed URL from the provider is inherently valid.
+        # Don't gate on a server-side health check here — it can produce false
+        # negatives (e.g. dev servers that reject HEAD, or network differences
+        # between backend→proxy vs browser→proxy). The frontend's polling health
+        # check handles dead-server detection and restart.
+        await _set_cached_signed_url(
+            sandbox.sandbox_id, body.port, preview_info.url,
+            expires_in=body.expires_in,
+        )
         return PreviewUrlResponse(
             url=preview_info.url,
             port=body.port,
             expires_in=body.expires_in,
         )
+    except HTTPException:
+        raise
     except NotImplementedError:
         raise HTTPException(
             status_code=501,
@@ -499,7 +585,7 @@ async def get_sandbox_preview_url(
 
 
 class PreviewHealthRequest(BaseModel):
-    url: str
+    port: int = Field(..., ge=3000, le=9999)
 
 
 class PreviewHealthResponse(BaseModel):
@@ -513,32 +599,124 @@ async def check_preview_health(
     x_user_id: CurrentUserId,
     body: PreviewHealthRequest,
 ) -> PreviewHealthResponse:
-    """Check if a preview URL is still reachable."""
-    from urllib.parse import urlparse
+    """Check if a preview service is still reachable on the given port.
 
+    Uses the sandbox's standard preview link (cached) to avoid repeated
+    provider API calls on the 2-minute polling interval.
+    """
     _session, sandbox = await _get_sandbox(workspace_id, x_user_id)
 
-    # Validate URL scheme and domain
-    parsed = urlparse(body.url)
-    if parsed.scheme not in ("http", "https"):
-        raise HTTPException(status_code=400, detail="Invalid URL scheme")
-
-    proxy_host = getattr(sandbox, "proxy_domain", None)
-    if not proxy_host or "." not in proxy_host:
-        raise HTTPException(status_code=501, detail="Preview health checks not supported")
-
-    # Extract shared domain suffix (toolbox: {sandbox_id}.{domain}, preview: {port}-{token}.{domain})
-    proxy_suffix = proxy_host.split(".", 1)[1]
-    if not parsed.hostname or not parsed.hostname.endswith(proxy_suffix):
-        raise HTTPException(status_code=400, detail="Invalid preview URL for this workspace")
-
     checked_at = int(time.time())
+    reachable = False
     try:
+        preview_link = await sandbox.get_preview_link(body.port)
         async with httpx.AsyncClient(timeout=5.0) as client:
-            resp = await client.head(body.url, follow_redirects=False)
-            return PreviewHealthResponse(
-                reachable=200 <= resp.status_code < 400,
-                checked_at=checked_at,
+            resp = await client.head(
+                preview_link.url,
+                headers=preview_link.auth_headers,
+                follow_redirects=True,
             )
+            reachable = 200 <= resp.status_code < 400
+    except NotImplementedError:
+        raise HTTPException(
+            status_code=501, detail="Preview health checks not supported"
+        ) from None
     except Exception:
-        return PreviewHealthResponse(reachable=False, checked_at=checked_at)
+        pass
+
+    # Invalidate cached signed URL when server is down so next resolve gets a fresh one
+    if not reachable:
+        await _delete_cached_signed_url(sandbox.sandbox_id, body.port)
+
+    return PreviewHealthResponse(reachable=reachable, checked_at=checked_at)
+
+
+
+class PreviewRestartRequest(BaseModel):
+    port: int = Field(..., ge=3000, le=9999)
+    command: str
+
+
+class PreviewRestartResponse(BaseModel):
+    success: bool
+
+
+@router.post("/{workspace_id}/sandbox/preview-restart")
+async def restart_preview_server(
+    workspace_id: str,
+    x_user_id: CurrentUserId,
+    body: PreviewRestartRequest,
+) -> PreviewRestartResponse:
+    """Restart a preview server process in the workspace sandbox."""
+    _session, sandbox = await _get_sandbox(workspace_id, x_user_id)
+
+    try:
+        await sandbox.start_preview_server(body.command)
+        return PreviewRestartResponse(success=True)
+    except Exception as e:
+        logger.exception(
+            "Failed to restart preview server for workspace %s", workspace_id,
+        )
+        raise HTTPException(status_code=500, detail=str(e)) from None
+
+
+# ---------------------------------------------------------------------------
+# Unauthenticated preview redirect
+# ---------------------------------------------------------------------------
+
+preview_redirect_router = APIRouter(prefix="/api/v1", tags=["Preview Redirect"])
+
+
+async def _resolve_preview_url(sandbox_id: str, port: int) -> str:
+    """Resolve a signed preview URL for the given sandbox+port, with Redis caching."""
+    from ptc_agent.core.sandbox.providers import create_provider
+
+    cached_url = await _get_cached_signed_url(sandbox_id, port)
+    if cached_url and await _check_signed_url_healthy(cached_url):
+        return cached_url
+    if cached_url:
+        await _delete_cached_signed_url(sandbox_id, port)
+
+    manager = WorkspaceManager.get_instance()
+    provider = create_provider(manager.config.to_core_config())
+    try:
+        try:
+            runtime = await provider.get(sandbox_id)
+        except Exception:
+            raise HTTPException(status_code=404, detail="Sandbox not found") from None
+
+        state = await runtime.get_state()
+        if state.value != "running":
+            raise HTTPException(
+                status_code=503,
+                detail="Sandbox not running",
+                headers={"Retry-After": "30"},
+            )
+
+        preview_info = await runtime.get_preview_url(port, expires_in=3600)
+        await _set_cached_signed_url(sandbox_id, port, preview_info.url)
+        return preview_info.url
+    finally:
+        await provider.close()
+
+
+@preview_redirect_router.get("/preview/{workspace_id}/{port}")
+async def preview_redirect_by_workspace(
+    workspace_id: str,
+    port: int = PathParam(ge=3000, le=9999),
+) -> Response:
+    """Stable preview URL — deterministic for a given workspace+port.
+
+    Resolves to a cached signed URL via 302 redirect.
+    The workspace UUID (128-bit) acts as the access credential.
+    """
+    workspace = await db_get_workspace(workspace_id)
+    if not workspace:
+        raise HTTPException(status_code=404, detail="Workspace not found")
+
+    sandbox_id = workspace.get("sandbox_id")
+    if not sandbox_id:
+        raise HTTPException(status_code=404, detail="No sandbox for this workspace")
+
+    signed_url = await _resolve_preview_url(sandbox_id, port)
+    return RedirectResponse(url=signed_url, status_code=302)

--- a/src/server/app/workspace_sandbox.py
+++ b/src/server/app/workspace_sandbox.py
@@ -575,13 +575,13 @@ async def get_sandbox_preview_url(
             status_code=501,
             detail="Preview URLs are not supported by the current sandbox provider",
         ) from None
-    except Exception as e:
+    except Exception:
         logger.exception(
             "Failed to get preview URL for workspace %s port %d",
             workspace_id,
             body.port,
         )
-        raise HTTPException(status_code=500, detail=str(e)) from None
+        raise HTTPException(status_code=500, detail="Failed to get preview URL") from None
 
 
 class PreviewHealthRequest(BaseModel):
@@ -653,11 +653,11 @@ async def restart_preview_server(
     try:
         await sandbox.start_preview_server(body.command)
         return PreviewRestartResponse(success=True)
-    except Exception as e:
+    except Exception:
         logger.exception(
             "Failed to restart preview server for workspace %s", workspace_id,
         )
-        raise HTTPException(status_code=500, detail=str(e)) from None
+        raise HTTPException(status_code=500, detail="Failed to restart preview server") from None
 
 
 # ---------------------------------------------------------------------------
@@ -680,22 +680,27 @@ async def _resolve_preview_url(sandbox_id: str, port: int) -> str:
     manager = WorkspaceManager.get_instance()
     provider = create_provider(manager.config.to_core_config())
     try:
-        try:
-            runtime = await provider.get(sandbox_id)
-        except Exception:
-            raise HTTPException(status_code=404, detail="Sandbox not found") from None
+        async def _fetch_fresh_url() -> str:
+            try:
+                runtime = await provider.get(sandbox_id)
+            except Exception:
+                raise HTTPException(status_code=404, detail="Sandbox not found") from None
 
-        state = await runtime.get_state()
-        if state.value != "running":
-            raise HTTPException(
-                status_code=503,
-                detail="Sandbox not running",
-                headers={"Retry-After": "30"},
-            )
+            state = await runtime.get_state()
+            if state.value != "running":
+                raise HTTPException(
+                    status_code=503,
+                    detail="Sandbox not running",
+                    headers={"Retry-After": "30"},
+                )
 
-        preview_info = await runtime.get_preview_url(port, expires_in=3600)
-        await _set_cached_signed_url(sandbox_id, port, preview_info.url)
-        return preview_info.url
+            preview_info = await runtime.get_preview_url(port, expires_in=3600)
+            await _set_cached_signed_url(sandbox_id, port, preview_info.url)
+            return preview_info.url
+
+        return await asyncio.wait_for(_fetch_fresh_url(), timeout=15)
+    except asyncio.TimeoutError:
+        raise HTTPException(status_code=504, detail="Preview URL resolution timed out") from None
     finally:
         await provider.close()
 

--- a/src/server/app/workspace_sandbox.py
+++ b/src/server/app/workspace_sandbox.py
@@ -443,3 +443,47 @@ async def install_sandbox_packages(
             output="",
             error=str(e),
         )
+
+
+class PreviewUrlResponse(BaseModel):
+    url: str
+    port: int
+    expires_in: int
+
+
+@router.get("/{workspace_id}/sandbox/preview-url")
+async def get_sandbox_preview_url(
+    workspace_id: str,
+    x_user_id: CurrentUserId,
+    port: int,
+    expires_in: int = 3600,
+) -> PreviewUrlResponse:
+    """Get a signed preview URL for a service running in the workspace sandbox."""
+    if not (3000 <= port <= 9999):
+        raise HTTPException(
+            status_code=400, detail="Port must be between 3000 and 9999"
+        )
+
+    _session, sandbox = await _get_sandbox(workspace_id, x_user_id)
+
+    try:
+        preview_info = await sandbox.get_preview_url(port, expires_in=expires_in)
+        return PreviewUrlResponse(
+            url=preview_info.url,
+            port=port,
+            expires_in=expires_in,
+        )
+    except NotImplementedError:
+        raise HTTPException(
+            status_code=501,
+            detail="Preview URLs are not supported by the current sandbox provider",
+        ) from None
+    except Exception as e:
+        logger.exception(
+            "Failed to get preview URL for workspace %s port %d",
+            workspace_id,
+            port,
+        )
+        raise HTTPException(
+            status_code=500, detail=f"Failed to generate preview URL: {e}"
+        ) from None

--- a/src/server/handlers/chat/ptc_workflow.py
+++ b/src/server/handlers/chat/ptc_workflow.py
@@ -252,6 +252,8 @@ async def astream_ptc_workflow(
         # Build graph with the workspace's session
         # Note: agent.md is injected dynamically by WorkspaceContextMiddleware
         # on every model call, ensuring it's always the latest content.
+        from src.server.app.workspace_sandbox import _set_cached_signed_url
+
         ptc_graph = await build_ptc_graph_with_session(
             session=session,
             config=config,
@@ -263,6 +265,7 @@ async def astream_ptc_workflow(
             plan_mode=effective_plan_mode,
             thread_id=thread_id,
             store=setup.store,
+            on_signed_url=_set_cached_signed_url,
         )
 
         if session.sandbox:

--- a/src/server/handlers/workflow_handler.py
+++ b/src/server/handlers/workflow_handler.py
@@ -330,8 +330,11 @@ async def _resolve_graph_and_state(thread_id: str, verb: str) -> tuple:
         raise HTTPException(
             status_code=500, detail="Agent configuration not initialized"
         )
+    from src.server.app.workspace_sandbox import _set_cached_signed_url
+
     graph = await build_ptc_graph_with_session(
-        session=session, config=setup.agent_config, checkpointer=checkpointer
+        session=session, config=setup.agent_config, checkpointer=checkpointer,
+        on_signed_url=_set_cached_signed_url,
     )
 
     # State with timeout

--- a/src/server/services/workspace_manager.py
+++ b/src/server/services/workspace_manager.py
@@ -803,6 +803,64 @@ class WorkspaceManager:
                                 user_id=workspace_user_id,
                                 lazy_init=True,
                             )
+
+                    # Still "stopping" after 10s — check actual sandbox state
+                    # from the provider. If the sandbox is actually running or
+                    # stopped, the DB status is stale (e.g. process crashed
+                    # mid-stop). Recover by correcting the DB.
+                    sandbox_id = workspace.get("sandbox_id")
+                    if sandbox_id:
+                        try:
+                            from ptc_agent.core.sandbox.providers import create_provider
+
+                            provider = create_provider(self.config.to_core_config())
+                            try:
+                                runtime = await provider.get(sandbox_id)
+                                actual_state = await runtime.get_state()
+                            finally:
+                                await provider.close()
+
+                            logger.warning(
+                                "Workspace %s stuck in 'stopping' but sandbox "
+                                "is actually '%s', recovering",
+                                workspace_id,
+                                actual_state.value,
+                            )
+                            # Correct the DB status based on actual sandbox state
+                            corrected = "stopped" if actual_state.value != "running" else "running"
+                            workspace = await update_workspace_status(
+                                workspace_id=workspace_id,
+                                status=corrected,
+                            )
+                            if corrected == "stopped":
+                                return await self._restart_workspace(
+                                    workspace,
+                                    user_id=workspace_user_id,
+                                    lazy_init=True,
+                                )
+                            # Sandbox is running — create session inline
+                            # (cannot recurse into get_session_for_workspace
+                            # because the per-workspace asyncio.Lock is held
+                            # and is not reentrant)
+                            core_config = self.config.to_core_config()
+                            session = SessionManager.get_session(workspace_id, core_config)
+                            if not session._initialized:
+                                await session.initialize(sandbox_id=sandbox_id)
+                                await self._sync_sandbox_assets(
+                                    workspace_id,
+                                    workspace_user_id,
+                                    session.sandbox,
+                                    reusing_sandbox=True,
+                                )
+                            self._sessions[workspace_id] = session
+                            return session
+                        except Exception as e:
+                            logger.error(
+                                "Failed to check actual sandbox state for %s: %s",
+                                workspace_id,
+                                e,
+                            )
+
                     raise RuntimeError(
                         f"Workspace {workspace_id} is still stopping after timeout. "
                         "Please wait and try again."

--- a/src/server/services/workspace_manager.py
+++ b/src/server/services/workspace_manager.py
@@ -827,7 +827,25 @@ class WorkspaceManager:
                                 actual_state.value,
                             )
                             # Correct the DB status based on actual sandbox state
-                            corrected = "stopped" if actual_state.value != "running" else "running"
+                            # Only treat definitively stopped/archived as "stopped";
+                            # transient states (starting, stopping, archiving) should
+                            # not trigger a restart — let them finish naturally.
+                            stopped_states = {"stopped", "archived"}
+                            if actual_state.value in stopped_states:
+                                corrected = "stopped"
+                            elif actual_state.value == "running":
+                                corrected = "running"
+                            else:
+                                logger.info(
+                                    "Workspace %s sandbox in transient state '%s', "
+                                    "not correcting — will retry on next request",
+                                    workspace_id,
+                                    actual_state.value,
+                                )
+                                raise RuntimeError(
+                                    f"Workspace {workspace_id} sandbox is in transient "
+                                    f"state '{actual_state.value}'. Please wait and try again."
+                                )
                             workspace = await update_workspace_status(
                                 workspace_id=workspace_id,
                                 status=corrected,

--- a/web/src/lib/panelUtils.ts
+++ b/web/src/lib/panelUtils.ts
@@ -2,7 +2,7 @@ const MIN_PANEL_WIDTH = 280;
 const MAX_PANEL_RATIO = 0.55;
 
 /** Clamp a desired panel width to fit within a container. */
-export function clampPanelWidth(desired: number, containerWidth: number): number {
+export function clampPanelWidth(desired: number, containerWidth: number, maxRatio = MAX_PANEL_RATIO): number {
   if (containerWidth <= 0) return desired;
-  return Math.max(MIN_PANEL_WIDTH, Math.min(desired, containerWidth * MAX_PANEL_RATIO));
+  return Math.max(MIN_PANEL_WIDTH, Math.min(desired, containerWidth * maxRatio));
 }

--- a/web/src/pages/ChatAgent/components/ActivityBlock.tsx
+++ b/web/src/pages/ChatAgent/components/ActivityBlock.tsx
@@ -17,6 +17,7 @@ import {
   InlineStockScreenerCard,
 } from './charts/InlineMarketCharts';
 import { InlineAutomationCard } from './charts/InlineAutomationCards';
+import { InlinePreviewCard } from './charts/InlinePreviewCard';
 import { useTranslation } from 'react-i18next';
 
 /** Tool names where clicking should open the file in the FilePanel */
@@ -36,6 +37,7 @@ const INLINE_ARTIFACT_MAP: Record<string, React.ComponentType<{ artifact: Record
   sec_filing: InlineSecFilingCard,
   stock_screener: InlineStockScreenerCard,
   automations: InlineAutomationCard,
+  preview_url: InlinePreviewCard,
 };
 
 /** Spring config matching radix-accordion feel */

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -943,6 +943,36 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     return clampPanelWidth(desired);
   }, [clampPanelWidth]);
 
+  // Resolve preview URL: get signed URL from backend, restart server on 503.
+  const resolvePreviewUrl = useCallback(async (wid: string, port: number, command?: string): Promise<string> => {
+    try {
+      const result = await getPreviewUrl(wid, port, undefined);
+      return result.url;
+    } catch (err: unknown) {
+      const status = (err as { response?: { status?: number } })?.response?.status;
+      if (status === 503 && command) {
+        const result = await getPreviewUrl(wid, port, command);
+        return result.url;
+      }
+      throw err;
+    }
+  }, []);
+
+  // Resolve a preview URL and update previewData state with the result
+  const resolveAndSetPreview = useCallback((wid: string, port: number, command?: string) => {
+    resolvePreviewUrl(wid, port, command)
+      .then((url: string) => {
+        setPreviewData(prev => prev?.port === port
+          ? { ...prev, url, loading: false, error: undefined }
+          : prev);
+      })
+      .catch(() => {
+        setPreviewData(prev => prev?.port === port
+          ? { ...prev, url: '', loading: false, error: true }
+          : prev);
+      });
+  }, [resolvePreviewUrl]);
+
   // Open preview URL in right panel
   const handleOpenPreview = useCallback((data: PreviewData) => {
     setPreviewData(data);
@@ -950,7 +980,11 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     const containerW = containerRef.current?.offsetWidth || window.innerWidth;
     setRightPanelWidth(clampPanelWidthUtil(850, containerW, PREVIEW_MAX_RATIO));
     pushPanelHistory();
-  }, [pushPanelHistory]);
+    // If opened with loading state (no URL yet), resolve via authenticated endpoint
+    if (data.loading && !data.url && workspaceId) {
+      resolveAndSetPreview(workspaceId, data.port, data.command);
+    }
+  }, [pushPanelHistory, workspaceId, resolveAndSetPreview]);
 
   // Keep the ref in sync so SSE events (via handleOpenPreviewFromStream) use the latest closure
   openPreviewRef.current = handleOpenPreview;
@@ -962,21 +996,15 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
       const port = artifact.port as number;
       const title = artifact.title as string | undefined;
       const command = artifact.command as string | undefined;
-      // Open panel immediately with loading state
+      // Show cached URL instantly, then verify in background (handles sandbox recreation + dead server)
+      if (previewData?.port === port && previewData.url) {
+        handleOpenPreview({ ...previewData, loading: false, error: undefined });
+        resolveAndSetPreview(workspaceId, port, command);
+        return;
+      }
+      // No cache — resolve (restarts server if needed via 503 fallback)
+      // handleOpenPreview will trigger resolution since loading=true and url=''
       handleOpenPreview({ url: '', port, title, command, loading: true });
-      // Then run restart chain in background
-      getPreviewUrl(workspaceId, port, command)
-        .then((fresh) => {
-          setPreviewData(prev => prev?.port === port ? { ...prev, url: fresh.url, loading: false } : prev);
-        })
-        .catch(() => {
-          // Fall back to stored URL if available
-          if (artifact.url) {
-            setPreviewData(prev => prev?.port === port ? { ...prev, url: artifact.url as string, loading: false } : prev);
-          } else {
-            setPreviewData(prev => prev?.port === port ? { ...prev, loading: false, error: true } : prev);
-          }
-        });
       return;
     }
     setDetailToolCall(toolCallProcess);
@@ -984,7 +1012,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     setRightPanelWidth(getDetailPanelWidth(toolCallProcess));
     setRightPanelType('detail');
     pushPanelHistory();
-  }, [getDetailPanelWidth, pushPanelHistory, workspaceId, handleOpenPreview]);
+  }, [getDetailPanelWidth, pushPanelHistory, workspaceId, handleOpenPreview, previewData, resolveAndSetPreview]);
 
   // Open plan detail in right panel
   const handlePlanDetailClick = useCallback((planData: PlanData) => {
@@ -1003,21 +1031,22 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     popPanelHistory();
   }, [popPanelHistory]);
 
-  // Close preview panel
+  // Close preview panel (keep previewData cached for instant reopen)
   const handleClosePreview = useCallback(() => {
     setRightPanelType(null);
-    setPreviewData(null);
     popPanelHistory();
   }, [popPanelHistory]);
 
-  // Refresh preview URL from backend
+  // Refresh preview: restart process + resolve fresh signed URL (force bypasses cache)
   const handleRefreshPreview = useCallback(async () => {
     if (!previewData || !workspaceId) return;
+    setPreviewData(prev => prev ? { ...prev, loading: true, error: undefined } : null);
     try {
-      const fresh = await getPreviewUrl(workspaceId, previewData.port, previewData.command);
-      setPreviewData(prev => prev ? { ...prev, url: fresh.url } : null);
+      const result = await getPreviewUrl(workspaceId, previewData.port, previewData.command, true);
+      setPreviewData(prev => prev ? { ...prev, url: result.url, loading: false } : null);
     } catch (e) {
-      console.error('Failed to refresh preview URL:', e);
+      console.error('Failed to refresh preview:', e);
+      setPreviewData(prev => prev ? { ...prev, loading: false, error: true } : null);
     }
   }, [previewData, workspaceId]);
 
@@ -1859,6 +1888,29 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
               onClose={handleCloseDetailPanel}
               onOpenFile={handleOpenFileFromChat}
               onOpenSubagentTask={handleOpenSubagentTask}
+            />
+          </Suspense>
+        </MobileBottomSheet>
+      )}
+
+      {/* Mobile preview bottom sheet */}
+      {isMobile && (
+        <MobileBottomSheet
+          open={rightPanelType === 'preview' && !!previewData}
+          onClose={handleClosePreview}
+          sizing="fixed"
+          height="75vh"
+          className="!px-0 !overflow-hidden"
+        >
+          <Suspense fallback={null}>
+            <PreviewViewer
+              url={previewData?.url ?? ''}
+              port={previewData?.port ?? 0}
+              title={previewData?.title}
+              loading={previewData?.loading}
+              error={previewData?.error}
+              onClose={handleClosePreview}
+              onRefresh={handleRefreshPreview}
             />
           </Suspense>
         </MobileBottomSheet>

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -11,6 +11,7 @@ import { updateCurrentUser } from '../../Dashboard/utils/api';
 import { softInterruptWorkflow, getWorkspace, summarizeThread, offloadThread, getPreviewUrl } from '../utils/api';
 import { useChatMessages } from '../hooks/useChatMessages';
 import { saveChatSession, getChatSession, clearChatSession } from '../hooks/utils/chatSessionRestore';
+import type { PreviewData } from '../hooks/utils/types';
 import { clampPanelWidth as clampPanelWidthUtil } from '@/lib/panelUtils';
 import { useCardState } from '../hooks/useCardState';
 import { useWorkspaceFiles } from '../hooks/useWorkspaceFiles';
@@ -283,7 +284,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
   // Right panel management - can show 'file', 'detail', 'preview', or null (closed)
   const [rightPanelType, setRightPanelType] = useState<'file' | 'detail' | 'preview' | null>(null);
   const [rightPanelWidth, setRightPanelWidth] = useState(750);
-  const [previewData, setPreviewData] = useState<{ url: string; port: number; title?: string } | null>(null);
+  const [previewData, setPreviewData] = useState<PreviewData | null>(null);
   const DIVIDER_WIDTH = 4; // px – matches .chat-split-divider
   // Active agent in main view (default: 'main', or from URL taskId)
   const [activeAgentId, setActiveAgentId] = useState(
@@ -490,8 +491,8 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
   // Stable ref-based callback for opening preview URLs from SSE events.
   // Defined here so it can be passed to useChatMessages; assigned after
   // clampPanelWidth/pushPanelHistory are defined further down.
-  const openPreviewRef = useRef<(data: { url: string; port: number; title?: string }) => void>(() => {});
-  const handleOpenPreviewFromStream = useCallback((data: { url: string; port: number; title?: string }) => {
+  const openPreviewRef = useRef<(data: PreviewData) => void>(() => {});
+  const handleOpenPreviewFromStream = useCallback((data: PreviewData) => {
     openPreviewRef.current(data);
   }, []);
 
@@ -798,7 +799,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
 
 
   const clampPanelWidth = useCallback(
-    (desired: number) => clampPanelWidthUtil(desired, contentAreaWidthRef.current),
+    (desired: number) => clampPanelWidthUtil(desired, containerRef.current?.offsetWidth || window.innerWidth),
     [],
   );
 
@@ -810,9 +811,10 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     setIsDragging(true);
     const startX = e.clientX;
     const startWidth = rightPanelWidth;
-    // Snapshot container width at drag start to avoid feedback loop
-    // (ResizeObserver updates contentAreaWidthRef as panel resizes)
-    const containerW = contentAreaWidthRef.current > 0 ? contentAreaWidthRef.current : window.innerWidth;
+    // Use total container width (chat area + panel + divider), not just the
+    // chat area — contentAreaWidthRef excludes the open panel, so clamping
+    // against it would immediately shrink the panel on the first mouse move.
+    const containerW = containerRef.current?.offsetWidth || window.innerWidth;
     const maxRatio = rightPanelType === 'preview' ? PREVIEW_MAX_RATIO : undefined;
 
     const onMouseMove = (moveEvent: MouseEvent) => {
@@ -942,10 +944,10 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
   }, [clampPanelWidth]);
 
   // Open preview URL in right panel
-  const handleOpenPreview = useCallback((data: { url: string; port: number; title?: string }) => {
+  const handleOpenPreview = useCallback((data: PreviewData) => {
     setPreviewData(data);
     setRightPanelType('preview');
-    const containerW = contentAreaWidthRef.current > 0 ? contentAreaWidthRef.current : window.innerWidth;
+    const containerW = containerRef.current?.offsetWidth || window.innerWidth;
     setRightPanelWidth(clampPanelWidthUtil(850, containerW, PREVIEW_MAX_RATIO));
     pushPanelHistory();
   }, [pushPanelHistory]);
@@ -957,17 +959,22 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
   const handleToolCallDetailClick = useCallback((toolCallProcess: ToolCallProcessRecord) => {
     const artifact = toolCallProcess.toolCallResult?.artifact as Record<string, unknown> | undefined;
     if (artifact?.type === 'preview_url' && artifact.port && workspaceId) {
-      // Fetch a fresh signed URL (the stored one may be expired) and open preview panel
       const port = artifact.port as number;
       const title = artifact.title as string | undefined;
-      getPreviewUrl(workspaceId, port)
+      const command = artifact.command as string | undefined;
+      // Open panel immediately with loading state
+      handleOpenPreview({ url: '', port, title, command, loading: true });
+      // Then run restart chain in background
+      getPreviewUrl(workspaceId, port, command)
         .then((fresh) => {
-          handleOpenPreview({ url: fresh.url, port, title });
+          setPreviewData(prev => prev?.port === port ? { ...prev, url: fresh.url, loading: false } : prev);
         })
         .catch(() => {
-          // Fall back to the stored URL if refresh fails
+          // Fall back to stored URL if available
           if (artifact.url) {
-            handleOpenPreview({ url: artifact.url as string, port, title });
+            setPreviewData(prev => prev?.port === port ? { ...prev, url: artifact.url as string, loading: false } : prev);
+          } else {
+            setPreviewData(prev => prev?.port === port ? { ...prev, loading: false, error: true } : prev);
           }
         });
       return;
@@ -1007,7 +1014,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
   const handleRefreshPreview = useCallback(async () => {
     if (!previewData || !workspaceId) return;
     try {
-      const fresh = await getPreviewUrl(workspaceId, previewData.port);
+      const fresh = await getPreviewUrl(workspaceId, previewData.port, previewData.command);
       setPreviewData(prev => prev ? { ...prev, url: fresh.url } : null);
     } catch (e) {
       console.error('Failed to refresh preview URL:', e);
@@ -1958,6 +1965,8 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
                       url={previewData.url}
                       port={previewData.port}
                       title={previewData.title}
+                      loading={previewData.loading}
+                      error={previewData.error}
                       onClose={handleClosePreview}
                       onRefresh={handleRefreshPreview}
                       isDragging={isDragging}

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -8,7 +8,7 @@ import { usePreferences } from '@/hooks/usePreferences';
 import { useQueryClient } from '@tanstack/react-query';
 import { queryKeys } from '@/lib/queryKeys';
 import { updateCurrentUser } from '../../Dashboard/utils/api';
-import { softInterruptWorkflow, getWorkspace, summarizeThread, offloadThread } from '../utils/api';
+import { softInterruptWorkflow, getWorkspace, summarizeThread, offloadThread, getPreviewUrl } from '../utils/api';
 import { useChatMessages } from '../hooks/useChatMessages';
 import { saveChatSession, getChatSession, clearChatSession } from '../hooks/utils/chatSessionRestore';
 import { clampPanelWidth as clampPanelWidthUtil } from '@/lib/panelUtils';
@@ -32,6 +32,7 @@ import { MobileBottomSheet } from '@/components/ui/mobile-bottom-sheet';
 
 const FilePanel = React.lazy(() => import('./FilePanel'));
 const DetailPanel = React.lazy(() => import('./DetailPanel'));
+const PreviewViewer = React.lazy(() => import('./viewers/PreviewViewer'));
 
 // --- Types ---
 
@@ -279,9 +280,10 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
   const isDraggingRef = useRef(false);
   const [isDragging, setIsDragging] = useState(false);
 
-  // Right panel management - can show 'file', 'detail', or null (closed)
-  const [rightPanelType, setRightPanelType] = useState<'file' | 'detail' | null>(null);
+  // Right panel management - can show 'file', 'detail', 'preview', or null (closed)
+  const [rightPanelType, setRightPanelType] = useState<'file' | 'detail' | 'preview' | null>(null);
   const [rightPanelWidth, setRightPanelWidth] = useState(750);
+  const [previewData, setPreviewData] = useState<{ url: string; port: number; title?: string } | null>(null);
   const DIVIDER_WIDTH = 4; // px – matches .chat-split-divider
   // Active agent in main view (default: 'main', or from URL taskId)
   const [activeAgentId, setActiveAgentId] = useState(
@@ -485,6 +487,14 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     });
   }, [navigate, navWorkspaces, workspaceName]);
 
+  // Stable ref-based callback for opening preview URLs from SSE events.
+  // Defined here so it can be passed to useChatMessages; assigned after
+  // clampPanelWidth/pushPanelHistory are defined further down.
+  const openPreviewRef = useRef<(data: { url: string; port: number; title?: string }) => void>(() => {});
+  const handleOpenPreviewFromStream = useCallback((data: { url: string; port: number; title?: string }) => {
+    openPreviewRef.current(data);
+  }, []);
+
   // Chat messages management - receives updateTodoListCard and updateSubagentCard from floating cards hook
   const {
     messages,
@@ -522,7 +532,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     getFeedbackForMessage,
     getSubagentHistory,
     resolveSubagentIdToAgentId,
-  } = useChatMessages(workspaceId, threadId, updateTodoListCard as (todoData: Record<string, unknown>) => void, updateSubagentCard, inactivateAllSubagents, finalizePendingTodos, handleOnboardingRelatedToolComplete, refreshFiles, agentMode, clearSubagentCards, handleWorkspaceCreated);
+  } = useChatMessages(workspaceId, threadId, updateTodoListCard as (todoData: Record<string, unknown>) => void, updateSubagentCard, inactivateAllSubagents, finalizePendingTodos, handleOnboardingRelatedToolComplete, refreshFiles, handleOpenPreviewFromStream, agentMode, clearSubagentCards, handleWorkspaceCreated);
 
   const chatPlaceholder = useMemo(() => {
     if (pendingRejection) return t('chat.placeholderPendingRejection');
@@ -861,6 +871,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
         setRightPanelType(null);
         setDetailToolCall(null);
         setDetailPlanData(null);
+        setPreviewData(null);
       }
     };
     window.addEventListener('popstate', onPopState);
@@ -951,6 +962,35 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     setDetailPlanData(null);
     popPanelHistory();
   }, [popPanelHistory]);
+
+  // Open preview URL in right panel
+  const handleOpenPreview = useCallback((data: { url: string; port: number; title?: string }) => {
+    setPreviewData(data);
+    setRightPanelType('preview');
+    setRightPanelWidth(clampPanelWidth(850));
+    pushPanelHistory();
+  }, [clampPanelWidth, pushPanelHistory]);
+
+  // Keep the ref in sync so SSE events (via handleOpenPreviewFromStream) use the latest closure
+  openPreviewRef.current = handleOpenPreview;
+
+  // Close preview panel
+  const handleClosePreview = useCallback(() => {
+    setRightPanelType(null);
+    setPreviewData(null);
+    popPanelHistory();
+  }, [popPanelHistory]);
+
+  // Refresh preview URL from backend
+  const handleRefreshPreview = useCallback(async () => {
+    if (!previewData || !workspaceId) return;
+    try {
+      const fresh = await getPreviewUrl(workspaceId, previewData.port);
+      setPreviewData(prev => prev ? { ...prev, url: fresh.url } : null);
+    } catch (e) {
+      console.error('Failed to refresh preview URL:', e);
+    }
+  }, [previewData, workspaceId]);
 
   // Toggle file panel
   const handleToggleFilePanel = useCallback(() => {
@@ -1889,6 +1929,14 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
                       onClose={handleCloseDetailPanel}
                       onOpenFile={handleOpenFileFromChat}
                       onOpenSubagentTask={handleOpenSubagentTask}
+                    />
+                  ) : rightPanelType === 'preview' && previewData ? (
+                    <PreviewViewer
+                      url={previewData.url}
+                      port={previewData.port}
+                      title={previewData.title}
+                      onClose={handleClosePreview}
+                      onRefresh={handleRefreshPreview}
                     />
                   ) : null}
                 </Suspense>

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -803,18 +803,22 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
   );
 
   // Handle drag panel width
+  const PREVIEW_MAX_RATIO = 0.92;
   const handleDividerMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
     isDraggingRef.current = true;
     setIsDragging(true);
     const startX = e.clientX;
     const startWidth = rightPanelWidth;
+    // Snapshot container width at drag start to avoid feedback loop
+    // (ResizeObserver updates contentAreaWidthRef as panel resizes)
+    const containerW = contentAreaWidthRef.current > 0 ? contentAreaWidthRef.current : window.innerWidth;
+    const maxRatio = rightPanelType === 'preview' ? PREVIEW_MAX_RATIO : undefined;
 
     const onMouseMove = (moveEvent: MouseEvent) => {
       if (!isDraggingRef.current) return;
       const delta = startX - moveEvent.clientX;
-      const containerW = contentAreaWidthRef.current > 0 ? contentAreaWidthRef.current : window.innerWidth;
-      setRightPanelWidth(clampPanelWidthUtil(startWidth + delta, containerW));
+      setRightPanelWidth(clampPanelWidthUtil(startWidth + delta, containerW, maxRatio));
     };
 
     const onMouseUp = () => {
@@ -830,7 +834,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     document.body.style.userSelect = 'none';
     document.addEventListener('mousemove', onMouseMove);
     document.addEventListener('mouseup', onMouseUp);
-  }, [rightPanelWidth]);
+  }, [rightPanelWidth, rightPanelType]);
 
   // Open a file in the right panel from chat tool calls
   // --- Mobile back-button integration for panels ---
@@ -937,14 +941,43 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     return clampPanelWidth(desired);
   }, [clampPanelWidth]);
 
-  // Open tool call detail in right panel
+  // Open preview URL in right panel
+  const handleOpenPreview = useCallback((data: { url: string; port: number; title?: string }) => {
+    setPreviewData(data);
+    setRightPanelType('preview');
+    const containerW = contentAreaWidthRef.current > 0 ? contentAreaWidthRef.current : window.innerWidth;
+    setRightPanelWidth(clampPanelWidthUtil(850, containerW, PREVIEW_MAX_RATIO));
+    pushPanelHistory();
+  }, [pushPanelHistory]);
+
+  // Keep the ref in sync so SSE events (via handleOpenPreviewFromStream) use the latest closure
+  openPreviewRef.current = handleOpenPreview;
+
+  // Open tool call detail in right panel (or preview panel for preview_url artifacts)
   const handleToolCallDetailClick = useCallback((toolCallProcess: ToolCallProcessRecord) => {
+    const artifact = toolCallProcess.toolCallResult?.artifact as Record<string, unknown> | undefined;
+    if (artifact?.type === 'preview_url' && artifact.port && workspaceId) {
+      // Fetch a fresh signed URL (the stored one may be expired) and open preview panel
+      const port = artifact.port as number;
+      const title = artifact.title as string | undefined;
+      getPreviewUrl(workspaceId, port)
+        .then((fresh) => {
+          handleOpenPreview({ url: fresh.url, port, title });
+        })
+        .catch(() => {
+          // Fall back to the stored URL if refresh fails
+          if (artifact.url) {
+            handleOpenPreview({ url: artifact.url as string, port, title });
+          }
+        });
+      return;
+    }
     setDetailToolCall(toolCallProcess);
     setDetailPlanData(null);
     setRightPanelWidth(getDetailPanelWidth(toolCallProcess));
     setRightPanelType('detail');
     pushPanelHistory();
-  }, [getDetailPanelWidth, pushPanelHistory]);
+  }, [getDetailPanelWidth, pushPanelHistory, workspaceId, handleOpenPreview]);
 
   // Open plan detail in right panel
   const handlePlanDetailClick = useCallback((planData: PlanData) => {
@@ -962,17 +995,6 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     setDetailPlanData(null);
     popPanelHistory();
   }, [popPanelHistory]);
-
-  // Open preview URL in right panel
-  const handleOpenPreview = useCallback((data: { url: string; port: number; title?: string }) => {
-    setPreviewData(data);
-    setRightPanelType('preview');
-    setRightPanelWidth(clampPanelWidth(850));
-    pushPanelHistory();
-  }, [clampPanelWidth, pushPanelHistory]);
-
-  // Keep the ref in sync so SSE events (via handleOpenPreviewFromStream) use the latest closure
-  openPreviewRef.current = handleOpenPreview;
 
   // Close preview panel
   const handleClosePreview = useCallback(() => {
@@ -1892,8 +1914,9 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
               initial={{ width: 0, opacity: 0 }}
               animate={{ width: rightPanelWidth + DIVIDER_WIDTH, opacity: 1 }}
               exit={{ width: 0, opacity: 0 }}
-              transition={{ duration: isDragging ? 0 : 0.25, ease: [0.22, 1, 0.36, 1] }}
+              transition={isDragging ? { duration: 0 } : { duration: 0.25, ease: [0.22, 1, 0.36, 1] }}
               className="flex flex-shrink-0 overflow-hidden"
+              style={isDragging ? { width: rightPanelWidth + DIVIDER_WIDTH } : undefined}
             >
               <div
                 className="chat-split-divider"
@@ -1937,6 +1960,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
                       title={previewData.title}
                       onClose={handleClosePreview}
                       onRefresh={handleRefreshPreview}
+                      isDragging={isDragging}
                     />
                   ) : null}
                 </Suspense>

--- a/web/src/pages/ChatAgent/components/MessageList.tsx
+++ b/web/src/pages/ChatAgent/components/MessageList.tsx
@@ -18,6 +18,7 @@ import {
   InlineStockScreenerCard,
 } from './charts/InlineMarketCharts';
 import { InlineAutomationCard } from './charts/InlineAutomationCards';
+import { InlinePreviewCard } from './charts/InlinePreviewCard';
 import { extractFilePaths, FileMentionCards } from './FileCard';
 import { useUser } from '@/hooks/useUser';
 import ReasoningMessageContent from './ReasoningMessageContent';
@@ -127,6 +128,7 @@ const INLINE_ARTIFACT_MAP: Record<string, React.ComponentType<{ artifact: Record
   sec_filing: InlineSecFilingCard,
   stock_screener: InlineStockScreenerCard,
   automations: InlineAutomationCard,
+  preview_url: InlinePreviewCard,
 };
 
 /* --- Attachment helpers --- */

--- a/web/src/pages/ChatAgent/components/charts/InlineMarketCharts.tsx
+++ b/web/src/pages/ChatAgent/components/charts/InlineMarketCharts.tsx
@@ -24,6 +24,7 @@ export const INLINE_ARTIFACT_TOOLS = new Set([
   'screen_stocks',
   'check_automations',
   'create_automation',
+  'GetPreviewUrl',
 ]);
 
 // ─── Helpers ────────────────────────────────────────────────────────

--- a/web/src/pages/ChatAgent/components/charts/InlinePreviewCard.tsx
+++ b/web/src/pages/ChatAgent/components/charts/InlinePreviewCard.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Globe, ExternalLink } from 'lucide-react';
+import { useWorkspaceId } from '../../contexts/WorkspaceContext';
+import { checkPreviewHealth } from '../../utils/api';
 
 const CARD_BG = 'var(--color-bg-tool-card)';
 const CARD_BORDER = 'var(--color-border-muted)';
@@ -11,11 +13,65 @@ interface InlinePreviewCardProps {
   onClick?: () => void;
 }
 
+function formatTimeAgo(epochSeconds: number): string {
+  const seconds = Math.max(0, Math.floor(Date.now() / 1000 - epochSeconds));
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ago`;
+}
+
 export function InlinePreviewCard({ artifact, onClick }: InlinePreviewCardProps): React.ReactElement | null {
+  const workspaceId = useWorkspaceId();
+  const [health, setHealth] = useState<{ reachable: boolean; checkedAt: number } | null>(null);
+  const [, setTick] = useState(0); // force re-render for "X min ago" updates
+  const checkingRef = useRef(false);
+
+  const doHealthCheck = useCallback(async () => {
+    if (!workspaceId || !artifact?.url || checkingRef.current) return;
+    checkingRef.current = true;
+    try {
+      const result = await checkPreviewHealth(workspaceId, artifact.url as string);
+      setHealth({ reachable: result.reachable, checkedAt: result.checked_at });
+    } catch {
+      setHealth({ reachable: false, checkedAt: Math.floor(Date.now() / 1000) });
+    } finally {
+      checkingRef.current = false;
+    }
+  }, [workspaceId, artifact?.url]);
+
+  // Health check on mount + every 2 minutes
+  useEffect(() => {
+    doHealthCheck();
+    const interval = setInterval(doHealthCheck, 2 * 60 * 1000);
+    return () => clearInterval(interval);
+  }, [doHealthCheck]);
+
+  // Tick every 30s to update "X min ago" display
+  useEffect(() => {
+    const interval = setInterval(() => setTick(t => t + 1), 30_000);
+    return () => clearInterval(interval);
+  }, []);
+
   if (!artifact) return null;
 
   const port = artifact.port as number | undefined;
   const title = (artifact.title as string) || (port ? `Port ${port}` : 'Preview');
+
+  // Status indicator
+  let dotColor: string;
+  let subtitle: string;
+  if (!health) {
+    dotColor = '#9ca3af';
+    subtitle = 'Checking...';
+  } else if (health.reachable) {
+    dotColor = '#22c55e';
+    subtitle = `Live \u00b7 checked ${formatTimeAgo(health.checkedAt)}`;
+  } else {
+    dotColor = '#9ca3af';
+    subtitle = `Offline \u00b7 checked ${formatTimeAgo(health.checkedAt)}`;
+  }
 
   return (
     <div
@@ -57,9 +113,19 @@ export function InlinePreviewCard({ artifact, onClick }: InlinePreviewCardProps)
               :{port}
             </span>
           )}
+          <span
+            style={{
+              width: 8,
+              height: 8,
+              borderRadius: '50%',
+              backgroundColor: dotColor,
+              flexShrink: 0,
+              animation: !health ? 'pulse 1.5s ease-in-out infinite' : undefined,
+            }}
+          />
         </div>
         <div style={{ fontSize: 11, color: TEXT_COLOR, marginTop: 1 }}>
-          Click to open preview
+          {subtitle}
         </div>
       </div>
       <ExternalLink size={14} style={{ color: TEXT_COLOR, flexShrink: 0 }} />

--- a/web/src/pages/ChatAgent/components/charts/InlinePreviewCard.tsx
+++ b/web/src/pages/ChatAgent/components/charts/InlinePreviewCard.tsx
@@ -24,22 +24,27 @@ function formatTimeAgo(epochSeconds: number): string {
 
 export function InlinePreviewCard({ artifact, onClick }: InlinePreviewCardProps): React.ReactElement | null {
   const workspaceId = useWorkspaceId();
-  const [health, setHealth] = useState<{ reachable: boolean; checkedAt: number } | null>(null);
+  const [health, setHealth] = useState<{ reachable: boolean; checkedAt: number; sandboxStopped?: boolean } | null>(null);
   const [, setTick] = useState(0); // force re-render for "X min ago" updates
   const checkingRef = useRef(false);
 
   const doHealthCheck = useCallback(async () => {
-    if (!workspaceId || !artifact?.url || checkingRef.current) return;
+    if (!workspaceId || !artifact?.port || checkingRef.current) return;
     checkingRef.current = true;
     try {
-      const result = await checkPreviewHealth(workspaceId, artifact.url as string);
+      const result = await checkPreviewHealth(workspaceId, artifact.port as number);
       setHealth({ reachable: result.reachable, checkedAt: result.checked_at });
-    } catch {
-      setHealth({ reachable: false, checkedAt: Math.floor(Date.now() / 1000) });
+    } catch (err: unknown) {
+      const status = (err as { response?: { status?: number } })?.response?.status;
+      if (status === 503) {
+        setHealth({ reachable: false, checkedAt: Math.floor(Date.now() / 1000), sandboxStopped: true });
+      } else {
+        setHealth({ reachable: false, checkedAt: Math.floor(Date.now() / 1000) });
+      }
     } finally {
       checkingRef.current = false;
     }
-  }, [workspaceId, artifact?.url]);
+  }, [workspaceId, artifact?.port]);
 
   // Health check on mount + every 2 minutes
   useEffect(() => {
@@ -68,6 +73,9 @@ export function InlinePreviewCard({ artifact, onClick }: InlinePreviewCardProps)
   } else if (health.reachable) {
     dotColor = '#22c55e';
     subtitle = `Live \u00b7 checked ${formatTimeAgo(health.checkedAt)}`;
+  } else if (health.sandboxStopped) {
+    dotColor = '#f59e0b';
+    subtitle = `Sandbox stopped \u00b7 checked ${formatTimeAgo(health.checkedAt)}`;
   } else {
     dotColor = '#9ca3af';
     subtitle = `Offline \u00b7 checked ${formatTimeAgo(health.checkedAt)}`;

--- a/web/src/pages/ChatAgent/components/charts/InlinePreviewCard.tsx
+++ b/web/src/pages/ChatAgent/components/charts/InlinePreviewCard.tsx
@@ -3,6 +3,20 @@ import { Globe, ExternalLink } from 'lucide-react';
 import { useWorkspaceId } from '../../contexts/WorkspaceContext';
 import { checkPreviewHealth } from '../../utils/api';
 
+// Module-level deduplication: share a single in-flight health check per (workspaceId, port)
+const inflightChecks = new Map<string, Promise<{ reachable: boolean; checked_at: number }>>();
+
+function deduplicatedHealthCheck(workspaceId: string, port: number) {
+  const key = `${workspaceId}:${port}`;
+  const existing = inflightChecks.get(key);
+  if (existing) return existing;
+  const promise = checkPreviewHealth(workspaceId, port).finally(() => {
+    inflightChecks.delete(key);
+  });
+  inflightChecks.set(key, promise);
+  return promise;
+}
+
 const CARD_BG = 'var(--color-bg-tool-card)';
 const CARD_BORDER = 'var(--color-border-muted)';
 const TEXT_COLOR = 'var(--color-text-tertiary)';
@@ -32,7 +46,7 @@ export function InlinePreviewCard({ artifact, onClick }: InlinePreviewCardProps)
     if (!workspaceId || !artifact?.port || checkingRef.current) return;
     checkingRef.current = true;
     try {
-      const result = await checkPreviewHealth(workspaceId, artifact.port as number);
+      const result = await deduplicatedHealthCheck(workspaceId, artifact.port as number);
       setHealth({ reachable: result.reachable, checkedAt: result.checked_at });
     } catch (err: unknown) {
       const status = (err as { response?: { status?: number } })?.response?.status;

--- a/web/src/pages/ChatAgent/components/charts/InlinePreviewCard.tsx
+++ b/web/src/pages/ChatAgent/components/charts/InlinePreviewCard.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { Globe, ExternalLink } from 'lucide-react';
+
+const CARD_BG = 'var(--color-bg-tool-card)';
+const CARD_BORDER = 'var(--color-border-muted)';
+const TEXT_COLOR = 'var(--color-text-tertiary)';
+const ACCENT = 'var(--color-accent-primary)';
+
+interface InlinePreviewCardProps {
+  artifact: Record<string, unknown> | null | undefined;
+  onClick?: () => void;
+}
+
+export function InlinePreviewCard({ artifact, onClick }: InlinePreviewCardProps): React.ReactElement | null {
+  if (!artifact) return null;
+
+  const port = artifact.port as number | undefined;
+  const title = (artifact.title as string) || (port ? `Port ${port}` : 'Preview');
+
+  return (
+    <div
+      style={{
+        background: CARD_BG,
+        border: `1px solid ${CARD_BORDER}`,
+        borderRadius: 8,
+        padding: '10px 14px',
+        cursor: 'pointer',
+        transition: 'border-color 0.15s',
+        outline: 'none',
+        WebkitTapHighlightColor: 'transparent',
+        userSelect: 'none',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+      }}
+      onClick={onClick}
+      onMouseEnter={(e) => (e.currentTarget.style.borderColor = ACCENT)}
+      onMouseLeave={(e) => (e.currentTarget.style.borderColor = CARD_BORDER)}
+    >
+      <Globe size={16} style={{ color: ACCENT, flexShrink: 0 }} />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ fontWeight: 600, color: 'var(--color-text-primary)', fontSize: 13 }}>
+            {title}
+          </span>
+          {port && (
+            <span
+              style={{
+                fontSize: 10,
+                fontFamily: 'var(--font-mono, monospace)',
+                padding: '1px 6px',
+                borderRadius: 10,
+                backgroundColor: 'var(--color-bg-surface)',
+                color: TEXT_COLOR,
+              }}
+            >
+              :{port}
+            </span>
+          )}
+        </div>
+        <div style={{ fontSize: 11, color: TEXT_COLOR, marginTop: 1 }}>
+          Click to open preview
+        </div>
+      </div>
+      <ExternalLink size={14} style={{ color: TEXT_COLOR, flexShrink: 0 }} />
+    </div>
+  );
+}

--- a/web/src/pages/ChatAgent/components/viewers/PreviewViewer.css
+++ b/web/src/pages/ChatAgent/components/viewers/PreviewViewer.css
@@ -9,7 +9,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 6px 8px;
+  padding: 12px 16px;
   border-bottom: 1px solid var(--color-border-muted);
   flex-shrink: 0;
 }
@@ -20,8 +20,8 @@
   gap: 6px;
   flex: 1;
   min-width: 0;
-  font-size: 12px;
-  font-weight: 500;
+  font-size: 14px;
+  font-weight: 600;
   color: var(--color-text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -53,8 +53,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 28px;
-  height: 28px;
+  width: 32px;
+  height: 32px;
   border-radius: 4px;
   border: none;
   background: transparent;
@@ -82,7 +82,7 @@
   justify-content: center;
   position: absolute;
   inset: 0;
-  top: 37px; /* toolbar height */
+  top: var(--preview-toolbar-height, 53px);
   background: var(--color-bg-page);
   z-index: 1;
 }
@@ -91,7 +91,7 @@
 .preview-viewer-resize-overlay {
   position: absolute;
   inset: 0;
-  top: 37px;
+  top: var(--preview-toolbar-height, 53px);
   z-index: 3;
   cursor: col-resize;
   display: flex;

--- a/web/src/pages/ChatAgent/components/viewers/PreviewViewer.css
+++ b/web/src/pages/ChatAgent/components/viewers/PreviewViewer.css
@@ -130,3 +130,15 @@
   font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
   color: var(--color-text-tertiary);
 }
+
+@keyframes preview-spinner {
+  to { transform: rotate(360deg); }
+}
+.preview-viewer-spinner {
+  width: 24px;
+  height: 24px;
+  border: 2.5px solid var(--color-border-muted, #e5e7eb);
+  border-top-color: var(--color-accent-primary, #6366f1);
+  border-radius: 50%;
+  animation: preview-spinner 0.8s linear infinite;
+}

--- a/web/src/pages/ChatAgent/components/viewers/PreviewViewer.css
+++ b/web/src/pages/ChatAgent/components/viewers/PreviewViewer.css
@@ -1,0 +1,88 @@
+.preview-viewer {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.preview-viewer-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--color-border-muted);
+  flex-shrink: 0;
+}
+
+.preview-viewer-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1;
+  min-width: 0;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.preview-viewer-port-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  color: var(--color-text-tertiary);
+  background: var(--color-accent-soft);
+  border: 1px solid var(--color-border-muted);
+  flex-shrink: 0;
+}
+
+.preview-viewer-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.preview-viewer-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+  border: none;
+  background: transparent;
+  color: var(--color-text-tertiary);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.preview-viewer-btn:hover {
+  color: var(--color-text-primary);
+  background: var(--color-border-muted);
+}
+
+.preview-viewer-frame {
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  border: none;
+  background: #ffffff;
+}
+
+.preview-viewer-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  inset: 0;
+  top: 37px; /* toolbar height */
+  background: var(--color-bg-page);
+  z-index: 1;
+}

--- a/web/src/pages/ChatAgent/components/viewers/PreviewViewer.css
+++ b/web/src/pages/ChatAgent/components/viewers/PreviewViewer.css
@@ -86,3 +86,47 @@
   background: var(--color-bg-page);
   z-index: 1;
 }
+
+/* Frosted overlay shown during panel resize */
+.preview-viewer-resize-overlay {
+  position: absolute;
+  inset: 0;
+  top: 37px;
+  z-index: 3;
+  cursor: col-resize;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in srgb, var(--color-bg-page) 75%, transparent);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+.preview-viewer-resize-card {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 16px 24px;
+  border-radius: 12px;
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-muted);
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.preview-viewer-resize-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.preview-viewer-resize-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.preview-viewer-resize-url {
+  font-size: 11px;
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  color: var(--color-text-tertiary);
+}

--- a/web/src/pages/ChatAgent/components/viewers/PreviewViewer.tsx
+++ b/web/src/pages/ChatAgent/components/viewers/PreviewViewer.tsx
@@ -70,13 +70,13 @@ export default function PreviewViewer({ url, port, title, loading: externalLoadi
         </div>
         <div className="preview-viewer-actions">
           <button className="preview-viewer-btn" onClick={handleRefresh} title="Refresh preview">
-            <RefreshCw size={14} />
+            <RefreshCw size={18} />
           </button>
           <button className="preview-viewer-btn" onClick={handleOpenExternal} title="Open in new tab">
-            <ExternalLink size={14} />
+            <ExternalLink size={18} />
           </button>
           <button className="preview-viewer-btn" onClick={onClose} title="Close preview">
-            <X size={14} />
+            <X size={18} />
           </button>
         </div>
       </div>
@@ -97,10 +97,10 @@ export default function PreviewViewer({ url, port, title, loading: externalLoadi
           <div className="preview-viewer-resize-card" style={{ flexDirection: 'column', alignItems: 'center', gap: 16, padding: '28px 36px' }}>
             <AlertCircle size={28} style={{ color: 'var(--color-text-tertiary)' }} />
             <div className="preview-viewer-resize-info" style={{ alignItems: 'center' }}>
-              <span className="preview-viewer-resize-title">Failed to start server</span>
+              <span className="preview-viewer-resize-title">Server offline</span>
               <span className="preview-viewer-resize-url">{displayTitle} :{port}</span>
               <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginTop: 4 }}>
-                Try clicking Refresh to retry
+                Click Refresh to restart
               </span>
             </div>
           </div>
@@ -128,9 +128,9 @@ export default function PreviewViewer({ url, port, title, loading: externalLoadi
             ref={iframeRef}
             key={iframeKey}
             src={url}
-            sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
             className="preview-viewer-frame"
             title={`Preview - port ${port}`}
+            sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
             onLoad={handleIframeLoad}
             style={isDragging ? { pointerEvents: 'none' } : undefined}
           />

--- a/web/src/pages/ChatAgent/components/viewers/PreviewViewer.tsx
+++ b/web/src/pages/ChatAgent/components/viewers/PreviewViewer.tsx
@@ -1,32 +1,43 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react';
-import { RefreshCw, ExternalLink, X, Loader2, Globe } from 'lucide-react';
+import { RefreshCw, ExternalLink, X, Loader2, Globe, AlertCircle } from 'lucide-react';
 import './PreviewViewer.css';
+import type { PreviewData } from '../../hooks/utils/types';
 
-interface PreviewViewerProps {
-  url: string;
-  port: number;
-  title?: string;
+interface PreviewViewerProps extends Pick<PreviewData, 'url' | 'port' | 'title' | 'loading' | 'error'> {
   onClose: () => void;
   onRefresh?: () => void;
   /** When true, a frosted overlay covers the iframe for smooth resizing. */
   isDragging?: boolean;
 }
 
-export default function PreviewViewer({ url, port, title, onClose, onRefresh, isDragging }: PreviewViewerProps) {
+export default function PreviewViewer({ url, port, title, loading: externalLoading, error: externalError, onClose, onRefresh, isDragging }: PreviewViewerProps) {
   const [loading, setLoading] = useState(true);
   const [iframeKey, setIframeKey] = useState(0);
   const iframeRef = useRef<HTMLIFrameElement>(null);
-  // Brief delay after drag ends so iframe repaints at new size before overlay lifts
-  const [overlayVisible, setOverlayVisible] = useState(false);
+  // Keep overlay visible briefly after drag ends so iframe repaints at new size
+  const [overlayLinger, setOverlayLinger] = useState(false);
 
   useEffect(() => {
     if (isDragging) {
-      setOverlayVisible(true);
-    } else if (overlayVisible) {
-      const t = setTimeout(() => setOverlayVisible(false), 80);
+      setOverlayLinger(true);
+    } else if (overlayLinger) {
+      const t = setTimeout(() => setOverlayLinger(false), 80);
       return () => clearTimeout(t);
     }
-  }, [isDragging, overlayVisible]);
+  }, [isDragging, overlayLinger]);
+
+  // Show overlay immediately when isDragging is true (first render), plus 80ms cooldown
+  const showDragOverlay = isDragging || overlayLinger;
+
+  // Reload iframe when url changes (e.g. after async refresh resolves)
+  const prevUrlRef = useRef(url);
+  useEffect(() => {
+    if (url && prevUrlRef.current && url !== prevUrlRef.current) {
+      setIframeKey(k => k + 1);
+      setLoading(true);
+    }
+    prevUrlRef.current = url;
+  }, [url]);
 
   const handleIframeLoad = useCallback(() => {
     setLoading(false);
@@ -36,8 +47,9 @@ export default function PreviewViewer({ url, port, title, onClose, onRefresh, is
     setLoading(true);
     if (onRefresh) {
       onRefresh();
+    } else {
+      setIframeKey((k) => k + 1);
     }
-    setIframeKey((k) => k + 1);
   }, [onRefresh]);
 
   const handleOpenExternal = useCallback(() => {
@@ -68,31 +80,62 @@ export default function PreviewViewer({ url, port, title, onClose, onRefresh, is
           </button>
         </div>
       </div>
-      {loading && !overlayVisible && (
-        <div className="preview-viewer-loading">
-          <Loader2 size={24} className="animate-spin" style={{ color: 'var(--color-text-tertiary)' }} />
-        </div>
-      )}
-      {overlayVisible && (
-        <div className="preview-viewer-resize-overlay">
-          <div className="preview-viewer-resize-card">
-            <Globe size={28} style={{ color: 'var(--color-accent-primary)' }} />
-            <div className="preview-viewer-resize-info">
-              <span className="preview-viewer-resize-title">{displayTitle}</span>
-              {hostname && <span className="preview-viewer-resize-url">{hostname}:{port}</span>}
+      {externalLoading && !url ? (
+        /* Server is starting — show frosted glass overlay with spinner */
+        <div className="preview-viewer-resize-overlay" style={{ cursor: 'default' }}>
+          <div className="preview-viewer-resize-card" style={{ flexDirection: 'column', alignItems: 'center', gap: 16, padding: '28px 36px' }}>
+            <div className="preview-viewer-spinner" />
+            <div className="preview-viewer-resize-info" style={{ alignItems: 'center' }}>
+              <span className="preview-viewer-resize-title">Starting server...</span>
+              <span className="preview-viewer-resize-url">{displayTitle} :{port}</span>
             </div>
           </div>
         </div>
+      ) : externalError ? (
+        /* Error state */
+        <div className="preview-viewer-resize-overlay" style={{ cursor: 'default' }}>
+          <div className="preview-viewer-resize-card" style={{ flexDirection: 'column', alignItems: 'center', gap: 16, padding: '28px 36px' }}>
+            <AlertCircle size={28} style={{ color: 'var(--color-text-tertiary)' }} />
+            <div className="preview-viewer-resize-info" style={{ alignItems: 'center' }}>
+              <span className="preview-viewer-resize-title">Failed to start server</span>
+              <span className="preview-viewer-resize-url">{displayTitle} :{port}</span>
+              <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginTop: 4 }}>
+                Try clicking Refresh to retry
+              </span>
+            </div>
+          </div>
+        </div>
+      ) : (
+        /* Normal iframe view */
+        <>
+          {loading && !showDragOverlay && (
+            <div className="preview-viewer-loading">
+              <Loader2 size={24} className="animate-spin" style={{ color: 'var(--color-text-tertiary)' }} />
+            </div>
+          )}
+          {showDragOverlay && (
+            <div className="preview-viewer-resize-overlay">
+              <div className="preview-viewer-resize-card">
+                <Globe size={28} style={{ color: 'var(--color-accent-primary)' }} />
+                <div className="preview-viewer-resize-info">
+                  <span className="preview-viewer-resize-title">{displayTitle}</span>
+                  {hostname && <span className="preview-viewer-resize-url">{hostname}:{port}</span>}
+                </div>
+              </div>
+            </div>
+          )}
+          <iframe
+            ref={iframeRef}
+            key={iframeKey}
+            src={url}
+            sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
+            className="preview-viewer-frame"
+            title={`Preview - port ${port}`}
+            onLoad={handleIframeLoad}
+            style={isDragging ? { pointerEvents: 'none' } : undefined}
+          />
+        </>
       )}
-      <iframe
-        ref={iframeRef}
-        key={iframeKey}
-        src={url}
-        sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
-        className="preview-viewer-frame"
-        title={`Preview - port ${port}`}
-        onLoad={handleIframeLoad}
-      />
     </div>
   );
 }

--- a/web/src/pages/ChatAgent/components/viewers/PreviewViewer.tsx
+++ b/web/src/pages/ChatAgent/components/viewers/PreviewViewer.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useCallback } from 'react';
-import { RefreshCw, ExternalLink, X, Loader2 } from 'lucide-react';
+import React, { useState, useCallback, useRef, useEffect } from 'react';
+import { RefreshCw, ExternalLink, X, Loader2, Globe } from 'lucide-react';
 import './PreviewViewer.css';
 
 interface PreviewViewerProps {
@@ -8,11 +8,25 @@ interface PreviewViewerProps {
   title?: string;
   onClose: () => void;
   onRefresh?: () => void;
+  /** When true, a frosted overlay covers the iframe for smooth resizing. */
+  isDragging?: boolean;
 }
 
-export default function PreviewViewer({ url, port, title, onClose, onRefresh }: PreviewViewerProps) {
+export default function PreviewViewer({ url, port, title, onClose, onRefresh, isDragging }: PreviewViewerProps) {
   const [loading, setLoading] = useState(true);
   const [iframeKey, setIframeKey] = useState(0);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  // Brief delay after drag ends so iframe repaints at new size before overlay lifts
+  const [overlayVisible, setOverlayVisible] = useState(false);
+
+  useEffect(() => {
+    if (isDragging) {
+      setOverlayVisible(true);
+    } else if (overlayVisible) {
+      const t = setTimeout(() => setOverlayVisible(false), 80);
+      return () => clearTimeout(t);
+    }
+  }, [isDragging, overlayVisible]);
 
   const handleIframeLoad = useCallback(() => {
     setLoading(false);
@@ -23,7 +37,6 @@ export default function PreviewViewer({ url, port, title, onClose, onRefresh }: 
     if (onRefresh) {
       onRefresh();
     }
-    // Force iframe reload via key change
     setIframeKey((k) => k + 1);
   }, [onRefresh]);
 
@@ -31,7 +44,10 @@ export default function PreviewViewer({ url, port, title, onClose, onRefresh }: 
     window.open(url, '_blank', 'noopener,noreferrer');
   }, [url]);
 
-  const displayTitle = title || `Preview`;
+  const displayTitle = title || 'Preview';
+  const hostname = (() => {
+    try { return new URL(url).hostname; } catch { return ''; }
+  })();
 
   return (
     <div className="preview-viewer" style={{ position: 'relative' }}>
@@ -41,35 +57,35 @@ export default function PreviewViewer({ url, port, title, onClose, onRefresh }: 
           <span className="preview-viewer-port-badge">:{port}</span>
         </div>
         <div className="preview-viewer-actions">
-          <button
-            className="preview-viewer-btn"
-            onClick={handleRefresh}
-            title="Refresh preview"
-          >
+          <button className="preview-viewer-btn" onClick={handleRefresh} title="Refresh preview">
             <RefreshCw size={14} />
           </button>
-          <button
-            className="preview-viewer-btn"
-            onClick={handleOpenExternal}
-            title="Open in new tab"
-          >
+          <button className="preview-viewer-btn" onClick={handleOpenExternal} title="Open in new tab">
             <ExternalLink size={14} />
           </button>
-          <button
-            className="preview-viewer-btn"
-            onClick={onClose}
-            title="Close preview"
-          >
+          <button className="preview-viewer-btn" onClick={onClose} title="Close preview">
             <X size={14} />
           </button>
         </div>
       </div>
-      {loading && (
+      {loading && !overlayVisible && (
         <div className="preview-viewer-loading">
           <Loader2 size={24} className="animate-spin" style={{ color: 'var(--color-text-tertiary)' }} />
         </div>
       )}
+      {overlayVisible && (
+        <div className="preview-viewer-resize-overlay">
+          <div className="preview-viewer-resize-card">
+            <Globe size={28} style={{ color: 'var(--color-accent-primary)' }} />
+            <div className="preview-viewer-resize-info">
+              <span className="preview-viewer-resize-title">{displayTitle}</span>
+              {hostname && <span className="preview-viewer-resize-url">{hostname}:{port}</span>}
+            </div>
+          </div>
+        </div>
+      )}
       <iframe
+        ref={iframeRef}
         key={iframeKey}
         src={url}
         sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"

--- a/web/src/pages/ChatAgent/components/viewers/PreviewViewer.tsx
+++ b/web/src/pages/ChatAgent/components/viewers/PreviewViewer.tsx
@@ -80,7 +80,7 @@ export default function PreviewViewer({ url, port, title, loading: externalLoadi
           </button>
         </div>
       </div>
-      {externalLoading && !url ? (
+      {externalLoading || !url ? (
         /* Server is starting — show frosted glass overlay with spinner */
         <div className="preview-viewer-resize-overlay" style={{ cursor: 'default' }}>
           <div className="preview-viewer-resize-card" style={{ flexDirection: 'column', alignItems: 'center', gap: 16, padding: '28px 36px' }}>

--- a/web/src/pages/ChatAgent/components/viewers/PreviewViewer.tsx
+++ b/web/src/pages/ChatAgent/components/viewers/PreviewViewer.tsx
@@ -1,0 +1,82 @@
+import React, { useState, useCallback } from 'react';
+import { RefreshCw, ExternalLink, X, Loader2 } from 'lucide-react';
+import './PreviewViewer.css';
+
+interface PreviewViewerProps {
+  url: string;
+  port: number;
+  title?: string;
+  onClose: () => void;
+  onRefresh?: () => void;
+}
+
+export default function PreviewViewer({ url, port, title, onClose, onRefresh }: PreviewViewerProps) {
+  const [loading, setLoading] = useState(true);
+  const [iframeKey, setIframeKey] = useState(0);
+
+  const handleIframeLoad = useCallback(() => {
+    setLoading(false);
+  }, []);
+
+  const handleRefresh = useCallback(() => {
+    setLoading(true);
+    if (onRefresh) {
+      onRefresh();
+    }
+    // Force iframe reload via key change
+    setIframeKey((k) => k + 1);
+  }, [onRefresh]);
+
+  const handleOpenExternal = useCallback(() => {
+    window.open(url, '_blank', 'noopener,noreferrer');
+  }, [url]);
+
+  const displayTitle = title || `Preview`;
+
+  return (
+    <div className="preview-viewer" style={{ position: 'relative' }}>
+      <div className="preview-viewer-toolbar">
+        <div className="preview-viewer-title">
+          <span>{displayTitle}</span>
+          <span className="preview-viewer-port-badge">:{port}</span>
+        </div>
+        <div className="preview-viewer-actions">
+          <button
+            className="preview-viewer-btn"
+            onClick={handleRefresh}
+            title="Refresh preview"
+          >
+            <RefreshCw size={14} />
+          </button>
+          <button
+            className="preview-viewer-btn"
+            onClick={handleOpenExternal}
+            title="Open in new tab"
+          >
+            <ExternalLink size={14} />
+          </button>
+          <button
+            className="preview-viewer-btn"
+            onClick={onClose}
+            title="Close preview"
+          >
+            <X size={14} />
+          </button>
+        </div>
+      </div>
+      {loading && (
+        <div className="preview-viewer-loading">
+          <Loader2 size={24} className="animate-spin" style={{ color: 'var(--color-text-tertiary)' }} />
+        </div>
+      )}
+      <iframe
+        key={iframeKey}
+        src={url}
+        sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
+        className="preview-viewer-frame"
+        title={`Preview - port ${port}`}
+        onLoad={handleIframeLoad}
+      />
+    </div>
+  );
+}

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -2629,10 +2629,11 @@ export function useChatMessages(
         } else if (artifactType === 'preview_url' && onPreviewUrl) {
           const payload = (event.payload || {}) as Record<string, unknown>;
           onPreviewUrl({
-            url: payload.url as string,
+            url: '',  // resolved by ChatView via authenticated endpoint
             port: payload.port as number,
             title: payload.title as string | undefined,
             command: payload.command as string | undefined,
+            loading: true,
           });
         } else if (artifactType === 'task') {
           const payload = (event.payload || {}) as Record<string, unknown>;

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -22,6 +22,7 @@ export { removeStoredThreadId } from './utils/threadStorage';
 import { createUserMessage, createAssistantMessage, createNotificationMessage, appendMessage, updateMessage, type AttachmentMeta } from './utils/messageHelpers';
 import type { ChatMessage, AssistantMessage } from '@/types/chat';
 import type { ActionRequest, ToolCallData, TodoItem } from '@/types/sse';
+import type { PreviewData } from './utils/types';
 import { createRecentlySentTracker } from './utils/recentlySentTracker';
 import {
   handleReasoningSignal,
@@ -420,7 +421,7 @@ export function useChatMessages(
   finalizePendingTodos: (() => void) | null = null,
   onOnboardingRelatedToolComplete: (() => void) | null = null,
   onFileArtifact: ((event: SSEEvent) => void) | null = null,
-  onPreviewUrl: ((data: { url: string; port: number; title?: string }) => void) | null = null,
+  onPreviewUrl: ((data: PreviewData) => void) | null = null,
   agentMode: string = 'ptc',
   clearSubagentCards: (() => void) | null = null,
   onWorkspaceCreated: ((info: { workspaceId: string; question: string }) => void) | null = null,
@@ -2631,6 +2632,7 @@ export function useChatMessages(
             url: payload.url as string,
             port: payload.port as number,
             title: payload.title as string | undefined,
+            command: payload.command as string | undefined,
           });
         } else if (artifactType === 'task') {
           const payload = (event.payload || {}) as Record<string, unknown>;

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -420,6 +420,7 @@ export function useChatMessages(
   finalizePendingTodos: (() => void) | null = null,
   onOnboardingRelatedToolComplete: (() => void) | null = null,
   onFileArtifact: ((event: SSEEvent) => void) | null = null,
+  onPreviewUrl: ((data: { url: string; port: number; title?: string }) => void) | null = null,
   agentMode: string = 'ptc',
   clearSubagentCards: (() => void) | null = null,
   onWorkspaceCreated: ((info: { workspaceId: string; question: string }) => void) | null = null,
@@ -2624,6 +2625,13 @@ export function useChatMessages(
           console.log('[Stream] handleTodoUpdate result:', result);
         } else if (artifactType === 'file_operation' && onFileArtifact) {
           onFileArtifact(event);
+        } else if (artifactType === 'preview_url' && onPreviewUrl) {
+          const payload = (event.payload || {}) as Record<string, unknown>;
+          onPreviewUrl({
+            url: payload.url as string,
+            port: payload.port as number,
+            title: payload.title as string | undefined,
+          });
         } else if (artifactType === 'task') {
           const payload = (event.payload || {}) as Record<string, unknown>;
           const { task_id, action: rawAction, description, prompt, type } = payload;

--- a/web/src/pages/ChatAgent/hooks/utils/types.ts
+++ b/web/src/pages/ChatAgent/hooks/utils/types.ts
@@ -34,3 +34,13 @@ export interface TodoPayload {
   pending?: number;
   [key: string]: unknown;
 }
+
+/** Data for a preview URL panel. */
+export interface PreviewData {
+  url: string;
+  port: number;
+  title?: string;
+  command?: string;
+  loading?: boolean;
+  error?: boolean;
+}

--- a/web/src/pages/ChatAgent/utils/api.ts
+++ b/web/src/pages/ChatAgent/utils/api.ts
@@ -539,11 +539,17 @@ export async function refreshWorkspace(workspaceId: string) {
   return data;
 }
 
-export async function getPreviewUrl(workspaceId: string, port: number) {
-  const { data } = await api.get(`/api/v1/workspaces/${workspaceId}/sandbox/preview-url`, {
-    params: { port },
+export async function getPreviewUrl(workspaceId: string, port: number, command?: string) {
+  const { data } = await api.post(`/api/v1/workspaces/${workspaceId}/sandbox/preview-url`, {
+    port,
+    ...(command && { command }),
   });
   return data;
+}
+
+export async function checkPreviewHealth(workspaceId: string, url: string) {
+  const { data } = await api.post(`/api/v1/workspaces/${workspaceId}/sandbox/preview-health`, { url });
+  return data as { reachable: boolean; checked_at: number };
 }
 
 // --- Thread Sharing ---

--- a/web/src/pages/ChatAgent/utils/api.ts
+++ b/web/src/pages/ChatAgent/utils/api.ts
@@ -539,16 +539,17 @@ export async function refreshWorkspace(workspaceId: string) {
   return data;
 }
 
-export async function getPreviewUrl(workspaceId: string, port: number, command?: string) {
+export async function getPreviewUrl(workspaceId: string, port: number, command?: string, force?: boolean) {
   const { data } = await api.post(`/api/v1/workspaces/${workspaceId}/sandbox/preview-url`, {
     port,
     ...(command && { command }),
+    ...(force && { force: true }),
   });
   return data;
 }
 
-export async function checkPreviewHealth(workspaceId: string, url: string) {
-  const { data } = await api.post(`/api/v1/workspaces/${workspaceId}/sandbox/preview-health`, { url });
+export async function checkPreviewHealth(workspaceId: string, port: number) {
+  const { data } = await api.post(`/api/v1/workspaces/${workspaceId}/sandbox/preview-health`, { port });
   return data as { reachable: boolean; checked_at: number };
 }
 

--- a/web/src/pages/ChatAgent/utils/api.ts
+++ b/web/src/pages/ChatAgent/utils/api.ts
@@ -539,6 +539,13 @@ export async function refreshWorkspace(workspaceId: string) {
   return data;
 }
 
+export async function getPreviewUrl(workspaceId: string, port: number) {
+  const { data } = await api.get(`/api/v1/workspaces/${workspaceId}/sandbox/preview-url`, {
+    params: { port },
+  });
+  return data;
+}
+
 // --- Thread Sharing ---
 
 /**


### PR DESCRIPTION
## Summary

Adds a **Preview URLs** feature that lets the agent start server processes in the Daytona sandbox and expose them to users via a live iframe panel in the chat UI. Also implements background Bash command tracking via a new `BashOutput` tool, and fixes a workspace "stuck in stopping" recovery path.

## Changes

- **New tools**: `GetPreviewUrl` (start server + generate signed preview URL + emit SSE artifact) and `BashOutput` (poll status/logs of background commands by command ID)
- **Daytona provider**: added session management for background processes (`create_session`, `session_execute`, `session_command_logs`) and signed/standard preview URL generation (`get_preview_url`, `get_preview_link`)
- **PTCSandbox**: lazy background session (`_ensure_bg_session`), `start_and_get_preview_url`, `get_preview_url`, `get_preview_link`, `get_background_command_status`; background execution in `execute_bash_command` now routes through the persistent session
- **Backend API**: three authenticated endpoints (`POST /preview-url`, `POST /preview-health`, `POST /preview-restart`) plus an unauthenticated `GET /api/v1/preview/{workspace_id}/{port}` stable-URL redirect backed by Redis-cached signed URLs
- **Frontend**: `InlinePreviewCard` with live health polling, `PreviewViewer` iframe panel (with drag-resize overlay, refresh, open-in-new-tab), panel integration in `ChatView`, and SSE `preview_url` artifact handling
- **Bug fix**: `workspace_manager.py` now recovers workspaces that are stuck in the "stopping" DB state by querying the actual sandbox state

## Test Plan

- Start a server in the sandbox (e.g. `python -m http.server 8080`) via the agent
- Verify `GetPreviewUrl` returns a stable URL and the preview panel opens automatically
- Verify `BashOutput` can poll the background server process
- Verify preview health card shows live/offline status and the restart flow works
- Verify the unauthenticated redirect endpoint resolves signed URLs via Redis cache