### PR TITLE
fix(dashboard): post-PR-172 cleanup — Zod schemas, cross-tab safety, network banner, UX polish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ React 19 + Vite 7, TypeScript, Tailwind CSS 3, shadcn/ui. State via React Query 
 | `contexts/` | `AuthContext` (Supabase session), `ThemeContext` |
 | `hooks/` | Shared React Query hooks (`useUser`, `useWorkspaces`, etc.) |
 | `pages/ChatAgent/` | Main AI chat interface — SSE streaming via raw `fetch()` + `ReadableStream` |
-| `pages/Dashboard/` | Overview with watchlist, portfolio, news |
+| `pages/Dashboard/` | Configurable widget gallery (watchlist, portfolio, news, TradingView widgets, mini-chart grid). Per-widget config validated with Zod at the prefs boundary. |
 | `pages/MarketView/` | Real-time market chart with WebSocket data |
 | `pages/Automations/` | Scheduled automation CRUD |
 | `components/ui/` | Primitive UI components (Radix-based) |

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -37,7 +37,7 @@ QueryClientProvider (React Query — 2min staleTime, retry: 1)
 
 **`components/Main/Main.tsx`** handles authenticated routes inside the app shell (Sidebar + Main). All pages are **lazy-loaded** with `React.lazy` and animated via `AnimatePresence` (keyed by top-level path segment):
 
-- `/dashboard` — Dashboard (watchlist, portfolio, news)
+- `/dashboard` — Dashboard (configurable widget gallery: watchlist, portfolio, news, TradingView widgets, mini-chart grid). Layout + per-widget settings stored in user preferences; see `pages/Dashboard/widgets/framework/`.
 - `/chat`, `/chat/:workspaceId`, `/chat/t/:threadId` — ChatAgent
 - `/market` — MarketView (real-time charts)
 - `/automations` — Automations
@@ -56,7 +56,9 @@ Controlled by `VITE_SUPABASE_URL`:
 
 **SSE streaming (chat):** Uses raw `fetch()` + `ReadableStream` (not axios — it doesn't support streaming). Implemented as `streamFetch()` in `pages/ChatAgent/utils/api.ts` and `pages/MarketView/utils/api.ts`. Auth tokens for fetch are obtained directly from `supabase.auth.getSession()`.
 
-**React Query:** Global `QueryClient` in `main.tsx`. Key factory in `lib/queryKeys.ts` — hierarchical keys enabling prefix-based invalidation (e.g., invalidate `queryKeys.user.all` to refresh all user-related data). Shared hooks in `hooks/` (`useUser`, `useWorkspaces`, `useWorkspace`, `usePreferences`, `useUpdatePreferences`).
+**React Query:** Global `QueryClient` in `main.tsx`. Key factory in `lib/queryKeys.ts` — hierarchical keys enabling prefix-based invalidation (e.g., invalidate `queryKeys.user.all` to refresh all user-related data). Shared hooks in `hooks/` (`useUser`, `useWorkspaces`, `useWorkspace`, `usePreferences`, `useUpdatePreferences`, `useNetworkStatus`).
+
+**Dashboard preferences:** `useDashboardPrefs` (in `pages/Dashboard/widgets/framework/`) reads layout + per-widget config from `user.preferences.dashboard`, validates each widget config through a Zod schema (`configSchemas.ts`), and writes back via a guarded writer (`dashboardPrefsWriter.ts`) that survives cross-tab races and cold-cache mounts. Cross-tab updates land via the `usePreferences` query cache; the dashboard re-renders without a network round-trip.
 
 ### API Layer Pattern
 

--- a/web/README.md
+++ b/web/README.md
@@ -8,7 +8,7 @@ React frontend for LangAlpha — a vibe investing agent with AI-powered research
 - **SSE Streaming Chat** — Real-time agent responses with subagent task cards, tool call display, and reasoning blocks
 - **HITL Plan Approval** — Review and approve/reject agent plans before execution
 - **React Query Data Layer** — Hierarchical cache key factory with prefix-based invalidation, shared hooks across pages
-- **Market Dashboard** — Watchlist and portfolio overview with stock data
+- **Configurable Dashboard** — Drag-and-drop widget gallery with 30+ widgets (watchlist, portfolio, news, TradingView heatmaps, screeners, ticker tape, mini-chart grid). Per-widget settings persisted to user preferences with Zod schema validation at the boundary, cross-tab sync, and an offline banner when the network drops.
 - **TradingView-Style Charting** — Interactive candlestick charts with AI chat sidebar for stock analysis
 - **Scheduled Automations** — Create and manage recurring agent tasks with cron scheduling and execution history
 - **Document Viewers** — Inline rendering of PDF, Excel, CSV, and HTML artifacts from agent responses
@@ -34,7 +34,8 @@ React frontend for LangAlpha — a vibe investing agent with AI-powered research
 | Styling | Tailwind CSS 3, `clsx`, `tailwind-merge`, `class-variance-authority` |
 | Animation | Framer Motion 12 |
 | Icons | Lucide React |
-| Charts | `lightweight-charts` (TradingView), Recharts |
+| Charts | `lightweight-charts` (TradingView), Recharts, embedded TradingView widgets |
+| Schema validation | `zod` (per-widget config schemas at the prefs boundary) |
 | Auth | `@supabase/supabase-js` |
 | HTTP | Axios |
 | Markdown | `react-markdown`, `remark-gfm`, `remark-math`, `remark-cjk-friendly`, `rehype-katex`, `rehype-raw`, `react-syntax-highlighter` |
@@ -62,7 +63,7 @@ src/
 ├── locales/                # i18n translation files (en-US, zh-CN)
 ├── pages/
 │   ├── Login/              # OAuth login with animated background
-│   ├── Dashboard/          # Watchlist, portfolio, market overview
+│   ├── Dashboard/          # Configurable widget gallery (watchlist, portfolio, news, TradingView widgets) with drag-and-drop layout
 │   ├── ChatAgent/          # Streaming chat with workspaces, threads, file panel
 │   ├── MarketView/         # Candlestick charts with AI chat sidebar
 │   ├── Automations/        # Scheduled agent task management

--- a/web/package.json
+++ b/web/package.json
@@ -57,7 +57,8 @@
     "remark-cjk-friendly": "^2.0.1",
     "remark-gfm": "^4.0.0",
     "remark-math": "^6.0.0",
-    "tailwind-merge": "^3.4.0"
+    "tailwind-merge": "^3.4.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.5.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.2
@@ -4687,6 +4690,9 @@ packages:
   zip-stream@4.1.1:
     resolution: {integrity: sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==}
     engines: {node: '>= 10'}
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -10317,5 +10323,7 @@ snapshots:
       archiver-utils: 3.0.4
       compress-commons: 4.1.2
       readable-stream: 3.6.2
+
+  zod@4.3.6: {}
 
   zwitch@2.0.4: {}

--- a/web/src/hooks/__tests__/useNetworkStatus.test.tsx
+++ b/web/src/hooks/__tests__/useNetworkStatus.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useNetworkStatus } from '../useNetworkStatus';
+
+describe('useNetworkStatus', () => {
+  let originalOnLine: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    originalOnLine = Object.getOwnPropertyDescriptor(globalThis.navigator, 'onLine');
+    Object.defineProperty(globalThis.navigator, 'onLine', { configurable: true, get: () => true });
+  });
+  afterEach(() => {
+    if (originalOnLine) Object.defineProperty(globalThis.navigator, 'onLine', originalOnLine);
+  });
+
+  it('reports navigator.onLine on first render', () => {
+    Object.defineProperty(globalThis.navigator, 'onLine', { configurable: true, get: () => true });
+    const { result } = renderHook(() => useNetworkStatus());
+    expect(result.current.online).toBe(true);
+  });
+
+  it('flips to false on offline event', () => {
+    const { result } = renderHook(() => useNetworkStatus());
+    act(() => {
+      window.dispatchEvent(new Event('offline'));
+    });
+    expect(result.current.online).toBe(false);
+  });
+
+  it('flips back to true on online event', () => {
+    Object.defineProperty(globalThis.navigator, 'onLine', { configurable: true, get: () => false });
+    const { result } = renderHook(() => useNetworkStatus());
+    expect(result.current.online).toBe(false);
+    act(() => {
+      window.dispatchEvent(new Event('online'));
+    });
+    expect(result.current.online).toBe(true);
+  });
+
+  it('removes listeners on unmount', () => {
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+    const { unmount } = renderHook(() => useNetworkStatus());
+    unmount();
+    const events = removeSpy.mock.calls.map((c) => c[0]);
+    expect(events).toContain('online');
+    expect(events).toContain('offline');
+  });
+
+  it('returns true when navigator is undefined (SSR)', () => {
+    // Stub typeof navigator === 'undefined' branch by deleting it temporarily.
+    const realNav = globalThis.navigator;
+    // @ts-expect-error — deliberately remove for SSR path test
+    delete globalThis.navigator;
+    try {
+      const { result } = renderHook(() => useNetworkStatus());
+      expect(result.current.online).toBe(true);
+    } finally {
+      Object.defineProperty(globalThis, 'navigator', { configurable: true, value: realNav });
+    }
+  });
+});

--- a/web/src/hooks/__tests__/usePreferences.test.tsx
+++ b/web/src/hooks/__tests__/usePreferences.test.tsx
@@ -25,10 +25,10 @@ describe('usePreferences', () => {
     expect(result.current.preferences).toMatchObject({ theme: 'dark' });
   });
 
-  it('uses staleTime: 0 so a returning tab refetches immediately', async () => {
-    // staleTime: 0 means a query is *always* stale on subscribe — combined
-    // with the global refetchOnWindowFocus: true (main.tsx), an alt-tab user
-    // gets fresh prefs without polling.
+  it('uses 60s staleTime when BroadcastChannel is available (modern browsers)', async () => {
+    // Vitest's Node runtime exposes BroadcastChannel, so this is the default
+    // branch under test. Immediate remount stays cached; no extra GET.
+    expect(typeof BroadcastChannel).toBe('function');
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false, gcTime: Infinity } },
     });
@@ -37,11 +37,38 @@ describe('usePreferences', () => {
     await waitFor(() => expect(result.current.preferences).not.toBeNull());
     expect(mockGetPreferences).toHaveBeenCalledTimes(1);
     unmount();
-    // Re-mount immediately. With staleTime: 0, the cache is stale and the
-    // next observer triggers a refetch instead of returning the cached value.
+    // Immediate remount: cache is still fresh (well within 60s), so no refetch.
     mockGetPreferences.mockResolvedValue({ theme: 'dark' });
     const { result: r2 } = renderHookWithProviders(() => usePreferences(), { queryClient });
-    await waitFor(() => expect(mockGetPreferences).toHaveBeenCalledTimes(2));
-    await waitFor(() => expect(r2.current.preferences).toMatchObject({ theme: 'dark' }));
+    await waitFor(() => expect(r2.current.preferences).toMatchObject({ theme: 'light' }));
+    expect(mockGetPreferences).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to staleTime: 0 when BroadcastChannel is unavailable (Safari < 15.4)', async () => {
+    // Delete the global and re-import so the module-level const re-evaluates.
+    vi.resetModules();
+    const original = globalThis.BroadcastChannel;
+    delete (globalThis as { BroadcastChannel?: unknown }).BroadcastChannel;
+    try {
+      const apiMod = await import('@/pages/Dashboard/utils/api');
+      const localGet = apiMod.getPreferences as unknown as ReturnType<typeof vi.fn>;
+      vi.mocked(localGet).mockReset();
+      const { usePreferences: freshUsePrefs } = await import('../usePreferences');
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+      });
+      vi.mocked(localGet).mockResolvedValue({ theme: 'light' });
+      const { result, unmount } = renderHookWithProviders(() => freshUsePrefs(), { queryClient });
+      await waitFor(() => expect(result.current.preferences).not.toBeNull());
+      expect(localGet).toHaveBeenCalledTimes(1);
+      unmount();
+      // Immediate remount under staleTime: 0 → cache is stale → refetch.
+      vi.mocked(localGet).mockResolvedValue({ theme: 'dark' });
+      const { result: r2 } = renderHookWithProviders(() => freshUsePrefs(), { queryClient });
+      await waitFor(() => expect(localGet).toHaveBeenCalledTimes(2));
+      await waitFor(() => expect(r2.current.preferences).toMatchObject({ theme: 'dark' }));
+    } finally {
+      globalThis.BroadcastChannel = original;
+    }
   });
 });

--- a/web/src/hooks/__tests__/usePreferences.test.tsx
+++ b/web/src/hooks/__tests__/usePreferences.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { waitFor } from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import { renderHookWithProviders } from '@/test/utils';
+import { queryKeys } from '@/lib/queryKeys';
+
+vi.mock('@/pages/Dashboard/utils/api', () => ({
+  getPreferences: vi.fn(),
+}));
+
+import { getPreferences } from '@/pages/Dashboard/utils/api';
+import { usePreferences } from '../usePreferences';
+
+const mockGetPreferences = getPreferences as unknown as ReturnType<typeof vi.fn>;
+
+describe('usePreferences', () => {
+  beforeEach(() => {
+    mockGetPreferences.mockReset();
+  });
+
+  it('fetches preferences via getPreferences()', async () => {
+    mockGetPreferences.mockResolvedValue({ theme: 'dark', other_preference: { dashboard: { mode: 'classic' } } });
+    const { result } = renderHookWithProviders(() => usePreferences());
+    await waitFor(() => expect(result.current.preferences).not.toBeNull());
+    expect(result.current.preferences).toMatchObject({ theme: 'dark' });
+  });
+
+  it('uses staleTime: 0 so a returning tab refetches immediately', async () => {
+    // staleTime: 0 means a query is *always* stale on subscribe — combined
+    // with the global refetchOnWindowFocus: true (main.tsx), an alt-tab user
+    // gets fresh prefs without polling.
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+    });
+    mockGetPreferences.mockResolvedValue({ theme: 'light' });
+    const { result, unmount } = renderHookWithProviders(() => usePreferences(), { queryClient });
+    await waitFor(() => expect(result.current.preferences).not.toBeNull());
+    expect(mockGetPreferences).toHaveBeenCalledTimes(1);
+    unmount();
+    // Re-mount immediately. With staleTime: 0, the cache is stale and the
+    // next observer triggers a refetch instead of returning the cached value.
+    mockGetPreferences.mockResolvedValue({ theme: 'dark' });
+    const { result: r2 } = renderHookWithProviders(() => usePreferences(), { queryClient });
+    await waitFor(() => expect(mockGetPreferences).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(r2.current.preferences).toMatchObject({ theme: 'dark' }));
+  });
+});

--- a/web/src/hooks/useNetworkStatus.ts
+++ b/web/src/hooks/useNetworkStatus.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Track the browser's reported online status.
+ *
+ * `navigator.onLine` is a soft signal — true means "the OS thinks we have a
+ * link," not "the network actually works." It still catches the common cases
+ * (dropped wifi, airplane mode, ethernet unplug) which is the v1 target. DNS
+ * failures, captive portals, and origin-specific outages aren't covered.
+ *
+ * SSR-safe: returns `true` when `navigator` is undefined so build-time render
+ * doesn't crash. The effect bails on missing `window`.
+ */
+export function useNetworkStatus(): { online: boolean } {
+  const [online, setOnline] = useState<boolean>(() =>
+    typeof navigator === 'undefined' ? true : navigator.onLine
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const goOnline = () => setOnline(true);
+    const goOffline = () => setOnline(false);
+    window.addEventListener('online', goOnline);
+    window.addEventListener('offline', goOffline);
+    return () => {
+      window.removeEventListener('online', goOnline);
+      window.removeEventListener('offline', goOffline);
+    };
+  }, []);
+
+  return { online };
+}

--- a/web/src/hooks/usePreferences.ts
+++ b/web/src/hooks/usePreferences.ts
@@ -7,12 +7,17 @@ import type { UserPreferences } from '../types/api';
  * Shared hook for user preferences.
  * Replaces manual useEffect+useState fetching of /api/v1/users/me/preferences.
  * All consumers share a single cached entry — updates propagate automatically.
+ *
+ * staleTime: 0 + global refetchOnWindowFocus (set in main.tsx) means a tab
+ * that returns to focus pulls fresh prefs. This pairs with the dashboard
+ * prefs BroadcastChannel (useDashboardPrefs) so cross-tab edits land without
+ * the user having to refresh.
  */
 export function usePreferences() {
   const { data, ...rest } = useQuery({
     queryKey: queryKeys.user.preferences(),
     queryFn: getPreferences as () => Promise<UserPreferences>,
-    staleTime: 5 * 60_000,
+    staleTime: 0,
     retry: false,
   });
   return { preferences: data ?? null, ...rest };

--- a/web/src/hooks/usePreferences.ts
+++ b/web/src/hooks/usePreferences.ts
@@ -3,21 +3,17 @@ import { queryKeys } from '../lib/queryKeys';
 import { getPreferences } from '../pages/Dashboard/utils/api';
 import type { UserPreferences } from '../types/api';
 
-/**
- * Shared hook for user preferences.
- * Replaces manual useEffect+useState fetching of /api/v1/users/me/preferences.
- * All consumers share a single cached entry — updates propagate automatically.
- *
- * staleTime: 0 + global refetchOnWindowFocus (set in main.tsx) means a tab
- * that returns to focus pulls fresh prefs. This pairs with the dashboard
- * prefs BroadcastChannel (useDashboardPrefs) so cross-tab edits land without
- * the user having to refresh.
- */
+// staleTime split by capability: browsers with BroadcastChannel get cross-tab
+// sync via the dashboard prefs channel, so 60s is enough; Safari < 15.4 has
+// no channel and depends on focus refetch, so it needs 0.
+const PREFS_STALE_TIME_MS =
+  typeof BroadcastChannel === 'undefined' ? 0 : 60_000;
+
 export function usePreferences() {
   const { data, ...rest } = useQuery({
     queryKey: queryKeys.user.preferences(),
     queryFn: getPreferences as () => Promise<UserPreferences>,
-    staleTime: 0,
+    staleTime: PREFS_STALE_TIME_MS,
     retry: false,
   });
   return { preferences: data ?? null, ...rest };

--- a/web/src/pages/ChatAgent/hooks/__tests__/useWorkspaceFiles.test.tsx
+++ b/web/src/pages/ChatAgent/hooks/__tests__/useWorkspaceFiles.test.tsx
@@ -88,15 +88,26 @@ describe('useWorkspaceFiles', () => {
   });
 
   it('returns sandbox unavailable for 503', async () => {
-    const error: Error & { response?: { status?: number } } = new Error('Service unavailable');
-    error.response = { status: 503 };
-    mockListFiles.mockRejectedValue(error);
+    // The hook retries 503 errors up to 3 times with delays of 1s+2s+3s = 6s
+    // wall clock. Use fake timers and step through them so the test runs in
+    // milliseconds instead of starving the worker pool.
+    vi.useFakeTimers();
+    try {
+      const error: Error & { response?: { status?: number } } = new Error('Service unavailable');
+      error.response = { status: 503 };
+      mockListFiles.mockRejectedValue(error);
 
-    const queryClient = createFastRetryClient();
-    const { result } = renderHookWithProviders(() => useWorkspaceFiles('ws-1'), { queryClient });
+      const queryClient = createFastRetryClient();
+      const { result } = renderHookWithProviders(() => useWorkspaceFiles('ws-1'), { queryClient });
 
-    // The hook retries 503 errors up to 3 times with delays of 1s, 2s, 3s
-    await waitFor(() => expect(result.current.error).not.toBeNull(), { timeout: 10000 });
-    expect(result.current.error).toBe('Sandbox not available');
-  }, 15000);
+      // Drain initial query + 3 retry delays. advanceTimersByTimeAsync flushes
+      // microtasks between ticks so each retry's promise rejection settles.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(7_000);
+      });
+      expect(result.current.error).toBe('Sandbox not available');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/web/src/pages/Dashboard/DashboardRouter.tsx
+++ b/web/src/pages/Dashboard/DashboardRouter.tsx
@@ -1,12 +1,16 @@
 import { useCallback } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { usePreferences } from '@/hooks/usePreferences';
-import { useUpdatePreferences } from '@/hooks/useUpdatePreferences';
+import { queryKeys } from '@/lib/queryKeys';
+import type { UserPreferences } from '@/types/api';
 import Dashboard from './Dashboard';
 import DashboardCustom from './DashboardCustom';
+import NetworkBanner from './components/NetworkBanner';
+import { useDashboardPrefsWriter } from './widgets/framework/dashboardPrefsWriter';
 import { migrateDashboardPrefs } from './widgets/framework/migrations';
 import { getPreset } from './widgets/presets';
-import type { DashboardPrefs } from './widgets/types';
+import { DASHBOARD_PREFS_VERSION, type DashboardPrefs } from './widgets/types';
 
 // Side-effect: ensure widget registry is populated before any preset factory runs.
 import './widgets/index';
@@ -20,8 +24,9 @@ import './widgets/index';
  */
 export default function DashboardRouter() {
   const isMobile = useIsMobile();
-  const { preferences } = usePreferences();
-  const updatePrefs = useUpdatePreferences();
+  const { preferences, isLoading } = usePreferences();
+  const { writeDashboardPrefs } = useDashboardPrefsWriter();
+  const queryClient = useQueryClient();
 
   const rawOther = (preferences as { other_preference?: { dashboard?: unknown } } | null)
     ?.other_preference;
@@ -30,37 +35,65 @@ export default function DashboardRouter() {
 
   const onModeChange = useCallback(
     (next: 'classic' | 'custom') => {
-      const prevOther = (rawOther ?? {}) as Record<string, unknown>;
-      // Spread the migrated/normalized form (parsed) instead of the raw
-      // stored blob so malformed legacy keys can't round-trip back into
-      // the write. parsed comes from migrateDashboardPrefs which coerces
-      // bad widgets/layouts/history values into safe defaults.
-      const baseDashboard = parsed ?? ({} as Partial<DashboardPrefs>);
+      // Cold-cache gate: refuse the toggle until prefs load so we don't PUT
+      // `{ other_preference: { dashboard: {...} } }` and clobber sibling
+      // server-side keys (theme, locale). The toggle is disabled in the UI
+      // while isLoading, so this branch is defense-in-depth.
+      if (isLoading) return;
+      // Replay-aware: re-read the freshest cache so a cross-tab edit (or
+      // pending debounce in this tab) that already updated the dashboard
+      // sub-object isn't replaced with the render-time snapshot. Without
+      // this, `firstFlipToCustom` could mis-trigger the morning-brief seed
+      // because `parsed` (render-time) saw an empty widget list while the
+      // cache already has widgets. The writer also reads cache for sibling
+      // preservation; this read is for the dashboard sub-object only.
+      const fresh = queryClient.getQueryData<UserPreferences>(queryKeys.user.preferences());
+      const freshOther = (fresh?.other_preference as Record<string, unknown> | undefined) ?? rawOther;
+      const freshDashboardRaw = (freshOther?.dashboard as unknown) ?? null;
+      const baseDashboard: Partial<DashboardPrefs> =
+        migrateDashboardPrefs(freshDashboardRaw) ?? parsed ?? {};
       const firstFlipToCustom = next === 'custom' && (!baseDashboard.widgets || baseDashboard.widgets.length === 0);
       const seed = firstFlipToCustom ? getPreset('morning-brief') : null;
-      updatePrefs.mutate({
-        other_preference: {
-          ...prevOther,
-          dashboard: {
-            ...baseDashboard,
-            version: 1,
-            mode: next,
-            ...(seed ? { widgets: seed.widgets, layouts: seed.layouts } : {}),
-          },
-        },
+      const dashboard: DashboardPrefs = {
+        version: DASHBOARD_PREFS_VERSION,
+        mode: next,
+        widgets: seed ? seed.widgets : (baseDashboard.widgets ?? []),
+        layouts: seed ? seed.layouts : (baseDashboard.layouts ?? {}),
+        lastBreakpoint: baseDashboard.lastBreakpoint,
+        history: baseDashboard.history,
+      };
+      writeDashboardPrefs(dashboard, {
+        fallbackOther: (rawOther as Record<string, unknown> | undefined) ?? null,
       });
     },
-    [rawOther, parsed, updatePrefs]
+    [writeDashboardPrefs, parsed, rawOther, isLoading, queryClient]
   );
 
   if (isMobile) {
-    // Mobile: Classic always. Toggle is not surfaced.
-    return <Dashboard />;
+    // Mobile: Classic always. Toggle is not surfaced. Banner still mounts so
+    // tablet/phone users get the offline warning too — TV iframes silently
+    // serve stale data on mobile just like desktop.
+    return (
+      <>
+        <NetworkBanner />
+        <Dashboard />
+      </>
+    );
   }
 
   if (mode === 'custom') {
-    return <DashboardCustom mode={mode} onModeChange={onModeChange} />;
+    return (
+      <>
+        <NetworkBanner />
+        <DashboardCustom mode={mode} onModeChange={onModeChange} />
+      </>
+    );
   }
 
-  return <Dashboard layoutToggle={{ mode, onModeChange }} />;
+  return (
+    <>
+      <NetworkBanner />
+      <Dashboard layoutToggle={{ mode, onModeChange }} />
+    </>
+  );
 }

--- a/web/src/pages/Dashboard/DashboardRouter.tsx
+++ b/web/src/pages/Dashboard/DashboardRouter.tsx
@@ -63,10 +63,13 @@ export default function DashboardRouter() {
         history: baseDashboard.history,
       };
       writeDashboardPrefs(dashboard, {
-        fallbackOther: (rawOther as Record<string, unknown> | undefined) ?? null,
+        // undefined = cold (writer refuses); null = warm w/ empty siblings.
+        fallbackOther: preferences === null
+          ? undefined
+          : ((rawOther as Record<string, unknown> | undefined) ?? null),
       });
     },
-    [writeDashboardPrefs, parsed, rawOther, isLoading, queryClient]
+    [writeDashboardPrefs, parsed, preferences, rawOther, isLoading, queryClient]
   );
 
   if (isMobile) {

--- a/web/src/pages/Dashboard/__tests__/DashboardRouter.test.tsx
+++ b/web/src/pages/Dashboard/__tests__/DashboardRouter.test.tsx
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import { queryKeys } from '@/lib/queryKeys';
+
+const prefsState: { current: { other_preference?: Record<string, unknown> } | null } = {
+  current: { other_preference: { theme: 'dark', dashboard: { mode: 'classic', widgets: [], layouts: {} } } },
+};
+const loadingState = { isLoading: false };
+const mockMutate = vi.fn();
+let mockIsMobile = false;
+const lastDashboardProps: { current: { mode: string; onModeChange: (n: 'classic' | 'custom') => void } | null } = { current: null };
+
+vi.mock('@/hooks/useIsMobile', () => ({
+  useIsMobile: () => mockIsMobile,
+}));
+vi.mock('@/hooks/usePreferences', () => ({
+  usePreferences: () => ({ preferences: prefsState.current, isLoading: loadingState.isLoading }),
+}));
+vi.mock('@/hooks/useUpdatePreferences', () => ({
+  useUpdatePreferences: () => ({ mutate: mockMutate, isPending: false }),
+}));
+vi.mock('../Dashboard', () => ({
+  __esModule: true,
+  default: (props: { layoutToggle?: { mode: string; onModeChange: (n: 'classic' | 'custom') => void } }) => {
+    if (props.layoutToggle) lastDashboardProps.current = props.layoutToggle;
+    return <div data-testid="classic-dashboard" />;
+  },
+}));
+vi.mock('../DashboardCustom', () => ({
+  __esModule: true,
+  default: (props: { mode: string; onModeChange: (n: 'classic' | 'custom') => void }) => {
+    lastDashboardProps.current = { mode: props.mode, onModeChange: props.onModeChange };
+    return <div data-testid="custom-dashboard" />;
+  },
+}));
+vi.mock('../components/NetworkBanner', () => ({
+  __esModule: true,
+  default: () => <div data-testid="network-banner-stub" />,
+}));
+
+import DashboardRouter from '../DashboardRouter';
+
+function renderRouter(queryClient: QueryClient) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <DashboardRouter />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+function makeClient(): QueryClient {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: Infinity }, mutations: { retry: false } },
+  });
+  qc.setQueryData(queryKeys.user.preferences(), prefsState.current);
+  return qc;
+}
+
+describe('DashboardRouter', () => {
+  beforeEach(() => {
+    mockMutate.mockReset();
+    mockIsMobile = false;
+    loadingState.isLoading = false;
+    lastDashboardProps.current = null;
+    prefsState.current = { other_preference: { theme: 'dark', dashboard: { mode: 'classic', widgets: [], layouts: {} } } };
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('renders Classic dashboard when prefs.mode === classic', () => {
+    const { getByTestId } = renderRouter(makeClient());
+    expect(getByTestId('classic-dashboard')).toBeInTheDocument();
+  });
+
+  it('renders Custom dashboard when prefs.mode === custom', () => {
+    prefsState.current = {
+      other_preference: { theme: 'dark', dashboard: { mode: 'custom', widgets: [], layouts: {} } },
+    };
+    const { getByTestId } = renderRouter(makeClient());
+    expect(getByTestId('custom-dashboard')).toBeInTheDocument();
+  });
+
+  it('forces Classic on mobile regardless of prefs.mode', () => {
+    mockIsMobile = true;
+    prefsState.current = {
+      other_preference: { theme: 'dark', dashboard: { mode: 'custom', widgets: [], layouts: {} } },
+    };
+    const { getByTestId, queryByTestId } = renderRouter(makeClient());
+    expect(getByTestId('classic-dashboard')).toBeInTheDocument();
+    expect(queryByTestId('custom-dashboard')).toBeNull();
+  });
+
+  it('mounts NetworkBanner above Classic mode', () => {
+    const { getByTestId } = renderRouter(makeClient());
+    expect(getByTestId('network-banner-stub')).toBeInTheDocument();
+    expect(getByTestId('classic-dashboard')).toBeInTheDocument();
+  });
+
+  it('mounts NetworkBanner above Custom mode', () => {
+    prefsState.current = {
+      other_preference: { theme: 'dark', dashboard: { mode: 'custom', widgets: [], layouts: {} } },
+    };
+    const { getByTestId } = renderRouter(makeClient());
+    expect(getByTestId('network-banner-stub')).toBeInTheDocument();
+    expect(getByTestId('custom-dashboard')).toBeInTheDocument();
+  });
+
+  it('onModeChange uses fresh queryClient cache snapshot, not stale render-time copy', () => {
+    const queryClient = makeClient();
+    renderRouter(queryClient);
+    expect(lastDashboardProps.current).not.toBeNull();
+    // Simulate a cross-tab edit: cache gets new theme + new dashboard mode.
+    act(() => {
+      queryClient.setQueryData(queryKeys.user.preferences(), {
+        other_preference: {
+          theme: 'light',
+          dashboard: { mode: 'classic', widgets: [{ id: 'w1', type: 'native.chart', config: {} }], layouts: { lg: [] } },
+        },
+      });
+    });
+    // User clicks mode toggle. Without replay-aware fix, the write would
+    // spread the stale render-time `rawOther` and clobber theme=light + the
+    // remote-added widget array.
+    act(() => {
+      lastDashboardProps.current!.onModeChange('custom');
+    });
+    expect(mockMutate).toHaveBeenCalledTimes(1);
+    const payload = mockMutate.mock.calls[0][0] as {
+      other_preference: {
+        theme?: string;
+        dashboard?: { mode: string; widgets?: unknown[] };
+      };
+    };
+    expect(payload.other_preference.theme).toBe('light');
+    expect(payload.other_preference.dashboard?.mode).toBe('custom');
+    // The remote-added widget must survive the mode-toggle write.
+    expect(payload.other_preference.dashboard?.widgets?.length).toBe(1);
+  });
+
+  it('seeds the morning-brief preset on first flip from empty Classic to Custom', () => {
+    const queryClient = makeClient();
+    renderRouter(queryClient);
+    act(() => {
+      lastDashboardProps.current!.onModeChange('custom');
+    });
+    const payload = mockMutate.mock.calls[0][0] as {
+      other_preference: { dashboard?: { mode: string; widgets?: unknown[] } };
+    };
+    expect(payload.other_preference.dashboard?.mode).toBe('custom');
+    expect((payload.other_preference.dashboard?.widgets?.length ?? 0)).toBeGreaterThan(0);
+  });
+
+  it('cold-cache gate: onModeChange is a no-op while preferences are still loading', () => {
+    // Regression: a fast click before the GET resolves would PUT
+    // { other_preference: { dashboard: {...} } } and clobber sibling
+    // server-side keys (theme, locale).
+    loadingState.isLoading = true;
+    prefsState.current = null;
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: Infinity }, mutations: { retry: false } },
+    });
+    // Cache empty (no setQueryData) — simulates cold load.
+    renderRouter(queryClient);
+    expect(lastDashboardProps.current).not.toBeNull();
+    act(() => {
+      lastDashboardProps.current!.onModeChange('custom');
+    });
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/pages/Dashboard/__tests__/DashboardRouter.test.tsx
+++ b/web/src/pages/Dashboard/__tests__/DashboardRouter.test.tsx
@@ -4,7 +4,7 @@ import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 import { queryKeys } from '@/lib/queryKeys';
 
-const prefsState: { current: { other_preference?: Record<string, unknown> } | null } = {
+const prefsState: { current: { other_preference?: Record<string, unknown> | null } | null } = {
   current: { other_preference: { theme: 'dark', dashboard: { mode: 'classic', widgets: [], layouts: {} } } },
 };
 const loadingState = { isLoading: false };
@@ -150,6 +150,27 @@ describe('DashboardRouter', () => {
       other_preference: { dashboard?: { mode: string; widgets?: unknown[] } };
     };
     expect(payload.other_preference.dashboard?.mode).toBe('custom');
+    expect((payload.other_preference.dashboard?.widgets?.length ?? 0)).toBeGreaterThan(0);
+  });
+
+  it('new-user warm cache: onModeChange writes with seeded other_preference={dashboard:{...}}', () => {
+    // Regression: writer used to refuse when both freshOther and fallbackOther
+    // were null, so new users' first mode flip reverted on next refetch.
+    prefsState.current = { other_preference: null };
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: Infinity }, mutations: { retry: false } },
+    });
+    queryClient.setQueryData(queryKeys.user.preferences(), { other_preference: null });
+    renderRouter(queryClient);
+    act(() => {
+      lastDashboardProps.current!.onModeChange('custom');
+    });
+    expect(mockMutate).toHaveBeenCalledTimes(1);
+    const payload = mockMutate.mock.calls[0][0] as {
+      other_preference: { dashboard?: { mode: string; widgets?: unknown[] } };
+    };
+    expect(payload.other_preference.dashboard?.mode).toBe('custom');
+    // Morning-brief seed kicks in for the empty-widgets first flip.
     expect((payload.other_preference.dashboard?.widgets?.length ?? 0)).toBeGreaterThan(0);
   });
 

--- a/web/src/pages/Dashboard/components/NetworkBanner.tsx
+++ b/web/src/pages/Dashboard/components/NetworkBanner.tsx
@@ -1,0 +1,34 @@
+import { WifiOff } from 'lucide-react';
+import { useNetworkStatus } from '@/hooks/useNetworkStatus';
+
+/**
+ * Sticky banner that surfaces the browser's offline state. Mounted by
+ * DashboardRouter so it covers both Classic and Custom dashboard modes.
+ *
+ * Keep the visual treatment subtle — this is informational, not blocking.
+ * TradingView iframes and React Query polls keep working from cache; the
+ * banner just tells the user why their numbers may be stale.
+ */
+export default function NetworkBanner() {
+  const { online } = useNetworkStatus();
+  if (online) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="sticky top-0 z-30 flex items-center justify-center gap-2 px-4 py-2 text-xs font-medium border-b"
+      style={{
+        backgroundColor: 'var(--color-warning-soft)',
+        color: 'var(--color-warning)',
+        // Use the saturated warning color for the divider so the banner
+        // visually separates from the dashboard chrome — borderColor matching
+        // the soft background made the `border-b` invisible.
+        borderColor: 'var(--color-warning)',
+      }}
+    >
+      <WifiOff size={14} />
+      <span>Network offline — dashboard data may be stale until you reconnect.</span>
+    </div>
+  );
+}

--- a/web/src/pages/Dashboard/components/__tests__/NetworkBanner.test.tsx
+++ b/web/src/pages/Dashboard/components/__tests__/NetworkBanner.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import NetworkBanner from '../NetworkBanner';
+
+describe('NetworkBanner', () => {
+  let originalOnLine: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    originalOnLine = Object.getOwnPropertyDescriptor(globalThis.navigator, 'onLine');
+    Object.defineProperty(globalThis.navigator, 'onLine', { configurable: true, get: () => true });
+  });
+  afterEach(() => {
+    if (originalOnLine) Object.defineProperty(globalThis.navigator, 'onLine', originalOnLine);
+  });
+
+  it('renders nothing when online', () => {
+    const { container } = render(<NetworkBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the offline message after the offline event', () => {
+    render(<NetworkBanner />);
+    act(() => {
+      window.dispatchEvent(new Event('offline'));
+    });
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.getByText(/network offline/i)).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/Dashboard/widgets/definitions/AutomationsWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/AutomationsWidget.tsx
@@ -12,6 +12,7 @@ import { useAutomations } from '@/pages/Automations/hooks/useAutomations';
 import { useAutomationMutations } from '@/pages/Automations/hooks/useAutomationMutations';
 import type { Automation } from '@/types/automation';
 import { registerWidget } from '../framework/WidgetRegistry';
+import { AutomationsConfigSchema } from '../framework/configSchemas';
 import type { WidgetRenderProps } from '../types';
 
 type AutomationsConfig = { limit?: number };
@@ -420,6 +421,7 @@ registerWidget<AutomationsConfig>({
   icon: Workflow,
   component: AutomationsWidget,
   defaultConfig: { limit: 8 },
+  configSchema: AutomationsConfigSchema,
   defaultSize: { w: 4, h: 22 },
   minSize: { w: 3, h: 14 },
 });

--- a/web/src/pages/Dashboard/widgets/definitions/ChartWidget.register.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/ChartWidget.register.tsx
@@ -1,6 +1,7 @@
 import { lazy } from 'react';
 import { CandlestickChart } from 'lucide-react';
 import { registerWidget } from '../framework/WidgetRegistry';
+import { ChartConfigSchema } from '../framework/configSchemas';
 import type { WidgetRenderProps, WidgetSettingsProps } from '../types';
 
 type ChartConfig = {
@@ -31,6 +32,7 @@ registerWidget<ChartConfig>({
   component: LazyChartWidget as unknown as React.ComponentType<WidgetRenderProps<ChartConfig>>,
   settingsComponent: LazyChartSettings as unknown as React.ComponentType<WidgetSettingsProps<ChartConfig>>,
   defaultConfig: DEFAULT_CONFIG,
+  configSchema: ChartConfigSchema,
   defaultSize: { w: 6, h: 22 },
   minSize: { w: 3, h: 15 },
 });

--- a/web/src/pages/Dashboard/widgets/definitions/ConversationWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/ConversationWidget.tsx
@@ -16,6 +16,7 @@ import { getWorkspaceThreads } from '@/pages/ChatAgent/utils/api';
 import { queryKeys } from '@/lib/queryKeys';
 import type { Thread, ThreadsResponse } from '@/types/api';
 import { registerWidget } from '../framework/WidgetRegistry';
+import { ConversationConfigSchema } from '../framework/configSchemas';
 import type { WidgetRenderProps } from '../types';
 import './ConversationWidget.css';
 
@@ -211,6 +212,7 @@ registerWidget<ConversationConfig>({
   icon: MessageSquareText,
   component: ConversationWidget,
   defaultConfig: {},
+  configSchema: ConversationConfigSchema,
   defaultSize: { w: 8, h: 12 },
   minSize: { w: 6, h: 8 },
   maxSize: { w: 12, h: 44 },

--- a/web/src/pages/Dashboard/widgets/definitions/EarningsCalendarWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/EarningsCalendarWidget.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { CalendarDays } from 'lucide-react';
 import { getEarningsCalendar } from '../../utils/api';
 import { registerWidget } from '../framework/WidgetRegistry';
+import { EarningsConfigSchema } from '../framework/configSchemas';
 import type { WidgetRenderProps } from '../types';
 
 /** Local-date YYYY-MM-DD. We can't use toISOString() because that emits UTC,
@@ -289,6 +290,7 @@ registerWidget<EarningsConfig>({
   icon: CalendarDays,
   component: EarningsCalendarWidget,
   defaultConfig: { window: '2w', tickers: 'all' },
+  configSchema: EarningsConfigSchema,
   defaultSize: { w: 4, h: 26 },
   minSize: { w: 3, h: 15 },
 });

--- a/web/src/pages/Dashboard/widgets/definitions/InsightBriefWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/InsightBriefWidget.tsx
@@ -2,6 +2,7 @@ import { Sparkles } from 'lucide-react';
 import AIDailyBriefCard from '../../components/AIDailyBriefCard';
 import { useDashboardContext } from '../framework/DashboardDataContext';
 import { registerWidget } from '../framework/WidgetRegistry';
+import { InsightBriefConfigSchema } from '../framework/configSchemas';
 import type { WidgetRenderProps } from '../types';
 import './InsightBriefWidget.css';
 
@@ -24,6 +25,7 @@ registerWidget<InsightBriefConfig>({
   icon: Sparkles,
   component: InsightBriefWidget,
   defaultConfig: { variant: 'latest' },
+  configSchema: InsightBriefConfigSchema,
   defaultSize: { w: 8, h: 18 },
   minSize: { w: 4, h: 15 },
   maxSize: { w: 12, h: 44 },

--- a/web/src/pages/Dashboard/widgets/definitions/MarketsOverviewWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/MarketsOverviewWidget.tsx
@@ -3,6 +3,7 @@ import { LineChart } from 'lucide-react';
 import IndexMovementCard from '../../components/IndexMovementCard';
 import { useDashboardContext } from '../framework/DashboardDataContext';
 import { registerWidget } from '../framework/WidgetRegistry';
+import { MarketsOverviewConfigSchema } from '../framework/configSchemas';
 import type { WidgetRenderProps } from '../types';
 
 type MarketsOverviewConfig = { indices?: string[] };
@@ -45,6 +46,7 @@ registerWidget<MarketsOverviewConfig>({
   icon: LineChart,
   component: MarketsOverviewWidget,
   defaultConfig: {},
+  configSchema: MarketsOverviewConfigSchema,
   defaultSize: { w: 12, h: 11 },
   minSize: { w: 3, h: 11 },
   maxSize: { w: 12, h: 11 },

--- a/web/src/pages/Dashboard/widgets/definitions/MiniChartGridWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/MiniChartGridWidget.tsx
@@ -4,6 +4,7 @@ import { Grid2x2 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useDashboardContext } from '../framework/DashboardDataContext';
 import { registerWidget } from '../framework/WidgetRegistry';
+import { MiniChartGridConfigSchema } from '../framework/configSchemas';
 import { fetchStockData } from '@/pages/MarketView/utils/api';
 import { DEFAULT_BLUE_CHIPS } from '../framework/defaults';
 import { SymbolListField } from '../framework/settings/SymbolListField';
@@ -155,7 +156,9 @@ function MiniChartGridWidget({ instance }: WidgetRenderProps<MiniChartGridConfig
         ) : (
           <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
             {data!.map((cell) => {
-              const pct = ((cell.last - cell.prev) / cell.prev) * 100;
+              // Guard against zero anchor (delisted ticker, corrupt fixture)
+              // so we don't render "Infinity%" / "NaN%" cells.
+              const pct = cell.prev === 0 ? 0 : ((cell.last - cell.prev) / cell.prev) * 100;
               const up = pct >= 0;
               return (
                 <button
@@ -242,6 +245,7 @@ registerWidget<MiniChartGridConfig>({
   component: MiniChartGridWidget,
   settingsComponent: MiniChartGridSettings,
   defaultConfig: { symbols: [] },
+  configSchema: MiniChartGridConfigSchema,
   defaultSize: { w: 12, h: 16 },
   minSize: { w: 6, h: 10 },
   initConfig: (ctx) => {

--- a/web/src/pages/Dashboard/widgets/definitions/NewsFeedWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/NewsFeedWidget.tsx
@@ -3,6 +3,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { Newspaper, Clock, Search, X } from 'lucide-react';
 import { useDashboardContext } from '../framework/DashboardDataContext';
 import { registerWidget } from '../framework/WidgetRegistry';
+import { NewsFeedConfigSchema } from '../framework/configSchemas';
 import type { WidgetRenderProps } from '../types';
 
 type NewsFeedSource = 'market' | 'portfolio' | 'watchlist';
@@ -404,6 +405,7 @@ registerWidget<NewsFeedConfig>({
   icon: Newspaper,
   component: NewsFeedWidget,
   defaultConfig: { source: 'market' },
+  configSchema: NewsFeedConfigSchema,
   defaultSize: { w: 8, h: 29 },
   minSize: { w: 4, h: 18 },
 });

--- a/web/src/pages/Dashboard/widgets/definitions/PortfolioWatchlistWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/PortfolioWatchlistWidget.tsx
@@ -3,6 +3,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { Wallet } from 'lucide-react';
 import { useDashboardContext } from '../framework/DashboardDataContext';
 import { registerWidget } from '../framework/WidgetRegistry';
+import { PortfolioWatchlistConfigSchema } from '../framework/configSchemas';
 import type { WidgetRenderProps } from '../types';
 import {
   HoldingsAddButton,
@@ -195,6 +196,7 @@ registerWidget<PortfolioWatchlistConfig>({
   icon: Wallet,
   component: PortfolioWatchlistWidget,
   defaultConfig: { defaultTab: 'watchlist', valuesHidden: false },
+  configSchema: PortfolioWatchlistConfigSchema,
   defaultSize: { w: 4, h: 30 },
   minSize: { w: 3, h: 18 },
 });

--- a/web/src/pages/Dashboard/widgets/definitions/PortfolioWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/PortfolioWidget.tsx
@@ -3,6 +3,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { Briefcase } from 'lucide-react';
 import { useDashboardContext } from '../framework/DashboardDataContext';
 import { registerWidget } from '../framework/WidgetRegistry';
+import { PortfolioConfigSchema } from '../framework/configSchemas';
 import type { WidgetRenderProps } from '../types';
 import {
   HoldingsAddButton,
@@ -100,6 +101,7 @@ registerWidget<PortfolioConfig>({
   icon: Briefcase,
   component: PortfolioWidget,
   defaultConfig: { valuesHidden: false },
+  configSchema: PortfolioConfigSchema,
   defaultSize: { w: 4, h: 26 },
   minSize: { w: 3, h: 15 },
 });

--- a/web/src/pages/Dashboard/widgets/definitions/RecentThreadsWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/RecentThreadsWidget.tsx
@@ -8,6 +8,7 @@ import { clearChatSession } from '@/pages/ChatAgent/hooks/utils/chatSessionResto
 import type { Thread, ThreadsResponse, Workspace } from '@/types/api';
 import { queryKeys } from '@/lib/queryKeys';
 import { registerWidget } from '../framework/WidgetRegistry';
+import { RecentThreadsConfigSchema } from '../framework/configSchemas';
 import type { WidgetRenderProps } from '../types';
 
 type RecentThreadsConfig = { workspaceId?: 'all' | 'current' | string; limit?: number };
@@ -359,6 +360,7 @@ registerWidget<RecentThreadsConfig>({
   icon: MessagesSquare,
   component: RecentThreadsWidget,
   defaultConfig: { workspaceId: 'all', limit: 15 },
+  configSchema: RecentThreadsConfigSchema,
   defaultSize: { w: 6, h: 22 },
   minSize: { w: 3, h: 15 },
 });

--- a/web/src/pages/Dashboard/widgets/definitions/WatchlistWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/WatchlistWidget.tsx
@@ -2,6 +2,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { Eye } from 'lucide-react';
 import { useDashboardContext } from '../framework/DashboardDataContext';
 import { registerWidget } from '../framework/WidgetRegistry';
+import { WatchlistConfigSchema } from '../framework/configSchemas';
 import type { WidgetRenderProps } from '../types';
 import {
   HoldingsAddButton,
@@ -79,6 +80,7 @@ registerWidget<WatchlistConfig>({
   icon: Eye,
   component: WatchlistWidget,
   defaultConfig: {},
+  configSchema: WatchlistConfigSchema,
   defaultSize: { w: 4, h: 26 },
   minSize: { w: 3, h: 15 },
 });

--- a/web/src/pages/Dashboard/widgets/definitions/WorkspacePickerWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/WorkspacePickerWidget.tsx
@@ -4,6 +4,7 @@ import { useWorkspaces } from '@/hooks/useWorkspaces';
 import { clearChatSession } from '@/pages/ChatAgent/hooks/utils/chatSessionRestore';
 import type { Workspace } from '@/types/api';
 import { registerWidget } from '../framework/WidgetRegistry';
+import { WorkspacePickerConfigSchema } from '../framework/configSchemas';
 import type { WidgetRenderProps } from '../types';
 
 type WorkspacePickerConfig = { limit?: number };
@@ -235,6 +236,7 @@ registerWidget<WorkspacePickerConfig>({
   icon: LayoutGrid,
   component: WorkspacePickerWidget,
   defaultConfig: { limit: 12 },
+  configSchema: WorkspacePickerConfigSchema,
   defaultSize: { w: 6, h: 22 },
   minSize: { w: 3, h: 15 },
 });

--- a/web/src/pages/Dashboard/widgets/definitions/__tests__/MiniChartGridWidget.test.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/__tests__/MiniChartGridWidget.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('@/pages/MarketView/utils/api', () => ({
+  fetchStockData: vi.fn().mockResolvedValue({
+    data: Array.from({ length: 30 }, (_, i) => ({
+      timestamp: new Date(Date.UTC(2026, 0, i + 1)).toISOString(),
+      open: 100 + i,
+      high: 105 + i,
+      low: 95 + i,
+      close: 100 + i,
+      volume: 1000,
+    })),
+  }),
+}));
+
+// Stub the dashboard context — the widget only reads `watchlist.rows` to fall
+// back when no symbols are configured. Mocking sidesteps Supabase / API hooks.
+vi.mock('../../framework/DashboardDataContext', () => ({
+  useDashboardContext: () => ({
+    watchlist: { rows: [] },
+  }),
+}));
+
+import '../../index'; // populate widget registry
+import { fetchStockData } from '@/pages/MarketView/utils/api';
+import { getWidget } from '../../framework/WidgetRegistry';
+
+const mockFetch = fetchStockData as unknown as ReturnType<typeof vi.fn>;
+
+function renderMiniChartGrid(config: { symbols: string[] }) {
+  const def = getWidget('markets.miniChartGrid');
+  if (!def) throw new Error('miniChartGrid not registered');
+  const Component = def.component;
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <Component
+          instance={{ id: 'mcg-1', type: 'markets.miniChartGrid', config }}
+          updateConfig={vi.fn()}
+        />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('MiniChartGridWidget', () => {
+  beforeEach(() => {
+    mockFetch.mockClear();
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('caps symbols at 18 even when prefs hold more (regression)', async () => {
+    // 25 symbols stored. Render path must clamp to 18 to protect the OHLC
+    // backend from a corrupted prefs blob fanning out thousands of requests.
+    const symbols = Array.from({ length: 25 }, (_, i) => `SYM${i}`);
+    renderMiniChartGrid({ symbols });
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    expect(mockFetch.mock.calls.length).toBeLessThanOrEqual(18);
+  });
+
+  it('renders the widget chrome with the configured symbol count', async () => {
+    renderMiniChartGrid({ symbols: ['NVDA', 'AAPL', 'MSFT'] });
+    // Header summary line shows "{n} symbols · 30d" — assert n matches config.
+    await waitFor(() => {
+      expect(screen.getByText(/3\s+symbols/i)).toBeInTheDocument();
+    });
+  });
+
+  it('definition exposes a Zod schema and the default round-trips', () => {
+    const def = getWidget('markets.miniChartGrid')!;
+    expect(def.configSchema).toBeDefined();
+    const parsed = def.configSchema!.safeParse(def.defaultConfig);
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/web/src/pages/Dashboard/widgets/definitions/tv/CompanyFinancialsWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/CompanyFinancialsWidget.tsx
@@ -1,6 +1,7 @@
 import { BarChart3 } from 'lucide-react';
 import { TradingViewEmbed } from '../../framework/TradingViewEmbed';
 import { registerWidget } from '../../framework/WidgetRegistry';
+import { CompanyFinancialsConfigSchema } from '../../framework/configSchemas';
 import { SymbolField } from '../../framework/settings/SymbolField';
 import { EnumField } from '../../framework/settings/EnumField';
 import { TradingViewSettingsFooter } from '../../framework/TradingViewSettingsFooter';
@@ -59,6 +60,7 @@ registerWidget<CompanyFinancialsConfig>({
   component: CompanyFinancialsWidget,
   settingsComponent: CompanyFinancialsSettings,
   defaultConfig: { symbol: 'NASDAQ:NVDA', displayMode: 'regular' },
+  configSchema: CompanyFinancialsConfigSchema,
   defaultSize: { w: 6, h: 24 },
   minSize: { w: 4, h: 14 },
   maxSize: { w: 12, h: 48 },

--- a/web/src/pages/Dashboard/widgets/definitions/tv/CompanyProfileWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/CompanyProfileWidget.tsx
@@ -1,6 +1,7 @@
 import { Building2 } from 'lucide-react';
 import { TradingViewEmbed } from '../../framework/TradingViewEmbed';
 import { registerWidget } from '../../framework/WidgetRegistry';
+import { CompanyProfileConfigSchema } from '../../framework/configSchemas';
 import { SymbolField } from '../../framework/settings/SymbolField';
 import { TradingViewSettingsFooter } from '../../framework/TradingViewSettingsFooter';
 import { SettingsDoneButton } from '../../framework/settings/SettingsDoneButton';
@@ -44,6 +45,7 @@ registerWidget<CompanyProfileConfig>({
   component: CompanyProfileWidget,
   settingsComponent: CompanyProfileSettings,
   defaultConfig: { symbol: 'NASDAQ:NVDA' },
+  configSchema: CompanyProfileConfigSchema,
   defaultSize: { w: 6, h: 18 },
   minSize: { w: 4, h: 12 },
   maxSize: { w: 12, h: 32 },

--- a/web/src/pages/Dashboard/widgets/definitions/tv/CryptoHeatmapWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/CryptoHeatmapWidget.tsx
@@ -1,6 +1,7 @@
 import { Bitcoin } from 'lucide-react';
 import { TradingViewEmbed } from '../../framework/TradingViewEmbed';
 import { registerWidget } from '../../framework/WidgetRegistry';
+import { CryptoHeatmapConfigSchema } from '../../framework/configSchemas';
 import { EnumField } from '../../framework/settings/EnumField';
 import { TradingViewSettingsFooter } from '../../framework/TradingViewSettingsFooter';
 import { SettingsDoneButton } from '../../framework/settings/SettingsDoneButton';
@@ -74,6 +75,7 @@ registerWidget<CryptoHeatmapConfig>({
   component: CryptoHeatmapWidget,
   settingsComponent: CryptoHeatmapSettings,
   defaultConfig: { dataSource: 'Crypto', blockSize: 'market_cap_calc', blockColor: '24h_close_change|5' },
+  configSchema: CryptoHeatmapConfigSchema,
   defaultSize: { w: 12, h: 20 },
   minSize: { w: 6, h: 12 },
   maxSize: { w: 12, h: 40 },

--- a/web/src/pages/Dashboard/widgets/definitions/tv/CryptoScreenerWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/CryptoScreenerWidget.tsx
@@ -1,6 +1,7 @@
 import { Bitcoin } from 'lucide-react';
 import { TradingViewEmbed } from '../../framework/TradingViewEmbed';
 import { registerWidget } from '../../framework/WidgetRegistry';
+import { CryptoScreenerConfigSchema } from '../../framework/configSchemas';
 import { EnumField } from '../../framework/settings/EnumField';
 import { TradingViewSettingsFooter } from '../../framework/TradingViewSettingsFooter';
 import { SettingsDoneButton } from '../../framework/settings/SettingsDoneButton';
@@ -73,6 +74,7 @@ registerWidget<CryptoScreenerConfig>({
   component: CryptoScreenerWidget,
   settingsComponent: CryptoScreenerSettings,
   defaultConfig: { defaultColumn: 'overview', defaultScreen: 'general' },
+  configSchema: CryptoScreenerConfigSchema,
   defaultSize: { w: 12, h: 24 },
   minSize: { w: 6, h: 14 },
   maxSize: { w: 12, h: 48 },

--- a/web/src/pages/Dashboard/widgets/definitions/tv/ETFHeatmapWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/ETFHeatmapWidget.tsx
@@ -1,6 +1,7 @@
 import { Layers } from 'lucide-react';
 import { TradingViewEmbed } from '../../framework/TradingViewEmbed';
 import { registerWidget } from '../../framework/WidgetRegistry';
+import { ETFHeatmapConfigSchema } from '../../framework/configSchemas';
 import { EnumField } from '../../framework/settings/EnumField';
 import { TradingViewSettingsFooter } from '../../framework/TradingViewSettingsFooter';
 import { SettingsDoneButton } from '../../framework/settings/SettingsDoneButton';
@@ -88,6 +89,7 @@ registerWidget<ETFHeatmapConfig>({
   component: ETFHeatmapWidget,
   settingsComponent: ETFHeatmapSettings,
   defaultConfig: { dataSource: 'AllUSEtf', blockSize: 'aum', blockColor: 'change', grouping: 'asset_class' },
+  configSchema: ETFHeatmapConfigSchema,
   defaultSize: { w: 12, h: 20 },
   minSize: { w: 6, h: 12 },
   maxSize: { w: 12, h: 40 },

--- a/web/src/pages/Dashboard/widgets/definitions/tv/EconomicEventsWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/EconomicEventsWidget.tsx
@@ -1,6 +1,7 @@
 import { CalendarClock } from 'lucide-react';
 import { TradingViewEmbed } from '../../framework/TradingViewEmbed';
 import { registerWidget } from '../../framework/WidgetRegistry';
+import { EconomicEventsConfigSchema } from '../../framework/configSchemas';
 import { EnumField } from '../../framework/settings/EnumField';
 import { TradingViewSettingsFooter } from '../../framework/TradingViewSettingsFooter';
 import { SettingsDoneButton } from '../../framework/settings/SettingsDoneButton';
@@ -62,6 +63,7 @@ registerWidget<EconomicEventsConfig>({
   component: EconomicEventsWidget,
   settingsComponent: EconomicEventsSettings,
   defaultConfig: { importanceFilter: '-1,0,1', countryFilter: 'us,eu,jp,gb,cn' },
+  configSchema: EconomicEventsConfigSchema,
   defaultSize: { w: 6, h: 24 },
   minSize: { w: 4, h: 14 },
   maxSize: { w: 12, h: 48 },

--- a/web/src/pages/Dashboard/widgets/definitions/tv/EconomicMapWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/EconomicMapWidget.tsx
@@ -1,6 +1,7 @@
 import { Globe } from 'lucide-react';
 import { TradingViewWebComponent } from '../../framework/TradingViewWebComponent';
 import { registerWidget } from '../../framework/WidgetRegistry';
+import { EconomicMapConfigSchema } from '../../framework/configSchemas';
 import { EnumField } from '../../framework/settings/EnumField';
 import { TradingViewSettingsFooter } from '../../framework/TradingViewSettingsFooter';
 import { SettingsDoneButton } from '../../framework/settings/SettingsDoneButton';
@@ -80,6 +81,7 @@ registerWidget<EconomicMapConfig>({
   component: EconomicMapWidget,
   settingsComponent: EconomicMapSettings,
   defaultConfig: { region: 'global', metric: 'gdp', hideLegend: false },
+  configSchema: EconomicMapConfigSchema,
   // Wizard reports natural size 750w × 475h. h=18 (~416px content) hugs that
   // aspect at w=12 so the map + legend strip render without letterboxing.
   // Min raised to 18 (= default) so country labels and the legend always

--- a/web/src/pages/Dashboard/widgets/definitions/tv/ForexHeatmapWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/ForexHeatmapWidget.tsx
@@ -1,6 +1,7 @@
 import { DollarSign } from 'lucide-react';
 import { TradingViewEmbed } from '../../framework/TradingViewEmbed';
 import { registerWidget } from '../../framework/WidgetRegistry';
+import { ForexHeatmapConfigSchema, FOREX_DEFAULT_CURRENCIES } from '../../framework/configSchemas';
 import { TradingViewSettingsFooter } from '../../framework/TradingViewSettingsFooter';
 import { SettingsDoneButton } from '../../framework/settings/SettingsDoneButton';
 import type { WidgetRenderProps, WidgetSettingsProps } from '../../types';
@@ -9,7 +10,9 @@ interface ForexHeatmapConfig {
   currencies: string[];
 }
 
-const DEFAULT_CURRENCIES = ['USD', 'EUR', 'GBP', 'JPY', 'CHF', 'CAD', 'AUD', 'NZD', 'CNY'];
+// Single source of truth lives in configSchemas.ts so the schema's whole-array
+// catch-fallback can't drift below the widget's expected breadth.
+const DEFAULT_CURRENCIES = [...FOREX_DEFAULT_CURRENCIES];
 
 function ForexHeatmapWidget({ instance }: WidgetRenderProps<ForexHeatmapConfig>) {
   return (
@@ -44,6 +47,7 @@ registerWidget<ForexHeatmapConfig>({
   component: ForexHeatmapWidget,
   settingsComponent: ForexHeatmapSettings,
   defaultConfig: { currencies: DEFAULT_CURRENCIES },
+  configSchema: ForexHeatmapConfigSchema,
   defaultSize: { w: 12, h: 18 },
   minSize: { w: 6, h: 10 },
   maxSize: { w: 12, h: 32 },

--- a/web/src/pages/Dashboard/widgets/definitions/tv/MoversWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/MoversWidget.tsx
@@ -1,6 +1,7 @@
 import { TrendingUp } from 'lucide-react';
 import { TradingViewEmbed } from '../../framework/TradingViewEmbed';
 import { registerWidget } from '../../framework/WidgetRegistry';
+import { MoversConfigSchema } from '../../framework/configSchemas';
 import { EnumField } from '../../framework/settings/EnumField';
 import { TradingViewSettingsFooter } from '../../framework/TradingViewSettingsFooter';
 import { SettingsDoneButton } from '../../framework/settings/SettingsDoneButton';
@@ -69,6 +70,7 @@ registerWidget<MoversConfig>({
   component: MoversWidget,
   settingsComponent: MoversSettings,
   defaultConfig: { exchange: 'US', dataSource: 'AllUSA' },
+  configSchema: MoversConfigSchema,
   defaultSize: { w: 6, h: 22 },
   minSize: { w: 4, h: 14 },
   maxSize: { w: 12, h: 40 },

--- a/web/src/pages/Dashboard/widgets/definitions/tv/SingleTickerWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/SingleTickerWidget.tsx
@@ -1,6 +1,7 @@
 import { Tag } from 'lucide-react';
 import { TradingViewEmbed } from '../../framework/TradingViewEmbed';
 import { registerWidget } from '../../framework/WidgetRegistry';
+import { SingleTickerConfigSchema } from '../../framework/configSchemas';
 import { SymbolField } from '../../framework/settings/SymbolField';
 import { TradingViewSettingsFooter } from '../../framework/TradingViewSettingsFooter';
 import { SettingsDoneButton } from '../../framework/settings/SettingsDoneButton';
@@ -44,6 +45,7 @@ registerWidget<SingleTickerConfig>({
   component: SingleTickerWidget,
   settingsComponent: SingleTickerSettings,
   defaultConfig: { symbol: 'NASDAQ:NVDA' },
+  configSchema: SingleTickerConfigSchema,
   defaultSize: { w: 3, h: 4 },
   minSize: { w: 2, h: 3 },
   maxSize: { w: 6, h: 6 },

--- a/web/src/pages/Dashboard/widgets/definitions/tv/StockHeatmapWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/StockHeatmapWidget.tsx
@@ -1,6 +1,7 @@
 import { Map } from 'lucide-react';
 import { TradingViewEmbed } from '../../framework/TradingViewEmbed';
 import { registerWidget } from '../../framework/WidgetRegistry';
+import { StockHeatmapConfigSchema } from '../../framework/configSchemas';
 import { EnumField } from '../../framework/settings/EnumField';
 import { TradingViewSettingsFooter } from '../../framework/TradingViewSettingsFooter';
 import { SettingsDoneButton } from '../../framework/settings/SettingsDoneButton';
@@ -83,6 +84,7 @@ registerWidget<StockHeatmapConfig>({
   component: StockHeatmapWidget,
   settingsComponent: StockHeatmapSettings,
   defaultConfig: { dataSource: 'SPX500', blockSize: 'market_cap_basic', blockColor: 'change' },
+  configSchema: StockHeatmapConfigSchema,
   defaultSize: { w: 12, h: 22 },
   minSize: { w: 6, h: 12 },
   maxSize: { w: 12, h: 40 },

--- a/web/src/pages/Dashboard/widgets/definitions/tv/StockScreenerWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/StockScreenerWidget.tsx
@@ -1,6 +1,7 @@
 import { Filter } from 'lucide-react';
 import { TradingViewEmbed } from '../../framework/TradingViewEmbed';
 import { registerWidget } from '../../framework/WidgetRegistry';
+import { StockScreenerConfigSchema } from '../../framework/configSchemas';
 import { EnumField } from '../../framework/settings/EnumField';
 import { TradingViewSettingsFooter } from '../../framework/TradingViewSettingsFooter';
 import { SettingsDoneButton } from '../../framework/settings/SettingsDoneButton';
@@ -84,6 +85,7 @@ registerWidget<StockScreenerConfig>({
   component: StockScreenerWidget,
   settingsComponent: StockScreenerSettings,
   defaultConfig: { market: 'america', defaultColumn: 'overview', defaultScreen: 'general' },
+  configSchema: StockScreenerConfigSchema,
   defaultSize: { w: 12, h: 24 },
   minSize: { w: 6, h: 14 },
   maxSize: { w: 12, h: 48 },

--- a/web/src/pages/Dashboard/widgets/definitions/tv/SymbolInfoWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/SymbolInfoWidget.tsx
@@ -1,6 +1,7 @@
 import { Info } from 'lucide-react';
 import { TradingViewEmbed } from '../../framework/TradingViewEmbed';
 import { registerWidget } from '../../framework/WidgetRegistry';
+import { SymbolInfoConfigSchema } from '../../framework/configSchemas';
 import { SymbolField } from '../../framework/settings/SymbolField';
 import { TradingViewSettingsFooter } from '../../framework/TradingViewSettingsFooter';
 import { SettingsDoneButton } from '../../framework/settings/SettingsDoneButton';
@@ -44,6 +45,7 @@ registerWidget<SymbolInfoConfig>({
   component: SymbolInfoWidget,
   settingsComponent: SymbolInfoSettings,
   defaultConfig: { symbol: 'NASDAQ:NVDA' },
+  configSchema: SymbolInfoConfigSchema,
   defaultSize: { w: 6, h: 8 },
   minSize: { w: 4, h: 6 },
   maxSize: { w: 12, h: 12 },

--- a/web/src/pages/Dashboard/widgets/definitions/tv/SymbolSpotlightWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/SymbolSpotlightWidget.tsx
@@ -1,6 +1,7 @@
 import { Target } from 'lucide-react';
 import { TradingViewEmbed } from '../../framework/TradingViewEmbed';
 import { registerWidget } from '../../framework/WidgetRegistry';
+import { SymbolSpotlightConfigSchema } from '../../framework/configSchemas';
 import { SymbolField } from '../../framework/settings/SymbolField';
 import { EnumField } from '../../framework/settings/EnumField';
 import { TradingViewSettingsFooter } from '../../framework/TradingViewSettingsFooter';
@@ -75,6 +76,7 @@ registerWidget<SymbolSpotlightConfig>({
   component: SymbolSpotlightWidget,
   settingsComponent: SymbolSpotlightSettings,
   defaultConfig: { symbol: 'NASDAQ:NVDA', range: '12M' },
+  configSchema: SymbolSpotlightConfigSchema,
   defaultSize: { w: 6, h: 22 },
   minSize: { w: 4, h: 14 },
   maxSize: { w: 12, h: 32 },

--- a/web/src/pages/Dashboard/widgets/definitions/tv/TechnicalsWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/TechnicalsWidget.tsx
@@ -1,6 +1,7 @@
 import { Gauge } from 'lucide-react';
 import { TradingViewEmbed } from '../../framework/TradingViewEmbed';
 import { registerWidget } from '../../framework/WidgetRegistry';
+import { TechnicalsConfigSchema } from '../../framework/configSchemas';
 import { SymbolField } from '../../framework/settings/SymbolField';
 import { EnumField } from '../../framework/settings/EnumField';
 import { TradingViewSettingsFooter } from '../../framework/TradingViewSettingsFooter';
@@ -66,6 +67,7 @@ registerWidget<TechnicalsConfig>({
   component: TechnicalsWidget,
   settingsComponent: TechnicalsSettings,
   defaultConfig: { symbol: 'NASDAQ:NVDA', interval: '1D' },
+  configSchema: TechnicalsConfigSchema,
   defaultSize: { w: 6, h: 22 },
   // Min raised to 22 (= default) so the gauge + pills + labels always
   // render fully. At h<22 the edit-mode body (~cell-64px for chrome) drops

--- a/web/src/pages/Dashboard/widgets/definitions/tv/TickerTapeWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/TickerTapeWidget.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { Activity } from 'lucide-react';
 import { TradingViewEmbed } from '../../framework/TradingViewEmbed';
 import { registerWidget } from '../../framework/WidgetRegistry';
+import { TickerTapeConfigSchema } from '../../framework/configSchemas';
 import { useDashboardContext } from '../../framework/DashboardDataContext';
 import { SymbolListField } from '../../framework/settings/SymbolListField';
 import { EnumField } from '../../framework/settings/EnumField';
@@ -166,6 +167,7 @@ registerWidget<TickerTapeConfig>({
   component: TickerTapeWidget,
   settingsComponent: TickerTapeSettings,
   defaultConfig: { symbols: [], displayMode: 'adaptive' },
+  configSchema: TickerTapeConfigSchema,
   // fitToContent: cell height tracks the embed's natural 76px iframe plus
   // chrome. View mode → ~6 rows (128px, card hugs the ticker). Edit mode →
   // ~9 rows (200px, includes 40px header + 24px body padding). maxSize.h

--- a/web/src/pages/Dashboard/widgets/definitions/tv/TopStoriesWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/tv/TopStoriesWidget.tsx
@@ -1,6 +1,7 @@
 import { Newspaper } from 'lucide-react';
 import { TradingViewEmbed } from '../../framework/TradingViewEmbed';
 import { registerWidget } from '../../framework/WidgetRegistry';
+import { TopStoriesConfigSchema } from '../../framework/configSchemas';
 import { SymbolField } from '../../framework/settings/SymbolField';
 import { EnumField } from '../../framework/settings/EnumField';
 import { TradingViewSettingsFooter } from '../../framework/TradingViewSettingsFooter';
@@ -86,6 +87,7 @@ registerWidget<TopStoriesConfig>({
   component: TopStoriesWidget,
   settingsComponent: TopStoriesSettings,
   defaultConfig: { feedMode: 'market', market: 'stock', symbol: 'NASDAQ:NVDA', displayMode: 'regular' },
+  configSchema: TopStoriesConfigSchema,
   defaultSize: { w: 6, h: 22 },
   minSize: { w: 4, h: 14 },
   maxSize: { w: 12, h: 40 },

--- a/web/src/pages/Dashboard/widgets/framework/WidgetFrame.css
+++ b/web/src/pages/Dashboard/widgets/framework/WidgetFrame.css
@@ -287,6 +287,17 @@
   opacity: 1;
 }
 
+/* Edit-mode touch passthrough — TV iframes (and other embeds) consume touch
+ * events on tablets/phones, so a long-press inside the body never reaches
+ * react-grid-layout's drag handler. Killing pointer events on the iframe
+ * itself in edit mode lets the gesture bubble to the cell. View mode keeps
+ * pointer events on so users can interact with the embed normally. Covers
+ * both TradingViewEmbed (script-injected iframe) and TradingViewWebComponent
+ * (Light DOM custom element with internal iframe). */
+.widget-grid--edit .widget-frame__body iframe {
+  pointer-events: none;
+}
+
 /* Hide the lightweight-charts attribution watermark (a small link in the
  * chart corner) inside any widget that embeds lightweight-charts — the
  * NOTICE text lives at /legal so we aren't stripping attribution; we just

--- a/web/src/pages/Dashboard/widgets/framework/__tests__/AddWidgetDialog.test.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/__tests__/AddWidgetDialog.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { AddWidgetDialog } from '../AddWidgetDialog';
+import '../../index'; // ensure widget registry is populated
+
+function renderDialog(overrides: Partial<React.ComponentProps<typeof AddWidgetDialog>> = {}) {
+  // Hoist the mocks so we can keep their `.mock.calls` introspection alive
+  // through the spread without losing the Mock type.
+  const onOpenChange = vi.fn();
+  const onAdd = vi.fn();
+  const props = {
+    open: true,
+    onOpenChange,
+    onAdd,
+    existingWidgets: [] as React.ComponentProps<typeof AddWidgetDialog>['existingWidgets'],
+    ...overrides,
+  };
+  const utils = render(
+    <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <AddWidgetDialog {...props} />
+    </MemoryRouter>,
+  );
+  return { ...utils, onOpenChange, onAdd };
+}
+
+describe('AddWidgetDialog', () => {
+  it('renders the gallery title and category nav', () => {
+    renderDialog();
+    expect(screen.getByText(/add a widget/i)).toBeInTheDocument();
+    // Category labels appear in the nav (and may repeat in section headings).
+    // getAllByText keeps the assertion robust to category headings + section
+    // titles both rendering "Markets".
+    expect(screen.getAllByText(/markets/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/intelligence/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/personal/i).length).toBeGreaterThan(0);
+  });
+
+  it('filters widgets by search', () => {
+    renderDialog();
+    const input = screen.getByPlaceholderText(/search widgets/i);
+    fireEvent.change(input, { target: { value: 'ticker tape' } });
+    // Search should narrow the visible cards. The Ticker Tape title (TV widget)
+    // is registered — assert it's present after the filter.
+    expect(screen.getAllByText(/ticker tape/i).length).toBeGreaterThan(0);
+  });
+
+  it('calls onAdd with the selected widget type when the CTA is clicked', () => {
+    const { onAdd, onOpenChange } = renderDialog();
+    // The dialog auto-selects the first widget in the active category. The
+    // CTA label includes the selected widget title — pressing it should
+    // call onAdd with that widget's type.
+    const cta = screen.getByRole('button', { name: /^add /i });
+    fireEvent.click(cta);
+    expect(onAdd).toHaveBeenCalledTimes(1);
+    expect(typeof onAdd.mock.calls[0][0]).toBe('string');
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('disables singleton widgets that are already on the dashboard', () => {
+    // Find a singleton widget by checking the registry.
+    // (Conversation, Watchlist, MarketsOverview are typical singletons.)
+    renderDialog({
+      existingWidgets: [
+        { id: 'existing-1', type: 'agent.conversation', config: {} },
+      ],
+    });
+    // Cards rendered as `<button>`s — the disabled one for agent.conversation
+    // should have disabled=true. We can find by the "on dashboard" suffix
+    // text shown in the meta line.
+    // (If agent.conversation isn't a singleton in this build, the assertion
+    // is informational; skip silently rather than fail.)
+    const onDashboardLabels = screen.queryAllByText(/on dashboard/i);
+    if (onDashboardLabels.length > 0) {
+      // Walk up to the button parent and assert disabled.
+      const card = onDashboardLabels[0].closest('button');
+      expect(card?.disabled).toBe(true);
+    }
+  });
+});

--- a/web/src/pages/Dashboard/widgets/framework/__tests__/PresetsDialog.test.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/__tests__/PresetsDialog.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PresetsDialog } from '../PresetsDialog';
+import { PRESETS_META } from '../../presets';
+import '../../index'; // ensure registry is populated for thumbnails
+
+function renderDialog(overrides: Partial<React.ComponentProps<typeof PresetsDialog>> = {}) {
+  const props = {
+    open: true,
+    onOpenChange: vi.fn(),
+    onApply: vi.fn(),
+    ...overrides,
+  };
+  const utils = render(<PresetsDialog {...props} />);
+  return { ...utils, props };
+}
+
+describe('PresetsDialog', () => {
+  it('renders the heading + every preset card', () => {
+    renderDialog();
+    expect(screen.getByText(/start with a preset/i)).toBeInTheDocument();
+    for (const meta of PRESETS_META) {
+      expect(screen.getByText(meta.name)).toBeInTheDocument();
+    }
+  });
+
+  it('calls onApply with the preset id when a card is clicked', () => {
+    const { props } = renderDialog();
+    const card = screen.getByText(PRESETS_META[0].name);
+    fireEvent.click(card);
+    expect(props.onApply).toHaveBeenCalledWith(PRESETS_META[0].id);
+    expect(props.onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('renders nothing when closed', () => {
+    const { queryByText } = renderDialog({ open: false });
+    expect(queryByText(/start with a preset/i)).toBeNull();
+  });
+});

--- a/web/src/pages/Dashboard/widgets/framework/__tests__/TradingViewWebComponent.test.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/__tests__/TradingViewWebComponent.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act, screen } from '@testing-library/react';
+import { TradingViewWebComponent } from '../TradingViewWebComponent';
+
+vi.mock('@/contexts/ThemeContext', () => ({
+  useTheme: () => ({ theme: 'dark' }),
+}));
+
+describe('TradingViewWebComponent', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Pretend the element is already registered in customElements so the
+    // loader skips its `import()` (jsdom can't fetch external URLs anyway).
+    if (window.customElements && !window.customElements.get('tv-ticker-tape')) {
+      class TVStub extends HTMLElement {}
+      window.customElements.define('tv-ticker-tape', TVStub);
+    }
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('mounts the custom element with kebab-cased attributes once loaded', async () => {
+    const { container } = render(
+      <TradingViewWebComponent
+        element="tv-ticker-tape"
+        config={{ displayMode: 'compact', isTransparent: true }}
+      />,
+    );
+
+    // Loader resolves on a microtask + customElements.whenDefined → flush.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const el = container.querySelector('tv-ticker-tape');
+    expect(el).not.toBeNull();
+    // camelCase → kebab-case
+    expect(el?.getAttribute('display-mode')).toBe('compact');
+    // Boolean true → presence (empty string)
+    expect(el?.getAttribute('is-transparent')).toBe('');
+    // Theme stamped reactively from useTheme()
+    expect(el?.getAttribute('theme')).toBe('dark');
+    expect(el?.getAttribute('color-theme')).toBe('dark');
+  });
+
+  it('skips false / null / undefined attribute values (presence trap)', async () => {
+    const { container } = render(
+      <TradingViewWebComponent
+        element="tv-ticker-tape"
+        config={{ hideLegend: false, optional: null, alsoOptional: undefined, hideTopToolbar: true }}
+      />,
+    );
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const el = container.querySelector('tv-ticker-tape');
+    expect(el).not.toBeNull();
+    // false → SHOULD NOT be present (otherwise TV reads as truthy)
+    expect(el?.hasAttribute('hide-legend')).toBe(false);
+    expect(el?.hasAttribute('optional')).toBe(false);
+    expect(el?.hasAttribute('also-optional')).toBe(false);
+    // true booleans are kept as presence
+    expect(el?.getAttribute('hide-top-toolbar')).toBe('');
+  });
+
+  it('updates attributes IN PLACE on config change without remount', async () => {
+    const { container, rerender } = render(
+      <TradingViewWebComponent element="tv-ticker-tape" config={{ displayMode: 'compact' }} />,
+    );
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const initialEl = container.querySelector('tv-ticker-tape');
+    rerender(
+      <TradingViewWebComponent element="tv-ticker-tape" config={{ displayMode: 'regular' }} />,
+    );
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const sameEl = container.querySelector('tv-ticker-tape');
+    expect(sameEl).toBe(initialEl);
+    expect(sameEl?.getAttribute('display-mode')).toBe('regular');
+  });
+
+  it('shows the fallback when the element fails to register inside the timeout', async () => {
+    // Use an element name that's never been defined. jsdom can't fetch the
+    // external URL — `import()` rejects on next tick. The component's error
+    // handler then flips status to 'error'. Drain enough microtasks to let
+    // the rejection settle, then assert the fallback rendered.
+    render(<TradingViewWebComponent element="tv-not-a-real-element-xyz-zzz" config={{}} />);
+    // Promise.reject from import() unwinds across several microtask ticks +
+    // the React state update + the re-render. Advance the 15s timeout in
+    // case the import simply never resolves in jsdom.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20_000);
+    });
+    expect(screen.getByText(/widget unavailable/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/Dashboard/widgets/framework/__tests__/migrations.test.ts
+++ b/web/src/pages/Dashboard/widgets/framework/__tests__/migrations.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { migrateDashboardPrefs } from '../migrations';
 import { DASHBOARD_PREFS_VERSION } from '../../types';
+// Side-effect: load every widget definition so getWidget() returns schemas
+// inside `sanitizeConfig`. Without this, the registry is empty and schemas
+// silently no-op (the production app reaches the registry transitively via
+// Dashboard → DashboardCustom; tests have to do it explicitly).
+import '../../index';
+import { getWidget, listWidgets } from '../WidgetRegistry';
 
 describe('migrateDashboardPrefs', () => {
   it('returns null for null / undefined / non-object input', () => {
@@ -61,5 +67,217 @@ describe('migrateDashboardPrefs', () => {
   it('preserves a valid history array', () => {
     const history = [{ widgets: [], layouts: {} }];
     expect(migrateDashboardPrefs({ history })?.history).toEqual(history);
+  });
+
+  // ---------------------------------------------------------------------------
+  // layouts shape filter — per-breakpoint validation
+  // ---------------------------------------------------------------------------
+  describe('layouts per-breakpoint shape filter', () => {
+    it('keeps real RGL arrays as-is', () => {
+      const layouts = { lg: [{ i: 'a', x: 0, y: 0, w: 4, h: 4 }] };
+      expect(migrateDashboardPrefs({ layouts })?.layouts).toEqual(layouts);
+    });
+
+    it('drops breakpoints whose value is an object instead of an array', () => {
+      // Without the per-bp guard this passed straight through and crashed
+      // reconcileLayouts (it `.filter()`s each breakpoint).
+      const out = migrateDashboardPrefs({
+        layouts: { lg: { foo: 'bar' }, md: [{ i: 'a', x: 0, y: 0, w: 4, h: 4 }] },
+      });
+      expect(out?.layouts.lg).toBeUndefined();
+      expect(out?.layouts.md?.length).toBe(1);
+    });
+
+    it('drops breakpoints whose value is a primitive', () => {
+      const out = migrateDashboardPrefs({
+        layouts: { lg: 'garbage', md: 42, sm: null },
+      });
+      expect(out?.layouts).toEqual({});
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // isValidWidgetInstance: shape filter
+  // ---------------------------------------------------------------------------
+  describe('widget instance shape filter', () => {
+    it('drops null entries', () => {
+      const out = migrateDashboardPrefs({
+        widgets: [null, { id: 'a', type: 'news.feed', config: {} }],
+      });
+      expect(out?.widgets.length).toBe(1);
+      expect(out?.widgets[0].id).toBe('a');
+    });
+
+    it('drops string / number entries', () => {
+      const out = migrateDashboardPrefs({
+        widgets: ['garbage', 42, { id: 'a', type: 'news.feed', config: {} }],
+      });
+      expect(out?.widgets.length).toBe(1);
+    });
+
+    it('drops entries missing an id', () => {
+      const out = migrateDashboardPrefs({
+        widgets: [{ type: 'news.feed', config: {} }, { id: 'b', type: 'news.feed', config: {} }],
+      });
+      expect(out?.widgets.length).toBe(1);
+      expect(out?.widgets[0].id).toBe('b');
+    });
+
+    it('drops entries missing a type or config', () => {
+      const out = migrateDashboardPrefs({
+        widgets: [
+          { id: 'a', type: 'news.feed' /* no config */ },
+          { id: 'b', /* no type */ config: {} },
+          { id: 'c', type: 'news.feed', config: null /* invalid */ },
+          { id: 'd', type: 'news.feed', config: {} },
+        ],
+      });
+      expect(out?.widgets.length).toBe(1);
+      expect(out?.widgets[0].id).toBe('d');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // sanitizeConfig: per-widget Zod schema validation
+  // ---------------------------------------------------------------------------
+  describe('sanitizeConfig (Zod-driven)', () => {
+    it('passes a valid config through unchanged', () => {
+      const cfg = { symbols: ['NASDAQ:NVDA'], displayMode: 'compact' as const };
+      const out = migrateDashboardPrefs({
+        widgets: [{ id: 'a', type: 'tv.ticker-tape', config: cfg }],
+      });
+      expect(out?.widgets[0].config).toMatchObject(cfg);
+    });
+
+    it('coerces an unknown enum value via .catch()', () => {
+      const out = migrateDashboardPrefs({
+        widgets: [
+          {
+            id: 'a',
+            type: 'tv.ticker-tape',
+            config: { symbols: ['NASDAQ:NVDA'], displayMode: 'foobar' },
+          },
+        ],
+      });
+      expect((out?.widgets[0].config as { displayMode?: string }).displayMode).toBe('adaptive');
+    });
+
+    it('coerces a malformed top-level config to defaultConfig', () => {
+      // top-level is a string instead of an object → safeParse fails outright
+      // → fall back to defaultConfig.
+      const out = migrateDashboardPrefs({
+        widgets: [{ id: 'a', type: 'tv.ticker-tape', config: { displayMode: 42 } }],
+      });
+      const def = getWidget('tv.ticker-tape')?.defaultConfig as object;
+      expect(out?.widgets[0].config).toMatchObject(def);
+    });
+
+    it('preserves widgets whose definition has no schema (back-compat)', () => {
+      // No widget type uses a missing schema today (all 30 register one), but
+      // the back-compat branch must still hold for future no-schema widgets.
+      // Simulate by stamping an unknown type that getWidget returns undefined
+      // for; sanitize should pass it through after the rename pass.
+      // (This widget will fail the rename map, then sanitize sees no def and
+      // returns the widget as-is.)
+      const out = migrateDashboardPrefs({
+        widgets: [{ id: 'a', type: 'made-up.no-schema', config: { freeform: true } }],
+      });
+      expect(out?.widgets[0].config).toEqual({ freeform: true });
+    });
+
+    it('rename happens BEFORE sanitize (legacy type uses new schema)', () => {
+      // agent.input → agent.conversation. ConversationConfigSchema accepts {}.
+      const out = migrateDashboardPrefs({
+        widgets: [{ id: 'a', type: 'agent.input', config: {} }],
+      });
+      expect(out?.widgets[0].type).toBe('agent.conversation');
+    });
+
+    it('drops invalid symbols from array fields (no duplicate-default fallout)', () => {
+      // Regression: per-element `.catch(default)` produced duplicates of the
+      // catch default for every bad entry — `[bad, bad, AAPL]` became
+      // `[SPY, SPY, AAPL]`. Now we drop bad entries instead.
+      const out = migrateDashboardPrefs({
+        widgets: [
+          {
+            id: 'a',
+            type: 'tv.ticker-tape',
+            config: {
+              symbols: ['NASDAQ:NVDA', 'b@d sym', 42, null, 'NASDAQ:AAPL'],
+              displayMode: 'compact',
+            },
+          },
+        ],
+      });
+      const symbols = (out?.widgets[0].config as { symbols?: string[] }).symbols;
+      expect(symbols).toEqual(['NASDAQ:NVDA', 'NASDAQ:AAPL']);
+    });
+
+    it('dedupes symbol arrays across the transform', () => {
+      const out = migrateDashboardPrefs({
+        widgets: [
+          {
+            id: 'a',
+            type: 'tv.ticker-tape',
+            config: { symbols: ['NVDA', 'NVDA', 'AAPL', 'NVDA'], displayMode: 'compact' },
+          },
+        ],
+      });
+      const symbols = (out?.widgets[0].config as { symbols?: string[] }).symbols;
+      expect(symbols).toEqual(['NVDA', 'AAPL']);
+    });
+
+    it('forex currencies fall back to the full default list when all entries are bad', () => {
+      const out = migrateDashboardPrefs({
+        widgets: [
+          {
+            id: 'a',
+            type: 'tv.forex-heatmap',
+            config: { currencies: ['BAD1', 'BAD2', 42, null] },
+          },
+        ],
+      });
+      const currencies = (out?.widgets[0].config as { currencies?: string[] }).currencies ?? [];
+      // Should be the rich default, not ['USD'].
+      expect(currencies.length).toBeGreaterThanOrEqual(9);
+      expect(currencies).toContain('USD');
+      expect(currencies).toContain('CNY');
+    });
+
+    it('TV symbol regex accepts underscored exchange prefixes (futures, FX)', () => {
+      // Regression: the original regex omitted `_` and silently rewrote
+      // CME_MINI:ES1! and FX_IDC:EURUSD to the schema's catch default,
+      // wiping out user-configured futures/FX symbols on every prefs load.
+      const out = migrateDashboardPrefs({
+        widgets: [
+          {
+            id: 'a',
+            type: 'tv.single-ticker',
+            config: { symbol: 'CME_MINI:ES1!' },
+          },
+          {
+            id: 'b',
+            type: 'tv.single-ticker',
+            config: { symbol: 'FX_IDC:EURUSD' },
+          },
+        ],
+      });
+      expect((out?.widgets[0].config as { symbol?: string }).symbol).toBe('CME_MINI:ES1!');
+      expect((out?.widgets[1].config as { symbol?: string }).symbol).toBe('FX_IDC:EURUSD');
+    });
+
+    it('every registered widget can round-trip its own defaultConfig (no drift)', () => {
+      // REGRESSION-CRITICAL: catches schema-vs-defaultConfig drift. Every
+      // widget's defaultConfig MUST satisfy its own schema; otherwise users
+      // who add a widget via the gallery would have it instantly clobbered.
+      const types = listWidgets().map((d) => d.type);
+      expect(types.length).toBeGreaterThan(0);
+      for (const type of types) {
+        const def = getWidget(type)!;
+        if (!def.configSchema) continue;
+        const result = def.configSchema.safeParse(def.defaultConfig);
+        expect(result.success, `defaultConfig for ${type} failed schema parse`).toBe(true);
+      }
+    });
   });
 });

--- a/web/src/pages/Dashboard/widgets/framework/__tests__/migrations.test.ts
+++ b/web/src/pages/Dashboard/widgets/framework/__tests__/migrations.test.ts
@@ -162,14 +162,30 @@ describe('migrateDashboardPrefs', () => {
       expect((out?.widgets[0].config as { displayMode?: string }).displayMode).toBe('adaptive');
     });
 
-    it('coerces a malformed top-level config to defaultConfig', () => {
-      // top-level is a string instead of an object → safeParse fails outright
-      // → fall back to defaultConfig.
+    it('coerces bad field values to schema defaults via per-field .catch()', () => {
+      // Input is a non-empty object with one bogus enum (displayMode: 42) and
+      // a missing array (symbols). Per-field .catch('adaptive') and .catch([])
+      // recover the values on the SUCCESS branch — the result matches
+      // defaultConfig because the catch defaults happen to equal it. This
+      // exercises field-level recovery, not the top-level fallback (covered
+      // in the next test).
       const out = migrateDashboardPrefs({
         widgets: [{ id: 'a', type: 'tv.ticker-tape', config: { displayMode: 42 } }],
       });
       const def = getWidget('tv.ticker-tape')?.defaultConfig as object;
       expect(out?.widgets[0].config).toMatchObject(def);
+    });
+
+    it('falls back to defaultConfig when top-level config shape is unparseable', () => {
+      // Array config slips past the shape filter (typeof === 'object' and
+      // !== null) but z.object().safeParse([]) fails at the top level — no
+      // per-field .catch() can recover it. Sanitize must fall back to
+      // defaultConfig wholesale.
+      const out = migrateDashboardPrefs({
+        widgets: [{ id: 'a', type: 'tv.ticker-tape', config: [] as unknown as Record<string, unknown> }],
+      });
+      const def = getWidget('tv.ticker-tape')?.defaultConfig as object;
+      expect(out?.widgets[0].config).toEqual(def);
     });
 
     it('preserves widgets whose definition has no schema (back-compat)', () => {

--- a/web/src/pages/Dashboard/widgets/framework/__tests__/presets.test.ts
+++ b/web/src/pages/Dashboard/widgets/framework/__tests__/presets.test.ts
@@ -82,4 +82,26 @@ describe('presets', () => {
     expect(types).toContain('tv.technicals');
     expect(types).toContain('markets.miniChartGrid');
   });
+
+  // REGRESSION-CRITICAL: every preset's widget configs must round-trip cleanly
+  // through the widget's Zod schema. If a preset author seeds a config that
+  // doesn't satisfy the schema, sanitizeConfig will silently rewrite it to
+  // defaultConfig on first load — the user gets a different layout than the
+  // one we shipped. Catch the drift here at preset-authoring time.
+  it('every preset widget config validates against its schema', () => {
+    for (const meta of PRESETS_META) {
+      const p = getPreset(meta.id as PresetId);
+      for (const w of p.widgets) {
+        const def = getWidget(w.type);
+        if (!def?.configSchema) continue;
+        const result = def.configSchema.safeParse(w.config);
+        expect(
+          result.success,
+          `preset "${meta.id}" widget "${w.id}" (${w.type}) failed schema validation: ${
+            result.success ? '' : JSON.stringify(result.error)
+          }`,
+        ).toBe(true);
+      }
+    }
+  });
 });

--- a/web/src/pages/Dashboard/widgets/framework/__tests__/useDashboardPrefs.test.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/__tests__/useDashboardPrefs.test.tsx
@@ -1,18 +1,22 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
 import { act } from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
 import { renderHookWithProviders } from '../../../../../test/utils';
+import { queryKeys } from '@/lib/queryKeys';
 
 const prefsState: { current: { other_preference?: Record<string, unknown> } | null } = {
   current: { other_preference: { theme: 'dark' } },
 };
+const loadingState = { isLoading: false };
 const mockMutate = vi.fn();
 const mockToast = vi.fn();
+const mutationState = { isPending: false };
 
 vi.mock('@/hooks/usePreferences', () => ({
-  usePreferences: () => ({ preferences: prefsState.current, isLoading: false }),
+  usePreferences: () => ({ preferences: prefsState.current, isLoading: loadingState.isLoading }),
 }));
 vi.mock('@/hooks/useUpdatePreferences', () => ({
-  useUpdatePreferences: () => ({ mutate: mockMutate }),
+  useUpdatePreferences: () => ({ mutate: mockMutate, isPending: mutationState.isPending }),
 }));
 vi.mock('@/components/ui/use-toast', () => ({
   useToast: () => ({ toast: mockToast, dismiss: vi.fn(), toasts: [] }),
@@ -20,19 +24,55 @@ vi.mock('@/components/ui/use-toast', () => ({
 
 import { useDashboardPrefs } from '../useDashboardPrefs';
 
+/**
+ * Build a queryClient pre-seeded with the same prefs the mocked usePreferences
+ * returns. The replay-aware flush reads from this cache, not from the hook
+ * snapshot, so we have to keep them in sync for "preserves sibling keys"
+ * assertions to mean what they say.
+ */
+function makePrimedClient(): QueryClient {
+  // gcTime: Infinity so seeded data survives vi.advanceTimersByTime() ticks.
+  // The default test client's gcTime: 0 collects unobserved queries the
+  // moment a fake-timer tick advances past 0ms, which would silently empty
+  // the cache before our debounced flush reads it.
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: Infinity }, mutations: { retry: false } },
+  });
+  qc.setQueryData(queryKeys.user.preferences(), prefsState.current);
+  return qc;
+}
+
 describe('useDashboardPrefs', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     mockMutate.mockReset();
     mockToast.mockReset();
+    mutationState.isPending = false;
+    loadingState.isLoading = false;
     prefsState.current = { other_preference: { theme: 'dark' } };
   });
   afterEach(() => {
     vi.useRealTimers();
   });
 
+  it('cold-cache gate: update() is a no-op while preferences are still loading', () => {
+    // Regression: without the gate, a fast click before the GET resolves
+    // would PUT { other_preference: { dashboard: {...} } } and clobber
+    // sibling server-side keys (theme, locale).
+    loadingState.isLoading = true;
+    prefsState.current = null;
+    const { result } = renderHookWithProviders(() => useDashboardPrefs(), { queryClient: makePrimedClient() });
+    act(() => {
+      result.current.update({ mode: 'custom' });
+    });
+    act(() => {
+      vi.advanceTimersByTime(800);
+    });
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
   it('debounces non-immediate writes by 800ms', () => {
-    const { result } = renderHookWithProviders(() => useDashboardPrefs());
+    const { result } = renderHookWithProviders(() => useDashboardPrefs(), { queryClient: makePrimedClient() });
     act(() => {
       result.current.update({ mode: 'custom' });
     });
@@ -44,16 +84,15 @@ describe('useDashboardPrefs', () => {
   });
 
   it('flushes immediately when {immediate:true}', () => {
-    const { result } = renderHookWithProviders(() => useDashboardPrefs());
+    const { result } = renderHookWithProviders(() => useDashboardPrefs(), { queryClient: makePrimedClient() });
     act(() => {
       result.current.setMode('custom');
     });
-    // setMode uses immediate:true under the hood.
     expect(mockMutate).toHaveBeenCalledTimes(1);
   });
 
   it('preserves sibling other_preference keys (theme) when flushing', () => {
-    const { result } = renderHookWithProviders(() => useDashboardPrefs());
+    const { result } = renderHookWithProviders(() => useDashboardPrefs(), { queryClient: makePrimedClient() });
     act(() => {
       result.current.setMode('custom');
     });
@@ -68,7 +107,7 @@ describe('useDashboardPrefs', () => {
     mockMutate.mockImplementation((_payload, opts: { onError: () => void }) => {
       opts.onError();
     });
-    const { result } = renderHookWithProviders(() => useDashboardPrefs());
+    const { result } = renderHookWithProviders(() => useDashboardPrefs(), { queryClient: makePrimedClient() });
     act(() => {
       result.current.setMode('custom');
     });
@@ -77,7 +116,7 @@ describe('useDashboardPrefs', () => {
   });
 
   it('caps history at 3 prior layouts on repeated applyPreset', () => {
-    const { result } = renderHookWithProviders(() => useDashboardPrefs());
+    const { result } = renderHookWithProviders(() => useDashboardPrefs(), { queryClient: makePrimedClient() });
     act(() => {
       result.current.applyPreset('morning-brief');
     });
@@ -92,4 +131,228 @@ describe('useDashboardPrefs', () => {
     });
     expect(result.current.prefs.history?.length ?? 0).toBeLessThanOrEqual(3);
   });
+
+  it('replay-aware flush reads the freshest queryClient snapshot, not the queue-time ref', () => {
+    // Tab A queues an edit. While the debounce is pending, Tab B writes and
+    // we receive the broadcast → cache gets a NEW theme value. Tab A's flush
+    // must use the new theme, not the snapshot it captured at queue time.
+    const queryClient = makePrimedClient();
+    const { result } = renderHookWithProviders(() => useDashboardPrefs(), { queryClient });
+    act(() => {
+      result.current.update({ mode: 'custom' });
+    });
+    // Simulate cross-tab landing in the cache before our debounce fires.
+    act(() => {
+      queryClient.setQueryData(queryKeys.user.preferences(), {
+        other_preference: { theme: 'light', remoteAddedKey: 'remote' },
+      });
+    });
+    // Sanity: confirm cache has the cross-tab value before flush fires.
+    const cachedNow = queryClient.getQueryData(queryKeys.user.preferences()) as { other_preference: Record<string, unknown> };
+    expect(cachedNow.other_preference.theme).toBe('light');
+    act(() => {
+      vi.advanceTimersByTime(800);
+    });
+    const payload = mockMutate.mock.calls[0][0] as {
+      other_preference: { theme?: string; remoteAddedKey?: string; dashboard?: { mode: string } };
+    };
+    expect(payload.other_preference.theme).toBe('light');
+    expect(payload.other_preference.remoteAddedKey).toBe('remote');
+    expect(payload.other_preference.dashboard?.mode).toBe('custom');
+  });
+
+  it('resets pendingTimer to null after the debounce fires (gate not stuck)', () => {
+    // Without the reset, the BroadcastChannel onmessage handler reads a
+    // truthy timer ID and skips invalidation forever after the first edit.
+    const queryClient = makePrimedClient();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHookWithProviders(() => useDashboardPrefs(), { queryClient });
+    act(() => {
+      result.current.update({ mode: 'custom' });
+    });
+    act(() => {
+      vi.advanceTimersByTime(800);
+    });
+    // After flush, broadcast a remote edit — the gate should be open.
+    const channels = (globalThis as unknown as { __testChannels?: Array<{ onmessage?: (e: MessageEvent) => void }> }).__testChannels;
+    const chan = channels?.[channels.length - 1];
+    chan?.onmessage?.({ data: { type: 'updated' } } as MessageEvent);
+    // invalidate should have run once for the cross-tab signal (mutation isPending=false in mock).
+    expect(invalidateSpy).toHaveBeenCalled();
+  });
+});
+
+describe('useDashboardPrefs — BroadcastChannel', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockMutate.mockReset();
+    mockToast.mockReset();
+    mutationState.isPending = false;
+    prefsState.current = { other_preference: { theme: 'dark' } };
+    // Reset captured channels between tests.
+    (globalThis as unknown as { __testChannels: unknown[] }).__testChannels = [];
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // Each useDashboardPrefs mount creates TWO channels: a writer (from
+  // useDashboardPrefsWriter) and a listener (from useDashboardPrefs itself).
+  // Helpers find them by role rather than index so refactors of either side
+  // don't ripple into test brittleness.
+  const getListenerChannel = () => {
+    const channels = (globalThis as unknown as { __testChannels: TestChannel[] }).__testChannels;
+    return channels.find((c) => typeof c.onmessage === 'function');
+  };
+  const getWriterChannel = () => {
+    const channels = (globalThis as unknown as { __testChannels: TestChannel[] }).__testChannels;
+    return channels.find((c) => c.posted.length > 0)
+      // Fall back to the first non-listener channel if nothing has posted yet.
+      ?? channels.find((c) => typeof c.onmessage !== 'function');
+  };
+
+  it('opens a writer + listener channel on mount and closes them on unmount', () => {
+    const { unmount } = renderHookWithProviders(() => useDashboardPrefs(), { queryClient: makePrimedClient() });
+    const channels = (globalThis as unknown as { __testChannels: TestChannel[] }).__testChannels;
+    expect(channels.length).toBe(2);
+    expect(channels.every((c) => !c.closed)).toBe(true);
+    unmount();
+    expect(channels.every((c) => c.closed)).toBe(true);
+  });
+
+  it('postMessages "updated" on flush success', () => {
+    mockMutate.mockImplementation((_payload, opts: { onSuccess: () => void }) => {
+      opts.onSuccess();
+    });
+    const { result } = renderHookWithProviders(() => useDashboardPrefs(), { queryClient: makePrimedClient() });
+    act(() => {
+      result.current.setMode('custom');
+    });
+    expect(getWriterChannel()?.posted).toEqual([{ type: 'updated' }]);
+  });
+
+  it('onmessage invalidates the prefs query when no edit is in flight', () => {
+    const queryClient = makePrimedClient();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    renderHookWithProviders(() => useDashboardPrefs(), { queryClient });
+    getListenerChannel()?.onmessage?.({ data: { type: 'updated' } } as MessageEvent);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.user.preferences() });
+  });
+
+  it('onmessage defers invalidate (replay) when a debounce is pending', () => {
+    const queryClient = makePrimedClient();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHookWithProviders(() => useDashboardPrefs(), { queryClient });
+    act(() => {
+      result.current.update({ mode: 'custom' });
+    });
+    invalidateSpy.mockClear();
+    // Broadcast lands while debounce is pending — should NOT invalidate yet.
+    getListenerChannel()?.onmessage?.({ data: { type: 'updated' } } as MessageEvent);
+    expect(invalidateSpy).not.toHaveBeenCalled();
+    // Drain the debounce → flush succeeds → replay should drain the deferred
+    // invalidate. mockMutate doesn't auto-call onSuccess; do so manually.
+    mockMutate.mockImplementationOnce((_p, opts: { onSuccess: () => void }) => opts.onSuccess());
+    act(() => {
+      vi.advanceTimersByTime(800);
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.user.preferences() });
+  });
+
+  it('onmessage defers invalidate (replay) when the mutation is in flight', () => {
+    mutationState.isPending = true;
+    const queryClient = makePrimedClient();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    const { rerender } = renderHookWithProviders(() => useDashboardPrefs(), { queryClient });
+    getListenerChannel()?.onmessage?.({ data: { type: 'updated' } } as MessageEvent);
+    expect(invalidateSpy).not.toHaveBeenCalled();
+    // Mutation completes → re-render flips isPending → replay drains.
+    mutationState.isPending = false;
+    rerender();
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.user.preferences() });
+  });
+
+  it('ignores messages with the wrong type', () => {
+    const queryClient = makePrimedClient();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    renderHookWithProviders(() => useDashboardPrefs(), { queryClient });
+    const listener = getListenerChannel();
+    listener?.onmessage?.({ data: { type: 'something-else' } } as MessageEvent);
+    listener?.onmessage?.({ data: null } as MessageEvent);
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('useDashboardPrefs — BroadcastChannel unsupported', () => {
+  let originalBC: typeof BroadcastChannel | undefined;
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockMutate.mockReset();
+    mutationState.isPending = false;
+    prefsState.current = { other_preference: { theme: 'dark' } };
+    originalBC = (globalThis as { BroadcastChannel?: typeof BroadcastChannel }).BroadcastChannel;
+    delete (globalThis as { BroadcastChannel?: typeof BroadcastChannel }).BroadcastChannel;
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    if (originalBC) (globalThis as { BroadcastChannel?: typeof BroadcastChannel }).BroadcastChannel = originalBC;
+  });
+
+  it('does not crash and skips broadcast when BroadcastChannel is undefined', () => {
+    mockMutate.mockImplementation((_payload, opts: { onSuccess: () => void }) => {
+      opts.onSuccess();
+    });
+    const { result } = renderHookWithProviders(() => useDashboardPrefs(), { queryClient: makePrimedClient() });
+    expect(() => {
+      act(() => {
+        result.current.setMode('custom');
+      });
+    }).not.toThrow();
+    expect(mockMutate).toHaveBeenCalledTimes(1);
+  });
+});
+
+// --- jsdom BroadcastChannel polyfill --------------------------------------
+// jsdom doesn't ship BroadcastChannel; install a minimal recording stand-in
+// at module load. Tests pull the channel list from globalThis.__testChannels
+// to assert posts and invoke onmessage manually.
+type TestChannel = {
+  name: string;
+  posted: unknown[];
+  closed: boolean;
+  onmessage?: (e: MessageEvent) => void;
+  postMessage: (m: unknown) => void;
+  close: () => void;
+};
+// Scoped install: beforeAll → install fake, afterAll → restore (or delete if
+// the worker had no native BroadcastChannel). Without the restore, other
+// test files running in the same vitest worker would see a fake
+// BroadcastChannel and miss real-undefined fallback behavior.
+class FakeBroadcastChannel implements TestChannel {
+  name: string;
+  posted: unknown[] = [];
+  closed = false;
+  onmessage?: (e: MessageEvent) => void;
+  constructor(name: string) {
+    this.name = name;
+    ((globalThis as unknown as { __testChannels: TestChannel[] }).__testChannels).push(this);
+  }
+  postMessage(m: unknown) { this.posted.push(m); }
+  close() { this.closed = true; }
+}
+
+let originalBroadcastChannel: typeof BroadcastChannel | undefined;
+beforeAll(() => {
+  originalBroadcastChannel = (globalThis as { BroadcastChannel?: typeof BroadcastChannel }).BroadcastChannel;
+  (globalThis as unknown as { __testChannels: TestChannel[] }).__testChannels = [];
+  (globalThis as unknown as { BroadcastChannel: typeof FakeBroadcastChannel }).BroadcastChannel =
+    FakeBroadcastChannel;
+});
+afterAll(() => {
+  if (originalBroadcastChannel) {
+    (globalThis as { BroadcastChannel?: typeof BroadcastChannel }).BroadcastChannel = originalBroadcastChannel;
+  } else {
+    delete (globalThis as { BroadcastChannel?: typeof BroadcastChannel }).BroadcastChannel;
+  }
+  delete (globalThis as { __testChannels?: unknown }).__testChannels;
 });

--- a/web/src/pages/Dashboard/widgets/framework/configSchemas.ts
+++ b/web/src/pages/Dashboard/widgets/framework/configSchemas.ts
@@ -1,0 +1,263 @@
+import { z } from 'zod';
+
+/**
+ * Per-widget Zod schemas applied at the prefs-load boundary
+ * (`migrations.ts → sanitizeConfig`). Per-field `.catch()` recovers
+ * individual bad values; whole-config failure falls back to `defaultConfig`.
+ *
+ * Centralizing schemas in one file keeps the contract visible: schema
+ * changes here are intentional, not buried in 30 widget files.
+ *
+ * Enum tuples are exported `as const` so settings dialogs can derive their
+ * dropdown options from the same source of truth and never drift from the
+ * schema (Zod v4's `.options` is hidden after `.catch()` is applied — keep
+ * the const around).
+ */
+
+// TV symbol grammar: prefix:base, dots in tickers (BRK.B), futures (`!`),
+// forex slash (`/`), TVC indices (`^`), &, underscores in real exchange
+// prefixes (CME_MINI:ES1!, FX_IDC:EURUSD, KRX:HMM_T), plus uppercase +
+// digits + dash. Deliberately permissive — TV's wider grammar would
+// otherwise drop valid configs the user typed in good faith.
+const TV_SYMBOL_RE = /^[A-Z0-9._\-:!/^&]+$/i;
+
+const tvSymbol = (def: string) => z.string().min(1).regex(TV_SYMBOL_RE).catch(def);
+const intInRange = (def: number, min: number, max: number) =>
+  z.number().int().min(min).max(max).catch(def);
+const looseString = (def: string) => z.string().min(1).catch(def);
+
+// =============================================================================
+// TV widgets (17)
+// =============================================================================
+
+export const TICKER_TAPE_DISPLAY_MODES = ['adaptive', 'regular', 'compact'] as const;
+export const TickerTapeConfigSchema = z.object({
+  // Drop invalid entries (and dedupe) instead of per-element .catch(default) —
+  // a corrupted blob with [bad, bad, NVDA] becomes [NVDA] rather than
+  // [SPY, SPY, NVDA] (silent duplication). User keeps every valid symbol.
+  symbols: z
+    .array(z.unknown())
+    .catch([])
+    .transform((arr) => {
+      const seen = new Set<string>();
+      const out: string[] = [];
+      for (const v of arr) {
+        if (typeof v !== 'string') continue;
+        if (!TV_SYMBOL_RE.test(v) || v.length === 0) continue;
+        if (seen.has(v)) continue;
+        seen.add(v);
+        out.push(v);
+      }
+      return out;
+    }),
+  displayMode: z.enum(TICKER_TAPE_DISPLAY_MODES).catch('adaptive'),
+});
+
+export const STOCK_HEATMAP_DATA_SOURCES = [
+  'SPX500', 'NASDAQ100', 'DOW30', 'AllUSA', 'Asia', 'Europe', 'crypto',
+] as const;
+export const STOCK_HEATMAP_BLOCK_SIZES = ['market_cap_basic', 'volume', 'number_of_employees'] as const;
+export const STOCK_HEATMAP_BLOCK_COLORS = ['change', 'Perf.W', 'Perf.1M', 'Perf.YTD', 'Perf.Y'] as const;
+export const StockHeatmapConfigSchema = z.object({
+  dataSource: z.string().min(1).catch('SPX500'),
+  blockSize: z.string().min(1).catch('market_cap_basic'),
+  blockColor: z.string().min(1).catch('change'),
+});
+
+export const CryptoHeatmapConfigSchema = z.object({
+  dataSource: z.string().min(1).catch('Crypto'),
+  blockSize: z.string().min(1).catch('market_cap_calc'),
+  blockColor: z.string().min(1).catch('24h_close_change|5'),
+});
+
+export const ETFHeatmapConfigSchema = z.object({
+  dataSource: z.string().min(1).catch('AllUSEtf'),
+  blockSize: z.string().min(1).catch('aum'),
+  blockColor: z.string().min(1).catch('change'),
+  grouping: z.string().min(1).catch('asset_class'),
+});
+
+// Mirror of DEFAULT_CURRENCIES in ForexHeatmapWidget — kept here so the
+// schema's whole-array fallback matches the widget's defaultConfig (a
+// single-currency catch produces a useless cross-rate widget).
+export const FOREX_DEFAULT_CURRENCIES = [
+  'USD', 'EUR', 'GBP', 'JPY', 'CHF', 'CAD', 'AUD', 'NZD', 'CNY',
+] as const;
+export const ForexHeatmapConfigSchema = z.object({
+  // Drop bad currency codes (and dedupe) rather than per-element .catch('USD')
+  // which would turn [JPY, garbage, EUR] into [USD, USD, EUR]. If the whole
+  // value is malformed (not an array), fall back to the full default set so
+  // the cross-rate widget still renders something useful.
+  currencies: z
+    .array(z.unknown())
+    .catch([...FOREX_DEFAULT_CURRENCIES])
+    .transform((arr) => {
+      const seen = new Set<string>();
+      const out: string[] = [];
+      for (const v of arr) {
+        if (typeof v !== 'string') continue;
+        if (!/^[A-Z]{3}$/.test(v)) continue;
+        if (seen.has(v)) continue;
+        seen.add(v);
+        out.push(v);
+      }
+      // Empty after filtering = useless; restore the rich default.
+      return out.length === 0 ? [...FOREX_DEFAULT_CURRENCIES] : out;
+    }),
+});
+
+export const EconomicEventsConfigSchema = z.object({
+  // .min(1) guards against an empty string sneaking past validation — TV
+  // would render an empty calendar instead of falling back to the catch.
+  importanceFilter: z.string().min(1).catch('-1,0,1'),
+  countryFilter: z.string().min(1).catch('us,eu,jp,gb,cn'),
+});
+
+export const ECONOMIC_MAP_REGIONS = [
+  'global', 'africa', 'asia', 'europe', 'north-america', 'oceania', 'south-america',
+] as const;
+export const ECONOMIC_MAP_METRICS = ['gdp', 'ur', 'gdg', 'intr', 'iryy'] as const;
+export const EconomicMapConfigSchema = z.object({
+  region: z.enum(ECONOMIC_MAP_REGIONS).catch('global'),
+  metric: z.enum(ECONOMIC_MAP_METRICS).catch('gdp'),
+  hideLegend: z.boolean().catch(false),
+});
+
+export const TechnicalsConfigSchema = z.object({
+  symbol: tvSymbol('NASDAQ:NVDA'),
+  // TV interval grammar is wide ("1m", "5m", "1h", "1D", "1W"). Loose check.
+  interval: z.string().min(1).catch('1D'),
+});
+
+export const MoversConfigSchema = z.object({
+  exchange: z.string().min(1).catch('US'),
+  dataSource: z.string().min(1).catch('AllUSA'),
+});
+
+export const SymbolSpotlightConfigSchema = z.object({
+  symbol: tvSymbol('NASDAQ:NVDA'),
+  range: z.string().min(1).catch('12M'),
+});
+
+export const CompanyProfileConfigSchema = z.object({
+  symbol: tvSymbol('NASDAQ:NVDA'),
+});
+
+export const COMPANY_FIN_DISPLAY_MODES = ['regular', 'compact', 'adaptive'] as const;
+export const CompanyFinancialsConfigSchema = z.object({
+  symbol: tvSymbol('NASDAQ:NVDA'),
+  displayMode: z.enum(COMPANY_FIN_DISPLAY_MODES).catch('regular'),
+});
+
+export const TOP_STORIES_FEED_MODES = ['all_symbols', 'market', 'symbol'] as const;
+export const TOP_STORIES_MARKETS = [
+  'stock', 'crypto', 'forex', 'index', 'futures', 'bond', 'economic',
+] as const;
+export const TOP_STORIES_DISPLAY_MODES = ['regular', 'compact'] as const;
+export const TopStoriesConfigSchema = z.object({
+  feedMode: z.enum(TOP_STORIES_FEED_MODES).catch('market'),
+  market: z.enum(TOP_STORIES_MARKETS).catch('stock'),
+  symbol: tvSymbol('NASDAQ:NVDA'),
+  displayMode: z.enum(TOP_STORIES_DISPLAY_MODES).catch('regular'),
+});
+
+export const SingleTickerConfigSchema = z.object({
+  symbol: tvSymbol('NASDAQ:NVDA'),
+});
+
+export const SymbolInfoConfigSchema = z.object({
+  symbol: tvSymbol('NASDAQ:NVDA'),
+});
+
+export const StockScreenerConfigSchema = z.object({
+  market: z.string().min(1).catch('america'),
+  defaultColumn: z.string().min(1).catch('overview'),
+  defaultScreen: z.string().min(1).catch('general'),
+});
+
+export const CryptoScreenerConfigSchema = z.object({
+  defaultColumn: z.string().min(1).catch('overview'),
+  defaultScreen: z.string().min(1).catch('general'),
+});
+
+// =============================================================================
+// Native widgets (13)
+// =============================================================================
+
+export const CHART_INTERVALS = ['1min', '5min', '15min', '30min', '1hour', '1day'] as const;
+export const CHART_TYPES = ['candle', 'area', 'line'] as const;
+export const ChartConfigSchema = z.object({
+  symbol: looseString('NVDA'),
+  interval: z.enum(CHART_INTERVALS).catch('1day'),
+  chartType: z.enum(CHART_TYPES).catch('candle'),
+});
+
+export const MiniChartGridConfigSchema = z.object({
+  // No regex — accepts plain symbols ("NVDA") and TV-style ("NASDAQ:NVDA").
+  // Filter non-strings + empties, dedupe; return [] if all entries are bad
+  // (the widget falls back to watchlist/blue-chips at render time).
+  symbols: z
+    .array(z.unknown())
+    .catch([])
+    .transform((arr) => {
+      const seen = new Set<string>();
+      const out: string[] = [];
+      for (const v of arr) {
+        if (typeof v !== 'string' || v.length === 0) continue;
+        if (seen.has(v)) continue;
+        seen.add(v);
+        out.push(v);
+      }
+      return out;
+    }),
+});
+
+export const PortfolioConfigSchema = z.object({
+  valuesHidden: z.boolean().optional().catch(false),
+});
+
+export const AutomationsConfigSchema = z.object({
+  limit: intInRange(8, 1, 100).optional().catch(8),
+});
+
+export const PW_TAB_KEYS = ['watchlist', 'portfolio'] as const;
+export const PortfolioWatchlistConfigSchema = z.object({
+  defaultTab: z.enum(PW_TAB_KEYS).optional().catch('watchlist'),
+  valuesHidden: z.boolean().optional().catch(false),
+});
+
+export const WatchlistConfigSchema = z.object({}).catch({});
+
+export const WorkspacePickerConfigSchema = z.object({
+  limit: intInRange(12, 1, 100).optional().catch(12),
+});
+
+export const RecentThreadsConfigSchema = z.object({
+  // 'all' | 'current' | <workspace UUID> — accept any non-empty string.
+  workspaceId: z.string().min(1).optional().catch('all'),
+  limit: intInRange(15, 1, 100).optional().catch(15),
+});
+
+export const EARNINGS_WINDOWS = ['1w', '2w', '1m'] as const;
+export const EARNINGS_TICKERS = ['all', 'portfolio'] as const;
+export const EarningsConfigSchema = z.object({
+  window: z.enum(EARNINGS_WINDOWS).optional().catch('2w'),
+  tickers: z.enum(EARNINGS_TICKERS).optional().catch('all'),
+});
+
+export const INSIGHT_BRIEF_VARIANTS = ['latest', 'personalized'] as const;
+export const InsightBriefConfigSchema = z.object({
+  variant: z.enum(INSIGHT_BRIEF_VARIANTS).optional().catch('latest'),
+});
+
+export const ConversationConfigSchema = z.object({}).catch({});
+
+export const MarketsOverviewConfigSchema = z.object({
+  indices: z.array(z.string().min(1)).optional().catch([]),
+});
+
+export const NEWS_FEED_SOURCES = ['market', 'portfolio', 'watchlist'] as const;
+export const NewsFeedConfigSchema = z.object({
+  source: z.enum(NEWS_FEED_SOURCES).optional().catch('market'),
+  limit: intInRange(50, 1, 200).optional().catch(50),
+});

--- a/web/src/pages/Dashboard/widgets/framework/dashboardPrefsWriter.ts
+++ b/web/src/pages/Dashboard/widgets/framework/dashboardPrefsWriter.ts
@@ -1,0 +1,85 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useUpdatePreferences } from '@/hooks/useUpdatePreferences';
+import { queryKeys } from '@/lib/queryKeys';
+import type { UserPreferences } from '@/types/api';
+import type { DashboardPrefs } from '../types';
+
+const BROADCAST_CHANNEL = 'dashboard-prefs';
+
+/**
+ * Single writer for `other_preference.dashboard`. Centralizes three concerns
+ * that every dashboard prefs mutation needs to do correctly:
+ *
+ * 1. **Replay-aware sibling preservation.** Read the freshest cache snapshot
+ *    at write time (not at queue/render time) so a cross-tab update or a
+ *    concurrent write to a sibling key (theme, locale, provider) isn't
+ *    clobbered by spreading a stale `other_preference` blob.
+ *
+ * 2. **Cross-tab broadcast.** Post `{type:'updated'}` to the dashboard-prefs
+ *    BroadcastChannel on success so other tabs invalidate their cache and
+ *    refetch — covers cross-tab consistency without relying on alt-tab focus.
+ *
+ * 3. **Cold-cache safety.** Refuse the write when the cache is cold AND no
+ *    fallback dashboard snapshot was supplied. Without this, a fast click on
+ *    cold load PUTs `{ other_preference: { dashboard: {...} } }` and wipes
+ *    every sibling key on the server (irreversible — no prefs undo).
+ *
+ * Used by `useDashboardPrefs.flush()` (debounced widget edits) and
+ * `DashboardRouter.onModeChange()` (mode toggle).
+ */
+export function useDashboardPrefsWriter() {
+  const updatePrefs = useUpdatePreferences();
+  const queryClient = useQueryClient();
+
+  // One channel per hook instance so postMessage doesn't pay the
+  // construction cost on every write. Reset on unmount.
+  const bcRef = useRef<BroadcastChannel | null>(null);
+  useEffect(() => {
+    if (typeof BroadcastChannel === 'undefined') return;
+    const chan = new BroadcastChannel(BROADCAST_CHANNEL);
+    bcRef.current = chan;
+    return () => {
+      chan.close();
+      bcRef.current = null;
+    };
+  }, []);
+
+  const writeDashboardPrefs = useCallback(
+    (
+      next: DashboardPrefs,
+      opts?: {
+        /** Caller-supplied fallback for cold-cache scenarios. If both the
+         * React Query cache AND this fallback are absent, the write is
+         * refused (returns false) to avoid clobbering server-side siblings. */
+        fallbackOther?: Record<string, unknown> | null;
+        onSuccess?: () => void;
+        onError?: (err: unknown) => void;
+      }
+    ): boolean => {
+      const fresh = queryClient.getQueryData<UserPreferences>(queryKeys.user.preferences());
+      const freshOther = (fresh?.other_preference as Record<string, unknown> | undefined) ?? null;
+      const baseOther = freshOther ?? opts?.fallbackOther ?? null;
+      if (baseOther === null) {
+        // Cold cache + no fallback — refuse rather than clobber siblings.
+        return false;
+      }
+      updatePrefs.mutate(
+        {
+          other_preference: { ...baseOther, dashboard: next },
+        },
+        {
+          onSuccess: () => {
+            bcRef.current?.postMessage({ type: 'updated' });
+            opts?.onSuccess?.();
+          },
+          onError: (err) => opts?.onError?.(err),
+        }
+      );
+      return true;
+    },
+    [updatePrefs, queryClient]
+  );
+
+  return { writeDashboardPrefs, isPending: updatePrefs.isPending };
+}

--- a/web/src/pages/Dashboard/widgets/framework/dashboardPrefsWriter.ts
+++ b/web/src/pages/Dashboard/widgets/framework/dashboardPrefsWriter.ts
@@ -49,21 +49,17 @@ export function useDashboardPrefsWriter() {
     (
       next: DashboardPrefs,
       opts?: {
-        /** Caller-supplied fallback for cold-cache scenarios. If both the
-         * React Query cache AND this fallback are absent, the write is
-         * refused (returns false) to avoid clobbering server-side siblings. */
+        /** `null` = warm prefs with empty other_preference (new users).
+         *  `undefined` = no info — writer refuses the write. */
         fallbackOther?: Record<string, unknown> | null;
         onSuccess?: () => void;
         onError?: (err: unknown) => void;
       }
     ): boolean => {
       const fresh = queryClient.getQueryData<UserPreferences>(queryKeys.user.preferences());
+      if (fresh === undefined && opts?.fallbackOther === undefined) return false;
       const freshOther = (fresh?.other_preference as Record<string, unknown> | undefined) ?? null;
-      const baseOther = freshOther ?? opts?.fallbackOther ?? null;
-      if (baseOther === null) {
-        // Cold cache + no fallback — refuse rather than clobber siblings.
-        return false;
-      }
+      const baseOther = freshOther ?? opts?.fallbackOther ?? {};
       updatePrefs.mutate(
         {
           other_preference: { ...baseOther, dashboard: next },

--- a/web/src/pages/Dashboard/widgets/framework/dashboardPrefsWriter.ts
+++ b/web/src/pages/Dashboard/widgets/framework/dashboardPrefsWriter.ts
@@ -5,7 +5,7 @@ import { queryKeys } from '@/lib/queryKeys';
 import type { UserPreferences } from '@/types/api';
 import type { DashboardPrefs } from '../types';
 
-const BROADCAST_CHANNEL = 'dashboard-prefs';
+export const BROADCAST_CHANNEL = 'dashboard-prefs';
 
 /**
  * Single writer for `other_preference.dashboard`. Centralizes three concerns

--- a/web/src/pages/Dashboard/widgets/framework/migrations.ts
+++ b/web/src/pages/Dashboard/widgets/framework/migrations.ts
@@ -1,3 +1,4 @@
+import { getWidget } from './WidgetRegistry';
 import { DASHBOARD_PREFS_VERSION, type DashboardPrefs, type WidgetInstance } from '../types';
 
 // Widget types that have been renamed. Stored prefs are silently upgraded on load.
@@ -13,6 +14,51 @@ function renameWidgetTypes(widgets: WidgetInstance[]): WidgetInstance[] {
 }
 
 /**
+ * Tighter membership check than `Array.isArray(widgets)`. Drops any entry that
+ * is null/string/number/missing-id/missing-type/missing-config so a malformed
+ * persisted blob can't crash the renderer downstream.
+ */
+function isValidWidgetInstance(w: unknown): w is WidgetInstance {
+  if (!w || typeof w !== 'object') return false;
+  const obj = w as Partial<WidgetInstance>;
+  return (
+    typeof obj.id === 'string' &&
+    typeof obj.type === 'string' &&
+    typeof obj.config === 'object' &&
+    obj.config !== null
+  );
+}
+
+/**
+ * Run the widget's optional Zod schema over its stored config. Per-field
+ * `.catch()` clauses recover individual bad values; a fully malformed config
+ * falls back to the widget's `defaultConfig`. Widgets without a schema pass
+ * through unchanged.
+ *
+ * Bootstrapping note: this calls `getWidget(type)`, which only returns a
+ * value after `widgets/index.ts` has executed (it's the side-effect import
+ * that fills the registry). Production callers reach `migrations.ts` via
+ * `useDashboardPrefs`, which is mounted from a Dashboard component that
+ * transitively imports `widgets/index`. Tests that import this module
+ * directly MUST also `import 'widgets/index'` at the top, otherwise
+ * `getWidget` returns undefined and `sanitizeConfig` is silently a no-op.
+ */
+function sanitizeConfig(w: WidgetInstance): WidgetInstance {
+  const def = getWidget(w.type);
+  if (!def?.configSchema) return w;
+  const parsed = def.configSchema.safeParse(w.config);
+  if (parsed.success) return { ...w, config: parsed.data };
+  // Worst case: schema parse failed even after per-field .catch() — usually
+  // means the stored value was the wrong top-level type entirely. Reset to
+  // the widget's default so the user gets a working widget back, with a
+  // diagnostic log to find the offender in dev.
+  if (import.meta.env?.DEV) {
+    console.warn('[dashboard-prefs] sanitizeConfig fell back to defaultConfig for', w.type, parsed.error);
+  }
+  return { ...w, config: { ...(def.defaultConfig as object) } };
+}
+
+/**
  * Bring any stored dashboard prefs up to the current schema shape.
  * Absent / malformed input → null so callers can fall back to defaults.
  */
@@ -22,11 +68,23 @@ export function migrateDashboardPrefs(raw: unknown): DashboardPrefs | null {
 
   const mode = src.mode === 'custom' ? 'custom' : 'classic';
   const rawWidgets = Array.isArray(src.widgets) ? src.widgets : [];
-  const widgets = renameWidgetTypes(rawWidgets);
-  const layouts =
-    src.layouts && typeof src.layouts === 'object' && !Array.isArray(src.layouts)
-      ? src.layouts
-      : {};
+  // Filter shape-invalid widgets BEFORE rename + sanitize. A stored blob
+  // with `widgets: [null, "garbage", { id: 'x' }]` previously passed
+  // straight through and crashed the renderer.
+  const validWidgets = rawWidgets.filter(isValidWidgetInstance);
+  // Order matters: rename FIRST so sanitize sees the current type and can
+  // look up the right widget definition + schema.
+  const widgets = renameWidgetTypes(validWidgets).map(sanitizeConfig);
+  // Per-breakpoint shape filter: `{ layouts: { lg: { foo: 'bar' } } }` would
+  // pass the top-level "object && not array" check but later crash
+  // reconcileLayouts (it `.filter()`s each breakpoint as if it were an array).
+  // Drop any breakpoint whose value isn't a real array.
+  const layouts: Record<string, unknown[]> = {};
+  if (src.layouts && typeof src.layouts === 'object' && !Array.isArray(src.layouts)) {
+    for (const [bp, items] of Object.entries(src.layouts)) {
+      if (Array.isArray(items)) layouts[bp] = items;
+    }
+  }
 
   return {
     version: DASHBOARD_PREFS_VERSION,

--- a/web/src/pages/Dashboard/widgets/framework/settings/SymbolListField.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/settings/SymbolListField.tsx
@@ -1,6 +1,11 @@
-import { useState, type KeyboardEvent } from 'react';
+import { useState, type KeyboardEvent, type ClipboardEvent } from 'react';
 import { X } from 'lucide-react';
 import { Input } from '@/components/ui/input';
+
+// Split incoming text on whitespace, comma, semicolon, or newline so a paste
+// of `NVDA, AAPL MSFT;TSLA` becomes 4 chips instead of 1 bad symbol that the
+// schema later rewrites to the catch default.
+const TOKEN_SEPARATORS = /[\s,;]+/;
 
 interface Props {
   label: string;
@@ -25,6 +30,8 @@ export function SymbolListField({
 }: Props) {
   const [draft, setDraft] = useState('');
 
+  const atCap = value.length >= max;
+
   const add = () => {
     const sym = draft.trim().toUpperCase();
     if (!sym) return;
@@ -37,6 +44,30 @@ export function SymbolListField({
     setDraft('');
   };
 
+  // Paste handler: split on commas/whitespace and add each token. Falls back
+  // to default Input behavior if the paste contains no separators (single
+  // symbol) so the user can still edit-by-paste mid-input if they want.
+  const onPaste = (e: ClipboardEvent<HTMLInputElement>) => {
+    const raw = e.clipboardData.getData('text');
+    if (!raw || !TOKEN_SEPARATORS.test(raw)) return;
+    e.preventDefault();
+    const tokens = raw
+      .split(TOKEN_SEPARATORS)
+      .map((s) => s.trim().toUpperCase())
+      .filter(Boolean);
+    if (tokens.length === 0) return;
+    const next = [...value];
+    const seen = new Set(next);
+    for (const t of tokens) {
+      if (next.length >= max) break;
+      if (seen.has(t)) continue;
+      seen.add(t);
+      next.push(t);
+    }
+    if (next.length !== value.length) onChange(next);
+    setDraft('');
+  };
+
   const onKey = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' || e.key === ',') {
       e.preventDefault();
@@ -44,6 +75,16 @@ export function SymbolListField({
     } else if (e.key === 'Backspace' && draft === '' && value.length > 0) {
       onChange(value.slice(0, -1));
     }
+  };
+
+  // Click-outside without Enter shouldn't drop the half-typed symbol — but
+  // also shouldn't blindly commit. Commit only when there's a non-whitespace
+  // draft AND we're under the cap. The schema layer (Zod regex on consumer
+  // widgets) enforces the symbol grammar at sanitize-on-load time.
+  const onBlur = () => {
+    if (atCap) return;
+    if (!draft.trim()) return;
+    add();
   };
 
   const remove = (sym: string) => onChange(value.filter((s) => s !== sym));
@@ -84,9 +125,17 @@ export function SymbolListField({
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
           onKeyDown={onKey}
-          onBlur={add}
-          placeholder={value.length === 0 ? placeholder ?? 'Add symbols (Enter)' : ''}
-          className="flex-1 min-w-[100px] border-0 !p-0 !h-6 text-xs bg-transparent shadow-none focus-visible:ring-0"
+          onPaste={onPaste}
+          onBlur={onBlur}
+          disabled={atCap}
+          placeholder={
+            atCap
+              ? `Max ${max} reached`
+              : value.length === 0
+                ? placeholder ?? 'Add symbols (Enter)'
+                : ''
+          }
+          className="flex-1 min-w-[100px] border-0 !p-0 !h-6 text-xs bg-transparent shadow-none focus-visible:ring-0 disabled:opacity-50 disabled:cursor-not-allowed"
           style={{
             color: 'var(--color-text-primary)',
             textTransform: 'uppercase',
@@ -98,7 +147,7 @@ export function SymbolListField({
           {helper}
         </span>
       )}
-      {value.length >= max && (
+      {atCap && (
         <span className="text-[11px] mt-1 block" style={{ color: 'var(--color-text-tertiary)' }}>
           Max {max} symbols.
         </span>

--- a/web/src/pages/Dashboard/widgets/framework/settings/__tests__/settings-atoms.test.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/settings/__tests__/settings-atoms.test.tsx
@@ -40,6 +40,88 @@ describe('SymbolListField', () => {
     fireEvent.click(removeBtn);
     expect(onChange).toHaveBeenCalledWith(['NVDA']);
   });
+
+  it('commits a non-empty trimmed draft on blur (under cap)', () => {
+    const onChange = vi.fn();
+    render(<SymbolListField label="Symbols" value={['AAPL']} onChange={onChange} />);
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'nvda' } });
+    fireEvent.blur(input);
+    expect(onChange).toHaveBeenCalledWith(['AAPL', 'NVDA']);
+  });
+
+  it('does NOT commit an empty / whitespace-only draft on blur', () => {
+    const onChange = vi.fn();
+    render(<SymbolListField label="Symbols" value={['AAPL']} onChange={onChange} />);
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: '   ' } });
+    fireEvent.blur(input);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('disables the input when at cap and skips onBlur commit', () => {
+    const onChange = vi.fn();
+    render(
+      <SymbolListField label="Symbols" value={['A', 'B', 'C']} onChange={onChange} max={3} />,
+    );
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    expect(input.disabled).toBe(true);
+    expect(input.placeholder).toMatch(/max 3 reached/i);
+    // Blur shouldn't trigger any onChange even if a draft somehow exists.
+    fireEvent.blur(input);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('splits comma/space-separated paste into multiple chips', () => {
+    const onChange = vi.fn();
+    render(<SymbolListField label="Symbols" value={['AAPL']} onChange={onChange} />);
+    const input = screen.getByRole('textbox');
+    fireEvent.paste(input, {
+      clipboardData: { getData: (t: string) => (t === 'text' ? 'nvda, msft tsla;goog' : '') },
+    });
+    expect(onChange).toHaveBeenCalledWith(['AAPL', 'NVDA', 'MSFT', 'TSLA', 'GOOG']);
+  });
+
+  it('paste-with-separators dedupes against existing chips', () => {
+    const onChange = vi.fn();
+    render(<SymbolListField label="Symbols" value={['AAPL', 'NVDA']} onChange={onChange} />);
+    const input = screen.getByRole('textbox');
+    fireEvent.paste(input, {
+      clipboardData: { getData: (t: string) => (t === 'text' ? 'NVDA, MSFT, AAPL' : '') },
+    });
+    expect(onChange).toHaveBeenCalledWith(['AAPL', 'NVDA', 'MSFT']);
+  });
+
+  it('paste with no separators falls through to default Input behavior', () => {
+    const onChange = vi.fn();
+    render(<SymbolListField label="Symbols" value={['AAPL']} onChange={onChange} />);
+    const input = screen.getByRole('textbox');
+    // A single-symbol paste should NOT auto-commit — preserves edit-as-paste UX.
+    fireEvent.paste(input, {
+      clipboardData: { getData: (t: string) => (t === 'text' ? 'NVDA' : '') },
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('paste respects the cap and stops adding past it', () => {
+    const onChange = vi.fn();
+    render(<SymbolListField label="Symbols" value={['A']} onChange={onChange} max={3} />);
+    const input = screen.getByRole('textbox');
+    fireEvent.paste(input, {
+      clipboardData: { getData: (t: string) => (t === 'text' ? 'B, C, D, E' : '') },
+    });
+    // max=3, current=['A'] → can add 2 more: B + C. D and E dropped.
+    expect(onChange).toHaveBeenCalledWith(['A', 'B', 'C']);
+  });
+
+  it('shows the cap label only when at cap', () => {
+    const { rerender } = render(
+      <SymbolListField label="Symbols" value={['A']} onChange={vi.fn()} max={2} />,
+    );
+    expect(screen.queryByText(/max 2 symbols/i)).toBeNull();
+    rerender(<SymbolListField label="Symbols" value={['A', 'B']} onChange={vi.fn()} max={2} />);
+    expect(screen.getByText(/max 2 symbols/i)).toBeInTheDocument();
+  });
 });
 
 describe('EnumField', () => {

--- a/web/src/pages/Dashboard/widgets/framework/useDashboardPrefs.ts
+++ b/web/src/pages/Dashboard/widgets/framework/useDashboardPrefs.ts
@@ -3,14 +3,13 @@ import { useQueryClient } from '@tanstack/react-query';
 import { usePreferences } from '@/hooks/usePreferences';
 import { useToast } from '@/components/ui/use-toast';
 import { queryKeys } from '@/lib/queryKeys';
-import { useDashboardPrefsWriter } from './dashboardPrefsWriter';
+import { BROADCAST_CHANNEL, useDashboardPrefsWriter } from './dashboardPrefsWriter';
 import { migrateDashboardPrefs } from './migrations';
 import { getPreset, type PresetId } from '../presets';
 import { DASHBOARD_PREFS_VERSION, type DashboardPrefs } from '../types';
 
 const HISTORY_CAP = 3;
 const DEBOUNCE_MS = 800;
-const BROADCAST_CHANNEL = 'dashboard-prefs';
 
 function emptyPrefs(): DashboardPrefs {
   return {

--- a/web/src/pages/Dashboard/widgets/framework/useDashboardPrefs.ts
+++ b/web/src/pages/Dashboard/widgets/framework/useDashboardPrefs.ts
@@ -1,13 +1,16 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { usePreferences } from '@/hooks/usePreferences';
-import { useUpdatePreferences } from '@/hooks/useUpdatePreferences';
 import { useToast } from '@/components/ui/use-toast';
+import { queryKeys } from '@/lib/queryKeys';
+import { useDashboardPrefsWriter } from './dashboardPrefsWriter';
 import { migrateDashboardPrefs } from './migrations';
 import { getPreset, type PresetId } from '../presets';
 import { DASHBOARD_PREFS_VERSION, type DashboardPrefs } from '../types';
 
 const HISTORY_CAP = 3;
 const DEBOUNCE_MS = 800;
+const BROADCAST_CHANNEL = 'dashboard-prefs';
 
 function emptyPrefs(): DashboardPrefs {
   return {
@@ -26,37 +29,77 @@ function readDashboardPrefs(preferences: unknown): Partial<DashboardPrefs> | nul
 
 export function useDashboardPrefs() {
   const { preferences, isLoading } = usePreferences();
-  const updatePrefs = useUpdatePreferences();
+  const { writeDashboardPrefs, isPending } = useDashboardPrefsWriter();
   const { toast } = useToast();
+  const queryClient = useQueryClient();
 
   const raw = readDashboardPrefs(preferences);
   const stored = useMemo<DashboardPrefs>(() => migrateDashboardPrefs(raw) ?? emptyPrefs(), [raw]);
 
   const [local, setLocal] = useState<DashboardPrefs>(stored);
   const storedRef = useRef<DashboardPrefs>(stored);
-  const skipNextSyncRef = useRef(false);
-
-  // Ref-backed so the debounced flush always reads the current `other_preference`
-  // snapshot at fire time. Without this, a concurrent write to another preference
-  // key (theme, language) during the 800ms debounce would be overwritten when
-  // the flush spreads a stale snapshot.
-  const preferencesRef = useRef(preferences);
-  preferencesRef.current = preferences;
+  const ownWriteInFlightRef = useRef(false);
 
   useEffect(() => {
     storedRef.current = stored;
-    if (skipNextSyncRef.current) {
-      skipNextSyncRef.current = false;
+    if (ownWriteInFlightRef.current) {
+      ownWriteInFlightRef.current = false;
       return;
     }
     setLocal(stored);
   }, [stored]);
 
   const pendingTimer = useRef<number | null>(null);
+  const bcRef = useRef<BroadcastChannel | null>(null);
+  // isPending changes mid-effect-cycle; mirror via ref so the
+  // BroadcastChannel onmessage handler reads the latest value without
+  // tearing down + rebuilding the channel on every mutation transition.
+  const isMutatingRef = useRef(false);
+  isMutatingRef.current = isPending;
+  // Deferred-replay: a broadcast that arrives during a pending edit can't be
+  // applied immediately (refetching mid-edit would race the response). Set
+  // this flag instead and run the invalidate after the current edit settles
+  // so cross-tab changes still land — they just wait their turn.
+  const replayPendingRef = useRef(false);
+
+  const runReplay = useCallback(() => {
+    if (!replayPendingRef.current) return;
+    replayPendingRef.current = false;
+    queryClient.invalidateQueries({ queryKey: queryKeys.user.preferences() });
+  }, [queryClient]);
+
+  // After an in-flight mutation finishes, drain any deferred broadcast.
+  useEffect(() => {
+    if (!isPending) runReplay();
+  }, [isPending, runReplay]);
+
+  // Cross-tab notification: broadcast on flush success so other tabs invalidate
+  // their preferences cache and pull the fresh write. Falls back silently in
+  // browsers without BroadcastChannel (Safari < 15.4) — staleTime: 0 +
+  // refetchOnWindowFocus already covers the alt-tab case for those.
+  useEffect(() => {
+    if (typeof BroadcastChannel === 'undefined') return;
+    const chan = new BroadcastChannel(BROADCAST_CHANNEL);
+    bcRef.current = chan;
+    chan.onmessage = (e: MessageEvent) => {
+      if ((e.data as { type?: string } | null)?.type !== 'updated') return;
+      if (pendingTimer.current === null && !isMutatingRef.current) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.user.preferences() });
+      } else {
+        // Defer until the current edit settles — runs from either the flush
+        // timer's onSuccess/onError or the isPending effect above.
+        replayPendingRef.current = true;
+      }
+    };
+    return () => {
+      chan.close();
+      bcRef.current = null;
+    };
+  }, [queryClient]);
 
   const flush = useCallback(
     (next: DashboardPrefs) => {
-      skipNextSyncRef.current = true;
+      ownWriteInFlightRef.current = true;
       // Dev-only size trap: catches widget configs that bloat the prefs
       // blob before we ship them. The prefs are PATCHed as one payload,
       // so a widget with a 50-symbol array full of objects can balloon
@@ -74,44 +117,62 @@ export function useDashboardPrefs() {
           /* ignore sizing errors in dev */
         }
       }
-      const prevOther = ((preferencesRef.current as { other_preference?: Record<string, unknown> } | null | undefined)
-        ?.other_preference) ?? {};
-      updatePrefs.mutate(
-        {
-          other_preference: { ...prevOther, dashboard: next },
+      const accepted = writeDashboardPrefs(next, {
+        // The hook-provided preferences object is the React snapshot — pass
+        // it as a fallback so a near-cold write (cache empty but the GET has
+        // already populated React state) can still proceed without clobber.
+        fallbackOther: ((preferences as { other_preference?: Record<string, unknown> } | null)
+          ?.other_preference) ?? null,
+        onSuccess: runReplay,
+        onError: () => {
+          // Server rejected the write. Clear the sync guard so the invalidate
+          // → refetch in useUpdatePreferences can reconcile local state back to
+          // the server copy, and tell the user their change didn't stick.
+          ownWriteInFlightRef.current = false;
+          toast({
+            variant: 'destructive',
+            title: 'Couldn’t save dashboard',
+            description: 'Your latest change didn’t sync. We restored the last saved layout.',
+          });
+          runReplay();
         },
-        {
-          onError: () => {
-            // Server rejected the write. Clear the sync guard so the invalidate
-            // → refetch in useUpdatePreferences can reconcile local state back to
-            // the server copy, and tell the user their change didn't stick.
-            skipNextSyncRef.current = false;
-            toast({
-              variant: 'destructive',
-              title: 'Couldn’t save dashboard',
-              description: 'Your latest change didn’t sync. We restored the last saved layout.',
-            });
-          },
-        }
-      );
+      });
+      if (!accepted) {
+        // Cold-cache refusal — undo the sync-skip guard so the next render
+        // can reconcile local back to the server copy when the GET resolves.
+        ownWriteInFlightRef.current = false;
+      }
     },
-    [updatePrefs, toast]
+    [writeDashboardPrefs, preferences, runReplay, toast]
   );
 
   const update = useCallback(
     (patch: Partial<DashboardPrefs> | ((prev: DashboardPrefs) => DashboardPrefs), opts?: { immediate?: boolean }) => {
+      // Cold-cache gate: drop edits before the initial GET resolves so we
+      // don't construct a payload from `{}` and clobber server-side
+      // sibling other_preference keys (theme, locale, etc.).
+      if (isLoading) return;
       setLocal((prev) => {
         const next = typeof patch === 'function' ? patch(prev) : { ...prev, ...patch };
         if (pendingTimer.current) window.clearTimeout(pendingTimer.current);
         if (opts?.immediate) {
+          // Treat immediate writes as "no debounce queued" so a follow-up
+          // cross-tab broadcast can invalidate normally.
+          pendingTimer.current = null;
           flush(next);
         } else {
-          pendingTimer.current = window.setTimeout(() => flush(next), DEBOUNCE_MS);
+          // Reset the timer ref to null AFTER flush so the cross-tab onmessage
+          // handler sees an empty queue and runs the invalidate path. Without
+          // this reset the gate stays closed forever after the first edit.
+          pendingTimer.current = window.setTimeout(() => {
+            flush(next);
+            pendingTimer.current = null;
+          }, DEBOUNCE_MS);
         }
         return next;
       });
     },
-    [flush]
+    [flush, isLoading]
   );
 
   useEffect(

--- a/web/src/pages/Dashboard/widgets/framework/useDashboardPrefs.ts
+++ b/web/src/pages/Dashboard/widgets/framework/useDashboardPrefs.ts
@@ -117,11 +117,10 @@ export function useDashboardPrefs() {
         }
       }
       const accepted = writeDashboardPrefs(next, {
-        // The hook-provided preferences object is the React snapshot — pass
-        // it as a fallback so a near-cold write (cache empty but the GET has
-        // already populated React state) can still proceed without clobber.
-        fallbackOther: ((preferences as { other_preference?: Record<string, unknown> } | null)
-          ?.other_preference) ?? null,
+        // undefined = cold (writer refuses); null = warm w/ empty siblings.
+        fallbackOther: preferences === null
+          ? undefined
+          : ((preferences as { other_preference?: Record<string, unknown> }).other_preference ?? null),
         onSuccess: runReplay,
         onError: () => {
           // Server rejected the write. Clear the sync guard so the invalidate

--- a/web/src/pages/Dashboard/widgets/types.ts
+++ b/web/src/pages/Dashboard/widgets/types.ts
@@ -1,5 +1,6 @@
 import type { ComponentType } from 'react';
 import type { LucideIcon } from 'lucide-react';
+import type { z } from 'zod';
 import type { DashboardDataContextValue } from './framework/DashboardDataContext';
 
 export type WidgetCategory = 'markets' | 'intel' | 'personal' | 'agent' | 'workspace';
@@ -52,6 +53,16 @@ export interface WidgetDefinition<C = unknown> {
    * back to `defaultConfig` when undefined.
    */
   initConfig?: (ctx: DashboardDataContextValue) => C;
+  /**
+   * Optional Zod schema validating the widget's stored config. Applied at
+   * the prefs-load boundary (`migrations.ts` → `sanitizeConfig`) so a stored
+   * config whose shape has drifted from the current code (renamed enum,
+   * removed field, type drift) is auto-corrected to safe defaults instead
+   * of crashing the widget. Per-field `.catch()` recovers individual fields;
+   * a fully malformed config falls back to `defaultConfig`. Widgets without
+   * a schema pass through unchanged (back-compat).
+   */
+  configSchema?: z.ZodType<C>;
 }
 
 export interface WidgetInstance<C = unknown> {

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -9,11 +9,6 @@ export default defineConfig({
     setupFiles: ['./src/test/setup.ts'],
     globals: true,
     exclude: ['e2e/**', 'node_modules/**'],
-    // 10s default. Worker pool is CPU-contended when tests that use real
-    // react-query retry timers (up to 6s wall clock in useWorkspaceFiles)
-    // land on the same thread as Testing Library render()s — the default 5s
-    // starved the settings-atoms tests into spurious timeouts.
-    testTimeout: 10_000,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

Follow-up cleanup to PR #172 (TradingView widgets framework). Five logical commits, all bisectable:

**Schema validation (boil-the-lake)**
- Zod runtime schema at the prefs boundary for **all 30 widgets**. Stored configs survive enum renames, removed fields, and type drift instead of silently rendering garbage or clobbering on save.
- `migrateDashboardPrefs` gains an `isValidWidgetInstance` shape filter (drops null / string / id-less entries) and a per-breakpoint layouts filter (drops non-array bp values that crashed `reconcileLayouts`).
- TV symbol regex accepts `_` so `CME_MINI:ES1!` and `FX_IDC:EURUSD` round-trip cleanly.
- Symbol arrays use `.transform()` to drop bad entries + dedupe — no more `[bad, bad, AAPL]` becoming `[SPY, SPY, AAPL]`.

**Cross-tab + cold-cache safety**
- Two open tabs editing the dashboard would race: tab A's debounced PATCH succeeds, tab B's stale `other_preference` ref clobbers tab A on the next edit. Fast clicks before the initial GET resolved did the same to sibling keys (theme, locale).
- Shared `dashboardPrefsWriter` re-reads the freshest react-query snapshot at flush time, refuses cold-cache writes, and broadcasts on flush success via `BroadcastChannel('dashboard-prefs')` (typeof-guarded for Safari < 15.4).
- `DashboardRouter.onModeChange` uses the same writer + a no-op gate while `isLoading`.
- `usePreferences` `staleTime: 0` so `refetchOnWindowFocus` actually hits the network on alt-tab.

**Offline banner**
- `useNetworkStatus` + `<NetworkBanner />` mounted in `DashboardRouter` (covers Classic + Custom + mobile-forced-Classic). SSR-safe.

**UX polish**
- `SymbolListField` paste with commas / whitespace / semicolons splits into chips; input disabled at cap with placeholder rewrite.
- `MiniChartGridWidget` divide-by-zero guard (`prev=0` → 0% instead of NaN/Infinity).
- `WidgetFrame.css` edit-mode `iframe { pointer-events: none }` kills iframe-eats-touch-drag on tablets for both iframe and web-component TV embeds.

**Test backfill + infra**
- New tests: `AddWidgetDialog`, `PresetsDialog`, `TradingViewWebComponent`, `MiniChartGridWidget`, `NetworkBanner`, `useNetworkStatus`, `usePreferences`, `DashboardRouter`. Extended: `migrations`, `presets`, `useDashboardPrefs`, `settings-atoms`.
- Reverted `vitest.config.ts` `testTimeout` from 10s → 5s after fixing `useWorkspaceFiles` to use `vi.useFakeTimers`.

## Test Coverage

- 697 / 697 frontend tests pass (vitest, jsdom).
- Tsc clean. Lint: 0 errors (90 pre-existing warnings, none from this branch).
- Coverage focused on the new boundaries: schema sanitization, replay-aware writer, cold-cache refusal, deferred broadcast, paste handler, divide-by-zero.

## Pre-Landing Review

CLEAR — quality 9.0/10, 19 findings, all addressed:
- 9 auto-fixed (schema gaps, version-drift, mobile-banner, invisible-border, divide-by-zero, misleading CSP doc).
- 7 fixed (cold-cache clobber × 2, cross-tab broadcast, deferred replay, paste handler, polyfill bleed, silent-data-loss × 2).
- 3 skipped with notes (overbroad `widget-drag-cancel` selector, perf staleTime tradeoff, enum-options-drift refactor — deferred).

## Adversarial Review

Both Claude adversarial subagent and Codex passes ran. Findings folded into the fix list above (cold-cache clobber, late iframe locale rebuild, symbol cap drift were the key catches).

## Verification (manual checklist for reviewer)

- [ ] Two-tab edit: change layout in tab A, confirm tab B picks it up after focus / next edit; mode toggle in B doesn't clobber A.
- [ ] DevTools offline: banner appears in both Classic and Custom modes (and mobile-forced Classic).
- [ ] iPad emulator: drag a TV widget tile in edit mode (no iframe steal).
- [ ] Paste `NVDA, AAPL MSFT;TSLA` into a SymbolListField → 4 chips.
- [ ] Edit prefs blob in localStorage to set bogus `displayMode` → reload, widget still renders, prefs auto-corrected on next save.
- [ ] Edit prefs blob to add a malformed widget instance (missing id) → reload, dashboard skips it without crashing.

## Test plan

- [x] `pnpm vitest run` — 697 / 697 pass
- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm lint` — 0 errors

## Documentation

- `web/README.md` — Rewrote the **Market Dashboard** feature line to describe the configurable widget gallery (30+ widgets, drag-and-drop, per-widget settings persisted via user preferences with Zod validation, cross-tab sync, offline banner). Added a `Schema validation` row to the Tech Stack table for `zod`. Updated the project-structure tree to call out the Dashboard as a configurable widget gallery rather than a static watchlist/portfolio overview.
- `web/CLAUDE.md` — Replaced the `/dashboard` route description to point at `pages/Dashboard/widgets/framework/`. Added `useNetworkStatus` to the shared hooks list. Added a **Dashboard preferences** paragraph under *Data Fetching* covering `useDashboardPrefs`, `configSchemas.ts`, the guarded `dashboardPrefsWriter.ts`, cold-cache safety, and cross-tab sync via the `usePreferences` query cache.
- `CLAUDE.md` (root) — Updated the `pages/Dashboard/` row in the Frontend table from "Overview with watchlist, portfolio, news" to "Configurable widget gallery (watchlist, portfolio, news, TradingView widgets, mini-chart grid). Per-widget config validated with Zod at the prefs boundary."