### PR TITLE
feat(manifest): add DeepSeek V4 models

### DIFF
--- a/src/llms/manifest/models.json
+++ b/src/llms/manifest/models.json
@@ -401,12 +401,33 @@
       }
     }
   },
-  "deepseek-reasoner": {
-    "model_id": "deepseek-reasoner",
+  "deepseek-v4-pro": {
+    "model_id": "deepseek-v4-pro",
     "provider": "deepseek",
+    "visible": true,
     "input_modalities": [
       "text"
-    ]
+    ],
+    "parameters": {
+      "max_tokens": 384000,
+      "thinking": {
+        "type": "enabled"
+      }
+    }
+  },
+  "deepseek-v4-flash": {
+    "model_id": "deepseek-v4-flash",
+    "provider": "deepseek",
+    "visible": true,
+    "input_modalities": [
+      "text"
+    ],
+    "parameters": {
+      "max_tokens": 384000,
+      "thinking": {
+        "type": "enabled"
+      }
+    }
   },
   "glm-5.1": {
     "model_id": "glm-5.1",

--- a/src/llms/manifest/providers.json
+++ b/src/llms/manifest/providers.json
@@ -269,14 +269,30 @@
     "openrouter": [],
     "deepseek": [
       {
-        "id": "deepseek-reasoner",
-        "name": "DeepSeek V3.2",
+        "id": "deepseek-v4-pro",
+        "name": "DeepSeek V4 Pro",
         "is_reasoning": true,
-        "description": "DeepSeek's V3.2 reasoning model with extended thinking capabilities",
+        "description": "DeepSeek's V4 Pro model with extended thinking and 1M context",
+        "context_window": 1000000,
+        "max_output": 384000,
         "pricing": {
-          "input": 0.28,
+          "input": 1.74,
+          "cached_input": 0.145,
+          "output": 3.48,
+          "unit": "per_1m_tokens"
+        }
+      },
+      {
+        "id": "deepseek-v4-flash",
+        "name": "DeepSeek V4 Flash",
+        "is_reasoning": true,
+        "description": "DeepSeek's V4 Flash model with extended thinking and 1M context",
+        "context_window": 1000000,
+        "max_output": 384000,
+        "pricing": {
+          "input": 0.14,
           "cached_input": 0.028,
-          "output": 0.42,
+          "output": 0.28,
           "unit": "per_1m_tokens"
         }
       }
@@ -1408,7 +1424,7 @@
       "base_url": "https://api.deepseek.com/anthropic",
       "env_key": "DEEPSEEK_API_KEY",
       "access_type": "api_key",
-      "byok_eligible": false,
+      "byok_eligible": true,
       "display_name": "DeepSeek"
     },
     "groq": {

--- a/tests/unit/llms/test_input_modalities.py
+++ b/tests/unit/llms/test_input_modalities.py
@@ -34,7 +34,7 @@ class TestGetInputModalities:
         assert "pdf" not in result
 
     def test_deepseek_text_only(self, model_config):
-        result = model_config.get_input_modalities("deepseek-reasoner")
+        result = model_config.get_input_modalities("deepseek-v4-flash")
         assert result == ["text"]
 
     def test_minimax_text_only(self, model_config):

--- a/tests/unit/server/app/test_preferences_validation.py
+++ b/tests/unit/server/app/test_preferences_validation.py
@@ -187,7 +187,7 @@ class TestValidateCustomProviders:
     def test_invalid_parent_provider_raises(self):
         """parent_provider must be a BYOK-eligible builtin."""
         with pytest.raises(HTTPException, match="not a BYOK-eligible"):
-            self._validate([{"name": "my-deepseek", "parent_provider": "deepseek"}])
+            self._validate([{"name": "my-groq", "parent_provider": "groq"}])
 
     def test_builtin_collision_raises(self):
         """Custom provider name must not collide with builtin."""

--- a/tests/unit/server/app/test_preferences_validation.py
+++ b/tests/unit/server/app/test_preferences_validation.py
@@ -187,7 +187,7 @@ class TestValidateCustomProviders:
     def test_invalid_parent_provider_raises(self):
         """parent_provider must be a BYOK-eligible builtin."""
         with pytest.raises(HTTPException, match="not a BYOK-eligible"):
-            self._validate([{"name": "my-groq", "parent_provider": "groq"}])
+            self._validate([{"name": "my-fake", "parent_provider": "not-a-real-provider"}])
 
     def test_builtin_collision_raises(self):
         """Custom provider name must not collide with builtin."""


### PR DESCRIPTION
## Summary

- Add `deepseek-v4-flash` and `deepseek-v4-pro` to the model manifest, using the Anthropic SDK format against `api.deepseek.com/anthropic`.
- Drop the legacy `deepseek-reasoner` (V3.2) entry — DeepSeek deprecates `deepseek-chat`/`deepseek-reasoner` in favor of the V4 lineup.
- 1M context window, 384K max output, thinking enabled by default (V4 supports both thinking and non-thinking modes).
- Mark the deepseek provider \`byok_eligible\` so users can plug in their own DeepSeek keys.
- Update the deepseek text-only modality test to point at \`deepseek-v4-flash\`.

## Pricing (per 1M tokens, USD)

| Model | Input | Cached input | Output |
|---|---|---|---|
| deepseek-v4-flash | \$0.14 | \$0.028 | \$0.28 |
| deepseek-v4-pro | \$1.74 | \$0.145 | \$3.48 |

Pro is currently offered at a 75% promo by DeepSeek; this PR uses the post-promo prices so the manifest doesn't need to be edited again when the discount expires.

## Test plan

- [x] \`uv run ruff check src/llms/manifest/ tests/unit/llms/test_input_modalities.py\` — clean
- [x] \`uv run pytest tests/unit/llms/ -q\` — 394 passed