### PR TITLE
feat: redesign TodoDrawer with stepper-track UI

### DIFF
--- a/web/src/components/ui/__tests__/stepper-track.test.tsx
+++ b/web/src/components/ui/__tests__/stepper-track.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import StepperList, { StepperTrack, type AgentPlanItem } from '../stepper-track';
+
+// Mock ThemeContext
+vi.mock('@/contexts/ThemeContext', () => ({
+  useTheme: () => ({ theme: 'dark' as const, preference: 'dark' as const, setTheme: () => {}, toggleTheme: () => {} }),
+}));
+
+const makeItems = (statuses: AgentPlanItem['status'][]): AgentPlanItem[] =>
+  statuses.map((s, i) => ({ id: `item-${i}`, label: `Task ${i + 1}`, status: s }));
+
+describe('StepperTrack', () => {
+  it('returns null for empty items', () => {
+    const { container } = render(<StepperTrack items={[]} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders nodes for each item', () => {
+    const items = makeItems(['completed', 'in_progress', 'pending']);
+    const { container } = render(<StepperTrack items={items} />);
+    const nodes = container.querySelectorAll('[style*="border-radius: 50%"]');
+    expect(nodes).toHaveLength(3);
+  });
+
+  it('renders connectors between nodes', () => {
+    const items = makeItems(['completed', 'in_progress', 'pending']);
+    const { container } = render(<StepperTrack items={items} />);
+    const connectors = container.querySelectorAll('.relative.overflow-hidden');
+    expect(connectors).toHaveLength(2);
+  });
+
+  it('caps nodes at MAX_VISIBLE_NODES with overflow indicator', () => {
+    const items = makeItems(Array(15).fill('pending'));
+    const { container } = render(<StepperTrack items={items} />);
+    const nodes = container.querySelectorAll('[style*="border-radius: 50%"]');
+    expect(nodes.length).toBeLessThanOrEqual(12);
+    expect(container.textContent).toContain('+3');
+  });
+
+  it('applies glow to in_progress nodes', () => {
+    const items = makeItems(['in_progress']);
+    const { container } = render(<StepperTrack items={items} />);
+    const node = container.querySelector('[style*="border-radius: 50%"]');
+    expect(node?.getAttribute('style')).toContain('box-shadow');
+  });
+});
+
+describe('StepperList', () => {
+  it('returns null for empty items', () => {
+    const { container } = render(<StepperList items={[]} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders correct status labels', () => {
+    const items = makeItems(['completed', 'in_progress', 'stale', 'pending']);
+    render(<StepperList items={items} />);
+    expect(screen.getByText('Done')).toBeTruthy();
+    expect(screen.getByText('Active')).toBeTruthy();
+    expect(screen.getByText('Stale')).toBeTruthy();
+    expect(screen.getByText('Queue')).toBeTruthy();
+  });
+
+  it('renders item labels', () => {
+    const items: AgentPlanItem[] = [
+      { id: '0', label: 'Search for data', status: 'completed' },
+      { id: '1', label: 'Analyze results', status: 'in_progress' },
+    ];
+    render(<StepperList items={items} />);
+    expect(screen.getByText('Search for data')).toBeTruthy();
+    expect(screen.getByText('Analyze results')).toBeTruthy();
+  });
+
+  it('applies line-through to completed and stale items', () => {
+    const items: AgentPlanItem[] = [
+      { id: '0', label: 'Finished', status: 'completed' },
+      { id: '1', label: 'Abandoned', status: 'stale' },
+      { id: '2', label: 'Working', status: 'in_progress' },
+    ];
+    render(<StepperList items={items} />);
+    expect(screen.getByText('Finished')).toHaveStyle({ textDecoration: 'line-through' });
+    expect(screen.getByText('Abandoned')).toHaveStyle({ textDecoration: 'line-through' });
+    expect(screen.getByText('Working')).toHaveStyle({ textDecoration: 'none' });
+  });
+});

--- a/web/src/components/ui/__tests__/stepper-track.test.tsx
+++ b/web/src/components/ui/__tests__/stepper-track.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import StepperList, { StepperTrack, type AgentPlanItem } from '../stepper-track';
 

--- a/web/src/components/ui/stepper-track.tsx
+++ b/web/src/components/ui/stepper-track.tsx
@@ -1,0 +1,256 @@
+import { motion } from "framer-motion";
+import { useTheme } from "@/contexts/ThemeContext";
+
+export interface AgentPlanItem {
+  id: string;
+  label: string;
+  status: "pending" | "in_progress" | "completed" | "stale";
+}
+
+// --- Theme-aware color palette (Warm Tinted / F2) ---
+
+interface StatusColors {
+  node: string;
+  conn: string;
+  status: string;
+  glow?: string;
+  size?: number;
+  border?: string;
+}
+
+interface ThemePalette {
+  completed: StatusColors;
+  in_progress: StatusColors;
+  stale: StatusColors;
+  pending: StatusColors;
+  indicator: string;
+}
+
+const darkPalette: ThemePalette = {
+  completed: { node: "#7BAE8E", conn: "rgba(123,174,142,0.6)", status: "#7BAE8E" },
+  in_progress: { node: "#3D5A99", conn: "rgba(61,90,153,0.6)", status: "#3D5A99", glow: "rgba(61,90,153,0.25)", size: 9 },
+  stale: { node: "#B8A07A", conn: "rgba(184,160,122,0.5)", status: "#B8A07A" },
+  pending: { node: "transparent", border: "var(--color-border-muted)", conn: "var(--color-border-muted)", status: "var(--color-text-quaternary)" },
+  indicator: "#3D5A99",
+};
+
+const lightPalette: ThemePalette = {
+  completed: { node: "#4E8A64", conn: "rgba(78,138,100,0.5)", status: "#4E8A64" },
+  in_progress: { node: "#2E4A87", conn: "rgba(46,74,135,0.55)", status: "#2E4A87", glow: "rgba(46,74,135,0.18)", size: 9 },
+  stale: { node: "#9A7F58", conn: "rgba(154,127,88,0.45)", status: "#9A7F58" },
+  pending: { node: "transparent", border: "var(--color-border-muted)", conn: "var(--color-border-muted)", status: "var(--color-text-quaternary)" },
+  indicator: "#2E4A87",
+};
+
+function usePalette(): ThemePalette {
+  const { theme } = useTheme();
+  return theme === "light" ? lightPalette : darkPalette;
+}
+
+function getColors(status: string, palette: ThemePalette): StatusColors {
+  const map: Record<string, StatusColors> = {
+    completed: palette.completed,
+    in_progress: palette.in_progress,
+    stale: palette.stale,
+    pending: palette.pending,
+  };
+  return map[status] || palette.pending;
+}
+
+function connectorColor(from: string, to: string, palette: ThemePalette): string {
+  const fromDone = from === "completed" || from === "stale";
+  if (!fromDone) return palette.pending.conn;
+  const toDone = to === "completed" || to === "stale";
+  if (toDone) return getColors(from, palette).conn;
+  if (to === "in_progress") return palette.in_progress.conn;
+  return palette.pending.conn;
+}
+
+function textColor(status: string): string {
+  switch (status) {
+    case "completed":
+    case "stale":
+      return "var(--color-text-tertiary)";
+    case "in_progress":
+      return "var(--color-text-primary)";
+    default:
+      return "var(--color-text-secondary)";
+  }
+}
+
+// --- Stepper Track ---
+
+interface StepperTrackProps {
+  items: AgentPlanItem[];
+}
+
+const MAX_VISIBLE_NODES = 12;
+
+export function StepperTrack({ items }: StepperTrackProps) {
+  const palette = usePalette();
+  if (!items.length) return null;
+
+  const overflow = items.length > MAX_VISIBLE_NODES;
+  const visible = overflow ? items.slice(0, MAX_VISIBLE_NODES) : items;
+
+  return (
+    <div className="flex items-center flex-1" style={{ height: 20, gap: 0 }}>
+      {visible.map((item, i) => {
+        const colors = getColors(item.status, palette);
+        const size = colors.size || 7;
+        const nodeStyle: React.CSSProperties = {
+          width: size,
+          height: size,
+          borderRadius: "50%",
+          background: colors.node,
+          flexShrink: 0,
+          position: "relative",
+          zIndex: 1,
+        };
+        if (colors.border) nodeStyle.border = `1.5px solid ${colors.border}`;
+        if (colors.glow) nodeStyle.boxShadow = `0 0 0 3px ${colors.glow}`;
+
+        const nextItem = visible[i + 1];
+        const isLastVisible = i === visible.length - 1;
+
+        return (
+          <div key={item.id} className="contents">
+            <div style={nodeStyle} />
+            {(nextItem || (isLastVisible && overflow)) && (
+              <div
+                className="flex-1 relative overflow-hidden"
+                style={{
+                  height: 3,
+                  borderRadius: 1.5,
+                  background: nextItem
+                    ? connectorColor(item.status, nextItem.status, palette)
+                    : palette.pending.conn,
+                }}
+              >
+                {nextItem &&
+                  (item.status === "completed" || item.status === "stale") &&
+                  nextItem.status === "in_progress" && (
+                    <motion.div
+                      className="absolute inset-0"
+                      style={{
+                        width: "30%",
+                        background: "rgba(255,255,255,0.25)",
+                      }}
+                      animate={{ left: ["-30%", "100%"] }}
+                      transition={{
+                        duration: 1.2,
+                        repeat: Infinity,
+                        ease: "easeInOut",
+                      }}
+                    />
+                  )}
+              </div>
+            )}
+          </div>
+        );
+      })}
+      {overflow && (
+        <span
+          className="flex-shrink-0 text-xs tabular-nums"
+          style={{ color: "var(--color-text-quaternary)", marginLeft: 2 }}
+        >
+          +{items.length - MAX_VISIBLE_NODES}
+        </span>
+      )}
+    </div>
+  );
+}
+
+// --- Expanded List (Ticker-tape style) ---
+
+export const EASING: [number, number, number, number] = [0.22, 1, 0.36, 1];
+
+const listVariants = {
+  visible: {
+    transition: { staggerChildren: 0.04 },
+  },
+};
+
+const itemVariants = {
+  hidden: { opacity: 0, x: -6 },
+  visible: {
+    opacity: 1,
+    x: 0,
+    transition: { duration: 0.3, ease: EASING },
+  },
+};
+
+function statusLabel(status: string): string {
+  switch (status) {
+    case "in_progress":
+      return "Active";
+    case "completed":
+      return "Done";
+    case "stale":
+      return "Stale";
+    default:
+      return "Queue";
+  }
+}
+
+export default function StepperList({ items }: { items: AgentPlanItem[] }) {
+  const palette = usePalette();
+  if (!items.length) return null;
+
+  return (
+    <motion.div
+      className="flex flex-col"
+      style={{ gap: 2 }}
+      variants={listVariants}
+      initial="hidden"
+      animate="visible"
+    >
+      {items.map((item) => {
+        const isDone = item.status === "completed" || item.status === "stale";
+        const colors = getColors(item.status, palette);
+
+        return (
+          <motion.div
+            key={item.id}
+            className="flex items-center"
+            style={{ gap: 8, padding: "4px 0", fontSize: 13 }}
+            variants={itemVariants}
+          >
+            <span
+              className="flex-shrink-0 text-right"
+              style={{
+                fontSize: 10,
+                fontWeight: 600,
+                textTransform: "uppercase",
+                letterSpacing: "0.04em",
+                width: 52,
+                color: colors.status,
+              }}
+            >
+              {statusLabel(item.status)}
+            </span>
+
+            <div
+              className="flex-shrink-0"
+              style={{
+                width: 1,
+                height: 12,
+                background: "var(--color-border-muted)",
+              }}
+            />
+
+            <span
+              className="truncate min-w-0"
+              style={{
+                color: textColor(item.status),
+                textDecoration: isDone ? "line-through" : "none",
+              }}
+            >
+              {item.label}
+            </span>
+          </motion.div>
+        );
+      })}
+    </motion.div>
+  );
+}

--- a/web/src/components/ui/stepper-track.tsx
+++ b/web/src/components/ui/stepper-track.tsx
@@ -166,6 +166,7 @@ export function StepperTrack({ items }: StepperTrackProps) {
 export const EASING: [number, number, number, number] = [0.22, 1, 0.36, 1];
 
 const listVariants = {
+  hidden: {},
   visible: {
     transition: { staggerChildren: 0.04 },
   },

--- a/web/src/pages/ChatAgent/components/TodoDrawer.tsx
+++ b/web/src/pages/ChatAgent/components/TodoDrawer.tsx
@@ -1,15 +1,16 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { ChevronDown, ChevronUp, Circle, CircleMinus, Loader2 } from 'lucide-react';
+import { useState, useEffect, useRef, useMemo } from 'react';
+import { ChevronDown } from 'lucide-react';
 import { AnimatePresence, motion } from 'framer-motion';
+import StepperList, { StepperTrack, EASING, type AgentPlanItem } from '@/components/ui/stepper-track';
 
-interface TodoItem {
+export interface TodoItem {
   status: 'pending' | 'in_progress' | 'completed' | 'stale';
   activeForm?: string;
   content?: string;
   [key: string]: unknown;
 }
 
-interface TodoData {
+export interface TodoData {
   todos: TodoItem[];
   total: number;
   completed: number;
@@ -17,16 +18,12 @@ interface TodoData {
   pending: number;
 }
 
-interface TodoDrawerProps {
-  todoData: TodoData | null;
-}
-
 /**
  * Get items to display in collapsed view.
  * - If any in_progress: return ALL in_progress items
  * - Otherwise fallback to single most relevant: last stale > last completed > first pending > first item
  */
-function getPreviewItems(todos: TodoItem[]): { item: TodoItem; index: number }[] {
+export function getPreviewItems(todos: TodoItem[]): { item: TodoItem; index: number }[] {
   if (!todos || todos.length === 0) return [];
 
   const inProgress = todos
@@ -34,12 +31,10 @@ function getPreviewItems(todos: TodoItem[]): { item: TodoItem; index: number }[]
     .filter(({ item }) => item.status === 'in_progress');
   if (inProgress.length > 0) return inProgress;
 
-  // Find last stale (where work stopped)
   for (let i = todos.length - 1; i >= 0; i--) {
     if (todos[i].status === 'stale') return [{ item: todos[i], index: i }];
   }
 
-  // Find last completed
   for (let i = todos.length - 1; i >= 0; i--) {
     if (todos[i].status === 'completed') return [{ item: todos[i], index: i }];
   }
@@ -50,50 +45,16 @@ function getPreviewItems(todos: TodoItem[]): { item: TodoItem; index: number }[]
   return [{ item: todos[0], index: 0 }];
 }
 
-function getStatusIcon(status: string) {
-  switch (status) {
-    case 'completed':
-      return (
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          viewBox="0 0 1024 1024"
-          className="w-4 h-4"
-          style={{ color: 'currentColor' }}
-        >
-          <path
-            d="M89.6 512c0-233.301333 189.098667-422.4 422.4-422.4s422.4 189.098667 422.4 422.4-189.098667 422.4-422.4 422.4-422.4-189.098667-422.4-422.4zM512 166.4a345.6 345.6 0 1 0 0 691.2 345.6 345.6 0 1 0 0-691.2z"
-            fill="currentColor"
-          />
-          <path
-            d="M731.136 365.397333a38.4 38.4 0 0 1 0 54.272l-255.445333 255.488a38.4 38.4 0 0 1-54.314667 0l-116.138667-116.138666a38.4 38.4 0 0 1 54.314667-54.314667l88.96 89.002667 228.309333-228.309334a38.4 38.4 0 0 1 54.314667 0z"
-            fill="currentColor"
-          />
-        </svg>
-      );
-    case 'in_progress':
-      return <Loader2 className="w-4 h-4 animate-spin" style={{ color: 'currentColor' }} />;
-    case 'stale':
-      return <CircleMinus className="w-4 h-4" style={{ color: 'currentColor' }} />;
-    case 'pending':
-    default:
-      return <Circle className="w-4 h-4" style={{ color: 'currentColor' }} />;
-  }
+/** Map TodoItem[] to AgentPlanItem[] for the UI component. */
+export function toAgentPlanItems(todos: TodoItem[]): AgentPlanItem[] {
+  return todos.map((todo, i) => ({
+    id: todo.activeForm || todo.content || `task-${i}`,
+    label: todo.activeForm || todo.content || `Task ${i + 1}`,
+    status: todo.status,
+  }));
 }
 
-function getStatusColor(status: string): string {
-  switch (status) {
-    case 'completed':
-      return 'var(--color-profit)';
-    case 'in_progress':
-      return 'var(--color-accent-primary)';
-    default:
-      return 'var(--color-text-tertiary)';
-  }
-}
-
-function TodoDrawer({ todoData }: TodoDrawerProps) {
+function TodoDrawer({ todoData }: { todoData: TodoData | null }) {
   const [isExpanded, setIsExpanded] = useState(false);
   const wasAllCompleted = useRef(false);
 
@@ -102,145 +63,142 @@ function TodoDrawer({ todoData }: TodoDrawerProps) {
   const completed = todoData?.completed || 0;
 
   const staleCount = todos?.filter(t => t.status === 'stale').length || 0;
+  const doneCount = completed + staleCount;
 
   // Auto-collapse when all todos are done (completed or stale)
   useEffect(() => {
-    const allDone = total > 0 && (completed + staleCount) === total;
+    const allDone = total > 0 && doneCount === total;
     if (allDone && !wasAllCompleted.current) {
       setIsExpanded(false);
     }
     wasAllCompleted.current = allDone;
-  }, [completed, total, staleCount]);
+  }, [doneCount, total]);
+
+  const planItems = useMemo(
+    () => (todos ? toAgentPlanItems(todos) : []),
+    [todos],
+  );
 
   if (!todoData || !todos || todos.length === 0) {
     return null;
   }
 
   const previewItems = getPreviewItems(todos);
-  // Stable key for AnimatePresence based on the set of preview items
-  const previewKey = previewItems.map(p => `${p.index}-${p.item.status}-${p.item.activeForm || p.item.content}`).join('|');
+  const previewKey = previewItems
+    .map(p => `${p.index}-${p.item.status}-${p.item.activeForm || p.item.content}`)
+    .join('|');
 
   return (
-    <div
-      className="w-full border rounded-lg overflow-hidden"
-      style={{
-        borderColor: 'var(--color-border-muted)',
-        backgroundColor: 'var(--color-bg-elevated)',
-        backdropFilter: 'blur(8px)',
-      }}
+    <motion.div
+      className="w-full"
+      initial={{ opacity: 0, y: 4 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.35, ease: EASING }}
     >
-      {/* Header */}
+      {/* Header: stepper track + counter + chevron */}
       <button
         onClick={() => setIsExpanded(!isExpanded)}
-        className="w-full flex items-center justify-between px-4 py-3 hover:bg-foreground/5 transition-colors"
+        aria-expanded={isExpanded}
+        aria-label={`Task progress ${doneCount} of ${total}`}
+        className="w-full flex items-center gap-2.5"
+        style={{
+          background: 'transparent',
+          padding: '8px 0',
+          borderBottom: '1px solid var(--color-border-muted)',
+        }}
       >
-        <div className="flex items-center gap-2">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            viewBox="0 0 1024 1024"
-            className="w-5 h-5"
-            style={{ color: 'var(--color-accent-primary)' }}
-          >
-            <path
-              d="M512 132.266667c197.589333 0 291.84 21.333333 333.354667 35.84 2.986667 1.066667 8.96 3.029333 15.018666 6.4 6.698667 3.712 12.117333 8.234667 17.152 13.226666 5.418667 5.376 10.026667 11.093333 13.824 17.962667 3.285333 6.101333 5.376 12.245333 6.613334 15.701333 13.824 38.741333 36.437333 121.472 36.437333 247.978667 0 129.152-23.552 210.56-37.418667 247.253333-1.109333 2.858667-3.114667 8.362667-6.272 13.952-3.498667 6.186667-7.68 11.264-12.416 16.085334a78.506667 78.506667 0 0 1-14.933333 12.288c-5.546667 3.413333-10.794667 5.461333-13.226667 6.4-2.432 1.024-5.12 1.877333-8.021333 2.901333l-12.970667 74.325333c-1.578667 9.045333-3.242667 19.968-10.794666 33.066667-3.456 5.973333-8.192 11.434667-11.52 14.976a77.781333 77.781333 0 0 1-42.752 24.021333c-39.210667 9.130667-114.176 19.754667-252.074667 19.754667s-212.906667-10.666667-252.074667-19.754667a77.738667 77.738667 0 0 1-42.752-24.021333 84.309333 84.309333 0 0 1-11.52-14.933333c-7.552-13.141333-9.216-24.064-10.794666-33.109334l-13.013334-74.325333c-2.858667-1.024-5.546667-1.92-7.978666-2.858667-2.432-1.024-7.68-3.072-13.226667-6.4a78.506667 78.506667 0 0 1-14.933333-12.330666 77.312 77.312 0 0 1-12.416-16.085334c-3.157333-5.546667-5.162667-11.093333-6.229334-13.952-13.909333-36.693333-37.461333-118.101333-37.461333-247.253333 0-126.506667 22.613333-209.237333 36.437333-247.978667 1.28-3.456 3.328-9.6 6.613334-15.701333 3.797333-6.912 8.405333-12.586667 13.824-17.92 5.034667-5.034667 10.453333-9.557333 17.152-13.269333 6.058667-3.370667 12.032-5.333333 15.061333-6.4 41.429333-14.506667 135.68-35.84 333.312-35.84z m248.533333 656.64c-55.125333 9.685333-134.784 17.493333-248.533333 17.493333-113.792 0-193.450667-7.808-248.576-17.493333l7.082667 40.448 0.981333 5.418666 0.426667 1.792 1.024 1.28 1.237333 1.194667c0.64 0.170667 1.493333 0.426667 3.2 0.810667 31.488 7.338667 100.138667 17.749333 234.624 17.749333 134.485333 0 203.093333-10.410667 234.624-17.749333l3.157333-0.810667 1.28-1.194667 1.024-1.28 0.426667-1.834666 0.981333-5.418667 7.04-40.405333z m-11.136 50.56l0.085334-0.085334 0.085333-0.085333-0.213333 0.170667zM512 209.066667c-192.981333 0-277.76 20.992-308.010667 31.573333l-2.218666 0.768-0.469334 0.128-1.408 1.408c-0.384 0.896-0.768 2.005333-1.578666 4.266667C187.306667 278.186667 166.4 352.170667 166.4 469.333333c0 119.594667 21.76 191.744 32.469333 220.032l0.853334 2.176 0.256 0.682667 0.597333 0.64 0.682667 0.64 1.322666 0.597333c27.392 11.008 110.848 35.413333 309.418667 35.413334s282.026667-24.405333 309.418667-35.413334l1.28-0.597333 0.725333-0.64 0.597333-0.64 0.256-0.682667 0.853334-2.133333c10.666667-28.330667 32.426667-100.48 32.426666-220.074667 0-117.162667-20.821333-191.189333-31.872-222.165333l-1.621333-4.266667c-0.128-0.170667-0.341333-0.426667-0.64-0.682666l-0.768-0.725334-0.426667-0.128-2.218666-0.768c-30.293333-10.581333-115.029333-31.573333-308.010667-31.573333z m153.6 362.752v76.8H358.4v-76.8h307.2z m76.8 0h-76.8v-76.8h76.8v76.8z m-384 0H281.6v-76.8h76.8v76.8z m153.642667-76.842667h-76.8V418.133333H512v76.8z m76.8-0.042667H512L512 341.333333h76.8v153.6zM358.4 375.466667H281.6V298.666667h76.8v76.8z m384 0H665.6V298.666667h76.8v76.8z"
-              fill="currentColor"
-            />
-          </svg>
-          <span className="text-sm font-medium" style={{ color: 'var(--color-text-primary)' }}>
-            Task Progress {completed + staleCount}/{total}
-          </span>
-        </div>
+        <StepperTrack items={planItems} />
 
-        <div style={{ color: 'var(--color-text-tertiary)' }}>
-          {isExpanded ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
-        </div>
+        <span
+          className="text-xs tabular-nums flex-shrink-0"
+          style={{ color: 'var(--color-text-quaternary)' }}
+        >
+          {doneCount}/{total}
+        </span>
+
+        <motion.div
+          className="flex-shrink-0"
+          style={{ color: 'var(--color-icon-muted)' }}
+          animate={{ rotate: isExpanded ? 180 : 0 }}
+          transition={{ duration: 0.2, ease: EASING }}
+        >
+          <ChevronDown className="w-3.5 h-3.5" />
+        </motion.div>
       </button>
 
-      {/* Preview items (collapsed) */}
-      {!isExpanded && previewItems.length > 0 && (
-        <div className="px-4 pb-3 -mt-1">
-          <AnimatePresence mode="wait">
-            <motion.div
-              key={previewKey}
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -8 }}
-              transition={{ duration: 0.2 }}
-              className="space-y-1"
-            >
-              {previewItems.map(({ item, index }) => (
-                <div key={`preview-${index}`} className="flex items-center gap-2">
-                  <div
-                    className="flex-shrink-0"
-                    style={{ color: getStatusColor(item.status) }}
-                  >
-                    {getStatusIcon(item.status)}
-                  </div>
-                  <span
-                    className="text-sm truncate"
+      {/* Collapsed preview: current task(s) */}
+      <AnimatePresence mode="wait">
+        {!isExpanded && previewItems.length > 0 && doneCount < total && (
+          <motion.div
+            key={previewKey}
+            className="space-y-0.5"
+            style={{ padding: '6px 0 2px' }}
+            initial={{ opacity: 0, y: 4 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -4 }}
+            transition={{ duration: 0.2, ease: EASING }}
+          >
+            {previewItems.map(({ item, index }) => (
+              <div key={`preview-${index}`} className="flex items-center gap-1.5">
+                {item.status === 'in_progress' && (
+                  <motion.div
+                    className="flex-shrink-0 rounded-full"
                     style={{
-                      color: item.status === 'completed' || item.status === 'stale'
-                        ? 'var(--color-text-secondary)'
-                        : 'var(--color-text-primary)',
+                      width: 4,
+                      height: 4,
                     }}
+                    animate={{ opacity: [0.4, 1, 0.4] }}
+                    transition={{ duration: 1.5, repeat: Infinity, ease: 'easeInOut' }}
                   >
-                    {item.activeForm || item.content || `Task ${index + 1}`}
-                  </span>
-                </div>
-              ))}
-            </motion.div>
-          </AnimatePresence>
-        </div>
-      )}
+                    <div
+                      className="w-full h-full rounded-full"
+                      style={{
+                        background: 'var(--color-text-secondary)',
+                      }}
+                    />
+                  </motion.div>
+                )}
 
-      {/* Expanded Content - Full Todo List */}
+                <span
+                  className="text-sm truncate"
+                  style={{
+                    color: item.status === 'in_progress'
+                      ? 'var(--color-text-primary)'
+                      : 'var(--color-text-secondary)',
+                  }}
+                >
+                  {item.activeForm || item.content || `Task ${index + 1}`}
+                </span>
+              </div>
+            ))}
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* Expanded: ticker-tape list */}
       <AnimatePresence>
         {isExpanded && (
           <motion.div
+            className="overflow-hidden"
             initial={{ height: 0, opacity: 0 }}
-            animate={{ height: 'auto', opacity: 1 }}
-            exit={{ height: 0, opacity: 0 }}
-            transition={{ duration: 0.2 }}
-            className="border-t overflow-hidden"
-            style={{ borderColor: 'var(--color-border-muted)' }}
+            animate={{
+              height: 'auto',
+              opacity: 1,
+              transition: { duration: 0.25, ease: EASING },
+            }}
+            exit={{
+              height: 0,
+              opacity: 0,
+              transition: { duration: 0.2, ease: EASING },
+            }}
           >
-            <div
-              style={{ maxHeight: '320px', overflowY: 'auto' }}
-            >
-              <div className="p-3 space-y-2">
-                {todos.map((todo, index) => (
-                  <div
-                    key={`todo-${index}-${todo.activeForm || index}`}
-                    className="flex items-start gap-2"
-                  >
-                    <div
-                      className="flex-shrink-0 mt-0.5"
-                      style={{ color: getStatusColor(todo.status) }}
-                    >
-                      {getStatusIcon(todo.status)}
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <div
-                        className="text-sm"
-                        style={{
-                          color: todo.status === 'completed' || todo.status === 'stale'
-                            ? 'var(--color-text-secondary)'
-                            : 'var(--color-text-primary)',
-                        }}
-                      >
-                        {todo.activeForm || todo.content || `Task ${index + 1}`}
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
+            <div style={{ maxHeight: 320, overflowY: 'auto', padding: '8px 0' }}>
+              <StepperList items={planItems} />
             </div>
           </motion.div>
         )}
       </AnimatePresence>
-    </div>
+    </motion.div>
   );
 }
 

--- a/web/src/pages/ChatAgent/components/__tests__/TodoDrawer.test.ts
+++ b/web/src/pages/ChatAgent/components/__tests__/TodoDrawer.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { getPreviewItems, toAgentPlanItems, type TodoItem } from '../TodoDrawer';
+
+describe('getPreviewItems', () => {
+  it('returns empty array for empty todos', () => {
+    expect(getPreviewItems([])).toEqual([]);
+  });
+
+  it('returns all in_progress items when present', () => {
+    const todos: TodoItem[] = [
+      { status: 'completed' },
+      { status: 'in_progress', activeForm: 'Searching' },
+      { status: 'in_progress', activeForm: 'Analyzing' },
+      { status: 'pending' },
+    ];
+    const result = getPreviewItems(todos);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ item: todos[1], index: 1 });
+    expect(result[1]).toEqual({ item: todos[2], index: 2 });
+  });
+
+  it('falls back to last stale item when no in_progress', () => {
+    const todos: TodoItem[] = [
+      { status: 'completed' },
+      { status: 'stale', activeForm: 'First stale' },
+      { status: 'stale', activeForm: 'Last stale' },
+    ];
+    const result = getPreviewItems(todos);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ item: todos[2], index: 2 });
+  });
+
+  it('falls back to last completed when no in_progress or stale', () => {
+    const todos: TodoItem[] = [
+      { status: 'completed', activeForm: 'First' },
+      { status: 'completed', activeForm: 'Last' },
+    ];
+    const result = getPreviewItems(todos);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ item: todos[1], index: 1 });
+  });
+
+  it('falls back to first pending when no other statuses', () => {
+    const todos: TodoItem[] = [
+      { status: 'pending', activeForm: 'First pending' },
+      { status: 'pending', activeForm: 'Second pending' },
+    ];
+    const result = getPreviewItems(todos);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ item: todos[0], index: 0 });
+  });
+
+  it('falls back to first item as last resort', () => {
+    const todos: TodoItem[] = [{ status: 'pending' as const }];
+    const result = getPreviewItems(todos);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ item: todos[0], index: 0 });
+  });
+});
+
+describe('toAgentPlanItems', () => {
+  it('uses activeForm as label when present', () => {
+    const todos: TodoItem[] = [{ status: 'in_progress', activeForm: 'Searching' }];
+    const result = toAgentPlanItems(todos);
+    expect(result[0].label).toBe('Searching');
+    expect(result[0].id).toBe('Searching');
+    expect(result[0].status).toBe('in_progress');
+  });
+
+  it('falls back to content when activeForm is absent', () => {
+    const todos: TodoItem[] = [{ status: 'completed', content: 'Analyze data' }];
+    const result = toAgentPlanItems(todos);
+    expect(result[0].label).toBe('Analyze data');
+  });
+
+  it('falls back to Task N+1 when both absent', () => {
+    const todos: TodoItem[] = [{ status: 'pending' }, { status: 'pending' }];
+    const result = toAgentPlanItems(todos);
+    expect(result[0].label).toBe('Task 1');
+    expect(result[1].label).toBe('Task 2');
+  });
+
+  it('uses content-based id with index fallback', () => {
+    const todos: TodoItem[] = [
+      { status: 'pending', activeForm: 'Search' },
+      { status: 'pending', content: 'Analyze' },
+      { status: 'pending' },
+    ];
+    const result = toAgentPlanItems(todos);
+    expect(result[0].id).toBe('Search');
+    expect(result[1].id).toBe('Analyze');
+    expect(result[2].id).toBe('task-2');
+  });
+
+  it('maps all status values correctly', () => {
+    const statuses: TodoItem['status'][] = ['pending', 'in_progress', 'completed', 'stale'];
+    const todos = statuses.map(s => ({ status: s, activeForm: s }));
+    const result = toAgentPlanItems(todos);
+    statuses.forEach((s, i) => expect(result[i].status).toBe(s));
+  });
+});


### PR DESCRIPTION
## Summary

Redesigns the TodoDrawer component (task progress indicator above chat input) with a horizontal stepper-track UI replacing the old card-based list.

**Visual redesign:**
- Horizontal connected nodes showing task status with animated sweep on active connectors
- Warm tinted color palette: deep navy active (#3D5A99), sage green done (#7BAE8E), ochre stale (#B8A07A)
- Borderless layout with collapsed preview and expandable ticker-tape detail list
- Theme-aware colors via `useTheme()` hook (reactive to light/dark toggle)

**Robustness improvements from pre-landing review:**
- Type-safe status color lookup (replaced unsafe `keyof` cast with explicit map)
- Content-based React keys for correct reconciliation on plan revisions
- `aria-expanded` + `aria-label` on toggle button for screen readers
- `min-w-0` on label spans for reliable truncation in flex containers
- Node overflow capped at 12 with `+N` indicator for large plans
- Deduplicated EASING constant (single export from stepper-track.tsx)

## Test Coverage

Tests: 37 → 39 (+2 files, +20 tests)

- `TodoDrawer.test.ts`: getPreviewItems (5 fallback branches), toAgentPlanItems (label/key generation)
- `stepper-track.test.tsx`: StepperTrack (empty, nodes, connectors, overflow, glow), StepperList (empty, labels, line-through)

## Pre-Landing Review

7 informational issues found, all resolved:
- 4 auto-fixed (type safety, DRY, accessibility, truncation)
- 3 user-approved (theme reactivity, React keys, node overflow)

Quality score: 9.0/10

## Test plan
- [x] All Vitest tests pass (39 files, 439 tests)
- [x] Pre-landing review passed (0 open issues)
- [x] Adversarial review completed (Claude + Codex)