### PR TITLE
fix: prevent variant model leak across credential boundaries

### DIFF
--- a/src/llms/llm.py
+++ b/src/llms/llm.py
@@ -144,7 +144,7 @@ class ModelConfig:
         return provider.title()
 
     def get_model_metadata(self) -> dict[str, dict[str, str]]:
-        """Return {model_key: {sdk, provider, access_type}} for all visible models."""
+        """Return {model_key: {sdk, provider, access_type, ...}} for all visible models."""
         result = {}
         for model_name, model_info in self.llm_config.items():
             if not model_info or not model_info.get("visible", False):
@@ -153,7 +153,15 @@ class ModelConfig:
             provider_info = self.get_provider_info(provider)
             sdk = provider_info.get("sdk", "unknown")
             access_type = provider_info.get("access_type", "api_key")
-            result[model_name] = {"sdk": sdk, "provider": provider, "access_type": access_type}
+            entry: dict[str, str] = {"sdk": sdk, "provider": provider, "access_type": access_type}
+            # Mark variants that require their own API key (different env_key from parent).
+            # e.g. z-ai-cn needs ZAI_CN_API_KEY, not ZAI_API_KEY.
+            parent_provider = provider_info.get("parent_provider")
+            if parent_provider:
+                parent_info = self.get_provider_info(parent_provider)
+                if provider_info.get("env_key") != parent_info.get("env_key"):
+                    entry["requires_own_key"] = "true"
+            result[model_name] = entry
         return result
 
 

--- a/src/llms/llm.py
+++ b/src/llms/llm.py
@@ -144,14 +144,16 @@ class ModelConfig:
         return provider.title()
 
     def get_model_metadata(self) -> dict[str, dict[str, str]]:
-        """Return {model_key: {sdk, provider}} for all visible models."""
+        """Return {model_key: {sdk, provider, access_type}} for all visible models."""
         result = {}
         for model_name, model_info in self.llm_config.items():
             if not model_info or not model_info.get("visible", False):
                 continue
             provider = model_info.get("provider", "unknown")
-            sdk = self.get_provider_info(provider).get("sdk", "unknown")
-            result[model_name] = {"sdk": sdk, "provider": provider}
+            provider_info = self.get_provider_info(provider)
+            sdk = provider_info.get("sdk", "unknown")
+            access_type = provider_info.get("access_type", "api_key")
+            result[model_name] = {"sdk": sdk, "provider": provider, "access_type": access_type}
         return result
 
 

--- a/src/server/handlers/chat/llm_config.py
+++ b/src/server/handlers/chat/llm_config.py
@@ -389,7 +389,7 @@ async def resolve_llm_config(
                 )
             return client
         except Exception:
-            logger.warning("[CHAT] Failed to resolve fallback model %s, skipping", model_name)
+            logger.warning("[CHAT] Failed to resolve model %s, skipping", model_name, exc_info=True)
             return None
 
     subsidiary_pairs = [(role, m) for role, m in [("summarization", config.llm.summarization), ("fetch", config.llm.fetch)] if m]

--- a/src/server/handlers/chat/llm_config.py
+++ b/src/server/handlers/chat/llm_config.py
@@ -381,12 +381,16 @@ async def resolve_llm_config(
     import asyncio
 
     async def _resolve_one(model_name: str):
-        client = await resolve_oauth_llm_client(user_id, model_name)
-        if not client and is_byok:
-            client = await resolve_byok_llm_client(
-                user_id, model_name, is_byok, _pref_cache=model_pref,
-            )
-        return client
+        try:
+            client = await resolve_oauth_llm_client(user_id, model_name)
+            if not client and is_byok:
+                client = await resolve_byok_llm_client(
+                    user_id, model_name, is_byok, _pref_cache=model_pref,
+                )
+            return client
+        except Exception:
+            logger.warning("[CHAT] Failed to resolve fallback model %s, skipping", model_name)
+            return None
 
     subsidiary_pairs = [(role, m) for role, m in [("summarization", config.llm.summarization), ("fetch", config.llm.fetch)] if m]
     fallback_models = config.llm.fallback or []

--- a/src/server/handlers/chat/llm_config.py
+++ b/src/server/handlers/chat/llm_config.py
@@ -389,7 +389,7 @@ async def resolve_llm_config(
                 )
             return client
         except Exception:
-            logger.warning("[CHAT] Failed to resolve model %s, skipping", model_name, exc_info=True)
+            logger.error("[CHAT] Failed to resolve model %s, skipping", model_name, exc_info=True)
             return None
 
     subsidiary_pairs = [(role, m) for role, m in [("summarization", config.llm.summarization), ("fetch", config.llm.fetch)] if m]

--- a/tests/unit/llms/test_model_config_flatten.py
+++ b/tests/unit/llms/test_model_config_flatten.py
@@ -226,6 +226,7 @@ class TestFlattenProviders:
 
         # z-ai-cn models should have requires_own_key (different env_key from z-ai parent)
         cn_models = {k: v for k, v in metadata.items() if v.get("provider") == "z-ai-cn"}
+        assert cn_models, "Expected at least one z-ai-cn model in manifest"
         for model_name, entry in cn_models.items():
             assert entry.get("requires_own_key") == "true", (
                 f"{model_name} (z-ai-cn) should have requires_own_key='true'"
@@ -233,16 +234,18 @@ class TestFlattenProviders:
 
         # z-ai models should NOT have requires_own_key (direct parent, no parent_provider)
         zai_models = {k: v for k, v in metadata.items() if v.get("provider") == "z-ai"}
+        assert zai_models, "Expected at least one z-ai model in manifest"
         for model_name, entry in zai_models.items():
             assert "requires_own_key" not in entry, (
                 f"{model_name} (z-ai) should not have requires_own_key"
             )
 
-        # deepinfra models should NOT have requires_own_key (inherits openrouter env_key)
-        di_models = {k: v for k, v in metadata.items() if v.get("provider") == "deepinfra"}
-        for model_name, entry in di_models.items():
+        # doubao-anthropic models should NOT have requires_own_key (inherits volcengine env_key)
+        da_models = {k: v for k, v in metadata.items() if v.get("provider") == "doubao-anthropic"}
+        assert da_models, "Expected at least one doubao-anthropic model in manifest"
+        for model_name, entry in da_models.items():
             assert "requires_own_key" not in entry, (
-                f"{model_name} (deepinfra) should not have requires_own_key"
+                f"{model_name} (doubao-anthropic) should not have requires_own_key"
             )
 
     def test_get_display_name_prefers_own_over_parent(self):

--- a/tests/unit/llms/test_model_config_flatten.py
+++ b/tests/unit/llms/test_model_config_flatten.py
@@ -219,6 +219,32 @@ class TestFlattenProviders:
         with pytest.raises(ValueError, match="sdk"):
             ModelConfig._flatten_providers(grouped)
 
+    def test_get_model_metadata_requires_own_key_for_regional_variants(self):
+        """Models from variants with different env_key should have requires_own_key."""
+        mc = ModelConfig()
+        metadata = mc.get_model_metadata()
+
+        # z-ai-cn models should have requires_own_key (different env_key from z-ai parent)
+        cn_models = {k: v for k, v in metadata.items() if v.get("provider") == "z-ai-cn"}
+        for model_name, entry in cn_models.items():
+            assert entry.get("requires_own_key") == "true", (
+                f"{model_name} (z-ai-cn) should have requires_own_key='true'"
+            )
+
+        # z-ai models should NOT have requires_own_key (direct parent, no parent_provider)
+        zai_models = {k: v for k, v in metadata.items() if v.get("provider") == "z-ai"}
+        for model_name, entry in zai_models.items():
+            assert "requires_own_key" not in entry, (
+                f"{model_name} (z-ai) should not have requires_own_key"
+            )
+
+        # deepinfra models should NOT have requires_own_key (inherits openrouter env_key)
+        di_models = {k: v for k, v in metadata.items() if v.get("provider") == "deepinfra"}
+        for model_name, entry in di_models.items():
+            assert "requires_own_key" not in entry, (
+                f"{model_name} (deepinfra) should not have requires_own_key"
+            )
+
     def test_get_display_name_prefers_own_over_parent(self):
         """Variant with its own display_name should use it, not parent's."""
         grouped = {

--- a/tests/unit/server/app/test_models_endpoint.py
+++ b/tests/unit/server/app/test_models_endpoint.py
@@ -175,3 +175,32 @@ class TestListModelsResponse:
             resp = await client.get("/api/v1/models")
 
         assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_model_metadata_includes_access_type(self, client):
+        """model_metadata values should include access_type alongside sdk and provider."""
+        mock_models = {
+            "openai": [{"name": "gpt-4o", "model_id": "gpt-4o"}],
+        }
+        mock_mc = MagicMock()
+        mock_mc.get_display_name.side_effect = lambda p: p.title()
+        mock_mc.get_model_metadata.return_value = {
+            "gpt-4o": {"sdk": "openai", "provider": "openai", "access_type": "api_key"},
+        }
+
+        mock_llm_cls = MagicMock()
+        mock_llm_cls.get_model_config.return_value = mock_mc
+
+        agent_cfg = _mock_agent_config(name="gpt-4o")
+        with (
+            patch("src.llms.llm.get_configured_llm_models", return_value=mock_models),
+            patch("src.llms.llm.LLM", mock_llm_cls),
+            patch("src.server.app.setup.agent_config", agent_cfg),
+        ):
+            resp = await client.get("/api/v1/models")
+
+        body = resp.json()
+        metadata = body["model_metadata"]
+        assert "gpt-4o" in metadata
+        assert "access_type" in metadata["gpt-4o"]
+        assert metadata["gpt-4o"]["access_type"] == "api_key"

--- a/tests/unit/server/handlers/test_resolve_llm_config.py
+++ b/tests/unit/server/handlers/test_resolve_llm_config.py
@@ -488,3 +488,86 @@ class TestFastMode:
             )
         call_kwargs = mock_oauth.call_args
         assert call_kwargs.kwargs.get("service_tier") == "priority"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_one error handling (fallback model resolution)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveOneFallbackGuard:
+    @pytest.mark.asyncio
+    async def test_resolve_one_catches_exception_from_oauth(self, base_config):
+        """If resolve_oauth_llm_client raises for a fallback model, it should be skipped (not crash)."""
+        from src.server.handlers.chat.llm_config import resolve_llm_config
+
+        mock_mc = _mock_model_config(system_models={"system-default-model", "system-flash-model", "oauth-model"})
+
+        async def _oauth_side_effect(user_id, model_name, *args, **kwargs):
+            if model_name == "oauth-model":
+                raise Exception("OAuth token expired")
+            return None
+
+        with (
+            patch(
+                f"{HANDLER}.get_model_preference",
+                new_callable=AsyncMock,
+                return_value={"fallback_models": ["oauth-model"]},
+            ),
+            patch(
+                f"{HANDLER}.resolve_oauth_llm_client",
+                new_callable=AsyncMock,
+                side_effect=_oauth_side_effect,
+            ),
+            patch("src.llms.llm.LLM.get_model_config", return_value=mock_mc),
+        ):
+            config = await resolve_llm_config(base_config, "user-1", None, False)
+
+        # The fallback should be skipped, not crash the whole request
+        assert config.llm.name == "system-default-model"
+        # No fallback clients resolved (the one model failed)
+        assert not getattr(config, "fallback_llm_clients", None)
+
+    @pytest.mark.asyncio
+    async def test_mixed_fallback_valid_and_invalid(self, base_config):
+        """Mixed fallback list: valid API-key model resolves, invalid OAuth model is skipped."""
+        from src.server.handlers.chat.llm_config import resolve_llm_config
+
+        mock_mc = _mock_model_config(
+            system_models={"system-default-model", "system-flash-model", "valid-model", "oauth-model"}
+        )
+        mock_valid_client = MagicMock(name="valid-fallback-client")
+
+        async def _oauth_side_effect(user_id, model_name, *args, **kwargs):
+            if model_name == "oauth-model":
+                raise Exception("OAuth provider not configured")
+            return None
+
+        async def _byok_side_effect(user_id, model_name, is_byok, *args, **kwargs):
+            if model_name == "valid-model":
+                return mock_valid_client
+            return None
+
+        with (
+            patch(
+                f"{HANDLER}.get_model_preference",
+                new_callable=AsyncMock,
+                return_value={"fallback_models": ["valid-model", "oauth-model"]},
+            ),
+            patch(
+                f"{HANDLER}.resolve_oauth_llm_client",
+                new_callable=AsyncMock,
+                side_effect=_oauth_side_effect,
+            ),
+            patch(
+                f"{HANDLER}.resolve_byok_llm_client",
+                new_callable=AsyncMock,
+                side_effect=_byok_side_effect,
+            ),
+            patch("src.llms.llm.LLM.get_model_config", return_value=mock_mc),
+        ):
+            config = await resolve_llm_config(base_config, "user-1", None, True)
+
+        # Valid model resolved, invalid skipped
+        assert len(config.fallback_llm_clients) == 1
+        assert config.fallback_llm_clients[0] is mock_valid_client

--- a/web/src/hooks/__tests__/useFilteredModels.test.ts
+++ b/web/src/hooks/__tests__/useFilteredModels.test.ts
@@ -121,6 +121,24 @@ describe('filterModelsByAccess', () => {
     expect(result.openai?.models).toEqual(['gpt-4o']);
   });
 
+  it('excludes groupKey fallback when access_type differs (coding_plan leak)', () => {
+    // dashscope-coding models grouped under dashscope — user only has api_key
+    const providerMap = makeProviderMap({
+      dashscope: ['qwen3-turbo', 'qwen3.5-plus-coding'],
+    });
+    const metadata: Record<string, ModelMetadataEntry> = {
+      'qwen3-turbo': { provider: 'dashscope', access_type: 'api_key' },
+      'qwen3.5-plus-coding': { provider: 'dashscope-coding', access_type: 'coding_plan' },
+    };
+    const { configuredSet, configuredTypeMap } = makeConfigured([
+      { provider: 'dashscope', displayName: 'DashScope', type: 'api_key' },
+    ]);
+
+    const result = filterModelsByAccess(providerMap, metadata, configuredSet, configuredTypeMap);
+
+    expect(result.dashscope?.models).toEqual(['qwen3-turbo']);
+  });
+
   it('excludes groupKey fallback when variant requires own key (regional variant)', () => {
     // z-ai-cn models grouped under z-ai — both api_key but different env_key
     const providerMap = makeProviderMap({

--- a/web/src/hooks/__tests__/useFilteredModels.test.ts
+++ b/web/src/hooks/__tests__/useFilteredModels.test.ts
@@ -49,8 +49,8 @@ describe('filterModelsByAccess', () => {
     expect(result.openai?.models).toEqual(['gpt-4o', 'gpt-4o-mini']);
   });
 
-  it('includes groupKey fallback when access_type matches', () => {
-    // DeepInfra models grouped under openrouter — both are api_key type
+  it('includes groupKey fallback when access_type matches and no own key required', () => {
+    // DeepInfra models grouped under openrouter — same api_key, shares credentials
     const providerMap = makeProviderMap({
       openrouter: ['deepinfra-model-1'],
     });
@@ -119,6 +119,25 @@ describe('filterModelsByAccess', () => {
     const result = filterModelsByAccess(providerMap, metadata, configuredSet, configuredTypeMap);
 
     expect(result.openai?.models).toEqual(['gpt-4o']);
+  });
+
+  it('excludes groupKey fallback when variant requires own key (regional variant)', () => {
+    // z-ai-cn models grouped under z-ai — both api_key but different env_key
+    const providerMap = makeProviderMap({
+      'z-ai': ['glm-5', 'glm-5-turbo-cn'],
+    });
+    const metadata: Record<string, ModelMetadataEntry> = {
+      'glm-5': { provider: 'z-ai', access_type: 'api_key' },
+      'glm-5-turbo-cn': { provider: 'z-ai-cn', access_type: 'api_key', requires_own_key: 'true' },
+    };
+    const { configuredSet, configuredTypeMap } = makeConfigured([
+      { provider: 'z-ai', displayName: 'Zhipu AI', type: 'api_key' },
+    ]);
+
+    const result = filterModelsByAccess(providerMap, metadata, configuredSet, configuredTypeMap);
+
+    // glm-5 included (direct match), glm-5-turbo-cn excluded (requires own key)
+    expect(result['z-ai']?.models).toEqual(['glm-5']);
   });
 
   it('includes model when metadata is missing access_type (defaults to api_key)', () => {

--- a/web/src/hooks/__tests__/useFilteredModels.test.ts
+++ b/web/src/hooks/__tests__/useFilteredModels.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import { filterModelsByAccess, buildConfiguredTypeMap } from '../useFilteredModels';
+import type { ModelMetadataEntry } from '../useFilteredModels';
+import type { ConfiguredProvider } from '../useConfiguredProviders';
+import type { ProviderModelsData } from '@/components/model/types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProviderMap(
+  entries: Record<string, string[]>,
+): Record<string, ProviderModelsData> {
+  const out: Record<string, ProviderModelsData> = {};
+  for (const [key, models] of Object.entries(entries)) {
+    out[key] = { models, display_name: key };
+  }
+  return out;
+}
+
+function makeConfigured(
+  providers: ConfiguredProvider[],
+): { configuredSet: Set<string>; configuredTypeMap: Map<string, string> } {
+  return {
+    configuredSet: new Set(providers.map((p) => p.provider)),
+    configuredTypeMap: buildConfiguredTypeMap(providers),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('filterModelsByAccess', () => {
+  it('includes models with a direct provider match', () => {
+    const providerMap = makeProviderMap({
+      openai: ['gpt-4o', 'gpt-4o-mini'],
+    });
+    const metadata: Record<string, ModelMetadataEntry> = {
+      'gpt-4o': { provider: 'openai', access_type: 'api_key' },
+      'gpt-4o-mini': { provider: 'openai', access_type: 'api_key' },
+    };
+    const { configuredSet, configuredTypeMap } = makeConfigured([
+      { provider: 'openai', displayName: 'OpenAI', type: 'api_key' },
+    ]);
+
+    const result = filterModelsByAccess(providerMap, metadata, configuredSet, configuredTypeMap);
+
+    expect(result.openai?.models).toEqual(['gpt-4o', 'gpt-4o-mini']);
+  });
+
+  it('includes groupKey fallback when access_type matches', () => {
+    // DeepInfra models grouped under openrouter — both are api_key type
+    const providerMap = makeProviderMap({
+      openrouter: ['deepinfra-model-1'],
+    });
+    const metadata: Record<string, ModelMetadataEntry> = {
+      'deepinfra-model-1': { provider: 'deepinfra', access_type: 'api_key' },
+    };
+    const { configuredSet, configuredTypeMap } = makeConfigured([
+      { provider: 'openrouter', displayName: 'OpenRouter', type: 'api_key' },
+    ]);
+
+    const result = filterModelsByAccess(providerMap, metadata, configuredSet, configuredTypeMap);
+
+    expect(result.openrouter?.models).toEqual(['deepinfra-model-1']);
+  });
+
+  it('excludes groupKey fallback when access_type differs (OAuth leak)', () => {
+    // codex-oauth models grouped under openai — user only has api_key for openai
+    const providerMap = makeProviderMap({
+      openai: ['gpt-4o', 'gpt-5.4-oauth'],
+    });
+    const metadata: Record<string, ModelMetadataEntry> = {
+      'gpt-4o': { provider: 'openai', access_type: 'api_key' },
+      'gpt-5.4-oauth': { provider: 'codex-oauth', access_type: 'oauth' },
+    };
+    const { configuredSet, configuredTypeMap } = makeConfigured([
+      { provider: 'openai', displayName: 'OpenAI', type: 'api_key' },
+    ]);
+
+    const result = filterModelsByAccess(providerMap, metadata, configuredSet, configuredTypeMap);
+
+    // gpt-4o should be included (direct match), gpt-5.4-oauth excluded (different access_type)
+    expect(result.openai?.models).toEqual(['gpt-4o']);
+  });
+
+  it('passes all models through when configuredSet is empty (no filtering)', () => {
+    const providerMap = makeProviderMap({
+      openai: ['gpt-4o'],
+      anthropic: ['claude-sonnet'],
+    });
+    const metadata: Record<string, ModelMetadataEntry> = {
+      'gpt-4o': { provider: 'openai', access_type: 'api_key' },
+      'claude-sonnet': { provider: 'anthropic', access_type: 'api_key' },
+    };
+    const configuredSet = new Set<string>();
+    const configuredTypeMap = new Map<string, string>();
+
+    const result = filterModelsByAccess(providerMap, metadata, configuredSet, configuredTypeMap);
+
+    // All models should pass through unchanged
+    expect(result.openai?.models).toEqual(['gpt-4o']);
+    expect(result.anthropic?.models).toEqual(['claude-sonnet']);
+  });
+
+  it('excludes models with no metadata entry', () => {
+    const providerMap = makeProviderMap({
+      openai: ['gpt-4o', 'unknown-model'],
+    });
+    const metadata: Record<string, ModelMetadataEntry> = {
+      'gpt-4o': { provider: 'openai', access_type: 'api_key' },
+      // 'unknown-model' has no metadata
+    };
+    const { configuredSet, configuredTypeMap } = makeConfigured([
+      { provider: 'openai', displayName: 'OpenAI', type: 'api_key' },
+    ]);
+
+    const result = filterModelsByAccess(providerMap, metadata, configuredSet, configuredTypeMap);
+
+    expect(result.openai?.models).toEqual(['gpt-4o']);
+  });
+
+  it('includes model when metadata is missing access_type (defaults to api_key)', () => {
+    const providerMap = makeProviderMap({
+      openai: ['gpt-4o'],
+    });
+    const metadata: Record<string, ModelMetadataEntry> = {
+      'gpt-4o': { provider: 'openai' }, // no access_type field
+    };
+    const { configuredSet, configuredTypeMap } = makeConfigured([
+      { provider: 'openai', displayName: 'OpenAI', type: 'api_key' },
+    ]);
+
+    const result = filterModelsByAccess(providerMap, metadata, configuredSet, configuredTypeMap);
+
+    // Should include — access_type defaults to 'api_key', matches configured type
+    expect(result.openai?.models).toEqual(['gpt-4o']);
+  });
+});

--- a/web/src/hooks/useConfiguredProviders.ts
+++ b/web/src/hooks/useConfiguredProviders.ts
@@ -17,14 +17,14 @@ export interface ConfiguredProvider {
 export function useConfiguredProviders() {
   const { apiKeys, isLoading: keysLoading } = useApiKeys();
 
-  const { data: codexStatus } = useQuery({
+  const { data: codexStatus, isLoading: codexLoading } = useQuery({
     queryKey: queryKeys.oauth.codex(),
     queryFn: getCodexOAuthStatus,
     staleTime: 60_000,
     retry: false,
   });
 
-  const { data: claudeStatus } = useQuery({
+  const { data: claudeStatus, isLoading: claudeLoading } = useQuery({
     queryKey: queryKeys.oauth.claude(),
     queryFn: getClaudeOAuthStatus,
     staleTime: 60_000,
@@ -83,6 +83,6 @@ export function useConfiguredProviders() {
     providers,
     configuredSet,
     hasAny: providers.length > 0,
-    isLoading: keysLoading,
+    isLoading: keysLoading || codexLoading || claudeLoading,
   };
 }

--- a/web/src/hooks/useFilteredModels.ts
+++ b/web/src/hooks/useFilteredModels.ts
@@ -9,6 +9,8 @@ export interface ModelMetadataEntry {
   provider?: string;
   sdk?: string;
   access_type?: string;
+  /** "true" when variant needs its own API key (different env_key from parent). */
+  requires_own_key?: string;
 }
 
 /**
@@ -45,8 +47,10 @@ export function filterModelsByAccess(
       // 1. Direct match on model's own provider
       if (configuredSet.has(modelProvider)) return true;
 
-      // 2. GroupKey fallback — only if access_type matches
+      // 2. GroupKey fallback — only if access_type matches AND variant
+      //    shares credentials with parent (no independent env_key).
       if (configuredSet.has(groupKey)) {
+        if (meta?.requires_own_key === 'true') return false;
         const configuredType = configuredTypeMap.get(groupKey);
         const modelAccessType = meta?.access_type ?? 'api_key';
         return configuredType === modelAccessType;

--- a/web/src/hooks/useFilteredModels.ts
+++ b/web/src/hooks/useFilteredModels.ts
@@ -1,0 +1,94 @@
+import { useMemo } from 'react';
+import type { ProviderModelsData } from '@/components/model/types';
+import type { ConfiguredProvider } from './useConfiguredProviders';
+
+/**
+ * Model metadata entry as returned by the `/api/v1/models` endpoint.
+ */
+export interface ModelMetadataEntry {
+  provider?: string;
+  sdk?: string;
+  access_type?: string;
+}
+
+/**
+ * Pure function: filter a grouped models map so only models the user
+ * has access to remain.
+ *
+ * Filter logic per model:
+ *   1. Direct match: configuredSet has the model's own provider -> include
+ *   2. GroupKey fallback: configuredSet has the groupKey AND the configured
+ *      provider's type matches the model's access_type -> include
+ *   3. Otherwise -> exclude
+ *   4. If configuredSet is empty -> no filtering (all pass)
+ */
+export function filterModelsByAccess(
+  providerMap: Record<string, ProviderModelsData>,
+  metadata: Record<string, ModelMetadataEntry>,
+  configuredSet: Set<string>,
+  configuredTypeMap: Map<string, string>,
+): Record<string, ProviderModelsData> {
+  const hasFilter = configuredSet.size > 0;
+  if (!hasFilter) return providerMap;
+
+  const out: Record<string, ProviderModelsData> = {};
+
+  for (const [groupKey, data] of Object.entries(providerMap)) {
+    if (!data || typeof data !== 'object') continue;
+    const allModels = data.models ?? [];
+
+    const filtered = allModels.filter((m) => {
+      const meta = metadata[m];
+      const modelProvider = meta?.provider;
+      if (!modelProvider) return false;
+
+      // 1. Direct match on model's own provider
+      if (configuredSet.has(modelProvider)) return true;
+
+      // 2. GroupKey fallback — only if access_type matches
+      if (configuredSet.has(groupKey)) {
+        const configuredType = configuredTypeMap.get(groupKey);
+        const modelAccessType = meta?.access_type ?? 'api_key';
+        return configuredType === modelAccessType;
+      }
+
+      return false;
+    });
+
+    if (filtered.length > 0) {
+      out[groupKey] = {
+        models: filtered,
+        display_name: data.display_name ?? groupKey,
+      };
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Build a type map from configured providers: provider key -> type.
+ */
+export function buildConfiguredTypeMap(
+  providers: ConfiguredProvider[],
+): Map<string, string> {
+  return new Map(providers.map((p) => [p.provider, p.type]));
+}
+
+/**
+ * React hook: filters models using `filterModelsByAccess`.
+ *
+ * Takes the grouped models map, model metadata, and configured providers.
+ * Returns only models the user has access to.
+ */
+export function useFilteredModels(
+  providerMap: Record<string, ProviderModelsData>,
+  metadata: Record<string, ModelMetadataEntry>,
+  configuredProviders: ConfiguredProvider[],
+): Record<string, ProviderModelsData> {
+  return useMemo(() => {
+    const configuredSet = new Set(configuredProviders.map((p) => p.provider));
+    const configuredTypeMap = buildConfiguredTypeMap(configuredProviders);
+    return filterModelsByAccess(providerMap, metadata, configuredSet, configuredTypeMap);
+  }, [providerMap, metadata, configuredProviders]);
+}

--- a/web/src/pages/Dashboard/components/UserConfigPanel.tsx
+++ b/web/src/pages/Dashboard/components/UserConfigPanel.tsx
@@ -17,6 +17,7 @@ import { ProviderManager } from '@/components/model/ProviderManager';
 import { ModelTierConfig } from '@/components/model/ModelTierConfig';
 import type { ByokProvider, ProviderModelsData } from '@/components/model/types';
 import { filterModelsByAccess, buildConfiguredTypeMap } from '@/hooks/useFilteredModels';
+import type { ModelMetadataEntry } from '@/hooks/useFilteredModels';
 import type { ConfiguredProvider } from '@/hooks/useConfiguredProviders';
 
 type SettingsTab = 'userInfo' | 'preferences' | 'model';
@@ -85,7 +86,7 @@ function UserConfigPanel({ isOpen, onClose, onModifyPreferences, onStartOnboardi
 
   // Model tab state
   const [availableModels, setAvailableModels] = useState<Record<string, string[] | ProviderModelsData>>({});
-  const [modelMetadata, setModelMetadata] = useState<Record<string, { provider?: string; sdk?: string; access_type?: string }>>({});
+  const [modelMetadata, setModelMetadata] = useState<Record<string, ModelMetadataEntry>>({});
   const [preferredModel, setPreferredModel] = useState('');
   const [preferredFlashModel, setPreferredFlashModel] = useState('');
   const [starredModels, setStarredModels] = useState<string[]>([]);

--- a/web/src/pages/Dashboard/components/UserConfigPanel.tsx
+++ b/web/src/pages/Dashboard/components/UserConfigPanel.tsx
@@ -16,6 +16,8 @@ import ConfirmDialog from './ConfirmDialog';
 import { ProviderManager } from '@/components/model/ProviderManager';
 import { ModelTierConfig } from '@/components/model/ModelTierConfig';
 import type { ByokProvider, ProviderModelsData } from '@/components/model/types';
+import { filterModelsByAccess, buildConfiguredTypeMap } from '@/hooks/useFilteredModels';
+import type { ConfiguredProvider } from '@/hooks/useConfiguredProviders';
 
 type SettingsTab = 'userInfo' | 'preferences' | 'model';
 
@@ -83,6 +85,7 @@ function UserConfigPanel({ isOpen, onClose, onModifyPreferences, onStartOnboardi
 
   // Model tab state
   const [availableModels, setAvailableModels] = useState<Record<string, string[] | ProviderModelsData>>({});
+  const [modelMetadata, setModelMetadata] = useState<Record<string, { provider?: string; sdk?: string; access_type?: string }>>({});
   const [preferredModel, setPreferredModel] = useState('');
   const [preferredFlashModel, setPreferredFlashModel] = useState('');
   const [starredModels, setStarredModels] = useState<string[]>([]);
@@ -230,9 +233,10 @@ function UserConfigPanel({ isOpen, onClose, onModifyPreferences, onStartOnboardi
         getCodexOAuthStatus(),
         getClaudeOAuthStatus(),
       ]);
-      const modelsData = modelsRes as { models?: Record<string, string[] | ProviderModelsData> };
+      const modelsData = modelsRes as { models?: Record<string, string[] | ProviderModelsData>; model_metadata?: Record<string, { provider?: string; sdk?: string; access_type?: string }> };
       const keysData = keysRes as { byok_enabled?: boolean; providers?: ByokProvider[] };
       setAvailableModels(modelsData?.models || {});
+      setModelMetadata(modelsData?.model_metadata || {});
       setByokEnabled(keysData?.byok_enabled || false);
       setByokProviders(keysData?.providers || []);
       const initialBaseUrls: Record<string, string> = {};
@@ -677,8 +681,26 @@ function UserConfigPanel({ isOpen, onClose, onModifyPreferences, onStartOnboardi
     onClose();
   };
 
+  // Build configured providers list from local state for access filtering
+  const localConfiguredProviders = useMemo<ConfiguredProvider[]>(() => {
+    const result: ConfiguredProvider[] = [];
+    for (const p of byokProviders) {
+      if (p.has_key) {
+        result.push({ provider: p.provider, displayName: p.display_name || p.provider, type: 'api_key' });
+      }
+    }
+    if (codexOAuthStatus.connected) {
+      result.push({ provider: 'codex-oauth', displayName: 'ChatGPT Codex', type: 'oauth' });
+    }
+    if (claudeOAuthStatus.connected) {
+      result.push({ provider: 'claude-oauth', displayName: 'Claude (OAuth)', type: 'oauth' });
+    }
+    return result;
+  }, [byokProviders, codexOAuthStatus, claudeOAuthStatus]);
+
   // Normalize availableModels to the Record<string, ProviderModelsData> shape
   // expected by ModelTierConfig / ModelSelector (backend may return string[]).
+  // Filters by access type to prevent OAuth/coding_plan variants from leaking.
   const normalizedModels = useMemo<Record<string, ProviderModelsData>>(() => {
     const out: Record<string, ProviderModelsData> = {};
     for (const [provider, pd] of Object.entries(availableModels)) {
@@ -688,8 +710,11 @@ function UserConfigPanel({ isOpen, onClose, onModifyPreferences, onStartOnboardi
         out[provider] = pd as ProviderModelsData;
       }
     }
-    return out;
-  }, [availableModels]);
+    // Filter by access type to prevent OAuth/coding_plan variants from leaking
+    const configuredSet = new Set(localConfiguredProviders.map(p => p.provider));
+    const configuredTypeMap = buildConfiguredTypeMap(localConfiguredProviders);
+    return filterModelsByAccess(out, modelMetadata, configuredSet, configuredTypeMap);
+  }, [availableModels, modelMetadata, localConfiguredProviders]);
 
   // Build provider manifest for ProviderManager from byokProviders list.
   const providerManifest = useMemo(() => {

--- a/web/src/pages/Settings/Settings.tsx
+++ b/web/src/pages/Settings/Settings.tsx
@@ -19,6 +19,7 @@ import ConfirmDialog from '@/pages/Dashboard/components/ConfirmDialog';
 import { ModelTierConfig } from '@/components/model/ModelTierConfig';
 import type { ByokProvider, CustomModelEntry, CustomModelFormState, AddProviderFormState, ProviderModelsData } from '@/components/model/types';
 import { filterModelsByAccess, buildConfiguredTypeMap } from '@/hooks/useFilteredModels';
+import type { ModelMetadataEntry } from '@/hooks/useFilteredModels';
 import type { ConfiguredProvider } from '@/hooks/useConfiguredProviders';
 import './Settings.css';
 
@@ -81,7 +82,7 @@ function Settings() {
 
   // Model tab state
   const [availableModels, setAvailableModels] = useState<Record<string, string[] | ProviderModelsData>>({});
-  const [modelMetadata, setModelMetadata] = useState<Record<string, { provider?: string; sdk?: string; access_type?: string }>>({});
+  const [modelMetadata, setModelMetadata] = useState<Record<string, ModelMetadataEntry>>({});
   const [preferredModel, setPreferredModel] = useState('');
   const [preferredFlashModel, setPreferredFlashModel] = useState('');
   const [starredModels, setStarredModels] = useState<string[]>([]);

--- a/web/src/pages/Settings/Settings.tsx
+++ b/web/src/pages/Settings/Settings.tsx
@@ -18,6 +18,8 @@ import { getFlashWorkspace } from '@/pages/ChatAgent/utils/api';
 import ConfirmDialog from '@/pages/Dashboard/components/ConfirmDialog';
 import { ModelTierConfig } from '@/components/model/ModelTierConfig';
 import type { ByokProvider, CustomModelEntry, CustomModelFormState, AddProviderFormState, ProviderModelsData } from '@/components/model/types';
+import { filterModelsByAccess, buildConfiguredTypeMap } from '@/hooks/useFilteredModels';
+import type { ConfiguredProvider } from '@/hooks/useConfiguredProviders';
 import './Settings.css';
 
 interface CodexDeviceCode {
@@ -79,6 +81,7 @@ function Settings() {
 
   // Model tab state
   const [availableModels, setAvailableModels] = useState<Record<string, string[] | ProviderModelsData>>({});
+  const [modelMetadata, setModelMetadata] = useState<Record<string, { provider?: string; sdk?: string; access_type?: string }>>({});
   const [preferredModel, setPreferredModel] = useState('');
   const [preferredFlashModel, setPreferredFlashModel] = useState('');
   const [starredModels, setStarredModels] = useState<string[]>([]);
@@ -246,6 +249,7 @@ function Settings() {
         getClaudeOAuthStatus(),
       ]) as [Record<string, unknown>, Record<string, unknown>, OAuthStatus, OAuthStatus];
       setAvailableModels((modelsRes?.models as Record<string, string[] | ProviderModelsData>) || {});
+      setModelMetadata((modelsRes?.model_metadata as Record<string, { provider?: string; sdk?: string; access_type?: string }>) || {});
       const defaults = (modelsRes?.system_defaults as Record<string, unknown>) || {};
       setSystemDefaults(defaults);
       setByokEnabled(!!keysRes?.byok_enabled);
@@ -762,9 +766,27 @@ function Settings() {
     }
   };
 
+  // Build configured providers list from local state for access filtering
+  const localConfiguredProviders = useMemo<ConfiguredProvider[]>(() => {
+    const result: ConfiguredProvider[] = [];
+    for (const p of byokProviders) {
+      if (p.has_key) {
+        result.push({ provider: p.provider, displayName: p.display_name || p.provider, type: 'api_key' });
+      }
+    }
+    if (codexOAuthStatus.connected) {
+      result.push({ provider: 'codex-oauth', displayName: 'ChatGPT Codex', type: 'oauth' });
+    }
+    if (claudeOAuthStatus.connected) {
+      result.push({ provider: 'claude-oauth', displayName: 'Claude (OAuth)', type: 'oauth' });
+    }
+    return result;
+  }, [byokProviders, codexOAuthStatus, claudeOAuthStatus]);
+
   // Normalize availableModels to the Record<string, ProviderModelsData> shape
   // expected by ModelTierConfig / ModelSelector (backend may return string[]).
   // Also merges custom models so they appear in the model dropdowns.
+  // Finally filters by access type to prevent OAuth/coding_plan model leaks.
   const normalizedModels = useMemo<Record<string, ProviderModelsData>>(() => {
     const out: Record<string, ProviderModelsData> = {};
     for (const [provider, pd] of Object.entries(availableModels)) {
@@ -785,8 +807,11 @@ function Settings() {
         out[key].models!.push(cm.name);
       }
     }
-    return out;
-  }, [availableModels, customModels]);
+    // Filter by access type to prevent OAuth/coding_plan variants from leaking
+    const configuredSet = new Set(localConfiguredProviders.map(p => p.provider));
+    const configuredTypeMap = buildConfiguredTypeMap(localConfiguredProviders);
+    return filterModelsByAccess(out, modelMetadata, configuredSet, configuredTypeMap);
+  }, [availableModels, customModels, modelMetadata, localConfiguredProviders]);
 
   // All valid model names for filtering stale references
   const allValidModels = useMemo(() => {

--- a/web/src/pages/Setup/steps/DefaultsStep.tsx
+++ b/web/src/pages/Setup/steps/DefaultsStep.tsx
@@ -6,6 +6,8 @@ import { ModelTierConfig } from '@/components/model/ModelTierConfig';
 import type { ProviderModelsData } from '@/components/model/types';
 import { useAllModels } from '@/hooks/useAllModels';
 import { useConfiguredProviders } from '@/hooks/useConfiguredProviders';
+import { useFilteredModels } from '@/hooks/useFilteredModels';
+import type { ModelMetadataEntry } from '@/hooks/useFilteredModels';
 import { usePreferences } from '@/hooks/usePreferences';
 import { useUpdatePreferences } from '@/hooks/useUpdatePreferences';
 
@@ -16,53 +18,37 @@ import { useUpdatePreferences } from '@/hooks/useUpdatePreferences';
 export default function DefaultsStep() {
   const navigate = useNavigate();
   const { models, isLoading: modelsLoading } = useAllModels();
-  const { configuredSet } = useConfiguredProviders();
+  const { providers: configuredProviders, isLoading: providersLoading } = useConfiguredProviders();
   const { preferences } = usePreferences();
   const updatePreferences = useUpdatePreferences();
 
   // ---------------------------------------------------------------------------
   // Filter models to only those the user has access to.
   //
-  // model_metadata has per-model { provider, sdk }. The "provider" is the
-  // actual provider key (e.g. "claude-oauth", "anthropic", "codex-oauth").
-  // We check if that provider is in the user's configured set.
-  //
-  // The "models" response groups by parent provider, so we rebuild the
-  // grouped structure with only accessible models.
+  // Uses the shared filterModelsByAccess logic which checks both the model's
+  // own provider (direct match) and the groupKey fallback (only when the
+  // configured provider's access_type matches the model's access_type).
+  // This prevents OAuth/coding_plan variants from leaking through groupKey.
   // ---------------------------------------------------------------------------
 
-  const normalizedModels = useMemo<Record<string, ProviderModelsData>>(() => {
-    if (!models) return {};
+  const { providerMap, metadata } = useMemo(() => {
+    if (!models) return { providerMap: {} as Record<string, ProviderModelsData>, metadata: {} as Record<string, ModelMetadataEntry> };
     const raw = models as Record<string, unknown>;
-    const providerMap = (raw.models ?? raw) as Record<string, Record<string, unknown>>;
-    const metadata = (raw.model_metadata ?? {}) as Record<string, { provider?: string }>;
+    const rawProviderMap = (raw.models ?? raw) as Record<string, Record<string, unknown>>;
+    const rawMetadata = (raw.model_metadata ?? {}) as Record<string, ModelMetadataEntry>;
 
-    const hasFilter = configuredSet.size > 0;
-    const out: Record<string, ProviderModelsData> = {};
-
-    for (const [groupKey, data] of Object.entries(providerMap)) {
+    const pm: Record<string, ProviderModelsData> = {};
+    for (const [groupKey, data] of Object.entries(rawProviderMap)) {
       if (!data || typeof data !== 'object') continue;
-      const allModels = (data.models as string[]) ?? [];
-
-      // Filter: keep model if its actual provider (from metadata) is configured
-      const filtered = hasFilter
-        ? allModels.filter((m) => {
-            const modelProvider = metadata[m]?.provider;
-            if (!modelProvider) return false;
-            // Check direct match or parent match
-            return configuredSet.has(modelProvider) || configuredSet.has(groupKey);
-          })
-        : allModels;
-
-      if (filtered.length > 0) {
-        out[groupKey] = {
-          models: filtered,
-          display_name: (data.display_name as string) ?? groupKey,
-        };
-      }
+      pm[groupKey] = {
+        models: (data.models as string[]) ?? [],
+        display_name: (data.display_name as string) ?? groupKey,
+      };
     }
-    return out;
-  }, [models, configuredSet]);
+    return { providerMap: pm, metadata: rawMetadata };
+  }, [models]);
+
+  const normalizedModels = useFilteredModels(providerMap, metadata, configuredProviders);
 
   // System defaults from models response
   const systemDefaults = useMemo(() => {
@@ -113,17 +99,19 @@ export default function DefaultsStep() {
     return out;
   }, [normalizedModels]);
 
-  // Seed fallback with all accessible models (minus primary/flash) once
+  // Seed fallback with all accessible models (minus primary/flash) once.
+  // Guard on !providersLoading to avoid seeding with unfiltered models
+  // before the configured provider set has loaded.
   const fallbackSeeded = useRef(false);
   useEffect(() => {
-    if (!fallbackSeeded.current && allAccessibleModels.length > 0) {
+    if (!fallbackSeeded.current && !providersLoading && allAccessibleModels.length > 0) {
       fallbackSeeded.current = true;
       setAdvancedModels((prev) => ({
         ...prev,
         fallbackModels: allAccessibleModels.filter((m) => m !== primaryModel && m !== flashModel),
       }));
     }
-  }, [allAccessibleModels, primaryModel, flashModel]);
+  }, [allAccessibleModels, providersLoading, primaryModel, flashModel]);
 
   // ---------------------------------------------------------------------------
   // Handlers

--- a/web/src/pages/Setup/steps/ProviderStep.tsx
+++ b/web/src/pages/Setup/steps/ProviderStep.tsx
@@ -160,6 +160,7 @@ export default function ProviderStep() {
               provider={p.provider}
               displayName={p.display_name}
               selected={selected === p.provider}
+              // brand_key fallback only for api_key — OAuth/coding_plan providers have unique keys
               configured={configuredSet.has(p.provider) || (method === 'api_key' && configuredSet.has(p.brand_key))}
               onSelect={setSelected}
             />

--- a/web/src/pages/Setup/steps/ProviderStep.tsx
+++ b/web/src/pages/Setup/steps/ProviderStep.tsx
@@ -160,7 +160,7 @@ export default function ProviderStep() {
               provider={p.provider}
               displayName={p.display_name}
               selected={selected === p.provider}
-              configured={configuredSet.has(p.provider) || configuredSet.has(p.brand_key)}
+              configured={configuredSet.has(p.provider) || (method === 'api_key' && configuredSet.has(p.brand_key))}
               onSelect={setSelected}
             />
           ))}


### PR DESCRIPTION
## Summary

**Provider variant models (OAuth, coding_plan, regional) were leaking into user fallback preferences, crashing chat at runtime.**

When a user configured only an API key for a provider (e.g. OpenAI), ALL variant models in the same provider group leaked into accessible model lists — including OAuth variants (`codex-oauth`, `claude-oauth`), coding plan variants (`dashscope-coding`, `moonshot-coding`), and regional variants (`z-ai-cn`, `dashscope-intl`). These leaked models got auto-seeded into fallback preferences and caused HTTP 400 crashes when no OAuth token exists.

**Root cause:** `configuredSet.has(groupKey)` admitted all variants regardless of access type or credential requirements.

### Changes

**Backend**
- `src/llms/llm.py` — `get_model_metadata()` now returns `access_type` and `requires_own_key` per model. `requires_own_key` is set when a variant overrides `env_key` from its parent (regional variants like z-ai-cn).
- `src/server/handlers/chat/llm_config.py` — `_resolve_one()` wrapped in `try/except Exception` so a single bad fallback model doesn't crash the entire chat request. Returns `None` + logs with traceback.

**Frontend**
- `web/src/hooks/useFilteredModels.ts` — **New.** Shared `filterModelsByAccess()` with three gates: direct provider match, groupKey fallback (only if access_type matches AND no independent credentials), else exclude.
- `web/src/hooks/useConfiguredProviders.ts` — Exposes `isLoading` to prevent race condition in fallback seeding.
- `web/src/pages/Setup/steps/DefaultsStep.tsx` — Uses shared filter, guards seeding on `!isLoading`.
- `web/src/pages/Settings/Settings.tsx` — Applies shared filter with model metadata.
- `web/src/pages/Dashboard/components/UserConfigPanel.tsx` — Same pattern.
- `web/src/pages/Setup/steps/ProviderStep.tsx` — `brand_key` checkmark fallback restricted to `api_key` method (prevents false "connected" on OAuth cards).

## Test Coverage

- `web/src/hooks/__tests__/useFilteredModels.test.ts` — **8 test cases**: direct match, groupKey+same type, OAuth leak exclusion, coding_plan leak exclusion, regional variant exclusion, empty set passthrough, missing metadata, default access_type.
- `tests/unit/llms/test_model_config_flatten.py` — `requires_own_key` correctness: z-ai-cn (set), z-ai (absent), doubao-anthropic (absent, shares credentials). Non-empty guards prevent vacuous assertions.
- `tests/unit/server/app/test_models_endpoint.py` — `access_type` present in API response.
- `tests/unit/server/handlers/test_resolve_llm_config.py` — `_resolve_one` catches exceptions; mixed fallback list resolves valid models, skips invalid.

## Pre-Landing Review

No critical issues. 3 informational findings (duplicate local provider construction in Settings/UserConfigPanel, ConfiguredProvider.type union width, long line) — all pre-existing patterns, intentionally deferred.

## Test plan
- [x] All backend tests pass (2007 tests, 0 failures)
- [x] All frontend tests pass (306 tests, 0 failures)
- [x] Setup wizard with OpenAI API key: DefaultsStep does NOT show OAuth models in fallback
- [x] Setup wizard with OpenRouter key: DeepInfra models still show (shares credentials)
- [x] Setup wizard with Zhipu AI International: China regional models do NOT leak
- [x] OAuth provider card does NOT show green checkmark when only API key configured