### PR TITLE
feat(docker): preview URL and session support for Docker sandbox

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -57,6 +57,12 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# ---------- socat (for preview URL port forwarding) ----------
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends socat \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 # Playwright browsers were installed to /usr/local/ms-playwright (as root).
 # Set the env var so the Python playwright package finds them at runtime
 # regardless of which user runs the sandbox.

--- a/src/ptc_agent/agent/agent.py
+++ b/src/ptc_agent/agent/agent.py
@@ -560,9 +560,8 @@ class PTCAgent:
 
         # Custom SSE-enabled summarization emits 'summarization_signal' events
         # Pass backend for offloading conversation history to sandbox
-        summ_config = None
-        if self.config.llm.summarization:
-            summ_config = self.config.summarization.model_dump()
+        summ_config = self.config.summarization.model_dump()
+        if self.config.llm and self.config.llm.summarization:
             summ_config["llm"] = self.config.llm.summarization
             summ_client = self.config.subsidiary_llm_clients.get("summarization")
             if summ_client:
@@ -571,6 +570,9 @@ class PTCAgent:
                 # Deep-copy so SummarizationMiddleware.from_config() can set
                 # streaming=False without mutating the main agent's model.
                 summ_config["_llm_client"] = self.config.llm_client.model_copy()
+        elif self.config.llm_client:
+            # No dedicated summarization model; fall back to main agent LLM
+            summ_config["_llm_client"] = self.config.llm_client.model_copy()
         summarization = SummarizationMiddleware.from_config(config=summ_config, backend=backend)
 
         # Build model resilience middleware (retry + fallback)

--- a/src/ptc_agent/config/core.py
+++ b/src/ptc_agent/config/core.py
@@ -173,6 +173,8 @@ class DockerConfig(BaseModel):
     host_work_dir: str | None = None
     volumes: list[str] = Field(default_factory=list)
     network_mode: str = "bridge"
+    preview_proxy_ports: str = "13000-13009"
+    preview_base_url: str | None = None
 
 
 class SandboxConfig(BaseModel):

--- a/src/ptc_agent/core/sandbox/providers/docker.py
+++ b/src/ptc_agent/core/sandbox/providers/docker.py
@@ -491,13 +491,16 @@ class DockerRuntime(SandboxRuntime):
             encoded = base64.b64encode(command.encode()).decode("ascii")
             # Use setsid to create a new process group so delete_session
             # can kill the entire tree (not just the wrapper).
+            # Note: there is a sub-millisecond window between exec returning
+            # and the .pid file being written. delete_session called in that
+            # window would miss the PID. In practice this is not an issue
+            # because sessions are long-lived (preview servers, etc.).
             wrapped = (
                 f"nohup setsid bash -c '"
                 f"echo $$ > {session_dir}/{cmd_id}.pid; "
                 f"eval \"$(echo {encoded} | base64 -d)\"; "
                 f"echo $? > {session_dir}/{cmd_id}.exit"
-                f"' > {session_dir}/{cmd_id}.stdout 2> {session_dir}/{cmd_id}.stderr &\n"
-                f"echo $!"
+                f"' > {session_dir}/{cmd_id}.stdout 2> {session_dir}/{cmd_id}.stderr &"
             )
             await self.exec(wrapped, timeout=10)
             return SessionCommandResult(cmd_id=cmd_id, exit_code=None, stdout="", stderr="")

--- a/src/ptc_agent/core/sandbox/providers/docker.py
+++ b/src/ptc_agent/core/sandbox/providers/docker.py
@@ -107,6 +107,7 @@ class DockerRuntime(SandboxRuntime):
         dev_mode: bool = False,
         host_work_dir: str | None = None,
         proxy_ports: list[int] | None = None,
+        host_port_map: dict[int, int] | None = None,
         preview_base_url: str | None = None,
     ) -> None:
         self._container = container
@@ -116,8 +117,10 @@ class DockerRuntime(SandboxRuntime):
         self._host_work_dir = host_work_dir
         self._preview_base_url = preview_base_url
         self._proxy_ports: list[int] = proxy_ports or []
-        self._port_map: dict[int, int] = {}  # agent port → proxy port
-        self._forwarder_pids: dict[int, str] = {}  # proxy port → socat PID
+        # container port → host port (for dynamic port publishing)
+        self._host_port_map: dict[int, int] = host_port_map or {}
+        self._port_map: dict[int, int] = {}  # agent port → container proxy port
+        self._forwarder_pids: dict[int, str] = {}  # container proxy port → socat PID
 
     # -- Properties --
 
@@ -413,16 +416,27 @@ class DockerRuntime(SandboxRuntime):
         )
         return proxy_port
 
+    def _host_port_for(self, container_port: int) -> int:
+        """Return the host-side port for a given container proxy port.
+
+        When Docker publishes with dynamic host ports (``HostPort: ""``),
+        the actual host port differs from the container port.  Falls back
+        to the container port itself (static publishing or tests).
+        """
+        return self._host_port_map.get(container_port, container_port)
+
     async def get_preview_url(self, port: int, expires_in: int = 3600) -> PreviewInfo:
         proxy_port = await self._allocate_proxy_port(port)
+        host_port = self._host_port_for(proxy_port)
         base = (self._preview_base_url or "http://localhost").rstrip("/")
-        return PreviewInfo(url=f"{base}:{proxy_port}", token="")
+        return PreviewInfo(url=f"{base}:{host_port}", token="")
 
     async def get_preview_link(self, port: int) -> PreviewInfo:
         proxy_port = await self._allocate_proxy_port(port)
+        host_port = self._host_port_for(proxy_port)
         # Server-side: resolve host for health checks (may differ from browser URL)
         base = (self._preview_base_url or await self._resolve_server_side_host()).rstrip("/")
-        return PreviewInfo(url=f"{base}:{proxy_port}", token="")
+        return PreviewInfo(url=f"{base}:{host_port}", token="")
 
     _server_side_host: str | None = None  # class-level cache
 
@@ -475,8 +489,10 @@ class DockerRuntime(SandboxRuntime):
 
         if run_async:
             encoded = base64.b64encode(command.encode()).decode("ascii")
+            # Use setsid to create a new process group so delete_session
+            # can kill the entire tree (not just the wrapper).
             wrapped = (
-                f"nohup bash -c '"
+                f"nohup setsid bash -c '"
                 f"echo $$ > {session_dir}/{cmd_id}.pid; "
                 f"eval \"$(echo {encoded} | base64 -d)\"; "
                 f"echo $? > {session_dir}/{cmd_id}.exit"
@@ -528,9 +544,12 @@ class DockerRuntime(SandboxRuntime):
         if not _SESSION_ID_RE.match(session_id):
             raise ValueError(f"Invalid session_id: {session_id!r}")
         session_dir = f"/tmp/.sessions/{session_id}"
+        # Kill the entire process group (negative PID) so child processes
+        # spawned by the session command are also terminated.
         await self.exec(
             f"for f in {session_dir}/*.pid; do "
             f"  pid=$(cat \"$f\" 2>/dev/null | tr -cd '0-9'); "
+            f"  [ -n \"$pid\" ] && kill -- -\"$pid\" 2>/dev/null; "
             f"  [ -n \"$pid\" ] && kill \"$pid\" 2>/dev/null; "
             f"done; rm -rf {session_dir}",
             timeout=10,
@@ -664,10 +683,12 @@ class DockerProvider(SandboxProvider):
             "Init": True,  # tini as PID 1 for zombie reaping
         }
 
-        # Publish proxy ports so preview URLs are reachable from the host
+        # Publish proxy ports so preview URLs are reachable from the host.
+        # Use dynamic host ports (HostPort: "") so multiple containers can
+        # coexist without port conflicts.
         if proxy_ports:
             host_config["PortBindings"] = {
-                f"{p}/tcp": [{"HostPort": str(p)}] for p in proxy_ports
+                f"{p}/tcp": [{"HostPort": ""}] for p in proxy_ports
             }
 
         binds: list[str] = list(self._config.volumes)  # extra user-defined mounts
@@ -701,11 +722,25 @@ class DockerProvider(SandboxProvider):
         )
         await container_obj.start()
 
+        # Read actual host port mappings (dynamic ports picked by Docker)
+        host_port_map: dict[int, int] = {}
+        if proxy_ports:
+            info = await container_obj.show()
+            port_bindings = (
+                info.get("NetworkSettings", {})
+                .get("Ports", {})
+            )
+            for cp in proxy_ports:
+                bindings = port_bindings.get(f"{cp}/tcp", [])
+                if bindings and bindings[0].get("HostPort"):
+                    host_port_map[cp] = int(bindings[0]["HostPort"])
+
         logger.info(
             "Docker container started",
             container_name=container_name,
             runtime_id=runtime_id,
             image=self._config.image,
+            host_port_map=host_port_map or None,
         )
 
         runtime = DockerRuntime(
@@ -715,6 +750,7 @@ class DockerProvider(SandboxProvider):
             dev_mode=self._config.dev_mode,
             host_work_dir=host_work_dir,
             proxy_ports=proxy_ports,
+            host_port_map=host_port_map,
             preview_base_url=self._config.preview_base_url,
         )
 
@@ -755,13 +791,23 @@ class DockerProvider(SandboxProvider):
                 host_work_dir = mount.get("Source")
                 break
 
+        # Read actual host port mappings from running container
+        proxy_ports = _parse_proxy_port_range(self._config.preview_proxy_ports)
+        host_port_map: dict[int, int] = {}
+        port_bindings = info.get("NetworkSettings", {}).get("Ports", {})
+        for cp in proxy_ports:
+            bindings = port_bindings.get(f"{cp}/tcp", [])
+            if bindings and bindings[0].get("HostPort"):
+                host_port_map[cp] = int(bindings[0]["HostPort"])
+
         return DockerRuntime(
             container_obj,
             runtime_id=sandbox_id,
             working_dir=self._working_dir,
             dev_mode=dev_mode,
             host_work_dir=host_work_dir,
-            proxy_ports=_parse_proxy_port_range(self._config.preview_proxy_ports),
+            proxy_ports=proxy_ports,
+            host_port_map=host_port_map,
             preview_base_url=self._config.preview_base_url,
         )
 

--- a/src/ptc_agent/core/sandbox/providers/docker.py
+++ b/src/ptc_agent/core/sandbox/providers/docker.py
@@ -31,10 +31,12 @@ from ptc_agent.core.sandbox.providers._chart_capture import (
 from ptc_agent.core.sandbox.runtime import (
     CodeRunResult,
     ExecResult,
+    PreviewInfo,
     RuntimeState,
     SandboxProvider,
     SandboxRuntime,
     SandboxTransientError,
+    SessionCommandResult,
 )
 
 logger = structlog.get_logger(__name__)
@@ -54,8 +56,26 @@ _DOCKER_STATE_MAP: dict[str, RuntimeState] = {
 
 
 # ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_SESSION_ID_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _parse_proxy_port_range(range_str: str) -> list[int]:
+    """Parse a port range string like ``"13000-13009"`` into a list of ints."""
+    parts = range_str.strip().split("-")
+    if len(parts) != 2:
+        raise ValueError(f"Invalid proxy port range: {range_str!r} (expected 'START-END')")
+    start, end = int(parts[0]), int(parts[1])
+    if start > end:
+        raise ValueError(f"Invalid proxy port range: start ({start}) > end ({end})")
+    return list(range(start, end + 1))
 
 
 def _parse_memory(limit_str: str) -> int:
@@ -86,12 +106,18 @@ class DockerRuntime(SandboxRuntime):
         working_dir: str = "/home/sandbox",
         dev_mode: bool = False,
         host_work_dir: str | None = None,
+        proxy_ports: list[int] | None = None,
+        preview_base_url: str | None = None,
     ) -> None:
         self._container = container
         self._id = runtime_id
         self._working_dir = working_dir
         self._dev_mode = dev_mode
         self._host_work_dir = host_work_dir
+        self._preview_base_url = preview_base_url
+        self._proxy_ports: list[int] = proxy_ports or []
+        self._port_map: dict[int, int] = {}  # agent port → proxy port
+        self._forwarder_pids: dict[int, str] = {}  # proxy port → socat PID
 
     # -- Properties --
 
@@ -299,11 +325,204 @@ class DockerRuntime(SandboxRuntime):
                 entries.append({"name": line.strip(), "is_dir": False})
         return entries
 
+    # -- Preview URLs --
+
+    async def _allocate_proxy_port(self, target_port: int) -> int:
+        """Allocate a proxy port and start socat forwarding to the target port."""
+        if target_port in self._port_map:
+            return self._port_map[target_port]
+
+        used = set(self._port_map.values())
+        free = [p for p in self._proxy_ports if p not in used]
+        if not free:
+            raise RuntimeError(
+                f"No free proxy ports. All {len(self._proxy_ports)} ports in use. "
+                f"Increase preview_proxy_ports range in config."
+            )
+        proxy_port = free[0]
+
+        # Write a minimal Python TCP proxy as fallback when socat is unavailable
+        proxy_script = (
+            f"import socket as S,threading as T\n"
+            f"def f(a,b):\n"
+            f" try:\n"
+            f"  while True:\n"
+            f"   d=a.recv(4096)\n"
+            f"   if not d:break\n"
+            f"   b.sendall(d)\n"
+            f" except:pass\n"
+            f" finally:a.close();b.close()\n"
+            f"s=S.socket();s.setsockopt(S.SOL_SOCKET,S.SO_REUSEADDR,1)\n"
+            f"s.bind(('0.0.0.0',{proxy_port}));s.listen(5)\n"
+            f"while True:\n"
+            f" c,_=s.accept();d=S.socket();d.connect(('127.0.0.1',{target_port}))\n"
+            f" T.Thread(target=f,args=(c,d),daemon=True).start()\n"
+            f" T.Thread(target=f,args=(d,c),daemon=True).start()\n"
+        )
+        encoded_script = base64.b64encode(proxy_script.encode()).decode("ascii")
+        proxy_path = f"/tmp/.proxy_{proxy_port}.py"
+        await self.exec(
+            f"echo {encoded_script} | base64 -d > {proxy_path}", timeout=5
+        )
+
+        # Kill any stale forwarder on this proxy port (survives Python-side
+        # reconnects while the container stays running).
+        await self.exec(
+            f"fuser -k {proxy_port}/tcp 2>/dev/null || true", timeout=5
+        )
+
+        # Start socat forwarder; fall back to Python proxy if socat is not installed
+        result = await self.exec(
+            f"nohup bash -c 'socat TCP-LISTEN:{proxy_port},fork,reuseaddr "
+            f"TCP:localhost:{target_port} 2>/dev/null "
+            f"|| python3 {proxy_path}' > /dev/null 2>&1 & echo $!",
+            timeout=10,
+        )
+        pid = result.stdout.strip()
+
+        # Verify the forwarder is actually listening
+        check = await self.exec(
+            f"sleep 0.2 && fuser {proxy_port}/tcp >/dev/null 2>&1", timeout=5
+        )
+        if check.exit_code != 0:
+            logger.warning(
+                "Proxy forwarder may not have started",
+                proxy_port=proxy_port,
+                target_port=target_port,
+                pid=pid,
+            )
+
+        self._port_map[target_port] = proxy_port
+        self._forwarder_pids[proxy_port] = pid
+
+        logger.info(
+            "Proxy port allocated",
+            target_port=target_port,
+            proxy_port=proxy_port,
+            pid=pid,
+        )
+        return proxy_port
+
+    async def get_preview_url(self, port: int, expires_in: int = 3600) -> PreviewInfo:
+        proxy_port = await self._allocate_proxy_port(port)
+        base = (self._preview_base_url or "http://localhost").rstrip("/")
+        return PreviewInfo(url=f"{base}:{proxy_port}", token="")
+
+    async def get_preview_link(self, port: int) -> PreviewInfo:
+        proxy_port = await self._allocate_proxy_port(port)
+        # Server-side: resolve host for health checks (may differ from browser URL)
+        base = (self._preview_base_url or self._resolve_server_side_host()).rstrip("/")
+        return PreviewInfo(url=f"{base}:{proxy_port}", token="")
+
+    _server_side_host: str | None = None  # class-level cache
+
+    @classmethod
+    def _resolve_server_side_host(cls) -> str:
+        """Resolve host for server-side requests to published proxy ports.
+
+        When the backend itself runs inside Docker, ``localhost`` points to the
+        backend container, not the host where sandbox ports are published.
+        Docker Desktop exposes ``host.docker.internal`` for this purpose.
+
+        Result is cached at the class level — it won't change during process
+        lifetime and avoids repeated blocking DNS lookups.
+        """
+        if cls._server_side_host is not None:
+            return cls._server_side_host
+
+        import socket
+
+        try:
+            socket.getaddrinfo("host.docker.internal", None)
+            cls._server_side_host = "http://host.docker.internal"
+        except socket.gaierror:
+            cls._server_side_host = "http://localhost"
+        return cls._server_side_host
+
+    # -- Sessions --
+
+    async def create_session(self, session_id: str) -> None:
+        if not _SESSION_ID_RE.match(session_id):
+            raise ValueError(f"Invalid session_id: {session_id!r}")
+        check = await self.exec(f"test -d /tmp/.sessions/{session_id}", timeout=5)
+        if check.exit_code == 0:
+            raise RuntimeError(f"Session already exists: {session_id}")
+        await self.exec(f"mkdir -p /tmp/.sessions/{session_id}", timeout=5)
+
+    async def session_execute(
+        self,
+        session_id: str,
+        command: str,
+        *,
+        run_async: bool = False,
+        timeout: int = 60,
+    ) -> SessionCommandResult:
+        if not _SESSION_ID_RE.match(session_id):
+            raise ValueError(f"Invalid session_id: {session_id!r}")
+        cmd_id = uuid.uuid4().hex[:8]
+        session_dir = f"/tmp/.sessions/{session_id}"
+
+        if run_async:
+            encoded = base64.b64encode(command.encode()).decode("ascii")
+            wrapped = (
+                f"nohup bash -c '"
+                f"echo $$ > {session_dir}/{cmd_id}.pid; "
+                f"eval \"$(echo {encoded} | base64 -d)\"; "
+                f"echo $? > {session_dir}/{cmd_id}.exit"
+                f"' > {session_dir}/{cmd_id}.stdout 2> {session_dir}/{cmd_id}.stderr &\n"
+                f"echo $!"
+            )
+            await self.exec(wrapped, timeout=10)
+            return SessionCommandResult(cmd_id=cmd_id, exit_code=None, stdout="", stderr="")
+
+        result = await self.exec(command, timeout=timeout)
+        return SessionCommandResult(
+            cmd_id=cmd_id,
+            exit_code=result.exit_code,
+            stdout=result.stdout,
+            stderr=result.stderr,
+        )
+
+    async def session_command_logs(
+        self, session_id: str, command_id: str
+    ) -> SessionCommandResult:
+        if not _SESSION_ID_RE.match(session_id):
+            raise ValueError(f"Invalid session_id: {session_id!r}")
+        if not _SESSION_ID_RE.match(command_id):
+            raise ValueError(f"Invalid command_id: {command_id!r}")
+        session_dir = f"/tmp/.sessions/{session_id}"
+        stdout_r = await self.exec(f"cat {session_dir}/{command_id}.stdout 2>/dev/null", timeout=5)
+        stderr_r = await self.exec(f"cat {session_dir}/{command_id}.stderr 2>/dev/null", timeout=5)
+        exit_r = await self.exec(f"cat {session_dir}/{command_id}.exit 2>/dev/null", timeout=5)
+        exit_code = (
+            int(exit_r.stdout.strip())
+            if exit_r.exit_code == 0 and exit_r.stdout.strip().isdigit()
+            else None
+        )
+        return SessionCommandResult(
+            cmd_id=command_id,
+            exit_code=exit_code,
+            stdout=stdout_r.stdout,
+            stderr=stderr_r.stdout,
+        )
+
+    async def delete_session(self, session_id: str) -> None:
+        if not _SESSION_ID_RE.match(session_id):
+            raise ValueError(f"Invalid session_id: {session_id!r}")
+        session_dir = f"/tmp/.sessions/{session_id}"
+        await self.exec(
+            f"for f in {session_dir}/*.pid; do "
+            f"  pid=$(cat \"$f\" 2>/dev/null | tr -cd '0-9'); "
+            f"  [ -n \"$pid\" ] && kill \"$pid\" 2>/dev/null; "
+            f"done; rm -rf {session_dir}",
+            timeout=10,
+        )
+
     # -- Capabilities & metadata --
 
     @property
     def capabilities(self) -> set[str]:
-        return {"exec", "code_run", "file_io"}
+        return {"exec", "code_run", "file_io", "preview_url", "sessions"}
 
     async def archive(self) -> None:
         raise NotImplementedError("Docker provider does not support archive")
@@ -415,13 +634,23 @@ class DockerProvider(SandboxProvider):
         runtime_id = f"docker-{uuid.uuid4().hex[:12]}"
         container_name = f"langalpha-sandbox-{runtime_id}"
 
+        # Parse proxy port pool for preview URL support
+        proxy_ports = _parse_proxy_port_range(self._config.preview_proxy_ports)
+
         # Build container config
         host_config: dict[str, Any] = {
             "Memory": _parse_memory(self._config.memory_limit),
             "NanoCpus": int(self._config.cpu_count * 1e9),
             "NetworkMode": self._config.network_mode,
             "AutoRemove": False,  # We manage removal ourselves
+            "Init": True,  # tini as PID 1 for zombie reaping
         }
+
+        # Publish proxy ports so preview URLs are reachable from the host
+        if proxy_ports:
+            host_config["PortBindings"] = {
+                f"{p}/tcp": [{"HostPort": str(p)}] for p in proxy_ports
+            }
 
         binds: list[str] = list(self._config.volumes)  # extra user-defined mounts
         host_work_dir: str | None = None
@@ -441,6 +670,9 @@ class DockerProvider(SandboxProvider):
             "Hostname": "sandbox",
             "HostConfig": host_config,
         }
+
+        if proxy_ports:
+            container_config["ExposedPorts"] = {f"{p}/tcp": {} for p in proxy_ports}
 
         if env_vars:
             container_config["Env"] = [f"{k}={v}" for k, v in env_vars.items()]
@@ -464,6 +696,8 @@ class DockerProvider(SandboxProvider):
             working_dir=self._working_dir,
             dev_mode=self._config.dev_mode,
             host_work_dir=host_work_dir,
+            proxy_ports=proxy_ports,
+            preview_base_url=self._config.preview_base_url,
         )
 
         # Install MCP npm packages if needed (mirrors Daytona snapshot behavior)
@@ -509,6 +743,8 @@ class DockerProvider(SandboxProvider):
             working_dir=self._working_dir,
             dev_mode=dev_mode,
             host_work_dir=host_work_dir,
+            proxy_ports=_parse_proxy_port_range(self._config.preview_proxy_ports),
+            preview_base_url=self._config.preview_base_url,
         )
 
     async def close(self) -> None:

--- a/src/ptc_agent/core/sandbox/providers/docker.py
+++ b/src/ptc_agent/core/sandbox/providers/docker.py
@@ -341,59 +341,69 @@ class DockerRuntime(SandboxRuntime):
             )
         proxy_port = free[0]
 
-        # Write a minimal Python TCP proxy as fallback when socat is unavailable
-        proxy_script = (
-            f"import socket as S,threading as T\n"
-            f"def f(a,b):\n"
-            f" try:\n"
-            f"  while True:\n"
-            f"   d=a.recv(4096)\n"
-            f"   if not d:break\n"
-            f"   b.sendall(d)\n"
-            f" except:pass\n"
-            f" finally:a.close();b.close()\n"
-            f"s=S.socket();s.setsockopt(S.SOL_SOCKET,S.SO_REUSEADDR,1)\n"
-            f"s.bind(('0.0.0.0',{proxy_port}));s.listen(5)\n"
-            f"while True:\n"
-            f" c,_=s.accept();d=S.socket();d.connect(('127.0.0.1',{target_port}))\n"
-            f" T.Thread(target=f,args=(c,d),daemon=True).start()\n"
-            f" T.Thread(target=f,args=(d,c),daemon=True).start()\n"
-        )
-        encoded_script = base64.b64encode(proxy_script.encode()).decode("ascii")
-        proxy_path = f"/tmp/.proxy_{proxy_port}.py"
-        await self.exec(
-            f"echo {encoded_script} | base64 -d > {proxy_path}", timeout=5
-        )
+        # Reserve immediately to prevent concurrent coroutines from picking
+        # the same proxy port (multiple awaits follow).
+        self._port_map[target_port] = proxy_port
+        self._forwarder_pids[proxy_port] = ""  # mark in-progress
 
-        # Kill any stale forwarder on this proxy port (survives Python-side
-        # reconnects while the container stays running).
-        await self.exec(
-            f"fuser -k {proxy_port}/tcp 2>/dev/null || true", timeout=5
-        )
-
-        # Start socat forwarder; fall back to Python proxy if socat is not installed
-        result = await self.exec(
-            f"nohup bash -c 'socat TCP-LISTEN:{proxy_port},fork,reuseaddr "
-            f"TCP:localhost:{target_port} 2>/dev/null "
-            f"|| python3 {proxy_path}' > /dev/null 2>&1 & echo $!",
-            timeout=10,
-        )
-        pid = result.stdout.strip()
-
-        # Verify the forwarder is actually listening
-        check = await self.exec(
-            f"sleep 0.2 && fuser {proxy_port}/tcp >/dev/null 2>&1", timeout=5
-        )
-        if check.exit_code != 0:
-            logger.warning(
-                "Proxy forwarder may not have started",
-                proxy_port=proxy_port,
-                target_port=target_port,
-                pid=pid,
+        try:
+            # Write a minimal Python TCP proxy as fallback when socat is unavailable
+            proxy_script = (
+                f"import socket as S,threading as T\n"
+                f"def f(a,b):\n"
+                f" try:\n"
+                f"  while True:\n"
+                f"   d=a.recv(4096)\n"
+                f"   if not d:break\n"
+                f"   b.sendall(d)\n"
+                f" except:pass\n"
+                f" finally:a.close();b.close()\n"
+                f"s=S.socket();s.setsockopt(S.SOL_SOCKET,S.SO_REUSEADDR,1)\n"
+                f"s.bind(('0.0.0.0',{proxy_port}));s.listen(5)\n"
+                f"while True:\n"
+                f" c,_=s.accept();d=S.socket();d.connect(('127.0.0.1',{target_port}))\n"
+                f" T.Thread(target=f,args=(c,d),daemon=True).start()\n"
+                f" T.Thread(target=f,args=(d,c),daemon=True).start()\n"
+            )
+            encoded_script = base64.b64encode(proxy_script.encode()).decode("ascii")
+            proxy_path = f"/tmp/.proxy_{proxy_port}.py"
+            await self.exec(
+                f"echo {encoded_script} | base64 -d > {proxy_path}", timeout=5
             )
 
-        self._port_map[target_port] = proxy_port
-        self._forwarder_pids[proxy_port] = pid
+            # Kill any stale forwarder on this proxy port (survives Python-side
+            # reconnects while the container stays running).
+            await self.exec(
+                f"fuser -k {proxy_port}/tcp 2>/dev/null || true", timeout=5
+            )
+
+            # Start socat forwarder; fall back to Python proxy if socat is not installed
+            result = await self.exec(
+                f"nohup bash -c 'socat TCP-LISTEN:{proxy_port},fork,reuseaddr "
+                f"TCP:localhost:{target_port} 2>/dev/null "
+                f"|| python3 {proxy_path}' > /dev/null 2>&1 & echo $!",
+                timeout=10,
+            )
+            pid = result.stdout.strip()
+
+            # Verify the forwarder is actually listening
+            check = await self.exec(
+                f"sleep 0.2 && fuser {proxy_port}/tcp >/dev/null 2>&1", timeout=5
+            )
+            if check.exit_code != 0:
+                logger.warning(
+                    "Proxy forwarder may not have started",
+                    proxy_port=proxy_port,
+                    target_port=target_port,
+                    pid=pid,
+                )
+
+            self._forwarder_pids[proxy_port] = pid
+        except Exception:
+            # Roll back reservation so the port is available for retry
+            del self._port_map[target_port]
+            del self._forwarder_pids[proxy_port]
+            raise
 
         logger.info(
             "Proxy port allocated",
@@ -411,13 +421,13 @@ class DockerRuntime(SandboxRuntime):
     async def get_preview_link(self, port: int) -> PreviewInfo:
         proxy_port = await self._allocate_proxy_port(port)
         # Server-side: resolve host for health checks (may differ from browser URL)
-        base = (self._preview_base_url or self._resolve_server_side_host()).rstrip("/")
+        base = (self._preview_base_url or await self._resolve_server_side_host()).rstrip("/")
         return PreviewInfo(url=f"{base}:{proxy_port}", token="")
 
     _server_side_host: str | None = None  # class-level cache
 
     @classmethod
-    def _resolve_server_side_host(cls) -> str:
+    async def _resolve_server_side_host(cls) -> str:
         """Resolve host for server-side requests to published proxy ports.
 
         When the backend itself runs inside Docker, ``localhost`` points to the
@@ -425,17 +435,18 @@ class DockerRuntime(SandboxRuntime):
         Docker Desktop exposes ``host.docker.internal`` for this purpose.
 
         Result is cached at the class level — it won't change during process
-        lifetime and avoids repeated blocking DNS lookups.
+        lifetime and avoids repeated DNS lookups.
         """
         if cls._server_side_host is not None:
             return cls._server_side_host
 
-        import socket
+        import asyncio
 
+        loop = asyncio.get_event_loop()
         try:
-            socket.getaddrinfo("host.docker.internal", None)
+            await loop.getaddrinfo("host.docker.internal", None)
             cls._server_side_host = "http://host.docker.internal"
-        except socket.gaierror:
+        except OSError:
             cls._server_side_host = "http://localhost"
         return cls._server_side_host
 
@@ -491,19 +502,26 @@ class DockerRuntime(SandboxRuntime):
         if not _SESSION_ID_RE.match(command_id):
             raise ValueError(f"Invalid command_id: {command_id!r}")
         session_dir = f"/tmp/.sessions/{session_id}"
-        stdout_r = await self.exec(f"cat {session_dir}/{command_id}.stdout 2>/dev/null", timeout=5)
-        stderr_r = await self.exec(f"cat {session_dir}/{command_id}.stderr 2>/dev/null", timeout=5)
-        exit_r = await self.exec(f"cat {session_dir}/{command_id}.exit 2>/dev/null", timeout=5)
-        exit_code = (
-            int(exit_r.stdout.strip())
-            if exit_r.exit_code == 0 and exit_r.stdout.strip().isdigit()
-            else None
+        # Single exec round-trip: emit all three files separated by a null byte
+        _SEP = "\\x00"
+        result = await self.exec(
+            f"cat {session_dir}/{command_id}.stdout 2>/dev/null; "
+            f"printf '{_SEP}'; "
+            f"cat {session_dir}/{command_id}.stderr 2>/dev/null; "
+            f"printf '{_SEP}'; "
+            f"cat {session_dir}/{command_id}.exit 2>/dev/null",
+            timeout=5,
         )
+        parts = result.stdout.split("\x00", 2)
+        stdout = parts[0] if len(parts) > 0 else ""
+        stderr = parts[1] if len(parts) > 1 else ""
+        exit_str = parts[2].strip() if len(parts) > 2 else ""
+        exit_code = int(exit_str) if exit_str.isdigit() else None
         return SessionCommandResult(
             cmd_id=command_id,
             exit_code=exit_code,
-            stdout=stdout_r.stdout,
-            stderr=stderr_r.stdout,
+            stdout=stdout,
+            stderr=stderr,
         )
 
     async def delete_session(self, session_id: str) -> None:

--- a/src/ptc_agent/core/sandbox/providers/docker.py
+++ b/src/ptc_agent/core/sandbox/providers/docker.py
@@ -442,7 +442,7 @@ class DockerRuntime(SandboxRuntime):
 
         import asyncio
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         try:
             await loop.getaddrinfo("host.docker.internal", None)
             cls._server_side_host = "http://host.docker.internal"

--- a/src/server/handlers/chat/llm_config.py
+++ b/src/server/handlers/chat/llm_config.py
@@ -292,7 +292,7 @@ async def resolve_llm_config(
         config.llm = LLMConfig(
             name=resolved_name if mode == "ptc" else "placeholder",
             flash=resolved_name if mode == "flash" else model_pref.get("preferred_flash_model"),
-            summarization=model_pref.get("summarization_model"),
+            summarization=model_pref.get("summarization_model") or model_pref.get("preferred_flash_model"),
             fetch=model_pref.get("fetch_model"),
             fallback=model_pref.get("fallback_models"),
         )

--- a/tests/integration/sandbox/providers/test_docker_modes.py
+++ b/tests/integration/sandbox/providers/test_docker_modes.py
@@ -239,3 +239,121 @@ print("two charts")
         assert result.exit_code == 0
         assert "no charts here" in result.stdout
         assert result.artifacts == []
+
+
+# ---------------------------------------------------------------------------
+# Preview URL support
+# ---------------------------------------------------------------------------
+
+
+class TestPreviewUrl:
+    """Test preview URL proxy port allocation and socat forwarding."""
+
+    @pytest_asyncio.fixture(scope="class", loop_scope="class")
+    async def runtime(self):
+        provider = DockerProvider(DockerConfig(
+            image=os.environ.get("DOCKER_SANDBOX_IMAGE", "langalpha-sandbox:latest"),
+            dev_mode=False,
+        ))
+        rt = await provider.create()
+        yield rt
+        try:
+            await rt.delete()
+        except Exception:
+            pass
+        await provider.close()
+
+    async def test_get_preview_url_returns_url(self, runtime: DockerRuntime):
+        """get_preview_url should return a valid URL with a host port."""
+        info = await runtime.get_preview_url(8080)
+        assert info.url.startswith("http")
+        # URL should contain a port number
+        port_str = info.url.rsplit(":", 1)[-1]
+        assert port_str.isdigit()
+
+    async def test_get_preview_url_reuses_port(self, runtime: DockerRuntime):
+        """Calling get_preview_url twice for the same port returns the same URL."""
+        info1 = await runtime.get_preview_url(8080)
+        info2 = await runtime.get_preview_url(8080)
+        assert info1.url == info2.url
+
+    async def test_different_ports_get_different_urls(self, runtime: DockerRuntime):
+        """Different target ports should get different proxy ports."""
+        info1 = await runtime.get_preview_url(8080)
+        info2 = await runtime.get_preview_url(9090)
+        assert info1.url != info2.url
+
+    async def test_get_preview_link_returns_url(self, runtime: DockerRuntime):
+        """get_preview_link should return a valid URL."""
+        info = await runtime.get_preview_link(8080)
+        assert info.url.startswith("http")
+
+    async def test_capabilities_include_preview(self, runtime: DockerRuntime):
+        """Docker runtime should report preview_url capability."""
+        assert "preview_url" in runtime.capabilities
+
+
+# ---------------------------------------------------------------------------
+# Session support
+# ---------------------------------------------------------------------------
+
+
+class TestSessions:
+    """Test session lifecycle (create, execute, logs, delete)."""
+
+    @pytest_asyncio.fixture(scope="class", loop_scope="class")
+    async def runtime(self):
+        provider = DockerProvider(DockerConfig(
+            image=os.environ.get("DOCKER_SANDBOX_IMAGE", "langalpha-sandbox:latest"),
+            dev_mode=False,
+        ))
+        rt = await provider.create()
+        yield rt
+        try:
+            await rt.delete()
+        except Exception:
+            pass
+        await provider.close()
+
+    async def test_session_lifecycle(self, runtime: DockerRuntime):
+        """Create a session, run a sync command, check logs, delete."""
+        await runtime.create_session("test-session")
+
+        # Sync execute
+        result = await runtime.session_execute(
+            "test-session", "echo hello-from-session", run_async=False
+        )
+        assert result.exit_code == 0
+        assert "hello-from-session" in result.stdout
+
+        # Delete
+        await runtime.delete_session("test-session")
+
+    async def test_async_session_execute(self, runtime: DockerRuntime):
+        """Async session execute should start a background process."""
+        import asyncio
+
+        await runtime.create_session("async-test")
+
+        result = await runtime.session_execute(
+            "async-test",
+            "echo async-output && sleep 0.5 && echo done",
+            run_async=True,
+        )
+        assert result.exit_code is None  # async, no exit code yet
+        assert result.cmd_id  # should have a command ID
+
+        # Wait for the command to finish
+        await asyncio.sleep(2)
+
+        # Check logs
+        logs = await runtime.session_command_logs("async-test", result.cmd_id)
+        assert logs.exit_code == 0
+        assert "async-output" in logs.stdout
+        assert "done" in logs.stdout
+
+        await runtime.delete_session("async-test")
+
+    async def test_capabilities_include_sessions(self, runtime: DockerRuntime):
+        """Docker runtime should report sessions capability."""
+        assert "sessions" in runtime.capabilities

--- a/tests/unit/core/sandbox/test_docker_provider.py
+++ b/tests/unit/core/sandbox/test_docker_provider.py
@@ -30,6 +30,7 @@ from ptc_agent.core.sandbox.providers.docker import (
     DockerRuntime,
     _DOCKER_STATE_MAP,
     _parse_memory,
+    _parse_proxy_port_range,
 )
 from ptc_agent.core.sandbox.runtime import (
     ExecResult,
@@ -744,3 +745,449 @@ class TestDockerProviderLazyClient:
 
         assert client is mock_docker_instance
         assert p._client is mock_docker_instance
+
+
+# ---------------------------------------------------------------------------
+# _parse_proxy_port_range helper
+# ---------------------------------------------------------------------------
+
+
+class TestParseProxyPortRange:
+    def test_valid_range(self):
+        assert _parse_proxy_port_range("13000-13009") == list(range(13000, 13010))
+
+    def test_single_port(self):
+        assert _parse_proxy_port_range("8080-8080") == [8080]
+
+    def test_invalid_format(self):
+        with pytest.raises(ValueError, match="Invalid proxy port range"):
+            _parse_proxy_port_range("8080")
+
+    def test_start_greater_than_end(self):
+        with pytest.raises(ValueError, match="start.*>.*end"):
+            _parse_proxy_port_range("9000-8000")
+
+
+# ---------------------------------------------------------------------------
+# DockerRuntime — preview URLs (proxy port pool)
+# ---------------------------------------------------------------------------
+
+
+class TestDockerRuntimePreviewUrl:
+    @pytest.fixture
+    def container(self):
+        return _make_mock_container()
+
+    @pytest.fixture
+    def runtime(self, container):
+        return DockerRuntime(
+            container,
+            runtime_id="docker-test123",
+            working_dir="/home/workspace",
+            proxy_ports=[13000, 13001, 13002],
+        )
+
+    @pytest.mark.asyncio
+    async def test_allocates_proxy_port(self, runtime):
+        """get_preview_url allocates a proxy port and starts socat."""
+        runtime._container.exec = AsyncMock(
+            return_value=_make_exec_mock(output="12345\n")
+        )
+        info = await runtime.get_preview_url(8080)
+        assert info.url == "http://localhost:13000"
+        assert info.token == ""
+        assert runtime._port_map[8080] == 13000
+
+    @pytest.mark.asyncio
+    async def test_reuses_existing_mapping(self, runtime):
+        """Same target port returns same proxy port without re-allocating."""
+        runtime._container.exec = AsyncMock(
+            return_value=_make_exec_mock(output="12345\n")
+        )
+        info1 = await runtime.get_preview_url(8080)
+        call_count_after_first = runtime._container.exec.call_count
+        info2 = await runtime.get_preview_url(8080)
+        assert info1.url == info2.url
+        # No additional exec calls for the second request (cached)
+        assert runtime._container.exec.call_count == call_count_after_first
+
+    @pytest.mark.asyncio
+    async def test_multiple_ports_different_proxies(self, runtime):
+        """Different target ports get different proxy ports."""
+        runtime._container.exec = AsyncMock(
+            return_value=_make_exec_mock(output="12345\n")
+        )
+        info1 = await runtime.get_preview_url(8080)
+        info2 = await runtime.get_preview_url(3000)
+        assert info1.url == "http://localhost:13000"
+        assert info2.url == "http://localhost:13001"
+
+    @pytest.mark.asyncio
+    async def test_exhausted_pool_raises(self, runtime):
+        """RuntimeError when all proxy ports are allocated."""
+        runtime._container.exec = AsyncMock(
+            return_value=_make_exec_mock(output="12345\n")
+        )
+        await runtime.get_preview_url(8080)
+        await runtime.get_preview_url(8081)
+        await runtime.get_preview_url(8082)
+        with pytest.raises(RuntimeError, match="No free proxy ports"):
+            await runtime.get_preview_url(8083)
+
+    @pytest.mark.asyncio
+    async def test_explicit_base_url(self, container):
+        """preview_base_url overrides localhost."""
+        runtime = DockerRuntime(
+            container,
+            runtime_id="docker-test",
+            working_dir="/home/workspace",
+            proxy_ports=[13000],
+            preview_base_url="http://192.168.1.100",
+        )
+        runtime._container.exec = AsyncMock(
+            return_value=_make_exec_mock(output="12345\n")
+        )
+        info = await runtime.get_preview_url(8080)
+        assert info.url == "http://192.168.1.100:13000"
+
+    @pytest.mark.asyncio
+    async def test_get_preview_link_reuses_proxy_port(self, runtime):
+        """get_preview_link allocates the same proxy port as get_preview_url."""
+        runtime._container.exec = AsyncMock(
+            return_value=_make_exec_mock(output="12345\n")
+        )
+        url_info = await runtime.get_preview_url(8080)
+        link_info = await runtime.get_preview_link(8080)
+        # Same proxy port even if host may differ (server-side vs browser)
+        assert url_info.url.split(":")[-1] == link_info.url.split(":")[-1]
+
+    @pytest.mark.asyncio
+    async def test_preview_link_uses_docker_internal_when_available(self, runtime):
+        """get_preview_link uses host.docker.internal when DNS resolves."""
+        runtime._container.exec = AsyncMock(
+            return_value=_make_exec_mock(output="12345\n")
+        )
+        DockerRuntime._server_side_host = None  # clear class cache
+        with patch("socket.getaddrinfo", return_value=[("", "", 0, "", ("127.0.0.1", 0))]):
+            info = await runtime.get_preview_link(8080)
+        assert info.url == "http://host.docker.internal:13000"
+        DockerRuntime._server_side_host = None  # cleanup
+
+    @pytest.mark.asyncio
+    async def test_preview_link_falls_back_to_localhost(self, runtime):
+        """get_preview_link falls back to localhost when not in Docker."""
+        runtime._container.exec = AsyncMock(
+            return_value=_make_exec_mock(output="12345\n")
+        )
+        DockerRuntime._server_side_host = None  # clear class cache
+        import socket as _socket
+        with patch("socket.getaddrinfo", side_effect=_socket.gaierror):
+            info = await runtime.get_preview_link(8080)
+        assert info.url == "http://localhost:13000"
+        DockerRuntime._server_side_host = None  # cleanup
+
+    @pytest.mark.asyncio
+    async def test_resolve_server_side_host_is_cached(self, runtime):
+        """_resolve_server_side_host only does DNS once, then caches."""
+        DockerRuntime._server_side_host = None
+        import socket as _socket
+        with patch("socket.getaddrinfo", side_effect=_socket.gaierror) as mock_dns:
+            DockerRuntime._resolve_server_side_host()
+            DockerRuntime._resolve_server_side_host()
+            assert mock_dns.call_count == 1
+        DockerRuntime._server_side_host = None  # cleanup
+
+    @pytest.mark.asyncio
+    async def test_socat_exec_command(self, runtime):
+        """Verify the exec calls include fuser kill, socat start, and fuser check."""
+        runtime._container.exec = AsyncMock(
+            return_value=_make_exec_mock(output="12345\n")
+        )
+        await runtime.get_preview_url(8080)
+        # Collect all exec commands (write proxy script, fuser -k, socat nohup, fuser check)
+        all_cmds = []
+        for call in runtime._container.exec.call_args_list:
+            cmd = call[1].get("cmd", call[0][0] if call[0] else None)
+            cmd_str = cmd[-1] if isinstance(cmd, list) else str(cmd)
+            all_cmds.append(cmd_str)
+        # Should have: base64 write, fuser -k, socat nohup, fuser verify
+        assert any("fuser -k" in c and "13000" in c for c in all_cmds)
+        assert any("socat" in c and "13000" in c and "8080" in c for c in all_cmds)
+        assert any("fuser" in c and "13000" in c and "-k" not in c for c in all_cmds)
+
+    @pytest.mark.asyncio
+    async def test_kills_stale_forwarder_before_allocating(self, runtime):
+        """_allocate_proxy_port kills existing listeners before starting socat."""
+        exec_calls = []
+        async def capture_exec(*args, **kwargs):
+            cmd = kwargs.get("cmd", args[0] if args else None)
+            cmd_str = cmd[-1] if isinstance(cmd, list) else str(cmd)
+            exec_calls.append(cmd_str)
+            return _make_exec_mock(output="12345\n")
+        runtime._container.exec = AsyncMock(side_effect=capture_exec)
+        await runtime.get_preview_url(8080)
+        # fuser -k must come before the socat nohup
+        kill_idx = next(i for i, c in enumerate(exec_calls) if "fuser -k" in c)
+        socat_idx = next(i for i, c in enumerate(exec_calls) if "socat" in c)
+        assert kill_idx < socat_idx
+
+
+# ---------------------------------------------------------------------------
+# DockerRuntime — sessions
+# ---------------------------------------------------------------------------
+
+
+class TestDockerRuntimeSessions:
+    @pytest.fixture
+    def container(self):
+        return _make_mock_container()
+
+    @pytest.fixture
+    def runtime(self, container):
+        return DockerRuntime(
+            container,
+            runtime_id="docker-test123",
+            working_dir="/home/workspace",
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_session(self, runtime):
+        """create_session creates the session directory."""
+        runtime._container.exec = AsyncMock(
+            return_value=_make_exec_mock(exit_code=1)  # dir doesn't exist
+        )
+        await runtime.create_session("preview-8080")
+        assert runtime._container.exec.call_count == 2  # test -d + mkdir -p
+
+    @pytest.mark.asyncio
+    async def test_create_session_already_exists(self, runtime):
+        """create_session raises when session dir already exists."""
+        runtime._container.exec = AsyncMock(
+            return_value=_make_exec_mock(exit_code=0)  # dir exists
+        )
+        with pytest.raises(RuntimeError, match="Session already exists"):
+            await runtime.create_session("preview-8080")
+
+    @pytest.mark.asyncio
+    async def test_create_session_invalid_id(self, runtime):
+        """create_session rejects invalid session IDs."""
+        with pytest.raises(ValueError, match="Invalid session_id"):
+            await runtime.create_session("../evil")
+
+    @pytest.mark.asyncio
+    async def test_session_execute_async(self, runtime):
+        """session_execute with run_async=True returns None exit_code."""
+        runtime._container.exec = AsyncMock(
+            return_value=_make_exec_mock(output="99999\n")
+        )
+        result = await runtime.session_execute("preview-8080", "python -m http.server 8080", run_async=True)
+        assert result.exit_code is None
+        assert result.cmd_id  # non-empty
+        # Verify base64 encoding is in the exec command
+        call_args = runtime._container.exec.call_args
+        cmd = call_args[1].get("cmd", call_args[0][0] if call_args[0] else None)
+        cmd_str = cmd[-1] if isinstance(cmd, list) else str(cmd)
+        assert "base64" in cmd_str
+        assert "nohup" in cmd_str
+
+    @pytest.mark.asyncio
+    async def test_session_execute_sync(self, runtime):
+        """session_execute with run_async=False returns actual exit code."""
+        runtime._container.exec = AsyncMock(
+            return_value=_make_exec_mock(output="hello\n", exit_code=0)
+        )
+        result = await runtime.session_execute("preview-8080", "echo hello", run_async=False)
+        assert result.exit_code == 0
+        assert result.stdout == "hello\n"
+
+    @pytest.mark.asyncio
+    async def test_session_command_logs_finished(self, runtime):
+        """session_command_logs returns exit code when process finished."""
+        # Mock three sequential exec calls: stdout, stderr, exit code
+        runtime._container.exec = AsyncMock(
+            side_effect=[
+                _make_exec_mock(output="output data\n", exit_code=0),
+                _make_exec_mock(output="", exit_code=0),
+                _make_exec_mock(output="0\n", exit_code=0),
+            ]
+        )
+        # Need to use the real exec method, so patch at container level
+        result = await runtime.session_command_logs("preview-8080", "abc12345")
+        assert result.exit_code == 0
+        assert result.cmd_id == "abc12345"
+
+    @pytest.mark.asyncio
+    async def test_session_command_logs_running(self, runtime):
+        """session_command_logs returns None exit_code when process still running."""
+        runtime._container.exec = AsyncMock(
+            side_effect=[
+                _make_exec_mock(output="", exit_code=0),   # stdout
+                _make_exec_mock(output="", exit_code=0),   # stderr
+                _make_exec_mock(output="", exit_code=1),   # exit file not found
+            ]
+        )
+        result = await runtime.session_command_logs("preview-8080", "abc12345")
+        assert result.exit_code is None
+
+    @pytest.mark.asyncio
+    async def test_session_command_logs_invalid_id(self, runtime):
+        """session_command_logs rejects invalid command IDs."""
+        with pytest.raises(ValueError, match="Invalid command_id"):
+            await runtime.session_command_logs("preview-8080", "../etc/passwd")
+
+    @pytest.mark.asyncio
+    async def test_delete_session(self, runtime):
+        """delete_session kills PIDs and removes directory."""
+        runtime._container.exec = AsyncMock(
+            return_value=_make_exec_mock(exit_code=0)
+        )
+        await runtime.delete_session("preview-8080")
+        call_args = runtime._container.exec.call_args
+        cmd = call_args[1].get("cmd", call_args[0][0] if call_args[0] else None)
+        cmd_str = cmd[-1] if isinstance(cmd, list) else str(cmd)
+        assert "kill" in cmd_str
+        assert "rm -rf" in cmd_str
+
+    @pytest.mark.asyncio
+    async def test_delete_session_invalid_id(self, runtime):
+        """delete_session rejects invalid session IDs."""
+        with pytest.raises(ValueError, match="Invalid session_id"):
+            await runtime.delete_session("../../etc")
+
+    @pytest.mark.asyncio
+    async def test_session_execute_invalid_id(self, runtime):
+        """session_execute rejects invalid session IDs."""
+        with pytest.raises(ValueError, match="Invalid session_id"):
+            await runtime.session_execute("../evil", "echo hi")
+
+    @pytest.mark.asyncio
+    async def test_session_command_logs_invalid_session_id(self, runtime):
+        """session_command_logs rejects invalid session IDs."""
+        with pytest.raises(ValueError, match="Invalid session_id"):
+            await runtime.session_command_logs("../evil", "abc12345")
+
+
+# ---------------------------------------------------------------------------
+# DockerRuntime — updated capabilities
+# ---------------------------------------------------------------------------
+
+
+class TestDockerRuntimeUpdatedCapabilities:
+    def test_capabilities_include_preview_and_sessions(self):
+        container = _make_mock_container()
+        runtime = DockerRuntime(
+            container,
+            runtime_id="docker-test",
+            working_dir="/home/workspace",
+        )
+        caps = runtime.capabilities
+        assert "preview_url" in caps
+        assert "sessions" in caps
+        assert "exec" in caps
+        assert "code_run" in caps
+        assert "file_io" in caps
+
+
+# ---------------------------------------------------------------------------
+# DockerProvider — container creation with proxy ports and Init
+# ---------------------------------------------------------------------------
+
+
+class TestDockerProviderPreviewConfig:
+    @pytest.mark.asyncio
+    async def test_create_publishes_proxy_ports(self):
+        """Container creation includes PortBindings for proxy port range."""
+        config = DockerConfig(preview_proxy_ports="13000-13002")
+        provider = DockerProvider(config, working_dir="/home/workspace")
+
+        mock_container = _make_mock_container()
+        mock_client = MagicMock()
+        mock_client.containers = MagicMock()
+        mock_client.containers.create = AsyncMock(return_value=mock_container)
+        mock_client.images = MagicMock()
+        mock_client.images.inspect = AsyncMock()
+        provider._client = mock_client
+
+        await provider.create()
+
+        create_call = mock_client.containers.create.call_args
+        container_config = create_call[1]["config"]
+        host_config = container_config["HostConfig"]
+
+        assert "PortBindings" in host_config
+        assert "13000/tcp" in host_config["PortBindings"]
+        assert "13001/tcp" in host_config["PortBindings"]
+        assert "13002/tcp" in host_config["PortBindings"]
+
+        assert "ExposedPorts" in container_config
+        assert "13000/tcp" in container_config["ExposedPorts"]
+
+    @pytest.mark.asyncio
+    async def test_create_includes_init(self):
+        """Container creation includes Init: True for zombie reaping."""
+        config = DockerConfig()
+        provider = DockerProvider(config, working_dir="/home/workspace")
+
+        mock_container = _make_mock_container()
+        mock_client = MagicMock()
+        mock_client.containers = MagicMock()
+        mock_client.containers.create = AsyncMock(return_value=mock_container)
+        mock_client.images = MagicMock()
+        mock_client.images.inspect = AsyncMock()
+        provider._client = mock_client
+
+        await provider.create()
+
+        create_call = mock_client.containers.create.call_args
+        host_config = create_call[1]["config"]["HostConfig"]
+        assert host_config.get("Init") is True
+
+    @pytest.mark.asyncio
+    async def test_create_passes_proxy_ports_to_runtime(self):
+        """Runtime receives proxy_ports from provider config."""
+        config = DockerConfig(preview_proxy_ports="13000-13002")
+        provider = DockerProvider(config, working_dir="/home/workspace")
+
+        mock_container = _make_mock_container()
+        mock_client = MagicMock()
+        mock_client.containers = MagicMock()
+        mock_client.containers.create = AsyncMock(return_value=mock_container)
+        mock_client.images = MagicMock()
+        mock_client.images.inspect = AsyncMock()
+        provider._client = mock_client
+
+        runtime = await provider.create()
+        assert runtime._proxy_ports == [13000, 13001, 13002]
+
+    @pytest.mark.asyncio
+    async def test_create_passes_preview_base_url(self):
+        """Runtime receives preview_base_url from provider config."""
+        config = DockerConfig(preview_base_url="http://10.0.0.1")
+        provider = DockerProvider(config, working_dir="/home/workspace")
+
+        mock_container = _make_mock_container()
+        mock_client = MagicMock()
+        mock_client.containers = MagicMock()
+        mock_client.containers.create = AsyncMock(return_value=mock_container)
+        mock_client.images = MagicMock()
+        mock_client.images.inspect = AsyncMock()
+        provider._client = mock_client
+
+        runtime = await provider.create()
+        assert runtime._preview_base_url == "http://10.0.0.1"
+
+    @pytest.mark.asyncio
+    async def test_get_passes_proxy_ports(self):
+        """get() passes proxy_ports from provider config to runtime."""
+        config = DockerConfig(preview_proxy_ports="13000-13004")
+        provider = DockerProvider(config, working_dir="/home/workspace")
+
+        mock_container = _make_mock_container()
+        mock_client = MagicMock()
+        mock_client.containers = MagicMock()
+        mock_client.containers.get = AsyncMock(return_value=mock_container)
+        provider._client = mock_client
+
+        runtime = await provider.get("docker-abc123")
+        assert runtime._proxy_ports == [13000, 13001, 13002, 13003, 13004]
+        assert runtime._preview_base_url is None

--- a/tests/unit/core/sandbox/test_docker_provider.py
+++ b/tests/unit/core/sandbox/test_docker_provider.py
@@ -868,7 +868,9 @@ class TestDockerRuntimePreviewUrl:
             return_value=_make_exec_mock(output="12345\n")
         )
         DockerRuntime._server_side_host = None  # clear class cache
-        with patch("socket.getaddrinfo", return_value=[("", "", 0, "", ("127.0.0.1", 0))]):
+        mock_loop = AsyncMock()
+        mock_loop.getaddrinfo = AsyncMock(return_value=[("", "", 0, "", ("127.0.0.1", 0))])
+        with patch("asyncio.get_event_loop", return_value=mock_loop):
             info = await runtime.get_preview_link(8080)
         assert info.url == "http://host.docker.internal:13000"
         DockerRuntime._server_side_host = None  # cleanup
@@ -880,8 +882,9 @@ class TestDockerRuntimePreviewUrl:
             return_value=_make_exec_mock(output="12345\n")
         )
         DockerRuntime._server_side_host = None  # clear class cache
-        import socket as _socket
-        with patch("socket.getaddrinfo", side_effect=_socket.gaierror):
+        mock_loop = AsyncMock()
+        mock_loop.getaddrinfo = AsyncMock(side_effect=OSError)
+        with patch("asyncio.get_event_loop", return_value=mock_loop):
             info = await runtime.get_preview_link(8080)
         assert info.url == "http://localhost:13000"
         DockerRuntime._server_side_host = None  # cleanup
@@ -890,11 +893,12 @@ class TestDockerRuntimePreviewUrl:
     async def test_resolve_server_side_host_is_cached(self, runtime):
         """_resolve_server_side_host only does DNS once, then caches."""
         DockerRuntime._server_side_host = None
-        import socket as _socket
-        with patch("socket.getaddrinfo", side_effect=_socket.gaierror) as mock_dns:
-            DockerRuntime._resolve_server_side_host()
-            DockerRuntime._resolve_server_side_host()
-            assert mock_dns.call_count == 1
+        mock_loop = AsyncMock()
+        mock_loop.getaddrinfo = AsyncMock(side_effect=OSError)
+        with patch("asyncio.get_event_loop", return_value=mock_loop) as mock_get_loop:
+            await DockerRuntime._resolve_server_side_host()
+            await DockerRuntime._resolve_server_side_host()
+            assert mock_loop.getaddrinfo.call_count == 1
         DockerRuntime._server_side_host = None  # cleanup
 
     @pytest.mark.asyncio
@@ -930,6 +934,34 @@ class TestDockerRuntimePreviewUrl:
         kill_idx = next(i for i, c in enumerate(exec_calls) if "fuser -k" in c)
         socat_idx = next(i for i, c in enumerate(exec_calls) if "socat" in c)
         assert kill_idx < socat_idx
+
+    @pytest.mark.asyncio
+    async def test_concurrent_allocations_get_different_ports(self, runtime):
+        """Two concurrent _allocate_proxy_port calls get different proxy ports."""
+        import asyncio
+
+        runtime._container.exec = AsyncMock(
+            return_value=_make_exec_mock(output="12345\n")
+        )
+        p1, p2 = await asyncio.gather(
+            runtime._allocate_proxy_port(8080),
+            runtime._allocate_proxy_port(9090),
+        )
+        assert p1 != p2
+        assert {p1, p2} == {13000, 13001}
+
+    @pytest.mark.asyncio
+    async def test_allocate_proxy_port_rolls_back_on_failure(self, runtime):
+        """Port reservation is rolled back if exec raises a transient error."""
+        # "no such container" triggers SandboxTransientError (re-raised by exec)
+        runtime._container.exec = AsyncMock(
+            side_effect=RuntimeError("no such container")
+        )
+        with pytest.raises(SandboxTransientError):
+            await runtime._allocate_proxy_port(8080)
+        # Port should be released for retry
+        assert 8080 not in runtime._port_map
+        assert 13000 not in runtime._forwarder_pids
 
 
 # ---------------------------------------------------------------------------
@@ -1003,28 +1035,24 @@ class TestDockerRuntimeSessions:
     @pytest.mark.asyncio
     async def test_session_command_logs_finished(self, runtime):
         """session_command_logs returns exit code when process finished."""
-        # Mock three sequential exec calls: stdout, stderr, exit code
+        # Single exec returns stdout, stderr, exit code separated by null bytes
         runtime._container.exec = AsyncMock(
-            side_effect=[
-                _make_exec_mock(output="output data\n", exit_code=0),
-                _make_exec_mock(output="", exit_code=0),
-                _make_exec_mock(output="0\n", exit_code=0),
-            ]
+            return_value=_make_exec_mock(
+                output="output data\n\x00error data\n\x000\n", exit_code=0
+            ),
         )
-        # Need to use the real exec method, so patch at container level
         result = await runtime.session_command_logs("preview-8080", "abc12345")
         assert result.exit_code == 0
+        assert result.stdout == "output data\n"
+        assert result.stderr == "error data\n"
         assert result.cmd_id == "abc12345"
 
     @pytest.mark.asyncio
     async def test_session_command_logs_running(self, runtime):
         """session_command_logs returns None exit_code when process still running."""
+        # Exit file doesn't exist yet, so the exit segment is empty
         runtime._container.exec = AsyncMock(
-            side_effect=[
-                _make_exec_mock(output="", exit_code=0),   # stdout
-                _make_exec_mock(output="", exit_code=0),   # stderr
-                _make_exec_mock(output="", exit_code=1),   # exit file not found
-            ]
+            return_value=_make_exec_mock(output="\x00\x00", exit_code=0),
         )
         result = await runtime.session_command_logs("preview-8080", "abc12345")
         assert result.exit_code is None

--- a/tests/unit/core/sandbox/test_docker_provider.py
+++ b/tests/unit/core/sandbox/test_docker_provider.py
@@ -870,7 +870,7 @@ class TestDockerRuntimePreviewUrl:
         DockerRuntime._server_side_host = None  # clear class cache
         mock_loop = AsyncMock()
         mock_loop.getaddrinfo = AsyncMock(return_value=[("", "", 0, "", ("127.0.0.1", 0))])
-        with patch("asyncio.get_event_loop", return_value=mock_loop):
+        with patch("asyncio.get_running_loop", return_value=mock_loop):
             info = await runtime.get_preview_link(8080)
         assert info.url == "http://host.docker.internal:13000"
         DockerRuntime._server_side_host = None  # cleanup
@@ -884,7 +884,7 @@ class TestDockerRuntimePreviewUrl:
         DockerRuntime._server_side_host = None  # clear class cache
         mock_loop = AsyncMock()
         mock_loop.getaddrinfo = AsyncMock(side_effect=OSError)
-        with patch("asyncio.get_event_loop", return_value=mock_loop):
+        with patch("asyncio.get_running_loop", return_value=mock_loop):
             info = await runtime.get_preview_link(8080)
         assert info.url == "http://localhost:13000"
         DockerRuntime._server_side_host = None  # cleanup
@@ -895,7 +895,7 @@ class TestDockerRuntimePreviewUrl:
         DockerRuntime._server_side_host = None
         mock_loop = AsyncMock()
         mock_loop.getaddrinfo = AsyncMock(side_effect=OSError)
-        with patch("asyncio.get_event_loop", return_value=mock_loop) as mock_get_loop:
+        with patch("asyncio.get_running_loop", return_value=mock_loop) as mock_get_loop:
             await DockerRuntime._resolve_server_side_host()
             await DockerRuntime._resolve_server_side_host()
             assert mock_loop.getaddrinfo.call_count == 1

--- a/tests/unit/core/sandbox/test_docker_provider.py
+++ b/tests/unit/core/sandbox/test_docker_provider.py
@@ -1020,7 +1020,7 @@ class TestDockerRuntimeSessions:
         cmd = call_args[1].get("cmd", call_args[0][0] if call_args[0] else None)
         cmd_str = cmd[-1] if isinstance(cmd, list) else str(cmd)
         assert "base64" in cmd_str
-        assert "nohup" in cmd_str
+        assert "nohup setsid" in cmd_str
 
     @pytest.mark.asyncio
     async def test_session_execute_sync(self, runtime):
@@ -1065,7 +1065,7 @@ class TestDockerRuntimeSessions:
 
     @pytest.mark.asyncio
     async def test_delete_session(self, runtime):
-        """delete_session kills PIDs and removes directory."""
+        """delete_session kills process groups and removes directory."""
         runtime._container.exec = AsyncMock(
             return_value=_make_exec_mock(exit_code=0)
         )
@@ -1073,7 +1073,9 @@ class TestDockerRuntimeSessions:
         call_args = runtime._container.exec.call_args
         cmd = call_args[1].get("cmd", call_args[0][0] if call_args[0] else None)
         cmd_str = cmd[-1] if isinstance(cmd, list) else str(cmd)
-        assert "kill" in cmd_str
+        # Kills entire process group (negative PID) and the process itself
+        assert 'kill -- -"$pid"' in cmd_str
+        assert 'kill "$pid"' in cmd_str
         assert "rm -rf" in cmd_str
 
     @pytest.mark.asyncio
@@ -1123,8 +1125,8 @@ class TestDockerRuntimeUpdatedCapabilities:
 
 class TestDockerProviderPreviewConfig:
     @pytest.mark.asyncio
-    async def test_create_publishes_proxy_ports(self):
-        """Container creation includes PortBindings for proxy port range."""
+    async def test_create_publishes_proxy_ports_with_dynamic_host_ports(self):
+        """Container creation uses dynamic host ports (HostPort: '') for proxy ports."""
         config = DockerConfig(preview_proxy_ports="13000-13002")
         provider = DockerProvider(config, working_dir="/home/workspace")
 
@@ -1144,8 +1146,10 @@ class TestDockerProviderPreviewConfig:
 
         assert "PortBindings" in host_config
         assert "13000/tcp" in host_config["PortBindings"]
-        assert "13001/tcp" in host_config["PortBindings"]
-        assert "13002/tcp" in host_config["PortBindings"]
+        # Verify dynamic host ports (empty string = Docker picks)
+        assert host_config["PortBindings"]["13000/tcp"] == [{"HostPort": ""}]
+        assert host_config["PortBindings"]["13001/tcp"] == [{"HostPort": ""}]
+        assert host_config["PortBindings"]["13002/tcp"] == [{"HostPort": ""}]
 
         assert "ExposedPorts" in container_config
         assert "13000/tcp" in container_config["ExposedPorts"]
@@ -1219,3 +1223,72 @@ class TestDockerProviderPreviewConfig:
         runtime = await provider.get("docker-abc123")
         assert runtime._proxy_ports == [13000, 13001, 13002, 13003, 13004]
         assert runtime._preview_base_url is None
+
+    @pytest.mark.asyncio
+    async def test_create_reads_dynamic_host_ports(self):
+        """create() reads actual host port mappings from container inspect."""
+        config = DockerConfig(preview_proxy_ports="13000-13001")
+        provider = DockerProvider(config, working_dir="/home/workspace")
+
+        mock_container = _make_mock_container()
+        # After start, show() returns port mappings with dynamic host ports
+        mock_container.show = AsyncMock(return_value={
+            "State": {"Status": "running"},
+            "NetworkSettings": {
+                "Ports": {
+                    "13000/tcp": [{"HostIp": "0.0.0.0", "HostPort": "49152"}],
+                    "13001/tcp": [{"HostIp": "0.0.0.0", "HostPort": "49153"}],
+                }
+            },
+        })
+        mock_client = MagicMock()
+        mock_client.containers = MagicMock()
+        mock_client.containers.create = AsyncMock(return_value=mock_container)
+        mock_client.images = MagicMock()
+        mock_client.images.inspect = AsyncMock()
+        provider._client = mock_client
+
+        runtime = await provider.create()
+        assert runtime._host_port_map == {13000: 49152, 13001: 49153}
+
+    @pytest.mark.asyncio
+    async def test_preview_url_uses_dynamic_host_port(self):
+        """Preview URL uses the host port, not the container port."""
+        container = _make_mock_container()
+        runtime = DockerRuntime(
+            container,
+            runtime_id="docker-test",
+            working_dir="/home/workspace",
+            proxy_ports=[13000, 13001],
+            host_port_map={13000: 49152, 13001: 49153},
+        )
+        runtime._container.exec = AsyncMock(
+            return_value=_make_exec_mock(output="12345\n")
+        )
+        info = await runtime.get_preview_url(8080)
+        assert info.url == "http://localhost:49152"
+
+    @pytest.mark.asyncio
+    async def test_get_reads_dynamic_host_ports(self):
+        """get() reads host port mappings from running container inspect."""
+        config = DockerConfig(preview_proxy_ports="13000-13001")
+        provider = DockerProvider(config, working_dir="/home/workspace")
+
+        mock_container = _make_mock_container()
+        mock_container.show = AsyncMock(return_value={
+            "State": {"Status": "running"},
+            "Mounts": [],
+            "NetworkSettings": {
+                "Ports": {
+                    "13000/tcp": [{"HostIp": "0.0.0.0", "HostPort": "49200"}],
+                    "13001/tcp": [{"HostIp": "0.0.0.0", "HostPort": "49201"}],
+                }
+            },
+        })
+        mock_client = MagicMock()
+        mock_client.containers = MagicMock()
+        mock_client.containers.get = AsyncMock(return_value=mock_container)
+        provider._client = mock_client
+
+        runtime = await provider.get("docker-abc123")
+        assert runtime._host_port_map == {13000: 49200, 13001: 49201}


### PR DESCRIPTION
## Summary

Enables self-hosted Docker deployments (without Daytona) to serve preview URLs from sandbox containers. The agent can now start HTTP servers inside Docker sandboxes and expose them to the browser via stable preview URLs.

**Preview URL support**
- Proxy port pool (default 13000-13009) published at container creation
- socat TCP forwarding with Python fallback for environments without socat installed
- Stale forwarder cleanup on reconnect (`fuser -k`) prevents orphaned ports after server restart
- Forwarder readiness verification after startup
- Server-side host resolution (`host.docker.internal`) for Docker-in-Docker health checks
- DNS result caching at class level to avoid repeated blocking lookups

**Session support**
- Background process management via `nohup` + base64-encoded commands + PID tracking
- Session lifecycle: `create_session`, `session_execute`, `session_command_logs`, `delete_session`

**Security & reliability**
- Shell injection prevention: regex validation on `session_id` and `command_id` in all session methods
- `Init: true` (tini as PID 1) for zombie process reaping
- socat installed in `Dockerfile.sandbox` as separate layer (avoids cache-busting main apt layer)

**Summarization bugfix (separate commit)**
- Fix crash when no dedicated summarization model is configured: fall back to main agent LLM

## Files changed

| File | Change |
|------|--------|
| `Dockerfile.sandbox` | Add socat package |
| `src/ptc_agent/config/core.py` | Add `preview_proxy_ports`, `preview_base_url` to DockerConfig |
| `src/ptc_agent/core/sandbox/providers/docker.py` | Preview URL methods, session management, proxy port pool, host resolution |
| `tests/unit/core/sandbox/test_docker_provider.py` | 105 tests (33 new for preview/session functionality) |
| `src/ptc_agent/agent/agent.py` | Summarization middleware initialization fix |
| `src/server/handlers/chat/llm_config.py` | Default summarization model to flash model |

## Test plan
- [x] All 105 unit tests pass (0.38s)
- [x] Manually tested on macOS Docker Desktop: socat forwarding, preview URL redirect, NVIDIA dashboard rendering