### PR TITLE
feat: improve serper error visibility and workspace limit UX

### DIFF
--- a/src/tools/search_services/serper/serper.py
+++ b/src/tools/search_services/serper/serper.py
@@ -84,7 +84,13 @@ class SerperAPI:
                 headers=headers,
                 json=payload,
             )
-            response.raise_for_status()
+            if response.status_code >= 400:
+                body = response.text
+                raise httpx.HTTPStatusError(
+                    f"Serper API error {response.status_code}: {body}",
+                    request=response.request,
+                    response=response,
+                )
             return response.json()
 
     def _format_news_results(

--- a/src/tools/search_services/serper/serper_search_tool.py
+++ b/src/tools/search_services/serper/serper_search_tool.py
@@ -109,9 +109,10 @@ async def web_search(
         return detailed_results, metadata
 
     except httpx.HTTPStatusError as e:
+        status = e.response.status_code if e.response is not None else "unknown"
         body = e.response.text if e.response is not None else "no response body"
-        logger.error(f"Serper API HTTP {e.response.status_code}: {body}")
-        error_message = f"Search failed (HTTP {e.response.status_code}): {body}"
+        logger.error(f"Serper API HTTP {status}: {body}")
+        error_message = f"Search failed (HTTP {status}): {body}"
         return error_message, {"error": error_message, "query": query}
     except httpx.HTTPError as e:
         logger.error(f"Serper search failed: {e}", exc_info=True)

--- a/src/tools/search_services/serper/serper_search_tool.py
+++ b/src/tools/search_services/serper/serper_search_tool.py
@@ -108,6 +108,11 @@ async def web_search(
         logger.debug(f"Serper search completed: {len(detailed_results)} results returned")
         return detailed_results, metadata
 
+    except httpx.HTTPStatusError as e:
+        body = e.response.text if e.response is not None else "no response body"
+        logger.error(f"Serper API HTTP {e.response.status_code}: {body}")
+        error_message = f"Search failed (HTTP {e.response.status_code}): {body}"
+        return error_message, {"error": error_message, "query": query}
     except httpx.HTTPError as e:
         logger.error(f"Serper search failed: {e}", exc_info=True)
         error_message = f"Search failed: {str(e)}"

--- a/web/src/pages/ChatAgent/components/CreateWorkspaceModal.tsx
+++ b/web/src/pages/ChatAgent/components/CreateWorkspaceModal.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { X, Upload, FileText, CheckCircle2, Loader2, Circle, AlertCircle } from 'lucide-react';
 import { Input } from '../../../components/ui/input';
 import { uploadWorkspaceFile } from '../utils/api';
+import { buildRateLimitError } from '@/utils/rateLimitError';
 import './CreateWorkspaceModal.css';
 
 
@@ -141,7 +142,12 @@ function CreateWorkspaceModal({ isOpen, onClose, onCreate, onComplete }: CreateW
       setCreatedWorkspace(workspace);
     } catch (err: any) { // TODO: type properly
       setCreationStep('error');
-      setProgressError(err.message || t('workspace.failedCreateWorkspace'));
+      if (err.status === 429 && err.rateLimitInfo) {
+        const { message } = buildRateLimitError(err.rateLimitInfo);
+        setProgressError(message);
+      } else {
+        setProgressError(err.message || t('workspace.failedCreateWorkspace'));
+      }
       return;
     }
 

--- a/web/src/pages/ChatAgent/components/CreateWorkspaceModal.tsx
+++ b/web/src/pages/ChatAgent/components/CreateWorkspaceModal.tsx
@@ -143,7 +143,8 @@ function CreateWorkspaceModal({ isOpen, onClose, onCreate, onComplete }: CreateW
     } catch (err: any) { // TODO: type properly
       setCreationStep('error');
       if (err.status === 429 && err.rateLimitInfo) {
-        const { message } = buildRateLimitError(err.rateLimitInfo);
+        const accountUrl = (import.meta.env.VITE_ACCOUNT_URL as string | undefined) || '/account';
+        const { message } = buildRateLimitError(err.rateLimitInfo, accountUrl);
         setProgressError(message);
       } else {
         setProgressError(err.message || t('workspace.failedCreateWorkspace'));

--- a/web/src/utils/__tests__/rateLimitError.test.ts
+++ b/web/src/utils/__tests__/rateLimitError.test.ts
@@ -36,7 +36,7 @@ describe('buildRateLimitError', () => {
       { type: 'workspace_limit', current: 3, limit: 3 },
       'https://ginlix.ai/account',
     );
-    expect(result.message).toBe('Active workspace limit reached (3/3).');
+    expect(result.message).toBe('Active workspace limit reached (3/3). Stop or delete an existing workspace to free up a slot.');
     expect(result.link).toBeUndefined();
   });
 

--- a/web/src/utils/rateLimitError.ts
+++ b/web/src/utils/rateLimitError.ts
@@ -32,7 +32,7 @@ export function buildRateLimitError(
   } else if (info.type === 'negative_balance') {
     message = (info.message as string) || 'Outstanding credit balance. Please add credits to continue.';
   } else if (info.type === 'workspace_limit') {
-    message = `Active workspace limit reached (${info.current}/${info.limit}).`;
+    message = `Active workspace limit reached (${info.current}/${info.limit}). Stop or delete an existing workspace to free up a slot.`;
   } else if (info.type === 'burst_limit') {
     message = `Too many concurrent requests. Please wait a moment.`;
   } else {


### PR DESCRIPTION
## Summary

**Serper error handling:**
- Include HTTP response body in Serper API error messages for better debugging — previously `raise_for_status()` gave no detail on what Serper returned
- Add dedicated `HTTPStatusError` catch in `web_search()` that logs status + body and returns a structured error tuple instead of crashing the tool call
- Guard `e.response.status_code` against None for defensive safety

**Workspace limit UX:**
- Show actionable guidance on workspace 429 errors: "Stop or delete an existing workspace to free up a slot"
- Wire `buildRateLimitError` into `CreateWorkspaceModal` so rate-limit errors get structured messages instead of generic "failed to create workspace"
- Pass `accountUrl` so credit/balance errors also show the "View Usage" link

## Test Coverage
- `rateLimitError.test.ts` updated for new workspace_limit message (8 tests passing)
- Serper error paths are integration-level (httpx error handling) — covered by existing `HTTPError` catch structure

## Pre-Landing Review
No issues found. Two adversarial findings were auto-fixed:
- `[AUTO-FIXED]` serper_search_tool.py:113 — null-deref guard on `e.response.status_code`
- `[AUTO-FIXED]` CreateWorkspaceModal.tsx:146 — missing `accountUrl` param in `buildRateLimitError`

## Test plan
- [x] All backend tests pass (2334 passed)
- [x] All frontend tests pass (345 passed)