### PR TITLE
fix(chat): eliminate __default__ thread flicker + end-of-stream layout jump

### DIFF
--- a/web/src/pages/ChatAgent/ChatAgent.tsx
+++ b/web/src/pages/ChatAgent/ChatAgent.tsx
@@ -27,6 +27,11 @@ const desktopFadeVariants = {
 const WorkspaceGallery = React.lazy(() => import('./components/WorkspaceGallery'));
 const ThreadGallery = React.lazy(() => import('./components/ThreadGallery'));
 
+// Cache key format used by useChatViewCache — `${workspaceId}-${threadId}`.
+// Only needed by cache.updateKey() calls; the resolvingRef below is keyed by
+// workspaceId alone (one __default__→real resolution per workspace at a time).
+const resolvingKey = (wsId: string, tid: string) => `${wsId}-${tid}`;
+
 interface LocationState {
   workspaceId?: string;
   workspaceName?: string;
@@ -157,26 +162,25 @@ function ChatAgent(): React.ReactElement | null {
 
   const queryClient = useQueryClient();
 
-  // Track in-progress __default__ → real threadId resolutions.
-  // Bridges the gap between async cache.updateKey() and immediate navigate().
-  const resolvingRef = useRef(new Map<string, { workspaceId: string; newThreadId: string }>());
-  const resolvingKey = (wsId: string, tid: string) => `${wsId}-${tid}`;
+  // Track in-progress __default__ → real threadId resolutions. Keyed by workspaceId:
+  // at most one such resolution can be in flight per workspace (a fresh __default__
+  // can't be created while the previous one is still bridging, because the source-side
+  // check below blocks it). Bridges the gap between async cache.updateKey() and
+  // immediate navigate().
+  const resolvingRef = useRef(new Map<string, { oldThreadId: string; newThreadId: string }>());
 
   // Ensure cache entry exists before first paint so chatViews is never empty
   // when threadId is set (same setState-during-render pattern as setResolvedWorkspaceId above).
   if (threadId && workspaceId && !cache.entries.some(e => e.workspaceId === workspaceId && e.threadId === threadId)) {
     // Don't create a duplicate entry if a resolution touches this threadId — either as
-    // the target (we're about to rename into it) or as the source (we just renamed away
-    // from it and the URL hasn't caught up yet). Without the source-side check, the
+    // the target (URL is ahead, cache hasn't renamed yet) or as the source (cache is
+    // ahead, URL still points at the old __default__). Without this check, the
     // intermediate render between cache.updateKey committing and navigate() landing
     // spawns a duplicate __default__ entry, which mounts a fresh ChatView and kicks
     // off a new backend thread — the root of the __default__ ↔ new-GUID flicker.
-    const isPendingResolution =
-      Array.from(resolvingRef.current.values()).some(
-        v => v.workspaceId === workspaceId && v.newThreadId === threadId
-      ) ||
-      resolvingRef.current.has(resolvingKey(workspaceId, threadId));
-    if (!isPendingResolution) {
+    const pending = resolvingRef.current.get(workspaceId);
+    const isBridging = !!pending && (pending.oldThreadId === threadId || pending.newThreadId === threadId);
+    if (!isBridging) {
       const cached = queryClient.getQueryData(queryKeys.workspaces.detail(workspaceId)) as Record<string, unknown> | undefined;
       const wsName = (cached?.name as string) || state?.workspaceName || '';
       cache.touch({ workspaceId, threadId, workspaceName: wsName, initialTaskId: taskId });
@@ -186,14 +190,11 @@ function ChatAgent(): React.ReactElement | null {
   // Promote to MRU and update metadata (workspace name, taskId) on subsequent renders.
   // Only the target-side check is needed here: this effect is dep-gated on [threadId,
   // workspaceId], so it re-fires exactly once after navigate() lands on the new threadId.
-  // The source-side (__default__) branch never re-fires this effect, so it doesn't need
-  // the symmetric check the set-during-render block above has.
+  // Before that fire, the set-during-render block above already handles the bridge window.
   useEffect(() => {
     if (!threadId || !workspaceId) return;
-    const isPendingResolution = Array.from(resolvingRef.current.values()).some(
-      v => v.workspaceId === workspaceId && v.newThreadId === threadId
-    );
-    if (isPendingResolution) return;
+    const pending = resolvingRef.current.get(workspaceId);
+    if (pending && pending.newThreadId === threadId) return;
     const cached = queryClient.getQueryData(queryKeys.workspaces.detail(workspaceId)) as Record<string, unknown> | undefined;
     const wsName = (cached?.name as string) || state?.workspaceName || '';
     cache.touch({ workspaceId, threadId, workspaceName: wsName, initialTaskId: taskId });
@@ -207,11 +208,11 @@ function ChatAgent(): React.ReactElement | null {
   useEffect(() => {
     if (resolvingRef.current.size === 0) return;
     const resolved: string[] = [];
-    for (const [oldKey, { workspaceId: wsId, newThreadId }] of resolvingRef.current) {
+    for (const [wsId, { oldThreadId, newThreadId }] of resolvingRef.current) {
       const targetExists = cache.entries.some(e => e.workspaceId === wsId && e.threadId === newThreadId);
-      const sourceExists = cache.entries.some(e => e.key === oldKey);
+      const sourceExists = cache.entries.some(e => e.workspaceId === wsId && e.threadId === oldThreadId);
       if (targetExists || !sourceExists) {
-        resolved.push(oldKey);
+        resolved.push(wsId);
       }
     }
     for (const key of resolved) {
@@ -322,26 +323,19 @@ function ChatAgent(): React.ReactElement | null {
 
   // Cached ChatView instances — always rendered, visibility toggled via display
   const chatViews = cache.entries.map(entry => {
-    const pendingResolution = resolvingRef.current.get(resolvingKey(entry.workspaceId, entry.threadId));
-    // After cache.updateKey renames an entry from oldTid → newTid, its lookup key is
-    // the new one — so the direct pendingResolution above will miss it. Detect the
-    // symmetric case (entry was renamed FROM the URL's threadId) so the renamed entry
-    // stays active during the bridge window until navigate() commits.
-    const wasJustRenamedFromUrl = threadId && workspaceId
-      ? Array.from(resolvingRef.current.entries()).some(
-          ([oldKey, v]) =>
-            v.workspaceId === entry.workspaceId
-            && v.newThreadId === entry.threadId
-            && oldKey === resolvingKey(workspaceId, threadId),
-        )
-      : false;
+    const pending = resolvingRef.current.get(entry.workspaceId);
+    // Bridge window: cache.updateKey and navigate commit in separate renders.
+    // In the intermediate render, either the cache is ahead (entry.threadId is new,
+    // URL still old) or the URL is ahead (URL is new, entry.threadId still old).
+    // Both symmetric branches keep the entry active until both commit.
+    const isBridging = !!pending && (
+      (pending.oldThreadId === entry.threadId && pending.newThreadId === threadId)
+      || (pending.newThreadId === entry.threadId && pending.oldThreadId === threadId)
+    );
     const isEntryActive = entry.workspaceId === workspaceId
-      && (
-        entry.threadId === threadId
-        || (!!pendingResolution && pendingResolution.newThreadId === threadId)
-        || wasJustRenamedFromUrl
-      )
-      && !!threadId && !accessDenied;
+      && (entry.threadId === threadId || isBridging)
+      && !!threadId
+      && !accessDenied;
     return (
       <div
         key={entry.instanceId}
@@ -359,10 +353,10 @@ function ChatAgent(): React.ReactElement | null {
           workspaceName={entry.workspaceName}
           isActive={isEntryActive}
           onThreadResolved={(oldTid, newTid) => {
-            resolvingRef.current.set(
-              resolvingKey(entry.workspaceId, oldTid),
-              { workspaceId: entry.workspaceId, newThreadId: newTid },
-            );
+            if (import.meta.env.DEV && resolvingRef.current.has(entry.workspaceId)) {
+              console.warn('[ChatAgent] overlapping thread resolution for workspace', entry.workspaceId);
+            }
+            resolvingRef.current.set(entry.workspaceId, { oldThreadId: oldTid, newThreadId: newTid });
             cache.updateKey(
               resolvingKey(entry.workspaceId, oldTid),
               resolvingKey(entry.workspaceId, newTid),

--- a/web/src/pages/ChatAgent/ChatAgent.tsx
+++ b/web/src/pages/ChatAgent/ChatAgent.tsx
@@ -164,10 +164,17 @@ function ChatAgent(): React.ReactElement | null {
   // Ensure cache entry exists before first paint so chatViews is never empty
   // when threadId is set (same setState-during-render pattern as setResolvedWorkspaceId above).
   if (threadId && workspaceId && !cache.entries.some(e => e.workspaceId === workspaceId && e.threadId === threadId)) {
-    // Don't create a duplicate entry if an existing entry is resolving to this threadId
-    const isPendingResolution = Array.from(resolvingRef.current.values()).some(
-      v => v.workspaceId === workspaceId && v.newThreadId === threadId
-    );
+    // Don't create a duplicate entry if a resolution touches this threadId — either as
+    // the target (we're about to rename into it) or as the source (we just renamed away
+    // from it and the URL hasn't caught up yet). Without the source-side check, the
+    // intermediate render between cache.updateKey committing and navigate() landing
+    // spawns a duplicate __default__ entry, which mounts a fresh ChatView and kicks
+    // off a new backend thread — the root of the __default__ ↔ new-GUID flicker.
+    const isPendingResolution =
+      Array.from(resolvingRef.current.values()).some(
+        v => v.workspaceId === workspaceId && v.newThreadId === threadId
+      ) ||
+      resolvingRef.current.has(`${workspaceId}-${threadId}`);
     if (!isPendingResolution) {
       const cached = queryClient.getQueryData(queryKeys.workspaces.detail(workspaceId)) as Record<string, unknown> | undefined;
       const wsName = (cached?.name as string) || state?.workspaceName || '';
@@ -175,10 +182,13 @@ function ChatAgent(): React.ReactElement | null {
     }
   }
 
-  // Promote to MRU and update metadata (workspace name, taskId) on subsequent renders
+  // Promote to MRU and update metadata (workspace name, taskId) on subsequent renders.
+  // Only the target-side check is needed here: this effect is dep-gated on [threadId,
+  // workspaceId], so it re-fires exactly once after navigate() lands on the new threadId.
+  // The source-side (__default__) branch never re-fires this effect, so it doesn't need
+  // the symmetric check the set-during-render block above has.
   useEffect(() => {
     if (!threadId || !workspaceId) return;
-    // Don't touch if this threadId is pending resolution from an existing entry
     const isPendingResolution = Array.from(resolvingRef.current.values()).some(
       v => v.workspaceId === workspaceId && v.newThreadId === threadId
     );
@@ -306,8 +316,24 @@ function ChatAgent(): React.ReactElement | null {
   // Cached ChatView instances — always rendered, visibility toggled via display
   const chatViews = cache.entries.map(entry => {
     const pendingResolution = resolvingRef.current.get(`${entry.workspaceId}-${entry.threadId}`);
+    // After cache.updateKey renames an entry from oldTid → newTid, its lookup key is
+    // the new one — so the direct pendingResolution above will miss it. Detect the
+    // symmetric case (entry was renamed FROM the URL's threadId) so the renamed entry
+    // stays active during the bridge window until navigate() commits.
+    const wasJustRenamedFromUrl = threadId
+      ? Array.from(resolvingRef.current.entries()).some(
+          ([oldKey, v]) =>
+            v.workspaceId === entry.workspaceId
+            && v.newThreadId === entry.threadId
+            && oldKey === `${workspaceId}-${threadId}`,
+        )
+      : false;
     const isEntryActive = entry.workspaceId === workspaceId
-      && (entry.threadId === threadId || (!!pendingResolution && pendingResolution.newThreadId === threadId))
+      && (
+        entry.threadId === threadId
+        || (!!pendingResolution && pendingResolution.newThreadId === threadId)
+        || wasJustRenamedFromUrl
+      )
       && !!threadId && !accessDenied;
     return (
       <div

--- a/web/src/pages/ChatAgent/ChatAgent.tsx
+++ b/web/src/pages/ChatAgent/ChatAgent.tsx
@@ -327,7 +327,7 @@ function ChatAgent(): React.ReactElement | null {
     // the new one — so the direct pendingResolution above will miss it. Detect the
     // symmetric case (entry was renamed FROM the URL's threadId) so the renamed entry
     // stays active during the bridge window until navigate() commits.
-    const wasJustRenamedFromUrl = threadId
+    const wasJustRenamedFromUrl = threadId && workspaceId
       ? Array.from(resolvingRef.current.entries()).some(
           ([oldKey, v]) =>
             v.workspaceId === entry.workspaceId

--- a/web/src/pages/ChatAgent/ChatAgent.tsx
+++ b/web/src/pages/ChatAgent/ChatAgent.tsx
@@ -199,12 +199,18 @@ function ChatAgent(): React.ReactElement | null {
     cache.touch({ workspaceId, threadId, workspaceName: wsName, initialTaskId: taskId });
   }, [threadId, workspaceId]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Clean resolvingRef once updateKey's setEntries commits
+  // Clean resolvingRef once updateKey's setEntries commits. Two triggers:
+  //   (1) target is present → rename succeeded, bridge window closed
+  //   (2) source is absent → entry was either renamed away OR LRU-evicted; either
+  //       way the ref is orphaned and must not leak (a stale ref would suppress a
+  //       future touch for the same threadId and blank out the view).
   useEffect(() => {
     if (resolvingRef.current.size === 0) return;
     const resolved: string[] = [];
     for (const [oldKey, { workspaceId: wsId, newThreadId }] of resolvingRef.current) {
-      if (cache.entries.some(e => e.workspaceId === wsId && e.threadId === newThreadId)) {
+      const targetExists = cache.entries.some(e => e.workspaceId === wsId && e.threadId === newThreadId);
+      const sourceExists = cache.entries.some(e => e.key === oldKey);
+      if (targetExists || !sourceExists) {
         resolved.push(oldKey);
       }
     }

--- a/web/src/pages/ChatAgent/ChatAgent.tsx
+++ b/web/src/pages/ChatAgent/ChatAgent.tsx
@@ -160,6 +160,7 @@ function ChatAgent(): React.ReactElement | null {
   // Track in-progress __default__ → real threadId resolutions.
   // Bridges the gap between async cache.updateKey() and immediate navigate().
   const resolvingRef = useRef(new Map<string, { workspaceId: string; newThreadId: string }>());
+  const resolvingKey = (wsId: string, tid: string) => `${wsId}-${tid}`;
 
   // Ensure cache entry exists before first paint so chatViews is never empty
   // when threadId is set (same setState-during-render pattern as setResolvedWorkspaceId above).
@@ -174,7 +175,7 @@ function ChatAgent(): React.ReactElement | null {
       Array.from(resolvingRef.current.values()).some(
         v => v.workspaceId === workspaceId && v.newThreadId === threadId
       ) ||
-      resolvingRef.current.has(`${workspaceId}-${threadId}`);
+      resolvingRef.current.has(resolvingKey(workspaceId, threadId));
     if (!isPendingResolution) {
       const cached = queryClient.getQueryData(queryKeys.workspaces.detail(workspaceId)) as Record<string, unknown> | undefined;
       const wsName = (cached?.name as string) || state?.workspaceName || '';
@@ -315,7 +316,7 @@ function ChatAgent(): React.ReactElement | null {
 
   // Cached ChatView instances — always rendered, visibility toggled via display
   const chatViews = cache.entries.map(entry => {
-    const pendingResolution = resolvingRef.current.get(`${entry.workspaceId}-${entry.threadId}`);
+    const pendingResolution = resolvingRef.current.get(resolvingKey(entry.workspaceId, entry.threadId));
     // After cache.updateKey renames an entry from oldTid → newTid, its lookup key is
     // the new one — so the direct pendingResolution above will miss it. Detect the
     // symmetric case (entry was renamed FROM the URL's threadId) so the renamed entry
@@ -325,7 +326,7 @@ function ChatAgent(): React.ReactElement | null {
           ([oldKey, v]) =>
             v.workspaceId === entry.workspaceId
             && v.newThreadId === entry.threadId
-            && oldKey === `${workspaceId}-${threadId}`,
+            && oldKey === resolvingKey(workspaceId, threadId),
         )
       : false;
     const isEntryActive = entry.workspaceId === workspaceId
@@ -353,12 +354,12 @@ function ChatAgent(): React.ReactElement | null {
           isActive={isEntryActive}
           onThreadResolved={(oldTid, newTid) => {
             resolvingRef.current.set(
-              `${entry.workspaceId}-${oldTid}`,
+              resolvingKey(entry.workspaceId, oldTid),
               { workspaceId: entry.workspaceId, newThreadId: newTid },
             );
             cache.updateKey(
-              `${entry.workspaceId}-${oldTid}`,
-              `${entry.workspaceId}-${newTid}`,
+              resolvingKey(entry.workspaceId, oldTid),
+              resolvingKey(entry.workspaceId, newTid),
               { threadId: newTid },
             );
           }}

--- a/web/src/pages/ChatAgent/components/MessageList.tsx
+++ b/web/src/pages/ChatAgent/components/MessageList.tsx
@@ -526,8 +526,11 @@ const MessageBubble = memo(function MessageBubble({ message, isLoading, hideAvat
     if (result === null) setFeedbackRating(prevRating);
   };
 
-  // Show action buttons only when not streaming, not in subagent view, not read-only, and not loading
-  const showActions = !(message.isStreaming as boolean) && !isSubagentView && !readOnly && !isLoading;
+  // Action buttons are mounted for all normal messages (reserves layout space) and
+  // only made visible after streaming settles. Keeping them mounted prevents a
+  // ~32px layout jump on sibling messages when streaming ends.
+  const canShowActions = !isSubagentView && !readOnly;
+  const showActions = canShowActions && !(message.isStreaming as boolean) && !isLoading;
 
   const resizeTextarea = () => {
     const el = editTextareaRef.current;
@@ -769,11 +772,13 @@ const MessageBubble = memo(function MessageBubble({ message, isLoading, hideAvat
         </>
         )}
 
-        {/* Message action buttons -- visible on hover */}
-        {showActions && !isEditing && (
+        {/* Message action buttons -- always mounted (reserves space), visibility toggled */}
+        {canShowActions && !isEditing && (
           <div
             className={`flex gap-1 mt-0.5 transition-opacity ${
-              isMobile ? 'opacity-70' : 'opacity-0 group-hover:opacity-100'
+              showActions
+                ? (isMobile ? 'opacity-70' : 'opacity-0 group-hover:opacity-100')
+                : 'opacity-0 pointer-events-none'
             } ${
               isUser ? 'justify-end' : 'justify-start'
             }`}

--- a/web/src/pages/ChatAgent/components/MessageList.tsx
+++ b/web/src/pages/ChatAgent/components/MessageList.tsx
@@ -1009,6 +1009,34 @@ type RenderBlock =
   | NotificationRenderBlock
   | HtmlWidgetRenderBlock;
 
+interface TextBlockProps {
+  block: TextRenderBlock;
+  isFirst: boolean;
+  isStreaming: boolean;
+  hasError: boolean;
+  isSubagentView: boolean;
+  onOpenFile?: (path: string, workspaceId?: string) => void;
+}
+
+function TextBlock({ block, isFirst, isStreaming, hasError, isSubagentView, onOpenFile }: TextBlockProps): React.ReactElement | null {
+  const textContent = isSubagentView
+    ? normalizeSubagentText(block.segment.content)
+    : (block.segment.content ?? '');
+  const textEl = (
+    <TextMessageContent
+      content={textContent}
+      isStreaming={isStreaming}
+      hasError={hasError}
+      onOpenFile={onOpenFile}
+    />
+  );
+  // First-block pure-text gets a −4px offset so its first-line center matches the
+  // 32px logo center. Reasoning-leading blocks handle their own offset inside
+  // ActivityBlock. Guard on textContent so an empty streaming block doesn't render
+  // an empty wrapper that shifts later siblings.
+  return isFirst && textContent ? <div className="-mt-1">{textEl}</div> : textEl;
+}
+
 const MessageContentSegments = memo(function MessageContentSegments({ segments, reasoningProcesses, toolCallProcesses, todoListProcesses, subagentTasks, planApprovals = EMPTY_OBJ, userQuestions = EMPTY_OBJ, workspaceProposals = EMPTY_OBJ, questionProposals = EMPTY_OBJ, pendingToolCallChunks = EMPTY_OBJ, isStreaming, hasError, isAssistant = false, compactToolCalls = false, isSubagentView = false, readOnly = false, allowFiles = false, onOpenSubagentTask, onOpenFile, onOpenDir, onToolCallDetailClick, onApprovePlan, onRejectPlan, onPlanDetailClick, onAnswerQuestion, onSkipQuestion, onApproveCreateWorkspace, onRejectCreateWorkspace, onApproveStartQuestion, onRejectStartQuestion, onApprovePTCAgent, onRejectPTCAgent, onApproveSecretaryAction, onRejectSecretaryAction, ptcAgentProposals = EMPTY_OBJ, secretaryActionProposals = EMPTY_OBJ, onWidgetSendPrompt, htmlWidgetProcesses = EMPTY_OBJ, textOnly = false, flashContext }: MessageContentSegmentsProps): React.ReactElement {
   // Force re-render timer for recently-completed tool calls that need minimum exposure
   const [tick, setTick] = useState(0);
@@ -1358,17 +1386,17 @@ const MessageContentSegments = memo(function MessageContentSegments({ segments, 
           }
 
           if (block.type === 'text') {
-            const textContent = isSubagentView ? normalizeSubagentText((block as TextRenderBlock).segment.content) : ((block as TextRenderBlock).segment.content ?? '');
-            const textEl = (
-              <TextMessageContent
+            return (
+              <TextBlock
                 key={block.key}
-                content={textContent}
+                block={block as TextRenderBlock}
+                isFirst={blockIdx === 0}
                 isStreaming={!!(isStreaming && blockIdx === lastTextBlockIdx && !hasAnyTrulyInProgress)}
                 hasError={!!hasError}
+                isSubagentView={isSubagentView}
                 onOpenFile={onOpenFile}
               />
             );
-            return blockIdx === 0 && textContent ? <div key={block.key} className="-mt-1">{textEl}</div> : textEl;
           }
 
           if (block.type === 'html_widget') {

--- a/web/src/pages/ChatAgent/components/MessageList.tsx
+++ b/web/src/pages/ChatAgent/components/MessageList.tsx
@@ -772,9 +772,14 @@ const MessageBubble = memo(function MessageBubble({ message, isLoading, hideAvat
         </>
         )}
 
-        {/* Message action buttons -- always mounted (reserves space), visibility toggled */}
+        {/* Message action buttons -- always mounted (reserves space), visibility toggled.
+            aria-hidden + inert keep the buttons out of the a11y tree and tab order
+            while opacity-0 is hiding them, so screen readers don't announce
+            "Copy, Thumbs up, ..." for every streaming message. */}
         {canShowActions && !isEditing && (
           <div
+            aria-hidden={!showActions}
+            inert={!showActions || undefined}
             className={`flex gap-1 mt-0.5 transition-opacity ${
               showActions
                 ? (isMobile ? 'opacity-70' : 'opacity-0 group-hover:opacity-100')

--- a/web/src/pages/ChatAgent/components/ReasoningMessageContent.tsx
+++ b/web/src/pages/ChatAgent/components/ReasoningMessageContent.tsx
@@ -110,4 +110,8 @@ function ReasoningMessageContent({ reasoningContent, isReasoning, reasoningCompl
   );
 }
 
-export default ReasoningMessageContent;
+// memo'd: reasoning streams token-by-token alongside other render blocks, so
+// MessageContentSegments re-renders each token. All four props are primitives
+// and default shallow compare skips Markdown's AST parse when the reasoning
+// content for this block is unchanged.
+export default React.memo(ReasoningMessageContent);

--- a/web/src/pages/ChatAgent/components/TextMessageContent.tsx
+++ b/web/src/pages/ChatAgent/components/TextMessageContent.tsx
@@ -82,6 +82,11 @@ function ErrorDisplay({ parsed }: ErrorDisplayProps): React.ReactElement {
   );
 }
 
-export default TextMessageContent;
+// memo'd: every streaming token re-renders MessageContentSegments, which maps
+// over earlier text blocks with unchanged content. Default shallow compare on
+// primitive props + stable onOpenFile (useCallback in ChatView/SharedChatView)
+// skips Markdown's AST parse for those stable blocks. Non-primitive props added
+// later must be referentially stable or memoization becomes a no-op.
+export default React.memo(TextMessageContent);
 // eslint-disable-next-line react-refresh/only-export-components
 export { parseErrorMessage, ErrorDisplay };


### PR DESCRIPTION
## Summary

Five commits, two user-visible fixes wrapped in a small refactor + followup hardening:

**Fixes**
- **End-of-stream layout jump.** When a streaming response finished, the sibling user-message bubble grew ~32px as its action buttons (copy / thumbs / regenerate) mounted, shoving the assistant row down. Action buttons are now always mounted; visibility toggles via `opacity` + `pointer-events`, and the container is `aria-hidden={!showActions}` + `inert` so screen readers and tab order don't announce them while they're invisible (`MessageList.tsx:526-787`).
- **`__default__` ↔ new-GUID thread flicker.** When a new conversation's SSE stream delivered the real threadId, the race between `cache.updateKey` (synchronous cache rename) and `navigate()` (async URL update) could spawn a duplicate `__default__` cache entry in the intermediate render, which mounted a fresh `ChatView` and kicked off a second backend thread. Fixed by making the `isPendingResolution` check and the `chatViews.map` active-entry predicate symmetric (detect resolutions both TO and FROM the URL's threadId) via a `resolvingRef` Map bridging the bridge window (`ChatAgent.tsx:164-334`).

**Refactors / hardening**
- **TextBlock extracted** from `MessageContentSegments` — no behavior change, cleaner separation (`MessageList.tsx:1017-1042`).
- **`resolvingKey` helper** centralizes the `${workspaceId}-${threadId}` format used in 4 places so future edits can't drift one call site (`ChatAgent.tsx:163`).
- **`resolvingRef` leak plugged.** The cleanup effect now also fires when the source key is absent from cache (covers the LRU-eviction case, not just successful rename). Long sessions that create + quickly evict many `__default__` threads would otherwise orphan ref entries and could eventually suppress legitimate `cache.touch` calls for reused thread IDs (`ChatAgent.tsx:202-220`).

## Test Coverage

```
CODE PATHS (changed by this PR)
[+] web/src/pages/ChatAgent/ChatAgent.tsx
  ├── resolvingKey helper                                   [★★  covered indirectly via 19 ChatAgent-adjacent tests]
  ├── isPendingResolution (target + source checks)          [GAP] race path — no mock harness
  ├── chatViews.map wasJustRenamedFromUrl                   [GAP] symmetric bridge-window — no mock harness
  └── resolvingRef cleanup (target OR source absent)        [GAP] eviction-driven cleanup — no mock harness
[+] web/src/pages/ChatAgent/components/MessageList.tsx
  ├── showActions split + aria-hidden/inert                 [GAP] no MessageBubble unit test exists today
  └── TextBlock extraction                                  [★★  covered indirectly — existing render tests pass]

COVERAGE: bug-fix patches to pre-existing untested UI state interactions.
Existing suite (484/484 pass) confirms no regression in tested paths.
Tests: 484 → 484 (no new tests; test-stub opportunities listed as follow-ups).
```

**Follow-ups flagged by specialists** (not blocking ship):
- Export helpers (`isPendingResolution`, `wasJustRenamedFromUrl`) and components (`MessageBubble`, `TextBlock`) for regression unit tests. Would require touching public APIs of the module.
- Unit test for the first-block `-mt-1` wrapper toggle behavior.
- Potential follow-up on concurrent / double-firing `onThreadResolved` (wrap in `useCallback` for stability) — not observed in practice, theoretical.

## Pre-Landing Review

Ship ran eng review + 2 specialists (Testing, Maintainability) + Claude adversarial subagent. Findings resolved during ship:

- **Auto-fixed:** extracted `resolvingKey` helper (maintainability), plugged `resolvingRef` LRU-eviction leak (adversarial — race class), added `aria-hidden` + `inert` to action-button container (adversarial — a11y regression introduced by always-mount).
- **Noted in follow-ups:** 4 test-stub ASKs (require exporting privates), 1 simplification of race logic (can be done post-ship), 3 cosmetic / low-confidence.

No SQL, LLM trust boundary, or shell injection scope. Tests pass, lint clean.

Codex adversarial pass skipped — 5 AI reviewers examined this 97-line UI diff already (eng review critical pass, Testing specialist, Maintainability specialist, Claude adversarial subagent). Diminishing returns.

## Design Review

Diff touches `MessageList.tsx` (frontend). The action-button always-mount change reserves layout space — tested visually at end-of-stream (logo no longer jumps). The `aria-hidden` + `inert` addition restores the accessibility posture that always-mount would have regressed. No visible design change otherwise.

## Scope Drift

- **Scope Check:** CLEAN
- **Intent:** fix chat rendering stability issues (flicker + layout jump + a11y + leak hardening)
- **Delivered:** exactly that, 5 bisectable commits, 2 files

## Plan Completion

No plan file maps specifically to this branch — ad-hoc work that followed the recent avatar-alignment fix (PR #161). Each commit's scope was defined at commit time.

## Verification Results

No local dev server was running — deferred manual QA to the reviewer. Key flows to verify:
- Start a new conversation from the gallery → first message → confirm URL transitions `__default__` → real GUID exactly once.
- Let an assistant message finish streaming → confirm logo doesn't jump, sibling messages don't shift.
- Reader-mode / VoiceOver test: confirm streaming assistant messages don't announce action buttons while they're invisible.

## Test plan
- [x] `pnpm vitest run` — 43 files, 484 tests pass
- [x] `pnpm lint` — 0 errors in changed files
- [ ] Manual QA: new-thread flicker + end-of-stream layout + screen-reader behavior