### PR TITLE
fix: resolve code quality and security issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,7 +78,7 @@ temp/
 *.tmp
 
 CLAUDE.md
-.cluade/
+.claude/
 WARP.md
 
 posts/

--- a/agent_config.yaml
+++ b/agent_config.yaml
@@ -169,7 +169,7 @@ mcp:
       args: ["mcp"]
       env: {}
 
-    # Not enabled in Porduction or maintained by us
+    # Not enabled in Production or maintained by us
     - name: "alphavantage"
       enabled: false
       description: "Financial market data API for stocks, forex, crypto, and economic indicators"

--- a/src/data_client/ginlix_data/__init__.py
+++ b/src/data_client/ginlix_data/__init__.py
@@ -7,6 +7,7 @@ ginlix-data market data proxy service.
 from __future__ import annotations
 
 import asyncio
+import os
 from typing import Optional
 
 from .client import GinlixDataClient
@@ -36,7 +37,7 @@ async def get_ginlix_data_client() -> GinlixDataClient:
         if _client is None:
             from src.config.settings import GINLIX_DATA_URL
 
-            service_token = __import__("os").getenv("INTERNAL_SERVICE_TOKEN", "")
+            service_token = os.getenv("INTERNAL_SERVICE_TOKEN", "")
             _client = GinlixDataClient(base_url=GINLIX_DATA_URL, service_token=service_token)
         return _client
 

--- a/src/llms/api_call.py
+++ b/src/llms/api_call.py
@@ -219,6 +219,6 @@ async def parse_structured_output(llm: object, text: str, schema_class: Optional
         try:
             data = json.loads(content)
             return schema_class(**data)
-        except:
+        except Exception:
             raise e
     

--- a/src/ptc_agent/core/security.py
+++ b/src/ptc_agent/core/security.py
@@ -12,6 +12,8 @@ logger = structlog.get_logger(__name__)
 class ExecutionMonitor:
     """Monitors code execution for security and performance."""
 
+    MAX_HISTORY = 1000
+
     def __init__(self) -> None:
         """Initialize execution monitor."""
         self.execution_history: list[dict[str, Any]] = []
@@ -78,6 +80,9 @@ class ExecutionMonitor:
 
         # Move to history
         self.execution_history.append(execution_info)
+        # Prune oldest entries to prevent unbounded memory growth
+        if len(self.execution_history) > self.MAX_HISTORY:
+            self.execution_history = self.execution_history[-self.MAX_HISTORY:]
         del self.active_executions[execution_id]
 
         logger.info(
@@ -252,6 +257,8 @@ class ResourceMonitor:
 class SecurityLogger:
     """Specialized logger for security events."""
 
+    MAX_EVENTS = 1000
+
     def __init__(self) -> None:
         """Initialize security logger."""
         self.security_events: list[dict[str, Any]] = []
@@ -278,6 +285,8 @@ class SecurityLogger:
         }
 
         self.security_events.append(event)
+        if len(self.security_events) > self.MAX_EVENTS:
+            self.security_events = self.security_events[-self.MAX_EVENTS:]
 
         logger.warning(
             "Code validation failed",
@@ -301,6 +310,8 @@ class SecurityLogger:
         }
 
         self.security_events.append(event)
+        if len(self.security_events) > self.MAX_EVENTS:
+            self.security_events = self.security_events[-self.MAX_EVENTS:]
 
         logger.error("Execution timeout", execution_id=execution_id, duration=duration)
 
@@ -323,6 +334,8 @@ class SecurityLogger:
         }
 
         self.security_events.append(event)
+        if len(self.security_events) > self.MAX_EVENTS:
+            self.security_events = self.security_events[-self.MAX_EVENTS:]
 
         logger.warning("Suspicious activity detected", activity_type=activity_type, details=details)
 

--- a/src/server/app/cache.py
+++ b/src/server/app/cache.py
@@ -41,7 +41,7 @@ async def get_cache_stats():
 
     except Exception as e:
         logger.exception(f"Error in get_cache_stats endpoint: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Failed to retrieve cache stats: {str(e)}")
+        raise HTTPException(status_code=500, detail="Failed to retrieve cache stats.")
 
 
 @router.post("/clear")
@@ -75,4 +75,4 @@ async def clear_cache(
 
     except Exception as e:
         logger.exception(f"Error in clear_cache endpoint: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Failed to clear cache: {str(e)}")
+        raise HTTPException(status_code=500, detail="Failed to clear cache.")

--- a/src/server/app/market_data.py
+++ b/src/server/app/market_data.py
@@ -457,7 +457,7 @@ async def search_stocks(
         raise
     except Exception as e:
         logger.error(f"Error searching stocks for query '{query}': {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to search stocks: {str(e)}")
+        raise HTTPException(status_code=500, detail="Failed to search stocks. Please try again later.")
 
 
 # =============================================================================
@@ -510,7 +510,7 @@ async def get_company_overview(symbol: str, user_id: CurrentUserId) -> CompanyOv
         raise
     except Exception as e:
         logger.error(f"Error fetching company overview for {symbol}: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to fetch company overview: {str(e)}")
+        raise HTTPException(status_code=500, detail="Failed to fetch company overview. Please try again later.")
 
 
 # =============================================================================
@@ -606,7 +606,7 @@ async def get_analyst_data(
         raise
     except Exception as e:
         logger.error(f"Error fetching analyst data for {symbol}: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to fetch analyst data: {str(e)}")
+        raise HTTPException(status_code=500, detail="Failed to fetch analyst data. Please try again later.")
 
 
 # =============================================================================

--- a/src/server/app/threads.py
+++ b/src/server/app/threads.py
@@ -240,7 +240,7 @@ async def list_threads(
         logger.exception(f"Error listing threads: {e}")
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to list threads: {str(e)}",
+            detail="Failed to list threads. Please try again later.",
         )
 
 
@@ -286,7 +286,7 @@ async def delete_thread_endpoint(thread_id: str, x_user_id: CurrentUserId):
     except Exception as e:
         logger.exception(f"Error deleting thread {thread_id}: {e}")
         raise HTTPException(
-            status_code=500, detail=f"Failed to delete thread: {str(e)}"
+            status_code=500, detail="Failed to delete thread. Please try again later."
         )
 
 
@@ -320,7 +320,7 @@ async def update_thread_endpoint(
     except Exception as e:
         logger.exception(f"Error updating thread {thread_id}: {e}")
         raise HTTPException(
-            status_code=500, detail=f"Failed to update thread: {str(e)}"
+            status_code=500, detail="Failed to update thread. Please try again later."
         )
 
 
@@ -773,7 +773,7 @@ async def replay_thread_messages(thread_id: str, x_user_id: CurrentUserId):
     except Exception as e:
         logger.exception(f"Error replaying thread {thread_id}: {e}")
         raise HTTPException(
-            status_code=500, detail=f"Failed to replay thread: {str(e)}"
+            status_code=500, detail="Failed to replay thread. Please try again later."
         )
 
 


### PR DESCRIPTION
## Summary

This PR fixes several code quality and security issues found during a codebase audit:

- **Fix bare `except:` clause** (`src/llms/api_call.py:222`) — was catching `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`, making graceful shutdown impossible during LLM calls. Changed to `except Exception`.
- **Replace obfuscated `__import__("os")`** (`src/data_client/ginlix_data/__init__.py:39`) — replaced with a proper `import os` at module level for readability and auditability.
- **Cap unbounded in-memory lists** (`src/ptc_agent/core/security.py`) — `ExecutionMonitor.execution_history` and `SecurityLogger.security_events` grew indefinitely in long-running server processes, causing memory leaks. Added `MAX_HISTORY`/`MAX_EVENTS` caps (1000 entries) with pruning.
- **Stop leaking internal exception details in HTTP 500 responses** (`threads.py`, `cache.py`, `market_data.py`) — error handlers were including `str(e)` in response bodies, which can leak SQL errors, connection strings, and stack info to API consumers. Replaced with generic error messages while preserving server-side logging.
- **Fix typos** — "Porduction" → "Production" (`agent_config.yaml:172`), ".cluade" → ".claude" (`.gitignore:81`).

## Changes by category

| Category | Files | Description |
|----------|-------|-------------|
| Bug fix | `src/llms/api_call.py` | Bare `except:` → `except Exception` |
| Code quality | `src/data_client/ginlix_data/__init__.py` | Normal import replaces `__import__()` |
| Performance | `src/ptc_agent/core/security.py` | Memory leak prevention |
| Security | `src/server/app/threads.py`, `cache.py`, `market_data.py` | Remove exception detail leaks |
| Cleanup | `agent_config.yaml`, `.gitignore` | Typo fixes |

## Test plan

- [ ] Verify structured output fallback in `api_call.py` still works (the `except Exception` preserves the original re-raise behavior)
- [ ] Confirm `ExecutionMonitor` and `SecurityLogger` still log events correctly and pruning works under load
- [ ] Verify HTTP 500 responses no longer contain internal error details
- [ ] Confirm `.gitignore` correctly ignores `.claude/` directory
- [ ] Run existing test suite to check for regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)