### PR TITLE
fix(workspace): stamp last_activity_at on stopped→running transitions

### DIFF
--- a/src/server/services/workspace_manager.py
+++ b/src/server/services/workspace_manager.py
@@ -1013,6 +1013,11 @@ class WorkspaceManager:
                                     workspace_id=workspace_id,
                                     status=corrected,
                                 )
+                                # Fresh last_activity_at so the idle sweep does
+                                # not immediately stop a just-corrected workspace
+                                # on a stale timestamp. Mirrors _recover_sandbox
+                                # and _restart_workspace.
+                                await update_workspace_activity(workspace_id)
                                 if corrected == "stopped":
                                     session = await self._restart_workspace(
                                         workspace,
@@ -1258,6 +1263,11 @@ class WorkspaceManager:
 
             # Cache session
             self._sessions[workspace_id] = session
+
+            # Stamp last_activity_at so the idle sweep cannot pick this workspace
+            # up using a stale timestamp during the remainder of the request
+            # lifetime. Mirrors _recover_sandbox.
+            await update_workspace_activity(workspace_id)
 
             logger.info(f"Workspace {workspace_id} restarted successfully")
             return session

--- a/tests/unit/server/services/test_workspace_manager.py
+++ b/tests/unit/server/services/test_workspace_manager.py
@@ -916,6 +916,62 @@ class TestSandboxRecovery:
         mock_session_mgr.remove_session.assert_called_with(ws_id)
         assert result is not None
 
+    @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.SessionManager")
+    @patch("src.server.services.workspace_manager.update_workspace_status")
+    @patch("src.server.services.workspace_manager.update_workspace_activity")
+    async def test_restart_workspace_stamps_activity_after_status(
+        self, mock_activity, mock_status, mock_session_mgr
+    ):
+        """REGRESSION: _restart_workspace must await update_workspace_activity
+        after flipping status to 'running'. Without this, an idle sweep firing
+        during the sandbox restore reads a stale last_activity_at and stops the
+        workspace mid-request, surfacing to the user as
+        'Session for workspace ... is not properly initialized'.
+        Mirrors _recover_sandbox.
+        """
+        manager = self._make_manager()
+        ws_id = str(uuid.uuid4())
+        workspace = _make_workspace(workspace_id=ws_id, status="stopped")
+
+        session = _make_mock_session()
+        mock_session_mgr.get_session.return_value = session
+
+        # Patch non-focus internals so execution reaches the final
+        # status + activity block on the happy reconnect path.
+        manager._sync_sandbox_assets = AsyncMock()
+        manager._maybe_restore_files = AsyncMock()
+        manager._maybe_migrate_sandbox = AsyncMock(return_value=None)
+
+        # Record relative order of the two awaited writes.
+        call_order: list[str] = []
+
+        async def record_status(**kwargs):
+            call_order.append("status")
+
+        async def record_activity(workspace_id):
+            call_order.append("activity")
+
+        mock_status.side_effect = record_status
+        mock_activity.side_effect = record_activity
+
+        result = await manager._restart_workspace(
+            workspace, user_id="user-1", lazy_init=False
+        )
+
+        assert result is session
+
+        mock_status.assert_awaited_once()
+        status_kwargs = mock_status.await_args.kwargs
+        assert status_kwargs["status"] == "running"
+        assert status_kwargs["workspace_id"] == ws_id
+        mock_activity.assert_awaited_once_with(ws_id)
+
+        # Ordering must match _recover_sandbox: status flip first, then
+        # activity stamp. Reversing the order would leave a larger window
+        # where cleanup_idle_workspaces could stop the workspace.
+        assert call_order == ["status", "activity"]
+
 
 # ---------------------------------------------------------------------------
 # on_state_observed forwarding — pin the kwarg threads through every


### PR DESCRIPTION
## Summary

Prod incident: `RuntimeError: Session for workspace … is not properly initialized` killed a user chat thread.

**Root cause.** `WorkspaceManager._restart_workspace` flipped `workspaces.status` to `running` but never stamped `last_activity_at`. The workspace's timestamp was 31 h old from before the sandbox was stopped. During the ~65 s archived-sandbox restore that follows the status flip on the lazy-init path, the 5-minute idle sweep (`cleanup_idle_workspaces`) picked the workspace up, read the stale timestamp, and called `stop_workspace` mid-restore. The chat's `build_ptc_graph_with_session` then ran against `session.sandbox = None` and raised.

**Fix.** Add `await update_workspace_activity(workspace_id)` immediately after each `stopped→running` (or corrected→running) transition inside `WorkspaceManager`, mirroring the pattern already present in `_recover_sandbox`. After the fix, `last_activity_at` is fresh at the instant `status` becomes `running`, so the Python-side idle check (`idle_seconds > idle_timeout=1800s`) cannot fire during any plausible restore.

Two callsites fixed:
- `_restart_workspace` (the primary incident path)
- The `_correct_stale_status` self-heal branch that corrects a DB row stuck in `stopping` to match the provider's actual state (found by adversarial review — same bug class)

`create_workspace` was audited and does not need the stamp (INSERT sets `last_activity_at` via DB default).

## Test Coverage

New regression test: `TestSandboxRecovery::test_restart_workspace_stamps_activity_after_status`

Exercises the real `_restart_workspace` happy reconnect path, patches both DB writes with async side-effect recorders, and asserts:
1. `update_workspace_status` awaited once with `status="running"` and the right workspace_id
2. `update_workspace_activity` awaited once with the workspace_id
3. Call order is `status → activity` (mirrors `_recover_sandbox`)

All 48 `test_workspace_manager.py` tests pass. Full `tests/unit/` (2683 tests) pass.

## Pre-Landing Review

- Structural checklist: clean (no SQL changes, no LLM trust-boundary changes, no migrations, no auth).
- Adversarial subagent caught the missing self-heal callsite (now fixed in this PR).
- `update_workspace_activity` is conditional in SQL (`last_activity_at < now() - 60s`), so the near-simultaneous fire-and-forget stamp from `ptc_workflow.py:372` is deduped — no write amplification.

## Perf

No hot-path cost. Warm chats (cached in-memory session) never enter `_restart_workspace`. Cold restart now does one extra ~1 ms `UPDATE` on top of a ~60 s sandbox restore.

## Test plan
- [x] `uv run pytest tests/unit/server/services/test_workspace_manager.py -v` → 48 passed
- [x] `uv run pytest tests/unit/` → 2683 passed
- [x] Ruff clean on the two changed files (pre-existing F821 on `PTCSandbox` is unrelated)
- [ ] Post-deploy: grep `langalpha_backend_*` logs for `Session for workspace … is not properly initialized` — should drop to zero on stopped→running restart paths