### PR TITLE
feat: update model manifest (Claude Opus 4.7 + Qwen3.6 Flash)

### DIFF
--- a/agent_config.yaml
+++ b/agent_config.yaml
@@ -8,9 +8,9 @@
 llm:
   # Model name from src/llms/manifest/models.json
   name: "qwen3.5-plus"
-  flash: "qwen3.5-flash"
-  summarization: "qwen3.5-flash" # defaults to flash model
-  fetch: "qwen3.5-flash"         # defaults to flash model
+  flash: "qwen3.6-flash"
+  summarization: "qwen3.6-flash" # defaults to flash model
+  fetch: "qwen3.6-flash"         # defaults to flash model
   fallback:
     - "kimi-k2.5"
     - "minimax-m2.7"

--- a/src/llms/manifest/models.json
+++ b/src/llms/manifest/models.json
@@ -50,8 +50,8 @@
       }
     }
   },
-  "claude-opus-4-6": {
-    "model_id": "claude-opus-4-6",
+  "claude-opus-4-7": {
+    "model_id": "claude-opus-4-7",
     "provider": "anthropic",
     "visible": true,
     "input_modalities": [
@@ -540,8 +540,8 @@
       "pdf"
     ]
   },
-  "qwen3.5-flash": {
-    "model_id": "qwen3.5-flash",
+  "qwen3.6-flash": {
+    "model_id": "qwen3.6-flash",
     "provider": "dashscope",
     "visible": true,
     "input_modalities": [
@@ -580,8 +580,8 @@
       "enable_thinking": true
     }
   },
-  "qwen3.5-flash-intl": {
-    "model_id": "qwen3.5-flash",
+  "qwen3.6-flash-intl": {
+    "model_id": "qwen3.6-flash",
     "provider": "dashscope-intl",
     "visible": true,
     "input_modalities": [
@@ -764,8 +764,8 @@
       }
     }
   },
-  "claude-opus-4-6-oauth": {
-    "model_id": "claude-opus-4-6",
+  "claude-opus-4-7-oauth": {
+    "model_id": "claude-opus-4-7",
     "provider": "claude-oauth",
     "visible": true,
     "input_modalities": [
@@ -819,8 +819,8 @@
       "dimensions": 1536
     }
   },
-  "claude-opus-4-6-oauth-1m": {
-    "model_id": "claude-opus-4-6",
+  "claude-opus-4-7-oauth-1m": {
+    "model_id": "claude-opus-4-7",
     "provider": "claude-oauth",
     "visible": true,
     "input_modalities": [

--- a/src/llms/manifest/providers.json
+++ b/src/llms/manifest/providers.json
@@ -103,12 +103,12 @@
     ],
     "anthropic": [
       {
-        "id": "claude-opus-4-6",
-        "name": "Claude 4.6 Opus",
+        "id": "claude-opus-4-7",
+        "name": "Claude 4.7 Opus",
         "is_reasoning": true,
-        "description": "Claude 4.6 Opus model",
+        "description": "Claude 4.7 Opus model",
         "alias": [
-          "claude-opus-4.6"
+          "claude-opus-4.7"
         ],
         "pricing": {
           "input": 5.0,
@@ -727,42 +727,33 @@
         }
       },
       {
-        "id": "qwen3.5-flash",
-        "name": "Qwen3.5 Flash",
+        "id": "qwen3.6-flash",
+        "name": "Qwen3.6 Flash",
         "is_reasoning": true,
-        "description": "Alibaba's Qwen3.5 Flash — fastest and most cost-efficient in the series, 1M context",
+        "description": "Alibaba's Qwen3.6 Flash — native vision-language model with agentic coding, math, and spatial reasoning improvements over 3.5-Flash",
         "context_window": 1000000,
         "max_output": 65536,
         "pricing": {
           "input_tiers": [
             {
-              "max_tokens": 128000,
-              "rate": 0.029,
-              "cached_input": 0.006
-            },
-            {
               "max_tokens": 256000,
-              "rate": 0.115,
-              "cached_input": 0.023
+              "rate": 0.172,
+              "cached_input": 0.017
             },
             {
               "max_tokens": 1000000,
-              "rate": 0.172,
-              "cached_input": 0.034
+              "rate": 0.689,
+              "cached_input": 0.069
             }
           ],
           "output_tiers": [
             {
-              "max_tokens": 128000,
-              "rate": 0.287
-            },
-            {
               "max_tokens": 256000,
-              "rate": 1.147
+              "rate": 1.033
             },
             {
               "max_tokens": 1000000,
-              "rate": 1.72
+              "rate": 4.132
             }
           ],
           "output_pricing_mode": "input_dependent",
@@ -966,31 +957,33 @@
         }
       },
       {
-        "id": "qwen3.5-flash",
-        "name": "Qwen3.5 Flash (SG)",
+        "id": "qwen3.6-flash",
+        "name": "Qwen3.6 Flash (SG)",
         "is_reasoning": true,
-        "description": "Alibaba's Qwen3.5 Flash — Singapore international region",
+        "description": "Alibaba's Qwen3.6 Flash — Singapore international region",
         "context_window": 1000000,
         "max_output": 65536,
         "pricing": {
           "input_tiers": [
             {
               "max_tokens": 256000,
-              "rate": 0.053
+              "rate": 0.269,
+              "cached_input": 0.027
             },
             {
               "max_tokens": 1000000,
-              "rate": 0.263
+              "rate": 1.075,
+              "cached_input": 0.108
             }
           ],
           "output_tiers": [
             {
               "max_tokens": 256000,
-              "rate": 0.421
+              "rate": 1.613
             },
             {
               "max_tokens": 1000000,
-              "rate": 2.103
+              "rate": 6.451
             }
           ],
           "output_pricing_mode": "input_dependent",

--- a/tests/unit/llms/test_input_modalities.py
+++ b/tests/unit/llms/test_input_modalities.py
@@ -48,7 +48,7 @@ class TestGetInputModalities:
 
     def test_oauth_variant_inherits_modalities(self, model_config):
         """OAuth models should have explicit modalities, not fall back to default."""
-        result = model_config.get_input_modalities("claude-opus-4-6-oauth")
+        result = model_config.get_input_modalities("claude-opus-4-7-oauth")
         assert "image" in result
         assert "pdf" in result
 


### PR DESCRIPTION
## Summary

**Model renames + Qwen3.6 Flash pricing update** in `src/llms/manifest/`.

**Claude Opus**
- `claude-opus-4-6` → `claude-opus-4-7` across `models.json` (main entry, OAuth variant, OAuth 1M variant) and `providers.json` (`id`, `name`, `description`, `alias`).

**Qwen Flash**
- `qwen3.5-flash` → `qwen3.6-flash` in both the CN and Intl entries of `models.json` (keys + `model_id`).
- Pricing restructured from the legacy 3-tier schedule to a 2-tier schedule matching DashScope's published pricing pages:

| Region | Tier | Input | Cached | Output |
|---|---|---|---|---|
| CN | `<=256k` | 0.172 | 0.017 | 1.033 |
| CN | `256k<=1M` | 0.689 | 0.069 | 4.132 |
| Intl | `<=256k` | 0.269 | 0.027 | 1.613 |
| Intl | `256k<=1M` | 1.075 | 0.108 | 6.451 |

Values converted from RMB at ~6.97 RMB/USD using the regular (non-discounted) rates from the DashScope pricing page — the `限时5折` Batch Chat discount was intentionally excluded.

## Test plan

- [x] `python3 -c "import json; json.load(...)"` — both files parse cleanly.
- [x] No stray `opus-4-6` / `opus-4.6` / `4.6 Opus` / `qwen3.5-flash` references remain.
- [ ] Downstream consumers of the old ids (if any) updated separately.