### PR TITLE
fix(sandbox): auto-recover workspace when sandbox is externally deleted

### DIFF
--- a/src/ptc_agent/core/sandbox/__init__.py
+++ b/src/ptc_agent/core/sandbox/__init__.py
@@ -10,7 +10,7 @@ from ptc_agent.core.sandbox.ptc_sandbox import (
     _sha256_file,
 )
 from ptc_agent.core.sandbox.retry import RetryPolicy
-from ptc_agent.core.sandbox.runtime import SandboxTransientError
+from ptc_agent.core.sandbox.runtime import SandboxGoneError, SandboxTransientError
 
 # Backward-compat alias: _DaytonaRetryPolicy was renamed to RetryPolicy
 _DaytonaRetryPolicy = RetryPolicy
@@ -20,6 +20,7 @@ __all__ = [
     "ChartData",
     "ExecutionResult",
     "SyncResult",
+    "SandboxGoneError",
     "SandboxTransientError",
     "_DaytonaRetryPolicy",
     "_hash_dict",

--- a/src/ptc_agent/core/sandbox/ptc_sandbox.py
+++ b/src/ptc_agent/core/sandbox/ptc_sandbox.py
@@ -23,6 +23,7 @@ from ptc_agent.core.sandbox.retry import RetryPolicy, async_retry_with_backoff
 from ptc_agent.core.sandbox.runtime import (
     PreviewInfo,
     RuntimeState,
+    SandboxGoneError,
     SandboxRuntime,
     SandboxTransientError,
     SessionCommandResult,
@@ -205,7 +206,7 @@ class PTCSandbox:
             raise RuntimeError("Sandbox initialization timed out after 300s")
 
         if self._init_error:
-            raise RuntimeError(f"Sandbox initialization failed: {self._init_error}")
+            raise self._init_error
 
     def is_ready(self) -> bool:
         """Check if sandbox is ready without blocking.
@@ -219,6 +220,17 @@ class PTCSandbox:
 
         # Using lazy init - check if event is set and no error
         return self._ready_event.is_set() and self._init_error is None
+
+    def has_failed(self) -> bool:
+        """Check if lazy initialization completed with an error."""
+        if self._ready_event is None:
+            return False
+        return self._ready_event.is_set() and self._init_error is not None
+
+    @property
+    def init_error(self) -> Exception | None:
+        """The error from lazy initialization, if any."""
+        return self._init_error
 
     @property
     def skills_manifest(self) -> dict[str, Any] | None:
@@ -543,7 +555,7 @@ class PTCSandbox:
             sandbox_id: The ID of an existing sandbox
 
         Raises:
-            RuntimeError: If sandbox cannot be found or is in invalid state
+            SandboxGoneError: If sandbox cannot be found or is in an unrecoverable state
         """
         logger.info("Reconnecting to stopped sandbox", sandbox_id=sandbox_id)
 
@@ -561,10 +573,7 @@ class PTCSandbox:
                 allow_reconnect=False,
             )
         except Exception as e:
-            raise RuntimeError(
-                f"Failed to find sandbox {sandbox_id}. It may have been deleted. "
-                f"Original error: {e}"
-            ) from e
+            raise SandboxGoneError(sandbox_id, f"not found: {e}") from e
 
         assert self.runtime is not None
         self.sandbox_id = sandbox_id
@@ -605,9 +614,9 @@ class PTCSandbox:
                 if state_value == "running":
                     break
             if state_value != "running":
-                raise RuntimeError(
-                    f"Sandbox still in state '{state_value}' after waiting. "
-                    f"Expected 'running'."
+                raise SandboxGoneError(
+                    sandbox_id,
+                    f"stuck in state '{state_value}', expected 'running'",
                 )
         elif state_value == "stopping":
             # Wait for sandbox to finish stopping, then start it.
@@ -638,9 +647,9 @@ class PTCSandbox:
                     retry_policy=RetryPolicy.SAFE,
                 )
             else:
-                raise RuntimeError(
-                    f"Sandbox still in state '{state_value}' after waiting. "
-                    f"Expected 'stopped'."
+                raise SandboxGoneError(
+                    sandbox_id,
+                    f"stuck in state '{state_value}', expected 'stopped'",
                 )
         elif state_value == "archived":
             logger.info(
@@ -664,9 +673,9 @@ class PTCSandbox:
                 retry_policy=RetryPolicy.SAFE,
             )
         else:
-            raise RuntimeError(
-                f"Cannot reconnect to sandbox in state: {state_value}. "
-                f"Expected 'stopped', 'running', or 'error'."
+            raise SandboxGoneError(
+                sandbox_id,
+                f"unrecoverable state: {state_value}",
             )
 
         # Get work directory reference

--- a/src/ptc_agent/core/sandbox/runtime.py
+++ b/src/ptc_agent/core/sandbox/runtime.py
@@ -14,6 +14,20 @@ class SandboxTransientError(RuntimeError):
     """
 
 
+class SandboxGoneError(RuntimeError):
+    """The sandbox no longer exists (deleted, expired, or in an unrecoverable state).
+
+    Callers should create a fresh sandbox and restore files from backup.
+    """
+
+    def __init__(self, sandbox_id: str, message: str = ""):
+        self.sandbox_id = sandbox_id
+        full_msg = f"Sandbox {sandbox_id} is gone"
+        if message:
+            full_msg += f": {message}"
+        super().__init__(full_msg)
+
+
 class RuntimeState(str, Enum):
     """Possible states of a sandbox runtime."""
 

--- a/src/server/services/workspace_manager.py
+++ b/src/server/services/workspace_manager.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, Optional
 import httpx
 
 from ptc_agent.config import AgentConfig
+from ptc_agent.core.sandbox.runtime import SandboxGoneError
 from ptc_agent.core.session import Session, SessionManager
 
 from src.server.database.workspace import (
@@ -749,11 +750,31 @@ class WorkspaceManager:
                     # Session exists but not usable, fall through to status-based handling
                     session = None
                 elif not session.sandbox.is_ready():
-                    # Sandbox still initializing (lazy init in progress)
-                    logger.info(
-                        f"Sandbox still initializing for {workspace_id}, skipping sync"
-                    )
-                    return session
+                    if session.sandbox.has_failed():
+                        # Lazy init completed with error — clear broken session
+                        init_err = session.sandbox.init_error
+                        logger.warning(
+                            f"Lazy init failed for workspace {workspace_id}: "
+                            f"{init_err}. Clearing session for recovery."
+                        )
+                        SessionManager.remove_session(workspace_id)
+                        del self._sessions[workspace_id]
+                        self._pending_lazy_sync.discard(workspace_id)
+
+                        if isinstance(init_err, SandboxGoneError):
+                            core_config = self.config.to_core_config()
+                            return await self._recover_sandbox(
+                                workspace_id, workspace_user_id, core_config
+                            )
+                        # Non-sandbox-gone error: fall through to status-based handling
+                        session = None
+                    else:
+                        # Sandbox still initializing (lazy init in progress)
+                        logger.info(
+                            f"Sandbox still initializing for {workspace_id}, "
+                            f"skipping sync"
+                        )
+                        return session
                 else:
                     # Sandbox ready — check if sync is needed
                     needs_deferred_sync = workspace_id in self._pending_lazy_sync
@@ -768,9 +789,13 @@ class WorkspaceManager:
             if session is None:
                 if status == "stopped":
                     logger.info(f"Restarting stopped workspace {workspace_id}")
-                    return await self._restart_workspace(
+                    session = await self._restart_workspace(
                         workspace, user_id=workspace_user_id, lazy_init=True
                     )
+                    # Don't return immediately for lazy init — fall through
+                    # to Phase 2 which waits for init and handles SandboxGoneError.
+                    needs_sync = True
+                    needs_deferred_sync = True
 
                 elif status == "running":
                     core_config = self.config.to_core_config()
@@ -780,22 +805,15 @@ class WorkspaceManager:
                         sandbox_id = workspace.get("sandbox_id")
                         try:
                             await session.initialize(sandbox_id=sandbox_id)
-                        except RuntimeError as e:
+                        except SandboxGoneError as e:
                             SessionManager.remove_session(workspace_id)
-                            err_msg = str(e)
-                            if (
-                                "Failed to find sandbox" in err_msg
-                                or "deleted" in err_msg
-                                or "still in state" in err_msg
-                            ):
-                                logger.warning(
-                                    f"Sandbox {sandbox_id} unavailable for workspace "
-                                    f"{workspace_id} ({err_msg}). Creating fresh sandbox."
-                                )
-                                return await self._recover_sandbox(
-                                    workspace_id, workspace_user_id, core_config
-                                )
-                            raise
+                            logger.warning(
+                                f"Sandbox {sandbox_id} unavailable for workspace "
+                                f"{workspace_id} ({e}). Creating fresh sandbox."
+                            )
+                            return await self._recover_sandbox(
+                                workspace_id, workspace_user_id, core_config
+                            )
 
                         await self._sync_sandbox_assets(
                             workspace_id,
@@ -833,91 +851,109 @@ class WorkspaceManager:
                             logger.info(
                                 f"Workspace {workspace_id} finished stopping, restarting"
                             )
-                            return await self._restart_workspace(
+                            session = await self._restart_workspace(
                                 workspace,
                                 user_id=workspace_user_id,
                                 lazy_init=True,
                             )
-
-                    # Still "stopping" after 10s — check actual sandbox state
-                    # from the provider. If the sandbox is actually running or
-                    # stopped, the DB status is stale (e.g. process crashed
-                    # mid-stop). Recover by correcting the DB.
-                    sandbox_id = workspace.get("sandbox_id")
-                    if sandbox_id:
-                        try:
-                            from ptc_agent.core.sandbox.providers import create_provider
-
-                            provider = create_provider(self.config.to_core_config())
+                            needs_sync = True
+                            needs_deferred_sync = True
+                            break
+                    else:
+                        # Still "stopping" after 10s — check actual sandbox state
+                        # from the provider. If the sandbox is actually running or
+                        # stopped, the DB status is stale (e.g. process crashed
+                        # mid-stop). Recover by correcting the DB.
+                        sandbox_id = workspace.get("sandbox_id")
+                        if sandbox_id:
                             try:
-                                runtime = await provider.get(sandbox_id)
-                                actual_state = await runtime.get_state()
-                            finally:
-                                await provider.close()
+                                from ptc_agent.core.sandbox.providers import create_provider
 
-                            logger.warning(
-                                "Workspace %s stuck in 'stopping' but sandbox "
-                                "is actually '%s', recovering",
-                                workspace_id,
-                                actual_state.value,
-                            )
-                            # Correct the DB status based on actual sandbox state
-                            # Only treat definitively stopped/archived as "stopped";
-                            # transient states (starting, stopping, archiving) should
-                            # not trigger a restart — let them finish naturally.
-                            stopped_states = {"stopped", "archived"}
-                            if actual_state.value in stopped_states:
-                                corrected = "stopped"
-                            elif actual_state.value == "running":
-                                corrected = "running"
-                            else:
-                                logger.info(
-                                    "Workspace %s sandbox in transient state '%s', "
-                                    "not correcting — will retry on next request",
+                                provider = create_provider(self.config.to_core_config())
+                                try:
+                                    runtime = await provider.get(sandbox_id)
+                                    actual_state = await runtime.get_state()
+                                finally:
+                                    await provider.close()
+
+                                logger.warning(
+                                    "Workspace %s stuck in 'stopping' but sandbox "
+                                    "is actually '%s', recovering",
                                     workspace_id,
                                     actual_state.value,
                                 )
-                                raise RuntimeError(
-                                    f"Workspace {workspace_id} sandbox is in transient "
-                                    f"state '{actual_state.value}'. Please wait and try again."
+                                # Correct the DB status based on actual sandbox state
+                                # Only treat definitively stopped/archived as "stopped";
+                                # transient states (starting, stopping, archiving) should
+                                # not trigger a restart — let them finish naturally.
+                                stopped_states = {"stopped", "archived"}
+                                if actual_state.value in stopped_states:
+                                    corrected = "stopped"
+                                elif actual_state.value == "running":
+                                    corrected = "running"
+                                else:
+                                    logger.info(
+                                        "Workspace %s sandbox in transient state '%s', "
+                                        "not correcting — will retry on next request",
+                                        workspace_id,
+                                        actual_state.value,
+                                    )
+                                    raise RuntimeError(
+                                        f"Workspace {workspace_id} sandbox is in transient "
+                                        f"state '{actual_state.value}'. Please wait and try again."
+                                    )
+                                workspace = await update_workspace_status(
+                                    workspace_id=workspace_id,
+                                    status=corrected,
                                 )
-                            workspace = await update_workspace_status(
-                                workspace_id=workspace_id,
-                                status=corrected,
-                            )
-                            if corrected == "stopped":
-                                return await self._restart_workspace(
-                                    workspace,
-                                    user_id=workspace_user_id,
-                                    lazy_init=True,
-                                )
-                            # Sandbox is running — create session inline
-                            # (cannot recurse into get_session_for_workspace
-                            # because the per-workspace asyncio.Lock is held
-                            # and is not reentrant)
-                            core_config = self.config.to_core_config()
-                            session = SessionManager.get_session(workspace_id, core_config)
-                            if not session._initialized:
-                                await session.initialize(sandbox_id=sandbox_id)
-                                await self._sync_sandbox_assets(
+                                if corrected == "stopped":
+                                    session = await self._restart_workspace(
+                                        workspace,
+                                        user_id=workspace_user_id,
+                                        lazy_init=True,
+                                    )
+                                    needs_sync = True
+                                    needs_deferred_sync = True
+                                else:
+                                    # Sandbox is running — create session inline
+                                    # (cannot recurse into get_session_for_workspace
+                                    # because the per-workspace asyncio.Lock is held
+                                    # and is not reentrant)
+                                    core_config = self.config.to_core_config()
+                                    session = SessionManager.get_session(workspace_id, core_config)
+                                    if not session._initialized:
+                                        await session.initialize(sandbox_id=sandbox_id)
+                                        await self._sync_sandbox_assets(
+                                            workspace_id,
+                                            workspace_user_id,
+                                            session.sandbox,
+                                            reusing_sandbox=True,
+                                        )
+                                    self._sessions[workspace_id] = session
+                            except SandboxGoneError as e:
+                                logger.warning(
+                                    "Sandbox gone for workspace %s during "
+                                    "stopping-state recovery (%s). Recovering.",
                                     workspace_id,
-                                    workspace_user_id,
-                                    session.sandbox,
-                                    reusing_sandbox=True,
+                                    e,
                                 )
-                            self._sessions[workspace_id] = session
-                            return session
-                        except Exception as e:
-                            logger.error(
-                                "Failed to check actual sandbox state for %s: %s",
-                                workspace_id,
-                                e,
-                            )
+                                core_config = self.config.to_core_config()
+                                SessionManager.remove_session(workspace_id)
+                                return await self._recover_sandbox(
+                                    workspace_id, workspace_user_id, core_config
+                                )
+                            except Exception as e:
+                                logger.error(
+                                    "Failed to check actual sandbox state for %s: %s",
+                                    workspace_id,
+                                    e,
+                                )
 
-                    raise RuntimeError(
-                        f"Workspace {workspace_id} is still stopping after timeout. "
-                        "Please wait and try again."
-                    )
+                        if session is None:
+                            raise RuntimeError(
+                                f"Workspace {workspace_id} is still stopping after timeout. "
+                                "Please wait and try again."
+                            )
 
                 elif status == "flash":
                     raise ValueError(
@@ -954,6 +990,25 @@ class WorkspaceManager:
                     workspace_id, workspace_user_id, session.sandbox
                 )
                 self._record_sync(workspace_id)
+            except SandboxGoneError as e:
+                logger.warning(
+                    f"Sandbox gone for workspace {workspace_id} during "
+                    f"Phase 2: {e}. Recovering."
+                )
+                SessionManager.remove_session(workspace_id)
+                self._sessions.pop(workspace_id, None)
+                self._pending_lazy_sync.discard(workspace_id)
+
+                async with self._acquire_workspace_lock(workspace_id):
+                    # Guard: another request may have recovered while we
+                    # waited for the lock
+                    existing = self._sessions.get(workspace_id)
+                    if existing and existing.sandbox and existing.sandbox.is_ready():
+                        return existing
+                    core_config = self.config.to_core_config()
+                    return await self._recover_sandbox(
+                        workspace_id, workspace_user_id, core_config
+                    )
             except Exception as e:
                 logger.warning(
                     f"Phase 2 sync failed for workspace {workspace_id} "
@@ -1023,22 +1078,13 @@ class WorkspaceManager:
                 else:
                     await session.initialize(sandbox_id=sandbox_id)
                     logger.info(f"Session initialized for workspace {workspace_id}")
-            except RuntimeError as e:
-                err_msg = str(e)
-                if (
-                    "Failed to find sandbox" in err_msg
-                    or "deleted" in err_msg
-                    or "still in state" in err_msg
-                    or "Cannot reconnect" in err_msg
-                ):
-                    sandbox_gone = True
-                    SessionManager.remove_session(workspace_id)
-                    logger.warning(
-                        f"Sandbox {sandbox_id} unavailable for workspace "
-                        f"{workspace_id} ({err_msg}). Creating fresh sandbox."
-                    )
-                else:
-                    raise
+            except SandboxGoneError as e:
+                sandbox_gone = True
+                SessionManager.remove_session(workspace_id)
+                logger.warning(
+                    f"Sandbox {sandbox_id} unavailable for workspace "
+                    f"{workspace_id} ({e}). Creating fresh sandbox."
+                )
 
             # Sandbox was deleted — recover with fresh one
             if sandbox_gone:

--- a/tests/unit/server/services/test_workspace_manager.py
+++ b/tests/unit/server/services/test_workspace_manager.py
@@ -8,11 +8,13 @@ idle cleanup, singleton pattern, and background cleanup tasks.
 import asyncio
 import time
 import uuid
+from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from ptc_agent.core.sandbox.runtime import SandboxGoneError
 from src.server.services.workspace_manager import WorkspaceManager
 
 
@@ -513,3 +515,365 @@ class TestSeedAgentMd:
 
         # Should not raise
         await WorkspaceManager._seed_agent_md(sandbox, "Name")
+
+
+# ---------------------------------------------------------------------------
+# SandboxGoneError
+# ---------------------------------------------------------------------------
+
+class TestSandboxGoneError:
+    """Test SandboxGoneError exception class."""
+
+    def test_attributes_and_message(self):
+        err = SandboxGoneError("sandbox-123", "not found: 404")
+        assert err.sandbox_id == "sandbox-123"
+        assert "sandbox-123" in str(err)
+        assert "not found: 404" in str(err)
+
+    def test_is_runtime_error(self):
+        err = SandboxGoneError("sandbox-123")
+        assert isinstance(err, RuntimeError)
+
+    def test_empty_message(self):
+        err = SandboxGoneError("sandbox-123")
+        assert str(err) == "Sandbox sandbox-123 is gone"
+
+
+# ---------------------------------------------------------------------------
+# PTCSandbox.has_failed() state matrix
+# ---------------------------------------------------------------------------
+
+class TestHasFailed:
+    """Test PTCSandbox.has_failed() distinguishes 'init failed' from 'still initializing'."""
+
+    def test_no_lazy_init(self):
+        """Non-lazy sandbox: _ready_event is None → has_failed() returns False."""
+        sandbox = MagicMock()
+        sandbox._ready_event = None
+        sandbox._init_error = None
+        # Call the real has_failed logic
+        from ptc_agent.core.sandbox.ptc_sandbox import PTCSandbox
+        result = PTCSandbox.has_failed(sandbox)
+        assert result is False
+
+    def test_still_initializing(self):
+        """Lazy init in progress: event not set → has_failed() returns False."""
+        sandbox = MagicMock()
+        sandbox._ready_event = asyncio.Event()
+        sandbox._init_error = None
+        from ptc_agent.core.sandbox.ptc_sandbox import PTCSandbox
+        result = PTCSandbox.has_failed(sandbox)
+        assert result is False
+
+    def test_success(self):
+        """Lazy init succeeded: event set, no error → has_failed() returns False."""
+        sandbox = MagicMock()
+        sandbox._ready_event = asyncio.Event()
+        sandbox._ready_event.set()
+        sandbox._init_error = None
+        from ptc_agent.core.sandbox.ptc_sandbox import PTCSandbox
+        result = PTCSandbox.has_failed(sandbox)
+        assert result is False
+
+    def test_with_error(self):
+        """Lazy init failed: event set + error → has_failed() returns True."""
+        sandbox = MagicMock()
+        sandbox._ready_event = asyncio.Event()
+        sandbox._ready_event.set()
+        sandbox._init_error = SandboxGoneError("sb-1", "not found")
+        from ptc_agent.core.sandbox.ptc_sandbox import PTCSandbox
+        result = PTCSandbox.has_failed(sandbox)
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# Sandbox recovery — Gap 1 & Gap 2 fixes
+# ---------------------------------------------------------------------------
+
+class TestSandboxRecovery:
+    """Test sandbox recovery when lazy init fails with sandbox-gone error."""
+
+    def setup_method(self):
+        WorkspaceManager.reset_instance()
+
+    def teardown_method(self):
+        WorkspaceManager.reset_instance()
+
+    def _make_manager(self):
+        config = _make_config()
+        return WorkspaceManager.get_instance(config=config)
+
+    def _make_failed_session(self, error=None):
+        """Create a session whose sandbox has a failed lazy init."""
+        session = _make_mock_session()
+        session.sandbox.is_ready = MagicMock(return_value=False)
+        session.sandbox.has_failed = MagicMock(return_value=True)
+        session.sandbox.init_error = error or SandboxGoneError("sb-old", "not found")
+        return session
+
+    def _make_initializing_session(self):
+        """Create a session whose sandbox is still lazy-initializing."""
+        session = _make_mock_session()
+        session.sandbox.is_ready = MagicMock(return_value=False)
+        session.sandbox.has_failed = MagicMock(return_value=False)
+        return session
+
+    @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.db_get_workspace")
+    @patch("src.server.services.workspace_manager.SessionManager")
+    @patch("src.server.services.workspace_manager.update_workspace_status")
+    @patch("src.server.services.workspace_manager.update_workspace_activity")
+    async def test_cache_hit_failed_lazy_sandbox_gone_recovers(
+        self, mock_activity, mock_status, mock_session_mgr, mock_get_ws
+    ):
+        """Gap 1: cached session with SandboxGoneError → _recover_sandbox called."""
+        manager = self._make_manager()
+        ws_id = str(uuid.uuid4())
+        workspace = _make_workspace(workspace_id=ws_id, status="running")
+        mock_get_ws.return_value = workspace
+
+        # Place broken session in cache
+        broken_session = self._make_failed_session()
+        manager._sessions[ws_id] = broken_session
+
+        # Mock recovery: SessionManager.get_session returns a new working session
+        new_session = _make_mock_session()
+        new_session.sandbox.sandbox_id = "sb-new"
+        mock_session_mgr.get_session.return_value = new_session
+
+        result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
+
+        # Broken session should be removed
+        mock_session_mgr.remove_session.assert_called_with(ws_id)
+        # Recovery creates a new session
+        new_session.initialize.assert_called_once()
+        # Status updated
+        assert result is not None
+
+    @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.db_get_workspace")
+    @patch("src.server.services.workspace_manager.SessionManager")
+    @patch("src.server.services.workspace_manager.update_workspace_status")
+    @patch("src.server.services.workspace_manager.update_workspace_activity")
+    async def test_cache_hit_failed_lazy_other_error_clears(
+        self, mock_activity, mock_status, mock_session_mgr, mock_get_ws
+    ):
+        """Gap 1: cached session with non-SandboxGoneError → clears session, falls through."""
+        manager = self._make_manager()
+        ws_id = str(uuid.uuid4())
+        workspace = _make_workspace(workspace_id=ws_id, status="running")
+        mock_get_ws.return_value = workspace
+
+        # Broken session with a non-SandboxGoneError
+        broken_session = self._make_failed_session(
+            error=RuntimeError("network timeout")
+        )
+        manager._sessions[ws_id] = broken_session
+
+        # Fall-through: SessionManager.get_session returns a new session for reconnect
+        new_session = _make_mock_session()
+        mock_session_mgr.get_session.return_value = new_session
+
+        result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
+
+        # Broken session removed
+        mock_session_mgr.remove_session.assert_called_with(ws_id)
+        # Falls through to status-based handling (reconnect)
+        assert result is not None
+
+    @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.db_get_workspace")
+    async def test_cache_hit_still_initializing_returns(self, mock_get_ws):
+        """Sandbox still initializing → returns session immediately, no recovery."""
+        manager = self._make_manager()
+        ws_id = str(uuid.uuid4())
+        workspace = _make_workspace(workspace_id=ws_id, status="running")
+        mock_get_ws.return_value = workspace
+
+        session = self._make_initializing_session()
+        manager._sessions[ws_id] = session
+
+        result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
+
+        # Same session returned, no recovery triggered
+        assert result is session
+
+    @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.db_get_workspace")
+    @patch("src.server.services.workspace_manager.SessionManager")
+    @patch("src.server.services.workspace_manager.update_workspace_status")
+    @patch("src.server.services.workspace_manager.update_workspace_activity")
+    async def test_phase2_sandbox_gone_recovers(
+        self, mock_activity, mock_status, mock_session_mgr, mock_get_ws
+    ):
+        """Gap 2: ensure_sandbox_ready raises SandboxGoneError → recovery in Phase 2."""
+        manager = self._make_manager()
+        ws_id = str(uuid.uuid4())
+        workspace = _make_workspace(workspace_id=ws_id, status="running")
+        mock_get_ws.return_value = workspace
+
+        # Ready session but ensure_sandbox_ready fails (sandbox gone after cooldown)
+        session = _make_mock_session()
+        session.sandbox.ensure_sandbox_ready = AsyncMock(
+            side_effect=SandboxGoneError("sb-old", "not found")
+        )
+        manager._sessions[ws_id] = session
+        # Force sync by clearing cooldown
+        manager._last_sync_at = {}
+
+        # Mock recovery
+        new_session = _make_mock_session()
+        new_session.sandbox.sandbox_id = "sb-new"
+        mock_session_mgr.get_session.return_value = new_session
+
+        result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
+
+        # Recovery triggered
+        mock_session_mgr.remove_session.assert_called_with(ws_id)
+        new_session.initialize.assert_called_once()
+        assert result is not None
+
+    @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.db_get_workspace")
+    @patch("src.server.services.workspace_manager.SessionManager")
+    async def test_phase2_concurrent_recovery_skips(
+        self, mock_session_mgr, mock_get_ws
+    ):
+        """Gap 2: SandboxGoneError but session already recovered → uses existing."""
+        manager = self._make_manager()
+        ws_id = str(uuid.uuid4())
+        workspace = _make_workspace(workspace_id=ws_id, status="running")
+        mock_get_ws.return_value = workspace
+
+        # Session with sandbox-gone error in Phase 2
+        broken_session = _make_mock_session()
+        broken_session.sandbox.ensure_sandbox_ready = AsyncMock(
+            side_effect=SandboxGoneError("sb-old", "not found")
+        )
+        manager._sessions[ws_id] = broken_session
+        manager._last_sync_at = {}
+
+        # Simulate concurrent recovery: when we re-acquire the lock,
+        # another request has already placed a working session in the cache.
+        already_recovered = _make_mock_session()
+        already_recovered.sandbox.is_ready = MagicMock(return_value=True)
+
+        original_acquire = manager._acquire_workspace_lock
+
+        @asynccontextmanager
+        async def mock_acquire(wid, timeout=60.0):
+            # Before yielding the lock, simulate concurrent recovery
+            manager._sessions[wid] = already_recovered
+            async with original_acquire(wid, timeout=timeout):
+                yield
+
+        manager._acquire_workspace_lock = mock_acquire
+
+        result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
+
+        # Should return the already-recovered session, not create a new one
+        assert result is already_recovered
+
+    @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.db_get_workspace")
+    async def test_phase2_other_error_logs_warning(self, mock_get_ws):
+        """Phase 2: non-SandboxGoneError → logs warning, returns session."""
+        manager = self._make_manager()
+        ws_id = str(uuid.uuid4())
+        workspace = _make_workspace(workspace_id=ws_id, status="running")
+        mock_get_ws.return_value = workspace
+
+        session = _make_mock_session()
+        session.sandbox.ensure_sandbox_ready = AsyncMock(
+            side_effect=RuntimeError("network blip")
+        )
+        manager._sessions[ws_id] = session
+        manager._last_sync_at = {}
+
+        result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
+
+        # Same session returned (broken, but we don't know it's sandbox-gone)
+        assert result is session
+
+    @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.db_get_workspace")
+    @patch("src.server.services.workspace_manager.SessionManager")
+    @patch("src.server.services.workspace_manager.update_workspace_status")
+    @patch("src.server.services.workspace_manager.update_workspace_activity")
+    async def test_running_reconnect_sandbox_gone_recovers(
+        self, mock_activity, mock_status, mock_session_mgr, mock_get_ws
+    ):
+        """Existing path: status=running, initialize raises SandboxGoneError → recovery."""
+        manager = self._make_manager()
+        ws_id = str(uuid.uuid4())
+        workspace = _make_workspace(workspace_id=ws_id, status="running")
+        mock_get_ws.return_value = workspace
+
+        # First session fails to initialize (sandbox gone)
+        failing_session = _make_mock_session(initialized=False)
+        failing_session.initialize = AsyncMock(
+            side_effect=SandboxGoneError("sb-old", "not found")
+        )
+
+        # Recovery session
+        recovered_session = _make_mock_session()
+        recovered_session.sandbox.sandbox_id = "sb-new"
+
+        mock_session_mgr.get_session.side_effect = [failing_session, recovered_session]
+
+        result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
+
+        # Recovery triggered
+        mock_session_mgr.remove_session.assert_called_with(ws_id)
+        recovered_session.initialize.assert_called_once()
+        assert result is not None
+
+    @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.db_get_workspace")
+    @patch("src.server.services.workspace_manager.SessionManager")
+    @patch("src.server.services.workspace_manager.update_workspace_status")
+    @patch("src.server.services.workspace_manager.update_workspace_activity")
+    async def test_stopped_workspace_lazy_init_sandbox_gone_recovers(
+        self, mock_activity, mock_status, mock_session_mgr, mock_get_ws
+    ):
+        """REGRESSION: First request to a stopped workspace whose sandbox is deleted.
+
+        Previously, _restart_workspace(lazy_init=True) returned a session
+        with a pending background reconnect. The reconnect failed with
+        SandboxGoneError but the error only surfaced when the chat handler
+        called _wait_ready(). Now, the stopped path falls through to Phase 2
+        which waits for lazy init and handles SandboxGoneError.
+        """
+        manager = self._make_manager()
+        ws_id = str(uuid.uuid4())
+        workspace = _make_workspace(workspace_id=ws_id, status="stopped")
+        mock_get_ws.return_value = workspace
+
+        # _restart_workspace returns a session whose sandbox will fail in Phase 2
+        lazy_session = _make_mock_session()
+        lazy_session.sandbox.ensure_sandbox_ready = AsyncMock(
+            side_effect=SandboxGoneError("sb-old", "not found")
+        )
+
+        # Recovery session
+        recovered_session = _make_mock_session()
+        recovered_session.sandbox.sandbox_id = "sb-new"
+
+        # First call: _restart_workspace gets lazy_session
+        # Second call: _recover_sandbox gets recovered_session
+        mock_session_mgr.get_session.side_effect = [lazy_session, recovered_session]
+
+        # Patch _restart_workspace to return the lazy session directly
+        # (simulates the real lazy init path)
+        async def mock_restart(workspace, user_id, lazy_init=True):
+            session = lazy_session
+            manager._sessions[ws_id] = session
+            manager._pending_lazy_sync.add(ws_id)
+            return session
+
+        with patch.object(manager, "_restart_workspace", side_effect=mock_restart):
+            result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
+
+        # Phase 2 caught SandboxGoneError and triggered recovery
+        mock_session_mgr.remove_session.assert_called_with(ws_id)
+        assert result is not None


### PR DESCRIPTION
## Summary

When a workspace's Daytona sandbox is externally deleted (e.g., by auto_delete_interval), the workspace should auto-recover by creating a fresh sandbox and restoring files from DB backup. The recovery logic (`_recover_sandbox`) existed but was never triggered for lazy-initialized sessions.

**Structured exception type:**
- `bcf5437` — Adds `SandboxGoneError(RuntimeError)` with `sandbox_id` attribute, raised from `reconnect()` at all 4 failure sites. Replaces fragile string matching (`"Failed to find sandbox"`, `"deleted"`, `"still in state"`, `"Cannot reconnect"`). Fixes `_wait_ready()` to re-raise original exception type. Adds `has_failed()` and `init_error` property to `PTCSandbox`.

**Recovery in all code paths:**
- `57208d7` — Three gaps fixed in `get_session_for_workspace()`:
  1. **Phase 1 (cache hit):** `has_failed()` detects broken lazy init. `SandboxGoneError` triggers `_recover_sandbox()` under workspace lock.
  2. **Phase 2 (sync):** `ensure_sandbox_ready()` failure now caught with lock re-acquisition + concurrent-recovery guard.
  3. **First-request path:** Stopped/stopping workspace restarts fall through to Phase 2 instead of returning a broken session immediately. This was the actual bug the user was hitting.

**Tests:**
- `baf0230` — 15 new tests: `SandboxGoneError` attributes, `has_failed()` state matrix, Gap 1/2 recovery, concurrent-recovery guard, regression test for first-request stopped workspace.

## Test Coverage
```
COVERAGE: 15/15 paths tested (100%)
QUALITY:  ★★★: 8  ★★: 7  ★: 0
```

## Pre-Landing Review
No issues found. Adversarial review (Claude subagent) found 1 fixable issue in the stopping-state branch (broad `except Exception` swallowing `SandboxGoneError`) — fixed inline.

## Plan Completion
All 14 plan items DONE, 1 CHANGED (first-request path fix discovered during investigation).

## Test plan
- [x] All unit tests pass (299 tests, 0 failures)
- [x] Regression test specifically covers the user-reported scenario (stopped workspace, sandbox deleted, first message triggers recovery)