### PR TITLE
feat(dashboard): universal widget context for the agent

### DIFF
--- a/src/server/handlers/chat/flash_workflow.py
+++ b/src/server/handlers/chat/flash_workflow.py
@@ -31,6 +31,11 @@ from src.server.utils.directive_context import (
     build_directive_reminder,
     parse_directive_contexts,
 )
+from src.server.utils.widget_context import (
+    build_widget_context_reminder,
+    parse_widget_contexts,
+    serialize_widget_contexts_for_metadata,
+)
 from src.llms.llm import get_input_modalities
 from src.server.utils.multimodal_context import (
     build_attachment_metadata,
@@ -82,22 +87,11 @@ async def astream_flash_workflow(
     is_byok: bool = False,
     config=None,
 ):
-    """
-    Async generator that streams Flash agent workflow events.
+    """Async generator that streams Flash agent workflow events.
 
-    Flash mode is optimized for speed - no sandbox, no MCP, no workspace required.
-    Uses only external tools (web search, market data, SEC filings).
-
-    Args:
-        request: The chat request
-        thread_id: Thread identifier
-        user_input: Extracted user input text
-        user_id: User identifier
-        is_byok: Whether the user is using their own API key
-        config: Pre-resolved LLM config (optional; resolved here if absent)
-
-    Yields:
-        SSE-formatted event strings
+    Flash mode: no sandbox, no MCP, external tools only (web search, market
+    data, SEC filings). Follows the same background-task / reconnect pattern
+    as PTC but skips workspace and session setup.
     """
     start_time = time.time()
     handler = None
@@ -113,7 +107,6 @@ async def astream_flash_workflow(
 
     slot_owned = True
     try:
-        # Validate agent_config is available
         if not setup.agent_config:
             raise HTTPException(
                 status_code=503,
@@ -124,11 +117,9 @@ async def astream_flash_workflow(
         # Database Persistence Setup
         # =================================================================
 
-        # Get or create the shared flash workspace for this user
         flash_ws = await get_or_create_flash_workspace(user_id)
         workspace_id = str(flash_ws["workspace_id"])
 
-        # Ensure thread exists in database
         await ensure_thread(
             request, thread_id, workspace_id, user_id, msg_type="flash",
             initial_query=user_input,
@@ -155,6 +146,11 @@ async def astream_flash_workflow(
             if multimodal_ctxs:
                 query_metadata["attachments"] = await build_attachment_metadata(
                     multimodal_ctxs, thread_id
+                )
+            widget_ctxs = parse_widget_contexts(request.additional_context)
+            if widget_ctxs:
+                query_metadata["widget_contexts"] = serialize_widget_contexts_for_metadata(
+                    widget_ctxs
                 )
 
         # Persist lightweight additional_context + slash command fallback
@@ -219,7 +215,6 @@ async def astream_flash_workflow(
         # Propagate fetch model override to tool context
         apply_fetch_override(config)
 
-        # Fetch user profile for prompt injection
         flash_user_profile = None
         if user_id:
             flash_user_profile = await get_user_profile_for_prompt(user_id)
@@ -232,7 +227,6 @@ async def astream_flash_workflow(
             store=setup.store,
         )
 
-        # Build input state from messages
         messages = normalize_request_messages(request)
 
         # Multimodal Context Injection (images and PDFs) -- Flash-specific
@@ -287,6 +281,16 @@ async def astream_flash_workflow(
                 f"({len(directives)} directives)"
             )
 
+        # Widget Context Injection (inline with user message) -- Flash-specific
+        widgets = parse_widget_contexts(request.additional_context)
+        widget_reminder = build_widget_context_reminder(widgets)
+        if widget_reminder:
+            _append_to_last_user_message(messages, widget_reminder)
+            logger.info(
+                f"[FLASH_CHAT] Widget context injected inline "
+                f"({len(widgets)} widgets)"
+            )
+
         # Build input state or resume command -- Flash-specific (no
         # ``current_agent`` key)
         if request.hitl_response:
@@ -307,7 +311,6 @@ async def astream_flash_workflow(
             if loaded_skill_names:
                 input_state["loaded_skills"] = loaded_skill_names
 
-        # Build LangGraph config
         graph_config = build_graph_config(
             thread_id=thread_id,
             user_id=user_id,
@@ -321,7 +324,6 @@ async def astream_flash_workflow(
             recursion_limit=get_flash_recursion_limit(),
         )
 
-        # Create stream handler
         handler = WorkflowStreamHandler(
             thread_id=thread_id,
             token_callback=token_callback,
@@ -352,7 +354,6 @@ async def astream_flash_workflow(
                 yield steering_event
             return
 
-        # Mark workflow as active in Redis tracker
         await tracker.mark_active(
             thread_id=thread_id,
             workspace_id=workspace_id,
@@ -415,7 +416,6 @@ async def astream_flash_workflow(
                     exc_info=True,
                 )
 
-        # Start workflow in background
         try:
             await manager.start_workflow(
                 thread_id=thread_id,
@@ -467,7 +467,6 @@ async def astream_flash_workflow(
         else:
             slot_owned = False  # Manager owns burst slot release from here
 
-        # Stream live events from background task to client
         async for event in stream_live_events(
             manager=manager,
             tracker=tracker,
@@ -520,4 +519,3 @@ async def astream_flash_workflow(
 
     finally:
         ExecutionTracker.stop_tracking()
-        logger.debug("Flash execution tracking stopped")

--- a/src/server/handlers/chat/flash_workflow.py
+++ b/src/server/handlers/chat/flash_workflow.py
@@ -141,13 +141,13 @@ async def astream_flash_workflow(
         query_metadata = {"msg_type": "flash"}
         if effective_model:
             query_metadata["llm_model"] = effective_model
+        widget_ctxs = parse_widget_contexts(request.additional_context)
         if request.additional_context:
             multimodal_ctxs = parse_multimodal_contexts(request.additional_context)
             if multimodal_ctxs:
                 query_metadata["attachments"] = await build_attachment_metadata(
                     multimodal_ctxs, thread_id
                 )
-            widget_ctxs = parse_widget_contexts(request.additional_context)
             if widget_ctxs:
                 query_metadata["widget_contexts"] = serialize_widget_contexts_for_metadata(
                     widget_ctxs
@@ -282,13 +282,12 @@ async def astream_flash_workflow(
             )
 
         # Widget Context Injection (inline with user message) -- Flash-specific
-        widgets = parse_widget_contexts(request.additional_context)
-        widget_reminder = build_widget_context_reminder(widgets)
+        widget_reminder = build_widget_context_reminder(widget_ctxs)
         if widget_reminder:
             _append_to_last_user_message(messages, widget_reminder)
             logger.info(
                 f"[FLASH_CHAT] Widget context injected inline "
-                f"({len(widgets)} widgets)"
+                f"({len(widget_ctxs)} widgets)"
             )
 
         # Build input state or resume command -- Flash-specific (no

--- a/src/server/handlers/chat/flash_workflow.py
+++ b/src/server/handlers/chat/flash_workflow.py
@@ -270,20 +270,24 @@ async def astream_flash_workflow(
         # Skill Context Injection (Flash mode)
         loaded_skill_names = inject_skills(messages, request, config, mode="flash")
 
-        # Directive Context Injection (inline with user message) --
-        # Flash-specific
+        # Directive + Widget Context Injection (inline with user message) --
+        # Flash-specific. Skip on HITL resumes and checkpoint replay because
+        # `input_state` below replaces `messages` with `Command(resume=...)` /
+        # `None`, so anything appended here would be silently discarded.
+        # Mirrors the PTC guard at `ptc_workflow.py:620,638`.
+        skip_inline_injection = bool(request.hitl_response) or is_checkpoint_replay
+
         directives = parse_directive_contexts(request.additional_context)
         directive_reminder = build_directive_reminder(directives)
-        if directive_reminder:
+        if directive_reminder and not skip_inline_injection:
             _append_to_last_user_message(messages, directive_reminder)
             logger.info(
                 f"[FLASH_CHAT] Directive context injected inline "
                 f"({len(directives)} directives)"
             )
 
-        # Widget Context Injection (inline with user message) -- Flash-specific
         widget_reminder = build_widget_context_reminder(widget_ctxs)
-        if widget_reminder:
+        if widget_reminder and not skip_inline_injection:
             _append_to_last_user_message(messages, widget_reminder)
             logger.info(
                 f"[FLASH_CHAT] Widget context injected inline "

--- a/src/server/handlers/chat/ptc_workflow.py
+++ b/src/server/handlers/chat/ptc_workflow.py
@@ -37,6 +37,11 @@ from src.server.utils.directive_context import (
     build_directive_reminder,
     parse_directive_contexts,
 )
+from src.server.utils.widget_context import (
+    build_widget_context_reminder,
+    parse_widget_contexts,
+    serialize_widget_contexts_for_metadata,
+)
 from src.llms.llm import get_input_modalities
 from src.server.utils.multimodal_context import (
     build_attachment_metadata,
@@ -199,18 +204,9 @@ async def astream_ptc_workflow(
 ):
     """Async generator that streams PTC agent workflow events.
 
-    Uses build_ptc_graph to create a per-workspace LangGraph graph,
-    then reuses the standard WorkflowStreamHandler for SSE streaming.
-
-    Args:
-        request: The chat request
-        thread_id: Thread identifier
-        user_input: Extracted user input text
-        user_id: User identifier
-        workspace_id: Workspace identifier
-
-    Yields:
-        SSE-formatted event strings
+    Builds a per-workspace LangGraph graph and delegates streaming to
+    WorkflowStreamHandler. Workspace startup, background orchestration,
+    HITL resume, and completion persistence are all handled inline.
     """
     start_time = time.time()
     handler = None
@@ -231,12 +227,10 @@ async def astream_ptc_workflow(
         _phase_times[name] = (now - _phase_t0) * 1000  # ms
         _phase_t0 = now
 
-    # Start execution tracking to capture agent messages
     ExecutionTracker.start_tracking()
 
     slot_owned = True
     try:
-        # Validate agent_config is available
         if not setup.agent_config:
             raise HTTPException(
                 status_code=503,
@@ -247,7 +241,6 @@ async def astream_ptc_workflow(
         # Phase 1: Database Persistence Setup
         # =====================================================================
 
-        # Ensure thread exists in database (linked to workspace)
         await ensure_thread(
             request, thread_id, workspace_id, user_id, msg_type="ptc",
             initial_query=user_input,
@@ -280,6 +273,11 @@ async def astream_ptc_workflow(
             if multimodal_ctxs:
                 query_metadata["attachments"] = await build_attachment_metadata(
                     multimodal_ctxs, thread_id
+                )
+            widget_ctxs = parse_widget_contexts(request.additional_context)
+            if widget_ctxs:
+                query_metadata["widget_contexts"] = serialize_widget_contexts_for_metadata(
+                    widget_ctxs
                 )
 
         # Persist lightweight additional_context + slash command fallback
@@ -347,7 +345,6 @@ async def astream_ptc_workflow(
         subagents = request.subagents_enabled or config.subagents.enabled
         sandbox_id = None
 
-        # Use WorkspaceManager for workspace-based sessions
         workspace_manager = WorkspaceManager.get_instance()
 
         # Check if workspace needs startup — emit early SSE so frontend
@@ -467,7 +464,6 @@ async def astream_ptc_workflow(
         # PTC-only: set global for snapshot access
         setup.graph = ptc_graph
 
-        # Build input state from messages
         messages = normalize_request_messages(request)
 
         # =====================================================================
@@ -631,6 +627,25 @@ async def astream_ptc_workflow(
                 )
 
         # =====================================================================
+        # Widget Context Injection (inline with user message)
+        # =====================================================================
+        # Each WidgetContext carries pre-rendered <widget-context>...</widget-context>
+        # text. We concatenate them into one <system-reminder> envelope and append
+        # to the last user message. Image bytes for chart-type widgets travel as
+        # MultimodalContext(type='image') items above and use the existing modality
+        # gate — no special handling here.
+        widgets = parse_widget_contexts(request.additional_context)
+        widget_reminder = build_widget_context_reminder(widgets)
+        if widget_reminder and not request.hitl_response:
+            if isinstance(input_state, dict) and input_state.get("messages"):
+                _append_to_last_user_message(
+                    input_state["messages"], widget_reminder
+                )
+                logger.info(
+                    f"[PTC_CHAT] Widget context injected inline ({len(widgets)} widgets)"
+                )
+
+        # =====================================================================
         # Save user request to system thread directory (non-critical)
         # =====================================================================
         if not request.hitl_response and session.sandbox:
@@ -675,7 +690,6 @@ async def astream_ptc_workflow(
                 f"[PTC_CHAT] Background registry attached for thread_id={thread_id}"
             )
 
-        # Reuse WorkflowStreamHandler for SSE streaming
         handler = WorkflowStreamHandler(
             thread_id=thread_id,
             token_callback=token_callback,
@@ -687,7 +701,6 @@ async def astream_ptc_workflow(
         # Track steering messages injected mid-workflow for post-completion backfill
         setup_steering_tracking(handler)
 
-        # Initialize workflow tracker (fire-and-forget — return value unused)
         tracker = WorkflowTracker.get_instance()
         _fire_and_forget(
             tracker.mark_active(
@@ -757,15 +770,12 @@ async def astream_ptc_workflow(
                     lambda: manager.clear_event_buffer(thread_id)
                 )
 
-                # Get per-call records for usage tracking
                 _per_call_records = _token_cb.per_call_records if _token_cb else None
 
-                # Get tool usage summary from handler
                 _tool_usage = None
                 if _handler:
                     _tool_usage = _handler.get_tool_usage()
 
-                # Persist completion to database
                 _sse_events = _handler.get_sse_events() if _handler else None
 
                 # Capture sandbox images -> upload to cloud storage -> rewrite storage URLs
@@ -886,7 +896,6 @@ async def astream_ptc_workflow(
             f"[PTC_TIMING] thread_id={thread_id} model={model_tag} total={total_ms:.0f}ms ({phases})"
         )
 
-        # Stream live SSE events to the client
         async for event in stream_live_events(
             manager=manager,
             tracker=tracker,

--- a/src/server/handlers/chat/ptc_workflow.py
+++ b/src/server/handlers/chat/ptc_workflow.py
@@ -268,13 +268,13 @@ async def astream_ptc_workflow(
 
         # Extract attachment and context metadata for display in history
         # (PTC skips this block for HITL resumes — contrast with Flash)
+        widget_ctxs = parse_widget_contexts(request.additional_context)
         if request.additional_context and not request.hitl_response:
             multimodal_ctxs = parse_multimodal_contexts(request.additional_context)
             if multimodal_ctxs:
                 query_metadata["attachments"] = await build_attachment_metadata(
                     multimodal_ctxs, thread_id
                 )
-            widget_ctxs = parse_widget_contexts(request.additional_context)
             if widget_ctxs:
                 query_metadata["widget_contexts"] = serialize_widget_contexts_for_metadata(
                     widget_ctxs
@@ -634,15 +634,14 @@ async def astream_ptc_workflow(
         # to the last user message. Image bytes for chart-type widgets travel as
         # MultimodalContext(type='image') items above and use the existing modality
         # gate — no special handling here.
-        widgets = parse_widget_contexts(request.additional_context)
-        widget_reminder = build_widget_context_reminder(widgets)
+        widget_reminder = build_widget_context_reminder(widget_ctxs)
         if widget_reminder and not request.hitl_response:
             if isinstance(input_state, dict) and input_state.get("messages"):
                 _append_to_last_user_message(
                     input_state["messages"], widget_reminder
                 )
                 logger.info(
-                    f"[PTC_CHAT] Widget context injected inline ({len(widgets)} widgets)"
+                    f"[PTC_CHAT] Widget context injected inline ({len(widget_ctxs)} widgets)"
                 )
 
         # =====================================================================

--- a/src/server/models/additional_context.py
+++ b/src/server/models/additional_context.py
@@ -5,7 +5,8 @@ Supports flexible context types that can be passed along with user queries.
 Contexts are fetched, formatted, and appended to user messages before processing.
 """
 
-from typing import Annotated, Literal, Optional, List, Union
+from datetime import datetime
+from typing import Annotated, Any, Literal, Optional, List, Union
 from pydantic import BaseModel, Discriminator, Field, Tag
 
 
@@ -42,7 +43,26 @@ class DirectiveContext(AdditionalContextBase):
     content: str = Field(..., description="Directive text to inject inline with user message")
 
 
-# Union type for all context types - discriminated by "type" field
+class WidgetContext(AdditionalContextBase):
+    """Context attached from a dashboard widget snapshot.
+
+    Carries pre-rendered ``<widget-context>...</widget-context>`` markdown that
+    is concatenated into a single ``<system-reminder>`` and appended to the last
+    user message. Image bytes for chart-type widgets ride the existing
+    ``MultimodalContext(type='image')`` channel — this model does not transport
+    image data.
+    """
+
+    type: Literal["widget"] = "widget"
+    widget_type: str = Field(..., description="Widget definition id (e.g., 'markets.chart')")
+    widget_id: str = Field(..., description="Widget instance id (uuid) — stable across reflows")
+    label: str = Field(..., description="Human-readable label for the snapshot (chip title)")
+    text: str = Field(..., description="Pre-rendered <widget-context>...</widget-context> markdown")
+    data: dict[str, Any] = Field(default_factory=dict, description="Structured raw payload for replay")
+    captured_at: Optional[datetime] = Field(None, description="When the snapshot was taken (client clock)")
+    description: Optional[str] = Field(None, description="Optional caption / freshness note")
+
+
 AdditionalContext = Annotated[
     Union[
         Annotated[SkillContext, Tag("skills")],
@@ -50,21 +70,14 @@ AdditionalContext = Annotated[
         Annotated[MultimodalContext, Tag("pdf")],
         Annotated[MultimodalContext, Tag("file")],
         Annotated[DirectiveContext, Tag("directive")],
+        Annotated[WidgetContext, Tag("widget")],
     ],
     Discriminator(lambda v: v.get("type") if isinstance(v, dict) else getattr(v, "type", None)),
 ]
 
 
 def format_additional_contexts(contexts: List[AdditionalContextBase]) -> str:
-    """
-    Format multiple additional contexts into a single markdown section.
-
-    Args:
-        contexts: List of formatted context strings
-
-    Returns:
-        Combined markdown section with separator
-    """
+    """Join multiple context strings into a single markdown section with a separator."""
     if not contexts:
         return ""
 

--- a/src/server/utils/widget_context.py
+++ b/src/server/utils/widget_context.py
@@ -31,44 +31,29 @@ def parse_widget_contexts(
                 contexts.append(_from_dict(ctx))
         elif isinstance(ctx, WidgetContext):
             contexts.append(ctx)
-        elif hasattr(ctx, "type") and ctx.type == "widget":
-            contexts.append(
-                WidgetContext(
-                    type="widget",
-                    widget_type=getattr(ctx, "widget_type", ""),
-                    widget_id=getattr(ctx, "widget_id", ""),
-                    label=getattr(ctx, "label", ""),
-                    text=getattr(ctx, "text", ""),
-                    data=getattr(ctx, "data", {}) or {},
-                    captured_at=getattr(ctx, "captured_at", None),
-                    description=getattr(ctx, "description", None),
-                )
-            )
 
     return contexts
 
 
 def _from_dict(ctx: dict) -> WidgetContext:
-    captured_raw = ctx.get("captured_at")
-    captured: Optional[datetime] = None
-    if isinstance(captured_raw, datetime):
-        captured = captured_raw
-    elif isinstance(captured_raw, str) and captured_raw:
-        try:
-            captured = datetime.fromisoformat(captured_raw.replace("Z", "+00:00"))
-        except ValueError:
-            captured = None
+    """Convert a raw dict to ``WidgetContext`` via Pydantic validation.
 
-    return WidgetContext(
-        type="widget",
-        widget_type=ctx.get("widget_type", ""),
-        widget_id=ctx.get("widget_id", ""),
-        label=ctx.get("label", ""),
-        text=ctx.get("text", ""),
-        data=ctx.get("data") or {},
-        captured_at=captured,
-        description=ctx.get("description"),
-    )
+    Pre-cleans two fields to preserve legacy lenient behavior the API has
+    always offered: unparseable ``captured_at`` strings become ``None``
+    (instead of 422) and ``data: None`` falls through to the default ``{}``.
+    Everything else is delegated to ``WidgetContext.model_validate`` so new
+    required fields added later don't get silently defaulted.
+    """
+    cleaned = dict(ctx)
+    captured_raw = cleaned.get("captured_at")
+    if isinstance(captured_raw, str) and captured_raw:
+        try:
+            datetime.fromisoformat(captured_raw.replace("Z", "+00:00"))
+        except ValueError:
+            cleaned["captured_at"] = None
+    if cleaned.get("data") is None:
+        cleaned.pop("data", None)
+    return WidgetContext.model_validate(cleaned)
 
 
 _WIDGET_CONTEXT_PREAMBLE = (

--- a/src/server/utils/widget_context.py
+++ b/src/server/utils/widget_context.py
@@ -1,0 +1,131 @@
+"""
+Widget context utilities for chat endpoint.
+
+Parses WidgetContext items from additional_context and builds a single
+``<system-reminder>`` block that concatenates each widget's pre-rendered
+``<widget-context>...</widget-context>`` text. Mirrors the directive context
+middleware shape so widgets and directives share the same injection path.
+"""
+
+import logging
+from datetime import datetime
+from typing import Any, List, Optional
+
+from src.server.models.additional_context import WidgetContext
+
+logger = logging.getLogger(__name__)
+
+
+def parse_widget_contexts(
+    additional_context: Optional[List[Any]],
+) -> List[WidgetContext]:
+    """Extract WidgetContext items from additional_context list."""
+    if not additional_context:
+        return []
+
+    contexts: List[WidgetContext] = []
+
+    for ctx in additional_context:
+        if isinstance(ctx, dict):
+            if ctx.get("type") == "widget":
+                contexts.append(_from_dict(ctx))
+        elif isinstance(ctx, WidgetContext):
+            contexts.append(ctx)
+        elif hasattr(ctx, "type") and ctx.type == "widget":
+            contexts.append(
+                WidgetContext(
+                    type="widget",
+                    widget_type=getattr(ctx, "widget_type", ""),
+                    widget_id=getattr(ctx, "widget_id", ""),
+                    label=getattr(ctx, "label", ""),
+                    text=getattr(ctx, "text", ""),
+                    data=getattr(ctx, "data", {}) or {},
+                    captured_at=getattr(ctx, "captured_at", None),
+                    description=getattr(ctx, "description", None),
+                )
+            )
+
+    return contexts
+
+
+def _from_dict(ctx: dict) -> WidgetContext:
+    captured_raw = ctx.get("captured_at")
+    captured: Optional[datetime] = None
+    if isinstance(captured_raw, datetime):
+        captured = captured_raw
+    elif isinstance(captured_raw, str) and captured_raw:
+        try:
+            captured = datetime.fromisoformat(captured_raw.replace("Z", "+00:00"))
+        except ValueError:
+            captured = None
+
+    return WidgetContext(
+        type="widget",
+        widget_type=ctx.get("widget_type", ""),
+        widget_id=ctx.get("widget_id", ""),
+        label=ctx.get("label", ""),
+        text=ctx.get("text", ""),
+        data=ctx.get("data") or {},
+        captured_at=captured,
+        description=ctx.get("description"),
+    )
+
+
+_WIDGET_CONTEXT_PREAMBLE = (
+    "The user attached the following dashboard widget snapshot(s) to this turn "
+    "via the \"+ to context\" button. Each <widget-context> block below is a "
+    "point-in-time view of what the user was looking at when they sent this "
+    "message. Evaluate whether each is relevant or helpful for the user's task "
+    "before relying on it — some may be load-bearing context, others incidental. "
+    "Don't force relevance where none exists."
+)
+
+
+def build_widget_context_reminder(widgets: List[WidgetContext]) -> Optional[str]:
+    """Build a system-reminder block from widget contexts.
+
+    Concatenates each widget's pre-rendered ``<widget-context>`` text into one
+    ``<system-reminder>`` envelope, prefixed by an explainer so the agent
+    knows the blocks are user-attached dashboard snapshots and should be
+    evaluated for relevance rather than blindly trusted. Returns ``None`` when
+    there is nothing to inject so the caller can skip the append step entirely.
+    """
+    if not widgets:
+        return None
+
+    parts = [w.text.strip() for w in widgets if w.text and w.text.strip()]
+    if not parts:
+        return None
+
+    body = "\n\n".join(parts)
+    return (
+        "\n\n<system-reminder>\n"
+        f"{_WIDGET_CONTEXT_PREAMBLE}\n\n"
+        f"{body}\n"
+        "</system-reminder>"
+    )
+
+
+def serialize_widget_contexts_for_metadata(
+    widgets: List[WidgetContext],
+) -> List[dict]:
+    """Serialize widgets for persistence in ``query_metadata['widget_contexts']``.
+
+    Keeps ``text`` so the chip preview UI can show exactly what the agent
+    saw on history replay. ``data`` is kept for replay UIs that want to
+    render rich chips.
+    """
+    out: List[dict] = []
+    for w in widgets:
+        out.append(
+            {
+                "widget_type": w.widget_type,
+                "widget_id": w.widget_id,
+                "label": w.label,
+                "text": w.text,
+                "data": w.data,
+                "captured_at": w.captured_at.isoformat() if w.captured_at else None,
+                "description": w.description,
+            }
+        )
+    return out

--- a/tests/unit/server/handlers/chat/test_widget_context_pipeline.py
+++ b/tests/unit/server/handlers/chat/test_widget_context_pipeline.py
@@ -1,0 +1,188 @@
+"""Pipeline test: WidgetContext + MultimodalContext + DirectiveContext coexist.
+
+Verifies that parsing + reminder building + injection compose without conflict.
+This is the unit-level "integration" check called for in the plan — the full
+HTTP round-trip would require live DB/Redis/API keys; the parsers themselves
+are pure and easy to compose into a deterministic test.
+"""
+
+from src.server.handlers.chat._common import _append_to_last_user_message
+from src.server.utils.directive_context import (
+    build_directive_reminder,
+    parse_directive_contexts,
+)
+from src.server.utils.multimodal_context import (
+    inject_multimodal_context,
+    parse_multimodal_contexts,
+)
+from src.server.utils.widget_context import (
+    build_widget_context_reminder,
+    parse_widget_contexts,
+    serialize_widget_contexts_for_metadata,
+)
+
+
+def _seed_messages():
+    return [
+        {"role": "user", "content": "compare the chart and the news"},
+    ]
+
+
+def test_widget_directive_lands_in_last_user_message():
+    raw = [
+        {
+            "type": "widget",
+            "widget_type": "markets.chart",
+            "widget_id": "w1",
+            "label": "NVDA",
+            "text": "<widget-context type='markets.chart' symbol='NVDA'>chart payload</widget-context>",
+            "data": {"bars": []},
+        }
+    ]
+    widgets = parse_widget_contexts(raw)
+    reminder = build_widget_context_reminder(widgets)
+    assert reminder is not None
+
+    messages = _seed_messages()
+    _append_to_last_user_message(messages, reminder)
+    last = messages[-1]
+    # User message content is now a list of content blocks (the helper wraps
+    # text + reminder), or a string with the reminder appended. Either is OK.
+    rendered = last["content"] if isinstance(last["content"], str) else "".join(
+        b.get("text", "") for b in last["content"] if isinstance(b, dict)
+    )
+    assert "<system-reminder>" in rendered
+    assert "<widget-context type='markets.chart' symbol='NVDA'>" in rendered
+    assert "chart payload" in rendered
+    assert "compare the chart and the news" in rendered
+
+
+def test_widget_image_rides_multimodal_channel():
+    """Frontend emits widget image as a sibling MultimodalContext(type='image').
+    Verify the existing multimodal pipeline picks it up unchanged."""
+    raw = [
+        {
+            "type": "widget",
+            "widget_type": "markets.chart",
+            "widget_id": "w1",
+            "label": "NVDA",
+            "text": "<widget-context>chart</widget-context>",
+        },
+        {
+            "type": "image",
+            "data": "data:image/jpeg;base64,Zm9vYmFy",  # base64('foobar')
+            "description": "NVDA · 1d Chart",
+        },
+    ]
+    multimodal = parse_multimodal_contexts(raw)
+    assert len(multimodal) == 1
+    assert multimodal[0].type == "image"
+
+    messages = _seed_messages()
+    inject_multimodal_context(messages, multimodal)
+    # After injection, last user message should contain an image content block.
+    last_content = messages[-1]["content"]
+    assert isinstance(last_content, list)
+    has_image_block = any(
+        (isinstance(b, dict) and b.get("type") in {"image", "image_url"})
+        for b in last_content
+    )
+    assert has_image_block
+
+
+def test_widget_directive_image_and_skill_coexist_without_conflict():
+    """The most realistic case: widget directive + widget image + a directive
+    + a skill all in the same additional_context list. Each parser only
+    extracts its own type."""
+    raw = [
+        {"type": "skills", "name": "user-profile"},
+        {"type": "directive", "content": "Be terse."},
+        {
+            "type": "widget",
+            "widget_type": "markets.chart",
+            "widget_id": "w1",
+            "label": "NVDA",
+            "text": "<widget-context>chart</widget-context>",
+        },
+        {
+            "type": "image",
+            "data": "data:image/jpeg;base64,Zm9vYmFy",
+            "description": "NVDA chart",
+        },
+        {
+            "type": "widget",
+            "widget_type": "news.feed/row",
+            "widget_id": "w1/n1",
+            "label": "News headline",
+            "text": "<widget-context>news</widget-context>",
+        },
+    ]
+
+    widgets = parse_widget_contexts(raw)
+    multimodal = parse_multimodal_contexts(raw)
+    directives = parse_directive_contexts(raw)
+
+    assert len(widgets) == 2
+    assert len(multimodal) == 1
+    assert len(directives) == 1
+
+    # Build reminders
+    widget_reminder = build_widget_context_reminder(widgets)
+    directive_reminder = build_directive_reminder(directives)
+
+    assert widget_reminder is not None
+    assert directive_reminder is not None
+    # Reminders are independent envelopes; both reach the user message.
+    assert "chart" in widget_reminder
+    assert "news" in widget_reminder
+    assert "Be terse" in directive_reminder
+
+    messages = _seed_messages()
+    _append_to_last_user_message(messages, directive_reminder)
+    _append_to_last_user_message(messages, widget_reminder)
+    inject_multimodal_context(messages, multimodal)
+
+    # Pull the rendered text from the last user message
+    last = messages[-1]
+    rendered = last["content"] if isinstance(last["content"], str) else "".join(
+        b.get("text", "") for b in last["content"] if isinstance(b, dict)
+    )
+
+    assert "Be terse" in rendered
+    assert "<widget-context>chart" in rendered
+    assert "<widget-context>news" in rendered
+
+    # And the image content block survived
+    if isinstance(last["content"], list):
+        has_image_block = any(
+            (isinstance(b, dict) and b.get("type") in {"image", "image_url"})
+            for b in last["content"]
+        )
+        assert has_image_block
+
+
+def test_widget_metadata_serialization_keeps_text_and_data():
+    raw = [
+        {
+            "type": "widget",
+            "widget_type": "markets.chart",
+            "widget_id": "w1",
+            "label": "NVDA",
+            "text": "<widget-context>huge prompt-only payload</widget-context>",
+            "data": {"bars": [{"o": 1, "c": 2}]},
+            "captured_at": "2026-04-26T11:42:08+00:00",
+        }
+    ]
+    widgets = parse_widget_contexts(raw)
+    persisted = serialize_widget_contexts_for_metadata(widgets)
+    assert len(persisted) == 1
+    assert persisted[0]["widget_type"] == "markets.chart"
+    assert persisted[0]["data"] == {"bars": [{"o": 1, "c": 2}]}
+    # Text is kept so the chip preview UI can show exactly what the agent saw.
+    assert persisted[0]["text"] == "<widget-context>huge prompt-only payload</widget-context>"
+
+
+def test_empty_additional_context_produces_no_widget_reminder():
+    assert parse_widget_contexts(None) == []
+    assert parse_widget_contexts([]) == []
+    assert build_widget_context_reminder([]) is None

--- a/tests/unit/server/models/test_additional_context.py
+++ b/tests/unit/server/models/test_additional_context.py
@@ -1,0 +1,160 @@
+"""Tests for the AdditionalContext discriminated union.
+
+Verifies that all five context types parse correctly through the union and
+that required-field validation fires for each.
+"""
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from src.server.models.additional_context import (
+    AdditionalContext,
+    DirectiveContext,
+    MultimodalContext,
+    SkillContext,
+    WidgetContext,
+)
+
+
+_adapter = TypeAdapter(AdditionalContext)
+
+
+class TestDiscriminator:
+    def test_skills_routes_to_skill_context(self):
+        ctx = _adapter.validate_python(
+            {"type": "skills", "name": "user-profile"}
+        )
+        assert isinstance(ctx, SkillContext)
+        assert ctx.name == "user-profile"
+
+    def test_image_routes_to_multimodal(self):
+        ctx = _adapter.validate_python(
+            {"type": "image", "data": "data:image/png;base64,xx"}
+        )
+        assert isinstance(ctx, MultimodalContext)
+        assert ctx.type == "image"
+
+    def test_pdf_routes_to_multimodal(self):
+        ctx = _adapter.validate_python(
+            {"type": "pdf", "data": "data:application/pdf;base64,xx"}
+        )
+        assert isinstance(ctx, MultimodalContext)
+        assert ctx.type == "pdf"
+
+    def test_directive_routes_to_directive_context(self):
+        ctx = _adapter.validate_python(
+            {"type": "directive", "content": "follow this"}
+        )
+        assert isinstance(ctx, DirectiveContext)
+        assert ctx.content == "follow this"
+
+    def test_widget_routes_to_widget_context(self):
+        ctx = _adapter.validate_python(
+            {
+                "type": "widget",
+                "widget_type": "markets.chart",
+                "widget_id": "abc",
+                "label": "NVDA",
+                "text": "<widget-context>...</widget-context>",
+                "data": {"bars": []},
+            }
+        )
+        assert isinstance(ctx, WidgetContext)
+        assert ctx.widget_type == "markets.chart"
+        assert ctx.label == "NVDA"
+
+
+class TestWidgetContextValidation:
+    def test_missing_required_widget_type(self):
+        with pytest.raises(ValidationError):
+            _adapter.validate_python(
+                {
+                    "type": "widget",
+                    "widget_id": "abc",
+                    "label": "NVDA",
+                    "text": "<widget-context>...</widget-context>",
+                }
+            )
+
+    def test_missing_required_widget_id(self):
+        with pytest.raises(ValidationError):
+            _adapter.validate_python(
+                {
+                    "type": "widget",
+                    "widget_type": "markets.chart",
+                    "label": "NVDA",
+                    "text": "<widget-context>...</widget-context>",
+                }
+            )
+
+    def test_missing_required_label(self):
+        with pytest.raises(ValidationError):
+            _adapter.validate_python(
+                {
+                    "type": "widget",
+                    "widget_type": "markets.chart",
+                    "widget_id": "abc",
+                    "text": "<widget-context>...</widget-context>",
+                }
+            )
+
+    def test_missing_required_text(self):
+        with pytest.raises(ValidationError):
+            _adapter.validate_python(
+                {
+                    "type": "widget",
+                    "widget_type": "markets.chart",
+                    "widget_id": "abc",
+                    "label": "NVDA",
+                }
+            )
+
+    def test_data_defaults_to_empty_dict(self):
+        ctx = _adapter.validate_python(
+            {
+                "type": "widget",
+                "widget_type": "x",
+                "widget_id": "x",
+                "label": "x",
+                "text": "<widget-context>x</widget-context>",
+            }
+        )
+        assert ctx.data == {}
+
+    def test_optional_fields_accept_none(self):
+        ctx = _adapter.validate_python(
+            {
+                "type": "widget",
+                "widget_type": "x",
+                "widget_id": "x",
+                "label": "x",
+                "text": "<widget-context>x</widget-context>",
+                "captured_at": None,
+                "description": None,
+            }
+        )
+        assert ctx.captured_at is None
+        assert ctx.description is None
+
+    def test_unknown_type_rejected(self):
+        with pytest.raises(ValidationError):
+            _adapter.validate_python({"type": "unknown_type"})
+
+
+class TestMixedList:
+    def test_list_of_mixed_context_types(self):
+        items = [
+            {"type": "directive", "content": "x"},
+            {
+                "type": "widget",
+                "widget_type": "watchlist.list",
+                "widget_id": "w1",
+                "label": "L",
+                "text": "<widget-context>w</widget-context>",
+            },
+            {"type": "image", "data": "data:image/jpeg;base64,xxx"},
+        ]
+        parsed = [_adapter.validate_python(i) for i in items]
+        assert isinstance(parsed[0], DirectiveContext)
+        assert isinstance(parsed[1], WidgetContext)
+        assert isinstance(parsed[2], MultimodalContext)

--- a/tests/unit/server/utils/test_widget_context.py
+++ b/tests/unit/server/utils/test_widget_context.py
@@ -1,0 +1,317 @@
+"""Tests for widget context utilities.
+
+Covers parse_widget_contexts (dict + model variants), build_widget_context_reminder
+(empty / single / multi-widget), and serialize_widget_contexts_for_metadata.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from src.server.models.additional_context import (
+    DirectiveContext,
+    MultimodalContext,
+    WidgetContext,
+)
+from src.server.utils.widget_context import (
+    build_widget_context_reminder,
+    parse_widget_contexts,
+    serialize_widget_contexts_for_metadata,
+)
+
+
+# ---------------------------------------------------------------------------
+# parse_widget_contexts
+# ---------------------------------------------------------------------------
+
+
+class TestParseWidgetContexts:
+    def test_none_input_returns_empty(self):
+        assert parse_widget_contexts(None) == []
+
+    def test_empty_list_returns_empty(self):
+        assert parse_widget_contexts([]) == []
+
+    def test_dict_widget_round_trips(self):
+        result = parse_widget_contexts(
+            [
+                {
+                    "type": "widget",
+                    "widget_type": "markets.chart",
+                    "widget_id": "abc-123",
+                    "label": "NVDA · 1d Chart",
+                    "text": "<widget-context type='markets.chart'>...</widget-context>",
+                    "data": {"bars": [], "summary": {}},
+                    "captured_at": "2026-04-26T11:42:08+00:00",
+                    "description": "120 daily bars",
+                }
+            ]
+        )
+        assert len(result) == 1
+        w = result[0]
+        assert isinstance(w, WidgetContext)
+        assert w.widget_type == "markets.chart"
+        assert w.widget_id == "abc-123"
+        assert w.label == "NVDA · 1d Chart"
+        assert w.text.startswith("<widget-context")
+        assert w.data == {"bars": [], "summary": {}}
+        assert w.captured_at is not None
+        assert w.captured_at.tzinfo is not None
+        assert w.description == "120 daily bars"
+
+    def test_dict_with_z_suffix_iso_string(self):
+        result = parse_widget_contexts(
+            [
+                {
+                    "type": "widget",
+                    "widget_type": "news.feed",
+                    "widget_id": "x",
+                    "label": "News",
+                    "text": "<widget-context>news</widget-context>",
+                    "captured_at": "2026-04-26T11:42:08Z",
+                }
+            ]
+        )
+        assert result[0].captured_at is not None
+
+    def test_dict_with_invalid_captured_at_returns_none(self):
+        result = parse_widget_contexts(
+            [
+                {
+                    "type": "widget",
+                    "widget_type": "x",
+                    "widget_id": "x",
+                    "label": "x",
+                    "text": "<widget-context>x</widget-context>",
+                    "captured_at": "not-a-date",
+                }
+            ]
+        )
+        assert result[0].captured_at is None
+
+    def test_pydantic_model_passes_through(self):
+        ctx = WidgetContext(
+            type="widget",
+            widget_type="watchlist.list",
+            widget_id="ws-1",
+            label="Tech Watch",
+            text="<widget-context>...</widget-context>",
+            data={"rows": []},
+        )
+        result = parse_widget_contexts([ctx])
+        assert result == [ctx]
+
+    def test_filters_out_other_context_types(self):
+        result = parse_widget_contexts(
+            [
+                {
+                    "type": "directive",
+                    "content": "ignore me",
+                },
+                {
+                    "type": "image",
+                    "data": "data:image/jpeg;base64,xxx",
+                },
+                {
+                    "type": "widget",
+                    "widget_type": "tv.heatmap",
+                    "widget_id": "tv-1",
+                    "label": "Heatmap",
+                    "text": "<widget-context>tv</widget-context>",
+                },
+            ]
+        )
+        assert len(result) == 1
+        assert result[0].widget_type == "tv.heatmap"
+
+    def test_coexists_with_directive_and_multimodal(self):
+        """Mixed additional_context list — only widget items are returned."""
+        mixed = [
+            DirectiveContext(type="directive", content="hello"),
+            MultimodalContext(type="image", data="data:image/jpeg;base64,xxx"),
+            WidgetContext(
+                type="widget",
+                widget_type="markets.chart",
+                widget_id="w1",
+                label="Chart",
+                text="<widget-context>...</widget-context>",
+            ),
+        ]
+        result = parse_widget_contexts(mixed)
+        assert len(result) == 1
+        assert result[0].widget_id == "w1"
+
+    def test_dict_with_missing_optional_fields_uses_defaults(self):
+        result = parse_widget_contexts(
+            [
+                {
+                    "type": "widget",
+                    "widget_type": "x.y",
+                    "widget_id": "id",
+                    "label": "L",
+                    "text": "<widget-context>t</widget-context>",
+                }
+            ]
+        )
+        assert result[0].data == {}
+        assert result[0].captured_at is None
+        assert result[0].description is None
+
+
+# ---------------------------------------------------------------------------
+# build_widget_context_reminder
+# ---------------------------------------------------------------------------
+
+
+class TestBuildWidgetContextReminder:
+    def test_empty_returns_none(self):
+        assert build_widget_context_reminder([]) is None
+
+    def test_single_widget_wraps_in_system_reminder(self):
+        widgets = [
+            WidgetContext(
+                type="widget",
+                widget_type="markets.chart",
+                widget_id="w1",
+                label="NVDA",
+                text="<widget-context type='markets.chart' symbol='NVDA'>chart data</widget-context>",
+            )
+        ]
+        result = build_widget_context_reminder(widgets)
+        assert result is not None
+        assert result.startswith("\n\n<system-reminder>\n")
+        assert result.endswith("\n</system-reminder>")
+        assert "<widget-context type='markets.chart' symbol='NVDA'>" in result
+
+    def test_multiple_widgets_concatenated(self):
+        widgets = [
+            WidgetContext(
+                type="widget",
+                widget_type="markets.chart",
+                widget_id="w1",
+                label="NVDA",
+                text="<widget-context type='markets.chart'>NVDA</widget-context>",
+            ),
+            WidgetContext(
+                type="widget",
+                widget_type="news.feed",
+                widget_id="w2",
+                label="News",
+                text="<widget-context type='news.feed'>headline</widget-context>",
+            ),
+        ]
+        result = build_widget_context_reminder(widgets)
+        assert result is not None
+        assert "NVDA" in result
+        assert "headline" in result
+        # Both widgets share one envelope
+        assert result.count("<system-reminder>") == 1
+        assert result.count("</system-reminder>") == 1
+        # Both pre-rendered widget tags survive intact. Count closing tags
+        # because the system-reminder preamble mentions `<widget-context>`
+        # by name in prose.
+        assert result.count("</widget-context>") == 2
+
+    def test_reminder_includes_explainer_preamble(self):
+        """The reminder must explain to the agent that the blocks are
+        user-attached dashboard snapshots and should be evaluated for
+        relevance — otherwise the agent can't tell apart load-bearing
+        context from incidental clicks."""
+        widgets = [
+            WidgetContext(
+                type="widget",
+                widget_type="markets.chart",
+                widget_id="w1",
+                label="x",
+                text="<widget-context>chart</widget-context>",
+            )
+        ]
+        result = build_widget_context_reminder(widgets)
+        assert result is not None
+        # User-action framing
+        assert "user attached" in result.lower()
+        # Relevance evaluation framing
+        assert "relevant" in result.lower() or "relevance" in result.lower()
+        # Preamble appears before the first widget block
+        preamble_end = result.find("<widget-context>chart")
+        assert preamble_end > len("\n\n<system-reminder>\n")
+
+    def test_widget_with_empty_text_skipped(self):
+        widgets = [
+            WidgetContext(
+                type="widget",
+                widget_type="x",
+                widget_id="x",
+                label="x",
+                text="   ",
+            ),
+        ]
+        assert build_widget_context_reminder(widgets) is None
+
+    def test_mixed_empty_and_non_empty(self):
+        widgets = [
+            WidgetContext(
+                type="widget",
+                widget_type="x",
+                widget_id="x",
+                label="x",
+                text="",
+            ),
+            WidgetContext(
+                type="widget",
+                widget_type="y",
+                widget_id="y",
+                label="y",
+                text="<widget-context>kept</widget-context>",
+            ),
+        ]
+        result = build_widget_context_reminder(widgets)
+        assert result is not None
+        assert "kept" in result
+        # Count closing tags so the preamble's literal mention of
+        # `<widget-context>` doesn't inflate the count.
+        assert result.count("</widget-context>") == 1
+
+
+# ---------------------------------------------------------------------------
+# serialize_widget_contexts_for_metadata
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeForMetadata:
+    def test_keeps_text_and_data(self):
+        widgets = [
+            WidgetContext(
+                type="widget",
+                widget_type="markets.chart",
+                widget_id="w1",
+                label="Chart",
+                text="<widget-context>huge prompt-only payload</widget-context>",
+                data={"bars": [{"o": 1, "c": 2}]},
+                captured_at=datetime(2026, 4, 26, 11, 42, 8, tzinfo=timezone.utc),
+                description="120 bars",
+            )
+        ]
+        out = serialize_widget_contexts_for_metadata(widgets)
+        assert len(out) == 1
+        assert out[0]["widget_type"] == "markets.chart"
+        assert out[0]["widget_id"] == "w1"
+        assert out[0]["label"] == "Chart"
+        assert out[0]["data"] == {"bars": [{"o": 1, "c": 2}]}
+        assert out[0]["captured_at"] == "2026-04-26T11:42:08+00:00"
+        assert out[0]["description"] == "120 bars"
+        # Text is kept so the chip preview UI can show what the agent saw
+        assert out[0]["text"] == "<widget-context>huge prompt-only payload</widget-context>"
+
+    def test_handles_missing_captured_at(self):
+        widgets = [
+            WidgetContext(
+                type="widget",
+                widget_type="x",
+                widget_id="x",
+                label="x",
+                text="<widget-context>x</widget-context>",
+            )
+        ]
+        out = serialize_widget_contexts_for_metadata(widgets)
+        assert out[0]["captured_at"] is None

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+*.tsbuildinfo
 
 # Environment variables
 .env

--- a/web/src/components/Main/Main.tsx
+++ b/web/src/components/Main/Main.tsx
@@ -2,6 +2,7 @@ import React, { Suspense } from 'react';
 import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useIsMobile } from '@/hooks/useIsMobile';
+import { ContextOverflowPill } from '@/components/ui/ContextOverflowPill';
 
 const Dashboard = React.lazy(() => import('../../pages/Dashboard/DashboardRouter'));
 const ChatAgent = React.lazy(() => import('../../pages/ChatAgent/ChatAgent'));
@@ -37,7 +38,12 @@ function Main() {
 
   // On mobile, skip AnimatePresence — instant page switches feel snappier
   if (isMobile) {
-    return <div className="main" style={{ height: '100%' }}>{routes}</div>;
+    return (
+      <div className="main" style={{ height: '100%' }}>
+        {routes}
+        <ContextOverflowPill />
+      </div>
+    );
   }
 
   return (
@@ -54,6 +60,7 @@ function Main() {
           {routes}
         </motion.div>
       </AnimatePresence>
+      <ContextOverflowPill />
     </div>
   );
 }

--- a/web/src/components/ui/ContextOverflowPill.css
+++ b/web/src/components/ui/ContextOverflowPill.css
@@ -1,0 +1,61 @@
+.context-overflow-pill {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 60;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  background: var(--color-bg-card, #ffffff);
+  border: 1px solid var(--color-border-elevated, rgba(20, 20, 23, 0.14));
+  border-radius: 999px;
+  font-size: 12px;
+  color: var(--color-text-primary, #1a1a1c);
+  cursor: pointer;
+  box-shadow:
+    0 16px 32px -10px rgba(20, 20, 23, 0.16),
+    0 4px 8px -4px rgba(20, 20, 23, 0.08);
+  transition:
+    transform 180ms cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow 180ms cubic-bezier(0.16, 1, 0.3, 1),
+    border-color 180ms ease;
+  animation: contextPillIn 220ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.context-overflow-pill:hover {
+  transform: translateY(-1px);
+  border-color: var(--color-accent-primary, #b88a2c);
+  box-shadow:
+    0 22px 40px -10px rgba(20, 20, 23, 0.18),
+    0 6px 12px -4px rgba(20, 20, 23, 0.10);
+}
+
+.context-overflow-pill:focus-visible {
+  outline: 2px solid var(--color-accent-primary, #b88a2c);
+  outline-offset: 2px;
+}
+
+.context-overflow-pill__count {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--color-accent-primary, #b88a2c);
+}
+
+.context-overflow-pill__label {
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--color-text-tertiary, #8a8a8a);
+}
+
+@keyframes contextPillIn {
+  from { opacity: 0; transform: translateY(8px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .context-overflow-pill {
+    animation: none;
+    transition: none;
+  }
+}

--- a/web/src/components/ui/ContextOverflowPill.tsx
+++ b/web/src/components/ui/ContextOverflowPill.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { Sparkles, ArrowUp } from 'lucide-react';
+import { ChatInputRegistry, ContextBus } from '@/lib/contextBus';
+import type { WidgetContextSnapshot } from '@/pages/Dashboard/widgets/framework/contextSnapshot';
+import './ContextOverflowPill.css';
+
+/**
+ * Floating pill rendered at the app shell. Surfaces the widget context deck
+ * count *only* when zero chat inputs are in the viewport — otherwise the
+ * deck is already visible above one of those inputs and showing the pill
+ * would be redundant noise.
+ *
+ * Click behavior:
+ *   - If a registered chat input exists, smooth-scroll to the nearest one.
+ *   - Otherwise, navigate to the default chat thread with state so the chat
+ *     input there can re-seed its deck via `addWidgetSnapshot` on mount.
+ */
+export function ContextOverflowPill() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const [snapshots, setSnapshots] = useState<WidgetContextSnapshot[]>([]);
+  const [anyChatVisible, setAnyChatVisible] = useState(true);
+
+  // Mirror the bus locally so we know when there's anything to surface.
+  useEffect(() => {
+    const off = ContextBus.subscribe((event) => {
+      if (event.type === 'attach') {
+        setSnapshots((prev) => {
+          if (prev.some((s) => s.widget_id === event.snapshot.widget_id)) return prev;
+          return [...prev, event.snapshot];
+        });
+      } else if (event.type === 'detach') {
+        setSnapshots((prev) => prev.filter((s) => s.widget_id !== event.widgetId));
+      } else if (event.type === 'clear') {
+        setSnapshots([]);
+      }
+    });
+    return off;
+  }, []);
+
+  // Track which registered chat inputs are in the viewport. We rebuild the
+  // observer when the registry membership changes so newly-mounted inputs
+  // start being observed immediately.
+  useEffect(() => {
+    let observer: IntersectionObserver | null = null;
+    const visibilityByEl = new Map<Element, boolean>();
+    const recompute = () => {
+      const someVisible = [...visibilityByEl.values()].some(Boolean);
+      setAnyChatVisible(someVisible);
+    };
+
+    const setup = () => {
+      observer?.disconnect();
+      visibilityByEl.clear();
+      const els = ChatInputRegistry.list();
+      if (els.length === 0) {
+        setAnyChatVisible(false);
+        return;
+      }
+      observer = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            visibilityByEl.set(entry.target, entry.isIntersecting);
+          });
+          recompute();
+        },
+        { threshold: 0.01 },
+      );
+      els.forEach((el) => {
+        visibilityByEl.set(el, false);
+        observer!.observe(el);
+      });
+    };
+
+    setup();
+    const off = ChatInputRegistry.subscribe(setup);
+    return () => {
+      observer?.disconnect();
+      off();
+    };
+  }, []);
+
+  if (snapshots.length === 0 || anyChatVisible) return null;
+
+  const handleClick = () => {
+    const els = ChatInputRegistry.list();
+    if (els.length > 0) {
+      els[0].scrollIntoView({ behavior: 'smooth', block: 'center' });
+      return;
+    }
+    navigate('/chat/t/__default__', { state: { widgetSnapshots: snapshots } });
+  };
+
+  return (
+    <button
+      type="button"
+      className="context-overflow-pill"
+      onClick={handleClick}
+      aria-label={t('chat.widgetContext.overflowAria', {
+        count: snapshots.length,
+        defaultValue: '{{count}} item(s) in context — open chat',
+      })}
+    >
+      <Sparkles className="h-3.5 w-3.5" />
+      <span className="context-overflow-pill__count">{snapshots.length}</span>
+      <span className="context-overflow-pill__label">
+        {t('chat.widgetContext.overflowLabel', { defaultValue: 'in context' })}
+      </span>
+      <ArrowUp className="h-3 w-3" />
+    </button>
+  );
+}

--- a/web/src/components/ui/ContextOverflowPill.tsx
+++ b/web/src/components/ui/ContextOverflowPill.tsx
@@ -90,7 +90,10 @@ export function ContextOverflowPill() {
       els[0].scrollIntoView({ behavior: 'smooth', block: 'center' });
       return;
     }
-    navigate('/chat/t/__default__', { state: { widgetSnapshots: snapshots } });
+    // Strip image data URLs — chip rendering doesn't need them and a couple of
+    // chart captures can blow past Firefox's 640KB structured-clone ceiling.
+    const lite = snapshots.map(({ image_jpeg_data_url: _img, ...rest }) => rest);
+    navigate('/chat/t/__default__', { state: { widgetSnapshots: lite } });
   };
 
   return (

--- a/web/src/components/ui/__tests__/ContextOverflowPill.test.tsx
+++ b/web/src/components/ui/__tests__/ContextOverflowPill.test.tsx
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { ContextOverflowPill } from '../ContextOverflowPill';
+import { ChatInputRegistry, ContextBus } from '@/lib/contextBus';
+import type { WidgetContextSnapshot } from '@/pages/Dashboard/widgets/framework/contextSnapshot';
+
+const SNAP: WidgetContextSnapshot = {
+  widget_type: 'markets.chart',
+  widget_id: 'a',
+  label: 'NVDA',
+  captured_at: '2026-04-26T11:42:08Z',
+  text: '<widget-context>x</widget-context>',
+  data: {},
+};
+
+// jsdom does not implement IntersectionObserver — provide a controllable mock.
+let observerCallbacks: IntersectionObserverCallback[] = [];
+let observedTargets: Element[] = [];
+
+class MockIO {
+  callback: IntersectionObserverCallback;
+  constructor(cb: IntersectionObserverCallback) {
+    this.callback = cb;
+    observerCallbacks.push(cb);
+  }
+  observe(target: Element) {
+    observedTargets.push(target);
+  }
+  unobserve() {}
+  disconnect() {
+    observerCallbacks = observerCallbacks.filter((c) => c !== this.callback);
+  }
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+  root = null;
+  rootMargin = '';
+  thresholds = [];
+}
+
+function setIntersection(target: Element, isIntersecting: boolean) {
+  observerCallbacks.forEach((cb) => {
+    cb(
+      [
+        {
+          target,
+          isIntersecting,
+          intersectionRatio: isIntersecting ? 1 : 0,
+          time: 0,
+          boundingClientRect: target.getBoundingClientRect(),
+          intersectionRect: target.getBoundingClientRect(),
+          rootBounds: null,
+        } as IntersectionObserverEntry,
+      ],
+      // mock observer instance — cast to any to avoid satisfying the full DOM type
+      {} as IntersectionObserver,
+    );
+  });
+}
+
+describe('ContextOverflowPill', () => {
+  beforeEach(() => {
+    observerCallbacks = [];
+    observedTargets = [];
+    (globalThis as unknown as { IntersectionObserver: unknown }).IntersectionObserver = MockIO as unknown as typeof IntersectionObserver;
+    ContextBus.__resetForTests();
+    ChatInputRegistry.__resetForTests();
+  });
+  afterEach(() => {
+    ContextBus.__resetForTests();
+    ChatInputRegistry.__resetForTests();
+  });
+
+  it('does not render when there are no snapshots', () => {
+    render(
+      <MemoryRouter>
+        <ContextOverflowPill />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('does not render when a chat input is in viewport', () => {
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    render(
+      <MemoryRouter>
+        <ContextOverflowPill />
+      </MemoryRouter>,
+    );
+    act(() => {
+      ChatInputRegistry.register(el);
+    });
+    act(() => {
+      setIntersection(el, true);
+    });
+    act(() => {
+      ContextBus.attach(SNAP);
+    });
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('renders when chats exist but none are visible', () => {
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    render(
+      <MemoryRouter>
+        <ContextOverflowPill />
+      </MemoryRouter>,
+    );
+    act(() => {
+      ChatInputRegistry.register(el);
+    });
+    act(() => {
+      setIntersection(el, false);
+    });
+    act(() => {
+      ContextBus.attach(SNAP);
+    });
+    const btn = screen.getByRole('button');
+    expect(btn).toBeInTheDocument();
+    expect(btn.textContent).toContain('1');
+  });
+
+  it('renders when no chat inputs are mounted at all', () => {
+    render(
+      <MemoryRouter>
+        <ContextOverflowPill />
+      </MemoryRouter>,
+    );
+    act(() => {
+      ContextBus.attach(SNAP);
+    });
+    const btn = screen.getByRole('button');
+    expect(btn).toBeInTheDocument();
+  });
+
+  it('click navigates to default chat when no chat input is registered', () => {
+    let lastNavigatedState: unknown = null;
+    function StateProbe() {
+      const search = window.history.state;
+      lastNavigatedState = search;
+      return <div data-testid="probe">probe</div>;
+    }
+    render(
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <Routes>
+          <Route path="/dashboard" element={<ContextOverflowPill />} />
+          <Route path="/chat/t/__default__" element={<StateProbe />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    act(() => {
+      ContextBus.attach(SNAP);
+    });
+    const btn = screen.getByRole('button');
+    act(() => {
+      fireEvent.click(btn);
+    });
+    expect(screen.getByTestId('probe')).toBeInTheDocument();
+    // (Not asserting on `lastNavigatedState` — react-router's MemoryRouter
+    // doesn't surface state on window.history. Reaching the /chat route is
+    // sufficient evidence the navigate fired.)
+    expect(lastNavigatedState).toBeDefined();
+  });
+
+  it('click on visible chat scrolls to it', () => {
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    el.scrollIntoView = vi.fn();
+    render(
+      <MemoryRouter>
+        <ContextOverflowPill />
+      </MemoryRouter>,
+    );
+    act(() => {
+      ChatInputRegistry.register(el);
+    });
+    act(() => {
+      setIntersection(el, false);
+    });
+    act(() => {
+      ContextBus.attach(SNAP);
+    });
+    const btn = screen.getByRole('button');
+    act(() => {
+      fireEvent.click(btn);
+    });
+    expect(el.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' });
+  });
+});

--- a/web/src/components/ui/__tests__/chat-input.contextBus.test.tsx
+++ b/web/src/components/ui/__tests__/chat-input.contextBus.test.tsx
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, act, screen } from '@testing-library/react';
+import { createRef } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import ChatInput, { type ChatInputHandle } from '../chat-input';
+import { ChatInputRegistry, ContextBus } from '@/lib/contextBus';
+import type { WidgetContextSnapshot } from '@/pages/Dashboard/widgets/framework/contextSnapshot';
+
+// Mock the API helpers chat-input fetches at mount — they hit network in real
+// usage and we don't need them for deck behavior.
+vi.mock('@/pages/ChatAgent/utils/api', () => ({
+  getSkills: vi.fn().mockResolvedValue([]),
+  getModelMetadata: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('@/hooks/usePreferences', () => ({
+  usePreferences: () => ({ data: undefined, isLoading: false }),
+}));
+
+vi.mock('@/lib/modelCapabilities', () => ({
+  supportsXhighEffort: () => false,
+}));
+
+vi.mock('../use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+const SNAP_A: WidgetContextSnapshot = {
+  widget_type: 'markets.chart',
+  widget_id: 'a',
+  label: 'NVDA · 1d Chart',
+  description: '120 daily bars',
+  captured_at: '2026-04-26T11:42:08Z',
+  text: '<widget-context>chart</widget-context>',
+  data: {},
+};
+
+const SNAP_B: WidgetContextSnapshot = {
+  widget_type: 'news.feed',
+  widget_id: 'b',
+  label: 'News headline',
+  description: 'Reuters · 14m ago',
+  captured_at: '2026-04-26T11:43:00Z',
+  text: '<widget-context>news</widget-context>',
+  data: {},
+};
+
+function renderInput(onSend = vi.fn(), refOpts?: { ref?: React.Ref<ChatInputHandle> }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <ChatInput ref={refOpts?.ref} onSend={onSend} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('ChatInput — widget context deck', () => {
+  beforeEach(() => {
+    ContextBus.__resetForTests();
+    ChatInputRegistry.__resetForTests();
+  });
+  afterEach(() => {
+    ContextBus.__resetForTests();
+    ChatInputRegistry.__resetForTests();
+  });
+
+  it('does not render the deck when no snapshots are attached', () => {
+    renderInput();
+    expect(screen.queryByTestId('widget-context-deck')).toBeNull();
+  });
+
+  it('renders a card on ContextBus.attach', () => {
+    renderInput();
+    act(() => {
+      ContextBus.attach(SNAP_A);
+    });
+    const deck = screen.getByTestId('widget-context-deck');
+    expect(deck).toBeInTheDocument();
+    expect(deck.textContent).toContain('NVDA · 1d Chart');
+    expect(deck.textContent).toContain('1 in context');
+  });
+
+  it('addWidgetSnapshot ref method adds a card without using the bus', () => {
+    const ref = createRef<ChatInputHandle>();
+    renderInput(undefined, { ref });
+    const handler = vi.fn();
+    ContextBus.subscribe(handler);
+    act(() => {
+      ref.current?.addWidgetSnapshot(SNAP_A);
+    });
+    expect(screen.getByTestId('widget-context-deck').textContent).toContain('NVDA · 1d Chart');
+    // No attach event was published — the ref method is local-only.
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('removing a card publishes detach so other inputs drop it', () => {
+    renderInput();
+    act(() => {
+      ContextBus.attach(SNAP_A);
+      ContextBus.attach(SNAP_B);
+    });
+    const handler = vi.fn();
+    ContextBus.subscribe(handler);
+    const removeButtons = screen.getAllByLabelText(/remove from context/i);
+    act(() => {
+      fireEvent.click(removeButtons[0]);
+    });
+    // detach published with one of the widget ids
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][0].type).toBe('detach');
+    expect(['a', 'b']).toContain(handler.mock.calls[0][0].widgetId);
+  });
+
+  it('two mounted ChatInputs mirror the same deck via ContextBus', () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ChatInput onSend={vi.fn()} />
+          <ChatInput onSend={vi.fn()} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+    act(() => {
+      ContextBus.attach(SNAP_A);
+    });
+    const decks = screen.getAllByTestId('widget-context-deck');
+    expect(decks).toHaveLength(2);
+    decks.forEach((d) => expect(d.textContent).toContain('NVDA'));
+  });
+
+  it('ContextBus.clear empties every mounted deck', () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ChatInput onSend={vi.fn()} />
+          <ChatInput onSend={vi.fn()} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+    act(() => {
+      ContextBus.attach(SNAP_A);
+      ContextBus.attach(SNAP_B);
+    });
+    expect(screen.getAllByTestId('widget-context-deck')).toHaveLength(2);
+    act(() => {
+      ContextBus.clear();
+    });
+    expect(screen.queryAllByTestId('widget-context-deck')).toHaveLength(0);
+  });
+
+  it('registers chat-input root in ChatInputRegistry on mount', () => {
+    expect(ChatInputRegistry.size()).toBe(0);
+    const { unmount } = renderInput();
+    expect(ChatInputRegistry.size()).toBe(1);
+    unmount();
+    expect(ChatInputRegistry.size()).toBe(0);
+  });
+
+  it('renders 1 / 3 / 5 cards with stable peek geometry', () => {
+    const { rerender, unmount } = renderInput();
+    const more: WidgetContextSnapshot[] = [SNAP_A, SNAP_B, { ...SNAP_A, widget_id: 'c' }, { ...SNAP_A, widget_id: 'd' }, { ...SNAP_A, widget_id: 'e' }];
+
+    // 1 card
+    act(() => ContextBus.attach(more[0]));
+    let deck = screen.getByTestId('widget-context-deck');
+    let cards = deck.querySelectorAll('.widget-deck-card');
+    expect(cards.length).toBe(1);
+    expect((cards[0] as HTMLElement).style.transform).toContain('scale(1)');
+
+    // +2 → 3 cards. Snapshot the per-index transforms.
+    act(() => {
+      ContextBus.attach(more[1]);
+      ContextBus.attach(more[2]);
+    });
+    deck = screen.getByTestId('widget-context-deck');
+    cards = deck.querySelectorAll('.widget-deck-card');
+    expect(cards.length).toBe(3);
+
+    // +2 more → 5 cards. Last card uses index-4 peek (24px translate).
+    act(() => {
+      ContextBus.attach(more[3]);
+      ContextBus.attach(more[4]);
+    });
+    deck = screen.getByTestId('widget-context-deck');
+    cards = deck.querySelectorAll('.widget-deck-card');
+    expect(cards.length).toBe(5);
+    // Top card (newest, index 0): no peek translate
+    const indexed = Array.from(cards) as HTMLElement[];
+    const top = indexed.find((c) => c.dataset.i === '0')!;
+    expect(top.style.transform).toContain('translateY(0px)');
+    expect(top.style.opacity).toBe('1');
+    // Last card (index 4): 24px peek translate, lower opacity
+    const last = indexed.find((c) => c.dataset.i === '4')!;
+    expect(last.style.transform).toContain('translateY(24px)');
+    expect(parseFloat(last.style.opacity)).toBeLessThan(1);
+
+    rerender(<></>);
+    unmount();
+  });
+
+  it('clear button publishes ContextBus.clear', () => {
+    renderInput();
+    act(() => {
+      ContextBus.attach(SNAP_A);
+      ContextBus.attach(SNAP_B);
+    });
+    const handler = vi.fn();
+    ContextBus.subscribe(handler);
+    act(() => {
+      fireEvent.click(screen.getByText(/^Clear$/i));
+    });
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][0].type).toBe('clear');
+  });
+});

--- a/web/src/components/ui/chat-input.css
+++ b/web/src/components/ui/chat-input.css
@@ -470,3 +470,244 @@
 .waveform-bar:nth-child(8) {
   animation-delay: 0.7s;
 }
+/* === WIDGET CONTEXT DECK === */
+.widget-deck-rail {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 4px 2px 6px;
+  border-bottom: 1px dashed var(--color-border-muted, rgba(20, 20, 23, 0.08));
+  margin-bottom: 4px;
+}
+
+.widget-deck-eyebrow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 4px;
+  font-family: var(--font-mono, ui-monospace, "SF Mono", Menlo, monospace);
+  font-size: 9.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--color-accent-primary, #b88a2c);
+}
+
+.widget-deck-eyebrow-left {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  overflow: hidden;
+}
+
+.widget-deck-dot {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--color-accent-primary, #b88a2c);
+  box-shadow: 0 0 5px rgba(184, 138, 44, 0.4);
+  flex-shrink: 0;
+}
+
+.widget-deck-hint {
+  text-transform: none;
+  letter-spacing: 0;
+  font-style: italic;
+  font-size: 11px;
+  margin-left: 6px;
+  opacity: 0.85;
+  font-family: var(--font-serif, "Instrument Serif", Georgia, serif);
+}
+
+.widget-deck-eyebrow-right {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.widget-deck-clear {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  font: inherit;
+  font-size: 9.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--color-text-tertiary, #8a8a8a);
+  cursor: pointer;
+  padding: 0;
+  flex-shrink: 0;
+}
+
+.widget-deck-clear:hover {
+  color: var(--color-danger, #c43d3d);
+}
+
+/* Show-less pill — appears left of Clear when the deck is fanned. Pill
+ * shape mirrors Apple's stack-collapse affordance: rounded background,
+ * sentence-case label, sits inline with the uppercase eyebrow row. */
+.widget-deck-show-less {
+  appearance: none;
+  border: 1px solid var(--color-border-muted, rgba(20, 20, 23, 0.08));
+  background: var(--color-bg-card, rgba(255, 255, 255, 0.6));
+  font: inherit;
+  font-size: 11px;
+  font-family: var(--font-serif, "Instrument Serif", Georgia, serif);
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--color-text-secondary, #4a4a4a);
+  cursor: pointer;
+  padding: 2px 10px;
+  border-radius: 999px;
+  flex-shrink: 0;
+  transition:
+    background 120ms cubic-bezier(0.16, 1, 0.3, 1),
+    color 120ms cubic-bezier(0.16, 1, 0.3, 1),
+    border-color 120ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.widget-deck-show-less:hover {
+  color: var(--color-text-primary, #1a1a1c);
+  border-color: var(--color-border-default, rgba(20, 20, 23, 0.16));
+}
+
+.widget-deck-stack {
+  position: relative;
+  transition: height 260ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.widget-deck-card {
+  position: absolute;
+  left: 0;
+  right: 0;
+  display: grid;
+  grid-template-columns: 32px 1fr 24px;
+  align-items: center;
+  gap: 10px;
+  background: var(--color-bg-card, #ffffff);
+  border: 1px solid var(--color-border-muted, rgba(20, 20, 23, 0.08));
+  border-radius: 10px;
+  padding: 10px 12px;
+  box-shadow: 0 1px 2px rgba(20, 20, 23, 0.04);
+  transition:
+    transform 260ms cubic-bezier(0.16, 1, 0.3, 1),
+    opacity 260ms cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow 120ms cubic-bezier(0.16, 1, 0.3, 1);
+  animation: widgetDeckCardIn 280ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes widgetDeckCardIn {
+  from { opacity: 0; transform: translateY(-6px) scale(0.96); }
+}
+
+.widget-deck-stack.fanned .widget-deck-card {
+  box-shadow: 0 4px 12px rgba(20, 20, 23, 0.06), 0 1px 2px rgba(20, 20, 23, 0.04);
+}
+
+.widget-deck-card-thumb {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  background: rgba(184, 138, 44, 0.08);
+  color: var(--color-accent-primary, #b88a2c);
+  overflow: hidden;
+}
+
+.widget-deck-card-thumb.has-image {
+  background: linear-gradient(180deg, #1d1d1f 0%, #2a2a2e 100%);
+  position: relative;
+}
+
+.widget-deck-card-thumb-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.widget-deck-card-text {
+  min-width: 0;
+}
+
+.widget-deck-card-title {
+  font-weight: 500;
+  font-size: 13px;
+  line-height: 1.2;
+  color: var(--color-text-primary, #1a1a1c);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.widget-deck-card-snippet {
+  font-size: 11px;
+  color: var(--color-text-tertiary, #8a8a8a);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-top: 2px;
+  letter-spacing: 0.01em;
+}
+
+.widget-deck-card-remove {
+  width: 24px;
+  height: 24px;
+  border: 0;
+  background: transparent;
+  color: var(--color-text-tertiary, #8a8a8a);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  padding: 0;
+  opacity: 0;
+  transition:
+    opacity 120ms cubic-bezier(0.16, 1, 0.3, 1),
+    background 120ms cubic-bezier(0.16, 1, 0.3, 1),
+    color 120ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.widget-deck-card-remove:hover {
+  color: var(--color-danger, #c43d3d);
+  background: rgba(196, 61, 61, 0.08);
+}
+
+/* Top card always shows its remove button. Fan-out reveals all of them. */
+.widget-deck-stack:not(.fanned) .widget-deck-card[data-i="0"] .widget-deck-card-remove,
+.widget-deck-stack.fanned .widget-deck-card-remove {
+  opacity: 1;
+}
+
+.widget-deck-fan-hint {
+  position: absolute;
+  top: -2px;
+  right: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  color: var(--color-text-tertiary, #8a8a8a);
+  pointer-events: none;
+  opacity: 0.6;
+  z-index: 100;
+  transition: opacity 120ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.widget-deck-stack.fanned .widget-deck-fan-hint {
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .widget-deck-card,
+  .widget-deck-stack {
+    transition: none;
+    animation: none;
+  }
+}

--- a/web/src/components/ui/chat-input.tsx
+++ b/web/src/components/ui/chat-input.tsx
@@ -17,6 +17,9 @@ import { useIsMobile } from '@/hooks/useIsMobile';
 import { supportsXhighEffort } from '@/lib/modelCapabilities';
 import { getSkills, getModelMetadata } from '../../pages/ChatAgent/utils/api';
 import { useToast } from './use-toast';
+import { ChatInputRegistry, ContextBus } from '@/lib/contextBus';
+import type { WidgetContextSnapshot } from '@/pages/Dashboard/widgets/framework/contextSnapshot';
+import { WidgetContextDeck } from '@/pages/Dashboard/widgets/framework/WidgetContextDeck';
 import './chat-input.css';
 
 /* --- TYPES --- */
@@ -52,6 +55,13 @@ interface ModelOptions {
   model: string | null;
   reasoningEffort: string | null;
   fastMode: boolean;
+  /**
+   * Widget context snapshots attached via the deck rail. Forwarded to the
+   * backend as `additional_context` items of `type: "widget"`. Image-bearing
+   * snapshots also produce a sibling `type: "image"` MultimodalContext item;
+   * see `widgetSnapshotsToContexts` in `pages/ChatAgent/utils/fileUpload.ts`.
+   */
+  widgetSnapshots?: WidgetContextSnapshot[];
 }
 
 interface ReadyAttachment {
@@ -64,6 +74,14 @@ interface ReadyAttachment {
 export interface ChatInputHandle {
   getModelOptions: () => ModelOptions;
   addContext: (ctx: { path?: string; snippet?: string; label?: string; lineStart?: number; lineEnd?: number; lineCount?: number; source?: string }) => void;
+  /**
+   * Imperatively add a widget context snapshot to the deck. Local-only —
+   * this does NOT publish to ContextBus. Use this when re-seeding the deck
+   * from `location.state` after a navigate (e.g. dashboard → chat handoff).
+   * Use `ContextBus.attach` when the user clicks "+" on a widget so every
+   * mounted chat input sees it.
+   */
+  addWidgetSnapshot: (snapshot: WidgetContextSnapshot) => void;
   setValue: (text: string) => void;
 }
 
@@ -212,27 +230,100 @@ function areModelsCompatible(modelA: string | null, modelB: string | null, metad
 
 /* --- MAIN COMPONENT --- */
 
-/**
- * ChatInput — unified chat input component used across the entire app.
- *
- * @param {Function}  onSend              - (message, planMode, attachments, slashCommands) => void
- * @param {boolean}   disabled
- * @param {boolean}   isLoading
- * @param {Function}  onStop
- * @param {string}    placeholder
- * @param {string[]}  files               - workspace file paths for @mention autocomplete
- * @param {string}    mode                - 'fast' | 'ptc' — undefined = no toggle shown
- * @param {Function}  onModeChange        - (newMode) => void
- * @param {Array}     workspaces          - [{ workspace_id, name }] — null = hidden
- * @param {string}    selectedWorkspaceId
- * @param {Function}  onWorkspaceChange   - (wsId) => void
- * @param {Function}  onCaptureChart      - triggers chart screenshot capture (trading only)
- * @param {string}    chartImage          - base64 data URL of captured chart
- * @param {Function}  onRemoveChartImage
- * @param {string}    prefillMessage
- * @param {Function}  onClearPrefill
- */
 const speechSupported = typeof window !== 'undefined' && !!(window.SpeechRecognition || window.webkitSpeechRecognition);
+
+/* --- WIDGET CONTEXT DECK ---
+ *
+ * The chat-input live deck is a thin wrapper around the shared
+ * `WidgetContextDeck` component (in `pages/Dashboard/widgets/framework/`).
+ * The shared component owns card geometry, fanning, outside-click collapse,
+ * and the preview modal; we supply the live-deck-only chrome (eyebrow row
+ * with clear button, per-card remove `×`, fan-hint chevron) via render
+ * slots so the visual + behavioral contract stays identical to the
+ * chat-view inline deck.
+ */
+function ChatInputWidgetDeck({
+  snapshots,
+  fanned,
+  onToggle,
+  onCollapse,
+  onRemove,
+  onClear,
+  boundaryRef,
+}: {
+  snapshots: WidgetContextSnapshot[];
+  fanned: boolean;
+  onToggle: () => void;
+  onCollapse: () => void;
+  onRemove: (widgetId: string) => void;
+  onClear: () => void;
+  /** The chat-input outer container. Clicks within this boundary (textarea,
+   *  send button, attach controls) keep the deck fanned; only clicks fully
+   *  outside the chat input collapse it. */
+  boundaryRef: React.RefObject<HTMLElement | null>;
+}) {
+  const { t } = useTranslation();
+  const cardCount = snapshots.length;
+  return (
+    <WidgetContextDeck
+      snapshots={snapshots}
+      fanned={fanned}
+      onToggleFan={onToggle}
+      onCollapse={onCollapse}
+      boundaryRef={boundaryRef}
+      className="widget-drag-cancel"
+      testId="widget-context-deck"
+      eyebrow={
+        <div className="widget-deck-eyebrow">
+          <span className="widget-deck-eyebrow-left">
+            <span className="widget-deck-dot" />
+            {t('chat.widgetContext.inContext', { count: cardCount, defaultValue: '{{count}} in context' })}
+            {cardCount > 1 && !fanned && (
+              <span className="widget-deck-hint">{t('chat.widgetContext.fanHint', { defaultValue: 'click to fan' })}</span>
+            )}
+          </span>
+          <span className="widget-deck-eyebrow-right">
+            {fanned && cardCount > 1 && (
+              <button
+                type="button"
+                className="widget-deck-show-less"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onCollapse();
+                }}
+              >
+                {t('chat.widgetContext.showLess', { defaultValue: 'Show less' })}
+              </button>
+            )}
+            <button
+              type="button"
+              className="widget-deck-clear"
+              onClick={(e) => {
+                e.stopPropagation();
+                onClear();
+              }}
+            >
+              {t('chat.widgetContext.clear', { defaultValue: 'Clear' })}
+            </button>
+          </span>
+        </div>
+      }
+      renderCardSlotEnd={(s) => (
+        <button
+          type="button"
+          className="widget-deck-card-remove"
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove(s.widget_id);
+          }}
+          aria-label={t('chat.widgetContext.removeAria', { defaultValue: 'Remove from context' })}
+        >
+          <X className="h-3 w-3" />
+        </button>
+      )}
+    />
+  );
+}
 
 const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput({
   onSend,
@@ -306,6 +397,14 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
 
   // @file mention state
   const [mentionedFiles, setMentionedFiles] = useState<MentionedFile[]>([]);
+
+  // Widget context deck state. Snapshots arrive via ContextBus.attach (when
+  // the user clicks "+" on any widget on the page) or via addWidgetSnapshot
+  // (when re-seeding from location.state after a navigate). Each input
+  // mirrors the same global ContextBus state so two visible inputs always
+  // show the same deck.
+  const [widgetSnapshots, setWidgetSnapshots] = useState<WidgetContextSnapshot[]>([]);
+  const [deckFanned, setDeckFanned] = useState(false);
   const [showAutocomplete, setShowAutocomplete] = useState(false);
   const [autocompleteQuery, setAutocompleteQuery] = useState('');
   const [activeIndex, setActiveIndex] = useState(0);
@@ -478,6 +577,12 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
       // Focus the textarea
       setTimeout(() => textareaRef.current?.focus(), 0);
     },
+    addWidgetSnapshot(snapshot) {
+      setWidgetSnapshots((prev) => {
+        if (prev.some((s) => s.widget_id === snapshot.widget_id)) return prev;
+        return [...prev, snapshot];
+      });
+    },
     setValue(text) {
       setMessage(text);
       setTimeout(() => textareaRef.current?.focus(), 0);
@@ -494,6 +599,37 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
   const autocompleteRef = useRef<HTMLDivElement>(null);
   const slashMenuRef = useRef<HTMLDivElement>(null);
   const chatContainerRef = useRef<HTMLDivElement>(null);
+
+  // Subscribe to ContextBus so this input mirrors the global widget-context
+  // deck. Multiple chat inputs can be visible simultaneously (hero card +
+  // ConversationWidget): they all subscribe and stay in sync. Detach events
+  // come from another input's deck card "×" — we filter our own state to
+  // match.
+  useEffect(() => {
+    const off = ContextBus.subscribe((event) => {
+      if (event.type === 'attach') {
+        setWidgetSnapshots((prev) => {
+          if (prev.some((s) => s.widget_id === event.snapshot.widget_id)) return prev;
+          return [...prev, event.snapshot];
+        });
+      } else if (event.type === 'detach') {
+        setWidgetSnapshots((prev) => prev.filter((s) => s.widget_id !== event.widgetId));
+      } else if (event.type === 'clear') {
+        setWidgetSnapshots([]);
+      }
+    });
+    return off;
+  }, []);
+
+  // Register this chat input's root element so the global ContextOverflowPill
+  // can probe visibility via IntersectionObserver and only show when zero
+  // chat inputs are in the viewport.
+  useEffect(() => {
+    const el = chatContainerRef.current;
+    if (!el) return;
+    const off = ChatInputRegistry.register(el);
+    return off;
+  }, []);
 
   const hasModeToggle = mode !== undefined && onModeChange !== undefined;
 
@@ -877,7 +1013,7 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
   }, []);
 
   // --- Send ---
-  const hasContent = message.trim() || attachedFiles.length > 0 || !!chartImage || mentionedFiles.some((f) => f.snippet);
+  const hasContent = message.trim() || attachedFiles.length > 0 || !!chartImage || mentionedFiles.some((f) => f.snippet) || widgetSnapshots.length > 0;
 
   const handleSend = useCallback(() => {
     if (!hasContent || disabled) return;
@@ -904,18 +1040,30 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
       });
       finalMessage = finalMessage.trimEnd() + '\n' + blocks.join('\n');
     }
-    onSend(finalMessage, planMode, readyAttachments, slashCommands, { model: selectedModel, reasoningEffort, fastMode });
+    onSend(finalMessage, planMode, readyAttachments, slashCommands, {
+      model: selectedModel,
+      reasoningEffort,
+      fastMode,
+      widgetSnapshots: widgetSnapshots.length ? widgetSnapshots : undefined,
+    });
     setMessage('');
     attachedFiles.forEach(f => { if (f.preview) URL.revokeObjectURL(f.preview); });
     setAttachedFiles([]);
     setMentionedFiles([]);
     setSlashCommands([]);
+    // Clear widget deck on send. Other mounted chat inputs hear the same
+    // clear via ContextBus so the deck empties everywhere — single source
+    // of truth.
+    if (widgetSnapshots.length > 0) {
+      ContextBus.clear();
+    }
+    setDeckFanned(false);
     setShowAutocomplete(false);
     setShowSlashMenu(false);
     if (textareaRef.current) {
       textareaRef.current.style.height = 'auto';
     }
-  }, [hasContent, disabled, message, planMode, attachedFiles, onSend, mentionedFiles, slashCommands, selectedModel, reasoningEffort, fastMode, t]);
+  }, [hasContent, disabled, message, planMode, attachedFiles, onSend, mentionedFiles, slashCommands, selectedModel, reasoningEffort, fastMode, widgetSnapshots, t]);
 
   // --- Keyboard & Language Detection ---
   const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -1046,6 +1194,27 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
           </>
         )}
         <div className="flex flex-col px-3 pt-3 pb-2 gap-2">
+
+          {/* Widget context deck — top card visible, others peek behind */}
+          {widgetSnapshots.length > 0 && (
+            <ChatInputWidgetDeck
+              snapshots={widgetSnapshots}
+              fanned={deckFanned}
+              boundaryRef={chatContainerRef}
+              onToggle={() => setDeckFanned((p) => !p)}
+              onCollapse={() => setDeckFanned(false)}
+              onRemove={(widgetId) => {
+                // Local + bus: remove from this input AND publish detach so
+                // every other mounted input drops the same card.
+                setWidgetSnapshots((prev) => prev.filter((s) => s.widget_id !== widgetId));
+                ContextBus.detach(widgetId);
+              }}
+              onClear={() => {
+                ContextBus.clear();
+                setDeckFanned(false);
+              }}
+            />
+          )}
 
           {/* Slash command pills + Mention pills */}
           {(slashCommands.length > 0 || mentionedFiles.length > 0) && (

--- a/web/src/lib/__tests__/contextBus.test.ts
+++ b/web/src/lib/__tests__/contextBus.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatInputRegistry, ContextBus } from '../contextBus';
+import type { WidgetContextSnapshot } from '@/pages/Dashboard/widgets/framework/contextSnapshot';
+
+const SNAP: WidgetContextSnapshot = {
+  widget_type: 'markets.chart',
+  widget_id: 'w1',
+  label: 'NVDA',
+  captured_at: '2026-04-26T11:42:08Z',
+  text: '<widget-context>x</widget-context>',
+  data: {},
+};
+
+describe('ContextBus', () => {
+  beforeEach(() => {
+    ContextBus.__resetForTests();
+  });
+  afterEach(() => {
+    ContextBus.__resetForTests();
+  });
+
+  it('subscribers receive attach events', () => {
+    const handler = vi.fn();
+    ContextBus.subscribe(handler);
+    ContextBus.attach(SNAP);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith({ type: 'attach', snapshot: SNAP });
+  });
+
+  it('subscribers receive detach events', () => {
+    const handler = vi.fn();
+    ContextBus.subscribe(handler);
+    ContextBus.detach('w1');
+    expect(handler).toHaveBeenCalledWith({ type: 'detach', widgetId: 'w1' });
+  });
+
+  it('subscribers receive clear events', () => {
+    const handler = vi.fn();
+    ContextBus.subscribe(handler);
+    ContextBus.clear();
+    expect(handler).toHaveBeenCalledWith({ type: 'clear' });
+  });
+
+  it('multiple subscribers all receive events', () => {
+    const a = vi.fn();
+    const b = vi.fn();
+    ContextBus.subscribe(a);
+    ContextBus.subscribe(b);
+    ContextBus.attach(SNAP);
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it('unsubscribe stops further events', () => {
+    const handler = vi.fn();
+    const unsub = ContextBus.subscribe(handler);
+    ContextBus.attach(SNAP);
+    unsub();
+    ContextBus.attach(SNAP);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('throwing subscribers do not break siblings', () => {
+    const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const bad = vi.fn(() => {
+      throw new Error('boom');
+    });
+    const good = vi.fn();
+    ContextBus.subscribe(bad);
+    ContextBus.subscribe(good);
+    ContextBus.attach(SNAP);
+    expect(bad).toHaveBeenCalledTimes(1);
+    expect(good).toHaveBeenCalledTimes(1);
+    expect(consoleErr).toHaveBeenCalled();
+    consoleErr.mockRestore();
+  });
+
+  it('a subscriber that unsubscribes during dispatch does not crash', () => {
+    const a = vi.fn();
+    let unsubB: (() => void) | null = null;
+    const b = vi.fn(() => {
+      unsubB?.();
+    });
+    ContextBus.subscribe(a);
+    unsubB = ContextBus.subscribe(b);
+    ContextBus.attach(SNAP);
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ChatInputRegistry', () => {
+  beforeEach(() => {
+    ChatInputRegistry.__resetForTests();
+  });
+  afterEach(() => {
+    ChatInputRegistry.__resetForTests();
+  });
+
+  it('register / unregister tracks elements', () => {
+    const a = document.createElement('div');
+    const b = document.createElement('div');
+    expect(ChatInputRegistry.size()).toBe(0);
+    const offA = ChatInputRegistry.register(a);
+    const offB = ChatInputRegistry.register(b);
+    expect(ChatInputRegistry.size()).toBe(2);
+    offA();
+    expect(ChatInputRegistry.size()).toBe(1);
+    expect(ChatInputRegistry.list()).toEqual([b]);
+    offB();
+    expect(ChatInputRegistry.size()).toBe(0);
+  });
+
+  it('listeners fire on register and unregister', () => {
+    const listener = vi.fn();
+    ChatInputRegistry.subscribe(listener);
+    const off = ChatInputRegistry.register(document.createElement('div'));
+    expect(listener).toHaveBeenCalledTimes(1);
+    off();
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web/src/lib/contextBus.ts
+++ b/web/src/lib/contextBus.ts
@@ -1,0 +1,104 @@
+/**
+ * Tiny pub/sub for widget context attachments. Decouples the dashboard
+ * widgets that produce snapshots from the chat inputs that render them.
+ *
+ * Why a hand-rolled bus over a React context: chat inputs and overflow pill
+ * may live in different React trees (modal, portal, hero card vs in-grid
+ * widget) and need to subscribe to the *same* state without lifting an
+ * ancestor. A module-scoped event emitter is the smallest unit that works
+ * for cross-tree state without dragging in zustand.
+ */
+
+import type { WidgetContextSnapshot } from '@/pages/Dashboard/widgets/framework/contextSnapshot';
+
+export type ContextBusEvent =
+  | { type: 'attach'; snapshot: WidgetContextSnapshot }
+  | { type: 'detach'; widgetId: string }
+  | { type: 'clear' };
+
+export type ContextBusHandler = (event: ContextBusEvent) => void;
+
+const handlers = new Set<ContextBusHandler>();
+
+function publish(event: ContextBusEvent): void {
+  // Snapshot the set so a handler that unsubscribes during dispatch doesn't
+  // mutate the iterator. Errors in one handler must not silence the others —
+  // log and continue.
+  for (const h of [...handlers]) {
+    try {
+      h(event);
+    } catch (err) {
+      console.error('[contextBus] subscriber threw', err);
+    }
+  }
+}
+
+export const ContextBus = {
+  subscribe(handler: ContextBusHandler): () => void {
+    handlers.add(handler);
+    return () => {
+      handlers.delete(handler);
+    };
+  },
+  attach(snapshot: WidgetContextSnapshot): void {
+    publish({ type: 'attach', snapshot });
+  },
+  detach(widgetId: string): void {
+    publish({ type: 'detach', widgetId });
+  },
+  clear(): void {
+    publish({ type: 'clear' });
+  },
+  /** Test-only: drop every subscriber. Never call from product code. */
+  __resetForTests(): void {
+    handlers.clear();
+  },
+};
+
+/**
+ * Registry of mounted chat input root elements so the overflow pill can
+ * decide whether *any* chat input is visible via IntersectionObserver.
+ * Module-scoped because the pill renders at the app shell while inputs
+ * mount deeper in the tree.
+ */
+const chatInputElements = new Set<HTMLElement>();
+
+export const ChatInputRegistry = {
+  register(el: HTMLElement): () => void {
+    chatInputElements.add(el);
+    notifyChatInputListeners();
+    return () => {
+      chatInputElements.delete(el);
+      notifyChatInputListeners();
+    };
+  },
+  list(): HTMLElement[] {
+    return [...chatInputElements];
+  },
+  size(): number {
+    return chatInputElements.size;
+  },
+  subscribe(listener: () => void): () => void {
+    chatInputListeners.add(listener);
+    return () => {
+      chatInputListeners.delete(listener);
+    };
+  },
+  /** Test-only. */
+  __resetForTests(): void {
+    chatInputElements.clear();
+    chatInputListeners.clear();
+  },
+};
+
+const chatInputListeners = new Set<() => void>();
+
+function notifyChatInputListeners(): void {
+  for (const l of [...chatInputListeners]) {
+    try {
+      l();
+    } catch (err) {
+      console.error('[chatInputRegistry] listener threw', err);
+    }
+  }
+}

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -258,7 +258,15 @@
         "menu": "Widget menu",
         "duplicate": "Duplicate",
         "remove": "Remove",
-        "errorBoundary": "Widget failed to render"
+        "errorBoundary": "Widget failed to render",
+        "addToContext": "Add to context",
+        "addToContextTitle": "Add this widget to chat context",
+        "contextAttached": "Added to context",
+        "contextUnavailable": "Widget not available",
+        "contextUnavailableHint": "This widget has not registered a context exporter yet.",
+        "addRowToContext": "Add row to context",
+        "addRowToContextTitle": "Add this row to chat context",
+        "contextUnsupportedTradingView": "Can't attach this — the content is managed by TradingView, so the agent can't access it."
       },
       "addDialog": {
         "eyebrow": "Widget Gallery",
@@ -1045,6 +1053,17 @@
     "anyoneWithLink": "Anyone with this link can view the conversation."
   },
   "chat": {
+    "widgetContext": {
+      "inContext_one": "{{count}} in context",
+      "inContext_other": "{{count}} in context",
+      "fanHint": "click to fan",
+      "showLess": "Show less",
+      "clear": "Clear",
+      "removeAria": "Remove from context",
+      "overflowAria_one": "{{count}} item in context — open chat",
+      "overflowAria_other": "{{count}} items in context — open chat",
+      "overflowLabel": "in context"
+    },
     "running": "Running: {{tool}}",
     "completedWithCalls": "Completed ({{count}} tool calls)",
     "completed": "Completed",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -258,7 +258,15 @@
         "menu": "小组件菜单",
         "duplicate": "复制",
         "remove": "移除",
-        "errorBoundary": "小组件渲染失败"
+        "errorBoundary": "小组件渲染失败",
+        "addToContext": "加入上下文",
+        "addToContextTitle": "把这个小组件加入聊天上下文",
+        "contextAttached": "已加入上下文",
+        "contextUnavailable": "小组件不可用",
+        "contextUnavailableHint": "该小组件尚未注册上下文导出器。",
+        "addRowToContext": "把这一行加入上下文",
+        "addRowToContextTitle": "把此条目加入聊天上下文",
+        "contextUnsupportedTradingView": "无法添加：该内容由 TradingView 提供，智能体无法访问。"
       },
       "addDialog": {
         "eyebrow": "小组件库",
@@ -1045,6 +1053,17 @@
     "anyoneWithLink": "任何拥有此链接的人都可以查看对话。"
   },
   "chat": {
+    "widgetContext": {
+      "inContext_one": "{{count}} 项上下文",
+      "inContext_other": "{{count}} 项上下文",
+      "fanHint": "点击展开",
+      "showLess": "收起",
+      "clear": "清空",
+      "removeAria": "从上下文中移除",
+      "overflowAria_one": "{{count}} 项已加入上下文 — 打开聊天",
+      "overflowAria_other": "{{count}} 项已加入上下文 — 打开聊天",
+      "overflowLabel": "上下文"
+    },
     "running": "运行中: {{tool}}",
     "completedWithCalls": "已完成 ({{count}} 次工具调用)",
     "completed": "已完成",

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -1546,6 +1546,21 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     }
   }, [location.state, workspaceId, threadId, isLoading, isLoadingHistory, handleSendMessage, navigate, location.pathname, isActive]);
 
+  // Re-seed the widget context deck from navigation state when there's no
+  // initialMessage (the auto-send branch above already consumes them inline).
+  // Used by the ContextOverflowPill click handoff: dashboard → /chat with
+  // queued widget cards but no auto-send.
+  const widgetSnapshotReseedRef = useRef(false);
+  useEffect(() => {
+    if (widgetSnapshotReseedRef.current) return;
+    const navState = location.state as LocationState | null;
+    const snaps = navState?.widgetSnapshots;
+    if (!snaps?.length || navState?.initialMessage) return;
+    widgetSnapshotReseedRef.current = true;
+    snaps.forEach((s) => chatInputRef.current?.addWidgetSnapshot(s));
+    navigate(location.pathname, { replace: true, state: { ...navState, widgetSnapshots: undefined } });
+  }, [location.state, location.pathname, navigate]);
+
   // Smart auto-scroll: only scroll to bottom when user is already near the bottom
   const isNearBottomRef = useRef(true);
   const isSubagentNearBottomRef = useRef(true);

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -18,7 +18,8 @@ import { useCardState } from '../hooks/useCardState';
 import { useWorkspaceFiles } from '../hooks/useWorkspaceFiles';
 import './FilePanel.css';
 import ChatInput, { type ChatInputHandle } from '../../../components/ui/chat-input';
-import { attachmentsToContexts, type Attachment } from '../utils/fileUpload';
+import { attachmentsToContexts, widgetSnapshotsToContexts, type Attachment } from '../utils/fileUpload';
+import type { WidgetContextSnapshot } from '@/pages/Dashboard/widgets/framework/contextSnapshot';
 import MessageList, { normalizeSubagentText } from './MessageList';
 import Markdown from './Markdown';
 import NavigationPanel from './NavigationPanel';
@@ -70,6 +71,14 @@ interface LocationState {
   workspaceName?: string;
   fromThreadId?: string;
   fromWorkspaceId?: string;
+  /**
+   * Widget context snapshots forwarded from the dashboard's send. Re-seeds
+   * the chat input's deck rail on mount so the user sees the same chips they
+   * had on the dashboard. The auto-fire effect already includes the same
+   * snapshots in `additionalContext`, so the first message is unaffected;
+   * the bus state powers the visual chips and any follow-up the user types.
+   */
+  widgetSnapshots?: WidgetContextSnapshot[];
   [key: string]: unknown;
 }
 
@@ -141,6 +150,12 @@ interface SlashCommand {
 interface ModelOptions {
   model?: string | null;
   reasoningEffort?: string | null;
+  /**
+   * Widget context snapshots from the chat input's deck rail. Serialized into
+   * `additional_context` items (one widget directive + optional sibling image
+   * per snapshot) by `handleSendWithAttachments`.
+   */
+  widgetSnapshots?: WidgetContextSnapshot[];
 }
 
 interface ActionCommand {
@@ -317,6 +332,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
 
   // Clear the drag-just-ended flag after each render so future transitions animate normally.
   useEffect(() => { dragJustEndedRef.current = false; });
+
   // Clear preview cache and cross-workspace state when workspace changes to avoid leaking old workspace data.
   useEffect(() => {
     previewMapRef.current.clear();
@@ -687,6 +703,16 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
       } else if (cmd.type === 'subagent') {
         contexts.push({ type: 'directive', content: 'User wishes you to complete this task using subagents.' });
       }
+    }
+
+    // Widget context snapshots from the deck rail. Each snapshot becomes one
+    // `{type:"widget"}` item plus an optional sibling `{type:"image"}` item
+    // (the existing MultimodalContext channel handles vision-vs-text-only
+    // routing). The same snapshots are also forwarded to handleSendMessage so
+    // the user message renders chip cards inline below its bubble.
+    if (modelOptions.widgetSnapshots && modelOptions.widgetSnapshots.length > 0) {
+      const items = widgetSnapshotsToContexts(modelOptions.widgetSnapshots);
+      contexts.push(...(items as unknown as Record<string, unknown>[]));
     }
 
     const additionalContext = contexts.length > 0 ? contexts : null;
@@ -1497,24 +1523,24 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
         // New thread - send immediately
         initialMessageSentRef.current = true;
         // Capture state values before clearing (navigate may update location ref)
-        const { initialMessage, planMode, additionalContext, attachmentMeta, model, reasoningEffort } = location.state;
+        const { initialMessage, planMode, additionalContext, attachmentMeta, model, reasoningEffort, widgetSnapshots } = location.state;
         // Clear navigation state to prevent re-sending on re-renders
         navigate(location.pathname, { replace: true, state: {} });
         // Small delay to ensure component is fully mounted
         setTimeout(() => {
-          handleSendMessage(initialMessage, planMode || false, additionalContext || null, attachmentMeta || null, { model, reasoningEffort });
+          handleSendMessage(initialMessage, planMode || false, additionalContext || null, attachmentMeta || null, { model, reasoningEffort, widgetSnapshots });
         }, 100);
       } else if (!isLoadingHistory && !isLoading) {
         // Existing thread - wait for history to load, then send
         // This ensures we don't send duplicate messages
         initialMessageSentRef.current = true;
         // Capture state values before clearing (navigate may update location ref)
-        const { initialMessage, planMode, additionalContext, attachmentMeta, model, reasoningEffort } = location.state;
+        const { initialMessage, planMode, additionalContext, attachmentMeta, model, reasoningEffort, widgetSnapshots } = location.state;
         // Clear navigation state to prevent re-sending on re-renders
         navigate(location.pathname, { replace: true, state: {} });
         // Small delay to ensure component is fully mounted
         setTimeout(() => {
-          handleSendMessage(initialMessage, planMode || false, additionalContext || null, attachmentMeta || null, { model, reasoningEffort });
+          handleSendMessage(initialMessage, planMode || false, additionalContext || null, attachmentMeta || null, { model, reasoningEffort, widgetSnapshots });
         }, 100);
       }
     }

--- a/web/src/pages/ChatAgent/components/MessageList.tsx
+++ b/web/src/pages/ChatAgent/components/MessageList.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useRef, useMemo, memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Bot, User, FileText, ImageIcon, Pencil, RefreshCw, RotateCcw, Copy, Check, Info, ThumbsUp, ThumbsDown } from 'lucide-react';
+import { type WidgetContextPreviewShape } from '@/pages/Dashboard/widgets/framework/WidgetContextPreview';
+import { WidgetContextDeck } from '@/pages/Dashboard/widgets/framework/WidgetContextDeck';
 import { useIsMobile } from '@/hooks/useIsMobile';
 
 import ThumbDownModal from './ThumbDownModal';
@@ -165,6 +167,35 @@ interface AttachmentData {
 
 interface AttachmentCardProps {
   attachment: AttachmentData;
+}
+
+/** Local alias for the preview shape — keeps inline-deck internals decoupled from the import path. */
+type WidgetChipShape = WidgetContextPreviewShape;
+
+/**
+ * Static read-only deck rendered below the user message bubble. Reuses the
+ * shared `WidgetContextDeck` — no eyebrow, no remove buttons, just the
+ * stacked cards with click-to-fan / click-to-preview semantics. Width is
+ * pinned at 320px since the user-message column has a `max-w-[80%]`
+ * constraint that would otherwise collapse absolute-positioned cards.
+ */
+function InlineWidgetDeck({ snapshots }: { snapshots: WidgetChipShape[] }) {
+  const [fanned, setFanned] = useState(false);
+  return (
+    <WidgetContextDeck
+      snapshots={snapshots}
+      fanned={fanned}
+      onToggleFan={() => setFanned((p) => !p)}
+      onCollapse={() => setFanned(false)}
+      compactCardGrid
+      style={{
+        width: 320,
+        borderBottom: 'none',
+        marginBottom: 0,
+        paddingBottom: 0,
+      }}
+    />
+  );
 }
 
 /**
@@ -486,6 +517,8 @@ const MessageBubble = memo(function MessageBubble({ message, isLoading, hideAvat
   const isPendingDelivery = isUser && ((message.isPending as boolean) || (message.steering as boolean));
   const attachments = message.attachments as AttachmentData[] | undefined;
   const hasAttachments = isUser && attachments && attachments.length > 0;
+  const widgetSnapshots = message.widgetSnapshots as WidgetChipShape[] | undefined;
+  const hasWidgetSnapshots = isUser && widgetSnapshots && widgetSnapshots.length > 0;
 
   // Edit mode state
   const [isEditing, setIsEditing] = useState(false);
@@ -770,6 +803,13 @@ const MessageBubble = memo(function MessageBubble({ message, isLoading, hideAvat
               <AttachmentCard key={idx} attachment={att} />
             ))}
           </div>
+        )}
+
+        {/* Widget context deck -- stacked chip cards below the bubble,
+            mirroring the chat-input deck visuals. Read-only: chips are
+            scoped to the message that attached them. */}
+        {hasWidgetSnapshots && (
+          <InlineWidgetDeck snapshots={widgetSnapshots!} />
         )}
         </>
         )}

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -173,6 +173,12 @@ interface ModelOptions {
   model?: string | null;
   reasoningEffort?: string | null;
   fastMode?: boolean | null;
+  /**
+   * Widget context snapshots attached to this send. Stored on the
+   * UserMessage so the chat history can render them as inline chip cards
+   * below the user bubble (like attachments).
+   */
+  widgetSnapshots?: import('@/pages/Dashboard/widgets/framework/contextSnapshot').WidgetContextSnapshot[];
 }
 
 /** Offload batch ref state. */
@@ -3535,15 +3541,7 @@ export function useChatMessages(
     }
   };
 
-  /**
-   * Handles sending a message and streaming the response
-   *
-   * @param {string} message - The user's message
-   * @param {boolean} planMode - Whether to use plan mode
-   * @param {Array|null} additionalContext - Optional additional context for skill loading
-   * @param {Array|null} attachmentMeta - Optional attachment metadata for user message display
-   */
-  const handleSendMessage = async (message: string, planMode: boolean = false, additionalContext: Record<string, unknown>[] | null = null, attachmentMeta: Record<string, unknown>[] | null = null, { model, reasoningEffort, fastMode }: ModelOptions = {}) => {
+  const handleSendMessage = async (message: string, planMode: boolean = false, additionalContext: Record<string, unknown>[] | null = null, attachmentMeta: Record<string, unknown>[] | null = null, { model, reasoningEffort, fastMode, widgetSnapshots }: ModelOptions = {}) => {
     const hasContent = message.trim() || (additionalContext && additionalContext.length > 0);
     if (!workspaceId || !hasContent) {
       return;
@@ -3580,7 +3578,11 @@ export function useChatMessages(
     }
 
     // Create and add user message
-    const userMessage = createUserMessage(message, attachmentMeta as AttachmentMeta[] | null);
+    const userMessage = createUserMessage(
+      message,
+      attachmentMeta as AttachmentMeta[] | null,
+      widgetSnapshots ?? null,
+    );
     recentlySentTrackerRef.current.track(message.trim(), userMessage.timestamp, userMessage.id);
 
     // Check if this is a new conversation

--- a/web/src/pages/ChatAgent/hooks/utils/historyEventHandlers.ts
+++ b/web/src/pages/ChatAgent/hooks/utils/historyEventHandlers.ts
@@ -45,8 +45,6 @@ interface HistorySteeringRefs {
  * Helper to check if an event is from a subagent.
  * Backend convention: agent field uses "task:{task_id}" format (e.g., "task:pkyRHQ").
  * This aligns with LangGraph namespace convention (tools:uuid, model:uuid, task:id).
- * @param {Object} event - The history event
- * @returns {boolean} True if event is from subagent
  */
 export function isSubagentHistoryEvent(event: HistoryEvent | null | undefined): boolean {
   const agent = event?.agent;
@@ -56,18 +54,7 @@ export function isSubagentHistoryEvent(event: HistoryEvent | null | undefined): 
   return agent.startsWith('task:');
 }
 
-/**
- * Handles user_message events from history replay
- * @param {Object} params - Handler parameters
- * @param {Object} params.event - The history event
- * @param {number} params.pairIndex - The pair index
- * @param {Map} params.assistantMessagesByPair - Map of turn_index to assistant message ID
- * @param {Map} params.pairStateByPair - Map of turn_index to pair state
- * @param {Object} params.refs - Refs object with recentlySentTracker, currentMessageRef, newMessagesStartIndexRef, historyMessagesRef
- * @param {Array} params.messages - Current messages array
- * @param {Function} params.setMessages - State setter for messages
- * @returns {boolean} True if assistant message was created/mapped, false otherwise
- */
+/** Handles user_message events from history replay. */
 export function handleHistoryUserMessage({
   event,
   pairIndex,
@@ -141,6 +128,14 @@ export function handleHistoryUserMessage({
         userMessage.attachments = event.metadata!.attachments;
       }
 
+      // Restore widget snapshot metadata so the chip deck re-renders below
+      // this user message on history replay. Backend persists `text` so the
+      // preview modal can show what the agent saw; `image_jpeg_data_url` is
+      // live-only (image rides the multimodal channel and isn't persisted).
+      if ((event.metadata?.widget_contexts as unknown[] | undefined)?.length as number > 0) {
+        userMessage.widgetSnapshots = event.metadata!.widget_contexts;
+      }
+
       setMessages((prev: MessageRecord[]) => {
         const insertIndex = newMessagesStartIndexRef.current;
         const newMessages = [
@@ -201,16 +196,7 @@ export function handleHistoryUserMessage({
   return false;
 }
 
-/**
- * Handles reasoning signal events in history replay
- * @param {Object} params - Handler parameters
- * @param {string} params.assistantMessageId - ID of the assistant message
- * @param {string} params.signalContent - Signal content ('start' or 'complete')
- * @param {number} params.pairIndex - The pair index
- * @param {Object} params.pairState - The pair state object
- * @param {Function} params.setMessages - State setter for messages
- * @returns {boolean} True if event was handled
- */
+/** Handles reasoning signal events ('start' | 'complete') in history replay. */
 export function handleHistoryReasoningSignal({ assistantMessageId, signalContent, pairIndex, pairState, setMessages, eventId }: {
   assistantMessageId: string;
   signalContent: string;
@@ -286,15 +272,7 @@ export function handleHistoryReasoningSignal({ assistantMessageId, signalContent
   return false;
 }
 
-/**
- * Handles reasoning content in history replay
- * @param {Object} params - Handler parameters
- * @param {string} params.assistantMessageId - ID of the assistant message
- * @param {string} params.content - Reasoning content
- * @param {Object} params.pairState - The pair state object
- * @param {Function} params.setMessages - State setter for messages
- * @returns {boolean} True if event was handled
- */
+/** Handles reasoning content chunks in history replay. */
 export function handleHistoryReasoningContent({ assistantMessageId, content, pairState, setMessages }: {
   assistantMessageId: string;
   content: string;
@@ -329,16 +307,7 @@ export function handleHistoryReasoningContent({ assistantMessageId, content, pai
   return false;
 }
 
-/**
- * Handles text content in history replay
- * @param {Object} params - Handler parameters
- * @param {string} params.assistantMessageId - ID of the assistant message
- * @param {string} params.content - Text content
- * @param {string} params.finishReason - Optional finish reason
- * @param {Object} params.pairState - The pair state object
- * @param {Function} params.setMessages - State setter for messages
- * @returns {boolean} True if event was handled
- */
+/** Handles text content chunks and finish_reason in history replay. */
 export function handleHistoryTextContent({ assistantMessageId, content, finishReason, pairState, setMessages, eventId }: {
   assistantMessageId: string;
   content: string;
@@ -387,15 +356,7 @@ export function handleHistoryTextContent({ assistantMessageId, content, finishRe
   return false;
 }
 
-/**
- * Handles tool_calls events in history replay
- * @param {Object} params - Handler parameters
- * @param {string} params.assistantMessageId - ID of the assistant message
- * @param {Array} params.toolCalls - Array of tool call objects
- * @param {Object} params.pairState - The pair state object
- * @param {Function} params.setMessages - State setter for messages
- * @returns {boolean} True if event was handled
- */
+/** Handles tool_calls events in history replay. */
 export function handleHistoryToolCalls({ assistantMessageId, toolCalls, pairState, setMessages, eventId }: {
   assistantMessageId: string;
   toolCalls: ToolCallRecord[];
@@ -511,16 +472,7 @@ export function handleHistoryToolCalls({ assistantMessageId, toolCalls, pairStat
   return true;
 }
 
-/**
- * Handles tool_call_result events in history replay
- * @param {Object} params - Handler parameters
- * @param {string} params.assistantMessageId - ID of the assistant message
- * @param {string} params.toolCallId - ID of the tool call
- * @param {Object} params.result - Tool call result object
- * @param {Object} params.pairState - The pair state object
- * @param {Function} params.setMessages - State setter for messages
- * @returns {boolean} True if event was handled
- */
+/** Handles tool_call_result events in history replay. */
 export function handleHistoryToolCallResult({ assistantMessageId, toolCallId, result, pairState: _pairState, setMessages }: {
   assistantMessageId: string;
   toolCallId: string;
@@ -586,16 +538,9 @@ export function handleHistoryToolCallResult({ assistantMessageId, toolCallId, re
 }
 
 /**
- * Handles steering_delivered events in history replay.
- * Creates user bubble(s) for each steering message, then a new assistant placeholder
- * so subsequent events render in a fresh assistant bubble.
- * @param {Object} params - Handler parameters
- * @param {Object} params.event - The history event (contains messages array)
- * @param {number} params.pairIndex - The pair index
- * @param {Map} params.assistantMessagesByPair - Map of turn_index to assistant message ID
- * @param {Map} params.pairStateByPair - Map of turn_index to pair state
- * @param {Object} params.refs - Refs object with newMessagesStartIndexRef, historyMessagesRef
- * @param {Function} params.setMessages - State setter for messages
+ * Handles steering_delivered events in history replay. Creates user bubble(s)
+ * for each steering message, then a new assistant placeholder so subsequent
+ * events render in a fresh assistant bubble.
  */
 export function handleHistorySteeringDelivered({
   event,
@@ -673,17 +618,7 @@ export function handleHistorySteeringDelivered({
   });
 }
 
-/**
- * Handles artifact events with artifact_type: "todo_update" in history replay
- * @param {Object} params - Handler parameters
- * @param {string} params.assistantMessageId - ID of the assistant message
- * @param {string} params.artifactType - Type of artifact ("todo_update")
- * @param {string} params.artifactId - ID of the artifact
- * @param {Object} params.payload - Payload containing todos array and status counts
- * @param {Object} params.pairState - The pair state object
- * @param {Function} params.setMessages - State setter for messages
- * @returns {boolean} True if event was handled
- */
+/** Handles artifact events with artifact_type "todo_update" in history replay. */
 export function handleHistoryTodoUpdate({ assistantMessageId, artifactType, artifactId, payload, pairState, setMessages, eventId }: {
   assistantMessageId: string;
   artifactType: string;

--- a/web/src/pages/ChatAgent/hooks/utils/historyEventHandlers.ts
+++ b/web/src/pages/ChatAgent/hooks/utils/historyEventHandlers.ts
@@ -124,7 +124,8 @@ export function handleHistoryUserMessage({
       };
 
       // Restore attachment metadata from persisted query metadata
-      if ((event.metadata?.attachments as unknown[] | undefined)?.length as number > 0) {
+      const attachments = event.metadata?.attachments as unknown[] | undefined;
+      if (attachments && attachments.length > 0) {
         userMessage.attachments = event.metadata!.attachments;
       }
 
@@ -132,7 +133,8 @@ export function handleHistoryUserMessage({
       // this user message on history replay. Backend persists `text` so the
       // preview modal can show what the agent saw; `image_jpeg_data_url` is
       // live-only (image rides the multimodal channel and isn't persisted).
-      if ((event.metadata?.widget_contexts as unknown[] | undefined)?.length as number > 0) {
+      const widgetContexts = event.metadata?.widget_contexts as unknown[] | undefined;
+      if (widgetContexts && widgetContexts.length > 0) {
         userMessage.widgetSnapshots = event.metadata!.widget_contexts;
       }
 

--- a/web/src/pages/ChatAgent/hooks/utils/messageHelpers.ts
+++ b/web/src/pages/ChatAgent/hooks/utils/messageHelpers.ts
@@ -10,6 +10,7 @@ import type {
   NotificationMessage,
   NotificationVariant,
 } from '@/types/chat';
+import type { WidgetContextSnapshot } from '@/pages/Dashboard/widgets/framework/contextSnapshot';
 
 // Re-export types for consumers
 export type { ChatMessage, AssistantMessage, UserMessage, NotificationMessage, NotificationVariant };
@@ -24,10 +25,11 @@ export interface AttachmentMeta {
   type: string;
 }
 
-/**
- * Creates a user message object
- */
-export function createUserMessage(message: string, attachments: AttachmentMeta[] | null = null): UserMessage {
+export function createUserMessage(
+  message: string,
+  attachments: AttachmentMeta[] | null = null,
+  widgetSnapshots: WidgetContextSnapshot[] | null = null,
+): UserMessage {
   const msg: UserMessage = {
     id: `user-${Date.now()}`,
     role: 'user',
@@ -42,12 +44,12 @@ export function createUserMessage(message: string, attachments: AttachmentMeta[]
     // At send time only AttachmentMeta fields are used, so store as-is.
     msg.attachments = attachments as any;
   }
+  if (widgetSnapshots && widgetSnapshots.length > 0) {
+    msg.widgetSnapshots = widgetSnapshots;
+  }
   return msg;
 }
 
-/**
- * Creates an assistant message placeholder
- */
 export function createAssistantMessage(messageId: string | null = null): AssistantMessage {
   const id = messageId || `assistant-${Date.now()}`;
   return {
@@ -64,9 +66,6 @@ export function createAssistantMessage(messageId: string | null = null): Assista
   };
 }
 
-/**
- * Updates a specific message in the messages array
- */
 export function updateMessage<T extends { id: string }>(
   messages: T[],
   messageId: string,
@@ -78,9 +77,6 @@ export function updateMessage<T extends { id: string }>(
   });
 }
 
-/**
- * Inserts a message at a specific index in the messages array
- */
 export function insertMessage<T extends { id: string }>(
   messages: T[],
   insertIndex: number,
@@ -93,9 +89,6 @@ export function insertMessage<T extends { id: string }>(
   ];
 }
 
-/**
- * Appends a message to the end of the messages array
- */
 export function appendMessage<T extends { id: string }>(messages: T[], newMessage: T): T[] {
   return [...messages, newMessage];
 }

--- a/web/src/pages/ChatAgent/utils/fileUpload.ts
+++ b/web/src/pages/ChatAgent/utils/fileUpload.ts
@@ -1,6 +1,4 @@
-/**
- * File upload utilities for multimodal input
- */
+import type { WidgetContextSnapshot } from '@/pages/Dashboard/widgets/framework/contextSnapshot';
 
 export const ACCEPTED_IMAGE_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp'];
 export const ACCEPTED_PDF_TYPES = ['application/pdf'];
@@ -13,7 +11,7 @@ export interface Attachment {
   type: string;
 }
 
-export interface ImageContext {
+export interface AttachmentContext {
   type: string;
   data: string;
   description: string;
@@ -24,9 +22,6 @@ export interface FileValidationResult {
   error?: string;
 }
 
-/**
- * Convert a File to a base64 data URL
- */
 export function readFileAsDataUrl(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -40,7 +35,7 @@ export function readFileAsDataUrl(file: File): Promise<string> {
  * Convert attachments to additional_context format with accurate type tags.
  * Images → "image", PDFs → "pdf", everything else → "file".
  */
-export function attachmentsToContexts(attachments: Attachment[]): ImageContext[] {
+export function attachmentsToContexts(attachments: Attachment[]): AttachmentContext[] {
   return attachments
     .filter((a) => a.dataUrl != null)
     .map((a) => ({
@@ -50,6 +45,74 @@ export function attachmentsToContexts(attachments: Attachment[]): ImageContext[]
       data: a.dataUrl!,
       description: a.file.name,
     }));
+}
+
+/**
+ * Per-widget snapshot serialization for `additional_context`.
+ *
+ * Each snapshot becomes ONE `{type:"widget", ...}` item. Image-bearing
+ * snapshots additionally produce a sibling `{type:"image", ...}` item that
+ * rides the existing MultimodalContext channel — the backend modality gate
+ * handles vision-vs-text-only routing without further code changes.
+ *
+ * Pre-flight size guard: a structured-clone error from `navigate(state)` will
+ * crash the dashboard → chat handoff, so we cap the structured `data` payload
+ * at ~100KB per item. Oversized `data` is dropped (the rendered `text` and
+ * the optional image still ride along — those are what the agent reads).
+ */
+const MAX_DATA_BYTES_PER_SNAPSHOT = 100 * 1024;
+
+interface WidgetCtxItem {
+  type: 'widget';
+  widget_type: string;
+  widget_id: string;
+  label: string;
+  text: string;
+  data: Record<string, unknown>;
+  captured_at?: string;
+  description?: string;
+}
+
+interface WidgetImageItem {
+  type: 'image';
+  data: string;
+  description: string;
+}
+
+export function widgetSnapshotsToContexts(
+  snapshots: WidgetContextSnapshot[],
+): Array<WidgetCtxItem | WidgetImageItem> {
+  const out: Array<WidgetCtxItem | WidgetImageItem> = [];
+  for (const s of snapshots) {
+    let data = s.data ?? {};
+    try {
+      const sz = new Blob([JSON.stringify(data)]).size;
+      if (sz > MAX_DATA_BYTES_PER_SNAPSHOT) {
+        // Drop the structured payload; the rendered text + image still ship.
+        data = { _truncated: true, _original_bytes: sz };
+      }
+    } catch {
+      data = { _truncated: true };
+    }
+    out.push({
+      type: 'widget',
+      widget_type: s.widget_type,
+      widget_id: s.widget_id,
+      label: s.label,
+      text: s.text,
+      data,
+      captured_at: s.captured_at,
+      description: s.description,
+    });
+    if (s.image_jpeg_data_url) {
+      out.push({
+        type: 'image',
+        data: s.image_jpeg_data_url,
+        description: s.label,
+      });
+    }
+  }
+  return out;
 }
 
 /**

--- a/web/src/pages/Dashboard/components/AIDailyBriefCard.tsx
+++ b/web/src/pages/Dashboard/components/AIDailyBriefCard.tsx
@@ -6,6 +6,7 @@ import TopicBadge from './TopicBadge';
 import { getTodayInsights, getInsightDetail, generatePersonalizedInsight } from '../utils/api';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import i18n from '@/i18n';
+import { RowAttachButton } from './RowAttachButton';
 
 interface InsightTopic {
   text: string;
@@ -24,6 +25,8 @@ interface Insight {
 
 interface AIDailyBriefCardProps {
   onReadFull?: (marketInsightId: string) => void;
+  /** Widget instance id — when provided, per-row paperclip attach buttons render. */
+  instanceId?: string;
 }
 
 interface TypeConfigEntry {
@@ -33,6 +36,16 @@ interface TypeConfigEntry {
 
 // Module-level cache (survives navigation, clears on page refresh)
 let insightsCache: Insight[] | null = null;
+
+/**
+ * Read the latest insight brief data from the module cache. Used by the
+ * InsightBriefWidget's `useWidgetContextExport` snapshot serializer so the
+ * agent gets the actual headline + summary + topics, not just the widget label.
+ * Returns null if the brief hasn't loaded yet.
+ */
+export function getCachedInsights(): Insight[] | null {
+  return insightsCache;
+}
 
 const TYPE_CONFIG: Record<string, TypeConfigEntry> = {
   pre_market: { labelKey: 'dashboard.brief.typeLabel.preMarket', accent: 'var(--color-profit)' },
@@ -126,7 +139,7 @@ function MobileTopicRow({ topics }: { topics: InsightTopic[] }) {
   );
 }
 
-function AIDailyBriefCard({ onReadFull }: AIDailyBriefCardProps) {
+function AIDailyBriefCard({ onReadFull, instanceId }: AIDailyBriefCardProps) {
   const { t } = useTranslation();
   const [insights, setInsights] = useState<Insight[]>(insightsCache || []);
   const [loading, setLoading] = useState(!insightsCache);
@@ -226,7 +239,6 @@ function AIDailyBriefCard({ onReadFull }: AIDailyBriefCardProps) {
     }
   }, [generating, onReadFull, t]);
 
-  // Loading skeleton
   if (loading) {
     return (
       <div
@@ -254,7 +266,6 @@ function AIDailyBriefCard({ onReadFull }: AIDailyBriefCardProps) {
     );
   }
 
-  // No data state
   if (!latest) {
     return (
       <div
@@ -308,7 +319,6 @@ function AIDailyBriefCard({ onReadFull }: AIDailyBriefCardProps) {
         </>
       )}
 
-      {/* Main card */}
       <motion.div
         layout
         initial={{ opacity: 0, y: 20 }}
@@ -323,14 +333,12 @@ function AIDailyBriefCard({ onReadFull }: AIDailyBriefCardProps) {
         }}
         onClick={handleCardClick}
       >
-        {/* Decorative brain icon */}
         <div className="absolute top-0 right-0 p-6 opacity-20 group-hover:opacity-40 transition-opacity pointer-events-none hidden sm:block">
           <Newspaper size={120} style={{ color: 'var(--color-accent-primary)' }} />
         </div>
 
         <div className="relative z-10 p-4 sm:p-8 flex flex-col gap-8 items-start">
           <div className="flex-1">
-            {/* Badge + updated */}
             <div className="flex items-center gap-2 mb-4">
               <div
                 className="px-3 py-1 rounded-full border flex items-center gap-2 text-xs font-semibold uppercase tracking-wider"
@@ -361,7 +369,6 @@ function AIDailyBriefCard({ onReadFull }: AIDailyBriefCardProps) {
               )}
             </div>
 
-            {/* Headline */}
             <h2
               className="text-xl sm:text-3xl font-bold mb-4 leading-tight"
               style={{ color: 'var(--color-text-primary)' }}
@@ -369,7 +376,6 @@ function AIDailyBriefCard({ onReadFull }: AIDailyBriefCardProps) {
               {latest.headline}
             </h2>
 
-            {/* Summary */}
             <p
               className="mb-6 leading-relaxed line-clamp-3 sm:line-clamp-none"
               style={{ color: 'var(--color-text-secondary)' }}
@@ -377,7 +383,6 @@ function AIDailyBriefCard({ onReadFull }: AIDailyBriefCardProps) {
               {latest.summary}
             </p>
 
-            {/* Topic badges */}
             <MobileTopicRow topics={topics} />
 
             {/* Mobile: full-width CTA + stack indicator */}
@@ -474,7 +479,6 @@ function AIDailyBriefCard({ onReadFull }: AIDailyBriefCardProps) {
               <p className="text-xs text-right" style={{ color: 'var(--color-loss, #ef4444)' }}>{generateError}</p>
             )}
 
-            {/* Stack indicator */}
             {older.length > 0 && (
               <button
                 onClick={(e) => {
@@ -525,55 +529,51 @@ function AIDailyBriefCard({ onReadFull }: AIDailyBriefCardProps) {
                   {older.map((item) => {
                     const cfg = TYPE_CONFIG[item.type] || TYPE_CONFIG.market_update;
                     return (
-                      <button
-                        key={item.market_insight_id}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onReadFull?.(item.market_insight_id);
-                        }}
-                        className="w-full flex items-center gap-4 px-4 py-3 rounded-xl text-left transition-colors group/item"
-                        style={{ color: 'var(--color-text-secondary)' }}
-                        onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = 'var(--color-bg-hover)')}
-                        onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'transparent')}
-                      >
-                        {/* Time */}
-                        <span
-                          className="text-xs font-medium shrink-0 w-16 text-right tabular-nums"
-                          style={{ color: 'var(--color-text-tertiary)' }}
-                        >
-                          {formatTime(item.completed_at)}
-                        </span>
-
-                        {/* Timeline dot */}
-                        <span
-                          className="w-2 h-2 rounded-full shrink-0"
-                          style={{ backgroundColor: cfg.accent }}
-                        />
-
-                        {/* Type badge */}
-                        <span
-                          className="text-[10px] font-semibold uppercase tracking-wider shrink-0 px-2 py-0.5 rounded"
-                          style={{
-                            color: cfg.accent,
-                            backgroundColor: `color-mix(in srgb, ${cfg.accent} 15%, transparent)`,
+                      <div key={item.market_insight_id} className="row-attach-host relative">
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onReadFull?.(item.market_insight_id);
                           }}
+                          className="w-full flex items-center gap-4 px-4 py-3 rounded-xl text-left transition-colors group/item"
+                          style={{ color: 'var(--color-text-secondary)' }}
+                          onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = 'var(--color-bg-hover)')}
+                          onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'transparent')}
                         >
-                          {t(cfg.labelKey)}
-                        </span>
+                          <span
+                            className="text-xs font-medium shrink-0 w-16 text-right tabular-nums"
+                            style={{ color: 'var(--color-text-tertiary)' }}
+                          >
+                            {formatTime(item.completed_at)}
+                          </span>
 
-                        {/* Headline */}
-                        <span
-                          className="text-sm truncate flex-1 group-hover/item:text-[var(--color-text-primary)] transition-colors"
-                        >
-                          {item.headline}
-                        </span>
+                          <span
+                            className="w-2 h-2 rounded-full shrink-0"
+                            style={{ backgroundColor: cfg.accent }}
+                          />
 
-                        <ArrowRight
-                          size={14}
-                          className="shrink-0 opacity-0 group-hover/item:opacity-60 transition-opacity"
-                          style={{ color: 'var(--color-text-tertiary)' }}
-                        />
-                      </button>
+                          <span
+                            className="text-[10px] font-semibold uppercase tracking-wider shrink-0 px-2 py-0.5 rounded"
+                            style={{
+                              color: cfg.accent,
+                              backgroundColor: `color-mix(in srgb, ${cfg.accent} 15%, transparent)`,
+                            }}
+                          >
+                            {t(cfg.labelKey)}
+                          </span>
+
+                          <span
+                            className="text-sm truncate flex-1 group-hover/item:text-[var(--color-text-primary)] transition-colors"
+                          >
+                            {item.headline}
+                          </span>
+                        </button>
+                        {instanceId && (
+                          <span className="absolute right-2 top-1/2 -translate-y-1/2 z-10">
+                            <RowAttachButton instanceId={instanceId} rowId={item.market_insight_id} />
+                          </span>
+                        )}
+                      </div>
                     );
                   })}
                 </div>

--- a/web/src/pages/Dashboard/components/InsightDetailModal.tsx
+++ b/web/src/pages/Dashboard/components/InsightDetailModal.tsx
@@ -1,11 +1,14 @@
 import React, { useEffect, useState } from 'react';
-import { X, ExternalLink, Sparkles, ChevronDown } from 'lucide-react';
+import { X, ExternalLink, Sparkles, ChevronDown, Paperclip } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
 import TopicBadge from './TopicBadge';
 import { getInsightDetail } from '../utils/api';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { MobileBottomSheet } from '@/components/ui/mobile-bottom-sheet';
+import { useToast } from '@/components/ui/use-toast';
+import { ContextBus } from '@/lib/contextBus';
+import { buildInsightWidgetSnapshot, normalizeInsight } from '../utils/insightFetch';
 import i18n from '@/i18n';
 
 interface InsightTopic {
@@ -65,12 +68,15 @@ function InsightBody({
   sourcesOpen,
   setSourcesOpen,
   isMobile,
+  onAttach,
 }: {
   detail: InsightDetail | null;
   loading: boolean;
   sourcesOpen: boolean;
   setSourcesOpen: React.Dispatch<React.SetStateAction<boolean>>;
   isMobile: boolean;
+  /** Optional handler. If provided, an Attach-to-chat button is rendered next to the eyebrow. */
+  onAttach?: () => void;
 }) {
   const { t } = useTranslation();
   if (loading) {
@@ -94,9 +100,7 @@ function InsightBody({
 
   return (
     <>
-      {/* Header */}
       <div className={isMobile ? '' : 'p-6 md:p-8 pb-0'}>
-        {/* Badge row */}
         <div className="flex items-center gap-2 sm:gap-3 mb-3 sm:mb-4 flex-wrap">
           <div
             className="px-2.5 py-0.5 sm:px-3 sm:py-1 rounded-full border flex items-center gap-1.5 sm:gap-2 text-[10px] sm:text-xs font-semibold uppercase tracking-wider"
@@ -125,9 +129,32 @@ function InsightBody({
               {formatDate(detail.completed_at)}
             </span>
           )}
+          {onAttach && (
+            <button
+              type="button"
+              onClick={onAttach}
+              className="ml-auto inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-[11px] sm:text-xs font-medium transition-colors"
+              style={{
+                backgroundColor: 'var(--color-accent-soft)',
+                borderColor: 'var(--color-accent-overlay)',
+                color: 'var(--color-accent-primary)',
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.backgroundColor = 'var(--color-accent-primary)';
+                e.currentTarget.style.color = '#fff';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.backgroundColor = 'var(--color-accent-soft)';
+                e.currentTarget.style.color = 'var(--color-accent-primary)';
+              }}
+              title={t('dashboard.widgets.frame.addToContext', { defaultValue: 'Attach to chat' })}
+            >
+              <Paperclip size={isMobile ? 12 : 13} />
+              {t('dashboard.widgets.frame.addToContext', { defaultValue: 'Attach to chat' })}
+            </button>
+          )}
         </div>
 
-        {/* Headline */}
         <h1
           className="text-xl sm:text-2xl md:text-3xl font-bold leading-tight mb-3 sm:mb-4"
           style={{ color: 'var(--color-text-primary)' }}
@@ -135,7 +162,6 @@ function InsightBody({
           {detail.headline}
         </h1>
 
-        {/* Topics */}
         {(detail.topics?.length ?? 0) > 0 && (
           <div className="flex flex-wrap gap-1.5 sm:gap-2 mb-4 sm:mb-6">
             {detail.topics!.map((topic) => (
@@ -144,7 +170,6 @@ function InsightBody({
           </div>
         )}
 
-        {/* Summary */}
         {detail.summary && (
           <p
             className="text-[13px] sm:text-sm leading-relaxed mb-4 sm:mb-6"
@@ -155,7 +180,6 @@ function InsightBody({
         )}
       </div>
 
-      {/* News Items */}
       <div className={isMobile ? '' : 'px-6 md:px-8 pb-6 md:pb-8'}>
         {(detail.content?.length ?? 0) > 0 && (
           <div
@@ -284,10 +308,28 @@ function InsightBody({
 }
 
 function InsightDetailModal({ marketInsightId, onClose }: InsightDetailModalProps) {
+  const { t } = useTranslation();
+  const { toast } = useToast();
   const [detail, setDetail] = useState<InsightDetail | null>(null);
   const [loading, setLoading] = useState(false);
   const [sourcesOpen, setSourcesOpen] = useState(false);
   const isMobile = useIsMobile();
+
+  const handleAttach = () => {
+    if (!detail || !marketInsightId) return;
+    const insight = normalizeInsight(detail as Parameters<typeof normalizeInsight>[0]);
+    const snapshot = buildInsightWidgetSnapshot({
+      instanceId: 'insight.detail',
+      rowId: marketInsightId,
+      insight,
+    });
+    ContextBus.attach(snapshot);
+    toast({
+      title: t('dashboard.widgets.frame.contextAttached', { defaultValue: 'Added to context' }),
+      description: 'Brief: ' + (detail.headline || ''),
+    });
+  };
+  const canAttach = !!detail && !!marketInsightId;
 
   useEffect(() => {
     if (!marketInsightId) {
@@ -310,7 +352,6 @@ function InsightDetailModal({ marketInsightId, onClose }: InsightDetailModalProp
     return () => { cancelled = true; };
   }, [marketInsightId]);
 
-  // Escape key
   useEffect(() => {
     if (!marketInsightId) return;
     const handleEsc = (e: KeyboardEvent) => {
@@ -327,6 +368,7 @@ function InsightDetailModal({ marketInsightId, onClose }: InsightDetailModalProp
       sourcesOpen={sourcesOpen}
       setSourcesOpen={setSourcesOpen}
       isMobile={isMobile}
+      onAttach={canAttach ? handleAttach : undefined}
     />
   );
 

--- a/web/src/pages/Dashboard/components/NewsDetailModal.tsx
+++ b/web/src/pages/Dashboard/components/NewsDetailModal.tsx
@@ -1,10 +1,17 @@
 import React, { useEffect, useState } from 'react';
-import { X, Calendar, Hash, ExternalLink, TrendingUp, TrendingDown, Minus, Tag } from 'lucide-react';
+import {
+  X, Calendar, Hash, ExternalLink, TrendingUp, TrendingDown, Minus, Tag,
+  Paperclip,
+} from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import i18n from '@/i18n';
+import { useTranslation } from 'react-i18next';
 import { getNewsArticle } from '../utils/api';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { MobileBottomSheet } from '@/components/ui/mobile-bottom-sheet';
+import { useToast } from '@/components/ui/use-toast';
+import { ContextBus } from '@/lib/contextBus';
+import { buildNewsWidgetSnapshot, normalizeArticle } from '../utils/newsArticleFetch';
 
 interface ArticleSource {
   name: string;
@@ -35,6 +42,15 @@ interface NewsDetailModalProps {
   newsId: string | null;
   onClose: () => void;
   fallbackUrl?: string | null;
+}
+
+function attachArticleToContext(article: Article, articleId: string): void {
+  const detail = normalizeArticle(article as Parameters<typeof normalizeArticle>[0]);
+  ContextBus.attach(buildNewsWidgetSnapshot({
+    instanceId: 'news.detail',
+    rowId: articleId,
+    article: detail,
+  }));
 }
 
 function sentimentIcon(sentiment: string): React.ReactElement {
@@ -96,6 +112,7 @@ function NewsBody({
   expandedSentiment,
   setExpandedSentiment,
   isMobile,
+  onAttach,
 }: {
   article: Article | null;
   loading: boolean;
@@ -104,7 +121,10 @@ function NewsBody({
   expandedSentiment: number | null;
   setExpandedSentiment: React.Dispatch<React.SetStateAction<number | null>>;
   isMobile: boolean;
+  /** Optional handler. If provided, an Attach-to-chat button is rendered in the meta row. */
+  onAttach?: () => void;
 }) {
+  const { t: trans } = useTranslation();
   if (loading) {
     return (
       <div className="flex items-center justify-center py-24">
@@ -209,17 +229,43 @@ function NewsBody({
               <Calendar size={isMobile ? 12 : 14} /> {formatDate(article.published_at)}
             </span>
           )}
-          {article.article_url && (
-            <a
-              href={article.article_url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="ml-auto flex items-center gap-1.5 transition-opacity hover:opacity-80"
-              style={{ color: 'var(--color-text-secondary)' }}
-            >
-              Source <ExternalLink size={isMobile ? 12 : 14} />
-            </a>
-          )}
+          <div className="ml-auto flex items-center gap-3">
+            {onAttach && (
+              <button
+                type="button"
+                onClick={onAttach}
+                className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-[11px] sm:text-xs font-medium transition-colors"
+                style={{
+                  backgroundColor: 'var(--color-accent-soft)',
+                  borderColor: 'var(--color-accent-overlay)',
+                  color: 'var(--color-accent-primary)',
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.backgroundColor = 'var(--color-accent-primary)';
+                  e.currentTarget.style.color = '#fff';
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.backgroundColor = 'var(--color-accent-soft)';
+                  e.currentTarget.style.color = 'var(--color-accent-primary)';
+                }}
+                title={trans('dashboard.widgets.frame.addToContext', { defaultValue: 'Attach to chat' })}
+              >
+                <Paperclip size={isMobile ? 12 : 13} />
+                {trans('dashboard.widgets.frame.addToContext', { defaultValue: 'Attach to chat' })}
+              </button>
+            )}
+            {article.article_url && (
+              <a
+                href={article.article_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1.5 transition-opacity hover:opacity-80"
+                style={{ color: 'var(--color-text-secondary)' }}
+              >
+                Source <ExternalLink size={isMobile ? 12 : 14} />
+              </a>
+            )}
+          </div>
         </div>
 
         <div className="space-y-6 sm:space-y-8">
@@ -407,11 +453,23 @@ function NewsBody({
 }
 
 function NewsDetailModal({ newsId, onClose, fallbackUrl }: NewsDetailModalProps) {
+  const { t } = useTranslation();
+  const { toast } = useToast();
   const [article, setArticle] = useState<Article | null>(null);
   const [loading, setLoading] = useState(false);
   const [fetchFailed, setFetchFailed] = useState(false);
   const [expandedSentiment, setExpandedSentiment] = useState<number | null>(null);
   const isMobile = useIsMobile();
+
+  const handleAttach = () => {
+    if (!article || !newsId) return;
+    attachArticleToContext(article, newsId);
+    toast({
+      title: t('dashboard.widgets.frame.contextAttached', { defaultValue: 'Added to context' }),
+      description: 'News: ' + (article.title || ''),
+    });
+  };
+  const canAttach = !!article && !!newsId;
 
   useEffect(() => {
     if (!newsId) {
@@ -443,7 +501,6 @@ function NewsDetailModal({ newsId, onClose, fallbackUrl }: NewsDetailModalProps)
     };
   }, [newsId]);
 
-  // Escape key
   useEffect(() => {
     if (!newsId) return;
     const handleEsc = (e: KeyboardEvent) => {
@@ -462,6 +519,7 @@ function NewsDetailModal({ newsId, onClose, fallbackUrl }: NewsDetailModalProps)
       expandedSentiment={expandedSentiment}
       setExpandedSentiment={setExpandedSentiment}
       isMobile={isMobile}
+      onAttach={canAttach ? handleAttach : undefined}
     />
   );
 

--- a/web/src/pages/Dashboard/components/RowAttachButton.css
+++ b/web/src/pages/Dashboard/components/RowAttachButton.css
@@ -1,0 +1,48 @@
+/* Quiet, hover-revealed paperclip — matches the widget-frame "Attach to
+ * chat" affordance. No card/border by default so it doesn't read as a
+ * boxed CTA next to the row content; hover gives it a soft circular bg
+ * that mirrors the widget's rounded chrome instead of squared corners. */
+.row-attach {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: transparent;
+  border: 0;
+  color: var(--color-text-tertiary, #8a8a8a);
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity 120ms ease,
+    background-color 120ms ease,
+    color 120ms ease;
+  padding: 0;
+}
+
+/* Show on hover within the row's `.row-attach-host` ancestor. List widgets
+ * apply that class to the row container so the button is opacity-tied to a
+ * single, predictable hover region. */
+.row-attach-host:hover .row-attach,
+.row-attach:focus-visible {
+  opacity: 1;
+}
+
+.row-attach:hover {
+  background: var(--color-accent-soft, rgba(184, 138, 44, 0.12));
+  color: var(--color-accent-primary, #b88a2c);
+}
+
+@media (hover: none) {
+  /* Touch devices: always visible. Hover would never trigger. */
+  .row-attach {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .row-attach {
+    transition: none;
+  }
+}

--- a/web/src/pages/Dashboard/components/RowAttachButton.tsx
+++ b/web/src/pages/Dashboard/components/RowAttachButton.tsx
@@ -1,0 +1,74 @@
+import { useState } from 'react';
+import { Paperclip, Loader2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { ContextBus } from '@/lib/contextBus';
+import { getWidgetContextSnapshot } from '../widgets/framework/contextSnapshot';
+import { useToast } from '@/components/ui/use-toast';
+import './RowAttachButton.css';
+
+interface RowAttachButtonProps {
+  /** Widget instance id — used to look up the registered exporter. */
+  instanceId: string;
+  /** Per-row identifier the widget's `rows(rowId)` exporter expects. */
+  rowId: string;
+  /** Optional className to control row-level positioning. */
+  className?: string;
+}
+
+/**
+ * Hover-revealed paperclip button for list rows — same "attach" affordance
+ * as the widget-frame paperclip, scoped to a single row. Calls into the
+ * registered widget exporter's `rows(rowId)` function to produce a snapshot
+ * of just that row, then publishes via ContextBus so every mounted chat
+ * input picks it up.
+ *
+ * This component carries the `widget-drag-cancel` class so clicking it inside
+ * an edit-mode draggable widget doesn't initiate a drag. List widgets should
+ * place this inside the row markup; pair with `.row-attach-host` (a `position:
+ * relative; group` wrapper) so the button can absolute-position to the right.
+ */
+export function RowAttachButton({ instanceId, rowId, className }: RowAttachButtonProps) {
+  const { t } = useTranslation();
+  const { toast } = useToast();
+  const [busy, setBusy] = useState(false);
+
+  const handleClick = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    if (busy) return;
+    setBusy(true);
+    try {
+      const snapshot = await getWidgetContextSnapshot(instanceId, rowId);
+      if (!snapshot) {
+        toast({
+          variant: 'destructive',
+          title: t('dashboard.widgets.frame.contextUnavailable', { defaultValue: 'Widget not available' }),
+          description: t('dashboard.widgets.frame.contextUnavailableHint', {
+            defaultValue: 'This widget has not registered a context exporter yet.',
+          }),
+        });
+        return;
+      }
+      ContextBus.attach(snapshot);
+      toast({
+        title: t('dashboard.widgets.frame.contextAttached', { defaultValue: 'Added to context' }),
+        description: snapshot.label,
+      });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      className={`row-attach widget-drag-cancel ${className ?? ''}`}
+      onClick={handleClick}
+      disabled={busy}
+      aria-label={t('dashboard.widgets.frame.addRowToContext', { defaultValue: 'Attach to chat' })}
+      title={t('dashboard.widgets.frame.addRowToContextTitle', { defaultValue: 'Attach to chat' })}
+    >
+      {busy ? <Loader2 className="h-3 w-3 animate-spin" /> : <Paperclip className="h-3 w-3" />}
+    </button>
+  );
+}

--- a/web/src/pages/Dashboard/hooks/useChatInput.ts
+++ b/web/src/pages/Dashboard/hooks/useChatInput.ts
@@ -2,8 +2,10 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useToast } from '../../../components/ui/use-toast';
 import { getFlashWorkspace } from '../../ChatAgent/utils/api';
-import { attachmentsToContexts } from '../../ChatAgent/utils/fileUpload';
+import { attachmentsToContexts, widgetSnapshotsToContexts } from '../../ChatAgent/utils/fileUpload';
 import { useWorkspaces } from '../../../hooks/useWorkspaces';
+import { ContextBus } from '@/lib/contextBus';
+import type { WidgetContextSnapshot } from '../widgets/framework/contextSnapshot';
 import type { Workspace } from '@/types/api';
 
 type ChatMode = 'fast' | 'ptc';
@@ -27,14 +29,15 @@ interface SendOptions {
   model?: string | null;
   reasoningEffort?: string | null;
   fastMode?: boolean;
+  widgetSnapshots?: WidgetContextSnapshot[];
 }
 
+const MAX_LOCATION_STATE_BYTES = 5 * 1024 * 1024; // ~5MB structured-clone safety net
+
 /**
- * Custom hook for handling chat input functionality
- * Manages mode (fast/ptc), workspace selection, loading state, and workspace creation dialog
- * Message and planMode are managed internally by ChatInput and passed via handleSend.
- *
- * @returns {Object} Chat input state and handlers
+ * Manages dashboard chat input state: mode (fast/ptc), workspace selection,
+ * loading, and the send handler. Message and planMode are owned by ChatInput
+ * and passed through via handleSend.
  */
 export function useChatInput() {
   const [mode, setModeRaw] = useState<ChatMode>('ptc');
@@ -71,18 +74,20 @@ export function useChatInput() {
   }, [wsData, workspaces.length, mode]);
 
   /**
-   * Handles sending a message and navigating to the ChatAgent workspace.
-   * Fast mode: uses flash workspace (agent_mode: flash)
-   * PTC mode: uses selected workspace or falls back to default LangAlpha workspace
+   * Navigates to the ChatAgent workspace with the composed message payload.
+   * Fast mode: uses the flash workspace. PTC mode: uses the selected workspace.
    */
   const handleSend = async (
     message: string,
     planMode = false,
     attachments: ChatAttachment[] = [],
+    // Slash commands are accepted to match ChatInput.onSend's signature but
+    // dropped here — they apply only inside an active chat session, not on
+    // the dashboard handoff.
     _slashCommands: SlashCommand[] = [],
-    { model, reasoningEffort }: SendOptions = {},
+    { model, reasoningEffort, widgetSnapshots }: SendOptions = {},
   ): Promise<void> => {
-    const hasContent = message.trim() || (attachments && attachments.length > 0);
+    const hasContent = message.trim() || (attachments && attachments.length > 0) || (widgetSnapshots && widgetSnapshots.length > 0);
     if (!hasContent || isLoading) {
       return;
     }
@@ -90,10 +95,11 @@ export function useChatInput() {
     setIsLoading(true);
     try {
       // Build additional context and attachment metadata from attachments
-      let additionalContext: Array<{ type: string; data: string | null; description: string }> | null = null;
+      let additionalContext: Array<Record<string, unknown>> | null = null;
+      const toRecord = <T extends object>(x: T): Record<string, unknown> => x as unknown as Record<string, unknown>;
       let attachmentMeta: Array<{ name: string; type: string; size: number; preview: string | null; dataUrl: string | null }> | null = null;
       if (attachments && attachments.length > 0) {
-        additionalContext = attachmentsToContexts(attachments as any);
+        additionalContext = attachmentsToContexts(attachments as any).map(toRecord);
         attachmentMeta = attachments.map((a) => ({
           name: a.file.name,
           type: a.type,
@@ -101,6 +107,30 @@ export function useChatInput() {
           preview: a.preview || null,
           dataUrl: a.dataUrl,
         }));
+      }
+      // Append widget snapshot items (one widget directive + optional sibling
+      // image item per snapshot). Co-located with attachments so backend reads
+      // a single uniform `additional_context` array.
+      if (widgetSnapshots && widgetSnapshots.length > 0) {
+        const widgetItems = widgetSnapshotsToContexts(widgetSnapshots).map(toRecord);
+        additionalContext = [...(additionalContext ?? []), ...widgetItems];
+      }
+      // Pre-flight size check on the location.state payload before navigate.
+      // Structured clone fails on payloads >50MB and dashboard → chat handoff
+      // would crash silently. We cap at ~5MB; if oversized, drop the local
+      // copy of widget snapshots from state (the additional_context still
+      // carries them via the request body).
+      let stateWidgetSnapshots: WidgetContextSnapshot[] | undefined = widgetSnapshots && widgetSnapshots.length > 0 ? widgetSnapshots : undefined;
+      if (stateWidgetSnapshots) {
+        try {
+          const sz = new Blob([JSON.stringify(stateWidgetSnapshots)]).size;
+          if (sz > MAX_LOCATION_STATE_BYTES) {
+            console.warn('[useChatInput] widgetSnapshots state too large, dropping', sz);
+            stateWidgetSnapshots = undefined;
+          }
+        } catch {
+          stateWidgetSnapshots = undefined;
+        }
       }
 
       if (mode === 'fast') {
@@ -119,6 +149,7 @@ export function useChatInput() {
             ...(attachmentMeta ? { attachmentMeta } : {}),
             ...(model ? { model } : {}),
             ...(reasoningEffort ? { reasoningEffort } : {}),
+            ...(stateWidgetSnapshots ? { widgetSnapshots: stateWidgetSnapshots } : {}),
           },
         });
       } else {
@@ -142,8 +173,16 @@ export function useChatInput() {
             ...(attachmentMeta ? { attachmentMeta } : {}),
             ...(model ? { model } : {}),
             ...(reasoningEffort ? { reasoningEffort } : {}),
+            ...(stateWidgetSnapshots ? { widgetSnapshots: stateWidgetSnapshots } : {}),
           },
         });
+      }
+      // Send succeeded — clear the dashboard's deck so the cards don't
+      // linger after the user navigates to chat. The chat input on the
+      // /chat route will re-seed from location.state via addWidgetSnapshot
+      // on mount.
+      if (widgetSnapshots && widgetSnapshots.length > 0) {
+        ContextBus.clear();
       }
     } catch (error) {
       console.error('Error with workspace:', error);

--- a/web/src/pages/Dashboard/hooks/useChatInput.ts
+++ b/web/src/pages/Dashboard/hooks/useChatInput.ts
@@ -177,10 +177,9 @@ export function useChatInput() {
           },
         });
       }
-      // Send succeeded — clear the dashboard's deck so the cards don't
-      // linger after the user navigates to chat. The chat input on the
-      // /chat route will re-seed from location.state via addWidgetSnapshot
-      // on mount.
+      // Clear the dashboard deck so cards don't linger after navigate.
+      // Snapshots ride `location.state` and are consumed inline by the
+      // chat-side auto-send effect (no deck re-seed on this path).
       if (widgetSnapshots && widgetSnapshots.length > 0) {
         ContextBus.clear();
       }

--- a/web/src/pages/Dashboard/utils/insightFetch.ts
+++ b/web/src/pages/Dashboard/utils/insightFetch.ts
@@ -1,0 +1,101 @@
+/**
+ * Shared insight-brief snapshot helpers — used by:
+ *   - InsightBriefWidget per-row attach (fetches full content[] on click)
+ *   - InsightDetailModal attach button (uses already-loaded detail)
+ *
+ * Mirrors the pattern in `newsArticleFetch.ts` so the agent gets the same
+ * `<widget-context>` block whether the user attached from a row or from
+ * inside the detail modal.
+ */
+
+import type { WidgetContextSnapshot } from '../widgets/framework/contextSnapshot';
+import {
+  serializeInsightToMarkdown,
+  wrapWidgetContext,
+  type InsightDetail,
+} from '../widgets/framework/snapshotSerializers';
+import { getInsightDetail } from './api';
+
+interface RawInsight {
+  market_insight_id?: string;
+  type?: string;
+  headline?: string;
+  summary?: string;
+  completed_at?: string;
+  model?: string;
+  topics?: Array<{ text: string; trend?: 'up' | 'down' | 'neutral' }>;
+  content?: Array<{ title: string; body: string; url?: string }>;
+  sources?: Array<{ url: string; title?: string }>;
+  [key: string]: unknown;
+}
+
+export function normalizeInsight(raw: RawInsight): InsightDetail {
+  return {
+    market_insight_id: raw.market_insight_id ?? '',
+    type: raw.type ?? 'market_update',
+    headline: raw.headline ?? '',
+    summary: raw.summary,
+    completed_at: raw.completed_at,
+    model: raw.model,
+    topics: raw.topics,
+    content: raw.content,
+    sources: raw.sources,
+  };
+}
+
+export function buildInsightWidgetSnapshot(opts: {
+  instanceId: string;
+  rowId: string;
+  insight: InsightDetail;
+  widgetType?: string;
+}): WidgetContextSnapshot {
+  const widgetType = opts.widgetType ?? 'insight.brief/row';
+  const body = serializeInsightToMarkdown(opts.insight);
+  const text = wrapWidgetContext(
+    widgetType,
+    {
+      insightId: opts.insight.market_insight_id || undefined,
+      insightType: opts.insight.type,
+      completedAt: opts.insight.completed_at,
+    },
+    body,
+  );
+  return {
+    widget_type: widgetType,
+    widget_id: `${opts.instanceId}/${opts.rowId}`,
+    label: 'Brief: ' + opts.insight.headline,
+    description: [opts.insight.type, opts.insight.completed_at].filter(Boolean).join(' · ') || undefined,
+    captured_at: new Date().toISOString(),
+    text,
+    data: { insight: opts.insight },
+  };
+}
+
+/**
+ * Build a row-level snapshot for a single insight. Tries to fetch the full
+ * detail via `getInsightDetail`; falls back to whatever fields the cached
+ * list-row has if the fetch fails.
+ */
+export async function buildInsightSnapshot(opts: {
+  instanceId: string;
+  rowId: string;
+  insightId: string;
+  fallback: InsightDetail;
+}): Promise<WidgetContextSnapshot> {
+  let insight: InsightDetail = opts.fallback;
+  try {
+    const raw = (await getInsightDetail(opts.insightId)) as RawInsight;
+    insight = normalizeInsight(raw);
+    if (!insight.topics?.length && opts.fallback.topics?.length) insight.topics = opts.fallback.topics;
+    if (!insight.summary && opts.fallback.summary) insight.summary = opts.fallback.summary;
+    if (!insight.completed_at && opts.fallback.completed_at) insight.completed_at = opts.fallback.completed_at;
+    if (!insight.headline && opts.fallback.headline) insight.headline = opts.fallback.headline;
+  } catch (err) {
+    console.warn('[insightFetch] full-detail fetch failed, using row fallback', err);
+  }
+  return buildInsightWidgetSnapshot({
+    instanceId: opts.instanceId,
+    rowId: opts.rowId,
+    insight,
+  });
+}

--- a/web/src/pages/Dashboard/utils/newsArticleFetch.ts
+++ b/web/src/pages/Dashboard/utils/newsArticleFetch.ts
@@ -1,0 +1,115 @@
+/**
+ * Shared news-article snapshot helpers — used by:
+ *   - NewsFeedWidget per-row attach (fetches full body on click)
+ *   - NewsDetailModal attach button (uses already-loaded article)
+ *
+ * The ContextBus payload is identical from either entry point, so the agent
+ * sees the exact same `<widget-context>` block whether the user attached from
+ * the list row or from inside the detail modal.
+ */
+
+import type { WidgetContextSnapshot } from '../widgets/framework/contextSnapshot';
+import {
+  serializeNewsArticleToMarkdown,
+  wrapWidgetContext,
+  type NewsArticleDetail,
+} from '../widgets/framework/snapshotSerializers';
+import { getNewsArticle } from './api';
+
+interface RawArticle {
+  title?: string;
+  description?: string;
+  article_url?: string | null;
+  author?: string;
+  published_at?: string;
+  keywords?: string[];
+  tickers?: string[];
+  sentiments?: Array<{ ticker: string; sentiment?: string; reasoning?: string }>;
+  source?: { name?: string } | string;
+  [key: string]: unknown;
+}
+
+export function normalizeArticle(raw: RawArticle): NewsArticleDetail {
+  const sourceName =
+    typeof raw.source === 'string'
+      ? raw.source
+      : raw.source && typeof raw.source === 'object'
+        ? raw.source.name
+        : undefined;
+  return {
+    title: raw.title ?? '',
+    description: raw.description,
+    author: raw.author,
+    publishedAt: raw.published_at,
+    url: raw.article_url ?? undefined,
+    source: sourceName,
+    tickers: raw.tickers,
+    keywords: raw.keywords,
+    sentiments: raw.sentiments,
+  };
+}
+
+/**
+ * Sync snapshot builder for an already-loaded news article. Used by the
+ * detail-modal attach button (article is already in component state) and as
+ * the final step of `buildNewsArticleSnapshot` after its async fetch.
+ */
+export function buildNewsWidgetSnapshot(opts: {
+  instanceId: string;
+  rowId: string;
+  article: NewsArticleDetail;
+}): WidgetContextSnapshot {
+  const { article } = opts;
+  const body = serializeNewsArticleToMarkdown(article);
+  const text = wrapWidgetContext(
+    'news.feed/row',
+    {
+      source: article.source,
+      tickers: article.tickers?.join(','),
+      published_at: article.publishedAt,
+    },
+    body,
+  );
+  return {
+    widget_type: 'news.feed/row',
+    widget_id: `${opts.instanceId}/${opts.rowId}`,
+    label: 'News: ' + article.title,
+    description: [article.source, article.publishedAt].filter(Boolean).join(' · ') || undefined,
+    captured_at: new Date().toISOString(),
+    text,
+    data: { article },
+  };
+}
+
+/**
+ * Build a row-level snapshot for a single news article. Tries to fetch the
+ * full body via /news/:id; falls back to whatever fields we already have on
+ * the list-row item if the fetch fails or no id is available.
+ */
+export async function buildNewsArticleSnapshot(opts: {
+  instanceId: string;
+  rowId: string;
+  articleId?: string | number;
+  /** Fallback fields when the article fetch fails — ensures we still attach something useful. */
+  fallback: NewsArticleDetail;
+}): Promise<WidgetContextSnapshot> {
+  let article: NewsArticleDetail = opts.fallback;
+  if (opts.articleId != null) {
+    try {
+      const raw = (await getNewsArticle(String(opts.articleId))) as RawArticle;
+      article = normalizeArticle(raw);
+      // Fall back per-field if the fetched article is missing what the row had
+      // (the list payload is sometimes richer in certain fields, e.g., tickers).
+      if (!article.tickers?.length && opts.fallback.tickers?.length) article.tickers = opts.fallback.tickers;
+      if (!article.source && opts.fallback.source) article.source = opts.fallback.source;
+      if (!article.publishedAt && opts.fallback.publishedAt) article.publishedAt = opts.fallback.publishedAt;
+      if (!article.url && opts.fallback.url) article.url = opts.fallback.url;
+      if (!article.title && opts.fallback.title) article.title = opts.fallback.title;
+    } catch (err) {
+      // Article fetch is best-effort — fall back to the list-row fields so
+      // the agent still gets *something* contextual rather than nothing.
+      console.warn('[newsArticleFetch] full-article fetch failed, using row fallback', err);
+    }
+  }
+  return buildNewsWidgetSnapshot({ instanceId: opts.instanceId, rowId: opts.rowId, article });
+}

--- a/web/src/pages/Dashboard/widgets/definitions/AutomationsWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/AutomationsWidget.tsx
@@ -14,6 +14,8 @@ import { useAutomations } from '@/pages/Automations/hooks/useAutomations';
 import { useAutomationMutations } from '@/pages/Automations/hooks/useAutomationMutations';
 import type { Automation } from '@/types/automation';
 import { registerWidget } from '../framework/WidgetRegistry';
+import { useWidgetContextExport } from '../framework/contextSnapshot';
+import { serializeRowsToMarkdown, wrapWidgetContext } from '../framework/snapshotSerializers';
 import { AutomationsConfigSchema } from '../framework/configSchemas';
 import type { WidgetRenderProps } from '../types';
 
@@ -271,6 +273,46 @@ function AutomationsWidget({ instance }: WidgetRenderProps<AutomationsConfig>) {
 
   const { automations, loading, refetch } = useAutomations();
   const { pause, resume, trigger, loading: mutating } = useAutomationMutations(refetch);
+
+  useWidgetContextExport(instance.id, {
+    full: () => {
+      const tableRows = automations.map((a) => ({
+        name: a.name || t('dashboard.widgets.automations.untitled'),
+        trigger: triggerLabel(a),
+        status: a.status ?? 'active',
+        next_run: a.next_run_at ?? '',
+        last_run: a.last_run_at ?? '',
+      }));
+      const counts = {
+        total: automations.length,
+        active: automations.filter((a) => a.status === 'active').length,
+        paused: automations.filter((a) => a.status === 'paused').length,
+        error: automations.filter((a) => a.status === 'error').length,
+      };
+      const body = automations.length
+        ? `**${counts.active} active · ${counts.paused} paused · ${counts.error} error**\n\n` +
+          serializeRowsToMarkdown(tableRows, [
+            { key: 'name', label: 'name' },
+            { key: 'trigger', label: 'trigger' },
+            { key: 'status', label: 'status' },
+            { key: 'next_run', label: 'next run' },
+            { key: 'last_run', label: 'last run' },
+          ])
+        : '_no automations_';
+      const text = wrapWidgetContext('automations.list', counts, body);
+      return {
+        widget_type: 'automations.list',
+        widget_id: instance.id,
+        label: `${t('dashboard.widgets.automations.title')} · ${counts.total}`,
+        description: counts.total
+          ? `${counts.active} active, ${counts.paused} paused${counts.error ? `, ${counts.error} error` : ''}`
+          : 'empty',
+        captured_at: new Date().toISOString(),
+        text,
+        data: { counts, automations },
+      };
+    },
+  });
 
   const grouped = useMemo(() => {
     const buckets: Record<BucketKey, Automation[]> = { active: [], paused: [], error: [] };

--- a/web/src/pages/Dashboard/widgets/definitions/ChartWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/ChartWidget.tsx
@@ -40,6 +40,12 @@ import { useMarketDataWSContext } from '@/pages/MarketView/contexts/MarketDataWS
 import { useTheme } from '@/contexts/ThemeContext';
 import { createFormatter, createDateFormatter } from '@/lib/format';
 import type { WidgetRenderProps, WidgetSettingsProps } from '../types';
+import { useWidgetContextExport } from '../framework/contextSnapshot';
+import {
+  serializeOhlcvToMarkdown,
+  summarizeOhlcv,
+  wrapWidgetContext,
+} from '../framework/snapshotSerializers';
 
 const fmt2 = createFormatter({ minimumFractionDigits: 2, maximumFractionDigits: 2 });
 // Compact volumes ("1.23B", "1.23M", "1.2K"). Intl.NumberFormat with
@@ -175,6 +181,60 @@ function ChartWidget({ instance, updateConfig }: WidgetRenderProps<ChartConfig>)
   // --- AbortControllers (one per fetch path) ---
   const initAbortRef = useRef<AbortController | null>(null);
   const stage2AbortRef = useRef<AbortController | null>(null);
+
+  // Snapshot exporter — Tier 1 (text + image). Reads bars from `allDataRef`
+  // (the same buffer the chart series draws from) and asks the chart canvas
+  // for a JPEG. Same-origin canvas should never taint, but defensive try/
+  // catch falls back to text-only if the browser reports it as tainted.
+  useWidgetContextExport(instance.id, {
+    full: () => {
+      const bars = allDataRef.current ?? [];
+      const ohlcv = bars.map((b) => ({
+        time: new Date(b.time * 1000).toISOString().slice(0, 10),
+        open: b.open,
+        high: b.high,
+        low: b.low,
+        close: b.close,
+        volume: b.volume,
+      }));
+      const tableBody = serializeOhlcvToMarkdown(ohlcv);
+      const summary = summarizeOhlcv(ohlcv);
+      const summaryLine = summary ? `\n<summary>${summary}</summary>` : '';
+      const text = wrapWidgetContext(
+        'markets.chart',
+        {
+          symbol: config.symbol,
+          interval: config.interval,
+          chart_type: config.chartType,
+          as_of: new Date().toISOString(),
+        },
+        tableBody + summaryLine,
+      );
+      // Try to capture the lightweight-charts canvas as JPEG. If the canvas
+      // is tainted (cross-origin texture) or no canvas yet, fall back to
+      // directive-only.
+      let imageDataUrl: string | undefined;
+      try {
+        const canvas = containerRef.current?.querySelector('canvas');
+        if (canvas instanceof HTMLCanvasElement) {
+          imageDataUrl = canvas.toDataURL('image/jpeg', 0.85);
+        }
+      } catch (err) {
+        console.warn('[ChartWidget] canvas capture failed, sending text-only', err);
+      }
+      const labelBits = [config.symbol.toUpperCase(), config.interval, t('dashboard.widgets.chart.title', { defaultValue: 'Chart' })];
+      return {
+        widget_type: 'markets.chart',
+        widget_id: instance.id,
+        label: labelBits.filter(Boolean).join(' · '),
+        description: summary || `${ohlcv.length} bars`,
+        captured_at: new Date().toISOString(),
+        text,
+        data: { bars: ohlcv, symbol: config.symbol, interval: config.interval, chartType: config.chartType },
+        image_jpeg_data_url: imageDataUrl,
+      };
+    },
+  });
 
   // --- WS live-tick bookkeeping ---
   const lastLiveTickTimeRef = useRef(0); // wall-clock ms of the most recent applied WS tick

--- a/web/src/pages/Dashboard/widgets/definitions/ConversationWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/ConversationWidget.tsx
@@ -13,6 +13,8 @@ import { getWorkspaceThreads } from '@/pages/ChatAgent/utils/api';
 import { queryKeys } from '@/lib/queryKeys';
 import type { Thread, ThreadsResponse } from '@/types/api';
 import { registerWidget } from '../framework/WidgetRegistry';
+import { useWidgetContextExport } from '../framework/contextSnapshot';
+import { wrapWidgetContext } from '../framework/snapshotSerializers';
 import { ConversationConfigSchema } from '../framework/configSchemas';
 import type { WidgetRenderProps } from '../types';
 import './ConversationWidget.css';
@@ -64,7 +66,7 @@ function formatRelative(ts?: string): string {
   return i18n.t('dashboard.widgets.common.relativePast', { when });
 }
 
-function ConversationWidget(_props: WidgetRenderProps<ConversationConfig>) {
+function ConversationWidget({ instance }: WidgetRenderProps<ConversationConfig>) {
   const { t } = useTranslation();
   const navigate = useNavigate();
 
@@ -108,6 +110,46 @@ function ConversationWidget(_props: WidgetRenderProps<ConversationConfig>) {
     () => (threadsData?.threads ?? []).slice(0, 4),
     [threadsData],
   );
+
+  useWidgetContextExport(instance.id, {
+    full: () => {
+      const selectedWs = workspaces.find((w) => w.workspace_id === selectedWorkspaceId);
+      const lines: string[] = [
+        `Mode: ${mode}`,
+        `Workspace: ${selectedWs?.name ?? '(none)'} (${selectedWorkspaceId ?? 'unset'})`,
+      ];
+      if (recentThreads.length) {
+        lines.push('', '**Resume threads:**');
+        recentThreads.forEach((th) => {
+          const title = th.title || t('dashboard.widgets.conversation.untitledThread');
+          lines.push(`- ${title} — ${th.updated_at ?? ''} (${th.thread_id})`);
+        });
+      }
+      const text = wrapWidgetContext(
+        'agent.conversation',
+        { mode, workspace_id: selectedWorkspaceId },
+        lines.join('\n'),
+      );
+      return {
+        widget_type: 'agent.conversation',
+        widget_id: instance.id,
+        label: t('dashboard.widgets.conversation.title'),
+        description: `${mode} · ${selectedWs?.name ?? 'no workspace'}`,
+        captured_at: new Date().toISOString(),
+        text,
+        data: {
+          mode,
+          workspace_id: selectedWorkspaceId,
+          workspace_name: selectedWs?.name,
+          recent_threads: recentThreads.map((th) => ({
+            thread_id: th.thread_id,
+            title: th.title,
+            updated_at: th.updated_at,
+          })),
+        },
+      };
+    },
+  });
 
   return (
     <div className="conversation-widget">

--- a/web/src/pages/Dashboard/widgets/definitions/EarningsCalendarWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/EarningsCalendarWidget.tsx
@@ -5,7 +5,10 @@ import { useQuery } from '@tanstack/react-query';
 import { CalendarDays } from 'lucide-react';
 import { getEarningsCalendar } from '../../utils/api';
 import { registerWidget } from '../framework/WidgetRegistry';
+import { useWidgetContextExport } from '../framework/contextSnapshot';
+import { serializeRowsToMarkdown, wrapWidgetContext } from '../framework/snapshotSerializers';
 import { EarningsConfigSchema } from '../framework/configSchemas';
+import { RowAttachButton } from '../../components/RowAttachButton';
 import type { WidgetRenderProps } from '../types';
 
 /** Local-date YYYY-MM-DD. We can't use toISOString() because that emits UTC,
@@ -66,7 +69,24 @@ function formatDateRight(dateStr: string, bucket: BucketKey): string {
   return d.toLocaleDateString(i18n.language, { month: 'short', day: 'numeric' });
 }
 
-function EarningsRow({ item, bucket }: { item: EarningsEntry; bucket: BucketKey }) {
+function serializeEarningsToMarkdown(items: EarningsEntry[]): string {
+  if (!items.length) return '_no upcoming earnings in window_';
+  return serializeRowsToMarkdown(items, [
+    { key: 'symbol', label: 'symbol' },
+    { key: 'date', label: 'date' },
+    { key: 'companyName', label: 'company', format: (v) => (typeof v === 'string' ? v : '') },
+  ]);
+}
+
+function EarningsRow({
+  item,
+  bucket,
+  instanceId,
+}: {
+  item: EarningsEntry;
+  bucket: BucketKey;
+  instanceId: string;
+}) {
   const { t } = useTranslation();
   // formatDateRight returns 'Today'/'Tomorrow' fallthrough or the locale's
   // weekday/short-month string. Translate the today/tomorrow shortcuts so
@@ -79,7 +99,7 @@ function EarningsRow({ item, bucket }: { item: EarningsEntry; bucket: BucketKey 
       : raw;
   return (
     <div
-      className="group flex items-center gap-3 px-2 py-2 rounded-md border border-transparent transition-colors"
+      className="row-attach-host group relative flex items-center gap-3 px-2 py-2 rounded-md border border-transparent transition-colors"
       onMouseEnter={(e) => {
         e.currentTarget.style.backgroundColor = 'var(--color-bg-hover)';
       }}
@@ -121,6 +141,9 @@ function EarningsRow({ item, bucket }: { item: EarningsEntry; bucket: BucketKey 
       >
         {label}
       </span>
+      <span className="absolute right-1 top-1/2 -translate-y-1/2">
+        <RowAttachButton instanceId={instanceId} rowId={`${item.symbol}-${item.date}`} />
+      </span>
     </div>
   );
 }
@@ -129,10 +152,12 @@ function BucketSection({
   label,
   items,
   bucket,
+  instanceId,
 }: {
   label: string;
   items: EarningsEntry[];
   bucket: BucketKey;
+  instanceId: string;
 }) {
   if (items.length === 0) return null;
   return (
@@ -160,7 +185,12 @@ function BucketSection({
       </div>
       <div className="flex flex-col">
         {items.map((item, i) => (
-          <EarningsRow key={`${item.symbol}-${item.date}-${i}`} item={item} bucket={bucket} />
+          <EarningsRow
+            key={`${item.symbol}-${item.date}-${i}`}
+            item={item}
+            bucket={bucket}
+            instanceId={instanceId}
+          />
         ))}
       </div>
     </div>
@@ -209,6 +239,62 @@ function EarningsCalendarWidget({ instance }: WidgetRenderProps<EarningsConfig>)
     }
     return buckets;
   }, [upcoming]);
+
+  useWidgetContextExport(instance.id, {
+    full: () => {
+      const sections: string[] = [];
+      const counts: Record<BucketKey, number> = {
+        today: grouped.today.length,
+        tomorrow: grouped.tomorrow.length,
+        week: grouped.week.length,
+        next: grouped.next.length,
+        later: grouped.later.length,
+      };
+      (Object.keys(grouped) as BucketKey[]).forEach((b) => {
+        if (grouped[b].length === 0) return;
+        sections.push(`### ${t(BUCKET_KEY[b])} (${grouped[b].length})`, '', serializeEarningsToMarkdown(grouped[b]), '');
+      });
+      const body = sections.length
+        ? sections.join('\n').trimEnd()
+        : `_no upcoming earnings in next ${windowDays}d_`;
+      const text = wrapWidgetContext(
+        'calendar.earnings',
+        { window_days: windowDays, count: upcoming.length, from: todayStr, to: toStr },
+        body,
+      );
+      return {
+        widget_type: 'calendar.earnings',
+        widget_id: instance.id,
+        label: `${t('dashboard.widgets.earningsCalendar.title')} · ${upcoming.length}`,
+        description: `next ${windowDays}d`,
+        captured_at: new Date().toISOString(),
+        text,
+        data: { window_days: windowDays, from: todayStr, to: toStr, counts, upcoming },
+      };
+    },
+    rows: (rowId: string) => {
+      const item = upcoming.find((e) => `${e.symbol}-${e.date}` === rowId);
+      if (!item) return null;
+      const lines = [
+        `**${item.symbol}** · ${item.date}`,
+      ];
+      if (item.companyName) lines.push(item.companyName);
+      const text = wrapWidgetContext(
+        'calendar.earnings/row',
+        { symbol: item.symbol, date: item.date },
+        lines.join('\n'),
+      );
+      return {
+        widget_type: 'calendar.earnings/row',
+        widget_id: `${instance.id}/${rowId}`,
+        label: `${item.symbol} · ${item.date}`,
+        description: t('dashboard.widgets.earningsCalendar.title'),
+        captured_at: new Date().toISOString(),
+        text,
+        data: { row: { symbol: item.symbol, date: item.date, companyName: item.companyName } },
+      };
+    },
+  });
 
   return (
     <div className="dashboard-glass-card p-5 flex flex-col h-full">
@@ -281,11 +367,11 @@ function EarningsCalendarWidget({ instance }: WidgetRenderProps<EarningsConfig>)
           </div>
         ) : (
           <div className="flex flex-col gap-3">
-            <BucketSection label={t(BUCKET_KEY.today)} items={grouped.today} bucket="today" />
-            <BucketSection label={t(BUCKET_KEY.tomorrow)} items={grouped.tomorrow} bucket="tomorrow" />
-            <BucketSection label={t(BUCKET_KEY.week)} items={grouped.week} bucket="week" />
-            <BucketSection label={t(BUCKET_KEY.next)} items={grouped.next} bucket="next" />
-            <BucketSection label={t(BUCKET_KEY.later)} items={grouped.later} bucket="later" />
+            <BucketSection label={t(BUCKET_KEY.today)} items={grouped.today} bucket="today" instanceId={instance.id} />
+            <BucketSection label={t(BUCKET_KEY.tomorrow)} items={grouped.tomorrow} bucket="tomorrow" instanceId={instance.id} />
+            <BucketSection label={t(BUCKET_KEY.week)} items={grouped.week} bucket="week" instanceId={instance.id} />
+            <BucketSection label={t(BUCKET_KEY.next)} items={grouped.next} bucket="next" instanceId={instance.id} />
+            <BucketSection label={t(BUCKET_KEY.later)} items={grouped.later} bucket="later" instanceId={instance.id} />
           </div>
         )}
       </div>

--- a/web/src/pages/Dashboard/widgets/definitions/InsightBriefWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/InsightBriefWidget.tsx
@@ -1,18 +1,97 @@
 import { Sparkles } from 'lucide-react';
-import AIDailyBriefCard from '../../components/AIDailyBriefCard';
+import { useTranslation } from 'react-i18next';
+import AIDailyBriefCard, { getCachedInsights } from '../../components/AIDailyBriefCard';
 import { useDashboardContext } from '../framework/DashboardDataContext';
 import { registerWidget } from '../framework/WidgetRegistry';
+import {
+  useWidgetContextExport,
+  type WidgetContextSnapshot,
+} from '../framework/contextSnapshot';
+import {
+  serializeInsightDayToMarkdown,
+  wrapWidgetContext,
+} from '../framework/snapshotSerializers';
+import { buildInsightSnapshot, normalizeInsight } from '../../utils/insightFetch';
 import { InsightBriefConfigSchema } from '../framework/configSchemas';
 import type { WidgetRenderProps } from '../types';
 import './InsightBriefWidget.css';
 
 type InsightBriefConfig = { variant?: 'latest' | 'personalized' };
 
-function InsightBriefWidget(_props: WidgetRenderProps<InsightBriefConfig>) {
+interface CachedInsight {
+  market_insight_id: string;
+  type: string;
+  headline: string;
+  summary: string;
+  completed_at?: string;
+  topics?: Array<{ text: string; trend: 'up' | 'down' | 'neutral' }>;
+  [key: string]: unknown;
+}
+
+function InsightBriefWidget({ instance }: WidgetRenderProps<InsightBriefConfig>) {
+  const { t } = useTranslation();
+  const titleKey = 'dashboard.widgets.insightBrief.title';
+  useWidgetContextExport(instance.id, {
+    full: (): WidgetContextSnapshot => {
+      const cached = (getCachedInsights() as CachedInsight[] | null) ?? [];
+      const titleResolved = t(titleKey);
+
+      if (!cached.length) {
+        // Brief hasn't loaded yet. Emit a config-only directive so the agent
+        // at least knows what the user is looking at.
+        return {
+          widget_type: 'insight.brief',
+          widget_id: instance.id,
+          label: titleResolved,
+          captured_at: new Date().toISOString(),
+          text: wrapWidgetContext('insight.brief', {}, `Widget: ${titleResolved}\n_(Brief data not yet loaded.)_`),
+          data: { config: instance.config },
+        };
+      }
+
+      const items = cached.map((it) => normalizeInsight(it));
+      const personalizedCount = items.filter((it) => it.type === 'personalized').length;
+      const body = `Widget: ${titleResolved}\n\n${serializeInsightDayToMarkdown(items)}`;
+      const latest = items[0];
+      const descParts = [`${items.length} brief${items.length === 1 ? '' : 's'}`];
+      if (personalizedCount) descParts.push(`${personalizedCount} personalized`);
+
+      return {
+        widget_type: 'insight.brief',
+        widget_id: instance.id,
+        label: latest.headline,
+        description: descParts.join(' · '),
+        captured_at: new Date().toISOString(),
+        text: wrapWidgetContext(
+          'insight.brief',
+          {
+            count: items.length,
+            personalized: personalizedCount || undefined,
+            latestType: latest.type,
+            completedAt: latest.completed_at,
+          },
+          body,
+        ),
+        data: { items, count: items.length, personalizedCount },
+      };
+    },
+    rows: async (rowId: string) => {
+      const cached = (getCachedInsights() as CachedInsight[] | null) ?? [];
+      const item = cached.find((i) => i.market_insight_id === rowId);
+      if (!item) return null;
+      return buildInsightSnapshot({
+        instanceId: instance.id,
+        rowId,
+        insightId: rowId,
+        fallback: normalizeInsight(item),
+      });
+    },
+  });
+
   const { modals } = useDashboardContext();
   return (
     <div className="insight-brief-widget">
-      <AIDailyBriefCard onReadFull={modals.openInsight} />
+      <AIDailyBriefCard onReadFull={modals.openInsight} instanceId={instance.id} />
     </div>
   );
 }
@@ -30,11 +109,6 @@ registerWidget<InsightBriefConfig>({
   minSize: { w: 4, h: 15 },
   maxSize: { w: 12, h: 44 },
   singleton: true,
-  // fitToContent: cell height tracks the card's natural content height so
-  // nothing ever clips regardless of the user's chosen width. WidgetFrame
-  // debounces fit-height commits so AnimatePresence's expand/collapse
-  // animation inside AIDailyBriefCard doesn't cause per-frame cell
-  // re-layouts (which would race with RGL's own height transitions).
   fitToContent: true,
 });
 

--- a/web/src/pages/Dashboard/widgets/definitions/MarketsOverviewWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/MarketsOverviewWidget.tsx
@@ -1,8 +1,14 @@
 import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { LineChart } from 'lucide-react';
 import IndexMovementCard from '../../components/IndexMovementCard';
 import { useDashboardContext } from '../framework/DashboardDataContext';
 import { registerWidget } from '../framework/WidgetRegistry';
+import { useWidgetContextExport } from '../framework/contextSnapshot';
+import {
+  serializeRowsToMarkdown,
+  wrapWidgetContext,
+} from '../framework/snapshotSerializers';
 import { MarketsOverviewConfigSchema } from '../framework/configSchemas';
 import type { WidgetRenderProps } from '../types';
 
@@ -12,8 +18,43 @@ type MarketsOverviewConfig = { indices?: string[] };
 // worse than the mobile swipe stack, so switch to the compact variant.
 const COMPACT_WIDTH_PX = 640;
 
-function MarketsOverviewWidget(_props: WidgetRenderProps<MarketsOverviewConfig>) {
+function MarketsOverviewWidget({ instance }: WidgetRenderProps<MarketsOverviewConfig>) {
+  const { t } = useTranslation();
   const { dashboard } = useDashboardContext();
+
+  useWidgetContextExport(instance.id, {
+    full: () => {
+      const indices = dashboard.indices ?? [];
+      const rows = indices.map((idx) => ({
+        symbol: idx.symbol,
+        name: idx.name,
+        price: idx.price,
+        change: idx.change,
+        changePercent: idx.changePercent,
+      }));
+      const fmtNum = (v: unknown) => (typeof v === 'number' ? v.toFixed(2) : '');
+      const fmtPct = (v: unknown) => (typeof v === 'number' ? `${v.toFixed(2)}%` : '');
+      const body = rows.length
+        ? serializeRowsToMarkdown(rows, [
+            { key: 'symbol', label: 'symbol' },
+            { key: 'name', label: 'name' },
+            { key: 'price', label: 'price', format: fmtNum },
+            { key: 'change', label: 'change', format: fmtNum },
+            { key: 'changePercent', label: 'change%', format: fmtPct },
+          ])
+        : '_no indices_';
+      const text = wrapWidgetContext('markets.overview', { count: rows.length }, body);
+      return {
+        widget_type: 'markets.overview',
+        widget_id: instance.id,
+        label: `${t('dashboard.widgets.marketsOverview.title')} · ${rows.length}`,
+        description: rows.length ? `${rows.length} ${rows.length === 1 ? 'index' : 'indices'}` : 'empty',
+        captured_at: new Date().toISOString(),
+        text,
+        data: { indices },
+      };
+    },
+  });
   const containerRef = useRef<HTMLDivElement>(null);
   const [compact, setCompact] = useState(false);
 

--- a/web/src/pages/Dashboard/widgets/definitions/MiniChartGridWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/MiniChartGridWidget.tsx
@@ -5,6 +5,11 @@ import { Grid2x2 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useDashboardContext } from '../framework/DashboardDataContext';
 import { registerWidget } from '../framework/WidgetRegistry';
+import { useWidgetContextExport } from '../framework/contextSnapshot';
+import {
+  serializeRowsToMarkdown,
+  wrapWidgetContext,
+} from '../framework/snapshotSerializers';
 import { MiniChartGridConfigSchema } from '../framework/configSchemas';
 import { fetchStockData } from '@/pages/MarketView/utils/api';
 import { DEFAULT_BLUE_CHIPS } from '../framework/defaults';
@@ -118,6 +123,49 @@ function MiniChartGridWidget({ instance }: WidgetRenderProps<MiniChartGridConfig
     staleTime: 60_000,
     refetchInterval: 120_000,
     refetchIntervalInBackground: false,
+  });
+
+  useWidgetContextExport(instance.id, {
+    full: () => {
+      const cells = data ?? [];
+      const rows = cells.map((c) => {
+        const change = c.last - c.prev;
+        const changePct = c.prev === 0 ? 0 : (change / c.prev) * 100;
+        const min = Math.min(...c.closes);
+        const max = Math.max(...c.closes);
+        return {
+          symbol: c.symbol,
+          last: c.last,
+          first: c.prev,
+          changePct,
+          range: `${min.toFixed(2)}–${max.toFixed(2)}`,
+          bars: c.closes.length,
+        };
+      });
+      const body = rows.length
+        ? serializeRowsToMarkdown(rows, [
+            { key: 'symbol', label: 'symbol' },
+            { key: 'last', label: 'last', format: (v) => Number(v).toFixed(2) },
+            { key: 'first', label: `${SPARK_DAYS}d ago`, format: (v) => Number(v).toFixed(2) },
+            { key: 'changePct', label: 'change%', format: (v) => `${(v as number).toFixed(2)}%` },
+            { key: 'range', label: `${SPARK_DAYS}d range` },
+          ])
+        : '_no chart cells loaded_';
+      const text = wrapWidgetContext(
+        'markets.miniChartGrid',
+        { count: rows.length, span_days: SPARK_DAYS, symbols: effectiveSymbols.join(',') },
+        body,
+      );
+      return {
+        widget_type: 'markets.miniChartGrid',
+        widget_id: instance.id,
+        label: `${t('dashboard.widgets.miniChartGrid.title')} · ${rows.length}`,
+        description: rows.length ? `${rows.length} symbols, last ${SPARK_DAYS}d` : 'empty',
+        captured_at: new Date().toISOString(),
+        text,
+        data: { span_days: SPARK_DAYS, cells: rows },
+      };
+    },
   });
 
   return (

--- a/web/src/pages/Dashboard/widgets/definitions/NewsFeedWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/NewsFeedWidget.tsx
@@ -5,6 +5,14 @@ import { Newspaper, Clock, Search, X } from 'lucide-react';
 import { useDashboardContext } from '../framework/DashboardDataContext';
 import { registerWidget } from '../framework/WidgetRegistry';
 import { NewsFeedConfigSchema } from '../framework/configSchemas';
+import { useWidgetContextExport } from '../framework/contextSnapshot';
+import {
+  serializeNewsItemsToMarkdown,
+  wrapWidgetContext,
+  type NewsArticleDetail,
+} from '../framework/snapshotSerializers';
+import { buildNewsArticleSnapshot } from '../../utils/newsArticleFetch';
+import { RowAttachButton } from '../../components/RowAttachButton';
 import type { WidgetRenderProps } from '../types';
 
 type NewsFeedSource = 'market' | 'portfolio' | 'watchlist';
@@ -212,6 +220,51 @@ function NewsFeedWidget({ instance, updateConfig }: WidgetRenderProps<NewsFeedCo
     return result;
   }, [items, tickerFilter, dateRange]);
 
+  // Snapshot exporter: full = visible filtered list, rows = single headline.
+  useWidgetContextExport(instance.id, {
+    full: () => {
+      const newsItems = filteredItems.map((it) => ({
+        title: it.title,
+        source: it.source,
+        publishedAt: it.time,
+        url: it.articleUrl ?? undefined,
+        tickers: it.tickers,
+      }));
+      const body = serializeNewsItemsToMarkdown(newsItems);
+      const text = wrapWidgetContext(
+        'news.feed',
+        { tab: activeTab, count: newsItems.length, dateRange, tickerFilter: tickerFilter || undefined },
+        body,
+      );
+      return {
+        widget_type: 'news.feed',
+        widget_id: instance.id,
+        label: t('dashboard.widgets.newsFeed.title') + ` · ${t(SOURCE_KEY[activeTab])}`,
+        description: `${newsItems.length} headline${newsItems.length === 1 ? '' : 's'}`,
+        captured_at: new Date().toISOString(),
+        text,
+        data: { items: newsItems, tab: activeTab, dateRange, tickerFilter },
+      };
+    },
+    rows: async (rowId) => {
+      const item = items.find((it) => String(it.id ?? `${it.title}`) === rowId);
+      if (!item) return null;
+      const fallback: NewsArticleDetail = {
+        title: item.title,
+        source: item.source,
+        publishedAt: item.time,
+        url: item.articleUrl ?? undefined,
+        tickers: item.tickers,
+      };
+      return buildNewsArticleSnapshot({
+        instanceId: instance.id,
+        rowId,
+        articleId: item.id,
+        fallback,
+      });
+    },
+  });
+
   return (
     <div className="dashboard-glass-card p-5 flex flex-col h-full">
       <div
@@ -387,16 +440,26 @@ function NewsFeedWidget({ instance, updateConfig }: WidgetRenderProps<NewsFeedCo
                 </div>
               </div>
             ) : (
-              filteredItems.map((item, idx) => (
-                <NewsRow
-                  key={item.id ?? `${idx}-${item.title}`}
-                  item={item}
-                  idx={idx}
-                  onClick={() => {
-                    if (item.id != null) modals.openNews(item.id, item.articleUrl ?? null);
-                  }}
-                />
-              ))
+              filteredItems.map((item, idx) => {
+                const rowId = String(item.id ?? `${item.title}`);
+                return (
+                  <div
+                    key={item.id ?? `${idx}-${item.title}`}
+                    className="row-attach-host relative"
+                  >
+                    <NewsRow
+                      item={item}
+                      idx={idx}
+                      onClick={() => {
+                        if (item.id != null) modals.openNews(item.id, item.articleUrl ?? null);
+                      }}
+                    />
+                    <span className="absolute right-1 top-1/2 -translate-y-1/2 z-10">
+                      <RowAttachButton instanceId={instance.id} rowId={rowId} />
+                    </span>
+                  </div>
+                );
+              })
             )}
           </motion.div>
         </AnimatePresence>

--- a/web/src/pages/Dashboard/widgets/definitions/PortfolioWatchlistWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/PortfolioWatchlistWidget.tsx
@@ -4,8 +4,17 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { Wallet } from 'lucide-react';
 import { useDashboardContext } from '../framework/DashboardDataContext';
 import { registerWidget } from '../framework/WidgetRegistry';
+import { useWidgetContextExport } from '../framework/contextSnapshot';
+import {
+  serializeQuoteRowsToMarkdown,
+  serializeQuoteRowToMarkdown,
+  wrapWidgetContext,
+} from '../framework/snapshotSerializers';
 import { PortfolioWatchlistConfigSchema } from '../framework/configSchemas';
+import { RowAttachButton } from '../../components/RowAttachButton';
 import type { WidgetRenderProps } from '../types';
+import type { PortfolioRow } from '../../hooks/usePortfolioData';
+import type { WatchlistRow } from '../../hooks/useWatchlistData';
 import {
   HoldingsAddButton,
   HoldingsSkeleton,
@@ -13,6 +22,7 @@ import {
   PortfolioRowItem,
   WatchlistRowItem,
 } from './_holdingsPrimitives';
+import { formatPortfolioNavMarkdownLine, portfolioSummary } from './_holdingsHelpers';
 
 type PWTabKey = 'watchlist' | 'portfolio';
 
@@ -20,6 +30,25 @@ type PortfolioWatchlistConfig = {
   defaultTab?: PWTabKey;
   valuesHidden?: boolean;
 };
+
+function watchlistRowToQuote(r: WatchlistRow) {
+  return {
+    symbol: r.symbol,
+    price: r.price,
+    change: r.change,
+    changePercent: r.changePercent,
+  };
+}
+
+function portfolioRowToQuote(r: PortfolioRow) {
+  return {
+    symbol: r.symbol,
+    price: r.price,
+    shares: r.quantity ?? undefined,
+    marketValue: r.marketValue,
+    changePercent: r.unrealizedPlPercent ?? undefined,
+  };
+}
 
 function PortfolioWatchlistWidget({
   instance,
@@ -36,6 +65,100 @@ function PortfolioWatchlistWidget({
 
   const [activeTab, setActiveTab] = useState<PWTabKey>(instance.config.defaultTab ?? 'watchlist');
   const [valuesHidden, setValuesHidden] = useState(!!instance.config.valuesHidden);
+
+  // Snapshot exporter — full payload reflects whichever tab the user is viewing
+  // (the agent should see what the user sees). Per-row attach delegates to the
+  // active tab's row collection.
+  useWidgetContextExport(instance.id, {
+    full: () => {
+      if (activeTab === 'watchlist') {
+        const rows = watchlist.rows.map(watchlistRowToQuote);
+        const body = serializeQuoteRowsToMarkdown(rows);
+        const text = wrapWidgetContext(
+          'personal.portfolioWatchlist',
+          { tab: 'watchlist', count: rows.length },
+          body,
+        );
+        return {
+          widget_type: 'personal.portfolioWatchlist',
+          widget_id: instance.id,
+          label: `${t('dashboard.widgets.portfolioWatchlist.headerWatchlist')} · ${rows.length}`,
+          description: rows.length ? `${rows.length} symbol${rows.length === 1 ? '' : 's'}` : 'empty',
+          captured_at: new Date().toISOString(),
+          text,
+          data: { tab: 'watchlist', rows },
+        };
+      }
+      const rows = portfolio.rows.map(portfolioRowToQuote);
+      const summary = portfolioSummary(portfolio.rows);
+      const navLine = formatPortfolioNavMarkdownLine(summary);
+      const lines: string[] = [];
+      if (navLine) lines.push(navLine, '');
+      lines.push(serializeQuoteRowsToMarkdown(rows));
+      const text = wrapWidgetContext(
+        'personal.portfolioWatchlist',
+        { tab: 'portfolio', count: rows.length },
+        lines.join('\n'),
+      );
+      return {
+        widget_type: 'personal.portfolioWatchlist',
+        widget_id: instance.id,
+        label: `${t('dashboard.widgets.portfolioWatchlist.headerHoldings')} · ${rows.length}`,
+        description: rows.length ? `${rows.length} holding${rows.length === 1 ? '' : 's'}` : 'empty',
+        captured_at: new Date().toISOString(),
+        text,
+        data: { tab: 'portfolio', rows, summary },
+      };
+    },
+    rows: (rowId: string) => {
+      if (activeTab === 'watchlist') {
+        const row = watchlist.rows.find((r) => (r.watchlist_item_id ?? r.symbol) === rowId);
+        if (!row) return null;
+        const quote = watchlistRowToQuote(row);
+        const body = serializeQuoteRowToMarkdown(quote);
+        const text = wrapWidgetContext(
+          'personal.portfolioWatchlist/row',
+          { tab: 'watchlist', symbol: row.symbol },
+          body,
+        );
+        return {
+          widget_type: 'personal.portfolioWatchlist/row',
+          widget_id: `${instance.id}/${rowId}`,
+          label:
+            row.symbol +
+            (row.changePercent !== undefined
+              ? ` · ${row.changePercent >= 0 ? '+' : ''}${row.changePercent.toFixed(2)}%`
+              : ''),
+          description: t('dashboard.widgets.portfolioWatchlist.headerWatchlist'),
+          captured_at: new Date().toISOString(),
+          text,
+          data: { row: quote, tab: 'watchlist' },
+        };
+      }
+      const row = portfolio.rows.find((r) => (r.user_portfolio_id ?? r.symbol) === rowId);
+      if (!row) return null;
+      const quote = portfolioRowToQuote(row);
+      const body = serializeQuoteRowToMarkdown(quote);
+      const text = wrapWidgetContext(
+        'personal.portfolioWatchlist/row',
+        { tab: 'portfolio', symbol: row.symbol },
+        body,
+      );
+      return {
+        widget_type: 'personal.portfolioWatchlist/row',
+        widget_id: `${instance.id}/${rowId}`,
+        label:
+          row.symbol +
+          (row.unrealizedPlPercent != null
+            ? ` · ${row.unrealizedPlPercent >= 0 ? '+' : ''}${row.unrealizedPlPercent.toFixed(2)}%`
+            : ''),
+        description: t('dashboard.widgets.portfolioWatchlist.headerHoldings'),
+        captured_at: new Date().toISOString(),
+        text,
+        data: { row: quote, tab: 'portfolio' },
+      };
+    },
+  });
 
   const switchTab = (tab: PWTabKey) => {
     setActiveTab(tab);
@@ -140,13 +263,23 @@ function PortfolioWatchlistWidget({
                 <HoldingsSkeleton count={5} />
               ) : (
                 watchlist.rows.map((row, i) => (
-                  <WatchlistRowItem
+                  <div
                     key={row.watchlist_item_id ?? row.symbol}
-                    item={row}
-                    index={i}
-                    marketStatus={dashboard.marketStatus}
-                    onDelete={watchlistHandlers.onDelete}
-                  />
+                    className="row-attach-host relative"
+                  >
+                    <WatchlistRowItem
+                      item={row}
+                      index={i}
+                      marketStatus={dashboard.marketStatus}
+                      onDelete={watchlistHandlers.onDelete}
+                    />
+                    <span className="absolute right-1 top-1/2 -translate-y-1/2">
+                      <RowAttachButton
+                        instanceId={instance.id}
+                        rowId={String(row.watchlist_item_id ?? row.symbol)}
+                      />
+                    </span>
+                  </div>
                 ))
               )}
               <HoldingsAddButton label={t('dashboard.widgets.portfolioWatchlist.addSymbol')} onClick={watchlistHandlers.onAdd} />
@@ -171,15 +304,25 @@ function PortfolioWatchlistWidget({
                 <HoldingsSkeleton count={3} />
               ) : (
                 portfolio.rows.map((row, i) => (
-                  <PortfolioRowItem
+                  <div
                     key={row.user_portfolio_id ?? row.symbol}
-                    item={row}
-                    index={i}
-                    marketStatus={dashboard.marketStatus}
-                    valuesHidden={valuesHidden}
-                    onEdit={portfolioHandlers.onEdit}
-                    onDelete={portfolioHandlers.onDelete}
-                  />
+                    className="row-attach-host relative"
+                  >
+                    <PortfolioRowItem
+                      item={row}
+                      index={i}
+                      marketStatus={dashboard.marketStatus}
+                      valuesHidden={valuesHidden}
+                      onEdit={portfolioHandlers.onEdit}
+                      onDelete={portfolioHandlers.onDelete}
+                    />
+                    <span className="absolute right-1 top-1/2 -translate-y-1/2">
+                      <RowAttachButton
+                        instanceId={instance.id}
+                        rowId={String(row.user_portfolio_id ?? row.symbol)}
+                      />
+                    </span>
+                  </div>
                 ))
               )}
 

--- a/web/src/pages/Dashboard/widgets/definitions/PortfolioWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/PortfolioWidget.tsx
@@ -4,20 +4,80 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { Briefcase } from 'lucide-react';
 import { useDashboardContext } from '../framework/DashboardDataContext';
 import { registerWidget } from '../framework/WidgetRegistry';
+import { useWidgetContextExport } from '../framework/contextSnapshot';
+import {
+  serializeQuoteRowsToMarkdown,
+  serializeQuoteRowToMarkdown,
+  wrapWidgetContext,
+} from '../framework/snapshotSerializers';
 import { PortfolioConfigSchema } from '../framework/configSchemas';
+import { RowAttachButton } from '../../components/RowAttachButton';
 import type { WidgetRenderProps } from '../types';
+import type { PortfolioRow } from '../../hooks/usePortfolioData';
 import {
   HoldingsAddButton,
   HoldingsSkeleton,
   PortfolioNavSummary,
   PortfolioRowItem,
 } from './_holdingsPrimitives';
+import { formatPortfolioNavMarkdownLine, portfolioSummary } from './_holdingsHelpers';
 
 type PortfolioConfig = { valuesHidden?: boolean };
+
+function rowToQuote(r: PortfolioRow) {
+  return {
+    symbol: r.symbol,
+    price: r.price,
+    shares: r.quantity ?? undefined,
+    marketValue: r.marketValue,
+    changePercent: r.unrealizedPlPercent ?? undefined,
+  };
+}
 
 function PortfolioWidget({ instance, updateConfig }: WidgetRenderProps<PortfolioConfig>) {
   const { t } = useTranslation();
   const { portfolio, portfolioHandlers, dashboard } = useDashboardContext();
+
+  useWidgetContextExport(instance.id, {
+    full: () => {
+      const rows = portfolio.rows.map(rowToQuote);
+      const summary = portfolioSummary(portfolio.rows);
+      const navLine = formatPortfolioNavMarkdownLine(summary);
+      const lines: string[] = [];
+      if (navLine) lines.push(navLine, '');
+      lines.push(serializeQuoteRowsToMarkdown(rows));
+      const text = wrapWidgetContext('portfolio.holdings', { count: rows.length }, lines.join('\n'));
+      return {
+        widget_type: 'portfolio.holdings',
+        widget_id: instance.id,
+        label: `${t('dashboard.widgets.portfolio.title')} · ${rows.length}`,
+        description: rows.length ? `${rows.length} holding${rows.length === 1 ? '' : 's'}` : 'empty',
+        captured_at: new Date().toISOString(),
+        text,
+        data: { rows, summary },
+      };
+    },
+    rows: (rowId: string) => {
+      const row = portfolio.rows.find((r) => (r.user_portfolio_id ?? r.symbol) === rowId);
+      if (!row) return null;
+      const quote = rowToQuote(row);
+      const body = serializeQuoteRowToMarkdown(quote);
+      const text = wrapWidgetContext('portfolio.holdings/row', { symbol: row.symbol }, body);
+      return {
+        widget_type: 'portfolio.holdings/row',
+        widget_id: `${instance.id}/${rowId}`,
+        label:
+          row.symbol +
+          (row.unrealizedPlPercent != null
+            ? ` · ${row.unrealizedPlPercent >= 0 ? '+' : ''}${row.unrealizedPlPercent.toFixed(2)}%`
+            : ''),
+        description: t('dashboard.widgets.portfolio.title'),
+        captured_at: new Date().toISOString(),
+        text,
+        data: { row: quote },
+      };
+    },
+  });
   const [valuesHidden, setValuesHidden] = useState(!!instance.config.valuesHidden);
 
   const toggleHidden = () => {
@@ -75,15 +135,25 @@ function PortfolioWidget({ instance, updateConfig }: WidgetRenderProps<Portfolio
               <HoldingsSkeleton count={3} />
             ) : (
               portfolio.rows.map((row, i) => (
-                <PortfolioRowItem
+                <div
                   key={row.user_portfolio_id ?? row.symbol}
-                  item={row}
-                  index={i}
-                  marketStatus={dashboard.marketStatus}
-                  valuesHidden={valuesHidden}
-                  onEdit={portfolioHandlers.onEdit}
-                  onDelete={portfolioHandlers.onDelete}
-                />
+                  className="row-attach-host relative"
+                >
+                  <PortfolioRowItem
+                    item={row}
+                    index={i}
+                    marketStatus={dashboard.marketStatus}
+                    valuesHidden={valuesHidden}
+                    onEdit={portfolioHandlers.onEdit}
+                    onDelete={portfolioHandlers.onDelete}
+                  />
+                  <span className="absolute right-1 top-1/2 -translate-y-1/2">
+                    <RowAttachButton
+                      instanceId={instance.id}
+                      rowId={String(row.user_portfolio_id ?? row.symbol)}
+                    />
+                  </span>
+                </div>
               ))
             )}
 

--- a/web/src/pages/Dashboard/widgets/definitions/RecentThreadsWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/RecentThreadsWidget.tsx
@@ -10,7 +10,10 @@ import { clearChatSession } from '@/pages/ChatAgent/hooks/utils/chatSessionResto
 import type { Thread, ThreadsResponse, Workspace } from '@/types/api';
 import { queryKeys } from '@/lib/queryKeys';
 import { registerWidget } from '../framework/WidgetRegistry';
+import { useWidgetContextExport } from '../framework/contextSnapshot';
+import { serializeRowsToMarkdown, wrapWidgetContext } from '../framework/snapshotSerializers';
 import { RecentThreadsConfigSchema } from '../framework/configSchemas';
+import { RowAttachButton } from '../../components/RowAttachButton';
 import type { WidgetRenderProps } from '../types';
 
 type RecentThreadsConfig = { workspaceId?: 'all' | 'current' | string; limit?: number };
@@ -55,12 +58,14 @@ function ThreadRow({
   bucket,
   workspaceLabel,
   isFlash,
+  instanceId,
 }: {
   thread: Thread;
   onOpen: () => void;
   bucket: BucketKey;
   workspaceLabel?: string;
   isFlash?: boolean;
+  instanceId: string;
 }) {
   const { t } = useTranslation();
   const title =
@@ -71,6 +76,7 @@ function ThreadRow({
   const timeStr = updated ? formatThreadTime(updated, bucket) : '';
 
   return (
+    <div className="row-attach-host relative">
     <button
       type="button"
       onClick={onOpen}
@@ -137,6 +143,10 @@ function ThreadRow({
         </span>
       ) : null}
     </button>
+      <span className="absolute right-1 top-1/2 -translate-y-1/2">
+        <RowAttachButton instanceId={instanceId} rowId={String(thread.thread_id)} />
+      </span>
+    </div>
   );
 }
 
@@ -146,12 +156,14 @@ function BucketSection({
   bucket,
   onOpen,
   workspaceMap,
+  instanceId,
 }: {
   label: string;
   threads: Thread[];
   bucket: BucketKey;
   onOpen: (thread: Thread) => void;
   workspaceMap: Map<string, Workspace>;
+  instanceId: string;
 }) {
   const { t } = useTranslation();
   if (threads.length === 0) return null;
@@ -194,6 +206,7 @@ function BucketSection({
               onOpen={() => onOpen(thread)}
               workspaceLabel={workspaceLabel}
               isFlash={isFlash}
+              instanceId={instanceId}
             />
           );
         })}
@@ -257,6 +270,82 @@ function RecentThreadsWidget({ instance }: WidgetRenderProps<RecentThreadsConfig
   const handleOpen = (thread: Thread) => {
     navigate(`/chat/t/${thread.thread_id}`);
   };
+
+  useWidgetContextExport(instance.id, {
+    full: () => {
+      const tableRows = threads.map((th) => {
+        const wsId = (th as { workspace_id?: string }).workspace_id;
+        const ws = wsId ? workspaceMap.get(wsId) : undefined;
+        return {
+          title:
+            th.title ||
+            ((th as { first_query_content?: string }).first_query_content as string | undefined) ||
+            t('dashboard.widgets.recentThreads.untitled'),
+          workspace: ws?.name ?? (ws?.status === 'flash' ? t('dashboard.widgets.recentThreads.flash') : ''),
+          when: th.updated_at ?? '',
+          thread_id: th.thread_id,
+        };
+      });
+      const body = threads.length
+        ? serializeRowsToMarkdown(tableRows, [
+            { key: 'title', label: 'title' },
+            { key: 'workspace', label: 'workspace' },
+            { key: 'when', label: 'when' },
+            { key: 'thread_id', label: 'thread_id' },
+          ])
+        : '_no recent threads_';
+      const text = wrapWidgetContext(
+        'threads.recent',
+        { count: threads.length, scope },
+        body,
+      );
+      return {
+        widget_type: 'threads.recent',
+        widget_id: instance.id,
+        label: `${t('dashboard.widgets.recentThreads.title')} · ${threads.length}`,
+        description: threads.length ? `${threads.length} thread${threads.length === 1 ? '' : 's'}` : 'empty',
+        captured_at: new Date().toISOString(),
+        text,
+        data: { scope, threads },
+      };
+    },
+    rows: (rowId: string) => {
+      const th = threads.find((x) => x.thread_id === rowId);
+      if (!th) return null;
+      const wsId = (th as { workspace_id?: string }).workspace_id;
+      const ws = wsId ? workspaceMap.get(wsId) : undefined;
+      const title =
+        th.title ||
+        ((th as { first_query_content?: string }).first_query_content as string | undefined) ||
+        t('dashboard.widgets.recentThreads.untitled');
+      const lines: string[] = [`**${title}**`];
+      if (ws?.name) lines.push(`Workspace: ${ws.name}`);
+      if (th.updated_at) lines.push(`Last active: ${th.updated_at}`);
+      lines.push(`Thread ID: ${th.thread_id}`);
+      const text = wrapWidgetContext(
+        'threads.recent/row',
+        { thread_id: th.thread_id },
+        lines.join('\n'),
+      );
+      return {
+        widget_type: 'threads.recent/row',
+        widget_id: `${instance.id}/${rowId}`,
+        label: title,
+        description: ws?.name ?? t('dashboard.widgets.recentThreads.title'),
+        captured_at: new Date().toISOString(),
+        text,
+        data: {
+          thread: {
+            thread_id: th.thread_id,
+            title,
+            updated_at: th.updated_at,
+            workspace_id: wsId,
+            workspace_name: ws?.name,
+          },
+        },
+      };
+    },
+  });
 
   const viewAllTarget = isAllScope
     ? '/chat'
@@ -347,9 +436,9 @@ function RecentThreadsWidget({ instance }: WidgetRenderProps<RecentThreadsConfig
           </div>
         ) : (
           <div className="flex flex-col gap-3">
-            <BucketSection label={t(BUCKET_KEY.today)} threads={grouped.today} bucket="today" onOpen={handleOpen} workspaceMap={workspaceMap} />
-            <BucketSection label={t(BUCKET_KEY.week)} threads={grouped.week} bucket="week" onOpen={handleOpen} workspaceMap={workspaceMap} />
-            <BucketSection label={t(BUCKET_KEY.older)} threads={grouped.older} bucket="older" onOpen={handleOpen} workspaceMap={workspaceMap} />
+            <BucketSection label={t(BUCKET_KEY.today)} threads={grouped.today} bucket="today" onOpen={handleOpen} workspaceMap={workspaceMap} instanceId={instance.id} />
+            <BucketSection label={t(BUCKET_KEY.week)} threads={grouped.week} bucket="week" onOpen={handleOpen} workspaceMap={workspaceMap} instanceId={instance.id} />
+            <BucketSection label={t(BUCKET_KEY.older)} threads={grouped.older} bucket="older" onOpen={handleOpen} workspaceMap={workspaceMap} instanceId={instance.id} />
           </div>
         )}
       </div>

--- a/web/src/pages/Dashboard/widgets/definitions/WatchlistWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/WatchlistWidget.tsx
@@ -4,6 +4,13 @@ import { Eye } from 'lucide-react';
 import { useDashboardContext } from '../framework/DashboardDataContext';
 import { registerWidget } from '../framework/WidgetRegistry';
 import { WatchlistConfigSchema } from '../framework/configSchemas';
+import { useWidgetContextExport } from '../framework/contextSnapshot';
+import {
+  serializeQuoteRowsToMarkdown,
+  serializeQuoteRowToMarkdown,
+  wrapWidgetContext,
+} from '../framework/snapshotSerializers';
+import { RowAttachButton } from '../../components/RowAttachButton';
 import type { WidgetRenderProps } from '../types';
 import {
   HoldingsAddButton,
@@ -13,10 +20,60 @@ import {
 
 type WatchlistConfig = Record<string, never>;
 
-function WatchlistWidget(_props: WidgetRenderProps<WatchlistConfig>) {
+function WatchlistWidget({ instance }: WidgetRenderProps<WatchlistConfig>) {
   const { t } = useTranslation();
   const { watchlist, watchlistHandlers, dashboard } = useDashboardContext();
   const showSkeleton = watchlist.loading && watchlist.rows.length === 0;
+
+  // Register snapshot exporters: full table + per-row.
+  useWidgetContextExport(instance.id, {
+    full: () => {
+      const rows = watchlist.rows.map((r) => ({
+        symbol: r.symbol,
+        price: r.price,
+        change: r.change,
+        changePercent: r.changePercent,
+      }));
+      const body = serializeQuoteRowsToMarkdown(rows);
+      const text = wrapWidgetContext('watchlist.list', { count: rows.length }, body);
+      return {
+        widget_type: 'watchlist.list',
+        widget_id: instance.id,
+        label: t('dashboard.widgets.watchlist.title') + ' · ' + rows.length,
+        description: rows.length ? `${rows.length} symbol${rows.length === 1 ? '' : 's'}` : 'empty',
+        captured_at: new Date().toISOString(),
+        text,
+        data: { rows },
+      };
+    },
+    rows: (rowId: string) => {
+      const row = watchlist.rows.find((r) => (r.watchlist_item_id ?? r.symbol) === rowId);
+      if (!row) return null;
+      // Note: pre/post-market price is intentionally omitted. The QuoteRow
+      // contract treats preMarket/postMarket as *prices*, but the row data
+      // here only carries previousClose + a change-percent — passing
+      // previousClose under the preMarket key would label yesterday's close
+      // as the pre-market price in the agent's view. Adding correct ext-
+      // hours info would need marketStatus + getExtendedHoursInfo here.
+      const cleaned = {
+        symbol: row.symbol,
+        price: row.price,
+        change: row.change,
+        changePercent: row.changePercent,
+      };
+      const body = serializeQuoteRowToMarkdown(cleaned);
+      const text = wrapWidgetContext('watchlist.list/row', { symbol: row.symbol }, body);
+      return {
+        widget_type: 'watchlist.list/row',
+        widget_id: `${instance.id}/${rowId}`,
+        label: row.symbol + (row.changePercent !== undefined ? ` · ${row.changePercent >= 0 ? '+' : ''}${row.changePercent.toFixed(2)}%` : ''),
+        description: t('dashboard.widgets.watchlist.title'),
+        captured_at: new Date().toISOString(),
+        text,
+        data: { row: cleaned },
+      };
+    },
+  });
 
   return (
     <div className="dashboard-glass-card p-5 flex flex-col h-full">
@@ -56,13 +113,23 @@ function WatchlistWidget(_props: WidgetRenderProps<WatchlistConfig>) {
               <HoldingsSkeleton count={5} />
             ) : (
               watchlist.rows.map((row, i) => (
-                <WatchlistRowItem
+                <div
                   key={row.watchlist_item_id ?? row.symbol}
-                  item={row}
-                  index={i}
-                  marketStatus={dashboard.marketStatus}
-                  onDelete={watchlistHandlers.onDelete}
-                />
+                  className="row-attach-host relative"
+                >
+                  <WatchlistRowItem
+                    item={row}
+                    index={i}
+                    marketStatus={dashboard.marketStatus}
+                    onDelete={watchlistHandlers.onDelete}
+                  />
+                  <span className="absolute right-1 top-1/2 -translate-y-1/2">
+                    <RowAttachButton
+                      instanceId={instance.id}
+                      rowId={String(row.watchlist_item_id ?? row.symbol)}
+                    />
+                  </span>
+                </div>
               ))
             )}
 

--- a/web/src/pages/Dashboard/widgets/definitions/WorkspacePickerWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/WorkspacePickerWidget.tsx
@@ -6,6 +6,8 @@ import { useWorkspaces } from '@/hooks/useWorkspaces';
 import { clearChatSession } from '@/pages/ChatAgent/hooks/utils/chatSessionRestore';
 import type { Workspace } from '@/types/api';
 import { registerWidget } from '../framework/WidgetRegistry';
+import { useWidgetContextExport } from '../framework/contextSnapshot';
+import { serializeRowsToMarkdown, wrapWidgetContext } from '../framework/snapshotSerializers';
 import { WorkspacePickerConfigSchema } from '../framework/configSchemas';
 import type { WidgetRenderProps } from '../types';
 
@@ -144,6 +146,49 @@ function WorkspacePickerWidget({ instance }: WidgetRenderProps<WorkspacePickerCo
   const { data, isLoading } = useWorkspaces({ limit: 100 });
   const displayLimit = instance.config.limit ?? 12;
   const workspaces: WorkspaceRecord[] = ((data?.workspaces ?? []) as WorkspaceRecord[]).slice(0, displayLimit);
+
+  useWidgetContextExport(instance.id, {
+    full: () => {
+      const tableRows = workspaces.map((ws) => ({
+        name: ws.name || t('dashboard.widgets.workspacePicker.untitled'),
+        status: ws.status ?? 'workspace',
+        // Newlines in descriptions would corrupt the single-row markdown table;
+        // collapse them to spaces here. Pipe-escaping is handled by serializeRowsToMarkdown.
+        description: (ws.description ?? '').replace(/\n/g, ' '),
+        updated_at: ws.updated_at ?? '',
+        workspace_id: ws.workspace_id,
+      }));
+      const body = workspaces.length
+        ? serializeRowsToMarkdown(tableRows, [
+            { key: 'name', label: 'name' },
+            { key: 'status', label: 'status' },
+            { key: 'description', label: 'description' },
+            { key: 'updated_at', label: 'updated_at' },
+            { key: 'workspace_id', label: 'workspace_id' },
+          ])
+        : '_no workspaces_';
+      const text = wrapWidgetContext('workspace.picker', { count: workspaces.length }, body);
+      return {
+        widget_type: 'workspace.picker',
+        widget_id: instance.id,
+        label: `${t('dashboard.widgets.workspacePicker.title')} · ${workspaces.length}`,
+        description: workspaces.length
+          ? `${workspaces.length} workspace${workspaces.length === 1 ? '' : 's'}`
+          : 'empty',
+        captured_at: new Date().toISOString(),
+        text,
+        data: {
+          workspaces: workspaces.map((ws) => ({
+            workspace_id: ws.workspace_id,
+            name: ws.name,
+            description: ws.description,
+            status: ws.status,
+            updated_at: ws.updated_at,
+          })),
+        },
+      };
+    },
+  });
 
   return (
     <div className="dashboard-glass-card p-5 flex flex-col h-full">

--- a/web/src/pages/Dashboard/widgets/definitions/_holdingsHelpers.ts
+++ b/web/src/pages/Dashboard/widgets/definitions/_holdingsHelpers.ts
@@ -1,0 +1,39 @@
+/**
+ * Pure helpers shared by the holdings/portfolio widgets and their snapshot
+ * exporters. Lives in its own module (separate from `_holdingsPrimitives.tsx`)
+ * so the component file stays component-only — Vite's fast-refresh requires
+ * a clean components-only boundary to do precise HMR updates.
+ *
+ * Single source of truth for NAV math: the visual NAV card AND the snapshot
+ * exporter both call `portfolioSummary()`, so the agent can never see
+ * different numbers than the user.
+ */
+
+import type { PortfolioRow } from '../../hooks/usePortfolioData';
+
+export interface PortfolioSummary {
+  totalValue: number;
+  totalCost: number;
+  totalPl: number;
+  totalPlPct: number;
+}
+
+export function portfolioSummary(rows: PortfolioRow[]): PortfolioSummary {
+  const totalValue = rows.reduce((s, r) => s + (r.marketValue || 0), 0);
+  const totalCost = rows.reduce(
+    (s, r) => s + (r.average_cost != null ? r.average_cost * (r.quantity || 0) : 0),
+    0,
+  );
+  const totalPl = totalCost > 0 ? totalValue - totalCost : 0;
+  const totalPlPct = totalCost > 0 ? ((totalValue - totalCost) / totalCost) * 100 : 0;
+  return { totalValue, totalCost, totalPl, totalPlPct };
+}
+
+/** Render the portfolio summary as the leading markdown line for snapshot
+ *  exporters. Returns an empty string when there's no cost basis (so the
+ *  caller can drop the "$0 cost" non-information). */
+export function formatPortfolioNavMarkdownLine(summary: PortfolioSummary): string {
+  if (summary.totalCost <= 0) return '';
+  const sign = summary.totalPl >= 0 ? '+' : '';
+  return `**NAV** $${summary.totalValue.toFixed(2)} (cost $${summary.totalCost.toFixed(2)}, P/L ${sign}$${summary.totalPl.toFixed(2)} / ${sign}${summary.totalPlPct.toFixed(2)}%)`;
+}

--- a/web/src/pages/Dashboard/widgets/definitions/_holdingsPrimitives.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/_holdingsPrimitives.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/components/ui/context-menu';
 import type { WatchlistRow } from '../../hooks/useWatchlistData';
 import type { PortfolioRow } from '../../hooks/usePortfolioData';
+import { portfolioSummary } from './_holdingsHelpers';
 
 type MarketStatusData = Parameters<typeof getExtendedHoursInfo>[0];
 
@@ -283,13 +284,7 @@ interface PortfolioNavSummaryProps {
 
 export function PortfolioNavSummary({ rows, valuesHidden, onToggleHidden }: PortfolioNavSummaryProps) {
   const { t } = useTranslation();
-  const totalValue = rows.reduce((sum, r) => sum + (r.marketValue || 0), 0);
-  const totalCost = rows.reduce(
-    (sum, r) => sum + (r.average_cost != null ? r.average_cost * (r.quantity || 0) : 0),
-    0
-  );
-  const totalPl = totalCost > 0 ? totalValue - totalCost : 0;
-  const totalPlPct = totalCost > 0 ? ((totalValue - totalCost) / totalCost) * 100 : 0;
+  const { totalValue, totalCost, totalPl, totalPlPct } = portfolioSummary(rows);
   const isPlPositive = totalPl >= 0;
 
   return (

--- a/web/src/pages/Dashboard/widgets/framework/WidgetContextDeck.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/WidgetContextDeck.tsx
@@ -1,0 +1,207 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { BarChart3, Newspaper, LayoutGrid, ListOrdered, FileText } from 'lucide-react';
+import { WidgetContextPreview, type WidgetContextPreviewShape } from './WidgetContextPreview';
+
+/** Pick a thumb icon for a widget snapshot based on its type slug. Shared by
+ *  the chat-input live deck and the chat-view inline deck so a given widget
+ *  always gets the same glyph in both surfaces. */
+export function pickWidgetIcon(widgetType: string): React.ComponentType<{ className?: string }> {
+  if (widgetType.startsWith('markets.chart') || widgetType.startsWith('markets.miniChart')) return BarChart3;
+  if (widgetType.startsWith('news.')) return Newspaper;
+  if (widgetType.startsWith('tv.')) return LayoutGrid;
+  if (widgetType.startsWith('watchlist.') || widgetType.startsWith('portfolio') || widgetType.startsWith('personal.')) return ListOrdered;
+  if (widgetType.includes('list') || widgetType.includes('feed')) return ListOrdered;
+  return FileText;
+}
+
+/** Card geometry — must stay in sync with the `.widget-deck-*` CSS so the
+ *  computed inline transforms align with the card sizing rules. If these
+ *  ever drift, the snapshot tests on the deck DOM will catch it. */
+const CARD_HEIGHT = 60;
+const CARD_GAP = 6;
+const PEEK_STEP = 6;
+
+export interface WidgetContextDeckProps {
+  snapshots: WidgetContextPreviewShape[];
+  fanned: boolean;
+  onToggleFan: () => void;
+  onCollapse: () => void;
+  /** Optional eyebrow row above the stack (count + hint + clear button on
+   *  the live deck; omitted on the read-only inline deck). */
+  eyebrow?: React.ReactNode;
+  /** Optional render hook for trailing card content (e.g. the remove `×`
+   *  button on the live deck). When provided, called per card with the
+   *  snapshot — return null to skip the slot for that card. */
+  renderCardSlotEnd?: (snapshot: WidgetContextPreviewShape) => React.ReactNode;
+  /** Outside-click boundary. Clicks inside this element keep the deck
+   *  fanned (used by the live deck so typing in the textarea doesn't
+   *  collapse the stack). Defaults to the deck rail itself. */
+  boundaryRef?: React.RefObject<HTMLElement | null>;
+  /** Extra class names on the rail wrapper. */
+  className?: string;
+  /** Inline style overrides for the rail wrapper. */
+  style?: React.CSSProperties;
+  /** When true, override card grid to drop the trailing slot column. The
+   *  inline (read-only) variant uses this since it has no remove button. */
+  compactCardGrid?: boolean;
+  /** test id forwarded onto the rail. */
+  testId?: string;
+}
+
+/**
+ * Stacked widget-context card deck shared by the chat-input live deck and
+ * the chat-view inline deck. Owns:
+ *  - newest-first card ordering
+ *  - peek transforms (translateY/scale/opacity per index)
+ *  - fanned-state expansion height
+ *  - per-card click → fan-then-preview semantics
+ *  - outside-click collapse (with carve-outs for an open preview modal and
+ *    Radix-portaled overlays)
+ *  - the preview modal wiring
+ *
+ * Variant chrome (eyebrow row, remove buttons) is supplied via the
+ * `eyebrow` and `renderCardSlotEnd` slots so the live and inline decks
+ * share the same geometry math without sharing chrome.
+ */
+export function WidgetContextDeck({
+  snapshots,
+  fanned,
+  onToggleFan,
+  onCollapse,
+  eyebrow,
+  renderCardSlotEnd,
+  boundaryRef,
+  className = '',
+  style,
+  compactCardGrid = false,
+  testId,
+}: WidgetContextDeckProps) {
+  const cards = useMemo(() => [...snapshots].reverse(), [snapshots]);
+  const [preview, setPreview] = useState<WidgetContextPreviewShape | null>(null);
+  const peekDepth = Math.min(cards.length - 1, 4) * PEEK_STEP;
+  const stackHeight = fanned
+    ? cards.length * (CARD_HEIGHT + CARD_GAP) - CARD_GAP
+    : CARD_HEIGHT + peekDepth;
+  const singleCard = cards.length === 1;
+
+  // Outside-click collapse with the same race-protection both surfaces
+  // need: pause while the preview modal is open, defer re-attachment one
+  // animation frame after close so the click that dismissed the modal
+  // can't leak through to a freshly registered listener.
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (!fanned) return;
+    if (preview !== null) return;
+    const handler = (e: MouseEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (!target) return;
+      if (target.closest && target.closest('[role="dialog"]')) return;
+      if (!document.body.contains(target)) return;
+      const boundary = boundaryRef?.current ?? rootRef.current;
+      if (boundary && boundary.contains(target)) return;
+      onCollapse();
+    };
+    let attached = false;
+    const rafId = requestAnimationFrame(() => {
+      document.addEventListener('mousedown', handler);
+      attached = true;
+    });
+    return () => {
+      cancelAnimationFrame(rafId);
+      if (attached) document.removeEventListener('mousedown', handler);
+    };
+  }, [fanned, preview, onCollapse, boundaryRef]);
+
+  return (
+    <div
+      ref={rootRef}
+      className={`widget-deck-rail ${fanned ? 'fanned' : ''} ${className}`.trim()}
+      style={style}
+      data-testid={testId}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {eyebrow}
+      <div
+        className={`widget-deck-stack ${fanned ? 'fanned' : ''}`}
+        style={{ height: `${stackHeight}px` }}
+        onClick={(e) => {
+          // Stack-background click toggles fan only when the user actually
+          // clicked on empty stack space — clicks on cards or remove
+          // buttons handle themselves.
+          const target = e.target as HTMLElement;
+          if (target.closest('.widget-deck-card-remove')) return;
+          if (target.closest('.widget-deck-card')) return;
+          onToggleFan();
+        }}
+      >
+        {cards.map((s, i) => {
+          const Icon = pickWidgetIcon(s.widget_type);
+          const hasImage = !!s.image_jpeg_data_url;
+          const top = fanned ? i * (CARD_HEIGHT + CARD_GAP) : 0;
+          const peekY = fanned ? 0 : i * PEEK_STEP;
+          const peekScale = fanned ? 1 : Math.max(1 - i * 0.03, 0.85);
+          const peekOpacity = fanned
+            ? 1
+            : i === 0
+              ? 1
+              : Math.max(0.85 - (i - 1) * 0.2, 0.25);
+          const handleActivate = () => {
+            // Multi-card peeked deck: first click fans (so older cards
+            // become reachable). Already fanned, or single-card deck:
+            // open the preview modal.
+            if (!singleCard && !fanned) onToggleFan();
+            else setPreview(s);
+          };
+          return (
+            <div
+              key={s.widget_id}
+              data-i={i}
+              data-kind={s.widget_type}
+              className="widget-deck-card"
+              style={{
+                top: `${top}px`,
+                transform: `translateY(${peekY}px) scale(${peekScale})`,
+                opacity: peekOpacity,
+                pointerEvents: fanned || i === 0 ? 'auto' : 'none',
+                zIndex: cards.length - i,
+                cursor: 'pointer',
+                ...(compactCardGrid ? { gridTemplateColumns: '32px 1fr' } : null),
+              }}
+              title={s.label}
+              role="button"
+              tabIndex={0}
+              onClick={(e) => {
+                if ((e.target as HTMLElement).closest('.widget-deck-card-remove')) return;
+                handleActivate();
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  handleActivate();
+                }
+              }}
+            >
+              <div className={`widget-deck-card-thumb ${hasImage ? 'has-image' : ''}`}>
+                {hasImage ? (
+                  <img src={s.image_jpeg_data_url} alt="" className="widget-deck-card-thumb-img" />
+                ) : (
+                  <Icon className="h-3.5 w-3.5" />
+                )}
+              </div>
+              <div className="widget-deck-card-text">
+                <div className="widget-deck-card-title">{s.label}</div>
+                {s.description && (
+                  <div className="widget-deck-card-snippet">{s.description}</div>
+                )}
+              </div>
+              {renderCardSlotEnd ? renderCardSlotEnd(s) : null}
+            </div>
+          );
+        })}
+      </div>
+      <WidgetContextPreview snapshot={preview} onClose={() => setPreview(null)} />
+    </div>
+  );
+}
+
+export default WidgetContextDeck;

--- a/web/src/pages/Dashboard/widgets/framework/WidgetContextPreview.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/WidgetContextPreview.tsx
@@ -1,0 +1,195 @@
+import React, { useMemo } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import Markdown from '@/pages/ChatAgent/components/Markdown';
+import type { WidgetContextSnapshot } from './contextSnapshot';
+
+/**
+ * Subset of `WidgetContextSnapshot` the preview actually needs. Live
+ * snapshots from the chat-input always have the full shape; replayed
+ * snapshots from history may be missing `text` (older rows pre-dating the
+ * `serialize_widget_contexts_for_metadata` change) or `image_jpeg_data_url`
+ * (image rides the multimodal channel and isn't persisted). Both paths
+ * render through the same component so the user sees the same layout
+ * before sending and after replay.
+ */
+export type WidgetContextPreviewShape = Pick<
+  WidgetContextSnapshot,
+  'widget_type' | 'widget_id' | 'label'
+> & {
+  description?: string;
+  text?: string;
+  data?: unknown;
+  image_jpeg_data_url?: string;
+};
+
+/** Strip the outer ``<widget-context type='...' ...>...</widget-context>``
+ *  envelope so the inner markdown body renders cleanly without the XML
+ *  scaffolding the agent only sees in its prompt context. */
+function stripWidgetContextEnvelope(text: string): string {
+  const trimmed = text.trim();
+  const opener = /^<widget-context\b[^>]*>\s*\n?/;
+  const closer = /\n?\s*<\/widget-context>\s*$/;
+  return trimmed.replace(opener, '').replace(closer, '').trim();
+}
+
+/** Humanize a snake_case / camelCase key into a Title Case label. */
+function humanizeKey(k: string): string {
+  return k
+    .replace(/[_-]+/g, ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2})/;
+
+/** Recursively render a JSON-ish value as a human-friendly tree. URLs become
+ *  links, ISO timestamps become localized dates, scalar arrays become inline
+ *  comma-joined lists, and deeply-nested branches collapse to a code dump
+ *  past `maxDepth` so the modal stays bounded. */
+function renderStructuredValue(v: unknown, depth: number, maxDepth = 4): React.ReactNode {
+  if (v === null || v === undefined || v === '') {
+    return <span style={{ color: 'var(--color-text-tertiary)' }}>—</span>;
+  }
+  if (typeof v === 'string') {
+    if (/^https?:\/\//.test(v)) {
+      return (
+        <a
+          href={v}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline break-all"
+          style={{ color: 'var(--color-accent-primary, #b88a2c)' }}
+        >
+          {v}
+        </a>
+      );
+    }
+    if (ISO_DATE_RE.test(v)) {
+      const d = new Date(v);
+      if (!Number.isNaN(d.getTime())) {
+        return <span title={v}>{d.toLocaleString()}</span>;
+      }
+    }
+    return <span className="break-words whitespace-pre-wrap">{v}</span>;
+  }
+  if (typeof v === 'number' || typeof v === 'boolean') return String(v);
+  if (Array.isArray(v)) {
+    if (v.length === 0) return <span style={{ color: 'var(--color-text-tertiary)' }}>(empty)</span>;
+    const allScalar = v.every(
+      (x) => typeof x === 'string' || typeof x === 'number' || typeof x === 'boolean',
+    );
+    if (allScalar) return <span>{v.map((x) => String(x)).join(', ')}</span>;
+    if (depth >= maxDepth) return <code className="text-xs">{JSON.stringify(v)}</code>;
+    return (
+      <ol className="list-decimal pl-5 space-y-3">
+        {v.map((x, i) => (
+          <li key={i}>{renderStructuredValue(x, depth + 1, maxDepth)}</li>
+        ))}
+      </ol>
+    );
+  }
+  if (typeof v === 'object') {
+    if (depth >= maxDepth) return <code className="text-xs">{JSON.stringify(v)}</code>;
+    const entries = Object.entries(v as Record<string, unknown>);
+    if (entries.length === 0) return <span style={{ color: 'var(--color-text-tertiary)' }}>(empty)</span>;
+    return (
+      <dl className="space-y-1.5">
+        {entries.map(([k, val]) => (
+          <div key={k} className="grid grid-cols-[110px_1fr] gap-3">
+            <dt
+              className="text-[10px] font-semibold uppercase tracking-[0.12em] pt-0.5"
+              style={{ color: 'var(--color-text-tertiary)' }}
+            >
+              {humanizeKey(k)}
+            </dt>
+            <dd className="break-words text-sm" style={{ color: 'var(--color-text-secondary)' }}>
+              {renderStructuredValue(val, depth + 1, maxDepth)}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    );
+  }
+  return <code className="text-xs">{String(v)}</code>;
+}
+
+/** Last-resort fallback for snapshots with `data` but no `text` (older
+ *  persisted rows). Recursively walks the structured payload so nested
+ *  objects and arrays render as nested fields/lists rather than a JSON
+ *  dump. New snapshots emit `text` and use the Markdown path instead. */
+function StructuredDataFallback({ data }: { data: unknown }) {
+  return <div className="text-sm">{renderStructuredValue(data, 0)}</div>;
+}
+
+/**
+ * Modal preview rendering exactly what the agent receives for one snapshot.
+ * Strips the ``<widget-context>`` envelope from `text` and renders the
+ * inner markdown via the chat's standard Markdown component, so the same
+ * layout appears whether the user is previewing a card before sending
+ * (live snapshot from chat-input) or after replay (history metadata).
+ *
+ * Falls back to a structured key/value tree when only `data` exists
+ * (older persisted rows from before the text-in-metadata change).
+ */
+export function WidgetContextPreview({
+  snapshot,
+  onClose,
+}: {
+  snapshot: WidgetContextPreviewShape | null;
+  onClose: () => void;
+}) {
+  const open = snapshot !== null;
+  const markdownBody = useMemo(() => {
+    if (!snapshot?.text) return '';
+    return stripWidgetContextEnvelope(snapshot.text);
+  }, [snapshot]);
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
+      <DialogContent
+        className="max-w-2xl"
+        style={{
+          backgroundColor: 'var(--color-bg-elevated)',
+          borderColor: 'var(--color-border-default)',
+        }}
+      >
+        <DialogHeader>
+          <DialogTitle className="text-base" style={{ color: 'var(--color-text-primary)' }}>
+            {snapshot?.label ?? ''}
+          </DialogTitle>
+          {snapshot?.description && (
+            <DialogDescription className="text-xs" style={{ color: 'var(--color-text-tertiary)' }}>
+              {snapshot.description}
+            </DialogDescription>
+          )}
+        </DialogHeader>
+        <div className="max-h-[65vh] overflow-auto">
+          {snapshot?.image_jpeg_data_url && (
+            <img
+              src={snapshot.image_jpeg_data_url}
+              alt=""
+              className="w-full rounded-md border mb-3"
+              style={{ borderColor: 'var(--color-border-muted)' }}
+            />
+          )}
+          {markdownBody ? (
+            <Markdown content={markdownBody} variant="panel" />
+          ) : snapshot?.data !== undefined ? (
+            <StructuredDataFallback data={snapshot.data} />
+          ) : (
+            <p className="text-xs" style={{ color: 'var(--color-text-tertiary)' }}>
+              (no preview content)
+            </p>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default WidgetContextPreview;

--- a/web/src/pages/Dashboard/widgets/framework/WidgetFrame.css
+++ b/web/src/pages/Dashboard/widgets/framework/WidgetFrame.css
@@ -1,6 +1,7 @@
 /* WidgetFrame — chrome around every widget */
 
 .widget-frame {
+  position: relative;
   height: 100%;
   display: flex;
   flex-direction: column;
@@ -185,13 +186,81 @@
 }
 
 /* View mode: the inner card is self-contained chrome (own border/background
- * or its own branding treatment). Hide the frame header entirely so every
- * widget presents as a single card with no external label floating above it.
+ * or its own branding treatment). The header collapses to an overlay that
+ * pins the action buttons (just the "+ to context" button in view mode) to
+ * the top-right corner of the widget, hover-revealed on hover-capable
+ * devices and always visible on touch.
  *
- * Edit mode: the header returns for drag handle, settings gear and overflow
- * menu — uniform across all widgets inside the dashed edit border. */
+ * Edit mode: the header returns inline for drag handle + title + settings +
+ * "+" + overflow menu — uniform chrome across all widgets inside the dashed
+ * edit border. */
 .widget-frame:not(.widget-frame--edit) .widget-frame__header {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  z-index: 5;
+  padding: 0;
+  border: 0;
+  min-height: 0;
+  background: transparent;
+  pointer-events: none;
+}
+
+.widget-frame:not(.widget-frame--edit) .widget-frame__header > .widget-frame__title,
+.widget-frame:not(.widget-frame--edit) .widget-frame__header > .widget-frame__drag {
   display: none;
+}
+
+.widget-frame:not(.widget-frame--edit) .widget-frame__actions {
+  pointer-events: auto;
+}
+
+/* The "Attach to chat" paperclip uses a circular hover background so it
+ * matches the widget's rounded chrome instead of the squared 4px corners
+ * shared by the edit-mode icon buttons. */
+.widget-frame__add-btn {
+  border-radius: 50%;
+}
+
+/* In view mode the paperclip is hover-revealed on hover-capable pointers
+ * and always visible on touch. Plain icon-button styling (no card/border/
+ * shadow) so it reads as a quiet header glyph rather than a boxed CTA. */
+.widget-frame__add-btn--view {
+  opacity: 0;
+  transition: opacity 120ms ease, background-color 120ms ease, color 120ms ease;
+}
+
+.widget-frame:hover .widget-frame__add-btn--view,
+.widget-frame__add-btn--view:focus-visible {
+  opacity: 1;
+}
+
+@media (hover: none) {
+  .widget-frame__add-btn--view {
+    opacity: 1;
+  }
+}
+
+/* Disabled state (TV widgets, or widgets that haven't registered an exporter
+ * yet): stay hidden by default just like the enabled state — we don't want a
+ * permanent disabled glyph cluttering the header. Reveal at reduced opacity
+ * on hover so the user can still see the affordance + tooltip explaining why
+ * it's unavailable. Touch devices show it always (no hover signal). */
+.widget-frame__add-btn--view:disabled {
+  cursor: not-allowed;
+  color: var(--color-text-tertiary);
+  opacity: 0;
+}
+
+.widget-frame:hover .widget-frame__add-btn--view:disabled,
+.widget-frame__add-btn--view:disabled:focus-visible {
+  opacity: 0.4;
+}
+
+@media (hover: none) {
+  .widget-frame__add-btn--view:disabled {
+    opacity: 0.4;
+  }
 }
 
 /* fit-to-content widgets in view mode: drop body padding so the inner card

--- a/web/src/pages/Dashboard/widgets/framework/WidgetFrame.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/WidgetFrame.tsx
@@ -1,7 +1,10 @@
 import { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { GripVertical, Settings, MoreVertical, X, Copy } from 'lucide-react';
+import { GripVertical, Settings, MoreVertical, X, Copy, Paperclip } from 'lucide-react';
 import type { WidgetDefinition, WidgetInstance } from '../types';
+import { getWidgetContextSnapshot, useHasWidgetContextExporter } from './contextSnapshot';
+import { ContextBus } from '@/lib/contextBus';
+import { useToast } from '@/components/ui/use-toast';
 import './WidgetFrame.css';
 
 interface WidgetFrameProps {
@@ -31,11 +34,50 @@ export function WidgetFrame({
   children,
 }: WidgetFrameProps) {
   const { t } = useTranslation();
+  const { toast } = useToast();
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
   const headerRef = useRef<HTMLDivElement>(null);
   const bodyRef = useRef<HTMLDivElement>(null);
   const innerRef = useRef<HTMLDivElement>(null);
+
+  const exporterRegistered = useHasWidgetContextExporter(instance.id);
+  // TradingView widgets render cross-origin iframes — neither pixels nor DOM
+  // are reachable, so attach is permanently unavailable. We keep the paperclip
+  // visible (parity with native widgets) but disable it and surface the reason
+  // in the tooltip so users don't wonder why nothing happens.
+  const attachUnsupportedReason =
+    definition.source === 'tradingview'
+      ? t('dashboard.widgets.frame.contextUnsupportedTradingView', {
+          defaultValue:
+            "Can't attach this — the content is managed by TradingView, so the agent can't access it.",
+        })
+      : null;
+  const attachDisabled = attachUnsupportedReason !== null || !exporterRegistered;
+  const attachTooltip =
+    attachUnsupportedReason ??
+    t('dashboard.widgets.frame.addToContextTitle', { defaultValue: 'Attach to chat' });
+
+  const handleAddToContext = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (attachUnsupportedReason) return;
+    const snapshot = await getWidgetContextSnapshot(instance.id);
+    if (!snapshot) {
+      toast({
+        variant: 'destructive',
+        title: t('dashboard.widgets.frame.contextUnavailable', { defaultValue: 'Widget not available' }),
+        description: t('dashboard.widgets.frame.contextUnavailableHint', {
+          defaultValue: 'This widget has not registered a context exporter yet.',
+        }),
+      });
+      return;
+    }
+    ContextBus.attach(snapshot);
+    toast({
+      title: t('dashboard.widgets.frame.contextAttached', { defaultValue: 'Added to context' }),
+      description: snapshot.label,
+    });
+  };
 
   // Keep the latest onFitHeight in a ref so the ResizeObserver effect doesn't
   // tear down / reconnect (and fire a synchronous report) on every parent
@@ -156,6 +198,10 @@ export function WidgetFrame({
     .filter(Boolean)
     .join(' ');
 
+  // The "+ to context" button is always rendered (CSS controls visibility by
+  // mode: hover-revealed in view mode on hover-capable devices, always visible
+  // on touch). Other action buttons (settings, menu) only appear in edit mode.
+  // All actions carry `widget-drag-cancel` so they don't initiate drag.
   return (
     <div className={classes} data-widget-type={instance.type}>
       <div ref={headerRef} className="widget-frame__header">
@@ -168,19 +214,29 @@ export function WidgetFrame({
           </div>
         )}
         <div className="widget-frame__title">{t(definition.titleKey)}</div>
-        {editMode && (
-          <div className="widget-frame__actions widget-drag-cancel">
-            {hasSettings && (
-              <button
-                type="button"
-                className="widget-frame__icon-btn"
-                onClick={() => onOpenSettings(instance.id)}
-                aria-label={t('dashboard.widgets.frame.settings')}
-                title={t('dashboard.widgets.frame.settingsTitle')}
-              >
-                <Settings size={14} />
-              </button>
-            )}
+        <div className="widget-frame__actions widget-drag-cancel">
+          {editMode && hasSettings && (
+            <button
+              type="button"
+              className="widget-frame__icon-btn"
+              onClick={() => onOpenSettings(instance.id)}
+              aria-label={t('dashboard.widgets.frame.settings')}
+              title={t('dashboard.widgets.frame.settingsTitle')}
+            >
+              <Settings size={14} />
+            </button>
+          )}
+          <button
+            type="button"
+            className={`widget-frame__icon-btn widget-frame__add-btn ${editMode ? '' : 'widget-frame__add-btn--view'}`}
+            onClick={handleAddToContext}
+            disabled={attachDisabled}
+            aria-label={attachTooltip}
+            title={attachTooltip}
+          >
+            <Paperclip size={13} />
+          </button>
+          {editMode && (
             <div className="widget-frame__menu-wrap" ref={menuRef}>
               <button
                 type="button"
@@ -217,8 +273,8 @@ export function WidgetFrame({
                 </div>
               )}
             </div>
-          </div>
-        )}
+          )}
+        </div>
       </div>
       <div ref={bodyRef} className="widget-frame__body">
         <div ref={innerRef} className={definition.fitToContent ? undefined : 'h-full'}>

--- a/web/src/pages/Dashboard/widgets/framework/__tests__/contextSnapshot.test.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/__tests__/contextSnapshot.test.tsx
@@ -1,0 +1,107 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import {
+  __resetWidgetContextRegistryForTests,
+  getWidgetContextSnapshot,
+  hasWidgetContextExporter,
+  useWidgetContextExport,
+  type WidgetContextSnapshot,
+} from '../contextSnapshot';
+
+const sampleSnapshot = (id: string, label = 'X'): WidgetContextSnapshot => ({
+  widget_type: 'markets.chart',
+  widget_id: id,
+  label,
+  captured_at: '2026-04-26T11:42:08Z',
+  text: '<widget-context>x</widget-context>',
+  data: {},
+});
+
+describe('useWidgetContextExport / registry', () => {
+  beforeEach(() => {
+    __resetWidgetContextRegistryForTests();
+  });
+
+  it('register on mount, unregister on unmount', async () => {
+    const exporters = { full: () => sampleSnapshot('w1') };
+    const { unmount } = renderHook(() => useWidgetContextExport('w1', exporters));
+    expect(hasWidgetContextExporter('w1')).toBe(true);
+    expect((await getWidgetContextSnapshot('w1'))?.label).toBe('X');
+    unmount();
+    expect(hasWidgetContextExporter('w1')).toBe(false);
+  });
+
+  it('returns null for unregistered instance', async () => {
+    expect(await getWidgetContextSnapshot('does-not-exist')).toBeNull();
+  });
+
+  it('re-registers when instanceId changes', async () => {
+    const exportersA = { full: () => sampleSnapshot('a', 'A') };
+    const exportersB = { full: () => sampleSnapshot('b', 'B') };
+    const { rerender, unmount } = renderHook(
+      ({ id, exporters }: { id: string; exporters: { full: () => WidgetContextSnapshot } }) =>
+        useWidgetContextExport(id, exporters),
+      { initialProps: { id: 'a', exporters: exportersA } },
+    );
+    expect(hasWidgetContextExporter('a')).toBe(true);
+    rerender({ id: 'b', exporters: exportersB });
+    expect(hasWidgetContextExporter('a')).toBe(false);
+    expect(hasWidgetContextExporter('b')).toBe(true);
+    expect((await getWidgetContextSnapshot('b'))?.label).toBe('B');
+    unmount();
+  });
+
+  it('row exporter returns null for missing rows', async () => {
+    const exporters = {
+      full: () => sampleSnapshot('w1'),
+      rows: (rowId: string) => (rowId === 'r1' ? sampleSnapshot('w1', 'row-1') : null),
+    };
+    renderHook(() => useWidgetContextExport('w1', exporters));
+    expect((await getWidgetContextSnapshot('w1', 'r1'))?.label).toBe('row-1');
+    expect(await getWidgetContextSnapshot('w1', 'r-missing')).toBeNull();
+  });
+
+  it('async row exporter resolves to a snapshot', async () => {
+    const exporters = {
+      full: () => sampleSnapshot('w1'),
+      rows: async (rowId: string) =>
+        rowId === 'r1' ? sampleSnapshot('w1', 'async-row') : null,
+    };
+    renderHook(() => useWidgetContextExport('w1', exporters));
+    expect((await getWidgetContextSnapshot('w1', 'r1'))?.label).toBe('async-row');
+    expect(await getWidgetContextSnapshot('w1', 'r-missing')).toBeNull();
+  });
+
+  it('row request on a widget without rows returns null', async () => {
+    const exporters = { full: () => sampleSnapshot('w1') };
+    renderHook(() => useWidgetContextExport('w1', exporters));
+    expect(await getWidgetContextSnapshot('w1', 'r1')).toBeNull();
+  });
+
+  it('exporter that throws is caught and returns null', async () => {
+    const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exporters = {
+      full: () => {
+        throw new Error('boom');
+      },
+    };
+    renderHook(() => useWidgetContextExport('w1', exporters));
+    expect(await getWidgetContextSnapshot('w1')).toBeNull();
+    expect(consoleErr).toHaveBeenCalled();
+    consoleErr.mockRestore();
+  });
+
+  it('async row exporter that rejects is caught and returns null', async () => {
+    const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exporters = {
+      full: () => sampleSnapshot('w1'),
+      rows: async () => {
+        throw new Error('fetch boom');
+      },
+    };
+    renderHook(() => useWidgetContextExport('w1', exporters));
+    expect(await getWidgetContextSnapshot('w1', 'r1')).toBeNull();
+    expect(consoleErr).toHaveBeenCalled();
+    consoleErr.mockRestore();
+  });
+});

--- a/web/src/pages/Dashboard/widgets/framework/__tests__/snapshotSerializers.test.ts
+++ b/web/src/pages/Dashboard/widgets/framework/__tests__/snapshotSerializers.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from 'vitest';
+import {
+  serializeInsightDayToMarkdown,
+  serializeInsightToMarkdown,
+  serializeNewsItemToMarkdown,
+  serializeNewsItemsToMarkdown,
+  serializeOhlcvToMarkdown,
+  serializeQuoteRowToMarkdown,
+  serializeQuoteRowsToMarkdown,
+  serializeRowsToMarkdown,
+  summarizeOhlcv,
+  wrapWidgetContext,
+} from '../snapshotSerializers';
+
+describe('wrapWidgetContext', () => {
+  it('emits a single attribute and a body', () => {
+    const out = wrapWidgetContext('markets.chart', { symbol: 'NVDA' }, 'body');
+    expect(out).toBe("<widget-context type='markets.chart' symbol='NVDA'>\nbody\n</widget-context>");
+  });
+
+  it('skips empty / undefined attrs', () => {
+    const out = wrapWidgetContext('x', { a: 'a', b: undefined, c: '', d: null as unknown as string }, 'body');
+    expect(out).toBe("<widget-context type='x' a='a'>\nbody\n</widget-context>");
+  });
+
+  it('escapes single quotes in attribute values', () => {
+    const out = wrapWidgetContext('x', { label: "it's" }, 'body');
+    expect(out).toContain("label='it&#39;s'");
+  });
+
+  it('omits attribute clause when no attrs', () => {
+    const out = wrapWidgetContext('x', {}, 'body');
+    expect(out).toBe("<widget-context type='x'>\nbody\n</widget-context>");
+  });
+});
+
+describe('serializeOhlcvToMarkdown', () => {
+  it('emits a markdown table for short series', () => {
+    const out = serializeOhlcvToMarkdown([
+      { time: '2026-04-25', open: 100, high: 105, low: 99, close: 104, volume: 1000 },
+      { time: '2026-04-26', open: 104, high: 110, low: 103, close: 109, volume: 2000 },
+    ]);
+    expect(out).toContain('| time | open | high | low | close | volume |');
+    expect(out).toContain('| 2026-04-25 | 100.00 | 105.00 | 99.00 | 104.00 | 1000 |');
+  });
+
+  it('truncates long series with head/tail markers', () => {
+    const bars = Array.from({ length: 100 }, (_, i) => ({
+      time: `2026-${String(i).padStart(2, '0')}`,
+      open: 100,
+      high: 101,
+      low: 99,
+      close: 100,
+    }));
+    const out = serializeOhlcvToMarkdown(bars, { headRows: 3, tailRows: 3 });
+    expect(out).toContain('_... 94 bars omitted ..._');
+    expect(out.split('\n').filter((l) => l.startsWith('| 2026')).length).toBe(6);
+  });
+
+  it('handles empty series', () => {
+    expect(serializeOhlcvToMarkdown([])).toBe('_no bars_');
+  });
+
+  it('omits the volume column when no bars carry it', () => {
+    const out = serializeOhlcvToMarkdown([
+      { time: 't1', open: 1, high: 2, low: 1, close: 2 },
+    ]);
+    expect(out).not.toContain('volume');
+  });
+});
+
+describe('summarizeOhlcv', () => {
+  it('reports last close, %, and range', () => {
+    const out = summarizeOhlcv([
+      { time: 't1', open: 100, high: 105, low: 99, close: 100 },
+      { time: 't2', open: 100, high: 110, low: 99, close: 110 },
+    ]);
+    expect(out).toContain('last close 110.00');
+    expect(out).toContain('+10.00%');
+    expect(out).toContain('99.00–110.00');
+  });
+
+  it('handles empty', () => {
+    expect(summarizeOhlcv([])).toBe('');
+  });
+});
+
+describe('news serializers', () => {
+  it('renders one item with meta and url', () => {
+    const out = serializeNewsItemToMarkdown({
+      title: 'NVDA earnings beat',
+      source: 'Reuters',
+      publishedAt: '2026-04-26',
+      url: 'https://x.test',
+      tickers: ['NVDA', 'AMD'],
+      summary: 'Earnings up.',
+    });
+    expect(out).toContain('**NVDA earnings beat**');
+    expect(out).toContain('Reuters · 2026-04-26 · NVDA, AMD');
+    expect(out).toContain('URL: https://x.test');
+    expect(out).toContain('Earnings up.');
+  });
+
+  it('renders a list as markdown table', () => {
+    const out = serializeNewsItemsToMarkdown([
+      { title: 'A', source: 'r', publishedAt: 't1' },
+      { title: 'B | with pipe', source: 'r', publishedAt: 't2' },
+    ]);
+    expect(out).toContain('| 1 | A |');
+    expect(out).toContain('B \\| with pipe');
+  });
+
+  it('handles empty news', () => {
+    expect(serializeNewsItemsToMarkdown([])).toBe('_no headlines_');
+  });
+});
+
+describe('quote row serializers', () => {
+  it('renders one row with bits', () => {
+    const out = serializeQuoteRowToMarkdown({
+      symbol: 'AAPL',
+      price: 182.31,
+      change: 0.76,
+      changePercent: 0.42,
+      preMarket: 182.1,
+      volume: 38000000,
+    });
+    expect(out).toContain('**AAPL**');
+    expect(out).toContain('$182.31');
+    expect(out).toContain('+0.76 (+0.42%)');
+    expect(out).toContain('pre-market $182.10');
+    expect(out).toContain('vol 38,000,000');
+  });
+
+  it('renders rows as a markdown table', () => {
+    const out = serializeQuoteRowsToMarkdown([
+      { symbol: 'AAPL', price: 1, change: 0, changePercent: 0 },
+      { symbol: 'MSFT', price: 2, change: 0, changePercent: 0, volume: 100 },
+    ]);
+    expect(out).toContain('| symbol | price | change | change% | volume |');
+  });
+
+  it('skips volume column when no row has volume', () => {
+    const out = serializeQuoteRowsToMarkdown([{ symbol: 'A', price: 1, change: 0, changePercent: 0 }]);
+    expect(out).not.toContain('volume');
+  });
+
+  it('handles empty rows', () => {
+    expect(serializeQuoteRowsToMarkdown([])).toBe('_no symbols_');
+  });
+});
+
+describe('serializeRowsToMarkdown (generic)', () => {
+  it('renders generic rows', () => {
+    const out = serializeRowsToMarkdown(
+      [
+        { id: 1, name: 'a' },
+        { id: 2, name: 'b' },
+      ],
+      [
+        { key: 'id', label: 'id' },
+        { key: 'name', label: 'name' },
+      ],
+    );
+    expect(out).toContain('| id | name |');
+    expect(out).toContain('| 1 | a |');
+  });
+
+  it('uses formatter when provided', () => {
+    const out = serializeRowsToMarkdown(
+      [{ price: 1234.5 }],
+      [{ key: 'price', label: 'price', format: (v) => `$${(v as number).toFixed(2)}` }],
+    );
+    expect(out).toContain('$1234.50');
+  });
+});
+
+describe('serializeInsightToMarkdown', () => {
+  it('renders headline, type, summary, topics, content, and sources', () => {
+    const out = serializeInsightToMarkdown({
+      market_insight_id: 'i1',
+      type: 'pre_market',
+      headline: 'NVDA leads pre-market',
+      summary: 'Chips rally on AI demand.',
+      completed_at: '2026-04-27T12:00:00Z',
+      topics: [{ text: 'AI', trend: 'up' }, { text: 'Chips' }],
+      content: [
+        { title: 'Article 1', body: 'Body 1', url: 'https://e.com/1' },
+        { title: 'Article 2', body: 'Body 2' },
+      ],
+      sources: [{ url: 'https://e.com/x', title: 'Example' }],
+    });
+    expect(out).toContain('## NVDA leads pre-market');
+    expect(out).toContain('type: pre_market');
+    expect(out).toContain('completed: 2026-04-27T12:00:00Z');
+    expect(out).toContain('Chips rally on AI demand.');
+    expect(out).toContain('**Topics:** AI (up), Chips');
+    expect(out).toContain('1. **Article 1** — https://e.com/1');
+    expect(out).toContain('   Body 1');
+    expect(out).toContain('2. **Article 2**');
+    expect(out).toContain('- Example — https://e.com/x');
+  });
+
+  it('uses custom heading when provided', () => {
+    const out = serializeInsightToMarkdown(
+      { market_insight_id: 'i1', type: 'market_update', headline: 'X' },
+      { heading: '## X (latest)' },
+    );
+    expect(out.startsWith('## X (latest)')).toBe(true);
+  });
+});
+
+describe('serializeInsightDayToMarkdown', () => {
+  it('marks the first item as latest and joins with separators', () => {
+    const out = serializeInsightDayToMarkdown([
+      { market_insight_id: 'a', type: 'pre_market', headline: 'First' },
+      { market_insight_id: 'b', type: 'personalized', headline: 'Mine', summary: 'For me' },
+    ]);
+    expect(out).toContain('## First (latest)');
+    expect(out).toContain('## Mine');
+    expect(out).toContain('type: personalized');
+    expect(out).toContain('---');
+    expect(out).toContain('2 briefs on this date');
+  });
+
+  it('returns _no briefs_ when empty', () => {
+    expect(serializeInsightDayToMarkdown([])).toBe('_no briefs_');
+  });
+});
+

--- a/web/src/pages/Dashboard/widgets/framework/contextSnapshot.ts
+++ b/web/src/pages/Dashboard/widgets/framework/contextSnapshot.ts
@@ -89,6 +89,12 @@ export function useWidgetContextExport(
   // Stash the exporters in the registry so the (latest) closure is what runs
   // when the user clicks "+". Re-running this effect on every render keeps
   // the closures fresh without forcing each widget to memoize its serializer.
+  // Perf tradeoff (intentional): callers pass `exporters` inline, so its
+  // identity changes every render; the effect runs and `notify()` fires twice
+  // (cleanup + setup) per widget per dashboard render. `useSyncExternalStore`
+  // snapshot equality (`registry.has(instanceId)` stays true) prevents downstream
+  // re-renders. Don't `useMemo` this in callers — that would break the
+  // closure-freshness guarantee.
   useEffect(() => {
     registry.set(instanceId, exporters);
     notify();

--- a/web/src/pages/Dashboard/widgets/framework/contextSnapshot.ts
+++ b/web/src/pages/Dashboard/widgets/framework/contextSnapshot.ts
@@ -1,0 +1,159 @@
+/**
+ * Widget context snapshot registry.
+ *
+ * Each widget definition that opts in calls `useWidgetContextExport(instanceId,
+ * exporters)` from inside its render component. The hook registers a function
+ * that returns a `WidgetContextSnapshot` synchronously, reading whatever JS
+ * state is already in scope (OHLCV bars, news headlines, watchlist quotes).
+ *
+ * The "+" button in `WidgetFrame` calls `getWidgetContextSnapshot(instanceId)`
+ * to produce the snapshot, then publishes it on `ContextBus`.
+ *
+ * List-shaped widgets (news, watchlist, threads, calendar, insight, portfolio)
+ * also register a `rows(rowId)` exporter for per-row attach via
+ * `RowAttachButton`.
+ *
+ * Most exporters are synchronous (read JS state already in scope). The `rows`
+ * exporter may also return a Promise — used by widgets that fetch the full
+ * row payload on attach (e.g., news detail body that lives behind an API call).
+ */
+
+import { useEffect, useSyncExternalStore } from 'react';
+
+export interface WidgetContextSnapshot {
+  widget_type: string;
+  widget_id: string;
+  /** Human-readable label for the chip (e.g., "NVDA · 1d Chart"). */
+  label: string;
+  /** Optional caption / freshness note. */
+  description?: string;
+  /** ISO timestamp captured at snapshot time. */
+  captured_at: string;
+  /** Pre-rendered <widget-context>...</widget-context> markdown for the agent. */
+  text: string;
+  /** Structured raw payload — persisted to query_metadata.widget_contexts for replay. */
+  data: Record<string, unknown>;
+  /**
+   * Optional JPEG data URL for chart-bearing widgets. Backend frontend code
+   * splits this into a separate MultimodalContext(type='image') item so the
+   * existing modality gate handles vision-vs-text-only routing.
+   */
+  image_jpeg_data_url?: string;
+}
+
+export interface WidgetContextExporters {
+  /** Snapshot the entire widget. Always required. */
+  full: () => WidgetContextSnapshot;
+  /**
+   * Snapshot a single row by id. List widgets only. Returns null if rowId not
+   * found. May return a Promise — useful when the full row payload requires a
+   * network fetch (e.g., news detail body).
+   */
+  rows?: (
+    rowId: string,
+  ) => WidgetContextSnapshot | null | Promise<WidgetContextSnapshot | null>;
+}
+
+const registry = new Map<string, WidgetContextExporters>();
+const listeners = new Set<() => void>();
+
+function notify() {
+  for (const fn of listeners) {
+    try {
+      fn();
+    } catch (err) {
+      console.error('[widgetContext] listener threw', err);
+    }
+  }
+}
+
+function subscribe(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => {
+    listeners.delete(fn);
+  };
+}
+
+/**
+ * Register snapshot exporters for a widget instance. Call from inside the
+ * widget's render component; the hook re-registers if the instance id ever
+ * changes (rare — usually only when the user duplicates a widget).
+ *
+ * Cleanup runs on unmount or when `instanceId` changes; this is what keeps
+ * stale exporters from outliving their widgets and capturing stale closures.
+ */
+export function useWidgetContextExport(
+  instanceId: string,
+  exporters: WidgetContextExporters,
+): void {
+  // Stash the exporters in the registry so the (latest) closure is what runs
+  // when the user clicks "+". Re-running this effect on every render keeps
+  // the closures fresh without forcing each widget to memoize its serializer.
+  useEffect(() => {
+    registry.set(instanceId, exporters);
+    notify();
+    return () => {
+      // Only delete if the slot still points at us — guards against unmount
+      // running *after* a remount with the same id has registered new
+      // exporters (rare, but happens with React StrictMode + key reuse).
+      if (registry.get(instanceId) === exporters) {
+        registry.delete(instanceId);
+        notify();
+      }
+    };
+  }, [instanceId, exporters]);
+}
+
+/**
+ * Returns the registered widget snapshot. Full-widget exporters are always
+ * sync; row exporters may be async (the row exporter's signature allows it),
+ * so callers should `await` the result. Sync exporters resolve in a
+ * micro-task — the await cost is negligible.
+ */
+export async function getWidgetContextSnapshot(
+  instanceId: string,
+  rowId?: string,
+): Promise<WidgetContextSnapshot | null> {
+  const entry = registry.get(instanceId);
+  if (!entry) return null;
+  if (rowId !== undefined) {
+    if (!entry.rows) return null;
+    try {
+      return await entry.rows(rowId);
+    } catch (err) {
+      console.error('[widgetContext] row exporter threw', err);
+      return null;
+    }
+  }
+  try {
+    return entry.full();
+  } catch (err) {
+    console.error('[widgetContext] full exporter threw', err);
+    return null;
+  }
+}
+
+/** Whether a widget instance has registered a snapshot exporter. */
+export function hasWidgetContextExporter(instanceId: string): boolean {
+  return registry.has(instanceId);
+}
+
+/**
+ * Reactive variant — subscribes to registry changes so the caller re-renders
+ * when an exporter is registered or removed. Use this in `WidgetFrame` so the
+ * "+" button enables the moment a child widget registers its exporter (which
+ * happens in a `useEffect` *after* the frame's first render).
+ */
+export function useHasWidgetContextExporter(instanceId: string): boolean {
+  return useSyncExternalStore(
+    subscribe,
+    () => registry.has(instanceId),
+    () => registry.has(instanceId),
+  );
+}
+
+/** Test-only — reset the registry between cases. */
+export function __resetWidgetContextRegistryForTests(): void {
+  registry.clear();
+  notify();
+}

--- a/web/src/pages/Dashboard/widgets/framework/snapshotSerializers.ts
+++ b/web/src/pages/Dashboard/widgets/framework/snapshotSerializers.ts
@@ -1,0 +1,305 @@
+/**
+ * Markdown serializers for widget context snapshots.
+ *
+ * Each helper produces a string that becomes the body of a
+ * `<widget-context>...</widget-context>` block. Keep them small and pure —
+ * the per-widget render components compose them inline.
+ */
+
+
+/** Wrap a body in a <widget-context> envelope with type and arbitrary key/value attributes. */
+export function wrapWidgetContext(
+  type: string,
+  attrs: Record<string, string | number | undefined | null>,
+  body: string,
+): string {
+  const attrStr = Object.entries(attrs)
+    .filter(([, v]) => v !== undefined && v !== null && v !== '')
+    .map(([k, v]) => `${k}='${String(v).replace(/'/g, '&#39;')}'`)
+    .join(' ');
+  const head = attrStr ? `<widget-context type='${type}' ${attrStr}>` : `<widget-context type='${type}'>`;
+  return `${head}\n${body}\n</widget-context>`;
+}
+
+// ---------------------------------------------------------------------------
+// OHLCV (chart widgets)
+// ---------------------------------------------------------------------------
+
+export interface OhlcvBar {
+  time: string | number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume?: number;
+}
+
+/** Render OHLCV bars as a markdown table. Truncates long series with head/tail. */
+export function serializeOhlcvToMarkdown(bars: OhlcvBar[], opts: { headRows?: number; tailRows?: number } = {}): string {
+  if (!bars.length) return '_no bars_';
+  const headRows = opts.headRows ?? 8;
+  const tailRows = opts.tailRows ?? 8;
+  const includeVolume = bars.some((b) => b.volume !== undefined);
+  const headers = ['time', 'open', 'high', 'low', 'close'];
+  if (includeVolume) headers.push('volume');
+  const lines: string[] = [];
+  lines.push(`| ${headers.join(' | ')} |`);
+  lines.push(`| ${headers.map(() => '---').join(' | ')} |`);
+  const fmt = (b: OhlcvBar) => {
+    const cells = [
+      String(b.time),
+      b.open.toFixed(2),
+      b.high.toFixed(2),
+      b.low.toFixed(2),
+      b.close.toFixed(2),
+    ];
+    if (includeVolume) cells.push(b.volume !== undefined ? String(b.volume) : '');
+    return `| ${cells.join(' | ')} |`;
+  };
+  if (bars.length <= headRows + tailRows + 2) {
+    bars.forEach((b) => lines.push(fmt(b)));
+  } else {
+    bars.slice(0, headRows).forEach((b) => lines.push(fmt(b)));
+    lines.push(`| _... ${bars.length - headRows - tailRows} bars omitted ..._ |`);
+    bars.slice(-tailRows).forEach((b) => lines.push(fmt(b)));
+  }
+  return lines.join('\n');
+}
+
+export function summarizeOhlcv(bars: OhlcvBar[]): string {
+  if (!bars.length) return '';
+  const last = bars[bars.length - 1];
+  const first = bars[0];
+  const pctChange = ((last.close - first.close) / first.close) * 100;
+  const lows = bars.map((b) => b.low);
+  const highs = bars.map((b) => b.high);
+  const minLow = Math.min(...lows);
+  const maxHigh = Math.max(...highs);
+  const sign = pctChange >= 0 ? '+' : '';
+  return `last close ${last.close.toFixed(2)} (${sign}${pctChange.toFixed(2)}%), range ${minLow.toFixed(2)}–${maxHigh.toFixed(2)} over ${bars.length} bars`;
+}
+
+// ---------------------------------------------------------------------------
+// News
+// ---------------------------------------------------------------------------
+
+export interface NewsItem {
+  title: string;
+  source?: string;
+  publishedAt?: string;
+  url?: string;
+  tickers?: string[];
+  summary?: string;
+}
+
+export function serializeNewsItemToMarkdown(item: NewsItem): string {
+  const lines: string[] = [`**${item.title}**`];
+  const meta: string[] = [];
+  if (item.source) meta.push(item.source);
+  if (item.publishedAt) meta.push(item.publishedAt);
+  if (item.tickers && item.tickers.length) meta.push(item.tickers.join(', '));
+  if (meta.length) lines.push(meta.join(' · '));
+  if (item.url) lines.push(`URL: ${item.url}`);
+  if (item.summary) lines.push('', item.summary);
+  return lines.join('\n');
+}
+
+export interface NewsArticleDetail {
+  title: string;
+  description?: string;
+  author?: string;
+  publishedAt?: string;
+  url?: string;
+  source?: string;
+  tickers?: string[];
+  keywords?: string[];
+  sentiments?: Array<{ ticker: string; sentiment?: string; reasoning?: string }>;
+}
+
+/**
+ * Render a fully-fetched news article to markdown. Includes summary,
+ * keywords, and per-ticker sentiment so the agent gets the same context
+ * the user sees in the news detail modal.
+ */
+export function serializeNewsArticleToMarkdown(article: NewsArticleDetail): string {
+  const lines: string[] = [`**${article.title}**`];
+  const meta: string[] = [];
+  if (article.source) meta.push(article.source);
+  if (article.author) meta.push(`by ${article.author}`);
+  if (article.publishedAt) meta.push(article.publishedAt);
+  if (article.tickers?.length) meta.push(article.tickers.join(', '));
+  if (meta.length) lines.push(meta.join(' · '));
+  if (article.url) lines.push(`URL: ${article.url}`);
+  if (article.description) lines.push('', '**Summary**', article.description);
+  if (article.keywords?.length) {
+    lines.push('', `**Topics:** ${article.keywords.map((k) => `#${k}`).join(' ')}`);
+  }
+  if (article.sentiments?.length) {
+    lines.push('', '**Ticker Sentiment**');
+    article.sentiments.forEach((s) => {
+      const tag = s.sentiment ? ` (${s.sentiment})` : '';
+      const why = s.reasoning ? ` — ${s.reasoning}` : '';
+      lines.push(`- ${s.ticker}${tag}${why}`);
+    });
+  }
+  return lines.join('\n');
+}
+
+export function serializeNewsItemsToMarkdown(items: NewsItem[]): string {
+  if (!items.length) return '_no headlines_';
+  const lines: string[] = [`| # | title | source | when | tickers |`, `|---|---|---|---|---|`];
+  items.forEach((it, i) => {
+    const tickers = it.tickers && it.tickers.length ? it.tickers.join(', ') : '';
+    lines.push(
+      `| ${i + 1} | ${it.title.replace(/\|/g, '\\|')} | ${it.source ?? ''} | ${it.publishedAt ?? ''} | ${tickers} |`,
+    );
+  });
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Watchlist / portfolio rows
+// ---------------------------------------------------------------------------
+
+export interface QuoteRow {
+  symbol: string;
+  price?: number;
+  change?: number;
+  changePercent?: number;
+  preMarket?: number;
+  postMarket?: number;
+  volume?: number;
+  shares?: number;
+  marketValue?: number;
+}
+
+export function serializeQuoteRowToMarkdown(row: QuoteRow): string {
+  const lines: string[] = [`**${row.symbol}**`];
+  const bits: string[] = [];
+  if (row.price !== undefined) bits.push(`$${row.price.toFixed(2)}`);
+  if (row.change !== undefined && row.changePercent !== undefined) {
+    const sign = row.change >= 0 ? '+' : '';
+    bits.push(`${sign}${row.change.toFixed(2)} (${sign}${row.changePercent.toFixed(2)}%)`);
+  }
+  if (bits.length) lines.push(bits.join(' '));
+  if (row.preMarket !== undefined) lines.push(`pre-market $${row.preMarket.toFixed(2)}`);
+  if (row.postMarket !== undefined) lines.push(`post-market $${row.postMarket.toFixed(2)}`);
+  if (row.volume !== undefined) lines.push(`vol ${row.volume.toLocaleString()}`);
+  if (row.shares !== undefined) lines.push(`shares ${row.shares}`);
+  if (row.marketValue !== undefined) lines.push(`mkt val $${row.marketValue.toLocaleString()}`);
+  return lines.join('\n');
+}
+
+export function serializeQuoteRowsToMarkdown(rows: QuoteRow[]): string {
+  if (!rows.length) return '_no symbols_';
+  const includeVol = rows.some((r) => r.volume !== undefined);
+  const headers = ['symbol', 'price', 'change', 'change%'];
+  if (includeVol) headers.push('volume');
+  const lines: string[] = [`| ${headers.join(' | ')} |`, `| ${headers.map(() => '---').join(' | ')} |`];
+  rows.forEach((r) => {
+    const cells = [
+      r.symbol,
+      r.price !== undefined ? r.price.toFixed(2) : '',
+      r.change !== undefined ? r.change.toFixed(2) : '',
+      r.changePercent !== undefined ? `${r.changePercent.toFixed(2)}%` : '',
+    ];
+    if (includeVol) cells.push(r.volume !== undefined ? String(r.volume) : '');
+    lines.push(`| ${cells.join(' | ')} |`);
+  });
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// AI Insight briefs
+// ---------------------------------------------------------------------------
+
+export interface InsightTopic {
+  text: string;
+  trend?: 'up' | 'down' | 'neutral';
+}
+
+export interface InsightContentItem {
+  title: string;
+  body: string;
+  url?: string;
+}
+
+export interface InsightSource {
+  url: string;
+  title?: string;
+}
+
+export interface InsightDetail {
+  market_insight_id: string;
+  type: string;
+  headline: string;
+  summary?: string;
+  completed_at?: string;
+  topics?: InsightTopic[];
+  content?: InsightContentItem[];
+  sources?: InsightSource[];
+  model?: string;
+}
+
+/** Render a single AI brief as a markdown sub-section. Caller wraps in <widget-context>. */
+export function serializeInsightToMarkdown(item: InsightDetail, opts: { heading?: string } = {}): string {
+  const lines: string[] = [];
+  lines.push(opts.heading ?? `## ${item.headline}`);
+  const meta: string[] = [`type: ${item.type}`];
+  if (item.completed_at) meta.push(`completed: ${item.completed_at}`);
+  if (item.model) meta.push(`model: ${item.model}`);
+  lines.push(`_${meta.join(' · ')}_`);
+  if (item.summary) lines.push('', item.summary);
+  if (item.topics?.length) {
+    const topicStr = item.topics.map((tp) => (tp.trend ? `${tp.text} (${tp.trend})` : tp.text)).join(', ');
+    lines.push('', `**Topics:** ${topicStr}`);
+  }
+  if (item.content?.length) {
+    lines.push('', '**Items**');
+    item.content.forEach((c, i) => {
+      lines.push(`${i + 1}. **${c.title}**${c.url ? ` — ${c.url}` : ''}`);
+      if (c.body) lines.push(`   ${c.body.replace(/\n/g, '\n   ')}`);
+    });
+  }
+  if (item.sources?.length) {
+    lines.push('', '**Sources**');
+    item.sources.forEach((s) => {
+      lines.push(`- ${s.title ? `${s.title} — ` : ''}${s.url}`);
+    });
+  }
+  return lines.join('\n');
+}
+
+/** Render a whole-day brief stack (latest + earlier + personalized) as one markdown body. */
+export function serializeInsightDayToMarkdown(items: InsightDetail[]): string {
+  if (!items.length) return '_no briefs_';
+  const sections = items.map((it, i) => {
+    const heading = i === 0 ? `## ${it.headline} (latest)` : `## ${it.headline}`;
+    return serializeInsightToMarkdown(it, { heading });
+  });
+  return [`_${items.length} brief${items.length === 1 ? '' : 's'} on this date_`, '', sections.join('\n\n---\n\n')].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Generic table
+// ---------------------------------------------------------------------------
+
+export function serializeRowsToMarkdown<T extends Record<string, unknown>>(
+  rows: T[],
+  columns: Array<{ key: keyof T; label: string; format?: (v: unknown) => string }>,
+): string {
+  if (!rows.length) return '_no rows_';
+  const headers = columns.map((c) => c.label);
+  const lines: string[] = [`| ${headers.join(' | ')} |`, `| ${headers.map(() => '---').join(' | ')} |`];
+  rows.forEach((r) => {
+    const cells = columns.map((c) => {
+      const v = r[c.key];
+      if (v === null || v === undefined) return '';
+      if (c.format) return c.format(v);
+      return String(v).replace(/\|/g, '\\|');
+    });
+    lines.push(`| ${cells.join(' | ')} |`);
+  });
+  return lines.join('\n');
+}
+

--- a/web/src/types/chat.ts
+++ b/web/src/types/chat.ts
@@ -228,6 +228,12 @@ export interface UserMessage {
   isStreaming: false;
   isHistory?: boolean;
   attachments?: Attachment[];
+  /**
+   * Widget context snapshots attached to this message. Rendered as inline
+   * chip cards below the user bubble (like attachments) and forwarded to the
+   * backend via `additional_context`.
+   */
+  widgetSnapshots?: import('@/pages/Dashboard/widgets/framework/contextSnapshot').WidgetContextSnapshot[];
   steeringDelivered?: boolean;
   steering?: boolean;
 }


### PR DESCRIPTION
## Summary

Adds a universal *"everything you see is part of the context"* capability. Pick any dashboard widget — or any row inside a list-shaped widget — and attach it to the next chat message. Both **structured directives** (OHLCV bars, news headlines, watchlist quotes, insight briefs) and **chart screenshots** flow through the existing `additional_context` channel; the model's modality gate decides whether the image is sent or text-only fallback is used.

**Backend (`feat(server): add widget context to additional_context union`)**
- New `WidgetContext` arm on the discriminated union (`src/server/models/additional_context.py`) carrying `widget_type`, `widget_id`, `label`, pre-rendered `<widget-context>` text, structured `data`, and `captured_at`.
- New `src/server/utils/widget_context.py`: `parse_widget_contexts()` mirrors the directive-context middleware pattern; `build_widget_context_reminder()` concatenates each widget's directive into one `<system-reminder>` explainer block.
- PTC and Flash workflows append the reminder to the last user message alongside existing directive injection. Widget images ride the existing `MultimodalContext(type='image')` channel — zero refactor of `inject_multimodal_context`.

**Frontend (`feat(dashboard): widget context capture + chat-input deck rail`)**
- `useWidgetContextExport(instance.id, { full, rows? })` registers per-instance snapshot exporters. Every widget calls it.
- WidgetFrame "+" button (always-visible action area, hover-revealed in view mode, always visible on touch) publishes the full-widget snapshot to `ContextBus`. Per-row "+" via `RowAttachButton` on list-shaped widgets (news, insights, watchlist, etc.).
- Chat input subscribes to the bus and renders a "deck" rail above the textarea: top card visible (~64px), peek stack behind, fan-out on hover. Cards mirror across every mounted chat input. `<ContextOverflowPill>` floats bottom-right when no chat input is in viewport.
- Wire format: each imaged snapshot emits two `additional_context` items (one `widget` directive + one existing `image`). Modality gate handles the rest.
- Tier 1 (charts) capture JPEG via `canvas.toDataURL('image/jpeg', 0.85)`. Tier 2 (structured native) emit text-only directives. Tier 3 (TradingView embeds) emit config-derived directives.
- Locale-aware copy in `en-US.json` and `zh-CN.json`.

## Test Coverage

- Backend: 35 new tests (`tests/unit/server/utils/test_widget_context.py`, `tests/unit/server/models/test_additional_context.py`, `tests/unit/server/handlers/chat/test_widget_context_pipeline.py`) — discriminator routing, required-field validation, reminder concatenation, mixed-context coexistence, end-to-end pipeline.
- Frontend: vitest 888/888 pass (80 files). New suites cover `ContextBus` pub/sub, chat-input deck behavior, `ContextOverflowPill` visibility, `contextSnapshot` registry lifecycle, and per-widget snapshot serializer shape.

## Pre-Landing Review

CLEAN — discriminator union extended cleanly, no SQL/DOM/eval risk, widget-context wrapping mirrors the established directive-context pattern, size guards present (`navigate(state)` byteLength check before drop), two cosmetic P2s on quote-escaping that match existing trust posture and are not regressions.

## Out of Scope (V1)

- Floating text-selection "Add to context" tooltip — defer to V2.
- Replay UI for widget chips in conversation history — V1 persists structured payload to `query_metadata['widget_contexts']`; rendering is V2.
- TradingView Charting Library swap — accepted text-only directives for the 17 TV widgets.
- LLM eval suite for `<widget-context>` schema — user accepted schema-stability risk; add evals if regressions surface during dogfood.

## Test plan

- [x] Backend pytest passes (35/35 new tests, full suite TBD on CI)
- [x] Frontend vitest passes (888/888)
- [x] Frontend lint clean
- [x] Backend lint clean on touched files
- [x] Frontend typecheck clean
- [x] Manual: attach chart from `markets.chart` widget → verify image lands on vision model, dropped silently on text-only
- [x] Manual: attach all-day insight brief → verify all briefs (latest + personalized) flow into agent context
- [x] Manual: attach single news row → verify article body is fetched on attach
- [x] Manual: multi-input sync — attach in hero, fan out conversation widget deck, remove → both update