### PR TITLE
fix(setup): show invitation code option when providers are configured

### DIFF
--- a/web/src/pages/Setup/steps/MethodStep.tsx
+++ b/web/src/pages/Setup/steps/MethodStep.tsx
@@ -347,8 +347,8 @@ export default function MethodStep() {
         })}
       </div>
 
-      {/* Invitation code section — hide when already configured or invitation redeemed */}
-      {!canSkip && (
+      {/* Invitation code section — hide only when user already has platform access */}
+      {(userLoading || !hasPlatformAccess) && (
         <>
           {!showInvitation ? (
             <button


### PR DESCRIPTION
## Summary
- The invitation code section in the setup wizard was hidden when the user had any configured provider (`canSkip` was true)
- Changed the condition so it only hides when the user already has platform access (already redeemed an invitation)
- Users with configured API keys can now still redeem an invitation code

## Test plan
- [ ] Configure an API key provider, verify the invitation code link still appears on the Method step
- [ ] Redeem an invitation code, verify the section hides after redemption
- [ ] With no providers and no platform access, verify invitation code link still shows