### PR TITLE
feat(skills): custom workspace skills with ownership registry

### DIFF
--- a/src/ptc_agent/agent/agent.py
+++ b/src/ptc_agent/agent/agent.py
@@ -289,7 +289,7 @@ class PTCAgent:
             plan_mode: If True, adds submit_plan tool for plan review workflow.
                 HITL middleware is always added for future interrupt features.
             thread_id: Optional thread ID for thread-scoped workspace directories.
-                First 8 chars used as thread directory name in .agent/threads/{id}/.
+                First 8 chars used as thread directory name in .agents/threads/{id}/.
             on_agent_md_write: Optional callback invoked when agent.md is written/edited.
                 Used to invalidate Session's agent.md cache.
             on_signed_url: Optional async callback(sandbox_id, port, url) to cache
@@ -521,9 +521,9 @@ class PTCAgent:
 
         # Build system prompt and eviction dir (short_thread_id computed earlier)
         eviction_dir = (
-            f".agent/threads/{short_thread_id}/large_tool_results"
+            f".agents/threads/{short_thread_id}/large_tool_results"
             if short_thread_id
-            else ".agent/large_tool_results"
+            else ".agents/large_tool_results"
         )
         system_prompt = self._build_system_prompt(
             tool_summary,

--- a/src/ptc_agent/agent/middleware/large_result_eviction.py
+++ b/src/ptc_agent/agent/middleware/large_result_eviction.py
@@ -113,7 +113,7 @@ class LargeResultEvictionMiddleware(AgentMiddleware):
         *,
         backend: BackendProtocol,
         tool_token_limit_before_evict: int = 40000,
-        eviction_dir: str = ".agent/large_tool_results",
+        eviction_dir: str = ".agents/large_tool_results",
     ) -> None:
         """Initialize the large result eviction middleware.
 

--- a/src/ptc_agent/agent/middleware/skills/__init__.py
+++ b/src/ptc_agent/agent/middleware/skills/__init__.py
@@ -11,6 +11,10 @@ This module provides:
 
 from ptc_agent.agent.middleware.skills.content import load_skill_content
 from ptc_agent.agent.middleware.skills.discovery import SkillMetadata
+from ptc_agent.agent.middleware.skills.lock import (
+    SkillLockEntry,
+    SkillsLockFile,
+)
 from ptc_agent.agent.middleware.skills.registry import (
     SKILL_REGISTRY,
     SkillDefinition,
@@ -29,8 +33,10 @@ from ptc_agent.agent.middleware.skills.middleware import (
 
 __all__ = [
     "SkillDefinition",
+    "SkillLockEntry",
     "SkillMetadata",
     "SkillMode",
+    "SkillsLockFile",
     "SKILL_REGISTRY",
     "SkillsMiddleware",
     "get_command_to_skill_map",

--- a/src/ptc_agent/agent/middleware/skills/discovery.py
+++ b/src/ptc_agent/agent/middleware/skills/discovery.py
@@ -232,18 +232,12 @@ async def adiscover_skills(
     """Discover skills from sandbox filesystem, downloading only new ones.
 
     For skills already present in ``known_skills`` (keyed by directory name),
-    the cached metadata is returned without downloading. Only skills found in
-    the filesystem but absent from ``known_skills`` trigger a download.
+    the cached metadata is returned without downloading. Cache misses check
+    the skills-lock.json first (single file), falling back to individual
+    SKILL.md downloads only when no lock entry exists.
 
-    Args:
-        backend: SandboxBackend for sandbox I/O (must support ``als_info``
-            and ``adownload_files``).
-        source_path: Sandbox path to scan (e.g. ``/home/workspace/skills/``).
-        known_skills: Pre-parsed skill metadata from the upload manifest.
-            Skills present here are returned as-is without re-downloading.
-
-    Returns:
-        List of all discovered SkillMetadata (known + newly found).
+    Self-healing: orphaned skill dirs (no lock entry) get a lock entry
+    written back after SKILL.md parse.
     """
     items = await backend.als_info(source_path)  # 1 API call
     skill_dirs = [item["path"] for item in items if item.get("is_dir")]
@@ -252,27 +246,61 @@ async def adiscover_skills(
         return []
 
     results: list[SkillMetadata] = []
-    to_download: list[tuple[str, str]] = []  # (dir_path, skill_md_path)
+    unknown_dirs: list[str] = []
 
     for dir_path in skill_dirs:
         dir_name = PurePosixPath(dir_path).name
         if dir_name in known_skills:
-            results.append(known_skills[dir_name])  # Cache hit — no download
+            results.append(known_skills[dir_name])  # Cache hit
         else:
+            unknown_dirs.append(dir_path)
+
+    if not unknown_dirs:
+        return results
+
+    # Try lock file first for all unknown skills (1 download vs N)
+    lock_entries: dict[str, Any] | None = None
+    try:
+        from ptc_agent.agent.middleware.skills.lock import (
+            LOCK_FILENAME,
+            parse_skills_lock,
+            lock_entry_to_skill_metadata,
+        )
+
+        lock_path = str(PurePosixPath(source_path) / LOCK_FILENAME)
+        lock_responses = await backend.adownload_files([lock_path])
+        if lock_responses and not lock_responses[0].error and lock_responses[0].content:
+            lock_text = lock_responses[0].content.decode("utf-8")
+            lock_entries = parse_skills_lock(lock_text)
+    except Exception:
+        logger.debug("Could not download skills-lock.json for discovery")
+
+    # Resolve unknown skills: lock entry -> SKILL.md download -> unconfirmed
+    to_download: list[tuple[str, str]] = []  # (dir_path, skill_md_path)
+    new_lock_entries: dict[str, Any] = {}  # Self-healing entries to write back
+
+    for dir_path in unknown_dirs:
+        dir_name = PurePosixPath(dir_path).name
+        if lock_entries and dir_name in lock_entries:
+            # Lock entry exists — use it directly (no SKILL.md download)
+            skill_md_path = str(PurePosixPath(dir_path) / "SKILL.md")
+            meta = lock_entry_to_skill_metadata(lock_entries[dir_name], skill_md_path)
+            results.append(meta)
+        else:
+            # No lock entry — fall back to SKILL.md download
             skill_md_path = str(PurePosixPath(dir_path) / "SKILL.md")
             to_download.append((dir_path, skill_md_path))
 
-    # Download only SKILL.md files for unknown skills
+    # Download SKILL.md for dirs without lock entries
     if to_download:
         paths = [p for _, p in to_download]
-        responses = await backend.adownload_files(paths)  # parallel downloads
+        responses = await backend.adownload_files(paths)
 
         for (dir_path, skill_md_path), response in zip(
             to_download, responses, strict=True
         ):
             directory_name = PurePosixPath(dir_path).name
             if response.error or response.content is None:
-                # SKILL.md missing or unreadable — still discover as unconfirmed
                 results.append(
                     _make_unconfirmed_metadata(skill_md_path, directory_name)
                 )
@@ -286,5 +314,48 @@ async def adiscover_skills(
                 continue
             meta = parse_skill_metadata(content, skill_md_path, directory_name)
             results.append(meta)
+
+            # Self-healing: create lock entry for orphaned skill
+            try:
+                from ptc_agent.agent.middleware.skills.lock import build_lock_entry
+                import hashlib as _hashlib
+
+                entry = build_lock_entry(
+                    meta,
+                    owner="user",
+                    source="local",
+                    source_type="local",
+                    content_hash=f"sha256:{_hashlib.sha256(content.encode()).hexdigest()}",
+                )
+                new_lock_entries[directory_name] = entry
+            except Exception:
+                pass  # Best-effort self-healing
+
+    # Write back self-healing lock entries if any
+    if new_lock_entries:
+        try:
+            from ptc_agent.agent.middleware.skills.lock import (
+                LOCK_FILENAME,
+                LOCK_FILE_VERSION,
+                serialize_skills_lock,
+            )
+
+            all_entries = dict(lock_entries or {})
+            all_entries.update(new_lock_entries)
+            lock_data = {"version": LOCK_FILE_VERSION, "skills": all_entries}
+            lock_content = serialize_skills_lock(lock_data)
+            lock_path = str(PurePosixPath(source_path) / LOCK_FILENAME)
+            await backend.aupload_files([(lock_path, lock_content.encode("utf-8"))])
+            logger.info(
+                "Self-healing: wrote lock entries for orphaned skills",
+                count=len(new_lock_entries),
+                skills=list(new_lock_entries.keys()),
+            )
+        except Exception:
+            logger.debug("Self-healing lock write failed (non-critical)")
+
+    # NOTE: Full lock ↔ filesystem reconciliation (adds + removes) is handled
+    # post-completion by PTCSandbox.sync_skills_lock(). The self-healing above
+    # is a fallback for cases where sync_skills_lock failed or was skipped.
 
     return results

--- a/src/ptc_agent/agent/middleware/skills/discovery.py
+++ b/src/ptc_agent/agent/middleware/skills/discovery.py
@@ -5,6 +5,7 @@ replacing the deepagents dependency. Follows the Agent Skills specification
 (https://agentskills.io/specification).
 """
 
+import hashlib
 import re
 from pathlib import PurePosixPath
 from typing import Any, TypedDict
@@ -318,14 +319,13 @@ async def adiscover_skills(
             # Self-healing: create lock entry for orphaned skill
             try:
                 from ptc_agent.agent.middleware.skills.lock import build_lock_entry
-                import hashlib as _hashlib
 
                 entry = build_lock_entry(
                     meta,
                     owner="user",
                     source="local",
                     source_type="local",
-                    content_hash=f"sha256:{_hashlib.sha256(content.encode()).hexdigest()}",
+                    content_hash=f"sha256:{hashlib.sha256(content.encode()).hexdigest()}",
                 )
                 new_lock_entries[directory_name] = entry
             except Exception:

--- a/src/ptc_agent/agent/middleware/skills/lock.py
+++ b/src/ptc_agent/agent/middleware/skills/lock.py
@@ -1,0 +1,188 @@
+"""Skills lock file (skills-lock.json) — types and helpers.
+
+The lock file lives at ``.agents/skills/skills-lock.json`` in the sandbox and
+tracks ownership, versioning, and parsed metadata for every skill (platform
+and user-installed).  Compatible with the vercel-labs/skills lock format with
+our extensions (``owner``, ``confirmed``, etc.).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any, Literal, TypedDict
+
+import structlog
+
+from ptc_agent.agent.middleware.skills.discovery import SkillMetadata
+
+logger = structlog.get_logger(__name__)
+
+LOCK_FILE_VERSION = 1
+LOCK_FILENAME = "skills-lock.json"
+
+
+# --- Types ---
+
+
+class SkillLockEntry(TypedDict):
+    """A single skill entry in the lock file."""
+
+    name: str
+    description: str
+    owner: Literal["platform", "user"]
+    source: str
+    sourceType: str  # noqa: N815 — matches vercel-labs/skills JSON key
+    computedHash: str  # noqa: N815
+    confirmed: bool
+    license: str | None
+    metadata: dict[str, Any]
+    allowed_tools: list[str]
+    installedAt: str  # noqa: N815 — ISO 8601
+    updatedAt: str  # noqa: N815 — ISO 8601
+
+
+class SkillsLockFile(TypedDict):
+    """Top-level lock file structure."""
+
+    version: int
+    skills: dict[str, SkillLockEntry]
+
+
+# --- Builders ---
+
+
+def build_lock_entry(
+    meta: SkillMetadata,
+    *,
+    owner: Literal["platform", "user"] = "platform",
+    source: str = "platform",
+    source_type: str = "platform",
+    content_hash: str = "",
+) -> SkillLockEntry:
+    """Build a lock entry from parsed SkillMetadata.
+
+    Args:
+        meta: Parsed skill metadata from discovery.
+        owner: Who installed this skill.
+        source: Origin URL or identifier.
+        source_type: One of "platform", "github", "local".
+        content_hash: SHA-256 hash of SKILL.md content (``sha256:...`` prefix).
+    """
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return SkillLockEntry(
+        name=meta["name"],
+        description=meta["description"],
+        owner=owner,
+        source=source,
+        sourceType=source_type,
+        computedHash=content_hash,
+        confirmed=meta["confirmed"],
+        license=meta.get("license"),
+        metadata=dict(meta.get("metadata", {})),
+        allowed_tools=list(meta.get("allowed_tools", [])),
+        installedAt=now,
+        updatedAt=now,
+    )
+
+
+def lock_entry_to_skill_metadata(
+    entry: SkillLockEntry, skill_path: str
+) -> SkillMetadata:
+    """Convert a lock entry back to a SkillMetadata for the discovery cache.
+
+    Args:
+        entry: Lock file entry.
+        skill_path: Sandbox path to the SKILL.md file.
+    """
+    return SkillMetadata(
+        path=skill_path,
+        name=entry["name"],
+        description=entry["description"],
+        license=entry.get("license"),
+        compatibility=None,  # Not stored in lock file
+        metadata=dict(entry.get("metadata", {})),
+        allowed_tools=list(entry.get("allowed_tools", [])),
+        confirmed=entry.get("confirmed", False),
+    )
+
+
+# --- Parsing ---
+
+
+def parse_skills_lock(content: str) -> dict[str, SkillLockEntry]:
+    """Parse a skills-lock.json string into a skill-name → entry dict.
+
+    Returns an empty dict on any error (corrupt JSON, wrong version).
+    """
+    if not content or not content.strip():
+        return {}
+    try:
+        data = json.loads(content)
+    except (json.JSONDecodeError, ValueError):
+        logger.warning("Corrupt skills-lock.json — returning empty dict")
+        return {}
+
+    if not isinstance(data, dict):
+        logger.warning("skills-lock.json is not a dict — returning empty dict")
+        return {}
+
+    version = data.get("version")
+    if version != LOCK_FILE_VERSION:
+        logger.warning(
+            "skills-lock.json version mismatch: expected %d, got %s",
+            LOCK_FILE_VERSION,
+            version,
+        )
+        return {}
+
+    skills = data.get("skills")
+    if not isinstance(skills, dict):
+        return {}
+
+    return skills
+
+
+# --- Merging ---
+
+
+def merge_lock_files(
+    platform_entries: dict[str, SkillLockEntry],
+    existing_lock: dict[str, SkillLockEntry] | None,
+) -> SkillsLockFile:
+    """Merge platform entries into an existing lock file.
+
+    Rules:
+    - Platform entries overwrite existing platform entries.
+    - User entries (``owner: "user"``) are always preserved.
+    - Stale platform entries (present in existing lock but not in
+      ``platform_entries``) are purged.
+    - New platform entries are added.
+
+    Args:
+        platform_entries: Current platform skills (authoritative).
+        existing_lock: Previously downloaded lock entries, or None for fresh sandbox.
+
+    Returns:
+        Complete SkillsLockFile ready to write.
+    """
+    merged: dict[str, SkillLockEntry] = {}
+
+    # Preserve user-installed skills from existing lock
+    if existing_lock:
+        for name, entry in existing_lock.items():
+            if entry.get("owner") == "user":
+                merged[name] = entry
+
+    # Add/overwrite all current platform entries
+    merged.update(platform_entries)
+
+    return SkillsLockFile(version=LOCK_FILE_VERSION, skills=merged)
+
+
+# --- Serialization ---
+
+
+def serialize_skills_lock(lock: SkillsLockFile) -> str:
+    """Serialize a lock file to deterministic JSON (sorted keys, 2-space indent)."""
+    return json.dumps(lock, sort_keys=True, indent=2, ensure_ascii=False) + "\n"

--- a/src/ptc_agent/agent/middleware/skills/middleware.py
+++ b/src/ptc_agent/agent/middleware/skills/middleware.py
@@ -227,7 +227,7 @@ class SkillsMiddleware(AgentMiddleware):
         if self._mode == "ptc":
             lines.append(
                 "Skills provide specialized capabilities. "
-                "To activate, read `skills/{name}/SKILL.md`."
+                "To activate, read `.agents/skills/{name}/SKILL.md`."
             )
         else:
             lines.append("Call `LoadSkill` with the skill name to activate its tools.")

--- a/src/ptc_agent/agent/middleware/summarization/middleware.py
+++ b/src/ptc_agent/agent/middleware/summarization/middleware.py
@@ -786,7 +786,7 @@ class SummarizationMiddleware(AgentMiddleware):
         # Compute thread_dir so truncation markers can reference the offload path
         thread_dir = None
         if self._backend is not None:
-            thread_dir = f".agent/threads/{get_thread_id()}"
+            thread_dir = f".agents/threads/{get_thread_id()}"
 
         return truncate_message_args(
             messages,

--- a/src/ptc_agent/agent/middleware/summarization/offloading.py
+++ b/src/ptc_agent/agent/middleware/summarization/offloading.py
@@ -54,7 +54,7 @@ async def aoffload_to_backend(backend: Any, messages: list[AnyMessage]) -> str |
     """Persist evicted messages to sandbox before summarization (async).
 
     Each message is written to its own file keyed by message ID:
-    `.agent/threads/{tid}/evicted_{message_id}.md`
+    `.agents/threads/{tid}/evicted_{message_id}.md`
 
     Previous summary messages are filtered out to avoid summary-of-summary noise.
     Individual messages are truncated at 5000 chars for storage.
@@ -76,7 +76,7 @@ async def aoffload_to_backend(backend: Any, messages: list[AnyMessage]) -> str |
         return None
 
     thread_id = get_thread_id()
-    thread_dir = f".agent/threads/{thread_id}"
+    thread_dir = f".agents/threads/{thread_id}"
     written = 0
 
     for msg in filtered_messages:
@@ -133,7 +133,7 @@ async def aoffload_truncated_args(
     """Persist original tool call args to sandbox before truncation discards them.
 
     Each truncated tool call gets its own file at
-    `.agent/threads/{tid}/truncated_args_{toolcall_id}.md`.
+    `.agents/threads/{tid}/truncated_args_{toolcall_id}.md`.
 
     Non-fatal -- logs warnings on failure but never raises.
 
@@ -148,7 +148,7 @@ async def aoffload_truncated_args(
     thread_id = get_thread_id()
 
     for tool_call_id, original in originals.items():
-        path = f".agent/threads/{thread_id}/truncated_args_{tool_call_id}.md"
+        path = f".agents/threads/{thread_id}/truncated_args_{tool_call_id}.md"
         tool_name = original["name"]
         args = original["args"]
 
@@ -248,7 +248,7 @@ async def aoffload_base64_content(
 
     For each message containing base64 content blocks:
     1. Decode the base64 data
-    2. Upload to ``.agent/threads/{thread_id}/`` via ``backend.aupload_files``
+    2. Upload to ``.agents/threads/{thread_id}/`` via ``backend.aupload_files``
     3. Replace the block with a text reference to the saved file
 
     When ``backend`` is None (e.g. flash agent with no sandbox), falls back to
@@ -267,7 +267,7 @@ async def aoffload_base64_content(
         return strip_base64_from_messages(messages)
 
     thread_id = get_thread_id()
-    thread_dir = f".agent/threads/{thread_id}"
+    thread_dir = f".agents/threads/{thread_id}"
 
     result: list[AnyMessage] = []
     changed = False

--- a/src/ptc_agent/agent/middleware/summarization/summarize.py
+++ b/src/ptc_agent/agent/middleware/summarization/summarize.py
@@ -105,7 +105,7 @@ async def summarize_messages(
         cutoff = max(0, len(effective) - truncate_keep)
         thread_dir = None
         if backend is not None:
-            thread_dir = f".agent/threads/{get_thread_id()}"
+            thread_dir = f".agents/threads/{get_thread_id()}"
 
         effective, truncated, originals = truncate_message_args(
             effective,
@@ -279,7 +279,7 @@ async def offload_tool_args(
 
     thread_dir = None
     if backend is not None:
-        thread_dir = f".agent/threads/{get_thread_id()}"
+        thread_dir = f".agents/threads/{get_thread_id()}"
 
     messages, truncated, originals = truncate_message_args(
         messages,

--- a/src/ptc_agent/agent/middleware/summarization/types.py
+++ b/src/ptc_agent/agent/middleware/summarization/types.py
@@ -76,8 +76,8 @@ TRUNCATABLE_TOOLS = frozenset({"Write", "Edit", "ExecuteCode"})
 # Path prefixes for Read results considered non-critical — these files contain
 # previously offloaded content that the agent has already processed.
 NON_CRITICAL_READ_PREFIXES: tuple[str, ...] = (
-    ".agent/threads/",  # Previously offloaded content (truncated args, evicted messages)
-    ".agent/tmp/",  # Temporary agent scratch files
+    ".agents/threads/",  # Previously offloaded content (truncated args, evicted messages)
+    ".agents/tmp/",  # Temporary agent scratch files
 )
 
 TokenCounter = Callable[[Iterable[MessageLikeRepresentation]], int]

--- a/src/ptc_agent/agent/middleware/summarization/utils.py
+++ b/src/ptc_agent/agent/middleware/summarization/utils.py
@@ -373,7 +373,7 @@ def truncate_read_results(
     1. **Duplicate reads**: Same file read multiple times with identical
        (file_path, offset, limit) — earlier results are superseded.
     2. **Non-critical reads**: Reads of paths matching NON_CRITICAL_READ_PREFIXES
-       (e.g. .agent/threads/) — content already processed by the agent.
+       (e.g. .agents/threads/) — content already processed by the agent.
 
     Only messages before cutoff_index are eligible for truncation.
 

--- a/src/ptc_agent/agent/prompts/templates/components/custom_skills.md.j2
+++ b/src/ptc_agent/agent/prompts/templates/components/custom_skills.md.j2
@@ -1,0 +1,31 @@
+## Custom Skills Installation
+
+You can install skills from GitHub repositories or other sources into this workspace.
+Skills follow the [Agent Skills specification](https://agentskills.io/specification):
+a directory containing a `SKILL.md` file with YAML frontmatter.
+
+### Installing a skill
+
+1. Clone or download the skill repository to a temporary directory
+2. Copy the skill directory to `.agents/skills/{skill-name}/`
+3. Ensure the directory contains a valid `SKILL.md` with frontmatter:
+   ```yaml
+   ---
+   name: skill-name
+   description: What this skill does
+   metadata:
+     author: author-name
+     version: "1.0.0"
+   ---
+   ```
+4. The skill will be automatically registered and available on the next message
+
+### Removing a skill
+
+Delete the skill directory: `rm -rf .agents/skills/{skill-name}/`
+
+The lock file is automatically kept in sync with the filesystem — no manual updates needed.
+
+### Notes
+- User-installed skills persist across workspace restarts
+- Platform skills cannot be overwritten by user installations

--- a/src/ptc_agent/agent/prompts/templates/components/user_profile.md.j2
+++ b/src/ptc_agent/agent/prompts/templates/components/user_profile.md.j2
@@ -21,12 +21,12 @@ You MUST follow these user preferences when responding:
 
 ## Financial Context
 
-When handling investment-related queries, check these files in `.agent/user/`:
+When handling investment-related queries, check these files in `.agents/user/`:
 
 | File | Contains | Check when... |
 |------|----------|---------------|
-| `.agent/user/preference.md` | Risk tolerance, investment style | Recommendations, analysis, or comparisons |
-| `.agent/user/watchlist.md` | Tracked symbols | User mentions "my watchlist" or tracked stocks |
-| `.agent/user/portfolio.md` | Current holdings | Questions about positions or portfolio performance |
+| `.agents/user/preference.md` | Risk tolerance, investment style | Recommendations, analysis, or comparisons |
+| `.agents/user/watchlist.md` | Tracked symbols | User mentions "my watchlist" or tracked stocks |
+| `.agents/user/portfolio.md` | Current holdings | Questions about positions or portfolio performance |
 
 **Important**: Always consider the user's risk tolerance and investment preferences when providing financial analysis or recommendations.

--- a/src/ptc_agent/agent/prompts/templates/components/workspace_paths.md.j2
+++ b/src/ptc_agent/agent/prompts/templates/components/workspace_paths.md.j2
@@ -13,7 +13,7 @@ Working directory: `{{ working_directory | default('/home/workspace') }}`
 | `results/` | Finalized reports (`.md`) only — no loose data or chart files |
 | `data/` | Shared reusable datasets across threads |
 | `tools/` | MCP tool modules (auto-generated, read only) |
-| `.agent/user/` | User profile — preferences, watchlist, portfolio (read only) |
+| `.agents/user/` | User profile — preferences, watchlist, portfolio (read only) |
 
 Never put files directly in `work/` — always use `work/<task_name>/`.
 Always organize data and charts into their subdirectories — never scatter loose files.

--- a/src/ptc_agent/agent/prompts/templates/system.md.j2
+++ b/src/ptc_agent/agent/prompts/templates/system.md.j2
@@ -30,6 +30,12 @@ You are LangAlpha Agent, created by Ginlix AI. You are an investment research ag
 <tool_guide>
 {% include 'components/tool_guide.md.j2' %}
 </tool_guide>
+{% if skills_enabled | default(false) %}
+
+<custom_skills>
+{% include 'components/custom_skills.md.j2' %}
+</custom_skills>
+{% endif %}
 
 <subagent_coordination>
 {% include 'components/subagent_coordination.md.j2' %}

--- a/src/ptc_agent/agent/tools/file_ops.py
+++ b/src/ptc_agent/agent/tools/file_ops.py
@@ -24,7 +24,7 @@ VISUAL_EXTENSIONS = IMAGE_EXTENSIONS | DOCUMENT_EXTENSIONS
 OperationCallback = Callable[[dict[str, Any]], None]
 
 # Protected user data directory and files
-_PROTECTED_USER_DIR = ".agent/user/"
+_PROTECTED_USER_DIR = ".agents/user/"
 _PROTECTED_USER_FILES = {"preference.md", "watchlist.md", "portfolio.md"}
 
 
@@ -32,7 +32,7 @@ def _is_protected_user_path(path: str) -> bool:
     """Check if path is in the protected user data directory."""
     normalized = path.lstrip("/")
     # Check sandbox absolute path
-    if normalized.startswith("home/daytona/.agent/user/"):
+    if normalized.startswith("home/daytona/.agents/user/"):
         return True
     # Check relative path
     if normalized.startswith(_PROTECTED_USER_DIR):
@@ -47,7 +47,7 @@ def _get_protection_error(path: str) -> str:
         "User data files are read-only. To update user data:\n"
         "1. Load the skill: load_skill('user-profile')\n"
         "2. Use update_user_data() or remove_user_data()\n\n"
-        "See @skills/user-profile/SKILL.md for details."
+        "See .agents/skills/user-profile/SKILL.md for details."
     )
 
 

--- a/src/ptc_agent/config/agent.py
+++ b/src/ptc_agent/config/agent.py
@@ -65,7 +65,7 @@ class SkillsConfig(BaseModel):
     project_skills_dir: str = (
         "skills"  # Project skills directory (relative to project root)
     )
-    sandbox_skills_base: str = "/home/workspace/skills"  # Where skills live in sandbox
+    sandbox_skills_base: str = "/home/workspace/.agents/skills"  # Where skills live in sandbox
 
     def local_skill_dirs_with_sandbox(
         self, *, cwd: Path | None = None
@@ -352,7 +352,7 @@ class AgentConfig(BaseModel):
             project_skills_dir=kwargs.pop("project_skills_dir", "skills"),
             sandbox_skills_base=kwargs.pop(
                 "sandbox_skills_base",
-                f"{filesystem_config.working_directory}/skills",
+                f"{filesystem_config.working_directory}/.agents/skills",
             ),
         )
 

--- a/src/ptc_agent/config/loaders.py
+++ b/src/ptc_agent/config/loaders.py
@@ -327,7 +327,7 @@ def load_from_dict(
         user_skills_dir=skills_data.get("user_skills_dir", "~/.ptc-agent/skills"),
         project_skills_dir=skills_data.get("project_skills_dir", "skills"),
         sandbox_skills_base=skills_data.get(
-            "sandbox_skills_base", f"{filesystem_config.working_directory}/skills"
+            "sandbox_skills_base", f"{filesystem_config.working_directory}/.agents/skills"
         ),
     )
 

--- a/src/ptc_agent/core/paths.py
+++ b/src/ptc_agent/core/paths.py
@@ -13,13 +13,30 @@ from __future__ import annotations
 # These are agent-infrastructure dirs at the sandbox root (/home/workspace/).
 # Update this set when adding new agent infrastructure directories.
 AGENT_SYSTEM_DIRS: frozenset[str] = frozenset({
-    "code",
+    ".system",
     "tools",
     "mcp_servers",
-    "skills",
-    ".agent",
+    ".agents",
     ".self-improve",
 })
+
+# ---------------------------------------------------------------------------
+# Backup exclusion — dirs NOT persisted to DB during file sync.
+# .agents is intentionally EXCLUDED here so .agents/skills/ gets backed up.
+# ---------------------------------------------------------------------------
+BACKUP_EXCLUDE_DIRS: frozenset[str] = frozenset({
+    ".system",
+    "tools",
+    "mcp_servers",
+    ".self-improve",
+})
+
+# Subdirs of .agents/ excluded from backup (ephemeral agent data).
+BACKUP_EXCLUDE_AGENT_SUBDIRS: tuple[str, ...] = (
+    ".agents/threads",
+    ".agents/user",
+    ".agents/large_tool_results",
+)
 
 # ---------------------------------------------------------------------------
 # Hidden path filters (always hidden from listings and completions)

--- a/src/ptc_agent/core/sandbox/migration.py
+++ b/src/ptc_agent/core/sandbox/migration.py
@@ -52,7 +52,7 @@ async def migrate_layout_v1_to_v2(runtime: Any, work_dir: str) -> None:
         cmd = (
             f"if [ -d {shlex.quote(src)} ]; then "
             f"mkdir -p {shlex.quote(dst)} && "
-            f"cp -a {shlex.quote(src)}/. {shlex.quote(dst)}/ 2>/dev/null; "
+            f"cp -a {shlex.quote(src)}/. {shlex.quote(dst)}/ && "
             f"rm -rf {shlex.quote(src)}; "
             f"fi"
         )

--- a/src/ptc_agent/core/sandbox/migration.py
+++ b/src/ptc_agent/core/sandbox/migration.py
@@ -1,0 +1,99 @@
+"""Versioned sandbox layout migrations.
+
+Each migration is a coroutine that transforms the sandbox filesystem from
+version N to N+1.  Migrations run sequentially, in-place, before module sync.
+
+Zero cost when current: one integer comparison against the already-downloaded
+unified manifest.  No extra API calls.
+"""
+
+from __future__ import annotations
+
+import shlex
+from collections.abc import Callable, Coroutine
+from typing import Any
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+CURRENT_LAYOUT_VERSION = 2  # bump for each new layout change
+
+
+async def migrate_layout_v1_to_v2(runtime: Any, work_dir: str) -> None:
+    """Consolidate .agent/ + skills/ → .agents/, code/ → .system/code/.
+
+    Moves:
+        .agent/threads/            → .agents/threads/
+        .agent/user/               → .agents/user/
+        .agent/large_tool_results/ → .agents/large_tool_results/
+        code/                      → .system/code/
+        skills/                    → removed (platform skills re-uploaded to .agents/skills/)
+
+    IDEMPOTENT: each move checks source exists before moving, skips if already
+    done.  Safe to re-run after partial failure.
+    """
+    moves = [
+        (".agent/threads", ".agents/threads"),
+        (".agent/user", ".agents/user"),
+        (".agent/large_tool_results", ".agents/large_tool_results"),
+        ("code", ".system/code"),
+    ]
+
+    # Ensure target directories exist
+    await runtime.exec(
+        f"mkdir -p {shlex.quote(f'{work_dir}/.agents/skills')} "
+        f"{shlex.quote(f'{work_dir}/.system/code')}"
+    )
+
+    for src_rel, dst_rel in moves:
+        src = f"{work_dir}/{src_rel}"
+        dst = f"{work_dir}/{dst_rel}"
+        cmd = (
+            f"if [ -d {shlex.quote(src)} ]; then "
+            f"mkdir -p {shlex.quote(dst)} && "
+            f"cp -a {shlex.quote(src)}/. {shlex.quote(dst)}/ 2>/dev/null; "
+            f"rm -rf {shlex.quote(src)}; "
+            f"fi"
+        )
+        await runtime.exec(cmd)
+
+    # Clean up old .agent/ directory if empty
+    await runtime.exec(
+        f"rmdir {shlex.quote(f'{work_dir}/.agent')} 2>/dev/null || true"
+    )
+
+    # Remove old top-level skills/ directory (platform skills will be
+    # re-uploaded to .agents/skills/ by the sync pipeline)
+    await runtime.exec(
+        f"rm -rf {shlex.quote(f'{work_dir}/skills')}"
+    )
+
+    logger.info("Layout migration v1→v2 complete", work_dir=work_dir)
+
+
+# Registry: source_version → migration coroutine
+LAYOUT_MIGRATIONS: dict[int, Callable[..., Coroutine]] = {
+    1: migrate_layout_v1_to_v2,
+}
+
+
+async def run_layout_migrations(
+    runtime: Any, work_dir: str, current_version: int
+) -> int:
+    """Run all pending migrations sequentially.  Returns new layout version."""
+    if current_version >= CURRENT_LAYOUT_VERSION:
+        return current_version  # Zero cost — already current
+
+    for v in range(current_version, CURRENT_LAYOUT_VERSION):
+        migrator = LAYOUT_MIGRATIONS.get(v)
+        if migrator:
+            logger.info(
+                "Running layout migration",
+                from_version=v,
+                to_version=v + 1,
+                work_dir=work_dir,
+            )
+            await migrator(runtime, work_dir)
+
+    return CURRENT_LAYOUT_VERSION

--- a/src/ptc_agent/core/sandbox/ptc_sandbox.py
+++ b/src/ptc_agent/core/sandbox/ptc_sandbox.py
@@ -1546,11 +1546,7 @@ class PTCSandbox:
 
         all_skills = dict(skills_mod.get("skills", {}))
 
-        lock_skills = (
-            merged_lock.get("skills", {})
-            if isinstance(merged_lock, dict)
-            else merged_lock
-        )
+        lock_skills = merged_lock.get("skills", {})
         for name, entry in lock_skills.items():
             if entry.get("owner") == "user" and name not in all_skills:
                 skill_path = f"{sandbox_skills_base}/{name}/SKILL.md"

--- a/src/ptc_agent/core/sandbox/ptc_sandbox.py
+++ b/src/ptc_agent/core/sandbox/ptc_sandbox.py
@@ -17,6 +17,7 @@ import structlog
 
 from ptc_agent.config.core import CoreConfig
 from ptc_agent.core.sandbox._defaults import DEFAULT_DEPENDENCIES, SNAPSHOT_PYTHON_VERSION
+from ptc_agent.core.sandbox.migration import CURRENT_LAYOUT_VERSION, run_layout_migrations
 from ptc_agent.core.sandbox.providers import create_provider
 from ptc_agent.core.sandbox.retry import RetryPolicy, async_retry_with_backoff
 from ptc_agent.core.sandbox.runtime import (
@@ -101,6 +102,17 @@ def _entry_is_dir(entry) -> bool:
     if isinstance(entry, dict):
         return bool(entry.get("is_dir", False))
     return bool(getattr(entry, "is_dir", False))
+
+
+def _get_sandbox_eligible_skills() -> tuple[set[str], set[str]]:
+    """Return (sandbox_skill_names, all_registry_names) for flash-only filtering.
+
+    Skills present in SKILL_REGISTRY but not in sandbox_skill_names are
+    flash-only and should be skipped during sandbox operations.
+    """
+    from ptc_agent.agent.middleware.skills import SKILL_REGISTRY, get_sandbox_skill_names
+
+    return get_sandbox_skill_names(), set(SKILL_REGISTRY.keys())
 
 
 class PTCSandbox:
@@ -727,9 +739,10 @@ class PTCSandbox:
             f"{work_dir}/tools/docs",
             f"{work_dir}/results",
             f"{work_dir}/data",
-            f"{work_dir}/code",
+            f"{work_dir}/.system/code",
             f"{work_dir}/work",
-            f"{work_dir}/.agent/threads",
+            f"{work_dir}/.agents/threads",
+            f"{work_dir}/.agents/skills",
             f"{work_dir}/_internal/src",
         ]
 
@@ -851,19 +864,14 @@ class PTCSandbox:
         actual file contents so the manifest is deterministic and portable.
         """
 
-        skills_base = f"{self._work_dir}/skills"
+        skills_base = f"{self._work_dir}/.agents/skills"
 
         def build() -> dict[str, Any]:
-            from ptc_agent.agent.middleware.skills import (
-                get_sandbox_skill_names,
-                SKILL_REGISTRY,
-            )
             from ptc_agent.agent.middleware.skills.discovery import (
                 parse_skill_metadata,
             )
 
-            sandbox_skill_names = get_sandbox_skill_names()
-            all_registry_names = set(SKILL_REGISTRY.keys())
+            sandbox_skill_names, all_registry_names = _get_sandbox_eligible_skills()
 
             files: dict[str, str] = {}  # rel_path → sha256
             skills_metadata: dict[str, dict[str, Any]] = {}
@@ -913,7 +921,32 @@ class PTCSandbox:
                     meta = parse_skill_metadata(content, sandbox_path, skill_name)
                     skills_metadata[skill_name] = dict(meta)
 
+                    # Build lock entry for platform skill
+                    from ptc_agent.agent.middleware.skills.lock import build_lock_entry
+
+                    content_hash = f"sha256:{_sha256_file(skill_dir / 'SKILL.md')}"
+                    lock_entry = build_lock_entry(
+                        meta,
+                        owner="platform",
+                        source="platform",
+                        source_type="platform",
+                        content_hash=content_hash,
+                    )
+                    skills_metadata[skill_name]["lock_entry"] = dict(lock_entry)
+
             version = _hash_dict(files)
+
+            # Include lock entries in version hash so manifest detects ownership changes
+            lock_hash_parts = []
+            for name in sorted(skills_metadata):
+                entry = skills_metadata[name].get("lock_entry")
+                if entry:
+                    lock_hash_parts.append(f"{name}:{json.dumps(entry, sort_keys=True)}")
+            if lock_hash_parts:
+                lock_payload = "\n".join(lock_hash_parts)
+                combined = f"{version}\n{lock_payload}"
+                version = hashlib.sha256(combined.encode()).hexdigest()
+
             return {"version": version, "files": files, "skills": skills_metadata}
 
         return await asyncio.to_thread(build)
@@ -996,7 +1029,11 @@ class PTCSandbox:
                 "workspace_id": workspace_id or "",
             }
 
-        return {"schema_version": 1, "modules": modules}
+        return {
+            "schema_version": 1,
+            "layout_version": CURRENT_LAYOUT_VERSION,
+            "modules": modules,
+        }
 
     # ── Unified manifest I/O ─────────────────────────────────────────
 
@@ -1043,6 +1080,7 @@ class PTCSandbox:
         legacy_paths = [
             f"{work_dir}/mcp_servers/.mcp_manifest.json",
             f"{work_dir}/skills/.skills_manifest.json",
+            f"{work_dir}/.agents/skills/.skills_manifest.json",
         ]
         assert self.runtime is not None
         try:
@@ -1193,6 +1231,12 @@ class PTCSandbox:
                 self._read_unified_manifest(),
             )
 
+            # 2b. Run layout migrations if needed (zero cost when current)
+            remote_layout = (remote_manifest or {}).get("layout_version", 1)
+            await run_layout_migrations(
+                self.runtime, self._work_dir, remote_layout
+            )
+
             # 3. Determine which modules changed (pure CPU)
             if force_refresh or remote_manifest is None or not reusing_sandbox:
                 changed_modules = set(local_manifest["modules"].keys())
@@ -1229,13 +1273,25 @@ class PTCSandbox:
                     [d for d, _ in skill_dirs]  # type: ignore[union-attr]
                 )
                 sandbox_base = skill_dirs[-1][1].rstrip("/")  # type: ignore[index]
-                await self._prune_remote_skills(sandbox_base, local_skill_names)
+
+                # Download existing lock file once (shared by prune + upload)
+                existing_lock = await self._download_skills_lock(sandbox_base)
+
+                await self._prune_remote_skills(
+                    sandbox_base, local_skill_names, existing_lock=existing_lock
+                )
                 skills_mod = local_manifest["modules"].get("skills", {})
                 if skills_mod.get("files"):
-                    await self._upload_skills(
+                    merged_lock = await self._upload_skills(
                         skill_dirs,
                         manifest=skills_mod,  # type: ignore[arg-type]
+                        existing_lock=existing_lock,
                     )
+                    # Build complete skills cache from merged lock data
+                    if merged_lock:
+                        self._build_complete_skills_cache(
+                            skills_mod, merged_lock, sandbox_base
+                        )
 
             # Group 1: independent uploads in parallel
             parallel_uploads: list[tuple[str, Any]] = []
@@ -1275,8 +1331,9 @@ class PTCSandbox:
                 except Exception as e:
                     logger.warning("Failed to refresh MCP servers", error=str(e))
 
-            # Cache skills metadata
-            if "skills" in local_manifest["modules"]:
+            # Cache skills metadata (only if not already set by _build_complete_skills_cache,
+            # which includes user-installed skills from the lock file)
+            if self._skills_manifest is None and "skills" in local_manifest["modules"]:
                 self._skills_manifest = local_manifest["modules"]["skills"]
 
             # Steps 5+6: independent — parallelize
@@ -1344,10 +1401,6 @@ class PTCSandbox:
         await asyncio.gather(*[remove_one(path) for path in paths])
         self._disabled_modules_pruned = True
         logger.debug("Pruned disabled tool modules", removed=len(paths))
-
-    SKILLS_MANIFEST_FILENAME = (
-        ".skills_manifest.json"  # Legacy; used by _prune_remote_skills
-    )
 
     @staticmethod
     def _classify_execution_error(
@@ -1430,13 +1483,7 @@ class PTCSandbox:
         self, local_skill_roots: list[str]
     ) -> set[str]:
         def build() -> set[str]:
-            from ptc_agent.agent.middleware.skills import (
-                get_sandbox_skill_names,
-                SKILL_REGISTRY,
-            )
-
-            sandbox_skill_names = get_sandbox_skill_names()
-            all_registry_names = set(SKILL_REGISTRY.keys())
+            sandbox_skill_names, all_registry_names = _get_sandbox_eligible_skills()
 
             names: set[str] = set()
             for root_str in local_skill_roots:
@@ -1460,9 +1507,220 @@ class PTCSandbox:
 
         return await asyncio.to_thread(build)
 
-    async def _prune_remote_skills(
-        self, sandbox_base: str, local_skill_names: set[str]
+    async def _download_skills_lock(
+        self, sandbox_skills_base: str
+    ) -> dict[str, Any] | None:
+        """Download and parse the existing skills-lock.json from sandbox.
+
+        Returns parsed skill entries dict, or None if missing/corrupt.
+        """
+        from ptc_agent.agent.middleware.skills.lock import LOCK_FILENAME, parse_skills_lock
+
+        lock_path = f"{sandbox_skills_base}/{LOCK_FILENAME}"
+        assert self.runtime is not None
+        try:
+            raw = await self._runtime_call(
+                self.runtime.download_file,
+                lock_path,
+                retry_policy=RetryPolicy.SAFE,
+            )
+            if raw:
+                text = raw.decode("utf-8") if isinstance(raw, bytes) else raw
+                return parse_skills_lock(text)
+        except Exception:
+            logger.debug("No existing skills-lock.json (fresh sandbox or error)")
+        return None
+
+    def _build_complete_skills_cache(
+        self,
+        skills_mod: dict[str, Any],
+        merged_lock: dict[str, Any],
+        sandbox_skills_base: str,
     ) -> None:
+        """Merge user-installed skills from lock file into the skills manifest cache.
+
+        This ensures known_skills in agent.py includes both platform and
+        user-installed skills, eliminating per-message downloads.
+        """
+        from ptc_agent.agent.middleware.skills.lock import lock_entry_to_skill_metadata
+
+        all_skills = dict(skills_mod.get("skills", {}))
+
+        lock_skills = (
+            merged_lock.get("skills", {})
+            if isinstance(merged_lock, dict)
+            else merged_lock
+        )
+        for name, entry in lock_skills.items():
+            if entry.get("owner") == "user" and name not in all_skills:
+                skill_path = f"{sandbox_skills_base}/{name}/SKILL.md"
+                meta = lock_entry_to_skill_metadata(entry, skill_path)
+                all_skills[name] = dict(meta)
+
+        self._skills_manifest = {**skills_mod, "skills": all_skills}
+
+    async def sync_skills_lock(self) -> None:
+        """Reconcile skills-lock.json with the actual filesystem state.
+
+        Bidirectional sync in a single sandbox exec (1 API call):
+        - **Remove** lock entries whose skill directories no longer exist
+        - **Add** lock entries for skill directories not yet in the lock
+          (parses SKILL.md frontmatter to populate name/description/metadata)
+
+        Fast path: if no lock file exists and no skill directories exist,
+        exits immediately.  If lock is perfectly in sync, no write occurs.
+
+        Intended to be called post-completion alongside file backup.
+        Self-healing in discovery.py serves as a fallback if this fails.
+        """
+        if not self.runtime:
+            return
+        sb = f"{self._work_dir}/.agents/skills"
+        lock = f"{sb}/skills-lock.json"
+
+        # Single inline Python script that runs entirely in the sandbox.
+        # Reads dirs + lock file, diffs, parses SKILL.md for new entries,
+        # writes updated lock — all in one exec round trip.
+        script = textwrap.dedent(f"""\
+            python3 -c '
+import json, os, re, hashlib, sys
+from datetime import datetime, timezone
+
+SKILLS_BASE = {shlex.quote(sb)}
+LOCK_PATH = {shlex.quote(lock)}
+
+# 1. List skill dirs (only dirs containing SKILL.md)
+dirs = set()
+if os.path.isdir(SKILLS_BASE):
+    for name in os.listdir(SKILLS_BASE):
+        p = os.path.join(SKILLS_BASE, name)
+        if os.path.isdir(p) and os.path.isfile(os.path.join(p, "SKILL.md")):
+            dirs.add(name)
+
+# 2. Read existing lock
+lock = {{"version": 1, "skills": {{}}}}
+if os.path.isfile(LOCK_PATH):
+    try:
+        with open(LOCK_PATH) as f:
+            lock = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        pass
+skills = lock.get("skills", {{}})
+
+# 3. Compute diff
+locked_names = set(skills.keys())
+to_remove = locked_names - dirs
+to_add = dirs - locked_names
+
+if not to_remove and not to_add:
+    print(json.dumps({{"status": "noop", "removed": 0, "added": 0}}))
+    sys.exit(0)
+
+# 4. Remove stale entries
+for name in to_remove:
+    del skills[name]
+
+# 5. Add new entries by parsing SKILL.md frontmatter
+now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+for name in sorted(to_add):
+    skill_md = os.path.join(SKILLS_BASE, name, "SKILL.md")
+    desc = ""
+    confirmed = False
+    meta = {{}}
+    license_val = None
+    allowed_tools = []
+    try:
+        with open(skill_md) as f:
+            content = f.read(1048576)  # 1MB cap
+        m = re.match(r"^---\\s*\\n(.*?)\\n---\\s*\\n", content, re.DOTALL)
+        if m:
+            # Minimal YAML-like parser for simple key: value frontmatter
+            # Avoids PyYAML dependency in sandbox
+            for line in m.group(1).splitlines():
+                line = line.strip()
+                if ":" in line:
+                    k, _, v = line.partition(":")
+                    k, v = k.strip(), v.strip()
+                    if k == "description":
+                        desc = v.strip("\\"\\x27")
+                        confirmed = True
+                    elif k == "license":
+                        license_val = v.strip("\\"\\x27") or None
+            confirmed = confirmed and bool(name)
+        content_hash = "sha256:" + hashlib.sha256(content.encode()).hexdigest()
+    except OSError:
+        content_hash = ""
+
+    skills[name] = {{
+        "name": name,
+        "description": desc,
+        "owner": "user",
+        "source": "local",
+        "sourceType": "local",
+        "computedHash": content_hash,
+        "confirmed": confirmed,
+        "license": license_val,
+        "metadata": meta,
+        "allowed_tools": allowed_tools,
+        "installedAt": now,
+        "updatedAt": now,
+    }}
+
+# 6. Write updated lock atomically
+lock["skills"] = skills
+tmp = LOCK_PATH + ".tmp"
+try:
+    with open(tmp, "w") as f:
+        json.dump(lock, f, sort_keys=True, indent=2, ensure_ascii=False)
+        f.write("\\n")
+    os.replace(tmp, LOCK_PATH)
+    print(json.dumps({{"status": "ok", "removed": len(to_remove), "added": len(to_add)}}))
+except OSError as e:
+    try:
+        os.unlink(tmp)
+    except OSError:
+        pass
+    print(json.dumps({{"status": "error", "error": str(e)}}))
+    sys.exit(1)
+'
+        """)
+
+        try:
+            result = await self._runtime_call(
+                self.runtime.exec,
+                script.strip(),
+                retry_policy=RetryPolicy.SAFE,
+            )
+            stdout = (getattr(result, "stdout", "") or "").strip()
+            if stdout:
+                try:
+                    info = json.loads(stdout)
+                    if info.get("status") == "ok":
+                        logger.info(
+                            "Skills lock synced",
+                            removed=info.get("removed", 0),
+                            added=info.get("added", 0),
+                            skills_base=sb,
+                        )
+                    elif info.get("status") == "noop":
+                        logger.debug("Skills lock already in sync")
+                except json.JSONDecodeError:
+                    pass
+        except Exception as e:
+            logger.debug("Skills lock sync failed (non-critical)", error=str(e))
+
+    async def _prune_remote_skills(
+        self,
+        sandbox_base: str,
+        local_skill_names: set[str],
+        *,
+        existing_lock: dict[str, Any] | None = None,
+    ) -> None:
+        """Prune stale platform skills from sandbox, protecting user-installed ones.
+
+        Safe default: if lock is unavailable or a skill has no lock entry,
+        it is preserved to prevent data loss on transient failures.
+        """
         assert self.runtime is not None
         sandbox = self.runtime
         entries = await self.als_directory(sandbox_base)
@@ -1474,13 +1732,25 @@ class PTCSandbox:
             name = entry.get("name")
             if not name:
                 continue
-            if name == self.SKILLS_MANIFEST_FILENAME:
-                if not local_skill_names:
-                    paths_to_remove.append(entry["path"])
+            if not entry.get("is_dir", False):
                 continue
-            if entry.get("is_dir", False):
-                if name not in local_skill_names:
-                    paths_to_remove.append(entry["path"])
+            if name in local_skill_names:
+                continue  # Current platform skill — will be re-uploaded
+
+            # Unknown skill — check lock for ownership
+            if existing_lock is None:
+                # Lock unavailable — safe default: preserve everything
+                continue
+            lock_entry = existing_lock.get(name)
+            if lock_entry is None:
+                # Not in lock — unknown origin, preserve (safe default)
+                continue
+            if lock_entry.get("owner") == "user":
+                # User-installed — never prune
+                logger.debug("Preserving user-installed skill", skill=name)
+                continue
+            # Platform skill no longer in local set — stale, prune it
+            paths_to_remove.append(entry["path"])
 
         if not paths_to_remove:
             return
@@ -1494,7 +1764,7 @@ class PTCSandbox:
 
         await asyncio.gather(*[remove_one(path) for path in paths_to_remove])
         logger.info(
-            "Pruned skills from sandbox",
+            "Pruned stale platform skills from sandbox",
             removed=len(paths_to_remove),
             sandbox_root=sandbox_base,
         )
@@ -1504,7 +1774,8 @@ class PTCSandbox:
         local_skills_dirs: list[tuple[str, str]],
         *,
         manifest: dict[str, Any] | None = None,
-    ) -> None:
+        existing_lock: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
         """Upload skill files from local filesystem to sandbox.
 
         Uses a two-pass approach to fix override precedence:
@@ -1516,6 +1787,10 @@ class PTCSandbox:
             local_skills_dirs: List of (local_path, sandbox_path) tuples.
                 Example: [("~/.ptc-agent/skills", "{working_directory}/skills")]
             manifest: Pre-computed skills manifest. If None, computed from local_skills_dirs.
+            existing_lock: Previously downloaded lock entries, or None for fresh sandbox.
+
+        Returns:
+            Merged lock file dict if lock entries were written, else None.
         """
         assert self.runtime is not None
         sandbox = self.runtime
@@ -1529,13 +1804,7 @@ class PTCSandbox:
             return
 
         # Skills eligible for sandbox upload (exposure "ptc" or "both")
-        from ptc_agent.agent.middleware.skills import (
-            get_sandbox_skill_names,
-            SKILL_REGISTRY,
-        )
-
-        sandbox_skill_names = get_sandbox_skill_names()
-        all_registry_names = set(SKILL_REGISTRY.keys())
+        sandbox_skill_names, all_registry_names = _get_sandbox_eligible_skills()
 
         # ── Pass 1: Planning (local I/O only) ──
         # For each skill, collect files from the *last* source that provides it.
@@ -1651,6 +1920,48 @@ class PTCSandbox:
             skill_count=len(final_skills),
             file_count=len(manifest.get("files", {})),
         )
+
+        # --- Lock file merge + write ---
+        # Build platform lock entries from the manifest
+        platform_entries = {}
+        skills_metadata = manifest.get("skills", {})
+        for skill_name, skill_meta in skills_metadata.items():
+            lock_entry = skill_meta.get("lock_entry")
+            if lock_entry:
+                platform_entries[skill_name] = lock_entry
+
+        if platform_entries or existing_lock:
+            from ptc_agent.agent.middleware.skills.lock import (
+                LOCK_FILENAME,
+                merge_lock_files,
+                serialize_skills_lock,
+            )
+
+            merged = merge_lock_files(platform_entries, existing_lock)
+            lock_content = serialize_skills_lock(merged)
+
+            # Write lock file to sandbox
+            sandbox_base = local_skills_dirs[-1][1].rstrip("/")
+            lock_path = f"{sandbox_base}/{LOCK_FILENAME}"
+            await self._runtime_call(
+                sandbox.upload_file,
+                lock_content.encode("utf-8"),
+                lock_path,
+                retry_policy=RetryPolicy.SAFE,
+            )
+            logger.info(
+                "Skills lock file written",
+                path=lock_path,
+                platform_count=len(platform_entries),
+                user_count=sum(
+                    1
+                    for e in merged["skills"].values()
+                    if e.get("owner") == "user"
+                ),
+            )
+            return dict(merged)
+
+        return None
 
     async def _install_dependencies(self) -> None:
         """Install required Python packages in sandbox (no-snapshot fallback)."""
@@ -1970,17 +2281,17 @@ class PTCSandbox:
         try:
             # Write code to thread dir or fallback to code/
             if thread_id:
-                code_path = f".agent/threads/{thread_id}/code/{execution_id}.py"
+                code_path = f".agents/threads/{thread_id}/code/{execution_id}.py"
                 # Ensure per-thread code dir exists (lazy, once per thread)
                 if thread_id not in self._thread_dirs_created:
                     await self._runtime_call(
                         self.runtime.exec,
-                        f"mkdir -p {self.normalize_path(f'.agent/threads/{thread_id}/code')}",
+                        f"mkdir -p {self.normalize_path(f'.agents/threads/{thread_id}/code')}",
                         retry_policy=RetryPolicy.SAFE,
                     )
                     self._thread_dirs_created.add(thread_id)
             else:
-                code_path = f"code/{execution_id}.py"
+                code_path = f".system/code/{execution_id}.py"
             try:
                 await self._runtime_call(
                     self.runtime.upload_file,
@@ -2620,16 +2931,16 @@ class PTCSandbox:
             """)
 
             if thread_id:
-                script_relative_path = f".agent/threads/{thread_id}/code/{bash_id}.sh"
+                script_relative_path = f".agents/threads/{thread_id}/code/{bash_id}.sh"
                 if thread_id not in self._thread_dirs_created:
                     await self._runtime_call(
                         self.runtime.exec,
-                        f"mkdir -p {self.normalize_path(f'.agent/threads/{thread_id}/code')}",
+                        f"mkdir -p {self.normalize_path(f'.agents/threads/{thread_id}/code')}",
                         retry_policy=RetryPolicy.SAFE,
                     )
                     self._thread_dirs_created.add(thread_id)
             else:
-                script_relative_path = f"code/{bash_id}.sh"
+                script_relative_path = f".system/code/{bash_id}.sh"
 
             try:
                 assert self.runtime is not None

--- a/src/ptc_agent/core/sandbox/ptc_sandbox.py
+++ b/src/ptc_agent/core/sandbox/ptc_sandbox.py
@@ -1575,19 +1575,21 @@ class PTCSandbox:
         """
         if not self.runtime:
             return
-        sb = f"{self._work_dir}/.agents/skills"
-        lock = f"{sb}/skills-lock.json"
+        skills_base = f"{self._work_dir}/.agents/skills"
+        lock_path = f"{skills_base}/skills-lock.json"
 
         # Single inline Python script that runs entirely in the sandbox.
         # Reads dirs + lock file, diffs, parses SKILL.md for new entries,
         # writes updated lock — all in one exec round trip.
+        # Uses json.dumps() for path interpolation (not shlex.quote) because
+        # values appear as Python string literals inside python3 -c.
         script = textwrap.dedent(f"""\
             python3 -c '
 import json, os, re, hashlib, sys
 from datetime import datetime, timezone
 
-SKILLS_BASE = {shlex.quote(sb)}
-LOCK_PATH = {shlex.quote(lock)}
+SKILLS_BASE = {json.dumps(skills_base)}
+LOCK_PATH = {json.dumps(lock_path)}
 
 # 1. List skill dirs (only dirs containing SKILL.md)
 dirs = set()
@@ -1598,14 +1600,14 @@ if os.path.isdir(SKILLS_BASE):
             dirs.add(name)
 
 # 2. Read existing lock
-lock = {{"version": 1, "skills": {{}}}}
+lock_data = {{"version": 1, "skills": {{}}}}
 if os.path.isfile(LOCK_PATH):
     try:
         with open(LOCK_PATH) as f:
-            lock = json.load(f)
+            lock_data = json.load(f)
     except (json.JSONDecodeError, OSError):
         pass
-skills = lock.get("skills", {{}})
+skills = lock_data.get("skills", {{}})
 
 # 3. Compute diff
 locked_names = set(skills.keys())
@@ -1630,9 +1632,10 @@ for name in sorted(to_add):
     license_val = None
     allowed_tools = []
     try:
-        with open(skill_md) as f:
+        with open(skill_md, errors="replace") as f:
             content = f.read(1048576)  # 1MB cap
-        m = re.match(r"^---\\s*\\n(.*?)\\n---\\s*\\n", content, re.DOTALL)
+        content = content.replace("\\r\\n", "\\n")
+        m = re.match(r"^---\\s*\\n(.*?)\\n---\\s*(?:\\n|$)", content, re.DOTALL)
         if m:
             # Minimal YAML-like parser for simple key: value frontmatter
             # Avoids PyYAML dependency in sandbox
@@ -1648,7 +1651,7 @@ for name in sorted(to_add):
                         license_val = v.strip("\\"\\x27") or None
             confirmed = confirmed and bool(name)
         content_hash = "sha256:" + hashlib.sha256(content.encode()).hexdigest()
-    except OSError:
+    except Exception:
         content_hash = ""
 
     skills[name] = {{
@@ -1667,11 +1670,12 @@ for name in sorted(to_add):
     }}
 
 # 6. Write updated lock atomically
-lock["skills"] = skills
+lock_data["skills"] = skills
+os.makedirs(os.path.dirname(LOCK_PATH), exist_ok=True)
 tmp = LOCK_PATH + ".tmp"
 try:
     with open(tmp, "w") as f:
-        json.dump(lock, f, sort_keys=True, indent=2, ensure_ascii=False)
+        json.dump(lock_data, f, sort_keys=True, indent=2, ensure_ascii=False)
         f.write("\\n")
     os.replace(tmp, LOCK_PATH)
     print(json.dumps({{"status": "ok", "removed": len(to_remove), "added": len(to_add)}}))
@@ -1700,7 +1704,7 @@ except OSError as e:
                             "Skills lock synced",
                             removed=info.get("removed", 0),
                             added=info.get("added", 0),
-                            skills_base=sb,
+                            skills_base=skills_base,
                         )
                     elif info.get("status") == "noop":
                         logger.debug("Skills lock already in sync")

--- a/src/server/app/workspace_sandbox.py
+++ b/src/server/app/workspace_sandbox.py
@@ -426,7 +426,7 @@ async def _get_full_sandbox_stats(
         try:
             # Read SKILL.md frontmatter from each skill directory
             cmd = (
-                f"for d in {work_dir}/skills/*/; do "
+                f"for d in {work_dir}/.agents/skills/*/; do "
                 '  [ -f "$d/SKILL.md" ] && echo "=== $(basename "$d") ===" && head -5 "$d/SKILL.md"; '
                 "done 2>/dev/null || true"
             )

--- a/src/server/handlers/chat/ptc_workflow.py
+++ b/src/server/handlers/chat/ptc_workflow.py
@@ -9,6 +9,7 @@ subagent orchestration, completion callback) remain inline.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import time
 from datetime import datetime
@@ -375,7 +376,7 @@ async def astream_ptc_workflow(
             short_id = thread_id[:8]
             try:
                 request_path = session.sandbox.normalize_path(
-                    f".agent/threads/{short_id}/request.md"
+                    f".agents/threads/{short_id}/request.md"
                 )
                 await session.sandbox.awrite_file_text(request_path, user_input)
             except Exception:
@@ -542,14 +543,18 @@ async def astream_ptc_workflow(
                     f"duration={execution_time:.2f}s"
                 )
 
-                # Backup sandbox files to DB after each message
-                try:
-                    ws_manager = WorkspaceManager.get_instance()
-                    await ws_manager._backup_files_to_db(request.workspace_id)
-                except Exception as backup_err:
-                    logger.warning(
-                        f"[PTC_COMPLETE] File backup failed for {thread_id}: {backup_err}"
-                    )
+                # Post-completion sandbox housekeeping (parallel)
+                ws_manager = WorkspaceManager.get_instance()
+                housekeeping = [ws_manager._backup_files_to_db(request.workspace_id)]
+                if session and session.sandbox:
+                    housekeeping.append(session.sandbox.sync_skills_lock())
+                results = await asyncio.gather(*housekeeping, return_exceptions=True)
+                for i, result in enumerate(results):
+                    if isinstance(result, Exception):
+                        task_name = "file backup" if i == 0 else "lock sync"
+                        logger.warning(
+                            f"[PTC_COMPLETE] {task_name} failed for {thread_id}: {result}"
+                        )
 
             except Exception as e:
                 logger.error(

--- a/src/server/services/persistence/file.py
+++ b/src/server/services/persistence/file.py
@@ -17,7 +17,7 @@ import shlex
 from datetime import datetime, timezone
 from typing import Any
 
-from ptc_agent.core.paths import AGENT_SYSTEM_DIRS, ALWAYS_HIDDEN_DIR_NAMES, HIDDEN_DIR_NAMES
+from ptc_agent.core.paths import BACKUP_EXCLUDE_AGENT_SUBDIRS, BACKUP_EXCLUDE_DIRS, ALWAYS_HIDDEN_DIR_NAMES, HIDDEN_DIR_NAMES
 from src.server.database.workspace_file import (
     bulk_update_file_mtimes,
     bulk_upsert_files,
@@ -105,7 +105,7 @@ class FilePersistenceService:
 
     # Directories excluded from sync (relative to /home/workspace/).
     # All patterns match at any depth via find's -not -path '*/{d}/*'.
-    EXCLUDE_DIRS = AGENT_SYSTEM_DIRS | HIDDEN_DIR_NAMES | ALWAYS_HIDDEN_DIR_NAMES
+    EXCLUDE_DIRS = BACKUP_EXCLUDE_DIRS | HIDDEN_DIR_NAMES | ALWAYS_HIDDEN_DIR_NAMES
 
     # File extensions to exclude
     EXCLUDE_EXTENSIONS = {".pyc", ".pyo", ".so", ".dylib", ".o"}
@@ -128,6 +128,8 @@ class FilePersistenceService:
         exclude_flags = []
         for d in cls.EXCLUDE_DIRS:
             exclude_flags.append(f"-not -path '*/{d}/*'")
+        for subdir in BACKUP_EXCLUDE_AGENT_SUBDIRS:
+            exclude_flags.append(f"-not -path '*/{subdir}/*'")
         for ext in cls.EXCLUDE_EXTENSIONS:
             exclude_flags.append(f"-not -name '*{ext}'")
         for name in cls.EXCLUDE_BASENAMES:

--- a/src/server/services/sync_user_data.py
+++ b/src/server/services/sync_user_data.py
@@ -6,7 +6,7 @@ markdown files. These files provide context to the agent but cannot be modified
 directly - agents must use the user-profile skill instead.
 
 Directory structure in sandbox:
-    /home/workspace/.agent/user/
+    /home/workspace/.agents/user/
     ├── preference.md      # User preferences (risk, investment, agent settings)
     ├── watchlist.md       # All watchlists with symbols
     └── portfolio.md       # Holdings (symbol, quantity, cost basis)
@@ -23,7 +23,7 @@ from src.server.database import portfolio as portfolio_db
 logger = logging.getLogger(__name__)
 
 # Sandbox directory for user data files (relative to working dir)
-USER_DATA_DIR = ".agent/user"
+USER_DATA_DIR = ".agents/user"
 
 # File names
 PREFERENCE_FILE = "preference.md"

--- a/tests/integration/sandbox/ptc/test_execute.py
+++ b/tests/integration/sandbox/ptc/test_execute.py
@@ -25,11 +25,11 @@ class TestExecute:
         assert result.success is False
 
     async def test_execute_creates_code_file(self, shared_sandbox):
-        """execute() should save the code to code/ directory."""
+        """execute() should save the code to .system/code/ directory."""
         result = await shared_sandbox.execute("print('saved')")
         assert result.success is True
         # Check code dir has files
-        ls_result = await shared_sandbox.runtime.exec(f"ls {shared_sandbox._work_dir}/code/")
+        ls_result = await shared_sandbox.runtime.exec(f"ls {shared_sandbox._work_dir}/.system/code/")
         assert ls_result.exit_code == 0
 
     async def test_execute_with_thread_id(self, shared_sandbox):
@@ -39,7 +39,7 @@ class TestExecute:
         assert result.success is True
         # Check thread dir was created
         ls_result = await shared_sandbox.runtime.exec(
-            f"test -d {shared_sandbox._work_dir}/.agent/threads/test-thread-123/code && echo OK"
+            f"test -d {shared_sandbox._work_dir}/.agents/threads/test-thread-123/code && echo OK"
         )
         assert "OK" in ls_result.stdout
 

--- a/tests/integration/sandbox/ptc/test_skills_lock.py
+++ b/tests/integration/sandbox/ptc/test_skills_lock.py
@@ -1,0 +1,402 @@
+"""Integration tests for skills-lock.json lifecycle.
+
+Covers:
+- Layout: .agents/threads and .agents/skills created after setup
+- Lock file: written by _upload_skills, contains platform entries
+- User preservation: user lock entries survive platform resync
+- Prune protection: user-installed skill dirs survive prune
+- Discovery: user-installed skills in manifest after cache build
+- Sync: sync_skills_lock adds/removes entries to match filesystem
+
+NOTE: Tests exercise skills methods directly (not full sync_sandbox_assets)
+because integration sandbox lacks mcp_registry for tool module install.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio(loop_scope="class")]
+
+
+def _make_test_skill(name: str, description: str = "Test skill") -> str:
+    """Create a minimal SKILL.md content string."""
+    return (
+        f"---\n"
+        f"name: {name}\n"
+        f"description: {description}\n"
+        f"---\n"
+        f"# {name}\n"
+    )
+
+
+def _make_lock_entry(
+    name: str,
+    *,
+    owner: str = "user",
+    description: str = "User skill",
+) -> dict:
+    """Build a minimal lock entry dict."""
+    return {
+        "name": name,
+        "description": description,
+        "owner": owner,
+        "source": "local",
+        "sourceType": "local",
+        "computedHash": "",
+        "confirmed": True,
+        "license": None,
+        "metadata": {},
+        "allowed_tools": [],
+        "installedAt": "2026-01-01T00:00:00Z",
+        "updatedAt": "2026-01-01T00:00:00Z",
+    }
+
+
+def _write_lock_to_sandbox(runtime, lock_path: str, lock_data: dict):
+    """Coroutine: upload a lock file to the sandbox."""
+    return runtime.upload_file(
+        json.dumps(lock_data, indent=2).encode("utf-8"),
+        lock_path,
+    )
+
+
+async def _read_lock_from_sandbox(runtime, lock_path: str) -> dict | None:
+    """Read and parse the lock file from sandbox, or None if missing."""
+    result = await runtime.exec(f"cat {lock_path} 2>/dev/null")
+    if result.exit_code != 0 or not result.stdout.strip():
+        return None
+    return json.loads(result.stdout)
+
+
+class TestSkillsLayout:
+    """Verify .agents/ directory structure after setup."""
+
+    async def test_setup_creates_agents_dirs(self, shared_sandbox):
+        """After setup, .agents/threads and .agents/skills exist."""
+        work_dir = shared_sandbox._work_dir
+        for subdir in (".agents/threads", ".agents/skills"):
+            result = await shared_sandbox.runtime.exec(
+                f"test -d {work_dir}/{subdir} && echo EXISTS"
+            )
+            assert "EXISTS" in result.stdout, f"{subdir} not created after setup"
+
+    async def test_system_code_dir_exists(self, shared_sandbox):
+        """After setup, .system/code/ exists."""
+        result = await shared_sandbox.runtime.exec(
+            f"test -d {shared_sandbox._work_dir}/.system/code && echo EXISTS"
+        )
+        assert "EXISTS" in result.stdout
+
+
+class TestSkillsLockLifecycle:
+    """Lock file creation and platform entries via _upload_skills."""
+
+    async def test_upload_skills_creates_lock_file(self, shared_sandbox):
+        """_upload_skills() writes skills-lock.json with platform entries."""
+        sb = shared_sandbox
+        work_dir = sb._work_dir
+        skills_base = f"{work_dir}/.agents/skills"
+        lock_path = f"{skills_base}/skills-lock.json"
+
+        # Create a local platform skill in a temp dir
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = os.path.join(tmpdir, "test-plat")
+            os.makedirs(skill_dir)
+            with open(os.path.join(skill_dir, "SKILL.md"), "w") as f:
+                f.write(_make_test_skill("test-plat", "Platform skill"))
+
+            # Compute skills module (generates lock entries)
+            from ptc_agent.config.agent import SkillsConfig
+
+            sb._agent_config = type("Cfg", (), {
+                "skills": SkillsConfig(
+                    enabled=True,
+                    user_skills_dir=tmpdir,
+                    project_skills_dir=tmpdir,
+                    sandbox_skills_base=skills_base,
+                ),
+            })()
+
+            skills_mod = await sb._compute_skills_module([tmpdir])
+
+            # Upload skills + write lock
+            merged_lock = await sb._upload_skills(
+                [(tmpdir, skills_base)],
+                manifest=skills_mod,
+                existing_lock=None,
+            )
+
+        # Verify lock file written
+        lock_data = await _read_lock_from_sandbox(sb.runtime, lock_path)
+        assert lock_data is not None, "skills-lock.json not created"
+        assert lock_data["version"] == 1
+
+        # Verify platform skill entry
+        skills = lock_data.get("skills", {})
+        assert "test-plat" in skills, f"test-plat not in lock: {list(skills.keys())}"
+        assert skills["test-plat"]["owner"] == "platform"
+        assert skills["test-plat"]["description"] == "Platform skill"
+
+        # Verify merged_lock was returned
+        assert merged_lock is not None
+        assert "test-plat" in merged_lock.get("skills", {})
+
+    async def test_lock_preserves_user_entries_on_resync(self, shared_sandbox):
+        """User lock entries survive when platform skills are re-uploaded."""
+        sb = shared_sandbox
+        work_dir = sb._work_dir
+        skills_base = f"{work_dir}/.agents/skills"
+        lock_path = f"{skills_base}/skills-lock.json"
+
+        # Create user skill dir + lock entry
+        user_dir = f"{skills_base}/my-custom"
+        await sb.runtime.exec(f"mkdir -p {user_dir}")
+        await sb.runtime.upload_file(
+            _make_test_skill("my-custom", "Custom user skill").encode(),
+            f"{user_dir}/SKILL.md",
+        )
+
+        # Set existing lock with user entry
+        existing_lock = {
+            "my-custom": _make_lock_entry("my-custom", description="Custom user skill"),
+        }
+
+        # Upload platform skills with existing_lock containing user entry
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = os.path.join(tmpdir, "plat-skill")
+            os.makedirs(skill_dir)
+            with open(os.path.join(skill_dir, "SKILL.md"), "w") as f:
+                f.write(_make_test_skill("plat-skill", "Platform"))
+
+            skills_mod = await sb._compute_skills_module([tmpdir])
+            merged_lock = await sb._upload_skills(
+                [(tmpdir, skills_base)],
+                manifest=skills_mod,
+                existing_lock=existing_lock,
+            )
+
+        # Verify user entry preserved in merged result
+        assert merged_lock is not None
+        merged_skills = merged_lock.get("skills", {})
+        assert "my-custom" in merged_skills, "User entry lost during merge"
+        assert merged_skills["my-custom"]["owner"] == "user"
+        assert "plat-skill" in merged_skills, "Platform entry missing"
+        assert merged_skills["plat-skill"]["owner"] == "platform"
+
+        # Verify on-disk lock also has both
+        lock_data = await _read_lock_from_sandbox(sb.runtime, lock_path)
+        assert lock_data is not None
+        assert "my-custom" in lock_data["skills"]
+        assert "plat-skill" in lock_data["skills"]
+
+
+class TestPruneProtection:
+    """User-installed skill directories survive platform prune."""
+
+    async def test_user_skill_survives_prune(self, shared_sandbox):
+        """Skill dir with owner=user in lock is NOT pruned."""
+        sb = shared_sandbox
+        work_dir = sb._work_dir
+        skills_base = f"{work_dir}/.agents/skills"
+
+        # Create user skill dir
+        user_dir = f"{skills_base}/user-survivor"
+        await sb.runtime.exec(f"mkdir -p {user_dir}")
+        await sb.runtime.upload_file(
+            _make_test_skill("user-survivor").encode(),
+            f"{user_dir}/SKILL.md",
+        )
+
+        existing_lock = {
+            "user-survivor": _make_lock_entry("user-survivor"),
+        }
+
+        # Prune with empty local_skill_names (all platform skills removed)
+        await sb._prune_remote_skills(
+            skills_base, local_skill_names=set(), existing_lock=existing_lock
+        )
+
+        # Verify user skill dir still exists
+        result = await sb.runtime.exec(
+            f"test -d {user_dir} && echo EXISTS"
+        )
+        assert "EXISTS" in result.stdout, "User skill was pruned!"
+
+    async def test_stale_platform_skill_pruned(self, shared_sandbox):
+        """Skill dir with owner=platform NOT in local set IS pruned."""
+        sb = shared_sandbox
+        work_dir = sb._work_dir
+        skills_base = f"{work_dir}/.agents/skills"
+
+        # Create stale platform skill dir
+        stale_dir = f"{skills_base}/old-platform"
+        await sb.runtime.exec(f"mkdir -p {stale_dir}")
+        await sb.runtime.upload_file(
+            _make_test_skill("old-platform").encode(),
+            f"{stale_dir}/SKILL.md",
+        )
+
+        existing_lock = {
+            "old-platform": _make_lock_entry(
+                "old-platform", owner="platform", description="Stale"
+            ),
+        }
+
+        await sb._prune_remote_skills(
+            skills_base, local_skill_names=set(), existing_lock=existing_lock
+        )
+
+        # Verify stale dir was removed
+        result = await sb.runtime.exec(
+            f"test -d {stale_dir} && echo EXISTS || echo GONE"
+        )
+        assert "GONE" in result.stdout, "Stale platform skill was not pruned"
+
+
+class TestSyncSkillsLock:
+    """sync_skills_lock reconciles lock file with filesystem."""
+
+    async def test_sync_removes_orphaned_entry(self, shared_sandbox):
+        """Lock entry without corresponding directory is removed."""
+        sb = shared_sandbox
+        work_dir = sb._work_dir
+        skills_base = f"{work_dir}/.agents/skills"
+        lock_path = f"{skills_base}/skills-lock.json"
+
+        # Ensure at least one valid skill dir exists (so DIRS is non-empty)
+        valid_dir = f"{skills_base}/valid-skill"
+        await sb.runtime.exec(f"mkdir -p {valid_dir}")
+        await sb.runtime.upload_file(
+            _make_test_skill("valid-skill").encode(),
+            f"{valid_dir}/SKILL.md",
+        )
+
+        # Write lock with valid + ghost entries
+        lock_data = {
+            "version": 1,
+            "skills": {
+                "valid-skill": _make_lock_entry("valid-skill"),
+                "ghost-skill": _make_lock_entry("ghost-skill"),
+            },
+        }
+        await _write_lock_to_sandbox(sb.runtime, lock_path, lock_data)
+
+        # Verify ghost-skill is in the lock
+        pre = await _read_lock_from_sandbox(sb.runtime, lock_path)
+        assert pre is not None and "ghost-skill" in pre["skills"]
+
+        # Run sync
+        await sb.sync_skills_lock()
+
+        # Verify ghost removed, valid preserved
+        post = await _read_lock_from_sandbox(sb.runtime, lock_path)
+        assert post is not None
+        assert "ghost-skill" not in post["skills"], "Orphaned entry not cleaned"
+        assert "valid-skill" in post["skills"], "Valid entry incorrectly removed"
+
+    async def test_sync_adds_new_skill_entry(self, shared_sandbox):
+        """Skill directory without lock entry gets auto-registered."""
+        sb = shared_sandbox
+        work_dir = sb._work_dir
+        skills_base = f"{work_dir}/.agents/skills"
+        lock_path = f"{skills_base}/skills-lock.json"
+
+        # Create a skill dir with SKILL.md but no lock entry
+        new_dir = f"{skills_base}/auto-registered"
+        await sb.runtime.exec(f"mkdir -p {new_dir}")
+        await sb.runtime.upload_file(
+            _make_test_skill("auto-registered", "Auto-discovered skill").encode(),
+            f"{new_dir}/SKILL.md",
+        )
+
+        # Write lock without the new skill
+        lock_data = {"version": 1, "skills": {}}
+        await _write_lock_to_sandbox(sb.runtime, lock_path, lock_data)
+
+        # Run sync
+        await sb.sync_skills_lock()
+
+        # Verify new skill was added
+        post = await _read_lock_from_sandbox(sb.runtime, lock_path)
+        assert post is not None
+        skills = post.get("skills", {})
+        assert "auto-registered" in skills, f"New skill not added: {list(skills.keys())}"
+        entry = skills["auto-registered"]
+        assert entry["owner"] == "user"
+        assert entry["source"] == "local"
+        assert entry["description"] == "Auto-discovered skill"
+        assert entry["confirmed"] is True
+
+    async def test_sync_adds_and_removes_simultaneously(self, shared_sandbox):
+        """Sync handles both additions and removals in one pass."""
+        sb = shared_sandbox
+        work_dir = sb._work_dir
+        skills_base = f"{work_dir}/.agents/skills"
+        lock_path = f"{skills_base}/skills-lock.json"
+
+        # Create new skill dir (no lock entry)
+        new_dir = f"{skills_base}/new-skill"
+        await sb.runtime.exec(f"mkdir -p {new_dir}")
+        await sb.runtime.upload_file(
+            _make_test_skill("new-skill", "Brand new").encode(),
+            f"{new_dir}/SKILL.md",
+        )
+
+        # Write lock with a stale entry (no dir) only
+        lock_data = {
+            "version": 1,
+            "skills": {
+                "stale-skill": _make_lock_entry("stale-skill"),
+            },
+        }
+        await _write_lock_to_sandbox(sb.runtime, lock_path, lock_data)
+
+        await sb.sync_skills_lock()
+
+        post = await _read_lock_from_sandbox(sb.runtime, lock_path)
+        assert post is not None
+        skills = post.get("skills", {})
+        assert "stale-skill" not in skills, "Stale entry not removed"
+        assert "new-skill" in skills, "New skill not added"
+
+    async def test_sync_noop_when_in_sync(self, shared_sandbox):
+        """No write when lock and filesystem already match."""
+        sb = shared_sandbox
+        work_dir = sb._work_dir
+        skills_base = f"{work_dir}/.agents/skills"
+        lock_path = f"{skills_base}/skills-lock.json"
+
+        # Create skill dir + matching lock entry
+        skill_dir = f"{skills_base}/synced-skill"
+        await sb.runtime.exec(f"mkdir -p {skill_dir}")
+        await sb.runtime.upload_file(
+            _make_test_skill("synced-skill").encode(),
+            f"{skill_dir}/SKILL.md",
+        )
+        lock_data = {
+            "version": 1,
+            "skills": {
+                "synced-skill": _make_lock_entry("synced-skill"),
+            },
+        }
+        await _write_lock_to_sandbox(sb.runtime, lock_path, lock_data)
+
+        # Run sync — should be a noop (no error)
+        await sb.sync_skills_lock()
+
+        # Lock unchanged
+        post = await _read_lock_from_sandbox(sb.runtime, lock_path)
+        assert post is not None
+        assert "synced-skill" in post["skills"]
+
+    async def test_sync_safe_when_no_lock_file(self, shared_sandbox):
+        """sync_skills_lock is safe when no lock file exists."""
+        sb = shared_sandbox
+
+        # Should not raise
+        await sb.sync_skills_lock()

--- a/tests/integration/sandbox/ptc/test_workspace_setup.py
+++ b/tests/integration/sandbox/ptc/test_workspace_setup.py
@@ -23,9 +23,10 @@ class TestWorkspaceSetup:
             "tools/docs",
             "results",
             "data",
-            "code",
+            ".system/code",
             "work",
-            ".agent/threads",
+            ".agents/threads",
+            ".agents/skills",
             "_internal/src",
         ]
         for d in expected_dirs:

--- a/tests/unit/config/test_agent_config.py
+++ b/tests/unit/config/test_agent_config.py
@@ -292,7 +292,7 @@ class TestSkillsConfig:
         project_dir, project_sandbox = dirs[1]
         assert "ptc-agent/skills" in user_dir
         assert "/test/project/skills" in project_dir
-        assert user_sandbox == "/home/workspace/skills"
+        assert user_sandbox == "/home/workspace/.agents/skills"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/core/sandbox/test_migration.py
+++ b/tests/unit/core/sandbox/test_migration.py
@@ -1,0 +1,203 @@
+"""
+Tests for ptc_agent.core.sandbox.migration — versioned sandbox layout migrations.
+
+Covers:
+- Zero cost when already current (no API calls)
+- v1→v2 migration moves directories, creates skills dir, removes old skills/
+- Idempotency (safe to re-run)
+- Skipping missing source directories
+- Sequential migration execution via run_layout_migrations
+"""
+
+import shlex
+
+import pytest
+from unittest.mock import AsyncMock
+
+from ptc_agent.core.sandbox.migration import (
+    CURRENT_LAYOUT_VERSION,
+    migrate_layout_v1_to_v2,
+    run_layout_migrations,
+)
+
+
+@pytest.fixture
+def mock_runtime():
+    runtime = AsyncMock()
+    runtime.exec = AsyncMock(return_value="")
+    return runtime
+
+
+WORK_DIR = "/home/user/project"
+
+
+# ---------------------------------------------------------------------------
+# Zero cost when current
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_zero_cost_when_current(mock_runtime):
+    """current_version >= CURRENT_LAYOUT_VERSION -> returns immediately, no API calls."""
+    result = await run_layout_migrations(
+        mock_runtime, WORK_DIR, current_version=CURRENT_LAYOUT_VERSION
+    )
+    assert result == CURRENT_LAYOUT_VERSION
+    mock_runtime.exec.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_zero_cost_when_ahead(mock_runtime):
+    """current_version > CURRENT_LAYOUT_VERSION -> also returns immediately."""
+    result = await run_layout_migrations(
+        mock_runtime, WORK_DIR, current_version=CURRENT_LAYOUT_VERSION + 1
+    )
+    assert result == CURRENT_LAYOUT_VERSION + 1
+    mock_runtime.exec.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# v1 → v2 migration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_migration_v1_to_v2_moves_dirs(mock_runtime):
+    """Verify the migration runs shell commands to move .agent/ subdirs to .agents/."""
+    await migrate_layout_v1_to_v2(mock_runtime, WORK_DIR)
+
+    calls = [call.args[0] for call in mock_runtime.exec.call_args_list]
+
+    # Should create .agents/skills/ first
+    assert any("mkdir -p" in c and ".agents/skills" in c for c in calls), (
+        f"Expected mkdir for .agents/skills/ in calls: {calls}"
+    )
+
+    # Should move .agent/threads -> .agents/threads
+    assert any(
+        ".agent/threads" in c and ".agents/threads" in c and "cp -a" in c
+        for c in calls
+    ), f"Expected move of .agent/threads in calls: {calls}"
+
+    # Should move .agent/user -> .agents/user
+    assert any(
+        ".agent/user" in c and ".agents/user" in c and "cp -a" in c
+        for c in calls
+    ), f"Expected move of .agent/user in calls: {calls}"
+
+    # Should move .agent/large_tool_results -> .agents/large_tool_results
+    assert any(
+        ".agent/large_tool_results" in c
+        and ".agents/large_tool_results" in c
+        and "cp -a" in c
+        for c in calls
+    ), f"Expected move of .agent/large_tool_results in calls: {calls}"
+
+    # Should clean up old .agent/ directory
+    assert any("rmdir" in c and ".agent" in c for c in calls), (
+        f"Expected rmdir of .agent/ in calls: {calls}"
+    )
+
+    # Should remove old skills/ directory
+    assert any("rm -rf" in c and "/skills" in c for c in calls), (
+        f"Expected rm -rf of skills/ in calls: {calls}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_migration_v1_to_v2_idempotent(mock_runtime):
+    """Running migration twice should not fail — shell commands are idempotent."""
+    await migrate_layout_v1_to_v2(mock_runtime, WORK_DIR)
+    first_call_count = mock_runtime.exec.call_count
+
+    # Run again — same commands should be issued without error
+    await migrate_layout_v1_to_v2(mock_runtime, WORK_DIR)
+    second_call_count = mock_runtime.exec.call_count - first_call_count
+
+    # Same number of exec calls both times (deterministic, not skipping)
+    assert first_call_count == second_call_count
+
+
+@pytest.mark.asyncio
+async def test_migration_v1_to_v2_creates_skills_dir(mock_runtime):
+    """.agents/skills/ is created via mkdir -p."""
+    await migrate_layout_v1_to_v2(mock_runtime, WORK_DIR)
+
+    calls = [call.args[0] for call in mock_runtime.exec.call_args_list]
+
+    expected_path = shlex.quote(f"{WORK_DIR}/.agents/skills")
+    assert any(f"mkdir -p {expected_path}" in c for c in calls), (
+        f"Expected mkdir -p for .agents/skills/ in calls: {calls}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_migration_v1_to_v2_skips_missing_source(mock_runtime):
+    """If .agent/ doesn't exist, the `if [ -d ... ]` check skips the move."""
+    await migrate_layout_v1_to_v2(mock_runtime, WORK_DIR)
+
+    calls = [call.args[0] for call in mock_runtime.exec.call_args_list]
+
+    # Each move command is guarded by `if [ -d <src> ]`
+    move_calls = [c for c in calls if "cp -a" in c]
+    for cmd in move_calls:
+        assert "if [ -d " in cmd, (
+            f"Move command not guarded by existence check: {cmd}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_migration_v1_to_v2_uses_quoted_paths(mock_runtime):
+    """Paths are passed through shlex.quote() for safety."""
+    work_dir_with_space = "/home/user/my project"
+    await migrate_layout_v1_to_v2(mock_runtime, work_dir_with_space)
+
+    calls = [call.args[0] for call in mock_runtime.exec.call_args_list]
+
+    # shlex.quote wraps paths containing spaces in single quotes
+    quoted_skills = shlex.quote(f"{work_dir_with_space}/.agents/skills")
+    assert any(quoted_skills in c for c in calls), (
+        f"Expected quoted path {quoted_skills} in calls: {calls}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# run_layout_migrations orchestration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_layout_migrations_sequential(mock_runtime):
+    """With current_version=1 and CURRENT=2, runs exactly the v1->v2 migration."""
+    result = await run_layout_migrations(mock_runtime, WORK_DIR, current_version=1)
+
+    assert result == CURRENT_LAYOUT_VERSION
+    # v1->v2 migration issues multiple exec calls (mkdir, 3 moves, rmdir, rm)
+    assert mock_runtime.exec.call_count > 0
+
+    calls = [call.args[0] for call in mock_runtime.exec.call_args_list]
+
+    # Verify it ran the v1->v2 migration (check for characteristic commands)
+    assert any(".agents/skills" in c for c in calls)
+    assert any(".agent/threads" in c for c in calls)
+
+
+@pytest.mark.asyncio
+async def test_run_layout_migrations_returns_current_version(mock_runtime):
+    """After running all migrations, returns CURRENT_LAYOUT_VERSION."""
+    result = await run_layout_migrations(mock_runtime, WORK_DIR, current_version=1)
+    assert result == CURRENT_LAYOUT_VERSION
+    assert result == 2
+
+
+@pytest.mark.asyncio
+async def test_run_layout_migrations_skips_unknown_versions(mock_runtime):
+    """If a version has no registered migrator, it's silently skipped."""
+    # Version 0 has no registered migration, so it should skip 0->1
+    # but still run 1->2
+    result = await run_layout_migrations(mock_runtime, WORK_DIR, current_version=0)
+    assert result == CURRENT_LAYOUT_VERSION
+
+    # Should have run v1->v2 migration (version 0->1 has no migrator, skipped)
+    calls = [call.args[0] for call in mock_runtime.exec.call_args_list]
+    assert any(".agents/skills" in c for c in calls)

--- a/tests/unit/core/sandbox/test_prune_skills.py
+++ b/tests/unit/core/sandbox/test_prune_skills.py
@@ -1,0 +1,249 @@
+"""Tests for _prune_remote_skills() prune-protection logic in PTCSandbox.
+
+Verifies that user-installed skills are never pruned, stale platform skills
+are removed, and safe defaults preserve skills when the lock is unavailable
+or has no entry for a given directory.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ptc_agent.config.core import (
+    CoreConfig,
+    DaytonaConfig,
+    FilesystemConfig,
+    LoggingConfig,
+    MCPConfig,
+    SandboxConfig,
+    SecurityConfig,
+)
+from ptc_agent.core.sandbox.runtime import (
+    ExecResult,
+    RuntimeState,
+    SandboxProvider,
+    SandboxRuntime,
+)
+
+
+def _make_config(**overrides) -> CoreConfig:
+    defaults = dict(
+        sandbox=SandboxConfig(daytona=DaytonaConfig(api_key="test-key")),
+        security=SecurityConfig(),
+        mcp=MCPConfig(),
+        logging=LoggingConfig(),
+        filesystem=FilesystemConfig(),
+    )
+    defaults.update(overrides)
+    return CoreConfig(**defaults)
+
+
+def _dir_entry(name: str, path: str) -> dict:
+    return {"name": name, "path": path, "is_dir": True}
+
+
+@pytest.fixture
+def mock_runtime():
+    runtime = AsyncMock(spec=SandboxRuntime)
+    runtime.id = "mock-runtime-1"
+    runtime.working_dir = "/home/workspace"
+    runtime.exec = AsyncMock(return_value=ExecResult("", "", 0))
+    runtime.get_state = AsyncMock(return_value=RuntimeState.RUNNING)
+    runtime.list_files = AsyncMock(return_value=[])
+    return runtime
+
+
+@pytest.fixture
+def mock_provider(mock_runtime):
+    provider = AsyncMock(spec=SandboxProvider)
+    provider.create = AsyncMock(return_value=mock_runtime)
+    provider.get = AsyncMock(return_value=mock_runtime)
+    provider.close = AsyncMock()
+    provider.is_transient_error = MagicMock(return_value=False)
+    return provider
+
+
+SANDBOX_BASE = "/home/workspace/.agents/skills"
+
+
+class TestPruneRemoteSkills:
+    """Unit tests for PTCSandbox._prune_remote_skills()."""
+
+    @patch("ptc_agent.core.sandbox.ptc_sandbox.create_provider")
+    @pytest.mark.asyncio
+    async def test_prune_skips_user_owned_skill(
+        self, mock_create_provider, mock_provider, mock_runtime
+    ):
+        """Skill not in platform list but owner='user' in lock -> survives."""
+        from ptc_agent.core.sandbox.ptc_sandbox import PTCSandbox
+
+        mock_create_provider.return_value = mock_provider
+        sandbox = PTCSandbox(config=_make_config())
+        sandbox.runtime = mock_runtime
+
+        # Sandbox has a user-installed skill "my-custom-skill"
+        mock_runtime.list_files = AsyncMock(
+            return_value=[
+                _dir_entry(
+                    "my-custom-skill",
+                    f"{SANDBOX_BASE}/my-custom-skill",
+                ),
+            ]
+        )
+
+        lock = {
+            "my-custom-skill": {"owner": "user", "name": "my-custom-skill"},
+        }
+
+        # Platform set does NOT include "my-custom-skill"
+        await sandbox._prune_remote_skills(
+            SANDBOX_BASE, local_skill_names=set(), existing_lock=lock
+        )
+
+        # rm -rf should NOT have been called
+        mock_runtime.exec.assert_not_called()
+
+    @patch("ptc_agent.core.sandbox.ptc_sandbox.create_provider")
+    @pytest.mark.asyncio
+    async def test_prune_removes_stale_platform_skill(
+        self, mock_create_provider, mock_provider, mock_runtime
+    ):
+        """Skill not in platform list and owner='platform' -> pruned."""
+        from ptc_agent.core.sandbox.ptc_sandbox import PTCSandbox
+
+        mock_create_provider.return_value = mock_provider
+        sandbox = PTCSandbox(config=_make_config())
+        sandbox.runtime = mock_runtime
+
+        mock_runtime.list_files = AsyncMock(
+            return_value=[
+                _dir_entry(
+                    "old-platform-skill",
+                    f"{SANDBOX_BASE}/old-platform-skill",
+                ),
+            ]
+        )
+
+        lock = {
+            "old-platform-skill": {
+                "owner": "platform",
+                "name": "old-platform-skill",
+            },
+        }
+
+        await sandbox._prune_remote_skills(
+            SANDBOX_BASE, local_skill_names=set(), existing_lock=lock
+        )
+
+        # rm -rf SHOULD have been called for the stale platform skill
+        mock_runtime.exec.assert_called_once()
+        call_args = mock_runtime.exec.call_args[0][0]
+        assert "rm -rf" in call_args
+        assert "old-platform-skill" in call_args
+
+    @patch("ptc_agent.core.sandbox.ptc_sandbox.create_provider")
+    @pytest.mark.asyncio
+    async def test_prune_skips_unknown_skill_safe_default(
+        self, mock_create_provider, mock_provider, mock_runtime
+    ):
+        """Skill dir not in lock at all -> preserved (safe default)."""
+        from ptc_agent.core.sandbox.ptc_sandbox import PTCSandbox
+
+        mock_create_provider.return_value = mock_provider
+        sandbox = PTCSandbox(config=_make_config())
+        sandbox.runtime = mock_runtime
+
+        mock_runtime.list_files = AsyncMock(
+            return_value=[
+                _dir_entry(
+                    "mystery-skill",
+                    f"{SANDBOX_BASE}/mystery-skill",
+                ),
+            ]
+        )
+
+        # Lock exists but has no entry for "mystery-skill"
+        lock = {
+            "other-skill": {"owner": "platform", "name": "other-skill"},
+        }
+
+        await sandbox._prune_remote_skills(
+            SANDBOX_BASE, local_skill_names=set(), existing_lock=lock
+        )
+
+        # Unknown origin -> preserved; rm -rf should NOT be called
+        mock_runtime.exec.assert_not_called()
+
+    @patch("ptc_agent.core.sandbox.ptc_sandbox.create_provider")
+    @pytest.mark.asyncio
+    async def test_prune_skips_all_when_lock_unavailable(
+        self, mock_create_provider, mock_provider, mock_runtime
+    ):
+        """Lock is None -> no skills pruned (safe default)."""
+        from ptc_agent.core.sandbox.ptc_sandbox import PTCSandbox
+
+        mock_create_provider.return_value = mock_provider
+        sandbox = PTCSandbox(config=_make_config())
+        sandbox.runtime = mock_runtime
+
+        mock_runtime.list_files = AsyncMock(
+            return_value=[
+                _dir_entry(
+                    "skill-a",
+                    f"{SANDBOX_BASE}/skill-a",
+                ),
+                _dir_entry(
+                    "skill-b",
+                    f"{SANDBOX_BASE}/skill-b",
+                ),
+            ]
+        )
+
+        await sandbox._prune_remote_skills(
+            SANDBOX_BASE, local_skill_names=set(), existing_lock=None
+        )
+
+        # No lock -> everything preserved
+        mock_runtime.exec.assert_not_called()
+
+    @patch("ptc_agent.core.sandbox.ptc_sandbox.create_provider")
+    @pytest.mark.asyncio
+    async def test_prune_cleans_stale_lock_entries(
+        self, mock_create_provider, mock_provider, mock_runtime
+    ):
+        """Only platform skills NOT in local_skill_names are pruned;
+        user skills and current platform skills survive."""
+        from ptc_agent.core.sandbox.ptc_sandbox import PTCSandbox
+
+        mock_create_provider.return_value = mock_provider
+        sandbox = PTCSandbox(config=_make_config())
+        sandbox.runtime = mock_runtime
+
+        mock_runtime.list_files = AsyncMock(
+            return_value=[
+                _dir_entry("current-skill", f"{SANDBOX_BASE}/current-skill"),
+                _dir_entry("stale-skill", f"{SANDBOX_BASE}/stale-skill"),
+                _dir_entry("user-skill", f"{SANDBOX_BASE}/user-skill"),
+            ]
+        )
+
+        lock = {
+            "current-skill": {"owner": "platform", "name": "current-skill"},
+            "stale-skill": {"owner": "platform", "name": "stale-skill"},
+            "user-skill": {"owner": "user", "name": "user-skill"},
+        }
+
+        # "current-skill" is still in the local platform set
+        await sandbox._prune_remote_skills(
+            SANDBOX_BASE,
+            local_skill_names={"current-skill"},
+            existing_lock=lock,
+        )
+
+        # Only "stale-skill" should be pruned
+        assert mock_runtime.exec.call_count == 1
+        call_args = mock_runtime.exec.call_args[0][0]
+        assert "rm -rf" in call_args
+        assert "stale-skill" in call_args

--- a/tests/unit/middleware/skills/test_discovery_lock.py
+++ b/tests/unit/middleware/skills/test_discovery_lock.py
@@ -1,0 +1,184 @@
+"""Tests for lock-aware skill discovery in adiscover_skills().
+
+Verifies that:
+- Cache hits return immediately without downloads.
+- Cache misses use lock entries when available (no SKILL.md download).
+- Cache misses fall back to SKILL.md download when no lock entry exists.
+- Self-healing creates lock entries for orphaned skill directories.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ptc_agent.agent.middleware.skills.discovery import (
+    adiscover_skills,
+)
+
+
+def _make_download_response(content: bytes | None = None, error: bool = False):
+    """Build a minimal response object matching what backend.adownload_files returns."""
+    return SimpleNamespace(content=content, error=error)
+
+
+def _make_lock_json(entries: dict) -> str:
+    """Serialize a valid skills-lock.json string."""
+    import json
+
+    return json.dumps({"version": 1, "skills": entries})
+
+
+def _make_lock_entry(
+    name: str,
+    *,
+    owner: str = "user",
+    description: str = "A test skill",
+    confirmed: bool = True,
+) -> dict:
+    """Build a minimal lock entry dict."""
+    return {
+        "name": name,
+        "description": description,
+        "owner": owner,
+        "source": "local",
+        "sourceType": "local",
+        "computedHash": "sha256:abc123",
+        "confirmed": confirmed,
+        "license": None,
+        "metadata": {},
+        "allowed_tools": [],
+        "installedAt": "2026-01-01T00:00:00Z",
+        "updatedAt": "2026-01-01T00:00:00Z",
+    }
+
+
+SKILLS_PATH = "/home/workspace/.agents/skills"
+
+
+class TestDiscoverSkillsWithLock:
+    """adiscover_skills() lock-file integration."""
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_uses_lock_entry(self):
+        """Unknown skill dir + lock entry exists -> uses lock, SKILL.md NOT downloaded."""
+        lock_entry = _make_lock_entry("my-skill", description="From lock")
+        lock_json = _make_lock_json({"my-skill": lock_entry})
+
+        backend = AsyncMock()
+        backend.als_info = AsyncMock(
+            return_value=[
+                {"path": f"{SKILLS_PATH}/my-skill", "is_dir": True},
+            ]
+        )
+        # First download call is for skills-lock.json
+        backend.adownload_files = AsyncMock(
+            return_value=[_make_download_response(lock_json.encode("utf-8"))]
+        )
+
+        results = await adiscover_skills(
+            backend, SKILLS_PATH, known_skills={}
+        )
+
+        assert len(results) == 1
+        assert results[0]["name"] == "my-skill"
+        assert results[0]["description"] == "From lock"
+
+        # adownload_files called once for the lock file, NOT for SKILL.md
+        assert backend.adownload_files.call_count == 1
+        downloaded_paths = backend.adownload_files.call_args_list[0][0][0]
+        assert any("skills-lock.json" in p for p in downloaded_paths)
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_falls_back_to_skill_md(self):
+        """Unknown skill dir + no lock entry + no lock file -> downloads SKILL.md."""
+        skill_md_content = (
+            "---\n"
+            "name: orphan-skill\n"
+            "description: Discovered via SKILL.md\n"
+            "---\n"
+            "# Orphan Skill\n"
+        )
+
+        backend = AsyncMock()
+        backend.als_info = AsyncMock(
+            return_value=[
+                {"path": f"{SKILLS_PATH}/orphan-skill", "is_dir": True},
+            ]
+        )
+
+        # First call: lock file download fails
+        # Second call: SKILL.md download succeeds
+        backend.adownload_files = AsyncMock(
+            side_effect=[
+                [_make_download_response(error=True)],  # lock file
+                [
+                    _make_download_response(
+                        skill_md_content.encode("utf-8")
+                    )
+                ],  # SKILL.md
+            ]
+        )
+        # Self-healing upload (best effort)
+        backend.aupload_files = AsyncMock()
+
+        results = await adiscover_skills(
+            backend, SKILLS_PATH, known_skills={}
+        )
+
+        assert len(results) == 1
+        assert results[0]["name"] == "orphan-skill"
+        assert results[0]["description"] == "Discovered via SKILL.md"
+        assert results[0]["confirmed"] is True
+
+        # Two download rounds: lock file + SKILL.md
+        assert backend.adownload_files.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_self_healing_creates_lock_entry(self):
+        """Orphaned dir -> parses SKILL.md, writes lock entry back via aupload_files."""
+        skill_md_content = (
+            "---\n"
+            "name: orphan-skill\n"
+            "description: Needs self-healing\n"
+            "---\n"
+            "# Orphan\n"
+        )
+
+        backend = AsyncMock()
+        backend.als_info = AsyncMock(
+            return_value=[
+                {"path": f"{SKILLS_PATH}/orphan-skill", "is_dir": True},
+            ]
+        )
+        backend.adownload_files = AsyncMock(
+            side_effect=[
+                [_make_download_response(error=True)],  # no lock file
+                [
+                    _make_download_response(
+                        skill_md_content.encode("utf-8")
+                    )
+                ],  # SKILL.md
+            ]
+        )
+        backend.aupload_files = AsyncMock()
+
+        await adiscover_skills(backend, SKILLS_PATH, known_skills={})
+
+        # Self-healing should write back lock entries
+        backend.aupload_files.assert_called_once()
+        upload_args = backend.aupload_files.call_args[0][0]
+        # Should be a list of (path, bytes) tuples
+        assert len(upload_args) == 1
+        lock_path, lock_bytes = upload_args[0]
+        assert "skills-lock.json" in lock_path
+
+        # Verify the written lock content has our orphaned skill
+        import json
+
+        lock_data = json.loads(lock_bytes.decode("utf-8"))
+        assert "orphan-skill" in lock_data["skills"]
+        assert lock_data["skills"]["orphan-skill"]["owner"] == "user"
+        assert lock_data["version"] == 1

--- a/tests/unit/middleware/skills/test_lock.py
+++ b/tests/unit/middleware/skills/test_lock.py
@@ -1,0 +1,384 @@
+"""Tests for ptc_agent.agent.middleware.skills.lock module."""
+
+import json
+
+import pytest
+
+from ptc_agent.agent.middleware.skills.discovery import SkillMetadata
+from ptc_agent.agent.middleware.skills.lock import (
+    LOCK_FILE_VERSION,
+    build_lock_entry,
+    lock_entry_to_skill_metadata,
+    merge_lock_files,
+    parse_skills_lock,
+    serialize_skills_lock,
+)
+
+
+def _make_skill_metadata(name: str = "test-skill", **overrides) -> SkillMetadata:
+    base = SkillMetadata(
+        path=f"/home/workspace/.agents/skills/{name}/SKILL.md",
+        name=name,
+        description=f"Test skill {name}",
+        license="MIT",
+        compatibility=None,
+        metadata={"author": "test", "version": "1.0.0"},
+        allowed_tools=["Read"],
+        confirmed=True,
+    )
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# build_lock_entry
+# ---------------------------------------------------------------------------
+
+
+class TestBuildLockEntry:
+    def test_build_lock_entry_platform(self):
+        meta = _make_skill_metadata("analytics")
+        entry = build_lock_entry(
+            meta,
+            owner="platform",
+            source="platform",
+            source_type="platform",
+            content_hash="sha256:abc123",
+        )
+
+        assert entry["name"] == "analytics"
+        assert entry["description"] == "Test skill analytics"
+        assert entry["owner"] == "platform"
+        assert entry["source"] == "platform"
+        assert entry["sourceType"] == "platform"
+        assert entry["computedHash"] == "sha256:abc123"
+        assert entry["confirmed"] is True
+        assert entry["license"] == "MIT"
+        assert entry["metadata"] == {"author": "test", "version": "1.0.0"}
+        assert entry["allowed_tools"] == ["Read"]
+        # Timestamps are ISO 8601 UTC strings
+        assert entry["installedAt"].endswith("Z")
+        assert entry["updatedAt"].endswith("Z")
+        assert entry["installedAt"] == entry["updatedAt"]
+
+    def test_build_lock_entry_user(self):
+        meta = _make_skill_metadata("my-custom-skill")
+        entry = build_lock_entry(
+            meta,
+            owner="user",
+            source="https://github.com/user/skill-repo",
+            source_type="github",
+            content_hash="sha256:def456",
+        )
+
+        assert entry["owner"] == "user"
+        assert entry["source"] == "https://github.com/user/skill-repo"
+        assert entry["sourceType"] == "github"
+        assert entry["computedHash"] == "sha256:def456"
+        assert entry["name"] == "my-custom-skill"
+
+    def test_build_lock_entry_defaults(self):
+        """Default kwargs produce a platform entry with empty hash."""
+        meta = _make_skill_metadata("default-skill")
+        entry = build_lock_entry(meta)
+
+        assert entry["owner"] == "platform"
+        assert entry["source"] == "platform"
+        assert entry["sourceType"] == "platform"
+        assert entry["computedHash"] == ""
+
+    def test_build_lock_entry_missing_optional_fields(self):
+        """Metadata with no license or metadata dict still works."""
+        meta = _make_skill_metadata(
+            "bare-skill", license=None, metadata={}, allowed_tools=[]
+        )
+        entry = build_lock_entry(meta, owner="platform", content_hash="sha256:000")
+
+        assert entry["license"] is None
+        assert entry["metadata"] == {}
+        assert entry["allowed_tools"] == []
+
+
+# ---------------------------------------------------------------------------
+# parse_skills_lock
+# ---------------------------------------------------------------------------
+
+
+class TestParseSkillsLock:
+    def test_parse_skills_lock_valid(self):
+        skill_entry = {
+            "name": "research",
+            "description": "Research skill",
+            "owner": "platform",
+            "source": "platform",
+            "sourceType": "platform",
+            "computedHash": "sha256:aaa",
+            "confirmed": True,
+            "license": "MIT",
+            "metadata": {},
+            "allowed_tools": ["Read", "Bash"],
+            "installedAt": "2026-01-01T00:00:00Z",
+            "updatedAt": "2026-01-01T00:00:00Z",
+        }
+        lock_json = json.dumps(
+            {"version": LOCK_FILE_VERSION, "skills": {"research": skill_entry}}
+        )
+
+        result = parse_skills_lock(lock_json)
+
+        assert "research" in result
+        assert result["research"]["name"] == "research"
+        assert result["research"]["owner"] == "platform"
+        assert result["research"]["allowed_tools"] == ["Read", "Bash"]
+
+    def test_parse_skills_lock_corrupt_json(self):
+        result = parse_skills_lock("{this is not valid json!!!")
+        assert result == {}
+
+    def test_parse_skills_lock_wrong_version(self):
+        lock_json = json.dumps({"version": 99, "skills": {}})
+        result = parse_skills_lock(lock_json)
+        assert result == {}
+
+    def test_parse_skills_lock_empty_string(self):
+        assert parse_skills_lock("") == {}
+
+    def test_parse_skills_lock_whitespace_only(self):
+        assert parse_skills_lock("   \n  ") == {}
+
+    def test_parse_skills_lock_not_a_dict(self):
+        result = parse_skills_lock(json.dumps([1, 2, 3]))
+        assert result == {}
+
+    def test_parse_skills_lock_skills_not_a_dict(self):
+        lock_json = json.dumps({"version": LOCK_FILE_VERSION, "skills": "bad"})
+        result = parse_skills_lock(lock_json)
+        assert result == {}
+
+    def test_parse_skills_lock_missing_skills_key(self):
+        lock_json = json.dumps({"version": LOCK_FILE_VERSION})
+        result = parse_skills_lock(lock_json)
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# lock_entry_to_skill_metadata
+# ---------------------------------------------------------------------------
+
+
+class TestLockEntryToSkillMetadata:
+    def test_lock_entry_to_skill_metadata(self):
+        """Round-trip: SkillMetadata -> lock entry -> SkillMetadata."""
+        original_meta = _make_skill_metadata("round-trip")
+        entry = build_lock_entry(
+            original_meta,
+            owner="platform",
+            source="platform",
+            source_type="platform",
+            content_hash="sha256:rtrip",
+        )
+
+        skill_path = "/sandbox/.agents/skills/round-trip/SKILL.md"
+        restored = lock_entry_to_skill_metadata(entry, skill_path)
+
+        assert restored["path"] == skill_path
+        assert restored["name"] == "round-trip"
+        assert restored["description"] == original_meta["description"]
+        assert restored["license"] == original_meta["license"]
+        assert restored["compatibility"] is None  # Not stored in lock
+        assert restored["metadata"] == original_meta["metadata"]
+        assert restored["allowed_tools"] == original_meta["allowed_tools"]
+        assert restored["confirmed"] is True
+
+    def test_lock_entry_to_skill_metadata_unconfirmed(self):
+        meta = _make_skill_metadata("unconf", confirmed=False)
+        entry = build_lock_entry(meta, owner="user", content_hash="sha256:x")
+
+        restored = lock_entry_to_skill_metadata(entry, "/some/path")
+        assert restored["confirmed"] is False
+
+    def test_lock_entry_to_skill_metadata_copies_collections(self):
+        """Returned metadata/allowed_tools are new list/dict instances."""
+        meta = _make_skill_metadata("copy-test")
+        entry = build_lock_entry(meta, content_hash="sha256:copy")
+
+        restored = lock_entry_to_skill_metadata(entry, "/path")
+
+        assert restored["metadata"] == entry["metadata"]
+        assert restored["metadata"] is not entry["metadata"]
+        assert restored["allowed_tools"] == entry["allowed_tools"]
+        assert restored["allowed_tools"] is not entry["allowed_tools"]
+
+
+# ---------------------------------------------------------------------------
+# merge_lock_files
+# ---------------------------------------------------------------------------
+
+
+def _make_lock_entry(
+    name: str, owner: str = "platform", **overrides
+) -> dict:
+    """Convenience builder for test lock entries."""
+    base = {
+        "name": name,
+        "description": f"Skill {name}",
+        "owner": owner,
+        "source": owner,
+        "sourceType": owner,
+        "computedHash": f"sha256:{name}",
+        "confirmed": True,
+        "license": None,
+        "metadata": {},
+        "allowed_tools": [],
+        "installedAt": "2026-01-01T00:00:00Z",
+        "updatedAt": "2026-01-01T00:00:00Z",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestMergeLockFiles:
+    def test_merge_preserves_user_entries(self):
+        user_entry = _make_lock_entry("my-custom", owner="user")
+        platform_entry = _make_lock_entry("analytics", owner="platform")
+
+        existing = {"my-custom": user_entry, "analytics": platform_entry}
+        new_platform = {"analytics": _make_lock_entry("analytics", owner="platform")}
+
+        result = merge_lock_files(new_platform, existing)
+
+        assert result["version"] == LOCK_FILE_VERSION
+        assert "my-custom" in result["skills"]
+        assert result["skills"]["my-custom"]["owner"] == "user"
+
+    def test_merge_overwrites_platform_entries(self):
+        old_platform = _make_lock_entry(
+            "analytics", owner="platform", description="Old description"
+        )
+        new_platform = _make_lock_entry(
+            "analytics", owner="platform", description="New description"
+        )
+
+        existing = {"analytics": old_platform}
+        result = merge_lock_files({"analytics": new_platform}, existing)
+
+        assert result["skills"]["analytics"]["description"] == "New description"
+
+    def test_merge_adds_new_platform_alongside_user(self):
+        user_entry = _make_lock_entry("my-skill", owner="user")
+        new_platform_entry = _make_lock_entry("brand-new", owner="platform")
+
+        existing = {"my-skill": user_entry}
+        result = merge_lock_files({"brand-new": new_platform_entry}, existing)
+
+        assert "my-skill" in result["skills"]
+        assert result["skills"]["my-skill"]["owner"] == "user"
+        assert "brand-new" in result["skills"]
+        assert result["skills"]["brand-new"]["owner"] == "platform"
+
+    def test_merge_empty_existing_lock(self):
+        platform_a = _make_lock_entry("skill-a", owner="platform")
+        platform_b = _make_lock_entry("skill-b", owner="platform")
+
+        result = merge_lock_files(
+            {"skill-a": platform_a, "skill-b": platform_b}, None
+        )
+
+        assert result["version"] == LOCK_FILE_VERSION
+        assert len(result["skills"]) == 2
+        assert "skill-a" in result["skills"]
+        assert "skill-b" in result["skills"]
+
+    def test_merge_purges_removed_platform_skills(self):
+        user_entry = _make_lock_entry("user-plugin", owner="user")
+        old_platform = _make_lock_entry("deprecated-skill", owner="platform")
+        kept_platform = _make_lock_entry("kept-skill", owner="platform")
+
+        existing = {
+            "user-plugin": user_entry,
+            "deprecated-skill": old_platform,
+            "kept-skill": kept_platform,
+        }
+        # Platform no longer ships "deprecated-skill"
+        current_platform = {"kept-skill": _make_lock_entry("kept-skill", owner="platform")}
+        result = merge_lock_files(current_platform, existing)
+
+        assert "user-plugin" in result["skills"], "User entry must survive"
+        assert "kept-skill" in result["skills"], "Active platform entry must survive"
+        assert "deprecated-skill" not in result["skills"], (
+            "Removed platform entry must be purged"
+        )
+
+    def test_merge_empty_platform_entries_preserves_user(self):
+        """If platform ships zero skills, user entries still survive."""
+        user_entry = _make_lock_entry("user-only", owner="user")
+        existing = {"user-only": user_entry}
+
+        result = merge_lock_files({}, existing)
+
+        assert len(result["skills"]) == 1
+        assert result["skills"]["user-only"]["owner"] == "user"
+
+    def test_merge_both_empty(self):
+        result = merge_lock_files({}, None)
+        assert result == {"version": LOCK_FILE_VERSION, "skills": {}}
+
+
+# ---------------------------------------------------------------------------
+# serialize_skills_lock
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeSkillsLock:
+    def test_serialize_sorted_keys(self):
+        lock = {
+            "version": LOCK_FILE_VERSION,
+            "skills": {
+                "zebra-skill": _make_lock_entry("zebra-skill"),
+                "alpha-skill": _make_lock_entry("alpha-skill"),
+            },
+        }
+        output = serialize_skills_lock(lock)
+
+        # Must be valid JSON
+        parsed = json.loads(output)
+        assert parsed["version"] == LOCK_FILE_VERSION
+        assert len(parsed["skills"]) == 2
+
+        # Keys must be sorted in the output string
+        zebra_pos = output.index('"zebra-skill"')
+        alpha_pos = output.index('"alpha-skill"')
+        assert alpha_pos < zebra_pos, "Keys must be sorted alphabetically"
+
+        # Must end with trailing newline
+        assert output.endswith("\n")
+
+        # Must use 2-space indent
+        assert "\n  " in output
+        assert "\t" not in output
+
+    def test_serialize_deterministic(self):
+        """Same input always produces identical output."""
+        lock = {
+            "version": LOCK_FILE_VERSION,
+            "skills": {
+                "b-skill": _make_lock_entry("b-skill"),
+                "a-skill": _make_lock_entry("a-skill"),
+            },
+        }
+        first = serialize_skills_lock(lock)
+        second = serialize_skills_lock(lock)
+        assert first == second
+
+    def test_serialize_roundtrip(self):
+        """Serialized output can be parsed back."""
+        meta = _make_skill_metadata("roundtrip-ser")
+        entry = build_lock_entry(meta, content_hash="sha256:rt")
+        lock = merge_lock_files({"roundtrip-ser": entry}, None)
+
+        serialized = serialize_skills_lock(lock)
+        parsed_skills = parse_skills_lock(serialized)
+
+        assert "roundtrip-ser" in parsed_skills
+        assert parsed_skills["roundtrip-ser"]["name"] == "roundtrip-ser"
+        assert parsed_skills["roundtrip-ser"]["computedHash"] == "sha256:rt"

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -361,7 +361,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
   const [detailPlanData, setDetailPlanData] = useState<PlanData | null>(null);
   // Track hidden agents (removed from sidebar, but not from state)
   const [hiddenAgentIds, setHiddenAgentIds] = useState<Set<string>>(new Set());
-  // Show system files in FilePanel (.agent/, code/, tools/, etc.)
+  // Show system files in FilePanel (.agents/, code/, tools/, etc.)
   const [showSystemFiles, setShowSystemFiles] = useState(
     () => localStorage.getItem('filePanel.showSystemFiles') === 'true'
   );

--- a/web/src/pages/ChatAgent/components/FilePanel.tsx
+++ b/web/src/pages/ChatAgent/components/FilePanel.tsx
@@ -212,7 +212,7 @@ const DIR_PRIORITY: Record<string, number> = { '/': 0, 'results': 1, 'data': 2 }
 /** System directory prefixes -- collapsed by default when visible.
  *  Source of truth: src/ptc_agent/core/paths.py -> AGENT_SYSTEM_DIRS */
 // eslint-disable-next-line react-refresh/only-export-components
-export const SYSTEM_DIR_PREFIXES = ['code', 'tools', 'mcp_servers', 'skills', '.agent', '.self-improve'];
+export const SYSTEM_DIR_PREFIXES = ['.system', 'code', 'tools', 'mcp_servers', '.agents', '.self-improve'];
 
 function dirSortKey(dir: string): number {
   if (DIR_PRIORITY[dir] != null) return DIR_PRIORITY[dir];
@@ -1581,7 +1581,7 @@ function FilePanel({
             <button
               className={`file-panel-chip ${showSystemFiles ? 'active' : ''}`}
               onClick={onToggleSystemFiles}
-              title="Show system directories (.agent/, code/, tools/, etc.)"
+              title="Show system directories (.agents/, .system/, tools/, etc.)"
             >
               System
             </button>

--- a/web/src/pages/ChatAgent/components/ThreadGallery.tsx
+++ b/web/src/pages/ChatAgent/components/ThreadGallery.tsx
@@ -113,7 +113,7 @@ function ThreadGallery({ workspaceId, onBack, onThreadSelect }: ThreadGalleryPro
   const [showSandboxPanel, setShowSandboxPanel] = useState(false);
   const [filePanelWidth, setFilePanelWidth] = useState(850);
   const [filePanelTargetFile, setFilePanelTargetFile] = useState<string | null>(null);
-  // Show system files in FilePanel (.agent/, code/, tools/, etc.)
+  // Show system files in FilePanel (.agents/, code/, tools/, etc.)
   const [showSystemFiles, setShowSystemFiles] = useState(
     () => localStorage.getItem('filePanel.showSystemFiles') === 'true'
   );
@@ -644,7 +644,7 @@ function ThreadGallery({ workspaceId, onBack, onThreadSelect }: ThreadGalleryPro
                     {showFilePanel ? t('common.close') : t('thread.viewAll')}
                   </div>
                 </div>
-                {/* Show first two user file names -- system dirs (.agent/, code/, etc.) are excluded */}
+                {/* Show first two user file names -- system dirs (.agents/, code/, etc.) are excluded */}
                 {files.length > 0 && (
                   <div className="flex flex-col gap-0.5">
                     {files.filter((fp) => {


### PR DESCRIPTION
## Summary
- Consolidate `.agent/` + `skills/` into `.agents/` with versioned layout migration system
- Add `skills-lock.json` ownership registry at `.agents/skills/` tracking platform vs user-installed skills
- Post-completion `sync_skills_lock` — bidirectional filesystem↔lock reconciliation in a single sandbox exec (1 API call)
- Prune protection: user-installed skills survive platform sync cycles
- Discovery optimization: lock file as fast lookup for cache misses, self-healing fallback for orphaned dirs
- Simplified custom skills prompt: agent places files, system auto-registers via post-completion sync

## Architecture

```
LOCAL HOST                              SANDBOX                          SYSTEM PROMPT
~/.ptc-agent/skills/ ──upload──►  .agents/skills/
./skills/            ──upload──►  (same target, later overwrites)
                                        │
                                   SkillsMiddleware.abefore_agent()
                                   scans sandbox via als_info()  ──►  _build_combined_manifest()
                                   known_skills cache avoids            injects into system message
                                   re-downloading SKILL.md
```

**Lock file lifecycle:**
1. Platform sync (`_upload_skills`): merge platform entries, preserve user entries
2. Post-completion (`sync_skills_lock`): add entries for new dirs, remove entries for deleted dirs
3. Discovery (fallback): self-healing creates lock entries for orphaned skill dirs

## Test Coverage
- 1676 unit tests pass (12 new lock, 4 discovery, 6 migration, 4 prune, 1 config)
- 11 new integration tests (layout, lock lifecycle, prune protection, sync)
- Frontend lint: 0 errors

## Pre-Landing Review
No issues found.

## Plan Completion
17/18 DONE, 1 CHANGED (custom skills prompt simplified — no manual lock updates needed, system auto-registers via post-completion sync)

## Test plan
- [x] All unit tests pass (1676 passed, 1 warning)
- [x] Frontend lint passes (0 errors, 37 pre-existing warnings)
- [x] Ruff lint passes