### PR TITLE
feat: add Lissajous Drift loading animation for chat streaming

### DIFF
--- a/web/src/components/ui/lissajous-loading.tsx
+++ b/web/src/components/ui/lissajous-loading.tsx
@@ -3,12 +3,6 @@ import { cn } from "@/lib/utils";
 
 const SVG_NS = "http://www.w3.org/2000/svg";
 
-const containerSizes: Record<string, string> = {
-  sm: "w-4 h-4",
-  md: "w-6 h-6",
-  lg: "w-8 h-8",
-};
-
 const PARTICLE_COUNT = 68;
 const TRAIL_SPAN = 0.34;
 const DURATION_MS = 6000;
@@ -39,12 +33,10 @@ function point(progress: number, detailScale: number) {
 }
 
 interface LissajousLoadingProps {
-  size?: "sm" | "md" | "lg";
   className?: string;
 }
 
 export default function LissajousLoading({
-  size = "md",
   className,
 }: LissajousLoadingProps) {
   const groupRef = useRef<SVGGElement>(null);
@@ -96,7 +88,7 @@ export default function LissajousLoading({
   }, []);
 
   return (
-    <div className={cn("relative", containerSizes[size], className)}>
+    <div className={cn("relative", className)}>
       <svg
         viewBox="0 0 100 100"
         fill="none"

--- a/web/src/components/ui/lissajous-loading.tsx
+++ b/web/src/components/ui/lissajous-loading.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+const containerSizes: Record<string, string> = {
+  sm: "w-4 h-4",
+  md: "w-6 h-6",
+  lg: "w-8 h-8",
+};
+
+const PARTICLE_COUNT = 68;
+const TRAIL_SPAN = 0.34;
+const DURATION_MS = 6000;
+const PULSE_DURATION_MS = 5400;
+const AMP = 24;
+const AMP_BOOST = 6;
+const AX = 3;
+const BY = 4;
+const PHASE = 1.57;
+const Y_SCALE = 0.92;
+
+function normalizeProgress(p: number) {
+  return ((p % 1) + 1) % 1;
+}
+
+function getDetailScale(time: number) {
+  const pulseProgress = (time % PULSE_DURATION_MS) / PULSE_DURATION_MS;
+  return 0.52 + ((Math.sin(pulseProgress * Math.PI * 2 + 0.55) + 1) / 2) * 0.48;
+}
+
+function point(progress: number, detailScale: number) {
+  const t = progress * Math.PI * 2;
+  const amp = AMP + detailScale * AMP_BOOST;
+  return {
+    x: 50 + Math.sin(AX * t + PHASE) * amp,
+    y: 50 + Math.sin(BY * t) * amp * Y_SCALE,
+  };
+}
+
+function buildPath(detailScale: number, steps = 480) {
+  const parts: string[] = [];
+  for (let i = 0; i <= steps; i++) {
+    const p = point(i / steps, detailScale);
+    parts.push(`${i === 0 ? "M" : "L"} ${p.x.toFixed(2)} ${p.y.toFixed(2)}`);
+  }
+  return parts.join(" ");
+}
+
+interface LissajousLoadingProps {
+  size?: "sm" | "md" | "lg";
+  className?: string;
+}
+
+export default function LissajousLoading({
+  size = "md",
+  className,
+}: LissajousLoadingProps) {
+  const groupRef = useRef<SVGGElement>(null);
+  const pathRef = useRef<SVGPathElement>(null);
+  const rafRef = useRef<number>(0);
+  const startRef = useRef<number>(0);
+
+  useEffect(() => {
+    const group = groupRef.current;
+    const pathEl = pathRef.current;
+    if (!group || !pathEl) return;
+
+    const particles: SVGCircleElement[] = [];
+    for (let i = 0; i < PARTICLE_COUNT; i++) {
+      const circle = document.createElementNS(SVG_NS, "circle");
+      circle.setAttribute("fill", "currentColor");
+      group.appendChild(circle);
+      particles.push(circle);
+    }
+
+    startRef.current = performance.now();
+
+    function render(now: number) {
+      const time = now - startRef.current;
+      const progress = (time % DURATION_MS) / DURATION_MS;
+      const detailScale = getDetailScale(time);
+
+      pathEl!.setAttribute("d", buildPath(detailScale));
+
+      for (let i = 0; i < PARTICLE_COUNT; i++) {
+        const tailOffset = i / (PARTICLE_COUNT - 1);
+        const p = point(
+          normalizeProgress(progress - tailOffset * TRAIL_SPAN),
+          detailScale,
+        );
+        const fade = Math.pow(1 - tailOffset, 0.56);
+
+        particles[i].setAttribute("cx", p.x.toFixed(2));
+        particles[i].setAttribute("cy", p.y.toFixed(2));
+        particles[i].setAttribute("r", (0.9 + fade * 2.7).toFixed(2));
+        particles[i].setAttribute("opacity", (0.04 + fade * 0.96).toFixed(3));
+      }
+
+      rafRef.current = requestAnimationFrame(render);
+    }
+
+    rafRef.current = requestAnimationFrame(render);
+
+    return () => {
+      cancelAnimationFrame(rafRef.current);
+      particles.forEach((c) => c.remove());
+    };
+  }, []);
+
+  return (
+    <div className={cn("relative", containerSizes[size], className)}>
+      <svg
+        viewBox="0 0 100 100"
+        fill="none"
+        className="w-full h-full overflow-visible"
+        aria-hidden="true"
+      >
+        <g ref={groupRef}>
+          <path ref={pathRef} style={{ display: "none" }} />
+        </g>
+      </svg>
+    </div>
+  );
+}

--- a/web/src/components/ui/lissajous-loading.tsx
+++ b/web/src/components/ui/lissajous-loading.tsx
@@ -38,15 +38,6 @@ function point(progress: number, detailScale: number) {
   };
 }
 
-function buildPath(detailScale: number, steps = 480) {
-  const parts: string[] = [];
-  for (let i = 0; i <= steps; i++) {
-    const p = point(i / steps, detailScale);
-    parts.push(`${i === 0 ? "M" : "L"} ${p.x.toFixed(2)} ${p.y.toFixed(2)}`);
-  }
-  return parts.join(" ");
-}
-
 interface LissajousLoadingProps {
   size?: "sm" | "md" | "lg";
   className?: string;
@@ -57,14 +48,12 @@ export default function LissajousLoading({
   className,
 }: LissajousLoadingProps) {
   const groupRef = useRef<SVGGElement>(null);
-  const pathRef = useRef<SVGPathElement>(null);
   const rafRef = useRef<number>(0);
   const startRef = useRef<number>(0);
 
   useEffect(() => {
     const group = groupRef.current;
-    const pathEl = pathRef.current;
-    if (!group || !pathEl) return;
+    if (!group) return;
 
     const particles: SVGCircleElement[] = [];
     for (let i = 0; i < PARTICLE_COUNT; i++) {
@@ -80,8 +69,6 @@ export default function LissajousLoading({
       const time = now - startRef.current;
       const progress = (time % DURATION_MS) / DURATION_MS;
       const detailScale = getDetailScale(time);
-
-      pathEl!.setAttribute("d", buildPath(detailScale));
 
       for (let i = 0; i < PARTICLE_COUNT; i++) {
         const tailOffset = i / (PARTICLE_COUNT - 1);
@@ -116,9 +103,7 @@ export default function LissajousLoading({
         className="w-full h-full overflow-visible"
         aria-hidden="true"
       >
-        <g ref={groupRef}>
-          <path ref={pathRef} style={{ display: "none" }} />
-        </g>
+        <g ref={groupRef} />
       </svg>
     </div>
   );

--- a/web/src/components/ui/lissajous-loading.tsx
+++ b/web/src/components/ui/lissajous-loading.tsx
@@ -3,7 +3,7 @@ import { cn } from "@/lib/utils";
 
 const SVG_NS = "http://www.w3.org/2000/svg";
 
-const PARTICLE_COUNT = 36;
+const PARTICLE_COUNT = 68;
 const TRAIL_SPAN = 0.34;
 const DURATION_MS = 6000;
 const PULSE_DURATION_MS = 5400;

--- a/web/src/components/ui/lissajous-loading.tsx
+++ b/web/src/components/ui/lissajous-loading.tsx
@@ -3,7 +3,7 @@ import { cn } from "@/lib/utils";
 
 const SVG_NS = "http://www.w3.org/2000/svg";
 
-const PARTICLE_COUNT = 68;
+const PARTICLE_COUNT = 36;
 const TRAIL_SPAN = 0.34;
 const DURATION_MS = 6000;
 const PULSE_DURATION_MS = 5400;
@@ -51,6 +51,13 @@ export default function LissajousLoading({
     for (let i = 0; i < PARTICLE_COUNT; i++) {
       const circle = document.createElementNS(SVG_NS, "circle");
       circle.setAttribute("fill", "currentColor");
+
+      // Radius and opacity depend only on trail position (index), not time.
+      // Set once to avoid per-frame setAttribute overhead.
+      const fade = Math.pow(1 - i / (PARTICLE_COUNT - 1), 0.56);
+      circle.setAttribute("r", (0.9 + fade * 2.7).toFixed(2));
+      circle.setAttribute("opacity", (0.04 + fade * 0.96).toFixed(3));
+
       group.appendChild(circle);
       particles.push(circle);
     }
@@ -63,17 +70,12 @@ export default function LissajousLoading({
       const detailScale = getDetailScale(time);
 
       for (let i = 0; i < PARTICLE_COUNT; i++) {
-        const tailOffset = i / (PARTICLE_COUNT - 1);
         const p = point(
-          normalizeProgress(progress - tailOffset * TRAIL_SPAN),
+          normalizeProgress(progress - (i / (PARTICLE_COUNT - 1)) * TRAIL_SPAN),
           detailScale,
         );
-        const fade = Math.pow(1 - tailOffset, 0.56);
-
         particles[i].setAttribute("cx", p.x.toFixed(2));
         particles[i].setAttribute("cy", p.y.toFixed(2));
-        particles[i].setAttribute("r", (0.9 + fade * 2.7).toFixed(2));
-        particles[i].setAttribute("opacity", (0.04 + fade * 0.96).toFixed(3));
       }
 
       rafRef.current = requestAnimationFrame(render);

--- a/web/src/components/ui/morph-loading.tsx
+++ b/web/src/components/ui/morph-loading.tsx
@@ -1,3 +1,6 @@
+// Currently unused — replaced by LissajousLoading in the chat streaming indicator.
+// Kept as an alternative loading animation. Uses CSS keyframes (morph-0 to morph-3)
+// defined in index.css.
 import { cn } from "@/lib/utils";
 
 const containerSizes: Record<string, string> = {

--- a/web/src/pages/ChatAgent/components/MessageList.tsx
+++ b/web/src/pages/ChatAgent/components/MessageList.tsx
@@ -6,7 +6,7 @@ import ThumbDownModal from './ThumbDownModal';
 import logoLight from '../../../assets/img/logo.svg';
 import logoDark from '../../../assets/img/logo-dark.svg';
 import { useTheme } from '../../../contexts/ThemeContext';
-import MorphLoading from '@/components/ui/morph-loading';
+import LissajousLoading from '@/components/ui/lissajous-loading';
 import ActivityBlock from './ActivityBlock';
 import {
   INLINE_ARTIFACT_TOOLS,
@@ -720,7 +720,7 @@ const MessageBubble = memo(function MessageBubble({ message, isLoading, hideAvat
           {(message.isStreaming as boolean) && !Object.keys((message.pendingToolCallChunks as Record<string, unknown>) || {}).length && (() => {
             const contentSegments = message.contentSegments as ContentSegmentRecord[] | undefined;
             const hasContent = contentSegments?.some(s => s.content?.trim()) || (message.content as string)?.trim();
-            return <MorphLoading size="sm" className={`${hasContent ? "mt-2" : "mt-4"} text-[var(--color-accent-primary)]`} />;
+            return <LissajousLoading className={`${hasContent ? "mt-2" : "mt-3"} ${isMobile ? 'w-5 h-5' : 'w-6 h-6'} text-neutral-500 dark:text-neutral-400`} />;
           })()}
         </div>
 


### PR DESCRIPTION
## Summary

Replace the MorphLoading (4-square morph) streaming indicator with a Lissajous Drift particle animation. The new component renders 68 SVG particles tracing a 3:4 Lissajous curve with pulsing amplitude, creating a fluid organic motion while the AI is generating text.

- **New component**: `web/src/components/ui/lissajous-loading.tsx` — self-contained SVG animation using requestAnimationFrame, proper cleanup on unmount, no dependencies
- **Swapped in**: `MessageList.tsx` streaming indicator now uses `LissajousLoading` instead of `MorphLoading`
- **Responsive**: `w-5 h-5` on mobile, `w-6 h-6` on desktop, with neutral grey color (`text-neutral-500` / `dark:text-neutral-400`)

Applies to both ChatAgent and MarketView (MarketPanel reuses MessageList).

## Test plan
- [x] All 419 Vitest tests pass (37 files)
- [x] ESLint clean (no new warnings)
- [x] Verified animation renders at correct size and alignment next to agent avatar
- [x] Verified responsive sizing on mobile viewport