### PR TITLE
fix(chat): graceful recovery from stale model preferences

### DIFF
--- a/src/server/handlers/chat/llm_config.py
+++ b/src/server/handlers/chat/llm_config.py
@@ -8,6 +8,7 @@ lookups.
 from __future__ import annotations
 
 from enum import StrEnum
+from typing import NoReturn
 
 from ._common import logger
 
@@ -174,7 +175,9 @@ async def _cleanup_stale_model_preferences(user_id: str) -> list[tuple[str, str]
             or mc.get_model_config(name) is not None
         )
 
-    updates: dict = {}
+    # Values: ``None`` for scalar deletes, ``list[str]`` (or ``None``) for
+    # fallback_models. Merge-upsert interprets ``None`` as key deletion.
+    updates: dict[str, list[str] | None] = {}
     removed: list[tuple[str, str]] = []
 
     for key in _MODEL_PREF_KEYS:
@@ -196,6 +199,11 @@ async def _cleanup_stale_model_preferences(user_id: str) -> list[tuple[str, str]
             updates["fallback_models"] = kept or None
 
     if updates:
+        # Residual race window: between the re-read above and this upsert, a
+        # Settings save could still land and get overwritten by our ``None``
+        # delete. Narrow (single DB read → single DB write) and self-healing
+        # (the user saves again and it sticks). Not worth a CTE or advisory
+        # lock for the size of the hole.
         await upsert_user_preferences(user_id=user_id, other_preference=updates)
         await invalidate_user_prefs_cache(user_id)
         logger.info(
@@ -207,7 +215,7 @@ async def _cleanup_stale_model_preferences(user_id: str) -> list[tuple[str, str]
 
 def _raise_model_removed(
     model_name: str, removed: list[tuple[str, str]]
-) -> None:
+) -> NoReturn:
     """Raise a 400 with a CTA banner payload when a saved model no longer resolves."""
     from fastapi import HTTPException
 
@@ -608,6 +616,11 @@ async def resolve_llm_config(
     # culprit; raise a user-facing CTA either way. YAML-default UNKNOWN
     # falls through so the downstream error surfaces the config bug.
     if source == ModelSource.UNKNOWN and not is_custom_provider:
+        # Only the five scalar keys feed ``effective_model`` — fallback_models
+        # is tried by ``_resolve_one_with_fallbacks`` on a separate path and
+        # never flows through here, so it's intentionally excluded from this
+        # attribution check (the scrub in ``_cleanup_stale_model_preferences``
+        # still filters fallback_models once it fires).
         from_pref = any(
             model_pref.get(k) == effective_model for k in _MODEL_PREF_KEYS
         )

--- a/src/server/handlers/chat/llm_config.py
+++ b/src/server/handlers/chat/llm_config.py
@@ -138,6 +138,96 @@ def _raise_byok_key_required(model_name: str) -> None:
     )
 
 
+# Preference keys that hold a single model name. Used by the stale-pref
+# scrubber when a saved model vanishes from the manifest.
+_MODEL_PREF_KEYS = (
+    "preferred_model",
+    "preferred_flash_model",
+    "fetch_model",
+    "compaction_model",
+    "summarization_model",
+)
+
+
+async def _cleanup_stale_model_preferences(user_id: str) -> list[tuple[str, str]]:
+    """Drop stale model names from the user's prefs. Returns ``[(key, name), ...]``."""
+    from src.llms.llm import LLM as LLMFactory
+    from src.server.database.user import (
+        invalidate_user_prefs_cache,
+        upsert_user_preferences,
+    )
+
+    # Bust cache + re-read so a concurrent Settings save isn't clobbered.
+    await invalidate_user_prefs_cache(user_id)
+    pref = await get_model_preference(user_id)
+
+    mc = LLMFactory.get_model_config()
+    custom_models = {cm.get("name") for cm in (pref.get("custom_models") or [])}
+    custom_providers = {cp.get("name") for cp in (pref.get("custom_providers") or [])}
+
+    def resolvable(name: str | None) -> bool:
+        if not name:
+            return True  # empty = not set; nothing to scrub
+        return (
+            name in custom_models
+            or name in custom_providers
+            or mc.get_model_config(name) is not None
+        )
+
+    updates: dict = {}
+    removed: list[tuple[str, str]] = []
+
+    for key in _MODEL_PREF_KEYS:
+        val = pref.get(key)
+        if val and not resolvable(val):
+            updates[key] = None
+            removed.append((key, val))
+
+    fallback = pref.get("fallback_models")
+    if isinstance(fallback, list):
+        kept: list[str] = []
+        for m in fallback:
+            if resolvable(m):
+                kept.append(m)
+            else:
+                removed.append(("fallback_models", m))
+        if len(kept) != len(fallback):
+            # Empty list → delete the key entirely so it doesn't linger as ``[]``
+            updates["fallback_models"] = kept or None
+
+    if updates:
+        await upsert_user_preferences(user_id=user_id, other_preference=updates)
+        await invalidate_user_prefs_cache(user_id)
+        logger.info(
+            f"[CHAT] Scrubbed stale model prefs for user={user_id}: {removed}"
+        )
+
+    return removed
+
+
+def _raise_model_removed(
+    model_name: str, removed: list[tuple[str, str]]
+) -> None:
+    """Raise a 400 with a CTA banner payload when a saved model no longer resolves."""
+    from fastapi import HTTPException
+
+    other = sorted({name for _, name in removed if name != model_name})
+    extra = f" Also cleared: {', '.join(other)}." if other else ""
+
+    raise HTTPException(
+        status_code=400,
+        detail={
+            "message": (
+                f"Model '{model_name}' is no longer available. "
+                "Your saved preference has been cleared — open Settings to pick a current model."
+                + extra
+            ),
+            "type": "model_removed",
+            "link": {"url": "/settings?tab=model", "label": "Open Settings"},
+        },
+    )
+
+
 async def resolve_byok_llm_client(
     user_id: str,
     model_name: str,
@@ -513,6 +603,21 @@ async def resolve_llm_config(
     # so the frontend can show a CTA linking to Settings.
     if (is_custom or is_custom_provider) and not is_byok:
         _raise_byok_key_required(effective_model)
+
+    # Stale-model recovery. Scrub prefs if the user's saved name is the
+    # culprit; raise a user-facing CTA either way. YAML-default UNKNOWN
+    # falls through so the downstream error surfaces the config bug.
+    if source == ModelSource.UNKNOWN and not is_custom_provider:
+        from_pref = any(
+            model_pref.get(k) == effective_model for k in _MODEL_PREF_KEYS
+        )
+        from_request = request_model == effective_model
+
+        if from_pref:
+            removed = await _cleanup_stale_model_preferences(user_id)
+            _raise_model_removed(effective_model, removed)
+        elif from_request:
+            _raise_model_removed(effective_model, [])
 
     # Thread custom model input_modalities onto config
     if custom_cm and custom_cm.get("input_modalities"):

--- a/tests/unit/server/handlers/test_resolve_llm_config.py
+++ b/tests/unit/server/handlers/test_resolve_llm_config.py
@@ -1079,3 +1079,298 @@ class TestClassifyModelDedup:
         assert classify_mock.await_count == 3
         called_names = [call.args[1] for call in classify_mock.await_args_list]
         assert set(called_names) == {"system-default-model", "fb-a", "fb-b"}
+
+
+# ---------------------------------------------------------------------------
+# Stale-preference recovery: saved model vanished from the manifest
+# ---------------------------------------------------------------------------
+
+
+class TestStaleModelPreference:
+    @pytest.mark.asyncio
+    async def test_stale_preferred_model_scrubs_pref_and_raises(self, base_config):
+        """Saved preferred_model no longer in manifest → scrub pref + raise
+        model_removed CTA. Next request won't re-hit the same wall."""
+        from fastapi import HTTPException
+
+        from src.server.handlers.chat.llm_config import resolve_llm_config
+
+        mock_mc = _mock_model_config(
+            system_models={"system-default-model", "system-flash-model"}
+        )
+        pref = {"preferred_model": "qwen3.5-flash"}
+
+        with (
+            patch(
+                f"{HANDLER}.get_model_preference",
+                new_callable=AsyncMock,
+                return_value=pref,
+            ),
+            patch(
+                f"{HANDLER}.get_custom_model_config",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                f"{HANDLER}.get_custom_provider_config",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch("src.llms.llm.LLM.get_model_config", return_value=mock_mc),
+            patch(
+                "src.server.database.user.upsert_user_preferences",
+                new_callable=AsyncMock,
+            ) as mock_upsert,
+            patch(
+                "src.server.database.user.invalidate_user_prefs_cache",
+                new_callable=AsyncMock,
+            ) as mock_invalidate,
+        ):
+            with pytest.raises(HTTPException) as excinfo:
+                await resolve_llm_config(base_config, "user-1", None, False)
+
+        detail = excinfo.value.detail
+        assert isinstance(detail, dict)
+        assert detail.get("type") == "model_removed"
+        assert "qwen3.5-flash" in detail.get("message", "")
+        assert detail.get("link", {}).get("url")
+
+        # Pref was scrubbed: preferred_model deleted via None value
+        mock_upsert.assert_awaited_once()
+        kwargs = mock_upsert.await_args.kwargs
+        assert kwargs["user_id"] == "user-1"
+        assert kwargs["other_preference"] == {"preferred_model": None}
+        # Cache is invalidated twice: once to bust stale cache before the
+        # race-safe re-read, once after the write lands.
+        assert mock_invalidate.await_count == 2
+        for call in mock_invalidate.await_args_list:
+            assert call.args == ("user-1",)
+
+    @pytest.mark.asyncio
+    async def test_stale_pref_bulk_scrubs_fallback_list(self, base_config):
+        """When the main model is stale, scrub every stale entry in one DB
+        write — fallback_models included — so the user doesn't hit cascading
+        errors on subsequent requests."""
+        from fastapi import HTTPException
+
+        from src.server.handlers.chat.llm_config import resolve_llm_config
+
+        mock_mc = _mock_model_config(
+            system_models={"system-default-model", "system-flash-model", "good-model"}
+        )
+        pref = {
+            "preferred_model": "qwen3.5-flash",
+            "fetch_model": "gone-too",
+            "fallback_models": ["good-model", "also-gone", "qwen3.5-flash"],
+        }
+
+        with (
+            patch(
+                f"{HANDLER}.get_model_preference",
+                new_callable=AsyncMock,
+                return_value=pref,
+            ),
+            patch(
+                f"{HANDLER}.get_custom_model_config",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                f"{HANDLER}.get_custom_provider_config",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch("src.llms.llm.LLM.get_model_config", return_value=mock_mc),
+            patch(
+                "src.server.database.user.upsert_user_preferences",
+                new_callable=AsyncMock,
+            ) as mock_upsert,
+            patch(
+                "src.server.database.user.invalidate_user_prefs_cache",
+                new_callable=AsyncMock,
+            ),
+        ):
+            with pytest.raises(HTTPException):
+                await resolve_llm_config(base_config, "user-1", None, False)
+
+        written = mock_upsert.await_args.kwargs["other_preference"]
+        # Stale scalars deleted, fallback list filtered down to only "good-model"
+        assert written["preferred_model"] is None
+        assert written["fetch_model"] is None
+        assert written["fallback_models"] == ["good-model"]
+
+    @pytest.mark.asyncio
+    async def test_stale_request_model_raises_without_scrub(self, base_config):
+        """Frontend sent a stale model name as request_model (e.g. its
+        React Query cache still held the pre-scrub value). Raise
+        model_removed so the UI shows the CTA banner, but don't scrub the
+        saved prefs — there's nothing in them to clean."""
+        from fastapi import HTTPException
+
+        from src.server.handlers.chat.llm_config import resolve_llm_config
+
+        mock_mc = _mock_model_config(
+            system_models={"system-default-model", "system-flash-model"}
+        )
+        # Prefs already clean from a prior scrub pass
+        pref = {}
+
+        with (
+            patch(
+                f"{HANDLER}.get_model_preference",
+                new_callable=AsyncMock,
+                return_value=pref,
+            ),
+            patch(
+                f"{HANDLER}.get_custom_model_config",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                f"{HANDLER}.get_custom_provider_config",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch("src.llms.llm.LLM.get_model_config", return_value=mock_mc),
+            patch(
+                "src.server.database.user.upsert_user_preferences",
+                new_callable=AsyncMock,
+            ) as mock_upsert,
+        ):
+            with pytest.raises(HTTPException) as excinfo:
+                await resolve_llm_config(
+                    base_config, "user-1", "qwen3.5-flash", False
+                )
+
+        detail = excinfo.value.detail
+        assert detail.get("type") == "model_removed"
+        assert "qwen3.5-flash" in detail.get("message", "")
+        # No DB write — prefs are already clean, request_model has no pref to scrub
+        mock_upsert.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_yaml_default_stale_does_not_raise_model_removed(
+        self, base_config
+    ):
+        """If effective_model came from agent_config.yaml (not user pref),
+        fall through so the downstream error path surfaces the server bug —
+        raising model_removed would mislead every user on the instance."""
+        from src.server.handlers.chat.llm_config import resolve_llm_config
+
+        # YAML default is a model the mock_mc doesn't know about → UNKNOWN,
+        # but no user pref references it, so cleanup shouldn't flag it as
+        # "from pref" and shouldn't raise model_removed.
+        stale_yaml_config = _make_config(name="stale-yaml-default")
+        mock_mc = _mock_model_config(system_models={"system-flash-model"})
+
+        with (
+            patch(
+                f"{HANDLER}.get_model_preference",
+                new_callable=AsyncMock,
+                return_value={},
+            ),
+            patch(
+                f"{HANDLER}.get_custom_model_config",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                f"{HANDLER}.get_custom_provider_config",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                f"{HANDLER}.resolve_oauth_llm_client",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch("src.llms.llm.LLM.get_model_config", return_value=mock_mc),
+            patch(
+                "src.server.database.user.upsert_user_preferences",
+                new_callable=AsyncMock,
+            ) as mock_upsert,
+            patch(
+                "src.server.database.user.invalidate_user_prefs_cache",
+                new_callable=AsyncMock,
+            ),
+        ):
+            # Should NOT raise model_removed — falls through to normal resolution
+            result = await resolve_llm_config(
+                stale_yaml_config, "user-1", None, False
+            )
+
+        # No pref changes were written because no stale pref values existed
+        mock_upsert.assert_not_awaited()
+        # Config returned without an injected client — downstream will raise
+        # the original ValueError so the admin can fix agent_config.yaml
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_concurrent_save_is_not_clobbered(self, base_config):
+        """Race guard: the caller's pref snapshot says preferred_model is
+        stale, but between the snapshot read and the scrub write, the user
+        clicked Save in Settings and wrote a fresh valid value. The scrub
+        must NOT overwrite the fresh save — it re-reads the DB after busting
+        the cache and skips keys whose current value differs from the stale
+        name it originally detected."""
+        from fastapi import HTTPException
+
+        from src.server.handlers.chat.llm_config import resolve_llm_config
+
+        mock_mc = _mock_model_config(
+            system_models={"system-default-model", "system-flash-model", "freshly-saved"}
+        )
+        # Caller's snapshot: stale preferred_model
+        snapshot_pref = {"preferred_model": "qwen3.5-flash"}
+        # DB after the user's concurrent Save landed: new valid value
+        fresh_pref = {"preferred_model": "freshly-saved"}
+
+        call_count = {"n": 0}
+
+        async def prefs_sequence(_user_id):
+            """First call returns the stale snapshot (seen by resolve_llm_config).
+            Second call (inside the scrub after cache-bust) returns the
+            post-save fresh state."""
+            call_count["n"] += 1
+            return snapshot_pref if call_count["n"] == 1 else fresh_pref
+
+        with (
+            patch(
+                f"{HANDLER}.get_model_preference",
+                new=prefs_sequence,
+            ),
+            patch(
+                f"{HANDLER}.get_custom_model_config",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                f"{HANDLER}.get_custom_provider_config",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch("src.llms.llm.LLM.get_model_config", return_value=mock_mc),
+            patch(
+                "src.server.database.user.upsert_user_preferences",
+                new_callable=AsyncMock,
+            ) as mock_upsert,
+            patch(
+                "src.server.database.user.invalidate_user_prefs_cache",
+                new_callable=AsyncMock,
+            ) as mock_invalidate,
+        ):
+            with pytest.raises(HTTPException) as excinfo:
+                await resolve_llm_config(base_config, "user-1", None, False)
+
+        # Still raises model_removed for THIS request (its model is unusable)
+        detail = excinfo.value.detail
+        assert detail.get("type") == "model_removed"
+
+        # The cache gets busted so the re-read hits Postgres, but since the
+        # fresh DB value no longer matches the stale snapshot name, NO
+        # delete is queued and NO write happens. The user's just-saved
+        # "freshly-saved" pref survives.
+        mock_upsert.assert_not_awaited()
+        # Cache was invalidated once (pre-read), never a second time because
+        # no write happened.
+        assert mock_invalidate.await_count == 1

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -16,6 +16,8 @@
 import type React from 'react';
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '@/lib/queryKeys';
 import { useUser } from '@/hooks/useUser';
 import { sendChatMessageStream, replayThreadHistory, getWorkflowStatus, reconnectToWorkflowStream, sendHitlResponse, streamSubagentTaskEvents, fetchThreadTurns, submitFeedback, removeFeedback, getThreadFeedback, watchThread } from '../utils/api';
 import { buildRateLimitError, isUpstreamHint, type StructuredError } from '@/utils/rateLimitError';
@@ -495,6 +497,7 @@ export function useChatMessages(
   onWorkspaceCreated: ((info: { workspaceId: string; question: string }) => void) | null = null,
 ) {
   const { t } = useTranslation();
+  const queryClient = useQueryClient();
 
   // User locale/timezone — prefer saved preference, fall back to browser detection
   const { user } = useUser();
@@ -3699,6 +3702,14 @@ export function useChatMessages(
             // to send message" bubble under the banner looks broken.
             const errorInfo = errObj.errorInfo as Record<string, unknown> | undefined;
             if (errorInfo?.link) {
+              // Backend scrubbed stale model names from the user's saved
+              // preferences — invalidate our cached copy so the selector and
+              // Settings page re-render with the server's (cleaned) state.
+              // Without this, the frontend keeps sending the removed model
+              // name as request_model on every retry.
+              if (errorInfo.type === 'model_removed') {
+                queryClient.invalidateQueries({ queryKey: queryKeys.user.preferences() });
+              }
               setMessageError({
                 message: (errorInfo.message as string) || (err as Error).message || 'An error occurred.',
                 link: errorInfo.link as { url: string; label: string },


### PR DESCRIPTION
## Summary

When a model is removed from the manifest but a user still has it saved as a preference, the app now recovers gracefully instead of failing with a bare "Model not in models.json" error.

**Backend** (`src/server/handlers/chat/llm_config.py`):
- New `_cleanup_stale_model_preferences(user_id)` scrubs every stale entry in a single merge upsert (the five scalar prefs + `fallback_models`). Race-safe: busts the Redis cache and re-reads from Postgres before writing so a concurrent Settings save can't be clobbered.
- Hook in `resolve_llm_config` distinguishes two sources of stale `UNKNOWN` models: saved pref (scrub + raise) and `request_model` (raise only, prefs are already clean). YAML-default stale names fall through so admins see the original config error.
- `_raise_model_removed` returns a 400 with `type: "model_removed"` and a `/settings?tab=model` CTA link matching the existing `byok_key_required` / `oauth_required` error shape.

**Frontend** (`web/src/pages/ChatAgent/hooks/useChatMessages.ts`):
- On `errorInfo.type === 'model_removed'`, invalidate `queryKeys.user.preferences()` so the selector and Settings page re-render with the server-cleaned state. Without this, the next send round-trips the removed model name as `request_model` again.

## Test Coverage

New `TestStaleModelPreference` class in `tests/unit/server/handlers/test_resolve_llm_config.py` (5 tests):

- `test_stale_preferred_model_scrubs_pref_and_raises` — the happy path: stale `preferred_model` → DELETE + `model_removed` banner, cache invalidated pre-read and post-write.
- `test_stale_pref_bulk_scrubs_fallback_list` — a stale scalar triggers a bulk scrub that also filters `fallback_models` down to the still-valid entries in the same upsert.
- `test_stale_request_model_raises_without_scrub` — frontend sends a stale `request_model` while prefs are already clean → raise banner, no DB write.
- `test_yaml_default_stale_does_not_raise_model_removed` — stale YAML default with empty prefs falls through to the normal resolution path so the original config error surfaces.
- `test_concurrent_save_is_not_clobbered` — regression guard: caller's snapshot says stale, but a concurrent Settings save landed a fresh valid value; the scrub re-reads and skips the delete.

All 42 `test_resolve_llm_config.py` tests pass. `ruff check` clean on `llm_config.py`.

## Pre-Landing Review

`/review` ran clean on this diff. One concurrent-save race was found and fixed (the `test_concurrent_save_is_not_clobbered` regression test covers it). A second concern about `insight_service.py:229` silently scrubbing stale prefs from the background insight path was considered and left as-is — the behavior is arguably correct (stale prefs should get cleaned regardless of entry point).

## Test plan
- [x] Backend unit tests pass (42 tests, 0 failures)
- [x] Frontend hook tests pass (60 tests in `web/src/pages/ChatAgent/hooks`)
- [x] Lint clean (ruff on `llm_config.py`)
- [ ] Manual E2E: seed stale prefs, send a chat → banner renders with "Also cleared" message → click CTA → Settings shows scrubbed state → next send succeeds