### PR TITLE
fix(markdown): disable single-tilde strikethrough to preserve ~ in financial text

### DIFF
--- a/web/src/pages/ChatAgent/components/Markdown.tsx
+++ b/web/src/pages/ChatAgent/components/Markdown.tsx
@@ -577,7 +577,7 @@ function Markdown({ content, variant = 'panel', className = '', style, onOpenFil
       className={`${config.className} ${className}`.trim()}
       style={{ ...config.style, ...style }}
     >
-      <ReactMarkdown key={lineKey} remarkPlugins={[remarkGfm, remarkCjkFriendly, remarkMath]} rehypePlugins={[[rehypeKatex, { strict: false }], rehypeRaw]} components={components}>
+      <ReactMarkdown key={lineKey} remarkPlugins={[[remarkGfm, { singleTilde: false }], remarkCjkFriendly, remarkMath]} rehypePlugins={[[rehypeKatex, { strict: false }], rehypeRaw]} components={components}>
         {processed}
       </ReactMarkdown>
     </div>


### PR DESCRIPTION
## Summary

Disables single-tilde strikethrough in the markdown renderer so `~` characters used for "approximately" (e.g., `~$120B`) are rendered literally instead of being interpreted as strikethrough syntax.

**Root cause:** `remark-gfm` v4 defaults `singleTilde: true`, meaning `~text~` is treated as strikethrough. When the LLM outputs lines like `~$120B (~$55–65B to NVIDIA)`, the two tildes form a strikethrough pair, visually deleting the price. This is especially common in financial research output.

**Fix:** Pass `{ singleTilde: false }` to `remarkGfm` so only `~~double tilde~~` triggers strikethrough. All other GFM features (tables, task lists, autolinks) are unaffected.

## Test Coverage

Single config option change — no new code paths.

## Pre-Landing Review

No issues found.

## Test plan

- [x] All backend tests pass (2003 passed)
- [x] All frontend tests pass (247 passed, 24 suites)