### PR TITLE
fix(middleware): normalize non-list TodoWrite todos at emission

### DIFF
--- a/src/ptc_agent/agent/middleware/todo_operations/sse_middleware.py
+++ b/src/ptc_agent/agent/middleware/todo_operations/sse_middleware.py
@@ -67,7 +67,19 @@ class TodoWriteMiddleware(AgentMiddleware):
 
         tool_call_id = tool_call.get("id", "unknown")
         tool_args = tool_call.get("args", {})
-        todos = tool_args.get("todos", [])
+        raw_todos = tool_args.get("todos", [])
+
+        # Some LLMs emit `todos` as a stringified JSON blob (sometimes malformed).
+        # Iterating that as a list gives character-by-character garbage and persists
+        # a broken payload to conversation_responses.sse_events — normalize at source.
+        if isinstance(raw_todos, list):
+            todos = raw_todos
+        else:
+            logger.warning(
+                f"[TODO_MIDDLEWARE] Non-list todos payload "
+                f"(type={type(raw_todos).__name__}); coercing to []"
+            )
+            todos = []
 
         logger.debug(f"[TODO_MIDDLEWARE] Intercepting {tool_name} (id: {tool_call_id})")
 

--- a/tests/unit/middleware/test_todo_write_middleware.py
+++ b/tests/unit/middleware/test_todo_write_middleware.py
@@ -1,0 +1,125 @@
+"""Tests for TodoWriteMiddleware's SSE event emission.
+
+Focuses on resilience to malformed `todos` payloads — some LLMs emit
+`todos` as a stringified JSON blob (sometimes malformed) rather than a list.
+The middleware must normalize non-list values to `[]` before iterating.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from ptc_agent.agent.middleware.todo_operations.sse_middleware import (
+    TodoWriteMiddleware,
+)
+
+
+def _make_request(todos, tool_name="TodoWrite", tool_call_id="call-1"):
+    return SimpleNamespace(
+        tool_call={
+            "name": tool_name,
+            "id": tool_call_id,
+            "args": {"todos": todos},
+        }
+    )
+
+
+async def _run(middleware, request):
+    async def handler(_req):
+        return "tool-result"
+
+    return await middleware.awrap_tool_call(request, handler)
+
+
+@pytest.fixture
+def middleware():
+    return TodoWriteMiddleware()
+
+
+@pytest.mark.asyncio
+async def test_list_todos_pass_through_with_counts(middleware):
+    todos = [
+        {"status": "pending"},
+        {"status": "in_progress"},
+        {"status": "completed"},
+        {"status": "completed"},
+    ]
+    emitted = []
+
+    with patch(
+        "ptc_agent.agent.middleware.todo_operations.sse_middleware.get_stream_writer",
+        return_value=emitted.append,
+    ):
+        result = await _run(middleware, _make_request(todos))
+
+    assert result == "tool-result"
+    assert len(emitted) == 1
+    payload = emitted[0]["payload"]
+    assert payload["todos"] == todos
+    assert payload["total"] == 4
+    assert payload["completed"] == 2
+    assert payload["in_progress"] == 1
+    assert payload["pending"] == 1
+
+
+@pytest.mark.parametrize(
+    "bad_todos",
+    [
+        '[{"status":"pending"}]',  # stringified JSON
+        "not json at all",
+        {"status": "pending"},  # dict instead of list
+        None,
+        42,
+    ],
+)
+@pytest.mark.asyncio
+async def test_non_list_todos_normalized_to_empty(middleware, bad_todos):
+    emitted = []
+
+    with patch(
+        "ptc_agent.agent.middleware.todo_operations.sse_middleware.get_stream_writer",
+        return_value=emitted.append,
+    ):
+        result = await _run(middleware, _make_request(bad_todos))
+
+    assert result == "tool-result"
+    assert len(emitted) == 1
+    payload = emitted[0]["payload"]
+    assert payload["todos"] == []
+    assert payload["total"] == 0
+    assert payload["completed"] == 0
+    assert payload["in_progress"] == 0
+    assert payload["pending"] == 0
+
+
+@pytest.mark.asyncio
+async def test_non_todowrite_tool_passes_through(middleware):
+    emitted = []
+
+    with patch(
+        "ptc_agent.agent.middleware.todo_operations.sse_middleware.get_stream_writer",
+        return_value=emitted.append,
+    ):
+        result = await _run(
+            middleware, _make_request([], tool_name="SomethingElse")
+        )
+
+    assert result == "tool-result"
+    assert emitted == []
+
+
+@pytest.mark.asyncio
+async def test_non_list_todos_logs_warning(middleware, caplog):
+    emitted = []
+    caplog.set_level("WARNING")
+
+    with patch(
+        "ptc_agent.agent.middleware.todo_operations.sse_middleware.get_stream_writer",
+        return_value=emitted.append,
+    ):
+        await _run(middleware, _make_request('"not-a-list"'))
+
+    assert any(
+        "Non-list todos payload" in record.message for record in caplog.records
+    )

--- a/web/src/pages/ChatAgent/hooks/utils/historyEventHandlers.ts
+++ b/web/src/pages/ChatAgent/hooks/utils/historyEventHandlers.ts
@@ -732,7 +732,7 @@ export function handleHistoryTodoUpdate({ assistantMessageId, artifactType, arti
       // If this is an update to an existing logical todo list (same artifactId),
       // we still create a new segment but can reference the base ID for data updates
       todoListProcesses[segmentId] = {
-        todos: todos || [],
+        todos,
         total: total || 0,
         completed: completed || 0,
         in_progress: in_progress || 0,

--- a/web/src/pages/ChatAgent/hooks/utils/streamEventHandlers.ts
+++ b/web/src/pages/ChatAgent/hooks/utils/streamEventHandlers.ts
@@ -557,7 +557,7 @@ export function handleTodoUpdate({ assistantMessageId, artifactType, artifactId,
     }
     updateTodoListCard(
       {
-        todos: todos || [],
+        todos,
         total: total || 0,
         completed: completed || 0,
         in_progress: in_progress || 0,
@@ -606,7 +606,7 @@ export function handleTodoUpdate({ assistantMessageId, artifactType, artifactId,
       // If this is an update to an existing logical todo list (same artifactId),
       // we still create a new segment but can reference the base ID for data updates
       todoListProcesses[segmentId] = {
-        todos: todos || [],
+        todos,
         total: total || 0,
         completed: completed || 0,
         in_progress: in_progress || 0,


### PR DESCRIPTION
Follow-up to #153 — addresses the backend root cause that PR recovered from on the frontend.

## Problem

Some LLMs emit the `TodoWrite` tool's `todos` argument as a stringified JSON blob (sometimes malformed) instead of a list. `TodoWriteMiddleware` in `src/ptc_agent/agent/middleware/todo_operations/sse_middleware.py` took that value verbatim and iterated it (`for todo in todos`, `len(todos)`), producing character-by-character garbage status counts and persisting the malformed payload to `conversation_responses.sse_events`. That's what caused the ChatView crash fixed in #153.

Fixes #155.

## Changes

- **Backend guard** (`sse_middleware.py`): `isinstance(todos, list)` check with `logger.warning` on miss + coerce to `[]`. Stops garbage from being iterated, counted, or persisted in the first place.
- **Unit tests** (`tests/unit/middleware/test_todo_write_middleware.py`): 8 tests covering list pass-through, 5 parametrized non-list payloads (stringified JSON, garbage string, dict, None, int), non-TodoWrite pass-through, and warning log capture.
- **Frontend cleanup**: dropped three redundant `todos || []` fallbacks in `streamEventHandlers.ts` and `historyEventHandlers.ts`. After #153's `Array.isArray` coercion at the top of each handler, `todos` is always a valid array at the assignment sites.

## Test plan

- [x] `uv run pytest tests/unit/middleware/test_todo_write_middleware.py -v` — 8/8 pass
- [x] `uv run ruff check src/ptc_agent/agent/middleware/todo_operations/` — clean
- [x] `cd web && npx eslint src/pages/ChatAgent/hooks/utils/streamEventHandlers.ts src/pages/ChatAgent/hooks/utils/historyEventHandlers.ts` — clean
- [x] `cd web && npx vitest run src/pages/ChatAgent` — 209/209 pass