### PR TITLE
feat(mcp): read-only X (Twitter) API MCP server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,16 @@ TAVILY_API_KEY=
 # Alpha Vantage (alternative financial data MCP server, disabled by default)
 ALPHA_VANTAGE_API_KEY=
 
+# X (Twitter) API — read-only Bearer Token for the X MCP server.
+# Primary path: users store X_BEARER_TOKEN per-workspace via the UI —
+#   Workspace Files panel → settings icon (top of panel) → Workspace Settings
+#   → Vault tab → add secret named X_BEARER_TOKEN.
+# This host-env var is a single-tenant OSS-only fallback. Setting it here is NOT enough
+# on its own — you also need to uncomment the env passthrough in agent_config.yaml under
+# the `x_api` MCP server. Leaving env: {} means vault is the only auth path.
+# Get a token at https://console.x.com/ (App → Keys and tokens → Bearer Token).
+X_BEARER_TOKEN=
+
 # GitHub Bot (agent self-improvement — disabled by default, set github.enabled in config.yaml)
 # GITHUB_BOT_TOKEN=
 

--- a/agent_config.yaml
+++ b/agent_config.yaml
@@ -169,6 +169,25 @@ mcp:
       args: ["mcp"]
       env: {}
 
+    # X (Twitter) API MCP server — read-only post search, user lookup, tweet lookup, thread fetch.
+    # Bearer token flows as a per-call tool argument sourced from the workspace vault
+    # (`from vault import get; get("X_BEARER_TOKEN")`), not from the MCP subprocess env.
+    # Host-env X_BEARER_TOKEN acts as a single-tenant fallback if the arg is omitted.
+    - name: "x_api"
+      enabled: true
+      description: "Search X (Twitter) posts and fetch users, tweets, and reply threads. Read-only."
+      instruction: "Use for X/Twitter search and thread retrieval. Tools: search_posts, search_all_posts, get_conversation, get_user_by_username, get_tweet_by_id. For a single known X post URL, prefer web_fetch — reserve these tools for search, aggregation, and thread traversal. Every call needs bearer_token from the workspace vault: `from vault import get; token = get(\"X_BEARER_TOKEN\")`. Prefer search_posts by default; reach for search_all_posts only when the user needs posts older than ~7 days. See skills/x-api/ for usage and errors."
+      tool_exposure_mode: "summary"
+      transport: "stdio"
+      command: "uv"
+      args: ["run", "python", "mcp_servers/x_mcp_server.py"]
+      # env intentionally empty: in multi-tenant deployments the token MUST come
+      # from the per-workspace vault, not a shared host env. Single-tenant OSS
+      # users who want the convenience of a host-env fallback can uncomment:
+      #   X_BEARER_TOKEN: "${X_BEARER_TOKEN}"
+      # This will make every workspace's MCP subprocess share the same host token.
+      env: {}
+
     # Not enabled in Porduction or maintained by us
     - name: "alphavantage"
       enabled: false

--- a/mcp_servers/x_mcp_server.py
+++ b/mcp_servers/x_mcp_server.py
@@ -15,7 +15,6 @@ import re
 import time
 from contextlib import asynccontextmanager
 from typing import Any, Optional
-from urllib.parse import quote
 
 import httpx
 from mcp.server.fastmcp import FastMCP
@@ -157,6 +156,9 @@ def _error_from_response(resp: httpx.Response) -> dict:
 
 
 async def _get(path: str, params: dict[str, Any], token: str) -> httpx.Response | dict:
+    """Authenticated GET against X_API_BASE + path. Callers are responsible for
+    validating any interpolated path segments (see _USERNAME_RE, _TWEET_ID_RE);
+    this helper does no URL escaping."""
     if _client is None:
         return {"error": "client_unavailable", "detail": "HTTP client not initialized"}
     headers = {"Authorization": f"Bearer {token}"}
@@ -169,11 +171,15 @@ async def _get(path: str, params: dict[str, Any], token: str) -> httpx.Response 
     return resp
 
 
-def _parse_json_body(resp: httpx.Response) -> Any | dict:
+def _parse_json_body(resp: httpx.Response) -> tuple[Any, dict | None]:
+    """Parse the response JSON. Returns (payload, None) on success or
+    (None, error_dict) on decode failure. Using a tuple instead of a sentinel
+    dict avoids any collision with X response bodies that happen to carry an
+    ``error`` key."""
     try:
-        return resp.json()
+        return resp.json(), None
     except ValueError:
-        return {
+        return None, {
             "error": "malformed_response",
             "detail": "X API returned a non-JSON 2xx body",
         }
@@ -218,9 +224,9 @@ async def _search(
     if resp.status_code != 200:
         return _error_from_response(resp)
 
-    payload = _parse_json_body(resp)
-    if isinstance(payload, dict) and payload.get("error") == "malformed_response":
-        return payload
+    payload, err = _parse_json_body(resp)
+    if err is not None:
+        return err
 
     users_by_id = _index_users(payload.get("includes"))
     posts = [_enrich_post(p, users_by_id) for p in payload.get("data") or []]
@@ -336,7 +342,7 @@ async def get_user_by_username(
         }
 
     resp_or_err = await _get(
-        f"/users/by/username/{quote(username, safe='')}",
+        f"/users/by/username/{username}",
         {"user.fields": _USER_LOOKUP_FIELDS},
         token,
     )
@@ -346,9 +352,9 @@ async def get_user_by_username(
     if resp.status_code != 200:
         return _error_from_response(resp)
 
-    payload = _parse_json_body(resp)
-    if isinstance(payload, dict) and payload.get("error") == "malformed_response":
-        return payload
+    payload, err = _parse_json_body(resp)
+    if err is not None:
+        return err
     data = payload.get("data")
     if not data:
         return {"error": "not_found", "detail": f"User '{username}' not found"}
@@ -381,18 +387,16 @@ async def get_tweet_by_id(
         "expansions": _EXPANSIONS,
         "user.fields": _USER_FIELDS,
     }
-    resp_or_err = await _get(
-        f"/tweets/{quote(tweet_id, safe='')}", params, token
-    )
+    resp_or_err = await _get(f"/tweets/{tweet_id}", params, token)
     if isinstance(resp_or_err, dict):
         return resp_or_err
     resp = resp_or_err
     if resp.status_code != 200:
         return _error_from_response(resp)
 
-    payload = _parse_json_body(resp)
-    if isinstance(payload, dict) and payload.get("error") == "malformed_response":
-        return payload
+    payload, err = _parse_json_body(resp)
+    if err is not None:
+        return err
     data = payload.get("data")
     if not data:
         return {"error": "not_found", "detail": f"Tweet '{tweet_id}' not found"}

--- a/mcp_servers/x_mcp_server.py
+++ b/mcp_servers/x_mcp_server.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+"""X (Twitter) API MCP Server — read-only v2 endpoints for PTC-mode agents.
+
+Auth: per-call Bearer Token. Primary source is the workspace vault; falls back
+to the X_BEARER_TOKEN host env when explicitly passed through in agent_config.
+
+Tools: search_posts, search_all_posts, get_user_by_username, get_tweet_by_id,
+get_conversation. See skills/x-api/ for usage and error handling.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+from contextlib import asynccontextmanager
+from typing import Any, Optional
+from urllib.parse import quote
+
+import httpx
+from mcp.server.fastmcp import FastMCP
+
+X_API_BASE = "https://api.x.com/2"
+_HTTP_TIMEOUT = 30.0
+
+# Per-endpoint constraints (X API v2).
+# Recent Search:       query <=512 chars, page size 10-100.
+# Full-archive Search: query <=1024 chars, page size 10-500. Paid-tier only.
+_MIN_PAGE_SIZE = 10
+_MAX_QUERY_LEN_RECENT = 512
+_MAX_PAGE_SIZE_RECENT = 100
+_MAX_QUERY_LEN_ALL = 1024
+_MAX_PAGE_SIZE_ALL = 500
+
+_TWEET_FIELDS = "created_at,public_metrics,lang,author_id,conversation_id"
+_USER_FIELDS = "username,name,verified,public_metrics,description,created_at"
+_EXPANSIONS = "author_id"
+_USER_LOOKUP_FIELDS = "verified,public_metrics,description,created_at"
+
+_USERNAME_RE = re.compile(r"^[A-Za-z0-9_]{1,15}$")
+_TWEET_ID_RE = re.compile(r"^\d{1,25}$")
+
+_ERROR_DETAIL_KEYS = ("title", "type", "detail", "status", "reason")
+
+_client: httpx.AsyncClient | None = None
+
+
+@asynccontextmanager
+async def _lifespan(app):
+    global _client
+    _client = httpx.AsyncClient(
+        timeout=_HTTP_TIMEOUT,
+        limits=httpx.Limits(max_connections=10, max_keepalive_connections=5),
+        headers={"User-Agent": "langalpha-x-mcp/1.0"},
+    )
+    try:
+        yield
+    finally:
+        await _client.aclose()
+        _client = None
+
+
+mcp = FastMCP("XApiMCP", lifespan=_lifespan)
+
+
+def _resolve_token(bearer_token: Optional[str]) -> Optional[str]:
+    if bearer_token:
+        return bearer_token
+    env = os.getenv("X_BEARER_TOKEN")
+    return env or None
+
+
+def _missing_token_error() -> dict:
+    return {
+        "error": "missing_token",
+        "detail": (
+            "X bearer token required. Pass bearer_token from the workspace vault "
+            '(from vault import get; token = get("X_BEARER_TOKEN")), or set '
+            "X_BEARER_TOKEN in the host env for single-tenant deployments."
+        ),
+    }
+
+
+def _index_users(includes: dict | None) -> dict[str, dict]:
+    if not includes:
+        return {}
+    users = includes.get("users") or []
+    return {u["id"]: u for u in users if isinstance(u, dict) and "id" in u}
+
+
+def _enrich_post(post: dict, users_by_id: dict[str, dict]) -> dict:
+    out = dict(post)
+    author_id = post.get("author_id")
+    if not author_id:
+        out["author"] = None
+        return out
+    u = users_by_id.get(author_id)
+    if u is None:
+        out["author"] = {"id": author_id, "unresolved": True}
+    else:
+        out["author"] = {
+            "id": u.get("id"),
+            "username": u.get("username"),
+            "name": u.get("name"),
+            "verified": u.get("verified"),
+        }
+    return out
+
+
+def _safe_body(resp: httpx.Response) -> Any:
+    """Extract a safe error payload — whitelisted keys only, never raw text."""
+    try:
+        body = resp.json()
+    except ValueError:
+        return None
+    if not isinstance(body, dict):
+        return None
+    safe = {k: body[k] for k in _ERROR_DETAIL_KEYS if k in body}
+    errs = body.get("errors")
+    if isinstance(errs, list):
+        safe["errors"] = [
+            {k: e.get(k) for k in _ERROR_DETAIL_KEYS if k in e}
+            for e in errs
+            if isinstance(e, dict)
+        ]
+    return safe or None
+
+
+def _error_from_response(resp: httpx.Response) -> dict:
+    if resp.status_code in (401, 403):
+        return {
+            "error": "auth_failed",
+            "status": resp.status_code,
+            "detail": _safe_body(resp),
+        }
+    if resp.status_code == 429:
+        reset_raw = resp.headers.get("x-rate-limit-reset")
+        reset_at_epoch: Optional[int] = None
+        if reset_raw is not None:
+            try:
+                reset_at_epoch = int(reset_raw)
+            except ValueError:
+                reset_at_epoch = None
+        retry_after: Optional[int] = None
+        if reset_at_epoch is not None:
+            retry_after = max(0, reset_at_epoch - int(time.time()))
+        return {
+            "error": "rate_limited",
+            "reset_at_epoch": reset_at_epoch,
+            "retry_after_seconds": retry_after,
+        }
+    return {
+        "error": "http_error",
+        "status": resp.status_code,
+        "detail": _safe_body(resp),
+    }
+
+
+async def _get(path: str, params: dict[str, Any], token: str) -> httpx.Response | dict:
+    if _client is None:
+        return {"error": "client_unavailable", "detail": "HTTP client not initialized"}
+    headers = {"Authorization": f"Bearer {token}"}
+    url = f"{X_API_BASE}{path}"
+    clean = {k: v for k, v in params.items() if v is not None}
+    try:
+        resp = await _client.get(url, headers=headers, params=clean)
+    except httpx.HTTPError as exc:
+        return {"error": "network_error", "detail": type(exc).__name__}
+    return resp
+
+
+def _parse_json_body(resp: httpx.Response) -> Any | dict:
+    try:
+        return resp.json()
+    except ValueError:
+        return {
+            "error": "malformed_response",
+            "detail": "X API returned a non-JSON 2xx body",
+        }
+
+
+async def _search(
+    path: str,
+    query: str,
+    token: str,
+    max_results: int,
+    max_query_len: int,
+    max_page_size: int,
+    start_time: Optional[str] = None,
+    end_time: Optional[str] = None,
+    next_token: Optional[str] = None,
+) -> dict:
+    if len(query) > max_query_len:
+        return {
+            "error": "invalid_argument",
+            "detail": f"query must be <= {max_query_len} chars (got {len(query)})",
+        }
+    if not _MIN_PAGE_SIZE <= max_results <= max_page_size:
+        return {
+            "error": "invalid_argument",
+            "detail": f"max_results must be {_MIN_PAGE_SIZE}-{max_page_size}",
+        }
+
+    params: dict[str, Any] = {
+        "query": query,
+        "max_results": max_results,
+        "tweet.fields": _TWEET_FIELDS,
+        "expansions": _EXPANSIONS,
+        "user.fields": _USER_FIELDS,
+        "start_time": start_time,
+        "end_time": end_time,
+        "next_token": next_token,
+    }
+    resp_or_err = await _get(path, params, token)
+    if isinstance(resp_or_err, dict):
+        return resp_or_err
+    resp = resp_or_err
+    if resp.status_code != 200:
+        return _error_from_response(resp)
+
+    payload = _parse_json_body(resp)
+    if isinstance(payload, dict) and payload.get("error") == "malformed_response":
+        return payload
+
+    users_by_id = _index_users(payload.get("includes"))
+    posts = [_enrich_post(p, users_by_id) for p in payload.get("data") or []]
+    meta = payload.get("meta") or {}
+    return {
+        "posts": posts,
+        "next_token": meta.get("next_token"),
+        "result_count": meta.get("result_count", len(posts)),
+    }
+
+
+@mcp.tool()
+async def search_posts(
+    query: str,
+    bearer_token: Optional[str] = None,
+    max_results: int = 10,
+    start_time: Optional[str] = None,
+    end_time: Optional[str] = None,
+    next_token: Optional[str] = None,
+) -> dict:
+    """Search recent X posts (last ~7 days) using X search syntax.
+
+    Args:
+        query: X search syntax. Example: '$TSLA -is:retweet lang:en'.
+        bearer_token: Loaded from the sandbox vault:
+            `from vault import get; get("X_BEARER_TOKEN")`.
+        max_results: Posts per page. Default 10, max 100.
+        start_time: ISO8601 inclusive lower bound (e.g. "2026-04-20T00:00:00Z").
+        end_time: ISO8601 exclusive upper bound.
+        next_token: Pagination cursor from a previous response.
+
+    Returns:
+        {"posts": [...], "next_token": str | None, "result_count": int},
+        or {"error": ..., ...} on failure. See skills/x-api/ for post shape.
+    """
+    token = _resolve_token(bearer_token)
+    if not token:
+        return _missing_token_error()
+    return await _search(
+        path="/tweets/search/recent",
+        query=query,
+        token=token,
+        max_results=max_results,
+        max_query_len=_MAX_QUERY_LEN_RECENT,
+        max_page_size=_MAX_PAGE_SIZE_RECENT,
+        start_time=start_time,
+        end_time=end_time,
+        next_token=next_token,
+    )
+
+
+@mcp.tool()
+async def search_all_posts(
+    query: str,
+    bearer_token: Optional[str] = None,
+    max_results: int = 10,
+    start_time: Optional[str] = None,
+    end_time: Optional[str] = None,
+    next_token: Optional[str] = None,
+) -> dict:
+    """Full-archive X post search, back to March 2006. Use when `search_posts`
+    (recent 7-day window) doesn't reach far enough back.
+
+    Args:
+        query: X search syntax. Example: '$TSLA (earnings OR guidance)'.
+        bearer_token: Loaded from the sandbox vault (`get("X_BEARER_TOKEN")`).
+        max_results: Posts per page. Default 10, max 500.
+        start_time: ISO8601 inclusive lower bound (back to 2006-03-26).
+        end_time: ISO8601 exclusive upper bound.
+        next_token: Pagination cursor from a previous response.
+
+    Returns:
+        Same shape as search_posts, or {"error": ..., ...} on failure.
+    """
+    token = _resolve_token(bearer_token)
+    if not token:
+        return _missing_token_error()
+    return await _search(
+        path="/tweets/search/all",
+        query=query,
+        token=token,
+        max_results=max_results,
+        max_query_len=_MAX_QUERY_LEN_ALL,
+        max_page_size=_MAX_PAGE_SIZE_ALL,
+        start_time=start_time,
+        end_time=end_time,
+        next_token=next_token,
+    )
+
+
+@mcp.tool()
+async def get_user_by_username(
+    username: str,
+    bearer_token: Optional[str] = None,
+) -> dict:
+    """Look up an X user profile by handle (without @).
+
+    Args:
+        username: Handle without @ (e.g. "XDevelopers"). 1-15 chars, [A-Za-z0-9_].
+        bearer_token: Loaded from the sandbox vault (`get("X_BEARER_TOKEN")`).
+
+    Returns:
+        {"user": {id, username, name, verified, description, created_at,
+        public_metrics}}, or {"error": ...} on failure.
+    """
+    token = _resolve_token(bearer_token)
+    if not token:
+        return _missing_token_error()
+    if not _USERNAME_RE.match(username or ""):
+        return {
+            "error": "invalid_argument",
+            "detail": "username must match ^[A-Za-z0-9_]{1,15}$",
+        }
+
+    resp_or_err = await _get(
+        f"/users/by/username/{quote(username, safe='')}",
+        {"user.fields": _USER_LOOKUP_FIELDS},
+        token,
+    )
+    if isinstance(resp_or_err, dict):
+        return resp_or_err
+    resp = resp_or_err
+    if resp.status_code != 200:
+        return _error_from_response(resp)
+
+    payload = _parse_json_body(resp)
+    if isinstance(payload, dict) and payload.get("error") == "malformed_response":
+        return payload
+    data = payload.get("data")
+    if not data:
+        return {"error": "not_found", "detail": f"User '{username}' not found"}
+    return {"user": data}
+
+
+@mcp.tool()
+async def get_tweet_by_id(
+    tweet_id: str,
+    bearer_token: Optional[str] = None,
+) -> dict:
+    """Fetch a single X post by its numeric id.
+
+    Args:
+        tweet_id: Numeric tweet id as a string (the trailing digits of an X URL).
+        bearer_token: Loaded from the sandbox vault (`get("X_BEARER_TOKEN")`).
+
+    Returns:
+        {"post": {...}}, same shape as a search_posts item. Deleted or private
+        tweets return {"error": "not_found"}.
+    """
+    token = _resolve_token(bearer_token)
+    if not token:
+        return _missing_token_error()
+    if not _TWEET_ID_RE.match(tweet_id or ""):
+        return {"error": "invalid_argument", "detail": "tweet_id must be numeric"}
+
+    params = {
+        "tweet.fields": _TWEET_FIELDS,
+        "expansions": _EXPANSIONS,
+        "user.fields": _USER_FIELDS,
+    }
+    resp_or_err = await _get(
+        f"/tweets/{quote(tweet_id, safe='')}", params, token
+    )
+    if isinstance(resp_or_err, dict):
+        return resp_or_err
+    resp = resp_or_err
+    if resp.status_code != 200:
+        return _error_from_response(resp)
+
+    payload = _parse_json_body(resp)
+    if isinstance(payload, dict) and payload.get("error") == "malformed_response":
+        return payload
+    data = payload.get("data")
+    if not data:
+        return {"error": "not_found", "detail": f"Tweet '{tweet_id}' not found"}
+    users_by_id = _index_users(payload.get("includes"))
+    return {"post": _enrich_post(data, users_by_id)}
+
+
+@mcp.tool()
+async def get_conversation(
+    conversation_id: str,
+    bearer_token: Optional[str] = None,
+    max_results: int = 50,
+    next_token: Optional[str] = None,
+) -> dict:
+    """Fetch replies to an X conversation thread (last ~7 days).
+
+    Args:
+        conversation_id: Often equals the root tweet id — find it via
+            get_tweet_by_id on the root.
+        bearer_token: Loaded from the sandbox vault (`get("X_BEARER_TOKEN")`).
+        max_results: Posts per page. Default 50, max 100.
+        next_token: Pagination cursor from a previous response.
+
+    Returns:
+        Same shape as search_posts. Root tweet is NOT included — fetch it
+        separately with get_tweet_by_id if needed.
+    """
+    token = _resolve_token(bearer_token)
+    if not token:
+        return _missing_token_error()
+    if not _TWEET_ID_RE.match(conversation_id or ""):
+        return {
+            "error": "invalid_argument",
+            "detail": "conversation_id must be numeric",
+        }
+    return await _search(
+        path="/tweets/search/recent",
+        query=f"conversation_id:{conversation_id}",
+        token=token,
+        max_results=max_results,
+        max_query_len=_MAX_QUERY_LEN_RECENT,
+        max_page_size=_MAX_PAGE_SIZE_RECENT,
+        next_token=next_token,
+    )
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/mcp_servers/x_mcp_server.py
+++ b/mcp_servers/x_mcp_server.py
@@ -32,7 +32,10 @@ _MAX_QUERY_LEN_ALL = 1024
 _MAX_PAGE_SIZE_ALL = 500
 
 _TWEET_FIELDS = "created_at,public_metrics,lang,author_id,conversation_id"
-_USER_FIELDS = "username,name,verified,public_metrics,description,created_at"
+# Only the four fields _enrich_post surfaces onto each post's `author` object —
+# anything else would just pad the response. get_user_by_username asks for the
+# fuller profile via _USER_LOOKUP_FIELDS.
+_USER_FIELDS = "username,name,verified"
 _EXPANSIONS = "author_id"
 _USER_LOOKUP_FIELDS = "verified,public_metrics,description,created_at"
 

--- a/skills/x-api/SKILL.md
+++ b/skills/x-api/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: x-api
+description: "Search X (Twitter) posts, pull user profiles, fetch specific tweets, and read reply threads for sentiment, news, and event research. Triggers on 'X', 'Twitter', 'tweets about', 'sentiment on', 'what are people saying about', 'historical tweets', or any request to read public X content."
+---
+
+# X (Twitter) API
+
+Read-only access to X content via five MCP tools. Use for sentiment on tickers, exec announcements, launches, event tracking, and qualitative research alongside SEC/market data.
+
+> **Not for single-post URL lookups.** If the user hands you a specific X post URL and just wants its text or context, use `web_fetch` on the URL — no vault, no auth, no rate limit. Reach for this skill when the task is **search, aggregation, or thread traversal**.
+
+## Auth
+
+Every tool requires a `bearer_token`. Read it once per code block from the workspace vault:
+
+```python
+from vault import get
+token = get("X_BEARER_TOKEN")
+```
+
+If `token` is `None` or empty, the user hasn't added it yet. For the setup walkthrough and per-error fixes, see [TROUBLESHOOTING.md](./TROUBLESHOOTING.md).
+
+## Tools at a glance
+
+The primary use case is **search** — the first two tools are what you'll reach for most.
+
+| Tool | Use for | Page size | Notes |
+|---|---|---|---|
+| `search_posts` | Posts from the last ~7 days | default 10, max 100 | Default choice. Query ≤512 chars. |
+| `search_all_posts` | Posts older than 7 days (back to 2006) | default 10, max 500 | Paid-tier X plan only. Query ≤1024 chars. |
+| `get_conversation` | Reply thread to a root tweet | default 50, max 100 | Uses recent search — thread must be ≤7 days old. Root tweet not included. |
+| `get_user_by_username` | A user profile + metrics | — | Handle without `@`, ≤15 chars. |
+| `get_tweet_by_id` | Hydrate a single post (mainly to find its `conversation_id` before `get_conversation`) | — | For a one-off URL the user already has, prefer `web_fetch`. |
+
+## Examples
+
+### Recent sentiment on a ticker
+
+```python
+res = search_posts(
+    query="$NVDA -is:retweet lang:en",
+    bearer_token=token,
+    max_results=100,
+)
+posts = res["posts"]
+posts.sort(key=lambda p: p["public_metrics"].get("impression_count", 0), reverse=True)
+for p in posts[:10]:
+    print(p["author"]["username"], p["public_metrics"].get("like_count"), p["text"][:140])
+```
+
+### Historical reaction to a past event
+
+```python
+res = search_all_posts(
+    query="$TSLA earnings -is:retweet lang:en",
+    bearer_token=token,
+    max_results=500,
+    start_time="2020-03-13T00:00:00Z",
+    end_time="2020-03-20T00:00:00Z",
+)
+```
+
+### Full thread on a specific tweet
+
+```python
+root = get_tweet_by_id(tweet_id="1700000000000000001", bearer_token=token)
+thread = get_conversation(
+    conversation_id=root["post"]["conversation_id"],
+    bearer_token=token,
+    max_results=100,
+)
+all_posts = [root["post"], *thread["posts"]]
+```
+
+### Paginate through a large result
+
+```python
+posts, next_tok = [], None
+while len(posts) < 500:
+    res = search_posts(
+        query="from:FedSpeakers",
+        bearer_token=token,
+        max_results=100,
+        next_token=next_tok,
+    )
+    if "error" in res:
+        break
+    posts.extend(res["posts"])
+    next_tok = res.get("next_token")
+    if not next_tok:
+        break
+```
+
+## Post shape
+
+Each post: `id`, `text`, `created_at`, `lang`, `conversation_id`, `author_id`, `edit_history_tweet_ids`, `public_metrics` (retweet/reply/like/quote/bookmark/impression counts), `author` — which is `{id, username, name, verified}`, `{id, unresolved: true}` for suspended/deleted users, or `None` if the tweet has no author_id.
+
+Full per-tool response schemas (including user shape and error variants): [reference.md](./reference.md).
+
+## Query syntax
+
+`$TSLA` (cashtag), `#hashtag`, `from:elonmusk`, `to:@SEC_News`, `-is:retweet`, `is:verified`, `has:links`, `has:media`, `lang:en`, `"exact phrase"`, parentheses + `OR` for alternation. Full list: https://docs.x.com/x-api/posts/search/introduction.
+
+## Errors
+
+Every tool returns `{"error": "...", ...}` on failure — they never raise. Always check for `error` before accessing `posts` / `user` / `post`. For the per-error playbook (including setup fixes and tier gotchas), read [TROUBLESHOOTING.md](./TROUBLESHOOTING.md).
+
+## Do / Don't
+
+- **Do** read `token = get("X_BEARER_TOKEN")` once and reuse it across calls.
+- **Do** cross-reference with `get_stock_daily_prices` and `get_sec_filing` when investigating price moves or disclosures.
+- **Don't** hardcode tokens. Ever.
+- **Don't** cache `next_token` across sessions — cursors can expire.
+- **Don't** assume every author is resolved — check for `{unresolved: true}` before reading `username`.
+
+## Related
+
+- `get_stock_daily_prices` — cross-reference X sentiment with price action
+- `get_sec_filing` — pair chatter with official disclosures
+- `scrapling` `get` / `fetch` — fallback for public pages when the API is blocked
+- `web_search` — broader news search that also indexes X posts

--- a/skills/x-api/TROUBLESHOOTING.md
+++ b/skills/x-api/TROUBLESHOOTING.md
@@ -1,0 +1,174 @@
+# X API Troubleshooting
+
+Read this when:
+
+- A tool returned `{"error": "missing_token", ...}` and you need to tell the user how to fix it.
+- A tool returned `auth_failed`, `rate_limited`, `http_error`, `not_found`, `network_error`, `malformed_response`, or `invalid_argument` and you're not sure what to do.
+- The user asks "how do I set up X" or "where do I get the token."
+
+## First-time setup — get a Bearer Token and store it
+
+The X MCP tools are read-only and use a Bearer Token (app-only auth). The user supplies one per workspace via the vault. You (the agent) never see the raw token — you just call `get("X_BEARER_TOKEN")` inside sandbox code.
+
+Walk the user through these exact steps when the vault is empty:
+
+### Step 1 — Create an X developer app (one-time)
+
+1. Go to **https://console.x.com/** (requires an X account).
+2. Accept the developer terms if prompted. The Free tier is enough for low-volume read.
+3. In the Developer Portal, create a **Project** and an **App** inside it (any names are fine).
+
+### Step 2 — Copy the Bearer Token
+
+1. Open the App → **Keys and tokens** tab.
+2. Under **Bearer Token**, click **Generate** (or **Regenerate** if one already exists).
+3. Copy the token string immediately — X only shows it once. It looks like a long opaque string (often starts with `AAAA…`).
+
+> If the user regenerates, any previously-stored value in the vault becomes invalid and will start returning `auth_failed`. They'll need to paste the new one.
+
+### Step 3 — Store it in the workspace vault
+
+1. In the LangAlpha UI, open the **Workspace Files** panel on the right side of the chat.
+2. Click the **settings icon** in the top of the Workspace Files panel header — this opens **Workspace Settings**.
+3. Switch to the **Vault** tab (second tab, between **Overview** and **Storage**).
+4. Click **Add Secret** (or the equivalent "+" / new-entry button on that tab).
+5. Set **Name** to exactly `X_BEARER_TOKEN` (case-sensitive, no whitespace, no `Bearer ` prefix — just the token itself).
+6. Paste the token into **Value** and save.
+
+The value is encrypted at rest and scoped to that one workspace — other workspaces do not see it.
+
+### Step 4 — Verify from sandbox code
+
+Run this in an `execute_code` block to confirm the key is visible:
+
+```python
+from vault import get
+token = get("X_BEARER_TOKEN")
+print("present:", bool(token), "length:", len(token) if token else 0)
+```
+
+Expect `present: True` and a non-trivial length. If `present: False`, the secret wasn't saved under the exact name `X_BEARER_TOKEN` — ask the user to re-open **Workspace Settings → Vault** and double-check the secret name.
+
+**Never `print(token)` in full, paste it into a chat reply, or write it to a file.**
+
+## Error playbook
+
+Each tool returns `{"error": "...", ...}` on failure — never raises. Match the `error` value to the row below.
+
+### `missing_token`
+
+```json
+{"error": "missing_token", "detail": "X bearer token required. Pass bearer_token from the workspace vault ..."}
+```
+
+**Meaning:** `bearer_token` argument was empty/None AND the `X_BEARER_TOKEN` env var is unset inside the MCP subprocess.
+
+**What to do:**
+
+1. If you forgot to pass `bearer_token=token` to the tool — fix your call.
+2. Otherwise, the vault doesn't have `X_BEARER_TOKEN`. Stop trying. Tell the user:
+   > "I don't have an X API token in this workspace's vault. To add one: open the **Workspace Files** panel on the right → click the settings icon at the top → switch to the **Vault** tab in **Workspace Settings** → add a secret named `X_BEARER_TOKEN`. Get the token from https://console.x.com (App → Keys and tokens → Bearer Token)."
+3. Do not attempt a workaround (scraping, googling the data) unless the user says the token setup is blocked.
+
+### `auth_failed` (status 401 or 403)
+
+```json
+{"error": "auth_failed", "status": 401, "detail": {"title": "Unauthorized", ...}}
+```
+
+**Meaning:** The token exists but X rejected it.
+
+**First — is it a tier issue?** `search_all_posts` hits X's full-archive endpoint, which needs a pay-per-use or Enterprise X API plan. A free-tier token will 403 there even when it works fine for `search_posts`. If **only** `search_all_posts` fails, don't ask the user to regenerate anything — tell them full-archive search requires a paid X API plan and fall back to `search_posts` for the recent window.
+
+**Otherwise**, the token is bad. Common causes: regenerated in console.x.com and vault still has the old one; copied with whitespace or a `Bearer ` prefix; wrong token type (OAuth 1.0a user token instead of app-only Bearer Token).
+
+**What to do:**
+
+1. Surface the exact `status` to the user.
+2. Ask them to refresh: console.x.com → App → Keys and tokens → **Regenerate** Bearer Token → paste the new value into the vault (replacing `X_BEARER_TOKEN`).
+3. Do not retry more than once on the same token.
+
+### `rate_limited` (status 429)
+
+```json
+{"error": "rate_limited", "reset_at_epoch": 1777777760, "retry_after_seconds": 47}
+```
+
+**Meaning:** Rate limit hit. `search_all_posts` has a much tighter ceiling than the others (~1 req/sec), so back-to-back calls to it are the usual culprit.
+
+**What to do:**
+
+- `retry_after_seconds` ≤ ~60: `time.sleep(retry_after_seconds)` then retry once.
+- `retry_after_seconds` > 60 or `None`: stop. Tell the user the app is rate-limited and will recover at `reset_at_epoch` (convert to local time for the message). Don't loop.
+- Narrow future queries (`start_time`/`end_time`, higher `max_results` per page) to cut request volume.
+
+### `http_error` (400 / 404 / 5xx)
+
+```json
+{"error": "http_error", "status": 400, "detail": {"errors": [{"title": "Invalid query", "detail": "..."}]}}
+```
+
+**Meaning:** X returned a non-2xx that isn't 401/403/429.
+
+**What to do:**
+
+- **400 Bad Request**: look at `detail.errors[].title` and `.detail`. Usually your query used an unsupported operator, exceeded 512 chars, or had bad ISO8601 times. Fix and retry.
+- **404 Not Found**: the resource genuinely doesn't exist. Move on.
+- **5xx**: X side. Retry once after a 5–10s wait. If it persists, tell the user the X API is unhealthy and stop.
+
+### `not_found`
+
+```json
+{"error": "not_found", "detail": "User 'foo' not found"}
+```
+
+**Meaning:** User handle or tweet id doesn't resolve. Could be deleted, suspended, private, or never existed.
+
+**What to do:** Move on. If the user specifically asked about that account/tweet, tell them it's unavailable.
+
+### `network_error`
+
+```json
+{"error": "network_error", "detail": "ConnectError"}
+```
+
+**Meaning:** TCP/DNS/TLS failure before X could respond. `detail` is only the exception class name (deliberately — raw error strings can leak URLs/tokens).
+
+**What to do:** Retry once. If it fails again, stop and tell the user the sandbox can't reach `api.x.com`.
+
+### `malformed_response`
+
+**Meaning:** X returned 2xx with a non-JSON body (rare, usually a CDN edge hiccup).
+
+**What to do:** Retry once. If it recurs, treat as a transient X-side issue and stop.
+
+### `client_unavailable`
+
+**Meaning:** The MCP subprocess's HTTP client isn't initialized. Should never happen in normal operation — the lifespan context manager sets it up on startup and tears it down on shutdown.
+
+**What to do:** Retry the tool call once. If it persists, the MCP server subprocess is in a bad state — tell the user to restart their workspace.
+
+### `invalid_argument`
+
+```json
+{"error": "invalid_argument", "detail": "max_results must be 10-100"}
+```
+
+**Meaning:** You passed a value our own validator rejected before hitting X.
+
+Common triggers and fixes:
+
+| `detail` | Cause | Fix |
+|---|---|---|
+| `max_results must be 10-100` (search_posts / get_conversation) | Passed `<10` or `>100` | Use `max_results=10` minimum. Need fewer? Slice the result list. |
+| `max_results must be 10-500` (search_all_posts) | Passed outside `[10, 500]` | Full-archive allows up to 500/page. Use 10 minimum. |
+| `query must be <= 512 chars (got N)` (search_posts) | Long `OR`-chained query | Split calls, narrow with `lang:`, `-is:retweet`, `from:`, or switch to `search_all_posts` (1024-char limit). |
+| `query must be <= 1024 chars (got N)` (search_all_posts) | Extremely long query | Split into multiple calls; there's no higher tier than 1024 without Enterprise. |
+| `username must match ^[A-Za-z0-9_]{1,15}$` | Passed with `@`, spaces, or wrong length | Strip `@`, verify the handle with the user |
+| `tweet_id must be numeric` / `conversation_id must be numeric` | Passed a URL or non-digit id | Extract the trailing digits from `https://x.com/user/status/1234...` |
+
+## What not to do
+
+- Don't regenerate the user's token on their behalf — it's their console.
+- Don't hardcode or log the token. Not in code, not in comments, not in sandbox `print()`.
+- Don't scrape x.com via `scrapling` / `web_fetch` as a workaround when the token is the actual blocker — ask the user to add the key first.

--- a/skills/x-api/reference.md
+++ b/skills/x-api/reference.md
@@ -1,0 +1,130 @@
+# X API Response Reference
+
+Schemas observed from live calls against `api.x.com/2` (2026-04-21). Every tool returns either the success shape shown or the common error shape. All fields other than `id`, `text`, `author_id`, `conversation_id`, `created_at` should be treated as best-effort — X occasionally omits a metric on deleted/suspended authors.
+
+## Common error shape
+
+Every tool returns this on failure. Always check for `error` before accessing `posts` / `post` / `user`.
+
+```json
+{
+  "error": "missing_token | invalid_argument | auth_failed | rate_limited | http_error | not_found | network_error | malformed_response | client_unavailable",
+  "detail": "string"
+}
+```
+
+Some error types add extra keys:
+- `auth_failed`, `http_error` → `status` (int), `detail` (whitelisted X error body)
+- `rate_limited` → `reset_at_epoch` (int | null), `retry_after_seconds` (int | null)
+
+Full per-error playbook: [TROUBLESHOOTING.md](./TROUBLESHOOTING.md).
+
+## `search_posts` / `search_all_posts` / `get_conversation`
+
+All three return the same success shape. `get_conversation` omits the root tweet — fetch it with `get_tweet_by_id` if you need it.
+
+```json
+{
+  "posts": [
+    {
+      "id": "string",
+      "text": "string",
+      "created_at": "string (ISO8601 UTC, e.g. 2026-04-21T12:34:56.000Z)",
+      "lang": "string",
+      "conversation_id": "string",
+      "author_id": "string",
+      "edit_history_tweet_ids": ["string"],
+      "public_metrics": {
+        "retweet_count": "integer",
+        "reply_count": "integer",
+        "like_count": "integer",
+        "quote_count": "integer",
+        "bookmark_count": "integer",
+        "impression_count": "integer"
+      },
+      "author": {
+        "id": "string",
+        "username": "string",
+        "name": "string",
+        "verified": "boolean"
+      }
+    }
+  ],
+  "next_token": "string | null",
+  "result_count": "integer"
+}
+```
+
+**`author` can take three shapes:**
+- `{id, username, name, verified}` — resolved user (normal case)
+- `{id, unresolved: true}` — author_id was returned but user expansion didn't resolve (suspended/deleted)
+- `null` — the tweet has no `author_id` at all (rare; mostly data anomalies)
+
+Always branch on `author is None` / `author.get("unresolved")` before reading `username`.
+
+## `get_tweet_by_id`
+
+```json
+{
+  "post": {
+    "id": "string",
+    "text": "string",
+    "created_at": "string (ISO8601 UTC)",
+    "lang": "string",
+    "conversation_id": "string",
+    "author_id": "string",
+    "edit_history_tweet_ids": ["string"],
+    "public_metrics": { /* same 6 keys as above */ },
+    "author": { /* same 3-shape union as above */ }
+  }
+}
+```
+
+Deleted or private tweets return `{"error": "not_found", "detail": "Tweet '…' not found"}`.
+
+## `get_user_by_username`
+
+```json
+{
+  "user": {
+    "id": "string",
+    "username": "string",
+    "name": "string",
+    "verified": "boolean",
+    "description": "string",
+    "created_at": "string (ISO8601 UTC)",
+    "public_metrics": {
+      "followers_count": "integer",
+      "following_count": "integer",
+      "tweet_count": "integer",
+      "listed_count": "integer",
+      "like_count": "integer",
+      "media_count": "integer"
+    }
+  }
+}
+```
+
+Suspended, deactivated, or nonexistent handles return `{"error": "not_found", "detail": "User '…' not found"}`.
+
+## Input constraints (validated client-side before the API call)
+
+| Tool | Field | Rule |
+|---|---|---|
+| `search_posts` | `query` | length ≤ 512 chars |
+| `search_posts` | `max_results` | integer in [10, 100] |
+| `search_all_posts` | `query` | length ≤ 1024 chars |
+| `search_all_posts` | `max_results` | integer in [10, 500] |
+| `get_conversation` | `conversation_id` | matches `^\d{1,25}$` |
+| `get_conversation` | `max_results` | integer in [10, 100] |
+| `get_tweet_by_id` | `tweet_id` | matches `^\d{1,25}$` |
+| `get_user_by_username` | `username` | matches `^[A-Za-z0-9_]{1,15}$` (no leading `@`) |
+
+Violations return `{"error": "invalid_argument", "detail": "<reason>"}` without hitting the network.
+
+## Quick notes for downstream code
+
+- `public_metrics` keys on posts are whatever X returns — the 6 above cover normal tweets, but a deleted or limited-reach tweet may omit some. Use `.get("like_count", 0)` rather than direct indexing.
+- `edit_history_tweet_ids` includes the current tweet's id. Single-element list means unedited.
+- `next_token` is an opaque cursor. Don't cache across sessions — cursors expire.
+- `created_at` is always UTC. Parse with `datetime.fromisoformat(s.rstrip("Z") + "+00:00")` in Python 3.11+ or drop the `Z` and parse as UTC.

--- a/tests/unit/mcp_servers/test_x_mcp.py
+++ b/tests/unit/mcp_servers/test_x_mcp.py
@@ -1,0 +1,404 @@
+"""Tests for x_mcp_server: search_posts, get_user_by_username, get_tweet_by_id, get_conversation."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from mcp_servers import x_mcp_server as xm
+
+_MOD = "mcp_servers.x_mcp_server"
+
+
+def _mock_response(
+    status_code: int = 200,
+    json_body: dict | list | None = None,
+    headers: dict | None = None,
+    malformed: bool = False,
+) -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.headers = headers or {}
+    if malformed:
+        resp.json = MagicMock(side_effect=ValueError("not json"))
+    else:
+        resp.json = MagicMock(return_value=json_body if json_body is not None else {})
+    resp.text = "" if json_body else "body"
+    return resp
+
+
+@pytest.fixture
+def patched_client(monkeypatch):
+    """Patch the module-level _client with a fresh AsyncMock each test.
+
+    Returns the mock client so tests can configure `.get.return_value` etc.
+    """
+    mock_client = AsyncMock()
+    monkeypatch.setattr(xm, "_client", mock_client)
+    return mock_client
+
+
+_SEARCH_PAYLOAD = {
+    "data": [
+        {
+            "id": "1700000000000000001",
+            "text": "TSLA ripping after earnings",
+            "created_at": "2026-04-20T12:00:00.000Z",
+            "lang": "en",
+            "author_id": "U1",
+            "conversation_id": "1700000000000000001",
+            "public_metrics": {
+                "retweet_count": 10,
+                "reply_count": 2,
+                "like_count": 50,
+                "quote_count": 1,
+                "impression_count": 9000,
+            },
+        },
+        {
+            "id": "1700000000000000002",
+            "text": "skeptical",
+            "created_at": "2026-04-20T12:05:00.000Z",
+            "lang": "en",
+            "author_id": "U_DELETED",
+            "conversation_id": "1700000000000000002",
+            "public_metrics": {"like_count": 3},
+        },
+    ],
+    "includes": {
+        "users": [
+            {"id": "U1", "username": "alice", "name": "Alice", "verified": True},
+        ]
+    },
+    "meta": {"result_count": 2, "next_token": "abc123"},
+}
+
+
+class TestSearchPosts:
+    @pytest.mark.asyncio
+    async def test_success_normalizes_and_inlines_author(self, patched_client):
+        patched_client.get.return_value = _mock_response(200, _SEARCH_PAYLOAD)
+        out = await xm.search_posts(query="$TSLA", bearer_token="tok", max_results=10)
+
+        assert out["result_count"] == 2
+        assert out["next_token"] == "abc123"
+        assert len(out["posts"]) == 2
+        assert out["posts"][0]["author"] == {
+            "id": "U1", "username": "alice", "name": "Alice", "verified": True
+        }
+        # Unresolved author (deleted/suspended user): still shaped
+        assert out["posts"][1]["author"] == {"id": "U_DELETED", "unresolved": True}
+
+    @pytest.mark.asyncio
+    async def test_missing_token(self, monkeypatch):
+        monkeypatch.delenv("X_BEARER_TOKEN", raising=False)
+        out = await xm.search_posts(query="$TSLA", bearer_token=None)
+        assert out["error"] == "missing_token"
+        assert "vault" in out["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_env_fallback(self, monkeypatch, patched_client):
+        monkeypatch.setenv("X_BEARER_TOKEN", "envtok")
+        patched_client.get.return_value = _mock_response(200, _SEARCH_PAYLOAD)
+        out = await xm.search_posts(query="$TSLA", bearer_token=None)
+        assert "posts" in out
+        called_headers = patched_client.get.call_args.kwargs["headers"]
+        assert called_headers["Authorization"] == "Bearer envtok"
+
+    @pytest.mark.asyncio
+    async def test_invalid_max_results(self):
+        out = await xm.search_posts(query="$TSLA", bearer_token="tok", max_results=5)
+        assert out == {"error": "invalid_argument", "detail": "max_results must be 10-100"}
+
+    @pytest.mark.asyncio
+    async def test_query_too_long(self):
+        q = "x" * 600
+        out = await xm.search_posts(query=q, bearer_token="tok")
+        assert out["error"] == "invalid_argument"
+        assert "512" in out["detail"]
+
+    @pytest.mark.asyncio
+    async def test_rate_limited(self, patched_client, monkeypatch):
+        # Freeze time so retry_after_seconds is deterministic.
+        monkeypatch.setattr(xm.time, "time", lambda: 1777777700)
+        patched_client.get.return_value = _mock_response(
+            429, headers={"x-rate-limit-reset": "1777777760"}
+        )
+        out = await xm.search_posts(query="$TSLA", bearer_token="tok")
+        assert out["error"] == "rate_limited"
+        assert out["reset_at_epoch"] == 1777777760
+        assert out["retry_after_seconds"] == 60
+
+    @pytest.mark.asyncio
+    async def test_rate_limited_missing_header(self, patched_client):
+        patched_client.get.return_value = _mock_response(429)
+        out = await xm.search_posts(query="$TSLA", bearer_token="tok")
+        assert out == {
+            "error": "rate_limited",
+            "reset_at_epoch": None,
+            "retry_after_seconds": None,
+        }
+
+    @pytest.mark.asyncio
+    async def test_auth_failed_whitelists_body(self, patched_client):
+        patched_client.get.return_value = _mock_response(
+            401,
+            json_body={
+                "title": "Unauthorized",
+                "type": "about:blank",
+                "secret": "should not appear",
+            },
+        )
+        out = await xm.search_posts(query="$TSLA", bearer_token="bad")
+        assert out["error"] == "auth_failed"
+        assert out["status"] == 401
+        assert out["detail"] == {"title": "Unauthorized", "type": "about:blank"}
+        assert "secret" not in str(out["detail"])
+
+    @pytest.mark.asyncio
+    async def test_http_error_sanitizes_body(self, patched_client):
+        patched_client.get.return_value = _mock_response(
+            400,
+            json_body={
+                "errors": [
+                    {"title": "Invalid query", "detail": "bad operator", "other": "x"}
+                ],
+                "echo": {"Authorization": "Bearer MUST-NOT-LEAK"},
+            },
+        )
+        out = await xm.search_posts(query="$TSLA", bearer_token="tok")
+        assert out["error"] == "http_error"
+        assert out["status"] == 400
+        assert "MUST-NOT-LEAK" not in str(out["detail"])
+        assert out["detail"]["errors"][0]["title"] == "Invalid query"
+        assert "other" not in out["detail"]["errors"][0]
+
+    @pytest.mark.asyncio
+    async def test_network_error_no_leak(self, patched_client):
+        patched_client.get.side_effect = httpx.ConnectError(
+            "boom at https://api.x.com/2/... with Bearer TOKEN"
+        )
+        out = await xm.search_posts(query="$TSLA", bearer_token="tok")
+        assert out == {"error": "network_error", "detail": "ConnectError"}
+
+    @pytest.mark.asyncio
+    async def test_malformed_response(self, patched_client):
+        patched_client.get.return_value = _mock_response(200, malformed=True)
+        out = await xm.search_posts(query="$TSLA", bearer_token="tok")
+        assert out["error"] == "malformed_response"
+
+    @pytest.mark.asyncio
+    async def test_passes_query_params(self, patched_client):
+        patched_client.get.return_value = _mock_response(
+            200, {"data": [], "meta": {"result_count": 0}}
+        )
+        await xm.search_posts(
+            query="$TSLA",
+            bearer_token="tok",
+            max_results=50,
+            start_time="2026-04-20T00:00:00Z",
+            end_time="2026-04-20T23:59:59Z",
+            next_token="cursor",
+        )
+        params = patched_client.get.call_args.kwargs["params"]
+        assert params["query"] == "$TSLA"
+        assert params["max_results"] == 50
+        assert params["start_time"] == "2026-04-20T00:00:00Z"
+        assert params["end_time"] == "2026-04-20T23:59:59Z"
+        assert params["next_token"] == "cursor"
+        assert "tweet.fields" in params
+
+
+class TestSearchAllPosts:
+    @pytest.mark.asyncio
+    async def test_hits_full_archive_endpoint(self, patched_client):
+        patched_client.get.return_value = _mock_response(200, _SEARCH_PAYLOAD)
+        out = await xm.search_all_posts(query="$TSLA", bearer_token="tok")
+        # Must hit /tweets/search/all, NOT /tweets/search/recent
+        url = patched_client.get.call_args.args[0]
+        assert "/tweets/search/all" in url
+        assert "/tweets/search/recent" not in url
+        assert out["result_count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_allows_max_results_up_to_500(self, patched_client):
+        patched_client.get.return_value = _mock_response(
+            200, {"data": [], "meta": {"result_count": 0}}
+        )
+        out = await xm.search_all_posts(query="$TSLA", bearer_token="tok", max_results=500)
+        assert "error" not in out
+        assert patched_client.get.call_args.kwargs["params"]["max_results"] == 500
+
+    @pytest.mark.asyncio
+    async def test_rejects_max_results_over_500(self):
+        out = await xm.search_all_posts(query="$TSLA", bearer_token="tok", max_results=501)
+        assert out == {"error": "invalid_argument", "detail": "max_results must be 10-500"}
+
+    @pytest.mark.asyncio
+    async def test_rejects_max_results_below_10(self):
+        out = await xm.search_all_posts(query="$TSLA", bearer_token="tok", max_results=5)
+        assert out == {"error": "invalid_argument", "detail": "max_results must be 10-500"}
+
+    @pytest.mark.asyncio
+    async def test_allows_query_up_to_1024_chars(self, patched_client):
+        patched_client.get.return_value = _mock_response(
+            200, {"data": [], "meta": {"result_count": 0}}
+        )
+        q = "x" * 1024
+        out = await xm.search_all_posts(query=q, bearer_token="tok")
+        assert "error" not in out
+
+    @pytest.mark.asyncio
+    async def test_rejects_query_over_1024_chars(self):
+        q = "x" * 1025
+        out = await xm.search_all_posts(query=q, bearer_token="tok")
+        assert out["error"] == "invalid_argument"
+        assert "1024" in out["detail"]
+
+    @pytest.mark.asyncio
+    async def test_missing_token(self, monkeypatch):
+        monkeypatch.delenv("X_BEARER_TOKEN", raising=False)
+        out = await xm.search_all_posts(query="$TSLA", bearer_token=None)
+        assert out["error"] == "missing_token"
+
+    @pytest.mark.asyncio
+    async def test_paid_tier_required_returns_auth_failed(self, patched_client):
+        # Free-tier tokens get 403 from /tweets/search/all.
+        patched_client.get.return_value = _mock_response(
+            403, json_body={"title": "Forbidden", "type": "about:blank"}
+        )
+        out = await xm.search_all_posts(query="$TSLA", bearer_token="free-tok")
+        assert out["error"] == "auth_failed"
+        assert out["status"] == 403
+
+
+class TestGetUserByUsername:
+    @pytest.mark.asyncio
+    async def test_success(self, patched_client):
+        payload = {
+            "data": {
+                "id": "U1",
+                "username": "alice",
+                "name": "Alice",
+                "verified": True,
+                "description": "hi",
+                "created_at": "2010-01-01T00:00:00Z",
+                "public_metrics": {"followers_count": 100},
+            }
+        }
+        patched_client.get.return_value = _mock_response(200, payload)
+        out = await xm.get_user_by_username(username="alice", bearer_token="tok")
+        assert out == {"user": payload["data"]}
+        assert "users/by/username/alice" in patched_client.get.call_args.args[0]
+
+    @pytest.mark.asyncio
+    async def test_not_found(self, patched_client):
+        patched_client.get.return_value = _mock_response(
+            200, {"errors": [{"title": "Not Found"}]}
+        )
+        out = await xm.get_user_by_username(username="nouser", bearer_token="tok")
+        assert out == {"error": "not_found", "detail": "User 'nouser' not found"}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "bad",
+        ["", "has space", "toolongusername_123", "bad/slash", "../traversal"],
+    )
+    async def test_invalid_username(self, bad):
+        out = await xm.get_user_by_username(username=bad, bearer_token="tok")
+        assert out["error"] == "invalid_argument"
+
+
+class TestGetTweetById:
+    @pytest.mark.asyncio
+    async def test_success_inlines_author(self, patched_client):
+        payload = {
+            "data": {
+                "id": "1700000000000000001",
+                "text": "hi",
+                "author_id": "U1",
+                "conversation_id": "1700000000000000001",
+                "created_at": "2026-04-20T00:00:00Z",
+                "lang": "en",
+                "public_metrics": {"like_count": 10},
+            },
+            "includes": {
+                "users": [
+                    {"id": "U1", "username": "alice", "name": "Alice", "verified": False}
+                ]
+            },
+        }
+        patched_client.get.return_value = _mock_response(200, payload)
+        out = await xm.get_tweet_by_id(
+            tweet_id="1700000000000000001", bearer_token="tok"
+        )
+        assert out["post"]["id"] == "1700000000000000001"
+        assert out["post"]["author"]["username"] == "alice"
+
+    @pytest.mark.asyncio
+    async def test_not_found(self, patched_client):
+        patched_client.get.return_value = _mock_response(200, {})
+        out = await xm.get_tweet_by_id(tweet_id="1700000000000000404", bearer_token="tok")
+        assert out["error"] == "not_found"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("bad", ["", "abc", "12/34", "../x", "1" * 30])
+    async def test_invalid_tweet_id(self, bad):
+        out = await xm.get_tweet_by_id(tweet_id=bad, bearer_token="tok")
+        assert out["error"] == "invalid_argument"
+
+
+class TestGetConversation:
+    @pytest.mark.asyncio
+    async def test_delegates_with_conversation_query(self, patched_client):
+        patched_client.get.return_value = _mock_response(
+            200, {"data": [], "meta": {"result_count": 0}}
+        )
+        await xm.get_conversation(
+            conversation_id="1700000000000000001", bearer_token="tok", max_results=25
+        )
+        params = patched_client.get.call_args.kwargs["params"]
+        assert params["query"] == "conversation_id:1700000000000000001"
+        assert params["max_results"] == 25
+
+    @pytest.mark.asyncio
+    async def test_invalid_max_results(self):
+        out = await xm.get_conversation(
+            conversation_id="1700000000000000001",
+            bearer_token="tok",
+            max_results=500,
+        )
+        assert out == {"error": "invalid_argument", "detail": "max_results must be 10-100"}
+
+    @pytest.mark.asyncio
+    async def test_invalid_conversation_id(self):
+        out = await xm.get_conversation(
+            conversation_id="not-numeric", bearer_token="tok"
+        )
+        assert out["error"] == "invalid_argument"
+
+
+class TestHelpers:
+    def test_index_users_handles_malformed(self):
+        out = xm._index_users({"users": [{"id": "U1"}, "junk", None, {"no_id": True}]})
+        assert out == {"U1": {"id": "U1"}}
+
+    def test_index_users_none(self):
+        assert xm._index_users(None) == {}
+        assert xm._index_users({}) == {}
+
+    def test_enrich_post_no_author_id(self):
+        out = xm._enrich_post({"id": "T", "text": "x"}, {})
+        assert out["author"] is None
+
+    def test_resolve_token_empty_string(self, monkeypatch):
+        monkeypatch.delenv("X_BEARER_TOKEN", raising=False)
+        assert xm._resolve_token("") is None
+        assert xm._resolve_token(None) is None
+
+    def test_resolve_token_env_only(self, monkeypatch):
+        monkeypatch.setenv("X_BEARER_TOKEN", "env-tok")
+        assert xm._resolve_token(None) == "env-tok"
+        assert xm._resolve_token("explicit") == "explicit"


### PR DESCRIPTION
## Summary

Adds a new read-only MCP server `x_api` wrapping five X (Twitter) v2 endpoints so the PTC agent can search posts, fetch user profiles, hydrate tweets, and read reply threads alongside SEC and market-data tools.

**Core:**
- `mcp_servers/x_mcp_server.py` — FastMCP stdio server, 5 tools: `search_posts`, `search_all_posts`, `get_conversation`, `get_user_by_username`, `get_tweet_by_id`.
- Auth flows per-call via `bearer_token` arg sourced from the workspace vault (`from vault import get; get("X_BEARER_TOKEN")`); host-env fallback is opt-in only (`env: {}` by default in agent_config).
- Error sanitization: whitelist-based (`title|type|detail|status|reason|errors[]`) so X error bodies can't leak request headers through the MCP response.
- Input validation: username regex `^[A-Za-z0-9_]{1,15}$`, tweet_id `^\d{1,25}$`, per-endpoint `max_results` and query-length caps enforced before the HTTP call.

**Wiring:**
- `agent_config.yaml` — registers `x_api` with a terse agent-facing instruction (when to use, tool inventory, auth hint, `web_fetch` fallback for one-off URLs).
- `.env.example` — documents `X_BEARER_TOKEN` as single-tenant fallback with UI breadcrumbs to the Workspace Settings → Vault tab.

**Docs:**
- `skills/x-api/SKILL.md` — usage cheat sheet, query syntax, examples.
- `skills/x-api/TROUBLESHOOTING.md` — per-error playbook (9 error types including `client_unavailable`) and first-time vault setup.
- `skills/x-api/reference.md` — response schemas observed from live calls, input constraints table.

## Test Coverage

42 unit tests across `TestSearchPosts`, `TestSearchAllPosts`, `TestGetUserByUsername`, `TestGetTweetById`, `TestGetConversation`, `TestHelpers`. Coverage: auth-failure paths, rate-limit header parsing, malformed JSON bodies, network errors (name-only leak-safe), whitelist sanitization (including an explicit `Authorization` echo that must not appear in `detail`), every input-validation boundary.

## Pre-Landing Review

Clean, 0 critical. Security specialist dispatched — 8 informational findings reviewed; 1 auto-fixed (`TROUBLESHOOTING.md: client_unavailable` entry), 7 skipped with documented reasoning (by-design opt-in, not-reachable paths, worse-UX trade-offs, speculative X-API behavior).

## Plan Completion

All items from `~/.claude/plans/i-want-to-add-woolly-hamming.md` addressed:
- [x] `mcp_servers/x_mcp_server.py` with lifespan-managed httpx client
- [x] Vault-first auth, host-env fallback documented
- [x] Five tools wired (plan originally scoped four — `search_all_posts` added mid-build for full-archive coverage)
- [x] `agent_config.yaml` registration
- [x] `.env.example` documentation
- [x] Unit tests (not in original plan; added during build)

## Test plan

- [x] `uv run pytest tests/unit/mcp_servers/test_x_mcp.py -q` — 42 passed
- [x] `uv run ruff check mcp_servers/x_mcp_server.py tests/unit/mcp_servers/test_x_mcp.py` — clean
- [ ] End-to-end smoke in a live workspace with a real `X_BEARER_TOKEN` in the vault
- [ ] Verify `MCPRegistry` connects on backend startup and lists all 5 tools