### PR TITLE
feat: inline HTML widget rendering with data_files support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ Pages are lazy-loaded in `Main.jsx`. Each page group has its own `utils/api.js` 
 The agent does NOT use a hand-written `StateGraph`. It uses `create_agent()` from the `deepagents` library, wrapped in a deep middleware stack:
 
 **`src/ptc_agent/agent/agent.py` — `PTCAgent.create_agent()`** assembles:
-1. **Tools**: `execute_code`, `bash`, filesystem ops (read/write/edit/glob/grep), `web_search`, `web_fetch`, SEC/market tools
+1. **Tools**: `execute_code`, `bash`, filesystem ops (read/write/edit/glob/grep), `show_widget` (inline HTML visualizations), `web_search`, `web_fetch`, SEC/market tools
 2. **Middleware chain** (~23 layers): tool argument parsing → protected paths → error handling → leak detection → file/todo artifact emission → multimodal support → skills → steering → background subagents → HITL → summarization → model retry/fallback → prompt caching → workspace context injection
 3. **`BackgroundSubagentOrchestrator`** wraps the agent for parallel background task coordination
 

--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ flowchart TB
         T2["Filesystem<br/>read · write · edit<br/>glob · grep"]
         T3["Finance<br/>Market Data · SEC<br/>Options · Screener"]
         T4["Web<br/>Search · Fetch"]
+        T5["ShowWidget<br/>Inline HTML"]
     end
 
     T1 <--> Workspace
@@ -326,6 +327,7 @@ Vault secrets inherit every protection layer above — encrypted at rest, redact
 The web UI is more than a chat interface — it's a full research workbench:
 
 - **Inline financial charts** — tool results render as interactive sparklines, bar charts, and overview cards directly in the chat thread
+- **Inline HTML widgets** — the agent can render interactive HTML/SVG visualizations (Chart.js charts, metric cards, data tables) directly in the chat via the `ShowWidget` tool, with theme-aware styling and sandboxed iframes
 - **Multi-format file viewer** — PDF (paginated, zoomable), Excel, CSV, HTML preview, and source code (Monaco editor with diff mode) — all viewable inline without download
 - **TradingView charting** — full TradingView Advanced Chart with drawing tools, indicators, and professional candlestick styling
 - **Live market data** — real-time WebSocket price feed with 1-second tick resolution, extended hours visualization, and multiple moving average overlays

--- a/docs/api/markdown/chat.md
+++ b/docs/api/markdown/chat.md
@@ -312,6 +312,11 @@ Get information about active PTC sessions.
 - `pending`: Count of pending todos
 - `error`: Error message (failed status only)
 
+**For `html_widget` payload:**
+- `html`: Raw HTML fragment to render in a sandboxed iframe
+- `title`: Optional widget title metadata
+- `data_files`: Optional dict of filename to content (text as strings, binary as data URLs) for files loaded from the sandbox via the `data_files` parameter
+
 ## SSE Event Data Schemas
 
 ### message_chunk

--- a/skills/inline-widget/SKILL.md
+++ b/skills/inline-widget/SKILL.md
@@ -19,17 +19,19 @@ Render interactive HTML/SVG widgets directly inside the chat conversation using 
 ## ShowWidget API
 
 ```
-ShowWidget(html: str, title: str | None = None)
+ShowWidget(html: str, title: str | None = None, data_files: list[str] | None = None)
 ```
 
 - `html`: Raw HTML fragment — no `<!DOCTYPE>`, `<html>`, `<head>`, or `<body>` tags
 - `title`: Optional metadata (not displayed to user)
+- `data_files`: Optional list of sandbox file paths to make available as `window.__WIDGET_DATA__`
 
 The HTML is rendered in a sandboxed iframe with:
 - **CDN libraries**: `cdnjs.cloudflare.com`, `cdn.jsdelivr.net`, `unpkg.com`, `esm.sh`
 - **CSS theme variables**: automatically injected (see Theme section)
 - **`sendPrompt('text')`**: global function to trigger follow-up chat messages
-- **No network**: `fetch()` / `XMLHttpRequest` are blocked — all data must be embedded
+- **`window.__WIDGET_DATA__`**: dict of filename→content for files passed via `data_files`
+- **No network**: `fetch()` / `XMLHttpRequest` are blocked — use `data_files` for sandbox files, or embed small data directly in HTML
 
 ## Layout Rules (CRITICAL)
 
@@ -187,6 +189,52 @@ setInterval(function() {
   updateDisplay();
 }, 3000);
 ```
+
+## File Data
+
+Use `data_files` to load data from sandbox files instead of inlining everything in the HTML string. This is especially useful for larger datasets produced by `execute_code`.
+
+### Workflow
+
+1. Use `execute_code` to generate data files in the sandbox
+2. Pass file paths to `ShowWidget` via `data_files`
+3. Access data in the widget via `window.__WIDGET_DATA__["filename"]`
+
+```python
+# Step 1: Agent generates data via execute_code
+execute_code("""
+import json
+data = {"labels": ["Q1", "Q2", "Q3"], "values": [100, 150, 200]}
+with open("/home/workspace/work/chart_data.json", "w") as f:
+    json.dump(data, f)
+""")
+
+# Step 2: Agent calls ShowWidget with data_files
+ShowWidget(
+    html='<div id="chart">...</div><script>var d = JSON.parse(__WIDGET_DATA__["chart_data.json"]); ...</script>',
+    data_files=["/home/workspace/work/chart_data.json"]
+)
+```
+
+### Widget access
+
+```javascript
+// Text files (json, csv, txt, etc.) — returned as strings
+var data = JSON.parse(window.__WIDGET_DATA__["chart_data.json"]);
+var csvText = window.__WIDGET_DATA__["results.csv"];
+
+// Binary files (png, jpg, etc.) — returned as data URLs
+document.getElementById("img").src = window.__WIDGET_DATA__["chart.png"];
+```
+
+### Supported file types
+
+- **Text** (returned as strings): `.json`, `.csv`, `.txt`, `.html`, `.xml`, `.svg`, `.md`, `.yaml`, `.yml`, `.tsv`, `.geojson`, `.topojson`
+- **Binary** (returned as data URLs): `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.ico`
+
+### Size limits
+
+When cloud storage is configured, files are uploaded to CDN — no size limit. When cloud storage is unavailable, files are embedded inline with a 500KB total cap.
 
 ## Blocked Patterns
 

--- a/skills/inline-widget/SKILL.md
+++ b/skills/inline-widget/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: inline-widget
+description: "Inline HTML widgets: charts, dashboards, data tables rendered directly in the chat via ShowWidget"
+---
+
+# Inline Widget
+
+Render interactive HTML/SVG widgets directly inside the chat conversation using `ShowWidget`. Widgets appear inline between text — no sandbox, no preview URL, no side panel.
+
+## When to Use
+
+- User wants a **quick visualization** embedded in the conversation (chart, metric card, data table)
+- The visualization is **self-contained** — all data is embedded in the HTML, no server needed
+- User wants **interactivity** within the chat: buttons, toggles, hover effects, animated charts
+- The output is a **single view** — not a multi-page app or dashboard that needs routing
+
+**Use `interactive-dashboard` instead if:** User needs a multi-page web app, server-side data, live data refresh, or complex interactivity requiring React/FastAPI.
+
+## ShowWidget API
+
+```
+ShowWidget(html: str, title: str | None = None)
+```
+
+- `html`: Raw HTML fragment — no `<!DOCTYPE>`, `<html>`, `<head>`, or `<body>` tags
+- `title`: Optional metadata (not displayed to user)
+
+The HTML is rendered in a sandboxed iframe with:
+- **CDN libraries**: `cdnjs.cloudflare.com`, `cdn.jsdelivr.net`, `unpkg.com`, `esm.sh`
+- **CSS theme variables**: automatically injected (see Theme section)
+- **`sendPrompt('text')`**: global function to trigger follow-up chat messages
+- **No network**: `fetch()` / `XMLHttpRequest` are blocked — all data must be embedded
+
+## Layout Rules (CRITICAL)
+
+The widget sits directly on the chat surface inside a transparent iframe. Follow these rules for seamless integration:
+
+### Outer Element — Transparent Shell
+
+The **outermost HTML element** must have:
+- **NO background** (or `background: transparent`)
+- **NO border**
+- **NO border-radius**
+- **NO box-shadow**
+- **NO padding** — add padding on inner sections only
+
+```html
+<!-- CORRECT: transparent outer shell -->
+<div>
+  <div style="background: var(--color-bg-card); border-radius: 8px; padding: 16px; ...">
+    ...inner card content...
+  </div>
+</div>
+
+<!-- WRONG: styled outer wrapper — will be rejected -->
+<div style="background: var(--color-bg-page); border: 1px solid ...; border-radius: 8px; padding: 20px;">
+  ...content...
+</div>
+```
+
+### Inner Elements — Use Theme Variables
+
+Inner cards, sections, and components should use CSS variables for styling:
+
+```css
+/* Card */
+background: var(--color-bg-card);
+border: 0.5px solid var(--color-border-muted);
+border-radius: 8px;
+padding: 16px;
+
+/* Metric card */
+background: var(--color-bg-subtle);
+border: 0.5px solid var(--color-border-muted);
+border-radius: 8px;
+```
+
+### Positioning
+
+- **NO `position: fixed`** — breaks iframe auto-sizing (elements collapse to 0 height)
+- Use `position: relative` for chart containers
+- No nested scrolling — the iframe auto-sizes to fit all content
+
+## Theme Variables
+
+These CSS variables are automatically injected and resolve correctly in both light and dark mode:
+
+| Variable | Purpose |
+|----------|---------|
+| `--color-bg-page` | Page background |
+| `--color-bg-card` | Card/panel background |
+| `--color-bg-elevated` | Elevated surface |
+| `--color-bg-subtle` | Subtle/muted background |
+| `--color-bg-hover` | Hover state background |
+| `--color-text-primary` | Primary text |
+| `--color-text-secondary` | Secondary/muted text |
+| `--color-text-tertiary` | Hint/label text |
+| `--color-border-muted` | Default border (use with 0.5px) |
+| `--color-accent-primary` | Brand/accent color |
+| `--color-profit` | Positive/gain (green) |
+| `--color-loss` | Negative/loss (red) |
+| `--color-warning` | Warning (amber) |
+| `--color-info` | Info (blue) |
+| `--color-success` | Success (green) |
+
+**Never hardcode colors** like `#333` or `rgb(...)` for text, backgrounds, or borders — they break in dark mode. Use CSS variables for everything except chart canvas colors (Chart.js canvas cannot read CSS variables — use computed hex values via `getComputedStyle`).
+
+## Charts (Chart.js)
+
+Load Chart.js from CDN and follow these rules:
+
+```html
+<!-- Wrapper div with explicit height — REQUIRED -->
+<div style="position: relative; height: 200px;">
+  <canvas id="myChart"></canvas>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+  // Read CSS variables for chart colors (canvas can't use var())
+  var cs = getComputedStyle(document.documentElement);
+  var accent = cs.getPropertyValue('--color-accent-primary').trim();
+  var border = cs.getPropertyValue('--color-border-muted').trim();
+
+  new Chart(document.getElementById('myChart'), {
+    type: 'line',
+    data: {
+      labels: [...],
+      datasets: [{
+        data: [...],
+        borderColor: accent,
+        backgroundColor: accent + '20',
+        tension: 0.4,
+        fill: true
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,  // REQUIRED
+      plugins: { legend: { display: true } },
+      scales: {
+        y: { grid: { color: border } },
+        x: { grid: { display: false } }
+      }
+    }
+  });
+</script>
+```
+
+**Key rules:**
+- Set height on the **wrapper div**, never on the canvas
+- Always use `responsive: true, maintainAspectRatio: false`
+- Use UMD build from CDN (sets `window.Chart` global)
+- Read CSS variables via `getComputedStyle` for chart colors
+
+## Typography
+
+- Font: inherited from host (`-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif`)
+- Weight: **400** (regular) and **500** (medium) only — never 600 or 700
+- Heading sizes: h1 = 22px, h2 = 18px, h3 = 16px (all weight 500)
+- Body: 14-16px, weight 400
+- Use **sentence case** — no Title Case or ALL CAPS (except short metric labels)
+
+## Interactivity
+
+### sendPrompt()
+
+Call `sendPrompt('text')` from buttons to trigger a follow-up chat message:
+
+```html
+<button onclick="sendPrompt('Show detailed revenue breakdown')"
+        style="padding: 8px 16px; background: var(--color-accent-primary); color: white;
+               border: none; border-radius: 6px; cursor: pointer;">
+  Revenue Details ↗
+</button>
+```
+
+Add a **↗ arrow** on buttons that call `sendPrompt()` to signal they trigger a chat action.
+
+### Refresh / Animation
+
+`setInterval` and `requestAnimationFrame` work normally for animations and live tickers:
+
+```javascript
+setInterval(function() {
+  // Update prices, rotate data, animate
+  updateDisplay();
+}, 3000);
+```
+
+## Blocked Patterns
+
+The following will cause `ShowWidget` to **reject** your HTML with an error. Fix and retry:
+
+| Pattern | Why blocked |
+|---------|-------------|
+| `new ResizeObserver(...)` | Host handles iframe sizing — your observer creates infinite resize loops |
+| `parent.postMessage(...)` | Use `sendPrompt()` instead — direct postMessage bypasses the bridge |
+| `window.top.*` / `window.parent.*` | Sandboxed iframe — parent access is blocked |
+| `position: fixed` | Breaks iframe auto-sizing |
+| Background/border on outermost element | Breaks seamless integration with chat surface |
+
+## Design Patterns
+
+### Metric Cards Row
+
+```html
+<div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 12px; margin-bottom: 16px;">
+  <div style="background: var(--color-bg-subtle); padding: 14px 16px; border-radius: 8px; border: 0.5px solid var(--color-border-muted);">
+    <div style="font-size: 11px; color: var(--color-text-tertiary); text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 6px;">Revenue</div>
+    <div style="font-size: 24px; font-weight: 500;">$2.4M</div>
+    <div style="font-size: 12px; color: var(--color-profit);">+12.5%</div>
+  </div>
+  <!-- more cards... -->
+</div>
+```
+
+### Data Table
+
+```html
+<table style="width: 100%; border-collapse: collapse; font-size: 14px;">
+  <thead>
+    <tr style="border-bottom: 0.5px solid var(--color-border-muted);">
+      <th style="text-align: left; padding: 8px; color: var(--color-text-secondary); font-weight: 500; font-size: 12px;">Symbol</th>
+      <th style="text-align: right; padding: 8px; color: var(--color-text-secondary); font-weight: 500; font-size: 12px;">Price</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr style="border-bottom: 0.5px solid var(--color-border-muted);">
+      <td style="padding: 8px; font-weight: 500;">AAPL</td>
+      <td style="text-align: right; padding: 8px;">$213.18</td>
+    </tr>
+  </tbody>
+</table>
+```
+
+### Section with Chart
+
+```html
+<div style="background: var(--color-bg-card); border-radius: 8px; border: 0.5px solid var(--color-border-muted); padding: 16px; margin-bottom: 16px;">
+  <div style="font-size: 16px; font-weight: 500; margin-bottom: 12px;">Performance</div>
+  <div style="position: relative; height: 200px;">
+    <canvas id="perfChart"></canvas>
+  </div>
+</div>
+```

--- a/skills/inline-widget/SKILL.md
+++ b/skills/inline-widget/SKILL.md
@@ -234,7 +234,7 @@ document.getElementById("img").src = window.__WIDGET_DATA__["chart.png"];
 
 ### Size limits
 
-When cloud storage is configured, files are uploaded to CDN — no size limit. When cloud storage is unavailable, files are embedded inline with a 500KB total cap.
+Total inline data is capped at 500KB across all files. Keep datasets concise — aggregate or sample large files before passing them.
 
 ## Blocked Patterns
 

--- a/skills/inline-widget/SKILL.md
+++ b/skills/inline-widget/SKILL.md
@@ -31,7 +31,7 @@ The HTML is rendered in a sandboxed iframe with:
 - **CSS theme variables**: automatically injected (see Theme section)
 - **`sendPrompt('text')`**: global function to trigger follow-up chat messages
 - **`window.__WIDGET_DATA__`**: dict of filename→content for files passed via `data_files`
-- **No network**: `fetch()` / `XMLHttpRequest` are blocked — use `data_files` for sandbox files, or embed small data directly in HTML
+- **No network to non-CDN origins**: `fetch()` / `XMLHttpRequest` to arbitrary URLs are blocked by CSP — only CDN domains (cdnjs, jsdelivr, unpkg, esm.sh) are allowed. Use `data_files` for sandbox files, or embed small data directly in HTML
 
 ## Layout Rules (CRITICAL)
 

--- a/src/ptc_agent/agent/agent.py
+++ b/src/ptc_agent/agent/agent.py
@@ -323,7 +323,7 @@ class PTCAgent:
         preview_url_tool = create_preview_url_tool(sandbox, workspace_id=workspace_id, on_signed_url=on_signed_url)
 
         # Create the show widget tool for inline HTML visualizations
-        show_widget_tool = create_show_widget_tool()
+        show_widget_tool = create_show_widget_tool(sandbox)
 
         # Start with base tools
         tools: list[Any] = [execute_code_tool, bash_tool, bash_output_tool, preview_url_tool, show_widget_tool, TodoWrite]

--- a/src/ptc_agent/agent/agent.py
+++ b/src/ptc_agent/agent/agent.py
@@ -74,6 +74,7 @@ from ptc_agent.agent.tools import (
     create_glob_tool,
     create_grep_tool,
     create_preview_url_tool,
+    create_show_widget_tool,
     TodoWrite,
 )
 from src.tools.search import get_web_search_tool
@@ -321,8 +322,11 @@ class PTCAgent:
         workspace_id = getattr(session, "conversation_id", "") if session else ""
         preview_url_tool = create_preview_url_tool(sandbox, workspace_id=workspace_id, on_signed_url=on_signed_url)
 
+        # Create the show widget tool for inline HTML visualizations
+        show_widget_tool = create_show_widget_tool()
+
         # Start with base tools
-        tools: list[Any] = [execute_code_tool, bash_tool, bash_output_tool, preview_url_tool, TodoWrite]
+        tools: list[Any] = [execute_code_tool, bash_tool, bash_output_tool, preview_url_tool, show_widget_tool, TodoWrite]
 
         # Create backend for SkillsMiddleware and LargeResultEvictionMiddleware
         backend = SandboxBackend(sandbox, operation_callback=operation_callback)

--- a/src/ptc_agent/agent/middleware/skills/registry.py
+++ b/src/ptc_agent/agent/middleware/skills/registry.py
@@ -245,6 +245,13 @@ SKILL_REGISTRY: dict[str, SkillDefinition] = {
         exposure="ptc",
         command="report-issue",
     ),
+    "inline-widget": SkillDefinition(
+        name="inline-widget",
+        description="Inline HTML widgets: charts, dashboards, data tables rendered directly in the chat via ShowWidget",
+        tools=[],
+        skill_md_path="skills/inline-widget/SKILL.md",
+        exposure="ptc",
+    ),
     "interactive-dashboard": SkillDefinition(
         name="interactive-dashboard",
         description="Interactive web dashboards: stock trackers, sector heatmaps, portfolio monitors — served via preview URL",

--- a/src/ptc_agent/agent/prompts/templates/components/tool_guide.md.j2
+++ b/src/ptc_agent/agent/prompts/templates/components/tool_guide.md.j2
@@ -26,7 +26,7 @@ Quick reference:
 - **Inner cards** use `var(--color-bg-card)`, `0.5px solid var(--color-border-muted)`, `border-radius: 8px`
 - **Charts**: wrap `<canvas>` in a div with explicit height; use `responsive: true, maintainAspectRatio: false`
 - **CDN**: `cdnjs.cloudflare.com`, `cdn.jsdelivr.net`, `unpkg.com`, `esm.sh`
-- **No network**: `fetch()`/`XMLHttpRequest` blocked — use `data_files` for sandbox files, or embed small data directly in HTML
+- **No network to non-CDN origins**: `fetch()`/`XMLHttpRequest` to arbitrary URLs blocked by CSP — only CDN domains allowed. Use `data_files` for sandbox files, or embed small data directly in HTML
 - **`data_files`**: optional list of sandbox file paths — embedded as `window.__WIDGET_DATA__["filename"]` in the widget (text as strings, images as data URLs)
 - **No** `ResizeObserver`, `parent.postMessage`, `position: fixed`, `window.top`/`window.parent`
 - **`sendPrompt('text')`**: trigger follow-up chat messages from buttons (add ↗ arrow) (optional)

--- a/src/ptc_agent/agent/prompts/templates/components/tool_guide.md.j2
+++ b/src/ptc_agent/agent/prompts/templates/components/tool_guide.md.j2
@@ -26,7 +26,8 @@ Quick reference:
 - **Inner cards** use `var(--color-bg-card)`, `0.5px solid var(--color-border-muted)`, `border-radius: 8px`
 - **Charts**: wrap `<canvas>` in a div with explicit height; use `responsive: true, maintainAspectRatio: false`
 - **CDN**: `cdnjs.cloudflare.com`, `cdn.jsdelivr.net`, `unpkg.com`, `esm.sh`
-- **No network**: `fetch()`/`XMLHttpRequest` blocked — embed all data in HTML
+- **No network**: `fetch()`/`XMLHttpRequest` blocked — use `data_files` for sandbox files, or embed small data directly in HTML
+- **`data_files`**: optional list of sandbox file paths — embedded as `window.__WIDGET_DATA__["filename"]` in the widget (text as strings, images as data URLs)
 - **No** `ResizeObserver`, `parent.postMessage`, `position: fixed`, `window.top`/`window.parent`
 - **`sendPrompt('text')`**: trigger follow-up chat messages from buttons (add ↗ arrow) (optional)
 

--- a/src/ptc_agent/agent/prompts/templates/components/tool_guide.md.j2
+++ b/src/ptc_agent/agent/prompts/templates/components/tool_guide.md.j2
@@ -15,6 +15,20 @@ Call these directly as tool calls for all fundamental operations:
 | WebSearch | Search the web |
 | WebFetch | Fetch and extract content from URLs |
 | TodoWrite | Track task progress |
+| ShowWidget | Render interactive HTML/SVG inline in the chat |
+
+### ShowWidget
+
+Renders an HTML widget inline in the chat — charts, dashboards, data tables, or any interactive display. See **Visualizations** section below for when to use this vs image files. Detailed rules are in the **inline-widget** skill — load it before first use.
+
+Quick reference:
+- **Outer element must be transparent** — no background, border, or border-radius on the outermost div
+- **Inner cards** use `var(--color-bg-card)`, `0.5px solid var(--color-border-muted)`, `border-radius: 8px`
+- **Charts**: wrap `<canvas>` in a div with explicit height; use `responsive: true, maintainAspectRatio: false`
+- **CDN**: `cdnjs.cloudflare.com`, `cdn.jsdelivr.net`, `unpkg.com`, `esm.sh`
+- **No network**: `fetch()`/`XMLHttpRequest` blocked — embed all data in HTML
+- **No** `ResizeObserver`, `parent.postMessage`, `position: fixed`, `window.top`/`window.parent`
+- **`sendPrompt('text')`**: trigger follow-up chat messages from buttons (add ↗ arrow) (optional)
 
 ## Financial Tools (Direct)
 

--- a/src/ptc_agent/agent/prompts/templates/components/visualizations.md.j2
+++ b/src/ptc_agent/agent/prompts/templates/components/visualizations.md.j2
@@ -1,14 +1,14 @@
 # Visualizations
 
-Save visualizations to `work/<task_name>/charts/` and reference them with markdown image syntax.
+**Default**: Use **ShowWidget** for all visualizations — charts, dashboards, data tables, interactive displays. This is the preferred approach for direct responses.
 
-**CRITICAL**: Use RELATIVE paths, NOT absolute paths:
-- CORRECT: `plt.savefig('work/<task_name>/charts/chart.png')`
-- WRONG: `plt.savefig('/work/<task_name>/charts/chart.png')`
+**Image files**: Fall back to image files (matplotlib/plotly `savefig`) only when the user explicitly requests it, based on user preference, or when producing a report/PDF that requires embedded images. Save to `work/<task_name>/charts/` with relative paths:
 
-During work, save charts to your task directory:
 ```python
-plt.savefig('work/<task_name>/chart.png', dpi=150, bbox_inches='tight')
+# CORRECT — relative path
+plt.savefig('work/<task_name>/charts/chart.png', dpi=150, bbox_inches='tight')
+# WRONG — absolute path
+# plt.savefig('/work/<task_name>/charts/chart.png')
 ```
 
-Embed chart references in your report: `![Chart Title](work/<task_name>/charts/chart.png)`
+Embed in reports: `![Chart Title](work/<task_name>/charts/chart.png)`

--- a/src/ptc_agent/agent/tools/__init__.py
+++ b/src/ptc_agent/agent/tools/__init__.py
@@ -27,6 +27,7 @@ from .file_ops import create_filesystem_tools
 from .glob import create_glob_tool
 from .grep import create_grep_tool
 from .preview_url import create_preview_url_tool
+from .show_widget import create_show_widget_tool
 from .think import think_tool
 
 # Todo tracking
@@ -59,6 +60,8 @@ __all__ = [
     "create_grep_tool",
     # Preview URL
     "create_preview_url_tool",
+    # Show Widget
+    "create_show_widget_tool",
     # Helper
     "get_all_tools",
     # Research

--- a/src/ptc_agent/agent/tools/show_widget.py
+++ b/src/ptc_agent/agent/tools/show_widget.py
@@ -135,6 +135,25 @@ def _is_text_file(path: str) -> bool:
     return ext.lower() in _TEXT_EXTENSIONS
 
 
+async def _read_one_file(
+    sandbox: Any,
+    path: str,
+) -> tuple[str, str | bytes | None]:
+    """Read a single file from the sandbox, returning (path, content_or_None)."""
+    is_text = _is_text_file(path)
+    try:
+        if is_text:
+            content = await sandbox.aread_file_text(path)
+        else:
+            content = await sandbox.adownload_file_bytes(path)
+        if content is None:
+            logger.warning("ShowWidget data_files: file not found", path=path)
+        return path, content
+    except Exception:
+        logger.warning("ShowWidget data_files: failed to read", path=path, exc_info=True)
+        return path, None
+
+
 async def _resolve_data_files(
     sandbox: Any,
     data_files: list[str],
@@ -144,31 +163,41 @@ async def _resolve_data_files(
     Returns a mapping of filename → content string.  Text files are
     returned as raw strings; binary files as ``data:{mime};base64,...``
     data-URLs.  A cumulative size cap of ``_INLINE_DATA_CAP`` is enforced.
+
+    All sandbox reads are dispatched concurrently via ``asyncio.gather``
+    to avoid sequential-await latency.
     """
+    import asyncio
+
+    # Filter out empty basenames before issuing I/O
+    valid_paths = [p for p in data_files if os.path.basename(p)]
+    if not valid_paths:
+        return {}
+
+    # Read all files concurrently
+    results = await asyncio.gather(
+        *(_read_one_file(sandbox, p) for p in valid_paths)
+    )
+
+    # Post-process: encode and apply size cap (order-preserving)
     inline_data: dict[str, str] = {}
     inline_total = 0
+    seen_basenames: set[str] = set()
 
-    for path in data_files:
-        filename = os.path.basename(path)
-        if not filename:
+    for path, content in results:
+        if content is None:
             continue
+        filename = os.path.basename(path)
         is_text = _is_text_file(path)
 
-        try:
-            if is_text:
-                content_str = await sandbox.aread_file_text(path)
-                if content_str is None:
-                    logger.warning("ShowWidget data_files: file not found", path=path)
-                    continue
-            else:
-                content_bytes = await sandbox.adownload_file_bytes(path)
-                if content_bytes is None:
-                    logger.warning("ShowWidget data_files: file not found", path=path)
-                    continue
-                content_str = None  # will build data-URL below
-        except Exception:
-            logger.warning("ShowWidget data_files: failed to read", path=path, exc_info=True)
+        if filename in seen_basenames:
+            logger.warning(
+                "ShowWidget data_files: duplicate basename, skipping",
+                path=path,
+                basename=filename,
+            )
             continue
+        seen_basenames.add(filename)
 
         mime = mimetypes.guess_type(filename)[0] or (
             "text/plain" if is_text else "application/octet-stream"
@@ -176,9 +205,9 @@ async def _resolve_data_files(
 
         # Build inline value
         if is_text:
-            value = content_str  # type: ignore[assignment]
+            value = content  # type: ignore[assignment]
         else:
-            b64 = base64.b64encode(content_bytes).decode()  # type: ignore[arg-type]
+            b64 = base64.b64encode(content).decode()  # type: ignore[arg-type]
             value = f"data:{mime};base64,{b64}"
 
         entry_size = len(value.encode())

--- a/src/ptc_agent/agent/tools/show_widget.py
+++ b/src/ptc_agent/agent/tools/show_widget.py
@@ -1,0 +1,187 @@
+"""Show interactive HTML/SVG widgets inline in the chat."""
+
+import re
+from typing import Any
+from uuid import uuid4
+
+import structlog
+from langchain_core.tools import BaseTool, tool
+
+logger = structlog.get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Validation rules — each returns (violation_name, detail) or None
+# ---------------------------------------------------------------------------
+
+_RULES: list[tuple[str, re.Pattern[str], str]] = [
+    (
+        "ResizeObserver",
+        re.compile(r"new\s+ResizeObserver\b", re.IGNORECASE),
+        "Do not create ResizeObserver — the host handles iframe sizing automatically.",
+    ),
+    (
+        "position:fixed",
+        re.compile(r"position\s*:\s*fixed", re.IGNORECASE),
+        "Do not use position:fixed — the iframe auto-sizes to content; fixed elements collapse to 0 height.",
+    ),
+    (
+        "parent.postMessage",
+        re.compile(r"parent\.postMessage\b"),
+        "Do not call parent.postMessage directly — use the provided sendPrompt('text') global instead.",
+    ),
+    (
+        "frame escape",
+        re.compile(r"window\.(top|parent)\s*\."),
+        "Do not access window.top or window.parent — the widget runs in a sandboxed iframe.",
+    ),
+]
+
+
+def _detect_outer_wrapper_issues(html: str) -> list[str]:
+    """Check if the outermost element has background, border, or border-radius.
+
+    We parse the first opening tag's style attribute. This is intentionally
+    simple — it only looks at the very first HTML element.
+    """
+    issues: list[str] = []
+    # Find the first HTML tag with a style attribute
+    m = re.search(r"<\w+[^>]*\sstyle\s*=\s*[\"']([^\"']*)[\"']", html, re.DOTALL)
+    if not m:
+        return issues
+    style = m.group(1).lower()
+    # Only flag if this is the first substantial tag (skip whitespace)
+    prefix = html[: m.start()].strip()
+    if prefix:
+        return issues  # not the outermost element
+
+    if re.search(r"(?<!-)background\s*:", style):
+        bg_val = re.search(r"background\s*:\s*([^;]+)", style)
+        if bg_val and "transparent" not in bg_val.group(1):
+            issues.append(
+                "Outermost element must NOT have a background — it must be transparent so the widget sits seamlessly on the chat surface."
+            )
+    if re.search(r"(?<![a-z-])border\s*:", style):
+        border_val = re.search(r"(?<![a-z-])border\s*:\s*([^;]+)", style)
+        if border_val and "none" not in border_val.group(1):
+            issues.append(
+                "Outermost element must NOT have a border — only inner cards/sections should have borders."
+            )
+    if re.search(r"border-radius\s*:", style):
+        issues.append(
+            "Outermost element must NOT have border-radius — only inner cards/sections should be rounded."
+        )
+    return issues
+
+
+def _validate_html(html: str) -> list[str]:
+    """Return a list of violation descriptions, empty if HTML is clean."""
+    violations: list[str] = []
+    for name, pattern, detail in _RULES:
+        if pattern.search(html):
+            violations.append(f"[{name}] {detail}")
+    violations.extend(_detect_outer_wrapper_issues(html))
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Guidance text sent back on validation failure
+# ---------------------------------------------------------------------------
+
+_SKILL_CONTENT_CACHE: str | None = None
+
+
+def _load_widget_guidelines() -> str:
+    """Load the inline-widget SKILL.md as the canonical guideline source."""
+    global _SKILL_CONTENT_CACHE  # noqa: PLW0603
+    if _SKILL_CONTENT_CACHE is not None:
+        return _SKILL_CONTENT_CACHE
+
+    try:
+        from ptc_agent.agent.middleware.skills import load_skill_content
+
+        content = load_skill_content("inline-widget")
+        if content:
+            _SKILL_CONTENT_CACHE = content
+            return content
+    except Exception:
+        pass
+
+    # Fallback: minimal inline rules if skill file can't be loaded
+    # Don't cache the fallback — retry loading on next call
+    return (
+        "Outermost element: NO background/border/border-radius (transparent shell). "
+        "Inner cards use var(--color-bg-card), 0.5px border. "
+        "No ResizeObserver, no parent.postMessage, no position:fixed. "
+        "Charts: wrap canvas in div with explicit height, use responsive:true, maintainAspectRatio:false."
+    )
+
+
+def create_show_widget_tool() -> BaseTool:
+    """Factory function to create ShowWidget tool."""
+
+    @tool(response_format="content_and_artifact")
+    async def ShowWidget(
+        html: str,
+        title: str | None = None,
+    ) -> tuple[str, dict[str, Any]]:
+        """Render an interactive HTML/SVG widget inline in the chat.
+
+        Use this to display charts, dashboards, data tables, or any interactive
+        visualization directly in the conversation. The HTML is rendered in a
+        sandboxed iframe with access to CDN libraries (Chart.js, D3, etc.).
+
+        Available in the widget:
+        - CDN libraries: cdnjs.cloudflare.com, cdn.jsdelivr.net, unpkg.com, esm.sh
+        - CSS variables: var(--color-bg-page), var(--color-text-primary), etc. for theme matching
+        - sendPrompt('text'): trigger a follow-up chat message from a button click
+
+        Args:
+            html: Raw HTML string to render. No DOCTYPE/html/head/body tags needed.
+            title: Optional display title shown above the widget.
+
+        Returns:
+            Confirmation message and artifact dict for inline rendering.
+        """
+        # Validate HTML before rendering
+        violations = _validate_html(html)
+        if violations:
+            error_lines = "\n".join(f"  - {v}" for v in violations)
+            msg = (
+                f"Widget HTML rejected — fix the following issues and call ShowWidget again:\n"
+                f"{error_lines}\n\n{_load_widget_guidelines()}"
+            )
+            logger.warning(
+                "ShowWidget HTML rejected",
+                violations=[v.split("]")[0].strip("[") for v in violations],
+            )
+            return msg, {}
+
+        try:
+            from langgraph.config import get_stream_writer
+
+            writer = get_stream_writer()
+        except Exception:
+            writer = None
+
+        widget_id = f"widget_{uuid4().hex[:8]}"
+        display_title = title or ""
+
+        artifact = {
+            "type": "html_widget",
+            "html": html,
+            "title": display_title,
+        }
+
+        if writer:
+            writer({
+                "artifact_type": "html_widget",
+                "artifact_id": widget_id,
+                "payload": artifact,
+            })
+
+        logger.info("Rendered inline widget", widget_id=widget_id, title=display_title)
+
+        content = f"Widget rendered: {display_title or widget_id}"
+        return content, artifact
+
+    return ShowWidget

--- a/src/ptc_agent/agent/tools/show_widget.py
+++ b/src/ptc_agent/agent/tools/show_widget.py
@@ -1,5 +1,8 @@
 """Show interactive HTML/SVG widgets inline in the chat."""
 
+import base64
+import mimetypes
+import os
 import re
 from typing import Any
 from uuid import uuid4
@@ -8,6 +11,16 @@ import structlog
 from langchain_core.tools import BaseTool, tool
 
 logger = structlog.get_logger(__name__)
+
+# Max total size for inline-embedded data when cloud storage is unavailable.
+_INLINE_DATA_CAP = 500 * 1024  # 500 KB
+
+# Extensions treated as text (everything else is binary).
+_TEXT_EXTENSIONS = frozenset({
+    ".json", ".csv", ".txt", ".html", ".xml", ".svg",
+    ".md", ".yaml", ".yml", ".tsv", ".geojson", ".topojson",
+})
+
 
 # ---------------------------------------------------------------------------
 # Validation rules — each returns (violation_name, detail) or None
@@ -116,13 +129,81 @@ def _load_widget_guidelines() -> str:
     )
 
 
-def create_show_widget_tool() -> BaseTool:
+def _is_text_file(path: str) -> bool:
+    """Return True if *path* should be read as text based on its extension."""
+    _, ext = os.path.splitext(path)
+    return ext.lower() in _TEXT_EXTENSIONS
+
+
+async def _resolve_data_files(
+    sandbox: Any,
+    data_files: list[str],
+) -> dict[str, str]:
+    """Read *data_files* from *sandbox* and return inline data dict.
+
+    Returns a mapping of filename → content string.  Text files are
+    returned as raw strings; binary files as ``data:{mime};base64,...``
+    data-URLs.  A cumulative size cap of ``_INLINE_DATA_CAP`` is enforced.
+    """
+    inline_data: dict[str, str] = {}
+    inline_total = 0
+
+    for path in data_files:
+        filename = os.path.basename(path)
+        if not filename:
+            continue
+        is_text = _is_text_file(path)
+
+        try:
+            if is_text:
+                content_str = await sandbox.aread_file_text(path)
+                if content_str is None:
+                    logger.warning("ShowWidget data_files: file not found", path=path)
+                    continue
+            else:
+                content_bytes = await sandbox.adownload_file_bytes(path)
+                if content_bytes is None:
+                    logger.warning("ShowWidget data_files: file not found", path=path)
+                    continue
+                content_str = None  # will build data-URL below
+        except Exception:
+            logger.warning("ShowWidget data_files: failed to read", path=path, exc_info=True)
+            continue
+
+        mime = mimetypes.guess_type(filename)[0] or (
+            "text/plain" if is_text else "application/octet-stream"
+        )
+
+        # Build inline value
+        if is_text:
+            value = content_str  # type: ignore[assignment]
+        else:
+            b64 = base64.b64encode(content_bytes).decode()  # type: ignore[arg-type]
+            value = f"data:{mime};base64,{b64}"
+
+        entry_size = len(value.encode())
+        if inline_total + entry_size > _INLINE_DATA_CAP:
+            logger.warning(
+                "ShowWidget data_files: inline cap exceeded, skipping",
+                path=path,
+                cap=_INLINE_DATA_CAP,
+                current=inline_total,
+            )
+            continue
+        inline_total += entry_size
+        inline_data[filename] = value
+
+    return inline_data
+
+
+def create_show_widget_tool(sandbox: Any = None) -> BaseTool:
     """Factory function to create ShowWidget tool."""
 
     @tool(response_format="content_and_artifact")
     async def ShowWidget(
         html: str,
         title: str | None = None,
+        data_files: list[str] | None = None,
     ) -> tuple[str, dict[str, Any]]:
         """Render an interactive HTML/SVG widget inline in the chat.
 
@@ -134,10 +215,15 @@ def create_show_widget_tool() -> BaseTool:
         - CDN libraries: cdnjs.cloudflare.com, cdn.jsdelivr.net, unpkg.com, esm.sh
         - CSS variables: var(--color-bg-page), var(--color-text-primary), etc. for theme matching
         - sendPrompt('text'): trigger a follow-up chat message from a button click
+        - window.__WIDGET_DATA__: dict of filename→content for files passed via data_files
 
         Args:
             html: Raw HTML string to render. No DOCTYPE/html/head/body tags needed.
             title: Optional display title shown above the widget.
+            data_files: Optional list of sandbox file paths whose contents will be
+                made available in the widget as ``window.__WIDGET_DATA__["filename"]``.
+                Text files (json/csv/txt/…) are strings; binary files (png/jpg/…)
+                become data-URL strings.
 
         Returns:
             Confirmation message and artifact dict for inline rendering.
@@ -166,17 +252,27 @@ def create_show_widget_tool() -> BaseTool:
         widget_id = f"widget_{uuid4().hex[:8]}"
         display_title = title or ""
 
-        artifact = {
+        artifact: dict[str, Any] = {
             "type": "html_widget",
             "html": html,
             "title": display_title,
         }
 
+        # Resolve data files — inline only in the stream event, not the
+        # tool return, so we don't duplicate large payloads in the
+        # LangGraph checkpointer state.
+        resolved_data: dict[str, str] | None = None
+        if data_files and sandbox is not None:
+            resolved_data = await _resolve_data_files(sandbox, data_files) or None
+
         if writer:
+            stream_payload = artifact
+            if resolved_data:
+                stream_payload = {**artifact, "data": resolved_data}
             writer({
                 "artifact_type": "html_widget",
                 "artifact_id": widget_id,
-                "payload": artifact,
+                "payload": stream_payload,
             })
 
         logger.info("Rendered inline widget", widget_id=widget_id, title=display_title)

--- a/tests/unit/tools/test_show_widget.py
+++ b/tests/unit/tools/test_show_widget.py
@@ -1,0 +1,227 @@
+"""Unit tests for the ShowWidget tool and its validation helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import src.ptc_agent.agent.tools.show_widget as _mod
+from src.ptc_agent.agent.tools.show_widget import (
+    _detect_outer_wrapper_issues,
+    _load_widget_guidelines,
+    _validate_html,
+    create_show_widget_tool,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    """Reset the module-level skill content cache before each test."""
+    _mod._SKILL_CONTENT_CACHE = None
+    yield
+    _mod._SKILL_CONTENT_CACHE = None
+
+
+# ---------------------------------------------------------------------------
+# _validate_html
+# ---------------------------------------------------------------------------
+
+
+class TestValidateHtml:
+    def test_clean_html_returns_no_violations(self):
+        html = '<div style="color: red;">Hello</div>'
+        assert _validate_html(html) == []
+
+    def test_resize_observer_detected(self):
+        html = "<script>const ro = new ResizeObserver(cb);</script>"
+        violations = _validate_html(html)
+        assert len(violations) == 1
+        assert "[ResizeObserver]" in violations[0]
+
+    def test_position_fixed_detected(self):
+        html = '<div style="position: fixed; top: 0;">bar</div>'
+        violations = _validate_html(html)
+        assert any("[position:fixed]" in v for v in violations)
+
+    def test_parent_post_message_detected(self):
+        html = "<script>parent.postMessage('hi', '*');</script>"
+        violations = _validate_html(html)
+        assert any("[parent.postMessage]" in v for v in violations)
+
+    def test_frame_escape_window_top(self):
+        html = "<script>window.top.location = '/';</script>"
+        violations = _validate_html(html)
+        assert any("[frame escape]" in v for v in violations)
+
+    def test_frame_escape_window_parent(self):
+        html = "<script>window.parent.foo();</script>"
+        violations = _validate_html(html)
+        assert any("[frame escape]" in v for v in violations)
+
+    def test_multiple_violations_detected(self):
+        html = (
+            '<div style="position: fixed;">'
+            "<script>new ResizeObserver(cb); parent.postMessage('x','*');</script>"
+            "</div>"
+        )
+        violations = _validate_html(html)
+        names = {v.split("]")[0].strip("[") for v in violations}
+        assert "ResizeObserver" in names
+        assert "position:fixed" in names
+        assert "parent.postMessage" in names
+
+
+# ---------------------------------------------------------------------------
+# _detect_outer_wrapper_issues
+# ---------------------------------------------------------------------------
+
+
+class TestDetectOuterWrapperIssues:
+    def test_no_style_attribute_no_issues(self):
+        html = "<div>No style here</div>"
+        assert _detect_outer_wrapper_issues(html) == []
+
+    def test_first_element_with_prefix_content_no_issues(self):
+        # When there is text before the styled element, it is not outermost
+        html = 'some prefix text <div style="background: red;">inner</div>'
+        assert _detect_outer_wrapper_issues(html) == []
+
+    def test_background_non_transparent_flagged(self):
+        html = '<div style="background: #fff;">content</div>'
+        issues = _detect_outer_wrapper_issues(html)
+        assert len(issues) == 1
+        assert "background" in issues[0].lower()
+
+    def test_background_transparent_not_flagged(self):
+        html = '<div style="background: transparent;">content</div>'
+        assert _detect_outer_wrapper_issues(html) == []
+
+    def test_border_non_none_flagged(self):
+        html = '<div style="border: 1px solid red;">content</div>'
+        issues = _detect_outer_wrapper_issues(html)
+        assert len(issues) == 1
+        assert "border" in issues[0].lower()
+
+    def test_border_none_not_flagged(self):
+        html = '<div style="border: none;">content</div>'
+        assert _detect_outer_wrapper_issues(html) == []
+
+    def test_border_radius_flagged(self):
+        html = '<div style="border-radius: 8px;">content</div>'
+        issues = _detect_outer_wrapper_issues(html)
+        assert len(issues) == 1
+        assert "border-radius" in issues[0].lower()
+
+    def test_inner_element_with_background_not_flagged(self):
+        # Outer div has no style; inner div has background — should not flag
+        html = '<div><div style="background: blue;">inner</div></div>'
+        # The styled element is not outermost because prefix "<div>" is present
+        assert _detect_outer_wrapper_issues(html) == []
+
+
+# ---------------------------------------------------------------------------
+# _load_widget_guidelines
+# ---------------------------------------------------------------------------
+
+_SKILLS_MOD = "ptc_agent.agent.middleware.skills"
+
+
+class TestLoadWidgetGuidelines:
+    @patch(f"{_SKILLS_MOD}.load_skill_content", return_value="# Widget Guidelines\nDetailed rules here.")
+    def test_successful_load_caches_content(self, mock_load):
+        result1 = _load_widget_guidelines()
+        result2 = _load_widget_guidelines()
+
+        assert result1 == "# Widget Guidelines\nDetailed rules here."
+        assert result2 == result1
+        # Called only once because the second call uses the cache
+        mock_load.assert_called_once_with("inline-widget")
+
+    @patch(f"{_SKILLS_MOD}.load_skill_content", side_effect=RuntimeError("file not found"))
+    def test_failed_load_returns_fallback_without_caching(self, mock_load):
+        result = _load_widget_guidelines()
+        assert "Outermost element" in result  # fallback text
+        # Not cached — next call should retry
+        assert _mod._SKILL_CONTENT_CACHE is None
+
+        # Second call retries the load
+        _load_widget_guidelines()
+        assert mock_load.call_count == 2
+
+    @patch(f"{_SKILLS_MOD}.load_skill_content", return_value="")
+    def test_empty_string_returns_fallback(self, mock_load):
+        result = _load_widget_guidelines()
+        assert "Outermost element" in result
+        assert _mod._SKILL_CONTENT_CACHE is None
+
+
+# ---------------------------------------------------------------------------
+# ShowWidget tool (async)
+# ---------------------------------------------------------------------------
+
+
+def _tool_call(args: dict, call_id: str = "call_test_123") -> dict:
+    """Build a ToolCall-shaped dict so ainvoke returns a ToolMessage."""
+    return {
+        "name": "ShowWidget",
+        "args": args,
+        "id": call_id,
+        "type": "tool_call",
+    }
+
+
+class TestShowWidgetTool:
+    @pytest.fixture()
+    def tool(self):
+        return create_show_widget_tool()
+
+    @pytest.mark.asyncio
+    async def test_valid_html_returns_content_and_artifact(self, tool):
+        mock_writer = MagicMock()
+        with patch("langgraph.config.get_stream_writer", return_value=mock_writer):
+            result = await tool.ainvoke(
+                _tool_call({"html": "<div>Hello</div>", "title": "My Widget"})
+            )
+
+        assert "My Widget" in result.content
+        assert result.artifact["type"] == "html_widget"
+        assert result.artifact["html"] == "<div>Hello</div>"
+        assert result.artifact["title"] == "My Widget"
+        # Stream writer should have been called with the artifact payload
+        mock_writer.assert_called_once()
+        call_payload = mock_writer.call_args[0][0]
+        assert call_payload["artifact_type"] == "html_widget"
+
+    @pytest.mark.asyncio
+    async def test_invalid_html_returns_error_and_empty_dict(self, tool):
+        bad_html = "<script>new ResizeObserver(cb);</script>"
+        with patch("langgraph.config.get_stream_writer", return_value=MagicMock()):
+            result = await tool.ainvoke(_tool_call({"html": bad_html}))
+
+        assert "rejected" in result.content.lower()
+        assert "[ResizeObserver]" in result.content
+        assert result.artifact == {}
+
+    @pytest.mark.asyncio
+    async def test_title_reflected_in_artifact(self, tool):
+        with patch("langgraph.config.get_stream_writer", return_value=MagicMock()):
+            result = await tool.ainvoke(
+                _tool_call({"html": "<p>chart</p>", "title": "Revenue Chart"})
+            )
+
+        assert result.artifact["title"] == "Revenue Chart"
+        assert "Revenue Chart" in result.content
+
+    @pytest.mark.asyncio
+    async def test_no_title_uses_empty_string(self, tool):
+        with patch("langgraph.config.get_stream_writer", return_value=MagicMock()):
+            result = await tool.ainvoke(_tool_call({"html": "<p>data</p>"}))
+
+        assert result.artifact["title"] == ""
+        # Content should contain the widget_id fallback since no title
+        assert "widget_" in result.content

--- a/tests/unit/tools/test_show_widget.py
+++ b/tests/unit/tools/test_show_widget.py
@@ -225,3 +225,170 @@ class TestShowWidgetTool:
         assert result.artifact["title"] == ""
         # Content should contain the widget_id fallback since no title
         assert "widget_" in result.content
+
+
+# ---------------------------------------------------------------------------
+# _is_text_file
+# ---------------------------------------------------------------------------
+
+from src.ptc_agent.agent.tools.show_widget import _is_text_file
+
+
+class TestIsTextFile:
+    def test_json_is_text(self):
+        assert _is_text_file("data.json") is True
+
+    def test_csv_is_text(self):
+        assert _is_text_file("report.csv") is True
+
+    def test_png_is_not_text(self):
+        assert _is_text_file("image.png") is False
+
+    def test_jpg_is_not_text(self):
+        assert _is_text_file("photo.jpg") is False
+
+    def test_uppercase_extension_is_text(self):
+        assert _is_text_file("DATA.JSON") is True
+
+    def test_no_extension_is_not_text(self):
+        assert _is_text_file("README") is False
+
+
+# ---------------------------------------------------------------------------
+# _resolve_data_files
+# ---------------------------------------------------------------------------
+
+from unittest.mock import AsyncMock
+
+from src.ptc_agent.agent.tools.show_widget import _resolve_data_files
+
+
+class TestResolveDataFiles:
+    @pytest.mark.asyncio
+    async def test_text_file_reads_via_aread_file_text(self):
+        sandbox = AsyncMock()
+        sandbox.aread_file_text.return_value = '{"key": "value"}'
+
+        result = await _resolve_data_files(sandbox, ["/work/data.json"])
+
+        sandbox.aread_file_text.assert_awaited_once_with("/work/data.json")
+        assert result == {"data.json": '{"key": "value"}'}
+
+    @pytest.mark.asyncio
+    async def test_binary_file_reads_via_adownload_file_bytes(self):
+        sandbox = AsyncMock()
+        raw_bytes = b"\x89PNG\r\n\x1a\n"
+        sandbox.adownload_file_bytes.return_value = raw_bytes
+
+        result = await _resolve_data_files(sandbox, ["/work/chart.png"])
+
+        sandbox.adownload_file_bytes.assert_awaited_once_with("/work/chart.png")
+        assert "chart.png" in result
+        value = result["chart.png"]
+        assert value.startswith("data:image/png;base64,")
+
+    @pytest.mark.asyncio
+    async def test_empty_filename_is_skipped(self):
+        sandbox = AsyncMock()
+
+        result = await _resolve_data_files(sandbox, ["/"])
+
+        assert result == {}
+        sandbox.aread_file_text.assert_not_awaited()
+        sandbox.adownload_file_bytes.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_file_not_found_returns_none_skipped(self):
+        sandbox = AsyncMock()
+        sandbox.aread_file_text.return_value = None
+
+        result = await _resolve_data_files(sandbox, ["/work/missing.json"])
+
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_read_exception_is_skipped_and_logs_warning(self):
+        sandbox = AsyncMock()
+        sandbox.aread_file_text.side_effect = OSError("disk error")
+
+        with patch.object(_mod.logger, "warning") as mock_warn:
+            result = await _resolve_data_files(sandbox, ["/work/bad.csv"])
+
+        assert result == {}
+        mock_warn.assert_called_once()
+        assert "failed to read" in mock_warn.call_args[0][0].lower()
+
+    @pytest.mark.asyncio
+    async def test_size_cap_exceeded_skips_file(self):
+        sandbox = AsyncMock()
+        sandbox.aread_file_text.return_value = "x" * 100
+
+        with patch.object(_mod, "_INLINE_DATA_CAP", 50):
+            result = await _resolve_data_files(sandbox, ["/work/big.json"])
+
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_multiple_files_returns_all(self):
+        sandbox = AsyncMock()
+        sandbox.aread_file_text.return_value = "text content"
+        raw_bytes = b"\xff\xd8\xff\xe0"
+        sandbox.adownload_file_bytes.return_value = raw_bytes
+
+        result = await _resolve_data_files(
+            sandbox, ["/work/notes.txt", "/work/thumb.jpg"]
+        )
+
+        assert "notes.txt" in result
+        assert "thumb.jpg" in result
+        assert result["notes.txt"] == "text content"
+        assert result["thumb.jpg"].startswith("data:")
+
+
+# ---------------------------------------------------------------------------
+# ShowWidget tool with data_files
+# ---------------------------------------------------------------------------
+
+
+class TestShowWidgetWithDataFiles:
+    @pytest.mark.asyncio
+    async def test_data_files_with_sandbox_resolves_data_in_stream(self):
+        mock_sandbox = AsyncMock()
+        mock_sandbox.aread_file_text.return_value = '["a","b"]'
+
+        tool = create_show_widget_tool(sandbox=mock_sandbox)
+        mock_writer = MagicMock()
+
+        with patch("langgraph.config.get_stream_writer", return_value=mock_writer):
+            result = await tool.ainvoke(
+                _tool_call({
+                    "html": "<div>chart</div>",
+                    "title": "Chart",
+                    "data_files": ["/work/data.json"],
+                })
+            )
+
+        assert result.artifact["type"] == "html_widget"
+        mock_writer.assert_called_once()
+        stream_payload = mock_writer.call_args[0][0]["payload"]
+        assert "data" in stream_payload
+        assert "data.json" in stream_payload["data"]
+
+    @pytest.mark.asyncio
+    async def test_data_files_without_sandbox_no_resolution(self):
+        tool = create_show_widget_tool(sandbox=None)
+        mock_writer = MagicMock()
+
+        with patch("langgraph.config.get_stream_writer", return_value=mock_writer):
+            result = await tool.ainvoke(
+                _tool_call({
+                    "html": "<div>chart</div>",
+                    "title": "Chart",
+                    "data_files": ["/work/data.json"],
+                })
+            )
+
+        assert result.artifact["type"] == "html_widget"
+        mock_writer.assert_called_once()
+        stream_payload = mock_writer.call_args[0][0]["payload"]
+        assert "data" not in stream_payload

--- a/web/README.md
+++ b/web/README.md
@@ -12,6 +12,7 @@ React frontend for LangAlpha — a vibe investing agent with AI-powered research
 - **TradingView-Style Charting** — Interactive candlestick charts with AI chat sidebar for stock analysis
 - **Scheduled Automations** — Create and manage recurring agent tasks with cron scheduling and execution history
 - **Document Viewers** — Inline rendering of PDF, Excel, CSV, and HTML artifacts from agent responses
+- **Inline HTML Widgets** — Interactive HTML/SVG visualizations (charts, metric cards, data tables) rendered in sandboxed iframes directly within the chat thread
 - **Monaco Code Editor** — Syntax-highlighted code editor for code artifacts
 - **Todo Tracking** — Drawer-based task list synced with agent todo updates
 - **Dark/Light Theme** — Theme switching with CSS custom properties

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -1780,6 +1780,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
                         onReportWithAgent={(instruction) => {
                           handleSendMessage(`/self-improve ${instruction}`);
                         }}
+                        onWidgetSendPrompt={(text) => handleSendMessage(text)}
                       />
                     </div>
                   </div>

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -1780,7 +1780,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
                         onReportWithAgent={(instruction) => {
                           handleSendMessage(`/self-improve ${instruction}`);
                         }}
-                        onWidgetSendPrompt={(text) => handleSendMessage(text)}
+                        onWidgetSendPrompt={handleSendMessage}
                       />
                     </div>
                   </div>

--- a/web/src/pages/ChatAgent/components/MessageList.tsx
+++ b/web/src/pages/ChatAgent/components/MessageList.tsx
@@ -28,6 +28,7 @@ import CreateWorkspaceCard from './CreateWorkspaceCard';
 import StartQuestionCard from './StartQuestionCard';
 import SubagentTaskMessageContent from './SubagentTaskMessageContent';
 import TextMessageContent from './TextMessageContent';
+import InlineWidget from './viewers/InlineWidget';
 import ToolCallMessageContent from './ToolCallMessageContent';
 
 import { TextShimmer } from '@/components/ui/text-shimmer';
@@ -56,6 +57,7 @@ interface ContentSegmentRecord {
   planApprovalId?: string;
   questionId?: string;
   proposalId?: string;
+  widgetId?: string;
 }
 
 /** Subagent info for opening subagent task tabs */
@@ -272,6 +274,7 @@ interface MessageListProps {
   onThumbDown?: (messageId: string, issueCategories: string[], comment: string | null, consentHumanReview: boolean) => Promise<FeedbackResult | null>;
   getFeedbackForMessage?: (messageId: string) => FeedbackResult | null;
   onReportWithAgent?: (instruction: string) => void;
+  onWidgetSendPrompt?: (text: string) => void;
 }
 
 /**
@@ -283,7 +286,7 @@ interface MessageListProps {
  * - Streaming indicators
  * - Error state styling
  */
-function MessageList({ messages, isLoading, isLoadingHistory, hideAvatar, compactToolCalls, isSubagentView, readOnly, allowFiles, onOpenSubagentTask, onOpenFile, onOpenDir, onToolCallDetailClick, onApprovePlan, onRejectPlan, onPlanDetailClick, onAnswerQuestion, onSkipQuestion, onApproveCreateWorkspace, onRejectCreateWorkspace, onApproveStartQuestion, onRejectStartQuestion, onEditMessage, onRegenerate, onRetry, onThumbUp, onThumbDown, getFeedbackForMessage, onReportWithAgent }: MessageListProps): React.ReactElement | null {
+function MessageList({ messages, isLoading, isLoadingHistory, hideAvatar, compactToolCalls, isSubagentView, readOnly, allowFiles, onOpenSubagentTask, onOpenFile, onOpenDir, onToolCallDetailClick, onApprovePlan, onRejectPlan, onPlanDetailClick, onAnswerQuestion, onSkipQuestion, onApproveCreateWorkspace, onRejectCreateWorkspace, onApproveStartQuestion, onRejectStartQuestion, onEditMessage, onRegenerate, onRetry, onThumbUp, onThumbDown, getFeedbackForMessage, onReportWithAgent, onWidgetSendPrompt }: MessageListProps): React.ReactElement | null {
   const isMobile = useIsMobile();
 
   // Empty state - show when no messages exist (hidden in subagent view)
@@ -367,6 +370,7 @@ function MessageList({ messages, isLoading, isLoadingHistory, hideAvatar, compac
             onThumbDown={onThumbDown}
             getFeedbackForMessage={getFeedbackForMessage}
             onReportWithAgent={onReportWithAgent}
+            onWidgetSendPrompt={onWidgetSendPrompt}
           />
         )
       )}
@@ -404,6 +408,7 @@ interface MessageBubbleProps {
   onThumbDown?: (messageId: string, issueCategories: string[], comment: string | null, consentHumanReview: boolean) => Promise<FeedbackResult | null>;
   getFeedbackForMessage?: (messageId: string) => FeedbackResult | null;
   onReportWithAgent?: (instruction: string) => void;
+  onWidgetSendPrompt?: (text: string) => void;
   isMobile?: boolean;
 }
 
@@ -416,7 +421,7 @@ interface MessageBubbleProps {
  * Wrapped with React.memo — safe because updateMessage() in messageHelpers.ts
  * returns the same object reference for unchanged messages.
  */
-const MessageBubble = memo(function MessageBubble({ message, isLoading, hideAvatar, compactToolCalls, isSubagentView, readOnly, allowFiles, onOpenSubagentTask, onOpenFile, onOpenDir, onToolCallDetailClick, onApprovePlan, onRejectPlan, onPlanDetailClick, onAnswerQuestion, onSkipQuestion, onApproveCreateWorkspace, onRejectCreateWorkspace, onApproveStartQuestion, onRejectStartQuestion, onEditMessage, onRegenerate, onRetry, onThumbUp, onThumbDown, getFeedbackForMessage, onReportWithAgent, isMobile }: MessageBubbleProps): React.ReactElement {
+const MessageBubble = memo(function MessageBubble({ message, isLoading, hideAvatar, compactToolCalls, isSubagentView, readOnly, allowFiles, onOpenSubagentTask, onOpenFile, onOpenDir, onToolCallDetailClick, onApprovePlan, onRejectPlan, onPlanDetailClick, onAnswerQuestion, onSkipQuestion, onApproveCreateWorkspace, onRejectCreateWorkspace, onApproveStartQuestion, onRejectStartQuestion, onEditMessage, onRegenerate, onRetry, onThumbUp, onThumbDown, getFeedbackForMessage, onReportWithAgent, onWidgetSendPrompt, isMobile }: MessageBubbleProps): React.ReactElement {
   const { user } = useUser();
   const { theme } = useTheme();
   const logo = theme === 'light' ? logoDark : logoLight;
@@ -661,6 +666,8 @@ const MessageBubble = memo(function MessageBubble({ message, isLoading, hideAvat
               onRejectCreateWorkspace={onRejectCreateWorkspace}
               onApproveStartQuestion={onApproveStartQuestion}
               onRejectStartQuestion={onRejectStartQuestion}
+              onWidgetSendPrompt={onWidgetSendPrompt}
+              htmlWidgetProcesses={(message.htmlWidgetProcesses as Record<string, Record<string, unknown>>) || EMPTY_OBJ}
               textOnly={true}
               readOnly={readOnly}
               allowFiles={allowFiles}
@@ -842,6 +849,8 @@ interface MessageContentSegmentsProps {
   onRejectCreateWorkspace?: (proposalData: Record<string, unknown>) => void;
   onApproveStartQuestion?: (proposalData: Record<string, unknown>) => void;
   onRejectStartQuestion?: (proposalData: Record<string, unknown>) => void;
+  onWidgetSendPrompt?: (text: string) => void;
+  htmlWidgetProcesses?: Record<string, Record<string, unknown>>;
   textOnly?: boolean;
 }
 
@@ -850,7 +859,7 @@ const MAX_IN_PROGRESS_MS = 15000; // max time a tool call can stay in-progress i
 /** Tools that should stay in the live zone for their entire duration (no MAX_IN_PROGRESS_MS cap) */
 const ALWAYS_LIVE_TOOLS = new Set(['TaskOutput']);
 /** Tool calls that are never rendered as visible activity items — they have dedicated UI or are internal */
-const HIDDEN_TOOL_CALL_NAMES = new Set(['TodoWrite', 'task', 'Task', 'SubmitPlan', 'AskUserQuestion', 'create_workspace', 'start_question']);
+const HIDDEN_TOOL_CALL_NAMES = new Set(['TodoWrite', 'task', 'Task', 'SubmitPlan', 'AskUserQuestion', 'create_workspace', 'start_question', 'ShowWidget']);
 
 /** Render block types for the textOnly activity grouping */
 interface ActivityRenderBlock {
@@ -899,6 +908,11 @@ interface NotificationRenderBlock {
   key: string;
   segment: ContentSegmentRecord;
 }
+interface HtmlWidgetRenderBlock {
+  type: 'html_widget';
+  key: string;
+  segment: ContentSegmentRecord;
+}
 
 type RenderBlock =
   | ActivityRenderBlock
@@ -909,9 +923,10 @@ type RenderBlock =
   | UserQuestionRenderBlock
   | CreateWorkspaceRenderBlock
   | StartQuestionRenderBlock
-  | NotificationRenderBlock;
+  | NotificationRenderBlock
+  | HtmlWidgetRenderBlock;
 
-const MessageContentSegments = memo(function MessageContentSegments({ segments, reasoningProcesses, toolCallProcesses, todoListProcesses, subagentTasks, planApprovals = EMPTY_OBJ, userQuestions = EMPTY_OBJ, workspaceProposals = EMPTY_OBJ, questionProposals = EMPTY_OBJ, pendingToolCallChunks = EMPTY_OBJ, isStreaming, hasError, isAssistant = false, compactToolCalls = false, isSubagentView = false, readOnly = false, allowFiles = false, onOpenSubagentTask, onOpenFile, onOpenDir, onToolCallDetailClick, onApprovePlan, onRejectPlan, onPlanDetailClick, onAnswerQuestion, onSkipQuestion, onApproveCreateWorkspace, onRejectCreateWorkspace, onApproveStartQuestion, onRejectStartQuestion, textOnly = false }: MessageContentSegmentsProps): React.ReactElement {
+const MessageContentSegments = memo(function MessageContentSegments({ segments, reasoningProcesses, toolCallProcesses, todoListProcesses, subagentTasks, planApprovals = EMPTY_OBJ, userQuestions = EMPTY_OBJ, workspaceProposals = EMPTY_OBJ, questionProposals = EMPTY_OBJ, pendingToolCallChunks = EMPTY_OBJ, isStreaming, hasError, isAssistant = false, compactToolCalls = false, isSubagentView = false, readOnly = false, allowFiles = false, onOpenSubagentTask, onOpenFile, onOpenDir, onToolCallDetailClick, onApprovePlan, onRejectPlan, onPlanDetailClick, onAnswerQuestion, onSkipQuestion, onApproveCreateWorkspace, onRejectCreateWorkspace, onApproveStartQuestion, onRejectStartQuestion, onWidgetSendPrompt, htmlWidgetProcesses = EMPTY_OBJ, textOnly = false }: MessageContentSegmentsProps): React.ReactElement {
   // Force re-render timer for recently-completed tool calls that need minimum exposure
   const [tick, setTick] = useState(0);
   const expiryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -984,6 +999,7 @@ const MessageContentSegments = memo(function MessageContentSegments({ segments, 
         if (s.type === 'user_question') return true;
         if (s.type === 'create_workspace') return true;
         if (s.type === 'start_question') return true;
+        if (s.type === 'html_widget') return true;
         if (s.type === 'tool_call') {
           const toolName = toolCallProcesses[s.toolCallId!]?.toolName as string | undefined;
           if (HIDDEN_TOOL_CALL_NAMES.has(toolName || '')) return false;
@@ -1124,6 +1140,9 @@ const MessageContentSegments = memo(function MessageContentSegments({ segments, 
         } else if (seg.type === 'start_question') {
           flushActivity();
           blocks.push({ type: 'start_question', key: `start-question-${seg.proposalId}`, segment: seg });
+        } else if (seg.type === 'html_widget') {
+          flushActivity();
+          blocks.push({ type: 'html_widget', key: `widget-${seg.widgetId}`, segment: seg });
         } else if (seg.type === 'notification') {
           flushActivity();
           blocks.push({ type: 'notification', key: `notification-${seg.order}`, segment: seg });
@@ -1252,6 +1271,19 @@ const MessageContentSegments = memo(function MessageContentSegments({ segments, 
                 isStreaming={!!(isStreaming && blockIdx === lastTextBlockIdx && !hasAnyTrulyInProgress)}
                 hasError={!!hasError}
                 onOpenFile={onOpenFile}
+              />
+            );
+          }
+
+          if (block.type === 'html_widget') {
+            const widgetSeg = (block as HtmlWidgetRenderBlock).segment;
+            const widgetData = (htmlWidgetProcesses as Record<string, { html: string; title: string }> | undefined)?.[widgetSeg.widgetId!];
+            if (!widgetData) return null;
+            return (
+              <InlineWidget
+                key={block.key}
+                html={widgetData.html}
+                onSendPrompt={onWidgetSendPrompt}
               />
             );
           }

--- a/web/src/pages/ChatAgent/components/MessageList.tsx
+++ b/web/src/pages/ChatAgent/components/MessageList.tsx
@@ -1283,6 +1283,7 @@ const MessageContentSegments = memo(function MessageContentSegments({ segments, 
               <InlineWidget
                 key={block.key}
                 html={widgetData.html}
+                title={widgetData.title}
                 onSendPrompt={onWidgetSendPrompt}
                 data={widgetData.data}
               />

--- a/web/src/pages/ChatAgent/components/MessageList.tsx
+++ b/web/src/pages/ChatAgent/components/MessageList.tsx
@@ -1277,13 +1277,14 @@ const MessageContentSegments = memo(function MessageContentSegments({ segments, 
 
           if (block.type === 'html_widget') {
             const widgetSeg = (block as HtmlWidgetRenderBlock).segment;
-            const widgetData = (htmlWidgetProcesses as Record<string, { html: string; title: string }> | undefined)?.[widgetSeg.widgetId!];
+            const widgetData = (htmlWidgetProcesses as Record<string, { html: string; title: string; data?: Record<string, string> }> | undefined)?.[widgetSeg.widgetId!];
             if (!widgetData) return null;
             return (
               <InlineWidget
                 key={block.key}
                 html={widgetData.html}
                 onSendPrompt={onWidgetSendPrompt}
+                data={widgetData.data}
               />
             );
           }

--- a/web/src/pages/ChatAgent/components/viewers/InlineWidget.css
+++ b/web/src/pages/ChatAgent/components/viewers/InlineWidget.css
@@ -1,0 +1,12 @@
+.inline-widget-container {
+  overflow: hidden;
+  margin: 8px 0;
+}
+
+.inline-widget-frame {
+  display: block;
+  width: 100%;
+  border: none;
+  overflow: hidden;
+  transition: height 0.15s ease;
+}

--- a/web/src/pages/ChatAgent/components/viewers/InlineWidget.tsx
+++ b/web/src/pages/ChatAgent/components/viewers/InlineWidget.tsx
@@ -1,0 +1,176 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import './InlineWidget.css';
+
+interface InlineWidgetProps {
+  html: string;
+  title?: string;
+  onSendPrompt?: (text: string) => void;
+}
+
+/** CSS variables to inject into the widget iframe for theme matching. */
+const THEME_VARS = [
+  '--color-bg-page',
+  '--color-bg-card',
+  '--color-bg-elevated',
+  '--color-bg-input',
+  '--color-bg-surface',
+  '--color-bg-hover',
+  '--color-bg-subtle',
+  '--color-border-muted',
+  '--color-border-default',
+  '--color-border-elevated',
+  '--color-border-subtle',
+  '--color-text-primary',
+  '--color-text-secondary',
+  '--color-text-tertiary',
+  '--color-text-quaternary',
+  '--color-text-muted',
+  '--color-accent-primary',
+  '--color-accent-soft',
+  '--color-profit',
+  '--color-profit-soft',
+  '--color-loss',
+  '--color-loss-soft',
+  '--color-warning',
+  '--color-info',
+  '--color-success',
+];
+
+/** CSS safety net: force outermost element to be seamless regardless of agent HTML. */
+const SEAMLESS_OVERRIDE = `
+body > :first-child {
+  background: transparent !important;
+  border: none !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+  margin: 0 !important;
+}`;
+
+function resolveThemeVars(): string {
+  const style = getComputedStyle(document.documentElement);
+  return THEME_VARS.map((v) => {
+    const val = style.getPropertyValue(v).trim();
+    return val ? `${v}: ${val};` : '';
+  })
+    .filter(Boolean)
+    .join('\n  ');
+}
+
+function buildSrcDoc(html: string): string {
+  const themeCSS = resolveThemeVars();
+
+  return `<!DOCTYPE html><html><head>
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' cdnjs.cloudflare.com cdn.jsdelivr.net unpkg.com esm.sh; style-src 'unsafe-inline'; img-src data: blob:; font-src cdnjs.cloudflare.com cdn.jsdelivr.net; connect-src 'none';">
+<style>
+:root {
+  ${themeCSS}
+}
+*, *::before, *::after { box-sizing: border-box; }
+body { margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: var(--color-text-primary); background: transparent; overflow: hidden; }
+${SEAMLESS_OVERRIDE}
+</style>
+<script>
+window.sendPrompt = function(text) {
+  parent.postMessage({ type: 'widget:sendPrompt', text: String(text) }, '*');
+};
+(function() {
+  var lastH = 0;
+  var pending = 0;
+  function reportHeight() {
+    if (!document.body) return;
+    var h = document.body.scrollHeight;
+    if (h > 0 && Math.abs(h - lastH) > 2) {
+      lastH = h;
+      parent.postMessage({ type: 'widget:resize', height: h }, '*');
+    }
+  }
+  function debouncedReport() {
+    if (pending) return;
+    pending = requestAnimationFrame(function() {
+      pending = 0;
+      reportHeight();
+    });
+  }
+  document.addEventListener('DOMContentLoaded', function() {
+    var mo = new MutationObserver(debouncedReport);
+    mo.observe(document.body, { childList: true, subtree: true });
+    reportHeight();
+  });
+  var checks = [100, 300, 800, 2000, 5000];
+  checks.forEach(function(ms) { setTimeout(reportHeight, ms); });
+  window.addEventListener('message', function(e) {
+    if (e.data && e.data.type === 'widget:themeUpdate' && e.data.css) {
+      var style = document.querySelector('style');
+      if (style) {
+        style.textContent = style.textContent.replace(
+          /:root\\s*\\{[^}]*\\}/,
+          ':root {\\n  ' + e.data.css + '\\n}'
+        );
+      }
+    }
+  });
+})();
+</script>
+</head><body>${html}</body></html>`;
+}
+
+export default function InlineWidget({ html, onSendPrompt }: InlineWidgetProps) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [height, setHeight] = useState<number | null>(null);
+
+  const srcDoc = useMemo(() => buildSrcDoc(html), [html]);
+
+  const handleMessage = useCallback(
+    (e: MessageEvent) => {
+      if (!iframeRef.current || e.source !== iframeRef.current.contentWindow) return;
+
+      const { type, height: h, text } = e.data || {};
+      if (type === 'widget:resize' && typeof h === 'number' && h > 0) {
+        setHeight((prev) => {
+          const next = Math.ceil(h);
+          return prev === next ? prev : next;
+        });
+      } else if (type === 'widget:sendPrompt' && typeof text === 'string' && text.trim()) {
+        onSendPrompt?.(text.trim());
+      }
+    },
+    [onSendPrompt],
+  );
+
+  useEffect(() => {
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, [handleMessage]);
+
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      if (!iframeRef.current?.contentWindow) return;
+      const themeCSS = resolveThemeVars();
+      iframeRef.current.contentWindow.postMessage(
+        { type: 'widget:themeUpdate', css: themeCSS },
+        '*',
+      );
+    });
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-theme'],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div className="inline-widget-container">
+      <iframe
+        ref={iframeRef}
+        srcDoc={srcDoc}
+        sandbox="allow-scripts"
+        title="Widget"
+        className="inline-widget-frame"
+        style={{
+          height: height != null ? `${height}px` : '150px',
+          opacity: height != null ? 1 : 0,
+        }}
+      />
+    </div>
+  );
+}

--- a/web/src/pages/ChatAgent/components/viewers/InlineWidget.tsx
+++ b/web/src/pages/ChatAgent/components/viewers/InlineWidget.tsx
@@ -5,6 +5,8 @@ interface InlineWidgetProps {
   html: string;
   title?: string;
   onSendPrompt?: (text: string) => void;
+  /** Inline data file contents — injected directly as __WIDGET_DATA__. */
+  data?: Record<string, string>;
 }
 
 /** CSS variables to inject into the widget iframe for theme matching. */
@@ -56,11 +58,14 @@ function resolveThemeVars(): string {
     .join('\n  ');
 }
 
-function buildSrcDoc(html: string): string {
+function buildSrcDoc(html: string, widgetData?: Record<string, string>): string {
   const themeCSS = resolveThemeVars();
+  const dataScript = widgetData && Object.keys(widgetData).length > 0
+    ? `<script>window.__WIDGET_DATA__ = ${JSON.stringify(widgetData).replace(/<\//g, '<\\/')};</script>\n`
+    : '';
 
   return `<!DOCTYPE html><html><head>
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' cdnjs.cloudflare.com cdn.jsdelivr.net unpkg.com esm.sh; style-src 'unsafe-inline'; img-src data: blob:; font-src cdnjs.cloudflare.com cdn.jsdelivr.net; connect-src 'none';">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' cdnjs.cloudflare.com cdn.jsdelivr.net unpkg.com esm.sh; style-src 'unsafe-inline'; img-src data: blob:; font-src cdnjs.cloudflare.com cdn.jsdelivr.net; connect-src cdnjs.cloudflare.com cdn.jsdelivr.net unpkg.com esm.sh;">
 <style>
 :root {
   ${themeCSS}
@@ -69,7 +74,7 @@ function buildSrcDoc(html: string): string {
 body { margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: var(--color-text-primary); background: transparent; overflow: hidden; }
 ${SEAMLESS_OVERRIDE}
 </style>
-<script>
+${dataScript}<script>
 window.sendPrompt = function(text) {
   parent.postMessage({ type: 'widget:sendPrompt', text: String(text) }, '*');
 };
@@ -114,11 +119,11 @@ window.sendPrompt = function(text) {
 </head><body>${html}</body></html>`;
 }
 
-export default function InlineWidget({ html, onSendPrompt }: InlineWidgetProps) {
+export default function InlineWidget({ html, onSendPrompt, data }: InlineWidgetProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [height, setHeight] = useState<number | null>(null);
 
-  const srcDoc = useMemo(() => buildSrcDoc(html), [html]);
+  const srcDoc = useMemo(() => buildSrcDoc(html, data), [html, data]);
 
   const handleMessage = useCallback(
     (e: MessageEvent) => {

--- a/web/src/pages/ChatAgent/components/viewers/InlineWidget.tsx
+++ b/web/src/pages/ChatAgent/components/viewers/InlineWidget.tsx
@@ -163,6 +163,10 @@ export default function InlineWidget({ html, onSendPrompt, data }: InlineWidgetP
     return () => observer.disconnect();
   }, []);
 
+  // No max-height cap — widgets span naturally to fit content (charts, tables,
+  // dashboards). The agent controls HTML output and the skill doc guides it to
+  // keep widgets reasonable. A cap would add scroll-in-scroll UX that's worse
+  // than a tall widget pushing chat down.
   return (
     <div className="inline-widget-container">
       <iframe

--- a/web/src/pages/ChatAgent/components/viewers/InlineWidget.tsx
+++ b/web/src/pages/ChatAgent/components/viewers/InlineWidget.tsx
@@ -119,7 +119,7 @@ window.sendPrompt = function(text) {
 </head><body>${html}</body></html>`;
 }
 
-export default function InlineWidget({ html, onSendPrompt, data }: InlineWidgetProps) {
+export default function InlineWidget({ html, title, onSendPrompt, data }: InlineWidgetProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [height, setHeight] = useState<number | null>(null);
 
@@ -173,7 +173,7 @@ export default function InlineWidget({ html, onSendPrompt, data }: InlineWidgetP
         ref={iframeRef}
         srcDoc={srcDoc}
         sandbox="allow-scripts"
-        title="Widget"
+        title={title || 'Widget'}
         className="inline-widget-frame"
         style={{
           height: height != null ? `${height}px` : '150px',

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -22,7 +22,7 @@ export { removeStoredThreadId } from './utils/threadStorage';
 import { createUserMessage, createAssistantMessage, createNotificationMessage, appendMessage, updateMessage, type AttachmentMeta } from './utils/messageHelpers';
 import type { ChatMessage, AssistantMessage } from '@/types/chat';
 import type { ActionRequest, ToolCallData, TodoItem } from '@/types/sse';
-import type { PreviewData } from './utils/types';
+import type { HtmlWidgetData, PreviewData } from './utils/types';
 import { createRecentlySentTracker } from './utils/recentlySentTracker';
 import {
   handleReasoningSignal,
@@ -32,6 +32,7 @@ import {
   handleToolCallResult,
   handleToolCallChunks,
   handleTodoUpdate,
+  handleHtmlWidget,
   isSubagentEvent,
   handleSubagentMessageChunk,
   handleSubagentToolCallChunks,
@@ -48,6 +49,7 @@ import {
   handleHistoryToolCalls,
   handleHistoryToolCallResult,
   handleHistoryTodoUpdate,
+  handleHistoryHtmlWidget,
   handleHistorySteeringDelivered,
   isSubagentHistoryEvent,
 } from './utils/historyEventHandlers';
@@ -987,6 +989,55 @@ export function useChatMessages(
                   artifactType: artifactType as string,
                   artifactId: event.artifact_id as string,
                   payload,
+                  pairState: targetPairState,
+                  setMessages: setMessagesForHandlers,
+                  eventId: event._eventId as number | undefined,
+                });
+              }
+            }
+          }
+          if (artifactType === 'html_widget') {
+            const payload = (event.payload || {}) as unknown as HtmlWidgetData;
+
+            if (hasPairIndex) {
+              const pairIndex = event.turn_index!;
+              currentActivePairIndex = pairIndex;
+              currentActivePairState = pairStateByPair.get(pairIndex);
+
+              const currentAssistantMessageId = assistantMessagesByPair.get(pairIndex);
+              const pairState = pairStateByPair.get(pairIndex);
+
+              if (currentAssistantMessageId && pairState) {
+                handleHistoryHtmlWidget({
+                  assistantMessageId: currentAssistantMessageId,
+                  artifactType: artifactType as string,
+                  artifactId: event.artifact_id as string,
+                  payload: payload as HtmlWidgetData | null,
+                  pairState,
+                  setMessages: setMessagesForHandlers,
+                  eventId: event._eventId as number | undefined,
+                });
+              }
+            } else {
+              let targetAssistantMessageId = null;
+              let targetPairState = null;
+
+              if (currentActivePairIndex !== null && currentActivePairState) {
+                targetAssistantMessageId = assistantMessagesByPair.get(currentActivePairIndex);
+                targetPairState = currentActivePairState;
+              } else if (assistantMessagesByPair.size > 0) {
+                const pairIndices = Array.from(assistantMessagesByPair.keys()).sort((a, b) => b - a);
+                const lastPairIndex = pairIndices[0];
+                targetAssistantMessageId = assistantMessagesByPair.get(lastPairIndex);
+                targetPairState = pairStateByPair.get(lastPairIndex);
+              }
+
+              if (targetAssistantMessageId && targetPairState) {
+                handleHistoryHtmlWidget({
+                  assistantMessageId: targetAssistantMessageId,
+                  artifactType: artifactType as string,
+                  artifactId: event.artifact_id as string,
+                  payload: payload as HtmlWidgetData | null,
                   pairState: targetPairState,
                   setMessages: setMessagesForHandlers,
                   eventId: event._eventId as number | undefined,
@@ -2654,6 +2705,16 @@ export function useChatMessages(
             eventId: event._eventId as number,
           });
           console.log('[Stream] handleTodoUpdate result:', result);
+        } else if (artifactType === 'html_widget') {
+          handleHtmlWidget({
+            assistantMessageId,
+            artifactType,
+            artifactId: event.artifact_id as string,
+            payload: (event.payload || {}) as unknown as HtmlWidgetData,
+            refs,
+            setMessages: setMessagesForHandlers,
+            eventId: event._eventId as number,
+          });
         } else if (artifactType === 'file_operation' && onFileArtifact) {
           onFileArtifact(event);
         } else if (artifactType === 'preview_url' && onPreviewUrl) {

--- a/web/src/pages/ChatAgent/hooks/utils/__tests__/htmlWidgetHandlers.test.ts
+++ b/web/src/pages/ChatAgent/hooks/utils/__tests__/htmlWidgetHandlers.test.ts
@@ -1,0 +1,441 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { MessageRecord, SetMessages } from '../types';
+import { handleHtmlWidget } from '../streamEventHandlers';
+import { handleHistoryHtmlWidget } from '../historyEventHandlers';
+
+// ---- helpers ----------------------------------------------------------------
+
+/** Build a minimal assistant message with empty widget state. */
+function makeAssistantMessage(
+  id: string,
+  overrides: Partial<MessageRecord> = {},
+): MessageRecord {
+  return {
+    id,
+    role: 'assistant',
+    content: '',
+    contentSegments: [],
+    htmlWidgetProcesses: {},
+    ...overrides,
+  };
+}
+
+/** Build a minimal non-target message to verify it stays untouched. */
+function makeOtherMessage(id: string): MessageRecord {
+  return {
+    id,
+    role: 'assistant',
+    content: 'other',
+    contentSegments: [],
+    htmlWidgetProcesses: {},
+  };
+}
+
+/**
+ * Creates a mock setMessages that captures the updater and applies it
+ * to the provided initial messages array, returning the result.
+ */
+function applySetMessages(
+  initial: MessageRecord[],
+  callHandler: (setMessages: SetMessages) => void,
+): MessageRecord[] {
+  let result: MessageRecord[] = initial;
+  const setMessages: SetMessages = (updater) => {
+    result = updater(result);
+  };
+  callHandler(setMessages);
+  return result;
+}
+
+/** Minimal StreamRefs shape needed by handleHtmlWidget. */
+function makeStreamRefs(counterStart = 0) {
+  return {
+    contentOrderCounterRef: { current: counterStart },
+    currentReasoningIdRef: { current: null },
+    currentToolCallIdRef: { current: null },
+  };
+}
+
+/** Minimal PairState shape needed by handleHistoryHtmlWidget. */
+function makePairState(counterStart = 0) {
+  return {
+    contentOrderCounter: counterStart,
+    reasoningId: null,
+    toolCallId: null,
+  };
+}
+
+// ---- handleHtmlWidget (streaming) -------------------------------------------
+
+describe('handleHtmlWidget (streaming)', () => {
+  const assistantMessageId = 'ast-1';
+  const artifactId = 'w-abc';
+
+  it('returns false when artifactType is not html_widget', () => {
+    const refs = makeStreamRefs();
+    const initial = [makeAssistantMessage(assistantMessageId)];
+    let called = false;
+    const setMessages: SetMessages = () => { called = true; };
+
+    const result = handleHtmlWidget({
+      assistantMessageId,
+      artifactType: 'code',
+      artifactId,
+      payload: { html: '<p>hi</p>', title: 'Test' },
+      refs,
+      setMessages,
+    });
+
+    expect(result).toBe(false);
+    expect(called).toBe(false);
+  });
+
+  it('returns false when payload is null', () => {
+    const refs = makeStreamRefs();
+    let called = false;
+    const setMessages: SetMessages = () => { called = true; };
+
+    const result = handleHtmlWidget({
+      assistantMessageId,
+      artifactType: 'html_widget',
+      artifactId,
+      payload: null,
+      refs,
+      setMessages,
+    });
+
+    expect(result).toBe(false);
+    expect(called).toBe(false);
+  });
+
+  it('creates a content segment with type html_widget and correct widgetId', () => {
+    const refs = makeStreamRefs();
+    const initial = [makeAssistantMessage(assistantMessageId)];
+
+    const messages = applySetMessages(initial, (setMessages) => {
+      handleHtmlWidget({
+        assistantMessageId,
+        artifactType: 'html_widget',
+        artifactId,
+        payload: { html: '<p>chart</p>', title: 'Chart' },
+        refs,
+        setMessages,
+      });
+    });
+
+    const msg = messages[0];
+    const segments = msg.contentSegments as Record<string, unknown>[];
+    expect(segments).toHaveLength(1);
+    expect(segments[0]).toMatchObject({
+      type: 'html_widget',
+      widgetId: `widget-${artifactId}`,
+    });
+  });
+
+  it('populates htmlWidgetProcesses with html and title', () => {
+    const refs = makeStreamRefs();
+    const initial = [makeAssistantMessage(assistantMessageId)];
+
+    const messages = applySetMessages(initial, (setMessages) => {
+      handleHtmlWidget({
+        assistantMessageId,
+        artifactType: 'html_widget',
+        artifactId,
+        payload: { html: '<div>Hello</div>', title: 'My Widget' },
+        refs,
+        setMessages,
+      });
+    });
+
+    const msg = messages[0];
+    const processes = msg.htmlWidgetProcesses as Record<string, { html: string; title: string }>;
+    const segmentId = `widget-${artifactId}`;
+    expect(processes[segmentId]).toEqual({
+      html: '<div>Hello</div>',
+      title: 'My Widget',
+    });
+  });
+
+  it('uses eventId for ordering when provided', () => {
+    const refs = makeStreamRefs(10);
+    const initial = [makeAssistantMessage(assistantMessageId)];
+
+    const messages = applySetMessages(initial, (setMessages) => {
+      handleHtmlWidget({
+        assistantMessageId,
+        artifactType: 'html_widget',
+        artifactId,
+        payload: { html: '<p>x</p>', title: 'T' },
+        refs,
+        setMessages,
+        eventId: 42,
+      });
+    });
+
+    const segments = messages[0].contentSegments as Record<string, unknown>[];
+    expect(segments[0].order).toBe(42);
+    // Counter should not have been incremented
+    expect(refs.contentOrderCounterRef.current).toBe(10);
+  });
+
+  it('falls back to contentOrderCounterRef when eventId is null', () => {
+    const refs = makeStreamRefs(5);
+    const initial = [makeAssistantMessage(assistantMessageId)];
+
+    const messages = applySetMessages(initial, (setMessages) => {
+      handleHtmlWidget({
+        assistantMessageId,
+        artifactType: 'html_widget',
+        artifactId,
+        payload: { html: '<p>x</p>', title: 'T' },
+        refs,
+        setMessages,
+        eventId: null,
+      });
+    });
+
+    const segments = messages[0].contentSegments as Record<string, unknown>[];
+    expect(segments[0].order).toBe(6); // incremented from 5 to 6
+    expect(refs.contentOrderCounterRef.current).toBe(6);
+  });
+
+  it('prevents duplicate segments with same widgetId', () => {
+    const refs = makeStreamRefs();
+    const segmentId = `widget-${artifactId}`;
+    const initial = [
+      makeAssistantMessage(assistantMessageId, {
+        contentSegments: [{ type: 'html_widget', widgetId: segmentId, order: 1 }],
+        htmlWidgetProcesses: { [segmentId]: { html: '<p>old</p>', title: 'Old' } },
+      }),
+    ];
+
+    const messages = applySetMessages(initial, (setMessages) => {
+      handleHtmlWidget({
+        assistantMessageId,
+        artifactType: 'html_widget',
+        artifactId,
+        payload: { html: '<p>new</p>', title: 'New' },
+        refs,
+        setMessages,
+      });
+    });
+
+    const msg = messages[0];
+    const segments = msg.contentSegments as Record<string, unknown>[];
+    expect(segments).toHaveLength(1);
+    // Should be the original message object (identity unchanged)
+    expect(msg).toBe(initial[0]);
+  });
+
+  it('only updates the matching assistant message (leaves others untouched)', () => {
+    const refs = makeStreamRefs();
+    const other = makeOtherMessage('other-1');
+    const initial = [other, makeAssistantMessage(assistantMessageId)];
+
+    const messages = applySetMessages(initial, (setMessages) => {
+      handleHtmlWidget({
+        assistantMessageId,
+        artifactType: 'html_widget',
+        artifactId,
+        payload: { html: '<p>hi</p>', title: 'W' },
+        refs,
+        setMessages,
+      });
+    });
+
+    // The other message should be the exact same reference
+    expect(messages[0]).toBe(other);
+    // The target message should have been updated
+    const target = messages[1];
+    const segments = target.contentSegments as Record<string, unknown>[];
+    expect(segments).toHaveLength(1);
+    expect(segments[0]).toMatchObject({ type: 'html_widget' });
+  });
+});
+
+// ---- handleHistoryHtmlWidget (history) --------------------------------------
+
+describe('handleHistoryHtmlWidget (history)', () => {
+  const assistantMessageId = 'ast-2';
+  const artifactId = 'w-xyz';
+
+  it('returns false when artifactType is not html_widget', () => {
+    const pairState = makePairState();
+    let called = false;
+    const setMessages: SetMessages = () => { called = true; };
+
+    const result = handleHistoryHtmlWidget({
+      assistantMessageId,
+      artifactType: 'file',
+      artifactId,
+      payload: { html: '<p>hi</p>', title: 'Test' },
+      pairState,
+      setMessages,
+    });
+
+    expect(result).toBe(false);
+    expect(called).toBe(false);
+  });
+
+  it('returns false when payload is null', () => {
+    const pairState = makePairState();
+    let called = false;
+    const setMessages: SetMessages = () => { called = true; };
+
+    const result = handleHistoryHtmlWidget({
+      assistantMessageId,
+      artifactType: 'html_widget',
+      artifactId,
+      payload: null,
+      pairState,
+      setMessages,
+    });
+
+    expect(result).toBe(false);
+    expect(called).toBe(false);
+  });
+
+  it('creates a content segment with type html_widget and correct widgetId', () => {
+    const pairState = makePairState();
+    const initial = [makeAssistantMessage(assistantMessageId)];
+
+    const messages = applySetMessages(initial, (setMessages) => {
+      handleHistoryHtmlWidget({
+        assistantMessageId,
+        artifactType: 'html_widget',
+        artifactId,
+        payload: { html: '<p>chart</p>', title: 'Chart' },
+        pairState,
+        setMessages,
+      });
+    });
+
+    const msg = messages[0];
+    const segments = msg.contentSegments as Record<string, unknown>[];
+    expect(segments).toHaveLength(1);
+    expect(segments[0]).toMatchObject({
+      type: 'html_widget',
+      widgetId: `widget-${artifactId}`,
+    });
+  });
+
+  it('populates htmlWidgetProcesses with html and title', () => {
+    const pairState = makePairState();
+    const initial = [makeAssistantMessage(assistantMessageId)];
+
+    const messages = applySetMessages(initial, (setMessages) => {
+      handleHistoryHtmlWidget({
+        assistantMessageId,
+        artifactType: 'html_widget',
+        artifactId,
+        payload: { html: '<section>Data</section>', title: 'Data Widget' },
+        pairState,
+        setMessages,
+      });
+    });
+
+    const msg = messages[0];
+    const processes = msg.htmlWidgetProcesses as Record<string, { html: string; title: string }>;
+    const segmentId = `widget-${artifactId}`;
+    expect(processes[segmentId]).toEqual({
+      html: '<section>Data</section>',
+      title: 'Data Widget',
+    });
+  });
+
+  it('uses eventId for ordering when provided', () => {
+    const pairState = makePairState(10);
+    const initial = [makeAssistantMessage(assistantMessageId)];
+
+    const messages = applySetMessages(initial, (setMessages) => {
+      handleHistoryHtmlWidget({
+        assistantMessageId,
+        artifactType: 'html_widget',
+        artifactId,
+        payload: { html: '<p>x</p>', title: 'T' },
+        pairState,
+        setMessages,
+        eventId: 99,
+      });
+    });
+
+    const segments = messages[0].contentSegments as Record<string, unknown>[];
+    expect(segments[0].order).toBe(99);
+    // Counter should not have been incremented
+    expect(pairState.contentOrderCounter).toBe(10);
+  });
+
+  it('falls back to pairState.contentOrderCounter when eventId is null', () => {
+    const pairState = makePairState(3);
+    const initial = [makeAssistantMessage(assistantMessageId)];
+
+    const messages = applySetMessages(initial, (setMessages) => {
+      handleHistoryHtmlWidget({
+        assistantMessageId,
+        artifactType: 'html_widget',
+        artifactId,
+        payload: { html: '<p>x</p>', title: 'T' },
+        pairState,
+        setMessages,
+        eventId: null,
+      });
+    });
+
+    const segments = messages[0].contentSegments as Record<string, unknown>[];
+    expect(segments[0].order).toBe(4); // incremented from 3 to 4
+    expect(pairState.contentOrderCounter).toBe(4);
+  });
+
+  it('prevents duplicate segments with same widgetId', () => {
+    const pairState = makePairState();
+    const segmentId = `widget-${artifactId}`;
+    const initial = [
+      makeAssistantMessage(assistantMessageId, {
+        contentSegments: [{ type: 'html_widget', widgetId: segmentId, order: 1 }],
+        htmlWidgetProcesses: { [segmentId]: { html: '<p>old</p>', title: 'Old' } },
+      }),
+    ];
+
+    const messages = applySetMessages(initial, (setMessages) => {
+      handleHistoryHtmlWidget({
+        assistantMessageId,
+        artifactType: 'html_widget',
+        artifactId,
+        payload: { html: '<p>new</p>', title: 'New' },
+        pairState,
+        setMessages,
+      });
+    });
+
+    const msg = messages[0];
+    const segments = msg.contentSegments as Record<string, unknown>[];
+    expect(segments).toHaveLength(1);
+    // Should be the original message object (identity unchanged)
+    expect(msg).toBe(initial[0]);
+  });
+
+  it('only updates the matching assistant message (leaves others untouched)', () => {
+    const pairState = makePairState();
+    const other = makeOtherMessage('other-2');
+    const initial = [other, makeAssistantMessage(assistantMessageId)];
+
+    const messages = applySetMessages(initial, (setMessages) => {
+      handleHistoryHtmlWidget({
+        assistantMessageId,
+        artifactType: 'html_widget',
+        artifactId,
+        payload: { html: '<p>hi</p>', title: 'W' },
+        pairState,
+        setMessages,
+      });
+    });
+
+    // The other message should be the exact same reference
+    expect(messages[0]).toBe(other);
+    // The target message should have been updated
+    const target = messages[1];
+    const segments = target.contentSegments as Record<string, unknown>[];
+    expect(segments).toHaveLength(1);
+    expect(segments[0]).toMatchObject({ type: 'html_widget' });
+  });
+});

--- a/web/src/pages/ChatAgent/hooks/utils/__tests__/htmlWidgetHandlers.test.ts
+++ b/web/src/pages/ChatAgent/hooks/utils/__tests__/htmlWidgetHandlers.test.ts
@@ -251,6 +251,27 @@ describe('handleHtmlWidget (streaming)', () => {
     expect(segments).toHaveLength(1);
     expect(segments[0]).toMatchObject({ type: 'html_widget' });
   });
+
+  it('passes data field through to htmlWidgetProcesses when present in payload', () => {
+    const refs = makeStreamRefs();
+    const initial = [makeAssistantMessage(assistantMessageId)];
+
+    const messages = applySetMessages(initial, (setMessages) => {
+      handleHtmlWidget({
+        assistantMessageId,
+        artifactType: 'html_widget',
+        artifactId,
+        payload: { html: '<p>chart</p>', title: 'Chart', data: { 'prices.json': '{"AAPL": 150}' } },
+        refs,
+        setMessages,
+      });
+    });
+
+    const msg = messages[0];
+    const segmentId = `widget-${artifactId}`;
+    const processes = msg.htmlWidgetProcesses as Record<string, { html: string; title: string; data?: Record<string, string> }>;
+    expect(processes[segmentId].data).toEqual({ 'prices.json': '{"AAPL": 150}' });
+  });
 });
 
 // ---- handleHistoryHtmlWidget (history) --------------------------------------
@@ -437,5 +458,26 @@ describe('handleHistoryHtmlWidget (history)', () => {
     const segments = target.contentSegments as Record<string, unknown>[];
     expect(segments).toHaveLength(1);
     expect(segments[0]).toMatchObject({ type: 'html_widget' });
+  });
+
+  it('passes data field through to htmlWidgetProcesses when present in payload', () => {
+    const pairState = makePairState();
+    const initial = [makeAssistantMessage(assistantMessageId)];
+
+    const messages = applySetMessages(initial, (setMessages) => {
+      handleHistoryHtmlWidget({
+        assistantMessageId,
+        artifactType: 'html_widget',
+        artifactId,
+        payload: { html: '<p>chart</p>', title: 'Chart', data: { 'data.csv': 'a,b\n1,2' } },
+        pairState,
+        setMessages,
+      });
+    });
+
+    const msg = messages[0];
+    const segmentId = `widget-${artifactId}`;
+    const processes = msg.htmlWidgetProcesses as Record<string, { html: string; title: string; data?: Record<string, string> }>;
+    expect(processes[segmentId].data).toEqual({ 'data.csv': 'a,b\n1,2' });
   });
 });

--- a/web/src/pages/ChatAgent/hooks/utils/historyEventHandlers.ts
+++ b/web/src/pages/ChatAgent/hooks/utils/historyEventHandlers.ts
@@ -4,7 +4,7 @@
  */
 
 import { normalizeAction } from './eventUtils';
-import type { MessageRecord, SetMessages, ToolCallRecord, ToolCallResultRecord, TodoPayload } from './types';
+import type { MessageRecord, SetMessages, ToolCallRecord, ToolCallResultRecord, TodoPayload, HtmlWidgetData } from './types';
 
 let _steeringIdCounter = 0;
 
@@ -742,6 +742,62 @@ export function handleHistoryTodoUpdate({ assistantMessageId, artifactType, arti
         ...msg,
         contentSegments,
         todoListProcesses,
+      };
+    });
+
+    return updated;
+  });
+
+  return true;
+}
+
+/**
+ * Handles artifact events with artifact_type: "html_widget" in history replay.
+ * Creates a content segment for inline rendering of interactive HTML widgets.
+ */
+export function handleHistoryHtmlWidget({ assistantMessageId, artifactType, artifactId, payload, pairState, setMessages, eventId }: {
+  assistantMessageId: string;
+  artifactType: string;
+  artifactId: string;
+  payload: HtmlWidgetData | null;
+  pairState: PairState;
+  setMessages: SetMessages;
+  eventId?: number | null;
+}): boolean {
+  if (artifactType !== 'html_widget' || !payload) {
+    return false;
+  }
+
+  const { html, title } = payload;
+  const segmentId = `widget-${artifactId}`;
+  const currentOrder = eventId != null ? eventId : ++pairState.contentOrderCounter;
+
+  setMessages((prev: MessageRecord[]) => {
+    const updated = prev.map((msg: MessageRecord) => {
+      if (msg.id !== assistantMessageId) return msg;
+
+      const htmlWidgetProcesses = { ...((msg.htmlWidgetProcesses as Record<string, HtmlWidgetData>) || {}) };
+      const contentSegments = [...((msg.contentSegments as Record<string, unknown>[]) || [])];
+
+      // Prevent duplicates
+      const segmentExists = contentSegments.some((s: Record<string, unknown>) => s.widgetId === segmentId);
+      if (segmentExists) return msg;
+
+      contentSegments.push({
+        type: 'html_widget',
+        widgetId: segmentId,
+        order: currentOrder,
+      });
+
+      htmlWidgetProcesses[segmentId] = {
+        html: html || '',
+        title: title || '',
+      };
+
+      return {
+        ...msg,
+        contentSegments,
+        htmlWidgetProcesses,
       };
     });
 

--- a/web/src/pages/ChatAgent/hooks/utils/historyEventHandlers.ts
+++ b/web/src/pages/ChatAgent/hooks/utils/historyEventHandlers.ts
@@ -789,10 +789,14 @@ export function handleHistoryHtmlWidget({ assistantMessageId, artifactType, arti
         order: currentOrder,
       });
 
-      htmlWidgetProcesses[segmentId] = {
+      const widgetEntry: HtmlWidgetData = {
         html: html || '',
         title: title || '',
       };
+      if ((payload as Record<string, unknown>).data) {
+        widgetEntry.data = (payload as Record<string, unknown>).data as Record<string, string>;
+      }
+      htmlWidgetProcesses[segmentId] = widgetEntry;
 
       return {
         ...msg,

--- a/web/src/pages/ChatAgent/hooks/utils/historyEventHandlers.ts
+++ b/web/src/pages/ChatAgent/hooks/utils/historyEventHandlers.ts
@@ -793,8 +793,8 @@ export function handleHistoryHtmlWidget({ assistantMessageId, artifactType, arti
         html: html || '',
         title: title || '',
       };
-      if ((payload as Record<string, unknown>).data) {
-        widgetEntry.data = (payload as Record<string, unknown>).data as Record<string, string>;
+      if (payload.data) {
+        widgetEntry.data = payload.data;
       }
       htmlWidgetProcesses[segmentId] = widgetEntry;
 

--- a/web/src/pages/ChatAgent/hooks/utils/streamEventHandlers.ts
+++ b/web/src/pages/ChatAgent/hooks/utils/streamEventHandlers.ts
@@ -4,7 +4,7 @@
  */
 
 import { normalizeAction } from './eventUtils';
-import type { MessageRecord, SetMessages, ToolCallRecord, ToolCallResultRecord, TodoPayload } from './types';
+import type { MessageRecord, SetMessages, ToolCallRecord, ToolCallResultRecord, TodoPayload, HtmlWidgetData } from './types';
 
 /** Callback to update a subagent card by task ID. */
 type UpdateSubagentCard = (taskId: string, patch: Record<string, unknown>) => void;
@@ -634,6 +634,64 @@ export function handleTodoUpdate({ assistantMessageId, artifactType, artifactId,
     if (process.env.NODE_ENV === 'development') {
       console.log('[handleTodoUpdate] Final messages after update:', updated.map((m: MessageRecord) => ({ id: m.id, segmentsCount: (m.contentSegments as unknown[])?.length, todoListIds: Object.keys((m.todoListProcesses as Record<string, unknown>) || {}) })));
     }
+    return updated;
+  });
+
+  return true;
+}
+
+/**
+ * Handles artifact events with artifact_type: "html_widget" during streaming.
+ * Creates a content segment for inline rendering of interactive HTML widgets.
+ */
+export function handleHtmlWidget({ assistantMessageId, artifactType, artifactId, payload, refs, setMessages, eventId }: {
+  assistantMessageId: string;
+  artifactType: string;
+  artifactId: string;
+  payload: HtmlWidgetData | null;
+  refs: StreamRefs;
+  setMessages: SetMessages;
+  eventId?: number | null;
+}): boolean {
+  const { contentOrderCounterRef } = refs;
+
+  if (artifactType !== 'html_widget' || !payload) {
+    return false;
+  }
+
+  const { html, title } = payload;
+  const segmentId = `widget-${artifactId}`;
+
+  setMessages((prev: MessageRecord[]) => {
+    const updated = prev.map((msg: MessageRecord) => {
+      if (msg.id !== assistantMessageId) return msg;
+
+      const htmlWidgetProcesses = { ...((msg.htmlWidgetProcesses as Record<string, HtmlWidgetData>) || {}) };
+      const contentSegments = [...((msg.contentSegments as Record<string, unknown>[]) || [])];
+
+      // Prevent duplicates (e.g. on SSE reconnect replay)
+      const segmentExists = contentSegments.some((s: Record<string, unknown>) => s.widgetId === segmentId);
+      if (segmentExists) return msg;
+
+      const currentOrder = eventId != null ? eventId : ++contentOrderCounterRef.current;
+
+      contentSegments.push({
+        type: 'html_widget',
+        widgetId: segmentId,
+        order: currentOrder,
+      });
+
+      htmlWidgetProcesses[segmentId] = {
+        html: html || '',
+        title: title || '',
+      };
+
+      return {
+        ...msg,
+        contentSegments,
+        htmlWidgetProcesses,
+      };
+    });
     return updated;
   });
 

--- a/web/src/pages/ChatAgent/hooks/utils/streamEventHandlers.ts
+++ b/web/src/pages/ChatAgent/hooks/utils/streamEventHandlers.ts
@@ -685,8 +685,8 @@ export function handleHtmlWidget({ assistantMessageId, artifactType, artifactId,
         html: html || '',
         title: title || '',
       };
-      if ((payload as Record<string, unknown>).data) {
-        widgetEntry.data = (payload as Record<string, unknown>).data as Record<string, string>;
+      if (payload.data) {
+        widgetEntry.data = payload.data;
       }
       htmlWidgetProcesses[segmentId] = widgetEntry;
 

--- a/web/src/pages/ChatAgent/hooks/utils/streamEventHandlers.ts
+++ b/web/src/pages/ChatAgent/hooks/utils/streamEventHandlers.ts
@@ -681,10 +681,14 @@ export function handleHtmlWidget({ assistantMessageId, artifactType, artifactId,
         order: currentOrder,
       });
 
-      htmlWidgetProcesses[segmentId] = {
+      const widgetEntry: HtmlWidgetData = {
         html: html || '',
         title: title || '',
       };
+      if ((payload as Record<string, unknown>).data) {
+        widgetEntry.data = (payload as Record<string, unknown>).data as Record<string, string>;
+      }
+      htmlWidgetProcesses[segmentId] = widgetEntry;
 
       return {
         ...msg,

--- a/web/src/pages/ChatAgent/hooks/utils/types.ts
+++ b/web/src/pages/ChatAgent/hooks/utils/types.ts
@@ -35,6 +35,12 @@ export interface TodoPayload {
   [key: string]: unknown;
 }
 
+/** Data for an inline HTML widget. */
+export interface HtmlWidgetData {
+  html: string;
+  title: string;
+}
+
 /** Data for a preview URL panel. */
 export interface PreviewData {
   url: string;

--- a/web/src/pages/ChatAgent/hooks/utils/types.ts
+++ b/web/src/pages/ChatAgent/hooks/utils/types.ts
@@ -39,6 +39,8 @@ export interface TodoPayload {
 export interface HtmlWidgetData {
   html: string;
   title: string;
+  /** Inline data file contents — injected as window.__WIDGET_DATA__ in the iframe. */
+  data?: Record<string, string>;
 }
 
 /** Data for a preview URL panel. */

--- a/web/src/pages/ChatAgent/utils/api.ts
+++ b/web/src/pages/ChatAgent/utils/api.ts
@@ -138,7 +138,14 @@ async function streamFetch(
     if (res.status === 404 && url.includes('/replay')) {
       throw new Error(`HTTP error! status: ${res.status}`);
     }
-    throw new Error(`HTTP error! status: ${res.status}`);
+    // Read response body for error detail
+    let detail = '';
+    try {
+      const body = await res.json();
+      detail = typeof body?.detail === 'string' ? body.detail : JSON.stringify(body?.detail || body);
+    } catch { /* ignore parse errors */ }
+    console.error(`[api] ${opts.method || 'GET'} ${url} failed:`, res.status, detail);
+    throw new Error(detail || `HTTP error! status: ${res.status}`);
   }
 
   const reader = res.body!.getReader();


### PR DESCRIPTION
## Summary
- Add `ShowWidget` tool for rendering interactive HTML/SVG widgets inline in chat messages (charts, dashboards, data tables)
- Add `data_files` parameter to load sandbox files into widgets as `window.__WIDGET_DATA__`
- Add inline-widget skill with layout rules, theme variables, Chart.js patterns, and blocked pattern validation
- Frontend: sandboxed iframe renderer with CSP, theme sync, auto-resize, and `sendPrompt()` bridge
- Update prompt templates to prefer ShowWidget for visualizations over image files

## Test Coverage
```
Tests: 22 → 24 test files (+2 new)
Backend: 1601 passed (37 ShowWidget-specific tests)
Frontend: 210 passed (18 widget handler tests)

CODE PATH COVERAGE: 24/24 paths tested (100% after generation)
  - _validate_html: all rules + multi-violation ★★★
  - _detect_outer_wrapper_issues: all branches ★★★
  - _load_widget_guidelines: cache/error/empty ★★★
  - _is_text_file: text/binary/uppercase/no-ext ★★★
  - _resolve_data_files: text/binary/cap/error/skip ★★★
  - ShowWidget: valid/invalid/title/data_files ★★★
  - handleHtmlWidget: all 9 stream paths ★★★
  - handleHistoryHtmlWidget: all 9 history paths ★★★
```

## Pre-Landing Review
No issues found.

## Design Review
Design Review (lite): 0 findings. Clean CSS, 8px spacing scale, no AI slop.

## Adversarial Review
17 findings from Claude adversarial subagent — all informational, none blocking.
Key mitigations: iframe `sandbox="allow-scripts"` (no `allow-same-origin`), strict CSP,
HTML validation layer, SEAMLESS_OVERRIDE CSS safety net.

## Test plan
- [x] All backend tests pass (1601 tests, 0 failures)
- [x] All frontend tests pass (210 tests, 0 failures)
- [x] Verification gate passed after final commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)