### PR TITLE
fix: restore hover interactions broken by modal DropdownMenu

### DIFF
--- a/web/src/pages/ChatAgent/components/FileHeaderActions.tsx
+++ b/web/src/pages/ChatAgent/components/FileHeaderActions.tsx
@@ -199,7 +199,7 @@ function FileHeaderActions({
 
   return (
     <>
-      <DropdownMenu>
+      <DropdownMenu modal={false}>
         <DropdownMenuTrigger asChild>
           <button
             className="file-panel-icon-btn"

--- a/web/src/pages/ChatAgent/components/WorkspaceGallery.tsx
+++ b/web/src/pages/ChatAgent/components/WorkspaceGallery.tsx
@@ -71,7 +71,7 @@ function CardMenu({ workspace, onTogglePin, onDelete }: CardMenuProps) {
   const { t } = useTranslation();
 
   return (
-    <DropdownMenu>
+    <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
         <button
           onPointerDown={(e) => e.stopPropagation()}

--- a/web/src/pages/Dashboard/components/AvatarDropdown.tsx
+++ b/web/src/pages/Dashboard/components/AvatarDropdown.tsx
@@ -27,7 +27,7 @@ const AvatarDropdown: React.FC = () => {
 
   return (
     <>
-      <DropdownMenu>
+      <DropdownMenu modal={false}>
         <DropdownMenuTrigger asChild>
           <button
             className="flex items-center gap-2 text-sm font-medium transition-colors hover:text-[var(--color-text-primary)]"

--- a/web/src/pages/Dashboard/components/PortfolioWatchlistCard.tsx
+++ b/web/src/pages/Dashboard/components/PortfolioWatchlistCard.tsx
@@ -110,7 +110,7 @@ function WatchlistItem({ item, index, onDelete, marketStatus, isMobile }: Watchl
 
         {/* Mobile: visible menu button */}
         {isMobile && hasId && (
-          <DropdownMenu>
+          <DropdownMenu modal={false}>
             <DropdownMenuTrigger asChild>
               <button
                 className="p-1 -mr-1 rounded-md transition-colors"
@@ -229,7 +229,7 @@ function PortfolioItem({ item, index, onEdit, onDelete, valuesHidden, marketStat
 
         {/* Mobile: visible menu button */}
         {isMobile && hasId && (
-          <DropdownMenu>
+          <DropdownMenu modal={false}>
             <DropdownMenuTrigger asChild>
               <button
                 className="p-1 -mr-1 rounded-md transition-colors"


### PR DESCRIPTION
## Summary

Fixes broken hover interactions across the ChatAgent and Dashboard pages. Both CSS `:hover` (minimap expansion) and Tailwind `group-hover` (message action buttons) stopped working after commit `3994c21` migrated several components from Popover to DropdownMenu without preserving `modal={false}`.

**Root cause:** Radix `DropdownMenu` defaults `modal={true}`, which activates `DismissableLayer` and sets `document.body.style.pointerEvents = "none"` while the menu is open, disabling ALL pointer interactions page-wide.

**Fix:** Add `modal={false}` at each DropdownMenu call site (5 instances across 4 files). Call-site approach chosen over wrapper default after Codex review flagged mobile click-through concerns with the global approach.

**Files changed:**
- `FileHeaderActions.tsx` — file download menu
- `WorkspaceGallery.tsx` — workspace card menu
- `AvatarDropdown.tsx` — user avatar menu
- `PortfolioWatchlistCard.tsx` — watchlist + portfolio mobile menus (×2)

## Pre-Landing Review

No issues found. 10 lines of prop additions, no application logic changes.

## Adversarial Review

Both Claude and Codex adversarial passes ran. No bugs found. Both flagged the inherent non-modal behavior (outside-click propagation on mobile) as a behavioral tradeoff, not a regression — this restores the pre-3994c21 Popover-era behavior.

## Plan Completion

Plan used wrapper approach; implementation uses call-site fixes per Codex review recommendation. All affected instances patched.

## Test plan

- [x] ESLint: 0 errors (51 pre-existing warnings)
- [x] Vitest: 419/419 tests pass
- [ ] Manual: hover over chat messages — action buttons should appear
- [ ] Manual: hover over minimap — should expand with labels
- [ ] Manual: open file download dropdown, close it, then hover messages — should still work