### PR TITLE
fix: Opus 4.7 thinking-block schema + xhigh effort + tool-reasoning leak

### DIFF
--- a/src/llms/manifest/models.json
+++ b/src/llms/manifest/models.json
@@ -60,11 +60,13 @@
       "pdf"
     ],
     "parameters": {
+      "max_tokens": 128000,
       "thinking": {
-        "type": "adaptive"
+        "type": "adaptive",
+        "display": "summarized"
       },
       "output_config": {
-        "effort": "medium"
+        "effort": "xhigh"
       }
     }
   },
@@ -78,6 +80,7 @@
       "pdf"
     ],
     "parameters": {
+      "max_tokens": 64000,
       "thinking": {
         "type": "adaptive"
       }
@@ -93,6 +96,7 @@
       "pdf"
     ],
     "parameters": {
+      "max_tokens": 64000,
       "thinking": {
         "type": "enabled"
       }
@@ -759,6 +763,7 @@
       "pdf"
     ],
     "parameters": {
+      "max_tokens": 64000,
       "thinking": {
         "type": "adaptive"
       }
@@ -774,11 +779,13 @@
       "pdf"
     ],
     "parameters": {
+      "max_tokens": 128000,
       "thinking": {
-        "type": "adaptive"
+        "type": "adaptive",
+        "display": "summarized"
       },
       "output_config": {
-        "effort": "medium"
+        "effort": "xhigh"
       }
     }
   },
@@ -792,6 +799,7 @@
       "pdf"
     ],
     "parameters": {
+      "max_tokens": 64000,
       "thinking": {
         "type": "enabled",
         "budget_tokens": 8000
@@ -829,11 +837,13 @@
       "pdf"
     ],
     "parameters": {
+      "max_tokens": 128000,
       "thinking": {
-        "type": "adaptive"
+        "type": "adaptive",
+        "display": "summarized"
       },
       "output_config": {
-        "effort": "medium"
+        "effort": "xhigh"
       }
     },
     "context_window": 1000000,

--- a/src/llms/reasoning.py
+++ b/src/llms/reasoning.py
@@ -1,18 +1,26 @@
 """
 Unified reasoning effort mapper.
 
-Maps abstract levels ("low", "medium", "high") to provider-specific parameters.
-Detection-based: checks which reasoning keys exist in the model's parameters/extra_body
-from models.json, then adjusts values for those specific keys.
+Maps abstract levels ("low", "medium", "high", "xhigh") to provider-specific
+parameters. Detection-based: checks which reasoning keys exist in the model's
+parameters/extra_body from models.json, then adjusts values for those specific keys.
+
+"xhigh" is only natively honored by Anthropic adaptive thinking (Opus 4.7+);
+for all other providers it is clamped to "high".
 """
 
-REASONING_LEVELS = ("low", "medium", "high")
+REASONING_LEVELS = ("low", "medium", "high", "xhigh")
 
 # Anthropic thinking budgets per level
 _ANTHROPIC_BUDGETS = {"low": 5000, "medium": 10000, "high": 32000}
 
 # Gemini numeric thinking budgets per level (for thinking_budget pattern)
 _GEMINI_BUDGETS = {"low": 1024, "medium": 8192, "high": 32768}
+
+
+def _clamp(level: str) -> str:
+    """Clamp xhigh down to high for providers that don't support xhigh."""
+    return "high" if level == "xhigh" else level
 
 
 def apply_reasoning_effort(
@@ -26,7 +34,8 @@ def apply_reasoning_effort(
     in parameters and extra_body, then adjusts their values.
 
     Args:
-        level: One of "low", "medium", "high".
+        level: One of "low", "medium", "high", "xhigh". "xhigh" only affects
+            Anthropic adaptive thinking; elsewhere it is clamped to "high".
         parameters: Model parameters dict (will be mutated).
         extra_body: Extra body dict (will be mutated).
 
@@ -41,11 +50,11 @@ def apply_reasoning_effort(
     # OpenAI: parameters.reasoning.effort
     if "reasoning" in parameters:
         if isinstance(parameters["reasoning"], dict):
-            parameters["reasoning"]["effort"] = level
+            parameters["reasoning"]["effort"] = _clamp(level)
         else:
-            parameters["reasoning"] = {"effort": level}
+            parameters["reasoning"] = {"effort": _clamp(level)}
 
-    # Anthropic adaptive: control via output_config.effort
+    # Anthropic adaptive: control via output_config.effort (supports xhigh natively)
     elif "output_config" in parameters or (
         "thinking" in parameters
         and isinstance(parameters["thinking"], dict)
@@ -55,25 +64,26 @@ def apply_reasoning_effort(
 
     # Anthropic enabled: control via budget_tokens
     elif "thinking" in parameters:
+        budget = _ANTHROPIC_BUDGETS[_clamp(level)]
         if isinstance(parameters["thinking"], dict):
-            parameters["thinking"]["budget_tokens"] = _ANTHROPIC_BUDGETS[level]
+            parameters["thinking"]["budget_tokens"] = budget
         else:
             parameters["thinking"] = {
                 "type": "enabled",
-                "budget_tokens": _ANTHROPIC_BUDGETS[level],
+                "budget_tokens": budget,
             }
 
     # Gemini 3.x: parameters.thinking_level
     elif "thinking_level" in parameters:
-        parameters["thinking_level"] = level
+        parameters["thinking_level"] = _clamp(level)
 
     # Gemini 2.x: parameters.thinking_budget (numeric)
     elif "thinking_budget" in parameters:
-        parameters["thinking_budget"] = _GEMINI_BUDGETS[level]
+        parameters["thinking_budget"] = _GEMINI_BUDGETS[_clamp(level)]
 
     # vLLM / Groq / Cerebras: parameters.reasoning_effort
     elif "reasoning_effort" in parameters:
-        parameters["reasoning_effort"] = level
+        parameters["reasoning_effort"] = _clamp(level)
 
     # --- extra_body patterns ---
 

--- a/src/ptc_agent/agent/agent.py
+++ b/src/ptc_agent/agent/agent.py
@@ -52,6 +52,9 @@ from ptc_agent.agent.middleware import (
     WorkspaceContextMiddleware,
 )
 from ptc_agent.agent.middleware.runtime_context import RuntimeContextMiddleware
+from ptc_agent.agent.middleware.anthropic_thinking_sanitizer import (
+    AnthropicThinkingSanitizerMiddleware,
+)
 from ptc_agent.agent.middleware.background_subagent.registry import (
     BackgroundTaskRegistry,
 )
@@ -576,6 +579,7 @@ class PTCAgent:
                 AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
                 EmptyToolCallRetryMiddleware(),
                 PatchToolCallsMiddleware(),
+                AnthropicThinkingSanitizerMiddleware(),
             ]
             if m is not None
         ]
@@ -623,6 +627,7 @@ class PTCAgent:
                 PatchToolCallsMiddleware(),
                 *workspace_context_middleware,
                 *runtime_context_middleware,
+                AnthropicThinkingSanitizerMiddleware(),
             ]
             if m is not None
         ]

--- a/src/ptc_agent/agent/middleware/__init__.py
+++ b/src/ptc_agent/agent/middleware/__init__.py
@@ -88,6 +88,11 @@ from .runtime_context import (
     RuntimeContextMiddleware,
 )
 
+# Anthropic thinking-block sanitizer (repairs orphan signature-only blocks)
+from .anthropic_thinking_sanitizer import (
+    AnthropicThinkingSanitizerMiddleware,
+)
+
 # Subagent steering middleware
 from .background_subagent.steering import (
     SubagentSteeringMiddleware,
@@ -145,6 +150,8 @@ __all__ = [
     "WorkspaceContextMiddleware",
     # Runtime context
     "RuntimeContextMiddleware",
+    # Anthropic thinking sanitizer
+    "AnthropicThinkingSanitizerMiddleware",
     # Subagent middleware
     "CompiledSubAgent",
     "SubAgent",

--- a/src/ptc_agent/agent/middleware/anthropic_thinking_sanitizer.py
+++ b/src/ptc_agent/agent/middleware/anthropic_thinking_sanitizer.py
@@ -1,0 +1,121 @@
+"""Sanitize malformed Anthropic thinking blocks before they reach the API.
+
+On Claude Opus 4.7 with adaptive thinking + default `display: "omitted"`,
+the Anthropic stream only emits `signature_delta` events (no `thinking_delta`).
+langchain-anthropic's stream handler turns each delta into a standalone
+content block: `{"type": "thinking", "signature": "...", "index": N}` — with
+no `thinking` field. The merged AIMessage lands in LangGraph state that way,
+and the next turn replaying it to Anthropic fails with:
+
+    messages.<i>.content.<j>.thinking.thinking: Field required
+
+Anthropic's contract is that `type="thinking"` blocks must always carry a
+`thinking` field, even when omitted (empty string is valid). This middleware
+walks every AIMessage in the outgoing request and injects `thinking: ""` on
+blocks that have a signature but are missing the `thinking` key. Signature
+continuity is preserved; the schema is satisfied.
+"""
+
+from collections.abc import Awaitable, Callable
+from copy import copy
+import logging
+from typing import Any
+
+from langchain.agents.middleware.types import AgentMiddleware, ModelRequest, ModelResponse
+from langchain_core.messages import AIMessage, AnyMessage
+
+logger = logging.getLogger(__name__)
+
+
+def _sanitize_thinking_block(block: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+    """Return (block, changed). Injects thinking='' on orphan signature-only blocks."""
+    if block.get("type") != "thinking":
+        return block, False
+    thinking = block.get("thinking")
+    if isinstance(thinking, str):
+        return block, False
+    repaired = {**block, "thinking": ""}
+    return repaired, True
+
+
+def _sanitize_message(msg: AnyMessage) -> tuple[AnyMessage, int]:
+    """Return (maybe-new message, count of blocks repaired)."""
+    if not isinstance(msg, AIMessage):
+        return msg, 0
+    content = msg.content
+    if not isinstance(content, list):
+        return msg, 0
+
+    new_blocks: list[Any] = []
+    repaired_count = 0
+    changed = False
+
+    for block in content:
+        if isinstance(block, dict):
+            new_block, block_changed = _sanitize_thinking_block(block)
+            if block_changed:
+                repaired_count += 1
+                changed = True
+            new_blocks.append(new_block)
+        else:
+            new_blocks.append(block)
+
+    if not changed:
+        return msg, 0
+
+    new_msg = copy(msg)
+    new_msg.content = new_blocks
+    return new_msg, repaired_count
+
+
+def _sanitize_messages(messages: list[AnyMessage]) -> tuple[list[AnyMessage], int]:
+    """Return (messages, total_blocks_repaired). Same list object if nothing changed."""
+    result: list[AnyMessage] = []
+    total = 0
+    changed = False
+    for msg in messages:
+        new_msg, count = _sanitize_message(msg)
+        total += count
+        if new_msg is not msg:
+            changed = True
+        result.append(new_msg)
+    return (result, total) if changed else (messages, 0)
+
+
+class AnthropicThinkingSanitizerMiddleware(AgentMiddleware):
+    """Repair orphan thinking blocks (missing `thinking` text) before the LLM call.
+
+    See module docstring for root cause. This middleware should run innermost so
+    it catches blocks introduced by any upstream middleware and it is the last
+    thing to touch messages before the API call.
+    """
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], ModelResponse],
+    ) -> ModelResponse:
+        sanitized, repaired = _sanitize_messages(request.messages)
+        if repaired:
+            logger.warning(
+                "[ThinkingSanitizer] Repaired %d orphan thinking block(s) "
+                "(injected thinking='') before Anthropic call",
+                repaired,
+            )
+            request = request.override(messages=sanitized)
+        return handler(request)
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelResponse:
+        sanitized, repaired = _sanitize_messages(request.messages)
+        if repaired:
+            logger.warning(
+                "[ThinkingSanitizer] Repaired %d orphan thinking block(s) "
+                "(injected thinking='') before Anthropic call",
+                repaired,
+            )
+            request = request.override(messages=sanitized)
+        return await handler(request)

--- a/src/ptc_agent/agent/middleware/anthropic_thinking_sanitizer.py
+++ b/src/ptc_agent/agent/middleware/anthropic_thinking_sanitizer.py
@@ -17,7 +17,7 @@ continuity is preserved; the schema is satisfied.
 """
 
 from collections.abc import Awaitable, Callable
-from copy import copy
+from copy import deepcopy
 import logging
 from typing import Any
 
@@ -63,7 +63,7 @@ def _sanitize_message(msg: AnyMessage) -> tuple[AnyMessage, int]:
     if not changed:
         return msg, 0
 
-    new_msg = copy(msg)
+    new_msg = deepcopy(msg)
     new_msg.content = new_blocks
     return new_msg, repaired_count
 

--- a/src/server/handlers/streaming_handler.py
+++ b/src/server/handlers/streaming_handler.py
@@ -838,21 +838,28 @@ class WorkflowStreamHandler:
         """Process a single message chunk and yield SSE events."""
         message_id = message_chunk.id or "unknown"
 
+        # Tool-node inner LLM reasoning (e.g. WebFetch's summarization model)
+        # is internal and should not surface as user-facing reasoning — the
+        # tool's output already arrives via tool_call_result. Subagents use
+        # "task:*"/"research:*"/etc. namespaces and are unaffected.
+        is_tool_agent = agent_name == "tools" or agent_name.startswith("tools:")
+
         # Check for thinking/reasoning status signals in main content
         status_info = is_thinking_status_signal(message_chunk.content)
         if status_info:
-            if status_info.get("status") == "completed":
-                # Reasoning completed - emit completion signal
-                if agent_name in self.reasoning_active:
-                    yield self._format_reasoning_signal(agent_name, message_id, "complete")
-                    self.reasoning_active.discard(agent_name)
-                self._reasoning_block_index.pop(agent_name, None)
-                self._reasoning_separator_pending.discard(agent_name)
-            else:
-                # Reasoning started - emit start signal
-                if agent_name not in self.reasoning_active:
-                    yield self._format_reasoning_signal(agent_name, message_id, "start")
-                    self.reasoning_active.add(agent_name)
+            if not is_tool_agent:
+                if status_info.get("status") == "completed":
+                    # Reasoning completed - emit completion signal
+                    if agent_name in self.reasoning_active:
+                        yield self._format_reasoning_signal(agent_name, message_id, "complete")
+                        self.reasoning_active.discard(agent_name)
+                    self._reasoning_block_index.pop(agent_name, None)
+                    self._reasoning_separator_pending.discard(agent_name)
+                else:
+                    # Reasoning started - emit start signal
+                    if agent_name not in self.reasoning_active:
+                        yield self._format_reasoning_signal(agent_name, message_id, "start")
+                        self.reasoning_active.add(agent_name)
             return  # Don't process status signals as regular content
 
         # Check for thinking status in reasoning_content field as well
@@ -864,18 +871,19 @@ class WorkflowStreamHandler:
         if reasoning_content_from_kwargs:
             reasoning_status = is_thinking_status_signal(reasoning_content_from_kwargs)
             if reasoning_status:
-                if reasoning_status.get("status") == "completed":
-                    # Reasoning completed - emit completion signal if agent was actively streaming
-                    if agent_name in self.reasoning_active:
-                        yield self._format_reasoning_signal(agent_name, message_id, "complete")
-                        self.reasoning_active.discard(agent_name)
-                    self._reasoning_block_index.pop(agent_name, None)
-                    self._reasoning_separator_pending.discard(agent_name)
-                else:
-                    # Reasoning started - emit start signal
-                    if agent_name not in self.reasoning_active:
-                        yield self._format_reasoning_signal(agent_name, message_id, "start")
-                        self.reasoning_active.add(agent_name)
+                if not is_tool_agent:
+                    if reasoning_status.get("status") == "completed":
+                        # Reasoning completed - emit completion signal if agent was actively streaming
+                        if agent_name in self.reasoning_active:
+                            yield self._format_reasoning_signal(agent_name, message_id, "complete")
+                            self.reasoning_active.discard(agent_name)
+                        self._reasoning_block_index.pop(agent_name, None)
+                        self._reasoning_separator_pending.discard(agent_name)
+                    else:
+                        # Reasoning started - emit start signal
+                        if agent_name not in self.reasoning_active:
+                            yield self._format_reasoning_signal(agent_name, message_id, "start")
+                            self.reasoning_active.add(agent_name)
                 return  # Don't process status signals as regular content
 
         # Check for function_call in content (Response API tool call streaming)
@@ -1031,8 +1039,10 @@ class WorkflowStreamHandler:
             "role": "assistant",
         }
 
-        # Add text content if present (can be regular text or reasoning)
-        if text_content and content_type:
+        # Add text content if present (can be regular text or reasoning).
+        # Drop reasoning content from tool-node inner LLMs — it's internal and
+        # the tool's user-facing output arrives via tool_call_result.
+        if text_content and content_type and not (is_tool_agent and content_type == "reasoning"):
             # Check if we need to emit reasoning completion signal
             if content_type != "reasoning" and agent_name in self.reasoning_active:
                 # Reasoning completed, emit completion signal before this content

--- a/src/server/models/chat.py
+++ b/src/server/models/chat.py
@@ -245,9 +245,11 @@ class ChatRequest(BaseModel):
     )
 
     # Reasoning effort override (optional - defaults to model's configured level)
-    reasoning_effort: Optional[Literal["low", "medium", "high"]] = Field(
+    # xhigh is honored only by Anthropic adaptive thinking (Opus 4.7+); other
+    # providers clamp it to high in src/llms/reasoning.py.
+    reasoning_effort: Optional[Literal["low", "medium", "high", "xhigh"]] = Field(
         default=None,
-        description="Override reasoning effort for this request (low/medium/high)",
+        description="Override reasoning effort for this request (low/medium/high/xhigh)",
     )
 
     fast_mode: Optional[bool] = Field(

--- a/tests/unit/llms/test_reasoning.py
+++ b/tests/unit/llms/test_reasoning.py
@@ -45,7 +45,7 @@ class TestReasoningInvalidLevel:
         assert params["reasoning"]["effort"] == "medium"
 
     def test_constants(self):
-        assert REASONING_LEVELS == ("low", "medium", "high")
+        assert REASONING_LEVELS == ("low", "medium", "high", "xhigh")
         assert "low" in _ANTHROPIC_BUDGETS
         assert "low" in _GEMINI_BUDGETS
 
@@ -92,12 +92,19 @@ class TestAnthropicAdaptive:
         apply_reasoning_effort("low", params, extra)
         assert params["output_config"]["effort"] == "low"
 
-    @pytest.mark.parametrize("level", ["low", "medium", "high"])
+    @pytest.mark.parametrize("level", ["low", "medium", "high", "xhigh"])
     def test_all_levels(self, level):
         params = {"thinking": {"type": "adaptive"}, "output_config": {"effort": "medium"}}
         extra = {}
         apply_reasoning_effort(level, params, extra)
         assert params["output_config"]["effort"] == level
+
+    def test_xhigh_passes_through(self):
+        """Anthropic adaptive natively supports xhigh — must pass through, not clamp."""
+        params = {"thinking": {"type": "adaptive"}}
+        extra = {}
+        apply_reasoning_effort("xhigh", params, extra)
+        assert params["output_config"]["effort"] == "xhigh"
 
 
 # ---------------------------------------------------------------------------
@@ -248,3 +255,35 @@ class TestCombinedPatterns:
         apply_reasoning_effort("high", params, extra)
         assert params == original_params
         assert extra == original_extra
+
+
+# ---------------------------------------------------------------------------
+# xhigh clamping: non-Anthropic-adaptive providers must clamp xhigh → high
+# ---------------------------------------------------------------------------
+
+
+class TestXhighClamping:
+    def test_openai_clamps_to_high(self):
+        params = {"reasoning": {"effort": "medium"}}
+        apply_reasoning_effort("xhigh", params, {})
+        assert params["reasoning"]["effort"] == "high"
+
+    def test_anthropic_enabled_clamps_to_high_budget(self):
+        params = {"thinking": {"type": "enabled", "budget_tokens": 10000}}
+        apply_reasoning_effort("xhigh", params, {})
+        assert params["thinking"]["budget_tokens"] == _ANTHROPIC_BUDGETS["high"]
+
+    def test_gemini_thinking_level_clamps_to_high(self):
+        params = {"thinking_level": "medium"}
+        apply_reasoning_effort("xhigh", params, {})
+        assert params["thinking_level"] == "high"
+
+    def test_gemini_thinking_budget_clamps_to_high(self):
+        params = {"thinking_budget": 4096}
+        apply_reasoning_effort("xhigh", params, {})
+        assert params["thinking_budget"] == _GEMINI_BUDGETS["high"]
+
+    def test_vllm_reasoning_effort_clamps_to_high(self):
+        params = {"reasoning_effort": "medium"}
+        apply_reasoning_effort("xhigh", params, {})
+        assert params["reasoning_effort"] == "high"

--- a/tests/unit/ptc_agent/middleware/test_anthropic_thinking_sanitizer.py
+++ b/tests/unit/ptc_agent/middleware/test_anthropic_thinking_sanitizer.py
@@ -1,0 +1,223 @@
+"""Tests for AnthropicThinkingSanitizerMiddleware.
+
+Protects against the Anthropic 400 error:
+  `messages.<i>.content.<j>.thinking.thinking: Field required`
+
+which surfaces when the stream produces a signature-only thinking block and
+that malformed block gets persisted into LangGraph state. The middleware
+repairs such blocks by injecting `thinking: ""` before the outgoing API call.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+from ptc_agent.agent.middleware.anthropic_thinking_sanitizer import (
+    AnthropicThinkingSanitizerMiddleware,
+    _sanitize_message,
+    _sanitize_messages,
+    _sanitize_thinking_block,
+)
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_thinking_block — individual block repair
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeBlock:
+    def test_orphan_signature_block_gets_empty_thinking(self):
+        block = {"type": "thinking", "signature": "sig-abc", "index": 0}
+        out, changed = _sanitize_thinking_block(block)
+        assert changed is True
+        assert out["thinking"] == ""
+        assert out["signature"] == "sig-abc"
+        assert out["index"] == 0
+
+    def test_well_formed_thinking_block_unchanged(self):
+        block = {"type": "thinking", "thinking": "I am reasoning", "signature": "s"}
+        out, changed = _sanitize_thinking_block(block)
+        assert changed is False
+        assert out is block
+
+    def test_empty_string_thinking_not_repaired(self):
+        block = {"type": "thinking", "thinking": "", "signature": "s"}
+        out, changed = _sanitize_thinking_block(block)
+        assert changed is False
+        assert out is block
+
+    def test_thinking_field_none_triggers_repair(self):
+        block = {"type": "thinking", "thinking": None, "signature": "s"}
+        out, changed = _sanitize_thinking_block(block)
+        assert changed is True
+        assert out["thinking"] == ""
+
+    def test_thinking_non_string_triggers_repair(self):
+        block = {"type": "thinking", "thinking": {"oops": 1}, "signature": "s"}
+        out, changed = _sanitize_thinking_block(block)
+        assert changed is True
+        assert out["thinking"] == ""
+
+    @pytest.mark.parametrize(
+        "block",
+        [
+            {"type": "text", "text": "hello"},
+            {"type": "tool_use", "id": "t1", "name": "x", "input": {}},
+            {"type": "tool_result", "tool_use_id": "t1", "content": "ok"},
+        ],
+    )
+    def test_non_thinking_blocks_untouched(self, block):
+        out, changed = _sanitize_thinking_block(block)
+        assert changed is False
+        assert out is block
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_message — whole-message scan
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeMessage:
+    def test_non_ai_message_untouched(self):
+        msg = HumanMessage(content=[{"type": "thinking", "signature": "s"}])
+        out, count = _sanitize_message(msg)
+        assert out is msg
+        assert count == 0
+
+    def test_str_content_untouched(self):
+        msg = AIMessage(content="plain text")
+        out, count = _sanitize_message(msg)
+        assert out is msg
+        assert count == 0
+
+    def test_non_dict_entries_preserved(self):
+        msg = AIMessage(
+            content=["bare string", {"type": "thinking", "signature": "s"}]
+        )
+        out, count = _sanitize_message(msg)
+        assert count == 1
+        assert out.content[0] == "bare string"
+        assert out.content[1]["thinking"] == ""
+
+    def test_multiple_orphans_counted(self):
+        msg = AIMessage(
+            content=[
+                {"type": "thinking", "signature": "a"},
+                {"type": "text", "text": "ok"},
+                {"type": "thinking", "signature": "b"},
+            ]
+        )
+        out, count = _sanitize_message(msg)
+        assert count == 2
+        assert out.content[0]["thinking"] == ""
+        assert out.content[1] == {"type": "text", "text": "ok"}
+        assert out.content[2]["thinking"] == ""
+
+    def test_well_formed_content_returns_same_message(self):
+        msg = AIMessage(
+            content=[
+                {"type": "thinking", "thinking": "reasoned", "signature": "s"},
+                {"type": "text", "text": "done"},
+            ]
+        )
+        out, count = _sanitize_message(msg)
+        assert out is msg
+        assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_messages — list-level identity + counting
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeMessages:
+    def test_empty_list(self):
+        out, total = _sanitize_messages([])
+        assert out == []
+        assert total == 0
+
+    def test_no_changes_returns_same_list_identity(self):
+        msgs = [AIMessage(content="hi"), HumanMessage(content="hey")]
+        out, total = _sanitize_messages(msgs)
+        assert out is msgs
+        assert total == 0
+
+    def test_repairs_across_messages(self):
+        msgs = [
+            AIMessage(content=[{"type": "thinking", "signature": "a"}]),
+            HumanMessage(content="question"),
+            AIMessage(
+                content=[
+                    {"type": "thinking", "signature": "b"},
+                    {"type": "text", "text": "answer"},
+                ]
+            ),
+        ]
+        out, total = _sanitize_messages(msgs)
+        assert total == 2
+        assert out is not msgs
+        assert out[0].content[0]["thinking"] == ""
+        assert out[1] is msgs[1]  # human message passes through by identity
+        assert out[2].content[0]["thinking"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Middleware wrapper — override / handler contract
+# ---------------------------------------------------------------------------
+
+
+class TestMiddlewareAsync:
+    @pytest.mark.asyncio
+    async def test_repairs_and_calls_override(self):
+        mw = AnthropicThinkingSanitizerMiddleware()
+        req = MagicMock()
+        req.messages = [AIMessage(content=[{"type": "thinking", "signature": "s"}])]
+        req.override.return_value = req
+        handler = AsyncMock(return_value="response")
+
+        result = await mw.awrap_model_call(req, handler)
+
+        req.override.assert_called_once()
+        handler.assert_awaited_once_with(req)
+        assert result == "response"
+
+    @pytest.mark.asyncio
+    async def test_noop_skips_override(self):
+        mw = AnthropicThinkingSanitizerMiddleware()
+        req = MagicMock()
+        req.messages = [AIMessage(content="plain text")]
+        handler = AsyncMock(return_value="response")
+
+        result = await mw.awrap_model_call(req, handler)
+
+        req.override.assert_not_called()
+        handler.assert_awaited_once_with(req)
+        assert result == "response"
+
+
+class TestMiddlewareSync:
+    def test_repairs_and_calls_override(self):
+        mw = AnthropicThinkingSanitizerMiddleware()
+        req = MagicMock()
+        req.messages = [AIMessage(content=[{"type": "thinking", "signature": "s"}])]
+        req.override.return_value = req
+        handler = MagicMock(return_value="response")
+
+        result = mw.wrap_model_call(req, handler)
+
+        req.override.assert_called_once()
+        handler.assert_called_once_with(req)
+        assert result == "response"
+
+    def test_noop_skips_override(self):
+        mw = AnthropicThinkingSanitizerMiddleware()
+        req = MagicMock()
+        req.messages = [AIMessage(content="plain text")]
+        handler = MagicMock(return_value="response")
+
+        result = mw.wrap_model_call(req, handler)
+
+        req.override.assert_not_called()
+        handler.assert_called_once_with(req)
+        assert result == "response"

--- a/tests/unit/server/handlers/test_streaming_handler.py
+++ b/tests/unit/server/handlers/test_streaming_handler.py
@@ -495,3 +495,67 @@ class TestEventCounter:
         assert "id: 42\n" in e1
         assert "id: 43\n" in e2
         assert counter.next.call_count == 2
+
+
+class TestToolAgentReasoningSuppression:
+    """Tool-node inner LLM reasoning must not surface as user-facing reasoning;
+    subagents (task:*/research:*) and the main model must still emit it."""
+
+    def _handler(self):
+        from src.server.handlers.streaming_handler import WorkflowStreamHandler
+        return WorkflowStreamHandler(thread_id="t-tool-gate")
+
+    def _chunk(self, content, kwargs=None):
+        from langchain_core.messages import AIMessageChunk
+        return AIMessageChunk(
+            content=content,
+            id="msg-1",
+            additional_kwargs=kwargs or {},
+            response_metadata={},
+        )
+
+    async def _drain(self, agen):
+        return [ev async for ev in agen]
+
+    def test_tool_agent_reasoning_content_suppressed(self):
+        handler = self._handler()
+        chunk = self._chunk(
+            [{"type": "text", "text": "internal CoT"}],
+            kwargs={"reasoning_content": "internal CoT"},
+        )
+        events = asyncio.run(self._drain(handler._process_message_chunk(chunk, "tools:abc")))
+        assert not any("reasoning_signal" in e for e in events)
+        assert not any('"content_type": "reasoning"' in e for e in events)
+        assert "tools:abc" not in handler.reasoning_active
+
+    def test_model_agent_reasoning_still_emitted(self):
+        handler = self._handler()
+        chunk = self._chunk(
+            [{"type": "text", "text": "thinking out loud"}],
+            kwargs={"reasoning_content": "thinking out loud"},
+        )
+        events = asyncio.run(self._drain(handler._process_message_chunk(chunk, "model:xyz")))
+        assert any("reasoning_signal" in e and '"content": "start"' in e for e in events)
+        assert any('"content_type": "reasoning"' in e for e in events)
+
+    def test_subagent_reasoning_still_emitted(self):
+        handler = self._handler()
+        chunk = self._chunk(
+            [{"type": "text", "text": "subagent thought"}],
+            kwargs={"reasoning_content": "subagent thought"},
+        )
+        events = asyncio.run(
+            self._drain(handler._process_message_chunk(chunk, "task:7d0e9f"))
+        )
+        assert any("reasoning_signal" in e and '"content": "start"' in e for e in events)
+        assert any('"content_type": "reasoning"' in e for e in events)
+
+    def test_bare_tools_agent_name_suppressed(self):
+        """The LangGraph default tool node name "tools" (no colon) is also gated."""
+        handler = self._handler()
+        chunk = self._chunk(
+            [{"type": "text", "text": "x"}],
+            kwargs={"reasoning_content": "x"},
+        )
+        events = asyncio.run(self._drain(handler._process_message_chunk(chunk, "tools")))
+        assert not any("reasoning_signal" in e for e in events)

--- a/tests/unit/server/models/test_chat_models.py
+++ b/tests/unit/server/models/test_chat_models.py
@@ -196,7 +196,7 @@ class TestChatRequest:
             ChatRequest(agent_mode="turbo")
 
     def test_reasoning_effort_values(self):
-        for level in ("low", "medium", "high"):
+        for level in ("low", "medium", "high", "xhigh"):
             req = ChatRequest(reasoning_effort=level)
             assert req.reasoning_effort == level
 

--- a/web/src/components/ui/chat-input.tsx
+++ b/web/src/components/ui/chat-input.tsx
@@ -3,7 +3,7 @@ import {
   Plus, ArrowUp, X, FileText, Loader2, Archive, Square,
   ScrollText, ChartCandlestick, Zap, FileStack, ChevronDown, ChevronRight, FolderOpen, TextSelect,
   Terminal, Bot, Shrink, HardDriveDownload, Check, Brain, Flame, Rocket, CircleHelp,
-  Mic, MicOff,
+  Mic, MicOff, Sparkles,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -14,6 +14,7 @@ import {
 } from './dropdown-menu';
 import { usePreferences } from '@/hooks/usePreferences';
 import { useIsMobile } from '@/hooks/useIsMobile';
+import { supportsXhighEffort } from '@/lib/modelCapabilities';
 import { getSkills, getModelMetadata } from '../../pages/ChatAgent/utils/api';
 import { useToast } from './use-toast';
 import './chat-input.css';
@@ -298,6 +299,7 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
   useEffect(() => { getModelMetadata().then((d: Record<string, unknown>) => setModelMetadata(d as typeof modelMetadata)).catch(() => { }); }, []);
 
   const isCodexModel = selectedModel ? modelMetadata[selectedModel]?.sdk === 'codex' : false;
+  const supportsXhigh = supportsXhighEffort(selectedModel);
 
   // @file mention state
   const [mentionedFiles, setMentionedFiles] = useState<MentionedFile[]>([]);
@@ -1370,7 +1372,12 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
                     <div className="model-effort-section">
                       <span className="model-effort-label">{t('chat.modelSelector.reasoningEffort')}</span>
                       <div className="model-effort-toggle">
-                        {([['low', Zap, t('chat.modelSelector.effortLow')], ['medium', Brain, t('chat.modelSelector.effortMedium')], ['high', Flame, t('chat.modelSelector.effortHigh')]] as const).map(([level, Icon, label]) => (
+                        {([
+                          ['low', Zap, t('chat.modelSelector.effortLow')],
+                          ['medium', Brain, t('chat.modelSelector.effortMedium')],
+                          ['high', Flame, t('chat.modelSelector.effortHigh')],
+                          ...(supportsXhigh ? [['xhigh', Sparkles, t('chat.modelSelector.effortXhigh')]] as const : []),
+                        ] as const).map(([level, Icon, label]) => (
                           <button
                             key={level}
                             className={`model-effort-btn ${level === reasoningEffort ? 'active' : ''}`}

--- a/web/src/lib/__tests__/modelCapabilities.test.ts
+++ b/web/src/lib/__tests__/modelCapabilities.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { supportsXhighEffort } from '../modelCapabilities';
+
+describe('supportsXhighEffort', () => {
+  it.each([
+    'claude-opus-4-7',
+    'claude-opus-4-7-oauth',
+    'claude-opus-4-7-oauth-1m',
+    'claude-opus-4-8',
+    'claude-opus-4-9',
+    'claude-opus-4-10',
+    'claude-opus-4-20',
+    'claude-opus-5',
+    'claude-opus-5-0',
+    'claude-opus-9',
+    'opus-4-7',
+  ])('accepts %s', (model) => {
+    expect(supportsXhighEffort(model)).toBe(true);
+  });
+
+  it.each([
+    'claude-opus-4-0',
+    'claude-opus-4-5',
+    'claude-opus-4-6',
+    'claude-opus-4-6-oauth',
+    'claude-opus-3',
+    'claude-opus-3-5',
+    'claude-sonnet-4-7',
+    'claude-haiku-4-7',
+    'gpt-4o',
+  ])('rejects %s', (model) => {
+    expect(supportsXhighEffort(model)).toBe(false);
+  });
+
+  it('rejects null/undefined/empty', () => {
+    expect(supportsXhighEffort(null)).toBe(false);
+    expect(supportsXhighEffort(undefined)).toBe(false);
+    expect(supportsXhighEffort('')).toBe(false);
+  });
+});

--- a/web/src/lib/modelCapabilities.ts
+++ b/web/src/lib/modelCapabilities.ts
@@ -1,0 +1,7 @@
+// Xhigh effort was introduced in Opus 4.7. Opus 4.6 and earlier don't support it.
+// Pattern covers opus-4-7/8/9, opus-4-10+, and any opus-5+ without manual updates.
+const XHIGH_PATTERN = /opus-(?:4-(?:[7-9]|\d{2,})|[5-9])/i;
+
+export function supportsXhighEffort(model: string | null | undefined): boolean {
+  return !!model && XHIGH_PATTERN.test(model);
+}

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -329,6 +329,7 @@
       "effortLow": "Low",
       "effortMedium": "Medium",
       "effortHigh": "High",
+      "effortXhigh": "X-High",
       "incompatibleSdk": "Cannot switch to this model in the current session (different provider)",
       "fastMode": "Fast",
       "fastModeDesc": "Priority routing for faster responses",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -329,6 +329,7 @@
       "effortLow": "低",
       "effortMedium": "中",
       "effortHigh": "高",
+      "effortXhigh": "极高",
       "incompatibleSdk": "当前会话无法切换到此模型（提供商不同）",
       "fastMode": "快速",
       "fastModeDesc": "优先路由以获得更快响应",


### PR DESCRIPTION
## Summary

Three related fixes for Opus 4.7 rollout.

**xhigh effort tier (`feat(reasoning)`)** — Introduces `xhigh` as a fourth reasoning effort alongside low/medium/high. Only the Anthropic adaptive path natively supports it; every other provider clamps `xhigh → high` via `_clamp()` in `reasoning.py`. Pydantic `ChatRequest.reasoning_effort` literal widens at the API boundary. Manifest adds `display: "summarized"` + `effort: "xhigh"` defaults to all three Opus 4.7 entries, plus `max_tokens` caps across the Anthropic family (Opus = 128k, Sonnet/Haiku = 64k). Frontend gates the X-High button behind a regex that accepts Opus 4.7/8/9/10+ and 5+ while rejecting 4.6 and earlier (forward-compat for future Opus releases without code changes).

**Sanitizer middleware (`fix(agent)`)** — Anthropic returns `messages.<i>.content.<j>.thinking.thinking: Field required` when an AI message carries a signature-only thinking block (no `thinking` text). This happens on Opus 4.7 when the stream produces a redacted/empty reasoning segment that LangGraph then persists. `AnthropicThinkingSanitizerMiddleware` runs innermost in both main and subagent chains, scans AI messages, and injects `thinking: ""` into orphan blocks while leaving everything else untouched by identity. Safe no-op for non-Anthropic providers (they don't emit thinking blocks).

**Tool-reasoning leak (`fix(streaming)`)** — Tools with internal LLMs (WebFetch, etc.) were emitting reasoning chunks under `agent: "tools:<uuid>"` with mis-ordered lifecycle signals, which the frontend painted as a second phantom Reasoning panel on the main agent's turn. `_process_message_chunk` now gates reasoning emission when `agent_name == "tools"` or starts with `"tools:"`. Subagents (`task:*`, `research:*`) are unaffected.

## Test Coverage

- **Backend (2515 passed)** — `test_reasoning.py` parametrized for xhigh + 5 clamping tests per provider, `test_chat_models.py` widens reasoning_effort loop, `test_streaming_handler.py` adds `TestToolAgentReasoningSuppression` (4 cases), `test_anthropic_thinking_sanitizer.py` new (18 cases: block-level repair, message scan, list identity, async + sync override contract).
- **Frontend (467 passed, +21 new)** — `modelCapabilities.test.ts` covers the xhigh regex against 11 accept + 9 reject + 3 null-ish cases to lock the forward-compat pattern.

## Pre-Landing Review

No P0/P1 findings. Three concerns verified:
- Sanitizer only mutates `{"type":"thinking"}` blocks; identity-preserving elsewhere.
- `_clamp()` leaves xhigh raw only on the adaptive Anthropic path.
- Tool-agent gate uses an exact `"tools"` match + `"tools:"` prefix, never touches `task:*` / `research:*`.

## Test plan

- [x] Backend unit tests: 2515 passed
- [x] Frontend vitest: 467 passed
- [x] TypeScript check: clean
- [ ] Manual smoke against Opus 4.7 with `reasoning_effort: xhigh` in prod traffic