### PR TITLE
fix: handle dict-typed cache_creation in usage metadata patch

### DIFF
--- a/src/llms/patches.py
+++ b/src/llms/patches.py
@@ -23,7 +23,10 @@ def _patch_langchain_anthropic_usage_metadata():
             cache_creation = getattr(anthropic_usage, "cache_creation", None)
             if cache_creation is not None:
                 for field in ("ephemeral_5m_input_tokens", "ephemeral_1h_input_tokens"):
-                    if getattr(cache_creation, field, None) is None:
+                    if isinstance(cache_creation, dict):
+                        if cache_creation.get(field) is None:
+                            cache_creation[field] = 0
+                    elif getattr(cache_creation, field, None) is None:
                         object.__setattr__(cache_creation, field, 0)
             return original_fn(anthropic_usage)
 

--- a/tests/unit/llms/test_patches.py
+++ b/tests/unit/llms/test_patches.py
@@ -60,6 +60,39 @@ class TestPatchLangchainAnthropicUsageMetadata:
         assert input_details.get("ephemeral_5m_input_tokens") == 10
         assert input_details.get("ephemeral_1h_input_tokens") == 20
 
+    def test_dict_cache_creation_with_none_fields(self):
+        """cache_creation as a plain dict with None values should not crash."""
+        from langchain_anthropic.chat_models import _create_usage_metadata
+
+        usage = MockUsage(input_tokens=100, output_tokens=50)
+        # Simulate cache_creation arriving as a plain dict (some providers do this)
+        object.__setattr__(
+            usage,
+            "cache_creation",
+            {"ephemeral_5m_input_tokens": None, "ephemeral_1h_input_tokens": None},
+        )
+
+        result = _create_usage_metadata(usage)
+        assert result["input_tokens"] == 100
+        assert result["output_tokens"] == 50
+
+    def test_dict_cache_creation_with_valid_values(self):
+        """cache_creation as a plain dict with valid int values should work."""
+        from langchain_anthropic.chat_models import _create_usage_metadata
+
+        usage = MockUsage(input_tokens=100, output_tokens=50)
+        object.__setattr__(
+            usage,
+            "cache_creation",
+            {"ephemeral_5m_input_tokens": 10, "ephemeral_1h_input_tokens": 20},
+        )
+
+        result = _create_usage_metadata(usage)
+        assert result["output_tokens"] == 50
+        input_details = result.get("input_token_details", {})
+        assert input_details.get("ephemeral_5m_input_tokens") == 10
+        assert input_details.get("ephemeral_1h_input_tokens") == 20
+
     def test_no_cache_creation_still_works(self):
         """Usage without cache_creation should work normally."""
         from langchain_anthropic.chat_models import _create_usage_metadata


### PR DESCRIPTION
## Summary

Fixes `AttributeError: 'dict' object has no attribute 'ephemeral_5m_input_tokens'` that crashes all chat requests when the Anthropic API returns `cache_creation` as a plain dict instead of a Pydantic BaseModel.

The existing monkey-patch for `langchain-anthropic`'s `_create_usage_metadata` (added in #108) assumed `cache_creation` is always a BaseModel and used `object.__setattr__()` to normalize None values. Some providers return it as a dict, which doesn't support attribute-style mutation.

**Fix:** `isinstance` check before mutating: dict path uses key assignment, BaseModel path uses `object.__setattr__` as before.

## Test Coverage

All new code paths have test coverage (100%).

- `test_dict_cache_creation_with_none_fields` — reproduces the exact crash
- `test_dict_cache_creation_with_valid_values` — verifies dict path with valid ints

```
tests/unit/llms/test_patches.py — 6 passed in 0.42s
```

## Pre-Landing Review

No issues found.

## Test plan

- [x] All 6 patch tests pass (BaseModel + dict paths, None + valid values, no cache_creation, patch applied)