### PR TITLE
fix(memo): hardening + cross-worker metadata cancel

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -109,6 +109,8 @@ redis:
     workflow_status: 3600   # Completed/cancelled workflow status key TTL (1 hour)
     cancel_flag: 300        # Workflow cancel flag TTL (5 minutes)
     steering: 3600          # Steering message key TTL (1 hour)
+    memo_metadata_inflight: 300  # Cross-worker visibility of in-flight memo metadata tasks (5 minutes)
+    memo_metadata_cancel: 60     # Cooperative cross-worker cancel flag for memo metadata (1 minute)
 
     # Per-interval OHLCV cache TTLs (≈ interval_seconds × 1.5)
     # SWR soft threshold stays at 50% of these values

--- a/src/config/models.py
+++ b/src/config/models.py
@@ -106,6 +106,19 @@ class RedisTTLConfig(BaseModel):
     steering: int = Field(
         default=3600, description="TTL for steering message Redis keys (1 hour)"
     )
+    memo_metadata_inflight: int = Field(
+        default=300,
+        description=(
+            "TTL for the cross-worker visibility key marking a memo metadata "
+            "task as in flight (5 minutes)"
+        ),
+    )
+    memo_metadata_cancel: int = Field(
+        default=60,
+        description=(
+            "TTL for the cooperative cross-worker memo metadata cancel flag (1 minute)"
+        ),
+    )
 
 
 class RedisSWRConfig(BaseModel):

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -290,6 +290,16 @@ def get_redis_ttl_steering() -> int:
     return get_infrastructure_config().redis.ttl.steering
 
 
+def get_redis_ttl_memo_metadata_inflight() -> int:
+    """Get Redis TTL for the memo metadata in-flight visibility key (seconds)."""
+    return get_infrastructure_config().redis.ttl.memo_metadata_inflight
+
+
+def get_redis_ttl_memo_metadata_cancel() -> int:
+    """Get Redis TTL for the memo metadata cooperative cancel flag (seconds)."""
+    return get_infrastructure_config().redis.ttl.memo_metadata_cancel
+
+
 def is_cache_invalidate_on_write_enabled() -> bool:
     """Check if cache invalidation on write is enabled."""
     return get_infrastructure_config().redis.cache_invalidate_on_write

--- a/src/ptc_agent/agent/memo/_time.py
+++ b/src/ptc_agent/agent/memo/_time.py
@@ -1,0 +1,15 @@
+"""ISO-8601 timestamp helpers for memo rows.
+
+Microsecond resolution. Burst regenerate (multiple writes inside the same
+wall-clock second) needs distinct timestamps so the ``modified_at`` CAS in
+``_merge_metadata`` / ``_mark_failed`` keeps distinguishing snapshots.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+
+def now_iso() -> str:
+    """Current UTC time as ``YYYY-MM-DDTHH:MM:SS.ffffffZ``."""
+    return datetime.now(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")

--- a/src/ptc_agent/agent/memo/cache_keys.py
+++ b/src/ptc_agent/agent/memo/cache_keys.py
@@ -1,0 +1,17 @@
+"""Redis key builders for memo metadata coordination.
+
+Lives in the agent layer so ``metadata.py`` (agent) and ``memo.py`` (server)
+can both import without crossing the agent → server boundary.
+"""
+
+from __future__ import annotations
+
+
+def memo_metadata_inflight_key(user_id: str, key: str) -> str:
+    """Redis key advertising that some worker is generating metadata for this memo."""
+    return f"memo:metadata:inflight:{user_id}:{key}"
+
+
+def memo_metadata_cancel_key(user_id: str, key: str) -> str:
+    """Redis key carrying a cooperative cross-worker cancel signal for this memo."""
+    return f"memo:metadata:cancel:{user_id}:{key}"

--- a/src/ptc_agent/agent/memo/index.py
+++ b/src/ptc_agent/agent/memo/index.py
@@ -10,12 +10,12 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
-from datetime import UTC, datetime
 from hashlib import sha256
 from typing import Any
 
 from langgraph.store.base import BaseStore
 
+from ptc_agent.agent.memo._time import now_iso
 from ptc_agent.agent.memo.schema import (
     METADATA_PLACEHOLDER_DESCRIPTION,
 )
@@ -89,7 +89,7 @@ def _format_entry(item: Any) -> str:
 def _render_memo_md(items: list[Any]) -> str:
     """Render the complete memo.md body from sorted memo items."""
     # Items are already sorted by the caller; preserve order.
-    now = datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+    now = now_iso()
     count = len(items)
     header = [
         "# Memos",
@@ -176,7 +176,7 @@ async def rebuild_memo_index(
     items = await _collect_items(store, namespace)
     state_hash = _index_state_hash(items)
 
-    now = datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+    now = now_iso()
     existing_created = now
     existing_hash: str | None = None
     try:

--- a/src/ptc_agent/agent/memo/metadata.py
+++ b/src/ptc_agent/agent/memo/metadata.py
@@ -12,16 +12,19 @@ import asyncio
 import logging
 import re
 import secrets
-from datetime import UTC, datetime
 from typing import Any
 
 from langgraph.store.base import BaseStore
 
+from ptc_agent.agent.backends import lock_for_namespace
+from ptc_agent.agent.memo._time import now_iso
+from ptc_agent.agent.memo.cache_keys import memo_metadata_cancel_key
 from ptc_agent.agent.memo.index import rebuild_memo_index
 from ptc_agent.agent.memo.schema import (
     METADATA_LLM_CONTENT_CHARS,
     MemoMetadata,
 )
+from src.utils.cache.redis_cache import get_cache_client
 
 logger = logging.getLogger(__name__)
 
@@ -139,7 +142,7 @@ async def _mark_failed(
             extra={"namespace": namespace, "key": key},
         )
         return
-    now = datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+    now = now_iso()
     updated = {
         **item.value,
         "metadata_status": "failed",
@@ -201,7 +204,7 @@ async def _merge_metadata(
         )
         return
     current_value = item.value
-    now = datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+    now = now_iso()
     updated = {
         **current_value,
         "description": metadata.description,
@@ -221,6 +224,22 @@ async def _merge_metadata(
             "memo metadata-merge aput failed",
             extra={"namespace": namespace, "key": key},
         )
+
+
+async def _is_cross_worker_cancelled(user_id: str | None, key: str) -> bool:
+    """Check the Redis cancel flag for this memo.
+
+    Fail-open: any Redis error is treated as "not cancelled" so a cache
+    outage never strands metadata generation.
+    """
+    if user_id is None:
+        return False
+    try:
+        flag = await get_cache_client().get(memo_metadata_cancel_key(user_id, key))
+    except Exception:
+        logger.debug("memo cross-worker cancel poll failed", exc_info=True)
+        return False
+    return flag is not None
 
 
 async def generate_memo_metadata(
@@ -263,6 +282,16 @@ async def generate_memo_metadata(
         value.get("modified_at") if isinstance(value.get("modified_at"), str) else None
     )
 
+    # Pre-LLM checkpoint: skip the call entirely if a sibling worker already
+    # asked us to cancel (e.g. delete on worker A while we picked up the row
+    # on worker B).
+    if await _is_cross_worker_cancelled(user_id, key):
+        logger.info(
+            "memo metadata cross-worker-cancelled before LLM call",
+            extra={"namespace": namespace, "key": key},
+        )
+        return
+
     try:
         metadata = await asyncio.wait_for(
             llm_service.complete(
@@ -289,27 +318,40 @@ async def generate_memo_metadata(
                 "timeout_s": _LLM_CALL_TIMEOUT_S,
             },
         )
-        await _mark_failed(
-            store, namespace, key,
-            f"LLM call timed out after {_LLM_CALL_TIMEOUT_S}s",
-            expected_modified_at=expected_modified_at,
-        )
-        await rebuild_memo_index(store, namespace)
+        async with lock_for_namespace(namespace):
+            await _mark_failed(
+                store, namespace, key,
+                f"LLM call timed out after {_LLM_CALL_TIMEOUT_S}s",
+                expected_modified_at=expected_modified_at,
+            )
+            await rebuild_memo_index(store, namespace)
         return
     except Exception as exc:
         logger.exception(
             "memo metadata LLM call failed",
             extra={"namespace": namespace, "key": key},
         )
-        await _mark_failed(
-            store, namespace, key, str(exc),
+        async with lock_for_namespace(namespace):
+            await _mark_failed(
+                store, namespace, key, str(exc),
+                expected_modified_at=expected_modified_at,
+            )
+            await rebuild_memo_index(store, namespace)
+        return
+
+    # Post-LLM checkpoint: a delete that landed during the LLM call should
+    # short-circuit the merge so we don't spend the round trip to the store
+    # only to have the CAS in _merge_metadata bounce.
+    if await _is_cross_worker_cancelled(user_id, key):
+        logger.info(
+            "memo metadata cross-worker-cancelled after LLM call",
+            extra={"namespace": namespace, "key": key},
+        )
+        return
+
+    async with lock_for_namespace(namespace):
+        await _merge_metadata(
+            store, namespace, key, metadata,
             expected_modified_at=expected_modified_at,
         )
         await rebuild_memo_index(store, namespace)
-        return
-
-    await _merge_metadata(
-        store, namespace, key, metadata,
-        expected_modified_at=expected_modified_at,
-    )
-    await rebuild_memo_index(store, namespace)

--- a/src/server/app/memo.py
+++ b/src/server/app/memo.py
@@ -156,23 +156,21 @@ async def _kickoff_metadata_handover(user_id: str, key: str) -> None:
     Single coroutine so the SET → DELETE → SET sequence at Redis is ordered
     from this worker's perspective. ``_kickoff_metadata`` awaits this before
     spawning the new metadata task so the new task cannot observe the
-    transient cancel flag, even if a partial Redis failure leaves DELETE
-    unrun (the awaiting caller still sees the success/failure outcome).
+    transient cancel flag we just set for sibling workers. Raises on Redis
+    failure so the caller can choose to skip task creation rather than
+    spawn one that may self-abort against a stuck cancel flag.
     """
-    try:
-        cache = get_cache_client()
-        cancel_key = memo_metadata_cancel_key(user_id, key)
-        await cache.set(
-            cancel_key, "1", ttl=get_redis_ttl_memo_metadata_cancel(),
-        )
-        await cache.delete(cancel_key)
-        await cache.set(
-            memo_metadata_inflight_key(user_id, key),
-            {"started_at": now_iso()},
-            ttl=get_redis_ttl_memo_metadata_inflight(),
-        )
-    except Exception:
-        logger.debug("memo metadata handover failed", exc_info=True)
+    cache = get_cache_client()
+    cancel_key = memo_metadata_cancel_key(user_id, key)
+    await cache.set(
+        cancel_key, "1", ttl=get_redis_ttl_memo_metadata_cancel(),
+    )
+    await cache.delete(cancel_key)
+    await cache.set(
+        memo_metadata_inflight_key(user_id, key),
+        {"started_at": now_iso()},
+        ttl=get_redis_ttl_memo_metadata_inflight(),
+    )
 
 
 def _namespace(user_id: str) -> tuple[str, ...]:
@@ -432,7 +430,20 @@ async def _kickoff_metadata(
     # time the new task reaches its cancel poll, so it cannot observe the
     # transient cancel flag we just set for sibling workers.
     _cancel_local_metadata_task(namespace, key)
-    await _kickoff_metadata_handover(user_id, key)
+    try:
+        await _kickoff_metadata_handover(user_id, key)
+    except Exception:
+        # If the handover failed mid-sequence (e.g. SET cancel succeeded but
+        # DELETE failed), the cancel flag could persist for its 60s TTL and
+        # any task we spawn now would self-abort at its pre-LLM cancel poll.
+        # Skip task creation; caller rebuilds the index itself. The user can
+        # hit Regenerate once Redis recovers.
+        logger.warning(
+            "memo metadata handover failed; skipping metadata task",
+            extra={"memo_key": key},
+            exc_info=True,
+        )
+        return False
 
     task = asyncio.create_task(
         generate_memo_metadata(
@@ -933,8 +944,7 @@ async def delete_user_memo(
     if isinstance(binary_ref, dict):
         await memo_binary_storage.delete_binary(binary_ref)
 
-    async with lock_for_namespace(namespace):
-        await rebuild_memo_index(store, namespace)
+    await _rebuild_index_under_lock(store, namespace)
     return {"status": "deleted", "key": key}
 
 

--- a/src/server/app/memo.py
+++ b/src/server/app/memo.py
@@ -24,7 +24,6 @@ import binascii
 import contextlib
 import logging
 import re
-from datetime import UTC, datetime
 from hashlib import sha256
 from typing import Annotated, Any
 from urllib.parse import quote
@@ -53,10 +52,19 @@ from ptc_agent.agent.memo import (
     random_collision_slug,
     slug_components,
 )
+from ptc_agent.agent.memo._time import now_iso
+from ptc_agent.agent.memo.cache_keys import (
+    memo_metadata_cancel_key,
+    memo_metadata_inflight_key,
+)
 from ptc_agent.agent.memo.content_types import is_pdf, resolve_mime_type
 from ptc_agent.agent.memo.index import rebuild_memo_index
 from ptc_agent.agent.memo.metadata import generate_memo_metadata
 from ptc_agent.core.paths import MEMO_INDEX_FILENAME
+from src.config.settings import (
+    get_redis_ttl_memo_metadata_cancel,
+    get_redis_ttl_memo_metadata_inflight,
+)
 from src.server.app import setup
 from src.server.app._store_helpers import (
     MAX_LIST_LIMIT,
@@ -72,6 +80,7 @@ from src.server.app._store_helpers import (
 from src.server.services import memo_binary_storage
 from src.server.database.workspace import get_workspace as db_get_workspace
 from src.server.utils.api import CurrentUserId, require_workspace_owner
+from src.utils.cache.redis_cache import get_cache_client
 
 logger = logging.getLogger(__name__)
 
@@ -79,25 +88,90 @@ router = APIRouter(prefix="/api/v1/memo", tags=["Memo"])
 
 _INDEX_KEY = MEMO_INDEX_FILENAME
 
-# Per-key registry of in-flight metadata tasks so a delete or replace can
-# cancel the prior task before issuing the new write. Without this, an LLM
-# call that resolves AFTER the user deleted the row would resurrect it via
-# the post-LLM ``_merge_metadata`` aput, or stamp stale description/summary
-# onto newer content if the user re-uploaded mid-flight. Keyed by
-# ``(namespace, key)`` so different memos do not interfere.
+# Per-key registry of in-flight metadata tasks. Process-local; the Redis
+# cancel flag is what crosses worker boundaries.
+#
+# Known limitation: the inflight Redis key is set/cleared but is not yet
+# surfaced via any GET endpoint. On a worker crash mid-LLM, the row stays
+# at ``metadata_status="pending"`` until the next user action (regenerate,
+# reupload, delete) since no client-visible signal can disambiguate
+# "actively generating" from "stranded". Follow-up: expose the inflight
+# key as a derived field on read/list, or add a dedicated polling endpoint.
 _TaskKey = tuple[tuple[str, ...], str]
 _METADATA_TASKS: dict[_TaskKey, asyncio.Task[Any]] = {}
 
+# Strong refs for fire-and-forget background coroutines. asyncio holds only
+# weak refs to tasks (Py3.11+), so without this set tasks can be GC'd before
+# their first await resolves and the cache op silently never lands.
+_BACKGROUND_TASKS: set[asyncio.Task[Any]] = set()
 
-def _cancel_pending_metadata(namespace: tuple[str, ...], key: str) -> None:
-    """Cancel any in-flight metadata task for this key (best effort)."""
+
+def _spawn_background(coro: Any) -> asyncio.Task[Any]:
+    """Schedule a fire-and-forget coroutine and keep a strong ref."""
+    task = asyncio.create_task(coro)
+    _BACKGROUND_TASKS.add(task)
+    task.add_done_callback(_BACKGROUND_TASKS.discard)
+    return task
+
+
+async def _signal_cross_worker_cancel(user_id: str, key: str) -> None:
+    """Write the cross-worker cancel flag to Redis; best-effort on cache outage."""
+    try:
+        cache = get_cache_client()
+        await cache.set(
+            memo_metadata_cancel_key(user_id, key),
+            "1",
+            ttl=get_redis_ttl_memo_metadata_cancel(),
+        )
+    except Exception:
+        # Cache outage: in-process cancel already ran; cross-worker is best-effort.
+        logger.debug("memo cross-worker cancel signal failed", exc_info=True)
+
+
+def _cancel_local_metadata_task(namespace: tuple[str, ...], key: str) -> None:
+    """Pop and cancel the registered metadata asyncio.Task for this key, if live."""
     task = _METADATA_TASKS.pop((namespace, key), None)
     if task is not None and not task.done():
         task.cancel()
 
 
-def _now_iso() -> str:
-    return datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+def _cancel_pending_metadata(
+    namespace: tuple[str, ...], key: str, *, user_id: str | None = None,
+) -> None:
+    """Cancel the local in-flight metadata task and raise the cross-worker flag.
+
+    ``user_id`` is optional; callers without it get the in-process cancel only.
+    Use this from delete-style paths that don't immediately re-spawn a new
+    task — the kickoff path uses ``_kickoff_metadata_handover`` instead so
+    the cancel flag set/clear happens in a single ordered Redis sequence.
+    """
+    _cancel_local_metadata_task(namespace, key)
+    if user_id is not None:
+        _spawn_background(_signal_cross_worker_cancel(user_id, key))
+
+
+async def _kickoff_metadata_handover(user_id: str, key: str) -> None:
+    """Cross-worker handover for the kickoff path: cancel siblings, then claim slot.
+
+    Single coroutine so the SET → DELETE → SET sequence at Redis is ordered
+    from this worker's perspective. A sibling-worker task observes the cancel
+    during the brief SET window; our own new task sees a cleared flag once
+    DELETE has run, so it never self-aborts.
+    """
+    try:
+        cache = get_cache_client()
+        cancel_key = memo_metadata_cancel_key(user_id, key)
+        await cache.set(
+            cancel_key, "1", ttl=get_redis_ttl_memo_metadata_cancel(),
+        )
+        await cache.delete(cancel_key)
+        await cache.set(
+            memo_metadata_inflight_key(user_id, key),
+            {"started_at": now_iso()},
+            ttl=get_redis_ttl_memo_metadata_inflight(),
+        )
+    except Exception:
+        logger.debug("memo metadata handover failed", exc_info=True)
 
 
 def _namespace(user_id: str) -> tuple[str, ...]:
@@ -328,30 +402,34 @@ async def _resolve_unique_slug(
     return random_collision_slug(base, suffix)
 
 
+async def _rebuild_index_under_lock(
+    store: Any, namespace: tuple[str, ...]
+) -> None:
+    async with lock_for_namespace(namespace):
+        await rebuild_memo_index(store, namespace)
+
+
 def _kickoff_metadata(
     *, user_id: str, namespace: tuple[str, ...], key: str
 ) -> bool:
     """Dispatch a background LLM call. Requires setup.llm_service to be wired.
 
-    Cancels any in-flight task for the same ``(namespace, key)`` before
-    scheduling — a fresh upload/write/regen supersedes a prior pending
-    metadata generation, so we don't want a stale LLM result writing the
-    older description over the new content.
-
-    Returns ``True`` when a task was scheduled. Callers use the return value
-    to decide whether to do their own ``rebuild_memo_index`` — when the
-    metadata task is going to call rebuild after the LLM resolves, the
-    caller's placeholder rebuild is redundant. When ``False`` (no LLM
-    service configured), the caller MUST rebuild itself.
+    Returns ``True`` when scheduled. Callers use the return value to skip
+    their own placeholder rebuild — the metadata task does its own rebuild
+    after the LLM resolves. ``False`` means the caller MUST rebuild itself.
     """
     llm_service = getattr(setup, "llm_service", None)
     if llm_service is None:
         logger.warning(
             "memo: llm_service not configured; skipping metadata generation",
-            extra={"key": key},
+            extra={"memo_key": key},
         )
         return False
-    _cancel_pending_metadata(namespace, key)
+    # In-process cancel runs synchronously; cross-worker cancel+inflight claim
+    # runs as a single ordered coroutine via _kickoff_metadata_handover.
+    _cancel_local_metadata_task(namespace, key)
+    _spawn_background(_kickoff_metadata_handover(user_id, key))
+
     task = asyncio.create_task(
         generate_memo_metadata(
             store=setup.store,
@@ -370,6 +448,15 @@ def _kickoff_metadata(
         current = _METADATA_TASKS.get((namespace, key))
         if current is _t:
             _METADATA_TASKS.pop((namespace, key), None)
+        # Best-effort: clear the in-flight visibility key so the UI doesn't
+        # show "regenerating" past the actual task lifetime.
+        async def _clear_inflight() -> None:
+            try:
+                cache = get_cache_client()
+                await cache.delete(memo_metadata_inflight_key(user_id, key))
+            except Exception:
+                logger.debug("memo inflight clear failed", exc_info=True)
+        _spawn_background(_clear_inflight())
 
     task.add_done_callback(_cleanup)
     return True
@@ -456,6 +543,12 @@ async def upload_user_memo(
                 ),
             ) from exc
 
+    # Postgres JSONB rejects NUL bytes in text. pdfminer occasionally emits
+    # \x00 from malformed font glyphs, and uploaded text files can contain
+    # stray NULs too. Strip at the ingestion boundary so the store write
+    # never trips UntranslatableCharacter.
+    content = content.replace("\x00", "")
+
     content_bytes = len(content.encode("utf-8"))
     if content_bytes > MEMO_MAX_CONTENT_BYTES:
         raise HTTPException(
@@ -469,127 +562,143 @@ async def upload_user_memo(
     namespace = _namespace(user_id)
     original_filename = file.filename or "memo"
 
-    # Slug allocation + dedup + aput run under the namespace lock so two
-    # concurrent uploads with the same filename or same sandbox source can't
-    # both observe an empty slot and both write — the prior code raced both
-    # ``_find_by_source`` and ``_resolve_unique_slug``'s aget probes.
-    async with lock_for_namespace(namespace):
-        # Dedup-by-source: re-uploading the same sandbox file replaces the
-        # existing entry instead of growing a new slug suffix.
-        is_sandbox_source = (
-            source_kind == "sandbox"
-            and source_workspace_id
-            and source_path
-        )
-        existing: tuple[str, dict[str, Any]] | None = None
-        if is_sandbox_source:
-            existing = await _find_by_source(
-                store,
-                namespace,
-                workspace_id=source_workspace_id,
-                path=source_path,
-            )
-
-        if existing is not None:
-            key, prev_value = existing
-            replaced = True
-            # Preserve created_at across replacements; only modified_at advances.
-            prior_binary_ref = prev_value.get("binary_ref")
-            created_at = prev_value.get("created_at") or _now_iso()
-        else:
-            key = await _resolve_unique_slug(
-                store, namespace, original_filename,
-            )
-            replaced = False
-            prior_binary_ref = None
-            created_at = _now_iso()
-
-        # Final safety: the slug must pass the store's own validator.
-        validate_key(key)
-        if key == _INDEX_KEY:
-            # Catalog file is server-maintained; refuse uploads that would clobber it.
-            raise HTTPException(
-                status_code=400,
-                detail=(
-                    f"'{_INDEX_KEY}' is a reserved key for the memo catalog. "
-                    "Rename the file before uploading."
-                ),
-            )
-
-        # Binary stash (PDF only) ----------------------------------------
-        # We upload the original bytes to object storage BEFORE the row aput
-        # so the row never points at a missing object. If the row aput then
-        # fails, we revert the upload to avoid orphan bytes in the bucket.
-        binary_ref: dict[str, Any] | None = None
-        original_bytes_b64: str | None = None
-        if is_pdf(mime_type):
-            if memo_binary_storage.is_configured():
-                try:
-                    binary_ref = await memo_binary_storage.store_binary(
-                        user_id=user_id,
-                        key=key,
-                        content=raw,
-                        content_type=mime_type,
-                    )
-                except memo_binary_storage.MemoBinaryUploadError as exc:
-                    logger.exception(
-                        "memo binary upload failed",
-                        extra={"user_id": user_id, "key": key},
-                    )
-                    raise HTTPException(
-                        status_code=500,
-                        detail="Could not store the original file — please retry.",
-                    ) from exc
-            else:
-                original_bytes_b64 = base64.b64encode(raw).decode("ascii")
-
-        # Build value and persist ----------------------------------------
-        now = _now_iso()
-        value: dict[str, Any] = {
-            "content": content,
-            "encoding": "utf-8",
-            "mime_type": mime_type,
-            "original_filename": original_filename,
-            "key": key,
-            "size_bytes": content_bytes,
-            "sha256": sha256(content.encode("utf-8")).hexdigest(),
-            "description": METADATA_PLACEHOLDER_DESCRIPTION,
-            "summary": "",
-            "metadata_status": "pending",
-            "metadata_error": None,
-            "binary_ref": binary_ref,
-            "original_bytes_b64": original_bytes_b64,
-            "created_at": created_at,
-            "modified_at": now,
-            "metadata_generated_at": None,
-            "source_kind": source_kind,
-            "source_workspace_id": source_workspace_id,
-            "source_path": source_path,
-        }
-        try:
-            await aput(store, namespace, key, value)
-        except Exception:
-            # Roll back the just-uploaded binary so we don't leave an orphan
-            # blob in R2/S3 with no row referencing it. delete_binary is
-            # best-effort; failing to revert just leaves the orphan, which
-            # is the same end-state we'd have without this rollback.
-            if binary_ref is not None:
-                with contextlib.suppress(Exception):
-                    await memo_binary_storage.delete_binary(binary_ref)
-            raise
-
-    # Replace-PDF-with-text: drop the orphaned object AFTER the row aput
-    # succeeds. Doing this before would leave a row referencing a deleted
-    # binary if aput later failed.
-    if replaced and prior_binary_ref and not is_pdf(mime_type):
+    # Phase A — outside the lock. Object-storage PUT is the slow part of
+    # an upload (~3–5 s for a multi-MB PDF). Issuing it before we acquire
+    # the per-user lock means concurrent memo ops for the same user no
+    # longer queue behind the upload's S3 round trip. Storage keys are
+    # UUIDs, so we never need to coordinate with the slug we'll allocate
+    # under the lock.
+    binary_ref: dict[str, Any] | None = None
+    original_bytes_b64: str | None = None
+    if is_pdf(mime_type):
         if memo_binary_storage.is_configured():
             try:
-                await memo_binary_storage.delete_binary(prior_binary_ref)
-            except Exception:
+                binary_ref = await memo_binary_storage.store_binary(
+                    user_id=user_id,
+                    content=raw,
+                    content_type=mime_type,
+                )
+            except memo_binary_storage.MemoBinaryUploadError as exc:
                 logger.exception(
-                    "memo binary delete failed during replace",
+                    "memo binary upload failed",
+                    extra={"user_id": user_id, "original_filename": original_filename},
+                )
+                # 502: upstream object store failure mirrors the symmetric
+                # download path (`MemoBinaryFetchError` → 502 below).
+                raise HTTPException(
+                    status_code=502,
+                    detail="Could not store the original file — please retry.",
+                ) from exc
+        else:
+            original_bytes_b64 = base64.b64encode(raw).decode("ascii")
+
+    # Phase B — inside the lock. Dedup, slug resolution, and the row aput
+    # must serialize against concurrent uploads/writes/deletes for this
+    # user so two callers can't both observe an empty slot and both write.
+    phase_b_succeeded = False
+    try:
+        async with lock_for_namespace(namespace):
+            # Dedup-by-source: re-uploading the same sandbox file replaces
+            # the existing entry instead of growing a new slug suffix.
+            is_sandbox_source = (
+                source_kind == "sandbox"
+                and source_workspace_id
+                and source_path
+            )
+            existing: tuple[str, dict[str, Any]] | None = None
+            if is_sandbox_source:
+                existing = await _find_by_source(
+                    store,
+                    namespace,
+                    workspace_id=source_workspace_id,
+                    path=source_path,
+                )
+
+            if existing is not None:
+                key, prev_value = existing
+                replaced = True
+                # Preserve created_at across replacements; only modified_at advances.
+                prior_binary_ref = prev_value.get("binary_ref")
+                created_at = prev_value.get("created_at") or now_iso()
+            else:
+                key = await _resolve_unique_slug(
+                    store, namespace, original_filename,
+                )
+                replaced = False
+                prior_binary_ref = None
+                created_at = now_iso()
+
+            # Final safety: the slug must pass the store's own validator.
+            validate_key(key)
+            if key == _INDEX_KEY:
+                # Catalog file is server-maintained; refuse uploads that would clobber it.
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"'{_INDEX_KEY}' is a reserved key for the memo catalog. "
+                        "Rename the file before uploading."
+                    ),
+                )
+
+            now = now_iso()
+            value: dict[str, Any] = {
+                "content": content,
+                "encoding": "utf-8",
+                "mime_type": mime_type,
+                "original_filename": original_filename,
+                "key": key,
+                "size_bytes": content_bytes,
+                "sha256": sha256(content.encode("utf-8")).hexdigest(),
+                "description": METADATA_PLACEHOLDER_DESCRIPTION,
+                "summary": "",
+                "metadata_status": "pending",
+                "metadata_error": None,
+                "binary_ref": binary_ref,
+                "original_bytes_b64": original_bytes_b64,
+                "created_at": created_at,
+                "modified_at": now,
+                "metadata_generated_at": None,
+                "source_kind": source_kind,
+                "source_workspace_id": source_workspace_id,
+                "source_path": source_path,
+            }
+            try:
+                await aput(store, namespace, key, value)
+            except HTTPException:
+                raise
+            except Exception as exc:
+                # Convert raw store outages into a clean 503 with retry intent
+                # so clients can backoff/retry instead of seeing a bare 500.
+                logger.exception(
+                    "memo store aput failed during upload",
                     extra={"user_id": user_id, "key": key},
                 )
+                raise HTTPException(
+                    status_code=503,
+                    detail="Memo store unavailable — please retry.",
+                ) from exc
+            phase_b_succeeded = True
+    finally:
+        # Drop the Phase A blob unless Phase B landed the row pointing at it.
+        # try/finally + flag (not `except Exception`) so CancelledError on
+        # client disconnect also triggers cleanup.
+        if not phase_b_succeeded and binary_ref is not None:
+            with contextlib.suppress(Exception):
+                await memo_binary_storage.delete_binary(binary_ref)
+
+    # Drop the prior blob whenever a replace lands. UUID storage keys mean
+    # every upload owns a distinct blob (PDF→PDF, PDF→text, anything), so
+    # the prior_binary_ref is never the same object as the new binary_ref.
+    # Run AFTER the row aput so a failed aput doesn't leave a row pointing
+    # at a deleted binary.
+    if replaced and prior_binary_ref and memo_binary_storage.is_configured():
+        try:
+            await memo_binary_storage.delete_binary(prior_binary_ref)
+        except Exception:
+            logger.exception(
+                "memo binary delete failed during replace",
+                extra={"user_id": user_id, "key": key},
+            )
 
     # When metadata generation is dispatched, the background task rebuilds
     # the index after the LLM resolves — doing it here too writes memo.md
@@ -599,7 +708,7 @@ async def upload_user_memo(
         user_id=user_id, namespace=namespace, key=key
     )
     if not metadata_dispatched:
-        await rebuild_memo_index(store, namespace)
+        await _rebuild_index_under_lock(store, namespace)
 
     return MemoUploadResponse(
         key=key,
@@ -625,7 +734,10 @@ async def write_user_memo(
     _reject_reserved_key(body.key)
 
     namespace = _namespace(user_id)
-    content_bytes = len(body.content.encode("utf-8"))
+    # See upload_user_memo: strip NULs at the ingestion boundary because
+    # Postgres JSONB rejects \x00 in text fields.
+    content = body.content.replace("\x00", "")
+    content_bytes = len(content.encode("utf-8"))
     if content_bytes > MEMO_MAX_CONTENT_BYTES:
         raise HTTPException(
             status_code=413,
@@ -655,7 +767,7 @@ async def write_user_memo(
                 ),
             )
 
-        new_hash = sha256(body.content.encode("utf-8")).hexdigest()
+        new_hash = sha256(content.encode("utf-8")).hexdigest()
         if new_hash == existing_value.get("sha256"):
             # No-op — content unchanged. Don't rebuild, don't regenerate.
             return MemoUploadResponse(
@@ -664,10 +776,10 @@ async def write_user_memo(
                 metadata_status=existing_value.get("metadata_status") or "ready",
             )
 
-        now = _now_iso()
+        now = now_iso()
         updated = {
             **existing_value,
-            "content": body.content,
+            "content": content,
             "sha256": new_hash,
             "size_bytes": content_bytes,
             "modified_at": now,
@@ -681,7 +793,7 @@ async def write_user_memo(
         user_id=user_id, namespace=namespace, key=body.key
     )
     if not metadata_dispatched:
-        await rebuild_memo_index(store, namespace)
+        await _rebuild_index_under_lock(store, namespace)
 
     return MemoUploadResponse(
         key=body.key,
@@ -797,8 +909,10 @@ async def delete_user_memo(
 
         # Cancel any in-flight metadata task before deleting the row —
         # otherwise a post-LLM ``_merge_metadata`` aput could resurrect this
-        # key after it is gone from the store.
-        _cancel_pending_metadata(namespace, key)
+        # key after it is gone from the store. ``user_id`` here also raises
+        # the cross-worker Redis cancel flag so a task running on another
+        # worker stops before its merge step.
+        _cancel_pending_metadata(namespace, key, user_id=user_id)
 
         # Capture the binary_ref BEFORE deleting the store row — once the row
         # is gone we can't recover where the bytes lived.
@@ -815,7 +929,8 @@ async def delete_user_memo(
     if isinstance(binary_ref, dict):
         await memo_binary_storage.delete_binary(binary_ref)
 
-    await rebuild_memo_index(store, namespace)
+    async with lock_for_namespace(namespace):
+        await rebuild_memo_index(store, namespace)
     return {"status": "deleted", "key": key}
 
 
@@ -839,7 +954,7 @@ async def regenerate_user_memo_metadata(
         if not isinstance(item.value, dict):
             raise HTTPException(status_code=500, detail="Malformed memo value")
 
-        now = _now_iso()
+        now = now_iso()
         updated = {
             **item.value,
             "metadata_status": "pending",
@@ -853,7 +968,7 @@ async def regenerate_user_memo_metadata(
         user_id=user_id, namespace=namespace, key=key
     )
     if not metadata_dispatched:
-        await rebuild_memo_index(store, namespace)
+        await _rebuild_index_under_lock(store, namespace)
     return MemoUploadResponse(
         key=key,
         original_filename=updated.get("original_filename") or key,

--- a/src/server/app/memo.py
+++ b/src/server/app/memo.py
@@ -154,9 +154,10 @@ async def _kickoff_metadata_handover(user_id: str, key: str) -> None:
     """Cross-worker handover for the kickoff path: cancel siblings, then claim slot.
 
     Single coroutine so the SET → DELETE → SET sequence at Redis is ordered
-    from this worker's perspective. A sibling-worker task observes the cancel
-    during the brief SET window; our own new task sees a cleared flag once
-    DELETE has run, so it never self-aborts.
+    from this worker's perspective. ``_kickoff_metadata`` awaits this before
+    spawning the new metadata task so the new task cannot observe the
+    transient cancel flag, even if a partial Redis failure leaves DELETE
+    unrun (the awaiting caller still sees the success/failure outcome).
     """
     try:
         cache = get_cache_client()
@@ -409,7 +410,7 @@ async def _rebuild_index_under_lock(
         await rebuild_memo_index(store, namespace)
 
 
-def _kickoff_metadata(
+async def _kickoff_metadata(
     *, user_id: str, namespace: tuple[str, ...], key: str
 ) -> bool:
     """Dispatch a background LLM call. Requires setup.llm_service to be wired.
@@ -425,10 +426,13 @@ def _kickoff_metadata(
             extra={"memo_key": key},
         )
         return False
-    # In-process cancel runs synchronously; cross-worker cancel+inflight claim
-    # runs as a single ordered coroutine via _kickoff_metadata_handover.
+    # Cancel any in-process predecessor, then complete the cross-worker
+    # handover BEFORE spawning the new metadata task. Awaiting here means
+    # the handover's SET → DELETE → SET sequence has fully landed by the
+    # time the new task reaches its cancel poll, so it cannot observe the
+    # transient cancel flag we just set for sibling workers.
     _cancel_local_metadata_task(namespace, key)
-    _spawn_background(_kickoff_metadata_handover(user_id, key))
+    await _kickoff_metadata_handover(user_id, key)
 
     task = asyncio.create_task(
         generate_memo_metadata(
@@ -704,7 +708,7 @@ async def upload_user_memo(
     # the index after the LLM resolves — doing it here too writes memo.md
     # twice for every upload. Only rebuild eagerly when no LLM service is
     # wired (dev mode) so the catalog still updates.
-    metadata_dispatched = _kickoff_metadata(
+    metadata_dispatched = await _kickoff_metadata(
         user_id=user_id, namespace=namespace, key=key
     )
     if not metadata_dispatched:
@@ -789,7 +793,7 @@ async def write_user_memo(
         }
         await aput(store, namespace, body.key, updated)
 
-    metadata_dispatched = _kickoff_metadata(
+    metadata_dispatched = await _kickoff_metadata(
         user_id=user_id, namespace=namespace, key=body.key
     )
     if not metadata_dispatched:
@@ -964,7 +968,7 @@ async def regenerate_user_memo_metadata(
         }
         await aput(store, namespace, key, updated)
 
-    metadata_dispatched = _kickoff_metadata(
+    metadata_dispatched = await _kickoff_metadata(
         user_id=user_id, namespace=namespace, key=key
     )
     if not metadata_dispatched:

--- a/src/server/services/memo_binary_storage.py
+++ b/src/server/services/memo_binary_storage.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+import uuid
 from typing import Any
 
 from src.utils.storage import (
@@ -65,51 +66,44 @@ def is_configured() -> bool:
     return is_storage_enabled()
 
 
-def _build_key(user_id: str, key: str) -> str:
-    """Build the object-storage key for a memo binary.
+_MIME_EXTENSION = {
+    "application/pdf": ".pdf",
+}
 
-    ``key`` is already a slug produced by ``validate_store_key`` so it is
-    path-safe; no escaping is required. ``user_id`` is normally a UUID from
-    the authenticated session — but the service-token auth path returns
-    ``X-User-Id`` verbatim, so we re-validate here so a header injection
-    can never escape the ``memo/`` prefix or stray into another tenant's
-    namespace.
-    """
+
+def _validate_user_id(user_id: str) -> None:
+    """Refuse user_ids that could escape the ``memo/{user_id}/...`` prefix."""
     if not _USER_ID_RE.match(user_id):
         msg = f"Refusing to build storage key for unsafe user_id: {user_id!r}"
         raise MemoBinaryStorageError(msg)
-    return f"memo/{user_id}/{key}"
+
+
+def _build_storage_key(user_id: str, content_type: str) -> str:
+    """Build a fresh ``memo/{user_id}/{uuid}{ext}`` storage key.
+
+    UUID-based so concurrent uploads to the same slug don't collide on bytes.
+    """
+    _validate_user_id(user_id)
+    ext = _MIME_EXTENSION.get(content_type, "")
+    return f"memo/{user_id}/{uuid.uuid4().hex}{ext}"
 
 
 async def store_binary(
     *,
     user_id: str,
-    key: str,
     content: bytes,
     content_type: str,
 ) -> dict[str, Any] | None:
-    """Upload memo binary bytes to object storage.
+    """Upload memo bytes to a fresh UUID storage key.
 
-    Returns a ``binary_ref`` dict when object storage is configured and the
-    upload succeeded. Returns ``None`` when object storage is not configured
-    (the caller must fall back to base64). Raises
-    :class:`MemoBinaryUploadError` when object storage is configured but the
-    upload failed — callers typically map that to an HTTP 500.
-
-    Args:
-        user_id: The owning user's id (used to scope the object key).
-        key: The slugified memo key (path-safe per ``validate_store_key``).
-        content: Raw bytes to upload.
-        content_type: The MIME type to stamp on the stored object.
-
-    Returns:
-        ``{"storage": "r2", "key": "memo/<user>/<slug>", "content_type": ...}``
-        when stored, else ``None``.
+    Returns the ``binary_ref`` dict on success, ``None`` when storage is not
+    configured. Raises :class:`MemoBinaryUploadError` when configured but the
+    upload failed.
     """
     if not is_configured():
         return None
 
-    storage_key = _build_key(user_id, key)
+    storage_key = _build_storage_key(user_id, content_type)
     # upload_bytes is a synchronous boto3 call; off-load to a thread so we
     # don't block the event loop (same pattern as persistence/image_capture).
     success = await asyncio.to_thread(
@@ -117,9 +111,9 @@ async def store_binary(
     )
     if not success:
         logger.error(
-            "Failed to upload memo binary to object storage (user=%s key=%s)",
+            "Failed to upload memo binary to object storage (user=%s storage_key=%s)",
             user_id,
-            key,
+            storage_key,
         )
         msg = (
             "Could not store the original file in object storage. Please retry."

--- a/src/utils/storage/s3_compatible.py
+++ b/src/utils/storage/s3_compatible.py
@@ -17,6 +17,8 @@ Environment Variables:
     STORAGE_ENDPOINT_URL      - Custom endpoint for non-AWS services (falls back to S3_ENDPOINT_URL)
     STORAGE_PUBLIC_URL_BASE   - Public URL base (falls back to S3_PUBLIC_URL_BASE)
     STORAGE_MAX_UPLOAD_SIZE   - Max upload size in bytes (default: 10MB)
+    STORAGE_CONNECT_TIMEOUT_S - boto3 connect timeout in seconds (default: 5)
+    STORAGE_READ_TIMEOUT_S    - boto3 read timeout in seconds (default: 30)
 
 Provider-specific examples:
     AWS S3:      No endpoint needed, just credentials + bucket + region
@@ -81,6 +83,9 @@ class StorageConfig:
     DEFAULT_IMAGE_PREFIX = os.getenv("STORAGE_DEFAULT_IMAGE_PREFIX", "images/")
     DEFAULT_CHART_PREFIX = os.getenv("STORAGE_DEFAULT_CHART_PREFIX", "charts/")
 
+    CONNECT_TIMEOUT_S = int(os.getenv("STORAGE_CONNECT_TIMEOUT_S", "5"))
+    READ_TIMEOUT_S = int(os.getenv("STORAGE_READ_TIMEOUT_S", "30"))
+
     @classmethod
     def get_public_url_base(cls) -> str:
         """Get the public URL base for the bucket."""
@@ -109,6 +114,8 @@ def _get_client() -> Any:
         "config": Config(
             signature_version="s3v4",
             retries={"max_attempts": 3, "mode": "standard"},
+            connect_timeout=StorageConfig.CONNECT_TIMEOUT_S,
+            read_timeout=StorageConfig.READ_TIMEOUT_S,
         ),
     }
     if StorageConfig.ENDPOINT_URL:

--- a/tests/unit/ptc_agent/agent/memo/test_index.py
+++ b/tests/unit/ptc_agent/agent/memo/test_index.py
@@ -156,12 +156,9 @@ class TestRebuild:
         )
         # Freeze time so both rebuilds produce byte-identical output.
         with patch(
-            "ptc_agent.agent.memo.index.datetime"
-        ) as mock_dt:
-            from datetime import UTC, datetime
-            frozen = datetime(2026, 4, 24, 10, 15, 0, tzinfo=UTC)
-            mock_dt.now.return_value = frozen
-            mock_dt.UTC = UTC
+            "ptc_agent.agent.memo.index.now_iso",
+            return_value="2026-04-24T10:15:00.000000Z",
+        ):
             await rebuild_memo_index(store, NAMESPACE)
             first = (await store.aget(NAMESPACE, "memo.md")).value["content"]
             await rebuild_memo_index(store, NAMESPACE)

--- a/tests/unit/ptc_agent/agent/memo/test_metadata.py
+++ b/tests/unit/ptc_agent/agent/memo/test_metadata.py
@@ -197,3 +197,225 @@ class TestGenerate:
         )
 
         assert await store.aget(NAMESPACE, "q1.md") is None
+
+    @pytest.mark.asyncio
+    async def test_cross_worker_cancel_flag_short_circuits_before_llm(self, store):
+        """When the Redis cancel flag is set, the LLM call must be skipped entirely."""
+        await _seed_pending(store, "q1.md")
+        llm_service = _make_llm_service(
+            return_value=MemoMetadata(description="d", summary="s"),
+        )
+
+        from unittest.mock import AsyncMock as _AsyncMock, patch as _patch
+        fake_cache = MagicMock()
+        fake_cache.get = _AsyncMock(return_value="1")  # cancel flag is set
+        fake_cache.set = _AsyncMock(return_value=True)
+        fake_cache.delete = _AsyncMock(return_value=True)
+
+        with _patch(
+            "ptc_agent.agent.memo.metadata.get_cache_client",
+            return_value=fake_cache,
+        ):
+            await generate_memo_metadata(
+                store=store,
+                namespace=NAMESPACE,
+                key="q1.md",
+                user_id="user_abc",
+                llm_service=llm_service,
+            )
+
+        llm_service.complete.assert_not_called()
+        # Row stays in 'pending' since merge never ran.
+        item = await store.aget(NAMESPACE, "q1.md")
+        assert item.value["metadata_status"] == "pending"
+
+    @pytest.mark.asyncio
+    async def test_cross_worker_cancel_after_llm_skips_merge(self, store):
+        """A cancel flag raised mid-LLM blocks the post-LLM merge."""
+        await _seed_pending(store, "q1.md")
+        llm_service = _make_llm_service(
+            return_value=MemoMetadata(description="d", summary="s"),
+        )
+
+        # First poll (pre-LLM) returns no flag; second poll (post-LLM) returns "1".
+        from unittest.mock import AsyncMock as _AsyncMock, patch as _patch
+        fake_cache = MagicMock()
+        fake_cache.get = _AsyncMock(side_effect=[None, "1"])
+        fake_cache.set = _AsyncMock(return_value=True)
+        fake_cache.delete = _AsyncMock(return_value=True)
+
+        with _patch(
+            "ptc_agent.agent.memo.metadata.get_cache_client",
+            return_value=fake_cache,
+        ):
+            await generate_memo_metadata(
+                store=store,
+                namespace=NAMESPACE,
+                key="q1.md",
+                user_id="user_abc",
+                llm_service=llm_service,
+            )
+
+        llm_service.complete.assert_called_once()
+        item = await store.aget(NAMESPACE, "q1.md")
+        # Merge skipped: row still pending, no description from this run.
+        assert item.value["metadata_status"] == "pending"
+
+    @pytest.mark.asyncio
+    async def test_cross_worker_cancel_fails_open_on_redis_error(self, store):
+        """A Redis outage must not strand metadata generation — fail open."""
+        await _seed_pending(store, "q1.md")
+        llm_service = _make_llm_service(
+            return_value=MemoMetadata(description="ok", summary="ok"),
+        )
+
+        from unittest.mock import AsyncMock as _AsyncMock, patch as _patch
+        fake_cache = MagicMock()
+        fake_cache.get = _AsyncMock(side_effect=RuntimeError("redis down"))
+
+        with _patch(
+            "ptc_agent.agent.memo.metadata.get_cache_client",
+            return_value=fake_cache,
+        ):
+            await generate_memo_metadata(
+                store=store,
+                namespace=NAMESPACE,
+                key="q1.md",
+                user_id="user_abc",
+                llm_service=llm_service,
+            )
+
+        item = await store.aget(NAMESPACE, "q1.md")
+        assert item.value["metadata_status"] == "ready"
+        assert item.value["description"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_post_llm_merge_holds_namespace_lock(self, store):
+        """Merge + rebuild must serialize against concurrent delete via lock_for_namespace.
+
+        Without the lock, a concurrent delete handler can complete between
+        _merge_metadata's CAS read and its aput, resurrecting the row.
+        """
+        import asyncio
+
+        from ptc_agent.agent.backends import lock_for_namespace
+
+        await _seed_pending(store, "q1.md")
+        llm_service = _make_llm_service(
+            return_value=MemoMetadata(description="d", summary="s"),
+        )
+
+        # Externally hold the lock; metadata-finish must block on it.
+        async with lock_for_namespace(NAMESPACE):
+            task = asyncio.create_task(
+                generate_memo_metadata(
+                    store=store,
+                    namespace=NAMESPACE,
+                    key="q1.md",
+                    user_id="user_abc",
+                    llm_service=llm_service,
+                ),
+            )
+            # Yield enough times for the LLM call to resolve and the task to
+            # reach the lock-protected merge/rebuild block.
+            for _ in range(20):
+                await asyncio.sleep(0)
+            assert not task.done(), "metadata-finish should be blocked by external lock"
+
+        await asyncio.wait_for(task, timeout=2.0)
+
+        item = await store.aget(NAMESPACE, "q1.md")
+        assert item.value["metadata_status"] == "ready"
+
+    @pytest.mark.asyncio
+    async def test_concurrent_delete_during_merge_does_not_resurrect_row(self, store):
+        """Real concurrent delete + merge must end with the row absent.
+
+        Stronger property than ``test_post_llm_merge_holds_namespace_lock``,
+        which only proves the metadata task waits when the lock is held by
+        an external acquirer. Here we run the merge against a delete that
+        holds the lock first — once delete drops the lock, the metadata
+        task acquires it, but its CAS on ``modified_at`` must skip the
+        merge because the row was deleted under it. End state: no row.
+        """
+        import asyncio as _asyncio
+
+        from ptc_agent.agent.backends import lock_for_namespace
+
+        await _seed_pending(store, "q1.md")
+        llm_service = _make_llm_service(
+            return_value=MemoMetadata(description="ZOMBIE", summary="ZOMBIE"),
+        )
+
+        # Hold the lock while the metadata task starts up. While we hold it,
+        # delete the row. When we release the lock, the metadata task should
+        # run its post-LLM CAS, see the row gone, and skip the merge.
+        async with lock_for_namespace(NAMESPACE):
+            task = _asyncio.create_task(
+                generate_memo_metadata(
+                    store=store,
+                    namespace=NAMESPACE,
+                    key="q1.md",
+                    user_id="user_abc",
+                    llm_service=llm_service,
+                ),
+            )
+            # Yield enough that the LLM mock resolves and the task is queued
+            # on the lock acquisition for the merge step.
+            for _ in range(20):
+                await _asyncio.sleep(0)
+            await store.adelete(NAMESPACE, "q1.md")
+
+        await _asyncio.wait_for(task, timeout=2.0)
+
+        # Row stays deleted: merge saw item is None and skipped the aput.
+        assert await store.aget(NAMESPACE, "q1.md") is None
+
+    @pytest.mark.asyncio
+    async def test_legacy_second_precision_modified_at_does_not_block_merge(self, store):
+        """Pre-microsecond rows should still flip pending → ready cleanly.
+
+        Older memos have ``modified_at`` at second precision
+        (``2026-04-24T10:00:00Z``); freshly written rows use microseconds
+        (``2026-04-24T10:00:00.123456Z``). The CAS in ``_merge_metadata``
+        compares strings, so it must compare the snapshot's value to the
+        re-fetched value — not to a fresh ``now_iso()``. This test seeds a
+        legacy timestamp, runs metadata, and asserts the row reaches ready
+        with the new microsecond timestamp on it.
+        """
+        await store.aput(
+            NAMESPACE,
+            "legacy.md",
+            {
+                "content": "Legacy memo body that is plenty long enough.",
+                "encoding": "utf-8",
+                "mime_type": "text/markdown",
+                "original_filename": "legacy.md",
+                "key": "legacy.md",
+                "description": "...",
+                "summary": "",
+                "metadata_status": "pending",
+                "metadata_error": None,
+                "created_at": "2026-04-24T10:00:00Z",
+                "modified_at": "2026-04-24T10:00:00Z",  # legacy second precision
+            },
+        )
+        llm_service = _make_llm_service(
+            return_value=MemoMetadata(description="legacy ok", summary="ok"),
+        )
+
+        await generate_memo_metadata(
+            store=store,
+            namespace=NAMESPACE,
+            key="legacy.md",
+            user_id="user_abc",
+            llm_service=llm_service,
+        )
+
+        item = await store.aget(NAMESPACE, "legacy.md")
+        assert item.value["metadata_status"] == "ready"
+        assert item.value["description"] == "legacy ok"
+        # Microsecond format on the new modified_at, distinguishable from the
+        # legacy seed.
+        assert "." in item.value["modified_at"]
+        assert item.value["modified_at"] != "2026-04-24T10:00:00Z"

--- a/tests/unit/ptc_agent/agent/memo/test_time.py
+++ b/tests/unit/ptc_agent/agent/memo/test_time.py
@@ -1,0 +1,24 @@
+"""Tests for the centralized memo timestamp helper."""
+
+from __future__ import annotations
+
+import re
+
+from ptc_agent.agent.memo._time import now_iso
+
+
+_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z$")
+
+
+def test_microsecond_format():
+    assert _PATTERN.match(now_iso())
+
+
+def test_two_calls_produce_distinct_timestamps_within_one_second():
+    """The whole point of microsecond precision: defeat same-second CAS collisions."""
+    a = now_iso()
+    b = now_iso()
+    # On any reasonable machine these calls are microseconds apart, never equal.
+    assert a != b
+    # Same second prefix, different microseconds.
+    assert a[:19] == b[:19] or a < b

--- a/tests/unit/server/app/test_memo_api.py
+++ b/tests/unit/server/app/test_memo_api.py
@@ -358,7 +358,8 @@ async def test_upload_pdf_uses_object_storage_when_configured(store):
 
 
 @pytest.mark.asyncio
-async def test_upload_pdf_r2_failure_returns_500(store):
+async def test_upload_pdf_r2_failure_returns_502(store):
+    """Object-store upload failure should surface as 502 (matches the symmetric fetch path)."""
     from src.server.services.memo_binary_storage import MemoBinaryUploadError
 
     with (
@@ -381,7 +382,7 @@ async def test_upload_pdf_r2_failure_returns_500(store):
                 user_id="user_abc",
                 file=_upload("bad.pdf", b"%PDF-1.4 bad", "application/pdf"),
             )
-    assert exc.value.status_code == 500
+    assert exc.value.status_code == 502
     # No store write on failure.
     assert await store.aget(NAMESPACE, "bad.pdf") is None
 
@@ -402,6 +403,35 @@ async def test_upload_pdf_empty_extraction_returns_422(store):
             )
     assert exc.value.status_code == 422
     assert await store.aget(NAMESPACE, "scan.pdf") is None
+
+
+@pytest.mark.asyncio
+async def test_upload_pdf_strips_nul_bytes_from_extracted_text(store):
+    """Postgres JSONB rejects \\x00 in text — sanitize at the boundary."""
+    extracted = "Lecture body\x00 with stray\x00 NULs from pdfminer"
+    with patch.object(
+        memo_mod, "extract_pdf_text", AsyncMock(return_value=extracted),
+    ):
+        await upload_user_memo(
+            user_id="user_abc",
+            file=_upload("lecture.pdf", b"%PDF-1.4 x", "application/pdf"),
+        )
+    item = await store.aget(NAMESPACE, "lecture.pdf")
+    assert "\x00" not in item.value["content"]
+    assert item.value["content"] == "Lecture body with stray NULs from pdfminer"
+
+
+@pytest.mark.asyncio
+async def test_upload_text_strips_nul_bytes(store):
+    """Non-PDF UTF-8 uploads with embedded NULs also get sanitized."""
+    raw = "intro\x00body\x00".encode("utf-8")
+    await upload_user_memo(
+        user_id="user_abc",
+        file=_upload("notes.txt", raw, "text/plain"),
+    )
+    item = await store.aget(NAMESPACE, "notes.txt")
+    assert "\x00" not in item.value["content"]
+    assert item.value["content"] == "introbody"
 
 
 # --- Write ----------------------------------------------------------------
@@ -479,6 +509,19 @@ async def test_write_missing_returns_404(store):
             body=MemoWriteRequest(key="ghost.md", content="x"),
         )
     assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_write_strips_nul_bytes(store):
+    """JSON deserialization can carry \\u0000 escapes through to body.content."""
+    await _seed(store, "note.md")
+    await write_user_memo(
+        user_id="user_abc",
+        body=MemoWriteRequest(key="note.md", content="hello\x00 world\x00"),
+    )
+    item = await store.aget(NAMESPACE, "note.md")
+    assert "\x00" not in item.value["content"]
+    assert item.value["content"] == "hello world"
 
 
 # --- List + Read ----------------------------------------------------------
@@ -853,3 +896,256 @@ async def test_delete_acquires_namespace_lock(store):
     # Lock released — delete should now proceed.
     await asyncio.wait_for(task, timeout=2.0)
     assert await store.aget(NAMESPACE, "to-delete.md") is None
+
+
+# --- Lock-split around R2 PUT (Phase A outside lock, Phase B inside) -----
+
+
+@pytest.mark.asyncio
+async def test_upload_pdf_put_runs_outside_namespace_lock(store):
+    """A slow R2 PUT must not block other memo ops on the same namespace.
+
+    Holds the lock externally while a PDF upload is in flight; the PUT
+    happens in Phase A (no lock) so it must reach store_binary even though
+    the lock is held. Phase B (lock + aput) is the only step that should
+    block.
+    """
+    pdf_bytes = b"%PDF-1.4 slow"
+    put_started = asyncio.Event()
+    put_unblock = asyncio.Event()
+
+    async def _slow_put(*_args, **_kwargs):
+        put_started.set()
+        await put_unblock.wait()
+        return {
+            "storage": "r2",
+            "key": "memo/user_abc/abc.pdf",
+            "content_type": "application/pdf",
+        }
+
+    with (
+        patch.object(
+            memo_mod,
+            "extract_pdf_text",
+            AsyncMock(return_value="Extracted PDF body well over the fifty-char floor."),
+        ),
+        patch.object(
+            memo_mod.memo_binary_storage, "is_configured", return_value=True
+        ),
+        patch.object(
+            memo_mod.memo_binary_storage,
+            "store_binary",
+            AsyncMock(side_effect=_slow_put),
+        ),
+    ):
+        async with lock_for_namespace(NAMESPACE):
+            task = asyncio.create_task(
+                upload_user_memo(
+                    user_id="user_abc",
+                    file=_upload("slow.pdf", pdf_bytes, "application/pdf"),
+                ),
+            )
+            # Phase A reaches the PUT even while we hold the lock.
+            await asyncio.wait_for(put_started.wait(), timeout=2.0)
+            put_unblock.set()
+            # Yield generously; Phase B must NOT have completed yet — it's
+            # waiting on us to release the lock.
+            for _ in range(30):
+                await asyncio.sleep(0)
+            assert not task.done(), (
+                "Phase B aput should still be blocked on the namespace lock"
+            )
+        # Lock released — Phase B proceeds.
+        await asyncio.wait_for(task, timeout=2.0)
+
+    item = await store.aget(NAMESPACE, "slow.pdf")
+    assert item is not None
+    assert item.value["binary_ref"]["key"] == "memo/user_abc/abc.pdf"
+
+
+@pytest.mark.asyncio
+async def test_upload_pdf_phase_b_failure_cleans_up_orphan_blob(store):
+    """If Phase B raises after Phase A's PUT, the blob is best-effort deleted."""
+    ref = {
+        "storage": "r2",
+        "key": "memo/user_abc/orphan-uuid.pdf",
+        "content_type": "application/pdf",
+    }
+    delete_calls: list[dict] = []
+
+    async def _fake_delete(binary_ref):
+        delete_calls.append(binary_ref)
+        return True
+
+    with (
+        patch.object(
+            memo_mod,
+            "extract_pdf_text",
+            AsyncMock(return_value="Extracted PDF body well over the fifty-char floor."),
+        ),
+        patch.object(
+            memo_mod.memo_binary_storage, "is_configured", return_value=True
+        ),
+        patch.object(
+            memo_mod.memo_binary_storage,
+            "store_binary",
+            AsyncMock(return_value=ref),
+        ),
+        patch.object(
+            memo_mod.memo_binary_storage,
+            "delete_binary",
+            AsyncMock(side_effect=_fake_delete),
+        ),
+        # Force Phase B aput to fail so the rollback path runs. Bare store
+        # exceptions are wrapped into HTTPException(503) on the way out.
+        patch.object(memo_mod, "aput", AsyncMock(side_effect=RuntimeError("store down"))),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await upload_user_memo(
+                user_id="user_abc",
+                file=_upload("orphan.pdf", b"%PDF-1.4 x", "application/pdf"),
+            )
+        assert exc.value.status_code == 503
+
+    # Orphan cleanup ran with the binary_ref we Phase-A'd into existence.
+    assert delete_calls == [ref]
+    # No catalog row created.
+    assert await store.aget(NAMESPACE, "orphan.pdf") is None
+
+
+@pytest.mark.asyncio
+async def test_kickoff_handover_clears_cancel_before_inflight_set(store):
+    """Regression: cancel→delete→inflight must run in one ordered Redis sequence.
+
+    Previous design fired the cross-worker cancel SET and the inflight DELETE+SET
+    as two independent fire-and-forget tasks. Their Redis ops could land out of
+    order, leaving the new task's pre-LLM cancel-poll observing a stale "1" and
+    self-aborting. The combined ``_kickoff_metadata_handover`` runs them in one
+    coroutine so the order is fixed: SET cancel → DELETE cancel → SET inflight.
+    """
+    ops: list[tuple[str, str]] = []
+
+    fake_cache = MagicMock()
+
+    async def _record_set(key: str, value, ttl=None):
+        ops.append(("set", key))
+        return True
+
+    async def _record_delete(key: str):
+        ops.append(("delete", key))
+        return True
+
+    async def _record_get(_key: str):
+        return None
+
+    fake_cache.set = AsyncMock(side_effect=_record_set)
+    fake_cache.delete = AsyncMock(side_effect=_record_delete)
+    fake_cache.get = AsyncMock(side_effect=_record_get)
+
+    with patch.object(memo_mod, "get_cache_client", return_value=fake_cache):
+        await memo_mod._kickoff_metadata_handover("user_abc", "q1.md")
+
+    # The cancel SET must precede the cancel DELETE; the inflight SET runs last.
+    cancel_key = memo_mod.memo_metadata_cancel_key("user_abc", "q1.md")
+    inflight_key = memo_mod.memo_metadata_inflight_key("user_abc", "q1.md")
+    assert ops == [
+        ("set", cancel_key),
+        ("delete", cancel_key),
+        ("set", inflight_key),
+    ], f"handover ordering wrong: {ops}"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_pdf_uploads_dedupe_to_one_row_and_clean_orphan_blob(store):
+    """Two parallel sandbox-source PDF uploads → exactly one row, one live blob.
+
+    Phase A runs outside the lock, so both uploads PUT distinct UUID blobs.
+    Phase B serializes via ``lock_for_namespace``; the second caller sees
+    the first's row through ``_find_by_source`` and replaces it. The
+    replaced row's ``prior_binary_ref`` must be deleted by the post-aput
+    cleanup so the loser's blob doesn't leak. (Pre-fix: cleanup was gated
+    on ``not is_pdf(mime_type)`` so PDF→PDF dedup orphaned the prior blob.)
+    """
+    blob_keys: list[str] = []
+    delete_calls: list[dict] = []
+
+    async def _store_unique_blob(*, user_id, content, content_type):
+        key = f"memo/{user_id}/{len(blob_keys):08x}.pdf"
+        blob_keys.append(key)
+        # Yield so the two coroutines interleave their Phase A PUTs.
+        await asyncio.sleep(0)
+        return {"storage": "r2", "key": key, "content_type": content_type}
+
+    async def _record_delete(binary_ref):
+        delete_calls.append(binary_ref)
+        return True
+
+    pdf_a = b"%PDF-1.4 first"
+    pdf_b = b"%PDF-1.4 second"
+
+    with (
+        patch.object(
+            memo_mod,
+            "extract_pdf_text",
+            AsyncMock(return_value="Plenty of extracted text well over the fifty-char floor."),
+        ),
+        patch.object(
+            memo_mod.memo_binary_storage, "is_configured", return_value=True
+        ),
+        patch.object(
+            memo_mod.memo_binary_storage,
+            "store_binary",
+            AsyncMock(side_effect=_store_unique_blob),
+        ),
+        patch.object(
+            memo_mod.memo_binary_storage,
+            "delete_binary",
+            AsyncMock(side_effect=_record_delete),
+        ),
+    ):
+        results = await asyncio.gather(
+            upload_user_memo(
+                user_id="user_abc",
+                file=_upload("doc.pdf", pdf_a, "application/pdf"),
+                source_kind="sandbox",
+                source_workspace_id="ws-1",
+                source_path="results/doc.pdf",
+            ),
+            upload_user_memo(
+                user_id="user_abc",
+                file=_upload("doc.pdf", pdf_b, "application/pdf"),
+                source_kind="sandbox",
+                source_workspace_id="ws-1",
+                source_path="results/doc.pdf",
+            ),
+        )
+
+    # Both PUTs ran outside the lock — two blobs created.
+    assert len(blob_keys) == 2
+
+    # Exactly one row remains for the source path.
+    matched = []
+    items = await store.asearch(NAMESPACE, limit=10)
+    for item in items:
+        v = item.value if isinstance(item.value, dict) else {}
+        if v.get("source_path") == "results/doc.pdf":
+            matched.append(item)
+    assert len(matched) == 1
+    surviving_blob = matched[0].value["binary_ref"]["key"]
+    assert surviving_blob in blob_keys
+
+    # The loser's blob got deleted via the post-aput cleanup. Pre-fix this
+    # would have been zero deletes for PDF→PDF dedup.
+    deleted_keys = [r["key"] for r in delete_calls]
+    losers = [k for k in blob_keys if k != surviving_blob]
+    assert losers, "test setup should produce at least one losing blob"
+    for loser in losers:
+        assert loser in deleted_keys, (
+            f"loser blob {loser} not cleaned up; orphan in storage. "
+            f"delete_calls={deleted_keys}"
+        )
+
+    # Both responses returned 202 with replaced True/False distinguishing
+    # winner from loser of the dedup race.
+    replaced_flags = sorted(r.replaced for r in results)
+    assert replaced_flags == [False, True]

--- a/tests/unit/server/app/test_memo_api.py
+++ b/tests/unit/server/app/test_memo_api.py
@@ -409,8 +409,13 @@ async def test_upload_pdf_empty_extraction_returns_422(store):
 async def test_upload_pdf_strips_nul_bytes_from_extracted_text(store):
     """Postgres JSONB rejects \\x00 in text — sanitize at the boundary."""
     extracted = "Lecture body\x00 with stray\x00 NULs from pdfminer"
-    with patch.object(
-        memo_mod, "extract_pdf_text", AsyncMock(return_value=extracted),
+    with (
+        patch.object(
+            memo_mod, "extract_pdf_text", AsyncMock(return_value=extracted),
+        ),
+        patch.object(
+            memo_mod.memo_binary_storage, "is_configured", return_value=False,
+        ),
     ):
         await upload_user_memo(
             user_id="user_abc",

--- a/tests/unit/server/app/test_memo_api.py
+++ b/tests/unit/server/app/test_memo_api.py
@@ -1061,6 +1061,34 @@ async def test_kickoff_handover_clears_cancel_before_inflight_set(store):
 
 
 @pytest.mark.asyncio
+async def test_kickoff_metadata_skips_task_when_handover_fails(store):
+    """Partial-Redis failure (SET succeeded, DELETE failed) leaves the cancel
+    flag set for its 60s TTL. Spawning a metadata task here would just have it
+    self-abort at the pre-LLM poll. Skip task creation instead so the caller
+    rebuilds the index and the user can retry once Redis recovers.
+    """
+    await _seed(store, "redis-down.md")
+    fake_llm = MagicMock()
+    fake_llm.complete = AsyncMock()
+
+    async def _failing_handover(_uid: str, _key: str) -> None:
+        raise RuntimeError("redis blip mid-handover")
+
+    with (
+        patch.object(
+            memo_mod, "_kickoff_metadata_handover", side_effect=_failing_handover,
+        ),
+        patch.object(memo_mod.setup, "llm_service", fake_llm, create=True),
+    ):
+        dispatched = await memo_mod._kickoff_metadata(
+            user_id="user_abc", namespace=NAMESPACE, key="redis-down.md",
+        )
+    assert dispatched is False
+    fake_llm.complete.assert_not_called()
+    assert (NAMESPACE, "redis-down.md") not in memo_mod._METADATA_TASKS
+
+
+@pytest.mark.asyncio
 async def test_kickoff_metadata_awaits_handover_before_creating_task(store):
     """The handover must fully complete before the new metadata task spawns.
 

--- a/tests/unit/server/app/test_memo_api.py
+++ b/tests/unit/server/app/test_memo_api.py
@@ -1061,6 +1061,57 @@ async def test_kickoff_handover_clears_cancel_before_inflight_set(store):
 
 
 @pytest.mark.asyncio
+async def test_kickoff_metadata_awaits_handover_before_creating_task(store):
+    """The handover must fully complete before the new metadata task spawns.
+
+    Regression: previously _kickoff_metadata fired the handover as a fire-and-
+    forget background task and immediately created the metadata task. If the
+    metadata task's pre-LLM cancel poll ran during the handover's brief SET
+    window (between SET cancel and DELETE cancel), it observed the flag and
+    self-aborted. Now _kickoff_metadata is async and awaits the handover, so
+    by the time the new task starts polling, the cancel flag is already gone.
+    """
+    await _seed(store, "regen.md")
+    handover_calls: list[str] = []
+    real_handover = memo_mod._kickoff_metadata_handover
+
+    async def _tracking_handover(user_id: str, key: str) -> None:
+        handover_calls.append("start")
+        await real_handover(user_id, key)
+        handover_calls.append("end")
+
+    fake_cache = MagicMock()
+    fake_cache.set = AsyncMock(return_value=True)
+    fake_cache.delete = AsyncMock(return_value=True)
+    fake_cache.get = AsyncMock(return_value=None)
+
+    fake_llm = MagicMock()
+    fake_llm.complete = AsyncMock(return_value=MagicMock(
+        description="d", summary="s",
+    ))
+    with (
+        patch.object(memo_mod, "get_cache_client", return_value=fake_cache),
+        patch.object(
+            memo_mod, "_kickoff_metadata_handover", side_effect=_tracking_handover,
+        ),
+        patch.object(memo_mod.setup, "llm_service", fake_llm, create=True),
+    ):
+        dispatched = await memo_mod._kickoff_metadata(
+            user_id="user_abc", namespace=NAMESPACE, key="regen.md",
+        )
+    assert dispatched is True
+    assert handover_calls == ["start", "end"], (
+        "handover must complete before _kickoff_metadata returns"
+    )
+
+    pending = memo_mod._METADATA_TASKS.get((NAMESPACE, "regen.md"))
+    if pending is not None:
+        pending.cancel()
+        with contextlib.suppress(BaseException):
+            await pending
+
+
+@pytest.mark.asyncio
 async def test_concurrent_pdf_uploads_dedupe_to_one_row_and_clean_orphan_blob(store):
     """Two parallel sandbox-source PDF uploads → exactly one row, one live blob.
 

--- a/tests/unit/server/services/test_memo_binary_storage.py
+++ b/tests/unit/server/services/test_memo_binary_storage.py
@@ -6,6 +6,7 @@ These tests mock the storage layer (``upload_bytes`` / ``get_bytes`` /
 
 from __future__ import annotations
 
+import re
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -19,6 +20,9 @@ from src.server.services.memo_binary_storage import (
     is_configured,
     store_binary,
 )
+
+
+_UUID_PDF_RE = re.compile(r"^memo/[A-Za-z0-9_-]+/[0-9a-f]{32}\.pdf$")
 
 
 # ---------------------------------------------------------------------------
@@ -53,7 +57,6 @@ async def test_store_binary_returns_none_when_not_configured():
     ):
         result = await store_binary(
             user_id="u1",
-            key="q1-thesis.pdf",
             content=b"%PDF-1.4 fake",
             content_type="application/pdf",
         )
@@ -63,9 +66,8 @@ async def test_store_binary_returns_none_when_not_configured():
 
 
 @pytest.mark.asyncio
-async def test_store_binary_uploads_and_returns_binary_ref():
-    """When configured, store_binary calls upload_bytes with the expected
-    key + content_type and returns the expected binary_ref shape."""
+async def test_store_binary_uploads_and_returns_uuid_keyed_ref():
+    """Uploads land at ``memo/{user}/{uuid}.pdf`` — opaque, slug-independent."""
     upload_mock = MagicMock(return_value=True)
     with (
         patch.object(memo_binary_storage, "is_storage_enabled", return_value=True),
@@ -73,22 +75,38 @@ async def test_store_binary_uploads_and_returns_binary_ref():
     ):
         ref = await store_binary(
             user_id="u1",
-            key="q1-thesis.pdf",
             content=b"%PDF-1.4 bytes",
             content_type="application/pdf",
         )
 
-    assert ref == {
-        "storage": "r2",
-        "key": "memo/u1/q1-thesis.pdf",
-        "content_type": "application/pdf",
-    }
-    # Also verify the exact positional args handed to upload_bytes.
-    upload_mock.assert_called_once_with(
-        "memo/u1/q1-thesis.pdf",
-        b"%PDF-1.4 bytes",
-        "application/pdf",
-    )
+    assert ref is not None
+    assert ref["storage"] == "r2"
+    assert ref["content_type"] == "application/pdf"
+    assert _UUID_PDF_RE.match(ref["key"]), ref["key"]
+    upload_mock.assert_called_once()
+    storage_key, body, content_type = upload_mock.call_args.args
+    assert storage_key == ref["key"]
+    assert body == b"%PDF-1.4 bytes"
+    assert content_type == "application/pdf"
+
+
+@pytest.mark.asyncio
+async def test_store_binary_two_calls_produce_distinct_keys():
+    """Two uploads of identical content go to distinct UUIDs — no overwrite."""
+    upload_mock = MagicMock(return_value=True)
+    with (
+        patch.object(memo_binary_storage, "is_storage_enabled", return_value=True),
+        patch.object(memo_binary_storage, "_storage_upload_bytes", upload_mock),
+    ):
+        ref_a = await store_binary(
+            user_id="u1", content=b"x", content_type="application/pdf",
+        )
+        ref_b = await store_binary(
+            user_id="u1", content=b"x", content_type="application/pdf",
+        )
+
+    assert ref_a is not None and ref_b is not None
+    assert ref_a["key"] != ref_b["key"]
 
 
 @pytest.mark.asyncio
@@ -102,7 +120,6 @@ async def test_store_binary_raises_upload_error_on_storage_failure():
         with pytest.raises(MemoBinaryUploadError):
             await store_binary(
                 user_id="u1",
-                key="q1-thesis.pdf",
                 content=b"bytes",
                 content_type="application/pdf",
             )
@@ -117,11 +134,7 @@ async def test_store_binary_raises_upload_error_on_storage_failure():
 
 @pytest.mark.asyncio
 async def test_store_and_fetch_round_trip():
-    """fetch_binary reads back what store_binary wrote (mocked storage layer).
-
-    Uses a shared in-memory dict as the fake storage to prove the key the
-    adapter writes to is the same key it reads from.
-    """
+    """fetch_binary reads back what store_binary wrote (mocked storage layer)."""
     fake_storage: dict[str, bytes] = {}
 
     def fake_upload(key: str, data: bytes, content_type: str | None = None) -> bool:
@@ -140,16 +153,38 @@ async def test_store_and_fetch_round_trip():
     ):
         ref = await store_binary(
             user_id="u1",
-            key="q1-thesis.pdf",
             content=payload,
             content_type="application/pdf",
         )
         assert ref is not None
-        assert ref["key"] == "memo/u1/q1-thesis.pdf"
 
         fetched = await fetch_binary(ref)
 
     assert fetched == payload
+
+
+@pytest.mark.asyncio
+async def test_fetch_binary_supports_legacy_slug_keys():
+    """Existing rows with slug-derived ``binary_ref.key`` still download.
+
+    Legacy uploads stored at ``memo/{user}/{slug}.pdf`` (e.g.
+    ``memo/u1/q1-thesis.pdf``). The key is opaque to fetch_binary, so any
+    string the storage layer can resolve still works.
+    """
+    legacy_ref = {
+        "storage": "r2",
+        "key": "memo/u1/legacy-slug.pdf",
+        "content_type": "application/pdf",
+    }
+    with (
+        patch.object(memo_binary_storage, "is_storage_enabled", return_value=True),
+        patch.object(
+            memo_binary_storage,
+            "_storage_get_bytes",
+            return_value=b"legacy bytes",
+        ),
+    ):
+        assert await fetch_binary(legacy_ref) == b"legacy bytes"
 
 
 @pytest.mark.asyncio
@@ -182,35 +217,6 @@ async def test_fetch_binary_raises_on_malformed_ref():
 
 
 # ---------------------------------------------------------------------------
-# Key format
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_stored_key_pattern_matches_memo_user_slug():
-    """The object-storage key must be exactly ``memo/{user_id}/{slug}``."""
-    captured: dict[str, str] = {}
-
-    def fake_upload(key: str, data: bytes, content_type: str | None = None) -> bool:
-        captured["key"] = key
-        captured["content_type"] = content_type or ""
-        return True
-
-    with (
-        patch.object(memo_binary_storage, "is_storage_enabled", return_value=True),
-        patch.object(memo_binary_storage, "_storage_upload_bytes", side_effect=fake_upload),
-    ):
-        await store_binary(
-            user_id="u1",
-            key="q1-thesis.pdf",
-            content=b"x",
-            content_type="application/pdf",
-        )
-
-    assert captured["key"] == "memo/u1/q1-thesis.pdf"
-
-
-# ---------------------------------------------------------------------------
 # user_id defense-in-depth
 # ---------------------------------------------------------------------------
 
@@ -229,18 +235,11 @@ async def test_stored_key_pattern_matches_memo_user_slug():
     ],
 )
 async def test_store_binary_rejects_unsafe_user_id(bad_user_id):
-    """``_build_key`` refuses user_ids that could escape the ``memo/`` prefix.
-
-    The check is defense-in-depth — every caller today resolves user_id via
-    ``CurrentUserId`` — but the service-token auth path returns the
-    ``X-User-Id`` header verbatim, so the storage layer enforces its own
-    invariant rather than trusting the caller.
-    """
+    """Refuse user_ids that could escape the ``memo/`` prefix."""
     with patch.object(memo_binary_storage, "is_storage_enabled", return_value=True):
         with pytest.raises(MemoBinaryStorageError):
             await store_binary(
                 user_id=bad_user_id,
-                key="q1.pdf",
                 content=b"x",
                 content_type="application/pdf",
             )

--- a/tests/unit/utils/storage/test_s3_compatible.py
+++ b/tests/unit/utils/storage/test_s3_compatible.py
@@ -1,0 +1,110 @@
+"""Tests for src/utils/storage/s3_compatible.py timeout config."""
+
+from __future__ import annotations
+
+import importlib
+from unittest.mock import patch
+
+import pytest
+
+
+def _reload_module():
+    """Reimport the module so env-var-derived class attributes refresh."""
+    import src.utils.storage.s3_compatible as mod
+    importlib.reload(mod)
+    return mod
+
+
+def test_default_timeouts_applied_to_boto3_config():
+    mod = _reload_module()
+    mod._reset_client_for_test()
+    captured: dict = {}
+
+    def fake_client(*_args, **kwargs):
+        captured["config"] = kwargs.get("config")
+        return object()
+
+    with patch.object(mod.boto3, "client", side_effect=fake_client):
+        mod._get_client()
+
+    cfg = captured["config"]
+    assert cfg.connect_timeout == 5
+    assert cfg.read_timeout == 30
+
+
+def test_env_overrides_timeouts(monkeypatch):
+    monkeypatch.setenv("STORAGE_CONNECT_TIMEOUT_S", "2")
+    monkeypatch.setenv("STORAGE_READ_TIMEOUT_S", "11")
+    mod = _reload_module()
+    mod._reset_client_for_test()
+    captured: dict = {}
+
+    def fake_client(*_args, **kwargs):
+        captured["config"] = kwargs.get("config")
+        return object()
+
+    with patch.object(mod.boto3, "client", side_effect=fake_client):
+        mod._get_client()
+
+    cfg = captured["config"]
+    assert cfg.connect_timeout == 2
+    assert cfg.read_timeout == 11
+
+
+# --- E2E timeout → upload error mapping ----------------------------------
+# The Config(...) wiring above is necessary but not sufficient. These tests
+# go through the real upload_bytes() path so we verify both halves:
+# 1. boto's ConnectTimeoutError / ReadTimeoutError get caught (they're
+#    botocore Exception subclasses, so the bare `except Exception:` in
+#    upload_bytes returns False instead of letting the exception escape).
+# 2. False from upload_bytes maps to MemoBinaryUploadError at the
+#    memo_binary_storage boundary, which the route then turns into 502.
+
+
+def _patch_put_object_to_raise(mod, exc):
+    """Wire boto3.client().put_object to raise the given exception."""
+    from unittest.mock import MagicMock
+
+    fake_client = MagicMock()
+    fake_client.put_object.side_effect = exc
+    mod._reset_client_for_test()
+    return patch.object(mod.boto3, "client", return_value=fake_client)
+
+
+def test_upload_bytes_returns_false_on_connect_timeout():
+    """Boto ConnectTimeoutError is caught inside upload_bytes (returns False)."""
+    from botocore.exceptions import ConnectTimeoutError
+
+    mod = _reload_module()
+    err = ConnectTimeoutError(endpoint_url="https://r2.example/")
+    with _patch_put_object_to_raise(mod, err):
+        # Force a configured state so upload_bytes doesn't short-circuit.
+        with patch.object(mod.StorageConfig, "BUCKET_NAME", "test-bucket"):
+            assert mod.upload_bytes("memo/u1/x.pdf", b"x", "application/pdf") is False
+
+
+def test_upload_bytes_returns_false_on_read_timeout():
+    """Boto ReadTimeoutError is caught inside upload_bytes (returns False)."""
+    from botocore.exceptions import ReadTimeoutError
+
+    mod = _reload_module()
+    err = ReadTimeoutError(endpoint_url="https://r2.example/")
+    with _patch_put_object_to_raise(mod, err):
+        with patch.object(mod.StorageConfig, "BUCKET_NAME", "test-bucket"):
+            assert mod.upload_bytes("memo/u1/x.pdf", b"x", "application/pdf") is False
+
+
+@pytest.mark.asyncio
+async def test_store_binary_raises_upload_error_when_put_times_out(monkeypatch):
+    """A timing-out PUT goes upload_bytes→False→MemoBinaryUploadError."""
+    from src.server.services import memo_binary_storage
+
+    def fake_upload(*_a, **_k):  # mimics upload_bytes's catch-and-return-False
+        return False
+
+    monkeypatch.setattr(memo_binary_storage, "is_configured", lambda: True)
+    monkeypatch.setattr(memo_binary_storage, "_storage_upload_bytes", fake_upload)
+    with pytest.raises(memo_binary_storage.MemoBinaryUploadError):
+        await memo_binary_storage.store_binary(
+            user_id="u1", content=b"%PDF-1.4 x", content_type="application/pdf",
+        )


### PR DESCRIPTION
## Summary

Six follow-ups on top of the memo feature shipped in #176. Five from the original hardening plan, plus one bug a smoke-test caught.

**Performance**
- **Lock-split upload.** Extract + R2 PUT run outside the per-namespace lock; only the catalog write stays inside. Uploads no longer block other memo ops on the same user for the 3-5 s the S3 round trip takes. Storage keys are UUIDs, so slug collisions can't overwrite each other's bytes.

**Robustness**
- **Microsecond `modified_at`.** Burst regenerate (5 clicks in one wall-clock second) used to produce identical second-precision timestamps, defeating the CAS check.
- **Lock around `rebuild_memo_index`.** All 7 call sites now serialize. Closes a resurrection race where concurrent rebuilds could interleave `asearch` + `aput` and leave `memo.md` claiming a deleted memo still exists.
- **Cross-worker metadata cancel.** Redis carries a cooperative cancel signal across uvicorn workers. A delete on worker A can now stop a pending LLM call on worker B. Single-process dev unaffected. Fail-open on Redis outage.
- **boto3 timeouts.** 5 s connect / 30 s read instead of botocore's 60/60 default. Configurable via env vars.
- **NUL byte sanitize.** Strip `\x00` at the three memo content ingestion points. `pdfminer` can emit NUL from malformed font glyphs and Postgres JSONB rejects it; smoke-caught on a real Android lecture PDF that had been failing 503.

**Cleaner error codes**
- Storage upload failures: 502 (was 500).
- Store-write failures during upload: 503 with retry hint (was 500).

## Test Coverage

117 unit tests pass across `tests/unit/server/app/test_memo_api.py`, `tests/unit/ptc_agent/agent/memo/`, `tests/unit/utils/storage/`, `tests/unit/server/services/`. New tests cover:

- boto3 timeout config + e2e upload→502 mapping for ConnectTimeoutError / ReadTimeoutError
- Microsecond `now_iso()` uniqueness + legacy second-precision CAS coexistence
- Concurrent delete during merge does not resurrect row
- Phase A → Phase B race + orphan blob cleanup
- Cross-worker handover SET → DELETE → SET ordering
- Cross-worker cancel before + after LLM call
- NUL byte stripping on PDF extract, UTF-8 decode, and `write_memo` paths
- Backwards compat: pre-PR slug-derived `binary_ref.key` still downloads cleanly

## Pre-Landing Review

Already CLEAR via prior `/review` run on this work. Specialists dispatched: testing, maintainability, security, performance, api-contract. PR Quality Score: 7.5. All critical findings either fixed or explicitly skipped (1 deferred — inflight-key endpoint, documented as follow-up). Adversarial review (Claude + Codex) passed.

## Plan Completion

All 5 plan items DONE plus 1 smoke-caught fix. The deferred item is the inflight-key GET endpoint for cross-worker UI visibility, documented inline as a known limitation.

## Smoke Test

Manually verified:
- Upload of a real PDF that previously crashed with 503 (pdfminer NUL bytes) now succeeds.
- Existing pre-PR memos still download correctly (slug-derived `binary_ref.key` backwards compat).

Recommend two minutes of clicking before merge:
- Open one pre-PR memo's preview to confirm legacy keys load.
- Upload a fresh PDF and watch the description/summary land.

## Test plan

- [x] All memo-related unit tests pass (117 / 117)
- [x] Ruff clean on changed files
- [x] No SQL injection / unsafe deserialization
- [ ] Smoke: open pre-PR memo preview
- [ ] Smoke: upload fresh PDF, confirm metadata renders