### PR TITLE
fix(ui): model dropdown overflow + snippet mention preservation

### DIFF
--- a/web/src/components/ui/chat-input.tsx
+++ b/web/src/components/ui/chat-input.tsx
@@ -558,7 +558,7 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [showWorkspaceMenu]);
 
-  // Close model menu on click outside
+  // Close model menu on click outside, scroll, or resize
   useEffect(() => {
     if (!showModelMenu) return;
     const handleClickOutside = (e: MouseEvent) => {
@@ -567,8 +567,15 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
       setShowModelMenu(false);
       setShowMoreModels(false);
     };
+    const dismiss = () => { setShowModelMenu(false); setShowMoreModels(false); };
     document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
+    window.addEventListener('scroll', dismiss, true);
+    window.addEventListener('resize', dismiss);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      window.removeEventListener('scroll', dismiss, true);
+      window.removeEventListener('resize', dismiss);
+    };
   }, [showModelMenu]);
 
   // --- File Upload Handling ---

--- a/web/src/components/ui/chat-input.tsx
+++ b/web/src/components/ui/chat-input.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect, useCallback, useMemo, forwardRef, useImperativeHandle } from 'react';
+import { createPortal } from 'react-dom';
 import {
   Plus, ArrowUp, X, FileText, Loader2, Archive, Square,
   ScrollText, ChartCandlestick, Zap, FileStack, ChevronDown, ChevronRight, FolderOpen, TextSelect,
@@ -284,6 +285,7 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
   const moreModelsTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [modelMetadata, setModelMetadata] = useState<Record<string, { sdk?: string; provider?: string }>>({});
   const modelMenuRef = useRef<HTMLDivElement>(null);
+  const modelDropdownRef = useRef<HTMLDivElement>(null);
   const navigate = useNavigate();
 
   // Sync selectedModel when initialModel or preferredModel changes
@@ -560,10 +562,10 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
   useEffect(() => {
     if (!showModelMenu) return;
     const handleClickOutside = (e: MouseEvent) => {
-      if (modelMenuRef.current && !modelMenuRef.current.contains(e.target as Node)) {
-        setShowModelMenu(false);
-        setShowMoreModels(false);
-      }
+      const target = e.target as Node;
+      if (modelMenuRef.current?.contains(target) || modelDropdownRef.current?.contains(target)) return;
+      setShowModelMenu(false);
+      setShowMoreModels(false);
     };
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
@@ -1392,8 +1394,21 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
                     {fastMode && isCodexModel && <Rocket className="h-3 w-3" style={{ color: 'var(--color-accent-light)' }} />}
                     <ChevronDown className="h-3 w-3" />
                   </button>
-                  {showModelMenu && (
-                    <div className={`model-dropdown ${dropdownDirection === 'down' ? 'model-dropdown-down' : 'model-dropdown-up'}`}>
+                  {showModelMenu && (() => {
+                    const btnRect = modelMenuRef.current?.getBoundingClientRect();
+                    if (!btnRect) return null;
+                    const fixedStyle: React.CSSProperties = {
+                      position: 'fixed',
+                      right: Math.max(8, window.innerWidth - btnRect.right),
+                      left: 'auto',
+                      margin: 0,
+                      ...(dropdownDirection === 'down'
+                        ? { top: btnRect.bottom + 4, bottom: 'auto' }
+                        : { bottom: window.innerHeight - btnRect.top + 4, top: 'auto' }),
+                    };
+                    return createPortal(
+                    <div ref={modelDropdownRef} className={`model-dropdown ${dropdownDirection === 'down' ? 'model-dropdown-down' : 'model-dropdown-up'}`} style={fixedStyle}>
+
                       {/* Primary menu: thread models + reasoning + "More models"
                          Submenu direction: open left if dropdown is near right edge of viewport */}
                       {(() => {
@@ -1474,7 +1489,7 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
                         <ChevronRight className={`h-3.5 w-3.5 transition-transform ${isMobile && showMoreModels ? 'rotate-90' : ''}`} />
                         {/* Submenu — flyout on desktop; inline on mobile */}
                         {showMoreModels && !isMobile && (() => {
-                          const menuRect = modelMenuRef.current?.getBoundingClientRect();
+                          const menuRect = modelDropdownRef.current?.getBoundingClientRect();
                           const openLeft = menuRect && menuRect.right + 244 > window.innerWidth;
                           return (
                             <div
@@ -1489,8 +1504,10 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
                       </div>
                       {/* Mobile inline expanded submenu */}
                       {showMoreModels && isMobile && renderMoreModelsList(true)}
-                    </div>
-                  )}
+                    </div>,
+                    document.body
+                    );
+                  })()}
                 </div>
               )}
               {/* Voice Input Button (Show only if enabled in user settings) */}

--- a/web/src/components/ui/chat-input.tsx
+++ b/web/src/components/ui/chat-input.tsx
@@ -710,7 +710,7 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
 
     // Remove pills whose /{command} or @mention text was deleted from the textarea
     setSlashCommands((prev) => prev.filter((cmd) => val.includes(`/${cmd.name}`)));
-    setMentionedFiles((prev) => prev.filter((f) => val.includes(`@${f.path}`)));
+    setMentionedFiles((prev) => prev.filter((f) => f.snippet || val.includes(`@${f.path}`)));
 
     const cursorPos = e.target.selectionStart;
 

--- a/web/src/pages/MarketView/components/MarketChart.css
+++ b/web/src/pages/MarketView/components/MarketChart.css
@@ -135,8 +135,7 @@
 .interval-disabled-tooltip {
   position: absolute;
   top: calc(100% + 6px);
-  left: 50%;
-  transform: translateX(-50%);
+  left: 0;
   white-space: nowrap;
   font-size: 11px;
   padding: 5px 10px;
@@ -151,8 +150,8 @@
 }
 
 @keyframes tooltip-fade-in {
-  from { opacity: 0; transform: translateX(-50%) translateY(-2px); }
-  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
+  from { opacity: 0; transform: translateY(-2px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
 
 .chart-tools-right {
@@ -228,6 +227,7 @@
   position: relative;
   min-height: 0;
   width: 100%;
+  overflow: hidden;
 }
 
 .rsi-container {


### PR DESCRIPTION
## Summary

**Overflow fixes (MarketView):**
- Model selector dropdown now renders via `createPortal` to `document.body` with `position: fixed`, preventing Framer Motion's composited layers from breaking overflow clipping in narrow panels
- Click-outside handler updated to check both the trigger button ref and the portaled dropdown ref
- Submenu left/right detection uses the dropdown's viewport rect instead of the trigger button's
- Interval-disabled tooltip (`"1s data is not available"`) left-aligned instead of centered to prevent left-edge clipping
- `overflow: hidden` added to `.chart-wrapper` for crosshair tooltip safety

**Snippet mention fix (ChatInput):**
- File mentions added via snippets (file panel selections) are no longer incorrectly removed when the user types, since they don't have `@path` syntax in the textarea. Users can still explicitly remove them via the X button.

## Pre-Landing Review
No issues found. Review passed clean (0 critical, 0 informational).

## Test plan
- [ ] Verify model dropdown stays within MarketView chat panel bounds
- [ ] Verify model dropdown positions correctly on ChatAgent page (wide layout)
- [ ] Verify "More models" submenu opens in correct direction
- [ ] Verify click-outside dismisses the portaled dropdown
- [ ] Verify snippet file mentions persist when typing in textarea
- [ ] Verify snippet file mentions can still be removed via X button