### PR TITLE
feat: inline citation bubbles with hover preview cards

### DIFF
--- a/src/ptc_agent/agent/prompts/templates/components/citation_rules.md.j2
+++ b/src/ptc_agent/agent/prompts/templates/components/citation_rules.md.j2
@@ -1,16 +1,13 @@
 # Citation Rules
 
-Use numbered citations throughout your report:
-- Cite sources inline using [1], [2], [3] format
-- Assign each unique URL a single citation number
-- End report with ### Sources section listing each numbered source
-- Number sources sequentially without gaps (1,2,3,4...)
-- Format: [1] Source Title: URL (each on separate line for proper list rendering)
+When referencing online information, cite sources inline using this format:
+([domain.com](full_url))
+
+Place the citation immediately after the claim it supports. Use the source's shortest recognizable domain (e.g., nypost.com, not www.nypost.com).
 
 **Example:**
+Oil prices surged above $110 ([nypost.com](https://nypost.com/2026/03/27/business/dow-falls-700-points))
 
-Some important finding [1]. Another key insight [2].
-
-### Sources
-[1] AI Research Paper: https://example.com/paper
-[2] Industry Analysis: https://example.com/analysis
+- Every factual claim from an online source MUST have an inline citation
+- Multiple citations can appear together: ...confirmed by multiple outlets ([reuters.com](url1)) ([bloomberg.com](url2))
+- Do NOT add a Sources/References section at the end — all citations are inline

--- a/src/ptc_agent/agent/prompts/templates/subagents/roles/researcher.md.j2
+++ b/src/ptc_agent/agent/prompts/templates/subagents/roles/researcher.md.j2
@@ -24,7 +24,7 @@ Research the delegated topic using web search and content extraction. Produce a 
 - **Complex queries:** up to 5 search calls.
 - **Stop when:** you can answer comprehensively, you have 3+ corroborating sources, or successive searches return redundant information.
 - **Maximum {{ max_iterations | default(5) }} tool call iterations.**
-- Every factual claim must have a source. Use inline citations: `[Source Name](URL)`.
+- Every factual claim must have a source. Use inline citations: `([domain.com](URL))`.
 - Prefer primary sources (company filings, official reports, press releases) over secondary commentary.
 - When sources conflict, note the discrepancy and indicate which source is more authoritative.
 </guidelines>
@@ -33,8 +33,7 @@ Research the delegated topic using web search and content extraction. Produce a 
 Your final response MUST contain:
 1. **Direct answer** — lead with the answer to the research question, not background context
 2. **Supporting evidence** — key facts, data points, and quotes with inline citations
-3. **Source list** — numbered list of all sources used with URLs
-4. **File references** — paths to any saved research files (if applicable)
+3. **File references** — paths to any saved research files (if applicable)
 
 Keep the response focused and well-structured. Do NOT pad with generic background — every paragraph should advance the answer.
 </output_format>

--- a/web/package.json
+++ b/web/package.json
@@ -21,6 +21,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-hover-card": "^1.1.15",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-toast": "^1.2.5",
     "@supabase/supabase-js": "^2.95.3",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-hover-card':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-popover':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -825,6 +828,19 @@ packages:
 
   '@radix-ui/react-focus-scope@1.1.7':
     resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-hover-card@1.1.15':
+    resolution: {integrity: sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -5083,6 +5099,23 @@ snapshots:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-hover-card@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:

--- a/web/src/pages/ChatAgent/components/CitationBubble.css
+++ b/web/src/pages/ChatAgent/components/CitationBubble.css
@@ -6,3 +6,7 @@
   outline: 2px solid var(--color-accent-primary);
   outline-offset: 2px;
 }
+
+.cite-bubble-card-title:hover {
+  color: var(--color-accent-primary);
+}

--- a/web/src/pages/ChatAgent/components/CitationBubble.css
+++ b/web/src/pages/ChatAgent/components/CitationBubble.css
@@ -10,3 +10,17 @@
 .cite-bubble-card-title:hover {
   color: var(--color-accent-primary);
 }
+
+@media print {
+  .cite-bubble-pill {
+    background: none !important;
+    color: #333 !important;
+    border: 1px solid #999;
+    padding: 0 4px;
+    font-size: 11px;
+  }
+
+  .cite-bubble-pill img {
+    display: none;
+  }
+}

--- a/web/src/pages/ChatAgent/components/CitationBubble.css
+++ b/web/src/pages/ChatAgent/components/CitationBubble.css
@@ -1,3 +1,7 @@
+.cite-bubble-pill:hover {
+  background: var(--color-bg-input);
+}
+
 .cite-bubble-pill:focus-visible {
   outline: 2px solid var(--color-accent-primary);
   outline-offset: 2px;

--- a/web/src/pages/ChatAgent/components/CitationBubble.css
+++ b/web/src/pages/ChatAgent/components/CitationBubble.css
@@ -1,0 +1,4 @@
+.cite-bubble-pill:focus-visible {
+  outline: 2px solid var(--color-accent-primary);
+  outline-offset: 2px;
+}

--- a/web/src/pages/ChatAgent/components/CitationBubble.css
+++ b/web/src/pages/ChatAgent/components/CitationBubble.css
@@ -13,14 +13,20 @@
 
 @media print {
   .cite-bubble-pill {
-    background: none !important;
-    color: #333 !important;
-    border: 1px solid #999;
-    padding: 0 4px;
-    font-size: 11px;
+    all: unset !important;
+    font-size: 0.75em !important;
+    color: #666 !important;
+  }
+
+  .cite-bubble-pill::before {
+    content: "[";
+  }
+
+  .cite-bubble-pill::after {
+    content: "]";
   }
 
   .cite-bubble-pill img {
-    display: none;
+    display: none !important;
   }
 }

--- a/web/src/pages/ChatAgent/components/CitationBubble.tsx
+++ b/web/src/pages/ChatAgent/components/CitationBubble.tsx
@@ -138,6 +138,7 @@ function CitationBubble({ node: _node, label, href, ...props }: MarkdownComponen
                 href={url}
                 target="_blank"
                 rel="noopener noreferrer"
+                className="cite-bubble-card-title"
                 style={{
                   fontSize: 14,
                   fontWeight: 500,
@@ -149,8 +150,6 @@ function CitationBubble({ node: _node, label, href, ...props }: MarkdownComponen
                   WebkitBoxOrient: 'vertical' as const,
                   overflow: 'hidden',
                 }}
-                onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--color-accent-primary)'; }}
-                onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--color-text-primary)'; }}
               >
                 {meta.title}
               </a>

--- a/web/src/pages/ChatAgent/components/CitationBubble.tsx
+++ b/web/src/pages/ChatAgent/components/CitationBubble.tsx
@@ -50,7 +50,7 @@ function Favicon({ domain, size = 14 }: { domain: string; size?: number }): Reac
 function CitationBubble({ node: _node, label, href, ...props }: MarkdownComponentProps): React.ReactElement {
   const meta = useCitationMetadata(href || '');
   const domain = label || '';
-  const displayName = meta?.source || domain;
+  const displayName = meta?.source || domain.replace(/\.[^.]+$/, '') || domain;
   const url = href || '';
 
   const handlePillClick = useCallback(() => {

--- a/web/src/pages/ChatAgent/components/CitationBubble.tsx
+++ b/web/src/pages/ChatAgent/components/CitationBubble.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useRef } from 'react';
+import React, { useState, useCallback } from 'react';
 import * as HoverCard from '@radix-ui/react-hover-card';
 import { useCitationMetadata } from './CitationMetadataContext';
 import './CitationBubble.css';
@@ -53,14 +53,6 @@ function CitationBubble({ node: _node, label, href, ...props }: MarkdownComponen
   const displayName = meta?.source || domain;
   const url = href || '';
 
-  const pillRef = useRef<HTMLSpanElement>(null);
-  const handlePillEnter = useCallback(() => {
-    if (pillRef.current) pillRef.current.style.background = 'var(--color-bg-input)';
-  }, []);
-  const handlePillLeave = useCallback(() => {
-    if (pillRef.current) pillRef.current.style.background = 'var(--color-bg-elevated)';
-  }, []);
-
   const handlePillClick = useCallback(() => {
     if (url && /^https?:\/\//.test(url)) window.open(url, '_blank', 'noopener,noreferrer');
   }, [url]);
@@ -79,14 +71,11 @@ function CitationBubble({ node: _node, label, href, ...props }: MarkdownComponen
     <HoverCard.Root openDelay={300} closeDelay={100}>
       <HoverCard.Trigger asChild>
         <span
-          ref={pillRef}
           role="link"
           tabIndex={0}
           aria-label={`Source: ${displayName}`}
           onClick={handlePillClick}
           onKeyDown={handleKeyDown}
-          onMouseEnter={handlePillEnter}
-          onMouseLeave={handlePillLeave}
           className="cite-bubble-pill"
           style={{
             display: 'inline-flex',
@@ -160,8 +149,8 @@ function CitationBubble({ node: _node, label, href, ...props }: MarkdownComponen
                   WebkitBoxOrient: 'vertical' as const,
                   overflow: 'hidden',
                 }}
-                onMouseEnter={(e) => { (e.target as HTMLElement).style.color = 'var(--color-accent-primary)'; }}
-                onMouseLeave={(e) => { (e.target as HTMLElement).style.color = 'var(--color-text-primary)'; }}
+                onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--color-accent-primary)'; }}
+                onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--color-text-primary)'; }}
               >
                 {meta.title}
               </a>

--- a/web/src/pages/ChatAgent/components/CitationBubble.tsx
+++ b/web/src/pages/ChatAgent/components/CitationBubble.tsx
@@ -1,0 +1,212 @@
+import React, { useState, useCallback, useRef } from 'react';
+import * as HoverCard from '@radix-ui/react-hover-card';
+import { useCitationMetadata } from './CitationMetadataContext';
+import './CitationBubble.css';
+
+type MarkdownComponentProps = Record<string, any>;
+
+function Monogram({ letter, size = 14 }: { letter: string; size?: number }): React.ReactElement {
+  return (
+    <span
+      style={{
+        width: size,
+        height: size,
+        borderRadius: size / 2,
+        background: 'var(--color-bg-surface)',
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: size * 0.65,
+        fontWeight: 600,
+        color: 'var(--color-text-secondary)',
+        flexShrink: 0,
+        textTransform: 'uppercase',
+      }}
+    >
+      {letter}
+    </span>
+  );
+}
+
+function Favicon({ domain, size = 14 }: { domain: string; size?: number }): React.ReactElement {
+  const [failed, setFailed] = useState(false);
+
+  if (failed) {
+    return <Monogram letter={domain.charAt(0)} size={size} />;
+  }
+
+  return (
+    <img
+      src={`https://www.google.com/s2/favicons?domain=${encodeURIComponent(domain)}&sz=32`}
+      alt=""
+      width={size}
+      height={size}
+      style={{ borderRadius: size > 14 ? 3 : 2, flexShrink: 0 }}
+      onError={() => setFailed(true)}
+    />
+  );
+}
+
+function CitationBubble({ node: _node, label, href, ...props }: MarkdownComponentProps): React.ReactElement {
+  const meta = useCitationMetadata(href || '');
+  const domain = label || '';
+  const displayName = meta?.source || domain;
+  const url = href || '';
+
+  const pillRef = useRef<HTMLSpanElement>(null);
+  const handlePillEnter = useCallback(() => {
+    if (pillRef.current) pillRef.current.style.background = 'var(--color-bg-input)';
+  }, []);
+  const handlePillLeave = useCallback(() => {
+    if (pillRef.current) pillRef.current.style.background = 'var(--color-bg-elevated)';
+  }, []);
+
+  const handlePillClick = useCallback(() => {
+    if (url && /^https?:\/\//.test(url)) window.open(url, '_blank', 'noopener,noreferrer');
+  }, [url]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handlePillClick();
+    }
+  }, [handlePillClick]);
+
+  // Note: Radix HoverCard is mouse-only by design. Keyboard/screen-reader users
+  // can still click through via Enter/Space but won't see the preview card.
+  // Switch to Popover if keyboard preview becomes a requirement.
+  return (
+    <HoverCard.Root openDelay={300} closeDelay={100}>
+      <HoverCard.Trigger asChild>
+        <span
+          ref={pillRef}
+          role="link"
+          tabIndex={0}
+          aria-label={`Source: ${displayName}`}
+          onClick={handlePillClick}
+          onKeyDown={handleKeyDown}
+          onMouseEnter={handlePillEnter}
+          onMouseLeave={handlePillLeave}
+          className="cite-bubble-pill"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 4,
+            padding: '1px 8px 1px 6px',
+            borderRadius: 9999,
+            background: 'var(--color-bg-elevated)',
+            fontSize: '0.8125rem',
+            fontWeight: 400,
+            color: 'var(--color-text-secondary)',
+            lineHeight: 1.4,
+            verticalAlign: 'baseline',
+            cursor: 'pointer',
+            transition: 'background 150ms ease',
+            marginLeft: 2,
+            maxWidth: 200,
+            whiteSpace: 'nowrap' as const,
+          }}
+          {...props}
+        >
+          <Favicon domain={domain} size={14} />
+          <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {displayName}
+          </span>
+        </span>
+      </HoverCard.Trigger>
+
+      <HoverCard.Portal>
+        <HoverCard.Content
+          sideOffset={5}
+          style={{
+            width: 320,
+            borderRadius: 10,
+            overflow: 'hidden',
+            boxShadow: 'var(--shadow-card, 0 4px 16px rgba(0,0,0,0.12))',
+            border: '1px solid var(--color-border-muted)',
+            background: 'var(--color-bg-card)',
+            zIndex: 100,
+            animationDuration: '150ms',
+          }}
+        >
+          <div style={{ padding: '12px 14px' }}>
+            {/* Source row */}
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 8 }}>
+              <Favicon domain={domain} size={16} />
+              <span style={{
+                fontSize: 12,
+                fontWeight: 500,
+                color: 'var(--color-text-tertiary)',
+                letterSpacing: '0.01em',
+              }}>
+                {displayName}
+              </span>
+            </div>
+
+            {/* Title or fallback URL */}
+            {meta?.title ? (
+              <a
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{
+                  fontSize: 14,
+                  fontWeight: 500,
+                  lineHeight: 1.45,
+                  color: 'var(--color-text-primary)',
+                  textDecoration: 'none',
+                  display: '-webkit-box',
+                  WebkitLineClamp: 3,
+                  WebkitBoxOrient: 'vertical' as const,
+                  overflow: 'hidden',
+                }}
+                onMouseEnter={(e) => { (e.target as HTMLElement).style.color = 'var(--color-accent-primary)'; }}
+                onMouseLeave={(e) => { (e.target as HTMLElement).style.color = 'var(--color-text-primary)'; }}
+              >
+                {meta.title}
+              </a>
+            ) : (
+              <a
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{
+                  fontSize: 12,
+                  color: 'var(--color-accent-primary)',
+                  textDecoration: 'none',
+                  display: 'block',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap' as const,
+                  lineHeight: 1.5,
+                }}
+              >
+                {url}
+              </a>
+            )}
+
+            {/* Date + Snippet */}
+            {(meta?.date || meta?.snippet) && (
+              <div style={{
+                fontSize: 12,
+                color: 'var(--color-text-tertiary)',
+                marginTop: 6,
+                lineHeight: 1.5,
+                display: '-webkit-box',
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: 'vertical' as const,
+                overflow: 'hidden',
+              }}>
+                {meta.date && meta.snippet
+                  ? `${meta.date} – ${meta.snippet}`
+                  : meta.date || meta.snippet}
+              </div>
+            )}
+          </div>
+        </HoverCard.Content>
+      </HoverCard.Portal>
+    </HoverCard.Root>
+  );
+}
+
+export default CitationBubble;

--- a/web/src/pages/ChatAgent/components/CitationBubble.tsx
+++ b/web/src/pages/ChatAgent/components/CitationBubble.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState } from 'react';
 import * as HoverCard from '@radix-ui/react-hover-card';
 import { useCitationMetadata } from './CitationMetadataContext';
 import './CitationBubble.css';
@@ -53,29 +53,18 @@ function CitationBubble({ node: _node, label, href, ...props }: MarkdownComponen
   const displayName = meta?.source || domain.replace(/\.[^.]+$/, '') || domain;
   const url = href || '';
 
-  const handlePillClick = useCallback(() => {
-    if (url && /^https?:\/\//.test(url)) window.open(url, '_blank', 'noopener,noreferrer');
-  }, [url]);
-
-  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      handlePillClick();
-    }
-  }, [handlePillClick]);
-
   // Note: Radix HoverCard is mouse-only by design. Keyboard/screen-reader users
   // can still click through via Enter/Space but won't see the preview card.
   // Switch to Popover if keyboard preview becomes a requirement.
   return (
     <HoverCard.Root openDelay={300} closeDelay={100}>
       <HoverCard.Trigger asChild>
-        <span
-          role="link"
-          tabIndex={0}
+        <a
+          href={url || undefined}
+          target="_blank"
+          rel="noopener noreferrer"
           aria-label={`Source: ${displayName}`}
-          onClick={handlePillClick}
-          onKeyDown={handleKeyDown}
+          onClick={(e) => { if (!url || !/^https?:\/\//.test(url)) e.preventDefault(); }}
           className="cite-bubble-pill"
           style={{
             display: 'inline-flex',
@@ -87,6 +76,7 @@ function CitationBubble({ node: _node, label, href, ...props }: MarkdownComponen
             fontSize: '0.8125rem',
             fontWeight: 400,
             color: 'var(--color-text-secondary)',
+            textDecoration: 'none',
             lineHeight: 1.4,
             verticalAlign: 'baseline',
             cursor: 'pointer',
@@ -101,7 +91,7 @@ function CitationBubble({ node: _node, label, href, ...props }: MarkdownComponen
           <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
             {displayName}
           </span>
-        </span>
+        </a>
       </HoverCard.Trigger>
 
       <HoverCard.Portal>

--- a/web/src/pages/ChatAgent/components/CitationMetadataContext.tsx
+++ b/web/src/pages/ChatAgent/components/CitationMetadataContext.tsx
@@ -1,0 +1,70 @@
+import React, { createContext, useContext, useMemo } from 'react';
+import { parseDisplayableResults, buildRichResultMap, resolveSnippet } from './webSearchUtils';
+
+export interface CitationMeta {
+  title: string;
+  url: string;
+  snippet: string;
+  date?: string;
+  domain: string;
+  source?: string;
+}
+
+const CitationMetadataContext = createContext<Map<string, CitationMeta>>(new Map());
+
+export function useCitationMetadata(url: string): CitationMeta | undefined {
+  const map = useContext(CitationMetadataContext);
+  return map.get(url);
+}
+
+interface CitationMetadataProviderProps {
+  toolCallProcesses: Record<string, Record<string, unknown>>;
+  children: React.ReactNode;
+}
+
+export function CitationMetadataProvider({ toolCallProcesses, children }: CitationMetadataProviderProps): React.ReactElement {
+  const metaMap = useMemo(() => {
+    const map = new Map<string, CitationMeta>();
+
+    for (const proc of Object.values(toolCallProcesses)) {
+      const toolName = proc.toolName as string | undefined;
+      if (toolName !== 'WebSearch' && toolName !== 'web_search') continue;
+
+      const result = proc.toolCallResult as Record<string, unknown> | undefined;
+      if (!result) continue;
+
+      const raw = result.content;
+      const displayable = parseDisplayableResults(raw);
+      if (!displayable) continue;
+
+      const artifact = result.artifact as Record<string, unknown> | undefined;
+      const richByUrl = buildRichResultMap(artifact);
+
+      for (const item of displayable) {
+        const itemUrl = (item.url as string) || '';
+        if (!itemUrl) continue;
+
+        const rich = richByUrl.get(itemUrl);
+        let domain = '';
+        try { domain = new URL(itemUrl).hostname.replace(/^www\./, ''); } catch { /* skip */ }
+
+        map.set(itemUrl, {
+          title: (item.title as string) || '',
+          url: itemUrl,
+          snippet: resolveSnippet(item, rich),
+          date: (item.date as string) || (item.publish_time as string) || undefined,
+          domain,
+          source: (item.source as string) || (item.site_name as string) || undefined,
+        });
+      }
+    }
+
+    return map;
+  }, [toolCallProcesses]);
+
+  return (
+    <CitationMetadataContext.Provider value={metaMap}>
+      {children}
+    </CitationMetadataContext.Provider>
+  );
+}

--- a/web/src/pages/ChatAgent/components/Markdown.tsx
+++ b/web/src/pages/ChatAgent/components/Markdown.tsx
@@ -11,6 +11,7 @@ import { Copy, Check } from 'lucide-react';
 import { useTheme } from '@/contexts/ThemeContext';
 import WorkspaceImage from './WorkspaceImage';
 import { isFilePath, isImagePath, normalizeFilePath } from './FileCard';
+import CitationBubble from './CitationBubble';
 
 interface CodeBlockProps {
   language: string | null;
@@ -321,6 +322,7 @@ const CHAT_COMPONENTS = {
   code: chatCode, pre: chatPre,
   blockquote: chatBlockquote, a: chatA, hr: chatHr,
   table: chatTable, thead: chatThead, tbody: chatTbody, tr: chatTr, th: chatTh, td: chatTd,
+  'cite-bubble': CitationBubble,
 };
 
 const PANEL_COMPONENTS = {
@@ -329,6 +331,7 @@ const PANEL_COMPONENTS = {
   code: panelCode, pre: panelPre,
   a: panelA, blockquote: panelBlockquote, hr: panelHr,
   table: panelTable, thead: panelThead, tr: panelTr, th: panelTh, td: panelTd,
+  'cite-bubble': CitationBubble,
 };
 
 // Compact table components -- reuse panel styles for consistency
@@ -352,6 +355,7 @@ const COMPACT_COMPONENTS = {
   code: compactCode, pre: compactPre,
   a: panelA, blockquote: panelBlockquote, hr: panelHr,
   table: compactTable, thead: compactThead, tr: compactTr, th: compactTh, td: compactTd,
+  'cite-bubble': CitationBubble,
 };
 
 interface VariantConfig {
@@ -501,6 +505,26 @@ function normalizeLatexDelimiters(content: string): string {
   return content;
 }
 
+/**
+ * Convert inline citation patterns ([label](url)) into <cite-bubble> HTML tags.
+ * rehype-raw will parse these into the AST and the CitationBubble component renders them.
+ */
+function escapeHtmlAttr(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
+}
+
+function transformCitationBubbles(content: string): string {
+  if (!content || typeof content !== 'string') return content;
+  return content.replace(
+    /\(\[([^\]]+)\]\((https?:\/\/[^)]+)\)\)/g,
+    (_, label, url) => {
+      // Encode $ as %24 so escapeCurrencyDollars won't mangle URLs (e.g. ?price=$100)
+      const safeUrl = url.replace(/\$/g, '%24');
+      return `<cite-bubble label="${escapeHtmlAttr(label)}" href="${escapeHtmlAttr(safeUrl)}"></cite-bubble>`;
+    }
+  );
+}
+
 type MarkdownVariant = 'chat' | 'panel' | 'compact';
 
 interface MarkdownProps {
@@ -514,7 +538,7 @@ interface MarkdownProps {
 function Markdown({ content, variant = 'panel', className = '', style, onOpenFile }: MarkdownProps): React.ReactElement {
   const config = VARIANTS[variant];
   const processed = useMemo(
-    () => normalizeLatexDelimiters(escapeCurrencyDollars(fixMarkdownTables(stripFrontMatter(content)))),
+    () => normalizeLatexDelimiters(escapeCurrencyDollars(transformCitationBubbles(fixMarkdownTables(stripFrontMatter(content))))),
     [content]
   );
 
@@ -560,4 +584,5 @@ function Markdown({ content, variant = 'panel', className = '', style, onOpenFil
   );
 }
 
+export { transformCitationBubbles, escapeHtmlAttr };
 export default Markdown;

--- a/web/src/pages/ChatAgent/components/MessageList.tsx
+++ b/web/src/pages/ChatAgent/components/MessageList.tsx
@@ -30,6 +30,7 @@ import SubagentTaskMessageContent from './SubagentTaskMessageContent';
 import TextMessageContent from './TextMessageContent';
 import InlineWidget from './viewers/InlineWidget';
 import ToolCallMessageContent from './ToolCallMessageContent';
+import { CitationMetadataProvider } from './CitationMetadataContext';
 
 import { TextShimmer } from '@/components/ui/text-shimmer';
 
@@ -637,6 +638,7 @@ const MessageBubble = memo(function MessageBubble({ message, isLoading, hideAvat
           <>
           {/* Render content segments in chronological order */}
           {(message.contentSegments as ContentSegmentRecord[] | undefined) && (message.contentSegments as ContentSegmentRecord[]).length > 0 ? (
+            <CitationMetadataProvider toolCallProcesses={(message.toolCallProcesses as Record<string, Record<string, unknown>>) || EMPTY_OBJ}>
             <MessageContentSegments
               segments={message.contentSegments as ContentSegmentRecord[]}
               reasoningProcesses={(message.reasoningProcesses as Record<string, Record<string, unknown>>) || EMPTY_OBJ}
@@ -672,6 +674,7 @@ const MessageBubble = memo(function MessageBubble({ message, isLoading, hideAvat
               readOnly={readOnly}
               allowFiles={allowFiles}
             />
+            </CitationMetadataProvider>
           ) : (
             // Fallback for messages without segments (backward compatibility) - main chat shows text only
             ((message.contentType as string) === 'text' || !(message.contentType as string)) && (

--- a/web/src/pages/ChatAgent/components/__tests__/citationTransform.test.ts
+++ b/web/src/pages/ChatAgent/components/__tests__/citationTransform.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { transformCitationBubbles, escapeHtmlAttr } from '../Markdown';
+
+describe('escapeHtmlAttr', () => {
+  it('escapes ampersands', () => {
+    expect(escapeHtmlAttr('a&b')).toBe('a&amp;b');
+  });
+
+  it('escapes double quotes', () => {
+    expect(escapeHtmlAttr('a"b')).toBe('a&quot;b');
+  });
+
+  it('escapes angle brackets', () => {
+    expect(escapeHtmlAttr('a<b')).toBe('a&lt;b');
+  });
+
+  it('escapes all special chars together', () => {
+    expect(escapeHtmlAttr('x&y"z<w')).toBe('x&amp;y&quot;z&lt;w');
+  });
+
+  it('passes through clean strings', () => {
+    expect(escapeHtmlAttr('hello world')).toBe('hello world');
+  });
+});
+
+describe('transformCitationBubbles', () => {
+  it('transforms a single citation', () => {
+    const input = 'Oil prices surged ([nypost.com](https://nypost.com/2026/03/27/business))';
+    const result = transformCitationBubbles(input);
+    expect(result).toBe(
+      'Oil prices surged <cite-bubble label="nypost.com" href="https://nypost.com/2026/03/27/business"></cite-bubble>'
+    );
+  });
+
+  it('transforms multiple citations in the same text', () => {
+    const input = 'Confirmed ([reuters.com](https://reuters.com/article)) ([bloomberg.com](https://bloomberg.com/news))';
+    const result = transformCitationBubbles(input);
+    expect(result).toContain('<cite-bubble label="reuters.com"');
+    expect(result).toContain('<cite-bubble label="bloomberg.com"');
+  });
+
+  it('does not transform standard markdown links without outer parens', () => {
+    const input = 'See [example](https://example.com) for more';
+    const result = transformCitationBubbles(input);
+    expect(result).toBe(input);
+  });
+
+  it('returns empty/falsy input unchanged', () => {
+    expect(transformCitationBubbles('')).toBe('');
+    expect(transformCitationBubbles(null as unknown as string)).toBe(null);
+    expect(transformCitationBubbles(undefined as unknown as string)).toBe(undefined);
+  });
+
+  it('escapes special characters in label and URL', () => {
+    const input = '([a&"b](https://example.com/q?a=1&b=2))';
+    const result = transformCitationBubbles(input);
+    expect(result).toContain('label="a&amp;&quot;b"');
+    expect(result).toContain('href="https://example.com/q?a=1&amp;b=2"');
+  });
+
+  it('only matches http/https URLs', () => {
+    const input = '([evil](javascript:alert(1)))';
+    const result = transformCitationBubbles(input);
+    expect(result).toBe(input); // no transform
+  });
+
+  it('preserves surrounding text', () => {
+    const input = 'Before ([a.com](https://a.com/path)) after text.';
+    const result = transformCitationBubbles(input);
+    expect(result).toMatch(/^Before /);
+    expect(result).toMatch(/ after text\.$/);
+  });
+
+  it('handles citation at start of text', () => {
+    const input = '([a.com](https://a.com)) is the source.';
+    const result = transformCitationBubbles(input);
+    expect(result).toMatch(/^<cite-bubble/);
+  });
+
+  it('handles citation at end of text', () => {
+    const input = 'Source: ([a.com](https://a.com))';
+    const result = transformCitationBubbles(input);
+    expect(result).toMatch(/cite-bubble>$/);
+  });
+
+  it('encodes $ as %24 in URLs to prevent escapeCurrencyDollars interference', () => {
+    const input = '([example.com](https://example.com/q?price=$100&other=1))';
+    const result = transformCitationBubbles(input);
+    expect(result).toContain('href="https://example.com/q?price=%24100&amp;other=1"');
+    expect(result).not.toContain('$100');
+  });
+});


### PR DESCRIPTION
## Summary

Replace numbered `[1]`, `[2]` citations with inline citation pills that show source name + favicon, with hover preview cards showing title, snippet, and date from web search metadata.

**Prompt changes:**
- `citation_rules.md.j2` — new inline `([domain.com](url))` format (applies to all agent modes via shared include)
- `researcher.md.j2` — aligned citation format, removed redundant source list section

**Frontend:**
- `CitationBubble.tsx` — pill component with Radix HoverCard, favicon with monogram fallback, keyboard accessible
- `CitationMetadataContext.tsx` — React context providing URL→metadata map from WebSearch tool call results
- `Markdown.tsx` — regex pre-processing transform `([domain](url))` → `<cite-bubble>` HTML tags, with `$` encoding to prevent `escapeCurrencyDollars` interference
- `MessageList.tsx` — wraps message segments with `CitationMetadataProvider`
- `CitationBubble.css` — `:focus-visible` outline for keyboard accessibility
- New dependency: `@radix-ui/react-hover-card`

**Security hardening (from adversarial review):**
- URL scheme validation (`https?://`) at both regex and click handler levels
- `$` in URLs encoded as `%24` to prevent pipeline transform corruption
- HTML attribute escaping for `&`, `"`, `<` in labels and URLs

## Test Coverage
Tests: 19 → 20 (+1 new file, 15 test cases)
Coverage: `transformCitationBubbles` and `escapeHtmlAttr` — happy path, edge cases, special chars, null guards, `$` encoding.

## Pre-Landing Review
4 informational findings, 0 critical. All addressed:
- [FIXED] Missing `:focus-visible` on pill → added `CitationBubble.css`
- [FIXED] No tests → added `citationTransform.test.ts` (15 tests)
- [FIXED] `$` in URLs corrupted by `escapeCurrencyDollars` → reordered pipeline + `%24` encoding
- [FIXED] No URL scheme validation at component level → added `https?://` check

## Plan Completion
Plan: `~/.claude/plans/declarative-tickling-island.md`
9/9 items DONE. All plan items implemented.

## Test plan
- [x] All Vitest tests pass (225 tests, 20 files)
- [x] Build passes (`vite build` clean)

## Known limitations
- URLs containing literal `)` (e.g., Wikipedia) get truncated by the regex — degrades to raw text, not a crash
- Radix HoverCard is mouse-only by design — keyboard users can click through but won't see preview card
- File panel renders pills but without rich metadata (no `CitationMetadataProvider` context)