### PR TITLE
fix: prevent sandbox shutdown race condition

### DIFF
--- a/src/ptc_agent/core/sandbox/providers/daytona.py
+++ b/src/ptc_agent/core/sandbox/providers/daytona.py
@@ -382,6 +382,14 @@ class DaytonaProvider(SandboxProvider):
     def is_transient_error(self, exc: Exception) -> bool:
         """Classify whether *exc* is a transient Daytona SDK error."""
         message = str(exc).lower()
+
+        # A closed HTTP client means the command never reached the server.
+        # The SDK wraps these as "Failed to execute command: Session is closed"
+        # so we must check BEFORE the execution-error guard.
+        client_dead_markers = ("session is closed", "client is closed")
+        if any(marker in message for marker in client_dead_markers):
+            return True
+
         # Execution errors are not transient — the command ran and the server
         # responded. Don't let "timeout" in the server message trigger
         # transient handling.

--- a/src/ptc_agent/core/sandbox/ptc_sandbox.py
+++ b/src/ptc_agent/core/sandbox/ptc_sandbox.py
@@ -166,7 +166,7 @@ class PTCSandbox:
         # Lazy initialization support
         self._ready_event: asyncio.Event | None = None
         self._init_task: asyncio.Task[None] | None = None
-        self._init_error: Exception | None = None
+        self._init_error: BaseException | None = None
 
         # Cached skills manifest (populated after sync_sandbox_assets)
         self._skills_manifest: dict[str, Any] | None = None
@@ -711,7 +711,7 @@ class PTCSandbox:
                 await self._init_task
             except (asyncio.CancelledError, Exception):
                 pass
-            self._init_task = None
+        self._init_task = None
 
     async def stop_sandbox(self) -> None:
         """Stop the sandbox without deleting it.

--- a/src/ptc_agent/core/sandbox/ptc_sandbox.py
+++ b/src/ptc_agent/core/sandbox/ptc_sandbox.py
@@ -168,9 +168,6 @@ class PTCSandbox:
         self._init_task: asyncio.Task[None] | None = None
         self._init_error: Exception | None = None
 
-        # Set by stop_sandbox()/cleanup() to short-circuit retries and reconnects
-        self._stopped: bool = False
-
         # Cached skills manifest (populated after sync_sandbox_assets)
         self._skills_manifest: dict[str, Any] | None = None
 
@@ -262,6 +259,14 @@ class PTCSandbox:
             logger.info("Starting lazy sandbox init", sandbox_id=sandbox_id)
             await self.reconnect(sandbox_id)
             logger.info("Lazy sandbox init complete", sandbox_id=sandbox_id)
+        except asyncio.CancelledError:
+            # CancelledError is BaseException, not Exception — must be
+            # caught explicitly so _init_error is set.  Without this,
+            # _ready_event.set() in the finally block signals "ready"
+            # with no error, and concurrent _wait_ready() callers
+            # proceed with a None runtime.
+            logger.info("Lazy sandbox init cancelled", sandbox_id=sandbox_id)
+            self._init_error = asyncio.CancelledError("Sandbox init was cancelled")
         except Exception as e:
             logger.error("Lazy sandbox init failed", error=str(e))
             self._init_error = e
@@ -560,8 +565,6 @@ class PTCSandbox:
         Raises:
             SandboxGoneError: If sandbox cannot be found or is in an unrecoverable state
         """
-        self._stopped = False
-
         logger.info("Reconnecting to stopped sandbox", sandbox_id=sandbox_id)
 
         # Clear stale state — sessions and preview links don't survive stop/start
@@ -700,13 +703,8 @@ class PTCSandbox:
             sandbox_id=self.sandbox_id,
         )
 
-    async def stop_sandbox(self) -> None:
-        """Stop the sandbox without deleting it.
-
-        Used for session persistence - stops the sandbox so it can be
-        restarted quickly on the next session, rather than deleting it.
-        """
-        # Cancel any in-flight lazy init task before stopping
+    async def _cancel_init_task(self) -> None:
+        """Cancel any in-flight lazy init task and wait for it to finish."""
         if self._init_task is not None and not self._init_task.done():
             self._init_task.cancel()
             try:
@@ -715,8 +713,15 @@ class PTCSandbox:
                 pass
             self._init_task = None
 
+    async def stop_sandbox(self) -> None:
+        """Stop the sandbox without deleting it.
+
+        Used for session persistence - stops the sandbox so it can be
+        restarted quickly on the next session, rather than deleting it.
+        """
+        await self._cancel_init_task()
+
         if not self.runtime:
-            self._stopped = True
             return
 
         # Check state before stopping to avoid errors when already stopped
@@ -724,7 +729,6 @@ class PTCSandbox:
             state = await self.runtime.get_state()
             if state == RuntimeState.STOPPED:
                 logger.info("Sandbox already stopped", sandbox_id=self.sandbox_id)
-                self._stopped = True
                 return
         except Exception as e:
             # If state check fails, log and continue with stop attempt
@@ -745,8 +749,6 @@ class PTCSandbox:
                 sandbox_id=self.sandbox_id,
                 error=str(e),
             )
-        finally:
-            self._stopped = True
 
     async def _setup_workspace(self) -> None:
         """Create workspace directory structure."""
@@ -1455,17 +1457,13 @@ class PTCSandbox:
         return is_timeout, error_detail, stderr_msg
 
     async def _ensure_sandbox_connected(self) -> None:
-        if self._stopped:
-            raise SandboxGoneError(
-                self.sandbox_id or "unknown",
-                "sandbox was intentionally stopped",
-            )
         if self.sandbox_id is None:
             raise SandboxTransientError(
                 "Sandbox disconnected and no sandbox_id is available"
             )
 
-        # Coalesce concurrent reconnect attempts.
+        # Coalesce concurrent reconnect attempts (including transparent
+        # restart when the sandbox was stopped externally).
         async with self._reconnect_lock:
             if (
                 self._reconnect_inflight is not None
@@ -1473,6 +1471,16 @@ class PTCSandbox:
             ):
                 await self._reconnect_inflight
                 return
+
+            # Always recreate the provider.  This callback only fires after
+            # a transient error, so the existing client may be dead (closed
+            # by a concurrent stop_workspace) or degraded (stale connection).
+            # Creating a new AsyncDaytona is cheap — just an aiohttp session.
+            try:
+                await self.provider.close()
+            except Exception:
+                pass
+            self.provider = create_provider(self.config)
 
             loop = asyncio.get_running_loop()
             self._reconnect_inflight = loop.create_future()
@@ -1498,11 +1506,6 @@ class PTCSandbox:
         total_timeout: float = 120.0,
         **kwargs: Any,
     ) -> Any:
-        if self._stopped:
-            raise SandboxGoneError(
-                self.sandbox_id or "unknown",
-                "sandbox was intentionally stopped",
-            )
         on_transient = self._ensure_sandbox_connected if allow_reconnect else None
         return await async_retry_with_backoff(
             func,
@@ -3724,14 +3727,7 @@ except OSError as e:
 
     async def cleanup(self) -> None:
         """Clean up and destroy the sandbox."""
-        # Cancel any in-flight lazy init task before cleanup
-        if self._init_task is not None and not self._init_task.done():
-            self._init_task.cancel()
-            try:
-                await self._init_task
-            except (asyncio.CancelledError, Exception):
-                pass
-            self._init_task = None
+        await self._cancel_init_task()
 
         logger.info("Cleaning up sandbox", sandbox_id=self.sandbox_id)
 
@@ -3759,7 +3755,6 @@ except OSError as e:
                 except Exception as e:
                     logger.error(f"Error deleting sandbox: {e}")
         finally:
-            self._stopped = True
             self.runtime = None
             self.sandbox_id = None
             await self.close()

--- a/src/ptc_agent/core/sandbox/ptc_sandbox.py
+++ b/src/ptc_agent/core/sandbox/ptc_sandbox.py
@@ -166,7 +166,7 @@ class PTCSandbox:
         # Lazy initialization support
         self._ready_event: asyncio.Event | None = None
         self._init_task: asyncio.Task[None] | None = None
-        self._init_error: BaseException | None = None
+        self._init_error: Exception | None = None
 
         # Cached skills manifest (populated after sync_sandbox_assets)
         self._skills_manifest: dict[str, Any] | None = None
@@ -266,7 +266,7 @@ class PTCSandbox:
             # with no error, and concurrent _wait_ready() callers
             # proceed with a None runtime.
             logger.info("Lazy sandbox init cancelled", sandbox_id=sandbox_id)
-            self._init_error = asyncio.CancelledError("Sandbox init was cancelled")
+            self._init_error = RuntimeError("Sandbox init was cancelled")
         except Exception as e:
             logger.error("Lazy sandbox init failed", error=str(e))
             self._init_error = e

--- a/src/ptc_agent/core/sandbox/ptc_sandbox.py
+++ b/src/ptc_agent/core/sandbox/ptc_sandbox.py
@@ -168,6 +168,9 @@ class PTCSandbox:
         self._init_task: asyncio.Task[None] | None = None
         self._init_error: Exception | None = None
 
+        # Set by stop_sandbox()/cleanup() to short-circuit retries and reconnects
+        self._stopped: bool = False
+
         # Cached skills manifest (populated after sync_sandbox_assets)
         self._skills_manifest: dict[str, Any] | None = None
 
@@ -557,6 +560,8 @@ class PTCSandbox:
         Raises:
             SandboxGoneError: If sandbox cannot be found or is in an unrecoverable state
         """
+        self._stopped = False
+
         logger.info("Reconnecting to stopped sandbox", sandbox_id=sandbox_id)
 
         # Clear stale state — sessions and preview links don't survive stop/start
@@ -701,7 +706,17 @@ class PTCSandbox:
         Used for session persistence - stops the sandbox so it can be
         restarted quickly on the next session, rather than deleting it.
         """
+        # Cancel any in-flight lazy init task before stopping
+        if self._init_task is not None and not self._init_task.done():
+            self._init_task.cancel()
+            try:
+                await self._init_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._init_task = None
+
         if not self.runtime:
+            self._stopped = True
             return
 
         # Check state before stopping to avoid errors when already stopped
@@ -709,6 +724,7 @@ class PTCSandbox:
             state = await self.runtime.get_state()
             if state == RuntimeState.STOPPED:
                 logger.info("Sandbox already stopped", sandbox_id=self.sandbox_id)
+                self._stopped = True
                 return
         except Exception as e:
             # If state check fails, log and continue with stop attempt
@@ -729,6 +745,8 @@ class PTCSandbox:
                 sandbox_id=self.sandbox_id,
                 error=str(e),
             )
+        finally:
+            self._stopped = True
 
     async def _setup_workspace(self) -> None:
         """Create workspace directory structure."""
@@ -1437,6 +1455,11 @@ class PTCSandbox:
         return is_timeout, error_detail, stderr_msg
 
     async def _ensure_sandbox_connected(self) -> None:
+        if self._stopped:
+            raise SandboxGoneError(
+                self.sandbox_id or "unknown",
+                "sandbox was intentionally stopped",
+            )
         if self.sandbox_id is None:
             raise SandboxTransientError(
                 "Sandbox disconnected and no sandbox_id is available"
@@ -1475,6 +1498,11 @@ class PTCSandbox:
         total_timeout: float = 120.0,
         **kwargs: Any,
     ) -> Any:
+        if self._stopped:
+            raise SandboxGoneError(
+                self.sandbox_id or "unknown",
+                "sandbox was intentionally stopped",
+            )
         on_transient = self._ensure_sandbox_connected if allow_reconnect else None
         return await async_retry_with_backoff(
             func,
@@ -3696,6 +3724,15 @@ except OSError as e:
 
     async def cleanup(self) -> None:
         """Clean up and destroy the sandbox."""
+        # Cancel any in-flight lazy init task before cleanup
+        if self._init_task is not None and not self._init_task.done():
+            self._init_task.cancel()
+            try:
+                await self._init_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._init_task = None
+
         logger.info("Cleaning up sandbox", sandbox_id=self.sandbox_id)
 
         try:
@@ -3722,6 +3759,7 @@ except OSError as e:
                 except Exception as e:
                     logger.error(f"Error deleting sandbox: {e}")
         finally:
+            self._stopped = True
             self.runtime = None
             self.sandbox_id = None
             await self.close()

--- a/src/server/handlers/chat/ptc_workflow.py
+++ b/src/server/handlers/chat/ptc_workflow.py
@@ -608,6 +608,26 @@ async def astream_ptc_workflow(
 
         manager = BackgroundTaskManager.get_instance()
 
+        # If the workspace was stopped since the last run, any old workflow
+        # holds stale sandbox references (closed Daytona client).  Cancel it
+        # cooperatively so the inner shielded task actually exits.
+        # Raw task.cancel() cannot penetrate asyncio.shield(), leaving the
+        # inner consumer running untracked against a dead sandbox.
+        if ws_status == "stopped":
+            await manager.cancel_workflow(thread_id)
+            # Also cancel the inner task directly so we don't have to wait
+            # for the next graph event to check cancel_event.
+            async with manager.task_lock:
+                stale = manager.tasks.get(thread_id)
+                if stale:
+                    if stale.inner_task and not stale.inner_task.done():
+                        stale.inner_task.cancel()
+                    stale_task = stale.task
+                else:
+                    stale_task = None
+            if stale_task and not stale_task.done():
+                done, _ = await asyncio.wait({stale_task}, timeout=10.0)
+
         # Wait for any soft-interrupted workflow to complete before starting new one
         ready, steering_event = await wait_or_steer(
             manager, thread_id, user_input, user_id

--- a/src/server/handlers/chat/ptc_workflow.py
+++ b/src/server/handlers/chat/ptc_workflow.py
@@ -626,7 +626,12 @@ async def astream_ptc_workflow(
                 else:
                     stale_task = None
             if stale_task and not stale_task.done():
-                await asyncio.wait({stale_task}, timeout=10.0)
+                done, _ = await asyncio.wait({stale_task}, timeout=10.0)
+                if not done:
+                    logger.warning(
+                        "Stale workflow did not exit within 10s after cancellation",
+                        thread_id=thread_id,
+                    )
 
         # Wait for any soft-interrupted workflow to complete before starting new one
         ready, steering_event = await wait_or_steer(

--- a/src/server/handlers/chat/ptc_workflow.py
+++ b/src/server/handlers/chat/ptc_workflow.py
@@ -626,7 +626,7 @@ async def astream_ptc_workflow(
                 else:
                     stale_task = None
             if stale_task and not stale_task.done():
-                done, _ = await asyncio.wait({stale_task}, timeout=10.0)
+                await asyncio.wait({stale_task}, timeout=10.0)
 
         # Wait for any soft-interrupted workflow to complete before starting new one
         ready, steering_event = await wait_or_steer(

--- a/src/server/handlers/streaming_handler.py
+++ b/src/server/handlers/streaming_handler.py
@@ -363,6 +363,7 @@ class WorkflowStreamHandler:
                     await keepalive_queue.put(keepalive_event)
                     logger.debug(f"[KEEPALIVE] Sent for thread_id={self.thread_id}")
 
+
         except asyncio.CancelledError:
             logger.debug(f"[KEEPALIVE] Task cancelled for thread_id={self.thread_id}")
             raise

--- a/src/server/services/background_task_manager.py
+++ b/src/server/services/background_task_manager.py
@@ -226,6 +226,21 @@ class BackgroundTaskManager:
         async with self.task_lock:
             return self.tasks.get(thread_id)
 
+    def has_active_tasks_for_workspace(self, workspace_id: str) -> bool:
+        """Check if any active tasks exist for a workspace.
+
+        Includes SOFT_INTERRUPTED because the workflow may still be
+        winding down (flushing checkpoints, writing final state).
+        """
+        active = (TaskStatus.RUNNING, TaskStatus.QUEUED, TaskStatus.SOFT_INTERRUPTED)
+        for info in self.tasks.values():
+            if (
+                info.metadata.get("workspace_id") == workspace_id
+                and info.status in active
+            ):
+                return True
+        return False
+
     async def start_cleanup_task(self):
         """Start periodic cleanup background task."""
         if self.cleanup_task is None or self.cleanup_task.done():

--- a/src/server/services/background_task_manager.py
+++ b/src/server/services/background_task_manager.py
@@ -226,19 +226,20 @@ class BackgroundTaskManager:
         async with self.task_lock:
             return self.tasks.get(thread_id)
 
-    def has_active_tasks_for_workspace(self, workspace_id: str) -> bool:
+    async def has_active_tasks_for_workspace(self, workspace_id: str) -> bool:
         """Check if any active tasks exist for a workspace.
 
         Includes SOFT_INTERRUPTED because the workflow may still be
         winding down (flushing checkpoints, writing final state).
         """
-        active = (TaskStatus.RUNNING, TaskStatus.QUEUED, TaskStatus.SOFT_INTERRUPTED)
-        for info in self.tasks.values():
-            if (
-                info.metadata.get("workspace_id") == workspace_id
-                and info.status in active
-            ):
-                return True
+        async with self.task_lock:
+            active = (TaskStatus.RUNNING, TaskStatus.QUEUED, TaskStatus.SOFT_INTERRUPTED)
+            for info in self.tasks.values():
+                if (
+                    info.metadata.get("workspace_id") == workspace_id
+                    and info.status in active
+                ):
+                    return True
         return False
 
     async def start_cleanup_task(self):

--- a/src/server/services/workspace_manager.py
+++ b/src/server/services/workspace_manager.py
@@ -23,6 +23,8 @@ from ptc_agent.config import AgentConfig
 from ptc_agent.core.sandbox.runtime import SandboxGoneError
 from ptc_agent.core.session import Session, SessionManager
 
+from src.server.services.background_task_manager import BackgroundTaskManager
+
 from src.server.database.workspace import (
     create_workspace as db_create_workspace,
     delete_workspace as db_delete_workspace,
@@ -1294,10 +1296,6 @@ class WorkspaceManager:
 
         # Get running workspaces
         running_workspaces = await get_workspaces_by_status("running", limit=1000)
-
-        from src.server.services.background_task_manager import (
-            BackgroundTaskManager,
-        )
 
         task_mgr = BackgroundTaskManager.get_instance()
 

--- a/src/server/services/workspace_manager.py
+++ b/src/server/services/workspace_manager.py
@@ -1295,6 +1295,12 @@ class WorkspaceManager:
         # Get running workspaces
         running_workspaces = await get_workspaces_by_status("running", limit=1000)
 
+        from src.server.services.background_task_manager import (
+            BackgroundTaskManager,
+        )
+
+        task_mgr = BackgroundTaskManager.get_instance()
+
         for workspace in running_workspaces:
             last_activity = workspace.get("last_activity_at")
             if not last_activity:
@@ -1309,6 +1315,15 @@ class WorkspaceManager:
 
             if idle_seconds > self.idle_timeout:
                 workspace_id = str(workspace["workspace_id"])
+
+                # Skip workspaces that still have an active agent workflow
+                if task_mgr.has_active_tasks_for_workspace(workspace_id):
+                    logger.info(
+                        f"Workspace {workspace_id} idle for {idle_seconds:.0f}s "
+                        "but has active workflow, skipping"
+                    )
+                    continue
+
                 logger.info(
                     f"Workspace {workspace_id} idle for {idle_seconds:.0f}s, stopping"
                 )

--- a/src/server/services/workspace_manager.py
+++ b/src/server/services/workspace_manager.py
@@ -1315,7 +1315,7 @@ class WorkspaceManager:
                 workspace_id = str(workspace["workspace_id"])
 
                 # Skip workspaces that still have an active agent workflow
-                if task_mgr.has_active_tasks_for_workspace(workspace_id):
+                if await task_mgr.has_active_tasks_for_workspace(workspace_id):
                     logger.info(
                         f"Workspace {workspace_id} idle for {idle_seconds:.0f}s "
                         "but has active workflow, skipping"

--- a/tests/unit/core/sandbox/test_sandbox_shutdown_race.py
+++ b/tests/unit/core/sandbox/test_sandbox_shutdown_race.py
@@ -1,14 +1,14 @@
 """
 Tests for sandbox shutdown race condition fix.
 
-Verifies that after stop_sandbox() or cleanup():
-- _runtime_call raises SandboxGoneError immediately (no retry)
-- _ensure_sandbox_connected raises SandboxGoneError immediately
-- _init_task is cancelled
-- reconnect() resets the _stopped flag for session reuse
+Verifies that:
+- cleanup_idle_workspaces skips workspaces with active workflows
+- BackgroundTaskManager.has_active_tasks_for_workspace works correctly
+- _init_task is cancelled during stop_sandbox() and cleanup()
 """
 
 import asyncio
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -22,14 +22,17 @@ from ptc_agent.config.core import (
     SandboxConfig,
     SecurityConfig,
 )
-from ptc_agent.core.sandbox.retry import RetryPolicy
 from ptc_agent.core.sandbox.runtime import (
     CodeRunResult,
     ExecResult,
     RuntimeState,
-    SandboxGoneError,
     SandboxProvider,
     SandboxRuntime,
+)
+from src.server.services.background_task_manager import (
+    BackgroundTaskManager,
+    TaskInfo,
+    TaskStatus,
 )
 
 
@@ -75,12 +78,181 @@ def mock_provider(mock_runtime):
     return provider
 
 
-class TestStoppedFlag:
-    """After stop_sandbox(), subsequent operations fail fast with SandboxGoneError."""
+class TestHasActiveTasksForWorkspace:
+    """BackgroundTaskManager.has_active_tasks_for_workspace returns correct results."""
+
+    def test_no_tasks(self):
+        mgr = BackgroundTaskManager()
+        assert mgr.has_active_tasks_for_workspace("ws-1") is False
+
+    def test_running_task_matches(self):
+        mgr = BackgroundTaskManager()
+        mgr.tasks["thread-1"] = TaskInfo(
+            thread_id="thread-1",
+            status=TaskStatus.RUNNING,
+            created_at=datetime.now(),
+            metadata={"workspace_id": "ws-1"},
+        )
+        assert mgr.has_active_tasks_for_workspace("ws-1") is True
+
+    def test_queued_task_matches(self):
+        mgr = BackgroundTaskManager()
+        mgr.tasks["thread-1"] = TaskInfo(
+            thread_id="thread-1",
+            status=TaskStatus.QUEUED,
+            created_at=datetime.now(),
+            metadata={"workspace_id": "ws-1"},
+        )
+        assert mgr.has_active_tasks_for_workspace("ws-1") is True
+
+    def test_completed_task_does_not_match(self):
+        mgr = BackgroundTaskManager()
+        mgr.tasks["thread-1"] = TaskInfo(
+            thread_id="thread-1",
+            status=TaskStatus.COMPLETED,
+            created_at=datetime.now(),
+            metadata={"workspace_id": "ws-1"},
+        )
+        assert mgr.has_active_tasks_for_workspace("ws-1") is False
+
+    def test_soft_interrupted_task_matches(self):
+        mgr = BackgroundTaskManager()
+        mgr.tasks["thread-1"] = TaskInfo(
+            thread_id="thread-1",
+            status=TaskStatus.SOFT_INTERRUPTED,
+            created_at=datetime.now(),
+            metadata={"workspace_id": "ws-1"},
+        )
+        assert mgr.has_active_tasks_for_workspace("ws-1") is True
+
+    def test_different_workspace_does_not_match(self):
+        mgr = BackgroundTaskManager()
+        mgr.tasks["thread-1"] = TaskInfo(
+            thread_id="thread-1",
+            status=TaskStatus.RUNNING,
+            created_at=datetime.now(),
+            metadata={"workspace_id": "ws-other"},
+        )
+        assert mgr.has_active_tasks_for_workspace("ws-1") is False
+
+
+class TestCleanupIdleWorkspacesGuard:
+    """cleanup_idle_workspaces skips workspaces with active workflows."""
+
+    @pytest.mark.asyncio
+    async def test_skips_workspace_with_active_task(self):
+        from ptc_agent.config import AgentConfig
+
+        config = MagicMock(spec=AgentConfig)
+        from src.server.services.workspace_manager import WorkspaceManager
+
+        mgr = WorkspaceManager(config=config, idle_timeout=1800)
+
+        stale_time = datetime.now(timezone.utc) - timedelta(seconds=3600)
+        workspace = {
+            "workspace_id": "ws-active",
+            "last_activity_at": stale_time,
+        }
+
+        # Patch DB query to return one "idle" workspace
+        with (
+            patch(
+                "src.server.services.workspace_manager.get_workspaces_by_status",
+                new_callable=AsyncMock,
+                return_value=[workspace],
+            ),
+            patch.object(mgr, "stop_workspace", new_callable=AsyncMock) as mock_stop,
+            patch(
+                "src.server.services.background_task_manager.BackgroundTaskManager.get_instance"
+            ) as mock_get_instance,
+        ):
+            mock_instance = MagicMock()
+            mock_instance.has_active_tasks_for_workspace.return_value = True
+            mock_get_instance.return_value = mock_instance
+
+            stopped = await mgr.cleanup_idle_workspaces()
+
+        assert stopped == 0
+        mock_stop.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_stops_workspace_without_active_task(self):
+        from ptc_agent.config import AgentConfig
+
+        config = MagicMock(spec=AgentConfig)
+        from src.server.services.workspace_manager import WorkspaceManager
+
+        mgr = WorkspaceManager(config=config, idle_timeout=1800)
+
+        stale_time = datetime.now(timezone.utc) - timedelta(seconds=3600)
+        workspace = {
+            "workspace_id": "ws-idle",
+            "last_activity_at": stale_time,
+        }
+
+        with (
+            patch(
+                "src.server.services.workspace_manager.get_workspaces_by_status",
+                new_callable=AsyncMock,
+                return_value=[workspace],
+            ),
+            patch.object(mgr, "stop_workspace", new_callable=AsyncMock) as mock_stop,
+            patch(
+                "src.server.services.background_task_manager.BackgroundTaskManager.get_instance"
+            ) as mock_get_instance,
+        ):
+            mock_instance = MagicMock()
+            mock_instance.has_active_tasks_for_workspace.return_value = False
+            mock_get_instance.return_value = mock_instance
+
+            stopped = await mgr.cleanup_idle_workspaces()
+
+        assert stopped == 1
+        mock_stop.assert_called_once_with("ws-idle")
+
+
+class TestSessionClosedIsTransient:
+    """DaytonaProvider classifies closed-client errors as transient."""
+
+    def test_session_is_closed(self):
+        from ptc_agent.core.sandbox.providers.daytona import DaytonaProvider
+
+        provider = DaytonaProvider.__new__(DaytonaProvider)
+        exc = Exception("DaytonaError: Session is closed: Daytona client is closed")
+        assert provider.is_transient_error(exc) is True
+
+    def test_client_is_closed(self):
+        from ptc_agent.core.sandbox.providers.daytona import DaytonaProvider
+
+        provider = DaytonaProvider.__new__(DaytonaProvider)
+        exc = Exception("client is closed")
+        assert provider.is_transient_error(exc) is True
+
+    def test_execute_command_with_closed_session_is_transient(self):
+        """The 'failed to execute command' guard must not block closed-client errors."""
+        from ptc_agent.core.sandbox.providers.daytona import DaytonaProvider
+
+        provider = DaytonaProvider.__new__(DaytonaProvider)
+        exc = Exception(
+            "Failed to execute command: Session is closed: "
+            "Daytona client is closed"
+        )
+        assert provider.is_transient_error(exc) is True
+
+    def test_execution_error_still_not_transient(self):
+        from ptc_agent.core.sandbox.providers.daytona import DaytonaProvider
+
+        provider = DaytonaProvider.__new__(DaytonaProvider)
+        exc = Exception("Failed to execute command: exit code 1")
+        assert provider.is_transient_error(exc) is False
+
+
+class TestEnsureSandboxConnectedRecreatesProvider:
+    """_ensure_sandbox_connected always recreates provider for reconnect."""
 
     @patch("ptc_agent.core.sandbox.ptc_sandbox.create_provider")
     @pytest.mark.asyncio
-    async def test_runtime_call_raises_after_stop(
+    async def test_provider_recreated_on_reconnect(
         self, mock_create_provider, mock_provider, mock_runtime
     ):
         from ptc_agent.core.sandbox.ptc_sandbox import PTCSandbox
@@ -88,54 +260,20 @@ class TestStoppedFlag:
         mock_create_provider.return_value = mock_provider
         sandbox = PTCSandbox(config=_make_config())
         sandbox.runtime = mock_runtime
+        sandbox.sandbox_id = "existing-sandbox"
 
-        await sandbox.stop_sandbox()
-        assert sandbox._stopped is True
+        # Fresh provider for the reconnect
+        fresh_provider = AsyncMock(spec=SandboxProvider)
+        fresh_provider.get = AsyncMock(return_value=mock_runtime)
+        fresh_provider.close = AsyncMock()
+        fresh_provider.is_transient_error = MagicMock(return_value=False)
+        mock_create_provider.return_value = fresh_provider
 
-        with pytest.raises(SandboxGoneError, match="intentionally stopped"):
-            await sandbox._runtime_call(
-                mock_runtime.exec,
-                "ls",
-                retry_policy=RetryPolicy.SAFE,
-            )
+        await sandbox._ensure_sandbox_connected()
 
-    @patch("ptc_agent.core.sandbox.ptc_sandbox.create_provider")
-    @pytest.mark.asyncio
-    async def test_ensure_connected_raises_after_stop(
-        self, mock_create_provider, mock_provider, mock_runtime
-    ):
-        from ptc_agent.core.sandbox.ptc_sandbox import PTCSandbox
-
-        mock_create_provider.return_value = mock_provider
-        sandbox = PTCSandbox(config=_make_config())
-        sandbox.runtime = mock_runtime
-        sandbox.sandbox_id = "test-sandbox"
-
-        await sandbox.stop_sandbox()
-
-        with pytest.raises(SandboxGoneError, match="intentionally stopped"):
-            await sandbox._ensure_sandbox_connected()
-
-    @patch("ptc_agent.core.sandbox.ptc_sandbox.create_provider")
-    @pytest.mark.asyncio
-    async def test_runtime_call_raises_after_cleanup(
-        self, mock_create_provider, mock_provider, mock_runtime
-    ):
-        from ptc_agent.core.sandbox.ptc_sandbox import PTCSandbox
-
-        mock_create_provider.return_value = mock_provider
-        sandbox = PTCSandbox(config=_make_config())
-        sandbox.runtime = mock_runtime
-
-        await sandbox.cleanup()
-        assert sandbox._stopped is True
-
-        with pytest.raises(SandboxGoneError, match="intentionally stopped"):
-            await sandbox._runtime_call(
-                mock_runtime.exec,
-                "ls",
-                retry_policy=RetryPolicy.SAFE,
-            )
+        # Provider was recreated (once at __init__, once in _ensure_sandbox_connected)
+        assert sandbox.provider is fresh_provider
+        assert mock_create_provider.call_count == 2
 
 
 class TestInitTaskCancellation:
@@ -152,7 +290,6 @@ class TestInitTaskCancellation:
         sandbox = PTCSandbox(config=_make_config())
         sandbox.runtime = mock_runtime
 
-        # Simulate a long-running lazy init task
         started = asyncio.Event()
 
         async def slow_reconnect(sid):
@@ -191,30 +328,3 @@ class TestInitTaskCancellation:
         await sandbox.cleanup()
 
         assert sandbox._init_task is None
-
-
-class TestReconnectResetsFlag:
-    """reconnect() clears _stopped so session reuse works."""
-
-    @patch("ptc_agent.core.sandbox.ptc_sandbox.create_provider")
-    @pytest.mark.asyncio
-    async def test_reconnect_clears_stopped(
-        self, mock_create_provider, mock_provider, mock_runtime
-    ):
-        from ptc_agent.core.sandbox.ptc_sandbox import PTCSandbox
-
-        mock_create_provider.return_value = mock_provider
-        mock_runtime.get_state = AsyncMock(return_value=RuntimeState.RUNNING)
-        mock_runtime.fetch_working_dir = AsyncMock(return_value="/home/workspace")
-
-        sandbox = PTCSandbox(config=_make_config())
-        sandbox._stopped = True
-
-        # reconnect should clear the _stopped flag early
-        # It will fail at some point during setup, but _stopped should be False
-        try:
-            await sandbox.reconnect("test-sandbox")
-        except Exception:
-            pass
-
-        assert sandbox._stopped is False

--- a/tests/unit/core/sandbox/test_sandbox_shutdown_race.py
+++ b/tests/unit/core/sandbox/test_sandbox_shutdown_race.py
@@ -1,0 +1,220 @@
+"""
+Tests for sandbox shutdown race condition fix.
+
+Verifies that after stop_sandbox() or cleanup():
+- _runtime_call raises SandboxGoneError immediately (no retry)
+- _ensure_sandbox_connected raises SandboxGoneError immediately
+- _init_task is cancelled
+- reconnect() resets the _stopped flag for session reuse
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ptc_agent.config.core import (
+    CoreConfig,
+    DaytonaConfig,
+    FilesystemConfig,
+    LoggingConfig,
+    MCPConfig,
+    SandboxConfig,
+    SecurityConfig,
+)
+from ptc_agent.core.sandbox.retry import RetryPolicy
+from ptc_agent.core.sandbox.runtime import (
+    CodeRunResult,
+    ExecResult,
+    RuntimeState,
+    SandboxGoneError,
+    SandboxProvider,
+    SandboxRuntime,
+)
+
+
+def _make_config(**overrides) -> CoreConfig:
+    defaults = dict(
+        sandbox=SandboxConfig(daytona=DaytonaConfig(api_key="test-key")),
+        security=SecurityConfig(),
+        mcp=MCPConfig(),
+        logging=LoggingConfig(),
+        filesystem=FilesystemConfig(),
+    )
+    defaults.update(overrides)
+    return CoreConfig(**defaults)
+
+
+@pytest.fixture
+def mock_runtime():
+    runtime = AsyncMock(spec=SandboxRuntime)
+    runtime.id = "mock-runtime-1"
+    runtime.working_dir = "/home/workspace"
+    runtime.exec = AsyncMock(return_value=ExecResult("output", "", 0))
+    runtime.upload_file = AsyncMock()
+    runtime.upload_files = AsyncMock()
+    runtime.download_file = AsyncMock(return_value=b"data")
+    runtime.list_files = AsyncMock(
+        return_value=[{"name": "file.txt", "is_dir": False}]
+    )
+    runtime.code_run = AsyncMock(return_value=CodeRunResult("result", "", 0, []))
+    runtime.get_state = AsyncMock(return_value=RuntimeState.RUNNING)
+    runtime.start = AsyncMock()
+    runtime.stop = AsyncMock()
+    runtime.delete = AsyncMock()
+    return runtime
+
+
+@pytest.fixture
+def mock_provider(mock_runtime):
+    provider = AsyncMock(spec=SandboxProvider)
+    provider.create = AsyncMock(return_value=mock_runtime)
+    provider.get = AsyncMock(return_value=mock_runtime)
+    provider.close = AsyncMock()
+    provider.is_transient_error = MagicMock(return_value=False)
+    return provider
+
+
+class TestStoppedFlag:
+    """After stop_sandbox(), subsequent operations fail fast with SandboxGoneError."""
+
+    @patch("ptc_agent.core.sandbox.ptc_sandbox.create_provider")
+    @pytest.mark.asyncio
+    async def test_runtime_call_raises_after_stop(
+        self, mock_create_provider, mock_provider, mock_runtime
+    ):
+        from ptc_agent.core.sandbox.ptc_sandbox import PTCSandbox
+
+        mock_create_provider.return_value = mock_provider
+        sandbox = PTCSandbox(config=_make_config())
+        sandbox.runtime = mock_runtime
+
+        await sandbox.stop_sandbox()
+        assert sandbox._stopped is True
+
+        with pytest.raises(SandboxGoneError, match="intentionally stopped"):
+            await sandbox._runtime_call(
+                mock_runtime.exec,
+                "ls",
+                retry_policy=RetryPolicy.SAFE,
+            )
+
+    @patch("ptc_agent.core.sandbox.ptc_sandbox.create_provider")
+    @pytest.mark.asyncio
+    async def test_ensure_connected_raises_after_stop(
+        self, mock_create_provider, mock_provider, mock_runtime
+    ):
+        from ptc_agent.core.sandbox.ptc_sandbox import PTCSandbox
+
+        mock_create_provider.return_value = mock_provider
+        sandbox = PTCSandbox(config=_make_config())
+        sandbox.runtime = mock_runtime
+        sandbox.sandbox_id = "test-sandbox"
+
+        await sandbox.stop_sandbox()
+
+        with pytest.raises(SandboxGoneError, match="intentionally stopped"):
+            await sandbox._ensure_sandbox_connected()
+
+    @patch("ptc_agent.core.sandbox.ptc_sandbox.create_provider")
+    @pytest.mark.asyncio
+    async def test_runtime_call_raises_after_cleanup(
+        self, mock_create_provider, mock_provider, mock_runtime
+    ):
+        from ptc_agent.core.sandbox.ptc_sandbox import PTCSandbox
+
+        mock_create_provider.return_value = mock_provider
+        sandbox = PTCSandbox(config=_make_config())
+        sandbox.runtime = mock_runtime
+
+        await sandbox.cleanup()
+        assert sandbox._stopped is True
+
+        with pytest.raises(SandboxGoneError, match="intentionally stopped"):
+            await sandbox._runtime_call(
+                mock_runtime.exec,
+                "ls",
+                retry_policy=RetryPolicy.SAFE,
+            )
+
+
+class TestInitTaskCancellation:
+    """_init_task is cancelled during stop_sandbox() and cleanup()."""
+
+    @patch("ptc_agent.core.sandbox.ptc_sandbox.create_provider")
+    @pytest.mark.asyncio
+    async def test_init_task_cancelled_on_stop(
+        self, mock_create_provider, mock_provider, mock_runtime
+    ):
+        from ptc_agent.core.sandbox.ptc_sandbox import PTCSandbox
+
+        mock_create_provider.return_value = mock_provider
+        sandbox = PTCSandbox(config=_make_config())
+        sandbox.runtime = mock_runtime
+
+        # Simulate a long-running lazy init task
+        started = asyncio.Event()
+
+        async def slow_reconnect(sid):
+            started.set()
+            await asyncio.sleep(60)
+
+        sandbox._ready_event = asyncio.Event()
+        sandbox._init_task = asyncio.create_task(slow_reconnect("test"))
+        await started.wait()
+
+        await sandbox.stop_sandbox()
+
+        assert sandbox._init_task is None
+
+    @patch("ptc_agent.core.sandbox.ptc_sandbox.create_provider")
+    @pytest.mark.asyncio
+    async def test_init_task_cancelled_on_cleanup(
+        self, mock_create_provider, mock_provider, mock_runtime
+    ):
+        from ptc_agent.core.sandbox.ptc_sandbox import PTCSandbox
+
+        mock_create_provider.return_value = mock_provider
+        sandbox = PTCSandbox(config=_make_config())
+        sandbox.runtime = mock_runtime
+
+        started = asyncio.Event()
+
+        async def slow_reconnect(sid):
+            started.set()
+            await asyncio.sleep(60)
+
+        sandbox._ready_event = asyncio.Event()
+        sandbox._init_task = asyncio.create_task(slow_reconnect("test"))
+        await started.wait()
+
+        await sandbox.cleanup()
+
+        assert sandbox._init_task is None
+
+
+class TestReconnectResetsFlag:
+    """reconnect() clears _stopped so session reuse works."""
+
+    @patch("ptc_agent.core.sandbox.ptc_sandbox.create_provider")
+    @pytest.mark.asyncio
+    async def test_reconnect_clears_stopped(
+        self, mock_create_provider, mock_provider, mock_runtime
+    ):
+        from ptc_agent.core.sandbox.ptc_sandbox import PTCSandbox
+
+        mock_create_provider.return_value = mock_provider
+        mock_runtime.get_state = AsyncMock(return_value=RuntimeState.RUNNING)
+        mock_runtime.fetch_working_dir = AsyncMock(return_value="/home/workspace")
+
+        sandbox = PTCSandbox(config=_make_config())
+        sandbox._stopped = True
+
+        # reconnect should clear the _stopped flag early
+        # It will fail at some point during setup, but _stopped should be False
+        try:
+            await sandbox.reconnect("test-sandbox")
+        except Exception:
+            pass
+
+        assert sandbox._stopped is False

--- a/tests/unit/core/sandbox/test_sandbox_shutdown_race.py
+++ b/tests/unit/core/sandbox/test_sandbox_shutdown_race.py
@@ -81,11 +81,13 @@ def mock_provider(mock_runtime):
 class TestHasActiveTasksForWorkspace:
     """BackgroundTaskManager.has_active_tasks_for_workspace returns correct results."""
 
-    def test_no_tasks(self):
+    @pytest.mark.asyncio
+    async def test_no_tasks(self):
         mgr = BackgroundTaskManager()
-        assert mgr.has_active_tasks_for_workspace("ws-1") is False
+        assert await mgr.has_active_tasks_for_workspace("ws-1") is False
 
-    def test_running_task_matches(self):
+    @pytest.mark.asyncio
+    async def test_running_task_matches(self):
         mgr = BackgroundTaskManager()
         mgr.tasks["thread-1"] = TaskInfo(
             thread_id="thread-1",
@@ -93,9 +95,10 @@ class TestHasActiveTasksForWorkspace:
             created_at=datetime.now(),
             metadata={"workspace_id": "ws-1"},
         )
-        assert mgr.has_active_tasks_for_workspace("ws-1") is True
+        assert await mgr.has_active_tasks_for_workspace("ws-1") is True
 
-    def test_queued_task_matches(self):
+    @pytest.mark.asyncio
+    async def test_queued_task_matches(self):
         mgr = BackgroundTaskManager()
         mgr.tasks["thread-1"] = TaskInfo(
             thread_id="thread-1",
@@ -103,9 +106,10 @@ class TestHasActiveTasksForWorkspace:
             created_at=datetime.now(),
             metadata={"workspace_id": "ws-1"},
         )
-        assert mgr.has_active_tasks_for_workspace("ws-1") is True
+        assert await mgr.has_active_tasks_for_workspace("ws-1") is True
 
-    def test_completed_task_does_not_match(self):
+    @pytest.mark.asyncio
+    async def test_completed_task_does_not_match(self):
         mgr = BackgroundTaskManager()
         mgr.tasks["thread-1"] = TaskInfo(
             thread_id="thread-1",
@@ -113,9 +117,10 @@ class TestHasActiveTasksForWorkspace:
             created_at=datetime.now(),
             metadata={"workspace_id": "ws-1"},
         )
-        assert mgr.has_active_tasks_for_workspace("ws-1") is False
+        assert await mgr.has_active_tasks_for_workspace("ws-1") is False
 
-    def test_soft_interrupted_task_matches(self):
+    @pytest.mark.asyncio
+    async def test_soft_interrupted_task_matches(self):
         mgr = BackgroundTaskManager()
         mgr.tasks["thread-1"] = TaskInfo(
             thread_id="thread-1",
@@ -123,9 +128,10 @@ class TestHasActiveTasksForWorkspace:
             created_at=datetime.now(),
             metadata={"workspace_id": "ws-1"},
         )
-        assert mgr.has_active_tasks_for_workspace("ws-1") is True
+        assert await mgr.has_active_tasks_for_workspace("ws-1") is True
 
-    def test_different_workspace_does_not_match(self):
+    @pytest.mark.asyncio
+    async def test_different_workspace_does_not_match(self):
         mgr = BackgroundTaskManager()
         mgr.tasks["thread-1"] = TaskInfo(
             thread_id="thread-1",
@@ -133,7 +139,7 @@ class TestHasActiveTasksForWorkspace:
             created_at=datetime.now(),
             metadata={"workspace_id": "ws-other"},
         )
-        assert mgr.has_active_tasks_for_workspace("ws-1") is False
+        assert await mgr.has_active_tasks_for_workspace("ws-1") is False
 
 
 class TestCleanupIdleWorkspacesGuard:
@@ -167,7 +173,7 @@ class TestCleanupIdleWorkspacesGuard:
             ) as mock_get_instance,
         ):
             mock_instance = MagicMock()
-            mock_instance.has_active_tasks_for_workspace.return_value = True
+            mock_instance.has_active_tasks_for_workspace = AsyncMock(return_value=True)
             mock_get_instance.return_value = mock_instance
 
             stopped = await mgr.cleanup_idle_workspaces()
@@ -202,7 +208,7 @@ class TestCleanupIdleWorkspacesGuard:
             ) as mock_get_instance,
         ):
             mock_instance = MagicMock()
-            mock_instance.has_active_tasks_for_workspace.return_value = False
+            mock_instance.has_active_tasks_for_workspace = AsyncMock(return_value=False)
             mock_get_instance.return_value = mock_instance
 
             stopped = await mgr.cleanup_idle_workspaces()


### PR DESCRIPTION
## Summary

Fixes a race condition where `cleanup_idle_workspaces` stops a workspace while an agent workflow is still actively using it, crashing the workflow with "Session is closed" errors that couldn't recover.

**Three-layer defense:**

1. **Cleanup guard** — `has_active_tasks_for_workspace()` checks for RUNNING, QUEUED, or SOFT_INTERRUPTED tasks before stopping a workspace (`workspace_manager.py`, `background_task_manager.py`)

2. **Error classification fix** — "session is closed" / "client is closed" markers are now checked *before* the "failed to execute command" guard in `DaytonaProvider.is_transient_error()`, so dead-client errors trigger reconnection instead of being misclassified as execution failures (`daytona.py`)

3. **Auto-restart on transient failure** — `_ensure_sandbox_connected` unconditionally recreates the provider (fresh aiohttp session) before reconnecting, avoiding 5 wasted retries through a permanently closed HTTP client (`ptc_sandbox.py`)

**Additional fixes from cross-model review (Claude + Codex gpt-5.4):**

- **Cooperative cancellation for stale workflows** — Uses `cancel_event` + `inner_task.cancel()` instead of raw `task.cancel()` which cannot penetrate `asyncio.shield()` (`ptc_workflow.py`)
- **CancelledError handling in lazy init** — `_lazy_reconnect` now catches `CancelledError` (BaseException, not Exception) so concurrent `_wait_ready()` callers see an error instead of a fake "ready" state (`ptc_sandbox.py`)
- **Init task cancellation** — `stop_sandbox()` and `cleanup()` cancel any in-flight lazy init task to prevent orphaned background work (`ptc_sandbox.py`)

## Pre-Landing Review

3 reviews ran (2 prior + 1 final). All findings resolved:
- 2 CRITICAL fixed (shielded workflow orphan, fake ready state on init cancel)
- 4 INFORMATIONAL auto-fixed (SOFT_INTERRUPTED gap, blocking DB write, silent swallows, duplication)

Adversarial review: Claude + Codex (gpt-5.4). Codex exclusively caught the asyncio.shield bypass.

## Test plan
- [x] 15 unit tests pass (5 task manager, 2 cleanup guard, 4 error classification, 1 provider recreation, 2 init cancellation, 1 SOFT_INTERRUPTED)
- [x] No new lint errors