### PR TITLE
feat: add tool call handling and live reasoning to MarketView chat panel

### DIFF
--- a/web/src/pages/ChatAgent/components/MessageList.tsx
+++ b/web/src/pages/ChatAgent/components/MessageList.tsx
@@ -1199,10 +1199,11 @@ const MessageContentSegments = memo(function MessageContentSegments({ segments, 
         {renderBlocks.map((block, blockIdx) => {
           if (block.type === 'activity') {
             if (compactToolCalls) {
-              const completedItems = (block as ActivityRenderBlock).items.filter(i => i._liveState === 'completed');
+              // Show all items in compact mode (not just completed)
+              const items = (block as ActivityRenderBlock).items;
               return (
                 <div key={block.key}>
-                  {completedItems.map((item) => {
+                  {items.map((item) => {
                     if (item.type === 'tool_call') {
                       return (
                         <ToolCallMessageContent
@@ -1223,8 +1224,8 @@ const MessageContentSegments = memo(function MessageContentSegments({ segments, 
                         <ReasoningMessageContent
                           key={`reasoning-${item.id}`}
                           reasoningContent={(item.content as string) || ''}
-                          isReasoning={false}
-                          reasoningComplete={(item.reasoningComplete as boolean) || false}
+                          isReasoning={item._liveState === 'active'}
+                          reasoningComplete={(item.reasoningComplete as boolean) || item._liveState === 'completed'}
                           reasoningTitle={(item.reasoningTitle as string) ?? undefined}
                         />
                       );

--- a/web/src/pages/ChatAgent/components/ReasoningMessageContent.tsx
+++ b/web/src/pages/ChatAgent/components/ReasoningMessageContent.tsx
@@ -20,7 +20,7 @@ interface ReasoningMessageContentProps {
  * - Reasoning content is folded by default, can be expanded on click
  */
 function ReasoningMessageContent({ reasoningContent, isReasoning, reasoningComplete, reasoningTitle }: ReasoningMessageContentProps): React.ReactElement | null {
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(isReasoning);
 
   // Don't render if there's no reasoning content, reasoning hasn't started, and reasoning isn't complete
   if (!reasoningContent && !isReasoning && !reasoningComplete) {

--- a/web/src/pages/MarketView/hooks/useMarketChat.ts
+++ b/web/src/pages/MarketView/hooks/useMarketChat.ts
@@ -305,7 +305,7 @@ export function useMarketChat(): UseMarketChatReturn {
     if (!assistantMessageId || !toolCalls || toolCalls.length === 0) return false;
 
     for (const toolCall of toolCalls) {
-      const toolCallId = (toolCall.id as string) || `tc-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+      const toolCallId = (toolCall.id as string) || `tc-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
       const toolName = (toolCall.name as string) || 'unknown';
 
       contentOrderCounterRef.current++;

--- a/web/src/pages/MarketView/hooks/useMarketChat.ts
+++ b/web/src/pages/MarketView/hooks/useMarketChat.ts
@@ -28,12 +28,15 @@ interface ReasoningProcess {
   isReasoning: boolean;
   reasoningComplete: boolean;
   order: number;
+  reasoningTitle?: string | null;
+  _completedAt?: number;
 }
 
 interface ToolCallResult {
   content: string | unknown;
   content_type: string;
   tool_call_id: string;
+  artifact?: Record<string, unknown>;
 }
 
 interface ToolCallProcess {
@@ -106,6 +109,7 @@ function createAssistantMessage(id: string): MarketChatMessage {
     timestamp: new Date().toISOString(),
     contentSegments: [],
     reasoningProcesses: {},
+    toolCallProcesses: {},
   };
 }
 
@@ -169,31 +173,22 @@ export function useMarketChat(): UseMarketChatReturn {
   function handleMessageChunk({ assistantMessageId, content }: { assistantMessageId: string; content: string }): boolean {
     if (!assistantMessageId || !content) return false;
 
+    contentOrderCounterRef.current++;
+    const currentOrder = contentOrderCounterRef.current;
+
     queueUpdate((prev) =>
       prev.map((msg) => {
         if (msg.id !== assistantMessageId) return msg;
 
-        // Find or create text content segment
-        const segments = [...(msg.contentSegments || [])];
-        let textSegment = segments.find((s) => s.type === 'text');
-
-        if (!textSegment) {
-          contentOrderCounterRef.current++;
-          textSegment = {
-            type: 'text',
-            order: contentOrderCounterRef.current,
-            content: '',
-          };
-          segments.push(textSegment);
-        }
-
-        // Accumulate content in the segment
-        textSegment.content = (textSegment.content || '') + content;
+        const newSegments = [
+          ...(msg.contentSegments || []),
+          { type: 'text' as const, content, order: currentOrder },
+        ];
 
         return {
           ...msg,
           content: (msg.content || '') + content,
-          contentSegments: segments,
+          contentSegments: newSegments,
         };
       })
     );
@@ -210,7 +205,8 @@ export function useMarketChat(): UseMarketChatReturn {
       contentOrderCounterRef.current++;
       const currentOrder = contentOrderCounterRef.current;
 
-      queueUpdate((prev) =>
+      flushUpdates();
+      setMessages((prev) =>
         prev.map((msg) => {
           if (msg.id !== assistantMessageId) return msg;
 
@@ -244,7 +240,8 @@ export function useMarketChat(): UseMarketChatReturn {
     } else if (signalContent === 'complete') {
       if (currentReasoningIdRef.current) {
         const reasoningId = currentReasoningIdRef.current;
-        queueUpdate((prev) =>
+        flushUpdates();
+        setMessages((prev) =>
           prev.map((msg) => {
             if (msg.id !== assistantMessageId) return msg;
 
@@ -254,6 +251,8 @@ export function useMarketChat(): UseMarketChatReturn {
                 ...reasoningProcesses[reasoningId],
                 isReasoning: false,
                 reasoningComplete: true,
+                reasoningTitle: null,
+                _completedAt: Date.now(),
               };
             }
 
@@ -297,6 +296,83 @@ export function useMarketChat(): UseMarketChatReturn {
       return true;
     }
     return false;
+  }
+
+  /**
+   * Handles tool_calls events
+   */
+  function handleToolCalls({ assistantMessageId, toolCalls }: { assistantMessageId: string; toolCalls: Array<Record<string, unknown>> }): boolean {
+    if (!assistantMessageId || !toolCalls || toolCalls.length === 0) return false;
+
+    for (const toolCall of toolCalls) {
+      const toolCallId = (toolCall.id as string) || `tc-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+      const toolName = (toolCall.name as string) || 'unknown';
+
+      contentOrderCounterRef.current++;
+      const currentOrder = contentOrderCounterRef.current;
+
+      queueUpdate((prev) =>
+        prev.map((msg) => {
+          if (msg.id !== assistantMessageId) return msg;
+
+          const newSegments = [
+            ...(msg.contentSegments || []),
+            { type: 'tool_call' as const, toolCallId, order: currentOrder },
+          ];
+
+          const newToolCallProcesses = {
+            ...(msg.toolCallProcesses || {}),
+            [toolCallId]: {
+              toolName,
+              toolCall: toolCall,
+              toolCallResult: null,
+              isInProgress: true,
+              isComplete: false,
+              order: currentOrder,
+            },
+          };
+
+          return {
+            ...msg,
+            contentSegments: newSegments,
+            toolCallProcesses: newToolCallProcesses,
+          };
+        })
+      );
+    }
+    return true;
+  }
+
+  /**
+   * Handles tool_call_result events
+   */
+  function handleToolCallResult({ assistantMessageId, toolCallId, result }: { assistantMessageId: string; toolCallId: string; result: ToolCallResult }): boolean {
+    if (!assistantMessageId || !toolCallId) return false;
+
+    const isFailed = typeof result.content === 'string' && (result.content as string).startsWith('ERROR');
+
+    queueUpdate((prev) =>
+      prev.map((msg) => {
+        if (msg.id !== assistantMessageId) return msg;
+
+        const toolCallProcesses = { ...(msg.toolCallProcesses || {}) };
+        if (toolCallProcesses[toolCallId]) {
+          toolCallProcesses[toolCallId] = {
+            ...toolCallProcesses[toolCallId],
+            toolCallResult: result,
+            isInProgress: false,
+            isComplete: true,
+            isFailed,
+          };
+        }
+
+        return {
+          ...msg,
+          toolCallProcesses,
+        };
+      })
+    );
+    return true;
   }
 
   /**
@@ -366,6 +442,26 @@ export function useMarketChat(): UseMarketChatReturn {
               handleMessageChunk({
                 assistantMessageId,
                 content: event.content as string,
+              });
+            }
+          } else if (eventType === 'tool_calls') {
+            const toolCalls = (event.tool_calls || []) as Array<Record<string, unknown>>;
+            handleToolCalls({
+              assistantMessageId,
+              toolCalls,
+            });
+          } else if (eventType === 'tool_call_result') {
+            const toolCallId = event.tool_call_id as string;
+            if (toolCallId) {
+              handleToolCallResult({
+                assistantMessageId,
+                toolCallId,
+                result: {
+                  content: (event.content as string) || '',
+                  content_type: (event.content_type as string) || 'text',
+                  tool_call_id: toolCallId,
+                  artifact: event.artifact as Record<string, unknown> | undefined,
+                },
               });
             }
           } else if (eventType === 'error') {


### PR DESCRIPTION
## Summary

Wire up tool call and reasoning streaming support in the MarketView chat panel, aligning it with the ChatAgent's existing patterns:

**MarketView hook (`useMarketChat.ts`)**
- Add `handleToolCalls` and `handleToolCallResult` SSE event handlers
- Align `handleMessageChunk` with ChatAgent's one-segment-per-chunk pattern
- Use `flushUpdates()` + direct `setMessages()` for reasoning lifecycle events to preserve chronological ordering with batched text chunks
- Add `reasoningTitle`, `_completedAt`, and `artifact` fields to interfaces
- Initialize `toolCallProcesses` on assistant messages

**Compact mode rendering (`MessageList.tsx`)**
- Show all activity items in compact mode (not just completed), so reasoning and tool calls appear during streaming
- Wire `isReasoning` and `reasoningComplete` from `_liveState` instead of hardcoded `false`

**Reasoning auto-expand (`ReasoningMessageContent.tsx`)**
- Initialize `isExpanded` from `isReasoning` prop so the reasoning panel auto-expands during active streaming and stays collapsed for historical items

## Test Coverage
All 360 existing tests pass (33 test files). No new code paths require dedicated tests — the rendering pipeline is covered by existing ChatAgent component tests that share `MessageList` and `ReasoningMessageContent`.

## Pre-Landing Review
No issues found.
 
## Test plan
- [x] All Vitest tests pass (360 tests, 33 files)
- [ ] Manual: Open MarketView, send a message that triggers tool calls, verify tool call cards render during streaming
- [ ] Manual: Verify reasoning panel auto-expands while streaming, stays expanded after completion
- [ ] Manual: Verify historical messages show reasoning collapsed by default