### PR TITLE
feat(sandbox): multi-port preview sessions with path routing and auto-restart

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -34,7 +34,8 @@ RUN apt-get update \
     && apt-get install -y nodejs \
     # -- NPM global packages --
     && npm install -g playwright docx pptxgenjs \
-    && npx playwright install --with-deps chromium \
+    && PLAYWRIGHT_BROWSERS_PATH=/usr/local/ms-playwright \
+       npx playwright install --with-deps chromium \
     # -- GitHub CLI --
     && curl -fsSL https://github.com/cli/cli/releases/download/v2.87.3/gh_2.87.3_linux_amd64.tar.gz \
         -o /tmp/gh.tar.gz \
@@ -56,6 +57,11 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# Playwright browsers were installed to /usr/local/ms-playwright (as root).
+# Set the env var so the Python playwright package finds them at runtime
+# regardless of which user runs the sandbox.
+ENV PLAYWRIGHT_BROWSERS_PATH=/usr/local/ms-playwright
+
 # ---------- Python packages ----------
 RUN uv pip install --system \
     mcp fastmcp \
@@ -67,7 +73,8 @@ RUN uv pip install --system \
     openpyxl xlrd python-docx pypdf \
     beautifulsoup4 lxml pyyaml \
     defusedxml pdfplumber reportlab "markitdown[pptx]" \
-    tqdm tabulate
+    tqdm tabulate \
+    playwright
 
 # ---------- Matplotlib CJK font config ----------
 RUN python3 -c "import matplotlib as mpl; import os; mpl_dir = mpl.get_configdir(); os.makedirs(mpl_dir, exist_ok=True); open(os.path.join(mpl_dir, 'matplotlibrc'), 'w').write('font.sans-serif: Noto Sans CJK SC, DejaVu Sans\n'); import matplotlib.font_manager; matplotlib.font_manager._load_fontmanager(try_read_cache=False)"

--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -29,8 +29,8 @@ RUN apt-get update \
     # -- uv (Python package manager) --
     && curl -LsSf https://astral.sh/uv/install.sh | sh \
     && mv /root/.local/bin/uv /usr/local/bin/uv \
-    # -- Node.js 20 --
-    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    # -- Node.js 24 --
+    && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get install -y nodejs \
     # -- NPM global packages --
     && npm install -g playwright docx pptxgenjs \
@@ -41,6 +41,17 @@ RUN apt-get update \
     && tar -xzf /tmp/gh.tar.gz -C /tmp \
     && mv /tmp/gh_2.87.3_linux_amd64/bin/gh /usr/local/bin/gh \
     && rm -rf /tmp/gh.tar.gz /tmp/gh_2.87.3_linux_amd64 \
+    # -- Docker Engine (for interactive-dashboard complex tier) --
+    && install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+        -o /etc/apt/keyrings/docker.asc \
+    && chmod a+r /etc/apt/keyrings/docker.asc \
+    && echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] \
+        https://download.docker.com/linux/ubuntu \
+        $(. /etc/os-release && echo $VERSION_CODENAME) stable" \
+        > /etc/apt/sources.list.d/docker.list \
+    && apt-get update \
+    && apt-get install -y docker-ce docker-ce-cli containerd.io \
     # -- Cleanup --
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/agent_config.yaml
+++ b/agent_config.yaml
@@ -35,7 +35,7 @@ sandbox:
 
     # Hash will be automatically appended based on dependencies
     snapshot_enabled: true # Recommended: Enable snapshot-based sandbox creation
-    snapshot_name: "open-ptc-v1" # Base name for snapshot (hash will be appended)
+    snapshot_name: "langalpha" # Base name for snapshot (hash will be appended)
     snapshot_auto_create: true # Automatically create snapshot if it doesn't exist
 
   # Docker local sandbox configuration

--- a/migrations/versions/004_add_workspace_artifacts.py
+++ b/migrations/versions/004_add_workspace_artifacts.py
@@ -1,0 +1,31 @@
+"""Add artifacts JSONB column to workspaces table.
+
+Stores per-workspace artifact state such as preview server commands
+(keyed by port) so the preview redirect endpoint can restart servers
+without the frontend's help.
+
+Revision ID: 004
+Revises: 003
+Create Date: 2026-03-25
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "004"
+down_revision: Union[str, None] = "003"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        ALTER TABLE workspaces
+        ADD COLUMN IF NOT EXISTS artifacts JSONB NOT NULL DEFAULT '{}'::jsonb
+    """)
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE workspaces DROP COLUMN IF EXISTS artifacts")

--- a/skills/interactive-dashboard/SKILL.md
+++ b/skills/interactive-dashboard/SKILL.md
@@ -22,12 +22,99 @@ Choose the tier based on complexity:
 
 | Tier | When | Stack | Serve command |
 |------|------|-------|---------------|
-| **Simple** | Static snapshot, few charts, no server-side logic | Self-contained HTML + CDN libs | `python -m http.server 8050` |
-| **Complex** | Live refresh, filtering, multi-page, heavy interactivity | FastAPI backend + Vite/React frontend | `bash start.sh` |
+| **Simple** | Static snapshot, few charts, no server-side logic | Self-contained HTML + CDN libs | `python -m http.server 8050 --bind 0.0.0.0` |
+| **FastAPI + HTML** | Live data refresh, server-side logic, no React needed | FastAPI serves `static/` + `fetch()` polling | `bash start.sh` |
+| **Complex** | Filtering, routing, component interactivity, multi-page | FastAPI backend + Vite/React frontend | `bash start.sh` |
 
-**Decision rule:** Start with simple. Escalate to complex only when user needs: live data refresh, server-side filtering/pagination, multi-route navigation, or React-level component interactivity.
+**Decision rule:** Start with Simple. Escalate to FastAPI + HTML when user needs live data refresh or server-side logic. Escalate to Complex only when user needs React-level component interactivity, client-side routing, or a multi-page SPA.
 
 **Port convention:** Use port **8050** (default). Range 8050-8059 for dashboards.
+
+### CSP / Iframe Safety
+
+The preview iframe enforces Content Security Policy (CSP). Certain patterns are **silently blocked** — no error banner, just dead UI elements. Always use the safe alternatives:
+
+| Blocked pattern | Safe alternative |
+|-----------------|-----------------|
+| `<button onclick="fn()">` | `el.addEventListener('click', fn)` |
+| `<div onmouseover="fn()">` | `el.addEventListener('mouseover', fn)` |
+| Any `on*="..."` HTML attribute | `el.addEventListener(event, fn)` |
+| `innerHTML` with `onclick` | `document.createElement()` + `addEventListener` |
+| `eval("code")` | Direct function calls |
+| `new Function("code")` | Named function declarations |
+| `setTimeout("code string", ms)` | `setTimeout(fn, ms)` (function reference) |
+| `<a href="javascript:...">` | `<a href="#" data-action="...">` + `addEventListener` |
+
+**Quick self-check** — run before serving to catch violations:
+
+```python
+import subprocess
+result = subprocess.run(
+    ["grep", "-rnE", r'on(click|input|change|focus|blur|submit|load|error|mouse|key)\s*=',
+     "work/dashboard/"],
+    capture_output=True, text=True
+)
+if result.stdout.strip():
+    raise RuntimeError(f"CSP-unsafe inline handlers found:\n{result.stdout}")
+```
+
+**Template literal hygiene** — when building HTML strings in JS template literals, CSS semicolons inside `${}` expressions cause silent parse failures:
+
+```javascript
+// BAD — semicolon inside ${} terminates the expression early
+const el = `<div style="color:${positive ? 'green' : 'red'; font-weight:600}">`;
+
+// GOOD — close the expression first, then continue the attribute string
+const el = `<div style="color:${positive ? 'green' : 'red'};font-weight:600">`;
+```
+
+Rule: **never put a CSS semicolon inside `${}`** — always close `}` before the semicolon.
+
+### How Preview Serving Works
+
+`GetPreviewUrl` is a **platform-level tool** available only to the main agent runtime. It is NOT a Python function — do not `import` it or call it from `execute_code`. The agent invokes it as a tool call.
+
+When you call `GetPreviewUrl(port, command, title)`:
+
+1. The **command is persisted to the database** automatically
+2. The platform starts the command in a dedicated sandbox session for that port
+3. It polls until the port is listening, then generates a signed URL
+4. If the port is **already reachable**, the command start is skipped entirely
+
+**Sub-agent fallback:** Sub-agents cannot call `GetPreviewUrl`. Instead, build the dashboard files, start the server for verification, then return the serve details so the orchestrating agent can call `GetPreviewUrl`.
+
+**All tiers** — use the Bash tool with `run_in_background=true` to start the server:
+
+```bash
+# Simple tier — Bash tool with run_in_background=true
+cd work/<task> && python -m http.server 8050 --bind 0.0.0.0
+
+# Docker tiers — Bash tool with run_in_background=true
+cd work/<task> && bash start.sh
+```
+
+Then verify it's up in a separate (foreground) Bash call:
+
+```bash
+for i in $(seq 1 15); do curl -sf http://127.0.0.1:8050/ > /dev/null && echo "Server ready" && exit 0 || sleep 1; done; echo "FAIL"; exit 1
+```
+
+Then return **all three fields** to the orchestrating agent (it needs the command for DB persistence / restart recovery):
+
+```
+port: 8050
+command: "cd work/<task> && python -m http.server 8050 --bind 0.0.0.0"  # or "bash work/<task>/start.sh"
+title: "AAPL Stock Dashboard"
+```
+
+The orchestrating agent calls `GetPreviewUrl(port=8050, command="...", title="...")` which persists the command.
+
+**On workspace restart** (user closes and reopens later):
+- The sandbox filesystem persists (files, installed packages, Docker image cache all survive)
+- Only processes die — the platform looks up the saved command and re-executes it
+- The preview URL auto-recovers
+
+**Implication:** Write commands that are **idempotent** — they must work whether run for the first time or re-run after a restart. The platform handles the rest. Docker image cache survives restart so rebuilds are fast (~2-5s with warm cache).
 
 ### Sandbox Capabilities
 
@@ -35,8 +122,9 @@ All pre-installed in the Daytona sandbox snapshot — no `pip install` or `apt-g
 
 - **Python 3.12** + pandas, numpy, plotly, matplotlib, requests, httpx, yfinance
 - **FastAPI + uvicorn** (available via `fastmcp` transitive dependency)
-- **Node.js 20 + npm** — scaffold Vite/React projects with `npm create vite@latest`
-- **Playwright + Chromium** — available for advanced rendering
+- **Node.js 24 + npm** (host sandbox) / **Node.js 20** (Docker `apt install nodejs`) — scaffold Vite/React projects with `npm create vite@latest`
+- **Docker Engine** — for complex tier containerized dashboards (backend + frontend in one image)
+- **Playwright + Chromium** — available for verification testing
 
 ## Workflow
 
@@ -96,7 +184,7 @@ html = f"""<!DOCTYPE html>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AAPL Dashboard</title>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
     <style>
         /* See references/ui-components.md for dark theme CSS */
     </style>
@@ -113,19 +201,73 @@ with open("work/dashboard/index.html", "w") as f:
     f.write(html)
 ```
 
-**Complex tier** — scaffold a FastAPI + Vite/React project (see Project Structure section below).
+**FastAPI + HTML tier** — write a FastAPI server with API routes + `StaticFiles` mount, and a single `static/index.html` with `fetch()` polling (see FastAPI + HTML Tier section below).
 
-### Step 5: Serve & Expose
+**Complex tier** — scaffold a FastAPI + Vite/React project (see Complex Tier section below).
+
+### Step 5: Verify Before Serving
+
+**Tier 1 — Syntax check (required, < 1 second)**
+
+Extract `<script>` blocks from the HTML and check with `node --check`:
+
+```python
+import re, subprocess, tempfile, os
+
+with open("work/dashboard/index.html") as f:
+    html = f.read()
+
+scripts = re.findall(r'<script(?![^>]*src)[^>]*>(.*?)</script>', html, re.DOTALL)
+for i, src in enumerate(scripts):
+    with tempfile.NamedTemporaryFile(suffix=".js", mode="w", delete=False) as tmp:
+        tmp.write(src)
+        tmp_path = tmp.name
+    result = subprocess.run(["node", "--check", tmp_path], capture_output=True, text=True)
+    os.unlink(tmp_path)
+    if result.returncode != 0:
+        raise RuntimeError(f"JS syntax error in script block {i+1}:\n{result.stderr}")
+print("Syntax check passed")
+```
+
+Also run the CSP self-check grep from the CSP section above.
+
+**Tier 2 — Browser verification (recommended for interactive dashboards)**
+
+Run when the dashboard has buttons, filters, or tabs. Skip for static data displays.
+
+After `GetPreviewUrl` starts the server, run a Playwright check to catch runtime errors:
+
+```python
+from playwright.sync_api import sync_playwright
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    page = browser.new_page()
+    js_errors = []
+    page.on("pageerror", lambda exc: js_errors.append(str(exc)))
+    page.goto("http://127.0.0.1:8050/", wait_until="networkidle", timeout=20000)
+    assert not js_errors, f"JS runtime errors: {js_errors}"
+    assert len(page.locator("body").inner_text().strip()) > 20, "Page appears blank"
+    page.screenshot(path="work/dashboard/verify-screenshot.png", full_page=True)
+    browser.close()
+print("Browser verification passed")
+```
+
+See [references/verification.md](references/verification.md) for extended templates with button-click testing and API response validation.
+
+### Step 6: Serve & Expose
 
 ```python
 # Simple tier
-GetPreviewUrl(port=8050, command="cd work/dashboard && python -m http.server 8050", title="AAPL Dashboard")
+GetPreviewUrl(port=8050, command="cd work/dashboard && python -m http.server 8050 --bind 0.0.0.0", title="AAPL Dashboard")
 
-# Complex tier
+# FastAPI + HTML tier / Complex tier
 GetPreviewUrl(port=8050, command="bash work/dashboard/start.sh", title="Stock Dashboard")
 ```
 
-### Step 6: Iterate
+**Local verification before `GetPreviewUrl`** — if you need the server running for Playwright verification, use the Bash tool with `run_in_background=true` (see sub-agent fallback above for the pattern). Do NOT use `subprocess.Popen` from `execute_code` — the process becomes a zombie when the tool-call shell exits.
+
+### Step 7: Iterate
 
 After the user sees the preview, adjust layout, data, or charts based on feedback.
 
@@ -162,6 +304,44 @@ Default data sources for common dashboard needs:
 | Earnings calendar | `yf_market` | `get_earnings_calendar` | `start, end` (YYYY-MM-DD) |
 | Sector info | `yf_market` | `get_sector_info` | `sector_key` (technology, healthcare, etc.) |
 | Industry info | `yf_market` | `get_industry_info` | `industry_key` |
+
+### Yahoo Finance Field Conventions
+
+Many fields are already in display units — do NOT multiply by 100:
+
+| Field | Unit | Example | Note |
+|-------|------|---------|------|
+| `regularMarketChangePercent` | % (not decimal) | `0.389` = +0.39% | Do NOT multiply by 100 |
+| `dividendYield` | % (not decimal) | `0.41` = 0.41% | Same convention |
+| `marketCap` | Absolute USD | `3.71e12` | Divide by 1e9 for $B display |
+| `trailingPE` | Ratio | `31.98` | Display directly |
+
+### `get_predefined_screen` Response Structure
+
+Quotes are nested — not at the top level:
+
+```python
+result = get_predefined_screen("day_gainers")
+quotes = result["data"]["quotes"]  # nested at result["data"]["quotes"], NOT result["quotes"]
+# Each quote: symbol, regularMarketPrice, regularMarketChangePercent, marketCap, ...
+```
+
+### Direct yfinance Usage (Docker / without MCP)
+
+Inside Docker containers, MCP tool modules are unavailable. Use `yfinance` directly:
+
+```python
+import yfinance as yf
+
+# Stock screener (yfinance 1.2.0+)
+result = yf.screen("day_gainers", count=5)
+quotes = result.get("quotes", [])
+
+# Stock data
+ticker = yf.Ticker("AAPL")
+info = ticker.info
+hist = ticker.history(period="1y")
+```
 
 ## UI Design Rules
 
@@ -213,71 +393,104 @@ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 
 See [references/ui-components.md](references/ui-components.md) for complete CSS and component code.
 
-## Complex Tier — Project Structure
+## FastAPI + HTML Tier — Project Structure
 
-When using FastAPI + Vite/React, scaffold this structure:
+For live-data dashboards without React. FastAPI serves API endpoints and static HTML directly — no npm, no build step. Use the **copy-ready template files** with `.fastapi-html` suffix in `references/`:
 
 ```
 work/<task>/
+├── Dockerfile           # cp references/Dockerfile.fastapi-html Dockerfile
+├── start.sh             # cp references/start.sh start.sh
 ├── server/
-│   ├── main.py          # FastAPI app with CORS, /api routes
+│   ├── main.py          # cp references/server-main.fastapi-html.py server/main.py
+│   └── requirements.txt # cp references/requirements.txt server/requirements.txt
+└── static/
+    └── index.html       # Single HTML file with fetch() polling
+```
+
+### Setup Workflow
+
+1. **Copy template files** — all four `cp` commands above, then add your API routes to `server/main.py`
+2. **Add your Python deps** to `server/requirements.txt` (append pandas, yfinance, etc.)
+3. **Write `static/index.html`** with `fetch()` calls to your API routes for live data
+4. **Serve**: `GetPreviewUrl(port=8050, command="bash work/<task>/start.sh", title="Dashboard")`
+
+### Template Files
+
+**`Dockerfile`** ([references/Dockerfile.fastapi-html](references/Dockerfile.fastapi-html)) — Python 3.12-slim only (no Node/npm). Uses `uv pip install` for fast deps.
+
+**`server/main.py`** ([references/server-main.fastapi-html.py](references/server-main.fastapi-html.py)) — FastAPI skeleton with CORS, `HEAD /`, `/healthz`, and `StaticFiles` mount for `static/` directory. `StaticFiles` is the last mount (catches all unmatched routes).
+
+**`start.sh`** — same `references/start.sh` template (works unchanged for all Docker tiers).
+
+### Key Differences from Complex Tier
+
+- **No `frontend/` directory** — HTML lives in `static/`
+- **No npm/Node** — Dockerfile uses `python:3.12-slim` only
+- **`StaticFiles` mount** — serves `static/` directory with `html=True` (auto-serves `index.html`)
+- **`fetch()` for live data** — HTML uses `setInterval(() => fetch('/api/data').then(...), 30000)` for auto-refresh
+- **No SPA routing** — single `index.html`, no client-side router needed
+
+## Complex Tier — Project Structure
+
+When using FastAPI + Vite/React, scaffold this structure using the **copy-ready template files** in `references/`:
+
+```
+work/<task>/
+├── Dockerfile           # Copy from references/Dockerfile
+├── start.sh             # Copy from references/start.sh
+├── server/
+│   ├── main.py          # Copy from references/server-main.py, add your API routes
+│   ├── requirements.txt # Copy from references/requirements.txt, add your deps
 │   ├── routes/          # API route modules (stocks.py, sectors.py)
 │   └── models.py        # Pydantic response models
 ├── frontend/
 │   ├── package.json     # Vite + React + chart libraries
-│   ├── vite.config.js   # Proxy /api to FastAPI, host 0.0.0.0
+│   ├── vite.config.js   # Copy from references/vite.config.js
 │   ├── index.html
 │   └── src/
 │       ├── App.jsx      # Main app with routing/tabs
 │       ├── components/  # Chart, KPI, Table components
 │       ├── hooks/       # useStockData, useSectorData, etc.
 │       └── utils/       # formatters, color helpers
-└── start.sh             # Starts both servers
+└── verify.py            # Copy from references/verification.md (optional)
 ```
 
-### FastAPI Backend (`server/main.py`)
+### Setup Workflow
 
-```python
-from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
+1. **Copy template files** from `references/` into `work/<task>/` — they work with zero modifications for port 8050
+2. **Add your API routes** to `server/main.py` (the template includes CORS, `HEAD /`, `/healthz`, and static file serving)
+3. **Add your Python deps** to `server/requirements.txt` (template includes fastapi + uvicorn)
+4. **Write frontend code** in `frontend/src/` (vite.config.js template proxies `/api` to backend on port 8051)
+5. **Serve**: `GetPreviewUrl(port=8050, command="bash work/<task>/start.sh", title="Dashboard")`
 
-app = FastAPI()
-app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"])
+### Template Files
 
-@app.get("/api/stock/{ticker}")
-async def get_stock(ticker: str, period: str = "1y"):
-    from tools.yf_price import get_stock_history
-    from tools.yf_fundamentals import get_company_info
-    return {"history": get_stock_history(ticker, period=period), "info": get_company_info(ticker)}
-```
+**`Dockerfile`** ([references/Dockerfile](references/Dockerfile)) — Python 3.12 + Node + uv + tzdata. Builds frontend at image time, serves static files from FastAPI. Uses `uv pip install` for fast dependency installation.
 
-### Vite Config (`frontend/vite.config.js`)
+**`start.sh`** ([references/start.sh](references/start.sh)) — Cold-boot safe Docker wrapper. Starts dockerd if needed, builds image (uses layer cache on re-runs), removes old container, starts new one, health-checks with log dump on failure. Env var overrides: `PORT` (default 8050), `NAME` (default "dashboard").
 
-```javascript
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
+**`server/main.py`** ([references/server-main.py](references/server-main.py)) — FastAPI skeleton with CORS, `HEAD /` (liveness for platform proxy), `/healthz`, SPA catch-all route for client-side routing (`/tab/news`, `/stocks/AAPL` → `index.html`), and a 503 fallback if the frontend build is missing.
 
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    host: '0.0.0.0',
-    port: 8050,
-    proxy: { '/api': 'http://localhost:8051' }
-  }
-});
-```
+**`server/requirements.txt`** ([references/requirements.txt](references/requirements.txt)) — Minimal: fastapi + uvicorn. Append project-specific packages (pandas, yfinance, etc.).
 
-### Startup Script (`start.sh`)
+**`frontend/vite.config.js`** ([references/vite.config.js](references/vite.config.js)) — Vite + React with `/api` proxy to backend on port 8051.
 
-```bash
-#!/bin/bash
-cd "$(dirname "$0")"
-cd server && uvicorn main:app --host 0.0.0.0 --port 8051 &
-cd frontend && npm install --prefer-offline && npx vite --host 0.0.0.0 --port 8050 &
-wait
-```
+> **Critical: Vite proxy is dev-only.** The `proxy` setting in `vite.config.js` only applies during `npm run dev`. The production build outputs plain static files with no proxy. In the Docker image, FastAPI serves both the built SPA from `frontend/dist/` and all `/api/*` routes from the **same port**. The reference `server-main.py` template already does this correctly — do NOT use a two-process architecture with separate static file server and API server.
 
-Call `GetPreviewUrl(port=8050, command="bash work/<task>/start.sh", title="Dashboard")`.
+### Docker Gotchas
+
+- **MCP tools are host-only**: The `tools/` modules (e.g., `from tools.yf_price import ...`) exist only in the host workspace Python environment — they are NOT copied into the Docker image. FastAPI server code inside Docker must call `yfinance` directly. Add `yfinance` to `server/requirements.txt`
+- **`--network host`**: Required for the container to reach external APIs (yfinance, MCP servers). Already set in `start.sh` template
+- **`tzdata`**: Required for yfinance timezone handling. Already in `Dockerfile` template
+- **Image cache**: Persists across workspace restarts. First build: 30-60s. Subsequent builds: ~2-5s (cached layers)
+- **Logs**: Use `docker logs dashboard` to debug startup failures
+- **Fallback without Docker**: If Docker is unavailable, build the frontend and run FastAPI directly:
+  ```bash
+  fuser -k 8050/tcp 2>/dev/null || true
+  cd frontend && npm install --prefer-offline && npm run build && cd ..
+  cd server && uvicorn main:app --host 0.0.0.0 --port 8050
+  ```
 
 ## Chart Libraries
 
@@ -285,9 +498,9 @@ Call `GetPreviewUrl(port=8050, command="bash work/<task>/start.sh", title="Dashb
 
 | Library | CDN URL | Best for |
 |---------|---------|----------|
-| **Chart.js** | `https://cdn.jsdelivr.net/npm/chart.js` | Line, bar, pie, doughnut, area |
+| **Chart.js** | `https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js` | Line, bar, pie, doughnut, area |
 | **Plotly.js** | `https://cdn.plot.ly/plotly-2.35.2.min.js` | Candlestick, heatmap, treemap |
-| **Lightweight Charts** | `https://unpkg.com/lightweight-charts/dist/lightweight-charts.standalone.production.js` | TradingView-style candlestick |
+| **Lightweight Charts** | `https://unpkg.com/lightweight-charts@4/dist/lightweight-charts.standalone.production.js` | TradingView-style candlestick |
 
 Default to **Chart.js**. Use Plotly for candlesticks/heatmaps. Lightweight Charts only for TradingView-style.
 
@@ -379,8 +592,8 @@ Layout:
 - **Component per widget**: One React component per chart/card/table
 - **Shared hooks**: `useStockData(ticker)`, `useSectorData(key)` for data fetching
 - **Error boundaries**: Wrap chart components so one failure doesn't crash the whole page
-- **Proxy, not CORS**: Prefer Vite proxy config over CORS middleware when possible
-- **`host: '0.0.0.0'`**: Both FastAPI and Vite must bind to `0.0.0.0`, not `127.0.0.1`
+- **Single-port production**: Vite proxy is dev-only. In production Docker builds, FastAPI serves both `/api/*` and the SPA from one port
+- **`host: '0.0.0.0'`**: Both FastAPI and Vite must bind to `0.0.0.0`, not `127.0.0.1` or `localhost`
 
 ## Error Handling & Debugging
 
@@ -389,22 +602,50 @@ Layout:
 | `GetPreviewUrl` returns error | Port already in use — try a different port (8051, 8052, ...) |
 | Page is blank | Check for JS errors — ensure all `getElementById` targets exist |
 | Data is empty | Validate MCP tool response before embedding — check for `None` or empty lists |
+| Buttons/inputs do nothing | CSP blocking inline handlers — replace `onclick=` etc. with `addEventListener`. Run CSP self-check |
 | FastAPI won't start | Ensure `host='0.0.0.0'` in `uvicorn.run()` |
 | Vite won't start | Ensure `--host 0.0.0.0` flag and check if port is free |
 | CORS errors | Add `CORSMiddleware` to FastAPI or use Vite proxy |
 | Charts don't render | CDN scripts must load before chart initialization — use `DOMContentLoaded` event |
 | Iframe shows "refused to connect" | Server not ready yet — add a small delay or retry logic |
+| HEAD / returns 404 or 405 | Add `@app.head("/")` as its own function — don't stack with `/healthz` (use `server-main.py` template) |
+| SPA deep route returns 404 | Add catch-all `@app.get("/{full_path:path}")` that serves `index.html` for non-file paths (use `server-main.py` template) |
+| `start.sh` fails on restart | Ensure idempotent: dockerd startup check, `docker rm -f` before `docker run` (use `start.sh` template) |
+| Docker: yfinance timezone error | Add `tzdata` package to Dockerfile (included in template) |
+| Docker: can't reach external APIs | Use `--network host` flag (included in `start.sh` template) |
+| `GetPreviewUrl` not found / `NameError` | Tool only available to main agent runtime — sub-agents use Bash tool with `run_in_background=true` to start the server, then report port/command/title back |
+| Playwright `ERR_CONNECTION_REFUSED` | Use `127.0.0.1:PORT` not `localhost` — sandbox resolves `localhost` to IPv6 (`::1`) first |
+| Background server died / `<defunct>` | Use Bash tool with `run_in_background=true` — do NOT use `subprocess.Popen` from `execute_code` (process becomes zombie when tool-call shell exits) |
+| `ModuleNotFoundError: tools.*` in Docker | MCP tools are host-only — use `yfinance` directly inside Docker containers |
 
 ## Quality Checklist
 
 Before calling `GetPreviewUrl`:
 
+**Data & Code**
 - [ ] All data fetched and validated (no empty dataframes or None values)
 - [ ] Files written to `work/<task>/` directory
 - [ ] JSON data properly escaped with `json.dumps()`
 - [ ] All chart containers exist in HTML before JS tries to reference them
+
+**CSP Safety**
+- [ ] No inline event handlers (`onclick`, `oninput`, `onchange`, etc.) — all events via `addEventListener`
+- [ ] No `eval()`, `new Function()`, or string-based `setTimeout()`
+- [ ] No `javascript:` URLs
+- [ ] CSP self-check grep passes (no matches)
+
+**Verification**
+- [ ] Tier 1: JS syntax check passed (`node --check` on extracted script blocks)
+- [ ] Tier 2: Playwright verification passed (for interactive dashboards with buttons/filters/tabs)
+
+**Serving**
 - [ ] Server binds to `0.0.0.0` (not `127.0.0.1` or `localhost`)
 - [ ] Correct port used (default 8050)
+- [ ] Command passed to `GetPreviewUrl` is idempotent (works on re-run after restart)
+- [ ] Complex tier: `start.sh` and `Dockerfile` copied from templates
+- [ ] Complex tier: FastAPI includes `HEAD /` endpoint (use `server-main.py` template)
+
+**UI Quality**
 - [ ] Dark theme applied consistently (see color table above)
 - [ ] Responsive layout — no horizontal scroll
 - [ ] Financial numbers properly formatted (currency, %, abbreviations)

--- a/skills/interactive-dashboard/references/Dockerfile
+++ b/skills/interactive-dashboard/references/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.12-slim
+ENV PORT=8050
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl nodejs npm tzdata \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install uv
+
+WORKDIR /app
+
+# Backend deps via uv (10-100x faster than pip, cached layer)
+COPY server/requirements.txt ./
+RUN uv pip install --system --no-cache -r requirements.txt
+
+# Frontend build (cached layer — only rebuilds when package.json changes)
+COPY frontend/package.json frontend/package-lock.json* ./frontend/
+RUN cd frontend && npm install --prefer-offline
+COPY frontend/ ./frontend/
+RUN cd frontend && npm run build
+
+# Backend code — serves frontend static from build output
+COPY server/ ./server/
+
+EXPOSE ${PORT}
+CMD uvicorn server.main:app --host 0.0.0.0 --port ${PORT}

--- a/skills/interactive-dashboard/references/Dockerfile.fastapi-html
+++ b/skills/interactive-dashboard/references/Dockerfile.fastapi-html
@@ -1,0 +1,18 @@
+FROM python:3.12-slim
+ENV PORT=8050
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl tzdata \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install uv
+
+WORKDIR /app
+
+COPY server/requirements.txt ./
+RUN uv pip install --system --no-cache -r requirements.txt
+
+COPY server/ ./server/
+COPY static/ ./static/
+
+EXPOSE ${PORT}
+CMD uvicorn server.main:app --host 0.0.0.0 --port ${PORT}

--- a/skills/interactive-dashboard/references/requirements.txt
+++ b/skills/interactive-dashboard/references/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn[standard]

--- a/skills/interactive-dashboard/references/server-main.fastapi-html.py
+++ b/skills/interactive-dashboard/references/server-main.fastapi-html.py
@@ -1,0 +1,26 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
+from fastapi.responses import JSONResponse
+
+app = FastAPI()
+app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"])
+
+
+@app.head("/")
+async def liveness():
+    """Platform proxy sends HEAD / to verify the server is up."""
+    return JSONResponse({"status": "ok"})
+
+
+@app.get("/healthz")
+async def healthz():
+    """Health check endpoint."""
+    return {"status": "ok"}
+
+
+# --- Add your API routes below ---
+
+
+# Serve static files (must be last — catches all unmatched routes)
+app.mount("/", StaticFiles(directory="static", html=True), name="static")

--- a/skills/interactive-dashboard/references/server-main.py
+++ b/skills/interactive-dashboard/references/server-main.py
@@ -1,0 +1,45 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse, JSONResponse
+from pathlib import Path
+
+app = FastAPI()
+app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"])
+
+build_dir = Path(__file__).parent.parent / "frontend" / "dist"
+
+
+@app.head("/")
+async def liveness():
+    """Platform proxy sends HEAD / to verify the server is up."""
+    return JSONResponse({"status": "ok"})
+
+
+@app.get("/healthz")
+async def healthz():
+    """Health check endpoint."""
+    return {"status": "ok"}
+
+
+# --- Add your API routes below ---
+
+
+# Serve frontend build with SPA catch-all (must be last)
+if build_dir.exists():
+
+    @app.get("/{full_path:path}")
+    async def spa(full_path: str = ""):
+        """Serve index.html for all non-API routes (SPA client-side routing)."""
+        file = (build_dir / full_path).resolve()
+        if file.is_file() and file.is_relative_to(build_dir.resolve()):
+            return FileResponse(str(file))
+        return FileResponse(str(build_dir / "index.html"))
+
+else:
+
+    @app.get("/")
+    async def no_build():
+        return JSONResponse(
+            {"error": "Frontend build not found. Run 'npm run build' in frontend/."},
+            status_code=503,
+        )

--- a/skills/interactive-dashboard/references/start.sh
+++ b/skills/interactive-dashboard/references/start.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -eo pipefail
+cd "$(dirname "$0")"
+
+PORT=${PORT:-8050}
+NAME=${NAME:-dashboard}
+
+# Skip restart if container is already healthy
+if docker inspect "$NAME" &>/dev/null && curl -sf "http://127.0.0.1:$PORT/" &>/dev/null; then
+  echo "Container already healthy on port $PORT — skipping restart"
+  exit 0
+fi
+
+# Start dockerd if not running (needed after workspace restart)
+if ! docker info &>/dev/null; then
+  echo "Starting Docker daemon..."
+  dockerd &>/tmp/dockerd.log &
+  for i in $(seq 1 10); do docker info &>/dev/null && break || sleep 1; done
+fi
+
+echo "Building image..."
+docker build -t "$NAME" .
+
+echo "Starting container on port $PORT..."
+docker rm -f "$NAME" 2>/dev/null || true
+sleep 1
+docker run -d --name "$NAME" --network host "$NAME"
+
+echo "Waiting for server on port $PORT..."
+for i in $(seq 1 30); do
+  curl -sf "http://127.0.0.1:$PORT/" &>/dev/null && { echo "Ready on port $PORT"; exit 0; } || sleep 1
+done
+echo "Failed to start. Logs:" && docker logs "$NAME" && exit 1

--- a/skills/interactive-dashboard/references/verification.md
+++ b/skills/interactive-dashboard/references/verification.md
@@ -1,0 +1,112 @@
+# Verification Templates
+
+Playwright + Chromium are pre-installed in the sandbox. Use these templates for Step 5 Tier 2 verification.
+
+## verify.py — Universal Template
+
+```python
+"""Dashboard verification script. Run after GetPreviewUrl starts the server."""
+import sys
+
+PORT = 8050  # Change to match your dashboard port
+
+try:
+    from playwright.sync_api import sync_playwright
+except ImportError:
+    print("SKIP: Playwright not available")
+    sys.exit(0)
+
+js_errors = []
+api_errors = []
+
+
+def on_page_error(exc):
+    js_errors.append(str(exc))
+
+
+def on_response(response):
+    if "/api/" in response.url and response.status >= 400:
+        api_errors.append(f"{response.status} {response.url}")
+
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    page = browser.new_page()
+    page.on("pageerror", on_page_error)
+    page.on("response", on_response)  # Remove this line for simple tier
+
+    # Load page
+    page.goto(f"http://127.0.0.1:{PORT}/", wait_until="networkidle", timeout=20000)
+
+    # Check page is not blank
+    body_text = page.locator("body").inner_text().strip()
+    assert len(body_text) > 20, f"Page appears blank (body text: {body_text[:50]!r})"
+
+    # Check for chart libraries
+    has_plotly = page.locator(".plotly, .js-plotly-plot").count() > 0
+    has_chartjs = page.locator("canvas").count() > 0
+    has_lw_charts = page.locator(".tv-lightweight-charts").count() > 0
+    has_recharts = page.locator(".recharts-wrapper").count() > 0
+    charts_found = has_plotly or has_chartjs or has_lw_charts or has_recharts
+    print(f"Charts detected: plotly={has_plotly} chartjs={has_chartjs} lw={has_lw_charts} recharts={has_recharts}")
+
+    # --- Optional: click primary action button ---
+    # Uncomment for interactive dashboards with buttons/filters/tabs
+    #
+    # errors_before_click = len(js_errors)
+    # btn = page.locator("button").first
+    # if btn.count() > 0:
+    #     btn.click()
+    #     page.wait_for_timeout(1000)
+    #     new_errors = js_errors[errors_before_click:]
+    #     assert not new_errors, f"JS errors after click: {new_errors}"
+    # --- End optional section ---
+
+    # Screenshot
+    page.screenshot(path="work/dashboard/verify-screenshot.png", full_page=True)
+
+    browser.close()
+
+# Results
+passed = True
+if js_errors:
+    print(f"FAIL: {len(js_errors)} JS error(s): {js_errors}")
+    passed = False
+if api_errors:
+    print(f"FAIL: {len(api_errors)} API error(s): {api_errors}")
+    passed = False
+if not charts_found:
+    print("WARN: No chart elements detected (may be OK for table-only dashboards)")
+
+if passed:
+    print("PASS: Dashboard verification succeeded")
+else:
+    sys.exit(1)
+```
+
+## Customization Guide
+
+Add assertions based on your dashboard type:
+
+| Dashboard type | Additional assertions |
+|---|---|
+| Stock tracker | `assert page.locator("text=AAPL").count() > 0` — ticker appears |
+| Sector heatmap | `assert page.locator("svg, .js-plotly-plot").count() > 0` — treemap rendered |
+| Portfolio monitor | `assert page.locator("table tr").count() > 1` — holdings table has rows |
+| Multi-stock comparison | `assert page.locator("canvas").count() >= 2` — multiple charts rendered |
+| Earnings tracker | `assert page.locator("text=EPS").count() > 0` — earnings data present |
+
+## Quick Inline Alternative
+
+For simple dashboards where a full `verify.py` is overkill — paste this directly after `GetPreviewUrl`:
+
+```python
+from playwright.sync_api import sync_playwright
+with sync_playwright() as p:
+    page = p.chromium.launch().new_page()
+    errors = []; page.on("pageerror", lambda e: errors.append(str(e)))
+    page.goto("http://127.0.0.1:8050/", wait_until="networkidle", timeout=15000)
+    page.screenshot(path="work/dashboard/verify.png", full_page=True)
+    assert not errors, f"JS errors: {errors}"
+    print("PASS")
+```

--- a/skills/interactive-dashboard/references/vite.config.js
+++ b/skills/interactive-dashboard/references/vite.config.js
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: '0.0.0.0',
+    port: 8050,
+    proxy: {
+      '/api': 'http://127.0.0.1:8051',
+    },
+  },
+  build: {
+    outDir: 'dist',
+  },
+});

--- a/src/ptc_agent/agent/tools/bash_output.py
+++ b/src/ptc_agent/agent/tools/bash_output.py
@@ -1,6 +1,6 @@
 """Get output and status of background bash commands."""
 
-from typing import Any
+from typing import Any, Literal
 
 import structlog
 from langchain_core.tools import BaseTool, tool
@@ -19,19 +19,25 @@ def create_bash_output_tool(sandbox: Any) -> BaseTool:
     """
 
     @tool
-    async def BashOutput(command_id: str) -> str:
-        """Get the output and status of a background bash command.
+    async def BashOutput(command_id: str, action: Literal["status", "stop"] = "status") -> str:
+        """Get the output/status of a background command, or stop it.
 
         Use this to check on commands started with run_in_background=True.
-        To stop a background command, use the Bash tool (e.g. pkill -f '...').
 
         Args:
             command_id: The command_id returned when the background command was started
+            action: "status" (default) to check output, or "stop" to terminate the command
 
         Returns:
-            Status and output of the background command
+            Status and output of the background command, or confirmation of stop
         """
         try:
+            if action == "stop":
+                stopped = await sandbox.stop_background_command(command_id)
+                if stopped:
+                    return f"Background command {command_id} stopped."
+                return f"No running background command found with id {command_id}."
+
             result = await sandbox.get_background_command_status(command_id)
 
             is_running = result["is_running"]

--- a/src/ptc_agent/agent/tools/preview_url.py
+++ b/src/ptc_agent/agent/tools/preview_url.py
@@ -74,6 +74,13 @@ def create_preview_url_tool(
                 except Exception:
                     logger.debug("Failed to cache signed URL for port %s", port, exc_info=True)
 
+            # Persist command to DB so the preview can auto-restart on workspace reopen
+            try:
+                from src.server.database.workspace import save_preview_command
+                await save_preview_command(workspace_id, port, command)
+            except Exception:
+                logger.debug("Failed to persist preview command for port %s", port, exc_info=True)
+
             logger.info(
                 "Generated preview URL",
                 port=port,
@@ -87,10 +94,11 @@ def create_preview_url_tool(
             normalized_path = ""
             if path:
                 # Reject traversal attempts at the tool layer (defense in depth)
-                clean = path.lstrip("/")
-                if ".." in clean.split("/"):
-                    clean = clean.replace("..", "")
-                normalized_path = "/" + clean
+                from urllib.parse import unquote
+                clean = unquote(path).lstrip("/")
+                # Strip any ".." segments (server-side also independently rejects them)
+                segments = [s for s in clean.split("/") if s and s != ".."]
+                normalized_path = "/" + "/".join(segments) if segments else ""
 
             stable_url = (
                 f"{SERVER_BASE_URL.rstrip('/')}/api/v1/preview/{workspace_id}/{port}"

--- a/src/ptc_agent/agent/tools/preview_url.py
+++ b/src/ptc_agent/agent/tools/preview_url.py
@@ -34,6 +34,7 @@ def create_preview_url_tool(
         port: int,
         command: str,
         title: str | None = None,
+        path: str | None = None,
     ) -> tuple[str, dict[str, Any]]:
         """Get a preview URL for a service running on the given port in the sandbox.
 
@@ -42,9 +43,11 @@ def create_preview_url_tool(
         server can be restarted automatically when the user reopens the preview later.
 
         Args:
-            port: Port number (3000-9999) the service is listening on
+            port: Port number (3000-9999) the command will listen on
             command: The shell command to start the server (e.g. "python -m http.server 8080")
             title: Optional display title for the preview (default: "Port {port}")
+            path: Optional URL path suffix appended to the preview URL
+                  (e.g. "/timeline.html" to open a specific file instead of the default index)
 
         Returns:
             The signed preview URL that can be used to access the service
@@ -78,16 +81,28 @@ def create_preview_url_tool(
                 workspace_id=workspace_id,
             )
 
-            # Stable URL: {base}/api/v1/preview/{workspace_id}/{port}
+            # Stable URL: {base}/api/v1/preview/{workspace_id}/{port}[/path]
             from src.config.env import SERVER_BASE_URL
 
-            stable_url = f"{SERVER_BASE_URL.rstrip('/')}/api/v1/preview/{workspace_id}/{port}"
+            normalized_path = ""
+            if path:
+                # Reject traversal attempts at the tool layer (defense in depth)
+                clean = path.lstrip("/")
+                if ".." in clean.split("/"):
+                    clean = clean.replace("..", "")
+                normalized_path = "/" + clean
+
+            stable_url = (
+                f"{SERVER_BASE_URL.rstrip('/')}/api/v1/preview/{workspace_id}/{port}"
+                f"{normalized_path}"
+            )
 
             artifact = {
                 "type": "preview_url",
                 "port": port,
                 "title": display_title,
                 "command": command,
+                **({"path": normalized_path} if normalized_path else {}),
             }
 
             # Emit SSE artifact so the frontend auto-opens the preview panel

--- a/src/ptc_agent/core/sandbox/_defaults.py
+++ b/src/ptc_agent/core/sandbox/_defaults.py
@@ -39,6 +39,8 @@ DEFAULT_DEPENDENCIES = [
     "pdfplumber",
     "reportlab",
     "markitdown[pptx]",
+    # Browser automation
+    "playwright",
     # Utilities
     "tqdm",
     "tabulate",

--- a/src/ptc_agent/core/sandbox/providers/daytona.py
+++ b/src/ptc_agent/core/sandbox/providers/daytona.py
@@ -81,15 +81,16 @@ class DaytonaRuntime(SandboxRuntime):
     async def fetch_working_dir(self) -> str:
         """Fetch and cache the sandbox working directory (must be awaited).
 
-        Prefers the explicitly configured default_working_dir over the SDK
-        result, which may return the Daytona user's home (/home/daytona)
-        instead of our snapshot's configured WORKDIR (/home/workspace).
+        When a snapshot is in use, prefers the configured default_working_dir
+        (/home/workspace) over the SDK result, which may return the Daytona
+        user's home (/home/daytona).  Without a snapshot the SDK-reported
+        directory is authoritative.
         """
         if self._working_dir is None:
-            self._working_dir = (
-                self._default_working_dir
-                or await self._sandbox.get_work_dir()
-            )
+            if self.snapshot_name and self._default_working_dir:
+                self._working_dir = self._default_working_dir
+            else:
+                self._working_dir = await self._sandbox.get_work_dir()
         return self._working_dir
 
     # -- Lifecycle --

--- a/src/ptc_agent/core/sandbox/providers/daytona.py
+++ b/src/ptc_agent/core/sandbox/providers/daytona.py
@@ -483,7 +483,8 @@ class DaytonaProvider(SandboxProvider):
                 " && mv /tmp/polymarket /usr/local/bin/polymarket"
                 " && rm -rf /tmp/polymarket.tar.gz",
                 "npm install -g playwright"
-                " && npx playwright install --with-deps chromium",
+                " && PLAYWRIGHT_BROWSERS_PATH=/usr/local/ms-playwright"
+                " npx playwright install --with-deps chromium",
                 # -- Docker Engine (for interactive-dashboard complex tier) --
                 "install -m 0755 -d /etc/apt/keyrings"
                 " && curl -fsSL https://download.docker.com/linux/ubuntu/gpg"

--- a/src/ptc_agent/core/sandbox/providers/daytona.py
+++ b/src/ptc_agent/core/sandbox/providers/daytona.py
@@ -79,9 +79,17 @@ class DaytonaRuntime(SandboxRuntime):
         return self._working_dir or self._default_working_dir
 
     async def fetch_working_dir(self) -> str:
-        """Fetch and cache the sandbox working directory (must be awaited)."""
+        """Fetch and cache the sandbox working directory (must be awaited).
+
+        Prefers the explicitly configured default_working_dir over the SDK
+        result, which may return the Daytona user's home (/home/daytona)
+        instead of our snapshot's configured WORKDIR (/home/workspace).
+        """
         if self._working_dir is None:
-            self._working_dir = await self._sandbox.get_work_dir()
+            self._working_dir = (
+                self._default_working_dir
+                or await self._sandbox.get_work_dir()
+            )
         return self._working_dir
 
     # -- Lifecycle --
@@ -424,6 +432,9 @@ class DaytonaProvider(SandboxProvider):
                 "gh",
                 "polymarket",
                 "playwright",
+                "docker-ce",
+                "docker-ce-cli",
+                "containerd.io",
             ],
         }
         config_str = json.dumps(config_data, sort_keys=True)
@@ -473,6 +484,17 @@ class DaytonaProvider(SandboxProvider):
                 " && rm -rf /tmp/polymarket.tar.gz",
                 "npm install -g playwright"
                 " && npx playwright install --with-deps chromium",
+                # -- Docker Engine (for interactive-dashboard complex tier) --
+                "install -m 0755 -d /etc/apt/keyrings"
+                " && curl -fsSL https://download.docker.com/linux/ubuntu/gpg"
+                " -o /etc/apt/keyrings/docker.asc"
+                " && chmod a+r /etc/apt/keyrings/docker.asc",
+                'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc]'
+                " https://download.docker.com/linux/ubuntu"
+                ' $(. /etc/os-release && echo $VERSION_CODENAME) stable"'
+                " > /etc/apt/sources.list.d/docker.list",
+                "apt-get update"
+                " && apt-get install -y docker-ce docker-ce-cli containerd.io",
                 "apt-get clean",
                 "rm -rf /var/lib/apt/lists/*",
             )

--- a/src/ptc_agent/core/sandbox/ptc_sandbox.py
+++ b/src/ptc_agent/core/sandbox/ptc_sandbox.py
@@ -282,7 +282,11 @@ class PTCSandbox:
         """
         import os
 
-        env_vars: dict[str, str] = {}
+        env_vars: dict[str, str] = {
+            # Playwright browsers are installed to /usr/local/ms-playwright
+            # in the snapshot image; tell the Python package where to find them.
+            "PLAYWRIGHT_BROWSERS_PATH": "/usr/local/ms-playwright",
+        }
 
         # MCP server env vars (resolve ${VAR} placeholders from host)
         for server in self.config.mcp.servers:
@@ -2197,7 +2201,25 @@ class PTCSandbox:
             )
         except Exception as e:
             if "already exists" in str(e).lower():
-                logger.debug("Preview session already exists", session_id=session_id)
+                # Stale session from a previous server process — delete and
+                # recreate to avoid inheriting a running command from the old
+                # session (same pattern as _create_bg_session).
+                try:
+                    await self._runtime_call(
+                        self.runtime.delete_session,
+                        session_id,
+                        retry_policy=RetryPolicy.SAFE,
+                    )
+                    await self._runtime_call(
+                        self.runtime.create_session,
+                        session_id,
+                        retry_policy=RetryPolicy.SAFE,
+                    )
+                except Exception:
+                    logger.debug(
+                        "Stale preview session cleanup failed, reusing",
+                        session_id=session_id,
+                    )
             else:
                 raise
 
@@ -2312,14 +2334,55 @@ class PTCSandbox:
 
         return await self.get_preview_url(port, expires_in=expires_in)
 
+    _MAX_BG_SESSIONS = 20
+
+    async def _evict_finished_bg_sessions(self) -> None:
+        """Evict finished background sessions to stay under the cap."""
+        assert self.runtime is not None
+        # Collect finished sessions (skip sentinel keys)
+        finished: list[str] = []
+        for cmd_id, sid in list(self._bg_sessions.items()):
+            if cmd_id.startswith("_pending:"):
+                continue
+            try:
+                result = await self._runtime_call(
+                    self.runtime.session_command_logs,
+                    sid, cmd_id,
+                    retry_policy=RetryPolicy.SAFE,
+                )
+                if result.exit_code is not None:
+                    finished.append(cmd_id)
+            except Exception:
+                # Can't check status (e.g. sandbox restarted) — treat as
+                # finished to avoid zombie entries that permanently block the cap.
+                finished.append(cmd_id)
+        # Delete finished sessions
+        for cmd_id in finished:
+            sid = self._bg_sessions.pop(cmd_id, None)
+            if sid:
+                try:
+                    await self._runtime_call(
+                        self.runtime.delete_session, sid,
+                        retry_policy=RetryPolicy.SAFE,
+                    )
+                except Exception:
+                    logger.debug("Evict bg session failed", session_id=sid)
+
     async def _create_bg_session(self, label: str) -> str:
         """Create a dedicated session for a background command.
 
         Each background command gets its own Daytona session so blocking
         commands don't prevent subsequent ones from executing.
+        Evicts finished sessions when the cap is reached.
         """
         await self._wait_ready()
         assert self.runtime is not None
+
+        # Evict finished sessions if at or above the cap
+        active_count = sum(1 for k in self._bg_sessions if not k.startswith("_pending:"))
+        if active_count >= self._MAX_BG_SESSIONS:
+            await self._evict_finished_bg_sessions()
+
         session_id = f"bg-{label}"
         try:
             await self._runtime_call(
@@ -2582,14 +2645,32 @@ class PTCSandbox:
             if background:
                 session_id = await self._create_bg_session(bash_id)
                 assert self.runtime is not None
-                result = await self._runtime_call(
-                    self.runtime.session_execute,
-                    session_id,
-                    full_command,
-                    run_async=True,
-                    retry_policy=RetryPolicy.UNSAFE,
-                    total_timeout=30,
-                )
+                # Track immediately so cleanup() can find it if execute fails
+                sentinel_key = f"_pending:{session_id}"
+                self._bg_sessions[sentinel_key] = session_id
+                try:
+                    result = await self._runtime_call(
+                        self.runtime.session_execute,
+                        session_id,
+                        full_command,
+                        run_async=True,
+                        retry_policy=RetryPolicy.UNSAFE,
+                        total_timeout=30,
+                    )
+                except Exception:
+                    # Clean up the session to avoid leaking on the Daytona side
+                    try:
+                        await self._runtime_call(
+                            self.runtime.delete_session,
+                            session_id,
+                            retry_policy=RetryPolicy.SAFE,
+                        )
+                    except Exception:
+                        logger.debug("Failed to clean up bg session after execute failure", session_id=session_id)
+                    self._bg_sessions.pop(sentinel_key, None)
+                    raise
+                # Replace sentinel with real cmd_id key
+                self._bg_sessions.pop(sentinel_key, None)
                 self._bg_sessions[result.cmd_id] = session_id
                 logger.info(
                     "Background command started",

--- a/src/ptc_agent/core/sandbox/ptc_sandbox.py
+++ b/src/ptc_agent/core/sandbox/ptc_sandbox.py
@@ -2272,7 +2272,7 @@ class PTCSandbox:
         port: int,
         *,
         expires_in: int = 3600,
-        startup_delay: float = 10.0,
+        startup_timeout: float = 10.0,
     ) -> PreviewInfo:
         """Start a server command in background and return a signed preview URL.
 
@@ -2280,7 +2280,7 @@ class PTCSandbox:
         If the port is already reachable through the Daytona proxy the server
         start is skipped entirely, making this method safe to call repeatedly.
 
-        Polls for up to ``startup_delay`` seconds to confirm the port is
+        Polls for up to ``startup_timeout`` seconds to confirm the port is
         actually listening before generating the URL.  If the port never
         becomes reachable the URL is still returned — the frontend
         health-check polling handles dead-server detection.
@@ -2312,23 +2312,23 @@ class PTCSandbox:
             # Poll until the port is listening.
             # Uses bash built-in /dev/tcp (no external tools like nc needed) via
             # a single lightweight runtime.exec call with an internal retry loop.
-            max_attempts = max(int(startup_delay / 0.5), 1)
+            max_attempts = max(int(startup_timeout / 0.5), 1)
             try:
                 result = await self._runtime_call(
                     self.runtime.exec,
                     f"bash -c 'for i in $(seq 1 {max_attempts}); do"
                     f" (echo > /dev/tcp/localhost/{port}) 2>/dev/null && echo READY && exit 0;"
                     f" sleep 0.5; done; echo TIMEOUT'",
-                    timeout=int(startup_delay) + 5,
+                    timeout=int(startup_timeout) + 5,
                     retry_policy=RetryPolicy.SAFE,
                 )
                 if "READY" in result.stdout:
                     logger.info("Preview server port ready", port=port)
                 else:
                     logger.warning(
-                        "Preview server port not reachable after startup delay",
+                        "Preview server port not reachable after startup timeout",
                         port=port,
-                        startup_delay=startup_delay,
+                        startup_timeout=startup_timeout,
                     )
             except Exception:
                 logger.warning(

--- a/src/ptc_agent/core/sandbox/ptc_sandbox.py
+++ b/src/ptc_agent/core/sandbox/ptc_sandbox.py
@@ -147,6 +147,8 @@ class PTCSandbox:
         self._bg_sessions: dict[str, str] = {}
         # Per-port sessions for preview servers (port → (session_id, cmd_id))
         self._preview_sessions: dict[int, tuple[str, str]] = {}
+        # Per-port locks to serialize start_and_get_preview_url (avoids races)
+        self._preview_locks: dict[int, asyncio.Lock] = {}
 
         # Lazy initialization support
         self._ready_event: asyncio.Event | None = None
@@ -2289,50 +2291,53 @@ class PTCSandbox:
         await self._wait_ready()
         assert self.runtime is not None
 
-        # Quick probe: is the server already reachable through the proxy?
-        # This catches the common case where the server is already running
-        # and avoids an unnecessary (destructive) session teardown + restart.
-        # We check the proxy — not an in-sandbox /dev/tcp — because a server
-        # binding to 127.0.0.1 would pass the in-sandbox check but return 502
-        # through the proxy.
-        if await self._is_preview_reachable(port):
-            logger.info("Preview already reachable via proxy, skipping server start", port=port)
-            return await self.get_preview_url(port, expires_in=expires_in)
+        if port not in self._preview_locks:
+            self._preview_locks[port] = asyncio.Lock()
+        async with self._preview_locks[port]:
+            # Quick probe: is the server already reachable through the proxy?
+            # This catches the common case where the server is already running
+            # and avoids an unnecessary (destructive) session teardown + restart.
+            # We check the proxy — not an in-sandbox /dev/tcp — because a server
+            # binding to 127.0.0.1 would pass the in-sandbox check but return 502
+            # through the proxy.
+            if await self._is_preview_reachable(port):
+                logger.info("Preview already reachable via proxy, skipping server start", port=port)
+                return await self.get_preview_url(port, expires_in=expires_in)
 
-        try:
-            await self.start_preview_server(command, port)
-        except Exception as e:
-            logger.warning("Failed to start preview server", command=command, error=str(e))
+            try:
+                await self.start_preview_server(command, port)
+            except Exception as e:
+                logger.warning("Failed to start preview server", command=command, error=str(e))
 
-        # Poll until the port is listening.
-        # Uses bash built-in /dev/tcp (no external tools like nc needed) via
-        # a single lightweight runtime.exec call with an internal retry loop.
-        max_attempts = max(int(startup_delay / 0.5), 1)
-        try:
-            result = await self._runtime_call(
-                self.runtime.exec,
-                f"bash -c 'for i in $(seq 1 {max_attempts}); do"
-                f" (echo > /dev/tcp/localhost/{port}) 2>/dev/null && echo READY && exit 0;"
-                f" sleep 0.5; done; echo TIMEOUT'",
-                timeout=int(startup_delay) + 5,
-                retry_policy=RetryPolicy.SAFE,
-            )
-            if "READY" in result.stdout:
-                logger.info("Preview server port ready", port=port)
-            else:
-                logger.warning(
-                    "Preview server port not reachable after startup delay",
-                    port=port,
-                    startup_delay=startup_delay,
+            # Poll until the port is listening.
+            # Uses bash built-in /dev/tcp (no external tools like nc needed) via
+            # a single lightweight runtime.exec call with an internal retry loop.
+            max_attempts = max(int(startup_delay / 0.5), 1)
+            try:
+                result = await self._runtime_call(
+                    self.runtime.exec,
+                    f"bash -c 'for i in $(seq 1 {max_attempts}); do"
+                    f" (echo > /dev/tcp/localhost/{port}) 2>/dev/null && echo READY && exit 0;"
+                    f" sleep 0.5; done; echo TIMEOUT'",
+                    timeout=int(startup_delay) + 5,
+                    retry_policy=RetryPolicy.SAFE,
                 )
-        except Exception:
-            logger.warning(
-                "Port readiness check failed, proceeding anyway",
-                port=port,
-                exc_info=True,
-            )
+                if "READY" in result.stdout:
+                    logger.info("Preview server port ready", port=port)
+                else:
+                    logger.warning(
+                        "Preview server port not reachable after startup delay",
+                        port=port,
+                        startup_delay=startup_delay,
+                    )
+            except Exception:
+                logger.warning(
+                    "Port readiness check failed, proceeding anyway",
+                    port=port,
+                    exc_info=True,
+                )
 
-        return await self.get_preview_url(port, expires_in=expires_in)
+            return await self.get_preview_url(port, expires_in=expires_in)
 
     _MAX_BG_SESSIONS = 20
 

--- a/src/ptc_agent/core/sandbox/ptc_sandbox.py
+++ b/src/ptc_agent/core/sandbox/ptc_sandbox.py
@@ -143,8 +143,10 @@ class PTCSandbox:
         # Track per-thread code dirs that have been created (avoids repeated mkdir)
         self._thread_dirs_created: set[str] = set()
 
-        # Background session for long-running commands (lazy-created)
-        self._bg_session_id: str | None = None
+        # Per-command sessions for background Bash commands (cmd_id → session_id)
+        self._bg_sessions: dict[str, str] = {}
+        # Per-port sessions for preview servers (port → (session_id, cmd_id))
+        self._preview_sessions: dict[int, tuple[str, str]] = {}
 
         # Lazy initialization support
         self._ready_event: asyncio.Event | None = None
@@ -528,7 +530,8 @@ class PTCSandbox:
         logger.info("Reconnecting to stopped sandbox", sandbox_id=sandbox_id)
 
         # Clear stale state — sessions and preview links don't survive stop/start
-        self._bg_session_id = None
+        self._bg_sessions.clear()
+        self._preview_sessions.clear()
         self._preview_link_cache.clear()
 
         # Get the existing sandbox via provider
@@ -2158,18 +2161,46 @@ class PTCSandbox:
         self._preview_link_cache[port] = result
         return result
 
-    async def start_preview_server(self, command: str) -> str:
-        """Start a command in background for preview URL serving.
+    async def start_preview_server(self, command: str, port: int) -> str:
+        """Start a command in a dedicated per-port session for preview URL serving.
 
-        Fire-and-forget: starts the command via the background session.
-        If the port is already in use (server already running), the command
-        fails silently in the background — existing server keeps serving.
+        Each port gets its own Daytona session so blocking server commands
+        (e.g. ``python -m http.server``) don't interfere with each other.
+        If a session for this port already exists the old one is deleted first.
 
         Returns:
             The command ID from the session.
         """
-        session_id = await self._ensure_bg_session()
+        await self._wait_ready()
         assert self.runtime is not None
+
+        session_id = f"preview-{port}"
+
+        # Tear down stale session for this port if one exists
+        if port in self._preview_sessions:
+            old_sid, _old_cmd = self._preview_sessions[port]
+            try:
+                await self._runtime_call(
+                    self.runtime.delete_session,
+                    old_sid,
+                    retry_policy=RetryPolicy.SAFE,
+                )
+            except Exception:
+                logger.debug("Stale preview session cleanup failed", port=port)
+            del self._preview_sessions[port]
+
+        try:
+            await self._runtime_call(
+                self.runtime.create_session,
+                session_id,
+                retry_policy=RetryPolicy.SAFE,
+            )
+        except Exception as e:
+            if "already exists" in str(e).lower():
+                logger.debug("Preview session already exists", session_id=session_id)
+            else:
+                raise
+
         result = await self._runtime_call(
             self.runtime.session_execute,
             session_id,
@@ -2178,12 +2209,38 @@ class PTCSandbox:
             retry_policy=RetryPolicy.UNSAFE,
             total_timeout=30,
         )
+        self._preview_sessions[port] = (session_id, result.cmd_id)
         logger.info(
-            "Preview server command started",
+            "Preview server started",
             cmd_id=result.cmd_id,
             session_id=session_id,
+            port=port,
         )
         return result.cmd_id
+
+    async def _is_preview_reachable(self, port: int, *, timeout: float = 3.0) -> bool:
+        """Check if a preview port is reachable via the Daytona proxy.
+
+        Uses the preview link (proxy URL + auth headers) to verify the server
+        is accessible from outside the sandbox — not just locally.  A server
+        binding to 127.0.0.1 passes an in-sandbox ``/dev/tcp`` check but
+        returns 502 through the proxy.
+        """
+        import httpx
+
+        try:
+            link = await self.get_preview_link(port)
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                resp = await client.head(
+                    link.url,
+                    headers=link.auth_headers,
+                    follow_redirects=True,
+                )
+                # 4xx means the server IS running (path not found, etc.)
+                # 5xx (especially 502) means the proxy can't reach the backend
+                return 200 <= resp.status_code < 500 and resp.status_code != 502
+        except Exception:
+            return False
 
     async def start_and_get_preview_url(
         self,
@@ -2191,29 +2248,79 @@ class PTCSandbox:
         port: int,
         *,
         expires_in: int = 3600,
-        startup_delay: float = 2.0,
+        startup_delay: float = 10.0,
     ) -> PreviewInfo:
         """Start a server command in background and return a signed preview URL.
 
-        Combines start_preview_server + sleep + get_preview_url into a single call.
-        If the server command fails (e.g. port already in use), the preview URL
-        is still generated — the existing server keeps serving.
+        Combines start_preview_server + port readiness poll + get_preview_url.
+        If the port is already reachable through the Daytona proxy the server
+        start is skipped entirely, making this method safe to call repeatedly.
+
+        Polls for up to ``startup_delay`` seconds to confirm the port is
+        actually listening before generating the URL.  If the port never
+        becomes reachable the URL is still returned — the frontend
+        health-check polling handles dead-server detection.
+
+        If the server command fails (e.g. port already in use), the preview
+        URL is still generated — the existing server keeps serving.
         """
-        try:
-            await self.start_preview_server(command)
-        except Exception as e:
-            logger.warning("Failed to start preview server", command=command, error=str(e))
-        await asyncio.sleep(startup_delay)
-        return await self.get_preview_url(port, expires_in=expires_in)
-
-    async def _ensure_bg_session(self) -> str:
-        """Lazily create a background session for long-running commands."""
-        if self._bg_session_id is not None:
-            return self._bg_session_id
-
         await self._wait_ready()
         assert self.runtime is not None
-        session_id = f"bg-{self.runtime.id[:12]}"
+
+        # Quick probe: is the server already reachable through the proxy?
+        # This catches the common case where the server is already running
+        # and avoids an unnecessary (destructive) session teardown + restart.
+        # We check the proxy — not an in-sandbox /dev/tcp — because a server
+        # binding to 127.0.0.1 would pass the in-sandbox check but return 502
+        # through the proxy.
+        if await self._is_preview_reachable(port):
+            logger.info("Preview already reachable via proxy, skipping server start", port=port)
+            return await self.get_preview_url(port, expires_in=expires_in)
+
+        try:
+            await self.start_preview_server(command, port)
+        except Exception as e:
+            logger.warning("Failed to start preview server", command=command, error=str(e))
+
+        # Poll until the port is listening.
+        # Uses bash built-in /dev/tcp (no external tools like nc needed) via
+        # a single lightweight runtime.exec call with an internal retry loop.
+        max_attempts = max(int(startup_delay / 0.5), 1)
+        try:
+            result = await self._runtime_call(
+                self.runtime.exec,
+                f"bash -c 'for i in $(seq 1 {max_attempts}); do"
+                f" (echo > /dev/tcp/localhost/{port}) 2>/dev/null && echo READY && exit 0;"
+                f" sleep 0.5; done; echo TIMEOUT'",
+                timeout=int(startup_delay) + 5,
+                retry_policy=RetryPolicy.SAFE,
+            )
+            if "READY" in result.stdout:
+                logger.info("Preview server port ready", port=port)
+            else:
+                logger.warning(
+                    "Preview server port not reachable after startup delay",
+                    port=port,
+                    startup_delay=startup_delay,
+                )
+        except Exception:
+            logger.warning(
+                "Port readiness check failed, proceeding anyway",
+                port=port,
+                exc_info=True,
+            )
+
+        return await self.get_preview_url(port, expires_in=expires_in)
+
+    async def _create_bg_session(self, label: str) -> str:
+        """Create a dedicated session for a background command.
+
+        Each background command gets its own Daytona session so blocking
+        commands don't prevent subsequent ones from executing.
+        """
+        await self._wait_ready()
+        assert self.runtime is not None
+        session_id = f"bg-{label}"
         try:
             await self._runtime_call(
                 self.runtime.create_session,
@@ -2221,12 +2328,24 @@ class PTCSandbox:
                 retry_policy=RetryPolicy.SAFE,
             )
         except Exception as e:
-            # Session may already exist from a previous sandbox reconnect
             if "already exists" in str(e).lower():
-                logger.debug("Background session already exists", session_id=session_id)
+                # Stale session from a previous run — delete and recreate
+                # to avoid inheriting env/state from the old session
+                try:
+                    await self._runtime_call(
+                        self.runtime.delete_session,
+                        session_id,
+                        retry_policy=RetryPolicy.SAFE,
+                    )
+                    await self._runtime_call(
+                        self.runtime.create_session,
+                        session_id,
+                        retry_policy=RetryPolicy.SAFE,
+                    )
+                except Exception:
+                    logger.debug("Stale bg session cleanup failed, reusing", session_id=session_id)
             else:
                 raise
-        self._bg_session_id = session_id
         logger.info("Background session ready", session_id=session_id)
         return session_id
 
@@ -2242,23 +2361,38 @@ class PTCSandbox:
         await self._wait_ready()
         assert self.runtime is not None
 
-        if not self._bg_session_id:
+        session_id = self._bg_sessions.get(cmd_id)
+        if not session_id:
             return {
                 "success": False,
                 "is_running": False,
                 "exit_code": None,
                 "stdout": "",
-                "stderr": "No background session exists",
+                "stderr": "No background session found for this command",
                 "cmd_id": cmd_id,
             }
 
         result: SessionCommandResult = await self._runtime_call(
             self.runtime.session_command_logs,
-            self._bg_session_id,
+            session_id,
             cmd_id,
             retry_policy=RetryPolicy.SAFE,
         )
         is_running = result.exit_code is None
+
+        # Auto-clean: if the command finished (e.g. killed via pkill), tear
+        # down the orphaned session so it doesn't leak on the Daytona side.
+        if not is_running:
+            sid = self._bg_sessions.pop(cmd_id, None)
+            if sid:
+                try:
+                    await self._runtime_call(
+                        self.runtime.delete_session, sid,
+                        retry_policy=RetryPolicy.SAFE,
+                    )
+                except Exception:
+                    logger.debug("Auto-clean bg session failed", session_id=sid)
+
         return {
             "success": not is_running and result.exit_code == 0,
             "is_running": is_running,
@@ -2267,6 +2401,95 @@ class PTCSandbox:
             "stderr": result.stderr,
             "cmd_id": cmd_id,
         }
+
+    async def stop_background_command(self, cmd_id: str) -> bool:
+        """Stop a background command by deleting its session.
+
+        Returns True if the session was found and deleted.
+        """
+        session_id = self._bg_sessions.get(cmd_id)
+        if not session_id:
+            return False
+        await self._wait_ready()
+        assert self.runtime is not None
+        try:
+            await self._runtime_call(
+                self.runtime.delete_session,
+                session_id,
+                retry_policy=RetryPolicy.SAFE,
+            )
+        except Exception:
+            logger.warning("Failed to delete bg session", session_id=session_id)
+            self._bg_sessions.pop(cmd_id, None)
+            return False
+        self._bg_sessions.pop(cmd_id, None)
+        return True
+
+    async def get_preview_server_logs(self, port: int) -> dict[str, Any]:
+        """Get logs for the preview server running on the given port.
+
+        Returns:
+            Dict with keys: success, is_running, stdout, stderr, port.
+        """
+        entry = self._preview_sessions.get(port)
+        if not entry:
+            return {
+                "success": False,
+                "is_running": False,
+                "stdout": "",
+                "stderr": f"No preview session for port {port}",
+                "port": port,
+            }
+        session_id, cmd_id = entry
+        await self._wait_ready()
+        assert self.runtime is not None
+        try:
+            result: SessionCommandResult = await self._runtime_call(
+                self.runtime.session_command_logs,
+                session_id,
+                cmd_id,
+                retry_policy=RetryPolicy.SAFE,
+            )
+            is_running = result.exit_code is None
+            return {
+                "success": True,
+                "is_running": is_running,
+                "exit_code": result.exit_code,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+                "port": port,
+            }
+        except Exception as e:
+            return {
+                "success": False,
+                "is_running": False,
+                "stdout": "",
+                "stderr": f"Failed to get logs: {e!s}",
+                "port": port,
+            }
+
+    async def stop_preview_server(self, port: int) -> bool:
+        """Stop the preview server on the given port by deleting its session.
+
+        Returns True if the session was found and deleted.
+        """
+        entry = self._preview_sessions.get(port)
+        if not entry:
+            return False
+        session_id, _cmd_id = entry
+        await self._wait_ready()
+        assert self.runtime is not None
+        try:
+            await self._runtime_call(
+                self.runtime.delete_session,
+                session_id,
+                retry_policy=RetryPolicy.SAFE,
+            )
+            logger.info("Preview server stopped", port=port, session_id=session_id)
+        except Exception:
+            logger.debug("Failed to delete preview session", session_id=session_id)
+        self._preview_sessions.pop(port, None)
+        return True
 
     async def execute_bash_command(
         self,
@@ -2355,9 +2578,9 @@ class PTCSandbox:
                     error=str(upload_err),
                 )
 
-            # Background execution via Daytona session
+            # Background execution via dedicated Daytona session per command
             if background:
-                session_id = await self._ensure_bg_session()
+                session_id = await self._create_bg_session(bash_id)
                 assert self.runtime is not None
                 result = await self._runtime_call(
                     self.runtime.session_execute,
@@ -2367,6 +2590,7 @@ class PTCSandbox:
                     retry_policy=RetryPolicy.UNSAFE,
                     total_timeout=30,
                 )
+                self._bg_sessions[result.cmd_id] = session_id
                 logger.info(
                     "Background command started",
                     bash_id=bash_id,
@@ -3047,17 +3271,18 @@ class PTCSandbox:
 
         try:
             if self.runtime:
-                # Clean up background session if one was created
-                if self._bg_session_id:
+                # Clean up all managed sessions (preview + background)
+                all_sessions = [sid for sid, _ in self._preview_sessions.values()] + list(self._bg_sessions.values())
+                for sid in dict.fromkeys(all_sessions):  # deduplicate
                     try:
                         await self._runtime_call(
-                            self.runtime.delete_session,
-                            self._bg_session_id,
+                            self.runtime.delete_session, sid,
                             retry_policy=RetryPolicy.SAFE,
                         )
-                    except Exception as e:
-                        logger.debug("Failed to delete background session", error=str(e))
-                    self._bg_session_id = None
+                    except Exception:
+                        logger.debug("Failed to delete session", session_id=sid)
+                self._preview_sessions.clear()
+                self._bg_sessions.clear()
 
                 try:
                     await self._runtime_call(

--- a/src/server/app/workspace_sandbox.py
+++ b/src/server/app/workspace_sandbox.py
@@ -28,7 +28,6 @@ from src.server.utils.api import CurrentUserId, require_workspace_owner
 from src.server.database.workspace import (
     get_preview_command,
     get_workspace as db_get_workspace,
-    save_preview_command,
 )
 from src.server.services.workspace_manager import WorkspaceManager
 from src.ptc_agent.core.sandbox import PTCSandbox
@@ -539,10 +538,6 @@ async def _resolve_preview(
         cmd = await get_preview_command(workspace_id, port)
 
     if cmd:
-        # Persist the command so future redirect requests can replay it
-        if command:
-            await save_preview_command(workspace_id, port, command)
-
         preview_info = await sandbox.start_and_get_preview_url(
             cmd, port, expires_in=expires_in,
         )
@@ -685,49 +680,66 @@ preview_redirect_router = APIRouter(prefix="/api/v1", tags=["Preview Redirect"])
 async def _preview_redirect(workspace_id: str, port: int, path: str = "") -> Response:
     """Shared logic for preview redirect with optional path suffix.
 
-    Uses the same ``_resolve_preview`` helper as the authenticated POST
-    endpoint — sandbox is auto-started via WorkspaceManager if stopped,
-    and the preview server is health-checked / restarted via
-    ``start_and_get_preview_url`` using the command stored in the DB.
+    Performs a lightweight DB check first — only proceeds if the workspace
+    is already running.  Unlike the authenticated POST endpoint, the
+    unauthenticated redirect does NOT start stopped sandboxes (to prevent
+    denial-of-wallet via cheap GET requests).
     """
-    manager = WorkspaceManager.get_instance()
+    # Lightweight DB check — don't start stopped sandboxes from this
+    # unauthenticated endpoint (workspace UUID is the only credential).
+    # Return uniform 404 for both missing and non-running workspaces to
+    # avoid leaking workspace existence via status-code differences.
     try:
-        session = await manager.get_session_for_workspace(workspace_id)
+        workspace = await db_get_workspace(workspace_id)
     except Exception:
-        raise HTTPException(status_code=503, detail="Sandbox not ready") from None
+        raise HTTPException(status_code=503, detail="Service temporarily unavailable") from None
+    if not workspace or workspace.get("status") != "running":
+        raise HTTPException(status_code=404, detail="Preview not available")
 
-    sandbox = getattr(session, "sandbox", None)
-    if sandbox is None:
-        raise HTTPException(status_code=503, detail="Sandbox not available")
+    async def _resolve() -> Response:
+        manager = WorkspaceManager.get_instance()
+        try:
+            session = await manager.get_session_for_workspace(workspace_id)
+        except Exception:
+            raise HTTPException(status_code=503, detail="Sandbox not ready") from None
+
+        sandbox = getattr(session, "sandbox", None)
+        if sandbox is None:
+            raise HTTPException(status_code=503, detail="Sandbox not available")
+
+        try:
+            signed_url = await _resolve_preview(sandbox, workspace_id, port)
+        except NotImplementedError:
+            raise HTTPException(
+                status_code=501,
+                detail="Preview URLs are not supported by the current sandbox provider",
+            ) from None
+        except Exception:
+            logger.exception("Failed to get preview URL for workspace %s port %d", workspace_id, port)
+            raise HTTPException(status_code=500, detail="Failed to get preview URL") from None
+
+        if path:
+            import posixpath
+            from urllib.parse import urlsplit, urlunsplit
+
+            if ".." in path.split("/"):
+                raise HTTPException(status_code=400, detail="Invalid path")
+            normalized = posixpath.normpath("/" + path)
+
+            parts = urlsplit(signed_url)
+            new_path = parts.path.rstrip("/") + normalized
+            signed_url = urlunsplit(parts._replace(path=new_path))
+
+        response = RedirectResponse(url=signed_url, status_code=302)
+        response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate"
+        return response
 
     try:
-        signed_url = await _resolve_preview(sandbox, workspace_id, port)
-    except NotImplementedError:
+        return await asyncio.wait_for(_resolve(), timeout=20)
+    except asyncio.TimeoutError:
         raise HTTPException(
-            status_code=501,
-            detail="Preview URLs are not supported by the current sandbox provider",
+            status_code=504, detail="Preview URL resolution timed out"
         ) from None
-    except Exception:
-        logger.exception("Failed to get preview URL for workspace %s port %d", workspace_id, port)
-        raise HTTPException(status_code=500, detail="Failed to get preview URL") from None
-
-    if path:
-        import posixpath
-        from urllib.parse import urlsplit, urlunsplit
-
-        # Reject path-traversal attempts before normalization
-        # (normpath resolves ".." making post-normpath checks ineffective)
-        if ".." in path.split("/"):
-            raise HTTPException(status_code=400, detail="Invalid path")
-        normalized = posixpath.normpath("/" + path)
-
-        parts = urlsplit(signed_url)
-        new_path = parts.path.rstrip("/") + normalized
-        signed_url = urlunsplit(parts._replace(path=new_path))
-
-    response = RedirectResponse(url=signed_url, status_code=302)
-    response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate"
-    return response
 
 
 @preview_redirect_router.get("/preview/{workspace_id}/{port}")

--- a/src/server/app/workspace_sandbox.py
+++ b/src/server/app/workspace_sandbox.py
@@ -75,6 +75,18 @@ async def _delete_cached_signed_url(sandbox_id: str, port: int) -> None:
     await cache.delete(_preview_cache_key(sandbox_id, port))
 
 
+async def _is_preview_live_confirmed(sandbox_id: str, port: int) -> bool:
+    """Check if the preview was recently confirmed live (avoids repeated HEAD probes)."""
+    cache = get_cache_client()
+    return await cache.get(f"preview:live:{sandbox_id}:{port}") is not None
+
+
+async def _set_preview_live_confirmed(sandbox_id: str, port: int, *, ttl: int = 10) -> None:
+    """Mark preview as confirmed live for a short window."""
+    cache = get_cache_client()
+    await cache.set(f"preview:live:{sandbox_id}:{port}", "1", ttl=ttl)
+
+
 async def _check_signed_url_healthy(signed_url: str) -> bool:
     """HEAD-check the actual signed URL the iframe would load."""
     try:
@@ -513,12 +525,15 @@ class PreviewUrlResponse(BaseModel):
     expires_in: int
 
 
+_UNSET = object()
+
+
 async def _resolve_preview(
     sandbox: Any,
     workspace_id: str,
     port: int,
     *,
-    command: str | None = None,
+    command: str | None | object = _UNSET,
     force: bool = False,
     expires_in: int = 3600,
 ) -> str:
@@ -531,10 +546,14 @@ async def _resolve_preview(
     returns a fresh signed URL.
 
     Falls back to a plain ``get_preview_url`` only when no command is known.
+
+    Pass ``command=None`` to indicate "already looked up, no command stored"
+    (skips the DB lookup).  Omit the argument (or pass ``_UNSET``) to have
+    this function look it up from the database.
     """
-    # Resolve command: explicit arg → DB lookup
+    # Resolve command: explicit arg → DB lookup (only when caller didn't provide)
     cmd = command
-    if not cmd:
+    if cmd is _UNSET:
         cmd = await get_preview_command(workspace_id, port)
 
     if cmd:
@@ -542,8 +561,11 @@ async def _resolve_preview(
         # asset requests (CSS/JS/images) without risking long-lived stale URLs.
         if not force:
             cached_url = await _get_cached_signed_url(sandbox.sandbox_id, port)
-            if cached_url and await _check_signed_url_healthy(cached_url):
-                return cached_url
+            if cached_url:
+                if await _is_preview_live_confirmed(sandbox.sandbox_id, port) \
+                        or await _check_signed_url_healthy(cached_url):
+                    await _set_preview_live_confirmed(sandbox.sandbox_id, port, ttl=10)
+                    return cached_url
 
         preview_info = await sandbox.start_and_get_preview_url(
             cmd, port, expires_in=expires_in,
@@ -556,8 +578,11 @@ async def _resolve_preview(
     # No command known — try signed-URL cache, then generate fresh.
     if not force:
         cached_url = await _get_cached_signed_url(sandbox.sandbox_id, port)
-        if cached_url and await _check_signed_url_healthy(cached_url):
-            return cached_url
+        if cached_url:
+            if await _is_preview_live_confirmed(sandbox.sandbox_id, port) \
+                    or await _check_signed_url_healthy(cached_url):
+                await _set_preview_live_confirmed(sandbox.sandbox_id, port, ttl=10)
+                return cached_url
 
     await _delete_cached_signed_url(sandbox.sandbox_id, port)
     preview_info = await sandbox.get_preview_url(port, expires_in=expires_in)
@@ -582,7 +607,8 @@ async def get_sandbox_preview_url(
     try:
         url = await _resolve_preview(
             sandbox, workspace_id, body.port,
-            command=body.command, force=body.force, expires_in=body.expires_in,
+            command=body.command if body.command else _UNSET,
+            force=body.force, expires_in=body.expires_in,
         )
         return PreviewUrlResponse(url=url, port=body.port, expires_in=body.expires_in)
     except HTTPException:
@@ -703,6 +729,11 @@ async def _preview_redirect(workspace_id: str, port: int, path: str = "") -> Res
     if not workspace or workspace.get("status") != "running":
         raise HTTPException(status_code=404, detail="Preview not available")
 
+    # Extract preview command from the already-fetched workspace to avoid a
+    # second DB query inside _resolve_preview.
+    artifacts = workspace.get("artifacts") or {}
+    preview_cmd = (artifacts.get("preview_servers") or {}).get(str(port))
+
     async def _resolve() -> Response:
         manager = WorkspaceManager.get_instance()
         try:
@@ -715,7 +746,7 @@ async def _preview_redirect(workspace_id: str, port: int, path: str = "") -> Res
             raise HTTPException(status_code=503, detail="Sandbox not available")
 
         try:
-            signed_url = await _resolve_preview(sandbox, workspace_id, port)
+            signed_url = await _resolve_preview(sandbox, workspace_id, port, command=preview_cmd)
         except NotImplementedError:
             raise HTTPException(
                 status_code=501,

--- a/src/server/app/workspace_sandbox.py
+++ b/src/server/app/workspace_sandbox.py
@@ -651,7 +651,7 @@ async def restart_preview_server(
     _session, sandbox = await _get_sandbox(workspace_id, x_user_id)
 
     try:
-        await sandbox.start_preview_server(body.command)
+        await sandbox.start_preview_server(body.command, body.port)
         return PreviewRestartResponse(success=True)
     except Exception:
         logger.exception(
@@ -705,6 +705,35 @@ async def _resolve_preview_url(sandbox_id: str, port: int) -> str:
         await provider.close()
 
 
+async def _preview_redirect(workspace_id: str, port: int, path: str = "") -> Response:
+    """Shared logic for preview redirect with optional path suffix."""
+    workspace = await db_get_workspace(workspace_id)
+    if not workspace:
+        raise HTTPException(status_code=404, detail="Workspace not found")
+
+    sandbox_id = workspace.get("sandbox_id")
+    if not sandbox_id:
+        raise HTTPException(status_code=404, detail="No sandbox for this workspace")
+
+    signed_url = await _resolve_preview_url(sandbox_id, port)
+
+    if path:
+        import posixpath
+        from urllib.parse import urlsplit, urlunsplit
+
+        # Reject path-traversal attempts before normalization
+        # (normpath resolves ".." making post-normpath checks ineffective)
+        if ".." in path.split("/"):
+            raise HTTPException(status_code=400, detail="Invalid path")
+        normalized = posixpath.normpath("/" + path)
+
+        parts = urlsplit(signed_url)
+        new_path = parts.path.rstrip("/") + normalized
+        signed_url = urlunsplit(parts._replace(path=new_path))
+
+    return RedirectResponse(url=signed_url, status_code=302)
+
+
 @preview_redirect_router.get("/preview/{workspace_id}/{port}")
 async def preview_redirect_by_workspace(
     workspace_id: str,
@@ -715,13 +744,18 @@ async def preview_redirect_by_workspace(
     Resolves to a cached signed URL via 302 redirect.
     The workspace UUID (128-bit) acts as the access credential.
     """
-    workspace = await db_get_workspace(workspace_id)
-    if not workspace:
-        raise HTTPException(status_code=404, detail="Workspace not found")
+    return await _preview_redirect(workspace_id, port)
 
-    sandbox_id = workspace.get("sandbox_id")
-    if not sandbox_id:
-        raise HTTPException(status_code=404, detail="No sandbox for this workspace")
 
-    signed_url = await _resolve_preview_url(sandbox_id, port)
-    return RedirectResponse(url=signed_url, status_code=302)
+@preview_redirect_router.get("/preview/{workspace_id}/{port}/{path:path}")
+async def preview_redirect_by_workspace_with_path(
+    workspace_id: str,
+    port: int = PathParam(ge=3000, le=9999),
+    path: str = "",
+) -> Response:
+    """Stable preview URL with path suffix — for serving non-index files.
+
+    E.g. /api/v1/preview/{workspace_id}/8080/timeline.html
+    Appends the path to the signed Daytona URL before redirecting.
+    """
+    return await _preview_redirect(workspace_id, port, path)

--- a/src/server/app/workspace_sandbox.py
+++ b/src/server/app/workspace_sandbox.py
@@ -25,7 +25,11 @@ from fastapi.responses import RedirectResponse
 from pydantic import BaseModel, Field
 
 from src.server.utils.api import CurrentUserId, require_workspace_owner
-from src.server.database.workspace import get_workspace as db_get_workspace
+from src.server.database.workspace import (
+    get_preview_command,
+    get_workspace as db_get_workspace,
+    save_preview_command,
+)
 from src.server.services.workspace_manager import WorkspaceManager
 from src.ptc_agent.core.sandbox import PTCSandbox
 from src.utils.cache.redis_cache import get_cache_client
@@ -510,6 +514,57 @@ class PreviewUrlResponse(BaseModel):
     expires_in: int
 
 
+async def _resolve_preview(
+    sandbox: Any,
+    workspace_id: str,
+    port: int,
+    *,
+    command: str | None = None,
+    force: bool = False,
+    expires_in: int = 3600,
+) -> str:
+    """Core preview URL resolution — shared by the POST and redirect endpoints.
+
+    When a *command* is available (supplied by the caller or read from the
+    workspace ``artifacts`` column), ``start_and_get_preview_url`` is called.
+    This is the same code path as clicking the artifact: it health-checks
+    the port, restarts the server if it's down, polls for readiness, and
+    returns a fresh signed URL.
+
+    Falls back to a plain ``get_preview_url`` only when no command is known.
+    """
+    # Resolve command: explicit arg → DB lookup
+    cmd = command
+    if not cmd:
+        cmd = await get_preview_command(workspace_id, port)
+
+    if cmd:
+        # Persist the command so future redirect requests can replay it
+        if command:
+            await save_preview_command(workspace_id, port, command)
+
+        preview_info = await sandbox.start_and_get_preview_url(
+            cmd, port, expires_in=expires_in,
+        )
+        await _set_cached_signed_url(
+            sandbox.sandbox_id, port, preview_info.url, expires_in=expires_in,
+        )
+        return preview_info.url
+
+    # No command known — try signed-URL cache, then generate fresh.
+    if not force:
+        cached_url = await _get_cached_signed_url(sandbox.sandbox_id, port)
+        if cached_url and await _check_signed_url_healthy(cached_url):
+            return cached_url
+
+    await _delete_cached_signed_url(sandbox.sandbox_id, port)
+    preview_info = await sandbox.get_preview_url(port, expires_in=expires_in)
+    await _set_cached_signed_url(
+        sandbox.sandbox_id, port, preview_info.url, expires_in=expires_in,
+    )
+    return preview_info.url
+
+
 @router.post("/{workspace_id}/sandbox/preview-url")
 async def get_sandbox_preview_url(
     workspace_id: str,
@@ -523,51 +578,11 @@ async def get_sandbox_preview_url(
     _session, sandbox = await _get_sandbox(workspace_id, x_user_id)
 
     try:
-        if body.command:
-            preview_info = await sandbox.start_and_get_preview_url(
-                body.command, body.port, expires_in=body.expires_in,
-            )
-            await _set_cached_signed_url(
-                sandbox.sandbox_id, body.port, preview_info.url,
-                expires_in=body.expires_in,
-            )
-            return PreviewUrlResponse(
-                url=preview_info.url,
-                port=body.port,
-                expires_in=body.expires_in,
-            )
-
-        # No command — try cache (unless force=True)
-        if body.force:
-            await _delete_cached_signed_url(sandbox.sandbox_id, body.port)
-        cached_url = None if body.force else await _get_cached_signed_url(sandbox.sandbox_id, body.port)
-        if cached_url and await _check_signed_url_healthy(cached_url):
-            return PreviewUrlResponse(
-                url=cached_url,
-                port=body.port,
-                expires_in=body.expires_in,
-            )
-
-        # Stale or missing — get a fresh signed URL from the provider
-        await _delete_cached_signed_url(sandbox.sandbox_id, body.port)
-        preview_info = await sandbox.get_preview_url(
-            body.port, expires_in=body.expires_in,
+        url = await _resolve_preview(
+            sandbox, workspace_id, body.port,
+            command=body.command, force=body.force, expires_in=body.expires_in,
         )
-
-        # A freshly-generated signed URL from the provider is inherently valid.
-        # Don't gate on a server-side health check here — it can produce false
-        # negatives (e.g. dev servers that reject HEAD, or network differences
-        # between backend→proxy vs browser→proxy). The frontend's polling health
-        # check handles dead-server detection and restart.
-        await _set_cached_signed_url(
-            sandbox.sandbox_id, body.port, preview_info.url,
-            expires_in=body.expires_in,
-        )
-        return PreviewUrlResponse(
-            url=preview_info.url,
-            port=body.port,
-            expires_in=body.expires_in,
-        )
+        return PreviewUrlResponse(url=url, port=body.port, expires_in=body.expires_in)
     except HTTPException:
         raise
     except NotImplementedError:
@@ -667,55 +682,34 @@ async def restart_preview_server(
 preview_redirect_router = APIRouter(prefix="/api/v1", tags=["Preview Redirect"])
 
 
-async def _resolve_preview_url(sandbox_id: str, port: int) -> str:
-    """Resolve a signed preview URL for the given sandbox+port, with Redis caching."""
-    from ptc_agent.core.sandbox.providers import create_provider
-
-    cached_url = await _get_cached_signed_url(sandbox_id, port)
-    if cached_url and await _check_signed_url_healthy(cached_url):
-        return cached_url
-    if cached_url:
-        await _delete_cached_signed_url(sandbox_id, port)
-
-    manager = WorkspaceManager.get_instance()
-    provider = create_provider(manager.config.to_core_config())
-    try:
-        async def _fetch_fresh_url() -> str:
-            try:
-                runtime = await provider.get(sandbox_id)
-            except Exception:
-                raise HTTPException(status_code=404, detail="Sandbox not found") from None
-
-            state = await runtime.get_state()
-            if state.value != "running":
-                raise HTTPException(
-                    status_code=503,
-                    detail="Sandbox not running",
-                    headers={"Retry-After": "30"},
-                )
-
-            preview_info = await runtime.get_preview_url(port, expires_in=3600)
-            await _set_cached_signed_url(sandbox_id, port, preview_info.url)
-            return preview_info.url
-
-        return await asyncio.wait_for(_fetch_fresh_url(), timeout=15)
-    except asyncio.TimeoutError:
-        raise HTTPException(status_code=504, detail="Preview URL resolution timed out") from None
-    finally:
-        await provider.close()
-
-
 async def _preview_redirect(workspace_id: str, port: int, path: str = "") -> Response:
-    """Shared logic for preview redirect with optional path suffix."""
-    workspace = await db_get_workspace(workspace_id)
-    if not workspace:
-        raise HTTPException(status_code=404, detail="Workspace not found")
+    """Shared logic for preview redirect with optional path suffix.
 
-    sandbox_id = workspace.get("sandbox_id")
-    if not sandbox_id:
-        raise HTTPException(status_code=404, detail="No sandbox for this workspace")
+    Uses the same ``_resolve_preview`` helper as the authenticated POST
+    endpoint — sandbox is auto-started via WorkspaceManager if stopped,
+    and the preview server is health-checked / restarted via
+    ``start_and_get_preview_url`` using the command stored in the DB.
+    """
+    manager = WorkspaceManager.get_instance()
+    try:
+        session = await manager.get_session_for_workspace(workspace_id)
+    except Exception:
+        raise HTTPException(status_code=503, detail="Sandbox not ready") from None
 
-    signed_url = await _resolve_preview_url(sandbox_id, port)
+    sandbox = getattr(session, "sandbox", None)
+    if sandbox is None:
+        raise HTTPException(status_code=503, detail="Sandbox not available")
+
+    try:
+        signed_url = await _resolve_preview(sandbox, workspace_id, port)
+    except NotImplementedError:
+        raise HTTPException(
+            status_code=501,
+            detail="Preview URLs are not supported by the current sandbox provider",
+        ) from None
+    except Exception:
+        logger.exception("Failed to get preview URL for workspace %s port %d", workspace_id, port)
+        raise HTTPException(status_code=500, detail="Failed to get preview URL") from None
 
     if path:
         import posixpath
@@ -731,7 +725,9 @@ async def _preview_redirect(workspace_id: str, port: int, path: str = "") -> Res
         new_path = parts.path.rstrip("/") + normalized
         signed_url = urlunsplit(parts._replace(path=new_path))
 
-    return RedirectResponse(url=signed_url, status_code=302)
+    response = RedirectResponse(url=signed_url, status_code=302)
+    response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate"
+    return response
 
 
 @preview_redirect_router.get("/preview/{workspace_id}/{port}")

--- a/src/server/app/workspace_sandbox.py
+++ b/src/server/app/workspace_sandbox.py
@@ -538,11 +538,18 @@ async def _resolve_preview(
         cmd = await get_preview_command(workspace_id, port)
 
     if cmd:
+        # Short-lived cache (60s) when a command is stored — covers burst
+        # asset requests (CSS/JS/images) without risking long-lived stale URLs.
+        if not force:
+            cached_url = await _get_cached_signed_url(sandbox.sandbox_id, port)
+            if cached_url and await _check_signed_url_healthy(cached_url):
+                return cached_url
+
         preview_info = await sandbox.start_and_get_preview_url(
             cmd, port, expires_in=expires_in,
         )
         await _set_cached_signed_url(
-            sandbox.sandbox_id, port, preview_info.url, expires_in=expires_in,
+            sandbox.sandbox_id, port, preview_info.url, expires_in=60,
         )
         return preview_info.url
 

--- a/src/server/database/workspace.py
+++ b/src/server/database/workspace.py
@@ -685,9 +685,15 @@ async def get_preview_command(
     workspace_id: str, port: int
 ) -> Optional[str]:
     """Read a preview server command from ``artifacts.preview_servers``."""
-    workspace = await get_workspace(workspace_id)
-    if not workspace:
+    try:
+        async with get_db_connection() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "SELECT artifacts->'preview_servers'->>%s FROM workspaces WHERE workspace_id = %s",
+                    (str(port), workspace_id),
+                )
+                row = await cur.fetchone()
+                return row[0] if row else None
+    except Exception:
+        logger.debug("Failed to read preview command", exc_info=True)
         return None
-    artifacts = workspace.get("artifacts") or {}
-    servers = artifacts.get("preview_servers") or {}
-    return servers.get(str(port))

--- a/src/server/database/workspace.py
+++ b/src/server/database/workspace.py
@@ -46,7 +46,7 @@ async def get_or_create_flash_workspace(
             VALUES (%s, %s, %s, %s, %s, %s, TRUE)
             ON CONFLICT (workspace_id) DO UPDATE SET updated_at = NOW(), is_pinned = TRUE
             RETURNING workspace_id, user_id, name, description, sandbox_id,
-                      status, created_at, updated_at, last_activity_at, stopped_at, config,
+                      status, created_at, updated_at, last_activity_at, stopped_at, config, artifacts,
                       is_pinned, sort_order
             """,
             (workspace_id, user_id, "Flash", "Flash mode conversations", config_json, "flash"),
@@ -112,7 +112,7 @@ async def create_workspace(
                     INSERT INTO workspaces (workspace_id, user_id, name, description, config, status)
                     VALUES (%s, %s, %s, %s, %s, %s)
                     RETURNING workspace_id, user_id, name, description, sandbox_id,
-                              status, created_at, updated_at, last_activity_at, stopped_at, config,
+                              status, created_at, updated_at, last_activity_at, stopped_at, config, artifacts,
                               is_pinned, sort_order
                     """,
                     (workspace_id, user_id, name, description, config_json, status),
@@ -124,7 +124,7 @@ async def create_workspace(
                     INSERT INTO workspaces (user_id, name, description, config, status)
                     VALUES (%s, %s, %s, %s, %s)
                     RETURNING workspace_id, user_id, name, description, sandbox_id,
-                              status, created_at, updated_at, last_activity_at, stopped_at, config,
+                              status, created_at, updated_at, last_activity_at, stopped_at, config, artifacts,
                               is_pinned, sort_order
                     """,
                     (user_id, name, description, config_json, status),
@@ -166,7 +166,7 @@ async def get_workspace(
             await cur.execute(
                 """
                 SELECT workspace_id, user_id, name, description, sandbox_id,
-                       status, created_at, updated_at, last_activity_at, stopped_at, config,
+                       status, created_at, updated_at, last_activity_at, stopped_at, config, artifacts,
                        is_pinned, sort_order
                 FROM workspaces
                 WHERE workspace_id = %s AND status != 'deleted'
@@ -244,7 +244,7 @@ async def get_workspaces_for_user(
             await cur.execute(
                 f"""
                 SELECT workspace_id, user_id, name, description, sandbox_id,
-                       status, created_at, updated_at, last_activity_at, stopped_at, config,
+                       status, created_at, updated_at, last_activity_at, stopped_at, config, artifacts,
                        is_pinned, sort_order
                 FROM workspaces
                 WHERE user_id = %s {status_filter} {flash_filter}
@@ -330,7 +330,7 @@ async def update_workspace(
                 SET {update_clause}
                 WHERE workspace_id = %s AND status != 'deleted'
                 RETURNING workspace_id, user_id, name, description, sandbox_id,
-                          status, created_at, updated_at, last_activity_at, stopped_at, config,
+                          status, created_at, updated_at, last_activity_at, stopped_at, config, artifacts,
                           is_pinned, sort_order
                 """,
                 params,
@@ -384,7 +384,7 @@ async def update_workspace_status(
                     SET status = %s, sandbox_id = %s, updated_at = %s, stopped_at = %s
                     WHERE workspace_id = %s
                     RETURNING workspace_id, user_id, name, description, sandbox_id,
-                              status, created_at, updated_at, last_activity_at, stopped_at, config,
+                              status, created_at, updated_at, last_activity_at, stopped_at, config, artifacts,
                               is_pinned, sort_order
                 """
                 params = (status, sandbox_id, now, now, workspace_id)
@@ -394,7 +394,7 @@ async def update_workspace_status(
                     SET status = %s, sandbox_id = %s, updated_at = %s
                     WHERE workspace_id = %s
                     RETURNING workspace_id, user_id, name, description, sandbox_id,
-                              status, created_at, updated_at, last_activity_at, stopped_at, config,
+                              status, created_at, updated_at, last_activity_at, stopped_at, config, artifacts,
                               is_pinned, sort_order
                 """
                 params = (status, sandbox_id, now, workspace_id)
@@ -405,7 +405,7 @@ async def update_workspace_status(
                     SET status = %s, updated_at = %s, stopped_at = %s
                     WHERE workspace_id = %s
                     RETURNING workspace_id, user_id, name, description, sandbox_id,
-                              status, created_at, updated_at, last_activity_at, stopped_at, config,
+                              status, created_at, updated_at, last_activity_at, stopped_at, config, artifacts,
                               is_pinned, sort_order
                 """
                 params = (status, now, now, workspace_id)
@@ -415,7 +415,7 @@ async def update_workspace_status(
                     SET status = %s, updated_at = %s
                     WHERE workspace_id = %s
                     RETURNING workspace_id, user_id, name, description, sandbox_id,
-                              status, created_at, updated_at, last_activity_at, stopped_at, config,
+                              status, created_at, updated_at, last_activity_at, stopped_at, config, artifacts,
                               is_pinned, sort_order
                 """
                 params = (status, now, workspace_id)
@@ -466,7 +466,7 @@ async def update_workspace_activity(
                 SET last_activity_at = %s, updated_at = %s
                 WHERE workspace_id = %s AND status != 'deleted'
                 RETURNING workspace_id, user_id, name, description, sandbox_id,
-                          status, created_at, updated_at, last_activity_at, stopped_at, config,
+                          status, created_at, updated_at, last_activity_at, stopped_at, config, artifacts,
                           is_pinned, sort_order
                 """,
                 (now, now, workspace_id),
@@ -626,7 +626,7 @@ async def get_workspaces_by_status(
             await cur.execute(
                 """
                 SELECT workspace_id, user_id, name, description, sandbox_id,
-                       status, created_at, updated_at, last_activity_at, stopped_at, config,
+                       status, created_at, updated_at, last_activity_at, stopped_at, config, artifacts,
                        is_pinned, sort_order
                 FROM workspaces
                 WHERE status = %s
@@ -649,3 +649,45 @@ async def get_workspaces_by_status(
     except Exception as e:
         logger.error(f"Error getting workspaces by status {status}: {e}")
         raise
+
+
+# ---------------------------------------------------------------------------
+# Preview server command persistence
+# ---------------------------------------------------------------------------
+
+
+async def save_preview_command(
+    workspace_id: str, port: int, command: str
+) -> None:
+    """Store a preview server command in ``artifacts.preview_servers``."""
+    try:
+        async with get_db_connection() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    """
+                    UPDATE workspaces
+                    SET artifacts = jsonb_set(
+                        COALESCE(artifacts, '{}'::jsonb),
+                        '{preview_servers}',
+                        COALESCE(artifacts->'preview_servers', '{}'::jsonb)
+                            || jsonb_build_object(%s::text, %s::text),
+                        true
+                    )
+                    WHERE workspace_id = %s
+                    """,
+                    (str(port), command, workspace_id),
+                )
+    except Exception:
+        logger.debug("Failed to persist preview command", exc_info=True)
+
+
+async def get_preview_command(
+    workspace_id: str, port: int
+) -> Optional[str]:
+    """Read a preview server command from ``artifacts.preview_servers``."""
+    workspace = await get_workspace(workspace_id)
+    if not workspace:
+        return None
+    artifacts = workspace.get("artifacts") or {}
+    servers = artifacts.get("preview_servers") or {}
+    return servers.get(str(port))

--- a/tests/integration/sandbox/api/test_preview_redirect.py
+++ b/tests/integration/sandbox/api/test_preview_redirect.py
@@ -1,0 +1,888 @@
+"""Integration tests for preview redirect endpoint and sandbox preview methods.
+
+Tests the unauthenticated preview redirect router (``preview_redirect_router``)
+wired to a real PTCSandbox (MemoryProvider), plus direct sandbox preview method
+tests (start/stop/logs for preview servers and background commands).
+
+Database, auth, and Redis cache layers are mocked so tests exercise the full
+sandbox-to-HTTP path without external infrastructure.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from ptc_agent.core.sandbox.runtime import PreviewInfo, SessionCommandResult
+from tests.conftest import create_test_app
+from tests.integration.sandbox.conftest import _make_core_config
+from tests.integration.sandbox.memory_provider import MemoryProvider
+
+from .conftest import TEST_USER_ID, TEST_WS_ID, _make_workspace
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+PREVIEW_BASE = f"/api/v1/preview/{TEST_WS_ID}"
+FAKE_SIGNED_URL = "https://test-preview.example.com/proxy/8080"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sandbox_base_dir(tmp_path):
+    d = tmp_path / "sandboxes"
+    d.mkdir()
+    return str(d)
+
+
+@pytest_asyncio.fixture
+async def sandbox(sandbox_base_dir):
+    """Self-contained PTCSandbox backed by MemoryProvider."""
+    from ptc_agent.core.sandbox.ptc_sandbox import PTCSandbox
+
+    provider = MemoryProvider(base_dir=sandbox_base_dir)
+    config = _make_core_config(working_directory=sandbox_base_dir)
+    with patch(
+        "ptc_agent.core.sandbox.ptc_sandbox.create_provider",
+        return_value=provider,
+    ):
+        sb = PTCSandbox(config)
+        await sb.setup_sandbox_workspace()
+        actual_work_dir = await sb.runtime.fetch_working_dir()
+        sb.config.filesystem.working_directory = actual_work_dir
+        sb.config.filesystem.allowed_directories = [actual_work_dir, "/tmp"]
+        yield sb
+        try:
+            await sb.cleanup()
+        except Exception:
+            pass
+
+
+@pytest_asyncio.fixture
+async def mock_session(sandbox):
+    """Mock session object with real sandbox."""
+    session = MagicMock()
+    session.sandbox = sandbox
+    session.mcp_registry = MagicMock()
+    session.mcp_registry.connectors = MagicMock()
+    session.mcp_registry.connectors.keys.return_value = ["fmp", "sec"]
+    return session
+
+
+@pytest_asyncio.fixture
+async def preview_client(mock_session, sandbox):
+    """httpx client wired to preview_redirect_router with real sandbox.
+
+    Unlike ``sandbox_client``, this mounts the unauthenticated
+    ``preview_redirect_router`` which serves the GET /api/v1/preview/...
+    endpoints.
+    """
+    from src.server.app.workspace_sandbox import preview_redirect_router
+
+    app = create_test_app(preview_redirect_router)
+
+    mock_manager = MagicMock()
+    mock_manager.get_session_for_workspace = AsyncMock(return_value=mock_session)
+    mock_manager._sessions = {TEST_WS_ID: mock_session}
+    mock_manager.config = MagicMock()
+    mock_manager.config.to_core_config.return_value = sandbox.config
+
+    with (
+        patch(
+            "src.server.app.workspace_sandbox.db_get_workspace",
+            AsyncMock(return_value=_make_workspace()),
+        ),
+        patch("src.server.app.workspace_sandbox.WorkspaceManager") as MockWM,
+        patch(
+            "src.server.app.workspace_sandbox._resolve_preview",
+            AsyncMock(return_value=FAKE_SIGNED_URL),
+        ),
+    ):
+        MockWM.get_instance.return_value = mock_manager
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            yield client, sandbox
+
+
+# ---------------------------------------------------------------------------
+# Endpoint tests: Preview Redirect
+# ---------------------------------------------------------------------------
+
+
+class TestPreviewRedirectWorkspaceNotFound:
+    """GET /api/v1/preview/{workspace_id}/{port} when workspace does not exist."""
+
+    async def test_returns_404(self, mock_session, sandbox):
+        from src.server.app.workspace_sandbox import preview_redirect_router
+
+        app = create_test_app(preview_redirect_router)
+        mock_manager = MagicMock()
+        mock_manager.get_session_for_workspace = AsyncMock(return_value=mock_session)
+
+        with (
+            patch(
+                "src.server.app.workspace_sandbox.db_get_workspace",
+                AsyncMock(return_value=None),
+            ),
+            patch("src.server.app.workspace_sandbox.WorkspaceManager") as MockWM,
+        ):
+            MockWM.get_instance.return_value = mock_manager
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+                follow_redirects=False,
+            ) as client:
+                resp = await client.get(f"{PREVIEW_BASE}/8080")
+
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Preview not available"
+
+
+class TestPreviewRedirectStoppedWorkspace:
+    """GET /api/v1/preview/{workspace_id}/{port} when workspace is stopped."""
+
+    async def test_returns_404_for_stopped(self, mock_session, sandbox):
+        """Stopped workspaces return 404 (same as missing) to avoid leaking existence."""
+        from src.server.app.workspace_sandbox import preview_redirect_router
+
+        app = create_test_app(preview_redirect_router)
+        mock_manager = MagicMock()
+        mock_manager.get_session_for_workspace = AsyncMock(return_value=mock_session)
+
+        with (
+            patch(
+                "src.server.app.workspace_sandbox.db_get_workspace",
+                AsyncMock(return_value=_make_workspace(status="stopped")),
+            ),
+            patch("src.server.app.workspace_sandbox.WorkspaceManager") as MockWM,
+        ):
+            MockWM.get_instance.return_value = mock_manager
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+                follow_redirects=False,
+            ) as client:
+                resp = await client.get(f"{PREVIEW_BASE}/8080")
+
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Preview not available"
+
+
+class TestPreviewRedirectRunningWorkspace:
+    """GET /api/v1/preview/{workspace_id}/{port} for a running workspace."""
+
+    async def test_returns_302_redirect(self, preview_client):
+        client, _sandbox = preview_client
+
+        resp = await client.get(f"{PREVIEW_BASE}/8080")
+
+        assert resp.status_code == 302
+        assert resp.headers["location"] == FAKE_SIGNED_URL
+        assert "no-store" in resp.headers.get("cache-control", "")
+        assert "no-cache" in resp.headers.get("cache-control", "")
+
+    async def test_redirect_has_must_revalidate(self, preview_client):
+        client, _sandbox = preview_client
+
+        resp = await client.get(f"{PREVIEW_BASE}/8080")
+
+        assert resp.status_code == 302
+        assert "must-revalidate" in resp.headers.get("cache-control", "")
+
+
+class TestPreviewRedirectWithPath:
+    """GET /api/v1/preview/{workspace_id}/{port}/{path} with path suffix."""
+
+    async def test_path_appended_to_redirect_url(self, mock_session, sandbox):
+        """The path suffix is appended to the signed URL before redirecting."""
+        from src.server.app.workspace_sandbox import preview_redirect_router
+
+        app = create_test_app(preview_redirect_router)
+        mock_manager = MagicMock()
+        mock_manager.get_session_for_workspace = AsyncMock(return_value=mock_session)
+
+        signed_url = "https://preview.example.com/proxy/8080"
+
+        with (
+            patch(
+                "src.server.app.workspace_sandbox.db_get_workspace",
+                AsyncMock(return_value=_make_workspace()),
+            ),
+            patch("src.server.app.workspace_sandbox.WorkspaceManager") as MockWM,
+            patch(
+                "src.server.app.workspace_sandbox._resolve_preview",
+                AsyncMock(return_value=signed_url),
+            ),
+        ):
+            MockWM.get_instance.return_value = mock_manager
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+                follow_redirects=False,
+            ) as client:
+                resp = await client.get(f"{PREVIEW_BASE}/8080/timeline.html")
+
+        assert resp.status_code == 302
+        location = resp.headers["location"]
+        assert location.endswith("/timeline.html")
+
+    async def test_nested_path_appended_to_redirect_url(self, mock_session, sandbox):
+        """Nested paths like assets/style.css are appended correctly."""
+        from src.server.app.workspace_sandbox import preview_redirect_router
+
+        app = create_test_app(preview_redirect_router)
+        mock_manager = MagicMock()
+        mock_manager.get_session_for_workspace = AsyncMock(return_value=mock_session)
+
+        signed_url = "https://preview.example.com/proxy/8080"
+
+        with (
+            patch(
+                "src.server.app.workspace_sandbox.db_get_workspace",
+                AsyncMock(return_value=_make_workspace()),
+            ),
+            patch("src.server.app.workspace_sandbox.WorkspaceManager") as MockWM,
+            patch(
+                "src.server.app.workspace_sandbox._resolve_preview",
+                AsyncMock(return_value=signed_url),
+            ),
+        ):
+            MockWM.get_instance.return_value = mock_manager
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+                follow_redirects=False,
+            ) as client:
+                resp = await client.get(f"{PREVIEW_BASE}/8080/assets/style.css")
+
+        assert resp.status_code == 302
+        location = resp.headers["location"]
+        assert "/assets/style.css" in location
+
+
+class TestPreviewRedirectPathTraversal:
+    """GET /api/v1/preview/{workspace_id}/{port}/{path} with path traversal.
+
+    HTTP clients and Starlette normalise bare ``..`` segments in URL paths
+    before the handler sees them.  The realistic attack vector is
+    percent-encoded dots (``%2e%2e``) which Starlette decodes into the
+    ``{path:path}`` parameter as literal ``..``.  We use that encoding here
+    so the check in ``_preview_redirect`` actually fires.
+    """
+
+    async def test_encoded_double_dot_returns_400(self, mock_session, sandbox):
+        """URL-encoded '..' (%2e%2e) at the start of the path is rejected."""
+        from src.server.app.workspace_sandbox import preview_redirect_router
+
+        app = create_test_app(preview_redirect_router)
+        mock_manager = MagicMock()
+        mock_manager.get_session_for_workspace = AsyncMock(return_value=mock_session)
+
+        with (
+            patch(
+                "src.server.app.workspace_sandbox.db_get_workspace",
+                AsyncMock(return_value=_make_workspace()),
+            ),
+            patch("src.server.app.workspace_sandbox.WorkspaceManager") as MockWM,
+            patch(
+                "src.server.app.workspace_sandbox._resolve_preview",
+                AsyncMock(return_value=FAKE_SIGNED_URL),
+            ),
+        ):
+            MockWM.get_instance.return_value = mock_manager
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+                follow_redirects=False,
+            ) as client:
+                # %2e%2e decodes to ".." inside the {path:path} parameter
+                resp = await client.get(f"{PREVIEW_BASE}/8080/%2e%2e/etc/passwd")
+
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Invalid path"
+
+    async def test_mid_path_traversal_returns_400(self, mock_session, sandbox):
+        """URL-encoded '..' in the middle of the path is also rejected."""
+        from src.server.app.workspace_sandbox import preview_redirect_router
+
+        app = create_test_app(preview_redirect_router)
+        mock_manager = MagicMock()
+        mock_manager.get_session_for_workspace = AsyncMock(return_value=mock_session)
+
+        with (
+            patch(
+                "src.server.app.workspace_sandbox.db_get_workspace",
+                AsyncMock(return_value=_make_workspace()),
+            ),
+            patch("src.server.app.workspace_sandbox.WorkspaceManager") as MockWM,
+            patch(
+                "src.server.app.workspace_sandbox._resolve_preview",
+                AsyncMock(return_value=FAKE_SIGNED_URL),
+            ),
+        ):
+            MockWM.get_instance.return_value = mock_manager
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+                follow_redirects=False,
+            ) as client:
+                # foo/%2e%2e/bar decodes to "foo/../bar" in the path param
+                resp = await client.get(f"{PREVIEW_BASE}/8080/foo/%2e%2e/bar")
+
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Invalid path"
+
+
+class TestPreviewRedirectTimeout:
+    """GET /api/v1/preview/{workspace_id}/{port} when resolution times out.
+
+    ``_preview_redirect`` wraps the inner ``_resolve()`` coroutine in
+    ``asyncio.wait_for(..., timeout=20)``.  To trigger the 504 path we make
+    ``_resolve_preview`` block longer than the timeout, and shorten the
+    timeout via a wrapper around ``asyncio.wait_for`` so the test finishes
+    quickly.
+    """
+
+    async def test_timeout_returns_504(self, mock_session, sandbox):
+        from src.server.app.workspace_sandbox import preview_redirect_router
+
+        app = create_test_app(preview_redirect_router)
+        mock_manager = MagicMock()
+        mock_manager.get_session_for_workspace = AsyncMock(return_value=mock_session)
+
+        async def slow_resolve(*_args, **_kwargs):
+            """Simulate a preview URL resolution that hangs."""
+            await asyncio.sleep(60)
+            return FAKE_SIGNED_URL
+
+        _real_wait_for = asyncio.wait_for
+
+        async def _short_wait_for(coro, *, timeout=None):
+            """Replace the 20s timeout with 0.05s so the test is fast."""
+            if timeout == 20:
+                timeout = 0.05
+            return await _real_wait_for(coro, timeout=timeout)
+
+        with (
+            patch(
+                "src.server.app.workspace_sandbox.db_get_workspace",
+                AsyncMock(return_value=_make_workspace()),
+            ),
+            patch("src.server.app.workspace_sandbox.WorkspaceManager") as MockWM,
+            patch(
+                "src.server.app.workspace_sandbox._resolve_preview",
+                side_effect=slow_resolve,
+            ),
+            patch(
+                "src.server.app.workspace_sandbox.asyncio.wait_for",
+                side_effect=_short_wait_for,
+            ),
+        ):
+            MockWM.get_instance.return_value = mock_manager
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+                follow_redirects=False,
+            ) as client:
+                resp = await client.get(f"{PREVIEW_BASE}/8080")
+
+        assert resp.status_code == 504
+        assert resp.json()["detail"] == "Preview URL resolution timed out"
+
+
+class TestPreviewRedirectNotImplemented:
+    """GET /api/v1/preview/{workspace_id}/{port} when provider lacks preview support."""
+
+    async def test_not_implemented_returns_501(self, mock_session, sandbox):
+        from src.server.app.workspace_sandbox import preview_redirect_router
+
+        app = create_test_app(preview_redirect_router)
+        mock_manager = MagicMock()
+        mock_manager.get_session_for_workspace = AsyncMock(return_value=mock_session)
+
+        with (
+            patch(
+                "src.server.app.workspace_sandbox.db_get_workspace",
+                AsyncMock(return_value=_make_workspace()),
+            ),
+            patch("src.server.app.workspace_sandbox.WorkspaceManager") as MockWM,
+            patch(
+                "src.server.app.workspace_sandbox._resolve_preview",
+                AsyncMock(side_effect=NotImplementedError("not supported")),
+            ),
+        ):
+            MockWM.get_instance.return_value = mock_manager
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+                follow_redirects=False,
+            ) as client:
+                resp = await client.get(f"{PREVIEW_BASE}/8080")
+
+        assert resp.status_code == 501
+        assert "not supported" in resp.json()["detail"].lower()
+
+
+class TestPreviewRedirectPortValidation:
+    """Verify FastAPI path parameter validation on port range."""
+
+    async def test_port_below_range_returns_422(self, preview_client):
+        client, _sandbox = preview_client
+        resp = await client.get(f"/api/v1/preview/{TEST_WS_ID}/80")
+        assert resp.status_code == 422
+
+    async def test_port_above_range_returns_422(self, preview_client):
+        client, _sandbox = preview_client
+        resp = await client.get(f"/api/v1/preview/{TEST_WS_ID}/99999")
+        assert resp.status_code == 422
+
+    async def test_port_at_lower_bound_succeeds(self, preview_client):
+        client, _sandbox = preview_client
+        resp = await client.get(f"/api/v1/preview/{TEST_WS_ID}/3000")
+        assert resp.status_code == 302
+
+    async def test_port_at_upper_bound_succeeds(self, preview_client):
+        client, _sandbox = preview_client
+        resp = await client.get(f"/api/v1/preview/{TEST_WS_ID}/9999")
+        assert resp.status_code == 302
+
+
+class TestPreviewRedirectSessionNotReady:
+    """GET /api/v1/preview/{workspace_id}/{port} when session lookup fails."""
+
+    async def test_session_error_returns_503(self, sandbox):
+        from src.server.app.workspace_sandbox import preview_redirect_router
+
+        app = create_test_app(preview_redirect_router)
+        mock_manager = MagicMock()
+        mock_manager.get_session_for_workspace = AsyncMock(
+            side_effect=RuntimeError("session init failed"),
+        )
+
+        with (
+            patch(
+                "src.server.app.workspace_sandbox.db_get_workspace",
+                AsyncMock(return_value=_make_workspace()),
+            ),
+            patch("src.server.app.workspace_sandbox.WorkspaceManager") as MockWM,
+        ):
+            MockWM.get_instance.return_value = mock_manager
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+                follow_redirects=False,
+            ) as client:
+                resp = await client.get(f"{PREVIEW_BASE}/8080")
+
+        assert resp.status_code == 503
+        assert resp.json()["detail"] == "Sandbox not ready"
+
+    async def test_sandbox_none_returns_503(self, sandbox):
+        """Session exists but sandbox attribute is None."""
+        from src.server.app.workspace_sandbox import preview_redirect_router
+
+        app = create_test_app(preview_redirect_router)
+
+        session_no_sandbox = MagicMock(spec=[])  # no sandbox attribute
+
+        mock_manager = MagicMock()
+        mock_manager.get_session_for_workspace = AsyncMock(
+            return_value=session_no_sandbox,
+        )
+
+        with (
+            patch(
+                "src.server.app.workspace_sandbox.db_get_workspace",
+                AsyncMock(return_value=_make_workspace()),
+            ),
+            patch("src.server.app.workspace_sandbox.WorkspaceManager") as MockWM,
+        ):
+            MockWM.get_instance.return_value = mock_manager
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+                follow_redirects=False,
+            ) as client:
+                resp = await client.get(f"{PREVIEW_BASE}/8080")
+
+        assert resp.status_code == 503
+        assert resp.json()["detail"] == "Sandbox not available"
+
+
+# ---------------------------------------------------------------------------
+# Sandbox method tests: Preview Server lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestStartPreviewServer:
+    """PTCSandbox.start_preview_server with MemoryProvider.
+
+    MemoryProvider's runtime does not implement sessions (raises
+    NotImplementedError), so we mock the session methods on the runtime
+    to verify the sandbox-level orchestration logic.
+    """
+
+    async def test_creates_per_port_session(self, sandbox):
+        """start_preview_server creates a session named 'preview-{port}'."""
+        created_sessions = []
+
+        async def fake_create_session(session_id):
+            created_sessions.append(session_id)
+
+        async def fake_session_execute(session_id, command, *, run_async=False, timeout=None):
+            return SessionCommandResult(
+                cmd_id="cmd-001", exit_code=None, stdout="", stderr="",
+            )
+
+        sandbox.runtime.create_session = fake_create_session
+        sandbox.runtime.session_execute = fake_session_execute
+
+        cmd_id = await sandbox.start_preview_server("python -m http.server 8080", 8080)
+
+        assert cmd_id == "cmd-001"
+        assert "preview-8080" in created_sessions
+        assert 8080 in sandbox._preview_sessions
+        session_id, stored_cmd_id = sandbox._preview_sessions[8080]
+        assert session_id == "preview-8080"
+        assert stored_cmd_id == "cmd-001"
+
+    async def test_replaces_existing_session_on_same_port(self, sandbox):
+        """Starting on a port that already has a session tears down the old one."""
+        deleted_sessions = []
+        created_sessions = []
+        call_count = 0
+
+        async def fake_create_session(session_id):
+            created_sessions.append(session_id)
+
+        async def fake_delete_session(session_id):
+            deleted_sessions.append(session_id)
+
+        async def fake_session_execute(session_id, command, *, run_async=False, timeout=None):
+            nonlocal call_count
+            call_count += 1
+            return SessionCommandResult(
+                cmd_id=f"cmd-{call_count:03d}",
+                exit_code=None,
+                stdout="",
+                stderr="",
+            )
+
+        sandbox.runtime.create_session = fake_create_session
+        sandbox.runtime.delete_session = fake_delete_session
+        sandbox.runtime.session_execute = fake_session_execute
+
+        # First start
+        cmd_id_1 = await sandbox.start_preview_server("python -m http.server 8080", 8080)
+        assert cmd_id_1 == "cmd-001"
+        assert 8080 in sandbox._preview_sessions
+
+        # Second start on the same port
+        cmd_id_2 = await sandbox.start_preview_server("python -m http.server 8080", 8080)
+        assert cmd_id_2 == "cmd-002"
+
+        # Old session should have been deleted
+        assert "preview-8080" in deleted_sessions
+        # New session entry should replace the old one
+        _, stored_cmd_id = sandbox._preview_sessions[8080]
+        assert stored_cmd_id == "cmd-002"
+
+    async def test_multiple_ports_get_separate_sessions(self, sandbox):
+        """Different ports get different sessions."""
+        created_sessions = []
+        call_count = 0
+
+        async def fake_create_session(session_id):
+            created_sessions.append(session_id)
+
+        async def fake_session_execute(session_id, command, *, run_async=False, timeout=None):
+            nonlocal call_count
+            call_count += 1
+            return SessionCommandResult(
+                cmd_id=f"cmd-{call_count:03d}",
+                exit_code=None,
+                stdout="",
+                stderr="",
+            )
+
+        sandbox.runtime.create_session = fake_create_session
+        sandbox.runtime.session_execute = fake_session_execute
+
+        await sandbox.start_preview_server("python -m http.server 3000", 3000)
+        await sandbox.start_preview_server("python -m http.server 8080", 8080)
+
+        assert "preview-3000" in created_sessions
+        assert "preview-8080" in created_sessions
+        assert 3000 in sandbox._preview_sessions
+        assert 8080 in sandbox._preview_sessions
+        assert sandbox._preview_sessions[3000][0] == "preview-3000"
+        assert sandbox._preview_sessions[8080][0] == "preview-8080"
+
+
+class TestStopPreviewServer:
+    """PTCSandbox.stop_preview_server with mocked runtime sessions."""
+
+    async def test_stop_deletes_session_and_cleans_up(self, sandbox):
+        """Stopping a preview server deletes the session and removes tracking."""
+        deleted_sessions = []
+
+        async def fake_create_session(session_id):
+            pass
+
+        async def fake_delete_session(session_id):
+            deleted_sessions.append(session_id)
+
+        async def fake_session_execute(session_id, command, *, run_async=False, timeout=None):
+            return SessionCommandResult(
+                cmd_id="cmd-001", exit_code=None, stdout="", stderr="",
+            )
+
+        sandbox.runtime.create_session = fake_create_session
+        sandbox.runtime.delete_session = fake_delete_session
+        sandbox.runtime.session_execute = fake_session_execute
+
+        await sandbox.start_preview_server("python -m http.server 8080", 8080)
+        assert 8080 in sandbox._preview_sessions
+
+        result = await sandbox.stop_preview_server(8080)
+
+        assert result is True
+        assert "preview-8080" in deleted_sessions
+        assert 8080 not in sandbox._preview_sessions
+
+    async def test_stop_nonexistent_port_returns_false(self, sandbox):
+        """Stopping a port with no preview server returns False."""
+        result = await sandbox.stop_preview_server(9999)
+        assert result is False
+
+
+class TestGetPreviewServerLogs:
+    """PTCSandbox.get_preview_server_logs with mocked runtime sessions."""
+
+    async def test_logs_for_running_server(self, sandbox):
+        """Get logs for a running preview server."""
+        async def fake_create_session(session_id):
+            pass
+
+        async def fake_session_execute(session_id, command, *, run_async=False, timeout=None):
+            return SessionCommandResult(
+                cmd_id="cmd-001", exit_code=None, stdout="", stderr="",
+            )
+
+        async def fake_session_command_logs(session_id, cmd_id):
+            return SessionCommandResult(
+                cmd_id=cmd_id,
+                exit_code=None,  # still running
+                stdout="Serving HTTP on 0.0.0.0 port 8080\n",
+                stderr="",
+            )
+
+        sandbox.runtime.create_session = fake_create_session
+        sandbox.runtime.session_execute = fake_session_execute
+        sandbox.runtime.session_command_logs = fake_session_command_logs
+
+        await sandbox.start_preview_server("python -m http.server 8080", 8080)
+
+        logs = await sandbox.get_preview_server_logs(8080)
+
+        assert logs["success"] is True
+        assert logs["is_running"] is True
+        assert logs["port"] == 8080
+        assert "Serving HTTP" in logs["stdout"]
+
+    async def test_logs_for_nonexistent_port(self, sandbox):
+        """Getting logs for a non-tracked port returns a failure result."""
+        logs = await sandbox.get_preview_server_logs(9999)
+
+        assert logs["success"] is False
+        assert logs["is_running"] is False
+        assert logs["port"] == 9999
+        assert "No preview session" in logs["stderr"]
+
+    async def test_logs_for_exited_server(self, sandbox):
+        """Logs show exit code when server has stopped."""
+        async def fake_create_session(session_id):
+            pass
+
+        async def fake_session_execute(session_id, command, *, run_async=False, timeout=None):
+            return SessionCommandResult(
+                cmd_id="cmd-001", exit_code=None, stdout="", stderr="",
+            )
+
+        async def fake_session_command_logs(session_id, cmd_id):
+            return SessionCommandResult(
+                cmd_id=cmd_id,
+                exit_code=1,
+                stdout="",
+                stderr="Address already in use",
+            )
+
+        sandbox.runtime.create_session = fake_create_session
+        sandbox.runtime.session_execute = fake_session_execute
+        sandbox.runtime.session_command_logs = fake_session_command_logs
+
+        await sandbox.start_preview_server("python -m http.server 8080", 8080)
+
+        logs = await sandbox.get_preview_server_logs(8080)
+
+        assert logs["success"] is True
+        assert logs["is_running"] is False
+        assert logs["exit_code"] == 1
+        assert "Address already in use" in logs["stderr"]
+
+
+# ---------------------------------------------------------------------------
+# Sandbox method tests: Background command lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestBackgroundCommandStop:
+    """PTCSandbox.stop_background_command via execute_bash_command(background=True)."""
+
+    async def test_run_and_stop_background_command(self, sandbox):
+        """Start a background command, then stop it."""
+        created_sessions = []
+        deleted_sessions = []
+        call_count = 0
+
+        async def fake_create_session(session_id):
+            created_sessions.append(session_id)
+
+        async def fake_delete_session(session_id):
+            deleted_sessions.append(session_id)
+
+        async def fake_session_execute(session_id, command, *, run_async=False, timeout=None):
+            nonlocal call_count
+            call_count += 1
+            return SessionCommandResult(
+                cmd_id=f"bg-cmd-{call_count:03d}",
+                exit_code=None,
+                stdout="",
+                stderr="",
+            )
+
+        sandbox.runtime.create_session = fake_create_session
+        sandbox.runtime.delete_session = fake_delete_session
+        sandbox.runtime.session_execute = fake_session_execute
+
+        # Start a background command
+        result = await sandbox.execute_bash_command(
+            "sleep 999",
+            background=True,
+        )
+
+        assert result["success"] is True
+        assert "bg-cmd-001" in result["stdout"]
+
+        # Verify the session was tracked
+        cmd_id = "bg-cmd-001"
+        assert cmd_id in sandbox._bg_sessions
+
+        # Stop the background command
+        stopped = await sandbox.stop_background_command(cmd_id)
+
+        assert stopped is True
+        assert cmd_id not in sandbox._bg_sessions
+        # The session should have been deleted
+        assert any("bg-" in s for s in deleted_sessions)
+
+    async def test_stop_unknown_command_returns_false(self, sandbox):
+        """Stopping a non-existent command ID returns False."""
+        result = await sandbox.stop_background_command("nonexistent-cmd")
+        assert result is False
+
+
+class TestGetBackgroundCommandStatus:
+    """PTCSandbox.get_background_command_status with mocked sessions."""
+
+    async def test_status_of_running_command(self, sandbox):
+        """Check status of a running background command."""
+        async def fake_create_session(session_id):
+            pass
+
+        async def fake_session_execute(session_id, command, *, run_async=False, timeout=None):
+            return SessionCommandResult(
+                cmd_id="bg-cmd-001", exit_code=None, stdout="", stderr="",
+            )
+
+        async def fake_session_command_logs(session_id, cmd_id):
+            return SessionCommandResult(
+                cmd_id=cmd_id,
+                exit_code=None,  # still running
+                stdout="working...\n",
+                stderr="",
+            )
+
+        sandbox.runtime.create_session = fake_create_session
+        sandbox.runtime.session_execute = fake_session_execute
+        sandbox.runtime.session_command_logs = fake_session_command_logs
+        sandbox.runtime.delete_session = AsyncMock()
+
+        result = await sandbox.execute_bash_command("sleep 999", background=True)
+        cmd_id = "bg-cmd-001"
+
+        status = await sandbox.get_background_command_status(cmd_id)
+
+        assert status["is_running"] is True
+        assert status["cmd_id"] == cmd_id
+        assert "working" in status["stdout"]
+        # Session should NOT be cleaned up yet
+        assert cmd_id in sandbox._bg_sessions
+
+    async def test_status_of_completed_command_auto_cleans(self, sandbox):
+        """Completed command status auto-cleans the session."""
+        deleted_sessions = []
+
+        async def fake_create_session(session_id):
+            pass
+
+        async def fake_delete_session(session_id):
+            deleted_sessions.append(session_id)
+
+        async def fake_session_execute(session_id, command, *, run_async=False, timeout=None):
+            return SessionCommandResult(
+                cmd_id="bg-cmd-001", exit_code=None, stdout="", stderr="",
+            )
+
+        async def fake_session_command_logs(session_id, cmd_id):
+            return SessionCommandResult(
+                cmd_id=cmd_id,
+                exit_code=0,  # completed
+                stdout="done\n",
+                stderr="",
+            )
+
+        sandbox.runtime.create_session = fake_create_session
+        sandbox.runtime.delete_session = fake_delete_session
+        sandbox.runtime.session_execute = fake_session_execute
+        sandbox.runtime.session_command_logs = fake_session_command_logs
+
+        await sandbox.execute_bash_command("echo hello", background=True)
+        cmd_id = "bg-cmd-001"
+
+        status = await sandbox.get_background_command_status(cmd_id)
+
+        assert status["is_running"] is False
+        assert status["success"] is True
+        assert status["exit_code"] == 0
+        # Session should be auto-cleaned
+        assert cmd_id not in sandbox._bg_sessions
+        assert len(deleted_sessions) > 0
+
+    async def test_status_of_unknown_command(self, sandbox):
+        """Querying status for an unknown command returns a failure dict."""
+        status = await sandbox.get_background_command_status("nonexistent")
+
+        assert status["success"] is False
+        assert status["is_running"] is False
+        assert "No background session" in status["stderr"]

--- a/tests/unit/core/sandbox/test_preview.py
+++ b/tests/unit/core/sandbox/test_preview.py
@@ -1,0 +1,794 @@
+"""
+Tests for PTCSandbox preview methods and workspace_sandbox preview redirect endpoint.
+
+Part 1: PTCSandbox unit tests covering background session management,
+         preview server lifecycle, reachability checks, and leak fixes.
+Part 2: _preview_redirect endpoint tests covering error states, redirects,
+         path handling, and timeouts.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ptc_agent.config.core import (
+    CoreConfig,
+    DaytonaConfig,
+    FilesystemConfig,
+    LoggingConfig,
+    MCPConfig,
+    SandboxConfig,
+    SecurityConfig,
+)
+from ptc_agent.core.sandbox.runtime import (
+    PreviewInfo,
+    SessionCommandResult,
+    SandboxProvider,
+    SandboxRuntime,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(**overrides) -> CoreConfig:
+    defaults = dict(
+        sandbox=SandboxConfig(daytona=DaytonaConfig(api_key="test-key")),
+        security=SecurityConfig(),
+        mcp=MCPConfig(),
+        logging=LoggingConfig(),
+        filesystem=FilesystemConfig(),
+    )
+    defaults.update(overrides)
+    return CoreConfig(**defaults)
+
+
+def _make_sandbox(mock_provider, mock_runtime):
+    """Create a ready PTCSandbox wired to mocks."""
+    from ptc_agent.core.sandbox.ptc_sandbox import PTCSandbox
+
+    with patch(
+        "ptc_agent.core.sandbox.ptc_sandbox.create_provider",
+        return_value=mock_provider,
+    ):
+        sandbox = PTCSandbox(config=_make_config())
+    sandbox.runtime = mock_runtime
+    sandbox._ready_event = asyncio.Event()
+    sandbox._ready_event.set()
+    return sandbox
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_runtime():
+    runtime = AsyncMock(spec=SandboxRuntime)
+    runtime.id = "test-sandbox"
+    runtime.working_dir = "/workspace"
+    runtime.create_session = AsyncMock()
+    runtime.delete_session = AsyncMock()
+    runtime.session_execute = AsyncMock(
+        return_value=SessionCommandResult(
+            cmd_id="cmd-001", exit_code=None, stdout="", stderr=""
+        )
+    )
+    runtime.session_command_logs = AsyncMock(
+        return_value=SessionCommandResult(
+            cmd_id="cmd-001", exit_code=None, stdout="some output", stderr=""
+        )
+    )
+    runtime.exec = AsyncMock()
+    runtime.upload_file = AsyncMock()
+    runtime.get_preview_url = AsyncMock(
+        return_value=PreviewInfo(url="https://preview.example.com/signed", token="tok")
+    )
+    runtime.get_preview_link = AsyncMock(
+        return_value=PreviewInfo(
+            url="https://preview.example.com/link",
+            token="tok",
+            auth_headers={"Authorization": "Bearer tok"},
+        )
+    )
+    return runtime
+
+
+@pytest.fixture
+def mock_provider():
+    provider = AsyncMock(spec=SandboxProvider)
+    provider.is_transient_error = MagicMock(return_value=False)
+    provider.close = AsyncMock()
+    return provider
+
+
+@pytest.fixture
+def sandbox(mock_provider, mock_runtime):
+    return _make_sandbox(mock_provider, mock_runtime)
+
+
+# ===================================================================
+# Part 1: PTCSandbox unit tests
+# ===================================================================
+
+
+class TestCreateBgSession:
+    """Tests for PTCSandbox._create_bg_session."""
+
+    @pytest.mark.asyncio
+    async def test_happy_path_creates_session(self, sandbox, mock_runtime):
+        session_id = await sandbox._create_bg_session("task-1")
+        assert session_id == "bg-task-1"
+        mock_runtime.create_session.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_already_exists_triggers_delete_and_recreate(
+        self, sandbox, mock_runtime
+    ):
+        mock_runtime.create_session.side_effect = [
+            Exception("session already exists"),
+            None,  # recreate succeeds
+        ]
+        mock_runtime.delete_session.return_value = None
+
+        session_id = await sandbox._create_bg_session("task-2")
+
+        assert session_id == "bg-task-2"
+        assert mock_runtime.delete_session.call_count == 1
+        assert mock_runtime.create_session.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_delete_recreate_failure_reuses_stale(
+        self, sandbox, mock_runtime
+    ):
+        mock_runtime.create_session.side_effect = [
+            Exception("session already exists"),
+            Exception("still broken"),
+        ]
+        mock_runtime.delete_session.side_effect = Exception("delete also failed")
+
+        # Should not raise — falls back to reusing stale session
+        session_id = await sandbox._create_bg_session("task-3")
+        assert session_id == "bg-task-3"
+
+    @pytest.mark.asyncio
+    async def test_non_already_exists_error_raises(self, sandbox, mock_runtime):
+        mock_runtime.create_session.side_effect = Exception("permission denied")
+
+        with pytest.raises(Exception, match="permission denied"):
+            await sandbox._create_bg_session("task-4")
+
+
+class TestStopBackgroundCommand:
+    """Tests for PTCSandbox.stop_background_command."""
+
+    @pytest.mark.asyncio
+    async def test_found_and_deleted(self, sandbox, mock_runtime):
+        sandbox._bg_sessions["cmd-abc"] = "bg-abc"
+        result = await sandbox.stop_background_command("cmd-abc")
+        assert result is True
+        mock_runtime.delete_session.assert_called_once()
+        assert "cmd-abc" not in sandbox._bg_sessions
+
+    @pytest.mark.asyncio
+    async def test_no_session_returns_false(self, sandbox):
+        result = await sandbox.stop_background_command("nonexistent")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_delete_fails_returns_false(self, sandbox, mock_runtime):
+        sandbox._bg_sessions["cmd-fail"] = "bg-fail"
+        mock_runtime.delete_session.side_effect = Exception("network error")
+
+        result = await sandbox.stop_background_command("cmd-fail")
+        assert result is False
+        # Session should be cleaned up from _bg_sessions even on failure
+        assert "cmd-fail" not in sandbox._bg_sessions
+
+
+class TestStartPreviewServer:
+    """Tests for PTCSandbox.start_preview_server."""
+
+    @pytest.mark.asyncio
+    async def test_happy_path_creates_per_port_session(self, sandbox, mock_runtime):
+        mock_runtime.session_execute.return_value = SessionCommandResult(
+            cmd_id="preview-cmd-1", exit_code=None, stdout="", stderr=""
+        )
+
+        cmd_id = await sandbox.start_preview_server("python -m http.server 8080", 8080)
+
+        assert cmd_id == "preview-cmd-1"
+        mock_runtime.create_session.assert_called_once()
+        # Verify the session is stored correctly
+        assert 8080 in sandbox._preview_sessions
+        session_id, stored_cmd_id = sandbox._preview_sessions[8080]
+        assert session_id == "preview-8080"
+        assert stored_cmd_id == "preview-cmd-1"
+
+    @pytest.mark.asyncio
+    async def test_stale_session_teardown(self, sandbox, mock_runtime):
+        # Pre-populate a stale session for port 8080
+        sandbox._preview_sessions[8080] = ("preview-8080", "old-cmd")
+
+        mock_runtime.session_execute.return_value = SessionCommandResult(
+            cmd_id="new-cmd", exit_code=None, stdout="", stderr=""
+        )
+
+        cmd_id = await sandbox.start_preview_server("python app.py", 8080)
+
+        assert cmd_id == "new-cmd"
+        # delete_session should have been called for the stale session
+        assert mock_runtime.delete_session.call_count >= 1
+        # Verify updated preview sessions
+        assert sandbox._preview_sessions[8080] == ("preview-8080", "new-cmd")
+
+    @pytest.mark.asyncio
+    async def test_stale_session_cleanup_failure_continues(
+        self, sandbox, mock_runtime
+    ):
+        sandbox._preview_sessions[8080] = ("preview-8080", "old-cmd")
+        # delete_session fails but we should continue
+        mock_runtime.delete_session.side_effect = Exception("cleanup failed")
+
+        mock_runtime.session_execute.return_value = SessionCommandResult(
+            cmd_id="new-cmd", exit_code=None, stdout="", stderr=""
+        )
+
+        cmd_id = await sandbox.start_preview_server("python app.py", 8080)
+        assert cmd_id == "new-cmd"
+
+    @pytest.mark.asyncio
+    async def test_already_exists_on_create_continues(self, sandbox, mock_runtime):
+        mock_runtime.create_session.side_effect = Exception(
+            "Session already exists for this sandbox"
+        )
+        mock_runtime.session_execute.return_value = SessionCommandResult(
+            cmd_id="reused-cmd", exit_code=None, stdout="", stderr=""
+        )
+
+        cmd_id = await sandbox.start_preview_server("node server.js", 3000)
+        assert cmd_id == "reused-cmd"
+
+
+class TestIsPreviewReachable:
+    """Tests for PTCSandbox._is_preview_reachable."""
+
+    @pytest.mark.asyncio
+    async def test_returns_true_for_200(self, sandbox, mock_runtime):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        with patch("httpx.AsyncClient") as MockClient:
+            client_instance = AsyncMock()
+            client_instance.head = AsyncMock(return_value=mock_response)
+            MockClient.return_value.__aenter__ = AsyncMock(
+                return_value=client_instance
+            )
+            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await sandbox._is_preview_reachable(8080)
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_returns_true_for_404(self, sandbox, mock_runtime):
+        """404 means server IS running but path not found."""
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+
+        with patch("httpx.AsyncClient") as MockClient:
+            client_instance = AsyncMock()
+            client_instance.head = AsyncMock(return_value=mock_response)
+            MockClient.return_value.__aenter__ = AsyncMock(
+                return_value=client_instance
+            )
+            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await sandbox._is_preview_reachable(8080)
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_returns_false_for_502(self, sandbox, mock_runtime):
+        """502 means proxy can't reach the backend."""
+        mock_response = MagicMock()
+        mock_response.status_code = 502
+
+        with patch("httpx.AsyncClient") as MockClient:
+            client_instance = AsyncMock()
+            client_instance.head = AsyncMock(return_value=mock_response)
+            MockClient.return_value.__aenter__ = AsyncMock(
+                return_value=client_instance
+            )
+            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await sandbox._is_preview_reachable(8080)
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_for_503(self, sandbox, mock_runtime):
+        mock_response = MagicMock()
+        mock_response.status_code = 503
+
+        with patch("httpx.AsyncClient") as MockClient:
+            client_instance = AsyncMock()
+            client_instance.head = AsyncMock(return_value=mock_response)
+            MockClient.return_value.__aenter__ = AsyncMock(
+                return_value=client_instance
+            )
+            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await sandbox._is_preview_reachable(8080)
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_exception(self, sandbox, mock_runtime):
+        mock_runtime.get_preview_link.side_effect = Exception("connection refused")
+
+        result = await sandbox._is_preview_reachable(8080)
+        assert result is False
+
+
+class TestStopPreviewServer:
+    """Tests for PTCSandbox.stop_preview_server."""
+
+    @pytest.mark.asyncio
+    async def test_found_and_deleted(self, sandbox, mock_runtime):
+        sandbox._preview_sessions[8080] = ("preview-8080", "cmd-1")
+        result = await sandbox.stop_preview_server(8080)
+        assert result is True
+        mock_runtime.delete_session.assert_called_once()
+        assert 8080 not in sandbox._preview_sessions
+
+    @pytest.mark.asyncio
+    async def test_not_found_returns_false(self, sandbox):
+        result = await sandbox.stop_preview_server(9999)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_delete_fails_still_cleans_up(self, sandbox, mock_runtime):
+        sandbox._preview_sessions[8080] = ("preview-8080", "cmd-1")
+        mock_runtime.delete_session.side_effect = Exception("network error")
+
+        result = await sandbox.stop_preview_server(8080)
+        # Returns True even if delete fails (session entry is still cleaned up)
+        assert result is True
+        assert 8080 not in sandbox._preview_sessions
+
+
+class TestGetPreviewServerLogs:
+    """Tests for PTCSandbox.get_preview_server_logs."""
+
+    @pytest.mark.asyncio
+    async def test_entry_exists_returns_logs(self, sandbox, mock_runtime):
+        sandbox._preview_sessions[8080] = ("preview-8080", "cmd-1")
+        mock_runtime.session_command_logs.return_value = SessionCommandResult(
+            cmd_id="cmd-1", exit_code=None, stdout="server started", stderr=""
+        )
+
+        result = await sandbox.get_preview_server_logs(8080)
+        assert result["success"] is True
+        assert result["is_running"] is True
+        assert result["stdout"] == "server started"
+        assert result["port"] == 8080
+
+    @pytest.mark.asyncio
+    async def test_no_entry_returns_error_dict(self, sandbox):
+        result = await sandbox.get_preview_server_logs(9999)
+        assert result["success"] is False
+        assert result["is_running"] is False
+        assert "No preview session" in result["stderr"]
+        assert result["port"] == 9999
+
+    @pytest.mark.asyncio
+    async def test_logs_api_failure_returns_error_dict(self, sandbox, mock_runtime):
+        sandbox._preview_sessions[8080] = ("preview-8080", "cmd-1")
+        mock_runtime.session_command_logs.side_effect = Exception("API error")
+
+        result = await sandbox.get_preview_server_logs(8080)
+        assert result["success"] is False
+        assert "Failed to get logs" in result["stderr"]
+
+
+class TestExecuteBashBackgroundSessionLeakFix:
+    """Test that session_execute failure triggers session cleanup.
+
+    Note: execute_bash_command has an outer try/except that catches all
+    exceptions and returns an error dict, so the exception does not propagate.
+    We verify the cleanup occurred by checking delete_session was called and
+    the returned dict indicates failure.
+    """
+
+    @pytest.mark.asyncio
+    async def test_session_execute_failure_cleans_up_session(
+        self, sandbox, mock_runtime
+    ):
+        # Make create_session succeed but session_execute fail
+        mock_runtime.create_session.return_value = None
+        mock_runtime.session_execute.side_effect = Exception("execute failed")
+        mock_runtime.delete_session.return_value = None
+
+        result = await sandbox.execute_bash_command(
+            "sleep 100", background=True
+        )
+
+        # The outer except catches and returns an error dict
+        assert result["success"] is False
+        assert result["exit_code"] == -1
+        # Verify the session was cleaned up after execute failure
+        mock_runtime.delete_session.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_session_cleanup_failure_does_not_mask_original_error(
+        self, sandbox, mock_runtime
+    ):
+        mock_runtime.create_session.return_value = None
+        mock_runtime.session_execute.side_effect = Exception("execute failed")
+        mock_runtime.delete_session.side_effect = Exception("cleanup also failed")
+
+        result = await sandbox.execute_bash_command(
+            "sleep 100", background=True
+        )
+
+        # Should still return error dict even when cleanup also fails
+        assert result["success"] is False
+        assert "execute failed" in result["stderr"] or result["exit_code"] == -1
+
+
+# ===================================================================
+# Part 2: _preview_redirect endpoint unit tests
+# ===================================================================
+
+
+def _make_workspace(status="running", **overrides):
+    ws = {
+        "id": "ws-test-001",
+        "user_id": "test-user-123",
+        "workspace_id": "ws-test-001",
+        "status": status,
+        "sandbox_id": "sb-123",
+        "created_at": "2026-01-01T00:00:00Z",
+    }
+    ws.update(overrides)
+    return ws
+
+
+@pytest.fixture
+def mock_sandbox_for_endpoint():
+    sandbox = AsyncMock()
+    sandbox.sandbox_id = "sb-123"
+    sandbox.start_and_get_preview_url = AsyncMock(
+        return_value=PreviewInfo(
+            url="https://preview.example.com/signed?token=abc", token="abc"
+        )
+    )
+    sandbox.get_preview_url = AsyncMock(
+        return_value=PreviewInfo(
+            url="https://preview.example.com/signed?token=abc", token="abc"
+        )
+    )
+    return sandbox
+
+
+@pytest.fixture
+def mock_session_for_endpoint(mock_sandbox_for_endpoint):
+    session = MagicMock()
+    session.sandbox = mock_sandbox_for_endpoint
+    return session
+
+
+class TestPreviewRedirectEndpoint:
+    """Tests for the _preview_redirect function via the GET endpoints."""
+
+    @pytest.mark.asyncio
+    async def test_workspace_not_found_returns_404(self):
+        from httpx import ASGITransport, AsyncClient
+
+        from src.server.app.workspace_sandbox import preview_redirect_router
+        from tests.conftest import create_test_app
+
+        app = create_test_app(preview_redirect_router)
+
+        with patch(
+            "src.server.app.workspace_sandbox.db_get_workspace",
+            AsyncMock(return_value=None),
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.get(
+                    "/api/v1/preview/ws-nonexistent/8080",
+                    follow_redirects=False,
+                )
+                assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_workspace_stopped_returns_404(self):
+        """Stopped workspaces return 404 (same as missing) to avoid leaking existence."""
+        from httpx import ASGITransport, AsyncClient
+
+        from src.server.app.workspace_sandbox import preview_redirect_router
+        from tests.conftest import create_test_app
+
+        app = create_test_app(preview_redirect_router)
+
+        with patch(
+            "src.server.app.workspace_sandbox.db_get_workspace",
+            AsyncMock(return_value=_make_workspace(status="stopped")),
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.get(
+                    "/api/v1/preview/ws-test-001/8080",
+                    follow_redirects=False,
+                )
+                assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_happy_path_running_returns_302_redirect(
+        self, mock_session_for_endpoint
+    ):
+        from httpx import ASGITransport, AsyncClient
+
+        from src.server.app.workspace_sandbox import preview_redirect_router
+        from tests.conftest import create_test_app
+
+        app = create_test_app(preview_redirect_router)
+
+        mock_manager = MagicMock()
+        mock_manager.get_session_for_workspace = AsyncMock(
+            return_value=mock_session_for_endpoint
+        )
+
+        with (
+            patch(
+                "src.server.app.workspace_sandbox.db_get_workspace",
+                AsyncMock(return_value=_make_workspace(status="running")),
+            ),
+            patch(
+                "src.server.app.workspace_sandbox.WorkspaceManager"
+            ) as MockWM,
+            patch(
+                "src.server.app.workspace_sandbox._resolve_preview",
+                AsyncMock(
+                    return_value="https://preview.example.com/signed?token=abc"
+                ),
+            ),
+        ):
+            MockWM.get_instance.return_value = mock_manager
+
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.get(
+                    "/api/v1/preview/ws-test-001/8080",
+                    follow_redirects=False,
+                )
+                assert resp.status_code == 302
+                assert "preview.example.com" in resp.headers["location"]
+                assert resp.headers.get("cache-control") == (
+                    "no-store, no-cache, must-revalidate"
+                )
+
+    @pytest.mark.asyncio
+    async def test_path_suffix_appended(self, mock_session_for_endpoint):
+        from httpx import ASGITransport, AsyncClient
+
+        from src.server.app.workspace_sandbox import preview_redirect_router
+        from tests.conftest import create_test_app
+
+        app = create_test_app(preview_redirect_router)
+
+        mock_manager = MagicMock()
+        mock_manager.get_session_for_workspace = AsyncMock(
+            return_value=mock_session_for_endpoint
+        )
+
+        with (
+            patch(
+                "src.server.app.workspace_sandbox.db_get_workspace",
+                AsyncMock(return_value=_make_workspace(status="running")),
+            ),
+            patch(
+                "src.server.app.workspace_sandbox.WorkspaceManager"
+            ) as MockWM,
+            patch(
+                "src.server.app.workspace_sandbox._resolve_preview",
+                AsyncMock(
+                    return_value="https://preview.example.com/base?token=abc"
+                ),
+            ),
+        ):
+            MockWM.get_instance.return_value = mock_manager
+
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.get(
+                    "/api/v1/preview/ws-test-001/8080/timeline.html",
+                    follow_redirects=False,
+                )
+                assert resp.status_code == 302
+                location = resp.headers["location"]
+                assert "/timeline.html" in location
+
+    @pytest.mark.asyncio
+    async def test_path_traversal_blocked(self, mock_session_for_endpoint):
+        """Test that '..' segments in the path are rejected with 400.
+
+        httpx normalizes URLs before sending, so we call _preview_redirect
+        directly to ensure the path traversal check is exercised.
+        """
+        from fastapi import HTTPException
+
+        from src.server.app.workspace_sandbox import _preview_redirect
+
+        mock_manager = MagicMock()
+        mock_manager.get_session_for_workspace = AsyncMock(
+            return_value=mock_session_for_endpoint
+        )
+
+        with (
+            patch(
+                "src.server.app.workspace_sandbox.db_get_workspace",
+                AsyncMock(return_value=_make_workspace(status="running")),
+            ),
+            patch(
+                "src.server.app.workspace_sandbox.WorkspaceManager"
+            ) as MockWM,
+            patch(
+                "src.server.app.workspace_sandbox._resolve_preview",
+                AsyncMock(
+                    return_value="https://preview.example.com/base?token=abc"
+                ),
+            ),
+        ):
+            MockWM.get_instance.return_value = mock_manager
+
+            with pytest.raises(HTTPException) as exc_info:
+                await _preview_redirect(
+                    "ws-test-001", 8080, "foo/../../../etc/passwd"
+                )
+            assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_timeout_returns_504(self):
+        from httpx import ASGITransport, AsyncClient
+
+        from src.server.app.workspace_sandbox import preview_redirect_router
+        from tests.conftest import create_test_app
+
+        app = create_test_app(preview_redirect_router)
+
+        mock_manager = MagicMock()
+
+        async def slow_get_session(*args, **kwargs):
+            await asyncio.sleep(60)
+
+        mock_manager.get_session_for_workspace = slow_get_session
+
+        with (
+            patch(
+                "src.server.app.workspace_sandbox.db_get_workspace",
+                AsyncMock(return_value=_make_workspace(status="running")),
+            ),
+            patch(
+                "src.server.app.workspace_sandbox.WorkspaceManager"
+            ) as MockWM,
+            # Patch the timeout to be very short for the test
+            patch(
+                "src.server.app.workspace_sandbox._preview_redirect",
+                wraps=None,
+            ) as mock_redirect,
+        ):
+            # Instead of wrapping, we directly test the timeout behavior
+            # by calling the real function with a mocked slow inner resolve
+            pass
+
+        # Better approach: test via the actual endpoint with a patched timeout
+        # We need to make _resolve() take longer than the asyncio.wait_for timeout
+
+        async def slow_resolve_preview(*args, **kwargs):
+            await asyncio.sleep(60)
+            return "https://never.reached"
+
+        mock_manager2 = MagicMock()
+        mock_manager2.get_session_for_workspace = slow_get_session
+
+        with (
+            patch(
+                "src.server.app.workspace_sandbox.db_get_workspace",
+                AsyncMock(return_value=_make_workspace(status="running")),
+            ),
+            patch(
+                "src.server.app.workspace_sandbox.WorkspaceManager"
+            ) as MockWM,
+            patch(
+                "src.server.app.workspace_sandbox.asyncio.wait_for",
+                side_effect=asyncio.TimeoutError,
+            ),
+        ):
+            MockWM.get_instance.return_value = mock_manager2
+
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.get(
+                    "/api/v1/preview/ws-test-001/8080",
+                    follow_redirects=False,
+                )
+                assert resp.status_code == 504
+
+    @pytest.mark.asyncio
+    async def test_sandbox_not_ready_returns_503(self):
+        from httpx import ASGITransport, AsyncClient
+
+        from src.server.app.workspace_sandbox import preview_redirect_router
+        from tests.conftest import create_test_app
+
+        app = create_test_app(preview_redirect_router)
+
+        mock_manager = MagicMock()
+        mock_manager.get_session_for_workspace = AsyncMock(
+            side_effect=Exception("sandbox not ready")
+        )
+
+        with (
+            patch(
+                "src.server.app.workspace_sandbox.db_get_workspace",
+                AsyncMock(return_value=_make_workspace(status="running")),
+            ),
+            patch(
+                "src.server.app.workspace_sandbox.WorkspaceManager"
+            ) as MockWM,
+        ):
+            MockWM.get_instance.return_value = mock_manager
+
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.get(
+                    "/api/v1/preview/ws-test-001/8080",
+                    follow_redirects=False,
+                )
+                assert resp.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_sandbox_attribute_none_returns_503(self):
+        from httpx import ASGITransport, AsyncClient
+
+        from src.server.app.workspace_sandbox import preview_redirect_router
+        from tests.conftest import create_test_app
+
+        app = create_test_app(preview_redirect_router)
+
+        mock_session = MagicMock()
+        mock_session.sandbox = None
+
+        mock_manager = MagicMock()
+        mock_manager.get_session_for_workspace = AsyncMock(
+            return_value=mock_session
+        )
+
+        with (
+            patch(
+                "src.server.app.workspace_sandbox.db_get_workspace",
+                AsyncMock(return_value=_make_workspace(status="running")),
+            ),
+            patch(
+                "src.server.app.workspace_sandbox.WorkspaceManager"
+            ) as MockWM,
+        ):
+            MockWM.get_instance.return_value = mock_manager
+
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.get(
+                    "/api/v1/preview/ws-test-001/8080",
+                    follow_redirects=False,
+                )
+                assert resp.status_code == 503

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -32,6 +32,18 @@ import { motion, AnimatePresence, type PanInfo } from 'framer-motion';
 import { MobileBottomSheet } from '@/components/ui/mobile-bottom-sheet';
 
 
+/** Append an optional path suffix to a base URL (e.g. "/timeline.html"). */
+function appendPathSuffix(baseUrl: string, path?: string): string {
+  if (!path) return baseUrl;
+  try {
+    const parsed = new URL(baseUrl);
+    parsed.pathname = parsed.pathname.replace(/\/+$/, '') + path;
+    return parsed.toString();
+  } catch {
+    return baseUrl;
+  }
+}
+
 const FilePanel = React.lazy(() => import('./FilePanel'));
 const DetailPanel = React.lazy(() => import('./DetailPanel'));
 const PreviewViewer = React.lazy(() => import('./viewers/PreviewViewer'));
@@ -290,6 +302,11 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
   // Right panel management - can show 'file', 'detail', 'preview', or null (closed)
   const [rightPanelType, setRightPanelType] = useState<'file' | 'detail' | 'preview' | null>(null);
   const [rightPanelWidth, setRightPanelWidth] = useState(750);
+  // Multi-port preview state: Map keyed by port lives in a ref (non-active updates don't re-render).
+  // activePreviewPort + derived previewData drive the panel render.
+  const previewMapRef = useRef<Map<number, PreviewData>>(new Map());
+  const activePreviewPortRef = useRef<number | null>(null);
+  const reloadCounterRef = useRef(0);
   const [previewData, setPreviewData] = useState<PreviewData | null>(null);
   const panelWrapperRef = useRef<HTMLDivElement>(null);
 
@@ -959,14 +976,18 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     return clampPanelWidth(desired);
   }, [clampPanelWidth]);
 
-  // Resolve preview URL: get signed URL from backend, restart server on 503.
+  // Resolve preview URL: always pass command so the backend can start the
+  // server if the port is idle (common for history sessions where the
+  // original server process is long gone).  The backend skips the start
+  // when the port is already listening, so this is safe for live sessions.
   const resolvePreviewUrl = useCallback(async (wid: string, port: number, command?: string): Promise<string> => {
     try {
-      const result = await getPreviewUrl(wid, port, undefined);
+      const result = await getPreviewUrl(wid, port, command);
       return result.url;
     } catch (err: unknown) {
       const status = (err as { response?: { status?: number } })?.response?.status;
       if (status === 503 && command) {
+        // Sandbox was stopped — retry (may trigger workspace start)
         const result = await getPreviewUrl(wid, port, command);
         return result.url;
       }
@@ -974,23 +995,32 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     }
   }, []);
 
-  // Resolve a preview URL and update previewData state with the result
+  // Resolve a preview URL and update the Map entry for this port.
+  // Only syncs to render state if this port is still active.
+  // If the entry has a `path` suffix (e.g. "/timeline.html"), it's appended to the signed URL.
   const resolveAndSetPreview = useCallback((wid: string, port: number, command?: string) => {
     resolvePreviewUrl(wid, port, command)
-      .then((url: string) => {
-        setPreviewData(prev => prev?.port === port
-          ? { ...prev, url, loading: false, error: undefined }
-          : prev);
+      .then((baseUrl: string) => {
+        const entry = previewMapRef.current.get(port);
+        if (!entry) return;
+        const url = appendPathSuffix(baseUrl, entry.path);
+        const updated = { ...entry, url, loading: false, error: undefined };
+        previewMapRef.current.set(port, updated);
+        if (activePreviewPortRef.current === port) setPreviewData(updated);
       })
       .catch(() => {
-        setPreviewData(prev => prev?.port === port
-          ? { ...prev, url: '', loading: false, error: true }
-          : prev);
+        const entry = previewMapRef.current.get(port);
+        if (!entry) return;
+        const updated = { ...entry, url: '', loading: false, error: true };
+        previewMapRef.current.set(port, updated);
+        if (activePreviewPortRef.current === port) setPreviewData(updated);
       });
   }, [resolvePreviewUrl]);
 
   // Open preview URL in right panel
   const handleOpenPreview = useCallback((data: PreviewData) => {
+    previewMapRef.current.set(data.port, data);
+    activePreviewPortRef.current = data.port;
     setPreviewData(data);
     setRightPanelType('preview');
     const containerW = containerRef.current?.offsetWidth || window.innerWidth;
@@ -1012,15 +1042,18 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
       const port = artifact.port as number;
       const title = artifact.title as string | undefined;
       const command = artifact.command as string | undefined;
-      // Show cached URL instantly, then verify in background (handles sandbox recreation + dead server)
-      if (previewData?.port === port && previewData.url) {
-        handleOpenPreview({ ...previewData, loading: false, error: undefined });
+      const path = artifact.path as string | undefined;
+      const token = ++reloadCounterRef.current;
+      // Check Map cache (not single state) — show cached URL instantly, then verify in background
+      const cached = previewMapRef.current.get(port);
+      if (cached?.url) {
+        handleOpenPreview({ ...cached, url: '', loading: true, error: undefined, reloadToken: token, path });
         resolveAndSetPreview(workspaceId, port, command);
         return;
       }
       // No cache — resolve (restarts server if needed via 503 fallback)
       // handleOpenPreview will trigger resolution since loading=true and url=''
-      handleOpenPreview({ url: '', port, title, command, loading: true });
+      handleOpenPreview({ url: '', port, title, command, path, loading: true, reloadToken: token });
       return;
     }
     setDetailToolCall(toolCallProcess);
@@ -1028,7 +1061,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     setRightPanelWidth(getDetailPanelWidth(toolCallProcess));
     setRightPanelType('detail');
     pushPanelHistory();
-  }, [getDetailPanelWidth, pushPanelHistory, workspaceId, handleOpenPreview, previewData, resolveAndSetPreview]);
+  }, [getDetailPanelWidth, pushPanelHistory, workspaceId, handleOpenPreview, resolveAndSetPreview]);
 
   // Open plan detail in right panel
   const handlePlanDetailClick = useCallback((planData: PlanData) => {
@@ -1047,8 +1080,9 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     popPanelHistory();
   }, [popPanelHistory]);
 
-  // Close preview panel (keep previewData cached for instant reopen)
+  // Close preview panel (keep Map cache for instant reopen, but stop background state updates)
   const handleClosePreview = useCallback(() => {
+    activePreviewPortRef.current = null;
     setRightPanelType(null);
     popPanelHistory();
   }, [popPanelHistory]);
@@ -1056,13 +1090,25 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
   // Refresh preview: restart process + resolve fresh signed URL (force bypasses cache)
   const handleRefreshPreview = useCallback(async () => {
     if (!previewData || !workspaceId) return;
-    setPreviewData(prev => prev ? { ...prev, loading: true, error: undefined } : null);
+    // Capture values before async gap to avoid stale closure if user switches ports
+    const { port, command, path } = previewData;
+    const loadingEntry = { ...previewData, loading: true, error: undefined };
+    previewMapRef.current.set(port, loadingEntry);
+    setPreviewData(loadingEntry);
     try {
-      const result = await getPreviewUrl(workspaceId, previewData.port, previewData.command, true);
-      setPreviewData(prev => prev ? { ...prev, url: result.url, loading: false } : null);
+      const result = await getPreviewUrl(workspaceId, port, command, true);
+      const token = ++reloadCounterRef.current;
+      const url = appendPathSuffix(result.url, path);
+      const entry = previewMapRef.current.get(port);
+      const updated = { ...(entry ?? previewData), url, loading: false, reloadToken: token };
+      previewMapRef.current.set(port, updated);
+      if (activePreviewPortRef.current === port) setPreviewData(updated);
     } catch (e) {
       console.error('Failed to refresh preview:', e);
-      setPreviewData(prev => prev ? { ...prev, loading: false, error: true } : null);
+      const entry = previewMapRef.current.get(port);
+      const updated = { ...(entry ?? previewData), loading: false, error: true };
+      previewMapRef.current.set(port, updated);
+      if (activePreviewPortRef.current === port) setPreviewData(updated);
     }
   }, [previewData, workspaceId]);
 
@@ -1971,6 +2017,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
               error={previewData?.error}
               onClose={handleClosePreview}
               onRefresh={handleRefreshPreview}
+              reloadToken={previewData?.reloadToken}
             />
           </Suspense>
         </MobileBottomSheet>
@@ -2089,6 +2136,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
                       onClose={handleClosePreview}
                       onRefresh={handleRefreshPreview}
                       isDragging={isDragging}
+                      reloadToken={previewData.reloadToken}
                     />
                   ) : null}
                 </Suspense>

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -312,6 +312,12 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
 
   // Clear the drag-just-ended flag after each render so future transitions animate normally.
   useEffect(() => { dragJustEndedRef.current = false; });
+  // Clear preview cache when workspace changes to avoid leaking old workspace data.
+  useEffect(() => {
+    previewMapRef.current.clear();
+    activePreviewPortRef.current = null;
+    setPreviewData(null);
+  }, [workspaceId]);
   // Active agent in main view (default: 'main', or from URL taskId)
   const [activeAgentId, setActiveAgentId] = useState(
     initialTaskId ? `task:${initialTaskId}` : 'main'
@@ -998,12 +1004,12 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
   // Resolve a preview URL and update the Map entry for this port.
   // Only syncs to render state if this port is still active.
   // If the entry has a `path` suffix (e.g. "/timeline.html"), it's appended to the signed URL.
-  const resolveAndSetPreview = useCallback((wid: string, port: number, command?: string) => {
+  const resolveAndSetPreview = useCallback((wid: string, port: number, command?: string, pathSuffix?: string) => {
     resolvePreviewUrl(wid, port, command)
       .then((baseUrl: string) => {
         const entry = previewMapRef.current.get(port);
         if (!entry) return;
-        const url = appendPathSuffix(baseUrl, entry.path);
+        const url = appendPathSuffix(baseUrl, pathSuffix ?? entry.path);
         const updated = { ...entry, url, loading: false, error: undefined };
         previewMapRef.current.set(port, updated);
         if (activePreviewPortRef.current === port) setPreviewData(updated);
@@ -1028,7 +1034,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     pushPanelHistory();
     // If opened with loading state (no URL yet), resolve via authenticated endpoint
     if (data.loading && !data.url && workspaceId) {
-      resolveAndSetPreview(workspaceId, data.port, data.command);
+      resolveAndSetPreview(workspaceId, data.port, data.command, data.path);
     }
   }, [pushPanelHistory, workspaceId, resolveAndSetPreview]);
 
@@ -1048,7 +1054,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
       const cached = previewMapRef.current.get(port);
       if (cached?.url) {
         handleOpenPreview({ ...cached, url: '', loading: true, error: undefined, reloadToken: token, path });
-        resolveAndSetPreview(workspaceId, port, command);
+        resolveAndSetPreview(workspaceId, port, command, path);
         return;
       }
       // No cache — resolve (restarts server if needed via 503 fallback)

--- a/web/src/pages/ChatAgent/components/viewers/PreviewViewer.tsx
+++ b/web/src/pages/ChatAgent/components/viewers/PreviewViewer.tsx
@@ -8,9 +8,11 @@ interface PreviewViewerProps extends Pick<PreviewData, 'url' | 'port' | 'title' 
   onRefresh?: () => void;
   /** When true, a frosted overlay covers the iframe for smooth resizing. */
   isDragging?: boolean;
+  /** Monotonic counter — when it changes, force iframe reload even if URL is the same. */
+  reloadToken?: number;
 }
 
-export default function PreviewViewer({ url, port, title, loading: externalLoading, error: externalError, onClose, onRefresh, isDragging }: PreviewViewerProps) {
+export default function PreviewViewer({ url, port, title, loading: externalLoading, error: externalError, onClose, onRefresh, isDragging, reloadToken }: PreviewViewerProps) {
   const [loading, setLoading] = useState(true);
   const [iframeKey, setIframeKey] = useState(0);
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -29,15 +31,19 @@ export default function PreviewViewer({ url, port, title, loading: externalLoadi
   // Show overlay immediately when isDragging is true (first render), plus 80ms cooldown
   const showDragOverlay = isDragging || overlayLinger;
 
-  // Reload iframe when url changes (e.g. after async refresh resolves)
+  // Reload iframe when url or reloadToken changes (token forces reload even with same URL)
   const prevUrlRef = useRef(url);
+  const prevTokenRef = useRef(reloadToken);
   useEffect(() => {
-    if (url && prevUrlRef.current && url !== prevUrlRef.current) {
+    const urlChanged = url && prevUrlRef.current && url !== prevUrlRef.current;
+    const tokenChanged = reloadToken !== undefined && reloadToken !== prevTokenRef.current;
+    if (urlChanged || (tokenChanged && url)) {
       setIframeKey(k => k + 1);
       setLoading(true);
     }
     prevUrlRef.current = url;
-  }, [url]);
+    prevTokenRef.current = reloadToken;
+  }, [url, reloadToken]);
 
   const handleIframeLoad = useCallback(() => {
     setLoading(false);

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -2663,6 +2663,7 @@ export function useChatMessages(
             port: payload.port as number,
             title: payload.title as string | undefined,
             command: payload.command as string | undefined,
+            path: payload.path as string | undefined,
             loading: true,
           });
         } else if (artifactType === 'task') {

--- a/web/src/pages/ChatAgent/hooks/utils/types.ts
+++ b/web/src/pages/ChatAgent/hooks/utils/types.ts
@@ -41,6 +41,10 @@ export interface PreviewData {
   port: number;
   title?: string;
   command?: string;
+  /** URL path suffix (e.g. "/timeline.html") appended to the resolved signed URL. */
+  path?: string;
   loading?: boolean;
   error?: boolean;
+  /** Monotonic counter — incremented on user clicks to force iframe reload even when URL is unchanged. */
+  reloadToken?: number;
 }


### PR DESCRIPTION
## Summary
- **Per-port preview sessions**: each preview port gets its own Daytona session (`preview-{port}`), replacing the single shared background command model
- **Path suffix support**: preview redirect endpoint accepts optional path segments (`/api/v1/preview/{ws}/{port}/assets/style.css`) with traversal protection
- **Command persistence**: preview server commands are stored in workspace artifacts JSONB and auto-restarted on workspace resume via the redirect endpoint
- **Preview URL caching**: Redis-backed signed URL cache with health checks — avoids re-signing on every request
- **Multi-port frontend**: `previewMapRef` tracks URL/loading/error state per port with `reloadToken` for forced iframe refresh
- **Sandbox image**: adds Docker Engine for interactive-dashboard complex tier, upgrades Node.js 20→24, adds playwright to defaults
- **Interactive dashboard skill**: three-tier complexity model (simple/standard/complex) with reference implementations

## Test Coverage
```
COVERAGE: 31/123 paths tested (25%)
Well-covered: redirect endpoint (12/14), stop_preview_server (3/3),
  get_preview_server_logs (4/4), _is_preview_reachable (5/6),
  start_preview_server (6/8)
Gaps: POST endpoints, DB persistence, tool wrappers, frontend
```
Tests: 1596 backend + 192 frontend = 1788 passed, 0 failed

## Pre-Landing Review
6 issues found — 1 fixed (path traversal hardening in preview_url.py), 2 accepted as-is (LLM command persistence is by design, TOCTOU degrades gracefully), 3 informational (no action).

## Test plan
- [x] All backend unit tests pass (1596 tests, 0 failures)
- [x] All frontend Vitest tests pass (192 tests, 18 files)
- [x] Preview redirect test assertions fixed to match production uniform-404 design
- [x] Path traversal hardening: URL-decode before segment stripping