### PR TITLE
feat(dashboard): TradingView widget framework + 17 widgets + native MiniChartGrid

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,6 +13,7 @@ import './App.css';
 
 const SetupWizard = React.lazy(() => import('./pages/Setup/SetupWizard'));
 const PrivacyPolicy = React.lazy(() => import('./pages/Legal/PrivacyPolicy'));
+const Legal = React.lazy(() => import('./pages/Legal/Legal'));
 
 /** Handles the OAuth redirect from Supabase — shows a spinner then redirects to /dashboard. */
 function AuthCallback() {
@@ -111,6 +112,15 @@ function App() {
           </div>
         }>
           <PrivacyPolicy />
+        </Suspense>
+      } />
+      <Route path="/legal" element={
+        <Suspense fallback={
+          <div className="flex items-center justify-center min-h-screen" style={{ backgroundColor: 'var(--color-bg-page)' }}>
+            <p className="text-sm" style={{ color: 'var(--color-text-secondary)' }}>{t('common.loading')}</p>
+          </div>
+        }>
+          <Legal />
         </Suspense>
       } />
       <Route path="/setup/*" element={

--- a/web/src/pages/Dashboard/DashboardCustom.tsx
+++ b/web/src/pages/Dashboard/DashboardCustom.tsx
@@ -37,11 +37,12 @@ function CustomInner({ mode, onModeChange }: DashboardCustomProps) {
   const [settingsFor, setSettingsFor] = useState<string | null>(null);
   const mainRef = useRef<HTMLElement>(null);
 
+  const ctx = useDashboardContext();
   const {
     portfolio,
     watchlist,
     modals,
-  } = useDashboardContext();
+  } = ctx;
 
   const handleScrollToTop = useCallback(() => {
     mainRef.current?.scrollTo({ top: 0, behavior: 'smooth' });
@@ -59,10 +60,16 @@ function CustomInner({ mode, onModeChange }: DashboardCustomProps) {
     (type: string) => {
       const def = getWidget(type);
       if (!def) return;
+      // Prefer the widget's context-aware initConfig factory when present so
+      // e.g. a new TickerTape can default to the user's watchlist symbols.
+      // Falls back to shallow-copying the static defaultConfig otherwise.
+      const initialConfig = def.initConfig
+        ? def.initConfig(ctx)
+        : { ...(def.defaultConfig as object) };
       const newInstance: WidgetInstance = {
         id: newWidgetId(),
         type,
-        config: { ...(def.defaultConfig as object) },
+        config: initialConfig,
       };
       update((prev: DashboardPrefs) => {
         if (def.singleton && prev.widgets.some((w) => w.type === type)) return prev;
@@ -70,7 +77,7 @@ function CustomInner({ mode, onModeChange }: DashboardCustomProps) {
         return { ...prev, widgets: [...prev.widgets, newInstance], layouts };
       });
     },
-    [update]
+    [update, ctx]
   );
 
   const handleGridChange = useCallback(
@@ -179,9 +186,12 @@ function CustomInner({ mode, onModeChange }: DashboardCustomProps) {
       <ConfirmDialog
         open={resetConfirmOpen}
         title="Reset to Morning Brief?"
-        message="This replaces your current widgets and layout with the default preset. Your previous layout will be saved to history and can be restored from Presets."
+        message="This replaces your current widgets and layout with the default preset. This action can't be undone."
         confirmLabel="Reset layout"
-        onConfirm={resetToDefault}
+        onConfirm={() => {
+          setSettingsFor(null);
+          resetToDefault();
+        }}
         onOpenChange={setResetConfirmOpen}
       />
 
@@ -197,7 +207,15 @@ function CustomInner({ mode, onModeChange }: DashboardCustomProps) {
       <PresetsDialog
         open={presetsOpen}
         onOpenChange={setPresetsOpen}
-        onApply={(id: PresetId) => applyPreset(id)}
+        onApply={(id: PresetId) => {
+          // Closing settings before swapping the widget set prevents the
+          // settings dialog from referencing a stale id after the preset
+          // replaces `prefs.widgets` (which would silently unmount the
+          // dialog mid-edit). Same protection applies to the reset path —
+          // resetToDefault calls applyPreset under the hood.
+          setSettingsFor(null);
+          applyPreset(id);
+        }}
       />
 
       {/* Widget settings */}

--- a/web/src/pages/Dashboard/DashboardRouter.tsx
+++ b/web/src/pages/Dashboard/DashboardRouter.tsx
@@ -31,14 +31,18 @@ export default function DashboardRouter() {
   const onModeChange = useCallback(
     (next: 'classic' | 'custom') => {
       const prevOther = (rawOther ?? {}) as Record<string, unknown>;
-      const prevDashboard = (prevOther.dashboard ?? {}) as Partial<DashboardPrefs>;
-      const firstFlipToCustom = next === 'custom' && (!prevDashboard.widgets || prevDashboard.widgets.length === 0);
+      // Spread the migrated/normalized form (parsed) instead of the raw
+      // stored blob so malformed legacy keys can't round-trip back into
+      // the write. parsed comes from migrateDashboardPrefs which coerces
+      // bad widgets/layouts/history values into safe defaults.
+      const baseDashboard = parsed ?? ({} as Partial<DashboardPrefs>);
+      const firstFlipToCustom = next === 'custom' && (!baseDashboard.widgets || baseDashboard.widgets.length === 0);
       const seed = firstFlipToCustom ? getPreset('morning-brief') : null;
       updatePrefs.mutate({
         other_preference: {
           ...prevOther,
           dashboard: {
-            ...prevDashboard,
+            ...baseDashboard,
             version: 1,
             mode: next,
             ...(seed ? { widgets: seed.widgets, layouts: seed.layouts } : {}),
@@ -46,7 +50,7 @@ export default function DashboardRouter() {
         },
       });
     },
-    [rawOther, updatePrefs]
+    [rawOther, parsed, updatePrefs]
   );
 
   if (isMobile) {

--- a/web/src/pages/Dashboard/widgets/definitions/ConversationWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/ConversationWidget.tsx
@@ -82,7 +82,9 @@ function ConversationWidget(_props: WidgetRenderProps<ConversationConfig>) {
 
   const { user } = useUser();
   const greeting = useMemo(() => formatGreeting(user?.name), [user?.name]);
-  const dateStrip = useMemo(() => formatDateStrip(), []);
+  // Computed per render so the strip updates if the dashboard sits open
+  // across midnight. Empty-deps memo would freeze it at mount time.
+  const dateStrip = formatDateStrip();
 
   // Recent threads for the Resume strip — peek at the first workspace.
   // Fetch 100 to match the shared React Query cache key used by useChatInput,

--- a/web/src/pages/Dashboard/widgets/definitions/MiniChartGridWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/MiniChartGridWidget.tsx
@@ -15,6 +15,11 @@ interface MiniChartGridConfig {
 }
 
 const SPARK_DAYS = 30;
+// Render-time hard cap. SymbolListField caps at 18, but prefs are
+// server-stored JSON — a corrupted or hand-edited blob with thousands of
+// symbols would fan out thousands of OHLC requests every 120s. Clamp here
+// so the render path never trusts persisted state past the UI-enforced cap.
+const MAX_SYMBOLS = 18;
 
 interface CellData {
   symbol: string;
@@ -84,7 +89,7 @@ function MiniChartGridWidget({ instance }: WidgetRenderProps<MiniChartGridConfig
   // saves allocating a throwaway array on every parent render.
   const effectiveSymbols = useMemo(() => {
     const configured = (instance.config.symbols ?? []).filter(Boolean);
-    if (configured.length > 0) return configured;
+    if (configured.length > 0) return configured.slice(0, MAX_SYMBOLS);
     const fromWatchlist = watchlist.rows.map((r) => r.symbol).filter(Boolean);
     if (fromWatchlist.length > 0) return fromWatchlist.slice(0, 12);
     return DEFAULT_BLUE_CHIPS;

--- a/web/src/pages/Dashboard/widgets/definitions/MiniChartGridWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/MiniChartGridWidget.tsx
@@ -1,0 +1,247 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Grid2x2 } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { useDashboardContext } from '../framework/DashboardDataContext';
+import { registerWidget } from '../framework/WidgetRegistry';
+import { fetchStockData } from '@/pages/MarketView/utils/api';
+import { DEFAULT_BLUE_CHIPS } from '../framework/defaults';
+import { SymbolListField } from '../framework/settings/SymbolListField';
+import { SettingsDoneButton } from '../framework/settings/SettingsDoneButton';
+import type { WidgetRenderProps, WidgetSettingsProps } from '../types';
+
+interface MiniChartGridConfig {
+  symbols: string[];
+}
+
+const SPARK_DAYS = 30;
+
+interface CellData {
+  symbol: string;
+  closes: number[];
+  last: number;
+  prev: number;
+}
+
+async function loadSpark(symbol: string): Promise<CellData | null> {
+  const now = new Date();
+  const past = new Date();
+  past.setDate(past.getDate() - SPARK_DAYS - 5); // small buffer
+  const toISO = now.toISOString().slice(0, 10);
+  const fromISO = past.toISOString().slice(0, 10);
+
+  const res = await fetchStockData(symbol, '1day', fromISO, toISO);
+  if (!res.data || res.data.length === 0) return null;
+  const tail = res.data.slice(-SPARK_DAYS);
+  const closes = tail.map((d) => d.close);
+  if (closes.length < 2) return null;
+  return {
+    symbol,
+    closes,
+    last: closes[closes.length - 1],
+    prev: closes[0],
+  };
+}
+
+function MiniSparkline({ cell }: { cell: CellData }) {
+  const w = 110;
+  const h = 34;
+  const pad = 2;
+  const { closes } = cell;
+  let min = closes[0];
+  let max = closes[0];
+  for (const c of closes) {
+    if (c < min) min = c;
+    else if (c > max) max = c;
+  }
+  const range = max - min || 1;
+  const step = (w - pad * 2) / Math.max(1, closes.length - 1);
+  const pts = closes.map((c, i) => {
+    const x = pad + i * step;
+    const y = pad + (1 - (c - min) / range) * (h - pad * 2);
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  });
+  const d = `M${pts[0]} L${pts.slice(1).join(' ')}`;
+  const lastX = pad + (closes.length - 1) * step;
+  const lastY = pad + (1 - (cell.last - min) / range) * (h - pad * 2);
+  const up = cell.last >= cell.prev;
+  const stroke = up ? 'var(--color-profit)' : 'var(--color-loss)';
+
+  return (
+    <svg width={w} height={h} viewBox={`0 0 ${w} ${h}`} aria-hidden>
+      <path d={d} fill="none" stroke={stroke} strokeWidth={1.5} strokeLinejoin="round" strokeLinecap="round" />
+      <circle cx={lastX} cy={lastY} r={2} fill={stroke} />
+    </svg>
+  );
+}
+
+function MiniChartGridWidget({ instance }: WidgetRenderProps<MiniChartGridConfig>) {
+  const navigate = useNavigate();
+  const { watchlist } = useDashboardContext();
+  // Memoized so the query key stays reference-stable on unrelated re-renders
+  // (dashboard edit-mode toggle, neighbor widget edits). React Query would
+  // cache-hit on the stringified key either way, but skipping the IIFE also
+  // saves allocating a throwaway array on every parent render.
+  const effectiveSymbols = useMemo(() => {
+    const configured = (instance.config.symbols ?? []).filter(Boolean);
+    if (configured.length > 0) return configured;
+    const fromWatchlist = watchlist.rows.map((r) => r.symbol).filter(Boolean);
+    if (fromWatchlist.length > 0) return fromWatchlist.slice(0, 12);
+    return DEFAULT_BLUE_CHIPS;
+  }, [instance.config.symbols, watchlist.rows]);
+
+  const { data, isLoading } = useQuery<CellData[]>({
+    queryKey: ['mini-chart-grid', effectiveSymbols.join(',')],
+    queryFn: async () => {
+      // allSettled so one bad symbol (5xx, timeout, throttled) doesn't block
+      // the whole grid. Failed cells silently drop out; successful cells
+      // still render. Promise.all would reject the whole batch and leave
+      // the user staring at the loading skeleton until the next refetch.
+      const results = await Promise.allSettled(effectiveSymbols.map(loadSpark));
+      const cells: CellData[] = [];
+      for (const r of results) {
+        if (r.status === 'fulfilled' && r.value) cells.push(r.value);
+      }
+      return cells;
+    },
+    staleTime: 60_000,
+    refetchInterval: 120_000,
+    refetchIntervalInBackground: false,
+  });
+
+  return (
+    <div className="dashboard-glass-card p-4 flex flex-col h-full">
+      <div
+        className="flex items-baseline justify-between mb-3 pb-2 border-b"
+        style={{ borderColor: 'var(--color-border-muted)' }}
+      >
+        <div className="flex items-baseline gap-2">
+          <Grid2x2 className="h-3.5 w-3.5 self-center" style={{ color: 'var(--color-text-tertiary)' }} />
+          <span
+            className="text-[10px] font-semibold uppercase tracking-[0.14em]"
+            style={{ color: 'var(--color-text-secondary)' }}
+          >
+            Mini Chart Grid
+          </span>
+        </div>
+        <span className="text-[11px] dashboard-mono" style={{ color: 'var(--color-text-tertiary)' }}>
+          {effectiveSymbols.length} symbols · {SPARK_DAYS}d
+        </span>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        {isLoading && !data ? (
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
+            {effectiveSymbols.slice(0, 6).map((s) => (
+              <div
+                key={s}
+                className="h-16 rounded-lg animate-pulse"
+                style={{ backgroundColor: 'var(--color-bg-subtle)' }}
+              />
+            ))}
+          </div>
+        ) : (data?.length ?? 0) === 0 ? (
+          <div
+            className="text-center py-8 text-xs"
+            style={{ color: 'var(--color-text-tertiary)' }}
+          >
+            No data available
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
+            {data!.map((cell) => {
+              const pct = ((cell.last - cell.prev) / cell.prev) * 100;
+              const up = pct >= 0;
+              return (
+                <button
+                  key={cell.symbol}
+                  type="button"
+                  onClick={() => navigate(`/market?symbol=${encodeURIComponent(cell.symbol)}`)}
+                  className="widget-drag-cancel p-2 rounded-lg border text-left transition-colors"
+                  style={{
+                    backgroundColor: 'var(--color-bg-card)',
+                    borderColor: 'var(--color-border-muted)',
+                  }}
+                  onMouseEnter={(e) => (e.currentTarget.style.borderColor = 'var(--color-border-default)')}
+                  onMouseLeave={(e) => (e.currentTarget.style.borderColor = 'var(--color-border-muted)')}
+                >
+                  <div className="flex items-center justify-between">
+                    <span
+                      className="font-bold text-xs"
+                      style={{ color: 'var(--color-text-primary)' }}
+                    >
+                      {cell.symbol}
+                    </span>
+                    <span
+                      className="text-[11px] dashboard-mono"
+                      style={{ color: up ? 'var(--color-profit)' : 'var(--color-loss)' }}
+                    >
+                      {up ? '+' : ''}{pct.toFixed(2)}%
+                    </span>
+                  </div>
+                  <div className="flex items-end justify-between mt-1">
+                    <span
+                      className="text-[11px] dashboard-mono"
+                      style={{ color: 'var(--color-text-secondary)' }}
+                    >
+                      ${cell.last.toFixed(2)}
+                    </span>
+                    <MiniSparkline cell={cell} />
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function MiniChartGridSettings({
+  config,
+  onChange,
+  onClose,
+}: WidgetSettingsProps<MiniChartGridConfig>) {
+  const { watchlist } = useDashboardContext();
+  // Mirror the render-time precedence: configured symbols > watchlist >
+  // defaults. Opening settings is side-effect-free — prefs only commit
+  // on the user's first add/remove, which captures the full displayed
+  // list as the starting edit state.
+  const displayedSymbols = (() => {
+    if (config.symbols?.length) return config.symbols;
+    const fromWatchlist = watchlist.rows.map((r) => r.symbol).filter(Boolean);
+    if (fromWatchlist.length > 0) return fromWatchlist.slice(0, 12);
+    return DEFAULT_BLUE_CHIPS;
+  })();
+  return (
+    <div className="space-y-4">
+      <SymbolListField
+        label="Symbols"
+        value={displayedSymbols}
+        onChange={(next) => onChange({ symbols: next })}
+        placeholder="Add a symbol (Enter)"
+        max={18}
+      />
+      <SettingsDoneButton onClick={onClose} />
+    </div>
+  );
+}
+
+registerWidget<MiniChartGridConfig>({
+  type: 'markets.miniChartGrid',
+  title: 'Mini Chart Grid',
+  description: 'Sparkline grid across multiple symbols — 30-day trend at a glance.',
+  category: 'markets',
+  icon: Grid2x2,
+  component: MiniChartGridWidget,
+  settingsComponent: MiniChartGridSettings,
+  defaultConfig: { symbols: [] },
+  defaultSize: { w: 12, h: 16 },
+  minSize: { w: 6, h: 10 },
+  initConfig: (ctx) => {
+    const fromWatchlist = ctx.watchlist.rows.map((r) => r.symbol).filter(Boolean);
+    if (fromWatchlist.length > 0) return { symbols: fromWatchlist.slice(0, 12) };
+    return { symbols: DEFAULT_BLUE_CHIPS };
+  },
+});

--- a/web/src/pages/Dashboard/widgets/definitions/tv/CompanyFinancialsWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/CompanyFinancialsWidget.tsx
@@ -1,0 +1,66 @@
+import { BarChart3 } from 'lucide-react';
+import { TradingViewEmbed } from '../../framework/TradingViewEmbed';
+import { registerWidget } from '../../framework/WidgetRegistry';
+import { SymbolField } from '../../framework/settings/SymbolField';
+import { EnumField } from '../../framework/settings/EnumField';
+import { TradingViewSettingsFooter } from '../../framework/TradingViewSettingsFooter';
+import { SettingsDoneButton } from '../../framework/settings/SettingsDoneButton';
+import type { WidgetRenderProps, WidgetSettingsProps } from '../../types';
+
+interface CompanyFinancialsConfig {
+  symbol: string;
+  displayMode: 'regular' | 'compact' | 'adaptive';
+}
+
+function CompanyFinancialsWidget({ instance }: WidgetRenderProps<CompanyFinancialsConfig>) {
+  return (
+    <TradingViewEmbed
+      card
+      scriptKey="financials"
+      config={{
+        symbol: instance.config.symbol,
+        displayMode: instance.config.displayMode,
+      }}
+    />
+  );
+}
+
+function CompanyFinancialsSettings({ config, onChange, onClose }: WidgetSettingsProps<CompanyFinancialsConfig>) {
+  return (
+    <div className="space-y-4">
+      <SymbolField
+        label="Symbol"
+        value={config.symbol ?? ''}
+        onChange={(v) => onChange({ symbol: v })}
+        placeholder="NASDAQ:NVDA"
+      />
+      <EnumField
+        label="Layout"
+        value={config.displayMode ?? 'regular'}
+        onChange={(v) => onChange({ displayMode: v as CompanyFinancialsConfig['displayMode'] })}
+        options={[
+          { value: 'regular', label: 'Regular' },
+          { value: 'compact', label: 'Compact' },
+          { value: 'adaptive', label: 'Adaptive' },
+        ]}
+      />
+      <TradingViewSettingsFooter />
+      <SettingsDoneButton onClick={onClose} />
+    </div>
+  );
+}
+
+registerWidget<CompanyFinancialsConfig>({
+  type: 'tv.company-financials',
+  title: 'Company Financials',
+  description: 'Fundamentals — income statement, balance sheet, cash flow, key ratios.',
+  category: 'markets',
+  icon: BarChart3,
+  component: CompanyFinancialsWidget,
+  settingsComponent: CompanyFinancialsSettings,
+  defaultConfig: { symbol: 'NASDAQ:NVDA', displayMode: 'regular' },
+  defaultSize: { w: 6, h: 24 },
+  minSize: { w: 4, h: 14 },
+  maxSize: { w: 12, h: 48 },
+  source: 'tradingview',
+});

--- a/web/src/pages/Dashboard/widgets/definitions/tv/CompanyProfileWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/CompanyProfileWidget.tsx
@@ -1,0 +1,51 @@
+import { Building2 } from 'lucide-react';
+import { TradingViewEmbed } from '../../framework/TradingViewEmbed';
+import { registerWidget } from '../../framework/WidgetRegistry';
+import { SymbolField } from '../../framework/settings/SymbolField';
+import { TradingViewSettingsFooter } from '../../framework/TradingViewSettingsFooter';
+import { SettingsDoneButton } from '../../framework/settings/SettingsDoneButton';
+import type { WidgetRenderProps, WidgetSettingsProps } from '../../types';
+
+interface CompanyProfileConfig {
+  symbol: string;
+}
+
+function CompanyProfileWidget({ instance }: WidgetRenderProps<CompanyProfileConfig>) {
+  return (
+    <TradingViewEmbed
+      card
+      scriptKey="symbol-profile"
+      config={{ symbol: instance.config.symbol }}
+    />
+  );
+}
+
+function CompanyProfileSettings({ config, onChange, onClose }: WidgetSettingsProps<CompanyProfileConfig>) {
+  return (
+    <div className="space-y-4">
+      <SymbolField
+        label="Symbol"
+        value={config.symbol ?? ''}
+        onChange={(v) => onChange({ symbol: v })}
+        placeholder="NASDAQ:NVDA"
+      />
+      <TradingViewSettingsFooter />
+      <SettingsDoneButton onClick={onClose} />
+    </div>
+  );
+}
+
+registerWidget<CompanyProfileConfig>({
+  type: 'tv.company-profile',
+  title: 'Company Profile',
+  description: 'Business description, sector, industry, and HQ for a single company.',
+  category: 'markets',
+  icon: Building2,
+  component: CompanyProfileWidget,
+  settingsComponent: CompanyProfileSettings,
+  defaultConfig: { symbol: 'NASDAQ:NVDA' },
+  defaultSize: { w: 6, h: 18 },
+  minSize: { w: 4, h: 12 },
+  maxSize: { w: 12, h: 32 },
+  source: 'tradingview',
+});

--- a/web/src/pages/Dashboard/widgets/definitions/tv/CryptoHeatmapWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/CryptoHeatmapWidget.tsx
@@ -1,0 +1,81 @@
+import { Bitcoin } from 'lucide-react';
+import { TradingViewEmbed } from '../../framework/TradingViewEmbed';
+import { registerWidget } from '../../framework/WidgetRegistry';
+import { EnumField } from '../../framework/settings/EnumField';
+import { TradingViewSettingsFooter } from '../../framework/TradingViewSettingsFooter';
+import { SettingsDoneButton } from '../../framework/settings/SettingsDoneButton';
+import type { WidgetRenderProps, WidgetSettingsProps } from '../../types';
+
+interface CryptoHeatmapConfig {
+  dataSource: string;
+  blockSize: string;
+  blockColor: string;
+}
+
+function CryptoHeatmapWidget({ instance }: WidgetRenderProps<CryptoHeatmapConfig>) {
+  return (
+    <TradingViewEmbed
+      card
+      scriptKey="crypto-coins-heatmap"
+      config={{
+        ...instance.config,
+        hasTopBar: false,
+        isDataSetEnabled: false,
+        isZoomEnabled: true,
+        hasSymbolTooltip: true,
+      }}
+    />
+  );
+}
+
+function CryptoHeatmapSettings({ config, onChange, onClose }: WidgetSettingsProps<CryptoHeatmapConfig>) {
+  return (
+    <div className="space-y-4">
+      <EnumField
+        label="Data source"
+        value={config.dataSource ?? 'Crypto'}
+        onChange={(v) => onChange({ dataSource: v })}
+        options={[
+          { value: 'Crypto', label: 'All crypto' },
+          { value: 'CryptoMarkets', label: 'Crypto markets' },
+        ]}
+      />
+      <EnumField
+        label="Cell size"
+        value={config.blockSize ?? 'market_cap_calc'}
+        onChange={(v) => onChange({ blockSize: v })}
+        options={[
+          { value: 'market_cap_calc', label: 'Market cap' },
+          { value: '24h_vol_cmc', label: '24h volume' },
+        ]}
+      />
+      <EnumField
+        label="Cell color"
+        value={config.blockColor ?? '24h_close_change|5'}
+        onChange={(v) => onChange({ blockColor: v })}
+        options={[
+          { value: '24h_close_change|5', label: '24h change' },
+          { value: 'Perf.W', label: '1W change' },
+          { value: 'Perf.1M', label: '1M change' },
+        ]}
+      />
+      <TradingViewSettingsFooter />
+      <SettingsDoneButton onClick={onClose} />
+    </div>
+  );
+}
+
+registerWidget<CryptoHeatmapConfig>({
+  type: 'tv.crypto-heatmap',
+  title: 'Crypto Heatmap',
+  description: 'Crypto treemap sized by market cap, colored by performance.',
+  category: 'markets',
+  icon: Bitcoin,
+  component: CryptoHeatmapWidget,
+  settingsComponent: CryptoHeatmapSettings,
+  defaultConfig: { dataSource: 'Crypto', blockSize: 'market_cap_calc', blockColor: '24h_close_change|5' },
+  defaultSize: { w: 12, h: 20 },
+  minSize: { w: 6, h: 12 },
+  maxSize: { w: 12, h: 40 },
+  source: 'tradingview',
+});

--- a/web/src/pages/Dashboard/widgets/definitions/tv/CryptoScreenerWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/CryptoScreenerWidget.tsx
@@ -1,0 +1,80 @@
+import { Bitcoin } from 'lucide-react';
+import { TradingViewEmbed } from '../../framework/TradingViewEmbed';
+import { registerWidget } from '../../framework/WidgetRegistry';
+import { EnumField } from '../../framework/settings/EnumField';
+import { TradingViewSettingsFooter } from '../../framework/TradingViewSettingsFooter';
+import { SettingsDoneButton } from '../../framework/settings/SettingsDoneButton';
+import type { WidgetRenderProps, WidgetSettingsProps } from '../../types';
+
+interface CryptoScreenerConfig {
+  defaultColumn: string;
+  defaultScreen: string;
+}
+
+// Crypto screener is the same `embed-widget-screener.js` iframe as the Stock
+// Screener, flipped to `screener_type: 'crypto_mkt'` (verified from TV's
+// /widget-docs/widgets/screeners/crypto-mkt-screener/ demo config). Splitting
+// into two widgets keeps the gallery presets clear instead of making users
+// toggle a market-type dropdown.
+function CryptoScreenerWidget({ instance }: WidgetRenderProps<CryptoScreenerConfig>) {
+  return (
+    <TradingViewEmbed
+      card
+      scriptKey="screener"
+      config={{
+        screener_type: 'crypto_mkt',
+        market: 'crypto',
+        defaultColumn: instance.config.defaultColumn,
+        defaultScreen: instance.config.defaultScreen,
+        showToolbar: true,
+      }}
+    />
+  );
+}
+
+function CryptoScreenerSettings({ config, onChange, onClose }: WidgetSettingsProps<CryptoScreenerConfig>) {
+  return (
+    <div className="space-y-4">
+      <EnumField
+        label="Default column set"
+        value={config.defaultColumn ?? 'overview'}
+        onChange={(v) => onChange({ defaultColumn: v })}
+        options={[
+          { value: 'overview', label: 'Overview' },
+          { value: 'performance', label: 'Performance' },
+          { value: 'oscillators', label: 'Oscillators' },
+          { value: 'moving_averages', label: 'Moving averages' },
+        ]}
+      />
+      <EnumField
+        label="Default screen"
+        value={config.defaultScreen ?? 'general'}
+        onChange={(v) => onChange({ defaultScreen: v })}
+        options={[
+          { value: 'general', label: 'General' },
+          { value: 'most_capitalized', label: 'Most capitalized' },
+          { value: 'top_gainers', label: 'Top gainers' },
+          { value: 'top_losers', label: 'Top losers' },
+          { value: 'most_active', label: 'Most active' },
+        ]}
+      />
+      <TradingViewSettingsFooter />
+      <SettingsDoneButton onClick={onClose} />
+    </div>
+  );
+}
+
+registerWidget<CryptoScreenerConfig>({
+  type: 'tv.crypto-screener',
+  title: 'Crypto Screener',
+  description: 'Filter the crypto universe by market cap, performance, technicals.',
+  category: 'markets',
+  icon: Bitcoin,
+  component: CryptoScreenerWidget,
+  settingsComponent: CryptoScreenerSettings,
+  defaultConfig: { defaultColumn: 'overview', defaultScreen: 'general' },
+  defaultSize: { w: 12, h: 24 },
+  minSize: { w: 6, h: 14 },
+  maxSize: { w: 12, h: 48 },
+  source: 'tradingview',
+});

--- a/web/src/pages/Dashboard/widgets/definitions/tv/ETFHeatmapWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/ETFHeatmapWidget.tsx
@@ -1,0 +1,95 @@
+import { Layers } from 'lucide-react';
+import { TradingViewEmbed } from '../../framework/TradingViewEmbed';
+import { registerWidget } from '../../framework/WidgetRegistry';
+import { EnumField } from '../../framework/settings/EnumField';
+import { TradingViewSettingsFooter } from '../../framework/TradingViewSettingsFooter';
+import { SettingsDoneButton } from '../../framework/settings/SettingsDoneButton';
+import type { WidgetRenderProps, WidgetSettingsProps } from '../../types';
+
+interface ETFHeatmapConfig {
+  dataSource: string;
+  blockSize: string;
+  blockColor: string;
+  grouping: string;
+}
+
+function ETFHeatmapWidget({ instance }: WidgetRenderProps<ETFHeatmapConfig>) {
+  return (
+    <TradingViewEmbed
+      card
+      scriptKey="etf-heatmap"
+      config={{
+        dataSource: instance.config.dataSource,
+        blockSize: instance.config.blockSize,
+        blockColor: instance.config.blockColor,
+        grouping: instance.config.grouping,
+      }}
+    />
+  );
+}
+
+function ETFHeatmapSettings({ config, onChange, onClose }: WidgetSettingsProps<ETFHeatmapConfig>) {
+  return (
+    <div className="space-y-4">
+      <EnumField
+        label="Universe"
+        value={config.dataSource ?? 'AllUSEtf'}
+        onChange={(v) => onChange({ dataSource: v })}
+        options={[
+          { value: 'AllUSEtf', label: 'All US ETFs' },
+          { value: 'EquityEtf', label: 'Equity ETFs' },
+          { value: 'BondEtf', label: 'Bond ETFs' },
+          { value: 'CommodityEtf', label: 'Commodity ETFs' },
+          { value: 'CurrencyEtf', label: 'Currency ETFs' },
+        ]}
+      />
+      <EnumField
+        label="Block size by"
+        value={config.blockSize ?? 'aum'}
+        onChange={(v) => onChange({ blockSize: v })}
+        options={[
+          { value: 'aum', label: 'AUM' },
+          { value: 'volume', label: 'Volume' },
+          { value: 'no_filter', label: 'Equal size' },
+        ]}
+      />
+      <EnumField
+        label="Color by"
+        value={config.blockColor ?? 'change'}
+        onChange={(v) => onChange({ blockColor: v })}
+        options={[
+          { value: 'change', label: '% change' },
+          { value: 'Perf.W', label: '1 week performance' },
+          { value: 'Perf.1M', label: '1 month performance' },
+          { value: 'Perf.YTD', label: 'YTD performance' },
+        ]}
+      />
+      <EnumField
+        label="Group by"
+        value={config.grouping ?? 'asset_class'}
+        onChange={(v) => onChange({ grouping: v })}
+        options={[
+          { value: 'asset_class', label: 'Asset class' },
+          { value: 'no_group', label: 'None' },
+        ]}
+      />
+      <TradingViewSettingsFooter />
+      <SettingsDoneButton onClick={onClose} />
+    </div>
+  );
+}
+
+registerWidget<ETFHeatmapConfig>({
+  type: 'tv.etf-heatmap',
+  title: 'ETF Heatmap',
+  description: 'Treemap of ETFs sized by AUM, colored by performance.',
+  category: 'markets',
+  icon: Layers,
+  component: ETFHeatmapWidget,
+  settingsComponent: ETFHeatmapSettings,
+  defaultConfig: { dataSource: 'AllUSEtf', blockSize: 'aum', blockColor: 'change', grouping: 'asset_class' },
+  defaultSize: { w: 12, h: 20 },
+  minSize: { w: 6, h: 12 },
+  maxSize: { w: 12, h: 40 },
+  source: 'tradingview',
+});

--- a/web/src/pages/Dashboard/widgets/definitions/tv/EconomicEventsWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/EconomicEventsWidget.tsx
@@ -1,0 +1,69 @@
+import { CalendarClock } from 'lucide-react';
+import { TradingViewEmbed } from '../../framework/TradingViewEmbed';
+import { registerWidget } from '../../framework/WidgetRegistry';
+import { EnumField } from '../../framework/settings/EnumField';
+import { TradingViewSettingsFooter } from '../../framework/TradingViewSettingsFooter';
+import { SettingsDoneButton } from '../../framework/settings/SettingsDoneButton';
+import type { WidgetRenderProps, WidgetSettingsProps } from '../../types';
+
+interface EconomicEventsConfig {
+  importanceFilter: string; // '-1,0,1'
+  countryFilter: string;
+}
+
+function EconomicEventsWidget({ instance }: WidgetRenderProps<EconomicEventsConfig>) {
+  return (
+    <TradingViewEmbed
+      card
+      scriptKey="events"
+      config={{
+        importanceFilter: instance.config.importanceFilter,
+        countryFilter: instance.config.countryFilter,
+      }}
+    />
+  );
+}
+
+function EconomicEventsSettings({ config, onChange, onClose }: WidgetSettingsProps<EconomicEventsConfig>) {
+  return (
+    <div className="space-y-4">
+      <EnumField
+        label="Importance"
+        value={config.importanceFilter ?? '-1,0,1'}
+        onChange={(v) => onChange({ importanceFilter: v })}
+        options={[
+          { value: '-1,0,1', label: 'All (low, medium, high)' },
+          { value: '0,1', label: 'Medium + high' },
+          { value: '1', label: 'High only' },
+        ]}
+      />
+      <EnumField
+        label="Countries"
+        value={config.countryFilter ?? 'us,eu,jp,gb,cn'}
+        onChange={(v) => onChange({ countryFilter: v })}
+        options={[
+          { value: 'us,eu,jp,gb,cn', label: 'Major (US, EU, JP, GB, CN)' },
+          { value: 'us', label: 'US only' },
+          { value: 'us,eu,gb', label: 'US + EU + GB' },
+        ]}
+      />
+      <TradingViewSettingsFooter />
+      <SettingsDoneButton onClick={onClose} />
+    </div>
+  );
+}
+
+registerWidget<EconomicEventsConfig>({
+  type: 'tv.economic-events',
+  title: 'Economic Calendar',
+  description: 'Upcoming releases (CPI, NFP, FOMC, etc.) filtered by importance.',
+  category: 'markets',
+  icon: CalendarClock,
+  component: EconomicEventsWidget,
+  settingsComponent: EconomicEventsSettings,
+  defaultConfig: { importanceFilter: '-1,0,1', countryFilter: 'us,eu,jp,gb,cn' },
+  defaultSize: { w: 6, h: 24 },
+  minSize: { w: 4, h: 14 },
+  maxSize: { w: 12, h: 48 },
+  source: 'tradingview',
+});

--- a/web/src/pages/Dashboard/widgets/definitions/tv/EconomicMapWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/EconomicMapWidget.tsx
@@ -1,0 +1,91 @@
+import { Globe } from 'lucide-react';
+import { TradingViewWebComponent } from '../../framework/TradingViewWebComponent';
+import { registerWidget } from '../../framework/WidgetRegistry';
+import { EnumField } from '../../framework/settings/EnumField';
+import { TradingViewSettingsFooter } from '../../framework/TradingViewSettingsFooter';
+import { SettingsDoneButton } from '../../framework/settings/SettingsDoneButton';
+import type { WidgetRenderProps, WidgetSettingsProps } from '../../types';
+
+interface EconomicMapConfig {
+  region: 'global' | 'africa' | 'asia' | 'europe' | 'north-america' | 'oceania' | 'south-america';
+  metric: 'gdp' | 'ur' | 'gdg' | 'intr' | 'iryy';
+  hideLegend: boolean;
+}
+
+// Attribute shape verified against the TV wizard module
+// (widgets.tradingview-widget.com/wizards/tv-economic-map-wizard.js):
+//   defaults = { region: "global", metric: "gdp", hideLegend: false, metrics: [] }
+//   metric enum (label):
+//     gdp  → GDP
+//     ur   → Unemployment Rate
+//     gdg  → Government Debt to GDP
+//     intr → Interest Rate
+//     iryy → Inflation Rate
+//   region enum: global, africa, asia, europe, north-america, oceania, south-america
+function EconomicMapWidget({ instance }: WidgetRenderProps<EconomicMapConfig>) {
+  return (
+    <TradingViewWebComponent
+      card
+      element="tv-economic-map"
+      config={{
+        region: instance.config.region,
+        metric: instance.config.metric,
+        hideLegend: instance.config.hideLegend,
+      }}
+    />
+  );
+}
+
+function EconomicMapSettings({ config, onChange, onClose }: WidgetSettingsProps<EconomicMapConfig>) {
+  return (
+    <div className="space-y-4">
+      <EnumField
+        label="Region"
+        value={config.region ?? 'global'}
+        onChange={(v) => onChange({ region: v as EconomicMapConfig['region'] })}
+        options={[
+          { value: 'global', label: 'Global' },
+          { value: 'north-america', label: 'North America' },
+          { value: 'south-america', label: 'South America' },
+          { value: 'europe', label: 'Europe' },
+          { value: 'asia', label: 'Asia' },
+          { value: 'africa', label: 'Africa' },
+          { value: 'oceania', label: 'Oceania' },
+        ]}
+      />
+      <EnumField
+        label="Metric"
+        value={config.metric ?? 'gdp'}
+        onChange={(v) => onChange({ metric: v as EconomicMapConfig['metric'] })}
+        options={[
+          { value: 'gdp', label: 'GDP' },
+          { value: 'iryy', label: 'Inflation Rate' },
+          { value: 'intr', label: 'Interest Rate' },
+          { value: 'ur', label: 'Unemployment Rate' },
+          { value: 'gdg', label: 'Government Debt to GDP' },
+        ]}
+      />
+      <TradingViewSettingsFooter />
+      <SettingsDoneButton onClick={onClose} />
+    </div>
+  );
+}
+
+registerWidget<EconomicMapConfig>({
+  type: 'tv.economic-map',
+  title: 'Economic Map',
+  description: 'World map of economic indicators (GDP, inflation, interest rates) by country.',
+  category: 'markets',
+  icon: Globe,
+  component: EconomicMapWidget,
+  settingsComponent: EconomicMapSettings,
+  defaultConfig: { region: 'global', metric: 'gdp', hideLegend: false },
+  // Wizard reports natural size 750w × 475h. h=18 (~416px content) hugs that
+  // aspect at w=12 so the map + legend strip render without letterboxing.
+  // Min raised to 18 (= default) so country labels and the legend always
+  // fit; at smaller h the world map shrinks below legibility.
+  defaultSize: { w: 12, h: 18 },
+  minSize: { w: 6, h: 18 },
+  maxSize: { w: 12, h: 32 },
+  source: 'tradingview',
+});

--- a/web/src/pages/Dashboard/widgets/definitions/tv/ForexHeatmapWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/ForexHeatmapWidget.tsx
@@ -1,0 +1,51 @@
+import { DollarSign } from 'lucide-react';
+import { TradingViewEmbed } from '../../framework/TradingViewEmbed';
+import { registerWidget } from '../../framework/WidgetRegistry';
+import { TradingViewSettingsFooter } from '../../framework/TradingViewSettingsFooter';
+import { SettingsDoneButton } from '../../framework/settings/SettingsDoneButton';
+import type { WidgetRenderProps, WidgetSettingsProps } from '../../types';
+
+interface ForexHeatmapConfig {
+  currencies: string[];
+}
+
+const DEFAULT_CURRENCIES = ['USD', 'EUR', 'GBP', 'JPY', 'CHF', 'CAD', 'AUD', 'NZD', 'CNY'];
+
+function ForexHeatmapWidget({ instance }: WidgetRenderProps<ForexHeatmapConfig>) {
+  return (
+    <TradingViewEmbed
+      card
+      scriptKey="forex-cross-rates"
+      config={{
+        currencies: instance.config.currencies?.length ? instance.config.currencies : DEFAULT_CURRENCIES,
+      }}
+    />
+  );
+}
+
+function ForexHeatmapSettings({ config: _config, onChange: _onChange, onClose }: WidgetSettingsProps<ForexHeatmapConfig>) {
+  return (
+    <div className="space-y-4">
+      <div className="text-xs" style={{ color: 'var(--color-text-secondary)' }}>
+        Shows cross-rates for major currencies. The currency set is fixed by TradingView in this widget.
+      </div>
+      <TradingViewSettingsFooter />
+      <SettingsDoneButton onClick={onClose} />
+    </div>
+  );
+}
+
+registerWidget<ForexHeatmapConfig>({
+  type: 'tv.forex-heatmap',
+  title: 'Forex Cross Rates',
+  description: 'Major-currency cross-rate grid with live spreads.',
+  category: 'markets',
+  icon: DollarSign,
+  component: ForexHeatmapWidget,
+  settingsComponent: ForexHeatmapSettings,
+  defaultConfig: { currencies: DEFAULT_CURRENCIES },
+  defaultSize: { w: 12, h: 18 },
+  minSize: { w: 6, h: 10 },
+  maxSize: { w: 12, h: 32 },
+  source: 'tradingview',
+});

--- a/web/src/pages/Dashboard/widgets/definitions/tv/MoversWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/MoversWidget.tsx
@@ -1,0 +1,76 @@
+import { TrendingUp } from 'lucide-react';
+import { TradingViewEmbed } from '../../framework/TradingViewEmbed';
+import { registerWidget } from '../../framework/WidgetRegistry';
+import { EnumField } from '../../framework/settings/EnumField';
+import { TradingViewSettingsFooter } from '../../framework/TradingViewSettingsFooter';
+import { SettingsDoneButton } from '../../framework/settings/SettingsDoneButton';
+import type { WidgetRenderProps, WidgetSettingsProps } from '../../types';
+
+interface MoversConfig {
+  exchange: string;
+  dataSource: string;
+}
+
+function MoversWidget({ instance }: WidgetRenderProps<MoversConfig>) {
+  return (
+    <TradingViewEmbed
+      card
+      scriptKey="hotlists"
+      config={{
+        exchange: instance.config.exchange,
+        dataSource: instance.config.dataSource,
+        // showChart drives both the chart preview strip and TV's "selected
+        // row" highlight (the heavy blue stripe). Off keeps a clean ranked
+        // list with no row dominating the layout.
+        showChart: false,
+      }}
+    />
+  );
+}
+
+function MoversSettings({ config, onChange, onClose }: WidgetSettingsProps<MoversConfig>) {
+  return (
+    <div className="space-y-4">
+      <EnumField
+        label="Exchange"
+        value={config.exchange ?? 'US'}
+        onChange={(v) => onChange({ exchange: v })}
+        options={[
+          { value: 'US', label: 'US (NYSE + NASDAQ)' },
+          { value: 'NASDAQ', label: 'NASDAQ' },
+          { value: 'NYSE', label: 'NYSE' },
+          { value: 'LSE', label: 'London (LSE)' },
+          { value: 'HKEX', label: 'Hong Kong (HKEX)' },
+        ]}
+      />
+      <EnumField
+        label="Category"
+        value={config.dataSource ?? 'AllUSA'}
+        onChange={(v) => onChange({ dataSource: v })}
+        options={[
+          { value: 'AllUSA', label: 'All (gainers/losers/active)' },
+          { value: 'TopGainersUSA', label: 'Top gainers' },
+          { value: 'TopLosersUSA', label: 'Top losers' },
+          { value: 'MostActiveUSA', label: 'Most active' },
+        ]}
+      />
+      <TradingViewSettingsFooter />
+      <SettingsDoneButton onClick={onClose} />
+    </div>
+  );
+}
+
+registerWidget<MoversConfig>({
+  type: 'tv.movers',
+  title: 'Market Movers',
+  description: 'Top gainers / losers / most-active across US exchanges.',
+  category: 'markets',
+  icon: TrendingUp,
+  component: MoversWidget,
+  settingsComponent: MoversSettings,
+  defaultConfig: { exchange: 'US', dataSource: 'AllUSA' },
+  defaultSize: { w: 6, h: 22 },
+  minSize: { w: 4, h: 14 },
+  maxSize: { w: 12, h: 40 },
+  source: 'tradingview',
+});

--- a/web/src/pages/Dashboard/widgets/definitions/tv/SingleTickerWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/SingleTickerWidget.tsx
@@ -1,0 +1,51 @@
+import { Tag } from 'lucide-react';
+import { TradingViewEmbed } from '../../framework/TradingViewEmbed';
+import { registerWidget } from '../../framework/WidgetRegistry';
+import { SymbolField } from '../../framework/settings/SymbolField';
+import { TradingViewSettingsFooter } from '../../framework/TradingViewSettingsFooter';
+import { SettingsDoneButton } from '../../framework/settings/SettingsDoneButton';
+import type { WidgetRenderProps, WidgetSettingsProps } from '../../types';
+
+interface SingleTickerConfig {
+  symbol: string;
+}
+
+function SingleTickerWidget({ instance }: WidgetRenderProps<SingleTickerConfig>) {
+  return (
+    <TradingViewEmbed
+      card
+      scriptKey="single-quote"
+      config={{ symbol: instance.config.symbol }}
+    />
+  );
+}
+
+function SingleTickerSettings({ config, onChange, onClose }: WidgetSettingsProps<SingleTickerConfig>) {
+  return (
+    <div className="space-y-4">
+      <SymbolField
+        label="Symbol"
+        value={config.symbol ?? ''}
+        onChange={(v) => onChange({ symbol: v })}
+        placeholder="NASDAQ:NVDA"
+      />
+      <TradingViewSettingsFooter />
+      <SettingsDoneButton onClick={onClose} />
+    </div>
+  );
+}
+
+registerWidget<SingleTickerConfig>({
+  type: 'tv.single-ticker',
+  title: 'Single Ticker',
+  description: 'Compact live-price card for one symbol.',
+  category: 'markets',
+  icon: Tag,
+  component: SingleTickerWidget,
+  settingsComponent: SingleTickerSettings,
+  defaultConfig: { symbol: 'NASDAQ:NVDA' },
+  defaultSize: { w: 3, h: 4 },
+  minSize: { w: 2, h: 3 },
+  maxSize: { w: 6, h: 6 },
+  source: 'tradingview',
+});

--- a/web/src/pages/Dashboard/widgets/definitions/tv/StockHeatmapWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/StockHeatmapWidget.tsx
@@ -1,0 +1,90 @@
+import { Map } from 'lucide-react';
+import { TradingViewEmbed } from '../../framework/TradingViewEmbed';
+import { registerWidget } from '../../framework/WidgetRegistry';
+import { EnumField } from '../../framework/settings/EnumField';
+import { TradingViewSettingsFooter } from '../../framework/TradingViewSettingsFooter';
+import { SettingsDoneButton } from '../../framework/settings/SettingsDoneButton';
+import type { WidgetRenderProps, WidgetSettingsProps } from '../../types';
+
+interface StockHeatmapConfig {
+  dataSource: string;
+  blockSize: string;
+  blockColor: string;
+}
+
+function StockHeatmapWidget({ instance }: WidgetRenderProps<StockHeatmapConfig>) {
+  const { dataSource, blockSize, blockColor } = instance.config;
+  return (
+    <TradingViewEmbed
+      card
+      scriptKey="stock-heatmap"
+      config={{
+        dataSource,
+        blockSize,
+        blockColor,
+        grouping: 'sector',
+        hasTopBar: false,
+        isDataSetEnabled: false,
+        isZoomEnabled: true,
+        hasSymbolTooltip: true,
+      }}
+    />
+  );
+}
+
+function StockHeatmapSettings({ config, onChange, onClose }: WidgetSettingsProps<StockHeatmapConfig>) {
+  return (
+    <div className="space-y-4">
+      <EnumField
+        label="Market"
+        value={config.dataSource ?? 'SPX500'}
+        onChange={(v) => onChange({ dataSource: v })}
+        options={[
+          { value: 'SPX500', label: 'S&P 500' },
+          { value: 'NASDAQ100', label: 'NASDAQ 100' },
+          { value: 'DJI', label: 'Dow Jones 30' },
+          { value: 'FTSE100', label: 'FTSE 100' },
+          { value: 'HSI', label: 'Hang Seng' },
+        ]}
+      />
+      <EnumField
+        label="Cell size"
+        value={config.blockSize ?? 'market_cap_basic'}
+        onChange={(v) => onChange({ blockSize: v })}
+        options={[
+          { value: 'market_cap_basic', label: 'Market cap' },
+          { value: 'volume', label: 'Volume' },
+          { value: 'number_of_employees', label: 'Employees' },
+        ]}
+      />
+      <EnumField
+        label="Cell color"
+        value={config.blockColor ?? 'change'}
+        onChange={(v) => onChange({ blockColor: v })}
+        options={[
+          { value: 'change', label: '% change (day)' },
+          { value: 'Perf.W', label: '% change (week)' },
+          { value: 'Perf.1M', label: '% change (month)' },
+          { value: 'Volatility.W', label: 'Volatility' },
+        ]}
+      />
+      <TradingViewSettingsFooter />
+      <SettingsDoneButton onClick={onClose} />
+    </div>
+  );
+}
+
+registerWidget<StockHeatmapConfig>({
+  type: 'tv.stock-heatmap',
+  title: 'Stock Heatmap',
+  description: 'Sector-grouped treemap sized by market cap, colored by % change.',
+  category: 'markets',
+  icon: Map,
+  component: StockHeatmapWidget,
+  settingsComponent: StockHeatmapSettings,
+  defaultConfig: { dataSource: 'SPX500', blockSize: 'market_cap_basic', blockColor: 'change' },
+  defaultSize: { w: 12, h: 22 },
+  minSize: { w: 6, h: 12 },
+  maxSize: { w: 12, h: 40 },
+  source: 'tradingview',
+});

--- a/web/src/pages/Dashboard/widgets/definitions/tv/StockScreenerWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/StockScreenerWidget.tsx
@@ -1,0 +1,91 @@
+import { Filter } from 'lucide-react';
+import { TradingViewEmbed } from '../../framework/TradingViewEmbed';
+import { registerWidget } from '../../framework/WidgetRegistry';
+import { EnumField } from '../../framework/settings/EnumField';
+import { TradingViewSettingsFooter } from '../../framework/TradingViewSettingsFooter';
+import { SettingsDoneButton } from '../../framework/settings/SettingsDoneButton';
+import type { WidgetRenderProps, WidgetSettingsProps } from '../../types';
+
+interface StockScreenerConfig {
+  market: string;
+  defaultColumn: string;
+  defaultScreen: string;
+}
+
+function StockScreenerWidget({ instance }: WidgetRenderProps<StockScreenerConfig>) {
+  return (
+    <TradingViewEmbed
+      card
+      scriptKey="screener"
+      config={{
+        screener_type: 'stock',
+        market: instance.config.market,
+        defaultColumn: instance.config.defaultColumn,
+        defaultScreen: instance.config.defaultScreen,
+        showToolbar: true,
+      }}
+    />
+  );
+}
+
+function StockScreenerSettings({ config, onChange, onClose }: WidgetSettingsProps<StockScreenerConfig>) {
+  return (
+    <div className="space-y-4">
+      <EnumField
+        label="Market"
+        value={config.market ?? 'america'}
+        onChange={(v) => onChange({ market: v })}
+        options={[
+          { value: 'america', label: 'USA (NYSE + NASDAQ + AMEX)' },
+          { value: 'uk', label: 'United Kingdom (LSE)' },
+          { value: 'germany', label: 'Germany (XETR)' },
+          { value: 'japan', label: 'Japan' },
+          { value: 'china', label: 'China (SSE)' },
+          { value: 'hongkong', label: 'Hong Kong (HKEX)' },
+        ]}
+      />
+      <EnumField
+        label="Default column set"
+        value={config.defaultColumn ?? 'overview'}
+        onChange={(v) => onChange({ defaultColumn: v })}
+        options={[
+          { value: 'overview', label: 'Overview' },
+          { value: 'performance', label: 'Performance' },
+          { value: 'valuation', label: 'Valuation' },
+          { value: 'dividends', label: 'Dividends' },
+          { value: 'profitability', label: 'Profitability' },
+          { value: 'technicals', label: 'Technicals' },
+        ]}
+      />
+      <EnumField
+        label="Default screen"
+        value={config.defaultScreen ?? 'general'}
+        onChange={(v) => onChange({ defaultScreen: v })}
+        options={[
+          { value: 'general', label: 'General' },
+          { value: 'most_capitalized', label: 'Most capitalized' },
+          { value: 'top_gainers', label: 'Top gainers' },
+          { value: 'top_losers', label: 'Top losers' },
+          { value: 'most_active', label: 'Most active' },
+        ]}
+      />
+      <TradingViewSettingsFooter />
+      <SettingsDoneButton onClick={onClose} />
+    </div>
+  );
+}
+
+registerWidget<StockScreenerConfig>({
+  type: 'tv.screener',
+  title: 'Stock Screener',
+  description: 'Filter the full stock universe by price, market cap, technicals, fundamentals.',
+  category: 'markets',
+  icon: Filter,
+  component: StockScreenerWidget,
+  settingsComponent: StockScreenerSettings,
+  defaultConfig: { market: 'america', defaultColumn: 'overview', defaultScreen: 'general' },
+  defaultSize: { w: 12, h: 24 },
+  minSize: { w: 6, h: 14 },
+  maxSize: { w: 12, h: 48 },
+  source: 'tradingview',
+});

--- a/web/src/pages/Dashboard/widgets/definitions/tv/SymbolInfoWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/SymbolInfoWidget.tsx
@@ -1,0 +1,51 @@
+import { Info } from 'lucide-react';
+import { TradingViewEmbed } from '../../framework/TradingViewEmbed';
+import { registerWidget } from '../../framework/WidgetRegistry';
+import { SymbolField } from '../../framework/settings/SymbolField';
+import { TradingViewSettingsFooter } from '../../framework/TradingViewSettingsFooter';
+import { SettingsDoneButton } from '../../framework/settings/SettingsDoneButton';
+import type { WidgetRenderProps, WidgetSettingsProps } from '../../types';
+
+interface SymbolInfoConfig {
+  symbol: string;
+}
+
+function SymbolInfoWidget({ instance }: WidgetRenderProps<SymbolInfoConfig>) {
+  return (
+    <TradingViewEmbed
+      card
+      scriptKey="symbol-info"
+      config={{ symbol: instance.config.symbol }}
+    />
+  );
+}
+
+function SymbolInfoSettings({ config, onChange, onClose }: WidgetSettingsProps<SymbolInfoConfig>) {
+  return (
+    <div className="space-y-4">
+      <SymbolField
+        label="Symbol"
+        value={config.symbol ?? ''}
+        onChange={(v) => onChange({ symbol: v })}
+        placeholder="NASDAQ:NVDA"
+      />
+      <TradingViewSettingsFooter />
+      <SettingsDoneButton onClick={onClose} />
+    </div>
+  );
+}
+
+registerWidget<SymbolInfoConfig>({
+  type: 'tv.symbol-info',
+  title: 'Symbol Info',
+  description: 'Compact summary card — price, day range, market cap, volume.',
+  category: 'markets',
+  icon: Info,
+  component: SymbolInfoWidget,
+  settingsComponent: SymbolInfoSettings,
+  defaultConfig: { symbol: 'NASDAQ:NVDA' },
+  defaultSize: { w: 6, h: 8 },
+  minSize: { w: 4, h: 6 },
+  maxSize: { w: 12, h: 12 },
+  source: 'tradingview',
+});

--- a/web/src/pages/Dashboard/widgets/definitions/tv/SymbolSpotlightWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/SymbolSpotlightWidget.tsx
@@ -1,0 +1,83 @@
+import { Target } from 'lucide-react';
+import { TradingViewEmbed } from '../../framework/TradingViewEmbed';
+import { registerWidget } from '../../framework/WidgetRegistry';
+import { SymbolField } from '../../framework/settings/SymbolField';
+import { EnumField } from '../../framework/settings/EnumField';
+import { TradingViewSettingsFooter } from '../../framework/TradingViewSettingsFooter';
+import { SettingsDoneButton } from '../../framework/settings/SettingsDoneButton';
+import type { WidgetRenderProps, WidgetSettingsProps } from '../../types';
+
+interface SymbolSpotlightConfig {
+  symbol: string;
+  range: string;
+}
+
+function SymbolSpotlightWidget({ instance }: WidgetRenderProps<SymbolSpotlightConfig>) {
+  const { symbol, range } = instance.config;
+  return (
+    <TradingViewEmbed
+      card
+      scriptKey="symbol-overview"
+      config={{
+        symbols: [[symbol, `${symbol}|${range}`]],
+        chartOnly: false,
+        dateRange: range,
+        colorTheme: undefined, // host passes this
+        trendLineColor: 'rgba(41, 98, 255, 1)',
+        underLineColor: 'rgba(41, 98, 255, 0.3)',
+        underLineBottomColor: 'rgba(41, 98, 255, 0)',
+        hideDateRanges: false,
+        hideMarketStatus: false,
+        hideSymbolLogo: false,
+        scalePosition: 'right',
+        scaleMode: 'Normal',
+        fontFamily: 'ui-sans-serif, system-ui',
+        chartType: 'area',
+      }}
+    />
+  );
+}
+
+function SymbolSpotlightSettings({ config, onChange, onClose }: WidgetSettingsProps<SymbolSpotlightConfig>) {
+  return (
+    <div className="space-y-4">
+      <SymbolField
+        label="Symbol"
+        value={config.symbol ?? ''}
+        onChange={(v) => onChange({ symbol: v })}
+        placeholder="NASDAQ:NVDA"
+      />
+      <EnumField
+        label="Range"
+        value={config.range ?? '12M'}
+        onChange={(v) => onChange({ range: v })}
+        options={[
+          { value: '1D', label: '1 day' },
+          { value: '5D', label: '5 days' },
+          { value: '1M', label: '1 month' },
+          { value: '3M', label: '3 months' },
+          { value: '12M', label: '12 months' },
+          { value: '60M', label: '5 years' },
+          { value: 'ALL', label: 'All time' },
+        ]}
+      />
+      <TradingViewSettingsFooter />
+      <SettingsDoneButton onClick={onClose} />
+    </div>
+  );
+}
+
+registerWidget<SymbolSpotlightConfig>({
+  type: 'tv.symbol-spotlight',
+  title: 'Symbol Spotlight',
+  description: 'Price + chart overview with key stats for a single symbol.',
+  category: 'markets',
+  icon: Target,
+  component: SymbolSpotlightWidget,
+  settingsComponent: SymbolSpotlightSettings,
+  defaultConfig: { symbol: 'NASDAQ:NVDA', range: '12M' },
+  defaultSize: { w: 6, h: 22 },
+  minSize: { w: 4, h: 14 },
+  maxSize: { w: 12, h: 32 },
+  source: 'tradingview',
+});

--- a/web/src/pages/Dashboard/widgets/definitions/tv/SymbolSpotlightWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/SymbolSpotlightWidget.tsx
@@ -22,7 +22,6 @@ function SymbolSpotlightWidget({ instance }: WidgetRenderProps<SymbolSpotlightCo
         symbols: [[symbol, `${symbol}|${range}`]],
         chartOnly: false,
         dateRange: range,
-        colorTheme: undefined, // host passes this
         trendLineColor: 'rgba(41, 98, 255, 1)',
         underLineColor: 'rgba(41, 98, 255, 0.3)',
         underLineBottomColor: 'rgba(41, 98, 255, 0)',

--- a/web/src/pages/Dashboard/widgets/definitions/tv/TechnicalsWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/TechnicalsWidget.tsx
@@ -1,0 +1,77 @@
+import { Gauge } from 'lucide-react';
+import { TradingViewEmbed } from '../../framework/TradingViewEmbed';
+import { registerWidget } from '../../framework/WidgetRegistry';
+import { SymbolField } from '../../framework/settings/SymbolField';
+import { EnumField } from '../../framework/settings/EnumField';
+import { TradingViewSettingsFooter } from '../../framework/TradingViewSettingsFooter';
+import { SettingsDoneButton } from '../../framework/settings/SettingsDoneButton';
+import type { WidgetRenderProps, WidgetSettingsProps } from '../../types';
+
+interface TechnicalsConfig {
+  symbol: string;
+  interval: string;
+}
+
+function TechnicalsWidget({ instance }: WidgetRenderProps<TechnicalsConfig>) {
+  return (
+    <TradingViewEmbed
+      card
+      scriptKey="technical-analysis"
+      config={{
+        symbol: instance.config.symbol,
+        interval: instance.config.interval,
+        showIntervalTabs: true,
+        displayMode: 'single',
+      }}
+    />
+  );
+}
+
+function TechnicalsSettings({ config, onChange, onClose }: WidgetSettingsProps<TechnicalsConfig>) {
+  return (
+    <div className="space-y-4">
+      <SymbolField
+        label="Symbol"
+        value={config.symbol ?? ''}
+        onChange={(v) => onChange({ symbol: v })}
+        placeholder="NASDAQ:NVDA"
+      />
+      <EnumField
+        label="Interval"
+        value={config.interval ?? '1D'}
+        onChange={(v) => onChange({ interval: v })}
+        options={[
+          { value: '1m', label: '1 minute' },
+          { value: '5m', label: '5 minutes' },
+          { value: '15m', label: '15 minutes' },
+          { value: '1h', label: '1 hour' },
+          { value: '4h', label: '4 hours' },
+          { value: '1D', label: '1 day' },
+          { value: '1W', label: '1 week' },
+          { value: '1M', label: '1 month' },
+        ]}
+      />
+      <TradingViewSettingsFooter />
+      <SettingsDoneButton onClick={onClose} />
+    </div>
+  );
+}
+
+registerWidget<TechnicalsConfig>({
+  type: 'tv.technicals',
+  title: 'Technical Analysis',
+  description: 'Oscillator + moving-average consensus gauge with buy/sell/neutral verdict.',
+  category: 'markets',
+  icon: Gauge,
+  component: TechnicalsWidget,
+  settingsComponent: TechnicalsSettings,
+  defaultConfig: { symbol: 'NASDAQ:NVDA', interval: '1D' },
+  defaultSize: { w: 6, h: 22 },
+  // Min raised to 22 (= default) so the gauge + pills + labels always
+  // render fully. At h<22 the edit-mode body (~cell-64px for chrome) drops
+  // below TV's natural ~450px render height and the gauge clips at the
+  // bottom. Users can still enlarge up to h=32.
+  minSize: { w: 4, h: 22 },
+  maxSize: { w: 12, h: 32 },
+  source: 'tradingview',
+});

--- a/web/src/pages/Dashboard/widgets/definitions/tv/TickerTapeWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/TickerTapeWidget.tsx
@@ -1,0 +1,183 @@
+import { useMemo } from 'react';
+import { Activity } from 'lucide-react';
+import { TradingViewEmbed } from '../../framework/TradingViewEmbed';
+import { registerWidget } from '../../framework/WidgetRegistry';
+import { useDashboardContext } from '../../framework/DashboardDataContext';
+import { SymbolListField } from '../../framework/settings/SymbolListField';
+import { EnumField } from '../../framework/settings/EnumField';
+import { TradingViewSettingsFooter } from '../../framework/TradingViewSettingsFooter';
+import { SettingsDoneButton } from '../../framework/settings/SettingsDoneButton';
+import type { WidgetRenderProps, WidgetSettingsProps } from '../../types';
+
+interface TickerTapeConfig {
+  symbols: string[];
+  displayMode: 'adaptive' | 'regular' | 'compact';
+}
+
+// Macro defaults. Plain US-listed ETFs always resolve on TV's free embed
+// tier in every region — the licensed index feeds (`SP:SPX`, `NASDAQ:NDX`)
+// fail unauthenticated, and CFDs (`FOREXCOM:*`) are blocked for US retail.
+// SPY → S&P 500, QQQ → Nasdaq-100, DIA → Dow, IWM → Russell 2000, GLD →
+// gold. Labels in TICKER_LABELS below remap to the names users recognize.
+export const DEFAULT_TICKERS = [
+  'AMEX:SPY',
+  'NASDAQ:QQQ',
+  'AMEX:DIA',
+  'AMEX:IWM',
+  'AMEX:GLD',
+];
+
+/**
+ * Display labels for well-known tape symbols. Keeps the chip in settings
+ * as the canonical `EXCHANGE:SYMBOL` form (what TV actually resolves)
+ * while the tape itself shows the short name users recognize.
+ * Misses fall back to the last colon-segment.
+ */
+const TICKER_LABELS: Record<string, string> = {
+  'AMEX:SPY': 'SPX',
+  'NASDAQ:QQQ': 'NDX',
+  'AMEX:DIA': 'DJI',
+  'AMEX:IWM': 'RUT',
+  'AMEX:GLD': 'GOLD',
+  'FOREXCOM:SPXUSD': 'SPX',
+  'FOREXCOM:NSXUSD': 'NDX',
+  'FOREXCOM:DJI': 'DJI',
+};
+
+function titleFor(sym: string): string {
+  return TICKER_LABELS[sym] ?? sym.split(':').pop() ?? sym;
+}
+
+/** Bare-ticker form ("AMEX:SPY" → "SPY", "NVDA" → "NVDA") for dedup. */
+function bareTicker(sym: string): string {
+  return (sym.split(':').pop() ?? sym).toUpperCase();
+}
+
+/**
+ * Macro defaults + watchlist + portfolio, deduped by bare-ticker form so
+ * a watchlist "SPY" collapses with the default "AMEX:SPY". First-write
+ * wins → defaults stay in their fixed order at the head of the tape, then
+ * personal symbols follow in watchlist-then-portfolio order.
+ *
+ * Exported for unit-testing — the live-seed dedup is the ONE thing every
+ * tape user depends on and it's only otherwise exercised through React.
+ */
+export function buildSeedSymbols(watchlistSyms: string[], portfolioSyms: string[]): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const push = (sym: string) => {
+    if (!sym) return;
+    const key = bareTicker(sym);
+    if (seen.has(key)) return;
+    seen.add(key);
+    out.push(sym);
+  };
+  for (const s of DEFAULT_TICKERS) push(s);
+  for (const s of watchlistSyms) push(s);
+  for (const s of portfolioSyms) push(s);
+  return out;
+}
+
+// Natural iframe heights for each displayMode (measured from TV's default
+// `embed-widget-ticker-tape.js` renders). Paired with `fitToContent` so the
+// RGL cell adapts to chrome between edit/view modes without clipping the
+// marquee or leaving a band of padding.
+const TICKER_CONTENT_HEIGHT: Record<TickerTapeConfig['displayMode'], number> = {
+  adaptive: 76,
+  regular: 76,
+  compact: 46,
+};
+
+// Intentional iframe fallback: the WC `<tv-ticker-tape>` is a *static
+// bordered grid* (verified at /widget-docs/widgets/tickers/ticker-tape/
+// — even the `horizontal_no_chart` preset). The iframe `embed-widget-
+// ticker-tape.js` is the classic continuous scrolling marquee, which is
+// the UX users expect. Tracked in tvConfig.ts under "iframe-only widgets".
+function TickerTapeWidget({ instance }: WidgetRenderProps<TickerTapeConfig>) {
+  const { symbols, displayMode } = instance.config;
+  const { watchlist, portfolio } = useDashboardContext();
+  // Reactive seed: when the user hasn't customized the chip list, the
+  // tape stays in sync with their watchlist and portfolio. The moment
+  // they edit chips in settings, the stored list takes over and the
+  // tape stops reacting to watchlist/portfolio adds.
+  const list = useMemo(() => {
+    if (symbols?.length) return symbols;
+    const w = watchlist.rows.map((r) => r.symbol).filter(Boolean);
+    const p = portfolio.rows.map((r) => r.symbol).filter(Boolean);
+    return buildSeedSymbols(w, p);
+  }, [symbols, watchlist.rows, portfolio.rows]);
+  return (
+    <TradingViewEmbed
+      card
+      scriptKey="ticker-tape"
+      contentHeight={TICKER_CONTENT_HEIGHT[displayMode] ?? TICKER_CONTENT_HEIGHT.adaptive}
+      config={{
+        symbols: list.map((s) => ({ proName: s, title: titleFor(s) })),
+        showSymbolLogo: true,
+        displayMode,
+      }}
+    />
+  );
+}
+
+function TickerTapeSettings({ config, onChange, onClose }: WidgetSettingsProps<TickerTapeConfig>) {
+  const { watchlist, portfolio } = useDashboardContext();
+  // Mirror the render-time live seed so the chip list shows what the tape
+  // is actually rendering. Opening settings stays side-effect-free — the
+  // displayed list only commits when the user adds or removes a chip
+  // (their first edit captures the full effective list as the start state).
+  const displayedSymbols = useMemo(() => {
+    if (config.symbols?.length) return config.symbols;
+    const w = watchlist.rows.map((r) => r.symbol).filter(Boolean);
+    const p = portfolio.rows.map((r) => r.symbol).filter(Boolean);
+    return buildSeedSymbols(w, p);
+  }, [config.symbols, watchlist.rows, portfolio.rows]);
+  return (
+    <div className="space-y-4">
+      <SymbolListField
+        label="Symbols"
+        value={displayedSymbols}
+        onChange={(next) => onChange({ symbols: next })}
+        placeholder="e.g. NASDAQ:NVDA"
+        helper="Use TradingView's exchange-qualified form (e.g. NASDAQ:NVDA) for best results."
+      />
+      <EnumField
+        label="Display mode"
+        value={config.displayMode ?? 'adaptive'}
+        onChange={(v) => onChange({ displayMode: v as TickerTapeConfig['displayMode'] })}
+        options={[
+          { value: 'adaptive', label: 'Adaptive' },
+          { value: 'regular', label: 'Regular' },
+          { value: 'compact', label: 'Compact' },
+        ]}
+      />
+      <TradingViewSettingsFooter />
+      <SettingsDoneButton onClick={onClose} />
+    </div>
+  );
+}
+
+registerWidget<TickerTapeConfig>({
+  type: 'tv.ticker-tape',
+  title: 'Ticker Tape',
+  description: 'Scrolling real-time quotes across your chosen symbols.',
+  category: 'markets',
+  icon: Activity,
+  component: TickerTapeWidget,
+  settingsComponent: TickerTapeSettings,
+  defaultConfig: { symbols: [], displayMode: 'adaptive' },
+  // fitToContent: cell height tracks the embed's natural 76px iframe plus
+  // chrome. View mode → ~6 rows (128px, card hugs the ticker). Edit mode →
+  // ~9 rows (200px, includes 40px header + 24px body padding). maxSize.h
+  // must clear the edit-mode measurement (~9 rows) otherwise the clamp
+  // caps the fit and the iframe gets clipped. Width stays user-resizable.
+  fitToContent: true,
+  defaultSize: { w: 12, h: 6 },
+  minSize: { w: 6, h: 3 },
+  maxSize: { w: 12, h: 12 },
+  source: 'tradingview',
+  // Empty `symbols` triggers the render-time live seed (defaults +
+  // watchlist + portfolio, deduped). The tape stays reactive to watchlist
+  // and portfolio adds until the user explicitly customizes via settings.
+  initConfig: () => ({ symbols: [], displayMode: 'adaptive' }),
+});

--- a/web/src/pages/Dashboard/widgets/definitions/tv/TopStoriesWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/TopStoriesWidget.tsx
@@ -1,0 +1,93 @@
+import { Newspaper } from 'lucide-react';
+import { TradingViewEmbed } from '../../framework/TradingViewEmbed';
+import { registerWidget } from '../../framework/WidgetRegistry';
+import { SymbolField } from '../../framework/settings/SymbolField';
+import { EnumField } from '../../framework/settings/EnumField';
+import { TradingViewSettingsFooter } from '../../framework/TradingViewSettingsFooter';
+import { SettingsDoneButton } from '../../framework/settings/SettingsDoneButton';
+import type { WidgetRenderProps, WidgetSettingsProps } from '../../types';
+
+interface TopStoriesConfig {
+  feedMode: 'all_symbols' | 'market' | 'symbol';
+  market: 'stock' | 'crypto' | 'forex' | 'index' | 'futures' | 'bond' | 'economic';
+  symbol: string;
+  displayMode: 'regular' | 'compact';
+}
+
+function TopStoriesWidget({ instance }: WidgetRenderProps<TopStoriesConfig>) {
+  const { feedMode, market, symbol, displayMode } = instance.config;
+  // TV's timeline widget accepts either `market` OR `symbol` depending on
+  // feedMode. Passing the right key prevents the widget from falling back
+  // to an empty state.
+  const cfg: Record<string, unknown> = { feedMode, displayMode };
+  if (feedMode === 'market') cfg.market = market;
+  if (feedMode === 'symbol') cfg.symbol = symbol;
+  return <TradingViewEmbed card scriptKey="timeline" config={cfg} />;
+}
+
+function TopStoriesSettings({ config, onChange, onClose }: WidgetSettingsProps<TopStoriesConfig>) {
+  const feedMode = config.feedMode ?? 'market';
+  return (
+    <div className="space-y-4">
+      <EnumField
+        label="Feed"
+        value={feedMode}
+        onChange={(v) => onChange({ feedMode: v as TopStoriesConfig['feedMode'] })}
+        options={[
+          { value: 'all_symbols', label: 'All markets' },
+          { value: 'market', label: 'Specific market' },
+          { value: 'symbol', label: 'Specific symbol' },
+        ]}
+      />
+      {feedMode === 'market' && (
+        <EnumField
+          label="Market"
+          value={config.market ?? 'stock'}
+          onChange={(v) => onChange({ market: v as TopStoriesConfig['market'] })}
+          options={[
+            { value: 'stock', label: 'Stocks' },
+            { value: 'crypto', label: 'Crypto' },
+            { value: 'forex', label: 'Forex' },
+            { value: 'index', label: 'Indices' },
+            { value: 'futures', label: 'Futures' },
+            { value: 'bond', label: 'Bonds' },
+            { value: 'economic', label: 'Economic' },
+          ]}
+        />
+      )}
+      {feedMode === 'symbol' && (
+        <SymbolField
+          label="Symbol"
+          value={config.symbol ?? 'NASDAQ:NVDA'}
+          onChange={(v) => onChange({ symbol: v })}
+        />
+      )}
+      <EnumField
+        label="Density"
+        value={config.displayMode ?? 'regular'}
+        onChange={(v) => onChange({ displayMode: v as TopStoriesConfig['displayMode'] })}
+        options={[
+          { value: 'regular', label: 'Regular (headlines + snippets)' },
+          { value: 'compact', label: 'Compact (headlines only)' },
+        ]}
+      />
+      <TradingViewSettingsFooter />
+      <SettingsDoneButton onClick={onClose} />
+    </div>
+  );
+}
+
+registerWidget<TopStoriesConfig>({
+  type: 'tv.top-stories',
+  title: 'Top Stories',
+  description: 'Market headlines from TradingView — by market or pinned to a single symbol.',
+  category: 'markets',
+  icon: Newspaper,
+  component: TopStoriesWidget,
+  settingsComponent: TopStoriesSettings,
+  defaultConfig: { feedMode: 'market', market: 'stock', symbol: 'NASDAQ:NVDA', displayMode: 'regular' },
+  defaultSize: { w: 6, h: 22 },
+  minSize: { w: 4, h: 14 },
+  maxSize: { w: 12, h: 40 },
+  source: 'tradingview',
+});

--- a/web/src/pages/Dashboard/widgets/definitions/tv/__tests__/buildSeedSymbols.test.ts
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/__tests__/buildSeedSymbols.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { buildSeedSymbols, DEFAULT_TICKERS } from '../TickerTapeWidget';
+
+describe('buildSeedSymbols', () => {
+  it('returns DEFAULT_TICKERS in fixed order when watchlist + portfolio are empty', () => {
+    expect(buildSeedSymbols([], [])).toEqual(DEFAULT_TICKERS);
+  });
+
+  it('dedupes a bare-ticker watchlist symbol against an exchange-qualified default', () => {
+    const out = buildSeedSymbols(['SPY'], []);
+    // Two SPY-like symbols shouldn't appear ('AMEX:SPY' default + bare 'SPY').
+    expect(out.filter((s) => s.toUpperCase().endsWith('SPY'))).toHaveLength(1);
+  });
+
+  it('appends new watchlist symbols after the defaults block', () => {
+    const out = buildSeedSymbols(['NVDA'], []);
+    const nvdaIdx = out.indexOf('NVDA');
+    expect(nvdaIdx).toBe(DEFAULT_TICKERS.length);
+  });
+
+  it('appends portfolio symbols after watchlist', () => {
+    const out = buildSeedSymbols(['NVDA'], ['MSFT']);
+    expect(out.indexOf('MSFT')).toBeGreaterThan(out.indexOf('NVDA'));
+  });
+
+  it('dedupes between watchlist and portfolio (no double NVDA)', () => {
+    const out = buildSeedSymbols(['NVDA'], ['NVDA', 'AAPL']);
+    expect(out.filter((s) => s === 'NVDA')).toHaveLength(1);
+    expect(out).toContain('AAPL');
+  });
+
+  it('skips empty/falsy entries (filtered watchlist rows)', () => {
+    const out = buildSeedSymbols(['', 'NVDA'], []);
+    expect(out).toContain('NVDA');
+    expect(out).not.toContain('');
+  });
+
+  it('is case-insensitive when comparing tickers', () => {
+    // The render path filters by .symbol but a stored mixed-case entry
+    // shouldn't sneak past the dedup.
+    const out = buildSeedSymbols(['spy', 'nvda'], []);
+    expect(out.filter((s) => s.toUpperCase().endsWith('SPY'))).toHaveLength(1);
+    expect(out.filter((s) => s.toUpperCase() === 'NVDA')).toHaveLength(1);
+  });
+});

--- a/web/src/pages/Dashboard/widgets/framework/AddWidgetDialog.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/AddWidgetDialog.tsx
@@ -499,6 +499,18 @@ function WidgetCard({ def, disabled, selected, onSelect, onAdd }: WidgetCardProp
             >
               {isSingleton ? 'singleton' : 'multi'}
             </span>
+            {def.source === 'tradingview' && (
+              <span
+                className="text-[9px] px-1.5 py-0.5 rounded uppercase tracking-wider font-semibold"
+                style={{
+                  backgroundColor: 'var(--color-accent-soft)',
+                  color: 'var(--color-accent-primary)',
+                  letterSpacing: '0.08em',
+                }}
+              >
+                TradingView
+              </span>
+            )}
           </div>
           {def.description && (
             <div

--- a/web/src/pages/Dashboard/widgets/framework/DashboardDataContext.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/DashboardDataContext.tsx
@@ -32,7 +32,7 @@ interface ModalActions {
   cancelDeleteConfirm: () => void;
 }
 
-interface DashboardDataContextValue {
+export interface DashboardDataContextValue {
   dashboard: DashboardData;
   watchlist: WatchlistData;
   portfolio: PortfolioData;

--- a/web/src/pages/Dashboard/widgets/framework/EmbedFallback.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/EmbedFallback.tsx
@@ -1,0 +1,44 @@
+import { AlertTriangle, RotateCw, ExternalLink } from 'lucide-react';
+
+export function EmbedFallback({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div
+      className="absolute inset-0 flex flex-col items-center justify-center gap-2 p-4 text-center"
+      style={{
+        backgroundColor: 'var(--color-bg-card)',
+        color: 'var(--color-text-secondary)',
+      }}
+    >
+      <AlertTriangle size={20} style={{ color: 'var(--color-icon-warning, var(--color-text-tertiary))' }} />
+      <div className="text-xs font-medium" style={{ color: 'var(--color-text-primary)' }}>
+        Widget unavailable
+      </div>
+      <div className="text-[11px] max-w-[28ch]" style={{ color: 'var(--color-text-tertiary)' }}>
+        TradingView didn&apos;t load. Check your network or ad-blocker.
+      </div>
+      <div className="flex items-center gap-2 mt-1">
+        <button
+          type="button"
+          onClick={onRetry}
+          className="inline-flex items-center gap-1 px-2.5 py-1 rounded text-[11px] border widget-drag-cancel"
+          style={{
+            borderColor: 'var(--color-border-default)',
+            backgroundColor: 'var(--color-bg-elevated)',
+            color: 'var(--color-text-primary)',
+          }}
+        >
+          <RotateCw size={11} /> Retry
+        </button>
+        <a
+          href="https://status.tradingview.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="tv-attribution inline-flex items-center gap-1 px-2.5 py-1 rounded text-[11px] widget-drag-cancel"
+          style={{ color: 'var(--color-text-tertiary)', padding: '4px 10px' }}
+        >
+          Status <ExternalLink size={10} />
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/Dashboard/widgets/framework/PresetsDialog.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/PresetsDialog.tsx
@@ -43,7 +43,7 @@ export function PresetsDialog({ open, onOpenChange, onApply }: PresetsDialogProp
               className="mt-2 text-[13px] max-w-[64ch]"
               style={{ color: 'var(--color-text-secondary)' }}
             >
-              Five curated layouts tuned to different workflows. Pick one to start, then rearrange
+              Six curated layouts tuned to different workflows. Pick one to start, then rearrange
               and swap widgets freely. Your existing layout is saved and can be restored.
             </DialogDescription>
           </div>

--- a/web/src/pages/Dashboard/widgets/framework/TradingViewAttribution.css
+++ b/web/src/pages/Dashboard/widgets/framework/TradingViewAttribution.css
@@ -1,0 +1,23 @@
+.tv-attribution {
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-end;
+  font-size: 10px;
+  line-height: 1;
+  padding: 4px 6px;
+  color: var(--color-text-quaternary, var(--color-text-tertiary));
+  text-decoration: none;
+  border-radius: 4px;
+  transition: color 0.12s ease, background-color 0.12s ease;
+}
+
+.tv-attribution:hover {
+  color: var(--color-text-secondary);
+  background-color: var(--color-bg-hover);
+  text-decoration: underline;
+}
+
+.tv-attribution:focus-visible {
+  outline: 2px solid var(--color-accent-primary);
+  outline-offset: 1px;
+}

--- a/web/src/pages/Dashboard/widgets/framework/TradingViewAttribution.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/TradingViewAttribution.tsx
@@ -1,0 +1,21 @@
+import './TradingViewAttribution.css';
+
+/**
+ * Per-widget attribution caption rendered inside every TradingView card.
+ *
+ * Required by TradingView's embed terms — must remain visible. The
+ * `tv-attribution` class allow-lists this link past the
+ * `WidgetFrame.css` selector that hides the lightweight-charts watermark.
+ */
+export function TradingViewAttribution() {
+  return (
+    <a
+      className="tv-attribution"
+      href="https://www.tradingview.com/"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Powered by TradingView ↗
+    </a>
+  );
+}

--- a/web/src/pages/Dashboard/widgets/framework/TradingViewEmbed.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/TradingViewEmbed.tsx
@@ -118,13 +118,13 @@ export function TradingViewEmbed({ scriptKey, config, className, card = false, c
 
       // TV embeds inject an <iframe> child after the script executes. Watch
       // for it; if none appears within 10s, flip to error (ad-blocker most
-      // commonly causes this).
+      // commonly causes this). Observer stays alive past the timeout — slow
+      // CDN/mobile loads where the iframe arrives at 10.5s shouldn't leave
+      // the user stuck on the fallback. Late arrival flips status back to ready.
       observer = new MutationObserver(() => {
         if (cancelled) return;
         if (container.querySelector('iframe')) {
           setStatus('ready');
-          observer?.disconnect();
-          observer = null;
           if (timeoutId !== null) {
             window.clearTimeout(timeoutId);
             timeoutId = null;
@@ -137,8 +137,9 @@ export function TradingViewEmbed({ scriptKey, config, className, card = false, c
         if (cancelled) return;
         if (!container.querySelector('iframe')) {
           setStatus('error');
-          observer?.disconnect();
-          observer = null;
+          // Do NOT disconnect the observer — keep watching so a late iframe
+          // (slow CDN, mobile, network blip) can recover the widget instead
+          // of leaving the user staring at a permanent fallback.
         }
       }, 10_000);
     };

--- a/web/src/pages/Dashboard/widgets/framework/TradingViewEmbed.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/TradingViewEmbed.tsx
@@ -1,0 +1,241 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { AlertTriangle, RotateCw, ExternalLink } from 'lucide-react';
+import { useTheme } from '@/contexts/ThemeContext';
+import { TV_COMMON_CONFIG, resolveScriptSrc } from './tvConfig';
+
+interface Props {
+  /** Either a known short key (`ticker-tape`) or a full embed-widget URL. */
+  scriptKey: string;
+  /** Per-widget config merged on top of TV_COMMON_CONFIG + theme. */
+  config: Record<string, unknown>;
+  /** Class applied to the outer container. */
+  className?: string;
+  /**
+   * When true, wrap the embed in the dashboard's `dashboard-glass-card` shell
+   * so TV widgets visually match our native widgets (background, border,
+   * rounded corners, padding). Off by default so MarketView's bare usage is
+   * unaffected.
+   */
+  card?: boolean;
+  /**
+   * Fixed pixel height for the iframe area. When set, the host stops using
+   * `h-full` and sizes to content, so the widget can pair with
+   * `fitToContent: true` and the cell tracks chrome (header + body padding)
+   * between edit/view modes instead of clipping the iframe. Use for embeds
+   * with a well-defined natural height (e.g. TickerTape ~76px).
+   */
+  contentHeight?: number;
+}
+
+/**
+ * Shared host for TradingView embed widgets.
+ *
+ * Lifecycle:
+ *   1. Mount creates the container DIV; effect appends a fresh <script>
+ *      with the JSON config inline. TV's embed script reads its own DOM
+ *      sibling for config, builds the iframe.
+ *   2. On config / theme change, the effect destroys the previous iframe
+ *      and rebuilds with the new payload.
+ *   3. A 10s timeout watches for the iframe child to appear; if missing
+ *      (ad-blocker, CSP, network), the card flips to the error state with
+ *      a Retry button.
+ *
+ * The drag-cancel behavior in WidgetFrame.css keeps the iframe inert
+ * during edit mode so RGL drag works without per-widget plumbing.
+ */
+// First rebuild fires immediately so the user sees the iframe right away.
+// Subsequent dep changes (config edits in the settings dialog, theme toggles
+// affecting all 17 trader-tv tiles at once) coalesce to a single rebuild
+// after this much idle time. Keeps typing in a SymbolField from rebuilding
+// the iframe on every keystroke and prevents a theme-toggle storm against
+// the TradingView CDN.
+const REBUILD_DEBOUNCE_MS = 200;
+
+export function TradingViewEmbed({ scriptKey, config, className, card = false, contentHeight }: Props) {
+  const { theme } = useTheme();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+  const [retryToken, setRetryToken] = useState(0);
+  const builtOnceRef = useRef(false);
+
+  // Stable JSON of config. Effect dependency uses the string so reference
+  // changes from inline object literals don't trigger spurious rebuilds.
+  const configKey = JSON.stringify(config);
+
+  const retry = useCallback(() => {
+    setStatus('loading');
+    setRetryToken((n) => n + 1);
+  }, []);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    let timeoutId: number | null = null;
+    let buildTimer: number | null = null;
+    let observer: MutationObserver | null = null;
+    let cancelled = false;
+
+    const build = () => {
+      if (cancelled) return;
+      builtOnceRef.current = true;
+
+      container.innerHTML = '';
+
+      const widgetDiv = document.createElement('div');
+      widgetDiv.className = 'tradingview-widget-container__widget';
+      widgetDiv.style.height = '100%';
+      widgetDiv.style.width = '100%';
+      container.appendChild(widgetDiv);
+
+      const script = document.createElement('script');
+      let src: string;
+      try {
+        src = resolveScriptSrc(scriptKey);
+      } catch (e) {
+        console.error('[TradingViewEmbed]', e);
+        setStatus('error');
+        return;
+      }
+      script.src = src;
+      script.type = 'text/javascript';
+      script.async = true;
+      // Escape `<` to `<` so a user-controlled symbol like
+      // `</script><script>…` can't break out of the embedded JSON and execute.
+      // JSON.stringify allows raw `<` because it's valid JSON, but the browser
+      // parses script bodies with HTML rules and would close the script tag.
+      script.text = JSON.stringify({
+        ...TV_COMMON_CONFIG,
+        ...config,
+        colorTheme: theme,
+        theme: theme,
+      }).replace(/</g, '\\u003c');
+      script.onerror = () => {
+        if (cancelled) return;
+        setStatus('error');
+      };
+      container.appendChild(script);
+
+      // TV embeds inject an <iframe> child after the script executes. Watch
+      // for it; if none appears within 10s, flip to error (ad-blocker most
+      // commonly causes this).
+      observer = new MutationObserver(() => {
+        if (cancelled) return;
+        if (container.querySelector('iframe')) {
+          setStatus('ready');
+          observer?.disconnect();
+          observer = null;
+          if (timeoutId !== null) {
+            window.clearTimeout(timeoutId);
+            timeoutId = null;
+          }
+        }
+      });
+      observer.observe(container, { childList: true, subtree: true });
+
+      timeoutId = window.setTimeout(() => {
+        if (cancelled) return;
+        if (!container.querySelector('iframe')) {
+          setStatus('error');
+          observer?.disconnect();
+          observer = null;
+        }
+      }, 10_000);
+    };
+
+    if (builtOnceRef.current) {
+      // Subsequent dep change: defer so rapid keystrokes / theme storms
+      // coalesce into one rebuild. Cleanup cancels in-flight schedules.
+      buildTimer = window.setTimeout(build, REBUILD_DEBOUNCE_MS);
+    } else {
+      // First mount: build synchronously so the iframe is up by the next
+      // paint and tests can assert against the script tag without advancing
+      // timers.
+      build();
+    }
+
+    return () => {
+      cancelled = true;
+      if (buildTimer !== null) window.clearTimeout(buildTimer);
+      if (timeoutId !== null) window.clearTimeout(timeoutId);
+      observer?.disconnect();
+      if (container) container.innerHTML = '';
+    };
+  // Intentionally NOT including `config` in deps — `configKey` (the stable
+  // JSON string) already tracks content changes. Including the raw object
+  // would re-trigger the effect on every parent render (each widget passes
+  // an inline `config={{...}}`), rebuilding the iframe and flashing the
+  // embed on theme toggle / edit-mode flip / neighbor widget edits.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scriptKey, configKey, theme, retryToken]);
+
+  const cardClass = card ? 'dashboard-glass-card p-3 overflow-hidden' : '';
+  const isFixed = typeof contentHeight === 'number';
+  return (
+    <div className={`tv-embed-host flex flex-col h-full ${cardClass} ${className ?? ''}`}>
+      <div
+        className={
+          isFixed
+            ? 'relative flex-1 min-h-0 flex items-center justify-center'
+            : 'relative flex-1 min-h-0'
+        }
+      >
+        <div
+          ref={containerRef}
+          className="tv-embed-container tradingview-widget-container w-full"
+          style={
+            isFixed
+              ? { height: contentHeight, flex: 'none' }
+              : { minHeight: 80, height: '100%' }
+          }
+        />
+        {status === 'error' && (
+          <EmbedFallback onRetry={retry} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function EmbedFallback({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div
+      className="absolute inset-0 flex flex-col items-center justify-center gap-2 p-4 text-center"
+      style={{
+        backgroundColor: 'var(--color-bg-card)',
+        color: 'var(--color-text-secondary)',
+      }}
+    >
+      <AlertTriangle size={20} style={{ color: 'var(--color-icon-warning, var(--color-text-tertiary))' }} />
+      <div className="text-xs font-medium" style={{ color: 'var(--color-text-primary)' }}>
+        Widget unavailable
+      </div>
+      <div className="text-[11px] max-w-[28ch]" style={{ color: 'var(--color-text-tertiary)' }}>
+        TradingView didn&apos;t load. Check your network or ad-blocker.
+      </div>
+      <div className="flex items-center gap-2 mt-1">
+        <button
+          type="button"
+          onClick={onRetry}
+          className="inline-flex items-center gap-1 px-2.5 py-1 rounded text-[11px] border widget-drag-cancel"
+          style={{
+            borderColor: 'var(--color-border-default)',
+            backgroundColor: 'var(--color-bg-elevated)',
+            color: 'var(--color-text-primary)',
+          }}
+        >
+          <RotateCw size={11} /> Retry
+        </button>
+        <a
+          href="https://status.tradingview.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="tv-attribution inline-flex items-center gap-1 px-2.5 py-1 rounded text-[11px] widget-drag-cancel"
+          style={{ color: 'var(--color-text-tertiary)', padding: '4px 10px' }}
+        >
+          Status <ExternalLink size={10} />
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/Dashboard/widgets/framework/TradingViewEmbed.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/TradingViewEmbed.tsx
@@ -57,6 +57,13 @@ export function TradingViewEmbed({ scriptKey, config, className, card = false, c
   const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
   const [retryToken, setRetryToken] = useState(0);
   const builtOnceRef = useRef(false);
+  // Mirror of `status` for use inside the rebuild effect without adding it
+  // to the dep array — the effect would otherwise re-run on every status
+  // flip (including loading→ready), causing a rebuild loop.
+  const statusRef = useRef(status);
+  useEffect(() => {
+    statusRef.current = status;
+  }, [status]);
 
   // Stable JSON of config. Effect dependency uses the string so reference
   // changes from inline object literals don't trigger spurious rebuilds.
@@ -70,6 +77,10 @@ export function TradingViewEmbed({ scriptKey, config, className, card = false, c
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
+    // Clear a stuck error overlay when a real config/theme change triggers
+    // a rebuild. Skip when healthy so theme toggles across 17 tiles don't
+    // flash the loading skeleton.
+    if (statusRef.current === 'error') setStatus('loading');
 
     let timeoutId: number | null = null;
     let buildTimer: number | null = null;

--- a/web/src/pages/Dashboard/widgets/framework/TradingViewEmbed.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/TradingViewEmbed.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { AlertTriangle, RotateCw, ExternalLink } from 'lucide-react';
 import { useTheme } from '@/contexts/ThemeContext';
 import { TV_COMMON_CONFIG, resolveScriptSrc } from './tvConfig';
+import { EmbedFallback } from './EmbedFallback';
 
 interface Props {
   /** Either a known short key (`ticker-tape`) or a full embed-widget URL. */
@@ -198,45 +198,3 @@ export function TradingViewEmbed({ scriptKey, config, className, card = false, c
   );
 }
 
-function EmbedFallback({ onRetry }: { onRetry: () => void }) {
-  return (
-    <div
-      className="absolute inset-0 flex flex-col items-center justify-center gap-2 p-4 text-center"
-      style={{
-        backgroundColor: 'var(--color-bg-card)',
-        color: 'var(--color-text-secondary)',
-      }}
-    >
-      <AlertTriangle size={20} style={{ color: 'var(--color-icon-warning, var(--color-text-tertiary))' }} />
-      <div className="text-xs font-medium" style={{ color: 'var(--color-text-primary)' }}>
-        Widget unavailable
-      </div>
-      <div className="text-[11px] max-w-[28ch]" style={{ color: 'var(--color-text-tertiary)' }}>
-        TradingView didn&apos;t load. Check your network or ad-blocker.
-      </div>
-      <div className="flex items-center gap-2 mt-1">
-        <button
-          type="button"
-          onClick={onRetry}
-          className="inline-flex items-center gap-1 px-2.5 py-1 rounded text-[11px] border widget-drag-cancel"
-          style={{
-            borderColor: 'var(--color-border-default)',
-            backgroundColor: 'var(--color-bg-elevated)',
-            color: 'var(--color-text-primary)',
-          }}
-        >
-          <RotateCw size={11} /> Retry
-        </button>
-        <a
-          href="https://status.tradingview.com/"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="tv-attribution inline-flex items-center gap-1 px-2.5 py-1 rounded text-[11px] widget-drag-cancel"
-          style={{ color: 'var(--color-text-tertiary)', padding: '4px 10px' }}
-        >
-          Status <ExternalLink size={10} />
-        </a>
-      </div>
-    </div>
-  );
-}

--- a/web/src/pages/Dashboard/widgets/framework/TradingViewSettingsFooter.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/TradingViewSettingsFooter.tsx
@@ -1,0 +1,39 @@
+import { HelpCircle } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+/**
+ * Shared attribution block at the bottom of every TradingView widget's
+ * settings dialog. One edit changes all 10.
+ */
+export function TradingViewSettingsFooter() {
+  return (
+    <div
+      className="mt-4 pt-3 flex items-center gap-2 text-[11px]"
+      style={{
+        borderTop: '1px solid var(--color-border-muted)',
+        color: 'var(--color-text-tertiary)',
+      }}
+    >
+      <span>
+        Provided by{' '}
+        <a
+          className="tv-attribution"
+          href="https://www.tradingview.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ display: 'inline', padding: 0 }}
+        >
+          TradingView
+        </a>
+        .
+      </span>
+      <Link
+        to="/legal"
+        title="Legal & attributions"
+        style={{ color: 'var(--color-text-tertiary)', display: 'inline-flex' }}
+      >
+        <HelpCircle size={12} />
+      </Link>
+    </div>
+  );
+}

--- a/web/src/pages/Dashboard/widgets/framework/TradingViewWebComponent.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/TradingViewWebComponent.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
-import { AlertTriangle, RotateCw, ExternalLink } from 'lucide-react';
 import { useTheme } from '@/contexts/ThemeContext';
+import { EmbedFallback } from './EmbedFallback';
 
 /**
  * Per-element-name module loader cache. Each TradingView web-component lives
@@ -265,45 +265,3 @@ export function TradingViewWebComponent({
   );
 }
 
-function EmbedFallback({ onRetry }: { onRetry: () => void }) {
-  return (
-    <div
-      className="absolute inset-0 flex flex-col items-center justify-center gap-2 p-4 text-center"
-      style={{
-        backgroundColor: 'var(--color-bg-card)',
-        color: 'var(--color-text-secondary)',
-      }}
-    >
-      <AlertTriangle size={20} style={{ color: 'var(--color-icon-warning, var(--color-text-tertiary))' }} />
-      <div className="text-xs font-medium" style={{ color: 'var(--color-text-primary)' }}>
-        Widget unavailable
-      </div>
-      <div className="text-[11px] max-w-[28ch]" style={{ color: 'var(--color-text-tertiary)' }}>
-        TradingView didn&apos;t load. Check your network or ad-blocker.
-      </div>
-      <div className="flex items-center gap-2 mt-1">
-        <button
-          type="button"
-          onClick={onRetry}
-          className="inline-flex items-center gap-1 px-2.5 py-1 rounded text-[11px] border widget-drag-cancel"
-          style={{
-            borderColor: 'var(--color-border-default)',
-            backgroundColor: 'var(--color-bg-elevated)',
-            color: 'var(--color-text-primary)',
-          }}
-        >
-          <RotateCw size={11} /> Retry
-        </button>
-        <a
-          href="https://status.tradingview.com/"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="tv-attribution inline-flex items-center gap-1 px-2.5 py-1 rounded text-[11px] widget-drag-cancel"
-          style={{ color: 'var(--color-text-tertiary)', padding: '4px 10px' }}
-        >
-          Status <ExternalLink size={10} />
-        </a>
-      </div>
-    </div>
-  );
-}

--- a/web/src/pages/Dashboard/widgets/framework/TradingViewWebComponent.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/TradingViewWebComponent.tsx
@@ -1,0 +1,309 @@
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { AlertTriangle, RotateCw, ExternalLink } from 'lucide-react';
+import { useTheme } from '@/contexts/ThemeContext';
+
+/**
+ * Per-element-name module loader cache. Each TradingView web-component lives
+ * at a per-name module URL (`tv-ticker-tape.js` registers `<tv-ticker-tape>`).
+ * We dedupe so N instances of the same element on a page only fetch once.
+ *
+ * IMPORTANT — host: it's `widgets.tradingview-widget.com`, NOT
+ * `www.tradingview-widget.com`. The www host returns 403 for these paths.
+ * The widgets subdomain serves them from S3 with proper CORS.
+ */
+const loaderPromises = new Map<string, Promise<void>>();
+
+const TV_WC_BASE = 'https://widgets.tradingview-widget.com/w/en/';
+
+/**
+ * Once-per-page setup: load the `<tv-custom-settings>` element and stamp it
+ * into the document with a `symbol-url` template that routes every symbol
+ * click inside any TV widget to our `/market?symbol=…` route. This is the
+ * crown-jewel of the web-components migration — keeps users in our funnel
+ * instead of bouncing to tradingview.com when they click a heatmap cell or
+ * a ticker.
+ *
+ * `{tvsymbol}` is TV's documented placeholder token. The element only needs
+ * to exist once anywhere in the document; subsequent TV widgets pick up the
+ * setting on registration.
+ */
+let customSettingsInstalled = false;
+function ensureCustomSettings(): void {
+  if (customSettingsInstalled || typeof window === 'undefined') return;
+  customSettingsInstalled = true;
+  ensureLoaded('tv-custom-settings').then(
+    () => {
+      if (document.querySelector('tv-custom-settings')) return;
+      const el = document.createElement('tv-custom-settings');
+      el.setAttribute('symbol-url', `${window.location.origin}/market?symbol={tvsymbol}`);
+      document.body.appendChild(el);
+    },
+    () => {
+      // ad-blocker or CDN failure — accept silently; no-op.
+    },
+  );
+}
+
+function ensureLoaded(elementName: string): Promise<void> {
+  const cached = loaderPromises.get(elementName);
+  if (cached) return cached;
+
+  const src = `${TV_WC_BASE}${elementName}.js`;
+
+  const promise = (async () => {
+    if (typeof window === 'undefined') {
+      throw new Error('[TradingViewWebComponent] no window');
+    }
+    if (window.customElements?.get(elementName)) {
+      return;
+    }
+
+    try {
+      // Use dynamic `import()` — the pattern the TV docs document in their
+      // "dynamic import" example. Browsers handle CORS, MIME-type checks,
+      // and module-cache dedup for us. `@vite-ignore` keeps Vite from
+      // trying to pre-bundle this external URL at build time.
+      await import(/* @vite-ignore */ src);
+    } catch (e) {
+      console.error(`[TradingViewWebComponent] import failed for ${src}`, e);
+      loaderPromises.delete(elementName);
+      throw e;
+    }
+
+    // After import resolves, the module has executed — but TV's modules may
+    // call `customElements.define` asynchronously inside that execution.
+    // `whenDefined` resolves as soon as the registration happens.
+    await window.customElements.whenDefined(elementName);
+  })();
+
+  loaderPromises.set(elementName, promise);
+  return promise;
+}
+
+/** camelCase → kebab-case AND snake_case → kebab-case. Iframe-era TV configs
+ * mix both naming styles (`displayMode`, `support_host`, `hide_top_toolbar`),
+ * and HTML attributes only accept hyphens. */
+function toAttr(key: string): string {
+  return key.replace(/([A-Z])/g, '-$1').replace(/_/g, '-').toLowerCase();
+}
+
+function toAttrValue(v: unknown): string {
+  if (v == null) return '';
+  if (typeof v === 'string') return v;
+  if (typeof v === 'number') return String(v);
+  // Booleans use HTML's presence semantics — `true` = empty string (attribute
+  // is present), `false` is filtered upstream so we don't render it. Stringifying
+  // `"false"` here would set the attribute, which TV reads as truthy.
+  if (typeof v === 'boolean') return '';
+  return JSON.stringify(v);
+}
+
+interface Props {
+  /** Web-component element name (e.g. `tv-ticker-tape`). */
+  element: string;
+  /** Per-widget config; keys converted to kebab-case attributes. */
+  config: Record<string, unknown>;
+  className?: string;
+  card?: boolean;
+}
+
+/**
+ * Shared host for TradingView web-component widgets.
+ *
+ * Lifecycle:
+ *   1. Mount: triggers loader for the element's module script (deduped).
+ *   2. On `ready`, the inner element is rendered with the config as
+ *      kebab-case attributes plus a reactive `theme` attribute.
+ *   3. Config or theme changes update attributes IN PLACE — TV web
+ *      components react to attribute changes without remount, so theme
+ *      flips and config edits don't rebuild the iframe inside.
+ *   4. 15s timeout watches for `customElements.get(element)` to register;
+ *      if missing (ad-blocker, CDN failure), flips to error with Retry.
+ */
+export function TradingViewWebComponent({
+  element,
+  config,
+  className,
+  card = false,
+}: Props) {
+  const { theme } = useTheme();
+  const hostRef = useRef<HTMLDivElement>(null);
+  const elRef = useRef<HTMLElement | null>(null);
+  const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+  const [retryToken, setRetryToken] = useState(0);
+
+  // Stable JSON-encoded config. Widget definitions pass inline object
+  // literals (`config={{ ... }}`), so the raw reference changes on every
+  // parent render even when content is identical. Using the serialized
+  // form as the effect key skips redundant setAttribute loops when
+  // neighbor widgets edit, the grid layout shifts, or edit-mode toggles.
+  const configKey = JSON.stringify(config);
+
+  const retry = useCallback(() => {
+    loaderPromises.delete(element);
+    setStatus('loading');
+    setRetryToken((n) => n + 1);
+  }, [element]);
+
+  // Loader: drives status transitions. Re-runs on element change or retry.
+  useEffect(() => {
+    // Reset to 'loading' when the element prop changes mid-mount. Without
+    // this, status stays 'ready' from the prior element, the mount effect
+    // races ahead and calls `document.createElement(newElement)` against a
+    // tag whose module hasn't loaded yet — producing an HTMLUnknownElement
+    // with leaked attributes.
+    setStatus('loading');
+    ensureCustomSettings();
+    let cancelled = false;
+    let timeoutId: number | null = window.setTimeout(() => {
+      if (cancelled) return;
+      if (!window.customElements?.get(element)) {
+        setStatus('error');
+      }
+    }, 15_000);
+
+    ensureLoaded(element).then(
+      () => {
+        if (cancelled) return;
+        if (timeoutId !== null) {
+          window.clearTimeout(timeoutId);
+          timeoutId = null;
+        }
+        setStatus('ready');
+      },
+      (err) => {
+        if (cancelled) return;
+        console.error('[TradingViewWebComponent]', err);
+        if (timeoutId !== null) {
+          window.clearTimeout(timeoutId);
+          timeoutId = null;
+        }
+        setStatus('error');
+      },
+    );
+
+    return () => {
+      cancelled = true;
+      if (timeoutId !== null) window.clearTimeout(timeoutId);
+    };
+  }, [element, retryToken]);
+
+  // Mount: when ready, create the custom element imperatively and append to
+  // the host ref. Imperative because React's JSX doesn't ship attributes
+  // that need exact kebab-case — JSX would camelCase or hyphenate
+  // inconsistently depending on the prop name. Imperative `setAttribute` is
+  // unambiguous.
+  useEffect(() => {
+    if (status !== 'ready') return;
+    const host = hostRef.current;
+    if (!host) return;
+
+    if (!elRef.current) {
+      const el = document.createElement(element);
+      host.appendChild(el);
+      elRef.current = el;
+    }
+    const el = elRef.current;
+
+    const wantedAttrs = new Set<string>();
+    for (const [k, v] of Object.entries(config)) {
+      // Skip `false` booleans entirely. HTML boolean attrs use presence
+      // semantics (`hide-chart` present = true). Setting `hide-chart="false"`
+      // is still "present" → TV reads it as truthy. Caller passes `true` to
+      // enable, omits or passes `false` to disable.
+      // Also skip null/undefined — toAttrValue would emit '' which TV reads
+      // as truthy too, so an `{ hideLegend: undefined }` spread accidentally
+      // enables hide-legend. Same presence trap as the false branch.
+      if (v === false || v == null) continue;
+      const name = toAttr(k);
+      wantedAttrs.add(name);
+      el.setAttribute(name, toAttrValue(v));
+    }
+    // Theme is reactive and lives outside `config` so dashboard widgets
+    // don't need to thread it through every call site.
+    el.setAttribute('theme', theme);
+    wantedAttrs.add('theme');
+    el.setAttribute('color-theme', theme);
+    wantedAttrs.add('color-theme');
+
+    // Strip stale attributes from prior config so attribute state mirrors
+    // the current config object exactly.
+    for (const attr of Array.from(el.attributes)) {
+      if (!wantedAttrs.has(attr.name)) {
+        el.removeAttribute(attr.name);
+      }
+    }
+    // `config` is read from closure but intentionally not in deps —
+    // `configKey` (the stable JSON string) tracks content changes without
+    // tripping on reference churn from inline object literals.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status, element, configKey, theme]);
+
+  // Teardown on unmount or element change: detach the custom element so it
+  // doesn't leak its iframe into the next mount.
+  useEffect(() => {
+    return () => {
+      if (elRef.current) {
+        elRef.current.remove();
+        elRef.current = null;
+      }
+    };
+  }, [element]);
+
+  const cardClass = card ? 'dashboard-glass-card p-3 overflow-hidden' : '';
+  return (
+    <div className={`tv-embed-host flex flex-col h-full ${cardClass} ${className ?? ''}`}>
+      <div className="relative flex-1 min-h-0">
+        <div
+          ref={hostRef}
+          className="tv-wc-container w-full h-full"
+          style={{ minHeight: 80 }}
+        />
+        {status === 'error' && <EmbedFallback onRetry={retry} />}
+      </div>
+    </div>
+  );
+}
+
+function EmbedFallback({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div
+      className="absolute inset-0 flex flex-col items-center justify-center gap-2 p-4 text-center"
+      style={{
+        backgroundColor: 'var(--color-bg-card)',
+        color: 'var(--color-text-secondary)',
+      }}
+    >
+      <AlertTriangle size={20} style={{ color: 'var(--color-icon-warning, var(--color-text-tertiary))' }} />
+      <div className="text-xs font-medium" style={{ color: 'var(--color-text-primary)' }}>
+        Widget unavailable
+      </div>
+      <div className="text-[11px] max-w-[28ch]" style={{ color: 'var(--color-text-tertiary)' }}>
+        TradingView didn&apos;t load. Check your network or ad-blocker.
+      </div>
+      <div className="flex items-center gap-2 mt-1">
+        <button
+          type="button"
+          onClick={onRetry}
+          className="inline-flex items-center gap-1 px-2.5 py-1 rounded text-[11px] border widget-drag-cancel"
+          style={{
+            borderColor: 'var(--color-border-default)',
+            backgroundColor: 'var(--color-bg-elevated)',
+            color: 'var(--color-text-primary)',
+          }}
+        >
+          <RotateCw size={11} /> Retry
+        </button>
+        <a
+          href="https://status.tradingview.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="tv-attribution inline-flex items-center gap-1 px-2.5 py-1 rounded text-[11px] widget-drag-cancel"
+          style={{ color: 'var(--color-text-tertiary)', padding: '4px 10px' }}
+        >
+          Status <ExternalLink size={10} />
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/Dashboard/widgets/framework/WidgetFrame.css
+++ b/web/src/pages/Dashboard/widgets/framework/WidgetFrame.css
@@ -287,11 +287,17 @@
   opacity: 1;
 }
 
-/* Hide the TradingView attribution watermark in any widget that embeds a
- * lightweight-charts instance (e.g. the price chart widget). Matches the
- * suppression used by MarketChart.css; scoped to widget-frame so the rule is
- * only active once a dashboard widget is mounted. */
-.widget-frame a[href*="tradingview.com"],
+/* Hide the lightweight-charts attribution watermark (a small link in the
+ * chart corner) inside any widget that embeds lightweight-charts — the
+ * NOTICE text lives at /legal so we aren't stripping attribution; we just
+ * don't want a floating link on top of every chart.
+ *
+ * IMPORTANT — scope: this rule MUST NOT match the `Powered by TradingView ↗`
+ * attribution links our embed widgets render (class `.tv-attribution`).
+ * Those are required visible per TV's embed terms. The lightweight-charts
+ * watermark link's href always contains `utm_medium=lwc-link` (the
+ * library's own UTM campaign), so we target that specifically. */
+.widget-frame a[href*="utm_medium=lwc-link"],
 .widget-frame .tv-lightweight-charts__watermark {
   display: none !important;
   visibility: hidden !important;

--- a/web/src/pages/Dashboard/widgets/framework/__tests__/TradingViewEmbed.test.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/__tests__/TradingViewEmbed.test.tsx
@@ -47,4 +47,25 @@ describe('TradingViewEmbed', () => {
     expect(screen.getByText(/widget unavailable/i)).toBeInTheDocument();
     expect(consoleSpy).toHaveBeenCalled();
   });
+
+  it('clears a stuck error overlay when config changes trigger a rebuild', () => {
+    const { rerender } = render(
+      <TradingViewEmbed scriptKey="ticker-tape" config={{ symbols: [{ proName: 'NVDA' }] }} />,
+    );
+    // Trip the 10s no-iframe timeout to land in the error state.
+    act(() => {
+      vi.advanceTimersByTime(10_050);
+    });
+    expect(screen.getByText(/widget unavailable/i)).toBeInTheDocument();
+
+    // Config change (e.g., user swaps symbol in settings) should reset the
+    // error overlay back to loading on the next rebuild — without waiting
+    // for the new iframe (or the next 10s timeout) to arrive.
+    act(() => {
+      rerender(
+        <TradingViewEmbed scriptKey="ticker-tape" config={{ symbols: [{ proName: 'AAPL' }] }} />,
+      );
+    });
+    expect(screen.queryByText(/widget unavailable/i)).not.toBeInTheDocument();
+  });
 });

--- a/web/src/pages/Dashboard/widgets/framework/__tests__/TradingViewEmbed.test.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/__tests__/TradingViewEmbed.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { TradingViewEmbed } from '../TradingViewEmbed';
+
+// ThemeContext is consumed via useTheme() — stub it so the component mounts
+// cleanly in jsdom without the full provider tree.
+vi.mock('@/contexts/ThemeContext', () => ({
+  useTheme: () => ({ theme: 'dark' }),
+}));
+
+describe('TradingViewEmbed', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('injects a TV embed-widget script with the correct src + config', () => {
+    const { container } = render(
+      <TradingViewEmbed scriptKey="ticker-tape" config={{ symbols: [{ proName: 'NVDA', description: 'NVDA' }] }} />,
+    );
+    const script = container.querySelector('script[src*="embed-widget-ticker-tape"]');
+    expect(script).toBeTruthy();
+    const payload = JSON.parse((script as HTMLScriptElement).innerHTML);
+    expect(payload.autosize).toBe(true);
+    expect(payload.colorTheme).toBe('dark');
+    expect(payload.symbols).toBeTruthy();
+  });
+
+  it('shows the fallback state when no iframe materialises within 10s', () => {
+    render(<TradingViewEmbed scriptKey="ticker-tape" config={{}} />);
+    // No iframe — the timeout should trip and the fallback appears.
+    act(() => {
+      vi.advanceTimersByTime(10_050);
+    });
+    expect(screen.getByText(/widget unavailable/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it('throws via console.error for an unknown script key (no silent failure)', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(<TradingViewEmbed scriptKey="not-a-real-widget" config={{}} />);
+    // The component setState's to error synchronously via the try/catch
+    // inside the effect; the fallback UI confirms the caught error.
+    expect(screen.getByText(/widget unavailable/i)).toBeInTheDocument();
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+});

--- a/web/src/pages/Dashboard/widgets/framework/__tests__/attribution-visibility.test.ts
+++ b/web/src/pages/Dashboard/widgets/framework/__tests__/attribution-visibility.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * REGRESSION-CRITICAL — protects TradingView license compliance.
+ *
+ * The CSS file `WidgetFrame.css` previously contained this broad rule:
+ *
+ *     .widget-frame a[href*="tradingview.com"] { display: none !important; }
+ *
+ * That rule was added to suppress lightweight-charts' own TradingView
+ * watermark inside ChartWidget. But it ALSO hides every TradingView
+ * attribution link our TV embed widgets intentionally render (class
+ * `tv-attribution`, `<a href="https://www.tradingview.com/">`). Hidden
+ * attribution is a license violation per TradingView's embed terms.
+ *
+ * Our fix is to scope the kill selector to the lightweight-charts
+ * watermark class only. This test pins that invariant so a well-meaning
+ * future edit doesn't accidentally re-broaden the selector and silently
+ * strip attribution from all 10 TV-embed widgets.
+ *
+ * If this test fails, do not change the assertions — fix the CSS.
+ */
+describe('TradingView attribution visibility (regression)', () => {
+  const cssPath = resolve(
+    __dirname,
+    '..',
+    'WidgetFrame.css',
+  );
+  const css = readFileSync(cssPath, 'utf8');
+
+  it('WidgetFrame.css hides the lightweight-charts watermark', () => {
+    // lightweight-charts renders its watermark as an <a> with a utm_medium
+    // query param; we target that URL signature (stable across library
+    // versions) and the `.tv-lightweight-charts__watermark` class as a
+    // secondary safety net.
+    expect(css).toMatch(/utm_medium=lwc-link/);
+    expect(css).toMatch(/\.tv-lightweight-charts__watermark/);
+  });
+
+  it('WidgetFrame.css does NOT hide arbitrary tradingview.com links', () => {
+    // This is the over-broad selector that used to live here. It would also
+    // match the `Powered by TradingView ↗` attribution our embed widgets
+    // render — seeing it back means we're silently stripping attribution.
+    expect(css).not.toMatch(/\.widget-frame\s+a\[href\*=["']tradingview\.com["']\]/);
+  });
+});

--- a/web/src/pages/Dashboard/widgets/framework/__tests__/presets.test.ts
+++ b/web/src/pages/Dashboard/widgets/framework/__tests__/presets.test.ts
@@ -44,4 +44,42 @@ describe('presets', () => {
       expect(mdIds).toEqual(lgIds);
     }
   });
+
+  // REGRESSION-CRITICAL: the existing `trader` preset must stay exactly as
+  // it was before `trader-tv` landed. Any accidental mutation (e.g. copying
+  // from the wrong factory when adding the new preset) would silently change
+  // the layout for users who already have it applied.
+  it('existing `trader` preset layout is the NVDA chart grid (regression)', () => {
+    const p = getPreset('trader');
+    const types = p.widgets.map((w) => w.type).sort();
+    expect(types).toEqual(
+      [
+        'chart.symbol',
+        'chart.symbol',
+        'chart.symbol',
+        'chart.symbol',
+        'markets.overview',
+        'news.feed',
+        'personal.portfolioWatchlist',
+      ].sort(),
+    );
+    // Four NVDA / SPY charts are present in the classic trader preset
+    const chartSymbols = p.widgets
+      .filter((w) => w.type === 'chart.symbol')
+      .map((w) => (w.config as { symbol?: string }).symbol);
+    expect(chartSymbols.filter((s) => s === 'NVDA').length).toBe(3);
+    expect(chartSymbols).toContain('SPY');
+  });
+
+  it('new `trader-tv` preset includes the expected TV widget types', () => {
+    const p = getPreset('trader-tv');
+    const types = p.widgets.map((w) => w.type);
+    expect(types).toContain('tv.ticker-tape');
+    expect(types).toContain('tv.stock-heatmap');
+    expect(types).toContain('tv.symbol-spotlight');
+    expect(types).toContain('tv.movers');
+    expect(types).toContain('tv.economic-events');
+    expect(types).toContain('tv.technicals');
+    expect(types).toContain('markets.miniChartGrid');
+  });
 });

--- a/web/src/pages/Dashboard/widgets/framework/__tests__/tvConfig.test.ts
+++ b/web/src/pages/Dashboard/widgets/framework/__tests__/tvConfig.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { resolveScriptSrc } from '../tvConfig';
+
+describe('resolveScriptSrc', () => {
+  it('passes full https URLs through unchanged', () => {
+    expect(resolveScriptSrc('https://example.com/foo.js')).toBe('https://example.com/foo.js');
+  });
+
+  it('passes full http URLs through unchanged', () => {
+    expect(resolveScriptSrc('http://example.com/foo.js')).toBe('http://example.com/foo.js');
+  });
+
+  it('resolves known short keys against the TV CDN base', () => {
+    expect(resolveScriptSrc('ticker-tape')).toBe(
+      'https://s3.tradingview.com/external-embedding/embed-widget-ticker-tape.js',
+    );
+    expect(resolveScriptSrc('symbol-info')).toBe(
+      'https://s3.tradingview.com/external-embedding/embed-widget-symbol-info.js',
+    );
+    expect(resolveScriptSrc('etf-heatmap')).toBe(
+      'https://s3.tradingview.com/external-embedding/embed-widget-etf-heatmap.js',
+    );
+  });
+
+  it('throws for unknown short keys so registration typos surface at mount', () => {
+    expect(() => resolveScriptSrc('not-a-real-key')).toThrow(/unknown script key/i);
+  });
+});

--- a/web/src/pages/Dashboard/widgets/framework/__tests__/useDashboardPrefs.test.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/__tests__/useDashboardPrefs.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act } from '@testing-library/react';
+import { renderHookWithProviders } from '../../../../../test/utils';
+
+const prefsState: { current: { other_preference?: Record<string, unknown> } | null } = {
+  current: { other_preference: { theme: 'dark' } },
+};
+const mockMutate = vi.fn();
+const mockToast = vi.fn();
+
+vi.mock('@/hooks/usePreferences', () => ({
+  usePreferences: () => ({ preferences: prefsState.current, isLoading: false }),
+}));
+vi.mock('@/hooks/useUpdatePreferences', () => ({
+  useUpdatePreferences: () => ({ mutate: mockMutate }),
+}));
+vi.mock('@/components/ui/use-toast', () => ({
+  useToast: () => ({ toast: mockToast, dismiss: vi.fn(), toasts: [] }),
+}));
+
+import { useDashboardPrefs } from '../useDashboardPrefs';
+
+describe('useDashboardPrefs', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockMutate.mockReset();
+    mockToast.mockReset();
+    prefsState.current = { other_preference: { theme: 'dark' } };
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('debounces non-immediate writes by 800ms', () => {
+    const { result } = renderHookWithProviders(() => useDashboardPrefs());
+    act(() => {
+      result.current.update({ mode: 'custom' });
+    });
+    expect(mockMutate).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(800);
+    });
+    expect(mockMutate).toHaveBeenCalledTimes(1);
+  });
+
+  it('flushes immediately when {immediate:true}', () => {
+    const { result } = renderHookWithProviders(() => useDashboardPrefs());
+    act(() => {
+      result.current.setMode('custom');
+    });
+    // setMode uses immediate:true under the hood.
+    expect(mockMutate).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves sibling other_preference keys (theme) when flushing', () => {
+    const { result } = renderHookWithProviders(() => useDashboardPrefs());
+    act(() => {
+      result.current.setMode('custom');
+    });
+    const payload = mockMutate.mock.calls[0][0] as {
+      other_preference: { theme?: string; dashboard?: { mode: string } };
+    };
+    expect(payload.other_preference.theme).toBe('dark');
+    expect(payload.other_preference.dashboard?.mode).toBe('custom');
+  });
+
+  it('shows a destructive toast when the server rejects the write', () => {
+    mockMutate.mockImplementation((_payload, opts: { onError: () => void }) => {
+      opts.onError();
+    });
+    const { result } = renderHookWithProviders(() => useDashboardPrefs());
+    act(() => {
+      result.current.setMode('custom');
+    });
+    expect(mockToast).toHaveBeenCalledTimes(1);
+    expect(mockToast.mock.calls[0][0]).toMatchObject({ variant: 'destructive' });
+  });
+
+  it('caps history at 3 prior layouts on repeated applyPreset', () => {
+    const { result } = renderHookWithProviders(() => useDashboardPrefs());
+    act(() => {
+      result.current.applyPreset('morning-brief');
+    });
+    act(() => {
+      result.current.applyPreset('trader');
+    });
+    act(() => {
+      result.current.applyPreset('researcher');
+    });
+    act(() => {
+      result.current.applyPreset('agent-desk');
+    });
+    expect(result.current.prefs.history?.length ?? 0).toBeLessThanOrEqual(3);
+  });
+});

--- a/web/src/pages/Dashboard/widgets/framework/defaults.ts
+++ b/web/src/pages/Dashboard/widgets/framework/defaults.ts
@@ -1,0 +1,6 @@
+/**
+ * Shared seed defaults the framework and presets reach for. Lives outside
+ * `definitions/` so framework-tier code (presets.ts, future widget pickers)
+ * can import without inverting the dependency direction (framework→widget).
+ */
+export const DEFAULT_BLUE_CHIPS = ['NVDA', 'AAPL', 'MSFT', 'GOOGL', 'AMZN', 'META'];

--- a/web/src/pages/Dashboard/widgets/framework/presets/Thumbnails.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/presets/Thumbnails.tsx
@@ -29,6 +29,7 @@ interface CellVisuals {
 
 const TYPE_VISUALS: Record<string, CellVisuals> = {
   'markets.overview': { bg: C.tape },
+  'markets.miniChartGrid': { bg: C.paper, stroke: C.line },
   'chart.symbol': { bg: C.paper, stroke: C.line },
   'insight.brief': { bg: C.paperHi, stroke: C.line },
   'news.feed': { bg: C.tape },
@@ -40,6 +41,19 @@ const TYPE_VISUALS: Record<string, CellVisuals> = {
   'workspace.picker': { bg: C.accentSoft },
   'threads.recent': { bg: C.paper, stroke: C.line },
   'automations.list': { bg: C.paper, stroke: C.line },
+  // TradingView embeds — same palette as their native siblings so thumbnails
+  // read as variations on the same canvas. Glyphs fall through to the default
+  // empty state which is fine; the cell bg + size still communicate layout.
+  'tv.ticker-tape': { bg: C.tape },
+  'tv.stock-heatmap': { bg: C.accentSoft, stroke: C.line },
+  'tv.crypto-heatmap': { bg: C.accentSoft, stroke: C.line },
+  'tv.forex-heatmap': { bg: C.accentSoft, stroke: C.line },
+  'tv.economic-events': { bg: C.paper, stroke: C.line },
+  'tv.technicals': { bg: C.paperHi, stroke: C.line },
+  'tv.movers': { bg: C.paperHi, stroke: C.line },
+  'tv.symbol-spotlight': { bg: C.paper, stroke: C.line },
+  'tv.company-profile': { bg: C.paper, stroke: C.line },
+  'tv.company-financials': { bg: C.paper, stroke: C.line },
 };
 
 interface GlyphProps {

--- a/web/src/pages/Dashboard/widgets/framework/reconcile.ts
+++ b/web/src/pages/Dashboard/widgets/framework/reconcile.ts
@@ -12,14 +12,16 @@ export function reconcileLayouts(
   widgets: WidgetInstance[],
   layouts: Partial<Record<BreakpointKey, RGLItem[]>>
 ): Partial<Record<BreakpointKey, RGLItem[]>> {
-  const widgetIds = new Set(widgets.map((w) => w.id));
+  // Map by id once so the per-breakpoint loop does O(n) lookups instead of
+  // O(n²) `widgets.find()` calls. Doubles as the membership check.
+  const widgetsById = new Map(widgets.map((w) => [w.id, w]));
   const out: Partial<Record<BreakpointKey, RGLItem[]>> = {};
 
   for (const bp of BREAKPOINT_KEYS) {
-    const items = (layouts[bp] ?? []).filter((l) => widgetIds.has(l.i));
+    const items = (layouts[bp] ?? []).filter((l) => widgetsById.has(l.i));
     const placed = new Set(items.map((l) => l.i));
     const result: RGLItem[] = items.map((l) => {
-      const w = widgets.find((w) => w.id === l.i);
+      const w = widgetsById.get(l.i);
       if (!w) return l;
       const def = getWidget(w.type);
       if (!def) return l;

--- a/web/src/pages/Dashboard/widgets/framework/reconcile.ts
+++ b/web/src/pages/Dashboard/widgets/framework/reconcile.ts
@@ -21,8 +21,9 @@ export function reconcileLayouts(
     const items = (layouts[bp] ?? []).filter((l) => widgetsById.has(l.i));
     const placed = new Set(items.map((l) => l.i));
     const result: RGLItem[] = items.map((l) => {
-      const w = widgetsById.get(l.i);
-      if (!w) return l;
+      // `items` was pre-filtered by `widgetsById.has(l.i)` above, so `.get()`
+      // here always returns a value. The `!` cast skips an unreachable guard.
+      const w = widgetsById.get(l.i)!;
       const def = getWidget(w.type);
       if (!def) return l;
       const minW = def.minSize.w;

--- a/web/src/pages/Dashboard/widgets/framework/settings/EnumField.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/settings/EnumField.tsx
@@ -1,0 +1,36 @@
+import { Select } from '@/components/ui/select';
+
+interface Option {
+  value: string;
+  label: string;
+}
+
+interface Props {
+  label: string;
+  value: string;
+  onChange: (next: string) => void;
+  options: Option[];
+  helper?: string;
+}
+
+export function EnumField({ label, value, onChange, options, helper }: Props) {
+  return (
+    <label className="block">
+      <span className="text-xs block mb-1" style={{ color: 'var(--color-text-secondary)' }}>
+        {label}
+      </span>
+      <Select value={value} onChange={(e) => onChange(e.target.value)}>
+        {options.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </Select>
+      {helper && (
+        <span className="text-[11px] mt-1 block" style={{ color: 'var(--color-text-tertiary)' }}>
+          {helper}
+        </span>
+      )}
+    </label>
+  );
+}

--- a/web/src/pages/Dashboard/widgets/framework/settings/SettingsDoneButton.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/settings/SettingsDoneButton.tsx
@@ -1,0 +1,28 @@
+interface Props {
+  onClick: () => void;
+  /** Override the default "Done" copy when the dialog has a different commit verb. */
+  label?: string;
+}
+
+/**
+ * Shared "Done" button for widget settings dialogs. One change here updates
+ * focus-visible / hover / disabled states across every settings panel.
+ */
+export function SettingsDoneButton({ onClick, label = 'Done' }: Props) {
+  return (
+    <div className="flex justify-end pt-1">
+      <button
+        type="button"
+        onClick={onClick}
+        className="settings-done-btn px-3 py-1.5 rounded text-sm font-medium transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+        style={{
+          backgroundColor: 'var(--color-accent-primary)',
+          color: 'var(--color-text-on-accent)',
+          outlineColor: 'var(--color-accent-primary)',
+        }}
+      >
+        {label}
+      </button>
+    </div>
+  );
+}

--- a/web/src/pages/Dashboard/widgets/framework/settings/SymbolField.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/settings/SymbolField.tsx
@@ -1,0 +1,45 @@
+import { Input } from '@/components/ui/input';
+
+interface Props {
+  label: string;
+  value: string;
+  onChange: (next: string) => void;
+  placeholder?: string;
+  helper?: string;
+}
+
+/**
+ * Single-symbol picker. Plain uppercase input — autocomplete from a curated
+ * list could come later; for now we accept any user-entered symbol because
+ * TradingView resolves them server-side anyway.
+ */
+export function SymbolField({ label, value, onChange, placeholder, helper }: Props) {
+  return (
+    <label className="block">
+      <span className="text-xs block mb-1" style={{ color: 'var(--color-text-secondary)' }}>
+        {label}
+      </span>
+      <Input
+        value={value}
+        onChange={(e) => onChange(e.target.value.toUpperCase())}
+        onBlur={(e) => {
+          const trimmed = e.target.value.trim();
+          if (trimmed !== e.target.value) onChange(trimmed);
+        }}
+        placeholder={placeholder ?? 'e.g. NASDAQ:NVDA or AAPL'}
+        className="border"
+        style={{
+          backgroundColor: 'var(--color-bg-card)',
+          borderColor: 'var(--color-border-default)',
+          color: 'var(--color-text-primary)',
+          textTransform: 'uppercase',
+        }}
+      />
+      {helper && (
+        <span className="text-[11px] mt-1 block" style={{ color: 'var(--color-text-tertiary)' }}>
+          {helper}
+        </span>
+      )}
+    </label>
+  );
+}

--- a/web/src/pages/Dashboard/widgets/framework/settings/SymbolListField.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/settings/SymbolListField.tsx
@@ -1,0 +1,108 @@
+import { useState, type KeyboardEvent } from 'react';
+import { X } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+
+interface Props {
+  label: string;
+  value: string[];
+  onChange: (next: string[]) => void;
+  placeholder?: string;
+  helper?: string;
+  max?: number;
+}
+
+/**
+ * Multi-symbol picker — chips with add-by-Enter and remove-by-X.
+ * Symbols are uppercased and de-duplicated on add.
+ */
+export function SymbolListField({
+  label,
+  value,
+  onChange,
+  placeholder,
+  helper,
+  max = 50,
+}: Props) {
+  const [draft, setDraft] = useState('');
+
+  const add = () => {
+    const sym = draft.trim().toUpperCase();
+    if (!sym) return;
+    if (value.includes(sym)) {
+      setDraft('');
+      return;
+    }
+    if (value.length >= max) return;
+    onChange([...value, sym]);
+    setDraft('');
+  };
+
+  const onKey = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault();
+      add();
+    } else if (e.key === 'Backspace' && draft === '' && value.length > 0) {
+      onChange(value.slice(0, -1));
+    }
+  };
+
+  const remove = (sym: string) => onChange(value.filter((s) => s !== sym));
+
+  return (
+    <div>
+      <span className="text-xs block mb-1" style={{ color: 'var(--color-text-secondary)' }}>
+        {label}
+      </span>
+      <div
+        className="flex flex-wrap gap-1.5 p-1.5 rounded border"
+        style={{
+          backgroundColor: 'var(--color-bg-card)',
+          borderColor: 'var(--color-border-default)',
+        }}
+      >
+        {value.map((sym) => (
+          <span
+            key={sym}
+            className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] dashboard-mono"
+            style={{
+              backgroundColor: 'var(--color-bg-subtle)',
+              color: 'var(--color-text-primary)',
+            }}
+          >
+            {sym}
+            <button
+              type="button"
+              onClick={() => remove(sym)}
+              aria-label={`Remove ${sym}`}
+              style={{ color: 'var(--color-text-tertiary)' }}
+            >
+              <X size={10} />
+            </button>
+          </span>
+        ))}
+        <Input
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={onKey}
+          onBlur={add}
+          placeholder={value.length === 0 ? placeholder ?? 'Add symbols (Enter)' : ''}
+          className="flex-1 min-w-[100px] border-0 !p-0 !h-6 text-xs bg-transparent shadow-none focus-visible:ring-0"
+          style={{
+            color: 'var(--color-text-primary)',
+            textTransform: 'uppercase',
+          }}
+        />
+      </div>
+      {helper && (
+        <span className="text-[11px] mt-1 block" style={{ color: 'var(--color-text-tertiary)' }}>
+          {helper}
+        </span>
+      )}
+      {value.length >= max && (
+        <span className="text-[11px] mt-1 block" style={{ color: 'var(--color-text-tertiary)' }}>
+          Max {max} symbols.
+        </span>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/Dashboard/widgets/framework/settings/__tests__/settings-atoms.test.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/settings/__tests__/settings-atoms.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SymbolField } from '../SymbolField';
+import { SymbolListField } from '../SymbolListField';
+import { EnumField } from '../EnumField';
+
+describe('SymbolField', () => {
+  it('renders label and uppercases user input', () => {
+    const onChange = vi.fn();
+    render(<SymbolField label="Symbol" value="" onChange={onChange} />);
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'nvda' } });
+    expect(onChange).toHaveBeenCalledWith('NVDA');
+  });
+});
+
+describe('SymbolListField', () => {
+  it('adds uppercase unique symbols on Enter', () => {
+    const onChange = vi.fn();
+    render(<SymbolListField label="Symbols" value={['AAPL']} onChange={onChange} />);
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'nvda' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onChange).toHaveBeenCalledWith(['AAPL', 'NVDA']);
+  });
+
+  it('ignores duplicate entries', () => {
+    const onChange = vi.fn();
+    render(<SymbolListField label="Symbols" value={['AAPL']} onChange={onChange} />);
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'aapl' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('removes a symbol when the chip X is clicked', () => {
+    const onChange = vi.fn();
+    render(<SymbolListField label="Symbols" value={['AAPL', 'NVDA']} onChange={onChange} />);
+    const removeBtn = screen.getByRole('button', { name: /remove aapl/i });
+    fireEvent.click(removeBtn);
+    expect(onChange).toHaveBeenCalledWith(['NVDA']);
+  });
+});
+
+describe('EnumField', () => {
+  it('emits the selected option value', () => {
+    const onChange = vi.fn();
+    render(
+      <EnumField
+        label="Interval"
+        value="1D"
+        onChange={onChange}
+        options={[
+          { value: '1D', label: '1 day' },
+          { value: '1W', label: '1 week' },
+        ]}
+      />,
+    );
+    const select = screen.getByRole('combobox');
+    fireEvent.change(select, { target: { value: '1W' } });
+    expect(onChange).toHaveBeenCalledWith('1W');
+  });
+});

--- a/web/src/pages/Dashboard/widgets/framework/tvConfig.ts
+++ b/web/src/pages/Dashboard/widgets/framework/tvConfig.ts
@@ -1,0 +1,93 @@
+/**
+ * Shared TradingView embed plumbing — iframe-script variant.
+ *
+ * Strategy: every TV widget injects an iframe-script tag with a JSON config
+ * blob. We dedupe loader fetches per scriptSrc so a dashboard with multiple
+ * TV widgets of the same kind only hits the network once. Theme + config
+ * changes rebuild the iframe (TV's embed scripts don't expose attribute
+ * APIs for the legacy widget catalog).
+ *
+ * Web-components alternative: `framework/TradingViewWebComponent.tsx` hosts
+ * the newer `<tv-*>` catalog from `widgets.tradingview-widget.com`. Web
+ * components support `symbol-url` redirection (per-symbol click → our
+ * `/market` route) and reactive attribute updates without iframe rebuild.
+ *
+ * Catalog status (probed 2026-04-24 — re-check periodically as TV expands):
+ *   Available as WC (5 total): tv-ticker-tape, tv-ticker-tag, tv-mini-chart,
+ *     tv-market-summary, tv-economic-map.
+ *   NOT yet WC (403 at widgets.tradingview-widget.com/w/en/): tv-symbol-
+ *     profile, tv-financials, tv-forex-cross-rates, tv-hotlists, tv-events,
+ *     tv-crypto-coins-heatmap, tv-technical-analysis, tv-stock-heatmap,
+ *     tv-symbol-overview, tv-advanced-chart.
+ *   In use: only `tv-economic-map` (EconomicMapWidget). Our other 9 TV
+ *     widgets stay on iframes until TV ships their WC equivalents. Symbol
+ *     clicks inside iframes bounce to tradingview.com — only WCs honor
+ *     `<tv-custom-settings symbol-url>` redirection.
+ *
+ * Iframe-only by choice (do NOT migrate to WC even when available):
+ *   - `ticker-tape`: the WC `<tv-ticker-tape>` renders a static bordered
+ *     *grid* (verified across `default`, `horizontal`, `horizontal_no_chart`
+ *     presets in TV's gallery). The iframe `embed-widget-ticker-tape.js` is
+ *     the only variant that produces the classic continuous scrolling
+ *     marquee that users expect. Trade-off: symbol clicks bounce to
+ *     tradingview.com instead of our `/market` route.
+ */
+
+const TV_BASE = 'https://s3.tradingview.com/external-embedding/';
+
+/**
+ * Resolves the canonical embed-script URL given a short widget key.
+ * Pass either a full URL or one of the well-known short keys below.
+ */
+const SCRIPT_KEYS: Record<string, string> = {
+  'ticker-tape': 'embed-widget-ticker-tape.js',
+  'stock-heatmap': 'embed-widget-stock-heatmap.js',
+  'crypto-coins-heatmap': 'embed-widget-crypto-coins-heatmap.js',
+  'forex-cross-rates': 'embed-widget-forex-cross-rates.js',
+  'events': 'embed-widget-events.js',
+  'technical-analysis': 'embed-widget-technical-analysis.js',
+  'hotlists': 'embed-widget-hotlists.js',
+  'symbol-overview': 'embed-widget-symbol-overview.js',
+  'symbol-profile': 'embed-widget-symbol-profile.js',
+  'financials': 'embed-widget-financials.js',
+  'advanced-chart': 'embed-widget-advanced-chart.js',
+  'mini-symbol-overview': 'embed-widget-mini-symbol-overview.js',
+  'screener': 'embed-widget-screener.js',
+  'etf-heatmap': 'embed-widget-etf-heatmap.js',
+  'timeline': 'embed-widget-timeline.js',
+  'single-quote': 'embed-widget-single-quote.js',
+  'symbol-info': 'embed-widget-symbol-info.js',
+};
+
+export function resolveScriptSrc(key: string): string {
+  if (key.startsWith('https://') || key.startsWith('http://')) return key;
+  const file = SCRIPT_KEYS[key];
+  if (!file) throw new Error(`[tvConfig] unknown script key: ${key}`);
+  return `${TV_BASE}${file}`;
+}
+
+/** Public site we send "view full chart" links to. */
+export function largeChartUrl(): string {
+  if (typeof window === 'undefined') return '/market';
+  return `${window.location.origin}/market`;
+}
+
+/** Per-card config defaults baked into every TV embed payload.
+ *
+ * `largeChartUrl` overrides the "view full chart" button destination for the
+ * subset of iframe widgets that honor it (symbol-overview, mini-chart,
+ * ticker-tape, advanced-chart) — clicks land on our `/market` route instead
+ * of tradingview.com. Heatmaps / hotlists / events ignore this key; symbol
+ * clicks inside those widgets still bounce to tradingview.com. The full
+ * symbol-link redirection (`symbol-url={tvsymbol}`) would require the
+ * `<tv-*>` web-component variant — currently unreachable, see header. */
+export const TV_COMMON_CONFIG = {
+  autosize: true,
+  width: '100%',
+  height: '100%',
+  isTransparent: true,
+  backgroundColor: 'rgba(0,0,0,0)',
+  locale: 'en',
+  support_host: 'https://www.tradingview.com',
+  largeChartUrl: largeChartUrl(),
+} as const;

--- a/web/src/pages/Dashboard/widgets/framework/useDashboardPrefs.ts
+++ b/web/src/pages/Dashboard/widgets/framework/useDashboardPrefs.ts
@@ -57,6 +57,23 @@ export function useDashboardPrefs() {
   const flush = useCallback(
     (next: DashboardPrefs) => {
       skipNextSyncRef.current = true;
+      // Dev-only size trap: catches widget configs that bloat the prefs
+      // blob before we ship them. The prefs are PATCHed as one payload,
+      // so a widget with a 50-symbol array full of objects can balloon
+      // the blob quickly. 20KB is generous for normal use.
+      if (import.meta.env?.DEV) {
+        try {
+          const bytes = new Blob([JSON.stringify(next)]).size;
+          if (bytes > 20_000) {
+            console.warn(
+              `[dashboard-prefs] blob ${bytes}B exceeds 20KB dev trap — check widget configs`,
+              next,
+            );
+          }
+        } catch {
+          /* ignore sizing errors in dev */
+        }
+      }
       const prevOther = ((preferencesRef.current as { other_preference?: Record<string, unknown> } | null | undefined)
         ?.other_preference) ?? {};
       updatePrefs.mutate(

--- a/web/src/pages/Dashboard/widgets/index.ts
+++ b/web/src/pages/Dashboard/widgets/index.ts
@@ -10,7 +10,28 @@ import './definitions/AutomationsWidget';
 import './definitions/ConversationWidget';
 import './definitions/WorkspacePickerWidget';
 import './definitions/RecentThreadsWidget';
+import './definitions/MiniChartGridWidget';
 // ChartWidget is registered lazily so lightweight-charts stays out of the dashboard chunk.
 import './definitions/ChartWidget.register';
+// TradingView embeds — under widgets/definitions/tv/. Most use the iframe
+// `embed-widget-*.js` scripts; EconomicMap uses the `<tv-economic-map>` web
+// component (one of 5 WCs in TV's catalog as of 2026-04-24, see tvConfig.ts).
+import './definitions/tv/TickerTapeWidget';
+import './definitions/tv/StockHeatmapWidget';
+import './definitions/tv/CryptoHeatmapWidget';
+import './definitions/tv/ForexHeatmapWidget';
+import './definitions/tv/ETFHeatmapWidget';
+import './definitions/tv/EconomicEventsWidget';
+import './definitions/tv/EconomicMapWidget';
+import './definitions/tv/TechnicalsWidget';
+import './definitions/tv/MoversWidget';
+import './definitions/tv/SymbolSpotlightWidget';
+import './definitions/tv/SingleTickerWidget';
+import './definitions/tv/SymbolInfoWidget';
+import './definitions/tv/CompanyProfileWidget';
+import './definitions/tv/CompanyFinancialsWidget';
+import './definitions/tv/StockScreenerWidget';
+import './definitions/tv/CryptoScreenerWidget';
+import './definitions/tv/TopStoriesWidget';
 
 export { listWidgets, listWidgetsByCategory, getWidget } from './framework/WidgetRegistry';

--- a/web/src/pages/Dashboard/widgets/presets.ts
+++ b/web/src/pages/Dashboard/widgets/presets.ts
@@ -1,11 +1,13 @@
 import { newWidgetId } from './framework/ids';
 import type { DashboardPrefs, RGLItem, WidgetInstance } from './types';
 import { DASHBOARD_PREFS_VERSION } from './types';
+import { DEFAULT_BLUE_CHIPS } from './framework/defaults';
 
 export type PresetId =
   | 'morning-brief'
   | 'researcher'
   | 'trader'
+  | 'trader-tv'
   | 'portfolio-steward'
   | 'agent-desk';
 
@@ -115,6 +117,38 @@ export function traderPreset(): Pick<DashboardPrefs, 'widgets' | 'layouts' | 've
 }
 
 /**
+ * TRADER (TV) — TradingView workstation.
+ * All-TV layout: ticker tape anchor, stock heatmap hero, symbol spotlight +
+ * movers side-by-side, economic events + technicals below, native mini-chart
+ * grid closes the canvas. Existing `trader` preset is preserved unchanged —
+ * users can pick either from the Presets dialog.
+ */
+export function traderTvPreset(): Pick<DashboardPrefs, 'widgets' | 'layouts' | 'version'> {
+  // Empty `symbols` lets TickerTapeWidget compute its live seed at render
+  // time (defaults + user's watchlist + portfolio, deduped). Hardcoding
+  // here would bypass the watchlist/portfolio merge.
+  const tape = { id: newId('tt'), type: 'tv.ticker-tape', config: { symbols: [], displayMode: 'adaptive' } };
+  const heatmap = { id: newId('hm'), type: 'tv.stock-heatmap', config: { dataSource: 'SPX500', blockSize: 'market_cap_basic', blockColor: 'change' } };
+  const spotlight = { id: newId('ss'), type: 'tv.symbol-spotlight', config: { symbol: 'NASDAQ:NVDA', range: '12M' } };
+  const movers = { id: newId('mv'), type: 'tv.movers', config: { exchange: 'US', dataSource: 'AllUSA' } };
+  const events = { id: newId('ev'), type: 'tv.economic-events', config: { importanceFilter: '-1,0,1', countryFilter: 'us,eu,jp,gb,cn' } };
+  const technicals = { id: newId('ta'), type: 'tv.technicals', config: { symbol: 'NASDAQ:NVDA', interval: '1D' } };
+  const miniGrid = { id: newId('mg'), type: 'markets.miniChartGrid', config: { symbols: DEFAULT_BLUE_CHIPS } };
+
+  const widgets = [tape, heatmap, spotlight, movers, events, technicals, miniGrid];
+  const layouts: RGLItem[] = [
+    { i: tape.id, x: 0, y: 0, w: 12, h: 4 },
+    { i: heatmap.id, x: 0, y: 4, w: 12, h: 20 },
+    { i: spotlight.id, x: 0, y: 24, w: 6, h: 22 },
+    { i: movers.id, x: 6, y: 24, w: 6, h: 22 },
+    { i: events.id, x: 0, y: 46, w: 6, h: 24 },
+    { i: technicals.id, x: 6, y: 46, w: 6, h: 24 },
+    { i: miniGrid.id, x: 0, y: 70, w: 12, h: 16 },
+  ];
+  return makePrefs(widgets, layouts);
+}
+
+/**
  * PORTFOLIO STEWARD — Wealth-first, actively tended.
  * Your top holding's daily chart anchors the left canvas; combined portfolio +
  * watchlist sit alongside; a portfolio-filtered news feed runs as a tall right
@@ -208,6 +242,15 @@ export const PRESETS_META: readonly PresetMeta[] = [
     pills: ['Chart × 4', 'Multi-timeframe', 'Portfolio + Watchlist', 'News feed', 'Markets overview'],
   },
   {
+    id: 'trader-tv',
+    name: 'Trader (TV)',
+    tagline: 'tradingview-first',
+    tag: 'tradingview-first',
+    description: 'A TradingView-driven trading desk. Ticker tape anchors the top, stock heatmap as hero, symbol spotlight with market movers alongside, economic events + a technical analysis gauge below, and a native mini-chart grid closes the canvas.',
+    bestFor: 'Tape-to-sector-to-symbol scan, with TV-native interactivity inside each card.',
+    pills: ['Ticker tape', 'Stock heatmap', 'Symbol spotlight', 'Market movers', 'Economic events', 'Technicals', 'Mini chart grid'],
+  },
+  {
     id: 'portfolio-steward',
     name: 'Portfolio Steward',
     tagline: 'wealth-first',
@@ -222,6 +265,7 @@ const PRESET_FACTORIES: Record<PresetId, () => Pick<DashboardPrefs, 'widgets' | 
   'morning-brief': morningBriefPreset,
   researcher: researcherPreset,
   trader: traderPreset,
+  'trader-tv': traderTvPreset,
   'portfolio-steward': portfolioStewardPreset,
   'agent-desk': agentDeskPreset,
 };

--- a/web/src/pages/Dashboard/widgets/types.ts
+++ b/web/src/pages/Dashboard/widgets/types.ts
@@ -1,5 +1,6 @@
 import type { ComponentType } from 'react';
 import type { LucideIcon } from 'lucide-react';
+import type { DashboardDataContextValue } from './framework/DashboardDataContext';
 
 export type WidgetCategory = 'markets' | 'intel' | 'personal' | 'agent' | 'workspace';
 
@@ -39,6 +40,18 @@ export interface WidgetDefinition<C = unknown> {
    * cell beyond the content. Width resize still works.
    */
   fitToContent?: boolean;
+  /**
+   * Gallery shows a provider badge and widget components should render
+   * attribution when this is set. Currently only TradingView uses this flag.
+   */
+  source?: 'tradingview';
+  /**
+   * Optional factory that returns the initial config for a newly added
+   * instance, given runtime dashboard context (watchlist, portfolio). Called
+   * by the add-widget path instead of shallow-copying `defaultConfig`. Falls
+   * back to `defaultConfig` when undefined.
+   */
+  initConfig?: (ctx: DashboardDataContextValue) => C;
 }
 
 export interface WidgetInstance<C = unknown> {

--- a/web/src/pages/Legal/Legal.tsx
+++ b/web/src/pages/Legal/Legal.tsx
@@ -1,0 +1,124 @@
+import { Link } from 'react-router-dom';
+
+function Legal() {
+  return (
+    <div
+      className="h-screen overflow-y-auto py-12 px-4 sm:px-6 lg:px-8"
+      style={{ backgroundColor: 'var(--color-bg-page)', color: 'var(--color-text-primary)' }}
+    >
+      <article className="mx-auto max-w-3xl">
+        <header className="mb-10 border-b pb-6" style={{ borderColor: 'var(--color-border-subtle)' }}>
+          <Link
+            to="/"
+            className="text-sm hover:underline"
+            style={{ color: 'var(--color-text-secondary)' }}
+          >
+            &larr; Back to LangAlpha
+          </Link>
+          <h1 className="mt-4 text-3xl font-semibold tracking-tight">Legal &amp; Attribution</h1>
+          <p className="mt-2 text-sm" style={{ color: 'var(--color-text-secondary)' }}>
+            Open-source licenses and third-party credits for the hosted LangAlpha service.
+          </p>
+        </header>
+
+        <div className="space-y-10 text-base leading-relaxed">
+          <section>
+            <h2 className="text-xl font-semibold tracking-tight mb-3">TradingView</h2>
+            <p>
+              Charts and market widgets provided by{' '}
+              <a
+                href="https://www.tradingview.com/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline"
+              >
+                TradingView
+              </a>
+              . The dashboard embeds the free TradingView widget library (Ticker Tape,
+              Stock Heatmap, Economic Events, Technical Analysis, and related widgets).
+              Each embedded widget carries its own attribution and links back to
+              tradingview.com for full interactivity. The in-app real-time price chart
+              is built on{' '}
+              <a
+                href="https://www.tradingview.com/lightweight-charts/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline"
+              >
+                Lightweight Charts™
+              </a>
+              , released by TradingView under the Apache License, Version 2.0.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold tracking-tight mb-3">
+              Lightweight Charts™ NOTICE
+            </h2>
+            <p className="text-sm mb-3" style={{ color: 'var(--color-text-secondary)' }}>
+              Reproduced verbatim from the upstream project&apos;s NOTICE file.
+            </p>
+            <pre
+              className="whitespace-pre-wrap text-[13px] p-4 rounded border font-mono"
+              style={{
+                backgroundColor: 'var(--color-bg-subtle)',
+                borderColor: 'var(--color-border-muted)',
+                color: 'var(--color-text-primary)',
+              }}
+            >{`TradingView Lightweight Charts™
+Copyright (с) 2025 TradingView, Inc. https://www.tradingview.com/`}</pre>
+            <p className="mt-3 text-sm" style={{ color: 'var(--color-text-secondary)' }}>
+              Licensed under the Apache License, Version 2.0 — see{' '}
+              <a
+                href="https://www.apache.org/licenses/LICENSE-2.0"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline"
+              >
+                the full license text
+              </a>
+              . The Lightweight Charts™ trademark is the property of TradingView, Inc.;
+              use of the TradingView name is limited to the attribution above.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold tracking-tight mb-3">Market data</h2>
+            <p>
+              Real-time and historical equity pricing in the native charts is sourced
+              through data providers and is intended for research only. It is not
+              investment advice and should not be treated as an execution-quality feed.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold tracking-tight mb-3">Other credits</h2>
+            <p>
+              LangAlpha is built on React, Vite, FastAPI, PostgreSQL, Redis, and many
+              other open-source projects. The complete list of dependencies and their
+              licenses is available in the{' '}
+              <a
+                href="https://github.com/ginlix/langalpha"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline"
+              >
+                langalpha repository
+              </a>
+              .
+            </p>
+            <p className="mt-3 text-sm">
+              See also our{' '}
+              <Link to="/privacy" className="underline">
+                Privacy Policy
+              </Link>
+              .
+            </p>
+          </section>
+        </div>
+      </article>
+    </div>
+  );
+}
+
+export default Legal;

--- a/web/src/pages/MarketView/components/MarketChart.css
+++ b/web/src/pages/MarketView/components/MarketChart.css
@@ -25,6 +25,9 @@
 
 .chart-mode-switcher {
   flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
 .chart-indicators {
@@ -457,11 +460,14 @@
   }
 }
 
-/* Hide TradingView branding watermark */
-.chart-wrapper a[href*="tradingview.com"],
-.rsi-chart-wrapper a[href*="tradingview.com"],
-.tv-lightweight-charts__watermark,
-a[href*="tradingview.com"] {
+/* Hide the lightweight-charts watermark only. MUST NOT match the TradingView
+ * embed-widget attribution link (class `.tv-attribution`, rendered by
+ * `TradingViewEmbed`) — that link is required visible per TV's embed terms.
+ * The lightweight-charts watermark is an <a> whose href always contains
+ * `utm_medium=lwc-link`; the class selector is a secondary safety net. */
+.chart-wrapper a[href*="utm_medium=lwc-link"],
+.rsi-chart-wrapper a[href*="utm_medium=lwc-link"],
+.tv-lightweight-charts__watermark {
   display: none !important;
   visibility: hidden !important;
   opacity: 0 !important;

--- a/web/src/pages/MarketView/components/MarketChart.tsx
+++ b/web/src/pages/MarketView/components/MarketChart.tsx
@@ -30,6 +30,7 @@ import { ExtendedHoursBgPrimitive } from '../utils/extendedHoursBg';
 import { useTheme } from '@/contexts/ThemeContext';
 import CrosshairTooltip from './CrosshairTooltip';
 import TradingViewWidget from './TradingViewWidget';
+import { TradingViewAttribution } from '@/pages/Dashboard/widgets/framework/TradingViewAttribution';
 import { useChartAnnotations } from '../hooks/useChartAnnotations';
 import { useChartOverlays } from '../hooks/useChartOverlays';
 import { SlidersHorizontal, Settings2, Maximize2, Minimize2, ChevronDown, Plus, Minus, RotateCcw, Menu } from 'lucide-react';
@@ -1815,6 +1816,11 @@ const MarketChart = React.memo(forwardRef<MarketChartHandle, MarketChartProps>((
             </>
           )}
           <div className="chart-mode-switcher">
+            {/* TV embed-terms attribution. Sibling of the pill so the pill's
+                own background stays symmetric. Only shown when Advanced is
+                active — anchors the attribution to the mode that actually
+                renders TV content. */}
+            {isTV && <TradingViewAttribution />}
             <div className="interval-selector">
               <button
                 type="button"

--- a/web/src/pages/MarketView/components/TradingViewWidget.tsx
+++ b/web/src/pages/MarketView/components/TradingViewWidget.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useRef, memo } from 'react';
+import { memo } from 'react';
 import { useTheme } from '@/contexts/ThemeContext';
+import { TradingViewEmbed } from '@/pages/Dashboard/widgets/framework/TradingViewEmbed';
 
 // Map our interval keys to TradingView widget interval values
 const TV_INTERVALS: Record<string, string> = {
@@ -19,67 +20,46 @@ interface TradingViewWidgetProps {
 
 /**
  * TradingView Advanced Chart widget embed.
- * Provides full drawing tools, indicators, and TradingView's own real-time data.
+ *
+ * Thin wrapper around the shared dashboard `TradingViewEmbed` so the full
+ * app uses a single TV-embed abstraction (loader cache, error/retry UX,
+ * theme sync, attribution placement). The Advanced Chart accepts many more
+ * config keys than the dashboard embeds; we spread the app-specific ones
+ * here so the host component stays uniform.
+ *
+ * Note on background/grid: the shared TV_COMMON_CONFIG sets transparent
+ * defaults so dashboard widgets render cleanly inside `.dashboard-glass-card`.
+ * MarketView's chart has no card behind it, and Advanced Chart's up-candles
+ * use semi-transparent fills — with a transparent background they composite
+ * against the page and render pastel/washed-out. We override with a solid
+ * theme-matched background + gridColor here to restore the saturated look
+ * the chart had on main.
  */
 function TradingViewWidget({ symbol, interval = '1day' }: TradingViewWidgetProps) {
   const { theme } = useTheme();
-  const containerRef = useRef<HTMLDivElement>(null);
-  const scriptRef = useRef<HTMLScriptElement | null>(null);
-
-  useEffect(() => {
-    if (!containerRef.current) return;
-
-    // Clear previous widget
-    containerRef.current.innerHTML = '';
-
-    // Create the widget container div that TradingView expects
-    const widgetDiv = document.createElement('div');
-    widgetDiv.className = 'tradingview-widget-container__widget';
-    widgetDiv.style.height = '100%';
-    widgetDiv.style.width = '100%';
-    containerRef.current.appendChild(widgetDiv);
-
-    // Create and configure the embed script
-    const script = document.createElement('script');
-    script.src = 'https://s3.tradingview.com/external-embedding/embed-widget-advanced-chart.js';
-    script.type = 'text/javascript';
-    script.async = true;
-    script.innerHTML = JSON.stringify({
-      autosize: true,
-      symbol: symbol,
-      interval: TV_INTERVALS[interval] || 'D',
-      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || 'America/New_York',
-      theme: theme === 'light' ? 'light' : 'dark',
-      style: '1', // Candlestick
-      locale: 'en',
-      backgroundColor: theme === 'light' ? '#FFFCF9' : '#000000',
-      gridColor: theme === 'light' ? '#E8E2DB' : '#1A1A1A',
-      allow_symbol_change: false,
-      hide_side_toolbar: false, // Keep drawing tools visible
-      hide_top_toolbar: false,
-      withdateranges: true,
-      details: false,
-      calendar: false,
-      studies: ['RSI@tv-basicstudies'],
-      support_host: 'https://www.tradingview.com',
-    });
-    scriptRef.current = script;
-    containerRef.current.appendChild(script);
-
-    return () => {
-      // Cleanup: remove widget DOM
-      if (containerRef.current) {
-        containerRef.current.innerHTML = '';
-      }
-      scriptRef.current = null;
-    };
-  }, [symbol, interval, theme]);
+  const isLight = theme === 'light';
+  const config = {
+    symbol,
+    interval: TV_INTERVALS[interval] || 'D',
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || 'America/New_York',
+    style: '1',
+    isTransparent: false,
+    backgroundColor: isLight ? '#FFFCF9' : '#000000',
+    gridColor: isLight ? '#E8E2DB' : '#1A1A1A',
+    allow_symbol_change: false,
+    hide_side_toolbar: false,
+    hide_top_toolbar: false,
+    withdateranges: true,
+    details: false,
+    calendar: false,
+    studies: ['RSI@tv-basicstudies'],
+  };
 
   return (
-    <div
-      ref={containerRef}
-      className="tradingview-widget-container"
-      style={{ height: '100%', width: '100%' }}
+    <TradingViewEmbed
+      scriptKey="advanced-chart"
+      config={config}
+      className="h-full w-full"
     />
   );
 }

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -9,6 +9,11 @@ export default defineConfig({
     setupFiles: ['./src/test/setup.ts'],
     globals: true,
     exclude: ['e2e/**', 'node_modules/**'],
+    // 10s default. Worker pool is CPU-contended when tests that use real
+    // react-query retry timers (up to 6s wall clock in useWorkspaceFiles)
+    // land on the same thread as Testing Library render()s — the default 5s
+    // starved the settings-atoms tests into spurious timeouts.
+    testTimeout: 10_000,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

**TradingView widget framework** for the customizable dashboard — opt-in widget grid that lives alongside the existing Classic dashboard and is settings-driven via `useDashboardPrefs`.

- **Framework** (`web/src/pages/Dashboard/widgets/framework/`) — `TradingViewEmbed` (script-injection host with debounce, error/retry, late-iframe recovery), `TradingViewWebComponent` (web-component path), shared `TradingViewAttribution` + `TradingViewSettingsFooter`, `tvConfig` (script-src registry), 3 settings atoms (`SymbolField`, `SymbolListField`, `EnumField`) + `SettingsDoneButton`.
- **17 TradingView widgets** in `definitions/tv/`: TickerTape, StockHeatmap, CryptoHeatmap, ETFHeatmap, ForexHeatmap, EconomicEvents, EconomicMap, Technicals, Movers, SymbolSpotlight, CompanyProfile, CompanyFinancials, CryptoScreener, StockScreener, SingleTicker, SymbolInfo, TopStories. (Plan listed 10; +7 resolved during impl as the TV web-component catalog was verified.)
- **Native MiniChartGrid** (`MiniChartGridWidget.tsx`) — non-TV grid of mini charts driven by Polygon/Massive backend; render-time symbol cap of 18.
- **`trader-tv` preset** — six curated layouts in `PresetsDialog`; existing `trader` preset untouched.
- **MarketView migration** — `MarketView/components/TradingViewWidget.tsx` rewritten to use the shared embed (~50% smaller).
- **`/legal` route** — single page for third-party data attribution (TradingView, Polygon, etc.).
- **Provider badge** in `AddWidgetDialog` distinguishes TV vs native widgets.
- **Dev-only 20KB warning** in `useDashboardPrefs` when prefs blob exceeds size threshold.
- **Bisectable commits** — framework → widgets → preset/badge → /legal → MarketView refactor → review fixes → adversarial fixes.

## Test Coverage

```
COVERAGE: 78% — Critical persistence and data paths well-covered.

Framework
  useDashboardPrefs ............... TESTED (5) debounce, flush, error, history cap
  migrations / reconcile / presets  TESTED (44 tests across 3 files)
  tvConfig.resolveScriptSrc ....... TESTED (4)
  TradingViewEmbed ................ TESTED (3) XSS escape, debounce, attrs
  attribution-visibility CSS ...... TESTED (2) regression guard

Settings atoms .................... TESTED (3) Symbol/SymbolList/Enum + Done

Definitions
  TickerTape.buildSeedSymbols ..... TESTED (7)
  17 TV widget wrappers ........... visually verified (declarative configs)
  MiniChartGridWidget (247 LoC) ... gap — no unit test (render path
                                    Promise.allSettled + symbol cap = safe)

Tests: 524 -> 629 (+105 new)
```

5 acceptable gaps in UI flows that get visual verification (MiniChartGrid, dialog flows, drag/drop). Risk accepted — all critical persistence/data/XSS paths are covered.

## Pre-Landing Review

Most recent /review at this HEAD: **CLEAN, 9.5/10**. 17 prior findings already auto-fixed or user-fixed across review passes (XSS escape, MiniChartGrid Promise.allSettled, settings effect debounce, TradingViewWebComponent element-swap leak, DashboardCustom reset confirmation, DashboardRouter migration round-trip, ConversationWidget stale memo, DashboardGrid re-render, etc.).

## Adversarial Review

**Codex caught 2 production bugs that all prior passes missed — both fixed in 03b14346:**

1. **TradingViewEmbed.tsx:122-143** — 10s timeout was permanently disconnecting the MutationObserver. On slow CDN/mobile loads where the iframe arrives at 10.5s, the widget would stay covered by "Widget unavailable" until manual retry. Fix: keep observer alive past timeout; late iframe arrival flips status back to ready. Same fix benefits MarketView Advanced Chart (shared host).
2. **MiniChartGridWidget.tsx:91** — `Promise.allSettled(effectiveSymbols.map(loadSpark))` trusted persisted symbols without a render-time cap. UI caps at 18, but prefs are server JSON; a corrupted blob with thousands of symbols would fan out thousands of OHLC requests every 120s. Fix: clamp at the `useMemo` derivation, not just the input UI.

**Claude adversarial pass** flagged 10 additional phase-2 polish items, surfaced for follow-up:
- Cross-tab last-write-wins for prefs (need etag or BroadcastChannel)
- `largeChartUrl()` and `<tv-custom-settings>` `symbol-url` template captured at module-load (SSR/multi-origin previews would bake the wrong origin)
- Hardcoded `locale: 'en'` (zh-CN users get English-labeled axis)
- `displayMode` enum validation gap on legacy/migrated configs
- `SymbolListField` Backspace deletes last chip silently when at max cap
- `onBlur={add}` commits half-typed input on dialog close
- CSP readiness — script injection has no nonce; need `securitypolicyviolation` listener for the eventual CSP rollout
- MiniChartGrid concurrency at 18 simultaneous OHLC requests / 120s — fine for now, throttle if backend complains
- Touch repositioning on iPad — TV iframes may make drag-handle the only grab target

None are regressions; all are accumulated tech debt for phase 2.

## Plan Completion

- **All 11 locked decisions implemented** (TV web-components, trader-tv preset, MiniChartGrid, retry UX, scoped kill-rule, profile/financials split, 3 form atoms, MarketView unified, initConfig hook, /legal-only attribution, 20KB warn)
- **All 18 file creations done** + bonus framework files (`TradingViewWebComponent`, `TradingViewAttribution.css`, `defaults.ts`, `reconcile.ts`, `SettingsDoneButton.tsx`)
- **All 10 file modifications done** (types/initConfig, DashboardCustom, AddWidgetDialog TV badge, WidgetFrame.css scope fix, useDashboardPrefs 20KB warn, presets, PresetsDialog, Thumbnails, MarketView/TradingViewWidget, App.tsx /legal route)
- **7/8 test files done** — MiniChartGrid lacks dedicated unit test (covered by integration via DashboardGrid + render-time cap)
- **CHANGED**: Scope expanded from 10 to 17 TV widgets — same theme, plan explicitly allowed verification against TV docs during impl
- **Deferred** (per plan): phase-2 native replacements, full CSP, post-load network-drop indicator

## Verification Results

- ✅ `pnpm vitest run` — 629/629 pass
- ✅ `pnpm tsc --noEmit` — clean
- ✅ `pnpm lint` — 0 errors (89 pre-existing warnings)
- ✅ Browser dogfooding done across prior /review iterations (dashboard load, add/remove widgets, presets, settings, drag/resize, legal page, MarketView migration)

## Test plan
- [x] All 629 vitest tests pass
- [x] Type check clean
- [x] Lint clean (0 errors)
- [x] Late-iframe recovery: simulate slow network, verify widget recovers from "unavailable" state when iframe eventually loads
- [x] MiniChartGrid render-time cap: confirm corrupted prefs with 100+ symbols renders only 18