### PR TITLE
fix: patch langchain-anthropic usage metadata TypeError on None cache values

### DIFF
--- a/src/llms/__init__.py
+++ b/src/llms/__init__.py
@@ -1,3 +1,6 @@
+from src.llms.patches import _patch_langchain_anthropic_usage_metadata
+_patch_langchain_anthropic_usage_metadata()
+
 from .llm import LLM, ModelConfig, create_llm, get_llm_by_type, get_configured_llm_models, get_input_modalities, should_enable_caching
 from .api_call import (
     make_api_call,

--- a/src/llms/patches.py
+++ b/src/llms/patches.py
@@ -16,6 +16,8 @@ def _patch_langchain_anthropic_usage_metadata():
         from pydantic import BaseModel
 
         original_fn = chat_models._create_usage_metadata
+        if getattr(original_fn, "_is_patched", False):
+            return
 
         def _patched(anthropic_usage: BaseModel):
             cache_creation = getattr(anthropic_usage, "cache_creation", None)
@@ -25,6 +27,7 @@ def _patch_langchain_anthropic_usage_metadata():
                         object.__setattr__(cache_creation, field, 0)
             return original_fn(anthropic_usage)
 
+        _patched._is_patched = True
         chat_models._create_usage_metadata = _patched
         logger.debug("Patched langchain_anthropic._create_usage_metadata for None cache values")
     except Exception as e:

--- a/src/llms/patches.py
+++ b/src/llms/patches.py
@@ -1,0 +1,31 @@
+"""Monkey-patches for upstream library bugs."""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _patch_langchain_anthropic_usage_metadata():
+    """Fix TypeError when cache_creation fields are None.
+
+    langchain-anthropic v1.4.0 crashes on dict.get(k, 0) returning None
+    when third-party providers return null for cache token fields.
+    """
+    try:
+        import langchain_anthropic.chat_models as chat_models
+        from pydantic import BaseModel
+
+        original_fn = chat_models._create_usage_metadata
+
+        def _patched(anthropic_usage: BaseModel):
+            cache_creation = getattr(anthropic_usage, "cache_creation", None)
+            if cache_creation is not None:
+                for field in ("ephemeral_5m_input_tokens", "ephemeral_1h_input_tokens"):
+                    if getattr(cache_creation, field, None) is None:
+                        object.__setattr__(cache_creation, field, 0)
+            return original_fn(anthropic_usage)
+
+        chat_models._create_usage_metadata = _patched
+        logger.debug("Patched langchain_anthropic._create_usage_metadata for None cache values")
+    except Exception as e:
+        logger.warning(f"Failed to patch langchain_anthropic: {e}")

--- a/tests/unit/llms/test_patches.py
+++ b/tests/unit/llms/test_patches.py
@@ -56,6 +56,9 @@ class TestPatchLangchainAnthropicUsageMetadata:
 
         result = _create_usage_metadata(usage)
         assert result["output_tokens"] == 50
+        input_details = result.get("input_token_details", {})
+        assert input_details.get("ephemeral_5m_input_tokens") == 10
+        assert input_details.get("ephemeral_1h_input_tokens") == 20
 
     def test_no_cache_creation_still_works(self):
         """Usage without cache_creation should work normally."""

--- a/tests/unit/llms/test_patches.py
+++ b/tests/unit/llms/test_patches.py
@@ -1,0 +1,75 @@
+"""Tests for upstream library monkey-patches."""
+
+import pytest
+from unittest.mock import MagicMock
+from pydantic import BaseModel
+
+# Apply the patch before importing _create_usage_metadata
+from src.llms.patches import _patch_langchain_anthropic_usage_metadata
+_patch_langchain_anthropic_usage_metadata()
+
+
+class MockCacheCreation(BaseModel):
+    ephemeral_5m_input_tokens: int = 0
+    ephemeral_1h_input_tokens: int = 0
+
+
+class MockUsage(BaseModel):
+    input_tokens: int = 100
+    output_tokens: int = 50
+    cache_read_input_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+    cache_creation: MockCacheCreation = None
+
+    model_config = {"arbitrary_types_allowed": True}
+
+
+class TestPatchLangchainAnthropicUsageMetadata:
+    """Test the _create_usage_metadata monkey-patch."""
+
+    def test_none_cache_creation_fields_dont_crash(self):
+        """Reproduces the original TypeError: int += None."""
+        from langchain_anthropic.chat_models import _create_usage_metadata
+
+        # Simulate what third-party providers return: cache_creation with None values
+        usage = MockUsage(
+            cache_creation=MockCacheCreation(ephemeral_5m_input_tokens=0, ephemeral_1h_input_tokens=0)
+        )
+        # Force None values like the Anthropic SDK's lenient parsing does
+        object.__setattr__(usage.cache_creation, "ephemeral_5m_input_tokens", None)
+        object.__setattr__(usage.cache_creation, "ephemeral_1h_input_tokens", None)
+
+        # This would raise TypeError without the patch
+        result = _create_usage_metadata(usage)
+        assert result["input_tokens"] == 100
+        assert result["output_tokens"] == 50
+
+    def test_normal_cache_creation_still_works(self):
+        """Normal cache_creation values should pass through correctly."""
+        from langchain_anthropic.chat_models import _create_usage_metadata
+
+        usage = MockUsage(
+            input_tokens=100,
+            output_tokens=50,
+            cache_creation=MockCacheCreation(ephemeral_5m_input_tokens=10, ephemeral_1h_input_tokens=20),
+        )
+
+        result = _create_usage_metadata(usage)
+        assert result["output_tokens"] == 50
+
+    def test_no_cache_creation_still_works(self):
+        """Usage without cache_creation should work normally."""
+        from langchain_anthropic.chat_models import _create_usage_metadata
+
+        usage = MockUsage(input_tokens=100, output_tokens=50)
+
+        result = _create_usage_metadata(usage)
+        assert result["input_tokens"] == 100
+        assert result["output_tokens"] == 50
+
+    def test_patch_is_applied(self):
+        """Verify the patch was applied to langchain_anthropic."""
+        import langchain_anthropic.chat_models as chat_models
+
+        # The patched function should be our wrapper, not the original
+        assert "patched" in chat_models._create_usage_metadata.__name__


### PR DESCRIPTION
## Summary

Fixes production `TypeError("unsupported operand type(s) for +=: 'int' and 'NoneType'")` in `langchain_anthropic.chat_models._create_usage_metadata`.

Third-party providers return `null` for `cache_creation.ephemeral_5m_input_tokens` / `ephemeral_1h_input_tokens`. The Anthropic SDK's lenient parsing stores `None` for these required `int` fields. Then `dict.get(k, 0)` returns `None` (key present, value `None`), causing `int += None`.

**Fix:** Wraps `_create_usage_metadata` to coerce `None` cache fields to `0` on the usage object before calling the original function. Applied at `src/llms` import time. Trivially removable once upstream fixes (langchain-anthropic v1.4.0 is latest, no fix available).

## Files Changed

- `src/llms/patches.py` (new) — monkey-patch wrapper
- `src/llms/__init__.py` — applies patch at import time
- `tests/unit/llms/test_patches.py` (new) — 4 tests covering None values, normal values, no cache_creation, and patch verification

## Test Coverage

All 4 new tests pass. Covers: bug reproduction (None fields), normal operation, missing cache_creation, and patch application verification.

## Pre-Landing Review

No issues found. Reviewed by Claude structured pass + Claude adversarial subagent + Codex adversarial (gpt-5.4). All agreed: clean diff.

## Plan Completion

3/3 plan items DONE (patches.py, __init__.py modification, unit tests).

## Test plan
- [x] All patch tests pass (4 tests, 0 failures)
- [x] Pre-landing review: clean
- [x] Adversarial review (Claude + Codex): clean