### PR TITLE
feat: vault credential blueprints with x_api backfill

### DIFF
--- a/agent_config.yaml
+++ b/agent_config.yaml
@@ -187,6 +187,15 @@ mcp:
       #   X_BEARER_TOKEN: "${X_BEARER_TOKEN}"
       # This will make every workspace's MCP subprocess share the same host token.
       env: {}
+      vault_blueprints:
+        - name: "X_BEARER_TOKEN"
+          label: "X (Twitter) Bearer Token"
+          description: "Read-only app-only auth for the x_api MCP server. Get one at console.x.com → App → Keys and tokens → Bearer Token. Paste the raw token — no 'Bearer ' prefix, no whitespace."
+          docs_url: "https://console.x.com/"
+          # Live X bearer tokens are opaque URL-safe strings, typically 100+ chars.
+          # Regex catches empty, short-paste, and 'Bearer <token>' prefix mistakes
+          # without being too strict about the exact character set.
+          regex: "^[A-Za-z0-9%_-]{20,}$"
 
     # Not enabled in Porduction or maintained by us
     - name: "alphavantage"

--- a/src/ptc_agent/config/core.py
+++ b/src/ptc_agent/config/core.py
@@ -8,10 +8,11 @@ This module defines pure data classes for core configuration:
 - Logging settings
 """
 
+import re
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 # Default security lists — used by SecurityConfig defaults and create_default_security_config()
 DEFAULT_ALLOWED_IMPORTS = [
@@ -61,6 +62,42 @@ class SecurityConfig(BaseModel):
     )
 
 
+class VaultBlueprint(BaseModel):
+    """Credential an MCP server expects users to set in the workspace vault.
+
+    Pure metadata — never touches actual values. Surfaced via
+    GET /api/v1/workspaces/{id}/vault/blueprints as a 'recommended but not set'
+    list in the UI's Vault tab, so users don't have to read docs to learn the
+    exact secret name for each integration.
+    """
+
+    # Same regex as CreateSecretRequest in src/server/app/vault.py:37.
+    # Blueprint name becomes a vault key, so it must satisfy the same rule.
+    name: str = Field(pattern=r"^[A-Za-z_][A-Za-z0-9_]{0,63}$", max_length=64)
+    label: str = Field(..., min_length=1, max_length=80)
+    # max_length matches CreateSecretRequest.description in src/server/app/vault.py
+    # so that pre-filling the add-secret form from a blueprint never produces a
+    # description that the create endpoint would reject with a 422.
+    description: str = Field("", max_length=256)
+    docs_url: str | None = None
+    # Optional client-side hint for the secret *value*. Stored as a string (not
+    # compiled at runtime on the value) because it ships to the frontend for
+    # validation. The backend never runs it against values — keeps secrets opaque.
+    regex: str | None = None
+
+    @field_validator("regex")
+    @classmethod
+    def _validate_regex_compiles(cls, v: str | None) -> str | None:
+        """Fail-fast at config-load time if an operator typos the pattern."""
+        if v is None:
+            return v
+        try:
+            re.compile(v)
+        except re.error as exc:
+            raise ValueError(f"vault_blueprint regex is not a valid pattern: {exc}")
+        return v
+
+
 class MCPServerConfig(BaseModel):
     """Configuration for a single MCP server."""
 
@@ -74,6 +111,7 @@ class MCPServerConfig(BaseModel):
     env: dict[str, str] = Field(default_factory=dict)
     url: str | None = None  # For SSE/HTTP transports
     tool_exposure_mode: Literal["summary", "detailed"] | None = None  # Per-server override
+    vault_blueprints: list[VaultBlueprint] = Field(default_factory=list)
 
 
 class MCPConfig(BaseModel):

--- a/src/ptc_agent/config/core.py
+++ b/src/ptc_agent/config/core.py
@@ -97,6 +97,17 @@ class VaultBlueprint(BaseModel):
             raise ValueError(f"vault_blueprint regex is not a valid pattern: {exc}")
         return v
 
+    @field_validator("docs_url")
+    @classmethod
+    def _validate_docs_url_scheme(cls, v: str | None) -> str | None:
+        # docs_url renders directly into an <a href>; rel=noopener noreferrer
+        # does not block javascript:/data: schemes, so reject them at load time.
+        if v is None:
+            return v
+        if not (v.startswith("https://") or v.startswith("http://")):
+            raise ValueError("vault_blueprint docs_url must start with https:// or http://")
+        return v
+
 
 class MCPServerConfig(BaseModel):
     """Configuration for a single MCP server."""

--- a/src/ptc_agent/config/core.py
+++ b/src/ptc_agent/config/core.py
@@ -73,7 +73,8 @@ class VaultBlueprint(BaseModel):
 
     # Same regex as CreateSecretRequest in src/server/app/vault.py:37.
     # Blueprint name becomes a vault key, so it must satisfy the same rule.
-    name: str = Field(pattern=r"^[A-Za-z_][A-Za-z0-9_]{0,63}$", max_length=64)
+    # The regex's {0,63} already caps length at 64 — no separate max_length needed.
+    name: str = Field(pattern=r"^[A-Za-z_][A-Za-z0-9_]{0,63}$")
     label: str = Field(..., min_length=1, max_length=80)
     # max_length matches CreateSecretRequest.description in src/server/app/vault.py
     # so that pre-filling the add-secret form from a blueprint never produces a

--- a/src/server/app/vault.py
+++ b/src/server/app/vault.py
@@ -9,6 +9,7 @@ Endpoints:
 - PUT    /api/v1/workspaces/{workspace_id}/vault/secrets/{name}
 - GET    /api/v1/workspaces/{workspace_id}/vault/secrets/{name}/reveal
 - DELETE /api/v1/workspaces/{workspace_id}/vault/secrets/{name}
+- GET    /api/v1/workspaces/{workspace_id}/vault/blueprints
 """
 
 from __future__ import annotations
@@ -20,8 +21,10 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field, field_validator
 
 from src.server.database.vault_secrets import (
+    MAX_SECRETS_PER_WORKSPACE,
     create_secret as create_secret_db,
     delete_secret,
+    get_workspace_secret_names,
     get_workspace_secrets,
     reveal_secret as reveal_secret_db,
     update_secret,
@@ -154,3 +157,55 @@ async def delete_secret_endpoint(
 
     await _push_to_sandbox(workspace_id)
     return {"ok": True}
+
+
+@router.get("/{workspace_id}/vault/blueprints")
+@handle_api_exceptions("list vault blueprints", logger)
+async def list_blueprints(workspace_id: str, user_id: CurrentUserId):
+    """Return the 'recommended but not yet set' credential blueprints.
+
+    Blueprints are declared inline on each MCP server entry in agent_config.yaml
+    (`vault_blueprints:` block). This endpoint walks all enabled servers, dedupes
+    by name, and subtracts credentials the workspace already has.
+
+    Note: agent_config is loaded once at server startup. Changes to
+    agent_config.yaml require a server restart to take effect here.
+    """
+    workspace = await db_get_workspace(workspace_id)
+    require_workspace_owner(workspace, user_id=user_id)
+
+    # Lazy import to avoid circular dependency between `setup` module and router
+    # registration. `setup.agent_config` is populated in `lifespan()` at startup.
+    from src.server.app import setup
+
+    existing_names = await get_workspace_secret_names(workspace_id)
+    remaining_slots = max(0, MAX_SECRETS_PER_WORKSPACE - len(existing_names))
+
+    if setup.agent_config is None:
+        # Startup race: request landed before lifespan completed.
+        return {"blueprints": [], "remaining_slots": remaining_slots}
+
+    # First-declaration wins on metadata; duplicate blueprint names across
+    # servers are treated as aliases: the second server's description/docs_url/
+    # regex are discarded, but its name is appended to `sources` so the UI can
+    # show which integrations share the credential.
+    collected: dict[str, dict] = {}
+    for server in setup.agent_config.mcp.servers:
+        if not server.enabled:
+            continue
+        for bp in server.vault_blueprints:
+            existing = collected.get(bp.name)
+            if existing is None:
+                collected[bp.name] = {
+                    "name": bp.name,
+                    "label": bp.label,
+                    "description": bp.description,
+                    "docs_url": bp.docs_url,
+                    "regex": bp.regex,
+                    "sources": [server.name],
+                }
+            else:
+                existing["sources"].append(server.name)
+
+    blueprints = [bp for name, bp in collected.items() if name not in existing_names]
+    return {"blueprints": blueprints, "remaining_slots": remaining_slots}

--- a/src/server/database/vault_secrets.py
+++ b/src/server/database/vault_secrets.py
@@ -83,6 +83,22 @@ async def get_workspace_secrets_decrypted(workspace_id: str) -> dict[str, str]:
             return {r["name"]: r["plaintext"] for r in rows}
 
 
+async def get_workspace_secret_names(workspace_id: str) -> set[str]:
+    """Return the set of secret names for a workspace. No decryption.
+
+    Used by the vault-blueprints endpoint to compute which declared credentials
+    are not yet set without paying the pgcrypto cost of the masking query.
+    """
+    async with get_db_connection() as conn:
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(
+                "SELECT name FROM workspace_vault_secrets WHERE workspace_id = %s",
+                (workspace_id,),
+            )
+            rows = await cur.fetchall()
+            return {r["name"] for r in rows}
+
+
 async def create_secret(
     workspace_id: str, name: str, value: str, description: str = ""
 ) -> None:

--- a/tests/unit/server/app/test_vault_blueprints.py
+++ b/tests/unit/server/app/test_vault_blueprints.py
@@ -1,0 +1,378 @@
+"""Tests for GET /api/v1/workspaces/{id}/vault/blueprints.
+
+Covers filtering (enabled-only, already-set), dedup across servers, auth guards,
+startup-race handling, and `remaining_slots` math.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from pydantic import ValidationError
+
+from src.ptc_agent.config.core import MCPServerConfig, VaultBlueprint
+from tests.conftest import create_test_app
+
+NOW = datetime.now(timezone.utc)
+
+
+def _ws(workspace_id=None, user_id="test-user-123", **overrides):
+    return {
+        "workspace_id": workspace_id or str(uuid.uuid4()),
+        "user_id": user_id,
+        "name": "Test Workspace",
+        "description": None,
+        "sandbox_id": "sandbox-abc",
+        "status": "running",
+        "mode": "ptc",
+        "sort_order": 0,
+        "is_pinned": False,
+        "created_at": NOW,
+        "updated_at": NOW,
+        "last_activity_at": None,
+        "stopped_at": None,
+        "config": None,
+        **overrides,
+    }
+
+
+def _agent_config(servers: list[MCPServerConfig]) -> MagicMock:
+    """Build a minimal agent_config double with the given MCP servers."""
+    cfg = MagicMock()
+    cfg.mcp.servers = servers
+    return cfg
+
+
+def _bp(name="X_BEARER_TOKEN", label="X Bearer Token", **overrides) -> VaultBlueprint:
+    return VaultBlueprint(
+        name=name,
+        label=label,
+        description=overrides.pop("description", "docs"),
+        docs_url=overrides.pop("docs_url", "https://console.x.com/"),
+        regex=overrides.pop("regex", "^[A-Za-z0-9%_-]{20,}$"),
+    )
+
+
+def _srv(
+    name="x_api",
+    enabled=True,
+    blueprints: list[VaultBlueprint] | None = None,
+) -> MCPServerConfig:
+    return MCPServerConfig(
+        name=name,
+        enabled=enabled,
+        transport="stdio",
+        vault_blueprints=blueprints or [],
+    )
+
+
+@pytest_asyncio.fixture
+async def client():
+    from src.server.app.vault import router
+
+    app = create_test_app(router)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Happy path — blueprint surfaces when vault is empty
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_blueprint_returned_when_key_not_set(client):
+    ws = _ws()
+    cfg = _agent_config([_srv(blueprints=[_bp()])])
+
+    with (
+        patch(
+            "src.server.app.vault.db_get_workspace",
+            new_callable=AsyncMock,
+            return_value=ws,
+        ),
+        patch(
+            "src.server.app.vault.get_workspace_secret_names",
+            new_callable=AsyncMock,
+            return_value=set(),
+        ),
+        patch("src.server.app.setup.agent_config", cfg),
+    ):
+        resp = await client.get(
+            f"/api/v1/workspaces/{ws['workspace_id']}/vault/blueprints"
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["remaining_slots"] == 20
+    assert len(body["blueprints"]) == 1
+    bp = body["blueprints"][0]
+    assert bp["name"] == "X_BEARER_TOKEN"
+    assert bp["label"] == "X Bearer Token"
+    assert bp["regex"] == "^[A-Za-z0-9%_-]{20,}$"
+    assert bp["sources"] == ["x_api"]
+
+
+# ---------------------------------------------------------------------------
+# Filter: already-set keys are removed from the recommended list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_keys_are_filtered_out(client):
+    ws = _ws()
+    cfg = _agent_config([_srv(blueprints=[_bp()])])
+
+    with (
+        patch("src.server.app.vault.db_get_workspace", new_callable=AsyncMock, return_value=ws),
+        patch(
+            "src.server.app.vault.get_workspace_secret_names",
+            new_callable=AsyncMock,
+            return_value={"X_BEARER_TOKEN"},
+        ),
+        patch("src.server.app.setup.agent_config", cfg),
+    ):
+        resp = await client.get(
+            f"/api/v1/workspaces/{ws['workspace_id']}/vault/blueprints"
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["blueprints"] == []
+    assert body["remaining_slots"] == 19  # 20 - 1 set secret
+
+
+# ---------------------------------------------------------------------------
+# Filter: disabled servers' blueprints are excluded
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_disabled_server_blueprints_excluded(client):
+    ws = _ws()
+    cfg = _agent_config([
+        _srv(name="x_api", enabled=False, blueprints=[_bp()]),
+        _srv(name="other", enabled=True, blueprints=[]),
+    ])
+
+    with (
+        patch("src.server.app.vault.db_get_workspace", new_callable=AsyncMock, return_value=ws),
+        patch(
+            "src.server.app.vault.get_workspace_secret_names",
+            new_callable=AsyncMock,
+            return_value=set(),
+        ),
+        patch("src.server.app.setup.agent_config", cfg),
+    ):
+        resp = await client.get(
+            f"/api/v1/workspaces/{ws['workspace_id']}/vault/blueprints"
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["blueprints"] == []
+
+
+# ---------------------------------------------------------------------------
+# Dedup: first-declaration wins on metadata; sources lists both origins
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_duplicate_blueprint_name_dedupes_first_wins(client):
+    ws = _ws()
+    first = _bp(description="FIRST", docs_url="https://first.example", regex="^first$")
+    second = _bp(description="SECOND", docs_url="https://second.example", regex="^second$")
+    cfg = _agent_config([
+        _srv(name="server_a", blueprints=[first]),
+        _srv(name="server_b", blueprints=[second]),
+    ])
+
+    with (
+        patch("src.server.app.vault.db_get_workspace", new_callable=AsyncMock, return_value=ws),
+        patch(
+            "src.server.app.vault.get_workspace_secret_names",
+            new_callable=AsyncMock,
+            return_value=set(),
+        ),
+        patch("src.server.app.setup.agent_config", cfg),
+    ):
+        resp = await client.get(
+            f"/api/v1/workspaces/{ws['workspace_id']}/vault/blueprints"
+        )
+
+    body = resp.json()
+    assert len(body["blueprints"]) == 1
+    bp = body["blueprints"][0]
+    assert bp["description"] == "FIRST"  # first wins
+    assert bp["docs_url"] == "https://first.example"
+    assert bp["regex"] == "^first$"
+    assert bp["sources"] == ["server_a", "server_b"]
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_workspace_not_found_returns_404(client):
+    with patch(
+        "src.server.app.vault.db_get_workspace",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        resp = await client.get(f"/api/v1/workspaces/{uuid.uuid4()}/vault/blueprints")
+
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_non_owner_returns_403(client):
+    ws = _ws(user_id="someone-else")
+    with patch(
+        "src.server.app.vault.db_get_workspace",
+        new_callable=AsyncMock,
+        return_value=ws,
+    ):
+        resp = await client.get(
+            f"/api/v1/workspaces/{ws['workspace_id']}/vault/blueprints"
+        )
+
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# remaining_slots edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_remaining_slots_at_cap_is_zero(client):
+    ws = _ws()
+    cfg = _agent_config([_srv(blueprints=[])])
+    full_vault = {f"SECRET_{i:02d}" for i in range(20)}  # exactly the cap
+
+    with (
+        patch("src.server.app.vault.db_get_workspace", new_callable=AsyncMock, return_value=ws),
+        patch(
+            "src.server.app.vault.get_workspace_secret_names",
+            new_callable=AsyncMock,
+            return_value=full_vault,
+        ),
+        patch("src.server.app.setup.agent_config", cfg),
+    ):
+        resp = await client.get(
+            f"/api/v1/workspaces/{ws['workspace_id']}/vault/blueprints"
+        )
+
+    assert resp.json()["remaining_slots"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Startup race — agent_config is None before lifespan completes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_startup_race_agent_config_none(client):
+    ws = _ws()
+    with (
+        patch("src.server.app.vault.db_get_workspace", new_callable=AsyncMock, return_value=ws),
+        patch(
+            "src.server.app.vault.get_workspace_secret_names",
+            new_callable=AsyncMock,
+            return_value=set(),
+        ),
+        patch("src.server.app.setup.agent_config", None),
+    ):
+        resp = await client.get(
+            f"/api/v1/workspaces/{ws['workspace_id']}/vault/blueprints"
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {"blueprints": [], "remaining_slots": 20}
+
+
+# ---------------------------------------------------------------------------
+# No MCP servers configured — valid empty state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_mcp_servers_list(client):
+    ws = _ws()
+    cfg = _agent_config([])  # no servers at all
+
+    with (
+        patch("src.server.app.vault.db_get_workspace", new_callable=AsyncMock, return_value=ws),
+        patch(
+            "src.server.app.vault.get_workspace_secret_names",
+            new_callable=AsyncMock,
+            return_value=set(),
+        ),
+        patch("src.server.app.setup.agent_config", cfg),
+    ):
+        resp = await client.get(
+            f"/api/v1/workspaces/{ws['workspace_id']}/vault/blueprints"
+        )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"blueprints": [], "remaining_slots": 20}
+
+
+# ---------------------------------------------------------------------------
+# VaultBlueprint model validation (covers the YAML-load failure path)
+# ---------------------------------------------------------------------------
+
+
+def test_blueprint_rejects_malformed_name():
+    with pytest.raises(ValidationError):
+        VaultBlueprint(name="1STARTS_WITH_DIGIT", label="x")
+
+    with pytest.raises(ValidationError):
+        VaultBlueprint(name="has-dashes", label="x")
+
+    with pytest.raises(ValidationError):
+        VaultBlueprint(name="", label="x")
+
+    with pytest.raises(ValidationError):
+        VaultBlueprint(name="A" * 65, label="x")  # > max_length
+
+
+def test_blueprint_requires_non_empty_label():
+    with pytest.raises(ValidationError):
+        VaultBlueprint(name="OK_NAME", label="")
+
+
+def test_blueprint_rejects_overlong_label():
+    with pytest.raises(ValidationError):
+        VaultBlueprint(name="OK_NAME", label="L" * 81)
+
+
+def test_blueprint_rejects_overlong_description():
+    # max_length=256 matches CreateSecretRequest.description so pre-fill never
+    # produces a body the create endpoint would 422 on.
+    with pytest.raises(ValidationError):
+        VaultBlueprint(name="OK_NAME", label="ok", description="D" * 257)
+
+
+def test_blueprint_rejects_malformed_regex():
+    with pytest.raises(ValidationError):
+        VaultBlueprint(name="OK_NAME", label="ok", regex="[unterminated")
+
+
+def test_blueprint_accepts_minimal_valid_input():
+    bp = VaultBlueprint(name="MY_KEY", label="My Key")
+    assert bp.name == "MY_KEY"
+    assert bp.label == "My Key"
+    assert bp.description == ""
+    assert bp.docs_url is None
+    assert bp.regex is None

--- a/tests/unit/server/app/test_vault_blueprints.py
+++ b/tests/unit/server/app/test_vault_blueprints.py
@@ -369,6 +369,19 @@ def test_blueprint_rejects_malformed_regex():
         VaultBlueprint(name="OK_NAME", label="ok", regex="[unterminated")
 
 
+def test_blueprint_rejects_non_http_docs_url_schemes():
+    # docs_url renders into an <a href>; javascript:/data: would execute on click.
+    for bad in ("javascript:alert(1)", "data:text/html,x", "file:///etc/passwd", "ftp://x"):
+        with pytest.raises(ValidationError):
+            VaultBlueprint(name="OK_NAME", label="ok", docs_url=bad)
+
+
+def test_blueprint_accepts_http_and_https_docs_url():
+    for good in ("https://console.x.com/", "http://localhost:8080/docs"):
+        bp = VaultBlueprint(name="OK_NAME", label="ok", docs_url=good)
+        assert bp.docs_url == good
+
+
 def test_blueprint_accepts_minimal_valid_input():
     bp = VaultBlueprint(name="MY_KEY", label="My Key")
     assert bp.name == "MY_KEY"

--- a/tests/unit/server/database/test_vault_blueprints_db.py
+++ b/tests/unit/server/database/test_vault_blueprints_db.py
@@ -1,0 +1,82 @@
+"""Tests for src/server/database/vault_secrets.get_workspace_secret_names.
+
+The helper powers the blueprints endpoint's "already set" subtraction without
+paying the pgcrypto decryption cost that get_workspace_secrets incurs.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.server.database.vault_secrets import get_workspace_secret_names
+
+
+@pytest.fixture
+def mock_cursor():
+    cursor = AsyncMock()
+    cursor.execute = AsyncMock()
+    cursor.fetchall = AsyncMock(return_value=[])
+    return cursor
+
+
+@pytest.fixture
+def vault_mock_db(mock_cursor):
+    conn = AsyncMock()
+
+    @asynccontextmanager
+    async def _cursor_cm(**kwargs):
+        yield mock_cursor
+
+    conn.cursor = _cursor_cm
+
+    @asynccontextmanager
+    async def _fake_connection():
+        yield conn
+
+    with patch(
+        "src.server.database.vault_secrets.get_db_connection",
+        new=_fake_connection,
+    ):
+        yield mock_cursor
+
+
+@pytest.mark.asyncio
+async def test_empty_vault_returns_empty_set(vault_mock_db):
+    vault_mock_db.fetchall.return_value = []
+    names = await get_workspace_secret_names("ws-1")
+    assert names == set()
+
+
+@pytest.mark.asyncio
+async def test_populated_vault_returns_full_name_set(vault_mock_db):
+    vault_mock_db.fetchall.return_value = [
+        {"name": "X_BEARER_TOKEN"},
+        {"name": "FMP_API_KEY"},
+        {"name": "POLYGON_KEY"},
+    ]
+    names = await get_workspace_secret_names("ws-1")
+    assert names == {"X_BEARER_TOKEN", "FMP_API_KEY", "POLYGON_KEY"}
+
+
+@pytest.mark.asyncio
+async def test_query_does_not_select_value_column(vault_mock_db):
+    """Guard rail: ensure we're not accidentally decrypting."""
+    await get_workspace_secret_names("ws-1")
+    executed_sql = vault_mock_db.execute.call_args.args[0]
+    assert "name" in executed_sql.lower()
+    assert "value" not in executed_sql.lower()
+    assert "pgp_sym_decrypt" not in executed_sql.lower()
+
+
+@pytest.mark.asyncio
+async def test_query_is_parametrized(vault_mock_db):
+    """Guard rail: ensure workspace_id is passed as a bound parameter, not
+    interpolated. Catches accidental f-string regressions that would reintroduce
+    SQL-injection risk."""
+    await get_workspace_secret_names("ws-42")
+    args = vault_mock_db.execute.call_args.args
+    assert args[1] == ("ws-42",)
+    assert "%s" in args[0]

--- a/web/src/pages/ChatAgent/components/SandboxSettingsPanel.tsx
+++ b/web/src/pages/ChatAgent/components/SandboxSettingsPanel.tsx
@@ -1,11 +1,15 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 import {
   X, Cpu, MemoryStick, HardDrive, MonitorCog, Play, Square,
   Package, Search, RefreshCw, ChevronDown, ChevronRight,
   Server, Loader2, BookOpen, Archive, KeyRound,
-  Plus, Trash2, Pencil, Eye, EyeOff,
+  Plus, Trash2, Pencil, Eye, EyeOff, ExternalLink, Sparkles,
 } from 'lucide-react';
-import { getSandboxStats, installSandboxPackages, refreshWorkspace, getVaultSecrets, createVaultSecret, updateVaultSecret, deleteVaultSecret, revealVaultSecret } from '../utils/api';
+import {
+  getSandboxStats, installSandboxPackages, refreshWorkspace,
+  getVaultSecrets, createVaultSecret, updateVaultSecret, deleteVaultSecret, revealVaultSecret,
+  getVaultBlueprints, type VaultBlueprint,
+} from '../utils/api';
 import { api } from '@/api/client';
 
 interface SandboxSettingsPanelProps {
@@ -833,6 +837,8 @@ interface VaultSecret {
 
 function SecretsTab({ workspaceId }: { workspaceId: string }) {
   const [secrets, setSecrets] = useState<VaultSecret[]>([]);
+  const [blueprints, setBlueprints] = useState<VaultBlueprint[]>([]);
+  const [remainingSlots, setRemainingSlots] = useState<number>(MAX_SECRETS);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -842,6 +848,9 @@ function SecretsTab({ workspaceId }: { workspaceId: string }) {
   const [newValue, setNewValue] = useState('');
   const [newDesc, setNewDesc] = useState('');
   const [saving, setSaving] = useState(false);
+  // When opened via a blueprint "Set up" click, carry the docs link + regex
+  // for inline hint rendering. Cleared when the form closes or save succeeds.
+  const [presetBlueprint, setPresetBlueprint] = useState<VaultBlueprint | null>(null);
 
   // Edit state
   const [editingName, setEditingName] = useState<string | null>(null);
@@ -858,20 +867,75 @@ function SecretsTab({ workspaceId }: { workspaceId: string }) {
   const [revealedSecrets, setRevealedSecrets] = useState<Record<string, string>>({});
   const [revealingName, setRevealingName] = useState<string | null>(null);
 
+  // Generation counter: guards against a stale in-flight load clobbering state
+  // when workspaceId changes rapidly (A → B → A). Increment on entry, check on
+  // every resolution path before writing state.
+  const loadGenRef = useRef(0);
+
   async function load() {
+    const myGen = ++loadGenRef.current;
     setLoading(true);
     setError(null);
     try {
-      const data = await getVaultSecrets(workspaceId);
-      setSecrets(data);
+      // Fetch both in parallel. Blueprints is secondary — a failure there
+      // must not block the primary secrets list (graceful degradation).
+      const [secretsData, blueprintsData] = await Promise.all([
+        getVaultSecrets(workspaceId),
+        getVaultBlueprints(workspaceId).catch(() => null),
+      ]);
+      if (loadGenRef.current !== myGen) return; // superseded, drop this result
+      setSecrets(secretsData);
+      if (blueprintsData) {
+        setBlueprints(blueprintsData.blueprints);
+        setRemainingSlots(blueprintsData.remaining_slots);
+      } else {
+        setBlueprints([]); // hide Recommended section on blueprint fetch failure
+        setRemainingSlots(MAX_SECRETS - secretsData.length);
+      }
     } catch (err: any) {
+      if (loadGenRef.current !== myGen) return;
       setError(err?.response?.data?.detail || err.message || 'Failed to load secrets');
     } finally {
-      setLoading(false);
+      if (loadGenRef.current === myGen) {
+        setLoading(false);
+      }
     }
   }
 
   useEffect(() => { load(); }, [workspaceId]);
+
+  // Safe regex compile for the active preset blueprint. Invalid patterns from a
+  // misconfigured agent_config.yaml must not crash the UI — on failure we just
+  // skip the hint.
+  const presetRegex = useMemo<RegExp | null>(() => {
+    if (!presetBlueprint?.regex) return null;
+    try {
+      return new RegExp(presetBlueprint.regex);
+    } catch {
+      return null;
+    }
+  }, [presetBlueprint]);
+  const valueHintFailing =
+    presetRegex !== null && newValue.length > 0 && !presetRegex.test(newValue);
+
+  function openAddForBlueprint(bp: VaultBlueprint) {
+    setError(null);
+    setPresetBlueprint(bp);
+    setNewName(bp.name);
+    setNewValue('');
+    setNewDesc(bp.description || '');
+    setShowNewValue(false);
+    setShowAdd(true);
+  }
+
+  function closeAddForm() {
+    setShowAdd(false);
+    setNewName('');
+    setNewValue('');
+    setNewDesc('');
+    setShowNewValue(false);
+    setPresetBlueprint(null);
+  }
 
   async function handleCreate() {
     if (!newName || !newValue) return;
@@ -887,11 +951,7 @@ function SecretsTab({ workspaceId }: { workspaceId: string }) {
         value: newValue,
         description: newDesc,
       });
-      setNewName('');
-      setNewValue('');
-      setNewDesc('');
-      setShowNewValue(false);
-      setShowAdd(false);
+      closeAddForm();
       await load();
     } catch (err: any) {
       setError(err?.response?.data?.detail || err.message || 'Failed to create secret');
@@ -1005,12 +1065,77 @@ function SecretsTab({ workspaceId }: { workspaceId: string }) {
         </div>
       )}
 
+      {/* Recommended credentials — blueprints declared by enabled MCP servers */}
+      {blueprints.length > 0 && !showAdd && (
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-1.5 text-xs font-medium" style={{ color: 'var(--color-text-secondary)' }}>
+            <Sparkles className="h-3 w-3" />
+            Recommended credentials
+          </div>
+          {blueprints.map(bp => {
+            const disabled = remainingSlots <= 0;
+            return (
+              <button
+                key={bp.name}
+                type="button"
+                onClick={() => !disabled && openAddForBlueprint(bp)}
+                disabled={disabled}
+                className="flex flex-col items-start gap-0.5 p-3 rounded-lg text-left transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                style={{
+                  backgroundColor: 'var(--color-bg-card)',
+                  border: '1px dashed var(--color-border-default)',
+                }}
+                title={disabled ? `Vault at ${MAX_SECRETS}/${MAX_SECRETS} — remove a secret first` : undefined}
+              >
+                <div className="flex items-center justify-between w-full gap-2">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span className="text-sm font-medium truncate" style={{ color: 'var(--color-text-primary)' }}>
+                      {bp.label}
+                    </span>
+                    <span className="text-xs font-mono px-1.5 py-0.5 rounded flex-shrink-0" style={{ color: 'var(--color-text-tertiary)', backgroundColor: 'var(--color-bg-default)' }}>
+                      {bp.name}
+                    </span>
+                  </div>
+                  <span className="text-xs flex items-center gap-1 flex-shrink-0" style={{ color: 'var(--color-accent-primary)' }}>
+                    <Plus className="h-3 w-3" />
+                    Set up
+                  </span>
+                </div>
+                {bp.description && (
+                  <div className="text-xs" style={{ color: 'var(--color-text-tertiary)' }}>
+                    {bp.description}
+                  </div>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
       {/* Add form */}
       {showAdd && (
         <div
           className="flex flex-col gap-2 p-3 rounded-lg"
           style={{ backgroundColor: 'var(--color-bg-card)', border: '1px solid var(--color-border-muted)' }}
         >
+          {presetBlueprint && (
+            <div className="flex items-center justify-between text-xs" style={{ color: 'var(--color-text-secondary)' }}>
+              <span>
+                Setting up <span style={{ color: 'var(--color-text-primary)' }}>{presetBlueprint.label}</span>
+              </span>
+              {presetBlueprint.docs_url && (
+                <a
+                  href={presetBlueprint.docs_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 hover:underline"
+                  style={{ color: 'var(--color-accent-primary)' }}
+                >
+                  Docs <ExternalLink className="h-3 w-3" />
+                </a>
+              )}
+            </div>
+          )}
           <input
             type="text"
             value={newName}
@@ -1040,6 +1165,13 @@ function SecretsTab({ workspaceId }: { workspaceId: string }) {
               {showNewValue ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
             </button>
           </div>
+          {valueHintFailing && (
+            <div className="text-xs" style={{ color: 'var(--color-text-tertiary)' }}>
+              This doesn&apos;t look like a valid {presetBlueprint?.label ?? 'token'}
+              {presetBlueprint?.docs_url ? ' — check the docs link above.' : '.'}
+              <span className="ml-1 opacity-70">You can still save.</span>
+            </div>
+          )}
           <input
             type="text"
             value={newDesc}
@@ -1051,7 +1183,7 @@ function SecretsTab({ workspaceId }: { workspaceId: string }) {
           />
           <div className="flex justify-end gap-2 mt-1">
             <button
-              onClick={() => { setShowAdd(false); setNewName(''); setNewValue(''); setNewDesc(''); setShowNewValue(false); }}
+              onClick={closeAddForm}
               className="px-3 py-1.5 text-xs rounded-md transition-colors hover:bg-foreground/10"
               style={{ color: 'var(--color-text-tertiary)' }}
             >

--- a/web/src/pages/ChatAgent/components/SandboxSettingsPanel.tsx
+++ b/web/src/pages/ChatAgent/components/SandboxSettingsPanel.tsx
@@ -1078,7 +1078,7 @@ function SecretsTab({ workspaceId }: { workspaceId: string }) {
               <button
                 key={bp.name}
                 type="button"
-                onClick={() => !disabled && openAddForBlueprint(bp)}
+                onClick={() => openAddForBlueprint(bp)}
                 disabled={disabled}
                 className="flex flex-col items-start gap-0.5 p-3 rounded-lg text-left transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 style={{

--- a/web/src/pages/ChatAgent/components/SandboxSettingsPanel.tsx
+++ b/web/src/pages/ChatAgent/components/SandboxSettingsPanel.tsx
@@ -902,7 +902,13 @@ function SecretsTab({ workspaceId }: { workspaceId: string }) {
     }
   }
 
-  useEffect(() => { load(); }, [workspaceId]);
+  useEffect(() => {
+    // Reset form state before reloading: a half-filled add form from the
+    // previous workspace must not carry over and silently target the new one.
+    closeAddForm();
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspaceId]);
 
   // Safe regex compile for the active preset blueprint. Invalid patterns from a
   // misconfigured agent_config.yaml must not crash the UI — on failure we just

--- a/web/src/pages/ChatAgent/components/__tests__/SandboxSettingsPanel.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/SandboxSettingsPanel.test.tsx
@@ -1,0 +1,296 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { SandboxSettingsContent } from '../SandboxSettingsPanel';
+
+// ---------------------------------------------------------------------------
+// Mocks — cover the full API surface SecretsTab uses
+// ---------------------------------------------------------------------------
+
+const mockGetVaultSecrets = vi.fn();
+const mockCreateVaultSecret = vi.fn();
+const mockUpdateVaultSecret = vi.fn();
+const mockDeleteVaultSecret = vi.fn();
+const mockRevealVaultSecret = vi.fn();
+const mockGetVaultBlueprints = vi.fn();
+const mockGetSandboxStats = vi.fn();
+
+vi.mock('../../utils/api', () => ({
+  getVaultSecrets: (...args: any[]) => mockGetVaultSecrets(...args),
+  createVaultSecret: (...args: any[]) => mockCreateVaultSecret(...args),
+  updateVaultSecret: (...args: any[]) => mockUpdateVaultSecret(...args),
+  deleteVaultSecret: (...args: any[]) => mockDeleteVaultSecret(...args),
+  revealVaultSecret: (...args: any[]) => mockRevealVaultSecret(...args),
+  getVaultBlueprints: (...args: any[]) => mockGetVaultBlueprints(...args),
+  getSandboxStats: (...args: any[]) => mockGetSandboxStats(...args),
+  installSandboxPackages: vi.fn(),
+  refreshWorkspace: vi.fn(),
+}));
+
+vi.mock('@/api/client', () => ({
+  api: { get: vi.fn(), post: vi.fn() },
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const X_BLUEPRINT = {
+  name: 'X_BEARER_TOKEN',
+  label: 'X (Twitter) Bearer Token',
+  description: 'Read-only app-only auth for x_api.',
+  docs_url: 'https://console.x.com/',
+  regex: '^[A-Za-z0-9%_-]{20,}$',
+  sources: ['x_api'],
+};
+
+function defaultStats() {
+  return {
+    state: 'running',
+    sandbox_id: 'sandbox-abc',
+    resources: {},
+    packages: [],
+    skills: [],
+    mcp_servers: [],
+  };
+}
+
+function renderVaultTab() {
+  const view = render(<SandboxSettingsContent workspaceId="ws-1" />);
+  // Switch to the Vault tab
+  fireEvent.click(screen.getByRole('button', { name: /vault/i }));
+  return view;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetSandboxStats.mockResolvedValue(defaultStats());
+  mockGetVaultSecrets.mockResolvedValue([]);
+  mockGetVaultBlueprints.mockResolvedValue({ blueprints: [], remaining_slots: 20 });
+});
+
+// ---------------------------------------------------------------------------
+// Recommended credentials section
+// ---------------------------------------------------------------------------
+
+describe('SecretsTab — Recommended credentials', () => {
+  it('renders when blueprints API returns items', async () => {
+    mockGetVaultBlueprints.mockResolvedValue({
+      blueprints: [X_BLUEPRINT],
+      remaining_slots: 20,
+    });
+
+    renderVaultTab();
+
+    await waitFor(() => {
+      expect(screen.getByText('Recommended credentials')).toBeInTheDocument();
+    });
+    expect(screen.getByText('X (Twitter) Bearer Token')).toBeInTheDocument();
+    expect(screen.getByText('X_BEARER_TOKEN')).toBeInTheDocument();
+  });
+
+  it('hides section when blueprints list is empty', async () => {
+    mockGetVaultBlueprints.mockResolvedValue({ blueprints: [], remaining_slots: 20 });
+
+    renderVaultTab();
+
+    await waitFor(() => {
+      expect(mockGetVaultBlueprints).toHaveBeenCalled();
+    });
+    expect(screen.queryByText('Recommended credentials')).not.toBeInTheDocument();
+  });
+
+  it('hides section when blueprints fetch fails (graceful degradation)', async () => {
+    mockGetVaultBlueprints.mockRejectedValue(new Error('backend down'));
+    mockGetVaultSecrets.mockResolvedValue([]);
+
+    renderVaultTab();
+
+    // Primary secrets list still renders — the empty-state message appears.
+    await waitFor(() => {
+      expect(screen.getByText(/No secrets stored/)).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Recommended credentials')).not.toBeInTheDocument();
+  });
+
+  it('opens the add form with name pre-filled on Set up click', async () => {
+    mockGetVaultBlueprints.mockResolvedValue({
+      blueprints: [X_BLUEPRINT],
+      remaining_slots: 20,
+    });
+
+    renderVaultTab();
+
+    await waitFor(() => expect(screen.getByText('Set up')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Set up'));
+
+    // Pre-fill check — name input value equals the blueprint name
+    const nameInput = screen.getByPlaceholderText('SECRET_NAME') as HTMLInputElement;
+    expect(nameInput.value).toBe('X_BEARER_TOKEN');
+    // Docs link rendered
+    expect(screen.getByText('Docs').closest('a')).toHaveAttribute(
+      'href',
+      'https://console.x.com/',
+    );
+  });
+
+  it('disables Set up button when remaining_slots is 0', async () => {
+    mockGetVaultBlueprints.mockResolvedValue({
+      blueprints: [X_BLUEPRINT],
+      remaining_slots: 0,
+    });
+
+    renderVaultTab();
+
+    await waitFor(() => expect(screen.getByText('Set up')).toBeInTheDocument());
+    // The button is the parent anchor wrapping the "Set up" label
+    const setupRow = screen.getByText('Set up').closest('button') as HTMLButtonElement;
+    expect(setupRow).toBeDisabled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regex hint on the add form
+// ---------------------------------------------------------------------------
+
+describe('SecretsTab — value regex hint', () => {
+  it('shows hint when value does not match blueprint regex', async () => {
+    mockGetVaultBlueprints.mockResolvedValue({
+      blueprints: [X_BLUEPRINT],
+      remaining_slots: 20,
+    });
+
+    renderVaultTab();
+
+    await waitFor(() => expect(screen.getByText('Set up')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Set up'));
+
+    const valueInput = screen.getByPlaceholderText('Secret value');
+    fireEvent.change(valueInput, { target: { value: 'Bearer abc' } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/doesn't look like a valid/i)).toBeInTheDocument();
+    });
+  });
+
+  it('hides hint when value matches the blueprint regex', async () => {
+    mockGetVaultBlueprints.mockResolvedValue({
+      blueprints: [X_BLUEPRINT],
+      remaining_slots: 20,
+    });
+
+    renderVaultTab();
+
+    await waitFor(() => expect(screen.getByText('Set up')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Set up'));
+
+    const valueInput = screen.getByPlaceholderText('Secret value');
+    // 25 URL-safe chars — matches the X regex ^[A-Za-z0-9%_-]{20,}$
+    fireEvent.change(valueInput, { target: { value: 'A'.repeat(25) } });
+
+    await waitFor(() => {
+      expect(screen.queryByText(/doesn't look like a valid/i)).not.toBeInTheDocument();
+    });
+  });
+
+  it('does not crash when blueprint regex is malformed (safe compile)', async () => {
+    const badBlueprint = {
+      ...X_BLUEPRINT,
+      regex: '[unterminated',
+    };
+    mockGetVaultBlueprints.mockResolvedValue({
+      blueprints: [badBlueprint],
+      remaining_slots: 20,
+    });
+
+    renderVaultTab();
+
+    await waitFor(() => expect(screen.getByText('Set up')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Set up'));
+
+    const valueInput = screen.getByPlaceholderText('Secret value');
+    fireEvent.change(valueInput, { target: { value: 'anything' } });
+
+    // No hint rendered; no crash; form still usable
+    expect(screen.queryByText(/doesn't look like a valid/i)).not.toBeInTheDocument();
+    expect(valueInput).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Refresh after create — blueprint disappears
+// ---------------------------------------------------------------------------
+
+describe('SecretsTab — load generation guard', () => {
+  it('discards stale load results when workspaceId changes mid-flight', async () => {
+    // Slow first blueprint fetch (ws-1), fast second (ws-2). If the stale
+    // resolution leaks through, ws-1's blueprint would appear after ws-2 rendered.
+    let resolveFirstBlueprint: ((v: any) => void) | null = null;
+    mockGetVaultSecrets.mockResolvedValue([]);
+    mockGetVaultBlueprints
+      .mockImplementationOnce(
+        () => new Promise(r => { resolveFirstBlueprint = r; }),
+      )
+      .mockImplementationOnce(
+        () => Promise.resolve({ blueprints: [], remaining_slots: 20 }),
+      );
+
+    const { rerender } = render(<SandboxSettingsContent workspaceId="ws-1" />);
+    fireEvent.click(screen.getByRole('button', { name: /vault/i }));
+
+    // Wait for the ws-1 load() to actually kick off before we swap props,
+    // so React's effect scheduling can't collapse both loads into a single call.
+    await waitFor(() => expect(mockGetVaultBlueprints).toHaveBeenCalledTimes(1));
+
+    // Switch to ws-2 while ws-1 blueprint fetch is still pending
+    rerender(<SandboxSettingsContent workspaceId="ws-2" />);
+
+    // Wait for the ws-2 load to fire
+    await waitFor(() => expect(mockGetVaultBlueprints).toHaveBeenCalledTimes(2));
+
+    // Resolve the stale ws-1 fetch AFTER ws-2 has already started
+    resolveFirstBlueprint!({
+      blueprints: [X_BLUEPRINT],
+      remaining_slots: 20,
+    });
+
+    // ws-1's stale blueprint must NOT leak into the UI now showing ws-2
+    await waitFor(() => {
+      expect(screen.queryByText('X (Twitter) Bearer Token')).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe('SecretsTab — blueprint lifecycle', () => {
+  it('refetches blueprints after successful create', async () => {
+    mockGetVaultBlueprints
+      .mockResolvedValueOnce({ blueprints: [X_BLUEPRINT], remaining_slots: 20 })
+      .mockResolvedValueOnce({ blueprints: [], remaining_slots: 19 });
+    mockCreateVaultSecret.mockResolvedValue({ name: 'X_BEARER_TOKEN' });
+
+    renderVaultTab();
+
+    await waitFor(() => expect(screen.getByText('Set up')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Set up'));
+
+    // Fill value and save
+    fireEvent.change(screen.getByPlaceholderText('Secret value'), {
+      target: { value: 'A'.repeat(25) },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() => {
+      expect(mockCreateVaultSecret).toHaveBeenCalledWith('ws-1', {
+        name: 'X_BEARER_TOKEN',
+        value: 'A'.repeat(25),
+        description: 'Read-only app-only auth for x_api.',
+      });
+    });
+    // Blueprints refetched; second call yields empty list → section gone.
+    await waitFor(() => {
+      expect(mockGetVaultBlueprints).toHaveBeenCalledTimes(2);
+      expect(screen.queryByText('Recommended credentials')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/pages/ChatAgent/components/__tests__/SandboxSettingsPanel.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/SandboxSettingsPanel.test.tsx
@@ -262,6 +262,33 @@ describe('SecretsTab — load generation guard', () => {
   });
 });
 
+describe('SecretsTab — workspace change resets form', () => {
+  it('closes the open add form when workspaceId changes mid-flow', async () => {
+    mockGetVaultBlueprints
+      .mockResolvedValueOnce({ blueprints: [X_BLUEPRINT], remaining_slots: 20 })
+      .mockResolvedValueOnce({ blueprints: [], remaining_slots: 20 });
+
+    const { rerender } = render(<SandboxSettingsContent workspaceId="ws-1" />);
+    fireEvent.click(screen.getByRole('button', { name: /vault/i }));
+
+    // Open the add form on ws-1 and type a value
+    await waitFor(() => expect(screen.getByText('Set up')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Set up'));
+    const valueInput = screen.getByPlaceholderText('Secret value');
+    fireEvent.change(valueInput, { target: { value: 'partially-typed-secret' } });
+    expect((valueInput as HTMLInputElement).value).toBe('partially-typed-secret');
+
+    // Swap workspaces mid-flow
+    rerender(<SandboxSettingsContent workspaceId="ws-2" />);
+
+    // Form must be gone: no lingering value input, no ws-1 pre-fill visible
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText('Secret value')).not.toBeInTheDocument();
+    });
+    expect(screen.queryByDisplayValue('partially-typed-secret')).not.toBeInTheDocument();
+  });
+});
+
 describe('SecretsTab — blueprint lifecycle', () => {
   it('refetches blueprints after successful create', async () => {
     mockGetVaultBlueprints

--- a/web/src/pages/ChatAgent/utils/api.ts
+++ b/web/src/pages/ChatAgent/utils/api.ts
@@ -790,3 +790,26 @@ export async function deleteVaultSecret(workspaceId: string, name: string) {
   const { data } = await api.delete(`/api/v1/workspaces/${workspaceId}/vault/secrets/${name}`);
   return data;
 }
+
+// --- Vault Blueprints (credentials recommended but not yet set) ---
+
+export interface VaultBlueprint {
+  name: string;
+  label: string;
+  description: string;
+  docs_url: string | null;
+  regex: string | null;
+  sources: string[];
+}
+
+export interface VaultBlueprintsResponse {
+  blueprints: VaultBlueprint[];
+  remaining_slots: number;
+}
+
+export async function getVaultBlueprints(workspaceId: string): Promise<VaultBlueprintsResponse> {
+  const { data } = await api.get<VaultBlueprintsResponse>(
+    `/api/v1/workspaces/${workspaceId}/vault/blueprints`,
+  );
+  return data;
+}


### PR DESCRIPTION
## Summary

Lets MCP servers declare the credentials they expect users to set in the workspace vault. The frontend Vault tab surfaces those as a "Recommended credentials" list with one-click setup — users no longer have to read TROUBLESHOOTING.md to learn exact secret names like `X_BEARER_TOKEN`.

**Config** — `MCPServerConfig` gains a `vault_blueprints` list. Each blueprint declares `name`, `label`, `description`, `docs_url`, optional `regex`. Pydantic validates the regex compiles at config-load time so typos fail fast.

**Backend** — `GET /api/v1/workspaces/{id}/vault/blueprints` returns the unset-but-declared list for a workspace. Auth pattern matches the 5 existing vault endpoints verbatim. Dedup: first declaration wins on metadata, `sources` array lists all declaring servers. New DB helper `get_workspace_secret_names` skips pgcrypto since only names are needed.

**Frontend** — `SecretsTab` fetches blueprints in parallel with secrets (fail-soft: a blueprints API error hides the section without blocking secrets CRUD). Each unset blueprint renders as a dashed "Set up" card that pre-fills the add form with the canonical name + docs link. A generation-counter race guard in `load()` discards stale responses when `workspaceId` changes mid-flight. Regex hint is non-blocking — value-format mismatches show an inline warning but still let the user save.

**Backfill** — `x_api` declares `X_BEARER_TOKEN` as the first consumer. Every other MCP server picks up an empty `vault_blueprints: []` by default and is unaffected.

## Test Coverage

```
CODE PATHS                                              USER FLOWS
[+] core.py — VaultBlueprint                            [+] First-time setup
  ├── [★★★] name regex (5 cases)                          ├── [★★★] empty → Recommended → click → save
  ├── [★★★] label bounds                                  ├── [★★★] graceful degradation on fetch fail
  ├── [★★★] description bounds                            └── [★★★] cap-disable at 20/20
  ├── [★★★] regex compile-time validation
  └── [★★★] minimal valid input                         [+] Regex hint
                                                          ├── [★★★] matches → hidden
[+] vault_secrets.py — get_workspace_secret_names       ├── [★★★] non-match → visible
  ├── [★★★] empty vault                                   └── [★★★] malformed pattern → safe
  ├── [★★★] populated vault
  ├── [★★★] value-column guard                          [+] Lifecycle
  └── [★★★] parametrized-binding guard                   ├── [★★★] post-create refetch
                                                          └── [★★★] stale-response discard
[+] vault.py — GET /vault/blueprints
  ├── [★★★] 404 / 403 auth
  ├── [★★★] empty vault + blueprint returned
  ├── [★★★] filter already-set
  ├── [★★★] filter disabled server
  ├── [★★★] dedup first-wins + sources
  ├── [★★★] remaining_slots at cap
  ├── [★★★] startup race (agent_config=None)
  └── [★★★] empty mcp.servers

COVERAGE: 29/29 paths tested (100%)
Tests: 473 → 483 (+10 frontend) / 2734 → 2763 (+29 backend)
```

## Pre-Landing Review

20 informational findings from 4 specialists (testing, maintainability, security, api-contract). 0 critical.

**Auto-fixed (5):** description cap 280→256, `regex` compile-time validator, 3 boundary tests, 1 parametrized-binding assertion.
**User-approved fix (1):** stale-response race guard in `SecretsTab.load()` + test.
**Acknowledged as follow-up (14):** shared `_NAME_RE` constant across backend/frontend, `MAX_SECRETS` served from API, typed Pydantic response model, plus narrower test-coverage gaps the user opted to defer.

Security: **0 findings**. API contract: **0 findings**.

## Plan Completion

All 10/10 plan items DONE. Plan at `~/.claude/plans/i-want-to-add-woolly-hamming.md`.

## Verification

- `uv run ruff check src/ tests/` — clean
- `uv run pytest tests/unit/` — **2763 passed**
- `cd web && pnpm lint` — 0 errors (53 pre-existing warnings untouched)
- `cd web && pnpm vitest run` — **483 passed**

## Test plan

- [x] Open a workspace → Workspace Files → settings icon → **Vault** tab. With `X_BEARER_TOKEN` unset, confirm the "Recommended credentials" card appears with the X Bearer Token label, description, and Docs link.
- [x] Click **Set up** — verify `X_BEARER_TOKEN` is pre-filled in the name input and the docs link is visible.
- [x] Paste `Bearer abc` (too short) — verify the "doesn't look like a valid token" hint appears but does NOT block save.
- [x] Paste a real X bearer token, save. Verify blueprint disappears from Recommended and the secret appears in the primary list.
- [x] Delete the secret. Verify the blueprint reappears in Recommended.
- [x] Run a PTC chat with X API to confirm the secret flows through the existing vault→sandbox path (unchanged by this PR).
- [x] Set `enabled: false` on x_api in `agent_config.yaml`, restart backend. Verify Recommended section is empty.