### PR TITLE
fix(sandbox): stop error-state cascade from archived-restore failures

### DIFF
--- a/migrations/versions/009_add_starting_workspace_status.py
+++ b/migrations/versions/009_add_starting_workspace_status.py
@@ -1,0 +1,51 @@
+"""Add 'starting' to workspaces.status CHECK constraint.
+
+Used by the lazy-restart path in WorkspaceManager: stopped -> starting -> running.
+The intermediate 'starting' lets /files and /public callers fall back to the DB
+while Phase 2 (ensure_sandbox_ready + asset sync) is still resolving.
+
+Revision ID: 009
+"""
+
+from alembic import op
+
+
+revision = "009"
+down_revision = "008"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        ALTER TABLE workspaces
+            DROP CONSTRAINT IF EXISTS workspaces_status_check
+    """)
+    op.execute("""
+        ALTER TABLE workspaces
+            ADD CONSTRAINT workspaces_status_check
+            CHECK (status IN (
+                'creating','running','starting','stopping',
+                'stopped','error','deleted','flash'
+            ))
+    """)
+
+
+def downgrade() -> None:
+    # Any rows parked in 'starting' would violate the older constraint; coerce
+    # them to 'stopped' so the next request re-enters the restart flow cleanly.
+    op.execute("""
+        UPDATE workspaces SET status = 'stopped' WHERE status = 'starting'
+    """)
+    op.execute("""
+        ALTER TABLE workspaces
+            DROP CONSTRAINT IF EXISTS workspaces_status_check
+    """)
+    op.execute("""
+        ALTER TABLE workspaces
+            ADD CONSTRAINT workspaces_status_check
+            CHECK (status IN (
+                'creating','running','stopping',
+                'stopped','error','deleted','flash'
+            ))
+    """)

--- a/src/ptc_agent/core/sandbox/ptc_sandbox.py
+++ b/src/ptc_agent/core/sandbox/ptc_sandbox.py
@@ -7,7 +7,7 @@ import json
 import shlex
 import textwrap
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 from types import TracebackType
@@ -154,7 +154,6 @@ class PTCSandbox:
 
         self._reconnect_lock = asyncio.Lock()
         self._tool_refresh_lock = asyncio.Lock()
-        self._reconnect_inflight: asyncio.Future[None] | None = None
         self._download_semaphore = asyncio.Semaphore(4)
 
         # Track per-thread code dirs that have been created (avoids repeated mkdir)
@@ -1590,38 +1589,19 @@ class PTCSandbox:
                 "Sandbox disconnected and no sandbox_id is available"
             )
 
-        # Coalesce concurrent reconnect attempts (including transparent
-        # restart when the sandbox was stopped externally).
+        # Serialize concurrent reconnect attempts. asyncio.Lock is held
+        # across internal awaits, so a second caller that acquires the lock
+        # runs after the first's reconnect has fully resolved (success or
+        # exception propagated). No explicit coalescing primitive needed.
         async with self._reconnect_lock:
-            if (
-                self._reconnect_inflight is not None
-                and not self._reconnect_inflight.done()
-            ):
-                await self._reconnect_inflight
-                return
-
-            # Always recreate the provider.  This callback only fires after
-            # a transient error, so the existing client may be dead (closed
-            # by a concurrent stop_workspace) or degraded (stale connection).
-            # Creating a new AsyncDaytona is cheap — just an aiohttp session.
+            # Always recreate the provider. This callback only fires after
+            # a transient error, so the existing client may be dead or stale.
             try:
                 await self.provider.close()
             except Exception:
                 pass
             self.provider = create_provider(self.config)
-
-            loop = asyncio.get_running_loop()
-            self._reconnect_inflight = loop.create_future()
-            inflight = self._reconnect_inflight
-
-            try:
-                await self.reconnect(self.sandbox_id)
-                inflight.set_result(None)
-            except Exception as e:
-                inflight.set_exception(e)
-                raise
-            finally:
-                self._reconnect_inflight = None
+            await self.reconnect(self.sandbox_id)
 
     async def _runtime_call(
         self,
@@ -3603,6 +3583,43 @@ except OSError as e:
             return True
         except Exception as e:
             logger.debug("Failed to create directory", dirpath=dirpath, error=str(e))
+            return False
+
+    async def acreate_directories(self, dirpaths: Iterable[str]) -> bool:
+        """Create multiple directories in a single ``mkdir -p`` exec call.
+
+        Much faster than N separate ``acreate_directory`` calls for bulk
+        setup (e.g. file restore), collapsing N round-trips into one.
+        ``mkdir -p`` is idempotent. Returns False if any validation or
+        exec fails; callers can fall back to per-dir creates.
+        """
+        paths = [p for p in dirpaths if p]
+        if not paths:
+            return True
+
+        await self._wait_ready()
+
+        if self.config.filesystem.enable_path_validation:
+            for p in paths:
+                if not self.validate_path(p):
+                    logger.error(f"Access denied: {p} is not in allowed directories")
+                    return False
+
+        try:
+            assert self.runtime is not None
+            quoted = " ".join(shlex.quote(p) for p in paths)
+            await self._runtime_call(
+                self.runtime.exec,
+                f"mkdir -p {quoted}",
+                retry_policy=RetryPolicy.SAFE,
+            )
+            return True
+        except Exception as e:
+            logger.debug(
+                "Failed to bulk-create directories",
+                count=len(paths),
+                error=str(e),
+            )
             return False
 
     async def aedit_file_text(

--- a/src/ptc_agent/core/session.py
+++ b/src/ptc_agent/core/session.py
@@ -377,8 +377,12 @@ class SessionManager:
         # replacement in place instead of evicting it.
         if cls._sessions.get(conversation_id) is session:
             cls._sessions.pop(conversation_id, None)
-
-        logger.info("Session removed", conversation_id=conversation_id)
+            logger.info("Session removed", conversation_id=conversation_id)
+        else:
+            logger.info(
+                "Session cleaned up (replacement retained)",
+                conversation_id=conversation_id,
+            )
 
     @classmethod
     async def cleanup_all(cls) -> None:

--- a/src/ptc_agent/core/session.py
+++ b/src/ptc_agent/core/session.py
@@ -360,15 +360,25 @@ class SessionManager:
     async def cleanup_session(cls, conversation_id: str) -> None:
         """Clean up a specific session.
 
+        Safe under concurrent callers: the final pop is identity-guarded
+        so a second caller does not tear down a replacement session that
+        another request installed while we were inside ``session.cleanup()``.
+
         Args:
             conversation_id: Conversation identifier
         """
-        if conversation_id in cls._sessions:
-            session = cls._sessions[conversation_id]
-            await session.cleanup()
-            del cls._sessions[conversation_id]
+        session = cls._sessions.get(conversation_id)
+        if session is None:
+            return
 
-            logger.info("Session removed", conversation_id=conversation_id)
+        await session.cleanup()
+        # Identity-guarded pop: if a concurrent request replaced the entry
+        # with a fresh session while we were awaiting cleanup(), leave the
+        # replacement in place instead of evicting it.
+        if cls._sessions.get(conversation_id) is session:
+            cls._sessions.pop(conversation_id, None)
+
+        logger.info("Session removed", conversation_id=conversation_id)
 
     @classmethod
     async def cleanup_all(cls) -> None:

--- a/src/server/app/public.py
+++ b/src/server/app/public.py
@@ -242,7 +242,7 @@ async def list_shared_files(
         return {"path": path, "files": files, "source": "database"}
 
     # Try live sandbox if DB has no files
-    if workspace.get("status") not in ("stopped", "stopping"):
+    if workspace.get("status") not in ("stopped", "stopping", "starting"):
         try:
             manager = WorkspaceManager.get_instance()
             session = await manager.get_session_for_workspace(workspace_id)
@@ -313,7 +313,7 @@ async def read_shared_file(
         }
 
     # Try live sandbox — vault secrets from session cache (instant)
-    if workspace.get("status") not in ("stopped", "stopping"):
+    if workspace.get("status") not in ("stopped", "stopping", "starting"):
         try:
             manager = WorkspaceManager.get_instance()
             session = await manager.get_session_for_workspace(workspace_id)
@@ -410,7 +410,7 @@ async def download_shared_file(
         )
 
     # Try live sandbox — vault secrets from session cache (instant)
-    if workspace.get("status") not in ("stopped", "stopping"):
+    if workspace.get("status") not in ("stopped", "stopping", "starting"):
         try:
             manager = WorkspaceManager.get_instance()
             session = await manager.get_session_for_workspace(workspace_id)

--- a/src/server/app/workspace_files.py
+++ b/src/server/app/workspace_files.py
@@ -265,7 +265,7 @@ async def list_workspace_files(
     work_dir = _get_work_dir()
 
     # DB fallback for stopped workspaces (unless auto_start requested)
-    if not auto_start and workspace.get("status") in ("stopped", "stopping"):
+    if not auto_start and workspace.get("status") in ("stopped", "stopping", "starting"):
         file_tree = await FilePersistenceService.get_file_tree(workspace_id)
         # Filter by path prefix if specified
         normalized_path = _normalize_requested_path(path, work_dir)
@@ -381,7 +381,7 @@ async def read_workspace_file(
         )
 
     # DB fallback for stopped workspaces
-    if workspace.get("status") in ("stopped", "stopping"):
+    if workspace.get("status") in ("stopped", "stopping", "starting"):
         work_dir = _get_work_dir()
         normalized_path = _normalize_requested_path(path, work_dir)
         if not normalized_path:
@@ -502,10 +502,10 @@ async def write_workspace_file(
             status_code=400, detail="Flash workspaces do not have a sandbox"
         )
 
-    if workspace.get("status") in ("stopped", "stopping"):
+    if workspace.get("status") in ("stopped", "stopping", "starting"):
         raise HTTPException(
             status_code=409,
-            detail="Cannot write files while workspace is stopped. Start the workspace first.",
+            detail=f"Cannot write files — workspace is {workspace.get('status')}. Wait for it to be running.",
         )
 
     content_bytes = body.content.encode("utf-8")
@@ -588,7 +588,7 @@ async def download_workspace_file(
         )
 
     # DB fallback for stopped workspaces
-    if workspace.get("status") in ("stopped", "stopping"):
+    if workspace.get("status") in ("stopped", "stopping", "starting"):
         work_dir = _get_work_dir()
         normalized_path = _normalize_requested_path(path, work_dir)
         if not normalized_path:
@@ -668,10 +668,10 @@ async def upload_workspace_file(
             status_code=400, detail="Flash workspaces do not have a sandbox"
         )
 
-    if workspace.get("status") in ("stopped", "stopping"):
+    if workspace.get("status") in ("stopped", "stopping", "starting"):
         raise HTTPException(
             status_code=409,
-            detail="Cannot upload files while workspace is stopped. Start the workspace first.",
+            detail=f"Cannot upload files — workspace is {workspace.get('status')}. Wait for it to be running.",
         )
 
     sandbox = await _acquire_sandbox(workspace_id, x_user_id)
@@ -724,10 +724,10 @@ async def backup_workspace_files(
             status_code=400, detail="Flash workspaces do not have a sandbox"
         )
 
-    if workspace.get("status") in ("stopped", "stopping"):
+    if workspace.get("status") in ("stopped", "stopping", "starting"):
         raise HTTPException(
             status_code=409,
-            detail="Cannot backup files while workspace is stopped.",
+            detail=f"Cannot backup files — workspace is {workspace.get('status')}.",
         )
 
     sandbox = await _acquire_sandbox(workspace_id, x_user_id)
@@ -779,7 +779,7 @@ async def get_backup_status(
     db_meta = await get_file_metadata_for_sync(workspace_id)
 
     # If sandbox is stopped, everything in DB is "backed_up", nothing else
-    if workspace.get("status") in ("stopped", "stopping"):
+    if workspace.get("status") in ("stopped", "stopping", "starting"):
         total_size = await get_workspace_total_size(workspace_id)
         return {
             "workspace_id": workspace_id,
@@ -867,10 +867,10 @@ async def delete_workspace_files(
             status_code=400, detail="Flash workspaces do not have a sandbox"
         )
 
-    if workspace.get("status") in ("stopped", "stopping"):
+    if workspace.get("status") in ("stopped", "stopping", "starting"):
         raise HTTPException(
             status_code=409,
-            detail="Cannot delete files while workspace is stopped. Start the workspace first.",
+            detail=f"Cannot delete files — workspace is {workspace.get('status')}. Wait for it to be running.",
         )
 
     sandbox = await _acquire_sandbox(workspace_id, x_user_id)

--- a/src/server/app/workspaces.py
+++ b/src/server/app/workspaces.py
@@ -289,6 +289,13 @@ async def start_workspace(
                 message="Workspace is already running",
             )
 
+        if workspace["status"] == "starting":
+            return WorkspaceActionResponse(
+                workspace_id=workspace_id,
+                status="starting",
+                message="Workspace is already starting",
+            )
+
         if workspace["status"] != "stopped":
             raise HTTPException(
                 status_code=400,

--- a/src/server/handlers/chat/ptc_workflow.py
+++ b/src/server/handlers/chat/ptc_workflow.py
@@ -397,8 +397,10 @@ async def astream_ptc_workflow(
 
                 logger.info(
                     "[WS_STATUS] state observation",
-                    workspace_id=workspace_id,
-                    sandbox_state=state_box["value"],
+                    extra={
+                        "workspace_id": workspace_id,
+                        "sandbox_state": state_box["value"],
+                    },
                 )
 
                 if state_box["value"] == "archived":

--- a/src/server/models/workspace.py
+++ b/src/server/models/workspace.py
@@ -17,11 +17,13 @@ class WorkspaceStatus(str, Enum):
     """Workspace lifecycle states."""
 
     CREATING = "creating"
+    STARTING = "starting"
     RUNNING = "running"
     STOPPING = "stopping"
     STOPPED = "stopped"
     ERROR = "error"
     DELETED = "deleted"
+    FLASH = "flash"
 
 
 class WorkspaceCreate(BaseModel):
@@ -80,7 +82,10 @@ class WorkspaceResponse(BaseModel):
         description="Daytona sandbox ID (null if not yet created)",
     )
     status: str = Field(
-        description="Workspace status: creating, running, stopping, stopped, error, deleted"
+        description=(
+            "Workspace status: creating, starting, running, stopping, stopped, "
+            "error, deleted, flash"
+        )
     )
     created_at: datetime = Field(description="Creation timestamp")
     updated_at: datetime = Field(description="Last update timestamp")

--- a/src/server/services/persistence/file.py
+++ b/src/server/services/persistence/file.py
@@ -430,6 +430,11 @@ class FilePersistenceService:
         """
         Restore workspace files from DB to sandbox.
 
+        Pre-creates all unique parent directories in one bulk mkdir, then
+        uploads files concurrently through a semaphore-bounded worker pool
+        so the next upload starts the instant any slot frees up (rather
+        than waiting for the slowest file in a fixed-size batch).
+
         Args:
             workspace_id: Workspace UUID
             sandbox: Sandbox instance
@@ -448,25 +453,40 @@ class FilePersistenceService:
 
             logger.info(f"Restoring {len(files)} files for workspace {workspace_id}")
 
-            # Process in batches for parallel upload
-            batch_size = 10
-            for i in range(0, len(files), batch_size):
-                batch = files[i : i + batch_size]
-                tasks = [
-                    cls._restore_single_file(sandbox, file_record)
-                    for file_record in batch
-                ]
-                results = await asyncio.gather(*tasks, return_exceptions=True)
-                for j, res in enumerate(results):
-                    if isinstance(res, Exception):
-                        logger.warning(
-                            f"Failed to restore {batch[j]['file_path']}: {res}"
-                        )
-                        result["errors"] += 1
-                    elif res:
-                        result["restored"] += 1
-                    else:
-                        result["errors"] += 1
+            # Bulk-create unique parent directories in one exec call so
+            # we skip ~N redundant round-trips inside the per-file path.
+            work_dir = sandbox.working_dir
+            unique_dirs = {
+                os.path.dirname(f"{work_dir}/{file_record['file_path']}")
+                for file_record in files
+            }
+            unique_dirs.discard("")
+            unique_dirs.discard(work_dir)
+            if unique_dirs:
+                await cls._bulk_create_directories(sandbox, unique_dirs)
+
+            # Worker-pool upload: semaphore bounds concurrency, but each
+            # task releases its slot as soon as it finishes — no batch
+            # waits for the slowest file.
+            sem = asyncio.Semaphore(16)
+
+            async def _upload(file_record: dict) -> tuple[str, bool | Exception]:
+                async with sem:
+                    try:
+                        ok = await cls._restore_file_content_only(sandbox, file_record)
+                        return (file_record["file_path"], ok)
+                    except Exception as e:
+                        return (file_record["file_path"], e)
+
+            outcomes = await asyncio.gather(*(_upload(f) for f in files))
+            for path, res in outcomes:
+                if isinstance(res, Exception):
+                    logger.warning(f"Failed to restore {path}: {res}")
+                    result["errors"] += 1
+                elif res:
+                    result["restored"] += 1
+                else:
+                    result["errors"] += 1
 
             # Write sync marker
             try:
@@ -507,16 +527,29 @@ class FilePersistenceService:
 
     @classmethod
     async def _restore_single_file(cls, sandbox: Any, file_record: dict) -> bool:
-        """Restore a single file to sandbox."""
+        """Restore a single file to sandbox, creating its parent directory.
+
+        Kept for callers outside the bulk restore path (e.g. single-file
+        writes). Bulk restore uses ``_restore_file_content_only`` after a
+        single pre-pass that creates all unique parents at once.
+        """
         work_dir = sandbox.working_dir
         abs_path = f"{work_dir}/{file_record['file_path']}"
 
-        # Ensure parent directory exists
         parent_dir = os.path.dirname(abs_path)
         if parent_dir and parent_dir != work_dir:
             await sandbox.acreate_directory(parent_dir)
 
-        # Get content
+        return await cls._restore_file_content_only(sandbox, file_record)
+
+    @classmethod
+    async def _restore_file_content_only(
+        cls, sandbox: Any, file_record: dict
+    ) -> bool:
+        """Upload file content assuming parent directory already exists."""
+        work_dir = sandbox.working_dir
+        abs_path = f"{work_dir}/{file_record['file_path']}"
+
         if file_record.get("is_binary") and file_record.get("content_binary"):
             content = file_record["content_binary"]
             if isinstance(content, memoryview):
@@ -527,6 +560,36 @@ class FilePersistenceService:
             return False
 
         return await sandbox.aupload_file_bytes(abs_path, content)
+
+    @classmethod
+    async def _bulk_create_directories(
+        cls, sandbox: Any, dirs: set[str]
+    ) -> None:
+        """Pre-create all unique parent directories before bulk upload.
+
+        Uses the sandbox's bulk API (single ``mkdir -p`` exec for all
+        paths). Falls back to parallel per-dir creates if the bulk call
+        fails (e.g. command-line length exceeded for huge workspaces).
+        ``mkdir -p`` is idempotent either way.
+        """
+        if not sandbox or not dirs:
+            return
+
+        ok = await sandbox.acreate_directories(dirs)
+        if ok:
+            return
+
+        logger.debug(
+            f"Bulk mkdir unavailable or failed for {len(dirs)} dirs; "
+            "falling back to parallel per-dir creates."
+        )
+        sem = asyncio.Semaphore(16)
+
+        async def _mkone(d: str) -> None:
+            async with sem:
+                await sandbox.acreate_directory(d)
+
+        await asyncio.gather(*(_mkone(d) for d in dirs), return_exceptions=True)
 
     @classmethod
     async def maybe_restore(cls, workspace_id: str, sandbox: Any) -> None:

--- a/src/server/services/workspace_manager.py
+++ b/src/server/services/workspace_manager.py
@@ -176,10 +176,22 @@ class WorkspaceManager:
         """Record that a sync was performed for this workspace."""
         self._last_sync_at[workspace_id] = time.monotonic()
 
-    async def _clear_session(self, workspace_id: str) -> None:
+    async def _clear_session(
+        self,
+        workspace_id: str,
+        *,
+        evict_session: "Session | None" = None,
+    ) -> None:
         """Remove all traces of a broken session and proactively release its
         resources (MCP connections + provider aiohttp client) instead of
         waiting for GC.
+
+        ``cleanup_session`` awaits ``session.cleanup()``, so a concurrent
+        request can install a replacement in ``self._sessions[workspace_id]``
+        while we're yielded. When the caller passes the session object it
+        intended to evict, we identity-check before popping — so the
+        replacement survives. Callers inside the workspace lock can omit
+        ``evict_session`` (the lock already prevents the race).
 
         Safe to call when the workspace is not present — idempotent.
         """
@@ -190,7 +202,8 @@ class WorkspaceManager:
                 "Error during session cleanup (continuing)",
                 extra={"workspace_id": workspace_id, "error": str(e)},
             )
-        self._sessions.pop(workspace_id, None)
+        if evict_session is None or self._sessions.get(workspace_id) is evict_session:
+            self._sessions.pop(workspace_id, None)
         self._pending_lazy_sync.discard(workspace_id)
 
     async def push_vault_secrets(
@@ -1161,8 +1174,10 @@ class WorkspaceManager:
                 # installed a replacement session while we were running
                 # Phase 2 outside the lock. Clearing that healthy session
                 # would tear down its MCP+provider and double-spawn Daytona.
+                # Pass evict_session so the pop inside _clear_session is
+                # also identity-guarded across its own await boundary.
                 if self._sessions.get(workspace_id) is session:
-                    await self._clear_session(workspace_id)
+                    await self._clear_session(workspace_id, evict_session=session)
 
                 async with self._acquire_workspace_lock(workspace_id):
                     # Guard: another request may have recovered while we
@@ -1188,8 +1203,10 @@ class WorkspaceManager:
                     # observed has_failed() in its own Phase 1, cleared this
                     # session, and installed a replacement. Clearing again
                     # would tear down the healthy replacement's MCP+provider.
+                    # Pass evict_session so the pop inside _clear_session is
+                    # also identity-guarded across its own await boundary.
                     if self._sessions.get(workspace_id) is session:
-                        await self._clear_session(workspace_id)
+                        await self._clear_session(workspace_id, evict_session=session)
                     raise
                 logger.warning(
                     f"Phase 2 sync transient for workspace {workspace_id} "

--- a/src/server/services/workspace_manager.py
+++ b/src/server/services/workspace_manager.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, Optional
 import httpx
 
 from ptc_agent.config import AgentConfig
-from ptc_agent.core.sandbox.runtime import SandboxGoneError
+from ptc_agent.core.sandbox.runtime import SandboxGoneError, SandboxTransientError
 from ptc_agent.core.session import Session, SessionManager
 
 from src.server.services.background_task_manager import BackgroundTaskManager
@@ -175,6 +175,23 @@ class WorkspaceManager:
     def _record_sync(self, workspace_id: str) -> None:
         """Record that a sync was performed for this workspace."""
         self._last_sync_at[workspace_id] = time.monotonic()
+
+    async def _clear_session(self, workspace_id: str) -> None:
+        """Remove all traces of a broken session and proactively release its
+        resources (MCP connections + provider aiohttp client) instead of
+        waiting for GC.
+
+        Safe to call when the workspace is not present — idempotent.
+        """
+        try:
+            await SessionManager.cleanup_session(workspace_id)
+        except Exception as e:
+            logger.warning(
+                "Error during session cleanup (continuing)",
+                extra={"workspace_id": workspace_id, "error": str(e)},
+            )
+        self._sessions.pop(workspace_id, None)
+        self._pending_lazy_sync.discard(workspace_id)
 
     async def push_vault_secrets(
         self, workspace_id: str, sandbox: "PTCSandbox | None" = None,
@@ -837,9 +854,7 @@ class WorkspaceManager:
                             f"Lazy init failed for workspace {workspace_id}: "
                             f"{init_err}. Clearing session for recovery."
                         )
-                        SessionManager.remove_session(workspace_id)
-                        del self._sessions[workspace_id]
-                        self._pending_lazy_sync.discard(workspace_id)
+                        await self._clear_session(workspace_id)
 
                         if isinstance(init_err, SandboxGoneError):
                             core_config = self.config.to_core_config()
@@ -887,8 +902,14 @@ class WorkspaceManager:
 
             # No usable cached session — handle based on status
             if session is None:
-                if status == "stopped":
-                    logger.info(f"Restarting stopped workspace {workspace_id}")
+                if status in ("stopped", "starting"):
+                    # "starting" means a prior lazy init is either in flight or
+                    # failed after clearing the cached session; re-entering the
+                    # restart flow is idempotent — it resets status to
+                    # "starting" (no-op) and kicks off a fresh lazy init.
+                    logger.info(
+                        f"Restarting workspace {workspace_id} from status={status}"
+                    )
                     session = await self._restart_workspace(
                         workspace,
                         user_id=workspace_user_id,
@@ -912,7 +933,7 @@ class WorkspaceManager:
                                 on_state_observed=on_state_observed,
                             )
                         except SandboxGoneError as e:
-                            SessionManager.remove_session(workspace_id)
+                            await self._clear_session(workspace_id)
                             logger.warning(
                                 f"Sandbox {sandbox_id} unavailable for workspace "
                                 f"{workspace_id} ({e}). Creating fresh sandbox."
@@ -1054,7 +1075,7 @@ class WorkspaceManager:
                                     e,
                                 )
                                 core_config = self.config.to_core_config()
-                                SessionManager.remove_session(workspace_id)
+                                await self._clear_session(workspace_id)
                                 return await self._recover_sandbox(
                                     workspace_id, workspace_user_id, core_config
                                 )
@@ -1092,6 +1113,16 @@ class WorkspaceManager:
                 _mark("sandbox_ready")
 
                 if needs_deferred_sync:
+                    # Only promote when a lazy init actually happened (row is
+                    # still in _pending_lazy_sync). A forced non-lazy restart
+                    # already flipped status to running + stamped activity
+                    # inside _restart_workspace — no-op here.
+                    if workspace_id in self._pending_lazy_sync:
+                        await update_workspace_status(
+                            workspace_id=workspace_id,
+                            status="running",
+                        )
+                        await update_workspace_activity(workspace_id)
                     logger.debug(
                         f"Completing deferred sync for lazy-init workspace {workspace_id}"
                     )
@@ -1126,9 +1157,12 @@ class WorkspaceManager:
                     f"Sandbox gone for workspace {workspace_id} during "
                     f"Phase 2: {e}. Recovering."
                 )
-                SessionManager.remove_session(workspace_id)
-                self._sessions.pop(workspace_id, None)
-                self._pending_lazy_sync.discard(workspace_id)
+                # Identity check: a concurrent request may have already
+                # installed a replacement session while we were running
+                # Phase 2 outside the lock. Clearing that healthy session
+                # would tear down its MCP+provider and double-spawn Daytona.
+                if self._sessions.get(workspace_id) is session:
+                    await self._clear_session(workspace_id)
 
                 async with self._acquire_workspace_lock(workspace_id):
                     # Guard: another request may have recovered while we
@@ -1140,6 +1174,27 @@ class WorkspaceManager:
                     return await self._recover_sandbox(
                         workspace_id, workspace_user_id, core_config
                     )
+            except SandboxTransientError as e:
+                # Narrow: if lazy init exhausted retries the session is
+                # marked failed — clearing it removes the zombie so the
+                # next request starts fresh. Post-init transient (asset
+                # sync etc.) leaves sandbox healthy; best-effort retry.
+                if session.sandbox.has_failed():
+                    logger.warning(
+                        f"Phase 2 init exhausted retries for {workspace_id}: "
+                        f"{e}. Clearing session for fresh recovery."
+                    )
+                    # Identity check: a concurrent request may have already
+                    # observed has_failed() in its own Phase 1, cleared this
+                    # session, and installed a replacement. Clearing again
+                    # would tear down the healthy replacement's MCP+provider.
+                    if self._sessions.get(workspace_id) is session:
+                        await self._clear_session(workspace_id)
+                    raise
+                logger.warning(
+                    f"Phase 2 sync transient for workspace {workspace_id} "
+                    f"(will retry next request): {e}"
+                )
             except Exception as e:
                 logger.warning(
                     f"Phase 2 sync failed for workspace {workspace_id} "
@@ -1228,7 +1283,7 @@ class WorkspaceManager:
                     logger.debug(f"Session initialized for workspace {workspace_id}")
             except SandboxGoneError as e:
                 sandbox_gone = True
-                SessionManager.remove_session(workspace_id)
+                await self._clear_session(workspace_id)
                 logger.warning(
                     f"Sandbox {sandbox_id} unavailable for workspace "
                     f"{workspace_id} ({e}). Creating fresh sandbox."
@@ -1255,21 +1310,33 @@ class WorkspaceManager:
                 if migrated is not None:
                     return migrated
 
-            # Update status to running
-            await update_workspace_status(
-                workspace_id=workspace_id,
-                status="running",
-            )
-
-            # Cache session
-            self._sessions[workspace_id] = session
-
-            # Stamp last_activity_at so the idle sweep cannot pick this workspace
-            # up using a stale timestamp during the remainder of the request
-            # lifetime. Mirrors _recover_sandbox.
-            await update_workspace_activity(workspace_id)
-
-            logger.info(f"Workspace {workspace_id} restarted successfully")
+            # Update DB status. Lazy path stops at "starting" so downstream
+            # read-side callers (workspace_files.py, public.py) use DB/safe
+            # fallbacks while Phase 2 resolves; Phase 2 promotes to "running"
+            # and stamps activity once the sandbox is actually ready.
+            # Non-lazy path completes synchronously here — keep the
+            # stopped → running transition plus activity stamp (PR #152).
+            if lazy_init:
+                await update_workspace_status(
+                    workspace_id=workspace_id,
+                    status="starting",
+                )
+                # Cache session
+                self._sessions[workspace_id] = session
+                # No activity stamp: cleanup_idle_workspaces only sweeps
+                # status="running", so "starting" rows are immune.
+                logger.info(f"Workspace {workspace_id} restart initiated (lazy)")
+            else:
+                await update_workspace_status(
+                    workspace_id=workspace_id,
+                    status="running",
+                )
+                # Cache session
+                self._sessions[workspace_id] = session
+                # Stamp last_activity_at so the idle sweep cannot pick this
+                # workspace up using a stale timestamp. Mirrors _recover_sandbox.
+                await update_workspace_activity(workspace_id)
+                logger.info(f"Workspace {workspace_id} restarted successfully")
             return session
 
         except Exception as e:

--- a/tests/unit/core/sandbox/test_sandbox_shutdown_race.py
+++ b/tests/unit/core/sandbox/test_sandbox_shutdown_race.py
@@ -282,6 +282,94 @@ class TestEnsureSandboxConnectedRecreatesProvider:
         assert mock_create_provider.call_count == 2
 
 
+class TestEnsureSandboxConnectedNoFutureLeak:
+    """After Fix 3, _ensure_sandbox_connected has no asyncio.Future coalescing
+    primitive, so a failing reconnect cannot produce a 'Future exception was
+    never retrieved' warning. Serialization is still enforced via the lock."""
+
+    @patch("ptc_agent.core.sandbox.ptc_sandbox.create_provider")
+    @pytest.mark.asyncio
+    async def test_no_future_leak_on_reconnect_failure(
+        self, mock_create_provider, mock_provider, mock_runtime, caplog
+    ):
+        import gc
+        import logging
+        from ptc_agent.core.sandbox.ptc_sandbox import PTCSandbox
+
+        mock_create_provider.return_value = mock_provider
+        sandbox = PTCSandbox(config=_make_config())
+        sandbox.runtime = mock_runtime
+        sandbox.sandbox_id = "existing-sandbox"
+
+        fresh_provider = AsyncMock(spec=SandboxProvider)
+        fresh_provider.close = AsyncMock()
+        mock_create_provider.return_value = fresh_provider
+
+        sandbox.reconnect = AsyncMock(
+            side_effect=RuntimeError("reconnect bombed")
+        )
+
+        caplog.set_level(logging.WARNING, logger="asyncio")
+
+        with pytest.raises(RuntimeError, match="reconnect bombed"):
+            await sandbox._ensure_sandbox_connected()
+
+        # Force GC; if there were a stranded Future with an unretrieved
+        # exception, the asyncio debug machinery would log here.
+        gc.collect()
+        await asyncio.sleep(0)
+
+        assert not any(
+            "Future exception was never retrieved" in rec.getMessage()
+            for rec in caplog.records
+        ), "Fix 3 regression: Future coalescing primitive reintroduced"
+
+        # No private state survives the failed attempt.
+        assert not hasattr(sandbox, "_reconnect_inflight")
+
+    @patch("ptc_agent.core.sandbox.ptc_sandbox.create_provider")
+    @pytest.mark.asyncio
+    async def test_concurrent_callers_serialized_by_lock(
+        self, mock_create_provider, mock_provider, mock_runtime
+    ):
+        """Two concurrent _ensure_sandbox_connected calls each invoke reconnect
+        serially (the lock was the only real serializer — Fix 3 removed the
+        dead Future that pretended to coalesce)."""
+        from ptc_agent.core.sandbox.ptc_sandbox import PTCSandbox
+
+        mock_create_provider.return_value = mock_provider
+        sandbox = PTCSandbox(config=_make_config())
+        sandbox.runtime = mock_runtime
+        sandbox.sandbox_id = "existing-sandbox"
+
+        fresh_provider = AsyncMock(spec=SandboxProvider)
+        fresh_provider.close = AsyncMock()
+        mock_create_provider.return_value = fresh_provider
+
+        running = 0
+        peak_concurrency = 0
+
+        async def tracked_reconnect(sid):
+            nonlocal running, peak_concurrency
+            running += 1
+            peak_concurrency = max(peak_concurrency, running)
+            await asyncio.sleep(0.01)
+            running -= 1
+
+        sandbox.reconnect = AsyncMock(side_effect=tracked_reconnect)
+
+        await asyncio.gather(
+            sandbox._ensure_sandbox_connected(),
+            sandbox._ensure_sandbox_connected(),
+        )
+
+        assert sandbox.reconnect.await_count == 2
+        assert peak_concurrency == 1, (
+            "Lock must serialize concurrent reconnects; saw "
+            f"peak_concurrency={peak_concurrency}"
+        )
+
+
 class TestInitTaskCancellation:
     """_init_task is cancelled during stop_sandbox() and cleanup()."""
 

--- a/tests/unit/server/app/test_workspace_files_routing.py
+++ b/tests/unit/server/app/test_workspace_files_routing.py
@@ -1,0 +1,115 @@
+"""
+Integration-style tests for the ``starting`` status routing in
+``src/server/app/workspace_files.py``.
+
+These pin the incident-day invariant: while a workspace is in the
+intermediate ``starting`` state (lazy init in flight, or Phase 2 failed),
+a concurrent ``GET /files`` call must route to the DB fallback. Before
+Fix 1 the DB read side only checked ``stopped``/``stopping`` so a
+concurrent request during lazy init went straight to live sandbox
+acquisition and collided with the in-flight Daytona restore — 503 storm.
+
+Plan item #8 (``investigate-backend-1-info-zesty-sketch.md``): request A
+fails lazy init, request B calls ``/files`` while status is
+``starting`` → B returns DB fallback, not 503.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from ptc_agent.core.sandbox.runtime import SandboxTransientError
+from src.server.app.workspace_files import list_workspace_files
+
+
+def _workspace(ws_id: str, user_id: str, status: str) -> dict:
+    return {
+        "workspace_id": ws_id,
+        "user_id": user_id,
+        "status": status,
+        "config": None,
+        "sandbox_id": "sb-existing",
+    }
+
+
+@pytest.mark.asyncio
+@patch("src.server.app.workspace_files._get_work_dir", return_value="/home/workspace")
+@patch("src.server.app.workspace_files.FilePersistenceService")
+@patch("src.server.app.workspace_files.db_get_workspace")
+async def test_starting_status_routes_to_db_fallback(
+    mock_get_ws, mock_fp, _mock_wd,
+):
+    """Happy path: status='starting' → handler returns the DB file tree
+    with ``source: 'database'``, never touching the sandbox."""
+    ws_id = "ws-starting"
+    mock_get_ws.return_value = _workspace(ws_id, "user-1", status="starting")
+    mock_fp.get_file_tree = AsyncMock(
+        return_value=[
+            {"path": "results/summary.md"},
+            {"path": "data/daily.csv"},
+        ]
+    )
+
+    result = await list_workspace_files(
+        workspace_id=ws_id,
+        x_user_id="user-1",
+        path=".",
+        include_system=False,
+        pattern="**/*",
+        wait_for_sandbox=False,
+        auto_start=False,
+    )
+
+    assert result["source"] == "database"
+    assert result["sandbox_ready"] is False
+    assert set(result["files"]) == {"results/summary.md", "data/daily.csv"}
+    mock_fp.get_file_tree.assert_awaited_once_with(ws_id)
+
+
+@pytest.mark.asyncio
+@patch("src.server.app.workspace_files._get_work_dir", return_value="/home/workspace")
+@patch("src.server.app.workspace_files.FilePersistenceService")
+@patch("src.server.app.workspace_files.db_get_workspace")
+async def test_files_during_concurrent_failing_lazy_init(
+    mock_get_ws, mock_fp, _mock_wd,
+):
+    """Plan item #8: A (``get_session_for_workspace`` with failing Phase 2)
+    races against B (``list_workspace_files``). As long as the DB row reads
+    ``status='starting'`` when B arrives, B must route to the DB fallback
+    and not raise 503 — even if A is mid-failure."""
+    ws_id = "ws-racing"
+    mock_get_ws.return_value = _workspace(ws_id, "user-1", status="starting")
+    mock_fp.get_file_tree = AsyncMock(return_value=[{"path": "results/x.txt"}])
+
+    async def failing_request_a() -> Exception:
+        """Simulate ``WorkspaceManager.get_session_for_workspace`` raising
+        a SandboxTransientError from Phase 2 while B is reading /files."""
+        await asyncio.sleep(0.005)
+        raise SandboxTransientError("phase 2 init exhausted retries")
+
+    async def request_b() -> dict:
+        # B intentionally has no knowledge of A — it just reads /files.
+        return await list_workspace_files(
+            workspace_id=ws_id,
+            x_user_id="user-1",
+            path=".",
+            include_system=False,
+            pattern="**/*",
+            wait_for_sandbox=False,
+            auto_start=False,
+        )
+
+    outcomes = await asyncio.gather(
+        failing_request_a(),
+        request_b(),
+        return_exceptions=True,
+    )
+
+    a_outcome, b_outcome = outcomes
+    assert isinstance(a_outcome, SandboxTransientError)  # A failed, as expected
+    assert isinstance(b_outcome, dict), f"B should not raise 503 / error: {b_outcome!r}"
+    assert b_outcome["source"] == "database"
+    assert b_outcome["files"] == ["results/x.txt"]

--- a/tests/unit/server/models/test_workspace_models.py
+++ b/tests/unit/server/models/test_workspace_models.py
@@ -31,7 +31,16 @@ class TestWorkspaceStatus:
     """Verify enum members and string compatibility."""
 
     def test_all_expected_values(self):
-        expected = {"creating", "running", "stopping", "stopped", "error", "deleted"}
+        expected = {
+            "creating",
+            "starting",
+            "running",
+            "stopping",
+            "stopped",
+            "error",
+            "deleted",
+            "flash",
+        }
         actual = {s.value for s in WorkspaceStatus}
         assert actual == expected
 

--- a/tests/unit/server/services/test_file_persistence_restore.py
+++ b/tests/unit/server/services/test_file_persistence_restore.py
@@ -1,0 +1,184 @@
+"""
+Unit tests for FilePersistenceService.restore_to_sandbox parallel path.
+
+The restore path previously ran files through a batch-of-10
+``asyncio.gather`` loop and issued one ``mkdir -p`` per file. The new
+path:
+
+1. Collects unique parent directories and issues a single bulk mkdir.
+2. Uploads all files through a semaphore-bounded worker pool so the
+   next upload starts the instant any slot frees up — no per-batch
+   wait for the slowest file.
+
+These tests pin that behavior so regressions of the restore latency
+budget are visible in CI.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.server.services.persistence.file import FilePersistenceService
+
+
+def _file(path: str, text: str = "hello") -> dict:
+    return {
+        "file_path": path,
+        "is_binary": False,
+        "content_binary": None,
+        "content_text": text,
+    }
+
+
+def _mock_sandbox() -> MagicMock:
+    sandbox = MagicMock()
+    sandbox.working_dir = "/workspace"
+    sandbox.acreate_directories = AsyncMock(return_value=True)
+    sandbox.acreate_directory = AsyncMock(return_value=True)
+    sandbox.aupload_file_bytes = AsyncMock(return_value=True)
+    return sandbox
+
+
+@pytest.mark.asyncio
+@patch("src.server.services.persistence.file.update_file_mtime", new_callable=AsyncMock)
+@patch("src.server.services.persistence.file.get_files_for_workspace", new_callable=AsyncMock)
+async def test_restore_bulk_creates_unique_dirs_once(mock_get, mock_update):
+    """All unique parent dirs are created in a SINGLE acreate_directories
+    call. 50 files across 3 unique parent dirs → 1 bulk mkdir, not 50."""
+    files = (
+        [_file(f"data/a/file_{i}.txt") for i in range(20)]
+        + [_file(f"data/b/file_{i}.txt") for i in range(20)]
+        + [_file(f"reports/file_{i}.txt") for i in range(10)]
+    )
+    mock_get.return_value = files
+
+    sandbox = _mock_sandbox()
+    # short-circuit post-restore mtime sync to keep the test focused
+    with patch.object(
+        FilePersistenceService, "list_sandbox_files", new=AsyncMock(return_value={})
+    ):
+        result = await FilePersistenceService.restore_to_sandbox("ws-1", sandbox)
+
+    assert result == {"restored": 50, "errors": 0}
+
+    # Exactly one bulk-mkdir call, with all three unique dirs.
+    sandbox.acreate_directories.assert_awaited_once()
+    dirs_arg = sandbox.acreate_directories.await_args.args[0]
+    dirs_set = set(dirs_arg)
+    assert dirs_set == {"/workspace/data/a", "/workspace/data/b", "/workspace/reports"}
+
+    # Per-file mkdir is NOT invoked on the happy bulk-success path.
+    sandbox.acreate_directory.assert_not_awaited()
+
+    # Upload is called once per file (+1 for the sync marker at the end).
+    upload_paths = [c.args[0] for c in sandbox.aupload_file_bytes.await_args_list]
+    file_uploads = [p for p in upload_paths if not p.endswith(".file_sync_marker")]
+    assert len(file_uploads) == 50
+
+
+@pytest.mark.asyncio
+@patch("src.server.services.persistence.file.get_files_for_workspace", new_callable=AsyncMock)
+async def test_restore_falls_back_to_per_dir_when_bulk_fails(mock_get):
+    """If acreate_directories returns False (e.g. command line too long
+    for huge workspaces), restore falls back to parallel per-dir creates
+    before uploads start."""
+    mock_get.return_value = [_file("a/x.txt"), _file("b/y.txt")]
+    sandbox = _mock_sandbox()
+    sandbox.acreate_directories = AsyncMock(return_value=False)
+
+    with patch.object(
+        FilePersistenceService, "list_sandbox_files", new=AsyncMock(return_value={})
+    ):
+        result = await FilePersistenceService.restore_to_sandbox("ws-1", sandbox)
+
+    assert result == {"restored": 2, "errors": 0}
+    sandbox.acreate_directories.assert_awaited_once()
+    # Fallback fires acreate_directory per unique parent dir.
+    dirs_from_fallback = {
+        call.args[0] for call in sandbox.acreate_directory.await_args_list
+    }
+    assert dirs_from_fallback == {"/workspace/a", "/workspace/b"}
+    upload_paths = [c.args[0] for c in sandbox.aupload_file_bytes.await_args_list]
+    file_uploads = [p for p in upload_paths if not p.endswith(".file_sync_marker")]
+    assert len(file_uploads) == 2
+
+
+@pytest.mark.asyncio
+@patch("src.server.services.persistence.file.get_files_for_workspace", new_callable=AsyncMock)
+async def test_restore_isolates_per_file_failures(mock_get):
+    """A single failed upload doesn't block the rest. 5 files, one
+    raises, one returns False — healthy 3 still restore, error count
+    tallied correctly, method does not raise."""
+    mock_get.return_value = [_file(f"f_{i}.txt") for i in range(5)]
+    sandbox = _mock_sandbox()
+
+    call_count = {"n": 0}
+
+    async def flaky_upload(_path, _content):
+        call_count["n"] += 1
+        if call_count["n"] == 2:
+            raise RuntimeError("transient network blip")
+        if call_count["n"] == 3:
+            return False
+        return True
+
+    sandbox.aupload_file_bytes = AsyncMock(side_effect=flaky_upload)
+
+    with patch.object(
+        FilePersistenceService, "list_sandbox_files", new=AsyncMock(return_value={})
+    ):
+        result = await FilePersistenceService.restore_to_sandbox("ws-1", sandbox)
+
+    assert result["restored"] == 3
+    assert result["errors"] == 2
+    # 5 file uploads + 1 sync-marker upload (sync marker runs in a best-effort
+    # try/except so it runs even when some files errored).
+    assert sandbox.aupload_file_bytes.await_count == 6
+
+
+@pytest.mark.asyncio
+@patch("src.server.services.persistence.file.get_files_for_workspace", new_callable=AsyncMock)
+async def test_restore_caps_concurrency_at_semaphore_size(mock_get):
+    """Worker pool semaphore caps concurrent uploads at 16. With 40
+    files each taking a tick, peak in-flight must never exceed 16."""
+    mock_get.return_value = [_file(f"f_{i}.txt") for i in range(40)]
+    sandbox = _mock_sandbox()
+
+    inflight = 0
+    peak = 0
+
+    async def tracking_upload(_path, _content):
+        nonlocal inflight, peak
+        inflight += 1
+        peak = max(peak, inflight)
+        await asyncio.sleep(0.002)
+        inflight -= 1
+        return True
+
+    sandbox.aupload_file_bytes = AsyncMock(side_effect=tracking_upload)
+
+    with patch.object(
+        FilePersistenceService, "list_sandbox_files", new=AsyncMock(return_value={})
+    ):
+        await FilePersistenceService.restore_to_sandbox("ws-1", sandbox)
+
+    assert peak <= 16, f"Concurrency cap breached: peak={peak}"
+    # Sanity: parallelism actually happened (not forced to 1).
+    assert peak > 1, f"Expected parallel uploads but peak={peak}"
+
+
+@pytest.mark.asyncio
+@patch("src.server.services.persistence.file.get_files_for_workspace", new_callable=AsyncMock)
+async def test_restore_empty_file_list_is_noop(mock_get):
+    """Zero files → no sandbox calls, no errors."""
+    mock_get.return_value = []
+    sandbox = _mock_sandbox()
+
+    result = await FilePersistenceService.restore_to_sandbox("ws-1", sandbox)
+
+    assert result == {"restored": 0, "errors": 0}
+    sandbox.acreate_directories.assert_not_awaited()
+    sandbox.aupload_file_bytes.assert_not_awaited()

--- a/tests/unit/server/services/test_workspace_manager.py
+++ b/tests/unit/server/services/test_workspace_manager.py
@@ -678,11 +678,12 @@ class TestSandboxRecovery:
         new_session = _make_mock_session()
         new_session.sandbox.sandbox_id = "sb-new"
         mock_session_mgr.get_session.return_value = new_session
+        mock_session_mgr.cleanup_session = AsyncMock()
 
         result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
 
-        # Broken session should be removed
-        mock_session_mgr.remove_session.assert_called_with(ws_id)
+        # Broken session should be proactively cleaned up (MCP + provider)
+        mock_session_mgr.cleanup_session.assert_awaited_with(ws_id)
         # Recovery creates a new session
         new_session.initialize.assert_called_once()
         # Status updated
@@ -711,11 +712,12 @@ class TestSandboxRecovery:
         # Fall-through: SessionManager.get_session returns a new session for reconnect
         new_session = _make_mock_session()
         mock_session_mgr.get_session.return_value = new_session
+        mock_session_mgr.cleanup_session = AsyncMock()
 
         result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
 
-        # Broken session removed
-        mock_session_mgr.remove_session.assert_called_with(ws_id)
+        # Broken session proactively cleaned up (MCP + provider)
+        mock_session_mgr.cleanup_session.assert_awaited_with(ws_id)
         # Falls through to status-based handling (reconnect)
         assert result is not None
 
@@ -763,11 +765,12 @@ class TestSandboxRecovery:
         new_session = _make_mock_session()
         new_session.sandbox.sandbox_id = "sb-new"
         mock_session_mgr.get_session.return_value = new_session
+        mock_session_mgr.cleanup_session = AsyncMock()
 
         result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
 
         # Recovery triggered
-        mock_session_mgr.remove_session.assert_called_with(ws_id)
+        mock_session_mgr.cleanup_session.assert_awaited_with(ws_id)
         new_session.initialize.assert_called_once()
         assert result is not None
 
@@ -858,11 +861,12 @@ class TestSandboxRecovery:
         recovered_session.sandbox.sandbox_id = "sb-new"
 
         mock_session_mgr.get_session.side_effect = [failing_session, recovered_session]
+        mock_session_mgr.cleanup_session = AsyncMock()
 
         result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
 
         # Recovery triggered
-        mock_session_mgr.remove_session.assert_called_with(ws_id)
+        mock_session_mgr.cleanup_session.assert_awaited_with(ws_id)
         recovered_session.initialize.assert_called_once()
         assert result is not None
 
@@ -900,6 +904,7 @@ class TestSandboxRecovery:
         # First call: _restart_workspace gets lazy_session
         # Second call: _recover_sandbox gets recovered_session
         mock_session_mgr.get_session.side_effect = [lazy_session, recovered_session]
+        mock_session_mgr.cleanup_session = AsyncMock()
 
         # Patch _restart_workspace to return the lazy session directly
         # (simulates the real lazy init path)
@@ -913,7 +918,7 @@ class TestSandboxRecovery:
             result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
 
         # Phase 2 caught SandboxGoneError and triggered recovery
-        mock_session_mgr.remove_session.assert_called_with(ws_id)
+        mock_session_mgr.cleanup_session.assert_awaited_with(ws_id)
         assert result is not None
 
     @pytest.mark.asyncio
@@ -1124,3 +1129,371 @@ class TestOnStateObservedForwarding:
 
         cached.initialize.assert_not_awaited()
         cached.initialize_lazy.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 error narrowing + _clear_session helper (Fix 2)
+# ---------------------------------------------------------------------------
+
+from ptc_agent.core.sandbox.runtime import SandboxTransientError  # noqa: E402
+
+
+class TestPhase2ErrorNarrowing:
+    """Phase 2 now distinguishes a failed lazy init (has_failed() == True,
+    clear + re-raise) from a post-init transient (has_failed() == False,
+    swallow + retry next request). Generic Exception keeps the legacy
+    best-effort-retry behavior — regression-guarded here."""
+
+    def setup_method(self):
+        WorkspaceManager.reset_instance()
+
+    def teardown_method(self):
+        WorkspaceManager.reset_instance()
+
+    def _make_manager(self):
+        return WorkspaceManager.get_instance(config=_make_config())
+
+    @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.db_get_workspace")
+    @patch("src.server.services.workspace_manager.SessionManager")
+    @patch("src.server.services.workspace_manager.update_workspace_status")
+    @patch("src.server.services.workspace_manager.update_workspace_activity")
+    async def test_phase2_transient_init_failure_clears_and_raises(
+        self, mock_activity, mock_status, mock_session_mgr, mock_get_ws
+    ):
+        """Phase 2 SandboxTransientError + has_failed() True → _clear_session
+        is called and the error propagates for handle_workflow_error to catch."""
+        manager = self._make_manager()
+        ws_id = str(uuid.uuid4())
+        mock_get_ws.return_value = _make_workspace(
+            workspace_id=ws_id, status="running"
+        )
+
+        session = _make_mock_session()
+        session.sandbox.ensure_sandbox_ready = AsyncMock(
+            side_effect=SandboxTransientError("transport failed after retries")
+        )
+        session.sandbox.has_failed = MagicMock(return_value=True)
+        manager._sessions[ws_id] = session
+        manager._last_sync_at = {}
+        mock_session_mgr.cleanup_session = AsyncMock()
+
+        with pytest.raises(SandboxTransientError):
+            await manager.get_session_for_workspace(ws_id, user_id="user-1")
+
+        mock_session_mgr.cleanup_session.assert_awaited_with(ws_id)
+        assert ws_id not in manager._sessions
+
+    @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.db_get_workspace")
+    @patch("src.server.services.workspace_manager.SessionManager")
+    @patch("src.server.services.workspace_manager.update_workspace_status")
+    @patch("src.server.services.workspace_manager.update_workspace_activity")
+    async def test_phase2_transient_post_init_swallowed(
+        self, mock_activity, mock_status, mock_session_mgr, mock_get_ws
+    ):
+        """SandboxTransientError after sandbox is ready (e.g., asset sync)
+        leaves the healthy session in cache and is best-effort retried next
+        request. has_failed() == False is the discriminator."""
+        manager = self._make_manager()
+        ws_id = str(uuid.uuid4())
+        mock_get_ws.return_value = _make_workspace(
+            workspace_id=ws_id, status="running"
+        )
+
+        session = _make_mock_session()
+        session.sandbox.has_failed = MagicMock(return_value=False)
+        session.sandbox.ensure_sandbox_ready = AsyncMock()
+
+        # Post-init transient: raise from a later sync step via patched method.
+        manager._sync_sandbox_assets = AsyncMock(
+            side_effect=SandboxTransientError("sync blip")
+        )
+        manager._maybe_restore_files = AsyncMock()
+        manager._pending_lazy_sync.add(ws_id)  # force deferred-sync branch
+        manager._sessions[ws_id] = session
+        manager._last_sync_at = {}
+        mock_session_mgr.cleanup_session = AsyncMock()
+
+        result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
+
+        assert result is session  # still cached, no clear
+        mock_session_mgr.cleanup_session.assert_not_awaited()
+        assert ws_id in manager._sessions
+
+    @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.db_get_workspace")
+    @patch("src.server.services.workspace_manager.SessionManager")
+    async def test_phase2_generic_exception_not_cleared(
+        self, mock_session_mgr, mock_get_ws
+    ):
+        """REGRESSION: plain Exception in Phase 2 keeps the legacy
+        'log and retry next request' behavior. Do not broaden the clear."""
+        manager = self._make_manager()
+        ws_id = str(uuid.uuid4())
+        mock_get_ws.return_value = _make_workspace(
+            workspace_id=ws_id, status="running"
+        )
+
+        session = _make_mock_session()
+        session.sandbox.ensure_sandbox_ready = AsyncMock(
+            side_effect=RuntimeError("some non-sandbox runtime error")
+        )
+        manager._sessions[ws_id] = session
+        manager._last_sync_at = {}
+        mock_session_mgr.cleanup_session = AsyncMock()
+
+        result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
+
+        assert result is session
+        mock_session_mgr.cleanup_session.assert_not_awaited()
+
+
+class TestClearSessionHelper:
+    """WorkspaceManager._clear_session proactively awaits cleanup_session
+    (closes MCP + provider) and clears local caches. Must be resilient when
+    cleanup_session raises and idempotent when workspace not present."""
+
+    def setup_method(self):
+        WorkspaceManager.reset_instance()
+
+    def teardown_method(self):
+        WorkspaceManager.reset_instance()
+
+    @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.SessionManager")
+    async def test_clear_session_happy_path(self, mock_sm):
+        """Awaits cleanup_session, pops from _sessions, discards from
+        _pending_lazy_sync."""
+        config = _make_config()
+        manager = WorkspaceManager.get_instance(config=config)
+        ws_id = str(uuid.uuid4())
+        manager._sessions[ws_id] = _make_mock_session()
+        manager._pending_lazy_sync.add(ws_id)
+        mock_sm.cleanup_session = AsyncMock()
+
+        await manager._clear_session(ws_id)
+
+        mock_sm.cleanup_session.assert_awaited_once_with(ws_id)
+        assert ws_id not in manager._sessions
+        assert ws_id not in manager._pending_lazy_sync
+
+    @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.SessionManager")
+    async def test_clear_session_idempotent_when_absent(self, mock_sm):
+        """Workspace not tracked — no KeyError; cleanup still attempted."""
+        config = _make_config()
+        manager = WorkspaceManager.get_instance(config=config)
+        ws_id = str(uuid.uuid4())
+        mock_sm.cleanup_session = AsyncMock()
+
+        await manager._clear_session(ws_id)  # must not raise
+
+        mock_sm.cleanup_session.assert_awaited_once_with(ws_id)
+
+    @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.SessionManager")
+    async def test_clear_session_survives_cleanup_exception(self, mock_sm):
+        """If cleanup_session raises, local caches still clear — the caller
+        must not see the exception bleed out of this helper."""
+        config = _make_config()
+        manager = WorkspaceManager.get_instance(config=config)
+        ws_id = str(uuid.uuid4())
+        manager._sessions[ws_id] = _make_mock_session()
+        manager._pending_lazy_sync.add(ws_id)
+        mock_sm.cleanup_session = AsyncMock(
+            side_effect=RuntimeError("MCP stuck")
+        )
+
+        await manager._clear_session(ws_id)  # must swallow
+
+        assert ws_id not in manager._sessions
+        assert ws_id not in manager._pending_lazy_sync
+
+
+# ---------------------------------------------------------------------------
+# Intermediate "starting" status (Fix 1)
+# ---------------------------------------------------------------------------
+
+
+class TestIntermediateStartingStatus:
+    """Lazy restart: status transitions stopped → starting → running.
+    The activity stamp moves with the running promotion (not the starting
+    flip) — cleanup_idle_workspaces only queries status=running, so rows
+    in "starting" are immune to the idle sweep regardless."""
+
+    def setup_method(self):
+        WorkspaceManager.reset_instance()
+
+    def teardown_method(self):
+        WorkspaceManager.reset_instance()
+
+    def _make_manager(self):
+        manager = WorkspaceManager.get_instance(config=_make_config())
+        manager._sync_sandbox_assets = AsyncMock()
+        manager._maybe_restore_files = AsyncMock()
+        manager._maybe_migrate_sandbox = AsyncMock(return_value=None)
+        # Stable config hash so lazy_init is not force-flipped to False
+        # by the config-migration guard in _restart_workspace.
+        manager._compute_sandbox_config_hash = MagicMock(return_value="stable")
+        return manager
+
+    @staticmethod
+    def _lazy_workspace(workspace_id, status="stopped"):
+        return _make_workspace(
+            workspace_id=workspace_id,
+            status=status,
+            config={"sandbox_config_hash": "stable"},
+        )
+
+    @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.SessionManager")
+    @patch("src.server.services.workspace_manager.update_workspace_status")
+    @patch("src.server.services.workspace_manager.update_workspace_activity")
+    async def test_lazy_restart_sets_starting_without_activity_stamp(
+        self, mock_activity, mock_status, mock_session_mgr
+    ):
+        """lazy_init=True flips status → "starting" and does NOT stamp
+        activity (sweep never sees "starting")."""
+        manager = self._make_manager()
+        ws_id = str(uuid.uuid4())
+        workspace = self._lazy_workspace(ws_id, status="stopped")
+
+        session = _make_mock_session()
+        mock_session_mgr.get_session.return_value = session
+
+        await manager._restart_workspace(
+            workspace, user_id="user-1", lazy_init=True
+        )
+
+        mock_status.assert_awaited_once()
+        kwargs = mock_status.await_args.kwargs
+        assert kwargs["status"] == "starting"
+        assert kwargs["workspace_id"] == ws_id
+        mock_activity.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.db_get_workspace")
+    @patch("src.server.services.workspace_manager.SessionManager")
+    @patch("src.server.services.workspace_manager.update_workspace_status")
+    @patch("src.server.services.workspace_manager.update_workspace_activity")
+    async def test_phase2_success_promotes_starting_to_running_and_stamps(
+        self, mock_activity, mock_status, mock_session_mgr, mock_get_ws
+    ):
+        """When Phase 2 finishes the deferred sync, DB is promoted to
+        running AND activity is stamped in that order (mirrors PR #152's
+        invariant for the lazy path)."""
+        manager = self._make_manager()
+        ws_id = str(uuid.uuid4())
+        mock_get_ws.return_value = self._lazy_workspace(ws_id, status="stopped")
+
+        lazy_session = _make_mock_session()
+        lazy_session.sandbox.ensure_sandbox_ready = AsyncMock()
+        mock_session_mgr.get_session.return_value = lazy_session
+
+        call_order: list[tuple[str, dict]] = []
+
+        async def record_status(**kwargs):
+            call_order.append(("status", kwargs))
+
+        async def record_activity(workspace_id):
+            call_order.append(("activity", {"workspace_id": workspace_id}))
+
+        mock_status.side_effect = record_status
+        mock_activity.side_effect = record_activity
+
+        await manager.get_session_for_workspace(ws_id, user_id="user-1")
+
+        # Expected sequence:
+        #   1. _restart_workspace: status=starting (no activity stamp yet)
+        #   2. Phase 2: status=running, then activity
+        names = [c[0] for c in call_order]
+        assert names == ["status", "status", "activity"], names
+        assert call_order[0][1]["status"] == "starting"
+        assert call_order[1][1]["status"] == "running"
+        assert call_order[2][1]["workspace_id"] == ws_id
+
+    @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.db_get_workspace")
+    @patch("src.server.services.workspace_manager.SessionManager")
+    @patch("src.server.services.workspace_manager.update_workspace_status")
+    @patch("src.server.services.workspace_manager.update_workspace_activity")
+    async def test_phase2_failure_leaves_status_at_starting(
+        self, mock_activity, mock_status, mock_session_mgr, mock_get_ws
+    ):
+        """Phase 2 exhausts retries → status stays "starting" (never flipped
+        to running), next request re-enters the stopped/starting branch."""
+        manager = self._make_manager()
+        ws_id = str(uuid.uuid4())
+        mock_get_ws.return_value = self._lazy_workspace(ws_id, status="stopped")
+
+        lazy_session = _make_mock_session()
+        lazy_session.sandbox.ensure_sandbox_ready = AsyncMock(
+            side_effect=SandboxTransientError("exhausted retries")
+        )
+        lazy_session.sandbox.has_failed = MagicMock(return_value=True)
+        mock_session_mgr.get_session.return_value = lazy_session
+        mock_session_mgr.cleanup_session = AsyncMock()
+
+        with pytest.raises(SandboxTransientError):
+            await manager.get_session_for_workspace(ws_id, user_id="user-1")
+
+        status_calls = [
+            c.kwargs for c in mock_status.await_args_list
+        ]
+        assert {c["status"] for c in status_calls} == {"starting"}
+
+    @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.db_get_workspace")
+    @patch("src.server.services.workspace_manager.SessionManager")
+    @patch("src.server.services.workspace_manager.update_workspace_status")
+    @patch("src.server.services.workspace_manager.update_workspace_activity")
+    async def test_status_starting_reenters_restart_flow(
+        self, mock_activity, mock_status, mock_session_mgr, mock_get_ws
+    ):
+        """If a prior lazy init left the row in "starting" (e.g. failed and
+        cleared), the next request with no cached session re-enters the
+        restart flow just like "stopped" would."""
+        manager = self._make_manager()
+        ws_id = str(uuid.uuid4())
+        mock_get_ws.return_value = self._lazy_workspace(ws_id, status="starting")
+
+        lazy_session = _make_mock_session()
+        lazy_session.sandbox.ensure_sandbox_ready = AsyncMock()
+        mock_session_mgr.get_session.return_value = lazy_session
+
+        await manager.get_session_for_workspace(ws_id, user_id="user-1")
+
+        lazy_session.initialize_lazy.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Status-tuple parametrization for DB-fallback routing (Fix 1 consumers)
+# ---------------------------------------------------------------------------
+
+
+class TestStatusRoutesToDbFallback:
+    """Smoke check: the status tuple the consumer modules (workspace_files,
+    public) compare against contains all three of stopped/stopping/starting.
+    A typo there would reproduce the 503 storm from the original incident."""
+
+    @pytest.mark.parametrize("status", ["stopped", "stopping", "starting"])
+    def test_workspace_files_tuple_includes_status(self, status):
+        from src.server.app import workspace_files
+        import inspect
+
+        source = inspect.getsource(workspace_files)
+        assert f'"{status}"' in source
+        # The exact tuple must remain in sync with public.py; if this ever
+        # has to change, grep for "stopped", "stopping", "starting" in both
+        # files and update together.
+        assert '"stopped", "stopping", "starting"' in source
+
+    @pytest.mark.parametrize("status", ["stopped", "stopping", "starting"])
+    def test_public_tuple_includes_status(self, status):
+        from src.server.app import public
+        import inspect
+
+        source = inspect.getsource(public)
+        assert f'"{status}"' in source
+        assert '"stopped", "stopping", "starting"' in source


### PR DESCRIPTION
## Summary

Production incident 2026-04-20 14:10-14:11: a failed Daytona archived-restore cascaded into ~75s of degraded behavior — 50s chat stall, workflow run on a broken session, 13s of 503s on `/files`, three "Future exception was never retrieved" asyncio warnings. One control-plane blip, an order of magnitude too much user-visible damage.

Four coordinated fixes + one opportunistic performance win + one logger regression.

**Workspace lifecycle**
- New `"starting"` status between `stopped` and `running`. Lazy-init flips to `starting`; Phase 2 promotes to `running` only after `ensure_sandbox_ready` actually succeeds. Consumers (`workspace_files.py`, `public.py`) route `starting` to the DB fallback so concurrent `/files` calls during restore no longer 503.
- Migration 009 adds `starting` to the `workspaces_status_check` CHECK constraint.
- Phase 2 error handling narrowed: `SandboxTransientError` + `has_failed()` → clear and re-raise. Post-init transient (sandbox already healthy) → best-effort retry. Plain `Exception` → legacy log-and-retry (regression-guarded).
- New `_clear_session` helper awaits `SessionManager.cleanup_session` so MCP and aiohttp provider close proactively, not on GC. Migrated all 5 broken-session clearing sites.
- Identity-guarded clear on both `SandboxGoneError` and `SandboxTransientError` paths (Phase 2 runs outside the workspace lock by design). `cleanup_session` itself is now identity-guarded on its final pop, fixing a latent `KeyError` under concurrent callers.
- `POST /start` returns 200 `"already starting"` for `starting`-state workspaces. `/files` write 409s include the actual status.

**Sandbox**
- Removed dead `asyncio.Future` from `_ensure_sandbox_connected` — the surrounding `_reconnect_lock` already fully serialized callers, so the Future only produced "Future exception was never retrieved" noise on every failed restore.
- Added `PTCSandbox.acreate_directories(paths)` — single `shlex`-quoted `mkdir -p` exec over all paths.

**File restore perf**
- Rewrote `FilePersistenceService.restore_to_sandbox` to bulk-mkdir unique parent dirs once, then upload through an `asyncio.Semaphore(16)` worker pool. On the incident workspace (230 files) this should cut `file_restore` from ~16s to ~2.5-3s. Per-file failures isolated via try/except tuples; fallback to parallel per-dir `acreate_directory` if bulk exec fails (ARG_MAX on huge workspaces).

**Unrelated regression fix**
- `src/server/handlers/chat/ptc_workflow.py:398` was passing structlog-style kwargs to a stdlib logger since PR #151. The fix had landed in #155 but was lost in a squash. Routed through `extra={}`.

## Test Coverage

- 14 new unit tests across sandbox, workspace, session, persistence, models.
- `tests/unit/server/app/test_workspace_files_routing.py` (new) pins plan item 8: concurrent failing lazy init + `/files` call → DB fallback, not 503.
- `tests/unit/server/services/test_file_persistence_restore.py` (new) pins the bulk-mkdir + semaphore-cap + per-file-failure behavior.
- No Future leak on reconnect failure; lock still serializes two concurrent `_ensure_sandbox_connected` callers.
- All 2744 unit tests pass on merged state.

## Pre-Landing Review

Cleared. Two rounds — initial review auto-fixed 4 UX strings and caught the P0 migration gap + P1 concurrent-clear race; second round caught stale `WorkspaceStatus` enum, bare 400 on `starting` state for `/start`, and `cleanup_session` KeyError under concurrent callers. All resolved in this PR.

## Test plan

- [x] `uv run pytest tests/unit/` → 2744 passed
- [x] `uv run ruff check` → clean on touched files
- [ ] Cold-restart an archived workspace and watch `file_restore` in `[SESSION_TIMING]` drop from ~16s to ~3s
- [ ] Force a Daytona control-plane conflict during restore; confirm `/files` returns `source: "database"` instead of 503 storm; confirm no zombie workflow runs on the failed session; confirm DB status stays at `starting` and next request recovers cleanly
- [ ] Grep logs for `"Future exception was never retrieved"` — should be zero after deploy

## Deploy ordering

Run migration 009 before rolling out the code (code writes `status='starting'`; CHECK constraint must accept it first). Standard `make migrate` → deploy ordering.