### PR TITLE
fix(codex): promote system messages to instructions field

### DIFF
--- a/src/llms/extension/codex.py
+++ b/src/llms/extension/codex.py
@@ -86,9 +86,11 @@ def _extract_system_to_instructions(payload: dict) -> None:
         else:
             filtered.append(item)
 
-    if system_parts:
-        payload["instructions"] = "\n\n".join(system_parts)
+    if len(filtered) < len(items):
+        # Always strip system messages from input (Codex rejects them)
         payload["input"] = filtered
+        if system_parts:
+            payload["instructions"] = "\n\n".join(system_parts)
         logger.debug("[codex] Promoted %d system message(s) to instructions", len(system_parts))
 
 

--- a/src/llms/extension/codex.py
+++ b/src/llms/extension/codex.py
@@ -90,8 +90,12 @@ def _extract_system_to_instructions(payload: dict) -> None:
         # Always strip system messages from input (Codex rejects them)
         payload["input"] = filtered
         if system_parts:
+            # Intentionally replaces any existing instructions (e.g. static
+            # model_kwargs placeholder) with the real agent system prompt.
             payload["instructions"] = "\n\n".join(system_parts)
-        logger.debug("[codex] Promoted %d system message(s) to instructions", len(system_parts))
+            logger.debug("[codex] Promoted %d system message(s) to instructions", len(system_parts))
+        else:
+            logger.debug("[codex] Stripped system message(s) with no text content")
 
 
 class ChatCodexOpenAI(ChatOpenAI):

--- a/src/llms/extension/codex.py
+++ b/src/llms/extension/codex.py
@@ -90,9 +90,10 @@ def _extract_system_to_instructions(payload: dict) -> None:
         # Always strip system messages from input (Codex rejects them)
         payload["input"] = filtered
         if system_parts:
-            # Intentionally replaces any existing instructions (e.g. static
-            # model_kwargs placeholder) with the real agent system prompt.
-            payload["instructions"] = "\n\n".join(system_parts)
+            extracted = "\n\n".join(system_parts)
+            existing = payload.get("instructions")
+            # Append any model-level instructions after the system prompt
+            payload["instructions"] = f"{extracted}\n\n{existing}" if existing else extracted
             logger.debug("[codex] Promoted %d system message(s) to instructions", len(system_parts))
         else:
             logger.debug("[codex] Stripped system message(s) with no text content")

--- a/src/llms/extension/codex.py
+++ b/src/llms/extension/codex.py
@@ -57,6 +57,41 @@ def _sanitize_input_for_stateless(items: list) -> list:
     return result
 
 
+def _extract_system_to_instructions(payload: dict) -> None:
+    """Move system messages from input to the top-level ``instructions`` field.
+
+    The Codex API rejects ``role:"system"`` in the input array. The Responses
+    API equivalent is the top-level ``instructions`` parameter (what the
+    official Codex CLI uses). Mutates *payload* in place.
+    """
+    items = payload.get("input")
+    if not items:
+        return
+
+    system_parts: list[str] = []
+    filtered: list = []
+
+    for item in items:
+        if isinstance(item, dict) and item.get("role") == "system":
+            content = item.get("content", "")
+            if isinstance(content, str):
+                system_parts.append(content)
+            elif isinstance(content, list):
+                # langchain-openai emits {"type": "input_text", "text": "..."}
+                system_parts.extend(
+                    block["text"]
+                    for block in content
+                    if isinstance(block, dict) and block.get("type") in ("text", "input_text")
+                )
+        else:
+            filtered.append(item)
+
+    if system_parts:
+        payload["instructions"] = "\n\n".join(system_parts)
+        payload["input"] = filtered
+        logger.debug("[codex] Promoted %d system message(s) to instructions", len(system_parts))
+
+
 class ChatCodexOpenAI(ChatOpenAI):
     """ChatOpenAI for Codex store=false backends.
 
@@ -70,4 +105,6 @@ class ChatCodexOpenAI(ChatOpenAI):
         items = payload.get("input")
         if items:
             payload["input"] = _sanitize_input_for_stateless(items)
+        # Codex API rejects role:"system" — promote to instructions field
+        _extract_system_to_instructions(payload)
         return payload

--- a/src/llms/manifest/models.json
+++ b/src/llms/manifest/models.json
@@ -456,10 +456,7 @@
       "include": [
         "reasoning.encrypted_content"
       ],
-      "store": false,
-      "model_kwargs": {
-        "instructions": "You are a helpful AI assistant."
-      }
+      "store": false
     }
   },
   "gpt-5.3-codex-spark-oauth": {
@@ -475,10 +472,7 @@
       "include": [
         "reasoning.encrypted_content"
       ],
-      "store": false,
-      "model_kwargs": {
-        "instructions": "You are a helpful AI assistant."
-      }
+      "store": false
     }
   },
   "gpt-5.4-oauth": {
@@ -494,10 +488,7 @@
       "include": [
         "reasoning.encrypted_content"
       ],
-      "store": false,
-      "model_kwargs": {
-        "instructions": "You are a helpful AI assistant."
-      }
+      "store": false
     }
   },
   "gpt-5.4-mini-oauth": {
@@ -513,10 +504,7 @@
       "include": [
         "reasoning.encrypted_content"
       ],
-      "store": false,
-      "model_kwargs": {
-        "instructions": "You are a helpful AI assistant."
-      }
+      "store": false
     }
   },
   "claude-sonnet-4-6-oauth": {

--- a/tests/unit/llms/test_codex_extension.py
+++ b/tests/unit/llms/test_codex_extension.py
@@ -29,7 +29,7 @@ class TestSystemToInstructions:
         ]
         payload = llm._get_request_payload(messages)
 
-        assert payload["instructions"] == "You are a research agent."
+        assert payload["instructions"] == "You are a research agent.\n\nstatic placeholder"
         roles = [i["role"] for i in payload["input"] if isinstance(i, dict)]
         assert "system" not in roles
 
@@ -46,7 +46,7 @@ class TestSystemToInstructions:
         ]
         payload = llm._get_request_payload(messages)
 
-        assert payload["instructions"] == "Part one.\n\nPart two."
+        assert payload["instructions"] == "Part one.\n\nPart two.\n\nstatic placeholder"
         roles = [i["role"] for i in payload["input"] if isinstance(i, dict)]
         assert "system" not in roles
 
@@ -64,7 +64,7 @@ class TestSystemToInstructions:
 
         assert "instructions" not in payload
 
-    def test_system_overrides_static_instructions(self):
+    def test_system_merges_with_existing_instructions(self):
         llm = _make_llm()
         messages = [
             SystemMessage(content="Dynamic prompt"),
@@ -72,8 +72,7 @@ class TestSystemToInstructions:
         ]
         payload = llm._get_request_payload(messages)
 
-        assert payload["instructions"] == "Dynamic prompt"
-        assert payload["instructions"] != "static placeholder"
+        assert payload["instructions"] == "Dynamic prompt\n\nstatic placeholder"
 
 
 class TestStatelessIdSanitization:

--- a/tests/unit/llms/test_codex_extension.py
+++ b/tests/unit/llms/test_codex_extension.py
@@ -1,0 +1,95 @@
+"""Tests for ChatCodexOpenAI system message → instructions promotion."""
+
+import pytest
+from langchain_core.messages import HumanMessage, SystemMessage
+
+from src.llms.extension.codex import ChatCodexOpenAI
+
+
+def _make_llm(**overrides):
+    defaults = {
+        "model": "gpt-5.4",
+        "api_key": "fake",
+        "output_version": "responses/v1",
+        "store": False,
+        "model_kwargs": {"instructions": "static placeholder"},
+    }
+    defaults.update(overrides)
+    return ChatCodexOpenAI(**defaults)
+
+
+class TestSystemToInstructions:
+    """Codex API rejects role:'system' in input — must promote to instructions."""
+
+    def test_string_system_message_promoted(self):
+        llm = _make_llm()
+        messages = [
+            SystemMessage(content="You are a research agent."),
+            HumanMessage(content="Hello"),
+        ]
+        payload = llm._get_request_payload(messages)
+
+        assert payload["instructions"] == "You are a research agent."
+        roles = [i["role"] for i in payload["input"] if isinstance(i, dict)]
+        assert "system" not in roles
+
+    def test_multiblock_system_message_promoted(self):
+        llm = _make_llm()
+        messages = [
+            SystemMessage(
+                content=[
+                    {"type": "text", "text": "Part one."},
+                    {"type": "text", "text": "Part two."},
+                ]
+            ),
+            HumanMessage(content="Hello"),
+        ]
+        payload = llm._get_request_payload(messages)
+
+        assert payload["instructions"] == "Part one.\n\nPart two."
+        roles = [i["role"] for i in payload["input"] if isinstance(i, dict)]
+        assert "system" not in roles
+
+    def test_no_system_message_preserves_existing_instructions(self):
+        llm = _make_llm()
+        messages = [HumanMessage(content="Hello")]
+        payload = llm._get_request_payload(messages)
+
+        assert payload["instructions"] == "static placeholder"
+
+    def test_no_system_message_no_model_kwargs_no_instructions(self):
+        llm = _make_llm(model_kwargs={})
+        messages = [HumanMessage(content="Hello")]
+        payload = llm._get_request_payload(messages)
+
+        assert "instructions" not in payload
+
+    def test_system_overrides_static_instructions(self):
+        llm = _make_llm()
+        messages = [
+            SystemMessage(content="Dynamic prompt"),
+            HumanMessage(content="Hi"),
+        ]
+        payload = llm._get_request_payload(messages)
+
+        assert payload["instructions"] == "Dynamic prompt"
+        assert payload["instructions"] != "static placeholder"
+
+
+class TestStatelessIdSanitization:
+    """Existing behavior: reasoning item IDs stripped for store=false."""
+
+    def test_reasoning_id_stripped(self):
+        llm = _make_llm()
+        messages = [HumanMessage(content="Hello")]
+        payload = llm._get_request_payload(messages)
+
+        # Manually inject reasoning item to test sanitization
+        payload["input"].append(
+            {"type": "reasoning", "id": "rs_abc123", "content": []}
+        )
+        from src.llms.extension.codex import _sanitize_input_for_stateless
+
+        sanitized = _sanitize_input_for_stateless(payload["input"])
+        reasoning = [i for i in sanitized if i.get("type") == "reasoning"][0]
+        assert "id" not in reasoning


### PR DESCRIPTION
## Summary

- The Codex API rejects `role:"system"` messages in the Responses API input array with `400 System messages are not allowed`
- `langchain-openai` converts `SystemMessage` to `role:"system"` input items instead of the top-level `instructions` parameter
- Added extraction in `ChatCodexOpenAI._get_request_payload()` to promote system content to the `instructions` field, matching official Codex CLI behavior
- Removed the now-redundant static `model_kwargs.instructions` from all codex-oauth model configs

## Test plan

- [x] Unit tests for string, multi-block, and no-system-message cases (6 tests)
- [x] Full test suite passes (2100 passed)
- [x] Manual verification with a Codex OAuth model end-to-end

Ref: BerriAI/litellm#21420