### PR TITLE
feat: specific file error messages in FilePanel

### DIFF
--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -396,7 +396,27 @@
     "save": "Save (Cmd+S)",
     "cancelEditing": "Cancel editing",
     "close": "Close",
-    "sortFiles": "Sort files"
+    "sortFiles": "Sort files",
+    "error": {
+      "notFound": "File not found",
+      "notFoundHint": "The file path may be incorrect, or the file has been deleted.",
+      "notBackedUp": "File not found in backup",
+      "notBackedUpHint": "This file may not have been saved before the workspace stopped. Start the workspace to check the sandbox.",
+      "sandboxStarting": "Sandbox is starting",
+      "sandboxStartingHint": "The sandbox is still initializing. Please try again shortly.",
+      "sandboxUnavailable": "Sandbox unavailable",
+      "sandboxUnavailableHint": "The sandbox is not available. Start the workspace to access files.",
+      "binaryFile": "Cannot preview this file",
+      "binaryFileHint": "This file type cannot be displayed in the browser, but you can download it.",
+      "noSandbox": "No sandbox available",
+      "noSandboxHint": "Flash mode workspaces do not have file storage.",
+      "accessDenied": "Access denied",
+      "accessDeniedHint": "This file is outside the allowed directories.",
+      "unknown": "Failed to load file",
+      "unknownHint": "An unexpected error occurred while loading the file.",
+      "retry": "Try again",
+      "download": "Download instead"
+    }
   },
   "automation": {
     "automations": "Automations",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -395,7 +395,27 @@
     "save": "保存 (Cmd+S)",
     "cancelEditing": "取消编辑",
     "close": "关闭",
-    "sortFiles": "排序文件"
+    "sortFiles": "排序文件",
+    "error": {
+      "notFound": "文件未找到",
+      "notFoundHint": "文件路径可能不正确，或文件已被删除。",
+      "notBackedUp": "备份中未找到文件",
+      "notBackedUpHint": "此文件可能在工作区停止前未被保存。请启动工作区以检查沙箱。",
+      "sandboxStarting": "沙箱正在启动",
+      "sandboxStartingHint": "沙箱仍在初始化中，请稍后重试。",
+      "sandboxUnavailable": "沙箱不可用",
+      "sandboxUnavailableHint": "沙箱当前不可用。请启动工作区以访问文件。",
+      "binaryFile": "无法预览此文件",
+      "binaryFileHint": "此文件类型无法在浏览器中显示，但可以下载。",
+      "noSandbox": "无可用沙箱",
+      "noSandboxHint": "Flash 模式工作区没有文件存储。",
+      "accessDenied": "访问被拒绝",
+      "accessDeniedHint": "此文件位于允许的目录之外。",
+      "unknown": "文件加载失败",
+      "unknownHint": "加载文件时发生意外错误。",
+      "retry": "重试",
+      "download": "改为下载"
+    }
   },
   "automation": {
     "automations": "自动化",

--- a/web/src/pages/ChatAgent/components/FilePanel.tsx
+++ b/web/src/pages/ChatAgent/components/FilePanel.tsx
@@ -511,7 +511,7 @@ export function FileErrorDisplay({ error, onRetry, onDownload }: FileErrorDispla
   const { t } = useTranslation();
   const key = ERROR_I18N_KEY[error.category];
 
-  const showRetry = error.category === 'sandbox_starting' || error.category === 'unknown';
+  const showRetry = error.category === 'sandbox_starting' || error.category === 'sandbox_unavailable' || error.category === 'unknown';
   const showDownload = error.category === 'binary_file';
 
   return (

--- a/web/src/pages/ChatAgent/components/FilePanel.tsx
+++ b/web/src/pages/ChatAgent/components/FilePanel.tsx
@@ -442,6 +442,111 @@ function DocumentErrorFallback({ onDownload }: DocumentErrorFallbackProps): Reac
   );
 }
 
+// --- File error categorization ---
+
+type FileErrorCategory =
+  | 'not_found'
+  | 'not_backed_up'
+  | 'sandbox_starting'
+  | 'sandbox_unavailable'
+  | 'binary_file'
+  | 'no_sandbox'
+  | 'access_denied'
+  | 'unknown';
+
+interface FileError {
+  category: FileErrorCategory;
+  detail?: string;
+}
+
+const ERROR_I18N_KEY: Record<FileErrorCategory, string> = {
+  not_found: 'notFound',
+  not_backed_up: 'notBackedUp',
+  sandbox_starting: 'sandboxStarting',
+  sandbox_unavailable: 'sandboxUnavailable',
+  binary_file: 'binaryFile',
+  no_sandbox: 'noSandbox',
+  access_denied: 'accessDenied',
+  unknown: 'unknown',
+};
+
+export function categorizeFileError(err: unknown, wsStatus?: string): FileError {
+  const response = (err as any)?.response;
+  const status: number | undefined = response?.status;
+  const raw = response?.data?.detail;
+  const detail: string = typeof raw === 'string' ? raw : '';
+
+  switch (status) {
+    case 404:
+      if (wsStatus === 'stopped' || wsStatus === 'stopping') {
+        return { category: 'not_backed_up', detail };
+      }
+      return { category: 'not_found', detail };
+    case 415:
+      return { category: 'binary_file', detail };
+    case 503:
+      if (detail.toLowerCase().includes('starting')) {
+        return { category: 'sandbox_starting', detail };
+      }
+      return { category: 'sandbox_unavailable', detail };
+    case 400:
+      if (detail.toLowerCase().includes('flash')) {
+        return { category: 'no_sandbox', detail };
+      }
+      return { category: 'unknown', detail };
+    case 403:
+      return { category: 'access_denied', detail };
+    default:
+      return { category: 'unknown', detail };
+  }
+}
+
+interface FileErrorDisplayProps {
+  error: FileError;
+  onRetry?: () => void;
+  onDownload?: () => void;
+}
+
+export function FileErrorDisplay({ error, onRetry, onDownload }: FileErrorDisplayProps): React.ReactElement {
+  const { t } = useTranslation();
+  const key = ERROR_I18N_KEY[error.category];
+
+  const showRetry = error.category === 'sandbox_starting' || error.category === 'unknown';
+  const showDownload = error.category === 'binary_file';
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 py-12">
+      <AlertTriangle className="h-6 w-6" style={{ color: 'var(--color-text-tertiary)' }} />
+      <p className="text-sm font-medium" style={{ color: 'var(--color-text-secondary)' }}>
+        {t(`filePanel.error.${key}`)}
+      </p>
+      <p className="text-xs text-center max-w-xs" style={{ color: 'var(--color-text-tertiary)' }}>
+        {t(`filePanel.error.${key}Hint`)}
+      </p>
+      <div className="flex gap-2 mt-1">
+        {showRetry && onRetry && (
+          <button
+            className="text-xs px-3 py-1.5 rounded"
+            style={{ background: 'var(--color-accent-soft)', color: 'var(--color-accent-primary)', border: '1px solid var(--color-accent-overlay)' }}
+            onClick={onRetry}
+          >
+            {t('filePanel.error.retry')}
+          </button>
+        )}
+        {showDownload && onDownload && (
+          <button
+            className="text-xs px-3 py-1.5 rounded"
+            style={{ background: 'var(--color-accent-soft)', color: 'var(--color-accent-primary)', border: '1px solid var(--color-accent-overlay)' }}
+            onClick={onDownload}
+          >
+            {t('filePanel.error.download')}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
 // --- FilePanel ---
 
 interface FilePanelProps {
@@ -518,6 +623,7 @@ function FilePanel({
   const [fileMime, setFileMime] = useState<string | null>(null);
   const [imageLightboxOpen, setImageLightboxOpen] = useState(false);
   const [fileLoading, setFileLoading] = useState(false);
+  const [fileError, setFileError] = useState<FileError | null>(null);
 
   // Upload state
   const [uploadProgress, setUploadProgress] = useState<number | null>(null);
@@ -918,9 +1024,10 @@ function FilePanel({
 
   const handleFileClick = async (filePath: string) => {
     const ext = getFileExtension(filePath);
+    setFileError(null);
 
     // Binary files
-    if (['pdf', 'png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'xlsx', 'docx', 'zip'].includes(ext)) {
+    if (['pdf', 'png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'xlsx', 'xls', 'docx', 'zip'].includes(ext)) {
       if (['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp'].includes(ext)) {
         if (fileMime === 'image' && fileContent) {
           URL.revokeObjectURL(fileContent);
@@ -933,9 +1040,9 @@ function FilePanel({
           setFileContent(blobUrl);
         } catch (err) {
           console.error('[FilePanel] Failed to download image:', err);
+          setFileError(categorizeFileError(err, wsData?.status));
           setFileContent(null);
-          setFileMime('text/plain');
-          setFileContent('Error: Failed to load image');
+          setFileMime(null);
         } finally {
           setFileLoading(false);
         }
@@ -950,7 +1057,8 @@ function FilePanel({
           setFileArrayBuffer(buf);
         } catch (err) {
           console.error('[FilePanel] Failed to load PDF:', err);
-          setFileMime('error');
+          setFileError(categorizeFileError(err, wsData?.status));
+          setFileMime(null);
         } finally {
           setFileLoading(false);
         }
@@ -965,7 +1073,8 @@ function FilePanel({
           setFileArrayBuffer(buf);
         } catch (err) {
           console.error('[FilePanel] Failed to load Excel file:', err);
-          setFileMime('error');
+          setFileError(categorizeFileError(err, wsData?.status));
+          setFileMime(null);
         } finally {
           setFileLoading(false);
         }
@@ -988,8 +1097,9 @@ function FilePanel({
       setFileMime(data.mime || 'text/plain');
     } catch (err) {
       console.error('[FilePanel] Failed to read file:', err);
-      setFileContent('Error: Failed to load file content');
-      setFileMime('text/plain');
+      setFileError(categorizeFileError(err, wsData?.status));
+      setFileContent(null);
+      setFileMime(null);
     } finally {
       setFileLoading(false);
     }
@@ -998,9 +1108,9 @@ function FilePanel({
   const selectedExt = selectedFile ? getFileExtension(selectedFile.split('/').pop() || '') : '';
   const canEdit = !!(selectedFile
     && !readOnly
+    && !fileError
     && EDITABLE_EXTENSIONS.has(selectedExt)
     && fileMime !== 'image'
-    && fileMime !== 'error'
     && fileMime !== 'pdf'
     && fileMime !== 'excel'
     && !['html', 'htm'].includes(selectedExt)
@@ -1024,6 +1134,7 @@ function FilePanel({
     setFileContent(null);
     setFileArrayBuffer(null);
     setFileMime(null);
+    setFileError(null);
     setExportModalOpen(false);
     setIsEditing(false);
     setEditContent(null);
@@ -1496,6 +1607,12 @@ function FilePanel({
                   <RefreshCw className="h-5 w-5 animate-spin" style={{ color: 'var(--color-text-tertiary)' }} />
                 </div>
               </div>
+            ) : fileError ? (
+              <FileErrorDisplay
+                error={fileError}
+                onRetry={() => handleFileClick(selectedFile)}
+                onDownload={() => triggerDownloadFn(workspaceId, selectedFile).catch((err: unknown) => console.error('[FilePanel] Download failed:', err))}
+              />
             ) : fileMime === 'pdf' ? (
               <Suspense fallback={<DocumentLoadingFallback />}>
                 <DocumentErrorBoundary fallback={<DocumentErrorFallback onDownload={() => triggerDownloadFn(workspaceId, selectedFile).catch((err: unknown) => console.error('[FilePanel] Download failed:', err))} />}>
@@ -1541,8 +1658,6 @@ function FilePanel({
                     <img src={fileContent!} alt={fileName} className="max-w-full rounded cursor-pointer" onClick={() => setImageLightboxOpen(true)} />
                     <ImageLightbox src={fileContent!} alt={fileName} open={imageLightboxOpen} onClose={() => setImageLightboxOpen(false)} />
                   </>
-                ) : fileMime === 'error' ? (
-                  <DocumentErrorFallback onDownload={() => triggerDownloadFn(workspaceId, selectedFile).catch((err: unknown) => console.error('[FilePanel] Download failed:', err))} />
                 ) : selectedFile?.startsWith('/large_tool_results/') ? (
                   <div className="markdown-print-content">
                     <Markdown variant="panel" content={stripLineNumbers(fileContent) ?? ''} className="text-sm" />

--- a/web/src/pages/ChatAgent/components/__tests__/FileErrorDisplay.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/FileErrorDisplay.test.tsx
@@ -21,6 +21,11 @@ describe('FileErrorDisplay', () => {
     expect(screen.getByText('filePanel.error.retry')).toBeInTheDocument();
   });
 
+  it('shows retry button for sandbox_unavailable category', () => {
+    render(<FileErrorDisplay error={{ category: 'sandbox_unavailable' }} onRetry={vi.fn()} />);
+    expect(screen.getByText('filePanel.error.retry')).toBeInTheDocument();
+  });
+
   it('does not show retry button for not_found category', () => {
     render(<FileErrorDisplay error={{ category: 'not_found' }} onRetry={vi.fn()} />);
     expect(screen.queryByText('filePanel.error.retry')).not.toBeInTheDocument();

--- a/web/src/pages/ChatAgent/components/__tests__/FileErrorDisplay.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/FileErrorDisplay.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FileErrorDisplay } from '../FilePanel';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe('FileErrorDisplay', () => {
+  it('shows retry button for sandbox_starting category', () => {
+    const onRetry = vi.fn();
+    render(<FileErrorDisplay error={{ category: 'sandbox_starting' }} onRetry={onRetry} />);
+    const btn = screen.getByText('filePanel.error.retry');
+    expect(btn).toBeInTheDocument();
+    fireEvent.click(btn);
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it('shows retry button for unknown category', () => {
+    render(<FileErrorDisplay error={{ category: 'unknown' }} onRetry={vi.fn()} />);
+    expect(screen.getByText('filePanel.error.retry')).toBeInTheDocument();
+  });
+
+  it('does not show retry button for not_found category', () => {
+    render(<FileErrorDisplay error={{ category: 'not_found' }} onRetry={vi.fn()} />);
+    expect(screen.queryByText('filePanel.error.retry')).not.toBeInTheDocument();
+  });
+
+  it('shows download button for binary_file category', () => {
+    const onDownload = vi.fn();
+    render(<FileErrorDisplay error={{ category: 'binary_file' }} onDownload={onDownload} />);
+    const btn = screen.getByText('filePanel.error.download');
+    expect(btn).toBeInTheDocument();
+    fireEvent.click(btn);
+    expect(onDownload).toHaveBeenCalledOnce();
+  });
+
+  it('does not show download button for non-binary categories', () => {
+    render(<FileErrorDisplay error={{ category: 'not_found' }} onDownload={vi.fn()} />);
+    expect(screen.queryByText('filePanel.error.download')).not.toBeInTheDocument();
+  });
+
+  it('hides retry button when onRetry is not provided', () => {
+    render(<FileErrorDisplay error={{ category: 'unknown' }} />);
+    expect(screen.queryByText('filePanel.error.retry')).not.toBeInTheDocument();
+  });
+
+  it('renders title and hint for each category', () => {
+    render(<FileErrorDisplay error={{ category: 'access_denied' }} />);
+    expect(screen.getByText('filePanel.error.accessDenied')).toBeInTheDocument();
+    expect(screen.getByText('filePanel.error.accessDeniedHint')).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/ChatAgent/components/__tests__/categorizeFileError.test.ts
+++ b/web/src/pages/ChatAgent/components/__tests__/categorizeFileError.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { categorizeFileError } from '../FilePanel';
+
+function makeAxiosError(status: number, detail: string) {
+  return { response: { status, data: { detail } } };
+}
+
+describe('categorizeFileError', () => {
+  it('returns not_found for 404 with running workspace', () => {
+    const err = makeAxiosError(404, 'File not found');
+    expect(categorizeFileError(err, 'running')).toEqual({
+      category: 'not_found',
+      detail: 'File not found',
+    });
+  });
+
+  it('returns not_backed_up for 404 with stopped workspace', () => {
+    const err = makeAxiosError(404, 'File not found');
+    expect(categorizeFileError(err, 'stopped')).toEqual({
+      category: 'not_backed_up',
+      detail: 'File not found',
+    });
+  });
+
+  it('returns not_backed_up for 404 with stopping workspace', () => {
+    const err = makeAxiosError(404, 'File not found');
+    expect(categorizeFileError(err, 'stopping')).toEqual({
+      category: 'not_backed_up',
+      detail: 'File not found',
+    });
+  });
+
+  it('returns binary_file for 415', () => {
+    const err = makeAxiosError(415, 'Cannot read binary file as text.');
+    expect(categorizeFileError(err)).toEqual({
+      category: 'binary_file',
+      detail: 'Cannot read binary file as text.',
+    });
+  });
+
+  it('returns sandbox_starting for 503 with "starting" in detail', () => {
+    const err = makeAxiosError(503, 'Sandbox is still starting');
+    expect(categorizeFileError(err)).toEqual({
+      category: 'sandbox_starting',
+      detail: 'Sandbox is still starting',
+    });
+  });
+
+  it('returns sandbox_unavailable for 503 without "starting"', () => {
+    const err = makeAxiosError(503, 'Sandbox not available');
+    expect(categorizeFileError(err)).toEqual({
+      category: 'sandbox_unavailable',
+      detail: 'Sandbox not available',
+    });
+  });
+
+  it('returns no_sandbox for 400 with "flash" in detail', () => {
+    const err = makeAxiosError(400, 'Flash workspaces do not have a sandbox');
+    expect(categorizeFileError(err)).toEqual({
+      category: 'no_sandbox',
+      detail: 'Flash workspaces do not have a sandbox',
+    });
+  });
+
+  it('returns unknown for 400 without "flash"', () => {
+    const err = makeAxiosError(400, 'File path is required');
+    expect(categorizeFileError(err)).toEqual({
+      category: 'unknown',
+      detail: 'File path is required',
+    });
+  });
+
+  it('returns access_denied for 403', () => {
+    const err = makeAxiosError(403, 'Access denied: /etc is not in allowed directories');
+    expect(categorizeFileError(err)).toEqual({
+      category: 'access_denied',
+      detail: 'Access denied: /etc is not in allowed directories',
+    });
+  });
+
+  it('returns unknown for network error (no response)', () => {
+    const err = new Error('Network Error');
+    expect(categorizeFileError(err)).toEqual({
+      category: 'unknown',
+      detail: '',
+    });
+  });
+
+  it('returns unknown for null error', () => {
+    expect(categorizeFileError(null)).toEqual({
+      category: 'unknown',
+      detail: '',
+    });
+  });
+
+  it('returns unknown for undefined error', () => {
+    expect(categorizeFileError(undefined)).toEqual({
+      category: 'unknown',
+      detail: '',
+    });
+  });
+
+  it('returns not_found for 404 when wsStatus is undefined', () => {
+    const err = makeAxiosError(404, 'File not found');
+    expect(categorizeFileError(err, undefined)).toEqual({
+      category: 'not_found',
+      detail: 'File not found',
+    });
+  });
+
+  it('returns not_found for 404 with unexpected wsStatus', () => {
+    const err = makeAxiosError(404, 'File not found');
+    expect(categorizeFileError(err, 'error')).toEqual({
+      category: 'not_found',
+      detail: 'File not found',
+    });
+  });
+
+  it('returns unknown for unhandled status codes like 500', () => {
+    const err = makeAxiosError(500, 'Internal server error');
+    expect(categorizeFileError(err)).toEqual({
+      category: 'unknown',
+      detail: 'Internal server error',
+    });
+  });
+
+  it('returns empty detail when response.data.detail is non-string', () => {
+    const err = { response: { status: 503, data: { detail: [{ msg: 'error' }] } } };
+    expect(categorizeFileError(err)).toEqual({
+      category: 'sandbox_unavailable',
+      detail: '',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Replace the generic "Error: Failed to load file content" message with specific, actionable error messages when file loading fails in the FilePanel.

**Error handling:**
- `categorizeFileError()` maps backend HTTP status codes (404, 415, 503, 400, 403) + workspace status into 8 distinct error categories
- `FileErrorDisplay` component renders category-specific title, hint, and action buttons (retry for transient errors, download for binary files)
- All 4 catch blocks (text, image, PDF, Excel) updated to use the new categorization
- Type-safe `typeof` guard on error detail extraction to prevent crashes on non-string responses

**Bug fix:** Added `.xls` to binary extension gate (previously only `xlsx` was handled, `.xls` fell through to text read path and failed with 415)

**Cleanup:** Removed dead `fileMime === 'error'` render branch, replaced with `fileError` state-driven display

## Test Coverage

- 16 unit tests for `categorizeFileError` covering all 8 categories + edge cases (undefined wsStatus, non-string detail, unhandled status codes, null/undefined errors)
- 7 render tests for `FileErrorDisplay` verifying button visibility logic (retry shown for sandbox_starting/unknown, download shown for binary_file, hidden when callbacks omitted)
- Tests: 407 → 418 (+11 new)

## Pre-Landing Review

Pre-Landing Review: 2 informational issues, 0 critical. 1 auto-fixed (typeof guard on detail extraction), 2 test gaps fixed (FileErrorDisplay render tests, categorizeFileError edge cases). PR Quality Score: 9.0/10.

## Adversarial Review

Claude adversarial + Codex adversarial both ran. Key findings all confirmed as accepted tradeoffs documented in plan:
- SharedChat errors fall to 'unknown' (different error shape, out of scope)
- Substring matching on backend detail text (would need backend error codes to fix)
- Blob response errors lose detail for binary file paths (low impact, reasonable fallback)

## Plan Completion

Plan: 12/12 items DONE, 0 PARTIAL, 0 NOT DONE. Scope: CLEAN.

## Test plan

- [x] All Vitest tests pass (418 tests, 37 files)
- [x] Lint clean (0 errors)
- [x] TypeScript clean