### PR TITLE
feat: consolidate LangGraph recursion limits into config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -15,7 +15,8 @@ cli:
 
 # Application Settings
 debug: false
-agent_recursion_limit: 100
+ptc_recursion_limit: 2000
+flash_recursion_limit: 500
 
 # Workflow Settings
 workflow_timeout: 3200  # seconds (53 minutes)

--- a/libs/ptc-cli/ptc_cli/core/__init__.py
+++ b/libs/ptc-cli/ptc_cli/core/__init__.py
@@ -8,7 +8,6 @@ from ptc_cli.core.config import (
     PTC_AGENT_ASCII,
     Settings,
     console,
-    langgraph_config,
     settings,
 )
 from ptc_cli.core.state import ReconnectStateManager, SessionState
@@ -33,6 +32,5 @@ __all__ = [
     "get_syntax_theme",
     "get_theme",
     "get_toolbar_styles",
-    "langgraph_config",
     "settings",
 ]

--- a/libs/ptc-cli/ptc_cli/core/config.py
+++ b/libs/ptc-cli/ptc_cli/core/config.py
@@ -113,9 +113,6 @@ MAX_ARG_LENGTH = 150
 # Maximum error message length for display
 MAX_ERROR_LENGTH = 500
 
-# Agent configuration for langgraph
-langgraph_config = {"recursion_limit": 1000}
-
 # Rich console instance (respects NO_COLOR environment variable)
 console = Console(highlight=False, no_color=get_theme().colors_disabled)
 

--- a/src/config/models.py
+++ b/src/config/models.py
@@ -165,7 +165,8 @@ class InfrastructureConfig(BaseModel):
 
     # Application Settings
     debug: bool = Field(default=False, description="Debug mode flag")
-    agent_recursion_limit: int = Field(default=100, description="Agent recursion limit")
+    ptc_recursion_limit: int = Field(default=2000, ge=1, le=10000, description="PTC agent recursion limit")
+    flash_recursion_limit: int = Field(default=500, ge=1, le=10000, description="Flash agent recursion limit")
     workflow_timeout: int = Field(default=3200, description="Workflow timeout in seconds")
     sse_keepalive_interval: float = Field(
         default=15.0, description="SSE keepalive interval in seconds"

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -41,9 +41,14 @@ def get_debug_mode() -> bool:
     return get_infrastructure_config().debug
 
 
-def get_agent_recursion_limit() -> int:
-    """Get agent recursion limit from config.yaml."""
-    return get_infrastructure_config().agent_recursion_limit
+def get_ptc_recursion_limit() -> int:
+    """Get PTC agent recursion limit from config.yaml."""
+    return get_infrastructure_config().ptc_recursion_limit
+
+
+def get_flash_recursion_limit() -> int:
+    """Get Flash agent recursion limit from config.yaml."""
+    return get_infrastructure_config().flash_recursion_limit
 
 
 def get_workflow_timeout() -> int:

--- a/src/ptc_agent/agent/agent.py
+++ b/src/ptc_agent/agent/agent.py
@@ -636,7 +636,7 @@ class PTCAgent:
             middleware=deepagent_middleware,
             checkpointer=checkpointer,
             store=store,
-        ).with_config({"recursion_limit": 1000})
+        ).with_config({"recursion_limit": 2000})
 
         # Wrap with orchestrator for background execution support
         return BackgroundSubagentOrchestrator(

--- a/src/ptc_agent/agent/flash/agent.py
+++ b/src/ptc_agent/agent/flash/agent.py
@@ -310,6 +310,6 @@ class FlashAgent:
         agent = create_agent(
             model,
             **create_kwargs,
-        ).with_config({"recursion_limit": 100})
+        ).with_config({"recursion_limit": 500})
 
         return agent

--- a/src/server/handlers/chat/_common.py
+++ b/src/server/handlers/chat/_common.py
@@ -629,7 +629,7 @@ def build_graph_config(
     request: ChatRequest,
     effective_model: str | None,
     is_byok: bool,
-    recursion_limit: int = 100,
+    recursion_limit: int,
     plan_mode: bool | None = None,
     extra_configurable: dict | None = None,
 ) -> dict:

--- a/src/server/handlers/chat/flash_workflow.py
+++ b/src/server/handlers/chat/flash_workflow.py
@@ -59,6 +59,8 @@ from ._common import (
     stream_live_events,
     wait_or_steer,
 )
+from src.config.settings import get_flash_recursion_limit
+
 from .llm_config import resolve_llm_config
 from .steering import backfill_steering_queries, steer_thread
 
@@ -283,7 +285,7 @@ async def astream_flash_workflow(
             request=request,
             effective_model=effective_model,
             is_byok=is_byok,
-            recursion_limit=100,
+            recursion_limit=get_flash_recursion_limit(),
         )
 
         # Create stream handler

--- a/src/server/handlers/chat/ptc_workflow.py
+++ b/src/server/handlers/chat/ptc_workflow.py
@@ -68,6 +68,8 @@ from ._common import (
     stream_live_events,
     wait_or_steer,
 )
+from src.config.settings import get_ptc_recursion_limit
+
 from .llm_config import resolve_llm_config
 from .steering import backfill_steering_queries
 
@@ -396,7 +398,7 @@ async def astream_ptc_workflow(
             request=request,
             effective_model=effective_model,
             is_byok=is_byok,
-            recursion_limit=1000,
+            recursion_limit=get_ptc_recursion_limit(),
             plan_mode=effective_plan_mode,
         )
 

--- a/tests/unit/config/test_infrastructure_config.py
+++ b/tests/unit/config/test_infrastructure_config.py
@@ -84,7 +84,8 @@ class TestInfrastructureConfigComplete:
             "debug": True,
             "workflow_timeout": 1600,
             "sse_keepalive_interval": 30,
-            "agent_recursion_limit": 50,
+            "ptc_recursion_limit": 3000,
+            "flash_recursion_limit": 800,
             "allowed_origins": ["http://localhost:3000"],
             "log_level": "DEBUG",
             "background_execution": {
@@ -112,6 +113,8 @@ class TestInfrastructureConfigComplete:
         cfg = InfrastructureConfig(**data)
         assert cfg.debug is True
         assert cfg.workflow_timeout == 1600
+        assert cfg.ptc_recursion_limit == 3000
+        assert cfg.flash_recursion_limit == 800
         assert cfg.background_execution.subagent_collector_timeout == 60
         assert len(cfg.market_data.providers) == 2
         assert cfg.market_data.providers[0].name == "ginlix-data"
@@ -167,6 +170,16 @@ class TestSettingsBackwardCompat:
         from src.config.settings import get_sse_keepalive_interval
         with self._patch_infra_config(sse_keepalive_interval=30):
             assert get_sse_keepalive_interval() == 30
+
+    def test_get_ptc_recursion_limit(self):
+        from src.config.settings import get_ptc_recursion_limit
+        with self._patch_infra_config(ptc_recursion_limit=3000):
+            assert get_ptc_recursion_limit() == 3000
+
+    def test_get_flash_recursion_limit(self):
+        from src.config.settings import get_flash_recursion_limit
+        with self._patch_infra_config(flash_recursion_limit=800):
+            assert get_flash_recursion_limit() == 800
 
     def test_background_execution_accessors(self):
         from src.config.settings import (

--- a/tests/unit/server/handlers/test_chat_common.py
+++ b/tests/unit/server/handlers/test_chat_common.py
@@ -562,6 +562,7 @@ class TestBuildGraphConfig:
             ),
             effective_model="gpt-4o",
             is_byok=False,
+            recursion_limit=100,
         )
         defaults.update(kwargs)
         with (
@@ -571,15 +572,15 @@ class TestBuildGraphConfig:
             return build_graph_config(**defaults)
 
     def test_basic_flash_config(self):
-        config = self._build(mode="flash")
+        config = self._build(mode="flash", recursion_limit=500)
         assert config["configurable"]["agent_mode"] == "flash"
         assert config["configurable"]["thread_id"] == "t-1"
-        assert config["recursion_limit"] == 100
+        assert config["recursion_limit"] == 500
 
     def test_ptc_config_with_plan_mode(self):
-        config = self._build(mode="ptc", plan_mode=True, recursion_limit=1000)
+        config = self._build(mode="ptc", plan_mode=True, recursion_limit=2000)
         assert config["configurable"]["agent_mode"] == "ptc"
-        assert config["recursion_limit"] == 1000
+        assert config["recursion_limit"] == 2000
 
     def test_checkpoint_id_added(self):
         request = MagicMock(


### PR DESCRIPTION
## Summary

Recursion limits were hardcoded in 3 independent layers (config.yaml, agent `.with_config()`, workflow callers) with config.yaml never actually read. This PR makes `config.yaml` the single source of truth.

**Config consolidation:**
- `config.yaml` now defines `ptc_recursion_limit: 2000` and `flash_recursion_limit: 500`
- Settings accessors (`get_ptc_recursion_limit()`, `get_flash_recursion_limit()`) read from config
- Workflow callers (`ptc_workflow.py`, `flash_workflow.py`) use the accessors
- Agent-level `.with_config()` retained as safe default for non-server callers

**Dead code removal:**
- Removed unused `langgraph_config` from `libs/ptc-cli/` (defined but never imported)
- Removed old `agent_recursion_limit` config field (replaced by per-mode fields)

**Safety improvements:**
- Added Pydantic `ge=1, le=10000` bounds on both recursion limit config fields
- Made `build_graph_config()` require explicit `recursion_limit` (no silent default)

## Test Coverage
All new code paths have test coverage. Tests: 2001 → 2003 (+2 new accessor tests).

## Pre-Landing Review
No issues found. Review ran during this session, clean verdict.

## Adversarial Review
Claude adversarial subagent (medium tier, 50 lines). 3 auto-fixed findings:
- [AUTO-FIXED] Pydantic validation bounds added to recursion limit fields
- [AUTO-FIXED] Restored `.with_config()` safe defaults on agents for non-server callers
- [AUTO-FIXED] Added accessor test coverage for new settings functions

## Test plan
- [x] All backend tests pass (2003 tests, 0 failures)
- [x] No frontend changes