### PR TITLE
feat(llms): add GLM-5.1, GLM-5V-Turbo and separate MiniMax models

### DIFF
--- a/src/llms/manifest/models.json
+++ b/src/llms/manifest/models.json
@@ -476,6 +476,20 @@
     ]
   },
   "minimax-m2.7": {
+    "model_id": "MiniMax-M2.7",
+    "provider": "minimax",
+    "visible": true,
+    "parameters": {
+      "max_tokens": 128000,
+      "thinking": {
+        "type": "enabled"
+      }
+    },
+    "input_modalities": [
+      "text"
+    ]
+  },
+  "minimax-m2.7-highspeed": {
     "model_id": "MiniMax-M2.7-highspeed",
     "provider": "minimax",
     "visible": true,

--- a/src/llms/manifest/models.json
+++ b/src/llms/manifest/models.json
@@ -387,8 +387,22 @@
       "text"
     ]
   },
-  "glm-5": {
-    "model_id": "glm-5",
+  "glm-5.1": {
+    "model_id": "glm-5.1",
+    "provider": "z-ai",
+    "visible": true,
+    "parameters": {
+      "max_tokens": 128000,
+      "thinking": {
+        "type": "enabled"
+      }
+    },
+    "input_modalities": [
+      "text"
+    ]
+  },
+  "glm-5v-turbo": {
+    "model_id": "glm-5v-turbo",
     "provider": "z-ai",
     "visible": true,
     "parameters": {
@@ -399,7 +413,8 @@
     },
     "input_modalities": [
       "text",
-      "image"
+      "image",
+      "pdf"
     ]
   },
   "glm-5-turbo": {
@@ -430,8 +445,22 @@
       "text"
     ]
   },
-  "glm-5-cn": {
-    "model_id": "glm-5",
+  "glm-5.1-cn": {
+    "model_id": "glm-5.1",
+    "provider": "z-ai-cn",
+    "visible": true,
+    "parameters": {
+      "max_tokens": 128000,
+      "thinking": {
+        "type": "enabled"
+      }
+    },
+    "input_modalities": [
+      "text"
+    ]
+  },
+  "glm-5v-turbo-cn": {
+    "model_id": "glm-5v-turbo",
     "provider": "z-ai-cn",
     "visible": true,
     "parameters": {
@@ -442,7 +471,8 @@
     },
     "input_modalities": [
       "text",
-      "image"
+      "image",
+      "pdf"
     ]
   },
   "minimax-m2.7": {

--- a/src/llms/manifest/providers.json
+++ b/src/llms/manifest/providers.json
@@ -263,14 +263,26 @@
     "vllm": [],
     "z-ai": [
       {
-        "id": "glm-5",
-        "name": "GLM-5",
+        "id": "glm-5.1",
+        "name": "GLM-5.1",
         "is_reasoning": true,
-        "description": "Z.AI's latest GLM-5 model with extended thinking capabilities",
+        "description": "Z.AI's latest GLM-5.1 model with extended thinking capabilities",
         "pricing": {
-          "input": 1.0,
-          "cached_input": 0.2,
-          "output": 3.2,
+          "input": 1.4,
+          "cached_input": 0.26,
+          "output": 4.4,
+          "unit": "per_1m_tokens"
+        }
+      },
+      {
+        "id": "glm-5v-turbo",
+        "name": "GLM-5V-Turbo",
+        "is_reasoning": true,
+        "description": "Z.AI's GLM-5V-Turbo multimodal Agent model with vision and tool calling",
+        "pricing": {
+          "input": 1.2,
+          "cached_input": 0.24,
+          "output": 4.0,
           "unit": "per_1m_tokens"
         }
       },
@@ -301,31 +313,63 @@
     ],
     "z-ai-cn": [
       {
-        "id": "glm-5",
-        "name": "GLM-5",
+        "id": "glm-5.1",
+        "name": "GLM-5.1",
         "is_reasoning": true,
-        "description": "Z.AI's latest GLM-5 model with input-dependent tiered pricing",
+        "description": "Z.AI's latest GLM-5.1 model with input-dependent tiered pricing",
         "pricing": {
           "input_tiers": [
             {
               "max_tokens": 32000,
-              "rate": 0.55,
-              "cached_input": 0.14
+              "rate": 0.83,
+              "cached_input": 0.18
             },
             {
               "max_tokens": null,
-              "rate": 0.83,
-              "cached_input": 0.21
+              "rate": 1.1,
+              "cached_input": 0.28
             }
           ],
           "output_tiers": [
             {
               "max_tokens": 32000,
-              "rate": 2.48
+              "rate": 3.31
             },
             {
               "max_tokens": null,
-              "rate": 3.03
+              "rate": 3.87
+            }
+          ],
+          "output_pricing_mode": "input_dependent",
+          "unit": "per_1m_tokens"
+        }
+      },
+      {
+        "id": "glm-5v-turbo",
+        "name": "GLM-5V-Turbo",
+        "is_reasoning": true,
+        "description": "Z.AI's GLM-5V-Turbo multimodal Agent model with vision, tiered pricing",
+        "pricing": {
+          "input_tiers": [
+            {
+              "max_tokens": 32000,
+              "rate": 0.69,
+              "cached_input": 0.17
+            },
+            {
+              "max_tokens": null,
+              "rate": 0.97,
+              "cached_input": 0.25
+            }
+          ],
+          "output_tiers": [
+            {
+              "max_tokens": 32000,
+              "rate": 3.04
+            },
+            {
+              "max_tokens": null,
+              "rate": 3.59
             }
           ],
           "output_pricing_mode": "input_dependent",

--- a/web/src/hooks/__tests__/useFilteredModels.test.ts
+++ b/web/src/hooks/__tests__/useFilteredModels.test.ts
@@ -142,10 +142,10 @@ describe('filterModelsByAccess', () => {
   it('excludes groupKey fallback when variant requires own key (regional variant)', () => {
     // z-ai-cn models grouped under z-ai — both api_key but different env_key
     const providerMap = makeProviderMap({
-      'z-ai': ['glm-5', 'glm-5-turbo-cn'],
+      'z-ai': ['glm-5.1', 'glm-5-turbo-cn'],
     });
     const metadata: Record<string, ModelMetadataEntry> = {
-      'glm-5': { provider: 'z-ai', access_type: 'api_key' },
+      'glm-5.1': { provider: 'z-ai', access_type: 'api_key' },
       'glm-5-turbo-cn': { provider: 'z-ai-cn', access_type: 'api_key', requires_own_key: 'true' },
     };
     const { configuredSet, configuredTypeMap } = makeConfigured([
@@ -154,8 +154,8 @@ describe('filterModelsByAccess', () => {
 
     const result = filterModelsByAccess(providerMap, metadata, configuredSet, configuredTypeMap);
 
-    // glm-5 included (direct match), glm-5-turbo-cn excluded (requires own key)
-    expect(result['z-ai']?.models).toEqual(['glm-5']);
+    // glm-5.1 included (direct match), glm-5-turbo-cn excluded (requires own key)
+    expect(result['z-ai']?.models).toEqual(['glm-5.1']);
   });
 
   it('includes model when metadata is missing access_type (defaults to api_key)', () => {


### PR DESCRIPTION
## Summary

**Model Updates (Z.AI)**
- Replace GLM-5 with GLM-5.1 (text-only, updated pricing) for both z-ai and z-ai-cn providers
- Add GLM-5V-Turbo vision model (text + image + pdf) for both z-ai and z-ai-cn providers
- Update pricing for z-ai international (flat rate) and z-ai-cn (tiered pricing)

**Model Updates (MiniMax)**
- Separate `minimax-m2.7` (was pointing to highspeed model_id) into two distinct entries:
  - `minimax-m2.7` → `MiniMax-M2.7` (standard)
  - `minimax-m2.7-highspeed` → `MiniMax-M2.7-highspeed` (faster inference)

**Test**
- Updated `useFilteredModels.test.ts` test data from `glm-5` to `glm-5.1`

## Test plan
- [x] All frontend tests pass (33 files, 360 tests)
- [x] JSON manifest files validated (models.json, providers.json)