### PR TITLE
fix(dashboard): stabilize watchlist E2E + fix chip a11y leak

### DIFF
--- a/web/e2e/dashboard.spec.js
+++ b/web/e2e/dashboard.spec.js
@@ -264,7 +264,7 @@ test.describe('Watchlist CRUD', () => {
     await expect(page.locator('h2', { hasText: 'Watchlist' })).toBeVisible();
 
     // Symbol renders
-    await expect(page.locator('text=TSLA').first()).toBeVisible();
+    await expect(page.getByTestId('watchlist-row-TSLA')).toBeVisible();
   });
 
   test('add watchlist item', async ({ page }) => {
@@ -367,16 +367,53 @@ test.describe('Watchlist CRUD', () => {
     await page.goto('/dashboard');
 
     // Wait for the item to render
-    await expect(page.locator('text=TSLA').first()).toBeVisible();
+    await expect(page.getByTestId('watchlist-row-TSLA')).toBeVisible();
 
     // Right-click to open context menu (Radix ContextMenu)
-    await page.locator('text=TSLA').first().click({ button: 'right' });
+    await page.getByTestId('watchlist-row-TSLA').click({ button: 'right' });
 
     // Click "Delete" in context menu (Radix renders items as role="menuitem")
     await page.getByRole('menuitem', { name: 'Delete' }).click();
 
     // Verify the DELETE request was made
     expect(deleteCalled).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suggestion chips (regression coverage for the dashboard chat input)
+// ---------------------------------------------------------------------------
+
+test.describe('Dashboard chat suggestion chips', () => {
+  test('chips: a11y-gated by focus, click fills input, blur unmounts', async ({ page }) => {
+    await mockAPI(page, dashboardOverrides({}));
+    await page.goto('/dashboard');
+
+    const bubbles = page.getByTestId('dashboard-suggestion-bubble');
+    const textarea = page.getByTestId('dashboard-chat-input').locator('textarea');
+    // Role-based check pins the a11y invariant (chips not in tab order / a11y tree
+    // when unfocused), so a future inert/aria-hidden refactor would still satisfy it
+    // even if DOM mounting changed.
+    const tslaChip = page.getByRole('button', { name: 'Compare TSLA vs BYD' });
+
+    // Unfocused: chips absent from DOM AND a11y tree.
+    await expect(bubbles).toHaveCount(0);
+    await expect(tslaChip).toHaveCount(0);
+
+    // Focus mounts chips in DOM and a11y tree.
+    await textarea.focus();
+    await expect(bubbles).toHaveCount(4);
+    await expect(tslaChip).toHaveCount(1);
+
+    // Click chip -> textarea value updates. Chip's onMouseDown preventDefault
+    // keeps focus on the textarea, so chips remain mounted.
+    await tslaChip.click();
+    await expect(textarea).toHaveValue('Compare TSLA vs BYD');
+
+    // Blur -> chips unmount from both DOM and a11y tree.
+    await textarea.blur();
+    await expect(bubbles).toHaveCount(0);
+    await expect(tslaChip).toHaveCount(0);
   });
 });
 
@@ -422,7 +459,7 @@ test.describe('Portfolio CRUD', () => {
     await expect(page.locator('h2', { hasText: 'Portfolio' })).toBeVisible();
 
     // Symbol and share count visible
-    await expect(page.locator('text=AAPL').first()).toBeVisible();
+    await expect(page.getByTestId('portfolio-row-AAPL')).toBeVisible();
     await expect(page.locator('text=10 shares')).toBeVisible();
 
     // Market value ($1,800.00 = 10 shares * $180.00)
@@ -515,10 +552,10 @@ test.describe('Portfolio CRUD', () => {
 
     // Switch to Holdings tab
     await page.getByRole('button', { name: 'Holdings' }).click();
-    await expect(page.locator('text=AAPL').first()).toBeVisible();
+    await expect(page.getByTestId('portfolio-row-AAPL')).toBeVisible();
 
     // Right-click to open context menu (Radix ContextMenu)
-    await page.locator('text=AAPL').first().click({ button: 'right' });
+    await page.getByTestId('portfolio-row-AAPL').click({ button: 'right' });
 
     // Click "Edit" in context menu (Radix renders items as role="menuitem")
     await page.getByRole('menuitem', { name: 'Edit' }).click();
@@ -559,10 +596,10 @@ test.describe('Portfolio CRUD', () => {
 
     // Switch to Holdings tab
     await page.getByRole('button', { name: 'Holdings' }).click();
-    await expect(page.locator('text=AAPL').first()).toBeVisible();
+    await expect(page.getByTestId('portfolio-row-AAPL')).toBeVisible();
 
     // Right-click to open context menu (Radix ContextMenu)
-    await page.locator('text=AAPL').first().click({ button: 'right' });
+    await page.getByTestId('portfolio-row-AAPL').click({ button: 'right' });
 
     // Click "Delete" in context menu (Radix renders items as role="menuitem")
     await page.getByRole('menuitem', { name: 'Delete' }).click();

--- a/web/e2e/dashboard.spec.js
+++ b/web/e2e/dashboard.spec.js
@@ -410,6 +410,11 @@ test.describe('Dashboard chat suggestion chips', () => {
     await tslaChip.click();
     await expect(textarea).toHaveValue('Compare TSLA vs BYD');
 
+    // setValue queues setTimeout(focus, 0) to refocus the textarea. Drain the
+    // macrotask queue before blurring, otherwise the queued refocus fires AFTER
+    // our blur and remounts the chips.
+    await page.evaluate(() => new Promise((r) => setTimeout(r, 0)));
+
     // Blur -> chips unmount from both DOM and a11y tree.
     await textarea.blur();
     await expect(bubbles).toHaveCount(0);

--- a/web/playwright.config.js
+++ b/web/playwright.config.js
@@ -19,9 +19,17 @@ export default defineConfig({
     {
       command: `npm run dev -- --port ${E2E_PORT}`,
       port: E2E_PORT,
-      reuseExistingServer: !process.env.CI,
+      // Always start fresh: the env block below is load-bearing (forces OSS mode
+      // and clears Supabase vars). If we reused an existing server, a developer's
+      // pre-running `pnpm dev` with personal .env would silently override these.
+      reuseExistingServer: false,
       env: {
+        // Force OSS mode so the Supabase auth branch never runs, regardless of
+        // what's in the developer's local .env. VITE_HOST_MODE is the single
+        // source of truth for mode selection (see web/src/config/hostMode.ts).
+        VITE_HOST_MODE: 'oss',
         VITE_SUPABASE_URL: '',
+        VITE_SUPABASE_PUBLISHABLE_KEY: '',
         VITE_API_BASE_URL: 'http://127.0.0.1:4100',
       },
     },

--- a/web/src/pages/Dashboard/Dashboard.css
+++ b/web/src/pages/Dashboard/Dashboard.css
@@ -176,9 +176,14 @@
   transform: translateY(6px);
   transition: opacity 0.3s ease, transform 0.3s ease, background-color 0.15s, border-color 0.15s, color 0.15s;
 }
+@keyframes dashboard-chip-enter {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
 .dashboard-suggestion-bubbles.visible .dashboard-suggestion-bubble {
   opacity: 1;
   transform: translateY(0);
+  animation: dashboard-chip-enter 0.3s ease both;
 }
 .dashboard-suggestion-bubble:hover,
 .dashboard-suggestion-bubble:active {

--- a/web/src/pages/Dashboard/components/ChatInputCard.tsx
+++ b/web/src/pages/Dashboard/components/ChatInputCard.tsx
@@ -67,23 +67,29 @@ function ChatInputCard() {
   return (
     <div className="dashboard-floating-chat-wrapper fixed bottom-8 left-0 right-0 z-40 flex justify-center pointer-events-none">
       <div className="pointer-events-auto w-full max-w-2xl px-4">
-        {/* Suggestion bubbles — above the input, outside focus container */}
-        <div className={`dashboard-suggestion-bubbles ${focused ? 'visible' : ''}`}>
-          {SUGGESTION_CHIPS.map((label, i) => (
-            <button
-              key={label}
-              type="button"
-              className="dashboard-suggestion-bubble"
-              style={{ transitionDelay: `${i * 60}ms` }}
-              onMouseDown={(e) => e.preventDefault()}
-              onClick={() => chatInputRef.current?.setValue(label)}
-            >
-              {label}
-            </button>
-          ))}
-        </div>
+        {/* Suggestion bubbles — above the input, outside focus container.
+            Only mount when focused so they stay out of the DOM, a11y tree,
+            and tab order otherwise. */}
+        {focused && (
+          <div className="dashboard-suggestion-bubbles visible">
+            {SUGGESTION_CHIPS.map((label, i) => (
+              <button
+                key={label}
+                type="button"
+                data-testid="dashboard-suggestion-bubble"
+                className="dashboard-suggestion-bubble"
+                style={{ transitionDelay: `${i * 60}ms` }}
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => chatInputRef.current?.setValue(label)}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        )}
 
         <div
+          data-testid="dashboard-chat-input"
           className="dashboard-floating-chat"
           onFocus={() => setFocused(true)}
           onBlur={(e) => {

--- a/web/src/pages/Dashboard/components/ChatInputCard.tsx
+++ b/web/src/pages/Dashboard/components/ChatInputCard.tsx
@@ -78,7 +78,7 @@ function ChatInputCard() {
                 type="button"
                 data-testid="dashboard-suggestion-bubble"
                 className="dashboard-suggestion-bubble"
-                style={{ transitionDelay: `${i * 60}ms` }}
+                style={{ animationDelay: `${i * 60}ms` }}
                 onMouseDown={(e) => e.preventDefault()}
                 onClick={() => chatInputRef.current?.setValue(label)}
               >

--- a/web/src/pages/Dashboard/components/PortfolioWatchlistCard.tsx
+++ b/web/src/pages/Dashboard/components/PortfolioWatchlistCard.tsx
@@ -58,6 +58,7 @@ function WatchlistItem({ item, index, onDelete, marketStatus, isMobile }: Watchl
 
   const rowContent = (
     <motion.div
+      data-testid={item.symbol ? `watchlist-row-${item.symbol}` : undefined}
       initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ delay: index * 0.05 }}
@@ -175,6 +176,7 @@ function PortfolioItem({ item, index, onEdit, onDelete, valuesHidden, marketStat
 
   const rowContent = (
     <motion.div
+      data-testid={item.symbol ? `portfolio-row-${item.symbol}` : undefined}
       initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ delay: index * 0.05 }}


### PR DESCRIPTION
## Summary

Fixes flaky `[chromium] › e2e/dashboard.spec.js › Watchlist CRUD › delete watchlist item` that was failing intermittently in CI. Investigation surfaced two real frontend issues, not just a test problem.

**Root cause.** `text=TSLA.first()` matched a hardcoded suggestion chip ("Compare TSLA vs BYD") that was always in the DOM under the floating chat input. Whether the test passed depended on a race between the watchlist API resolving and the moment Playwright snapshotted `.first()`. If the chip mounted before the row, `.first()` pinned to the chip and burned the 30s click budget on a `pointer-events-auto` overlay.

**Fixes.**

- **a11y**: `ChatInputCard.tsx` — suggestion chips now conditionally render on `focused`. Previously they were always mounted with a `.visible` class for opacity/pointer-events; chips were in the DOM, a11y tree, and tab order even when invisible.
- **Test handles**: `PortfolioWatchlistCard.tsx` — added `data-testid={watchlist-row-${symbol}}` and `data-testid={portfolio-row-${symbol}}` on the row `motion.div`. Symbol-falsy guard prevents `watchlist-row-undefined` collisions.
- **Selectors**: `dashboard.spec.js` — swapped 6 `text=TSLA/AAPL` locators to `getByTestId`. Plus a new regression test pinning the chip a11y invariant via role-based assertions, with click→input value and blur→unmount coverage.
- **Local-dev env**: `playwright.config.js` — forces `VITE_HOST_MODE=oss` and clears `VITE_SUPABASE_PUBLISHABLE_KEY` so a developer's personal `.env` can't pollute the E2E run. `reuseExistingServer: false` so the env block is always load-bearing.

## Pre-Landing Review

6 informational findings, all addressed:

- Regression test was pinning DOM count instead of the a11y invariant — now uses `getByRole('button', { name: 'Compare TSLA vs BYD' })` so a future inert/aria-hidden refactor still satisfies the contract.
- Chip selector was reverting to CSS classes — added `data-testid="dashboard-suggestion-bubble"` and `data-testid="dashboard-chat-input"` for consistency with the rest of the change.
- Symmetric coverage gap — added blur→unmount and click→input value assertions.
- `reuseExistingServer: !process.env.CI` would silently mask the env injection on a dev's stale server — flipped to `false`.
- `data-testid` on undefined symbol — guarded.

Skipped (informational, pre-existing or already-decided):
- AnimatePresence-based chip exit animation (plan accepted YAGNI).
- Platform-mode E2E coverage gap (pre-existing — env was already cleared before this branch).

## Test plan

- [x] `pnpm lint` — 0 errors (53 pre-existing warnings in MarketView, none in changed files)
- [x] `pnpm vitest run` — 598/598 passing in 7.4s
- [x] `pnpm exec playwright test --project=chromium` — 42/42 passing in 48.5s, including the new richer chip test
- [ ] CI Playwright job green on first attempt (no retries)