### PR TITLE
fix(web): prevent ChatView crash from non-array todo_update payloads

### DIFF
--- a/web/src/pages/ChatAgent/components/TodoDrawer.tsx
+++ b/web/src/pages/ChatAgent/components/TodoDrawer.tsx
@@ -58,7 +58,7 @@ function TodoDrawer({ todoData }: { todoData: TodoData | null }) {
   const [isExpanded, setIsExpanded] = useState(false);
   const wasAllCompleted = useRef(false);
 
-  const todos = todoData?.todos;
+  const todos = Array.isArray(todoData?.todos) ? todoData.todos : undefined;
   const total = todoData?.total || 0;
   const completed = todoData?.completed || 0;
 

--- a/web/src/pages/ChatAgent/hooks/useCardState.ts
+++ b/web/src/pages/ChatAgent/hooks/useCardState.ts
@@ -316,7 +316,7 @@ export function useCardState(initialCards: CardsMap = {}): UseCardStateResult {
   const finalizePendingTodos = () => {
     setCards((prev) => {
       const card = prev['todo-list-card'];
-      if (!card?.todoData?.todos) return prev;
+      if (!Array.isArray(card?.todoData?.todos)) return prev;
 
       const hasIncomplete = card.todoData.todos.some(
         (t) => t.status !== 'completed' && t.status !== 'stale'

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -416,7 +416,8 @@ export function finalizeTodoListProcessesInMessages(
     const entries = Object.entries(am.todoListProcesses);
     const lastEntry = entries.reduce((a, b) => ((a[1].order || 0) >= (b[1].order || 0) ? a : b));
     const [lastKey, lastVal] = lastEntry;
-    const hasIncomplete = lastVal.todos?.some(
+    if (!Array.isArray(lastVal.todos)) return m;
+    const hasIncomplete = lastVal.todos.some(
       (todo: TodoItem) => todo.status !== 'completed' && todo.status !== 'stale'
     );
     if (!hasIncomplete) return m;
@@ -972,7 +973,7 @@ export function useChatMessages(
             // Update floating todo card from history (last event wins, shows final state)
             if (updateTodoListCard) {
               updateTodoListCard({
-                todos: payload.todos || [],
+                todos: Array.isArray(payload.todos) ? payload.todos : [],
                 total: payload.total || 0,
                 completed: payload.completed || 0,
                 in_progress: payload.in_progress || 0,

--- a/web/src/pages/ChatAgent/hooks/utils/historyEventHandlers.ts
+++ b/web/src/pages/ChatAgent/hooks/utils/historyEventHandlers.ts
@@ -698,7 +698,8 @@ export function handleHistoryTodoUpdate({ assistantMessageId, artifactType, arti
     return false;
   }
 
-  const { todos, total, completed, in_progress, pending } = payload;
+  const { total, completed, in_progress, pending } = payload;
+  const todos = Array.isArray(payload.todos) ? payload.todos : [];
 
   // Use artifactId as the base todoListId to track updates to the same logical todo list
   // But create a unique segmentId for each event to preserve chronological order

--- a/web/src/pages/ChatAgent/hooks/utils/streamEventHandlers.ts
+++ b/web/src/pages/ChatAgent/hooks/utils/streamEventHandlers.ts
@@ -541,7 +541,8 @@ export function handleTodoUpdate({ assistantMessageId, artifactType, artifactId,
     return false;
   }
 
-  const { todos, total, completed, in_progress, pending } = payload;
+  const { total, completed, in_progress, pending } = payload;
+  const todos = Array.isArray(payload.todos) ? payload.todos : [];
   if (import.meta.env.DEV) {
     console.log('[handleTodoUpdate] Extracted data:', { todos, total, completed, in_progress, pending });
   }


### PR DESCRIPTION
## Summary

Some LLMs emit the `TodoWrite` tool's `todos` argument as a stringified JSON blob (sometimes malformed) instead of an array. The backend middleware passes it through unchanged, and the frontend's `todos || []` fallback does not catch a truthy non-array value. Downstream `.some()` and `.map()` calls then throw a `TypeError` during layout commit, unmounting `ChatView` and leaving the thread URL blank — and **unrecoverable on reload**, because the bad payload is persisted in `conversation_responses.sse_events` and replayed on every subsequent open of the thread.

Observed symptom: `/chat/t/<threadId>` renders, then goes blank a moment later. Console shows:

```
TypeError: card.todoData.todos.some is not a function
  at finalizePendingTodos (useCardState.ts)
TypeError: lastVal.todos.some is not a function
  at finalizeTodoListProcessesInMessages (useChatMessages.ts)
```

Inspecting the replay revealed `payload.todos` arriving as a string literal like `'[{"content": ..., status":completed"}, ...]'` — note the malformed JSON (missing opening quote on `status`).

## Fix

Belt-and-braces at both ends of the pipeline:

- **Coerce non-array `todos` to `[]` at the three SSE ingestion points** (live stream, history replay, and the artifact handler in `useChatMessages`), so bad data never enters `todoListProcesses` or the floating todo card state going forward.
- **Guard the two end-of-stream finalize paths** (`finalizePendingTodos` in `useCardState`, `finalizeTodoListProcessesInMessages` in `useChatMessages`) with `Array.isArray`, so threads that already captured the bad payload render cleanly on replay instead of crashing.
- **Normalize `TodoDrawer`'s local `todos`** to `undefined` when not an array, so downstream iterators short-circuit instead of throwing.

## Test plan

- [x] Loaded a thread whose persisted replay contained a `todo_update` event with string-typed `todos` — `ChatView` now renders instead of blanking.
- [x] Normal `todo_update` events (array-typed) still render the todo drawer and todo list card correctly.
- [ ] Backend middleware could additionally validate/normalize at emission (`src/ptc_agent/agent/middleware/todo_operations/sse_middleware.py`) — intentionally left out of this PR, since the frontend fix is required to recover threads whose bad payloads are already persisted, and a separate PR can address the upstream symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)