### PR TITLE
feat(manifest): add qwen3.6-max-preview, kimi-k2.6, GPT-5.4 dated aliases

### DIFF
--- a/src/llms/manifest/models.json
+++ b/src/llms/manifest/models.json
@@ -507,6 +507,17 @@
       "text"
     ]
   },
+  "qwen3.6-max-preview": {
+    "model_id": "qwen3.6-max-preview",
+    "provider": "dashscope",
+    "visible": true,
+    "input_modalities": [
+      "text"
+    ],
+    "extra_body": {
+      "enable_thinking": true
+    }
+  },
   "qwen3.6-plus": {
     "model_id": "qwen3.6-plus",
     "provider": "dashscope",
@@ -552,6 +563,17 @@
       "text",
       "image",
       "pdf"
+    ],
+    "extra_body": {
+      "enable_thinking": true
+    }
+  },
+  "qwen3.6-max-preview-intl": {
+    "model_id": "qwen3.6-max-preview",
+    "provider": "dashscope-intl",
+    "visible": true,
+    "input_modalities": [
+      "text"
     ],
     "extra_body": {
       "enable_thinking": true
@@ -643,6 +665,34 @@
     ],
     "extra_body": {
       "enable_thinking": true
+    }
+  },
+  "kimi-k2.6": {
+    "model_id": "kimi-k2.6",
+    "provider": "moonshot",
+    "visible": true,
+    "input_modalities": [
+      "text",
+      "image"
+    ],
+    "parameters": {
+      "thinking": {
+        "type": "enabled"
+      }
+    }
+  },
+  "kimi-k2.6-coding": {
+    "model_id": "kimi-k2.6",
+    "provider": "moonshot-coding",
+    "visible": true,
+    "input_modalities": [
+      "text",
+      "image"
+    ],
+    "parameters": {
+      "thinking": {
+        "type": "enabled"
+      }
     }
   },
   "kimi-k2.5": {

--- a/src/llms/manifest/providers.json
+++ b/src/llms/manifest/providers.json
@@ -45,6 +45,9 @@
         "name": "GPT-5.4 Mini",
         "is_reasoning": true,
         "description": "OpenAI's strongest mini model for coding, computer use, and subagents",
+        "alias": [
+          "gpt-5.4-mini-2026-03-17"
+        ],
         "context_window": 400000,
         "max_output": 128000,
         "pricing": {
@@ -59,6 +62,9 @@
         "name": "GPT-5.4 Nano",
         "is_reasoning": true,
         "description": "OpenAI's cheapest GPT-5.4-class model for simple high-volume tasks",
+        "alias": [
+          "gpt-5.4-nano-2026-03-17"
+        ],
         "context_window": 400000,
         "max_output": 128000,
         "pricing": {
@@ -73,6 +79,9 @@
         "name": "GPT-5.4",
         "is_reasoning": true,
         "description": "OpenAI's latest and most capable reasoning model with tiered pricing",
+        "alias": [
+          "gpt-5.4-2026-03-05"
+        ],
         "pricing": {
           "input_tiers": [
             {
@@ -650,6 +659,40 @@
     ],
     "dashscope": [
       {
+        "id": "qwen3.6-max-preview",
+        "name": "Qwen3.6 Max Preview",
+        "is_reasoning": true,
+        "description": "Alibaba's largest and most capable Qwen3.6 Max Preview — improved vibe coding, coding agent execution, and frontend development",
+        "context_window": 262144,
+        "max_output": 65536,
+        "pricing": {
+          "input_tiers": [
+            {
+              "max_tokens": 128000,
+              "rate": 1.291,
+              "cached_input": 0.129
+            },
+            {
+              "max_tokens": 256000,
+              "rate": 2.152,
+              "cached_input": 0.215
+            }
+          ],
+          "output_tiers": [
+            {
+              "max_tokens": 128000,
+              "rate": 7.747
+            },
+            {
+              "max_tokens": 256000,
+              "rate": 12.912
+            }
+          ],
+          "output_pricing_mode": "input_dependent",
+          "unit": "per_1m_tokens"
+        }
+      },
+      {
         "id": "qwen3.6-plus",
         "name": "Qwen3.6 Plus",
         "is_reasoning": true,
@@ -891,6 +934,40 @@
     ],
     "dashscope-intl": [
       {
+        "id": "qwen3.6-max-preview",
+        "name": "Qwen3.6 Max Preview (SG)",
+        "is_reasoning": true,
+        "description": "Alibaba's Qwen3.6 Max Preview — Singapore international region",
+        "context_window": 262144,
+        "max_output": 65536,
+        "pricing": {
+          "input_tiers": [
+            {
+              "max_tokens": 128000,
+              "rate": 1.398,
+              "cached_input": 0.140
+            },
+            {
+              "max_tokens": 256000,
+              "rate": 2.150,
+              "cached_input": 0.215
+            }
+          ],
+          "output_tiers": [
+            {
+              "max_tokens": 128000,
+              "rate": 8.387
+            },
+            {
+              "max_tokens": 256000,
+              "rate": 12.902
+            }
+          ],
+          "output_pricing_mode": "input_dependent",
+          "unit": "per_1m_tokens"
+        }
+      },
+      {
         "id": "qwen3.6-plus",
         "name": "Qwen3.6 Plus (SG)",
         "is_reasoning": true,
@@ -1037,6 +1114,19 @@
     ],
     "moonshot": [
       {
+        "id": "kimi-k2.6",
+        "name": "Kimi K2.6",
+        "is_reasoning": true,
+        "description": "Moonshot AI's Kimi K2.6 multi-modal model with extended context",
+        "context_window": 262144,
+        "pricing": {
+          "input": 0.95,
+          "cached_input": 0.16,
+          "output": 4.0,
+          "unit": "per_1m_tokens"
+        }
+      },
+      {
         "id": "kimi-k2.5",
         "name": "Kimi K2.5",
         "is_reasoning": true,
@@ -1061,6 +1151,19 @@
           "input": 0.6,
           "cached_input": 0.1,
           "output": 3.0,
+          "unit": "per_1m_tokens"
+        }
+      },
+      {
+        "id": "kimi-k2.6",
+        "name": "Kimi K2.6",
+        "is_reasoning": true,
+        "description": "Moonshot AI's Kimi K2.6 multi-modal model with extended context",
+        "context_window": 262144,
+        "pricing": {
+          "input": 0.95,
+          "cached_input": 0.16,
+          "output": 4.0,
           "unit": "per_1m_tokens"
         }
       },


### PR DESCRIPTION
## Summary

Pure manifest additions — no Python/TypeScript code changes.

### New models

**qwen3.6-max-preview** (Alibaba Qwen family, latest flagship)
- Registered as `qwen3.6-max-preview` (dashscope, mainland) and `qwen3.6-max-preview-intl` (dashscope-intl, Singapore region) in `models.json`
- Text-only, 262k context, 64k max output, thinking enabled
- Tiered input/output pricing under both dashscope and dashscope-intl variants (≤128k tier vs ≤256k tier, output priced by input tier)

**kimi-k2.6** (Moonshot)
- Registered as `kimi-k2.6` (moonshot) and `kimi-k2.6-coding` (moonshot-coding)
- Multi-modal (text + image), 262k context, thinking enabled
- Flat pricing on both plans: \$0.95 input / \$0.16 cached / \$4.00 output per 1M tokens

### OAuth dated aliases

Added `alias` arrays on `gpt-5.4-mini`, `gpt-5.4-nano`, and `gpt-5.4` in `providers.json` so the dated model IDs the OpenAI API returns (`gpt-5.4-mini-2026-03-17`, `gpt-5.4-nano-2026-03-17`, `gpt-5.4-2026-03-05`) resolve to pricing instead of hitting the `No exact match` log fallback.

## Verification

- JSON validates (`python3 -c "import json; json.load(...)"`) for both files.
- `LLM.get_model_config()` resolves all 4 new entries to their declared providers.
- `find_model_pricing()` returns pricing for all 4 entries **and** all 3 dated OAuth aliases.

## Test plan
- [x] JSON syntax valid for both manifest files
- [x] `get_model_config` resolves new entries
- [x] `find_model_pricing` resolves new entries + dated aliases
- [ ] Manual: select qwen3.6-max-preview / kimi-k2.6 / kimi-k2.6-coding from the model picker, send a message, confirm response streams and billing records accumulate