### PR TITLE
Feat/vault

### DIFF
--- a/migrations/versions/002_add_vault_secrets.py
+++ b/migrations/versions/002_add_vault_secrets.py
@@ -1,0 +1,51 @@
+"""Add workspace vault secrets table.
+
+Stores encrypted per-workspace secrets (API keys, credentials)
+that are injected into sandbox code execution.
+
+Revision ID: 002
+Revises: 001
+Create Date: 2026-03-20
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "002"
+down_revision: Union[str, None] = "001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS workspace_vault_secrets (
+            workspace_vault_secret_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            workspace_id UUID NOT NULL REFERENCES workspaces(workspace_id) ON DELETE CASCADE,
+            name VARCHAR(255) NOT NULL,
+            value BYTEA NOT NULL,
+            description TEXT DEFAULT '',
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            UNIQUE(workspace_id, name)
+        )
+    """)
+
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS idx_vault_secrets_workspace
+        ON workspace_vault_secrets(workspace_id)
+    """)
+
+    # Auto-update updated_at on row modification
+    op.execute("DROP TRIGGER IF EXISTS update_vault_secrets_updated_at ON workspace_vault_secrets")
+    op.execute("""
+        CREATE TRIGGER update_vault_secrets_updated_at
+        BEFORE UPDATE ON workspace_vault_secrets
+        FOR EACH ROW EXECUTE FUNCTION update_updated_at_column()
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS workspace_vault_secrets CASCADE")

--- a/migrations/versions/003_add_vault_secrets.py
+++ b/migrations/versions/003_add_vault_secrets.py
@@ -3,8 +3,8 @@
 Stores encrypted per-workspace secrets (API keys, credentials)
 that are injected into sandbox code execution.
 
-Revision ID: 002
-Revises: 001
+Revision ID: 003
+Revises: 002
 Create Date: 2026-03-20
 """
 
@@ -13,8 +13,8 @@ from typing import Sequence, Union
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "002"
-down_revision: Union[str, None] = "001"
+revision: str = "003"
+down_revision: Union[str, None] = "002"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/ptc_agent/agent/agent.py
+++ b/src/ptc_agent/agent/agent.py
@@ -263,6 +263,7 @@ class PTCAgent:
         on_agent_md_write: Any | None = None,
         store: Any | None = None,
         on_signed_url: Any | None = None,
+        vault_secrets: dict[str, str] | None = None,
     ) -> Any:
         """Create a deepagent with PTC pattern capabilities.
 
@@ -378,7 +379,10 @@ class PTCAgent:
                 ),
                 CodeValidationMiddleware(),
                 ToolErrorHandlingMiddleware(),
-                LeakDetectionMiddleware(mcp_servers=self.config.mcp.servers),
+                LeakDetectionMiddleware(
+                    mcp_servers=self.config.mcp.servers,
+                    vault_secrets=vault_secrets,
+                ),
                 ToolResultNormalizationMiddleware(),
             ]
         )

--- a/src/ptc_agent/agent/graph.py
+++ b/src/ptc_agent/agent/graph.py
@@ -231,6 +231,9 @@ async def build_ptc_graph_with_session(
     # Create the inner agent with the session's sandbox.
     # IMPORTANT: pass the server checkpointer into the deepagent so that partial
     # progress (tools, intermediate messages, etc.) is checkpointed frequently.
+    # Read cached vault secrets from sandbox (populated by vault API on mutation)
+    vault_secrets = getattr(session.sandbox, "vault_secrets", None)
+
     inner_agent = ptc_agent.create_agent(
         sandbox=session.sandbox,
         mcp_registry=session.mcp_registry,
@@ -245,6 +248,7 @@ async def build_ptc_graph_with_session(
         on_agent_md_write=session.invalidate_agent_md,
         store=store,
         on_signed_url=on_signed_url,
+        vault_secrets=vault_secrets,
     )
 
     logger.info(

--- a/src/ptc_agent/agent/middleware/tool/code_validation.py
+++ b/src/ptc_agent/agent/middleware/tool/code_validation.py
@@ -13,7 +13,7 @@ from langchain_core.messages import ToolMessage
 logger = structlog.get_logger(__name__)
 
 # Patterns that indicate attempts to access protected internal files
-_INTERNAL_PATH_PATTERNS = ("_internal/", ".mcp_tokens", ".mcp_secrets")
+_INTERNAL_PATH_PATTERNS = ("_internal/", ".mcp_tokens", ".mcp_secrets", ".vault_secrets")
 
 
 class CodeValidationMiddleware(AgentMiddleware):
@@ -31,9 +31,9 @@ class CodeValidationMiddleware(AgentMiddleware):
                 logger.warning("Internal path reference in code", pattern=pattern)
                 return (
                     "<system_warning>Code validation failed: references to internal "
-                    "system paths (_internal/, .mcp_tokens, .mcp_secrets) are not "
-                    "allowed. These are protected platform files that must not be "
-                    "accessed directly.</system_warning>"
+                    "system paths (_internal/, .mcp_tokens, .mcp_secrets, "
+                    ".vault_secrets) are not allowed. These are protected platform "
+                    "files that must not be accessed directly.</system_warning>"
                 )
         return None
 

--- a/src/ptc_agent/agent/middleware/tool/leak_detection.py
+++ b/src/ptc_agent/agent/middleware/tool/leak_detection.py
@@ -35,13 +35,19 @@ class LeakDetectionMiddleware(AgentMiddleware):
     # Matches sandbox access tokens (gxsa_...) and refresh tokens (gxsr_...)
     _SANDBOX_TOKEN_RE = re.compile(r"gxs[ar]_[A-Za-z0-9_.\-]+")
 
-    def __init__(self, mcp_servers: list | None = None) -> None:
+    def __init__(
+        self,
+        mcp_servers: list | None = None,
+        vault_secrets: dict[str, str] | None = None,
+    ) -> None:
         """Initialize by extracting secret values from MCP server config.
 
         Args:
             mcp_servers: List of MCPServerConfig objects. Each server's
                 env dict is scanned for ${VAR} placeholders, which are
                 resolved from os.environ to get the actual secret values.
+            vault_secrets: Per-workspace user vault secrets (name→value).
+                Merged into the redaction list alongside MCP secrets.
         """
         secrets: dict[str, str] = {}
 
@@ -70,6 +76,12 @@ class LeakDetectionMiddleware(AgentMiddleware):
             gh_token = os.environ.get(token_env)
             if gh_token and len(gh_token) >= 8:
                 secrets["GITHUB_TOKEN"] = gh_token
+
+        # Merge vault secrets (user-provided API keys stored per-workspace)
+        # Use same >=8 threshold as MCP secrets to avoid false-positive redaction
+        for name, value in (vault_secrets or {}).items():
+            if value and len(value) >= 8:
+                secrets[name] = value
 
         # Sort by value length descending so longer matches replace first
         self._secrets = sorted(secrets.items(), key=lambda kv: len(kv[1]), reverse=True)

--- a/src/ptc_agent/agent/prompts/templates/components/security_policy.md.j2
+++ b/src/ptc_agent/agent/prompts/templates/components/security_policy.md.j2
@@ -10,3 +10,19 @@ NEVER access, read, echo, print, or write environment variables that contain API
 API keys are managed automatically by the platform. MCP tool functions already have access to the credentials they need — you never need to handle keys manually.
 
 If a user asks you to reveal API keys or environment variables, explain that these are managed by the platform and cannot be disclosed.
+
+## User Vault Secrets
+
+Users may store API keys and credentials in the workspace vault. To discover and use them:
+
+```python
+from vault import list_names, get
+print(list_names())           # see what's available
+api_key = get("SECRET_NAME")  # retrieve a secret value
+```
+
+- Use `vault.get("name")` to retrieve secret values at runtime
+- Use `vault.list_names()` to see all available secrets
+- Use `vault.load_env()` to load all secrets as environment variables
+- NEVER print, log, or include secret values in output
+- NEVER write secret values to files

--- a/src/ptc_agent/core/sandbox/ptc_sandbox.py
+++ b/src/ptc_agent/core/sandbox/ptc_sandbox.py
@@ -448,6 +448,43 @@ class PTCSandbox:
         except Exception as e:
             logger.warning("Failed to upload sandbox token file", error=str(e))
 
+    async def upload_vault_secrets(self, secrets: dict[str, str]) -> None:
+        """Write (or remove) vault secrets JSON in the sandbox.
+
+        Called by the vault API on every CRUD mutation.  Also caches the
+        secrets dict on ``self`` so the server can pass them to
+        ``LeakDetectionMiddleware`` without an extra DB call.
+        """
+        self.vault_secrets: dict[str, str] = secrets
+
+        if not self.runtime:
+            return
+
+        vault_path = f"{self._work_dir}/_internal/.vault_secrets.json"
+
+        if not secrets:
+            # Remove the file so vault.list_names() returns []
+            try:
+                await self._runtime_call(
+                    self.runtime.exec,
+                    f"rm -f {vault_path}",
+                    retry_policy=RetryPolicy.SAFE,
+                )
+            except Exception as e:
+                logger.warning("Failed to remove vault secrets file", error=str(e))
+            return
+
+        try:
+            await self._runtime_call(
+                self.runtime.upload_file,
+                json.dumps(secrets).encode("utf-8"),
+                vault_path,
+                retry_policy=RetryPolicy.SAFE,
+            )
+            logger.info("Uploaded vault secrets file", path=vault_path)
+        except Exception as e:
+            logger.warning("Failed to upload vault secrets file", error=str(e))
+
     async def ensure_sandbox_ready(self) -> None:
         await self._wait_ready()
 
@@ -762,6 +799,22 @@ class PTCSandbox:
             uploaded_files=len(files),
             sandbox_root=str(internal_root),
         )
+
+        # Upload vault helper module so `from vault import get` is always
+        # importable, even if no secrets exist yet.
+        try:
+            from ptc_agent.core.sandbox.vault_helper import VAULT_MODULE_SOURCE
+
+            vault_dest = str(internal_root / "vault.py")
+            await self._runtime_call(
+                sandbox.upload_file,
+                VAULT_MODULE_SOURCE.encode("utf-8"),
+                vault_dest,
+                retry_policy=RetryPolicy.SAFE,
+            )
+            logger.info("Uploaded vault helper module", path=vault_dest)
+        except Exception as e:
+            logger.warning("Failed to upload vault helper module", error=str(e))
 
     # ── Unified manifest helpers ────────────────────────────────────────
 

--- a/src/ptc_agent/core/sandbox/vault_helper.py
+++ b/src/ptc_agent/core/sandbox/vault_helper.py
@@ -24,19 +24,12 @@ _SECRETS_FILE = os.path.join(
     ".vault_secrets.json",
 )
 
-_cache: dict[str, str] | None = None
-
-
 def _load() -> dict[str, str]:
-    global _cache
-    if _cache is not None:
-        return _cache
     try:
         with open(_SECRETS_FILE) as f:
-            _cache = json.load(f)
+            return json.load(f)
     except FileNotFoundError:
-        _cache = {}
-    return _cache
+        return {}
 
 
 def get(name: str) -> str:

--- a/src/ptc_agent/core/sandbox/vault_helper.py
+++ b/src/ptc_agent/core/sandbox/vault_helper.py
@@ -1,0 +1,78 @@
+"""Source code for the ``vault`` Python module uploaded to the sandbox.
+
+The module is written to ``_internal/src/vault.py`` so it's importable via
+``from vault import get, list_names, load_env``.  It reads secrets from
+``_internal/.vault_secrets.json`` at runtime.
+"""
+
+VAULT_MODULE_SOURCE = '''\
+"""Workspace vault — access user-provided API keys and credentials.
+
+Usage::
+
+    from vault import get, list_names
+
+    api_key = get("MY_API_KEY")
+    print(list_names())          # list available secret names
+"""
+
+import json
+import os
+
+_SECRETS_FILE = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    ".vault_secrets.json",
+)
+
+_cache: dict[str, str] | None = None
+
+
+def _load() -> dict[str, str]:
+    global _cache
+    if _cache is not None:
+        return _cache
+    try:
+        with open(_SECRETS_FILE) as f:
+            _cache = json.load(f)
+    except FileNotFoundError:
+        _cache = {}
+    return _cache
+
+
+def _reload() -> dict[str, str]:
+    """Force re-read from disk (picks up changes without restarting the process)."""
+    global _cache
+    _cache = None
+    return _load()
+
+
+def get(name: str) -> str:
+    """Return the value of a vault secret by name.
+
+    Raises ``KeyError`` if the secret does not exist.
+    """
+    secrets = _load()
+    if name not in secrets:
+        available = ", ".join(sorted(secrets)) or "(none)"
+        raise KeyError(
+            f"Vault secret {name!r} not found. Available: {available}"
+        )
+    return secrets[name]
+
+
+def list_names() -> list[str]:
+    """Return a sorted list of available secret names."""
+    return sorted(_load())
+
+
+def load_env() -> int:
+    """Set all vault secrets as environment variables.
+
+    Returns the number of variables set.  Useful for libraries that
+    read credentials from ``os.environ``.
+    """
+    secrets = _load()
+    for k, v in secrets.items():
+        os.environ[k] = v
+    return len(secrets)
+'''

--- a/src/ptc_agent/core/sandbox/vault_helper.py
+++ b/src/ptc_agent/core/sandbox/vault_helper.py
@@ -39,13 +39,6 @@ def _load() -> dict[str, str]:
     return _cache
 
 
-def _reload() -> dict[str, str]:
-    """Force re-read from disk (picks up changes without restarting the process)."""
-    global _cache
-    _cache = None
-    return _load()
-
-
 def get(name: str) -> str:
     """Return the value of a vault secret by name.
 

--- a/src/server/app/public.py
+++ b/src/server/app/public.py
@@ -12,6 +12,7 @@ Endpoints:
 - GET /api/v1/public/shared/{share_token}/files/download — Download raw file (requires allow_download)
 """
 
+import asyncio
 import json
 import logging
 import mimetypes
@@ -20,7 +21,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import StreamingResponse
 
-from src.server.utils.secret_redactor import get_redactor
+from src.server.utils.secret_redactor import get_redactor, get_vault_secrets_for_redaction
 
 from src.server.database.conversation import (
     get_thread_by_share_token,
@@ -281,14 +282,17 @@ async def read_shared_file(
     if _is_always_hidden_path(normalized_path) or _is_hidden_path(normalized_path) or _is_system_path(normalized_path):
         raise HTTPException(status_code=404, detail="File not found")
 
-    # Try DB first
-    file_record = await FilePersistenceService.get_file_content(workspace_id, normalized_path)
+    # Try DB first — parallel vault secrets + file content fetch
+    vault_secrets, file_record = await asyncio.gather(
+        get_vault_secrets_for_redaction(workspace_id),
+        FilePersistenceService.get_file_content(workspace_id, normalized_path),
+    )
     if file_record:
         if file_record.get("is_binary"):
             raise HTTPException(status_code=415, detail="Cannot read binary file as text.")
 
         text_content = file_record.get("content_text", "")
-        text_content = get_redactor().redact(text_content)
+        text_content = get_redactor().redact(text_content, vault_secrets=vault_secrets)
         lines = text_content.splitlines()
         content = "\n".join(lines[offset:offset + limit])
         mime = file_record.get("mime_type") or "text/plain"
@@ -303,7 +307,7 @@ async def read_shared_file(
             "source": "database",
         }
 
-    # Try live sandbox
+    # Try live sandbox — vault secrets from session cache (instant)
     if workspace.get("status") not in ("stopped", "stopping"):
         try:
             manager = WorkspaceManager.get_instance()
@@ -326,7 +330,8 @@ async def read_shared_file(
                 except UnicodeDecodeError:
                     raise HTTPException(status_code=415, detail="File appears to be binary.")
 
-                text_content = get_redactor().redact(text_content)
+                vault_secrets = await get_vault_secrets_for_redaction(workspace_id)
+                text_content = get_redactor().redact(text_content, vault_secrets=vault_secrets)
                 lines = text_content.splitlines()
                 content = "\n".join(lines[offset:offset + limit])
                 from src.server.app.workspace_files import _to_client_path
@@ -373,8 +378,11 @@ async def download_shared_file(
     if _is_always_hidden_path(normalized_path) or _is_hidden_path(normalized_path) or _is_system_path(normalized_path):
         raise HTTPException(status_code=404, detail="File not found")
 
-    # Try DB first
-    file_record = await FilePersistenceService.get_file_content(workspace_id, normalized_path)
+    # Try DB first — parallel vault secrets + file content fetch
+    vault_secrets, file_record = await asyncio.gather(
+        get_vault_secrets_for_redaction(workspace_id),
+        FilePersistenceService.get_file_content(workspace_id, normalized_path),
+    )
     if file_record:
         if file_record.get("is_binary") and file_record.get("content_binary"):
             content = file_record["content_binary"]
@@ -389,7 +397,7 @@ async def download_shared_file(
         mime = file_record.get("mime_type") or "application/octet-stream"
 
         if mime and mime.startswith("text/"):
-            content = get_redactor().redact_bytes(content)
+            content = get_redactor().redact_bytes(content, vault_secrets=vault_secrets)
 
         return StreamingResponse(
             iter([content]),
@@ -397,7 +405,7 @@ async def download_shared_file(
             headers={"Content-Disposition": f'attachment; filename="{filename}"'},
         )
 
-    # Try live sandbox
+    # Try live sandbox — vault secrets from session cache (instant)
     if workspace.get("status") not in ("stopped", "stopping"):
         try:
             manager = WorkspaceManager.get_instance()
@@ -421,7 +429,8 @@ async def download_shared_file(
                 mime, _ = mimetypes.guess_type(filename)
 
                 if mime and mime.startswith("text/"):
-                    content = get_redactor().redact_bytes(content)
+                    vault_secrets = await get_vault_secrets_for_redaction(workspace_id)
+                    content = get_redactor().redact_bytes(content, vault_secrets=vault_secrets)
 
                 return StreamingResponse(
                     iter([content]),

--- a/src/server/app/public.py
+++ b/src/server/app/public.py
@@ -330,7 +330,6 @@ async def read_shared_file(
                 except UnicodeDecodeError:
                     raise HTTPException(status_code=415, detail="File appears to be binary.")
 
-                vault_secrets = await get_vault_secrets_for_redaction(workspace_id)
                 text_content = get_redactor().redact(text_content, vault_secrets=vault_secrets)
                 lines = text_content.splitlines()
                 content = "\n".join(lines[offset:offset + limit])
@@ -429,7 +428,6 @@ async def download_shared_file(
                 mime, _ = mimetypes.guess_type(filename)
 
                 if mime and mime.startswith("text/"):
-                    vault_secrets = await get_vault_secrets_for_redaction(workspace_id)
                     content = get_redactor().redact_bytes(content, vault_secrets=vault_secrets)
 
                 return StreamingResponse(

--- a/src/server/app/setup.py
+++ b/src/server/app/setup.py
@@ -424,6 +424,7 @@ from src.server.app.insights import router as insights_router
 from src.server.app.oauth import router as oauth_router
 from src.server.app.public import router as public_router
 from src.server.app.skills import router as skills_router
+from src.server.app.vault import router as vault_router
 
 # Conditionally import ginlix-data WS proxy (only when GINLIX_DATA_WS_URL is set)
 from src.config.settings import GINLIX_DATA_ENABLED
@@ -482,6 +483,9 @@ app.include_router(
     public_router
 )  # /api/v1/public/* - Public shared thread access (no auth)
 app.include_router(skills_router)  # /api/v1/skills - Available agent skills
+app.include_router(
+    vault_router
+)  # /api/v1/workspaces/{id}/vault/secrets - Per-workspace secret storage
 app.include_router(health_router)  # /health - Health check
 app.include_router(
     preview_redirect_router

--- a/src/server/app/vault.py
+++ b/src/server/app/vault.py
@@ -7,6 +7,7 @@ Endpoints:
 - GET    /api/v1/workspaces/{workspace_id}/vault/secrets
 - POST   /api/v1/workspaces/{workspace_id}/vault/secrets
 - PUT    /api/v1/workspaces/{workspace_id}/vault/secrets/{name}
+- GET    /api/v1/workspaces/{workspace_id}/vault/secrets/{name}/reveal
 - DELETE /api/v1/workspaces/{workspace_id}/vault/secrets/{name}
 """
 
@@ -22,6 +23,7 @@ from src.server.database.vault_secrets import (
     create_secret as create_secret_db,
     delete_secret,
     get_workspace_secrets,
+    reveal_secret as reveal_secret_db,
     update_secret,
 )
 from src.server.database.workspace import get_workspace as db_get_workspace
@@ -122,6 +124,20 @@ async def update_secret_endpoint(
 
     await _push_to_sandbox(workspace_id)
     return {"name": name}
+
+
+@router.get("/{workspace_id}/vault/secrets/{name}/reveal")
+@handle_api_exceptions("reveal vault secret", logger)
+async def reveal_secret_endpoint(
+    workspace_id: str, name: str, user_id: CurrentUserId,
+):
+    workspace = await db_get_workspace(workspace_id)
+    require_workspace_owner(workspace, user_id=user_id)
+
+    value = await reveal_secret_db(workspace_id, name)
+    if value is None:
+        raise HTTPException(status_code=404, detail="Secret not found")
+    return {"value": value}
 
 
 @router.delete("/{workspace_id}/vault/secrets/{name}")

--- a/src/server/app/vault.py
+++ b/src/server/app/vault.py
@@ -1,0 +1,140 @@
+"""Workspace Vault Secrets API Router.
+
+CRUD for per-workspace encrypted secrets. On every mutation, secrets are
+pushed to the running sandbox (if any) so code can use them immediately.
+
+Endpoints:
+- GET    /api/v1/workspaces/{workspace_id}/vault/secrets
+- POST   /api/v1/workspaces/{workspace_id}/vault/secrets
+- PUT    /api/v1/workspaces/{workspace_id}/vault/secrets/{name}
+- DELETE /api/v1/workspaces/{workspace_id}/vault/secrets/{name}
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field, field_validator
+
+from src.server.database.vault_secrets import (
+    create_secret as create_secret_db,
+    delete_secret,
+    get_workspace_secrets,
+    update_secret,
+)
+from src.server.database.workspace import get_workspace as db_get_workspace
+from src.server.services.workspace_manager import WorkspaceManager
+from src.server.utils.api import CurrentUserId, handle_api_exceptions, require_workspace_owner
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/workspaces", tags=["Vault Secrets"])
+
+_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,63}$")
+
+
+# ---------------------------------------------------------------------------
+# Request / response models
+# ---------------------------------------------------------------------------
+
+class CreateSecretRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=64)
+    value: str = Field(..., min_length=1, max_length=4096)
+    description: str = Field("", max_length=256)
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        if not _NAME_RE.match(v):
+            raise ValueError(
+                "Name must be 1-64 characters: letters, digits, underscores; "
+                "must start with a letter or underscore"
+            )
+        return v
+
+
+class UpdateSecretRequest(BaseModel):
+    value: str | None = Field(None, min_length=1, max_length=4096)
+    description: str | None = Field(None, max_length=256)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _push_to_sandbox(workspace_id: str) -> None:
+    """Push vault secrets to the running sandbox (best-effort)."""
+    try:
+        wm = WorkspaceManager.get_instance()
+        await wm.push_vault_secrets(workspace_id)
+    except Exception:
+        logger.warning(
+            f"[vault] Failed to push secrets to sandbox for workspace {workspace_id}",
+            exc_info=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+@router.get("/{workspace_id}/vault/secrets")
+@handle_api_exceptions("list vault secrets", logger)
+async def list_secrets(workspace_id: str, user_id: CurrentUserId):
+    workspace = await db_get_workspace(workspace_id)
+    require_workspace_owner(workspace, user_id=user_id)
+    secrets = await get_workspace_secrets(workspace_id)
+    return {"secrets": secrets}
+
+
+@router.post("/{workspace_id}/vault/secrets", status_code=201)
+@handle_api_exceptions("create vault secret", logger)
+async def create_secret(
+    workspace_id: str, body: CreateSecretRequest, user_id: CurrentUserId,
+):
+    workspace = await db_get_workspace(workspace_id)
+    require_workspace_owner(workspace, user_id=user_id)
+
+    try:
+        await create_secret_db(workspace_id, body.name, body.value, body.description)
+    except ValueError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+
+    await _push_to_sandbox(workspace_id)
+    return {"name": body.name}
+
+
+@router.put("/{workspace_id}/vault/secrets/{name}")
+@handle_api_exceptions("update vault secret", logger)
+async def update_secret_endpoint(
+    workspace_id: str, name: str, body: UpdateSecretRequest, user_id: CurrentUserId,
+):
+    workspace = await db_get_workspace(workspace_id)
+    require_workspace_owner(workspace, user_id=user_id)
+
+    found = await update_secret(
+        workspace_id, name, value=body.value, description=body.description,
+    )
+    if not found:
+        raise HTTPException(status_code=404, detail="Secret not found")
+
+    await _push_to_sandbox(workspace_id)
+    return {"name": name}
+
+
+@router.delete("/{workspace_id}/vault/secrets/{name}")
+@handle_api_exceptions("delete vault secret", logger)
+async def delete_secret_endpoint(
+    workspace_id: str, name: str, user_id: CurrentUserId,
+):
+    workspace = await db_get_workspace(workspace_id)
+    require_workspace_owner(workspace, user_id=user_id)
+
+    found = await delete_secret(workspace_id, name)
+    if not found:
+        raise HTTPException(status_code=404, detail="Secret not found")
+
+    await _push_to_sandbox(workspace_id)
+    return {"ok": True}

--- a/src/server/app/workspace_files.py
+++ b/src/server/app/workspace_files.py
@@ -22,6 +22,7 @@ Endpoints:
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import logging
 import mimetypes
@@ -44,7 +45,7 @@ from ptc_agent.core.paths import (
 from src.server.database.workspace import get_workspace as db_get_workspace
 from src.server.services.workspace_manager import WorkspaceManager
 from src.server.services.persistence.file import FilePersistenceService
-from src.server.utils.secret_redactor import get_redactor
+from src.server.utils.secret_redactor import get_redactor, get_vault_secrets_for_redaction
 
 logger = logging.getLogger(__name__)
 
@@ -401,8 +402,10 @@ async def read_workspace_file(
         if not normalized_path:
             raise HTTPException(status_code=400, detail="File path is required")
 
-        file_record = await FilePersistenceService.get_file_content(
-            workspace_id, normalized_path
+        # Parallel: fetch vault secrets + file content in one round-trip window
+        vault_secrets, file_record = await asyncio.gather(
+            get_vault_secrets_for_redaction(workspace_id),
+            FilePersistenceService.get_file_content(workspace_id, normalized_path),
         )
         if not file_record:
             raise HTTPException(status_code=404, detail="File not found")
@@ -414,7 +417,7 @@ async def read_workspace_file(
             )
 
         text_content = file_record.get("content_text", "")
-        text_content = get_redactor().redact(text_content)
+        text_content = get_redactor().redact(text_content, vault_secrets=vault_secrets)
         if unlimited:
             content = text_content
         else:
@@ -463,7 +466,8 @@ async def read_workspace_file(
             detail="File appears to be binary and cannot be read as text. Use GET /files/download instead.",
         )
 
-    text_content = get_redactor().redact(text_content)
+    vault_secrets = await get_vault_secrets_for_redaction(workspace_id)
+    text_content = get_redactor().redact(text_content, vault_secrets=vault_secrets)
 
     # Apply line range (skip when unlimited=True for edit mode)
     if unlimited:
@@ -605,8 +609,10 @@ async def download_workspace_file(
         if not normalized_path:
             raise HTTPException(status_code=400, detail="File path is required")
 
-        file_record = await FilePersistenceService.get_file_content(
-            workspace_id, normalized_path
+        # Parallel: fetch vault secrets + file content in one round-trip window
+        vault_secrets, file_record = await asyncio.gather(
+            get_vault_secrets_for_redaction(workspace_id),
+            FilePersistenceService.get_file_content(workspace_id, normalized_path),
         )
         if not file_record:
             raise HTTPException(status_code=404, detail="File not found")
@@ -624,7 +630,7 @@ async def download_workspace_file(
         mime = file_record.get("mime_type") or "application/octet-stream"
 
         if mime and mime.startswith("text/"):
-            content = get_redactor().redact_bytes(content)
+            content = get_redactor().redact_bytes(content, vault_secrets=vault_secrets)
 
         return _build_download_response(content, filename, mime, request)
 
@@ -649,7 +655,8 @@ async def download_workspace_file(
     mime, _enc = mimetypes.guess_type(filename)
 
     if mime and mime.startswith("text/"):
-        content = get_redactor().redact_bytes(content)
+        vault_secrets = await get_vault_secrets_for_redaction(workspace_id)
+        content = get_redactor().redact_bytes(content, vault_secrets=vault_secrets)
 
     return _build_download_response(
         content, filename, mime or "application/octet-stream", request

--- a/src/server/database/vault_secrets.py
+++ b/src/server/database/vault_secrets.py
@@ -49,6 +49,23 @@ async def get_workspace_secrets(workspace_id: str) -> list[dict[str, Any]]:
             ]
 
 
+async def reveal_secret(workspace_id: str, name: str) -> str | None:
+    """Return the plaintext value of a single secret, or None if not found."""
+    enc_key = _get_encryption_key()
+    async with get_db_connection() as conn:
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(
+                """
+                SELECT pgp_sym_decrypt(value, %s) AS plaintext
+                FROM workspace_vault_secrets
+                WHERE workspace_id = %s AND name = %s
+                """,
+                (enc_key, workspace_id, name),
+            )
+            row = await cur.fetchone()
+            return row["plaintext"] if row else None
+
+
 async def get_workspace_secrets_decrypted(workspace_id: str) -> dict[str, str]:
     """Return {name: plaintext_value} for sandbox injection."""
     enc_key = _get_encryption_key()

--- a/src/server/database/vault_secrets.py
+++ b/src/server/database/vault_secrets.py
@@ -1,0 +1,166 @@
+"""
+Database CRUD for per-workspace vault secrets.
+
+Secrets are encrypted at rest using pgcrypto (pgp_sym_encrypt/decrypt).
+Encryption is transparent to callers — functions accept and return plaintext.
+"""
+
+import logging
+from typing import Any
+
+from psycopg.rows import dict_row
+
+from src.server.database.conversation import get_db_connection
+from src.server.database.encryption import get_encryption_key as _get_encryption_key
+
+logger = logging.getLogger(__name__)
+
+# Hard limit on secrets per workspace
+MAX_SECRETS_PER_WORKSPACE = 20
+
+
+async def get_workspace_secrets(workspace_id: str) -> list[dict[str, Any]]:
+    """List all secrets for a workspace (decrypted server-side for masking)."""
+    enc_key = _get_encryption_key()
+    async with get_db_connection() as conn:
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(
+                """
+                SELECT workspace_vault_secret_id, name, description,
+                       pgp_sym_decrypt(value, %s) AS plaintext,
+                       created_at, updated_at
+                FROM workspace_vault_secrets
+                WHERE workspace_id = %s
+                ORDER BY name
+                """,
+                (enc_key, workspace_id),
+            )
+            rows = await cur.fetchall()
+            return [
+                {
+                    "workspace_vault_secret_id": str(r["workspace_vault_secret_id"]),
+                    "name": r["name"],
+                    "description": r["description"] or "",
+                    "masked_value": _mask(r["plaintext"]),
+                    "created_at": r["created_at"].isoformat(),
+                    "updated_at": r["updated_at"].isoformat(),
+                }
+                for r in rows
+            ]
+
+
+async def get_workspace_secrets_decrypted(workspace_id: str) -> dict[str, str]:
+    """Return {name: plaintext_value} for sandbox injection."""
+    enc_key = _get_encryption_key()
+    async with get_db_connection() as conn:
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(
+                """
+                SELECT name, pgp_sym_decrypt(value, %s) AS plaintext
+                FROM workspace_vault_secrets
+                WHERE workspace_id = %s
+                """,
+                (enc_key, workspace_id),
+            )
+            rows = await cur.fetchall()
+            return {r["name"]: r["plaintext"] for r in rows}
+
+
+async def create_secret(
+    workspace_id: str, name: str, value: str, description: str = ""
+) -> None:
+    """Insert a new secret (encrypted). Raises ValueError on duplicate or limit."""
+    enc_key = _get_encryption_key()
+    async with get_db_connection() as conn:
+        async with conn.transaction():
+            async with conn.cursor(row_factory=dict_row) as cur:
+                # Check limit atomically within the transaction
+                await cur.execute(
+                    "SELECT COUNT(*) AS cnt FROM workspace_vault_secrets WHERE workspace_id = %s",
+                    (workspace_id,),
+                )
+                row = await cur.fetchone()
+                if row["cnt"] >= MAX_SECRETS_PER_WORKSPACE:
+                    raise ValueError(
+                        f"Maximum of {MAX_SECRETS_PER_WORKSPACE} secrets per workspace reached"
+                    )
+
+                await cur.execute(
+                    """
+                    INSERT INTO workspace_vault_secrets
+                        (workspace_id, name, value, description, created_at, updated_at)
+                    VALUES (%s, %s, pgp_sym_encrypt(%s, %s), %s, NOW(), NOW())
+                    ON CONFLICT (workspace_id, name) DO NOTHING
+                    RETURNING workspace_vault_secret_id
+                    """,
+                    (workspace_id, name, value, enc_key, description),
+                )
+                inserted = await cur.fetchone()
+                if not inserted:
+                    raise ValueError(
+                        f"Secret with name {name!r} already exists in this workspace"
+                    )
+                logger.info(
+                    f"[vault_db] create_secret workspace_id={workspace_id} name={name}"
+                )
+
+
+async def update_secret(
+    workspace_id: str,
+    name: str,
+    *,
+    value: str | None = None,
+    description: str | None = None,
+) -> bool:
+    """Partial update of a secret. Returns True if row was found."""
+    if value is None and description is None:
+        return True  # nothing to update
+
+    enc_key = _get_encryption_key()
+    async with get_db_connection() as conn:
+        async with conn.cursor() as cur:
+            parts: list[str] = []
+            params: list[Any] = []
+            if value is not None:
+                parts.append("value = pgp_sym_encrypt(%s, %s)")
+                params.extend([value, enc_key])
+            if description is not None:
+                parts.append("description = %s")
+                params.append(description)
+            parts.append("updated_at = NOW()")
+            params.extend([workspace_id, name])
+
+            await cur.execute(
+                f"UPDATE workspace_vault_secrets SET {', '.join(parts)} "
+                "WHERE workspace_id = %s AND name = %s",
+                params,
+            )
+            if cur.rowcount == 0:
+                return False
+            logger.info(
+                f"[vault_db] update_secret workspace_id={workspace_id} name={name}"
+            )
+            return True
+
+
+async def delete_secret(workspace_id: str, name: str) -> bool:
+    """Delete a secret by name. Returns True if row existed."""
+    async with get_db_connection() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                "DELETE FROM workspace_vault_secrets WHERE workspace_id = %s AND name = %s",
+                (workspace_id, name),
+            )
+            if cur.rowcount == 0:
+                return False
+            logger.info(
+                f"[vault_db] delete_secret workspace_id={workspace_id} name={name}"
+            )
+            return True
+
+
+def _mask(value: str) -> str:
+    """Mask a secret value for display: show first 3 and last 4 chars."""
+    if len(value) <= 8:
+        return "••••••••"
+    return value[:3] + "••••" + value[-4:]

--- a/src/server/database/vault_secrets.py
+++ b/src/server/database/vault_secrets.py
@@ -91,7 +91,11 @@ async def create_secret(
     async with get_db_connection() as conn:
         async with conn.transaction():
             async with conn.cursor(row_factory=dict_row) as cur:
-                # Check limit atomically within the transaction
+                # Serialize concurrent creates for the same workspace
+                await cur.execute(
+                    "SELECT pg_advisory_xact_lock(hashtext(%s))",
+                    (workspace_id,),
+                )
                 await cur.execute(
                     "SELECT COUNT(*) AS cnt FROM workspace_vault_secrets WHERE workspace_id = %s",
                     (workspace_id,),

--- a/src/server/services/workspace_manager.py
+++ b/src/server/services/workspace_manager.py
@@ -156,6 +156,36 @@ class WorkspaceManager:
         """Record that a sync was performed for this workspace."""
         self._last_sync_at[workspace_id] = time.monotonic()
 
+    async def push_vault_secrets(
+        self, workspace_id: str, sandbox: "PTCSandbox | None" = None,
+    ) -> None:
+        """Push vault secrets to the running sandbox.
+
+        Called by the vault API on mutation and by ``_sync_sandbox_assets``
+        during workspace startup/restart.
+
+        Args:
+            workspace_id: Workspace UUID.
+            sandbox: Optional sandbox to push to directly.  When omitted the
+                sandbox is looked up from the session cache — this fails during
+                initial startup (session not cached yet), so callers that
+                already hold a sandbox reference should pass it explicitly.
+        """
+        if sandbox is None:
+            session = self._sessions.get(workspace_id)
+            if not session or not session.sandbox:
+                return
+            sandbox = session.sandbox
+
+        from src.server.database.vault_secrets import get_workspace_secrets_decrypted
+
+        secrets = await get_workspace_secrets_decrypted(workspace_id)
+        await sandbox.upload_vault_secrets(secrets)
+        logger.info(
+            f"[vault] Pushed {len(secrets)} secret(s) to sandbox",
+            extra={"workspace_id": workspace_id},
+        )
+
     @staticmethod
     async def _mint_sandbox_tokens(user_id: str, workspace_id: str) -> dict:
         """Mint scoped OAuth2 tokens for sandbox ginlix-data access.
@@ -259,6 +289,11 @@ class WorkspaceManager:
                 workspace_id=workspace_id,
             )
         )
+
+        # Vault secrets — piggyback on existing parallel gather so
+        # secrets are available after stop/start and sandbox recovery.
+        # Pass sandbox directly: session may not be in self._sessions yet.
+        tasks.append(self.push_vault_secrets(workspace_id, sandbox=sandbox))
 
         # User data sync task
         if user_id:

--- a/src/server/utils/secret_redactor.py
+++ b/src/server/utils/secret_redactor.py
@@ -68,21 +68,38 @@ class SecretRedactor:
                 names=[name for name, _ in self._secrets],
             )
 
-    def redact(self, text: str) -> str:
-        """Replace known secret values with [REDACTED:KEY_NAME]."""
+    def redact(
+        self, text: str, vault_secrets: dict[str, str] | None = None,
+    ) -> str:
+        """Replace known secret values with [REDACTED:KEY_NAME].
+
+        Args:
+            text: Content to scan.
+            vault_secrets: Per-workspace vault secrets ({name: value}).
+                Merged into the scan alongside global MCP secrets.
+        """
         for name, value in self._secrets:
             if value in text:
                 text = text.replace(value, f"[REDACTED:{name}]")
+        if vault_secrets:
+            for name, value in sorted(
+                vault_secrets.items(), key=lambda kv: len(kv[1]), reverse=True,
+            ):
+                if value and len(value) >= 8 and value in text:
+                    text = text.replace(value, f"[REDACTED:{name}]")
         text = _SANDBOX_TOKEN_RE.sub("[REDACTED:SANDBOX_TOKEN]", text)
         return text
 
-    def redact_bytes(self, data: bytes, encoding: str = "utf-8") -> bytes:
+    def redact_bytes(
+        self, data: bytes, encoding: str = "utf-8",
+        vault_secrets: dict[str, str] | None = None,
+    ) -> bytes:
         """Decode bytes, redact secrets, re-encode. Returns original on decode failure."""
         try:
             text = data.decode(encoding)
         except (UnicodeDecodeError, LookupError):
             return data
-        return self.redact(text).encode(encoding)
+        return self.redact(text, vault_secrets=vault_secrets).encode(encoding)
 
 
 _instance: SecretRedactor | None = None
@@ -94,3 +111,32 @@ def get_redactor() -> SecretRedactor:
     if _instance is None:
         _instance = SecretRedactor()
     return _instance
+
+
+async def get_vault_secrets_for_redaction(workspace_id: str) -> dict[str, str]:
+    """Get per-workspace vault secrets for redaction.
+
+    Tries the active sandbox session first (zero cost), falls back to DB
+    for stopped workspaces.
+    """
+    # Fast path: read from active session (already in memory from push_vault_secrets)
+    try:
+        from src.server.services.workspace_manager import WorkspaceManager
+
+        wm = WorkspaceManager.get_instance()
+        session = wm._sessions.get(workspace_id)
+        if session and session.sandbox:
+            secrets = getattr(session.sandbox, "vault_secrets", None)
+            if secrets is not None:
+                return secrets
+    except Exception:
+        pass
+
+    # Slow path: DB query for stopped workspaces (infrequent, max 20 rows)
+    try:
+        from src.server.database.vault_secrets import get_workspace_secrets_decrypted
+
+        return await get_workspace_secrets_decrypted(workspace_id)
+    except Exception:
+        logger.warning("Failed to fetch vault secrets for redaction", workspace_id=workspace_id)
+        return {}

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -75,6 +75,10 @@ Cross-page data goes through shared hooks in `hooks/`.
 - **Per-component `.css` files** for scoped styles
 - **`clsx` + `tailwind-merge`** (`cn()` pattern) for conditional class merging in `components/ui/`
 
+### Layout Alignment
+
+The ChatAgent page has side-by-side panels (ChatView + FilePanel). Their headers must align horizontally. The ChatView top bar uses `px-4 py-2` with `p-2` buttons containing `h-5 w-5` icons (~52px total height). The FilePanel header (`file-panel-header` in `FilePanel.css`) must match this height — currently `padding: 12px 16px` with `6px`-padded buttons containing `h-4 w-4` icons. When modifying either header, verify they still align visually.
+
 ### Key Conventions
 
 - **Path alias:** `@` → `src/` (configured in both `vite.config.js` and `vitest.config.js`)

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -271,6 +271,7 @@
     "goToChats": "Go to Chats",
     "loadingHistory": "Loading history...",
     "workspaceFiles": "Workspace Files",
+    "workspaceSettings": "Workspace Settings",
     "agents": "Agents",
     "questionStarted": "Question started",
     "questionDeclined": "Question declined",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -271,6 +271,7 @@
     "goToChats": "返回对话列表",
     "loadingHistory": "加载历史记录...",
     "workspaceFiles": "工作区文件",
+    "workspaceSettings": "工作区设置",
     "agents": "智能体",
     "questionStarted": "问题已开始",
     "questionDeclined": "问题已跳过",

--- a/web/src/pages/ChatAgent/components/FilePanel.css
+++ b/web/src/pages/ChatAgent/components/FilePanel.css
@@ -10,7 +10,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 16px 16px;
+    padding: 12px 16px;
     border-bottom: 1px solid var(--color-border-muted);
     flex-shrink: 0;
   }

--- a/web/src/pages/ChatAgent/components/FilePanel.tsx
+++ b/web/src/pages/ChatAgent/components/FilePanel.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo, Suspense } from 'react';
 import type { editor } from 'monaco-editor';
-import { ArrowLeft, X, FileText, FileImage, File, RefreshCw, Download, Upload, Folder, ChevronRight, ChevronDown, ArrowUpDown, AlertTriangle, Trash2, CheckSquare, Square, HardDrive, Printer, Minus, Plus, Pencil, Save, FileDiff, Undo2, Redo2, TextSelect, FolderOpen } from 'lucide-react';
+import { ArrowLeft, X, FileText, FileImage, File, RefreshCw, Download, Upload, Folder, ChevronRight, ChevronDown, ArrowUpDown, AlertTriangle, Trash2, CheckSquare, Square, HardDrive, Printer, Minus, Plus, Pencil, Save, FileDiff, Undo2, Redo2, TextSelect, FolderOpen, Settings } from 'lucide-react';
+import { useWorkspace } from '@/hooks/useWorkspace';
+import { SandboxSettingsContent } from './SandboxSettingsPanel';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useReactToPrint } from 'react-to-print';
 import SyntaxHighlighter, { oneDark, oneLight } from './SyntaxHighlighter';
@@ -541,6 +543,12 @@ function FilePanel({
   const readFileFullFn = apiAdapter?.readFileFull
     ? (_: string, path: string) => apiAdapter.readFileFull!(path)
     : readWorkspaceFileFull;
+
+  // Workspace settings inline view
+  const [showSettings, setShowSettings] = useState(false);
+  const { data: wsData } = useWorkspace(workspaceId);
+  const isFlashWorkspace = wsData?.status === 'flash';
+  const workspaceName = wsData?.name;
 
   // File detail view state
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
@@ -1235,7 +1243,11 @@ function FilePanel({
       {/* Header */}
       <div className="file-panel-header">
         <div className="flex items-center gap-2 min-w-0">
-          {selectedFile ? (
+          {showSettings ? (
+            <button onClick={() => setShowSettings(false)} className="file-panel-icon-btn" title={t('filePanel.backToFileList')}>
+              <ArrowLeft className="h-4 w-4" />
+            </button>
+          ) : selectedFile ? (
             <button onClick={handleBack} className="file-panel-icon-btn" title={t('filePanel.backToFileList')}>
               <ArrowLeft className="h-4 w-4" />
             </button>
@@ -1249,11 +1261,11 @@ function FilePanel({
             </button>
           ) : null}
           <span className="text-sm font-semibold truncate" style={{ color: 'var(--color-text-primary)' }}>
-            {selectedFile ? (<>{fileName}{hasUnsavedChanges && <span style={{ color: 'var(--color-text-tertiary)' }}> *</span>}</>) : targetDirectory ? `${targetDirectory}/` : t('chat.workspaceFiles')}
+            {showSettings ? t('chat.workspaceSettings') : selectedFile ? (<>{fileName}{hasUnsavedChanges && <span style={{ color: 'var(--color-text-tertiary)' }}> *</span>}</>) : targetDirectory ? `${targetDirectory}/` : t('chat.workspaceFiles')}
           </span>
         </div>
         <div className="flex items-center gap-1">
-          {!selectedFile && !selectMode && (
+          {!showSettings && !selectedFile && !selectMode && (
             <>
               {!readOnly && files.length > 0 && (
                 <button
@@ -1547,7 +1559,7 @@ function FilePanel({
       )}
 
       {/* Filter & Sort toolbar */}
-      {!selectedFile && !filesLoading && !filesError && files.length > 0 && (
+      {!showSettings && !selectedFile && !filesLoading && !filesError && files.length > 0 && (
         <div className="file-panel-toolbar">
           <div className="file-panel-filter-chips">
             <button className={`file-panel-chip ${filterType === 'All' ? 'active' : ''}`} onClick={() => setFilterType('All')}>
@@ -1593,7 +1605,27 @@ function FilePanel({
         </div>
       )}
 
-      {/* Content */}
+      {/* Workspace settings card */}
+      {!showSettings && !selectedFile && !readOnly && !isFlashWorkspace && !selectMode && (
+        <div
+          className="flex items-center justify-between mx-3 mt-2 mb-1 px-3 py-2 rounded-lg cursor-pointer transition-colors hover:opacity-80"
+          style={{ backgroundColor: 'var(--color-bg-card)', border: '1px solid var(--color-border-muted)' }}
+          onClick={() => setShowSettings(true)}
+        >
+          <span className="text-xs truncate" style={{ color: 'var(--color-text-secondary)' }}>
+            {workspaceName || t('thread.workspace')}
+          </span>
+          <Settings className="h-3.5 w-3.5 flex-shrink-0" style={{ color: 'var(--color-text-tertiary)' }} />
+        </div>
+      )}
+
+      {/* Inline settings view */}
+      {showSettings ? (
+        <div style={{ flex: 1, minHeight: 0, overflow: 'hidden', padding: '0 12px 12px' }}>
+          <SandboxSettingsContent workspaceId={workspaceId} />
+        </div>
+      ) : (
+      /* Content */
       <div
         className="file-panel-content-wrapper"
         onDragEnter={!readOnly && !selectedFile ? handleDragEnter : undefined}
@@ -1775,6 +1807,7 @@ function FilePanel({
           )}
         </div>
       </div>
+      )}
     </div>
   );
 }

--- a/web/src/pages/ChatAgent/components/SandboxSettingsPanel.tsx
+++ b/web/src/pages/ChatAgent/components/SandboxSettingsPanel.tsx
@@ -3,9 +3,9 @@ import {
   X, Cpu, MemoryStick, HardDrive, MonitorCog, Play, Square,
   Package, Search, RefreshCw, ChevronDown, ChevronRight,
   Server, Loader2, BookOpen, Archive, KeyRound,
-  Plus, Trash2, Pencil,
+  Plus, Trash2, Pencil, Eye, EyeOff,
 } from 'lucide-react';
-import { getSandboxStats, installSandboxPackages, refreshWorkspace, getVaultSecrets, createVaultSecret, updateVaultSecret, deleteVaultSecret } from '../utils/api';
+import { getSandboxStats, installSandboxPackages, refreshWorkspace, getVaultSecrets, createVaultSecret, updateVaultSecret, deleteVaultSecret, revealVaultSecret } from '../utils/api';
 import { api } from '@/api/client';
 
 interface SandboxSettingsPanelProps {
@@ -70,11 +70,9 @@ interface RefreshResult {
 }
 
 /**
- * SandboxSettingsPanel -- full-screen overlay showing sandbox details.
- *
- * Tabs: Overview | Storage | Packages | Tools & Skills
+ * SandboxSettingsContent -- sandbox settings tabs and content, usable inline or in a modal.
  */
-export default function SandboxSettingsPanel({ onClose, workspaceId }: SandboxSettingsPanelProps) {
+export function SandboxSettingsContent({ workspaceId }: { workspaceId: string }) {
   const [activeTab, setActiveTab] = useState('overview');
   const [stats, setStats] = useState<SandboxStats | null>(null);
   const [loading, setLoading] = useState(true);
@@ -183,14 +181,104 @@ export default function SandboxSettingsPanel({ onClose, workspaceId }: SandboxSe
 
   const tabs = [
     { key: 'overview', label: 'Overview' },
+    { key: 'vault', label: 'Vault' },
     { key: 'storage', label: 'Storage' },
     { key: 'packages', label: 'Packages' },
     { key: 'tools', label: 'Tools & Skills' },
-    { key: 'secrets', label: 'Secrets' },
   ];
 
   const isRunning = stats?.state === 'started';
 
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      {/* Tabs */}
+      <div className="flex flex-wrap gap-1 mb-4 border-b" style={{ borderColor: 'var(--color-border-muted)' }}>
+        {tabs.map(t => (
+          <button
+            key={t.key}
+            type="button"
+            onClick={() => setActiveTab(t.key)}
+            className="px-3 py-2 text-sm font-medium"
+            style={{
+              color: activeTab === t.key ? 'var(--color-text-primary)' : 'var(--color-text-tertiary)',
+              borderBottom: activeTab === t.key ? '2px solid var(--color-accent-primary)' : '2px solid transparent',
+            }}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Content */}
+      <div style={{ flex: 1, minHeight: 0, overflowY: 'auto' }}>
+      {loading ? (
+        <LoadingSkeleton />
+      ) : error ? (
+        <ErrorState message={error} onRetry={loadStats} />
+      ) : (
+        <>
+          {activeTab === 'overview' && (
+            <OverviewTab
+              stats={stats!}
+              isRunning={isRunning!}
+              actionLoading={actionLoading}
+              onStartStop={handleStartStop}
+            />
+          )}
+          {activeTab === 'vault' && (
+            <SecretsTab workspaceId={workspaceId} />
+          )}
+          {activeTab === 'storage' && (
+            isRunning ? (
+              <StorageTab
+                stats={stats!}
+                showDirBreakdown={showDirBreakdown}
+                onToggleBreakdown={() => setShowDirBreakdown(!showDirBreakdown)}
+              />
+            ) : (
+              <OfflineTabPlaceholder tabName="storage" />
+            )
+          )}
+          {activeTab === 'packages' && (
+            isRunning ? (
+              <PackagesTab
+                filteredPackages={filteredPackages}
+                defaultPkgSet={defaultPkgSet}
+                pkgSearch={pkgSearch}
+                onSearchChange={setPkgSearch}
+                installInput={installInput}
+                onInstallInputChange={setInstallInput}
+                installing={installing}
+                installResult={installResult}
+                onInstall={handleInstall}
+              />
+            ) : (
+              <OfflineTabPlaceholder tabName="packages" />
+            )
+          )}
+          {activeTab === 'tools' && (
+            isRunning ? (
+              <ToolsTab
+                stats={stats!}
+                refreshing={refreshing}
+                refreshResult={refreshResult}
+                onRefresh={handleRefresh}
+              />
+            ) : (
+              <OfflineTabPlaceholder tabName="tools & skills" />
+            )
+          )}
+        </>
+      )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * SandboxSettingsPanel -- full-screen overlay showing sandbox details.
+ */
+export default function SandboxSettingsPanel({ onClose, workspaceId }: SandboxSettingsPanelProps) {
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center"
@@ -223,86 +311,7 @@ export default function SandboxSettingsPanel({ onClose, workspaceId }: SandboxSe
           Sandbox Settings
         </h2>
 
-        {/* Tabs */}
-        <div className="flex gap-2 mb-6 border-b" style={{ borderColor: 'var(--color-border-muted)' }}>
-          {tabs.map(t => (
-            <button
-              key={t.key}
-              type="button"
-              onClick={() => setActiveTab(t.key)}
-              className="px-4 py-2 text-sm font-medium"
-              style={{
-                color: activeTab === t.key ? 'var(--color-text-primary)' : 'var(--color-text-tertiary)',
-                borderBottom: activeTab === t.key ? '2px solid var(--color-accent-primary)' : '2px solid transparent',
-              }}
-            >
-              {t.label}
-            </button>
-          ))}
-        </div>
-
-        {/* Content */}
-        <div style={{ flex: 1, minHeight: 0, overflowY: 'auto' }}>
-        {loading ? (
-          <LoadingSkeleton />
-        ) : error ? (
-          <ErrorState message={error} onRetry={loadStats} />
-        ) : (
-          <>
-            {activeTab === 'overview' && (
-              <OverviewTab
-                stats={stats!}
-                isRunning={isRunning!}
-                actionLoading={actionLoading}
-                onStartStop={handleStartStop}
-              />
-            )}
-            {activeTab === 'storage' && (
-              isRunning ? (
-                <StorageTab
-                  stats={stats!}
-                  showDirBreakdown={showDirBreakdown}
-                  onToggleBreakdown={() => setShowDirBreakdown(!showDirBreakdown)}
-                />
-              ) : (
-                <OfflineTabPlaceholder tabName="storage" />
-              )
-            )}
-            {activeTab === 'packages' && (
-              isRunning ? (
-                <PackagesTab
-                  filteredPackages={filteredPackages}
-                  defaultPkgSet={defaultPkgSet}
-                  pkgSearch={pkgSearch}
-                  onSearchChange={setPkgSearch}
-                  installInput={installInput}
-                  onInstallInputChange={setInstallInput}
-                  installing={installing}
-                  installResult={installResult}
-                  onInstall={handleInstall}
-                />
-              ) : (
-                <OfflineTabPlaceholder tabName="packages" />
-              )
-            )}
-            {activeTab === 'tools' && (
-              isRunning ? (
-                <ToolsTab
-                  stats={stats!}
-                  refreshing={refreshing}
-                  refreshResult={refreshResult}
-                  onRefresh={handleRefresh}
-                />
-              ) : (
-                <OfflineTabPlaceholder tabName="tools & skills" />
-              )
-            )}
-            {activeTab === 'secrets' && (
-              <SecretsTab workspaceId={workspaceId} />
-            )}
-          </>
-        )}
-        </div>
+        <SandboxSettingsContent workspaceId={workspaceId} />
       </div>
     </div>
   );
@@ -843,6 +852,12 @@ function SecretsTab({ workspaceId }: { workspaceId: string }) {
   // Delete confirmation
   const [deletingName, setDeletingName] = useState<string | null>(null);
 
+  // Visibility toggles
+  const [showNewValue, setShowNewValue] = useState(false);
+  const [showEditValue, setShowEditValue] = useState(false);
+  const [revealedSecrets, setRevealedSecrets] = useState<Record<string, string>>({});
+  const [revealingName, setRevealingName] = useState<string | null>(null);
+
   async function load() {
     setLoading(true);
     setError(null);
@@ -875,6 +890,7 @@ function SecretsTab({ workspaceId }: { workspaceId: string }) {
       setNewName('');
       setNewValue('');
       setNewDesc('');
+      setShowNewValue(false);
       setShowAdd(false);
       await load();
     } catch (err: any) {
@@ -895,6 +911,12 @@ function SecretsTab({ workspaceId }: { workspaceId: string }) {
       setEditingName(null);
       setEditValue('');
       setEditDesc('');
+      setShowEditValue(false);
+      setRevealedSecrets(prev => {
+        const next = { ...prev };
+        delete next[name];
+        return next;
+      });
       await load();
     } catch (err: any) {
       setError(err?.response?.data?.detail || err.message || 'Failed to update secret');
@@ -919,6 +941,26 @@ function SecretsTab({ workspaceId }: { workspaceId: string }) {
     }
   }
 
+  async function handleRevealToggle(name: string) {
+    if (revealedSecrets[name] !== undefined) {
+      setRevealedSecrets(prev => {
+        const next = { ...prev };
+        delete next[name];
+        return next;
+      });
+      return;
+    }
+    setRevealingName(name);
+    try {
+      const value = await revealVaultSecret(workspaceId, name);
+      setRevealedSecrets(prev => ({ ...prev, [name]: value }));
+    } catch (err: any) {
+      setError(err?.response?.data?.detail || err.message || 'Failed to reveal secret');
+    } finally {
+      setRevealingName(null);
+    }
+  }
+
   if (loading) {
     return (
       <div className="flex flex-col gap-3">
@@ -936,7 +978,7 @@ function SecretsTab({ workspaceId }: { workspaceId: string }) {
         <div className="flex items-center gap-2">
           <KeyRound className="h-4 w-4" style={{ color: 'var(--color-accent-primary)' }} />
           <span className="text-sm font-medium" style={{ color: 'var(--color-text-primary)' }}>
-            Vault Secrets
+            Vault
           </span>
           <span className="text-xs px-1.5 py-0.5 rounded" style={{ color: 'var(--color-text-tertiary)', backgroundColor: 'var(--color-bg-card)' }}>
             {secrets.length} / {MAX_SECRETS}
@@ -978,15 +1020,26 @@ function SecretsTab({ workspaceId }: { workspaceId: string }) {
             style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
             maxLength={64}
           />
-          <input
-            type="password"
-            value={newValue}
-            onChange={e => setNewValue(e.target.value)}
-            placeholder="Secret value"
-            className="w-full px-3 py-2 text-sm rounded-md bg-transparent outline-none"
-            style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
-            maxLength={4096}
-          />
+          <div className="relative">
+            <input
+              type={showNewValue ? 'text' : 'password'}
+              value={newValue}
+              onChange={e => setNewValue(e.target.value)}
+              placeholder="Secret value"
+              className="w-full px-3 py-2 pr-9 text-sm rounded-md bg-transparent outline-none"
+              style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
+              maxLength={4096}
+            />
+            <button
+              type="button"
+              onClick={() => setShowNewValue(!showNewValue)}
+              className="absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded transition-colors hover:bg-foreground/10"
+              style={{ color: 'var(--color-text-tertiary)' }}
+              tabIndex={-1}
+            >
+              {showNewValue ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
+            </button>
+          </div>
           <input
             type="text"
             value={newDesc}
@@ -998,7 +1051,7 @@ function SecretsTab({ workspaceId }: { workspaceId: string }) {
           />
           <div className="flex justify-end gap-2 mt-1">
             <button
-              onClick={() => { setShowAdd(false); setNewName(''); setNewValue(''); setNewDesc(''); }}
+              onClick={() => { setShowAdd(false); setNewName(''); setNewValue(''); setNewDesc(''); setShowNewValue(false); }}
               className="px-3 py-1.5 text-xs rounded-md transition-colors hover:bg-foreground/10"
               style={{ color: 'var(--color-text-tertiary)' }}
             >
@@ -1035,15 +1088,26 @@ function SecretsTab({ workspaceId }: { workspaceId: string }) {
                   <div className="text-sm font-mono font-medium" style={{ color: 'var(--color-text-primary)' }}>
                     {secret.name}
                   </div>
-                  <input
-                    type="password"
-                    value={editValue}
-                    onChange={e => setEditValue(e.target.value)}
-                    placeholder="New value (leave empty to keep current)"
-                    className="w-full px-3 py-2 text-sm rounded-md bg-transparent outline-none"
-                    style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
-                    maxLength={4096}
-                  />
+                  <div className="relative">
+                    <input
+                      type={showEditValue ? 'text' : 'password'}
+                      value={editValue}
+                      onChange={e => setEditValue(e.target.value)}
+                      placeholder="New value (leave empty to keep current)"
+                      className="w-full px-3 py-2 pr-9 text-sm rounded-md bg-transparent outline-none"
+                      style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
+                      maxLength={4096}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowEditValue(!showEditValue)}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded transition-colors hover:bg-foreground/10"
+                      style={{ color: 'var(--color-text-tertiary)' }}
+                      tabIndex={-1}
+                    >
+                      {showEditValue ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
+                    </button>
+                  </div>
                   <input
                     type="text"
                     value={editDesc}
@@ -1055,7 +1119,7 @@ function SecretsTab({ workspaceId }: { workspaceId: string }) {
                   />
                   <div className="flex justify-end gap-2 mt-1">
                     <button
-                      onClick={() => { setEditingName(null); setEditValue(''); setEditDesc(''); }}
+                      onClick={() => { setEditingName(null); setEditValue(''); setEditDesc(''); setShowEditValue(false); }}
                       className="px-3 py-1.5 text-xs rounded-md transition-colors hover:bg-foreground/10"
                       style={{ color: 'var(--color-text-tertiary)' }}
                     >
@@ -1084,7 +1148,7 @@ function SecretsTab({ workspaceId }: { workspaceId: string }) {
                         {secret.name}
                       </span>
                       <span className="text-xs font-mono" style={{ color: 'var(--color-text-tertiary)' }}>
-                        {secret.masked_value}
+                        {revealedSecrets[secret.name] !== undefined ? revealedSecrets[secret.name] : secret.masked_value}
                       </span>
                     </div>
                     {secret.description && (
@@ -1094,6 +1158,21 @@ function SecretsTab({ workspaceId }: { workspaceId: string }) {
                     )}
                   </div>
                   <div className="flex items-center gap-1 flex-shrink-0 ml-2">
+                    <button
+                      onClick={() => handleRevealToggle(secret.name)}
+                      disabled={revealingName === secret.name}
+                      className="p-1.5 rounded transition-colors hover:bg-foreground/10 disabled:opacity-50"
+                      style={{ color: 'var(--color-text-tertiary)' }}
+                      title={revealedSecrets[secret.name] !== undefined ? 'Hide value' : 'Reveal value'}
+                    >
+                      {revealingName === secret.name ? (
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      ) : revealedSecrets[secret.name] !== undefined ? (
+                        <EyeOff className="h-3.5 w-3.5" />
+                      ) : (
+                        <Eye className="h-3.5 w-3.5" />
+                      )}
+                    </button>
                     <button
                       onClick={() => {
                         setEditingName(secret.name);
@@ -1143,12 +1222,29 @@ function SecretsTab({ workspaceId }: { workspaceId: string }) {
         </div>
       )}
 
-      {/* Usage hint */}
+      {/* Usage & Security info */}
       <div
-        className="text-xs p-3 rounded-lg mt-1"
+        className="flex flex-col gap-2.5 text-xs p-3 rounded-lg mt-1"
         style={{ backgroundColor: 'var(--color-bg-card)', color: 'var(--color-text-tertiary)' }}
       >
-        Access in code: <code className="font-mono" style={{ color: 'var(--color-text-secondary)' }}>from vault import get; key = get("SECRET_NAME")</code>
+        <div>
+          <span className="font-medium" style={{ color: 'var(--color-text-secondary)' }}>Usage</span>
+          <div className="mt-1">
+            Access in code: <code className="font-mono" style={{ color: 'var(--color-text-secondary)' }}>{'from vault import get; key = get("SECRET_NAME")'}</code>
+          </div>
+        </div>
+        <div
+          className="pt-2 flex flex-col gap-1.5"
+          style={{ borderTop: '1px solid var(--color-border-muted)' }}
+        >
+          <span className="font-medium" style={{ color: 'var(--color-text-secondary)' }}>Security</span>
+          <ul className="flex flex-col gap-1 pl-3" style={{ listStyleType: 'disc' }}>
+            <li>Secrets are encrypted at rest with AES (pgcrypto) and never stored in plaintext on our servers.</li>
+            <li>The AI agent cannot read secret values directly &mdash; it can only call <code className="font-mono" style={{ color: 'var(--color-text-secondary)' }}>vault.get()</code> inside sandboxed code.</li>
+            <li>All agent output is scanned by leak detection. Any secret value found in tool results is automatically redacted before reaching the model.</li>
+            <li>Direct file access to the internal secret store is blocked by code validation &mdash; only the <code className="font-mono" style={{ color: 'var(--color-text-secondary)' }}>vault</code> API is allowed.</li>
+          </ul>
+        </div>
       </div>
     </div>
   );

--- a/web/src/pages/ChatAgent/components/SandboxSettingsPanel.tsx
+++ b/web/src/pages/ChatAgent/components/SandboxSettingsPanel.tsx
@@ -2,9 +2,10 @@ import React, { useState, useEffect, useMemo } from 'react';
 import {
   X, Cpu, MemoryStick, HardDrive, MonitorCog, Play, Square,
   Package, Search, RefreshCw, ChevronDown, ChevronRight,
-  Server, Loader2, BookOpen, Archive,
+  Server, Loader2, BookOpen, Archive, KeyRound,
+  Plus, Trash2, Pencil,
 } from 'lucide-react';
-import { getSandboxStats, installSandboxPackages, refreshWorkspace } from '../utils/api';
+import { getSandboxStats, installSandboxPackages, refreshWorkspace, getVaultSecrets, createVaultSecret, updateVaultSecret, deleteVaultSecret } from '../utils/api';
 import { api } from '@/api/client';
 
 interface SandboxSettingsPanelProps {
@@ -185,6 +186,7 @@ export default function SandboxSettingsPanel({ onClose, workspaceId }: SandboxSe
     { key: 'storage', label: 'Storage' },
     { key: 'packages', label: 'Packages' },
     { key: 'tools', label: 'Tools & Skills' },
+    { key: 'secrets', label: 'Secrets' },
   ];
 
   const isRunning = stats?.state === 'started';
@@ -294,6 +296,9 @@ export default function SandboxSettingsPanel({ onClose, workspaceId }: SandboxSe
               ) : (
                 <OfflineTabPlaceholder tabName="tools & skills" />
               )
+            )}
+            {activeTab === 'secrets' && (
+              <SecretsTab workspaceId={workspaceId} />
             )}
           </>
         )}
@@ -795,6 +800,355 @@ function ToolsTab({ stats, refreshing, refreshResult, onRefresh }: ToolsTabProps
             )}
           </div>
         )}
+      </div>
+    </div>
+  );
+}
+
+
+// ---------------------------------------------------------------------------
+// Secrets Tab
+// ---------------------------------------------------------------------------
+
+const MAX_SECRETS = 20;
+const NAME_RE = /^[A-Za-z_][A-Za-z0-9_]{0,63}$/;
+
+interface VaultSecret {
+  workspace_vault_secret_id: string;
+  name: string;
+  description: string;
+  masked_value: string;
+  created_at: string;
+  updated_at: string;
+}
+
+function SecretsTab({ workspaceId }: { workspaceId: string }) {
+  const [secrets, setSecrets] = useState<VaultSecret[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Add form
+  const [showAdd, setShowAdd] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [newValue, setNewValue] = useState('');
+  const [newDesc, setNewDesc] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  // Edit state
+  const [editingName, setEditingName] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState('');
+  const [editDesc, setEditDesc] = useState('');
+  const [editSaving, setEditSaving] = useState(false);
+
+  // Delete confirmation
+  const [deletingName, setDeletingName] = useState<string | null>(null);
+
+  async function load() {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await getVaultSecrets(workspaceId);
+      setSecrets(data);
+    } catch (err: any) {
+      setError(err?.response?.data?.detail || err.message || 'Failed to load secrets');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { load(); }, [workspaceId]);
+
+  async function handleCreate() {
+    if (!newName || !newValue) return;
+    if (!NAME_RE.test(newName)) {
+      setError('Name must use letters, digits, underscores; start with letter or underscore');
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      await createVaultSecret(workspaceId, {
+        name: newName,
+        value: newValue,
+        description: newDesc,
+      });
+      setNewName('');
+      setNewValue('');
+      setNewDesc('');
+      setShowAdd(false);
+      await load();
+    } catch (err: any) {
+      setError(err?.response?.data?.detail || err.message || 'Failed to create secret');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleUpdate(name: string) {
+    setEditSaving(true);
+    setError(null);
+    try {
+      const body: { value?: string; description?: string } = {};
+      if (editValue) body.value = editValue;
+      body.description = editDesc;
+      await updateVaultSecret(workspaceId, name, body);
+      setEditingName(null);
+      setEditValue('');
+      setEditDesc('');
+      await load();
+    } catch (err: any) {
+      setError(err?.response?.data?.detail || err.message || 'Failed to update secret');
+    } finally {
+      setEditSaving(false);
+    }
+  }
+
+  const [deleteLoading, setDeleteLoading] = useState(false);
+
+  async function handleDelete(name: string) {
+    setDeleteLoading(true);
+    setError(null);
+    try {
+      await deleteVaultSecret(workspaceId, name);
+      setDeletingName(null);
+      await load();
+    } catch (err: any) {
+      setError(err?.response?.data?.detail || err.message || 'Failed to delete secret');
+    } finally {
+      setDeleteLoading(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex flex-col gap-3">
+        {[1, 2].map(i => (
+          <div key={i} className="h-14 rounded-lg animate-pulse" style={{ backgroundColor: 'var(--color-bg-card)' }} />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Header + counter */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <KeyRound className="h-4 w-4" style={{ color: 'var(--color-accent-primary)' }} />
+          <span className="text-sm font-medium" style={{ color: 'var(--color-text-primary)' }}>
+            Vault Secrets
+          </span>
+          <span className="text-xs px-1.5 py-0.5 rounded" style={{ color: 'var(--color-text-tertiary)', backgroundColor: 'var(--color-bg-card)' }}>
+            {secrets.length} / {MAX_SECRETS}
+          </span>
+        </div>
+        {secrets.length < MAX_SECRETS && (
+          <button
+            onClick={() => { setShowAdd(!showAdd); setError(null); }}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-md transition-colors"
+            style={{
+              color: 'var(--color-text-on-accent)',
+              backgroundColor: 'var(--color-accent-primary)',
+            }}
+          >
+            <Plus className="h-3 w-3" />
+            Add Secret
+          </button>
+        )}
+      </div>
+
+      {error && (
+        <div className="text-xs p-2 rounded" style={{ backgroundColor: 'var(--color-bg-card)', color: 'var(--color-loss)' }}>
+          {error}
+        </div>
+      )}
+
+      {/* Add form */}
+      {showAdd && (
+        <div
+          className="flex flex-col gap-2 p-3 rounded-lg"
+          style={{ backgroundColor: 'var(--color-bg-card)', border: '1px solid var(--color-border-muted)' }}
+        >
+          <input
+            type="text"
+            value={newName}
+            onChange={e => setNewName(e.target.value.toUpperCase().replace(/[^A-Z0-9_]/g, ''))}
+            placeholder="SECRET_NAME"
+            className="w-full px-3 py-2 text-sm rounded-md bg-transparent outline-none font-mono"
+            style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
+            maxLength={64}
+          />
+          <input
+            type="password"
+            value={newValue}
+            onChange={e => setNewValue(e.target.value)}
+            placeholder="Secret value"
+            className="w-full px-3 py-2 text-sm rounded-md bg-transparent outline-none"
+            style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
+            maxLength={4096}
+          />
+          <input
+            type="text"
+            value={newDesc}
+            onChange={e => setNewDesc(e.target.value)}
+            placeholder="Description (optional)"
+            className="w-full px-3 py-2 text-sm rounded-md bg-transparent outline-none"
+            style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
+            maxLength={256}
+          />
+          <div className="flex justify-end gap-2 mt-1">
+            <button
+              onClick={() => { setShowAdd(false); setNewName(''); setNewValue(''); setNewDesc(''); }}
+              className="px-3 py-1.5 text-xs rounded-md transition-colors hover:bg-foreground/10"
+              style={{ color: 'var(--color-text-tertiary)' }}
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleCreate}
+              disabled={saving || !newName || !newValue}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-md transition-colors disabled:opacity-50"
+              style={{ color: 'var(--color-text-on-accent)', backgroundColor: 'var(--color-accent-primary)' }}
+            >
+              {saving && <Loader2 className="h-3 w-3 animate-spin" />}
+              Save
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Secret list */}
+      {secrets.length === 0 ? (
+        <div className="py-8 text-center text-sm" style={{ color: 'var(--color-text-tertiary)' }}>
+          No secrets stored. Add API keys or credentials for agent code to use.
+        </div>
+      ) : (
+        <div className="flex flex-col gap-1">
+          {secrets.map(secret => (
+            <div key={secret.workspace_vault_secret_id}>
+              {editingName === secret.name ? (
+                /* Edit form */
+                <div
+                  className="flex flex-col gap-2 p-3 rounded-lg"
+                  style={{ backgroundColor: 'var(--color-bg-card)', border: '1px solid var(--color-accent-primary)' }}
+                >
+                  <div className="text-sm font-mono font-medium" style={{ color: 'var(--color-text-primary)' }}>
+                    {secret.name}
+                  </div>
+                  <input
+                    type="password"
+                    value={editValue}
+                    onChange={e => setEditValue(e.target.value)}
+                    placeholder="New value (leave empty to keep current)"
+                    className="w-full px-3 py-2 text-sm rounded-md bg-transparent outline-none"
+                    style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
+                    maxLength={4096}
+                  />
+                  <input
+                    type="text"
+                    value={editDesc}
+                    onChange={e => setEditDesc(e.target.value)}
+                    placeholder="Description"
+                    className="w-full px-3 py-2 text-sm rounded-md bg-transparent outline-none"
+                    style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
+                    maxLength={256}
+                  />
+                  <div className="flex justify-end gap-2 mt-1">
+                    <button
+                      onClick={() => { setEditingName(null); setEditValue(''); setEditDesc(''); }}
+                      className="px-3 py-1.5 text-xs rounded-md transition-colors hover:bg-foreground/10"
+                      style={{ color: 'var(--color-text-tertiary)' }}
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={() => handleUpdate(secret.name)}
+                      disabled={editSaving}
+                      className="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-md transition-colors disabled:opacity-50"
+                      style={{ color: 'var(--color-text-on-accent)', backgroundColor: 'var(--color-accent-primary)' }}
+                    >
+                      {editSaving && <Loader2 className="h-3 w-3 animate-spin" />}
+                      Update
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                /* Display row */
+                <div
+                  className="flex items-center justify-between py-2.5 px-3 rounded-lg"
+                  style={{ backgroundColor: 'var(--color-bg-card)' }}
+                >
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-mono font-medium" style={{ color: 'var(--color-text-primary)' }}>
+                        {secret.name}
+                      </span>
+                      <span className="text-xs font-mono" style={{ color: 'var(--color-text-tertiary)' }}>
+                        {secret.masked_value}
+                      </span>
+                    </div>
+                    {secret.description && (
+                      <p className="text-xs mt-0.5 truncate" style={{ color: 'var(--color-text-tertiary)' }}>
+                        {secret.description}
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-1 flex-shrink-0 ml-2">
+                    <button
+                      onClick={() => {
+                        setEditingName(secret.name);
+                        setEditValue('');
+                        setEditDesc(secret.description);
+                        setError(null);
+                      }}
+                      className="p-1.5 rounded transition-colors hover:bg-foreground/10"
+                      style={{ color: 'var(--color-text-tertiary)' }}
+                      title="Edit"
+                    >
+                      <Pencil className="h-3.5 w-3.5" />
+                    </button>
+                    {deletingName === secret.name ? (
+                      <div className="flex items-center gap-1">
+                        <button
+                          onClick={() => handleDelete(secret.name)}
+                          disabled={deleteLoading}
+                          className="px-2 py-1 text-xs rounded transition-colors disabled:opacity-50"
+                          style={{ color: 'var(--color-loss)', backgroundColor: 'var(--color-bg-card)' }}
+                        >
+                          {deleteLoading ? 'Deleting…' : 'Confirm'}
+                        </button>
+                        <button
+                          onClick={() => setDeletingName(null)}
+                          className="px-2 py-1 text-xs rounded transition-colors hover:bg-foreground/10"
+                          style={{ color: 'var(--color-text-tertiary)' }}
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    ) : (
+                      <button
+                        onClick={() => setDeletingName(secret.name)}
+                        className="p-1.5 rounded transition-colors hover:bg-foreground/10"
+                        style={{ color: 'var(--color-text-tertiary)' }}
+                        title="Delete"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Usage hint */}
+      <div
+        className="text-xs p-3 rounded-lg mt-1"
+        style={{ backgroundColor: 'var(--color-bg-card)', color: 'var(--color-text-tertiary)' }}
+      >
+        Access in code: <code className="font-mono" style={{ color: 'var(--color-text-secondary)' }}>from vault import get; key = get("SECRET_NAME")</code>
       </div>
     </div>
   );

--- a/web/src/pages/ChatAgent/components/SandboxSettingsPanel.tsx
+++ b/web/src/pages/ChatAgent/components/SandboxSettingsPanel.tsx
@@ -1014,7 +1014,7 @@ function SecretsTab({ workspaceId }: { workspaceId: string }) {
           <input
             type="text"
             value={newName}
-            onChange={e => setNewName(e.target.value.toUpperCase().replace(/[^A-Z0-9_]/g, ''))}
+            onChange={e => setNewName(e.target.value.toUpperCase().replace(/[^A-Z0-9_]/g, '').replace(/^[0-9]+/, ''))}
             placeholder="SECRET_NAME"
             className="w-full px-3 py-2 text-sm rounded-md bg-transparent outline-none font-mono"
             style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}

--- a/web/src/pages/ChatAgent/utils/api.ts
+++ b/web/src/pages/ChatAgent/utils/api.ts
@@ -693,6 +693,11 @@ export async function updateVaultSecret(workspaceId: string, name: string, body:
   return data;
 }
 
+export async function revealVaultSecret(workspaceId: string, name: string) {
+  const { data } = await api.get(`/api/v1/workspaces/${workspaceId}/vault/secrets/${name}/reveal`);
+  return data.value as string;
+}
+
 export async function deleteVaultSecret(workspaceId: string, name: string) {
   const { data } = await api.delete(`/api/v1/workspaces/${workspaceId}/vault/secrets/${name}`);
   return data;

--- a/web/src/pages/ChatAgent/utils/api.ts
+++ b/web/src/pages/ChatAgent/utils/api.ts
@@ -675,3 +675,25 @@ export async function uploadWorkspaceFile(
   );
   return data;
 }
+
+// --- Vault Secrets ---
+
+export async function getVaultSecrets(workspaceId: string) {
+  const { data } = await api.get(`/api/v1/workspaces/${workspaceId}/vault/secrets`);
+  return data.secrets;
+}
+
+export async function createVaultSecret(workspaceId: string, body: { name: string; value: string; description?: string }) {
+  const { data } = await api.post(`/api/v1/workspaces/${workspaceId}/vault/secrets`, body);
+  return data;
+}
+
+export async function updateVaultSecret(workspaceId: string, name: string, body: { value?: string; description?: string }) {
+  const { data } = await api.put(`/api/v1/workspaces/${workspaceId}/vault/secrets/${name}`, body);
+  return data;
+}
+
+export async function deleteVaultSecret(workspaceId: string, name: string) {
+  const { data } = await api.delete(`/api/v1/workspaces/${workspaceId}/vault/secrets/${name}`);
+  return data;
+}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -21,6 +21,7 @@ export interface UserPreferences {
 export interface Workspace {
   workspace_id: string;
   name: string;
+  status?: string;
   description?: string;
   config?: Record<string, unknown>;
   created_at?: string;


### PR DESCRIPTION
## Summary

Adds a per-workspace **Vault** for storing encrypted API keys and credentials. Secrets are encrypted at rest via pgcrypto (pgp_sym_encrypt), synced into running sandboxes so agent code can access them via `from vault import get`, and covered end-to-end by leak detection and code validation middleware.

## Changes

- **DB migration** (`003_add_vault_secrets.py`): `workspace_vault_secrets` table with pgcrypto encryption, unique index, and updated_at trigger
- **CRUD layer** (`src/server/database/vault_secrets.py`): encrypt/decrypt wrappers, 20-secret-per-workspace limit, masking for list view
- **REST API** (`src/server/app/vault.py`): GET/POST/PUT/DELETE/reveal endpoints, workspace ownership checked on every request
- **Sandbox integration** (`ptc_sandbox.py`, `vault_helper.py`): secrets JSON uploaded to `_internal/.vault_secrets.json`; `vault.py` helper module injected at init so `from vault import get` always works
- **Leak detection** (`leak_detection.py`, `secret_redactor.py`): vault secrets merged into redaction list both in the middleware stack and on file-read endpoints
- **Code validation** (`code_validation.py`): `.vault_secrets` path added to protected internal files
- **Frontend** (`SandboxSettingsPanel.tsx`, `FilePanel.tsx`): new Vault tab in settings with add/edit/delete/reveal UI; inline settings accessible via gear icon in FilePanel header

## Test Plan

- Sandbox integration CI passing (51 ops, 100% success)
- Manual: create/update/delete/reveal secrets via UI; verify `vault.get()` works in agent code; verify leak detection redacts vault values in file reads