### PR TITLE
fix(widget): sanitize NaN/Infinity and catch runtime errors in inline widgets

### DIFF
--- a/src/ptc_agent/agent/tools/show_widget.py
+++ b/src/ptc_agent/agent/tools/show_widget.py
@@ -211,7 +211,7 @@ async def _resolve_data_files(
             _, ext = os.path.splitext(path)
             if ext.lower() in ('.json', '.geojson', '.topojson'):
                 value = re.sub(r'\bNaN\b', 'null', value)
-                value = re.sub(r'-?Infinity\b', 'null', value)
+                value = re.sub(r'(?<![A-Za-z_])-?Infinity\b', 'null', value)
         else:
             b64 = base64.b64encode(content).decode()  # type: ignore[arg-type]
             value = f"data:{mime};base64,{b64}"

--- a/src/ptc_agent/agent/tools/show_widget.py
+++ b/src/ptc_agent/agent/tools/show_widget.py
@@ -209,9 +209,9 @@ async def _resolve_data_files(
             # Sanitize non-standard JSON tokens (NaN/Infinity) that Python's
             # json.dumps emits by default — these break browser JSON.parse.
             _, ext = os.path.splitext(path)
-            if ext.lower() == '.json':
+            if ext.lower() in ('.json', '.geojson', '.topojson'):
                 value = re.sub(r'\bNaN\b', 'null', value)
-                value = re.sub(r'\b-?Infinity\b', 'null', value)
+                value = re.sub(r'-?Infinity\b', 'null', value)
         else:
             b64 = base64.b64encode(content).decode()  # type: ignore[arg-type]
             value = f"data:{mime};base64,{b64}"

--- a/src/ptc_agent/agent/tools/show_widget.py
+++ b/src/ptc_agent/agent/tools/show_widget.py
@@ -206,6 +206,12 @@ async def _resolve_data_files(
         # Build inline value
         if is_text:
             value = content  # type: ignore[assignment]
+            # Sanitize non-standard JSON tokens (NaN/Infinity) that Python's
+            # json.dumps emits by default — these break browser JSON.parse.
+            _, ext = os.path.splitext(path)
+            if ext.lower() == '.json':
+                value = re.sub(r'\bNaN\b', 'null', value)
+                value = re.sub(r'\b-?Infinity\b', 'null', value)
         else:
             b64 = base64.b64encode(content).decode()  # type: ignore[arg-type]
             value = f"data:{mime};base64,{b64}"

--- a/web/src/pages/ChatAgent/components/viewers/InlineWidget.tsx
+++ b/web/src/pages/ChatAgent/components/viewers/InlineWidget.tsx
@@ -71,7 +71,7 @@ function buildSrcDoc(html: string, widgetData?: Record<string, string>): string 
 (function(){
   var _p=JSON.parse;
   JSON.parse=function(t,r){
-    if(typeof t==='string')t=t.replace(/\\bNaN\\b/g,'null').replace(/-?Infinity\\b/g,'null');
+    if(typeof t==='string')t=t.replace(/\\bNaN\\b/g,'null').replace(/(?<![A-Za-z_])-?Infinity\\b/g,'null');
     return _p.call(this,t,r);
   };
   var shown={},count=0,rendering=false;

--- a/web/src/pages/ChatAgent/components/viewers/InlineWidget.tsx
+++ b/web/src/pages/ChatAgent/components/viewers/InlineWidget.tsx
@@ -71,13 +71,16 @@ function buildSrcDoc(html: string, widgetData?: Record<string, string>): string 
 (function(){
   var _p=JSON.parse;
   JSON.parse=function(t,r){
-    if(typeof t==='string')t=t.replace(/\\bNaN\\b/g,'null').replace(/\\b-?Infinity\\b/g,'null');
+    if(typeof t==='string')t=t.replace(/\\bNaN\\b/g,'null').replace(/-?Infinity\\b/g,'null');
     return _p.call(this,t,r);
   };
-  var shown={};
+  var shown={},count=0,rendering=false;
   function showError(msg){
-    if(shown[msg])return;
+    if(rendering||shown[msg])return;
     shown[msg]=1;
+    if(++count>5)return;
+    rendering=true;
+    msg=String(msg).slice(0,500);
     var root=document.body||document.documentElement;
     var d=document.createElement('div');
     d.style.cssText='margin:12px;padding:14px 16px;background:var(--color-bg-card);border:0.5px solid var(--color-border-muted);border-radius:10px;display:flex;align-items:center;gap:12px;';
@@ -98,6 +101,7 @@ function buildSrcDoc(html: string, widgetData?: Record<string, string>): string 
     d.appendChild(dot);d.appendChild(mid);d.appendChild(b);
     root.appendChild(d);
     parent.postMessage({type:'widget:resize',height:root.scrollHeight},'*');
+    rendering=false;
   }
   window.onerror=function(_,__,___,____,e){showError(e&&e.message||String(_));};
   window.addEventListener('unhandledrejection',function(e){showError(e.reason&&e.reason.message||String(e.reason));});
@@ -105,7 +109,7 @@ function buildSrcDoc(html: string, widgetData?: Record<string, string>): string 
 </script>\n`;
 
   return `<!DOCTYPE html><html><head>
-${earlyScripts}<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' cdnjs.cloudflare.com cdn.jsdelivr.net unpkg.com esm.sh; style-src 'unsafe-inline'; img-src data: blob:; font-src cdnjs.cloudflare.com cdn.jsdelivr.net; connect-src cdnjs.cloudflare.com cdn.jsdelivr.net unpkg.com esm.sh;">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' cdnjs.cloudflare.com cdn.jsdelivr.net unpkg.com esm.sh; style-src 'unsafe-inline'; img-src data: blob:; font-src cdnjs.cloudflare.com cdn.jsdelivr.net; connect-src cdnjs.cloudflare.com cdn.jsdelivr.net unpkg.com esm.sh;">
 <style>
 :root {
   ${themeCSS}
@@ -114,7 +118,7 @@ ${earlyScripts}<meta http-equiv="Content-Security-Policy" content="default-src '
 body { margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: var(--color-text-primary); background: transparent; overflow: hidden; }
 ${SEAMLESS_OVERRIDE}
 </style>
-${dataScript}<script>
+${earlyScripts}${dataScript}<script>
 window.sendPrompt = function(text) {
   parent.postMessage({ type: 'widget:sendPrompt', text: String(text) }, '*');
 };

--- a/web/src/pages/ChatAgent/components/viewers/InlineWidget.tsx
+++ b/web/src/pages/ChatAgent/components/viewers/InlineWidget.tsx
@@ -64,8 +64,48 @@ function buildSrcDoc(html: string, widgetData?: Record<string, string>): string 
     ? `<script>window.__WIDGET_DATA__ = ${JSON.stringify(widgetData).replace(/<\//g, '<\\/')};</script>\n`
     : '';
 
+  // Injected before any widget code runs:
+  // 1. Patch JSON.parse to handle NaN/Infinity from Python's json.dumps (not valid JSON).
+  // 2. Catch uncaught errors and unhandled rejections, display an inline error overlay.
+  const earlyScripts = `<script>
+(function(){
+  var _p=JSON.parse;
+  JSON.parse=function(t,r){
+    if(typeof t==='string')t=t.replace(/\\bNaN\\b/g,'null').replace(/\\b-?Infinity\\b/g,'null');
+    return _p.call(this,t,r);
+  };
+  var shown={};
+  function showError(msg){
+    if(shown[msg])return;
+    shown[msg]=1;
+    var root=document.body||document.documentElement;
+    var d=document.createElement('div');
+    d.style.cssText='margin:12px;padding:14px 16px;background:var(--color-bg-card);border:0.5px solid var(--color-border-muted);border-radius:10px;display:flex;align-items:center;gap:12px;';
+    var dot=document.createElement('span');
+    dot.style.cssText='flex-shrink:0;width:6px;height:6px;border-radius:50%;background:var(--color-loss);';
+    var mid=document.createElement('div');
+    mid.style.cssText='flex:1;min-width:0;';
+    var detail=document.createElement('div');
+    detail.style.cssText='font:13px/1.4 ui-monospace,SFMono-Regular,monospace;color:var(--color-text-muted);white-space:pre-wrap;word-break:break-word;';
+    detail.textContent=msg;
+    mid.appendChild(detail);
+    var b=document.createElement('button');
+    b.textContent='Fix';
+    b.style.cssText='flex-shrink:0;padding:6px 14px;border-radius:8px;border:0.5px solid var(--color-border-default);background:var(--color-bg-elevated);color:var(--color-text-primary);font:500 13px/1 -apple-system,sans-serif;cursor:pointer;transition:background 0.15s;';
+    b.onmouseover=function(){b.style.background='var(--color-bg-hover)';};
+    b.onmouseout=function(){b.style.background='var(--color-bg-elevated)';};
+    b.onclick=function(){window.sendPrompt('The widget threw an error: '+msg+'. Please fix the widget code and call ShowWidget again.');b.textContent='Sent';b.disabled=true;b.style.opacity='0.4';b.style.cursor='default';};
+    d.appendChild(dot);d.appendChild(mid);d.appendChild(b);
+    root.appendChild(d);
+    parent.postMessage({type:'widget:resize',height:root.scrollHeight},'*');
+  }
+  window.onerror=function(_,__,___,____,e){showError(e&&e.message||String(_));};
+  window.addEventListener('unhandledrejection',function(e){showError(e.reason&&e.reason.message||String(e.reason));});
+})();
+</script>\n`;
+
   return `<!DOCTYPE html><html><head>
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' cdnjs.cloudflare.com cdn.jsdelivr.net unpkg.com esm.sh; style-src 'unsafe-inline'; img-src data: blob:; font-src cdnjs.cloudflare.com cdn.jsdelivr.net; connect-src cdnjs.cloudflare.com cdn.jsdelivr.net unpkg.com esm.sh;">
+${earlyScripts}<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' cdnjs.cloudflare.com cdn.jsdelivr.net unpkg.com esm.sh; style-src 'unsafe-inline'; img-src data: blob:; font-src cdnjs.cloudflare.com cdn.jsdelivr.net; connect-src cdnjs.cloudflare.com cdn.jsdelivr.net unpkg.com esm.sh;">
 <style>
 :root {
   ${themeCSS}


### PR DESCRIPTION
## Summary

Fixes two classes of widget rendering failures:

- **NaN/Infinity in JSON**: Python's `json.dumps()` outputs `NaN` for `float('nan')` (default `allow_nan=True`), common in pandas financial data (moving averages, etc.). Browser `JSON.parse()` rejects these. Fixed by patching `JSON.parse` inside the iframe and sanitizing `.json`/`.geojson`/`.topojson` data files on the backend.

- **Silent widget crashes**: Chart.js errors, missing libraries, and other runtime exceptions produced blank widgets with no feedback. Added an error overlay with a "Fix" button that sends the error back to the agent for self-correction.

**Defense-in-depth hardening from pre-landing review:**
- Fixed `-Infinity` regex (was producing `-null`, still invalid JSON)
- CSP meta tag moved before injected scripts
- Error overlay capped at 5, rendering guard against recursion
- Prompt truncation to 500 chars

## Pre-Landing Review
7 findings (2 critical, 5 informational) — all auto-fixed in second commit.

## Test plan
- [x] All backend tests pass (2380 passed)
- [x] All frontend tests pass (388 passed)
- [x] Linting clean (ruff + eslint)