### PR TITLE
feat(tools): enforce TodoWrite schema at the tool signature via pydantic

### DIFF
--- a/src/ptc_agent/agent/middleware/todo_operations/sse_middleware.py
+++ b/src/ptc_agent/agent/middleware/todo_operations/sse_middleware.py
@@ -86,10 +86,12 @@ class TodoWriteMiddleware(AgentMiddleware):
         try:
             result = await handler(request)
 
-            # Calculate status counts
+            # Calculate status counts. Lowercase to mirror the TodoItem
+            # validator's normalize_status — an LLM-sent "PENDING" would
+            # otherwise fall through as uncounted.
             status_counts = {"pending": 0, "in_progress": 0, "completed": 0}
             for todo in todos:
-                status = todo.get("status", "unknown")
+                status = str(todo.get("status", "")).lower()
                 if status in status_counts:
                     status_counts[status] += 1
 

--- a/src/ptc_agent/agent/middleware/todo_operations/sse_middleware.py
+++ b/src/ptc_agent/agent/middleware/todo_operations/sse_middleware.py
@@ -96,27 +96,29 @@ class TodoWriteMiddleware(AgentMiddleware):
             # Continue with tool execution even if streaming fails
             return await handler(request)
 
+        # Restrict payload to the TodoItem schema: strip any legacy
+        # or unknown fields the LLM may still send, and lowercase status
+        # so the frontend's strict equality (status === 'pending') holds
+        # regardless of case variance. Anything non-dict is dropped.
+        # Computed before the try block so the failed-event path below
+        # ships the same normalized shape instead of raw LLM input.
+        status_counts = {"pending": 0, "in_progress": 0, "completed": 0}
+        normalized_todos = []
+        for todo in todos:
+            if not isinstance(todo, dict):
+                continue
+            status = str(todo.get("status", "")).lower()
+            if status in status_counts:
+                status_counts[status] += 1
+            normalized_todos.append({
+                "content": todo.get("content", ""),
+                "activeForm": todo.get("activeForm", ""),
+                "status": status,
+            })
+
         # Execute the actual tool
         try:
             result = await handler(request)
-
-            # Restrict payload to the TodoItem schema: strip any legacy
-            # or unknown fields the LLM may still send, and lowercase status
-            # so the frontend's strict equality (status === 'pending') holds
-            # regardless of case variance. Anything non-dict is dropped.
-            status_counts = {"pending": 0, "in_progress": 0, "completed": 0}
-            normalized_todos = []
-            for todo in todos:
-                if not isinstance(todo, dict):
-                    continue
-                status = str(todo.get("status", "")).lower()
-                if status in status_counts:
-                    status_counts[status] += 1
-                normalized_todos.append({
-                    "content": todo.get("content", ""),
-                    "activeForm": todo.get("activeForm", ""),
-                    "status": status,
-                })
 
             # Build completed event with structure expected by streaming_handler
             # Must include artifact_type for handler to recognize and emit as SSE artifact event
@@ -166,8 +168,11 @@ class TodoWriteMiddleware(AgentMiddleware):
                 "timestamp": failed_timestamp,
                 "status": "failed",
                 "payload": {
-                    "todos": todos,
-                    "total": len(todos),
+                    "todos": normalized_todos,
+                    "total": len(normalized_todos),
+                    "completed": status_counts["completed"],
+                    "in_progress": status_counts["in_progress"],
+                    "pending": status_counts["pending"],
                     "error": str(e),
                 },
             }

--- a/src/ptc_agent/agent/middleware/todo_operations/sse_middleware.py
+++ b/src/ptc_agent/agent/middleware/todo_operations/sse_middleware.py
@@ -67,7 +67,21 @@ class TodoWriteMiddleware(AgentMiddleware):
 
         tool_call_id = tool_call.get("id", "unknown")
         tool_args = tool_call.get("args", {})
-        todos = tool_args.get("todos", [])
+        raw_todos = tool_args.get("todos", [])
+
+        # Defensive: the tool signature now enforces List[TodoItem] via pydantic,
+        # so a valid handler return implies a proper list. But the failed-event
+        # branch below calls len(todos) on the raw LLM input — a None or int
+        # payload would crash the error path and swallow the original
+        # ValidationError. Coerce to [] so both branches are safe.
+        if isinstance(raw_todos, list):
+            todos = raw_todos
+        else:
+            logger.warning(
+                f"[TODO_MIDDLEWARE] Non-list todos payload "
+                f"(type={type(raw_todos).__name__}); coercing to []"
+            )
+            todos = []
 
         logger.debug(f"[TODO_MIDDLEWARE] Intercepting {tool_name} (id: {tool_call_id})")
 

--- a/src/ptc_agent/agent/middleware/todo_operations/sse_middleware.py
+++ b/src/ptc_agent/agent/middleware/todo_operations/sse_middleware.py
@@ -86,14 +86,23 @@ class TodoWriteMiddleware(AgentMiddleware):
         try:
             result = await handler(request)
 
-            # Calculate status counts. Lowercase to mirror the TodoItem
-            # validator's normalize_status — an LLM-sent "PENDING" would
-            # otherwise fall through as uncounted.
+            # Restrict payload to the TodoItem schema: strip any legacy
+            # or unknown fields the LLM may still send, and lowercase status
+            # so the frontend's strict equality (status === 'pending') holds
+            # regardless of case variance. Anything non-dict is dropped.
             status_counts = {"pending": 0, "in_progress": 0, "completed": 0}
+            normalized_todos = []
             for todo in todos:
+                if not isinstance(todo, dict):
+                    continue
                 status = str(todo.get("status", "")).lower()
                 if status in status_counts:
                     status_counts[status] += 1
+                normalized_todos.append({
+                    "content": todo.get("content", ""),
+                    "activeForm": todo.get("activeForm", ""),
+                    "status": status,
+                })
 
             # Build completed event with structure expected by streaming_handler
             # Must include artifact_type for handler to recognize and emit as SSE artifact event
@@ -101,8 +110,8 @@ class TodoWriteMiddleware(AgentMiddleware):
 
             # Build payload with todo data
             payload: dict[str, Any] = {
-                "todos": todos,
-                "total": len(todos),
+                "todos": normalized_todos,
+                "total": len(normalized_todos),
                 "completed": status_counts["completed"],
                 "in_progress": status_counts["in_progress"],
                 "pending": status_counts["pending"],

--- a/src/ptc_agent/agent/prompts/templates/components/task_workflow.md.j2
+++ b/src/ptc_agent/agent/prompts/templates/components/task_workflow.md.j2
@@ -3,7 +3,11 @@
 Your working directory is `work/`. **Create a subdirectory for every task** — never put files directly in `work/`.
 
 1. **Create task directory**: `mkdir -p work/<name>/` (e.g., `work/sector_analysis/`, `work/earnings_q3_review/`)
-2. **Plan**: Use TodoWrite to break down the task
+2. **Plan**: Use `TodoWrite` to break down the task.
+   - Each call **fully replaces** the prior list — pass the entire collection every time.
+   - **Exactly one** task should have status `in_progress` at any moment.
+   - Mark tasks `completed` **immediately** after finishing; don't batch.
+   - Add tasks discovered mid-execution; remove tasks that become irrelevant.
 3. **Execute**: All intermediate files go in your task directory. Delegate to sub-agents with the directory path.
 4. **Deliver**: Match output to the task — answer in chat for simple queries, create a report in `results/` for complex analysis. When unsure, ask the user.
 5. **Update agent.md**: Key findings, file index, reusable artifacts

--- a/src/ptc_agent/agent/tools/todo/tool.py
+++ b/src/ptc_agent/agent/tools/todo/tool.py
@@ -1,9 +1,9 @@
 import logging
-from typing import List, Dict, Any, Annotated
+from typing import List, Annotated
 from langchain_core.tools import tool
 from pydantic import Field
 
-from .types import validate_todo_list_dict
+from .types import TodoItem, TodoStatus
 
 logger = logging.getLogger(__name__)
 
@@ -11,138 +11,69 @@ logger = logging.getLogger(__name__)
 @tool(parse_docstring=True)
 def TodoWrite(
     todos: Annotated[
-        List[Dict[str, Any]],
+        List[TodoItem],
         Field(
             description=(
-                "Complete collection of todo items. "
-                "PARAMETER NAME MUST BE 'todos' (plural), not 'todo' or 'todo_list'. "
-                "Each item requires: content (str), activeForm (str), status (str)"
+                "Full replacement of the todo list. Pass the ENTIRE collection every "
+                "call, not just changes. Each item must have content, activeForm, and status."
             )
-        )
-    ]
+        ),
+    ],
 ) -> str:
-    """Create or update todos for tracking task progress throughout execution.
+    """Replace the agent's todo list with the provided collection.
 
-    **PARAMETER NAME**: The parameter MUST be named `todos` (plural). Common mistakes:
-    - ✗ WRONG: `todo=...` (singular)
-    - ✗ WRONG: `todo_list=...`
-    - ✓ CORRECT: `todos=...` (plural)
-
-    **WRITE-ONLY INTERFACE**: This tool is write-only with no read capability. Agents cannot
-    query the current state - they must maintain the complete collection in their working memory
-    and pass the full updated collection with each call.
-
-    **PURPOSE**: Helps agents organize multi-step tasks, track progress systematically, and
-    provide transparency to users about current work status.
-
-    Each item MUST include these fields:
-    - content (str): Imperative description of the task (e.g., "Fetch market data")
-    - activeForm (str): Present continuous form shown during execution (e.g., "Fetching market data")
-    - status (str): One of "pending", "in_progress", or "completed"
-
-    **CRITICAL RULES**:
-    1. **Complete Replacement**: Each call completely REPLACES the previous collection. Always pass
-       the ENTIRE collection, not just changes.
-    2. **Single Focus**: Exactly ONE task must have status "in_progress" at any time. Never zero,
-       never multiple.
-    3. **Immediate Updates**: Mark tasks "completed" IMMEDIATELY after finishing them. Do not batch
-       multiple completions.
-    4. **Dynamic Management**: Add new tasks discovered during execution. Remove tasks that become
-       irrelevant.
-    5. **State Tracking**: You cannot read back the state. Track it in memory throughout execution.
-
-    **WHEN TO USE**:
-    - Multi-step tasks requiring 3+ distinct operations
-    - Complex workflows with dependencies between steps
-    - Long-running tasks where progress visibility is important
-    - Tasks that may discover additional subtasks during execution
+    Each call fully replaces the previous list. The tool has no read interface,
+    so track the list in memory and pass the complete set every time.
 
     Args:
-        todos: Complete collection of items, each with content, activeForm, and status.
-               Parameter name is 'todos' (plural), not 'todo' or 'todo_list'.
+        todos: Full replacement of the todo list. Pass the ENTIRE collection every
+            call, not just changes. Each item must have content, activeForm, and status.
 
     Returns:
-        str: Success confirmation message
+        str: Confirmation message describing the resulting list state.
 
-    Examples:
-        # Initial planning with multiple steps
-        # NOTE: Use 'todos=' (plural) as the parameter name
+    Example:
         TodoWrite(todos=[
-            {"content": "Search for company financial reports", "activeForm": "Searching for company financial reports", "status": "in_progress"},
-            {"content": "Extract key financial metrics", "activeForm": "Extracting key financial metrics", "status": "pending"},
-            {"content": "Verify data accuracy and completeness", "activeForm": "Verifying data accuracy and completeness", "status": "pending"}
-        ])
-
-        # First task completed, start second task
-        TodoWrite(todos=[
-            {"content": "Search for company financial reports", "activeForm": "Searching for company financial reports", "status": "completed"},
-            {"content": "Extract key financial metrics", "activeForm": "Extracting key financial metrics", "status": "in_progress"},
-            {"content": "Verify data accuracy and completeness", "activeForm": "Verifying data accuracy and completeness", "status": "pending"}
-        ])
-
-        # Discovered additional subtask during execution - add it
-        TodoWrite(todos=[
-            {"content": "Search for company financial reports", "activeForm": "Searching for company financial reports", "status": "completed"},
-            {"content": "Extract key financial metrics", "activeForm": "Extracting key financial metrics", "status": "completed"},
-            {"content": "Verify data accuracy and completeness", "activeForm": "Verifying data accuracy and completeness", "status": "in_progress"},
-            {"content": "Cross-reference with industry benchmarks", "activeForm": "Cross-referencing with industry benchmarks", "status": "pending"}
-        ])
-
-        # All tasks completed
-        TodoWrite(todos=[
-            {"content": "Search for company financial reports", "activeForm": "Searching for company financial reports", "status": "completed"},
-            {"content": "Extract key financial metrics", "activeForm": "Extracting key financial metrics", "status": "completed"},
-            {"content": "Verify data accuracy and completeness", "activeForm": "Verifying data accuracy and completeness", "status": "completed"},
-            {"content": "Cross-reference with industry benchmarks", "activeForm": "Cross-referencing with industry benchmarks", "status": "completed"}
+            {"content": "Fetch Q3 earnings", "activeForm": "Fetching Q3 earnings", "status": "in_progress"},
+            {"content": "Summarize key metrics", "activeForm": "Summarizing key metrics", "status": "pending"},
         ])
     """
     logger.info(f"Todo list updated with {len(todos)} items")
 
-    # Validate todo format and get errors
-    is_valid, validation_errors = validate_todo_list_dict(todos)
-
-    # Log todo statuses for debugging
-    status_counts = {"pending": 0, "in_progress": 0, "completed": 0}
+    status_counts = {
+        TodoStatus.PENDING: 0,
+        TodoStatus.IN_PROGRESS: 0,
+        TodoStatus.COMPLETED: 0,
+    }
     for todo in todos:
-        status = todo.get("status", "unknown")
-        if status in status_counts:
-            status_counts[status] += 1
-        logger.debug(f"  - [{status}] {todo.get('content', 'No content')}")
+        status_counts[todo.status] += 1
+        logger.debug(f"  - [{todo.status.value}] {todo.content}")
 
-    logger.debug(f"Status summary: {status_counts}")
+    total = len(todos)
+    completed = status_counts[TodoStatus.COMPLETED]
+    in_progress = status_counts[TodoStatus.IN_PROGRESS]
+    pending = status_counts[TodoStatus.PENDING]
+    remaining = pending + in_progress
 
-    # Calculate counts for conditional messaging
-    total_count = len(todos)
-    completed_count = status_counts["completed"]
-    pending_count = status_counts["pending"]
-    in_progress_count = status_counts["in_progress"]
-    remaining_count = pending_count + in_progress_count
-
-    # Build response message based on completion state
-    if completed_count == total_count and total_count > 0:
-        # Scenario A: All tasks completed
-        response = "✓ All tasks completed! You can now proceed to the next stage or add more tasks if needed."
+    if total > 0 and completed == total:
         logger.info("All todos completed")
-    elif remaining_count == 1 and total_count > 1:
-        # Scenario B: One task remaining (append to default)
-        response = (
-            "Todos have been modified successfully. Ensure that you continue to use the todo list to "
-            "track your progress. Please proceed with the current tasks if applicable\n\n"
-            "💡 Reminder: One task remaining - remember to mark it as completed after finishing it."
+        return (
+            "✓ All tasks completed! You can now proceed to the next stage "
+            "or add more tasks if needed."
         )
+
+    if total > 1 and remaining == 1:
         logger.info("One task remaining")
-    else:
-        # Scenario C: Multiple tasks remaining (default message)
-        response = (
-            "Todos have been modified successfully. Ensure that you continue to use the todo list to "
-            "track your progress. Please proceed with the current tasks if applicable"
+        return (
+            "Todos have been modified successfully. Ensure that you continue to use "
+            "the todo list to track your progress. Please proceed with the current "
+            "tasks if applicable\n\n"
+            "💡 Reminder: One task remaining — remember to mark it as completed after "
+            "finishing it."
         )
 
-    # Append validation warnings if format issues detected
-    if not is_valid:
-        logger.warning(f"Todo format validation failed: {validation_errors}")
-        validation_section = "\n\n⚠️ Format Validation Issues:\n"
-        validation_section += "\n".join(f"  - {error}" for error in validation_errors)
-        response += validation_section
-
-    return response
+    return (
+        "Todos have been modified successfully. Ensure that you continue to use the "
+        "todo list to track your progress. Please proceed with the current tasks if "
+        "applicable"
+    )

--- a/src/ptc_agent/agent/tools/todo/types.py
+++ b/src/ptc_agent/agent/tools/todo/types.py
@@ -4,9 +4,8 @@ This module provides data structures for tracking agent todos throughout workflo
 Follows Anthropic's Claude Code best practices for todo management.
 """
 
-from datetime import datetime
 from enum import Enum
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any
 from pydantic import BaseModel, Field, field_validator
 
 
@@ -18,7 +17,7 @@ class TodoStatus(str, Enum):
 
 
 class TodoItem(BaseModel):
-    """Individual todo item with tracking metadata."""
+    """Individual todo item passed by the agent."""
 
     content: str = Field(
         min_length=1,
@@ -36,9 +35,6 @@ class TodoItem(BaseModel):
     status: TodoStatus = Field(
         description="One of: pending, in_progress, completed"
     )
-    id: Optional[str] = Field(default=None, description="Unique identifier for the todo")
-    created_at: datetime = Field(default_factory=datetime.now, description="When the todo was created")
-    updated_at: datetime = Field(default_factory=datetime.now, description="When the todo was last updated")
 
     @field_validator("status", mode="before")
     @classmethod
@@ -47,7 +43,6 @@ class TodoItem(BaseModel):
         if isinstance(v, TodoStatus):
             return v
         if isinstance(v, str):
-            # Handle string values
             status_map = {
                 "pending": TodoStatus.PENDING,
                 "in_progress": TodoStatus.IN_PROGRESS,
@@ -55,26 +50,6 @@ class TodoItem(BaseModel):
             }
             return status_map.get(v.lower(), v)
         return v
-
-    def to_dict(self) -> Dict[str, Any]:
-        """Convert to dictionary format for tool calls."""
-        return {
-            "content": self.content,
-            "activeForm": self.activeForm,
-            "status": self.status.value if isinstance(self.status, TodoStatus) else self.status,
-        }
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "TodoItem":
-        """Create TodoItem from dictionary."""
-        return cls(
-            content=data.get("content", ""),
-            activeForm=data.get("activeForm", ""),
-            status=data.get("status", "pending"),
-            id=data.get("id"),
-            created_at=data.get("created_at", datetime.now()),
-            updated_at=data.get("updated_at", datetime.now()),
-        )
 
 
 def validate_single_in_progress(todos: List[TodoItem]) -> tuple[bool, List[str]]:

--- a/src/ptc_agent/agent/tools/todo/types.py
+++ b/src/ptc_agent/agent/tools/todo/types.py
@@ -20,9 +20,22 @@ class TodoStatus(str, Enum):
 class TodoItem(BaseModel):
     """Individual todo item with tracking metadata."""
 
-    content: str = Field(description="Description of the task (e.g., 'Run the build')")
-    activeForm: str = Field(description="Present continuous form (e.g., 'Running the build')")
-    status: TodoStatus = Field(description="Current status of the todo")
+    content: str = Field(
+        min_length=1,
+        description=(
+            "Imperative task description. Example: 'Fetch Q3 earnings for AAPL'"
+        ),
+    )
+    activeForm: str = Field(
+        min_length=1,
+        description=(
+            "Present-continuous form shown while the task runs. "
+            "Example: 'Fetching Q3 earnings for AAPL'"
+        ),
+    )
+    status: TodoStatus = Field(
+        description="One of: pending, in_progress, completed"
+    )
     id: Optional[str] = Field(default=None, description="Unique identifier for the todo")
     created_at: datetime = Field(default_factory=datetime.now, description="When the todo was created")
     updated_at: datetime = Field(default_factory=datetime.now, description="When the todo was last updated")

--- a/src/ptc_agent/agent/tools/todo/types.py
+++ b/src/ptc_agent/agent/tools/todo/types.py
@@ -6,7 +6,7 @@ Follows Anthropic's Claude Code best practices for todo management.
 
 from enum import Enum
 from typing import List, Dict, Any
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class TodoStatus(str, Enum):
@@ -18,6 +18,11 @@ class TodoStatus(str, Enum):
 
 class TodoItem(BaseModel):
     """Individual todo item passed by the agent."""
+
+    # extra='ignore' is pydantic v2's default; stated explicitly so a future
+    # base-class change to extra='forbid' can't silently break in-flight LLM
+    # sessions that learned the old schema and still send id/created_at/etc.
+    model_config = ConfigDict(extra="ignore")
 
     content: str = Field(
         min_length=1,

--- a/tests/unit/middleware/test_todo_write_middleware.py
+++ b/tests/unit/middleware/test_todo_write_middleware.py
@@ -191,3 +191,57 @@ async def test_handler_exception_emits_failed_event(middleware):
     assert emitted[0]["status"] == "failed"
     assert emitted[0]["payload"]["total"] == 0
     assert "simulated validation failure" in emitted[0]["payload"]["error"]
+
+
+@pytest.mark.asyncio
+async def test_failed_event_whitelists_and_lowercases_payload(middleware):
+    """Failed events must apply the same normalization as completed events —
+    strip legacy fields and lowercase status — so the frontend's strict
+    `status === 'pending'` checks hold on the error path too."""
+    todos = [
+        {**_todo(status="PENDING"), "id": "legacy-1", "created_at": "2026-01-01"},
+        _todo(status="In_Progress"),
+    ]
+    emitted = []
+
+    async def failing_handler(_req):
+        raise ValueError("boom")
+
+    with patch(
+        "ptc_agent.agent.middleware.todo_operations.sse_middleware.get_stream_writer",
+        return_value=emitted.append,
+    ):
+        with pytest.raises(ValueError):
+            await middleware.awrap_tool_call(_make_request(todos), failing_handler)
+
+    payload = emitted[0]["payload"]
+    assert all(set(t.keys()) == {"content", "activeForm", "status"} for t in payload["todos"])
+    assert [t["status"] for t in payload["todos"]] == ["pending", "in_progress"]
+    assert payload["total"] == 2
+    assert payload["pending"] == 1
+    assert payload["in_progress"] == 1
+    assert payload["completed"] == 0
+    assert "boom" in payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_failed_event_drops_non_dict_items_from_total(middleware):
+    """total on the failed event should match normalized length, not the raw
+    list length — otherwise non-dict garbage inflates the count inconsistently
+    with the completed path."""
+    todos = [_todo(status="pending"), "not-a-dict", 42, _todo(status="completed")]
+    emitted = []
+
+    async def failing_handler(_req):
+        raise RuntimeError("x")
+
+    with patch(
+        "ptc_agent.agent.middleware.todo_operations.sse_middleware.get_stream_writer",
+        return_value=emitted.append,
+    ):
+        with pytest.raises(RuntimeError):
+            await middleware.awrap_tool_call(_make_request(todos), failing_handler)
+
+    payload = emitted[0]["payload"]
+    assert payload["total"] == 2
+    assert len(payload["todos"]) == 2

--- a/tests/unit/middleware/test_todo_write_middleware.py
+++ b/tests/unit/middleware/test_todo_write_middleware.py
@@ -1,0 +1,193 @@
+"""Tests for TodoWriteMiddleware's SSE event emission.
+
+Adapted from the superseded PR #156. Covers:
+  - Normalized-payload emission (whitelist to {content, activeForm, status}
+    + lowercase status for frontend's strict-equality checks).
+  - Top-level guard against non-list `todos` payloads so the failed-event
+    branch's `len(todos)` call never crashes on None/int garbage.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from ptc_agent.agent.middleware.todo_operations.sse_middleware import (
+    TodoWriteMiddleware,
+)
+
+
+def _todo(content="Fetch Q3 earnings", active="Fetching Q3 earnings", status="pending"):
+    return {"content": content, "activeForm": active, "status": status}
+
+
+def _make_request(todos, tool_name="TodoWrite", tool_call_id="call-1"):
+    return SimpleNamespace(
+        tool_call={
+            "name": tool_name,
+            "id": tool_call_id,
+            "args": {"todos": todos},
+        }
+    )
+
+
+async def _run(middleware, request):
+    async def handler(_req):
+        return "tool-result"
+
+    return await middleware.awrap_tool_call(request, handler)
+
+
+@pytest.fixture
+def middleware():
+    return TodoWriteMiddleware()
+
+
+@pytest.mark.asyncio
+async def test_list_todos_pass_through_with_counts(middleware):
+    todos = [
+        _todo(status="pending"),
+        _todo(status="in_progress"),
+        _todo(status="completed"),
+        _todo(status="completed"),
+    ]
+    emitted = []
+
+    with patch(
+        "ptc_agent.agent.middleware.todo_operations.sse_middleware.get_stream_writer",
+        return_value=emitted.append,
+    ):
+        result = await _run(middleware, _make_request(todos))
+
+    assert result == "tool-result"
+    assert len(emitted) == 1
+    payload = emitted[0]["payload"]
+    assert payload["total"] == 4
+    assert payload["completed"] == 2
+    assert payload["in_progress"] == 1
+    assert payload["pending"] == 1
+    # Payload is whitelisted to the three schema fields
+    assert all(set(t.keys()) == {"content", "activeForm", "status"} for t in payload["todos"])
+
+
+@pytest.mark.asyncio
+async def test_status_case_normalized_in_payload(middleware):
+    """LLM-sent uppercase status must reach the frontend as lowercase — the
+    drawer uses strict equality checks and would otherwise render as unknown."""
+    todos = [_todo(status="PENDING"), _todo(status="In_Progress")]
+    emitted = []
+
+    with patch(
+        "ptc_agent.agent.middleware.todo_operations.sse_middleware.get_stream_writer",
+        return_value=emitted.append,
+    ):
+        await _run(middleware, _make_request(todos))
+
+    payload = emitted[0]["payload"]
+    assert [t["status"] for t in payload["todos"]] == ["pending", "in_progress"]
+    assert payload["pending"] == 1
+    assert payload["in_progress"] == 1
+
+
+@pytest.mark.asyncio
+async def test_legacy_fields_stripped_from_payload(middleware):
+    """id/created_at/updated_at were removed from TodoItem but LLMs on cached
+    schemas may still send them. They must not reach SSE or persistence."""
+    todos = [{**_todo(status="pending"), "id": "legacy-1", "created_at": "2026-01-01"}]
+    emitted = []
+
+    with patch(
+        "ptc_agent.agent.middleware.todo_operations.sse_middleware.get_stream_writer",
+        return_value=emitted.append,
+    ):
+        await _run(middleware, _make_request(todos))
+
+    payload = emitted[0]["payload"]
+    assert payload["todos"] == [_todo(status="pending")]
+
+
+@pytest.mark.parametrize(
+    "bad_todos",
+    [
+        '[{"status":"pending"}]',  # stringified JSON
+        "not json at all",
+        {"status": "pending"},  # dict instead of list
+        None,
+        42,
+    ],
+)
+@pytest.mark.asyncio
+async def test_non_list_todos_normalized_to_empty(middleware, bad_todos):
+    emitted = []
+
+    with patch(
+        "ptc_agent.agent.middleware.todo_operations.sse_middleware.get_stream_writer",
+        return_value=emitted.append,
+    ):
+        result = await _run(middleware, _make_request(bad_todos))
+
+    assert result == "tool-result"
+    assert len(emitted) == 1
+    payload = emitted[0]["payload"]
+    assert payload["todos"] == []
+    assert payload["total"] == 0
+    assert payload["completed"] == 0
+    assert payload["in_progress"] == 0
+    assert payload["pending"] == 0
+
+
+@pytest.mark.asyncio
+async def test_non_todowrite_tool_passes_through(middleware):
+    emitted = []
+
+    with patch(
+        "ptc_agent.agent.middleware.todo_operations.sse_middleware.get_stream_writer",
+        return_value=emitted.append,
+    ):
+        result = await _run(
+            middleware, _make_request([], tool_name="SomethingElse")
+        )
+
+    assert result == "tool-result"
+    assert emitted == []
+
+
+@pytest.mark.asyncio
+async def test_non_list_todos_logs_warning(middleware, caplog):
+    emitted = []
+    caplog.set_level("WARNING")
+
+    with patch(
+        "ptc_agent.agent.middleware.todo_operations.sse_middleware.get_stream_writer",
+        return_value=emitted.append,
+    ):
+        await _run(middleware, _make_request('"not-a-list"'))
+
+    assert any(
+        "Non-list todos payload" in record.message for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_handler_exception_emits_failed_event(middleware):
+    """Pydantic ValidationError (or any tool failure) must emit a failed event
+    without crashing. Previously the error-path's len(todos) could crash when
+    raw_todos was None/int — the top-level guard prevents that."""
+    emitted = []
+
+    async def failing_handler(_req):
+        raise ValueError("simulated validation failure")
+
+    request = _make_request(None)  # None would have crashed len() pre-guard
+
+    with patch(
+        "ptc_agent.agent.middleware.todo_operations.sse_middleware.get_stream_writer",
+        return_value=emitted.append,
+    ):
+        with pytest.raises(ValueError):
+            await middleware.awrap_tool_call(request, failing_handler)
+
+    assert len(emitted) == 1
+    assert emitted[0]["status"] == "failed"
+    assert emitted[0]["payload"]["total"] == 0
+    assert "simulated validation failure" in emitted[0]["payload"]["error"]

--- a/tests/unit/ptc_agent/agent/tools/todo/test_tool.py
+++ b/tests/unit/ptc_agent/agent/tools/todo/test_tool.py
@@ -1,0 +1,122 @@
+"""Tests for the TodoWrite tool's schema enforcement.
+
+The tool's signature uses `List[TodoItem]`, so LangChain's argument parser
+validates payloads via Pydantic before the function body runs. Invalid shapes
+(stringified JSON, missing required fields, bad enum values) raise
+ValidationError, which LangChain surfaces to the LLM as an error ToolMessage.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from ptc_agent.agent.tools.todo.tool import TodoWrite
+
+
+def _good_todo(status: str = "in_progress") -> dict:
+    return {
+        "content": "Fetch Q3 earnings",
+        "activeForm": "Fetching Q3 earnings",
+        "status": status,
+    }
+
+
+class TestTodoWriteValidInput:
+    def test_single_in_progress_todo(self):
+        result = TodoWrite.invoke({"todos": [_good_todo("in_progress")]})
+        assert "Todos have been modified successfully" in result
+
+    def test_all_completed_returns_completion_message(self):
+        todos = [_good_todo("completed"), _good_todo("completed")]
+        result = TodoWrite.invoke({"todos": todos})
+        assert "✓ All tasks completed" in result
+
+    def test_one_remaining_reminder(self):
+        todos = [
+            _good_todo("completed"),
+            _good_todo("completed"),
+            _good_todo("in_progress"),
+        ]
+        result = TodoWrite.invoke({"todos": todos})
+        assert "One task remaining" in result
+
+    def test_empty_list_is_valid(self):
+        result = TodoWrite.invoke({"todos": []})
+        assert "Todos have been modified successfully" in result
+
+
+class TestTodoWriteRejectsInvalidShapes:
+    """These payloads should fail at the tool's pydantic arg parser."""
+
+    def test_stringified_json_list_rejected(self):
+        with pytest.raises(ValidationError):
+            TodoWrite.invoke({"todos": '[{"status": "pending"}]'})
+
+    def test_malformed_string_rejected(self):
+        with pytest.raises(ValidationError):
+            TodoWrite.invoke({"todos": "not a list at all"})
+
+    def test_dict_instead_of_list_rejected(self):
+        with pytest.raises(ValidationError):
+            TodoWrite.invoke({"todos": {"status": "pending"}})
+
+    def test_none_rejected(self):
+        with pytest.raises(ValidationError):
+            TodoWrite.invoke({"todos": None})
+
+    def test_int_rejected(self):
+        with pytest.raises(ValidationError):
+            TodoWrite.invoke({"todos": 42})
+
+
+class TestTodoWriteRejectsMalformedItems:
+    def test_missing_content_rejected(self):
+        bad = {"activeForm": "Running", "status": "pending"}
+        with pytest.raises(ValidationError):
+            TodoWrite.invoke({"todos": [bad]})
+
+    def test_missing_activeForm_rejected(self):
+        bad = {"content": "Run", "status": "pending"}
+        with pytest.raises(ValidationError):
+            TodoWrite.invoke({"todos": [bad]})
+
+    def test_missing_status_rejected(self):
+        bad = {"content": "Run", "activeForm": "Running"}
+        with pytest.raises(ValidationError):
+            TodoWrite.invoke({"todos": [bad]})
+
+    def test_empty_content_rejected(self):
+        bad = {"content": "", "activeForm": "Running", "status": "pending"}
+        with pytest.raises(ValidationError):
+            TodoWrite.invoke({"todos": [bad]})
+
+    def test_empty_activeForm_rejected(self):
+        bad = {"content": "Run", "activeForm": "", "status": "pending"}
+        with pytest.raises(ValidationError):
+            TodoWrite.invoke({"todos": [bad]})
+
+    def test_invalid_status_value_rejected(self):
+        bad = {"content": "Run", "activeForm": "Running", "status": "stale"}
+        with pytest.raises(ValidationError):
+            TodoWrite.invoke({"todos": [bad]})
+
+    def test_item_must_be_dict_not_string(self):
+        with pytest.raises(ValidationError):
+            TodoWrite.invoke({"todos": ["just a string"]})
+
+
+class TestTodoWriteValidationErrorMessageIsUsable:
+    """LLM receives this as error ToolMessage — make sure the message names the problem."""
+
+    def test_missing_field_error_names_field(self):
+        with pytest.raises(ValidationError) as exc:
+            TodoWrite.invoke({"todos": [{"content": "X", "status": "pending"}]})
+        # Pydantic includes the missing field name in the error
+        assert "activeForm" in str(exc.value)
+
+    def test_bad_status_error_names_valid_options(self):
+        bad = {"content": "X", "activeForm": "Xing", "status": "archived"}
+        with pytest.raises(ValidationError) as exc:
+            TodoWrite.invoke({"todos": [bad]})
+        # Enum error mentions the invalid value or valid choices
+        msg = str(exc.value).lower()
+        assert "status" in msg

--- a/tests/unit/ptc_agent/agent/tools/todo/test_tool.py
+++ b/tests/unit/ptc_agent/agent/tools/todo/test_tool.py
@@ -99,9 +99,37 @@ class TestTodoWriteRejectsMalformedItems:
         with pytest.raises(ValidationError):
             TodoWrite.invoke({"todos": [bad]})
 
-    def test_item_must_be_dict_not_string(self):
+    @pytest.mark.parametrize("junk", [None, 42, 3.14, "string", ["nested"]])
+    def test_non_dict_list_element_rejected(self, junk):
         with pytest.raises(ValidationError):
-            TodoWrite.invoke({"todos": ["just a string"]})
+            TodoWrite.invoke({"todos": [junk]})
+
+
+class TestTodoWriteCompatAndNormalization:
+    """Behaviors the schema relies on: extras ignored, status normalization."""
+
+    def test_legacy_fields_silently_ignored(self):
+        """LLMs with cached tool schemas may still send id/created_at/updated_at.
+        Pydantic's default extra='ignore' must accept and drop these fields —
+        flipping to extra='forbid' later would break in-flight calls, so lock it in.
+        """
+        legacy = {
+            "content": "Fetch Q3 earnings",
+            "activeForm": "Fetching Q3 earnings",
+            "status": "in_progress",
+            "id": "legacy-abc-123",
+            "created_at": "2026-01-01T00:00:00",
+            "updated_at": "2026-01-01T00:00:00",
+        }
+        result = TodoWrite.invoke({"todos": [legacy]})
+        assert "Todos have been modified successfully" in result
+
+    @pytest.mark.parametrize("raw", ["PENDING", "In_Progress", "COMPLETED", "Pending"])
+    def test_status_normalization_is_case_insensitive(self, raw):
+        todo = {"content": "X", "activeForm": "Xing", "status": raw}
+        result = TodoWrite.invoke({"todos": [todo]})
+        assert ("Todos have been modified successfully" in result
+                or "All tasks completed" in result)
 
 
 class TestTodoWriteValidationErrorMessageIsUsable:
@@ -117,6 +145,7 @@ class TestTodoWriteValidationErrorMessageIsUsable:
         bad = {"content": "X", "activeForm": "Xing", "status": "archived"}
         with pytest.raises(ValidationError) as exc:
             TodoWrite.invoke({"todos": [bad]})
-        # Enum error mentions the invalid value or valid choices
         msg = str(exc.value).lower()
         assert "status" in msg
+        # The message should name at least one valid option so the LLM can self-correct
+        assert any(opt in msg for opt in ("pending", "in_progress", "completed"))

--- a/tests/unit/ptc_agent/agent/tools/todo/test_tool.py
+++ b/tests/unit/ptc_agent/agent/tools/todo/test_tool.py
@@ -45,7 +45,14 @@ class TestTodoWriteValidInput:
 
 
 class TestTodoWriteRejectsInvalidShapes:
-    """These payloads should fail at the tool's pydantic arg parser."""
+    """These payloads fail at the tool's pydantic arg parser when invoked directly.
+
+    Note: In production, `ToolArgumentParsingMiddleware` JSON-decodes string args
+    before they reach the tool — so an LLM emitting `'[{"status":"pending"}]'`
+    is auto-parsed into a list and then would fail on missing `content`/`activeForm`
+    rather than on "not a list". These tests lock in the fail-closed behavior of
+    the tool itself as a defense-in-depth layer.
+    """
 
     def test_stringified_json_list_rejected(self):
         with pytest.raises(ValidationError):

--- a/web/src/pages/ChatAgent/hooks/utils/historyEventHandlers.ts
+++ b/web/src/pages/ChatAgent/hooks/utils/historyEventHandlers.ts
@@ -732,7 +732,7 @@ export function handleHistoryTodoUpdate({ assistantMessageId, artifactType, arti
       // If this is an update to an existing logical todo list (same artifactId),
       // we still create a new segment but can reference the base ID for data updates
       todoListProcesses[segmentId] = {
-        todos: todos || [],
+        todos,
         total: total || 0,
         completed: completed || 0,
         in_progress: in_progress || 0,

--- a/web/src/pages/ChatAgent/hooks/utils/streamEventHandlers.ts
+++ b/web/src/pages/ChatAgent/hooks/utils/streamEventHandlers.ts
@@ -557,7 +557,7 @@ export function handleTodoUpdate({ assistantMessageId, artifactType, artifactId,
     }
     updateTodoListCard(
       {
-        todos: todos || [],
+        todos,
         total: total || 0,
         completed: completed || 0,
         in_progress: in_progress || 0,
@@ -606,7 +606,7 @@ export function handleTodoUpdate({ assistantMessageId, artifactType, artifactId,
       // If this is an update to an existing logical todo list (same artifactId),
       // we still create a new segment but can reference the base ID for data updates
       todoListProcesses[segmentId] = {
-        todos: todos || [],
+        todos,
         total: total || 0,
         completed: completed || 0,
         in_progress: in_progress || 0,


### PR DESCRIPTION
## Summary

Tightens the `TodoWrite` tool so the LLM hits Pydantic at the tool boundary instead of getting a silent "validation warnings appended to a success string" response. **Supersedes #156** — the upstream schema fix here makes most of #156 redundant, but the valuable defensive bits (middleware guard, middleware tests, frontend tautology cleanup) have been ported in (commits `984a8da7` + `9c41d3ec`). **Closes #160** (error-path normalization, commit `bbce68c9`).

**Schema enforcement**
- Tool signature changed from `List[Dict[str, Any]]` to `List[TodoItem]` (Pydantic v2 model with `content`/`activeForm`/`status` only, `min_length=1` on strings, `TodoStatus` enum).
- Invalid shapes now raise `ValidationError`, which LangChain surfaces to the LLM as an error `ToolMessage` — it can self-correct on the next turn.
- Removed the post-hoc `validate_todo_list_dict` call from the tool body. Pydantic at the boundary is authoritative.

**Schema hygiene**
- Stripped internal metadata (`id`, `created_at`, `updated_at`) from the agent-facing `TodoItem` — they leaked into the LLM schema but nothing in the codebase read them through the model.
- Dropped dead `to_dict`/`from_dict` methods.
- Explicit `model_config = ConfigDict(extra="ignore")` so a future base-class flip to `extra="forbid"` can't silently break in-flight LLM sessions.

**Prompt consolidation**
- Moved workflow rules from the tool's 85-line docstring into `task_workflow.md.j2`. Tool docstring is ~10 lines now.

**Middleware hardening** (partly ported from #156, error-path fix closes #160)
- Payload whitelisted to `{content, activeForm, status}` before SSE emission — strips LLM-sent legacy fields from the wire + persistence layer, lowercases status so the frontend's `status === 'pending'` strict equality holds regardless of case.
- Top-level `isinstance(list)` guard + `logger.warning` — protects the failed-event branch's `len(todos)` call from crashing on None/int payloads. Without this, a secondary TypeError would swallow the original ValidationError.
- **Error-path normalization** (#160): lifted the whitelist + lowercase + status-count loop above the `try` block so the failed event ships the same normalized shape as the success event. Previously the error path sent raw LLM todos with legacy fields and uppercase status, breaking the frontend's strict equality checks on failure.

**Frontend cleanup** (ported from #156)
- Three tautological `todos || []` fallbacks removed from `streamEventHandlers.ts` and `historyEventHandlers.ts`.

## Relationship to #156

PR #156 was the narrow "guard the middleware against non-list payloads" follow-up to #153. This PR fixes the root cause one layer higher (the tool schema itself). What was kept from #156:

| #156 item | Status in #159 | Why |
|---|---|---|
| `isinstance(list)` guard in middleware | **Kept** (ported) | Still protects the failed-event branch's `len(todos)` call — pydantic's ValidationError path would otherwise crash on None/int. |
| Middleware test file (8 tests) | **Kept + extended to 13** | Middleware had zero coverage; tests close that gap and cover new whitelist + status normalization behavior (including error-path normalization from #160). |
| Frontend `todos \|\| []` cleanup | **Kept** | Tautological after #153, readability win. |
| Single-point-of-defense "isinstance at the top" as the primary fix | **Superseded** | Primary defense is now the tool schema (pydantic rejects bad shapes before middleware runs). The guard is a belt-and-braces layer. |

#156 can be closed. All three valuable pieces live here.

## Relationship to #160

#160 flagged that the SSE failed-event branch still shipped raw LLM input (legacy fields, uppercase status, non-dict-inflated `total`) after the success path was normalized. Fixed by lifting the normalization loop above the `try` block so both paths share the same `normalized_todos` / `status_counts`. Closes on merge.

## Test Coverage

Tests: 18 → 40 (+9 tool-level in /review, +13 middleware).
Full unit suite: **2784/2784 pass**. Ruff clean.

Tool-level coverage: all 4 return-message branches, all 3 schema-field rejections, case-insensitive status normalization, legacy-field tolerance, 5 invalid payload shapes, 5 non-dict list-element variants, error messages that name valid options.

Middleware coverage (was zero before): list pass-through with counts, status case normalization in payload (not just counter), legacy-field stripping from payload, non-list payload coercion (5 variants), non-TodoWrite pass-through, warning log capture, handler-exception branch without secondary crash, **failed-event payload whitelist + lowercasing**, **failed-event `total` drops non-dict items**.

## Pre-Landing Review

Specialists (Testing + Maintainability) ran during `/review`. 4 findings auto-fixed (backward-compat test, case-insensitive status test, non-dict list parametrize, bad-status assertion strengthening). 2 out-of-scope items flagged for follow-up: `manager.py:158` still writes stripped fields (helper has zero callers, pre-existing dead code), and a minor duplicated string in `tool.py`.

PR Quality Score: 9.0/10.

## Adversarial Review

Claude adversarial subagent + Codex adversarial challenge both ran. Converged on the same high-priority issue: the initial middleware lowercase fix was a half-measure (counter normalized, payload still shipped raw casing to the frontend). Fixed during this PR with payload-field whitelisting. Post-merge bot review caught the same issue on the error path (#160), also now fixed.

**Fixed during this PR:**
- Payload status normalization (not just counter).
- Explicit `ConfigDict(extra='ignore')`.
- Test docstring corrected to clarify `ToolArgumentParsingMiddleware` JSON-decodes stringified args in production.
- Top-level isinstance guard (from #156) protects failed-event branch.
- Error-path payload normalization (#160): failed events now whitelist + lowercase.

**Known and accepted:**
- Backward-compat for in-flight threads: the refactor converts "warn-but-accept" into "hard-reject via ValidationError." By design — previous loose behavior is what allowed the stringified-JSON crash #153 worked around in the frontend.
- `manager.py` helpers still produce dicts with stripped fields. Zero callers, so nothing breaks; flagged for follow-up cleanup PR.

## Test plan

- [x] 27 tool-level tests pass.
- [x] 13 middleware tests pass (ported + extended from #156, +2 for #160).
- [x] Full unit suite: 2784/2784 pass.
- [x] Ruff: clean.
- [x] Pydantic JSON schema verified — LLM sees `{content, activeForm, status}` only.
- [x] Backward-compat verified — extra fields silently ignored.
- [x] Middleware payload normalization verified — uppercase status → lowercase at frontend; legacy fields stripped.
- [x] Failed-event branch verified — None/int payloads no longer crash in secondary TypeError.
- [x] Failed-event payload verified normalized — same whitelist + lowercase as success path (#160).
