### PR TITLE
feat(llms): add Qwen3.6 Plus model support

### DIFF
--- a/src/llms/manifest/models.json
+++ b/src/llms/manifest/models.json
@@ -503,6 +503,20 @@
       "text"
     ]
   },
+  "qwen3.6-plus": {
+    "model_id": "qwen3.6-plus",
+    "provider": "dashscope",
+    "visible": true,
+    "input_modalities": [
+      "text",
+      "image",
+      "pdf",
+      "video"
+    ],
+    "extra_body": {
+      "enable_thinking": true
+    }
+  },
   "qwen3.5-plus": {
     "model_id": "qwen3.5-plus",
     "provider": "dashscope",
@@ -534,6 +548,20 @@
       "text",
       "image",
       "pdf"
+    ],
+    "extra_body": {
+      "enable_thinking": true
+    }
+  },
+  "qwen3.6-plus-intl": {
+    "model_id": "qwen3.6-plus",
+    "provider": "dashscope-intl",
+    "visible": true,
+    "input_modalities": [
+      "text",
+      "image",
+      "pdf",
+      "video"
     ],
     "extra_body": {
       "enable_thinking": true

--- a/src/llms/manifest/providers.json
+++ b/src/llms/manifest/providers.json
@@ -650,6 +650,40 @@
     ],
     "dashscope": [
       {
+        "id": "qwen3.6-plus",
+        "name": "Qwen3.6 Plus",
+        "is_reasoning": true,
+        "description": "Alibaba's Qwen3.6 Plus flagship model with Agentic coding, vision, and 1M context",
+        "context_window": 1000000,
+        "max_output": 65536,
+        "pricing": {
+          "input_tiers": [
+            {
+              "max_tokens": 256000,
+              "rate": 0.287,
+              "cached_input": 0.029
+            },
+            {
+              "max_tokens": 1000000,
+              "rate": 1.147,
+              "cached_input": 0.115
+            }
+          ],
+          "output_tiers": [
+            {
+              "max_tokens": 256000,
+              "rate": 1.72
+            },
+            {
+              "max_tokens": 1000000,
+              "rate": 6.89
+            }
+          ],
+          "output_pricing_mode": "input_dependent",
+          "unit": "per_1m_tokens"
+        }
+      },
+      {
         "id": "qwen3.5-plus",
         "name": "Qwen3.5 Plus",
         "is_reasoning": true,
@@ -865,6 +899,40 @@
       }
     ],
     "dashscope-intl": [
+      {
+        "id": "qwen3.6-plus",
+        "name": "Qwen3.6 Plus (SG)",
+        "is_reasoning": true,
+        "description": "Alibaba's Qwen3.6 Plus flagship model — Singapore international region",
+        "context_window": 1000000,
+        "max_output": 65536,
+        "pricing": {
+          "input_tiers": [
+            {
+              "max_tokens": 256000,
+              "rate": 0.538,
+              "cached_input": 0.054
+            },
+            {
+              "max_tokens": 1000000,
+              "rate": 2.15,
+              "cached_input": 0.215
+            }
+          ],
+          "output_tiers": [
+            {
+              "max_tokens": 256000,
+              "rate": 3.227
+            },
+            {
+              "max_tokens": 1000000,
+              "rate": 6.452
+            }
+          ],
+          "output_pricing_mode": "input_dependent",
+          "unit": "per_1m_tokens"
+        }
+      },
       {
         "id": "qwen3.5-plus",
         "name": "Qwen3.5 Plus (SG)",

--- a/src/llms/manifest/providers.json
+++ b/src/llms/manifest/providers.json
@@ -926,7 +926,7 @@
             },
             {
               "max_tokens": 1000000,
-              "rate": 12.91
+              "rate": 6.452
             }
           ],
           "output_pricing_mode": "input_dependent",

--- a/src/llms/manifest/providers.json
+++ b/src/llms/manifest/providers.json
@@ -926,7 +926,7 @@
             },
             {
               "max_tokens": 1000000,
-              "rate": 6.452
+              "rate": 12.91
             }
           ],
           "output_pricing_mode": "input_dependent",


### PR DESCRIPTION
## Summary

- Add `qwen3.6-plus` model for DashScope (CN) with tiered pricing (≤256k and 256k-1M)
- Add `qwen3.6-plus-intl` model for DashScope International (Singapore) with tiered pricing
- Supports text, image, pdf, and video input modalities
- Pricing converted from CNY using the same rate as existing DashScope entries

## Test plan
- [x] All frontend tests pass (33 files, 360 tests)
- [x] JSON manifest files validated (models.json, providers.json)