### PR TITLE
fix: invalidate platform models cache after invitation code redemption

### DIFF
--- a/web/src/pages/Setup/steps/MethodStep.tsx
+++ b/web/src/pages/Setup/steps/MethodStep.tsx
@@ -257,9 +257,10 @@ export default function MethodStep() {
     try {
       await api.post('/api/auth/invitations/redeem', { code: invitationCode.trim() });
       setLocalRedeemed(true);
-      // Bust stale platform tier cache, then refresh the user query
+      // Bust stale platform tier cache, then refresh user + model access queries
       await getCurrentUser({ refresh_tier: true }).catch(() => {});
       await queryClient.invalidateQueries({ queryKey: queryKeys.user.me() });
+      await queryClient.invalidateQueries({ queryKey: queryKeys.platform.models() });
       navigate('/setup/defaults');
     } catch (e: unknown) {
       const err = e as {
@@ -279,6 +280,7 @@ export default function MethodStep() {
         setLocalRedeemed(true);
         await getCurrentUser({ refresh_tier: true }).catch(() => {});
         await queryClient.invalidateQueries({ queryKey: queryKeys.user.me() });
+        await queryClient.invalidateQueries({ queryKey: queryKeys.platform.models() });
         navigate('/setup/defaults');
         return;
       } else if (typeof detail === 'string') {


### PR DESCRIPTION
## Summary

After redeeming an invitation code in the Setup wizard, `queryKeys.platform.models()` was not invalidated. `usePlatformModels` has `staleTime: 5min` and `gcTime: Infinity`, so the old `model_tier` stayed in the React Query cache. Newly-unlocked models appeared locked until the cache expired or the user hard-refreshed.

- **Root cause**: `handleRedeemInvitation` in `MethodStep.tsx` invalidated `queryKeys.user.me()` but not `queryKeys.platform.models()`
- **Fix**: Add `queryClient.invalidateQueries({ queryKey: queryKeys.platform.models() })` in both the success and 409 (already redeemed) paths
- **Backend**: No caching issue. ginlix-platform's `ModelAccessService` does a live SQL query every call. The langalpha Redis tier cache is already busted via `?refresh_tier=true`.

## Pre-Landing Review

No issues found.

## Test plan
- [x] All Vitest tests pass (33 files, 360 tests)
- [x] ESLint clean