### PR TITLE
fix: user-friendly error message for HTTP 413 (file too large)

### DIFF
--- a/web/src/pages/ChatAgent/utils/api.ts
+++ b/web/src/pages/ChatAgent/utils/api.ts
@@ -134,6 +134,12 @@ async function streamFetch(
       err.retryAfter = parseInt(res.headers.get('Retry-After') as string, 10) || null;
       throw err;
     }
+    // Handle 413 (payload too large) with user-friendly message
+    if (res.status === 413) {
+      const err: Error & { status?: number } = new Error('Files too large. Try smaller files or fewer attachments.');
+      err.status = 413;
+      throw err;
+    }
     // Handle 404 specifically for history replay (expected for new threads)
     if (res.status === 404 && url.includes('/replay')) {
       throw new Error(`HTTP error! status: ${res.status}`);

--- a/web/src/pages/MarketView/utils/api.ts
+++ b/web/src/pages/MarketView/utils/api.ts
@@ -386,6 +386,12 @@ async function streamFetch(
       err.rateLimitInfo = (detail?.detail as Record<string, unknown>) || {};
       throw err;
     }
+    // Handle 413 (payload too large) with user-friendly message
+    if (res.status === 413) {
+      const err: StreamError = new Error('Files too large. Try smaller files or fewer attachments.');
+      err.status = 413;
+      throw err;
+    }
     let detail = '';
     let errorInfo: Record<string, unknown> | null = null;
     const text = await res.text().catch(() => '');


### PR DESCRIPTION
## Summary

When users upload file attachments (e.g., a 2.67MB PDF) that exceed the server's body size limit, they previously saw the unhelpful "HTTP error! status: 413". Now they see "Files too large. Try smaller files or fewer attachments."

Adds a 413 handler in `streamFetch()` in both ChatAgent and MarketView API modules, matching the existing 429 (rate limit) handler pattern.

## Pre-Landing Review

No issues found. Review passed clean (0 findings, quality score 10/10).

## Test plan

- [x] ESLint passes (0 errors)
- [ ] Verify error message appears when uploading files exceeding server limit