### PR TITLE
feat(manifest): add GPT-5.5 (coming soon)

### DIFF
--- a/src/llms/manifest/models.json
+++ b/src/llms/manifest/models.json
@@ -1,4 +1,21 @@
 {
+  "gpt-5.5": {
+    "model_id": "gpt-5.5",
+    "provider": "openai",
+    "display_name": "GPT-5.5",
+    "visible": true,
+    "input_modalities": [
+      "text",
+      "image",
+      "pdf"
+    ],
+    "parameters": {
+      "reasoning": {
+        "effort": "medium",
+        "summary": "auto"
+      }
+    }
+  },
   "gpt-5.4": {
     "model_id": "gpt-5.4",
     "provider": "openai",
@@ -745,6 +762,26 @@
   },
   "gpt-5.3-codex-spark-oauth": {
     "model_id": "gpt-5.3-codex-spark",
+    "provider": "codex-oauth",
+    "visible": true,
+    "input_modalities": [
+      "text",
+      "image",
+      "pdf"
+    ],
+    "parameters": {
+      "reasoning": {
+        "effort": "medium",
+        "summary": "auto"
+      },
+      "include": [
+        "reasoning.encrypted_content"
+      ],
+      "store": false
+    }
+  },
+  "gpt-5.5-oauth": {
+    "model_id": "gpt-5.5",
     "provider": "codex-oauth",
     "visible": true,
     "input_modalities": [

--- a/src/llms/manifest/providers.json
+++ b/src/llms/manifest/providers.json
@@ -41,6 +41,18 @@
   "models": {
     "openai": [
       {
+        "id": "gpt-5.5",
+        "name": "GPT-5.5",
+        "is_reasoning": true,
+        "description": "OpenAI's GPT-5.5 — a new class of intelligence for coding and professional work (coming soon)",
+        "pricing": {
+          "input": 5.0,
+          "cached_input": 0.5,
+          "output": 30.0,
+          "unit": "per_1m_tokens"
+        }
+      },
+      {
         "id": "gpt-5.4-mini",
         "name": "GPT-5.4 Mini",
         "is_reasoning": true,


### PR DESCRIPTION
## Summary

Adds GPT-5.5 to both OpenAI API and Codex OAuth routes so the model is wired up and ready when OpenAI flips the switch.

**models.json**
- `gpt-5.5` → provider `openai`
- `gpt-5.5-oauth` → provider `codex-oauth`

Both use the same reasoning params as the other GPT-5.x entries (`effort: medium`, `summary: auto`).

**providers.json** — flat pricing (per 1M tokens):
- Input: \$5.00
- Cached input: \$0.50
- Output: \$30.00

## Heads up

The model is "coming soon" per OpenAI's announcement, so calls will 404 until launch. Both entries are `visible: true` to match the convention used for other preview entries (e.g. qwen3.6-max-preview). Flip to `false` if we'd rather hide it from the UI until launch.

## Test plan

- [x] `uv run pytest tests/unit/llms/ tests/unit/config/test_agent_config.py` — 421 passed (manifest integrity, provider resolution, input modalities, pricing/tier validation)