### PR TITLE
feat: move dynamic context after prompt cache breakpoint

### DIFF
--- a/src/ptc_agent/agent/agent.py
+++ b/src/ptc_agent/agent/agent.py
@@ -51,6 +51,7 @@ from ptc_agent.agent.middleware import (
     # Workspace context middleware
     WorkspaceContextMiddleware,
 )
+from ptc_agent.agent.middleware.runtime_context import RuntimeContextMiddleware
 from ptc_agent.agent.middleware.background_subagent.registry import (
     BackgroundTaskRegistry,
 )
@@ -167,19 +168,15 @@ class PTCAgent:
         self,
         tool_summary: str,
         subagent_summary: str,
-        user_profile: dict | None = None,
         plan_mode: bool = False,
-        current_time: str | None = None,
         thread_id: str | None = None,
     ) -> str:
-        """Build the system prompt for the agent.
+        """Build the static system prompt (excludes time/profile for cacheability).
 
         Args:
             tool_summary: Formatted MCP tool summary
             subagent_summary: Formatted subagent summary
-            user_profile: Optional user profile dict with name, timezone, locale
             plan_mode: If True, includes plan mode workflow instructions
-            current_time: Pre-formatted current time string for time awareness
             thread_id: Optional thread ID (first 8 chars) for thread-scoped directories
 
         Returns:
@@ -187,18 +184,15 @@ class PTCAgent:
         """
         loader = get_loader()
 
-        # Render the main system prompt with all variables
         return loader.get_system_prompt(
             tool_summary=tool_summary,
             subagent_summary=subagent_summary,
-            user_profile=user_profile,
             max_concurrent_task_units=DEFAULT_MAX_CONCURRENT_TASK_UNITS,
             max_task_iterations=DEFAULT_MAX_TASK_ITERATIONS,
             ask_user_enabled=True,
             plan_mode=plan_mode,
             include_examples=True,
             include_anti_patterns=True,
-            current_time=current_time,
             thread_id=thread_id or "",
             working_directory=self.config.filesystem.working_directory,
         )
@@ -535,9 +529,7 @@ class PTCAgent:
         system_prompt = self._build_system_prompt(
             tool_summary,
             subagent_summary,
-            user_profile,
             plan_mode=plan_mode,
-            current_time=current_time,
             thread_id=short_thread_id,
         )
 
@@ -609,7 +601,21 @@ class PTCAgent:
         if session is not None:
             workspace_context_middleware = [WorkspaceContextMiddleware(session=session)]
 
+        # Runtime context middleware (time + user profile — after cache breakpoint)
+        runtime_context_middleware: list[Any] = [
+            RuntimeContextMiddleware(
+                current_time=current_time,
+                user_profile=user_profile,
+            )
+        ]
+
         # Main agent middleware (includes SubAgentMiddleware + main_only)
+        # Ordering matters for prompt caching:
+        #   - AnthropicPromptCachingMiddleware places cache_control breakpoint on
+        #     the last system message block it sees (the static prompt + skills).
+        #   - WorkspaceContextMiddleware (agent.md) and RuntimeContextMiddleware
+        #     (time + profile) are innermost — they append AFTER the breakpoint,
+        #     so dynamic content doesn't invalidate the cached prefix.
         deepagent_middleware = [
             m
             for m in [
@@ -632,6 +638,7 @@ class PTCAgent:
                 EmptyToolCallRetryMiddleware(),
                 PatchToolCallsMiddleware(),
                 *workspace_context_middleware,
+                *runtime_context_middleware,
             ]
             if m is not None
         ]

--- a/src/ptc_agent/agent/flash/agent.py
+++ b/src/ptc_agent/agent/flash/agent.py
@@ -21,6 +21,7 @@ from ptc_agent.agent.middleware import (
     SkillsMiddleware,
     AskUserMiddleware,
 )
+from ptc_agent.agent.middleware.runtime_context import RuntimeContextMiddleware
 from ptc_agent.agent.prompts import format_current_time, get_loader
 from ptc_agent.config import AgentConfig
 
@@ -139,25 +140,19 @@ class FlashAgent:
     def _build_system_prompt(
         self,
         tools: list[Any],
-        user_profile: dict | None = None,
-        current_time: str | None = None,
     ) -> str:
-        """Build minimal system prompt for Flash agent.
+        """Build the static system prompt (excludes time/profile for cacheability).
 
         Args:
             tools: List of available tools
-            user_profile: Optional user profile dict with name, timezone, locale
-            current_time: Pre-formatted current time string for time awareness
 
         Returns:
-            Minimal system prompt string
+            Rendered system prompt string
         """
         loader = get_loader()
         return loader.render(
             "flash_system.md.j2",
             tools=tools,
-            user_profile=user_profile,
-            current_time=current_time,
         )
 
     def create_agent(
@@ -192,10 +187,8 @@ class FlashAgent:
         # Build tools
         tools = self._build_tools()
 
-        # Build system prompt
-        system_prompt = self._build_system_prompt(
-            tools, user_profile=user_profile, current_time=current_time
-        )
+        # Build system prompt (time + profile injected by RuntimeContextMiddleware)
+        system_prompt = self._build_system_prompt(tools)
 
         # Minimal shared middleware stack
         shared_middleware: list[Any] = [
@@ -291,8 +284,16 @@ class FlashAgent:
             ]
         )
 
+        # Runtime context middleware (time + user profile — after cache breakpoint)
+        runtime_context_middleware = RuntimeContextMiddleware(
+            current_time=current_time,
+            user_profile=user_profile,
+        )
+
         # Build final middleware stack
-        middleware = [*shared_middleware, *main_middleware]
+        # RuntimeContextMiddleware is last (innermost) so it appends after
+        # the cache breakpoint, keeping the static prompt cacheable.
+        middleware = [*shared_middleware, *main_middleware, runtime_context_middleware]
 
         logger.info(
             "Creating Flash agent",

--- a/src/ptc_agent/agent/middleware/__init__.py
+++ b/src/ptc_agent/agent/middleware/__init__.py
@@ -83,6 +83,11 @@ from .workspace_context import (
     WorkspaceContextMiddleware,
 )
 
+# Runtime context middleware (time + user profile, after cache breakpoint)
+from .runtime_context import (
+    RuntimeContextMiddleware,
+)
+
 # Subagent steering middleware
 from .background_subagent.steering import (
     SubagentSteeringMiddleware,
@@ -138,6 +143,8 @@ __all__ = [
     "SubagentSteeringMiddleware",
     # Workspace context
     "WorkspaceContextMiddleware",
+    # Runtime context
+    "RuntimeContextMiddleware",
     # Subagent middleware
     "CompiledSubAgent",
     "SubAgent",

--- a/src/ptc_agent/agent/middleware/runtime_context.py
+++ b/src/ptc_agent/agent/middleware/runtime_context.py
@@ -1,0 +1,80 @@
+"""Middleware for injecting runtime context (time, user profile) into system prompt.
+
+Appends dynamic per-request context as the last content block of the system
+message.  Positioned after WorkspaceContextMiddleware in the middleware stack
+so this block appears after agent.md and outside the prompt cache breakpoint.
+
+This keeps the base system prompt + skills manifest fully static and cacheable
+across users and requests — only this block varies per request.
+"""
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from langchain.agents.middleware.types import AgentMiddleware, ModelRequest, ModelResponse
+
+from ptc_agent.agent.middleware._utils import append_to_system_message
+from ptc_agent.agent.prompts import get_loader
+
+
+class RuntimeContextMiddleware(AgentMiddleware):
+    """Injects current_time and user_profile into the system prompt.
+
+    These dynamic fields are placed after the cache breakpoint so the static
+    system prompt prefix remains cacheable across users and requests.
+
+    Args:
+        current_time: Pre-formatted current time string.
+        user_profile: Optional user profile dict with name, timezone, locale, etc.
+    """
+
+    def __init__(
+        self,
+        *,
+        current_time: str,
+        user_profile: dict[str, Any] | None = None,
+    ) -> None:
+        self._context_block = self._build_context_block(current_time, user_profile)
+
+    @staticmethod
+    def _build_context_block(
+        current_time: str, user_profile: dict[str, Any] | None
+    ) -> str:
+        """Render the context block once from templates."""
+        loader = get_loader()
+        parts: list[str] = []
+
+        time_content = loader.render(
+            "components/time_awareness.md.j2",
+            current_time=current_time,
+        )
+        parts.append(f"<time_awareness>\n{time_content}\n</time_awareness>")
+
+        if user_profile:
+            profile_content = loader.render(
+                "components/user_profile.md.j2",
+                user_profile=user_profile,
+            )
+            parts.append(f"<user_profile>\n{profile_content}\n</user_profile>")
+
+        return "\n".join(parts)
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], ModelResponse],
+    ) -> ModelResponse:
+        # Sync fallback — shouldn't be hit in async agent, but keep for safety
+        return handler(request)
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelResponse:
+        """Inject runtime context into system message before each model call."""
+        new_system_message = append_to_system_message(
+            request.system_message, self._context_block
+        )
+        modified_request = request.override(system_message=new_system_message)
+        return await handler(modified_request)

--- a/src/ptc_agent/agent/prompts/templates/flash_system.md.j2
+++ b/src/ptc_agent/agent/prompts/templates/flash_system.md.j2
@@ -1,13 +1,3 @@
-<time_awareness>
-{% include 'components/time_awareness.md.j2' %}
-</time_awareness>
-{% if user_profile %}
-
-<user_profile>
-{% include 'components/user_profile.md.j2' %}
-</user_profile>
-{% endif %}
-
 You are a assistant optimized for quick responses. You have access to web search, financial data, and SEC filing tools.
 
 ## Guidelines

--- a/src/ptc_agent/agent/prompts/templates/system.md.j2
+++ b/src/ptc_agent/agent/prompts/templates/system.md.j2
@@ -1,15 +1,5 @@
 You are LangAlpha Agent, created by Ginlix AI. You are an investment research agent specializing in financial analysis, market research, and trading strategy. You help users with equity research, portfolio analysis, SEC filings, economic data, and data-driven investment decisions — producing professional reports, visualizations, and quantitative models.
 
-<time_awareness>
-{% include 'components/time_awareness.md.j2' %}
-</time_awareness>
-{% if user_profile %}
-
-<user_profile>
-{% include 'components/user_profile.md.j2' %}
-</user_profile>
-{% endif %}
-
 <task_workflow>
 {% include 'components/task_workflow.md.j2' %}
 </task_workflow>

--- a/tests/unit/middleware/test_prompt_cache_breakpoint.py
+++ b/tests/unit/middleware/test_prompt_cache_breakpoint.py
@@ -1,0 +1,282 @@
+"""Integration test: prompt cache breakpoint placement across the middleware chain.
+
+Verifies that the system message ends up with 4 content blocks in the correct
+order, and that only the skills block (block index 1) carries cache_control —
+the breakpoint that Anthropic uses for prefix caching.
+
+Middleware chain (first = outermost = runs first):
+    SkillsMiddleware  →  appends skills manifest (block 1)
+    AnthropicPromptCachingMiddleware  →  tags LAST block it sees with cache_control
+    WorkspaceContextMiddleware  →  appends agent.md (block 2)
+    RuntimeContextMiddleware  →  appends time + profile (block 3)
+
+Expected final system message blocks:
+    [0] static system prompt         — no cache_control
+    [1] skills manifest              — cache_control (breakpoint)
+    [2] agent.md                     — no cache_control
+    [3] current_time + user_profile  — no cache_control
+"""
+
+from collections.abc import Awaitable, Callable
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_anthropic.chat_models import ChatAnthropic
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
+from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
+from langchain_core.messages import SystemMessage
+
+from ptc_agent.agent.middleware._utils import append_to_system_message
+from ptc_agent.agent.middleware.runtime_context import RuntimeContextMiddleware
+from ptc_agent.agent.middleware.workspace_context import WorkspaceContextMiddleware
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_model_request(system_prompt: str) -> ModelRequest:
+    """Create a ModelRequest with a mock ChatAnthropic model."""
+    model = MagicMock(spec=ChatAnthropic)
+    return ModelRequest(
+        model=model,
+        messages=[],
+        system_prompt=system_prompt,
+    )
+
+
+def _fake_skills_middleware():
+    """Simulate SkillsMiddleware by appending a skills manifest block."""
+
+    class FakeSkillsMiddleware:
+        async def awrap_model_call(
+            self,
+            request: ModelRequest,
+            handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+        ) -> ModelResponse:
+            new_sys = append_to_system_message(
+                request.system_message,
+                "<skills_manifest>\n- skill_a\n- skill_b\n</skills_manifest>",
+            )
+            return await handler(request.override(system_message=new_sys))
+
+    return FakeSkillsMiddleware()
+
+
+def _compose_middleware(middlewares, final_handler):
+    """Compose middlewares: first in list = outermost = runs first.
+
+    Each middleware wraps the next, producing a single callable that
+    processes the request through the full chain.
+    """
+
+    async def chain(request: ModelRequest) -> ModelResponse:
+        return await final_handler(request)
+
+    # Build from innermost to outermost
+    for mw in reversed(middlewares):
+        outer_handler = chain
+
+        async def wrapper(req, *, _mw=mw, _h=outer_handler):
+            return await _mw.awrap_model_call(req, _h)
+
+        chain = wrapper
+
+    return chain
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+class TestPromptCacheBreakpoint:
+    """Verify cache_control breakpoint placement across the full middleware chain."""
+
+    @pytest.mark.asyncio
+    async def test_block_ordering_and_breakpoint(self):
+        """Cache breakpoint should be on the skills block (block 1 only)."""
+        # 1. Build the middleware chain in the same order as agent.py
+        skills_mw = _fake_skills_middleware()
+        caching_mw = AnthropicPromptCachingMiddleware(
+            unsupported_model_behavior="ignore"
+        )
+
+        # Mock session for WorkspaceContextMiddleware
+        session = MagicMock()
+        session.get_agent_md = AsyncMock(return_value="# My Workspace\nResearch notes")
+        session.conversation_id = "ws-test"
+        workspace_mw = WorkspaceContextMiddleware(session=session)
+
+        runtime_mw = RuntimeContextMiddleware(
+            current_time="3:42 PM EST, Monday, April 5, 2026",
+            user_profile={"name": "Alice", "timezone": "US/Eastern", "locale": "en-US"},
+        )
+
+        # Capture the final request that would go to the model
+        captured_request = {}
+
+        async def capture_handler(request: ModelRequest) -> ModelResponse:
+            captured_request["request"] = request
+            return MagicMock()  # dummy response
+
+        # Compose: first = outermost = runs first
+        chain = _compose_middleware(
+            [skills_mw, caching_mw, workspace_mw, runtime_mw],
+            capture_handler,
+        )
+
+        # 2. Create initial request with static system prompt
+        request = _make_model_request("You are LangAlpha Agent, a research agent.")
+
+        # 3. Run through the chain
+        await chain(request)
+
+        # 4. Inspect the final system message
+        final_request = captured_request["request"]
+        sys_msg = final_request.system_message
+        assert sys_msg is not None, "System message should not be None"
+
+        content = sys_msg.content
+        assert isinstance(content, list), f"Expected list of blocks, got {type(content)}"
+        assert len(content) == 4, (
+            f"Expected 4 content blocks (static + skills + agent.md + runtime), "
+            f"got {len(content)}"
+        )
+
+        # Block 0: Static system prompt — no cache_control
+        block0 = content[0]
+        assert isinstance(block0, dict), f"Block 0 should be dict, got {type(block0)}"
+        assert "You are LangAlpha Agent" in block0["text"]
+        assert "cache_control" not in block0, (
+            "Block 0 (static prompt) should NOT have cache_control"
+        )
+
+        # Block 1: Skills manifest — HAS cache_control (the breakpoint)
+        block1 = content[1]
+        assert isinstance(block1, dict), f"Block 1 should be dict, got {type(block1)}"
+        assert "skills_manifest" in block1["text"]
+        assert "cache_control" in block1, (
+            "Block 1 (skills) MUST have cache_control — this is the breakpoint"
+        )
+        assert block1["cache_control"]["type"] == "ephemeral"
+
+        # Block 2: agent.md — no cache_control
+        block2 = content[2]
+        assert isinstance(block2, dict), f"Block 2 should be dict, got {type(block2)}"
+        assert "agentmd" in block2["text"]
+        assert "cache_control" not in block2, (
+            "Block 2 (agent.md) should NOT have cache_control"
+        )
+
+        # Block 3: Runtime context (time + profile) — no cache_control
+        block3 = content[3]
+        assert isinstance(block3, dict), f"Block 3 should be dict, got {type(block3)}"
+        assert "time_awareness" in block3["text"]
+        assert "3:42 PM EST" in block3["text"]
+        assert "user_profile" in block3["text"]
+        assert "Alice" in block3["text"]
+        assert "cache_control" not in block3, (
+            "Block 3 (runtime context) should NOT have cache_control"
+        )
+
+    @pytest.mark.asyncio
+    async def test_breakpoint_stable_across_different_times(self):
+        """Changing current_time should NOT affect which block has cache_control."""
+        skills_mw = _fake_skills_middleware()
+        caching_mw = AnthropicPromptCachingMiddleware(
+            unsupported_model_behavior="ignore"
+        )
+
+        session = MagicMock()
+        session.get_agent_md = AsyncMock(return_value="# Notes")
+        session.conversation_id = "ws-test"
+        workspace_mw = WorkspaceContextMiddleware(session=session)
+
+        captured_blocks = []
+
+        for time_str in [
+            "3:42 PM EST, Monday, April 5, 2026",
+            "3:43 PM EST, Monday, April 5, 2026",
+            "10:00 AM PST, Tuesday, April 6, 2026",
+        ]:
+            runtime_mw = RuntimeContextMiddleware(
+                current_time=time_str,
+                user_profile={"name": "Bob", "timezone": "UTC", "locale": "en-US"},
+            )
+
+            captured = {}
+
+            async def capture(req, _c=captured):
+                _c["req"] = req
+                return MagicMock()
+
+            chain = _compose_middleware(
+                [skills_mw, caching_mw, workspace_mw, runtime_mw],
+                capture,
+            )
+            await chain(_make_model_request("Static system prompt."))
+
+            blocks = captured["req"].system_message.content
+            captured_blocks.append(blocks)
+
+        # All three runs should have cache_control on block 1 only
+        for i, blocks in enumerate(captured_blocks):
+            assert len(blocks) == 4, f"Run {i}: expected 4 blocks"
+            assert "cache_control" not in blocks[0], f"Run {i}: block 0 should not be cached"
+            assert "cache_control" in blocks[1], f"Run {i}: block 1 must be cached"
+            assert "cache_control" not in blocks[2], f"Run {i}: block 2 should not be cached"
+            assert "cache_control" not in blocks[3], f"Run {i}: block 3 should not be cached"
+
+        # The static prefix (blocks 0 and 1 text) should be identical across runs
+        for i in range(1, len(captured_blocks)):
+            assert captured_blocks[0][0]["text"] == captured_blocks[i][0]["text"], (
+                f"Run {i}: static prompt block should be identical"
+            )
+            # Block 1 text (skills) should also be identical
+            assert captured_blocks[0][1]["text"] == captured_blocks[i][1]["text"], (
+                f"Run {i}: skills block should be identical"
+            )
+
+    @pytest.mark.asyncio
+    async def test_no_user_profile_omits_profile_from_runtime_block(self):
+        """Without user_profile, runtime context block should still have time_awareness."""
+        skills_mw = _fake_skills_middleware()
+        caching_mw = AnthropicPromptCachingMiddleware(
+            unsupported_model_behavior="ignore"
+        )
+
+        session = MagicMock()
+        session.get_agent_md = AsyncMock(return_value="# Notes")
+        session.conversation_id = "ws-test"
+        workspace_mw = WorkspaceContextMiddleware(session=session)
+
+        runtime_mw = RuntimeContextMiddleware(
+            current_time="12:00 PM UTC, Monday, April 5, 2026",
+            user_profile=None,
+        )
+
+        captured = {}
+
+        async def capture(req):
+            captured["req"] = req
+            return MagicMock()
+
+        chain = _compose_middleware(
+            [skills_mw, caching_mw, workspace_mw, runtime_mw],
+            capture,
+        )
+        await chain(_make_model_request("Static prompt."))
+
+        blocks = captured["req"].system_message.content
+        assert len(blocks) == 4, f"Expected 4 blocks, got {len(blocks)}"
+
+        # Block 3 should have time but NOT user_profile
+        block3 = blocks[3]
+        assert "time_awareness" in block3["text"]
+        assert "user_profile" not in block3["text"]
+
+        # Breakpoint still on block 1
+        assert "cache_control" in blocks[1]
+        assert "cache_control" not in blocks[3]

--- a/tests/unit/middleware/test_runtime_context.py
+++ b/tests/unit/middleware/test_runtime_context.py
@@ -1,0 +1,155 @@
+"""Tests for the RuntimeContextMiddleware.
+
+Covers context block construction with/without user profile,
+system message injection via awrap_model_call, and sync passthrough.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.messages import SystemMessage
+
+from ptc_agent.agent.middleware.runtime_context import RuntimeContextMiddleware
+
+
+# ---------------------------------------------------------------------------
+# Tests for _build_context_block
+# ---------------------------------------------------------------------------
+
+
+class TestBuildContextBlock:
+    """Tests for _build_context_block."""
+
+    def _make_middleware(self, *, current_time="3:42 PM EST, Monday, April 5, 2026", user_profile=None):
+        return RuntimeContextMiddleware(
+            current_time=current_time,
+            user_profile=user_profile,
+        )
+
+    @patch("ptc_agent.agent.middleware.runtime_context.get_loader")
+    def test_time_only(self, mock_get_loader):
+        """Without user_profile, only time_awareness block is rendered."""
+        loader = MagicMock()
+        loader.render.return_value = "**Current Date/Time:** 3:42 PM EST"
+        mock_get_loader.return_value = loader
+
+        mw = self._make_middleware()
+
+        assert "<time_awareness>" in mw._context_block
+        assert "3:42 PM EST" in mw._context_block
+        assert "<user_profile>" not in mw._context_block
+        loader.render.assert_called_once_with(
+            "components/time_awareness.md.j2",
+            current_time="3:42 PM EST, Monday, April 5, 2026",
+        )
+
+    @patch("ptc_agent.agent.middleware.runtime_context.get_loader")
+    def test_time_and_profile(self, mock_get_loader):
+        """With user_profile, both blocks are rendered."""
+        loader = MagicMock()
+        loader.render.side_effect = [
+            "**Current Date/Time:** 3:42 PM EST",
+            "# User Profile\n- **Name**: Alice",
+        ]
+        mock_get_loader.return_value = loader
+
+        profile = {"name": "Alice", "timezone": "US/Eastern", "locale": "en-US"}
+        mw = self._make_middleware(user_profile=profile)
+
+        assert "<time_awareness>" in mw._context_block
+        assert "<user_profile>" in mw._context_block
+        assert "Alice" in mw._context_block
+        assert loader.render.call_count == 2
+
+    @patch("ptc_agent.agent.middleware.runtime_context.get_loader")
+    def test_empty_profile_excluded(self, mock_get_loader):
+        """Empty dict user_profile is falsy — no profile block rendered."""
+        loader = MagicMock()
+        loader.render.return_value = "time content"
+        mock_get_loader.return_value = loader
+
+        mw = self._make_middleware(user_profile={})
+
+        assert "<user_profile>" not in mw._context_block
+        loader.render.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Tests for awrap_model_call
+# ---------------------------------------------------------------------------
+
+
+class TestAwrapModelCall:
+    """Tests for awrap_model_call system message injection."""
+
+    @pytest.mark.asyncio
+    @patch("ptc_agent.agent.middleware.runtime_context.get_loader")
+    async def test_appends_context_to_system_message(self, mock_get_loader):
+        loader = MagicMock()
+        loader.render.return_value = "time content"
+        mock_get_loader.return_value = loader
+
+        mw = RuntimeContextMiddleware(current_time="now")
+
+        mock_request = MagicMock()
+        modified_request = MagicMock()
+        mock_request.override = MagicMock(return_value=modified_request)
+        mock_request.system_message = SystemMessage(content="base prompt")
+
+        handler = AsyncMock(return_value="model_response")
+        result = await mw.awrap_model_call(mock_request, handler)
+
+        # override should have been called with a new system message
+        mock_request.override.assert_called_once()
+        call_kwargs = mock_request.override.call_args
+        assert "system_message" in call_kwargs.kwargs
+        new_sys = call_kwargs.kwargs["system_message"]
+        assert isinstance(new_sys, SystemMessage)
+
+        # handler should have been called with modified request
+        handler.assert_called_once_with(modified_request)
+        assert result == "model_response"
+
+    @pytest.mark.asyncio
+    @patch("ptc_agent.agent.middleware.runtime_context.get_loader")
+    async def test_appends_to_none_system_message(self, mock_get_loader):
+        """Works when system_message is None (creates a new one)."""
+        loader = MagicMock()
+        loader.render.return_value = "time content"
+        mock_get_loader.return_value = loader
+
+        mw = RuntimeContextMiddleware(current_time="now")
+
+        mock_request = MagicMock()
+        modified_request = MagicMock()
+        mock_request.override = MagicMock(return_value=modified_request)
+        mock_request.system_message = None
+
+        handler = AsyncMock(return_value="model_response")
+        await mw.awrap_model_call(mock_request, handler)
+
+        call_kwargs = mock_request.override.call_args
+        new_sys = call_kwargs.kwargs["system_message"]
+        assert isinstance(new_sys, SystemMessage)
+
+
+# ---------------------------------------------------------------------------
+# Tests for wrap_model_call (sync passthrough)
+# ---------------------------------------------------------------------------
+
+
+class TestWrapModelCall:
+    """Tests for sync wrap_model_call passthrough."""
+
+    @patch("ptc_agent.agent.middleware.runtime_context.get_loader")
+    def test_sync_passthrough(self, mock_get_loader):
+        """Sync path passes request through without modification."""
+        mw = RuntimeContextMiddleware(current_time="now")
+
+        mock_request = MagicMock()
+        handler = MagicMock(return_value="response")
+
+        result = mw.wrap_model_call(mock_request, handler)
+
+        handler.assert_called_once_with(mock_request)
+        assert result == "response"


### PR DESCRIPTION
## Summary

Move `current_time` and `user_profile` out of the Jinja2 system prompt templates into a new `RuntimeContextMiddleware`, so they are injected **after** the Anthropic prompt cache breakpoint instead of inside it.

**Before:** The system prompt contained `current_time` (changes every minute) and `user_profile` (varies per user) inside the cached prefix, causing near-constant cache invalidation across requests.

**After:** The static system prompt + skills manifest form a stable cached prefix. Dynamic content is appended by innermost middlewares outside the breakpoint:

```
Block 1: static system prompt          — no cache_control
Block 2: skills manifest               — cache_control (BREAKPOINT)
Block 3: agent.md (workspace context)  — no cache_control
Block 4: current_time + user_profile   — no cache_control (NEW)
```

### Changes
- **New middleware** `RuntimeContextMiddleware` renders time_awareness and user_profile templates and appends them as the last system message block
- **Removed** `current_time` and `user_profile` from `system.md.j2` and `flash_system.md.j2` templates
- **Updated** `_build_system_prompt()` in both PTC and Flash agents to no longer accept these params
- **Positioned** the new middleware after `WorkspaceContextMiddleware` (innermost = runs last)

### Impact
- System prompt cache hit rate goes from "only within same minute for same user" to "always, regardless of user or time"
- Cache read = 0.1x input cost (90% savings on system prompt tokens)
- No behavioral change for the agent... same content is injected, just in a different position

## Test Coverage

9 new tests:
- `test_runtime_context.py` — 6 unit tests (block construction, system message injection, sync passthrough)
- `test_prompt_cache_breakpoint.py` — 3 integration tests (4-block ordering, breakpoint stability across times, no-profile variant)

All 2352 unit tests pass.

## Pre-Landing Review
No issues found.

## Plan Completion
8/8 plan items DONE.

## Test plan
- [x] All unit tests pass (2352 tests, 0 failures)
- [x] Integration test verifies cache_control breakpoint on skills block only
- [x] Integration test verifies breakpoint stable across different current_time values