### PR TITLE
fix(dashboard): responsive layout for market insight brief card

### DIFF
--- a/web/src/pages/Dashboard/components/AIDailyBriefCard.tsx
+++ b/web/src/pages/Dashboard/components/AIDailyBriefCard.tsx
@@ -324,7 +324,7 @@ function AIDailyBriefCard({ onReadFull }: AIDailyBriefCardProps) {
           <Newspaper size={120} style={{ color: 'var(--color-accent-primary)' }} />
         </div>
 
-        <div className="relative z-10 p-4 sm:p-8 flex flex-col md:flex-row gap-8 items-start">
+        <div className="relative z-10 p-4 sm:p-8 flex flex-col gap-8 items-start">
           <div className="flex-1">
             {/* Badge + updated */}
             <div className="flex items-center gap-2 mb-4">
@@ -367,7 +367,7 @@ function AIDailyBriefCard({ onReadFull }: AIDailyBriefCardProps) {
 
             {/* Summary */}
             <p
-              className="mb-6 leading-relaxed max-w-2xl line-clamp-3 sm:line-clamp-none"
+              className="mb-6 leading-relaxed line-clamp-3 sm:line-clamp-none"
               style={{ color: 'var(--color-text-secondary)' }}
             >
               {latest.summary}


### PR DESCRIPTION
## Summary

The AIDailyBriefCard had broken responsive layout at viewport widths where the Dashboard grid splits into 3 columns (`lg`, 1024px+). The card's inner `md:flex-row` put text and CTA buttons side-by-side, but in the 2/3-width grid column (~640px), the buttons squeezed the text to ~200px making headlines unreadable and hiding action buttons below the fold.

**Changes:**
- **Remove `md:flex-row`** — card content always stacks vertically (text on top, CTA buttons below). The side-by-side layout didn't work at any realistic card width due to the long button labels.
- **Remove `max-w-2xl`** on summary text — allows text to fill the full card width on wider viewports instead of capping at 672px.

## Test Coverage
No new code paths — CSS-only change (2 Tailwind class removals).

## Pre-Landing Review
No issues found.

## Test plan
- [x] All Vitest tests pass (345 tests)
- [ ] Visual verification: resize browser between 768px, 1024px, 1280px, 1440px — card text should fill available width at all sizes, CTA buttons always visible below content