### PR TITLE
docs(prompts): prefer file-based Python for iterative work

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     image: postgres:18
     restart: unless-stopped
     ports:
-      - "127.0.0.1:5432:5432"
+      - "127.0.0.1:${PG_HOST_PORT:-5432}:5432"
     volumes:
       - langalpha-postgresql-data:/var/lib/postgresql
     environment:
@@ -31,7 +31,7 @@ services:
     image: redis:7-alpine
     restart: unless-stopped
     ports:
-      - "127.0.0.1:6379:6379"
+      - "127.0.0.1:${REDIS_HOST_PORT:-6379}:6379"
     command: redis-server --requirepass ${REDIS_PASSWORD:-redis}
     volumes:
       - langalpha-redis-data:/data
@@ -53,7 +53,7 @@ services:
     memswap_limit: 8g
     restart: unless-stopped
     ports:
-      - "8000:8000"
+      - "${BACKEND_PORT:-8000}:8000"
     env_file: .env
     environment:
       BYOK_ENCRYPTION_KEY: ${BYOK_ENCRYPTION_KEY:-langalpha-local-dev-encryption-key}
@@ -88,7 +88,7 @@ services:
     command: sh -c "npm install -g pnpm@10 && pnpm install --frozen-lockfile && pnpm dev --host 0.0.0.0"
     restart: unless-stopped
     ports:
-      - "5173:5173"
+      - "${FRONTEND_PORT:-5173}:5173"
     environment:
       VITE_PROXY_BACKEND: http://backend:8000
     volumes:

--- a/skills/dcf-model/SKILL.md
+++ b/skills/dcf-model/SKILL.md
@@ -53,6 +53,8 @@ These constraints apply throughout all DCF model building. Review before startin
 
 ## DCF Process Workflow
 
+**Execution pattern**: build the DCF as a saved Python script (e.g., `work/<task_name>/build_dcf.py`) rather than inline `ExecuteCode`. Model building is iterative — you will debug formulas, tweak assumptions, and rerun. Writing to a file + running via `Bash` lets you `Edit` specific sections and rerun cheaply; resubmitting the whole openpyxl block inline on every iteration is wasteful.
+
 ### Step 1: Data Retrieval and Validation
 
 Fetch data from MCP servers, user provided data, and the web.

--- a/skills/inline-widget/SKILL.md
+++ b/skills/inline-widget/SKILL.md
@@ -201,11 +201,13 @@ Use `data_files` to load data from sandbox files instead of inlining everything 
 3. Access data in the widget via `window.__WIDGET_DATA__["filename"]`
 
 ```python
-# Step 1: Generate data (small inline example via ExecuteCode)
+# Step 1: Generate data inline via ExecuteCode (small one-shot)
+execute_code("""
 import json
 data = {"labels": ["Q1", "Q2", "Q3"], "values": [100, 150, 200]}
 with open("work/<task_name>/chart_data.json", "w") as f:
     json.dump(data, f)
+""")
 
 # Step 2: Agent calls ShowWidget with data_files
 ShowWidget(

--- a/skills/inline-widget/SKILL.md
+++ b/skills/inline-widget/SKILL.md
@@ -192,27 +192,25 @@ setInterval(function() {
 
 ## File Data
 
-Use `data_files` to load data from sandbox files instead of inlining everything in the HTML string. This is especially useful for larger datasets produced by `execute_code`.
+Use `data_files` to load data from sandbox files instead of inlining everything in the HTML string. This is especially useful for larger datasets.
 
 ### Workflow
 
-1. Use `execute_code` to generate data files in the sandbox
+1. Generate data files via Python — inline `ExecuteCode` for small one-shots, or write a `.py` script under `work/<task_name>/` and run via `Bash` for larger/iterative pipelines
 2. Pass file paths to `ShowWidget` via `data_files`
 3. Access data in the widget via `window.__WIDGET_DATA__["filename"]`
 
 ```python
-# Step 1: Agent generates data via execute_code
-execute_code("""
+# Step 1: Generate data (small inline example via ExecuteCode)
 import json
 data = {"labels": ["Q1", "Q2", "Q3"], "values": [100, 150, 200]}
-with open("/home/workspace/work/chart_data.json", "w") as f:
+with open("work/<task_name>/chart_data.json", "w") as f:
     json.dump(data, f)
-""")
 
 # Step 2: Agent calls ShowWidget with data_files
 ShowWidget(
     html='<div id="chart">...</div><script>var d = JSON.parse(__WIDGET_DATA__["chart_data.json"]); ...</script>',
-    data_files=["/home/workspace/work/chart_data.json"]
+    data_files=["work/<task_name>/chart_data.json"]
 )
 ```
 

--- a/skills/inline-widget/SKILL.md
+++ b/skills/inline-widget/SKILL.md
@@ -196,18 +196,16 @@ Use `data_files` to load data from sandbox files instead of inlining everything 
 
 ### Workflow
 
-1. Generate data files via Python — inline `ExecuteCode` for small one-shots, or write a `.py` script under `work/<task_name>/` and run via `Bash` for larger/iterative pipelines
+1. Generate data files via Python
 2. Pass file paths to `ShowWidget` via `data_files`
 3. Access data in the widget via `window.__WIDGET_DATA__["filename"]`
 
 ```python
-# Step 1: Generate data inline via ExecuteCode (small one-shot)
-execute_code("""
+# Step 1: Generate data
 import json
 data = {"labels": ["Q1", "Q2", "Q3"], "values": [100, 150, 200]}
 with open("work/<task_name>/chart_data.json", "w") as f:
     json.dump(data, f)
-""")
 
 # Step 2: Agent calls ShowWidget with data_files
 ShowWidget(

--- a/skills/web-scraping/SKILL.md
+++ b/skills/web-scraping/SKILL.md
@@ -13,9 +13,11 @@ Two ways to scrape in the sandbox:
 1. **MCP tool wrappers** (recommended for simple fetches) — call `get()`, `fetch()`, `stealthy_fetch()` directly. Synchronous, returns dicts.
 2. **Direct Python API** (for advanced use) — import Scrapling classes for selectors, sessions, spiders. Async, returns Page objects.
 
-## MCP Tool Wrappers (via execute_code)
+## MCP Tool Wrappers (via Python)
 
 Auto-registered as top-level functions in the sandbox. No imports needed. **Synchronous** — no `await`.
+
+Quick fetches can run inline via `ExecuteCode`. For spiders, multi-URL crawls, or anything you'll iterate on, write the scraper to `work/<task_name>/scraper.py` and run it via `Bash` — edit-and-rerun beats resubmitting code.
 
 ### Basic Usage
 

--- a/skills/xlsx/SKILL.md
+++ b/skills/xlsx/SKILL.md
@@ -130,6 +130,9 @@ sheet['D20'] = '=AVERAGE(D2:D19)'
 This applies to ALL calculations - totals, percentages, ratios, differences, etc. The spreadsheet should be able to recalculate when source data changes.
 
 ## Common Workflow
+
+**Execution pattern**: for any non-trivial workbook (multi-sheet, formulas, styling loops, sensitivity grids), write the builder to `work/<task_name>/build_workbook.py` and run via `Bash` rather than sending the openpyxl code inline via `ExecuteCode`. You will iterate on styling, formulas, and layout — `Edit`+rerun is cheaper than resubmitting inline code.
+
 1. **Choose tool**: pandas for data, openpyxl for formulas/formatting
 2. **Create/Load**: Create new workbook or load existing file
 3. **Modify**: Add/edit data, formulas, and formatting

--- a/src/ptc_agent/agent/prompts/templates/components/tool_guide.md.j2
+++ b/src/ptc_agent/agent/prompts/templates/components/tool_guide.md.j2
@@ -11,7 +11,7 @@ Call these directly as tool calls for all fundamental operations:
 | Read / Write / Edit | File operations |
 | Glob / Grep | File search and content search |
 | Bash | Shell commands |
-| ExecuteCode | Run Python code (also used to invoke MCP tools) |
+| ExecuteCode | Run Python code |
 | WebSearch | Search the web |
 | WebFetch | Fetch and extract content from URLs |
 | TodoWrite | Track task progress |
@@ -45,9 +45,9 @@ Call these directly for quick data retrieval. No complex post-processing — jus
 
 **When to use**: Quick lookups, answering direct questions, gathering data for a report.
 
-## MCP Tools (via ExecuteCode)
+## MCP Tools (via Python)
 
-These servers expose raw data APIs for complex work — batch processing, modeling, calculations, and sophisticated analysis. Invoke them through ExecuteCode Python code:
+These servers expose raw data APIs for complex work — batch processing, modeling, calculations, and sophisticated analysis. Invoke them through Python — inline via `ExecuteCode` for one-shots, or by writing a `.py` file and running it via `Bash` for iterative/reusable work (see *Inline vs. file-based execution* below):
 
 {{ tool_summary }}
 
@@ -66,10 +66,23 @@ print(result)
 
 **When to use MCP tools**: When you need raw time-series data for calculations, multi-ticker batch analysis, financial modeling, charting with matplotlib/plotly, or any task requiring programmatic data manipulation.
 
+## Inline vs. file-based execution
+
+Two ways to run Python — pick based on how disposable the code is:
+
+- **Inline via `ExecuteCode`** — for one-shot, disposable work: a quick MCP call, a small transform, a sanity check, printing a single result. You don't plan to rerun it. Keep it short.
+- **`Write` a `.py` file + `Bash`** — when any of these is true:
+  - The code is long (~40+ lines) or has non-trivial structure
+  - You expect to iterate: debug, tweak parameters, rerun on new inputs
+  - The script is reusable logic (valuation model, data pipeline, openpyxl builder, scraper)
+  - You'll want to `Edit` specific sections after an error rather than resubmit the whole block
+
+Pattern: `Write("work/<task_name>/dcf.py", ...)` → `Bash("python work/<task_name>/dcf.py")` → `Edit` on failure → rerun. Edit-then-rerun is cheaper than resubmitting inline code.
+
 ## Tool Selection Principles
 
 - **Direct question about a stock/company** → Financial Tools (direct call)
-- **Need to compute, compare, or model data** → MCP Tools (via ExecuteCode)
+- **Need to compute, compare, or model data** → MCP Tools (via Python)
 - **File/web/search operations** → Core Tools (direct call)
 - Don't guess MCP tool parameters — always read the doc file first
 - Don't read entire .py files to find a signature — read the .md doc

--- a/src/ptc_agent/agent/prompts/templates/subagents/roles/data_prep.md.j2
+++ b/src/ptc_agent/agent/prompts/templates/subagents/roles/data_prep.md.j2
@@ -1,13 +1,13 @@
 Act as a data engineer tasked with fetching, cleaning, and preparing structured datasets from financial data sources. Note: Only the final response will be visible to the user.
 
 <task>
-Fetch data from MCP financial data servers via `ExecuteCode`, clean and transform it, and save structured datasets to the workspace for downstream analysis. Refer to the tool guide above for available MCP servers and follow the discovery workflow before first use of any MCP tool.
+Fetch data from MCP financial data servers via Python, clean and transform it, and save structured datasets to the workspace for downstream analysis. Refer to the tool guide above for available MCP servers and follow the discovery workflow before first use of any MCP tool.
 </task>
 
 <workflow>
 1. **Understand the data request** — identify tickers, date ranges, data types, and output format needed
 2. **Discover tools** — follow the discovery workflow in the tool guide: Glob docs → Read docs → then call
-3. **Fetch systematically** — call the appropriate MCP tools via ExecuteCode; batch multiple tickers where supported
+3. **Fetch systematically** — call the appropriate MCP tools via Python; batch multiple tickers where supported. For multi-ticker pipelines or anything you'll iterate on, write the fetcher to `work/<task_name>/fetch.py` and run it via `Bash` rather than sending it inline.
 4. **Clean and validate** — check for missing dates, NaN values, data gaps; log any issues
 5. **Transform and structure** — merge datasets, compute derived fields if requested, ensure consistent column naming
 6. **Save to workspace** — write files with clear naming (e.g., `{ticker}_financials_quarterly.csv`, `macro_treasury_rates.csv`)

--- a/src/ptc_agent/agent/prompts/templates/subagents/roles/equity_analyst.md.j2
+++ b/src/ptc_agent/agent/prompts/templates/subagents/roles/equity_analyst.md.j2
@@ -4,34 +4,6 @@ Act as a senior equity research analyst tasked with financial analysis and valua
 Perform rigorous financial analysis using MCP data tools, web research, and Python code execution. Produce investment-grade analysis with clear methodology, sourced data, and explicit assumptions. Refer to the tool guide above for available tools and follow the discovery workflow before first use of any MCP tool.
 </task>
 
-<skills>
-Specialized analysis skills are available. To activate a skill, read its SKILL.md file:
-```
-Read("skills/{skill_name}/SKILL.md")
-```
-
-Activate the relevant skill as your first action when the task matches:
-
-| Skill | Use when |
-|-------|----------|
-| `dcf-model` | Building DCF valuation models |
-| `comps-analysis` | Comparable company analysis |
-| `3-statements` | Integrated financial model (IS/BS/CF) |
-| `earnings-analysis` | Post-earnings update report |
-| `earnings-preview` | Pre-earnings setup note |
-| `initiating-coverage` | Full equity research initiation |
-| `sector-overview` | Industry landscape report |
-| `competitive-analysis` | Competitive positioning analysis |
-| `idea-generation` | Stock screening and idea sourcing |
-| `model-update` | Updating existing financial models |
-| `check-model` | Auditing financial models for errors |
-| `catalyst-calendar` | Building catalyst calendars |
-| `morning-note` | Daily pre-market briefing |
-| `thesis-tracker` | Investment thesis scorecard |
-
-If the task clearly maps to a skill, activate it immediately. If not, proceed with general analysis methodology.
-</skills>
-
 <methodology>
 - **Source all data** — cite where every number comes from (MCP tool, web search, filing)
 - **Cross-check key figures** — verify critical numbers against a second source when possible
@@ -43,7 +15,7 @@ If the task clearly maps to a skill, activate it immediately. If not, proceed wi
 <guidelines>
 - Maximum {{ max_iterations | default(15) }} tool call iterations
 - Use `WebSearch` for qualitative context: news, management commentary, industry trends
-- Use `ExecuteCode` with MCP tools for quantitative analysis: financial data, modeling, charting
+- Use MCP tools via Python for quantitative analysis (financial data, modeling, charting). Substantial model builds (DCF, comps, 3-statement) belong in a saved `.py` script under `work/<task_name>/` run via `Bash` so you can iterate via `Edit`; quick lookups can go inline via `ExecuteCode`.
 - Create charts for key findings — trends, comparisons, valuations
 </guidelines>
 

--- a/src/ptc_agent/agent/prompts/templates/subagents/roles/report_builder.md.j2
+++ b/src/ptc_agent/agent/prompts/templates/subagents/roles/report_builder.md.j2
@@ -4,22 +4,6 @@ Act as a document production specialist tasked with creating polished deliverabl
 Assemble professional documents from provided analysis, data, and files. Produce publication-ready output in the requested format (DOCX, XLSX, PPTX, or PDF).
 </task>
 
-<skills>
-Document format skills provide detailed formatting standards and tooling guides. **Activate the relevant skill as your first action** by reading its SKILL.md:
-```
-Read("skills/{skill_name}/SKILL.md")
-```
-
-| Skill | Format | Use when |
-|-------|--------|----------|
-| `xlsx` | Excel | Spreadsheets, financial models, data tables |
-| `docx` | Word | Research reports, memos, written deliverables |
-| `pptx` | PowerPoint | Presentations, pitch decks, slide materials |
-| `pdf` | PDF | PDF creation, merging, form filling, extraction |
-
-If the task requires multiple formats (e.g., a report with an Excel appendix), activate each relevant skill.
-</skills>
-
 <workflow>
 1. **Verify inputs** — read all referenced files and data to confirm everything needed is available
 2. **Activate format skill** — read the SKILL.md for the target format(s)


### PR DESCRIPTION
## Summary
**Prompt / subagent templates**
- `tool_guide.md.j2` — add *Inline vs. file-based execution* section. `ExecuteCode` = one-shots; `Write` a `.py` under `work/<task_name>/` + `Bash` = long, iterative, or reusable code. Relabel "MCP Tools (via ExecuteCode)" → "MCP Tools (via Python)".
- `data_prep.md.j2` — multi-ticker pipelines go in `work/<task_name>/fetch.py`.
- `equity_analyst.md.j2` — substantial models (DCF, comps, 3-statement) belong in saved `.py` scripts; drop the inline `<skills>` activation table (duplicative with tool guide).
- `report_builder.md.j2` — drop the inline `<skills>` activation table for the same reason.

**Skill guides**
- `dcf-model`, `inline-widget`, `web-scraping`, `xlsx` — each gets a short "execution pattern" paragraph pointing at file-based Python for iterative builds (formulas, styling loops, scrapers, chart data pipelines).

Net: 33 insertions / 59 deletions across 8 files. Pure prompt/docs — no runtime behavior change.

## Why
Agents were defaulting to resubmitting large openpyxl/pandas/scrapling blocks inline on every iteration. For anything you tweak more than once, `Edit`+rerun of a saved script is dramatically cheaper and less error-prone than regenerating the whole code block. This codifies that in the places where it matters (tool guide, skills you actually use for modeling work).

## Verification
- `scripts/utils/render_prompt.py --mode ptc` renders cleanly (25,174 chars).
- `scripts/utils/render_prompt.py --subagent {data-prep,equity-analyst,report-builder}` all render cleanly.
- `grep -rn "<skills>" src/ tests/` — no stale references to the removed blocks.

## Test plan
- [x] Templates render without Jinja errors
- [x] No code references the removed `<skills>` activation sections
- [ ] Spot-check an equity analysis run post-merge to confirm the subagent still activates skills via the tool guide flow