### PR TITLE
feat(chat-agent): path-aware tool labels + memory/memo panel routing + monochrome timeline

### DIFF
--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -58,6 +58,16 @@ Controlled by `VITE_SUPABASE_URL`:
 
 **File uploads (memo):** Use the same axios instance with `multipart/form-data`. Memo upload accepts PDF, markdown, plain text, CSV, and JSON; the backend extracts text from PDFs, generates metadata asynchronously via an LLM, and streams the original bytes back through `GET /api/v1/memo/user/download?key=...` for in-browser preview. UI lives in `pages/ChatAgent/components/MemoPanel.tsx` + `FilePanelMemo.tsx`, hooks in `pages/ChatAgent/hooks/useMemo.ts`.
 
+**Agent artifact path routing:** When a user clicks a tool-call row in the chat (e.g. `read_file('.agents/user/memory/risk-preferences.md')`), the right panel needs to open the right tab — Memory, Memo, Files, or none for skills. The single source of truth is `pages/ChatAgent/utils/agentPaths.ts`:
+
+- `classifyAgentPath(path)` returns a discriminated union (`memory | memo | skill | file`). Normalizes `file://`, `/home/(workspace|daytona)/`, `./`, query/hash, leading `/`, and `__wsref__/<wsid>/<rest>` cross-workspace refs.
+- `computeAgentArtifactRouting(path, opts)` is the pure decision function — what tab to open, which key to pre-select, which workspace to switch into.
+- `topicFromMemoryKey(key)` turns a memory filename into a display topic.
+
+`ChatView.handleOpenAgentArtifactFromChat` is the only chat-side caller. It clears all sibling target props before setting one, hosts an aria-live region for tool-call status, and hands routing decisions off to `computeAgentArtifactRouting`. `RightPanel` accepts `targetMemoryKey/Tier`, `targetMemoKey`, and `targetFile/Directory` with snap-back precedence (memory > memo > file). `MemoryPanel` and `MemoPanel` mirror those targets into selected state with an `isFetching` gate (so cache-refetch races don't false-trigger a not-found banner). `useMemory` exposes `isFetching` for that gate.
+
+Add new agent-artifact path types here, not in panel components — every new location duplicates the normalization rules.
+
 **React Query:** Global `QueryClient` in `main.tsx`. Key factory in `lib/queryKeys.ts` — hierarchical keys enabling prefix-based invalidation (e.g., invalidate `queryKeys.user.all` to refresh all user-related data). Shared hooks in `hooks/` (`useUser`, `useWorkspaces`, `useWorkspace`, `usePreferences`, `useUpdatePreferences`, `useNetworkStatus`).
 
 **Dashboard preferences:** `useDashboardPrefs` (in `pages/Dashboard/widgets/framework/`) reads layout + per-widget config from `user.preferences.dashboard`, validates each widget config through a Zod schema (`configSchemas.ts`), and writes back via a guarded writer (`dashboardPrefsWriter.ts`) that survives cross-tab races and cold-cache mounts. Cross-tab updates land via the `usePreferences` query cache; the dashboard re-renders without a network round-trip.

--- a/web/e2e/chat.spec.js
+++ b/web/e2e/chat.spec.js
@@ -359,8 +359,10 @@ test.describe('Chat View -- SSE Streaming', () => {
 
     await page.goto('/chat/t/th-1');
 
-    // The tool call card should appear (collapsed as "N step(s) completed")
-    await expect(page.getByText('step completed')).toBeVisible({ timeout: 10000 });
+    // The tool call card should appear. The accordion header is now
+    // content-aware (skill/memory/memo/code/web/search/file/generic) — for
+    // a single WebSearch call it renders as "made 1 web call".
+    await expect(page.getByText(/made \d+ web call/i)).toBeVisible({ timeout: 10000 });
     // The final assistant text should appear
     await expect(page.getByText('NVIDIA reported strong Q4 earnings')).toBeVisible({ timeout: 10000 });
   });

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -1287,6 +1287,8 @@
     "deleteSelected": "Delete selected",
     "backToList": "Back to memos",
     "unsavedDiscardConfirm": "You have unsaved memo edits. Discard them?",
+    "discardEditTitle": "Discard unsaved edits?",
+    "discardEdits": "Discard",
     "loading": "Loading…",
     "loadingList": "Loading memos…",
     "uploading": "Uploading…",
@@ -1726,7 +1728,9 @@
     },
     "a11y": {
       "toolCallFailed": "Tool call failed",
-      "openInTab": "Open in {{tab}}"
+      "openInTab": "Open in {{tab}}",
+      "collapseDiff": "Collapse diff",
+      "expandDiff": "Expand diff"
     }
   },
   "setup": {

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -1143,6 +1143,10 @@
       "listening": "Listening... (Type to cancel)",
       "permissionDenied": "Microphone permission denied",
       "serviceError": "Speech recognition service error"
+    },
+    "a11y": {
+      "toolCallCompleted": "completed",
+      "toolCallFailed": "failed"
     }
   },
   "context": {
@@ -1266,7 +1270,9 @@
     "emptyWorkspace": "No workspace memory yet.",
     "emptyHint": "The agent will create memory.md when it has something worth remembering.",
     "loadError": "Failed to load memory",
-    "readError": "Failed to read memory file"
+    "readError": "Failed to read memory file",
+    "notFound": "Entry \"{{key}}\" no longer exists. Showing all entries.",
+    "dismissNotFound": "Dismiss"
   },
   "memoPanel": {
     "title": "Memos",
@@ -1280,6 +1286,7 @@
     "selectedCount_other": "{{count}} selected",
     "deleteSelected": "Delete selected",
     "backToList": "Back to memos",
+    "unsavedDiscardConfirm": "You have unsaved memo edits. Discard them?",
     "loading": "Loading…",
     "loadingList": "Loading memos…",
     "uploading": "Uploading…",
@@ -1321,6 +1328,8 @@
       "loadFailed": "Failed to load memos",
       "bulkDeleteFailed": "{{count}} memo(s) failed to delete. {{first}}"
     },
+    "notFound": "Memo \"{{key}}\" no longer exists. Showing all memos.",
+    "dismissNotFound": "Dismiss",
     "confirm": {
       "deleteTitle": "Delete memo",
       "deleteBody": "Permanently delete \"{{name}}\"? This cannot be undone.",
@@ -1569,10 +1578,11 @@
     "nSearchResults_other": "{{count}} results for \"{{query}}\"",
     "untitled": "Untitled",
     "nReasoning": "{{count}} reasoning",
+    "andMore": "and more …",
     "nToolCalls": "{{count}} tool call",
     "nToolCalls_other": "{{count}} tool calls",
-    "nStepsCompleted": "{{count}} step completed",
-    "nStepsCompleted_other": "{{count}} steps completed",
+    "nStepsCompleted": "completed {{count}} step",
+    "nStepsCompleted_other": "completed {{count}} steps",
     "reasoning": "Reasoning",
     "reasoningLabel": "Reasoning: {{title}}",
     "reasoningPending": "Reasoning...",
@@ -1610,9 +1620,42 @@
       "taskOutput": "Task Output",
       "automations": "Automations",
       "createAutomation": "Create Automation",
-      "manageAutomation": "Manage Automation"
+      "manageAutomation": "Manage Automation",
+      "skill": "Skill",
+      "memory": "Memory",
+      "workspaceMemory": "Workspace Memory",
+      "memo": "Memo"
+    },
+    "completed": {
+      "activatedSkill": "Activated skill",
+      "readMemory": "Read memory",
+      "readWorkspaceMemory": "Read workspace memory",
+      "addedMemory": "Added memory",
+      "updatedMemory": "Updated memory",
+      "readMemo": "Read memo",
+      "readMemoIndex": "Read memo index",
+      "wroteMemo": "Wrote memo",
+      "updatedMemo": "Updated memo"
     },
     "inProgress": {
+      "activatingSkill": "activating skill...",
+      "activatingSkillName": "activating skill {{name}}...",
+      "readingMemory": "reading memory...",
+      "readingMemoryTopic": "reading memory about {{topic}}...",
+      "readingWorkspaceMemory": "reading workspace memory...",
+      "readingWorkspaceMemoryTopic": "reading workspace memory about {{topic}}...",
+      "addingMemory": "adding memory...",
+      "addingMemoryTopic": "adding memory {{topic}}...",
+      "addingWorkspaceMemory": "adding workspace memory...",
+      "addingWorkspaceMemoryTopic": "adding workspace memory {{topic}}...",
+      "updatingMemory": "updating memory...",
+      "updatingMemoryTopic": "updating memory {{topic}}...",
+      "updatingWorkspaceMemory": "updating workspace memory...",
+      "updatingWorkspaceMemoryTopic": "updating workspace memory {{topic}}...",
+      "readingMemoIndex": "reading memo index...",
+      "readingMemoSlug": "reading memo {{slug}}...",
+      "writingMemoSlug": "writing memo {{slug}}...",
+      "updatingMemoSlug": "updating memo {{slug}}...",
       "fetchingSymbolPrices": "fetching {{symbol}} prices...",
       "fetchingPrices": "fetching prices...",
       "analyzingSymbol": "analyzing {{symbol}}...",
@@ -1656,7 +1699,35 @@
       "generating": "generating{{size}}..."
     },
     "nChars": "~{{count}} chars",
-    "nKB": "~{{size}} KB"
+    "nKB": "~{{size}} KB",
+    "categoryCount": {
+      "skill": "activated {{count}} skill",
+      "skill_other": "activated {{count}} skills",
+      "memoryRead": "read memory",
+      "memoryUpdated": "updated memory",
+      "memo": "read {{count}} memo",
+      "memo_other": "read {{count}} memos",
+      "memoWrite": "wrote {{count}} memo",
+      "memoWrite_other": "wrote {{count}} memos",
+      "failed": "{{count}} failed",
+      "failed_other": "{{count}} failed",
+      "code": "executed {{count}} code block",
+      "code_other": "executed {{count}} code blocks",
+      "web": "made {{count}} web call",
+      "web_other": "made {{count}} web calls",
+      "search": "ran {{count}} search",
+      "search_other": "ran {{count}} searches",
+      "fileRead": "read {{count}} file",
+      "fileRead_other": "read {{count}} files",
+      "fileEdit": "edited {{count}} file",
+      "fileEdit_other": "edited {{count}} files",
+      "generic": "ran {{count}} step",
+      "generic_other": "ran {{count}} steps"
+    },
+    "a11y": {
+      "toolCallFailed": "Tool call failed",
+      "openInTab": "Open in {{tab}}"
+    }
   },
   "setup": {
     "brandedHeader": "Configure your LLM providers",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -1285,6 +1285,8 @@
     "deleteSelected": "删除所选",
     "backToList": "返回列表",
     "unsavedDiscardConfirm": "您有未保存的备忘修改。确定放弃吗？",
+    "discardEditTitle": "放弃未保存的修改？",
+    "discardEdits": "放弃",
     "loading": "加载中…",
     "loadingList": "正在加载备忘文档…",
     "uploading": "上传中…",
@@ -1705,7 +1707,9 @@
     },
     "a11y": {
       "toolCallFailed": "工具调用失败",
-      "openInTab": "在 {{tab}} 中打开"
+      "openInTab": "在 {{tab}} 中打开",
+      "collapseDiff": "折叠差异",
+      "expandDiff": "展开差异"
     }
   },
   "setup": {

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -1143,6 +1143,10 @@
       "listening": "正在倾听... (打字可中断)",
       "permissionDenied": "麦克风权限被拒绝",
       "serviceError": "语音识别服务错误"
+    },
+    "a11y": {
+      "toolCallCompleted": "已完成",
+      "toolCallFailed": "已失败"
     }
   },
   "context": {
@@ -1265,7 +1269,9 @@
     "emptyWorkspace": "暂无工作区记忆。",
     "emptyHint": "当有值得记住的内容时，智能体会创建 memory.md。",
     "loadError": "记忆加载失败",
-    "readError": "记忆文件读取失败"
+    "readError": "记忆文件读取失败",
+    "notFound": "记忆 “{{key}}” 已不存在，已显示全部条目。",
+    "dismissNotFound": "关闭"
   },
   "memoPanel": {
     "title": "备忘文档",
@@ -1278,6 +1284,7 @@
     "selectedCount_other": "已选 {{count}} 项",
     "deleteSelected": "删除所选",
     "backToList": "返回列表",
+    "unsavedDiscardConfirm": "您有未保存的备忘修改。确定放弃吗？",
     "loading": "加载中…",
     "loadingList": "正在加载备忘文档…",
     "uploading": "上传中…",
@@ -1319,6 +1326,8 @@
       "loadFailed": "备忘文档加载失败",
       "bulkDeleteFailed": "{{count}} 个备忘文档删除失败：{{first}}"
     },
+    "notFound": "备忘文档 “{{key}}” 已不存在，已显示全部备忘。",
+    "dismissNotFound": "关闭",
     "confirm": {
       "deleteTitle": "删除备忘文档",
       "deleteBody": "确定永久删除 “{{name}}” 吗？此操作无法撤销。",
@@ -1560,6 +1569,7 @@
     "nSearchResults": "\"{{query}}\" 的 {{count}} 个结果",
     "untitled": "无标题",
     "nReasoning": "{{count}} 次推理",
+    "andMore": "等更多 …",
     "nToolCalls": "{{count}} 次工具调用",
     "nStepsCompleted": "已完成 {{count}} 个步骤",
     "reasoning": "推理",
@@ -1599,9 +1609,42 @@
       "taskOutput": "任务输出",
       "automations": "自动化",
       "createAutomation": "创建自动化",
-      "manageAutomation": "管理自动化"
+      "manageAutomation": "管理自动化",
+      "skill": "技能",
+      "memory": "记忆",
+      "workspaceMemory": "工作区记忆",
+      "memo": "备忘录"
+    },
+    "completed": {
+      "activatedSkill": "已激活技能",
+      "readMemory": "已读取记忆",
+      "readWorkspaceMemory": "已读取工作区记忆",
+      "addedMemory": "已新增记忆",
+      "updatedMemory": "已更新记忆",
+      "readMemo": "已读取备忘",
+      "readMemoIndex": "已读取备忘索引",
+      "wroteMemo": "已写入备忘",
+      "updatedMemo": "已更新备忘"
     },
     "inProgress": {
+      "activatingSkill": "激活技能中...",
+      "activatingSkillName": "激活技能 {{name}}...",
+      "readingMemory": "读取记忆中...",
+      "readingMemoryTopic": "读取关于 {{topic}} 的记忆...",
+      "readingWorkspaceMemory": "读取工作区记忆中...",
+      "readingWorkspaceMemoryTopic": "读取关于 {{topic}} 的工作区记忆...",
+      "addingMemory": "新增记忆中...",
+      "addingMemoryTopic": "新增记忆 {{topic}}...",
+      "addingWorkspaceMemory": "新增工作区记忆中...",
+      "addingWorkspaceMemoryTopic": "新增工作区记忆 {{topic}}...",
+      "updatingMemory": "更新记忆中...",
+      "updatingMemoryTopic": "更新记忆 {{topic}}...",
+      "updatingWorkspaceMemory": "更新工作区记忆中...",
+      "updatingWorkspaceMemoryTopic": "更新工作区记忆 {{topic}}...",
+      "readingMemoIndex": "读取备忘索引...",
+      "readingMemoSlug": "读取备忘 {{slug}}...",
+      "writingMemoSlug": "写入备忘 {{slug}}...",
+      "updatingMemoSlug": "更新备忘 {{slug}}...",
       "fetchingSymbolPrices": "获取 {{symbol}} 价格...",
       "fetchingPrices": "获取价格...",
       "analyzingSymbol": "分析 {{symbol}}...",
@@ -1645,7 +1688,25 @@
       "generating": "生成中{{size}}..."
     },
     "nChars": "~{{count}} 字符",
-    "nKB": "~{{size}} KB"
+    "nKB": "~{{size}} KB",
+    "categoryCount": {
+      "skill": "激活 {{count}} 项技能",
+      "memoryRead": "读取记忆",
+      "memoryUpdated": "更新记忆",
+      "memo": "读取 {{count}} 份备忘",
+      "memoWrite": "写入 {{count}} 份备忘",
+      "failed": "{{count}} 个失败",
+      "code": "执行 {{count}} 段代码",
+      "web": "发起 {{count}} 次网络请求",
+      "search": "执行 {{count}} 次搜索",
+      "fileRead": "读取 {{count}} 个文件",
+      "fileEdit": "编辑 {{count}} 个文件",
+      "generic": "运行 {{count}} 个步骤"
+    },
+    "a11y": {
+      "toolCallFailed": "工具调用失败",
+      "openInTab": "在 {{tab}} 中打开"
+    }
   },
   "setup": {
     "brandedHeader": "配置您的 LLM 提供商",

--- a/web/src/pages/ChatAgent/components/ActivityBlock.css
+++ b/web/src/pages/ChatAgent/components/ActivityBlock.css
@@ -1,0 +1,310 @@
+/* ActivityBlock — monochrome timeline + state visuals. */
+
+/* --- Live row state cues -------------------------------------------------- */
+
+.nrow {
+  position: relative;
+}
+
+/* Active state: 2px left rule + label shimmer (handled by TextShimmer). */
+.nrow.state-active::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 4px;
+  bottom: 4px;
+  width: 2px;
+  background: var(--color-border-default, var(--color-text-secondary));
+  border-radius: 1px;
+}
+
+/* Completing/Failed/Preparing: no left rule, neutral state. */
+
+/* State badge — a small lucide icon overlaid on the tool icon. */
+.nrow-badge {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--Labels-Secondary);
+  background: var(--color-bg-page);
+  border-radius: 999px;
+  padding: 1px;
+}
+
+/* --- Accordion timeline --------------------------------------------------- */
+
+.timeline {
+  position: relative;
+  list-style: none;
+  margin: 0;
+  padding: 6px 0 4px;
+}
+
+.titem {
+  position: relative;
+  display: grid;
+  grid-template-columns: 24px 1fr;
+  gap: 12px;
+  align-items: start;
+  /* No left padding — icon column starts at 0 so center sits on the rule (11px). */
+  padding: 7px 8px 7px 0;
+  border-radius: 4px;
+  transition: background-color 80ms;
+}
+
+/* The vertical rule is segmented per row so it has visible padding around each
+ * icon (matches Claude's pattern). Two short segments: one above and one below
+ * the icon, both anchored to the row edges so they bridge the inter-row margin
+ * and visually connect into the neighboring row's segments. Segments extend
+ * 1px past the row top/bottom so the 2px row margin reads as a continuous line.
+ *
+ * Geometry (row padding 7px + icon container 20px, icon visual ~16px centered
+ * spans y=9..25 within the row):
+ *   - Upper: y=-1 → y=4     (stops 5px above icon visual top y=9)
+ *   - Lower: y=30 → y=row-bottom+1  (starts 5px below icon visual bottom y=25)
+ */
+.titem::before,
+.titem::after {
+  content: '';
+  position: absolute;
+  left: 11px;
+  width: 1px;
+  background: var(--color-border-default, var(--color-border-muted));
+  pointer-events: none;
+}
+
+.titem::before {
+  top: -1px;
+  height: 5px;
+}
+
+.titem::after {
+  top: 30px;
+  bottom: -1px;
+}
+
+/* First row has no segment going up (nothing above to connect to).
+ * Targets the parent <li> because each .titem is wrapped in its own <li>,
+ * which means .titem itself is always :first-child of that <li>. */
+.timeline > li:first-child .titem::before {
+  display: none;
+}
+
+/* Last row has no segment going down (nothing below to connect to). */
+.timeline > li:last-child .titem::after {
+  display: none;
+}
+
+.titem + .titem {
+  margin-top: 2px;
+}
+
+/* No hover background — keeps rows flush with body text and avoids visually
+ * "boxing" the timeline. Hover affordance is carried by the obj/title-button
+ * underline within the row, not the row container itself. */
+
+.titem-icon {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  /* No background mask — rule passes behind icons; lucide stroke interrupts it
+   * naturally and a solid mask creates a visible block on hover. */
+  z-index: 2;
+  height: 20px;
+  color: var(--Labels-Secondary);
+}
+
+.titem-body {
+  min-width: 0;
+  padding-top: 1px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+/* First row inside body: verb on the left, pill (and any chevron) inline.
+ * `align-items: baseline` keeps mixed sans + mono text on the same baseline
+ * (centering aligns box midpoints, which drifts visually across fonts). */
+.titem-line {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  min-width: 0;
+}
+
+.titem-title {
+  font-size: 13.5px;
+  font-weight: 400;
+  color: var(--color-text-primary);
+  line-height: 1.35;
+  letter-spacing: -0.005em;
+  /* Verb stays whole so the pill is what truncates if width gets tight. */
+  flex-shrink: 0;
+}
+
+/* Title acting as the row's click target (when no pill is rendered). */
+.titem-title-button {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  text-align: left;
+  transition: color 80ms;
+}
+
+.titem-title-button:hover {
+  text-decoration: underline;
+  text-decoration-color: var(--color-border-default);
+  text-underline-offset: 3px;
+  text-decoration-thickness: 1px;
+}
+
+.titem-title-button:focus-visible {
+  outline: 2px solid var(--color-accent-primary);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+.titem-pill-wrap {
+  display: inline-flex;
+  min-width: 0;
+  flex: 0 1 auto;
+}
+
+/* Pushed-right slot for trailing controls (chevron toggles, etc.).
+ * `align-self: center` overrides the line's baseline alignment for icon-only
+ * controls, which have no text baseline. */
+.titem-trail {
+  margin-left: auto;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  align-self: center;
+  color: var(--Labels-Tertiary);
+}
+
+/* "Done" terminus row anchors the timeline. */
+.titem.titem-done .titem-icon::after {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-border-default);
+}
+
+.titem.titem-done .titem-title {
+  color: var(--Labels-Tertiary);
+  font-weight: 400;
+}
+
+/* --- Object pill chip (clickable affordance) ------------------------------ */
+
+.obj {
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 12px;
+  line-height: 1.4;
+  padding: 0;
+  background: transparent;
+  color: var(--Labels-Secondary);
+  border: 0;
+  border-radius: 0;
+  transition: color 80ms;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.obj:hover {
+  color: var(--color-text-primary);
+  text-decoration: underline;
+  text-decoration-color: var(--color-border-default);
+  text-underline-offset: 3px;
+  text-decoration-thickness: 1px;
+}
+
+.obj:focus-visible {
+  outline: 2px solid var(--color-accent-primary);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+@media (pointer: coarse) {
+  .obj {
+    min-height: 28px;
+    padding: 0;
+  }
+}
+
+/* --- Content-aware accordion header -------------------------------------- */
+
+.nhdr {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--Labels-Tertiary);
+}
+
+.nhdr-frag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.nhdr-sep {
+  color: var(--Labels-Tertiary);
+  opacity: 0.5;
+  margin: 0 2px;
+}
+
+/* --- Reasoning content card (in timeline) -------------------------------- */
+
+.titem-reasoning-card {
+  margin-top: 4px;
+  padding: 0;
+  background: transparent;
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--Labels-Secondary);
+}
+
+/* --- Responsive ---------------------------------------------------------- */
+
+@media (max-width: 600px) {
+  .timeline {
+    padding: 4px 0;
+  }
+  .titem {
+    grid-template-columns: 20px 1fr;
+    gap: 10px;
+    /* Icon column center = 10px → rule at left:9px (1px line, half-aligned). */
+    padding: 6px 6px 6px 0;
+  }
+  /* Mobile: re-anchor segmented rule to the 20px icon column.
+   * Row padding 6px + icon container 20px → icon center y=16, visual y=8..24.
+   * Same 5px breathing room above/below the icon. */
+  .titem::before,
+  .titem::after {
+    left: 9px;
+  }
+  .titem::before {
+    height: 4px;
+  }
+  .titem::after {
+    top: 29px;
+  }
+  .nhdr {
+    font-size: 11.5px;
+    flex-wrap: wrap;
+    row-gap: 4px;
+  }
+}

--- a/web/src/pages/ChatAgent/components/ActivityBlock.tsx
+++ b/web/src/pages/ChatAgent/components/ActivityBlock.tsx
@@ -332,12 +332,12 @@ const ActivityBlock = memo(function ActivityBlock({ items, preparingToolCall, is
                   transition={SPRING}
                   style={{ overflow: 'hidden' }}
                 >
-                  <ol
+                  <div
                     id={timelinePanelId}
-                    className="timeline mt-1"
                     role="region"
                     aria-labelledby={summaryButtonId}
                   >
+                  <ol className="timeline mt-1">
                     {completedItems.map((item, idx) => {
                       const itemId = item.id || item.toolCallId;
                       const isNew = newlyCompletedIds.has(itemId);
@@ -363,6 +363,7 @@ const ActivityBlock = memo(function ActivityBlock({ items, preparingToolCall, is
                       return <li key={itemKey} style={{ listStyle: 'none' }}>{content}</li>;
                     })}
                   </ol>
+                  </div>
                 </motion.div>
               )}
             </AnimatePresence>
@@ -545,12 +546,11 @@ const ToolCallLiveRow = memo(function ToolCallLiveRow({ tc, liveState }: ToolCal
   const args = tc.toolCall?.args;
   const IconComponent = getToolIcon(toolName, args);
   const isInProgress = liveState === 'active' && !tc.isComplete && !tc._recentlyCompleted;
-  const isFailed = liveState === 'failed';
-  const stateClass = isInProgress
-    ? 'state-active'
-    : isFailed
-      ? 'state-failed'
-      : 'state-completing';
+  // Only `state-active` has a CSS treatment (left-rule shimmer in
+  // ActivityBlock.css). Completing and failed states get their visual cue
+  // from the inline icon badges below; keeping unused class hooks would
+  // mislead the next CSS author.
+  const stateClass = isInProgress ? 'state-active' : '';
 
   const activeLabel = isInProgress ? getActiveLabel(toolName, tc.toolCall, t) : null;
   const completedTitle = !isInProgress ? getCompletedRowTitle(toolName, tc.toolCall, t) : null;
@@ -622,7 +622,7 @@ function PreparingToolCallRow({ tc }: PreparingToolCallRowProps): React.ReactEle
 
   return (
     <div
-      className="nrow state-prep flex items-center gap-2 pl-3 pr-3"
+      className="nrow flex items-center gap-2 pl-3 pr-3"
       style={{
         fontSize: '13px',
         color: 'var(--Labels-Secondary)',
@@ -872,7 +872,7 @@ const EditToolRow = memo(function EditToolRow({ item, onOpenFile }: EditToolRowP
               onClick={() => setExpanded(!expanded)}
               className="titem-trail bg-transparent border-0 p-0 cursor-pointer"
               style={{ color: 'inherit' }}
-              aria-label={expanded ? t('toolArtifact.a11y.collapseDiff', { defaultValue: 'Collapse diff' }) : t('toolArtifact.a11y.expandDiff', { defaultValue: 'Expand diff' })}
+              aria-label={expanded ? t('toolArtifact.a11y.collapseDiff') : t('toolArtifact.a11y.expandDiff')}
             >
               <motion.div
                 animate={{ rotate: expanded ? 90 : 0 }}

--- a/web/src/pages/ChatAgent/components/ActivityBlock.tsx
+++ b/web/src/pages/ChatAgent/components/ActivityBlock.tsx
@@ -32,7 +32,7 @@ import { useTranslation } from 'react-i18next';
 import './ActivityBlock.css';
 
 /** Tool names where clicking should open the file in the FilePanel */
-const FILE_NAV_TOOLS = new Set(['Read', 'Write', 'Save', 'read_file', 'write_file', 'save_file']);
+const FILE_NAV_TOOLS = new Set(['Read', 'Write']);
 
 function getFilePathFromArgs(args: Record<string, unknown> | undefined): string | null {
   if (!args) return null;
@@ -479,7 +479,7 @@ function renderCompletedItem(
   if (item.type === 'tool_call') {
     const toolName = item.toolName || '';
 
-    if (toolName === 'Edit' || toolName === 'edit_file') {
+    if (toolName === 'Edit') {
       return <EditToolRow item={item} onOpenFile={onOpenFile} />;
     }
 

--- a/web/src/pages/ChatAgent/components/ActivityBlock.tsx
+++ b/web/src/pages/ChatAgent/components/ActivityBlock.tsx
@@ -1,8 +1,17 @@
-import React, { useState, useRef, useMemo, memo } from 'react';
+import React, { useState, useRef, useMemo, useId, memo } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Brain, ChevronDown, Wrench } from 'lucide-react';
+import { Brain, ChevronDown, Wrench, X as XIcon } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
-import { getDisplayName, getToolIcon, getInProgressText, getPreparingText, getCompletedSummary } from './toolDisplayConfig';
+import {
+  getDisplayName,
+  getToolIcon,
+  getPreparingText,
+  getCompletedSummary,
+  getActiveLabel,
+  getCompletedRowTitle,
+  categorizeTool,
+  type ToolCategory,
+} from './toolDisplayConfig';
 import { TextShimmer } from '@/components/ui/text-shimmer';
 import { DotLoader } from '@/components/ui/dot-loader';
 import { useAnimatedText } from '@/components/ui/animated-text';
@@ -20,6 +29,7 @@ import {
 import { InlineAutomationCard } from './charts/InlineAutomationCards';
 import { InlinePreviewCard } from './charts/InlinePreviewCard';
 import { useTranslation } from 'react-i18next';
+import './ActivityBlock.css';
 
 /** Tool names where clicking should open the file in the FilePanel */
 const FILE_NAV_TOOLS = new Set(['Read', 'Write', 'Save', 'read_file', 'write_file', 'save_file']);
@@ -46,7 +56,7 @@ const INLINE_ARTIFACT_MAP: Record<string, React.ComponentType<{ artifact: Record
 const SPRING = { type: 'spring' as const, stiffness: 150, damping: 17 };
 const SPRING_SNAPPY = { type: 'spring' as const, stiffness: 200, damping: 22 };
 
-type LiveState = 'active' | 'completing' | 'completed';
+type LiveState = 'active' | 'completing' | 'completed' | 'failed';
 
 interface ToolCallData {
   args?: Record<string, unknown>;
@@ -67,6 +77,9 @@ interface ActivityItem {
   toolCall?: ToolCallData;
   toolCallResult?: ToolCallResultData;
   isComplete?: boolean;
+  /** Set in MessageList from `proc.isFailed`. Persists across the live→completed
+   *  transition so the accordion timeline can render a failure indicator. */
+  isFailed?: boolean;
   _recentlyCompleted?: boolean;
   _liveState?: LiveState;
   content?: string;
@@ -91,17 +104,20 @@ interface ActivityBlockProps {
 /**
  * ActivityBlock -- unified component for completed + live activity items.
  *
- * Replaces the old ActivityAccordion + LiveActivity two-component architecture.
  * Items move from the live zone to the accordion zone in the same React render,
- * eliminating the visible gap caused by fade-out/reappear across render cycles.
- *
- * Uses framer-motion spring animations for smooth accordion expand/collapse,
- * item entrance/exit, and chevron rotation.
+ * eliminating the visible gap that separate components caused between
+ * fade-out and reappear across render cycles.
  */
 const ActivityBlock = memo(function ActivityBlock({ items, preparingToolCall, isStreaming, onToolCallClick, onOpenFile }: ActivityBlockProps): React.ReactElement | null {
   const { t } = useTranslation();
   const [isExpanded, setIsExpanded] = useState(false);
   const prevCompletedIdsRef = useRef<Set<string | undefined>>(new Set());
+  // Stable per-instance id pair for the toggle button + the timeline panel it
+  // controls — assistive tech needs both `aria-expanded`/`aria-controls` and
+  // a labelled region to announce the accordion correctly.
+  const reactId = useId();
+  const summaryButtonId = `activity-summary-${reactId}`;
+  const timelinePanelId = `activity-timeline-${reactId}`;
 
   // Memoize partition of items into zones
   const { completedItems, liveItems, inlineChartItems } = useMemo(() => {
@@ -139,6 +155,61 @@ const ActivityBlock = memo(function ActivityBlock({ items, preparingToolCall, is
   }
   prevCompletedIdsRef.current = currentCompletedIds;
 
+  // Content-aware accordion header \u2014 group completed items by category and
+  // emit `<count> <label>` fragments. Computed BEFORE any early-return so
+  // hook order stays stable.
+  //
+  // Fingerprint includes the file_path arg AND `isFailed` per item so the
+  // breakdown re-walks when an item's args arrive late (a common SSE pattern:
+  // row created with empty args, file_path patched in a later chunk) or when
+  // a failure flag flips after the initial completed render. The earlier
+  // `[length, lastId]` key silently froze the category counts in both cases.
+  const summaryFingerprint = completedItems
+    .map((i) => {
+      const args = i.toolCall?.args as Record<string, unknown> | undefined;
+      const fp = (args?.file_path || args?.filePath || '') as string;
+      const failed = i.isFailed ? '1' : '0';
+      return `${i.id || i.toolCallId || ''}:${i.type}:${i.toolName || ''}:${fp}:${failed}`;
+    })
+    .join('|');
+  // Slot = what we emit in the header. `memory` collapses read+write into one
+  // fragment whose verb flips on any write (its store is conceptually one
+  // surface). `fileRead`/`fileEdit` and `memo`/`memoWrite` stay separate —
+  // distinct file/memo paths shouldn't collide under one label, and any
+  // memo modification is surfaced distinctly so a future regression letting
+  // the agent mutate a memo is visible. `failed` is orthogonal to the
+  // category axis but is its own fragment so the user sees that the
+  // accordion contains failures even before expanding (otherwise a failed
+  // read counts identically to a successful one once `_liveState` flips to
+  // 'completed').
+  type SummarySlot = 'skill' | 'memory' | 'memo' | 'memoWrite' | 'code' | 'web' | 'search' | 'fileRead' | 'fileEdit' | 'reasoning' | 'generic' | 'failed';
+  const summaryFragments = useMemo<{ slot: SummarySlot; count: number; modified?: boolean }[]>(() => {
+    const counts = new Map<ToolCategory | 'reasoning', number>();
+    let failedCount = 0;
+    for (const item of completedItems) {
+      const key: ToolCategory | 'reasoning' = item.type === 'reasoning'
+        ? 'reasoning'
+        : categorizeTool(item.toolName || '', item.toolCall);
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+      if (item.isFailed) failedCount += 1;
+    }
+    const memReads = counts.get('memoryRead') ?? 0;
+    const memWrites = counts.get('memoryWrite') ?? 0;
+    const memTotal = memReads + memWrites;
+    const order: SummarySlot[] = ['skill', 'memory', 'memo', 'memoWrite', 'code', 'web', 'search', 'fileRead', 'fileEdit', 'reasoning', 'generic'];
+    const out: { slot: SummarySlot; count: number; modified?: boolean }[] = [];
+    for (const slot of order) {
+      if (slot === 'memory') {
+        if (memTotal > 0) out.push({ slot, count: memTotal, modified: memWrites > 0 });
+      } else if (counts.has(slot as ToolCategory | 'reasoning')) {
+        out.push({ slot, count: counts.get(slot as ToolCategory | 'reasoning')! });
+      }
+    }
+    if (failedCount > 0) out.push({ slot: 'failed', count: failedCount });
+    return out;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [summaryFingerprint]);
+
   const hasInlineCharts = inlineChartItems.length > 0;
   const hasCompleted = completedItems.length > 0;
   const hasLive = liveItems.length > 0;
@@ -146,17 +217,52 @@ const ActivityBlock = memo(function ActivityBlock({ items, preparingToolCall, is
 
   if (!hasInlineCharts && !hasCompleted && !hasLive && !hasPreparingTools) return null;
 
-  // Build accordion summary label
-  const reasoningCount = completedItems.filter(i => i.type === 'reasoning').length;
-  const toolCallCount = completedItems.filter(i => i.type === 'tool_call').length;
   let summaryLabel: string | undefined;
-  if (reasoningCount > 0 && toolCallCount > 0) {
-    const parts: string[] = [];
-    if (reasoningCount > 0) parts.push(t('toolArtifact.nReasoning', { count: reasoningCount }));
-    if (toolCallCount > 0) parts.push(t('toolArtifact.nToolCalls', { count: toolCallCount }));
-    summaryLabel = parts.join(' \u00b7 ');
+  if (summaryFragments.length > 0 && summaryFragments.some((f) => f.slot !== 'reasoning' && f.slot !== 'generic')) {
+    // When folded, cap the breakdown at 3 fragments + "…" so the header stays
+    // scannable on turns with many tool categories. Expanding the accordion
+    // reveals the full breakdown alongside the per-step rows.
+    // High-signal fragments (memory writes, memo writes, failures) get
+    // priority: they're information the user specifically needs to see and
+    // shouldn't drop into the "and more …" tail when 4+ categories are
+    // present. We hoist them to the front of the visible slice while
+    // preserving the relative order of everything else.
+    const FOLDED_MAX = 3;
+    const isPriority = (f: { slot: SummarySlot; modified?: boolean }) =>
+      f.slot === 'failed' || f.slot === 'memoWrite' || (f.slot === 'memory' && f.modified === true);
+    const priority = summaryFragments.filter(isPriority);
+    const rest = summaryFragments.filter((f) => !isPriority(f));
+    const ordered = [...priority, ...rest];
+    const overflowing = !isExpanded && ordered.length > FOLDED_MAX;
+    const visible = overflowing ? ordered.slice(0, FOLDED_MAX) : ordered;
+    const labels = visible
+      .map((f) => {
+        if (f.slot === 'reasoning') return t('toolArtifact.nReasoning', { count: f.count });
+        if (f.slot === 'skill') return t('toolArtifact.categoryCount.skill', { count: f.count });
+        if (f.slot === 'memory') {
+          // No count for memory — any write/edit overrules pure-read framing.
+          return t(f.modified ? 'toolArtifact.categoryCount.memoryUpdated' : 'toolArtifact.categoryCount.memoryRead');
+        }
+        if (f.slot === 'fileRead') return t('toolArtifact.categoryCount.fileRead', { count: f.count });
+        if (f.slot === 'fileEdit') return t('toolArtifact.categoryCount.fileEdit', { count: f.count });
+        if (f.slot === 'memo') return t('toolArtifact.categoryCount.memo', { count: f.count });
+        if (f.slot === 'memoWrite') return t('toolArtifact.categoryCount.memoWrite', { count: f.count });
+        if (f.slot === 'code') return t('toolArtifact.categoryCount.code', { count: f.count });
+        if (f.slot === 'web') return t('toolArtifact.categoryCount.web', { count: f.count });
+        if (f.slot === 'search') return t('toolArtifact.categoryCount.search', { count: f.count });
+        if (f.slot === 'failed') return t('toolArtifact.categoryCount.failed', { count: f.count });
+        return t('toolArtifact.categoryCount.generic', { count: f.count });
+      });
+    summaryLabel = labels.join(' \u00b7 ');
+    if (overflowing) summaryLabel = `${summaryLabel} ${t('toolArtifact.andMore')}`;
   } else if (completedItems.length > 0) {
     summaryLabel = t('toolArtifact.nStepsCompleted', { count: completedItems.length });
+  }
+  // Capitalize first character only \u2014 leave the rest untouched so embedded
+  // proper nouns / casing stay intact. Applies to both the fragment-based label
+  // and the fallback "completed N steps" label.
+  if (summaryLabel && summaryLabel.length > 0) {
+    summaryLabel = summaryLabel.charAt(0).toUpperCase() + summaryLabel.slice(1);
   }
 
   return (
@@ -192,22 +298,28 @@ const ActivityBlock = memo(function ActivityBlock({ items, preparingToolCall, is
             style={{ overflow: 'hidden' }}
           >
             <button
+              id={summaryButtonId}
+              type="button"
+              aria-expanded={isExpanded}
+              aria-controls={timelinePanelId}
               onClick={() => setIsExpanded(!isExpanded)}
-              className="flex items-center gap-2 transition-colors hover:bg-foreground/5 w-full rounded-md"
+              className="inline-flex items-center gap-2 text-left bg-transparent border-0 p-0 cursor-pointer transition-colors hover:text-foreground"
               style={{
-                padding: '5px 10px',
+                paddingTop: '5px',
+                paddingBottom: '5px',
                 fontSize: '13px',
                 color: 'var(--Labels-Tertiary)',
               }}
             >
+              <span className="truncate">{summaryLabel}</span>
               <motion.div
                 animate={{ rotate: isExpanded ? 90 : 0 }}
                 transition={SPRING}
                 className="flex-shrink-0"
+                style={{ opacity: 0.6 }}
               >
                 <ChevronDown className="h-3.5 w-3.5 -rotate-90" />
               </motion.div>
-              <span>{summaryLabel}</span>
             </button>
 
             <AnimatePresence initial={false}>
@@ -220,12 +332,11 @@ const ActivityBlock = memo(function ActivityBlock({ items, preparingToolCall, is
                   transition={SPRING}
                   style={{ overflow: 'hidden' }}
                 >
-                  <div
-                    className="mt-1 ml-2 space-y-0.5 rounded-md"
-                    style={{
-                      borderLeft: '2px solid var(--color-border-muted)',
-                      padding: '4px 0',
-                    }}
+                  <ol
+                    id={timelinePanelId}
+                    className="timeline mt-1"
+                    role="region"
+                    aria-labelledby={summaryButtonId}
                   >
                     {completedItems.map((item, idx) => {
                       const itemId = item.id || item.toolCallId;
@@ -237,21 +348,21 @@ const ActivityBlock = memo(function ActivityBlock({ items, preparingToolCall, is
 
                       if (isNew) {
                         return (
-                          <motion.div
+                          <motion.li
                             key={itemKey}
                             initial={{ opacity: 0, height: 0 }}
                             animate={{ opacity: 1, height: 'auto' }}
                             transition={SPRING_SNAPPY}
-                            style={{ overflow: 'hidden' }}
+                            style={{ overflow: 'hidden', listStyle: 'none' }}
                           >
                             {content}
-                          </motion.div>
+                          </motion.li>
                         );
                       }
 
-                      return <div key={itemKey}>{content}</div>;
+                      return <li key={itemKey} style={{ listStyle: 'none' }}>{content}</li>;
                     })}
-                  </div>
+                  </ol>
                 </motion.div>
               )}
             </AnimatePresence>
@@ -275,6 +386,9 @@ const ActivityBlock = memo(function ActivityBlock({ items, preparingToolCall, is
             <AnimatePresence initial={false}>
               {liveItems.map(item => {
                 if (item.type === 'reasoning') {
+                  const { title: extractedTitle, body: extractedBody } = extractLeadingBoldHeader(item.content || '');
+                  const effectiveTitle = item.reasoningTitle || extractedTitle;
+                  const liveBody = extractedTitle ? extractedBody : item.content;
                   return (
                     <motion.div
                       key={`live-r-${item.id}`}
@@ -296,18 +410,16 @@ const ActivityBlock = memo(function ActivityBlock({ items, preparingToolCall, is
                             className="font-medium truncate text-[13px] [--base-color:var(--Labels-Secondary)] [--base-gradient-color:var(--color-text-primary)]"
                             duration={1.5}
                           >
-                            {item.reasoningTitle
-                              ? t('toolArtifact.reasoningLabel', { title: item.reasoningTitle })
-                              : t('toolArtifact.reasoningPending')}
+                            {effectiveTitle || t('toolArtifact.reasoningPending')}
                           </TextShimmer>
                         ) : (
-                          <span className="font-medium truncate">{t('toolArtifact.reasoningComplete')}</span>
+                          <span className="font-medium truncate">{effectiveTitle || t('toolArtifact.reasoningComplete')}</span>
                         )}
                       </div>
 
-                      {item.content && (
+                      {liveBody && (
                         <AnimatedReasoningContent
-                          content={item.content}
+                          content={liveBody}
                           isStreaming={item._liveState === 'active'}
                         />
                       )}
@@ -354,7 +466,6 @@ const ActivityBlock = memo(function ActivityBlock({ items, preparingToolCall, is
   );
 });
 
-/** Renders a single completed item (reasoning or tool_call) for the accordion body */
 function renderCompletedItem(
   item: ActivityItem,
   idx: number,
@@ -402,7 +513,6 @@ interface AnimatedReasoningContentProps {
   isStreaming: boolean;
 }
 
-/** Animated reasoning content -- smoothly reveals text during streaming */
 function AnimatedReasoningContent({ content, isStreaming }: AnimatedReasoningContentProps): React.ReactElement {
   const displayText = useAnimatedText(content || '', { enabled: isStreaming });
   return (
@@ -420,46 +530,58 @@ interface ToolCallLiveRowProps {
   liveState?: LiveState;
 }
 
-/** Live tool call row -- shows active or completing state */
+/** Live tool call row -- monochrome state visuals.
+ *
+ * Active state:    2px left rule (.nrow.state-active::before) + label shimmer
+ *                  + gentle icon pulse.
+ * Completing state: no badge — row dims via opacity 0.7 and the title flips
+ *                  to past tense. (We deliberately dropped the green ✓ to
+ *                  avoid the SaaS-default badge look.)
+ * Failed state:    gray ✕ badge overlaid on the tool icon + past-tense title.
+ */
 const ToolCallLiveRow = memo(function ToolCallLiveRow({ tc, liveState }: ToolCallLiveRowProps): React.ReactElement {
   const { t } = useTranslation();
   const toolName = tc.toolName || '';
-  const displayName = getDisplayName(toolName, t);
-  const IconComponent = getToolIcon(toolName);
+  const args = tc.toolCall?.args;
+  const IconComponent = getToolIcon(toolName, args);
   const isInProgress = liveState === 'active' && !tc.isComplete && !tc._recentlyCompleted;
-  const progressText = isInProgress ? getInProgressText(toolName, tc.toolCall, t) : null;
+  const isFailed = liveState === 'failed';
+  const stateClass = isInProgress
+    ? 'state-active'
+    : isFailed
+      ? 'state-failed'
+      : 'state-completing';
+
+  const activeLabel = isInProgress ? getActiveLabel(toolName, tc.toolCall, t) : null;
+  const completedTitle = !isInProgress ? getCompletedRowTitle(toolName, tc.toolCall, t) : null;
+  const summary = !isInProgress ? getCompletedSummary(toolName, tc.toolCall, t) : null;
 
   return (
     <motion.div
-      className="flex items-center gap-2 px-3 rounded-md"
-      animate={{
-        backgroundColor: isInProgress ? 'var(--color-accent-soft)' : 'var(--color-border-muted)',
-        opacity: isInProgress ? 1 : 0.6,
-      }}
+      className={`nrow ${stateClass} flex items-center gap-2 pl-3 pr-3 py-1.5`}
+      animate={{ opacity: isInProgress ? 1 : 0.7 }}
       transition={{ duration: 0.3, ease: 'easeOut' }}
-      style={{
-        border: '1px solid var(--color-border-muted)',
-        fontSize: '13px',
-        color: 'var(--Labels-Secondary)',
-        paddingTop: '6px',
-        paddingBottom: '6px',
-      }}
+      style={{ fontSize: '13px', color: 'var(--Labels-Secondary)' }}
     >
-      <div className="relative flex-shrink-0">
-        <IconComponent className="h-4 w-4" />
+      <div className="relative flex-shrink-0 flex items-center justify-center h-5 w-5">
+        <motion.span
+          animate={isInProgress ? { opacity: [0.7, 1, 0.7] } : { opacity: 1 }}
+          transition={isInProgress ? { duration: 1.4, repeat: Infinity, ease: 'easeInOut' } : { duration: 0.2 }}
+          style={{ display: 'inline-flex' }}
+        >
+          <IconComponent className="h-4 w-4" />
+        </motion.span>
         <AnimatePresence>
-          {!isInProgress && (
+          {liveState === 'failed' && (
             <motion.span
+              key="fail"
+              className="nrow-badge"
               initial={{ scale: 0, opacity: 0 }}
               animate={{ scale: 1, opacity: 1 }}
               transition={SPRING_SNAPPY}
-              className="h-3 w-3 absolute -top-0.5 -right-0.5 flex items-center justify-center"
-              style={{ color: 'var(--color-profit-muted)' }}
+              aria-label={t('toolArtifact.a11y.toolCallFailed')}
             >
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-3 w-3">
-                <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
-                <polyline points="22 4 12 14.01 9 11.01" />
-              </svg>
+              <XIcon className="h-3 w-3" />
             </motion.span>
           )}
         </AnimatePresence>
@@ -467,20 +589,17 @@ const ToolCallLiveRow = memo(function ToolCallLiveRow({ tc, liveState }: ToolCal
       {isInProgress ? (
         <TextShimmer
           as="span"
-          className="font-medium text-[13px] [--base-color:var(--Labels-Secondary)] [--base-gradient-color:var(--color-text-primary)]"
+          className="font-medium text-[13px] [--base-color:var(--Labels-Secondary)] [--base-gradient-color:var(--color-text-primary)] truncate"
           duration={1.5}
         >
-          {`${displayName} ${progressText || ''}`}
+          {activeLabel || ''}
         </TextShimmer>
       ) : (
         <>
-          <span className="font-medium flex-shrink-0 whitespace-nowrap">{displayName}</span>
-          {(() => {
-            const summary = getCompletedSummary(toolName, tc.toolCall);
-            return summary
-              ? <span className="truncate min-w-0" style={{ opacity: 0.55 }}>&mdash; {summary}</span>
-              : <span style={{ opacity: 0.55 }}>{t('toolArtifact.done')}</span>;
-          })()}
+          <span className="font-medium flex-shrink-0 whitespace-nowrap">{completedTitle}</span>
+          {summary
+            ? <span className="truncate min-w-0" style={{ opacity: 0.55 }}>&mdash; {summary}</span>
+            : <span style={{ opacity: 0.55 }}>{t('toolArtifact.done')}</span>}
         </>
       )}
     </motion.div>
@@ -491,7 +610,9 @@ interface PreparingToolCallRowProps {
   tc: PreparingToolCallData;
 }
 
-/** Preparing row -- shown while tool_call_chunks are still streaming */
+/** Preparing row -- shown while tool_call_chunks are still streaming.
+ *  No left rule; just DotLoader + icon + label. Args aren't yet available
+ *  to classify, so we fall back to the generic display name. */
 function PreparingToolCallRow({ tc }: PreparingToolCallRowProps): React.ReactElement {
   const { t } = useTranslation();
   const toolName = tc.toolName || '';
@@ -501,7 +622,7 @@ function PreparingToolCallRow({ tc }: PreparingToolCallRowProps): React.ReactEle
 
   return (
     <div
-      className="flex items-center gap-2 px-3"
+      className="nrow state-prep flex items-center gap-2 pl-3 pr-3"
       style={{
         fontSize: '13px',
         color: 'var(--Labels-Secondary)',
@@ -513,7 +634,9 @@ function PreparingToolCallRow({ tc }: PreparingToolCallRowProps): React.ReactEle
         className="flex-shrink-0 gap-px"
         dotClassName="bg-foreground/15 [&.active]:bg-foreground size-[1.5px]"
       />
-      <IconComponent className="h-4 w-4 flex-shrink-0" />
+      <span className="flex-shrink-0 flex items-center justify-center h-5 w-5">
+        <IconComponent className="h-4 w-4" />
+      </span>
       <span className="font-medium">{displayName}</span>
       <span style={{ opacity: 0.55 }}>{prepText}</span>
     </div>
@@ -526,50 +649,91 @@ interface ReasoningRowProps {
   item: ActivityItem;
 }
 
+/** Extract a leading `**subtitle**` line from reasoning content so we can
+ * promote it into the row title and strip it from the body.
+ *
+ * Conservative on purpose — leaves content alone unless we see the o1-style
+ * "header line, blank line, body" pattern:
+ *   - bold appears at the very start (after optional whitespace)
+ *   - bold spans a single line, no inner newlines or asterisks
+ *   - bold is short enough to read as a heading (≤ 80 chars after trim)
+ *   - bold is followed by ≥ 1 newline AND a non-empty body
+ *
+ * If any check fails, returns { title: null, body: original } and the row
+ * keeps the generic "Reasoning" label. */
+// Exported for unit testing alongside the components below; the only export
+// in this file other than the default `ActivityBlock`. The HMR fast-refresh
+// rule complains about mixed exports, but extracting this 8-line pure helper
+// to its own module is more churn than it's worth.
+// eslint-disable-next-line react-refresh/only-export-components
+export function extractLeadingBoldHeader(content: string): { title: string | null; body: string } {
+  if (!content) return { title: null, body: content };
+  const match = content.match(/^\s*\*\*([^*\n]+?)\*\*\s*\n+([\s\S]+)$/);
+  if (!match) return { title: null, body: content };
+  const candidate = match[1].trim();
+  const body = match[2];
+  if (!candidate || candidate.length > 80 || !body.trim()) {
+    return { title: null, body: content };
+  }
+  return { title: candidate, body };
+}
+
 const ReasoningRow = memo(function ReasoningRow({ item }: ReasoningRowProps): React.ReactElement {
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(true);
-  const title = item.reasoningTitle ? t('toolArtifact.reasoningLabel', { title: item.reasoningTitle }) : t('toolArtifact.reasoning');
-  const hasContent = !!item.content;
+  const { title: extractedTitle, body: extractedBody } = useMemo(
+    () => extractLeadingBoldHeader(item.content || ''),
+    [item.content],
+  );
+  const effectiveTitle = item.reasoningTitle || extractedTitle;
+  const title = effectiveTitle || t('toolArtifact.reasoning');
+  const displayContent = extractedTitle ? extractedBody : item.content;
+  const hasContent = !!displayContent;
 
   return (
-    <div>
-      <button
-        onClick={() => hasContent && setExpanded(!expanded)}
-        className={`flex items-center gap-2 px-3 py-1 w-full text-left rounded ${hasContent ? 'transition-colors hover:bg-foreground/5 cursor-pointer' : ''}`}
-        style={{ fontSize: '13px', color: 'var(--Labels-Tertiary)' }}
-      >
-        <Brain className="h-3.5 w-3.5 flex-shrink-0" style={{ opacity: 0.7 }} />
-        <span className="truncate">{title}</span>
-        {hasContent && (
-          <motion.div
-            animate={{ rotate: expanded ? 180 : 0 }}
-            transition={SPRING}
-            className="ml-auto flex-shrink-0"
-          >
-            <ChevronDown className="h-3 w-3" style={{ opacity: 0.5 }} />
-          </motion.div>
-        )}
-      </button>
-      <AnimatePresence initial={false}>
-        {expanded && item.content && (
-          <motion.div
-            key="reasoning-content"
-            initial={{ height: 0, opacity: 0 }}
-            animate={{ height: 'auto', opacity: 1 }}
-            exit={{ height: 0, opacity: 0 }}
-            transition={SPRING}
-            style={{ overflow: 'hidden' }}
-          >
-            <Markdown
-              variant="compact"
-              content={item.content}
-              className="ml-3 pl-3 pr-2 py-1 text-xs"
-              style={{ borderLeft: '2px solid var(--color-accent-overlay)' }}
-            />
-          </motion.div>
-        )}
-      </AnimatePresence>
+    <div className="titem">
+      <div className="titem-icon">
+        <Brain className="h-4 w-4" />
+      </div>
+      <div className="titem-body">
+        <button
+          type="button"
+          onClick={() => hasContent && setExpanded(!expanded)}
+          className={`titem-line text-left bg-transparent border-0 p-0 ${hasContent ? 'cursor-pointer' : 'cursor-default'}`}
+          style={{ color: 'inherit' }}
+        >
+          <span className="titem-title truncate">{title}</span>
+          {hasContent && (
+            <motion.div
+              animate={{ rotate: expanded ? 90 : 0 }}
+              transition={SPRING}
+              className="flex-shrink-0 inline-flex items-center"
+              style={{ opacity: 0.6, alignSelf: 'center' }}
+            >
+              <ChevronDown className="h-3 w-3 -rotate-90" />
+            </motion.div>
+          )}
+        </button>
+        <AnimatePresence initial={false}>
+          {expanded && displayContent && (
+            <motion.div
+              key="reasoning-content"
+              initial={{ height: 0, opacity: 0 }}
+              animate={{ height: 'auto', opacity: 1 }}
+              exit={{ height: 0, opacity: 0 }}
+              transition={SPRING}
+              style={{ overflow: 'hidden' }}
+            >
+              <div className="titem-reasoning-card">
+                <Markdown
+                  variant="compact"
+                  content={displayContent}
+                />
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
     </div>
   );
 });
@@ -579,30 +743,74 @@ interface ToolCallRowProps {
   onClick?: () => void;
 }
 
+/** Gray ✕ overlay marking a completed-but-failed tool call in the accordion
+ * timeline. Reuses `.nrow-badge` from the live zone for visual parity. */
+function FailedIconBadge({ label }: { label: string }): React.ReactElement {
+  return (
+    <span className="nrow-badge" aria-label={label}>
+      <XIcon className="h-3 w-3" />
+    </span>
+  );
+}
+
 const ToolCallRow = memo(function ToolCallRow({ item, onClick }: ToolCallRowProps): React.ReactElement {
   const { t } = useTranslation();
   const toolName = item.toolName || '';
-  const displayName = getDisplayName(toolName, t);
-  const IconComponent = getToolIcon(toolName);
+  const args = item.toolCall?.args;
+  const title = getCompletedRowTitle(toolName, item.toolCall, t);
+  const IconComponent = getToolIcon(toolName, args);
+  const summary = getCompletedSummary(toolName, item.toolCall, t);
+  const isFailed = item.isFailed === true;
+  const failedLabel = t('toolArtifact.a11y.toolCallFailed');
 
-  const summary = getCompletedSummary(toolName, item.toolCall) || '';
+  // Decide the destination tab label for the pill tooltip.
+  const cat = categorizeTool(toolName, item.toolCall);
+  const isMemory = cat === 'memoryRead' || cat === 'memoryWrite';
+  const tabLabel = isMemory
+    ? t('rightPanel.tabs.memory')
+    : cat === 'memo' || cat === 'memoWrite'
+      ? t('rightPanel.tabs.memo')
+      : t('rightPanel.tabs.files');
+
+  // No pill → the row title becomes the click target so the affordance isn't
+  // lost (e.g., memory/memo index rows where the verb already names the file).
+  const titleNode = summary ? (
+    <span className="titem-title">{title}</span>
+  ) : (
+    <button
+      type="button"
+      onClick={onClick}
+      className="titem-title titem-title-button"
+      title={t('toolArtifact.a11y.openInTab', { tab: tabLabel })}
+    >
+      {title}
+    </button>
+  );
 
   return (
-    <button
-      onClick={onClick}
-      className="flex items-center gap-2 px-3 py-1 w-full text-left transition-colors hover:bg-foreground/5 rounded"
-      style={{ fontSize: '13px', color: 'var(--Labels-Tertiary)' }}
-    >
-      <IconComponent className="h-3.5 w-3.5 flex-shrink-0" style={{ opacity: 0.7 }} />
-      <span className="font-medium flex-shrink-0 whitespace-nowrap" style={{ color: 'var(--Labels-Secondary)' }}>
-        {displayName}
-      </span>
-      {summary && (
-        <span className="truncate min-w-0" style={{ opacity: 0.6 }}>
-          &mdash; {summary}
-        </span>
-      )}
-    </button>
+    <div className={`titem${isFailed ? ' failed' : ''}`}>
+      <div className="titem-icon" title={isFailed ? failedLabel : undefined}>
+        <IconComponent className="h-4 w-4" style={{ color: 'var(--Labels-Secondary)' }} />
+        {isFailed && <FailedIconBadge label={failedLabel} />}
+      </div>
+      <div className="titem-body">
+        <div className="titem-line">
+          {titleNode}
+          {summary && (
+            <span className="titem-pill-wrap">
+              <button
+                type="button"
+                onClick={onClick}
+                className="obj"
+                title={t('toolArtifact.a11y.openInTab', { tab: tabLabel })}
+              >
+                {summary}
+              </button>
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
   );
 });
 
@@ -614,96 +822,114 @@ interface EditToolRowProps {
 const EditToolRow = memo(function EditToolRow({ item, onOpenFile }: EditToolRowProps): React.ReactElement {
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(false);
-  const displayName = getDisplayName(item.toolName || 'Edit', t);
-  const IconComponent = getToolIcon(item.toolName || 'Edit');
-
   const args = (item.toolCall?.args || {}) as Record<string, unknown>;
+  const title = getCompletedRowTitle(item.toolName || 'Edit', item.toolCall, t);
+  const IconComponent = getToolIcon(item.toolName || 'Edit', args);
+  const isFailed = item.isFailed === true;
+  const failedLabel = t('toolArtifact.a11y.toolCallFailed');
+
   const filePath = getFilePathFromArgs(args);
   const fileName = filePath ? filePath.split('/').pop() : '';
   const oldStr = (args.old_string || args.oldString || '') as string;
   const newStr = (args.new_string || args.newString || '') as string;
   const hasDiff = !!(oldStr || newStr);
+  const summary = getCompletedSummary(item.toolName || 'Edit', item.toolCall, t) || fileName;
+
+  // Match the destination tab label to the actual classification of the
+  // path so the tooltip doesn't lie when the click routes to Memory.
+  const editCat = categorizeTool(item.toolName || 'Edit', item.toolCall);
+  const editTabLabel =
+    editCat === 'memoryWrite' || editCat === 'memoryRead'
+      ? t('rightPanel.tabs.memory')
+      : editCat === 'memo' || editCat === 'memoWrite'
+        ? t('rightPanel.tabs.memo')
+        : t('rightPanel.tabs.files');
 
   return (
-    <div>
-      <div
-        className="flex items-center gap-2 px-3 py-1 w-full text-left rounded"
-        style={{ fontSize: '13px', color: 'var(--Labels-Tertiary)' }}
-      >
-        <IconComponent className="h-3.5 w-3.5 flex-shrink-0" style={{ opacity: 0.7 }} />
-        <span className="font-medium" style={{ color: 'var(--Labels-Secondary)' }}>
-          {displayName}
-        </span>
-        {fileName && (
-          <button
-            onClick={() => filePath && onOpenFile?.(filePath)}
-            className="truncate transition-colors hover:underline"
-            style={{ opacity: 0.6, color: 'var(--color-accent-primary)', background: 'none', border: 'none', cursor: 'pointer', padding: 0, fontSize: 'inherit' }}
-          >
-            &mdash; {fileName}
-          </button>
-        )}
-        {hasDiff && (
-          <button
-            onClick={() => setExpanded(!expanded)}
-            className="ml-auto flex-shrink-0"
-            style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 0, color: 'inherit' }}
-          >
-            <motion.div
-              animate={{ rotate: expanded ? 180 : 0 }}
-              transition={SPRING}
-            >
-              <ChevronDown className="h-3 w-3" style={{ opacity: 0.5 }} />
-            </motion.div>
-          </button>
-        )}
+    <div className={`titem${isFailed ? ' failed' : ''}`}>
+      <div className="titem-icon" title={isFailed ? failedLabel : undefined}>
+        <IconComponent className="h-4 w-4" />
+        {isFailed && <FailedIconBadge label={failedLabel} />}
       </div>
+      <div className="titem-body">
+        <div className="titem-line">
+          <span className="titem-title">{title}</span>
+          {summary && (
+            <span className="titem-pill-wrap">
+              <button
+                type="button"
+                onClick={() => filePath && onOpenFile?.(filePath)}
+                className="obj"
+                title={t('toolArtifact.a11y.openInTab', { tab: editTabLabel })}
+              >
+                {summary}
+              </button>
+            </span>
+          )}
+          {hasDiff && (
+            <button
+              type="button"
+              onClick={() => setExpanded(!expanded)}
+              className="titem-trail bg-transparent border-0 p-0 cursor-pointer"
+              style={{ color: 'inherit' }}
+              aria-label={expanded ? t('toolArtifact.a11y.collapseDiff', { defaultValue: 'Collapse diff' }) : t('toolArtifact.a11y.expandDiff', { defaultValue: 'Expand diff' })}
+            >
+              <motion.div
+                animate={{ rotate: expanded ? 90 : 0 }}
+                transition={SPRING}
+              >
+                <ChevronDown className="h-3 w-3 -rotate-90" style={{ opacity: 0.5 }} />
+              </motion.div>
+            </button>
+          )}
+        </div>
 
-      <AnimatePresence initial={false}>
-        {expanded && hasDiff && (
-          <motion.div
-            key="diff-content"
-            initial={{ height: 0, opacity: 0 }}
-            animate={{ height: 'auto', opacity: 1 }}
-            exit={{ height: 0, opacity: 0 }}
-            transition={SPRING}
-            style={{ overflow: 'hidden' }}
-          >
-            <div className="ml-6 mr-2 mt-1 mb-1 rounded overflow-hidden" style={{ fontSize: '12px', border: '1px solid var(--color-border-muted)' }}>
-              {oldStr && (
-                <div style={{ backgroundColor: 'var(--color-loss-soft)' }}>
-                  {oldStr.split('\n').map((line, i) => (
-                    <div key={`old-${i}`} className="flex" style={{ minHeight: '20px' }}>
-                      <span
-                        className="flex-shrink-0 select-none text-right px-2"
-                        style={{ color: 'var(--color-loss-muted)', width: '20px', userSelect: 'none' }}
-                      >&minus;</span>
-                      <pre className="flex-1 font-mono whitespace-pre-wrap break-all m-0 pr-2" style={{ color: 'var(--color-loss)' }}>
-                        {line}
-                      </pre>
-                    </div>
-                  ))}
-                </div>
-              )}
-              {newStr && (
-                <div style={{ backgroundColor: 'var(--color-profit-soft)' }}>
-                  {newStr.split('\n').map((line, i) => (
-                    <div key={`new-${i}`} className="flex" style={{ minHeight: '20px' }}>
-                      <span
-                        className="flex-shrink-0 select-none text-right px-2"
-                        style={{ color: 'var(--color-profit-muted)', width: '20px', userSelect: 'none' }}
-                      >+</span>
-                      <pre className="flex-1 font-mono whitespace-pre-wrap break-all m-0 pr-2" style={{ color: 'var(--color-profit)' }}>
-                        {line}
-                      </pre>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-          </motion.div>
-        )}
-      </AnimatePresence>
+        <AnimatePresence initial={false}>
+          {expanded && hasDiff && (
+            <motion.div
+              key="diff-content"
+              initial={{ height: 0, opacity: 0 }}
+              animate={{ height: 'auto', opacity: 1 }}
+              exit={{ height: 0, opacity: 0 }}
+              transition={SPRING}
+              style={{ overflow: 'hidden' }}
+            >
+              <div className="mt-2 rounded overflow-hidden" style={{ fontSize: '12px', border: '1px solid var(--color-border-muted)' }}>
+                {oldStr && (
+                  <div style={{ backgroundColor: 'var(--color-loss-soft)' }}>
+                    {oldStr.split('\n').map((line, i) => (
+                      <div key={`old-${i}`} className="flex" style={{ minHeight: '20px' }}>
+                        <span
+                          className="flex-shrink-0 select-none text-right px-2"
+                          style={{ color: 'var(--color-loss-muted)', width: '20px', userSelect: 'none' }}
+                        >&minus;</span>
+                        <pre className="flex-1 font-mono whitespace-pre-wrap break-all m-0 pr-2" style={{ color: 'var(--color-loss)' }}>
+                          {line}
+                        </pre>
+                      </div>
+                    ))}
+                  </div>
+                )}
+                {newStr && (
+                  <div style={{ backgroundColor: 'var(--color-profit-soft)' }}>
+                    {newStr.split('\n').map((line, i) => (
+                      <div key={`new-${i}`} className="flex" style={{ minHeight: '20px' }}>
+                        <span
+                          className="flex-shrink-0 select-none text-right px-2"
+                          style={{ color: 'var(--color-profit-muted)', width: '20px', userSelect: 'none' }}
+                        >+</span>
+                        <pre className="flex-1 font-mono whitespace-pre-wrap break-all m-0 pr-2" style={{ color: 'var(--color-profit)' }}>
+                          {line}
+                        </pre>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
     </div>
   );
 });

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -283,6 +283,17 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
   const [filePanelTargetMemoryKey, setFilePanelTargetMemoryKey] = useState<string | null>(null);
   const [filePanelTargetMemoryTier, setFilePanelTargetMemoryTier] = useState<MemoryTier | null>(null);
   const [filePanelTargetMemoKey, setFilePanelTargetMemoKey] = useState<string | null>(null);
+  // Stable handlers — these land in useEffect deps in MemoryPanel/MemoPanel/
+  // FilePanel. Inline arrows would create a new identity on every ChatView
+  // render, re-triggering those effects on every streaming chunk (the
+  // `targetKey == null` guard makes them no-ops, but the wakeup is wasted).
+  const handleTargetFileHandled = useCallback(() => setFilePanelTargetFile(null), []);
+  const handleTargetDirHandled = useCallback(() => setFilePanelTargetDir(null), []);
+  const handleTargetMemoryHandled = useCallback(() => {
+    setFilePanelTargetMemoryKey(null);
+    setFilePanelTargetMemoryTier(null);
+  }, []);
+  const handleTargetMemoHandled = useCallback(() => setFilePanelTargetMemoKey(null), []);
   // Cross-workspace file panel: in flash mode, files live in PTC workspaces.
   // This tracks which workspace the file panel should fetch from.
   const [filePanelWorkspaceId, setFilePanelWorkspaceId] = useState<string | null>(null);
@@ -2319,17 +2330,14 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
                   workspaceId={effectiveFileWorkspaceId || workspaceId}
                   onClose={() => { setRightPanelType(null); popPanelHistory(); }}
                   targetFile={filePanelTargetFile}
-                  onTargetFileHandled={() => setFilePanelTargetFile(null)}
+                  onTargetFileHandled={handleTargetFileHandled}
                   targetDirectory={filePanelTargetDir}
-                  onTargetDirHandled={() => setFilePanelTargetDir(null)}
+                  onTargetDirHandled={handleTargetDirHandled}
                   targetMemoryKey={filePanelTargetMemoryKey}
                   targetMemoryTier={filePanelTargetMemoryTier}
-                  onTargetMemoryHandled={() => {
-                    setFilePanelTargetMemoryKey(null);
-                    setFilePanelTargetMemoryTier(null);
-                  }}
+                  onTargetMemoryHandled={handleTargetMemoryHandled}
                   targetMemoKey={filePanelTargetMemoKey}
-                  onTargetMemoHandled={() => setFilePanelTargetMemoKey(null)}
+                  onTargetMemoHandled={handleTargetMemoHandled}
                   onOpenFile={handleOpenFileFromChat}
                   files={workspaceFiles}
                   filesLoading={filesLoading}
@@ -2381,17 +2389,14 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
                       workspaceId={effectiveFileWorkspaceId || workspaceId}
                       onClose={() => { setRightPanelType(null); popPanelHistory(); }}
                       targetFile={filePanelTargetFile}
-                      onTargetFileHandled={() => setFilePanelTargetFile(null)}
+                      onTargetFileHandled={handleTargetFileHandled}
                       targetDirectory={filePanelTargetDir}
-                      onTargetDirHandled={() => setFilePanelTargetDir(null)}
+                      onTargetDirHandled={handleTargetDirHandled}
                       targetMemoryKey={filePanelTargetMemoryKey}
                       targetMemoryTier={filePanelTargetMemoryTier}
-                      onTargetMemoryHandled={() => {
-                        setFilePanelTargetMemoryKey(null);
-                        setFilePanelTargetMemoryTier(null);
-                      }}
+                      onTargetMemoryHandled={handleTargetMemoryHandled}
                       targetMemoKey={filePanelTargetMemoKey}
-                      onTargetMemoHandled={() => setFilePanelTargetMemoKey(null)}
+                      onTargetMemoHandled={handleTargetMemoHandled}
                       onOpenFile={handleOpenFileFromChat}
                       files={workspaceFiles}
                       filesLoading={filesLoading}

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -16,6 +16,8 @@ import type { PreviewData } from '../hooks/utils/types';
 import { clampPanelWidth as clampPanelWidthUtil } from '@/lib/panelUtils';
 import { useCardState } from '../hooks/useCardState';
 import { useWorkspaceFiles } from '../hooks/useWorkspaceFiles';
+import { classifyAgentPath, computeAgentArtifactRouting, type MemoryTier } from '../utils/agentPaths';
+import { getCompletedRowTitle } from './toolDisplayConfig';
 import './FilePanel.css';
 import ChatInput, { type ChatInputHandle } from '../../../components/ui/chat-input';
 import { attachmentsToContexts, type Attachment } from '../utils/fileUpload';
@@ -200,9 +202,6 @@ const MAIN_AGENT: AgentInfo = {
   isMainAgent: true,
 };
 
-/**
- * SubagentStatusIndicator — inline status line for subagent view.
- */
 function SubagentStatusIndicator({ status, currentTool, toolCalls = 0, messages = [] }: SubagentStatusIndicatorProps): React.ReactElement {
   const { t } = useTranslation();
   // Derive streaming state from messages (self-sufficient, no subagent_status dependency)
@@ -262,20 +261,6 @@ function SubagentStatusIndicator({ status, currentTool, toolCalls = 0, messages 
   );
 }
 
-/**
- * ChatView Component
- *
- * Displays the chat interface for a specific workspace and thread.
- * Handles:
- * - Message display and streaming
- * - Auto-scrolling
- * - Navigation back to thread gallery
- * - Auto-sending initial message from navigation state
- *
- * @param {string} workspaceId - The workspace ID to chat in
- * @param {string} threadId - The thread ID to chat in
- * @param {Function} onBack - Callback to navigate back to thread gallery
- */
 function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName: initialWorkspaceName, isActive = true, onThreadResolved }: ChatViewProps): React.ReactElement | null {
   const { t } = useTranslation();
   const isMobile = useIsMobile();
@@ -295,6 +280,9 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
   const [workspaceName, setWorkspaceName] = useState(initialWorkspaceName || '');
   const [filePanelTargetFile, setFilePanelTargetFile] = useState<string | null>(null);
   const [filePanelTargetDir, setFilePanelTargetDir] = useState<string | null>(null);
+  const [filePanelTargetMemoryKey, setFilePanelTargetMemoryKey] = useState<string | null>(null);
+  const [filePanelTargetMemoryTier, setFilePanelTargetMemoryTier] = useState<MemoryTier | null>(null);
+  const [filePanelTargetMemoKey, setFilePanelTargetMemoKey] = useState<string | null>(null);
   // Cross-workspace file panel: in flash mode, files live in PTC workspaces.
   // This tracks which workspace the file panel should fetch from.
   const [filePanelWorkspaceId, setFilePanelWorkspaceId] = useState<string | null>(null);
@@ -378,6 +366,16 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
   // Ref mirrors isActive prop for use in unmount cleanup closures (R1)
   const isActiveRef = useRef(isActive);
   isActiveRef.current = isActive;
+
+  // --- Aria-live announcement for screen readers ---
+  // String announced through a polite live region whenever a tool call
+  // transitions from in-progress → completed/failed. Auto-clears after 3s
+  // so re-focus on the live region doesn't replay stale announcements.
+  // Tool-call ids we've already announced so we don't re-trigger on every
+  // re-render once the transition has been observed.
+  const announcedToolCallIdsRef = useRef<Set<string>>(new Set());
+  const announcementClearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [recentlyCompletedAnnouncement, setRecentlyCompletedAnnouncement] = useState('');
 
   // --- Scroll position memory for tab switching ---
   // Stores scrollTop per agentId so switching tabs preserves position
@@ -506,22 +504,25 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     refresh: refreshFiles,
   } = useWorkspaceFiles(effectiveFileWorkspaceId, { includeSystem: showSystemFiles });
 
-  // When the agent writes to a memory-tier path, invalidate the memory queries
-  // so the Memory tab reflects the new content without a manual refresh.
+  // When the agent writes to a memory- or memo-tier path, invalidate the
+  // matching queries so the Memory / Memo tab reflects the new content
+  // without a manual refresh. classifyAgentPath is the single source of
+  // truth — same logic the chat row click routing uses.
   const handleFileArtifact = useCallback((event: { payload?: Record<string, unknown> }) => {
     refreshFiles();
     const filePath = (event?.payload?.file_path as string | undefined) ?? '';
     if (!filePath) return;
-    const normalized = filePath.replace(/^\/+/, '');
-    const matchesUser = normalized.includes('.agents/user/memory/');
-    const matchesWorkspace = normalized.includes('.agents/workspace/memory/');
-    if (matchesUser) {
-      queryClient.invalidateQueries({ queryKey: queryKeys.memory.user() });
-    }
-    if (matchesWorkspace && effectiveFileWorkspaceId) {
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.memory.workspace(effectiveFileWorkspaceId),
-      });
+    const info = classifyAgentPath(filePath);
+    if (info.kind === 'memory') {
+      if (info.tier === 'user') {
+        queryClient.invalidateQueries({ queryKey: queryKeys.memory.user() });
+      } else if (effectiveFileWorkspaceId) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.memory.workspace(effectiveFileWorkspaceId),
+        });
+      }
+    } else if (info.kind === 'memo') {
+      queryClient.invalidateQueries({ queryKey: queryKeys.memo.all });
     }
   }, [refreshFiles, queryClient, effectiveFileWorkspaceId]);
 
@@ -997,23 +998,45 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     };
   }, []);
 
-  const handleOpenFileFromChat = useCallback((filePath: string, targetWorkspaceId?: string) => {
-    // For cross-workspace file references (ws:// links from flash), switch the file panel workspace
-    if (targetWorkspaceId) {
-      setFilePanelWorkspaceId(targetWorkspaceId);
+  /**
+   * Routes a click on a tool-call artifact to the right panel tab that owns
+   * its domain. The pure decision is computed by computeAgentArtifactRouting;
+   * we apply the result atomically (clear everything, then set).
+   */
+  const handleOpenAgentArtifactFromChat = useCallback((rawPath: string, targetWorkspaceId?: string) => {
+    const r = computeAgentArtifactRouting(rawPath, targetWorkspaceId);
+
+    setFilePanelTargetDir(null);
+    setFilePanelTargetFile(r.targetFile);
+    setFilePanelTargetMemoryKey(r.targetMemoryKey);
+    setFilePanelTargetMemoryTier(r.targetMemoryTier);
+    setFilePanelTargetMemoKey(r.targetMemoKey);
+    if (r.clearWorkspaceId) {
+      setFilePanelWorkspaceId(null);
+    } else if (r.setWorkspaceId) {
+      setFilePanelWorkspaceId(r.setWorkspaceId);
     }
+
     setRightPanelWidth(clampPanelWidth(850));
     setRightPanelType('file');
-    setFilePanelTargetDir(null);
-    setFilePanelTargetFile(filePath);
     pushPanelHistory();
   }, [clampPanelWidth, pushPanelHistory]);
 
-  // Open file panel filtered to a specific directory
+  // Alias kept for the existing callers (tool-call rows, ws:// flash links,
+  // file-panel handoffs) that still use the older name. Pure identity — the
+  // unified router does the path-aware classification on every call.
+  const handleOpenFileFromChat = handleOpenAgentArtifactFromChat;
+
+  // Open file panel filtered to a specific directory. Clears every other
+  // target first — symmetric with handleOpenAgentArtifactFromChat — so a
+  // pending memory/memo pre-select can't snap-back hijack the dir click.
   const handleOpenDirFromChat = useCallback((dirPath: string) => {
     setRightPanelWidth(clampPanelWidth(850));
     setRightPanelType('file');
     setFilePanelTargetFile(null);
+    setFilePanelTargetMemoryKey(null);
+    setFilePanelTargetMemoryTier(null);
+    setFilePanelTargetMemoKey(null);
     setFilePanelTargetDir(dirPath);
     pushPanelHistory();
   }, [clampPanelWidth, pushPanelHistory]);
@@ -1565,6 +1588,62 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     }
   }, [messages]);
 
+  // Aria-live announcements for tool call completion. Watches assistant
+  // messages for tool-call processes that have transitioned out of
+  // `isInProgress: true` and emits a path-aware "<verb> <object> completed/failed"
+  // string into a polite live region. Each tool-call id is announced at most
+  // once; the announcement auto-clears after 3s so re-focus doesn't replay it.
+  useEffect(() => {
+    const seen = announcedToolCallIdsRef.current;
+    let latestLabel: string | null = null;
+    let latestFailed = false;
+
+    for (const m of messages as unknown as Array<Record<string, unknown>>) {
+      if (m?.role !== 'assistant') continue;
+      const procs = m.toolCallProcesses as Record<string, Record<string, unknown>> | undefined;
+      if (!procs) continue;
+      for (const [id, proc] of Object.entries(procs)) {
+        if (!proc) continue;
+        if (proc.isInProgress) continue;
+        // Only announce once per tool-call id.
+        if (seen.has(id)) continue;
+        // Only announce real terminal states (completed or failed). Skip
+        // entries that haven't reached either yet.
+        const isFailed = proc.isFailed === true;
+        const isCompleted = proc.isComplete === true || proc.toolCallResult != null;
+        if (!isFailed && !isCompleted) continue;
+        seen.add(id);
+        const toolName = (proc.toolName as string) || '';
+        const toolCall = proc.toolCall as { args?: Record<string, unknown> } | undefined;
+        const baseTitle = getCompletedRowTitle(toolName, toolCall, t);
+        latestLabel = baseTitle;
+        latestFailed = isFailed;
+      }
+    }
+
+    if (latestLabel) {
+      const tail = latestFailed
+        ? t('chat.a11y.toolCallFailed', 'failed')
+        : t('chat.a11y.toolCallCompleted', 'completed');
+      setRecentlyCompletedAnnouncement(`${latestLabel} ${tail}`);
+      if (announcementClearTimerRef.current) clearTimeout(announcementClearTimerRef.current);
+      announcementClearTimerRef.current = setTimeout(() => {
+        setRecentlyCompletedAnnouncement('');
+        announcementClearTimerRef.current = null;
+      }, 3000);
+    }
+  }, [messages, t]);
+
+  // Clear announcement timer on unmount.
+  useEffect(() => {
+    return () => {
+      if (announcementClearTimerRef.current) {
+        clearTimeout(announcementClearTimerRef.current);
+        announcementClearTimerRef.current = null;
+      }
+    };
+  }, []);
+
   // Auto-scroll subagent view when active subagent's messages change
   // Uses the same smart-scroll logic: only scroll if user is near the bottom
   // Skipped when restoring a saved scroll position after tab switch
@@ -1637,6 +1716,11 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
         backgroundColor: 'var(--color-bg-page)',
       }}
     >
+      {/* Polite aria-live region for screen-reader announcements when tool
+          calls reach a terminal state. Visually hidden via sr-only. */}
+      <div aria-live="polite" aria-atomic="false" className="sr-only">
+        {recentlyCompletedAnnouncement}
+      </div>
       {/* Left Side: Topbar + Sidebar + Chat Window */}
       <div className="flex flex-col flex-1 min-w-0">
         {/* Top bar */}
@@ -2223,6 +2307,15 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
                   onTargetFileHandled={() => setFilePanelTargetFile(null)}
                   targetDirectory={filePanelTargetDir}
                   onTargetDirHandled={() => setFilePanelTargetDir(null)}
+                  targetMemoryKey={filePanelTargetMemoryKey}
+                  targetMemoryTier={filePanelTargetMemoryTier}
+                  onTargetMemoryHandled={() => {
+                    setFilePanelTargetMemoryKey(null);
+                    setFilePanelTargetMemoryTier(null);
+                  }}
+                  targetMemoKey={filePanelTargetMemoKey}
+                  onTargetMemoHandled={() => setFilePanelTargetMemoKey(null)}
+                  onOpenFile={handleOpenFileFromChat}
                   files={workspaceFiles}
                   filesLoading={filesLoading}
                   filesError={filesError}
@@ -2276,6 +2369,15 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
                       onTargetFileHandled={() => setFilePanelTargetFile(null)}
                       targetDirectory={filePanelTargetDir}
                       onTargetDirHandled={() => setFilePanelTargetDir(null)}
+                      targetMemoryKey={filePanelTargetMemoryKey}
+                      targetMemoryTier={filePanelTargetMemoryTier}
+                      onTargetMemoryHandled={() => {
+                        setFilePanelTargetMemoryKey(null);
+                        setFilePanelTargetMemoryTier(null);
+                      }}
+                      targetMemoKey={filePanelTargetMemoKey}
+                      onTargetMemoHandled={() => setFilePanelTargetMemoKey(null)}
+                      onOpenFile={handleOpenFileFromChat}
                       files={workspaceFiles}
                       filesLoading={filesLoading}
                       filesError={filesError}

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -1063,7 +1063,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
 
       // Wide: file reading, SEC filings, subagent results
       if (artifactType === 'sec_filing') desired = 850;
-      else if (toolName === 'Read' || toolName === 'read_file') desired = 850;
+      else if (toolName === 'Read') desired = 850;
       else if (toolName === 'Task' || toolName === 'task') desired = 750;
       // Medium: charts, search results, default markdown
       else if (artifactType === 'stock_prices' || artifactType === 'market_indices' || artifactType === 'sector_performance') desired = 650;

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -369,12 +369,13 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
 
   // --- Aria-live announcement for screen readers ---
   // String announced through a polite live region whenever a tool call
-  // transitions from in-progress → completed/failed. Auto-clears after 3s
-  // so re-focus on the live region doesn't replay stale announcements.
-  // Tool-call ids we've already announced so we don't re-trigger on every
-  // re-render once the transition has been observed.
+  // transitions from in-progress → completed/failed. Each completion is
+  // queued and announced individually so a batch of completions in a single
+  // SSE tick doesn't collapse to "only the last one" — screen readers
+  // re-utter each one with a brief silence in between.
   const announcedToolCallIdsRef = useRef<Set<string>>(new Set());
   const announcementClearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const announcementQueueRef = useRef<Array<{ label: string; failed: boolean }>>([]);
   const [recentlyCompletedAnnouncement, setRecentlyCompletedAnnouncement] = useState('');
 
   // --- Scroll position memory for tab switching ---
@@ -1588,15 +1589,38 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     }
   }, [messages]);
 
+  // Drain the announcement queue one item at a time. Each announcement is
+  // displayed for 1500ms, followed by ~80ms of silence before the next so
+  // screen readers treat each as a fresh utterance. Stable identity (no
+  // deps) — uses tRef for fresh translations.
+  const tRef = useRef(t);
+  tRef.current = t;
+  const pumpAnnouncements = useCallback(() => {
+    if (announcementClearTimerRef.current) return;
+    const next = announcementQueueRef.current.shift();
+    if (!next) return;
+    const currentT = tRef.current;
+    const tail = next.failed
+      ? currentT('chat.a11y.toolCallFailed', 'failed')
+      : currentT('chat.a11y.toolCallCompleted', 'completed');
+    setRecentlyCompletedAnnouncement(`${next.label} ${tail}`);
+    announcementClearTimerRef.current = setTimeout(() => {
+      announcementClearTimerRef.current = null;
+      setRecentlyCompletedAnnouncement('');
+      if (announcementQueueRef.current.length > 0) {
+        setTimeout(pumpAnnouncements, 80);
+      }
+    }, 1500);
+  }, []);
+
   // Aria-live announcements for tool call completion. Watches assistant
   // messages for tool-call processes that have transitioned out of
-  // `isInProgress: true` and emits a path-aware "<verb> <object> completed/failed"
-  // string into a polite live region. Each tool-call id is announced at most
-  // once; the announcement auto-clears after 3s so re-focus doesn't replay it.
+  // `isInProgress: true` and pushes a path-aware
+  // "<verb> <object> completed/failed" string onto a queue that is drained
+  // by `pumpAnnouncements`. Each tool-call id is announced at most once.
   useEffect(() => {
     const seen = announcedToolCallIdsRef.current;
-    let latestLabel: string | null = null;
-    let latestFailed = false;
+    let enqueued = 0;
 
     for (const m of messages as unknown as Array<Record<string, unknown>>) {
       if (m?.role !== 'assistant') continue;
@@ -1616,31 +1640,22 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
         const toolName = (proc.toolName as string) || '';
         const toolCall = proc.toolCall as { args?: Record<string, unknown> } | undefined;
         const baseTitle = getCompletedRowTitle(toolName, toolCall, t);
-        latestLabel = baseTitle;
-        latestFailed = isFailed;
+        announcementQueueRef.current.push({ label: baseTitle, failed: isFailed });
+        enqueued++;
       }
     }
 
-    if (latestLabel) {
-      const tail = latestFailed
-        ? t('chat.a11y.toolCallFailed', 'failed')
-        : t('chat.a11y.toolCallCompleted', 'completed');
-      setRecentlyCompletedAnnouncement(`${latestLabel} ${tail}`);
-      if (announcementClearTimerRef.current) clearTimeout(announcementClearTimerRef.current);
-      announcementClearTimerRef.current = setTimeout(() => {
-        setRecentlyCompletedAnnouncement('');
-        announcementClearTimerRef.current = null;
-      }, 3000);
-    }
-  }, [messages, t]);
+    if (enqueued > 0) pumpAnnouncements();
+  }, [messages, t, pumpAnnouncements]);
 
-  // Clear announcement timer on unmount.
+  // Clear announcement timer + queue on unmount.
   useEffect(() => {
     return () => {
       if (announcementClearTimerRef.current) {
         clearTimeout(announcementClearTimerRef.current);
         announcementClearTimerRef.current = null;
       }
+      announcementQueueRef.current = [];
     };
   }, []);
 

--- a/web/src/pages/ChatAgent/components/DetailPanel.tsx
+++ b/web/src/pages/ChatAgent/components/DetailPanel.tsx
@@ -71,13 +71,6 @@ interface DetailPanelProps {
   onOpenSubagentTask?: (info: SubagentInfo) => void;
 }
 
-/**
- * DetailPanel Component
- *
- * Renders the detailed result of a single tool call in the right panel.
- * Routes artifact data to appropriate chart components when available,
- * otherwise falls back to markdown rendering.
- */
 function DetailPanel({ toolCallProcess, planData, onClose, onOpenFile, onOpenSubagentTask }: DetailPanelProps): React.ReactElement | null {
   const { t } = useTranslation();
   const isMobile = useIsMobile();
@@ -129,9 +122,10 @@ function DetailPanel({ toolCallProcess, planData, onClose, onOpenFile, onOpenSub
   if (!toolCallProcess) return null;
 
   const toolName = toolCallProcess.toolName || '';
+  const toolArgs = toolCallProcess.toolCall?.args;
   const isTaskTool = toolName === 'Task' || toolName === 'task';
-  const displayName = isTaskTool ? t('toolArtifact.subagentTask') : getDisplayName(toolName, t);
-  const IconComponent = getToolIcon(toolName);
+  const displayName = isTaskTool ? t('toolArtifact.subagentTask') : getDisplayName(toolName, t, toolArgs);
+  const IconComponent = getToolIcon(toolName, toolArgs);
   const artifact = toolCallProcess.toolCallResult?.artifact;
   const content = toolCallProcess.toolCallResult?.content;
 

--- a/web/src/pages/ChatAgent/components/MemoPanel.tsx
+++ b/web/src/pages/ChatAgent/components/MemoPanel.tsx
@@ -408,6 +408,31 @@ export default function MemoPanel({ targetKey, onTargetHandled, onOpenFile }: Me
   // Discard; Cancel just closes the dialog and leaves the editor intact.
   const [discardConfirmOpen, setDiscardConfirmOpen] = useState(false);
   const pendingDiscardActionRef = useRef<(() => void) | null>(null);
+  const handleDiscardConfirm = useCallback(() => {
+    const fn = pendingDiscardActionRef.current;
+    pendingDiscardActionRef.current = null;
+    setDiscardConfirmOpen(false);
+    fn?.();
+  }, []);
+  const handleDiscardCancel = useCallback(() => {
+    pendingDiscardActionRef.current = null;
+    setDiscardConfirmOpen(false);
+  }, []);
+  // Same dialog node is rendered in both the entry-view and list-view return
+  // branches. Both share `discardConfirmOpen` state, so only one is ever
+  // mounted at a time — but defining the JSX in one place keeps the two
+  // sites from drifting. NOTE: must be defined after `t` (line 331).
+  const discardConfirmDialog = (
+    <ConfirmDialog
+      open={discardConfirmOpen}
+      title={t('memoPanel.discardEditTitle')}
+      body={t('memoPanel.unsavedDiscardConfirm')}
+      confirmLabel={t('memoPanel.discardEdits')}
+      cancelLabel={t('common.cancel')}
+      onConfirm={handleDiscardConfirm}
+      onCancel={handleDiscardCancel}
+    />
+  );
 
   // Panel width drives the responsive layout below.
   const { ref: bodyRef, width: panelWidth } = useElementWidth();
@@ -996,23 +1021,7 @@ export default function MemoPanel({ targetKey, onTargetHandled, onOpenFile }: Me
           onConfirm={handleConfirmDelete}
           onCancel={() => setDeleteKey(null)}
         />
-        <ConfirmDialog
-          open={discardConfirmOpen}
-          title={t('memoPanel.discardEditTitle')}
-          body={t('memoPanel.unsavedDiscardConfirm')}
-          confirmLabel={t('memoPanel.discardEdits')}
-          cancelLabel={t('common.cancel')}
-          onConfirm={() => {
-            const fn = pendingDiscardActionRef.current;
-            pendingDiscardActionRef.current = null;
-            setDiscardConfirmOpen(false);
-            fn?.();
-          }}
-          onCancel={() => {
-            pendingDiscardActionRef.current = null;
-            setDiscardConfirmOpen(false);
-          }}
-        />
+        {discardConfirmDialog}
       </div>
     );
   }
@@ -1415,23 +1424,7 @@ export default function MemoPanel({ targetKey, onTargetHandled, onOpenFile }: Me
         onConfirm={handleBulkDelete}
         onCancel={() => setBulkDeleteOpen(false)}
       />
-      <ConfirmDialog
-        open={discardConfirmOpen}
-        title={t('memoPanel.discardEditTitle')}
-        body={t('memoPanel.unsavedDiscardConfirm')}
-        confirmLabel={t('memoPanel.discardEdits')}
-        cancelLabel={t('common.cancel')}
-        onConfirm={() => {
-          const fn = pendingDiscardActionRef.current;
-          pendingDiscardActionRef.current = null;
-          setDiscardConfirmOpen(false);
-          fn?.();
-        }}
-        onCancel={() => {
-          pendingDiscardActionRef.current = null;
-          setDiscardConfirmOpen(false);
-        }}
-      />
+      {discardConfirmDialog}
     </div>
   );
 }

--- a/web/src/pages/ChatAgent/components/MemoPanel.tsx
+++ b/web/src/pages/ChatAgent/components/MemoPanel.tsx
@@ -402,6 +402,12 @@ export default function MemoPanel({ targetKey, onTargetHandled, onOpenFile }: Me
   const [editContent, setEditContent] = useState<string>('');
   const [deleteKey, setDeleteKey] = useState<string | null>(null);
   const [pdfBlobUrl, setPdfBlobUrl] = useState<string | null>(null);
+  // Non-blocking discard-confirm dialog. Replaces window.confirm() — a sync
+  // confirm freezes the JS event loop including the SSE reader, so streaming
+  // animations stutter while the dialog is up. The pending action runs on
+  // Discard; Cancel just closes the dialog and leaves the editor intact.
+  const [discardConfirmOpen, setDiscardConfirmOpen] = useState(false);
+  const pendingDiscardActionRef = useRef<(() => void) | null>(null);
 
   // Panel width drives the responsive layout below.
   const { ref: bodyRef, width: panelWidth } = useElementWidth();
@@ -613,19 +619,19 @@ export default function MemoPanel({ targetKey, onTargetHandled, onOpenFile }: Me
   useEffect(() => {
     if (targetKey == null) return;
     if (targetKey === '') {
-      // User has an unsaved edit in the editor — confirm before discarding.
+      // User has an unsaved edit in the editor — open the non-blocking
+      // discard-confirm dialog. We ack the target immediately so the parent
+      // clears it (no render loop); the actual discard runs on user click.
       if (editing && editContent !== (read.data?.content ?? '')) {
-        const ok = window.confirm(
-          t('memoPanel.unsavedDiscardConfirm', {
-            defaultValue: 'You have unsaved memo edits. Discard them?',
-          }),
-        );
-        if (!ok) {
-          // Acknowledge the target so we don't loop on every render, but
-          // leave the editor mounted with the user's pending edits intact.
-          onTargetHandled?.();
-          return;
-        }
+        pendingDiscardActionRef.current = () => {
+          setSelectedKey(null);
+          setEditing(false);
+          setEditContent('');
+          setNotFoundKey(null);
+        };
+        setDiscardConfirmOpen(true);
+        onTargetHandled?.();
+        return;
       }
       setSelectedKey(null);
       setEditing(false);
@@ -654,7 +660,6 @@ export default function MemoPanel({ targetKey, onTargetHandled, onOpenFile }: Me
     editing,
     editContent,
     read.data,
-    t,
   ]);
 
   // Clear the not-found banner if the missing key later appears (e.g., the
@@ -991,6 +996,23 @@ export default function MemoPanel({ targetKey, onTargetHandled, onOpenFile }: Me
           onConfirm={handleConfirmDelete}
           onCancel={() => setDeleteKey(null)}
         />
+        <ConfirmDialog
+          open={discardConfirmOpen}
+          title={t('memoPanel.discardEditTitle')}
+          body={t('memoPanel.unsavedDiscardConfirm')}
+          confirmLabel={t('memoPanel.discardEdits')}
+          cancelLabel={t('common.cancel')}
+          onConfirm={() => {
+            const fn = pendingDiscardActionRef.current;
+            pendingDiscardActionRef.current = null;
+            setDiscardConfirmOpen(false);
+            fn?.();
+          }}
+          onCancel={() => {
+            pendingDiscardActionRef.current = null;
+            setDiscardConfirmOpen(false);
+          }}
+        />
       </div>
     );
   }
@@ -1169,6 +1191,7 @@ export default function MemoPanel({ targetKey, onTargetHandled, onOpenFile }: Me
             {t('memoPanel.notFound', { key: notFoundKey })}
           </span>
           <button
+            type="button"
             onClick={() => setNotFoundKey(null)}
             className="flex-shrink-0"
             title={t('memoPanel.dismissNotFound')}
@@ -1391,6 +1414,23 @@ export default function MemoPanel({ targetKey, onTargetHandled, onOpenFile }: Me
         busy={bulkDeleting}
         onConfirm={handleBulkDelete}
         onCancel={() => setBulkDeleteOpen(false)}
+      />
+      <ConfirmDialog
+        open={discardConfirmOpen}
+        title={t('memoPanel.discardEditTitle')}
+        body={t('memoPanel.unsavedDiscardConfirm')}
+        confirmLabel={t('memoPanel.discardEdits')}
+        cancelLabel={t('common.cancel')}
+        onConfirm={() => {
+          const fn = pendingDiscardActionRef.current;
+          pendingDiscardActionRef.current = null;
+          setDiscardConfirmOpen(false);
+          fn?.();
+        }}
+        onCancel={() => {
+          pendingDiscardActionRef.current = null;
+          setDiscardConfirmOpen(false);
+        }}
       />
     </div>
   );

--- a/web/src/pages/ChatAgent/components/MemoPanel.tsx
+++ b/web/src/pages/ChatAgent/components/MemoPanel.tsx
@@ -46,6 +46,7 @@ import {
   type MemoMetadataStatus,
 } from '../utils/api';
 import Markdown from './Markdown';
+import { MEMO_USER_DIR } from '../utils/agentPaths';
 import './FilePanel.css';
 
 // --- Constants -------------------------------------------------------------
@@ -316,8 +317,51 @@ function ConfirmDialog({
 
 // --- Main component -------------------------------------------------------
 
-export default function MemoPanel() {
+interface MemoPanelProps {
+  /** When set, the panel selects this entry once the list resolves. */
+  targetKey?: string | null;
+  onTargetHandled?: () => void;
+  /** Routes a clicked link inside the rendered memo body through the
+   * parent's path-aware router. Bare sibling slugs are resolved against
+   * the memo dir before calling. */
+  onOpenFile?: (path: string, workspaceId?: string) => void;
+}
+
+export default function MemoPanel({ targetKey, onTargetHandled, onOpenFile }: MemoPanelProps = {}) {
   const { t } = useTranslation();
+  const [notFoundKey, setNotFoundKey] = useState<string | null>(null);
+
+  // Mirror MemoryPanel: bare sibling refs in a memo body resolve against the
+  // memo dir so they classify as memo and pre-select the right entry.
+  //
+  // Heuristic: memos can be any of md / txt / csv / json / pdf, so we can't
+  // gate on extension alone. Sibling memos are pure root-level slugs — any
+  // href containing a `/` (e.g. `reports/q1.pdf`) is a sandbox file
+  // referenced from the memo body and must pass through to file routing.
+  const handleBodyLinkOpen = useCallback(
+    (href: string, wsId?: string) => {
+      if (!onOpenFile || !href) return;
+      const isAlreadyQualified =
+        href.startsWith('.agents/') ||
+        href.startsWith('__wsref__/') ||
+        href.startsWith('/') ||
+        /^[a-z][a-z0-9+.-]*:/i.test(href);
+      if (isAlreadyQualified) {
+        onOpenFile(href, wsId);
+        return;
+      }
+      const clean = href.replace(/^\.\//, '');
+      // A subdirectory = not a memo sibling. Pass through so the file router
+      // (or a 404 in the file panel) handles it instead of fabricating a
+      // bogus `.agents/user/memo/reports/q1.pdf` path.
+      if (clean.includes('/')) {
+        onOpenFile(clean, wsId);
+        return;
+      }
+      onOpenFile(`${MEMO_USER_DIR}/${clean}`, wsId);
+    },
+    [onOpenFile],
+  );
 
   const list = useUserMemoList(true);
   const uploadMutation = useUploadUserMemo();
@@ -556,6 +600,79 @@ export default function MemoPanel() {
     setEditing(false);
     setEditContent('');
   }, []);
+
+  // Mirror an external targetKey into selected state once the list resolves.
+  // Empty-string targetKey is the "open Memo tab to LIST" sentinel used for
+  // the memo index path — drop any current entry view so the user actually
+  // lands on the LIST. Null means no target.
+  //
+  // Both `isLoading` and `isFetching` defer the not-found decision: the
+  // first covers the initial fetch, the second covers a background refetch
+  // (e.g. the agent just wrote a new memo and triggered an invalidation —
+  // we must wait for the refresh before declaring "not found").
+  useEffect(() => {
+    if (targetKey == null) return;
+    if (targetKey === '') {
+      // User has an unsaved edit in the editor — confirm before discarding.
+      if (editing && editContent !== (read.data?.content ?? '')) {
+        const ok = window.confirm(
+          t('memoPanel.unsavedDiscardConfirm', {
+            defaultValue: 'You have unsaved memo edits. Discard them?',
+          }),
+        );
+        if (!ok) {
+          // Acknowledge the target so we don't loop on every render, but
+          // leave the editor mounted with the user's pending edits intact.
+          onTargetHandled?.();
+          return;
+        }
+      }
+      setSelectedKey(null);
+      setEditing(false);
+      setEditContent('');
+      setNotFoundKey(null);
+      onTargetHandled?.();
+      return;
+    }
+    if (list.isLoading || list.isFetching) return;
+    const hit = sortedEntries.find((e) => e.key === targetKey);
+    if (hit) {
+      handleOpen(targetKey);
+      setNotFoundKey(null);
+    } else {
+      setSelectedKey(null);
+      setNotFoundKey(targetKey);
+    }
+    onTargetHandled?.();
+  }, [
+    targetKey,
+    list.isLoading,
+    list.isFetching,
+    sortedEntries,
+    handleOpen,
+    onTargetHandled,
+    editing,
+    editContent,
+    read.data,
+    t,
+  ]);
+
+  // Clear the not-found banner if the missing key later appears (e.g., the
+  // user uploaded the memo from a different surface). Avoids the banner
+  // outliving the condition it described. Using a stable key signature
+  // (instead of length) catches the case where the user deletes the missing
+  // entry and the agent uploads the previously-missing key in the same
+  // refetch — net length unchanged, but membership did change.
+  const memoEntriesSig = useMemo(
+    () => sortedEntries.map((e) => e.key).join('|'),
+    [sortedEntries],
+  );
+  useEffect(() => {
+    if (notFoundKey && sortedEntries.some((e) => e.key === notFoundKey)) {
+      setNotFoundKey(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [memoEntriesSig, notFoundKey]);
 
   const handleBackToList = useCallback(() => {
     setSelectedKey(null);
@@ -846,7 +963,11 @@ export default function MemoPanel() {
               {t('memoPanel.loading')}
             </div>
           ) : isMarkdown ? (
-            <Markdown content={content} variant="panel" />
+            <Markdown
+              content={content}
+              variant="panel"
+              onOpenFile={onOpenFile ? handleBodyLinkOpen : undefined}
+            />
           ) : (
             <pre
               className="whitespace-pre-wrap break-words text-xs font-mono"
@@ -1033,6 +1154,27 @@ export default function MemoPanel() {
           }}
         >
           {listError}
+        </div>
+      )}
+
+      {notFoundKey && (
+        <div
+          className="flex items-start justify-between gap-2 px-3 py-2 text-xs"
+          style={{
+            backgroundColor: 'var(--color-loss-soft)',
+            color: 'var(--color-loss)',
+          }}
+        >
+          <span className="min-w-0">
+            {t('memoPanel.notFound', { key: notFoundKey })}
+          </span>
+          <button
+            onClick={() => setNotFoundKey(null)}
+            className="flex-shrink-0"
+            title={t('memoPanel.dismissNotFound')}
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
         </div>
       )}
 

--- a/web/src/pages/ChatAgent/components/MemoryPanel.tsx
+++ b/web/src/pages/ChatAgent/components/MemoryPanel.tsx
@@ -1,5 +1,5 @@
-import { useState, useMemo } from 'react';
-import { ArrowLeft, Brain, FileText, RefreshCw } from 'lucide-react';
+import { useCallback, useEffect, useState, useMemo } from 'react';
+import { ArrowLeft, Brain, FileText, RefreshCw, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import {
   useUserMemory,
@@ -9,11 +9,22 @@ import {
 } from '../hooks/useMemory';
 import Markdown from './Markdown';
 import type { MemoryEntry } from '../utils/api';
+import { MEMORY_USER_DIR, MEMORY_WORKSPACE_DIR } from '../utils/agentPaths';
 
 type Tier = 'user' | 'workspace';
 
 interface MemoryPanelProps {
   workspaceId: string | null;
+  /** When set, the panel switches to this entry once the list resolves. */
+  targetKey?: string | null;
+  targetTier?: Tier | null;
+  /** Called once the panel has consumed (or rejected) the target. */
+  onTargetHandled?: () => void;
+  /** Routes a clicked link inside the rendered markdown body through the
+   * parent's path-aware router. The panel resolves bare sibling refs
+   * (e.g. `feedback_visualization_preference.md`) against the current
+   * memory tier's dir before calling. */
+  onOpenFile?: (path: string, workspaceId?: string) => void;
 }
 
 function formatBytes(n: number): string {
@@ -46,13 +57,63 @@ function sortEntries(entries: MemoryEntry[]): MemoryEntry[] {
   });
 }
 
-export default function MemoryPanel({ workspaceId }: MemoryPanelProps) {
+export default function MemoryPanel({
+  workspaceId,
+  targetKey,
+  targetTier,
+  onTargetHandled,
+  onOpenFile,
+}: MemoryPanelProps) {
   const { t } = useTranslation();
-  const [tier, setTier] = useState<Tier>('user');
+  const [tier, setTier] = useState<Tier>(targetTier ?? 'user');
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const [notFoundKey, setNotFoundKey] = useState<string | null>(null);
 
-  const user = useUserMemory(tier === 'user');
-  const ws = useWorkspaceMemory(workspaceId, tier === 'workspace');
+  // Markdown links inside a memory body usually reference sibling entries by
+  // bare filename (`feedback_visualization_preference.md`). Resolve those
+  // against the current tier's dir so the parent router classifies them as
+  // memory and pre-selects the right entry. Already-qualified hrefs
+  // (`.agents/...`, `__wsref__/...`, absolute, or `scheme://`) pass through.
+  //
+  // Heuristic: only `.md` / `.markdown` hrefs are treated as sibling memory
+  // entries (the canonical extension). Other extensions (`.pdf`, `.csv`,
+  // `.png`, etc.) are sandbox files referenced from the memory body — pass
+  // them through to file routing instead of forcing them into the memory
+  // store path (where they'd 404).
+  const handleBodyLinkOpen = useCallback(
+    (href: string, wsId?: string) => {
+      if (!onOpenFile || !href) return;
+      const isAlreadyQualified =
+        href.startsWith('.agents/') ||
+        href.startsWith('__wsref__/') ||
+        href.startsWith('/') ||
+        /^[a-z][a-z0-9+.-]*:/i.test(href);
+      if (isAlreadyQualified) {
+        onOpenFile(href, wsId);
+        return;
+      }
+      const clean = href.replace(/^\.\//, '');
+      const tail = clean.split('?')[0].split('#')[0];
+      const ext = (tail.split('.').pop() || '').toLowerCase();
+      const SIBLING_EXTS = new Set(['md', 'markdown']);
+      if (!SIBLING_EXTS.has(ext)) {
+        // Not a memory entry — let file routing decide where it belongs.
+        onOpenFile(clean, wsId);
+        return;
+      }
+      const dir = tier === 'user' ? MEMORY_USER_DIR : MEMORY_WORKSPACE_DIR;
+      onOpenFile(`${dir}/${clean}`, wsId);
+    },
+    [onOpenFile, tier],
+  );
+
+  // Both tiers must be active when we're chasing a target so the entry can
+  // be located regardless of which tier the user was last viewing.
+  const user = useUserMemory(tier === 'user' || (targetKey != null && targetTier === 'user'));
+  const ws = useWorkspaceMemory(
+    workspaceId,
+    tier === 'workspace' || (targetKey != null && targetTier === 'workspace'),
+  );
   const list = tier === 'user' ? user : ws;
 
   const sorted = useMemo(() => sortEntries(list.entries), [list.entries]);
@@ -68,7 +129,56 @@ export default function MemoryPanel({ workspaceId }: MemoryPanelProps) {
     if (next === tier) return;
     setTier(next);
     setSelectedKey(null);
+    setNotFoundKey(null);
   };
+
+  // Mirror an external targetKey into selected state once the corresponding
+  // list resolves. If the list loaded but the target isn't there, fall back
+  // to the list view with an inline not-found banner.
+  //
+  // Both `loading` and `isFetching` defer the not-found decision: `loading`
+  // covers the first-ever fetch, `isFetching` covers a background refetch
+  // triggered by an invalidation (e.g. the agent just wrote a new entry —
+  // we must wait for the refresh before declaring "not found").
+  useEffect(() => {
+    if (targetKey == null) return;
+    if (targetTier && targetTier !== tier) {
+      setTier(targetTier);
+      setSelectedKey(null);
+      // A banner from the prior tier's lookup would mislead after the flip —
+      // the new tier's lookup hasn't decided yet.
+      setNotFoundKey(null);
+      // Wait for the next render after tier switch.
+      return;
+    }
+    if (list.loading || list.isFetching) return;
+    const hit = list.entries.find((e) => e.key === targetKey);
+    if (hit) {
+      setSelectedKey(targetKey);
+      setNotFoundKey(null);
+    } else {
+      setSelectedKey(null);
+      setNotFoundKey(targetKey);
+    }
+    onTargetHandled?.();
+  }, [targetKey, targetTier, tier, list.loading, list.isFetching, list.entries, onTargetHandled]);
+
+  // If the agent later writes a new entry, the not-found banner for an old
+  // missing key should clear so it doesn't lie about the current list state.
+  // Keying on `entries.length` would miss the case where the user deletes
+  // the missing entry and the agent writes the previously-missing key in
+  // the same refetch (net length unchanged) — a stable signature of the
+  // entry keys catches every membership mutation.
+  const entriesSig = useMemo(
+    () => list.entries.map((e) => e.key).join('|'),
+    [list.entries],
+  );
+  useEffect(() => {
+    if (notFoundKey && list.entries.some((e) => e.key === notFoundKey)) {
+      setNotFoundKey(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [entriesSig, notFoundKey]);
 
   const rootLabel =
     tier === 'user' ? '.agents/user/memory/' : '.agents/workspace/memory/';
@@ -105,7 +215,11 @@ export default function MemoryPanel({ workspaceId }: MemoryPanelProps) {
             </div>
           )}
           {read.data && (
-            <Markdown content={read.data.content} variant="panel" />
+            <Markdown
+              content={read.data.content}
+              variant="panel"
+              onOpenFile={onOpenFile ? handleBodyLinkOpen : undefined}
+            />
           )}
         </div>
       </div>
@@ -158,6 +272,27 @@ export default function MemoryPanel({ workspaceId }: MemoryPanelProps) {
            style={{ color: 'var(--color-text-tertiary)' }}>
         {rootLabel}
       </div>
+
+      {notFoundKey && (
+        <div
+          className="flex items-start justify-between gap-2 px-3 py-2 text-xs"
+          style={{
+            backgroundColor: 'var(--color-loss-soft)',
+            color: 'var(--color-loss)',
+          }}
+        >
+          <span className="min-w-0">
+            {t('memoryPanel.notFound', { key: notFoundKey })}
+          </span>
+          <button
+            onClick={() => setNotFoundKey(null)}
+            className="flex-shrink-0"
+            title={t('memoryPanel.dismissNotFound')}
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      )}
 
       {/* List body */}
       <div className="flex-1 overflow-y-auto">

--- a/web/src/pages/ChatAgent/components/MemoryPanel.tsx
+++ b/web/src/pages/ChatAgent/components/MemoryPanel.tsx
@@ -285,6 +285,7 @@ export default function MemoryPanel({
             {t('memoryPanel.notFound', { key: notFoundKey })}
           </span>
           <button
+            type="button"
             onClick={() => setNotFoundKey(null)}
             className="flex-shrink-0"
             title={t('memoryPanel.dismissNotFound')}

--- a/web/src/pages/ChatAgent/components/MessageList.tsx
+++ b/web/src/pages/ChatAgent/components/MessageList.tsx
@@ -322,15 +322,6 @@ interface MessageListProps {
   flashContext?: { threadId: string; workspaceId: string } | null;
 }
 
-/**
- * MessageList Component
- *
- * Displays the chat message history with support for:
- * - Empty state when no messages exist
- * - User and assistant message bubbles
- * - Streaming indicators
- * - Error state styling
- */
 function MessageList({ messages, isLoading, isLoadingHistory, hideAvatar, compactToolCalls, isSubagentView, readOnly, allowFiles, onOpenSubagentTask, onOpenFile, onOpenDir, onToolCallDetailClick, onApprovePlan, onRejectPlan, onPlanDetailClick, onAnswerQuestion, onSkipQuestion, onApproveCreateWorkspace, onRejectCreateWorkspace, onApproveStartQuestion, onRejectStartQuestion, onApprovePTCAgent, onRejectPTCAgent, onApproveSecretaryAction, onRejectSecretaryAction, onEditMessage, onRegenerate, onRetry, onThumbUp, onThumbDown, getFeedbackForMessage, onReportWithAgent, onWidgetSendPrompt, flashContext }: MessageListProps): React.ReactElement | null {
   const isMobile = useIsMobile();
 
@@ -468,11 +459,6 @@ interface MessageBubbleProps {
 }
 
 /**
- * MessageBubble Component
- *
- * Renders a single message bubble with appropriate styling
- * based on role (user/assistant) and state (streaming/error)
- *
  * Wrapped with React.memo — safe because updateMessage() in messageHelpers.ts
  * returns the same object reference for unchanged messages.
  */
@@ -1242,7 +1228,11 @@ const MessageContentSegments = memo(function MessageContentSegments({ segments, 
               toolCallId: seg.toolCallId,
               ...proc,
               _recentlyCompleted: true,
-              _liveState: 'completing',
+              // Failure flips the completing-window state to 'failed' so
+              // ActivityBlock renders the gray ✕ badge variant. Older failed
+              // calls drop to 'completed' below and merge into the accordion
+              // alongside successful ones.
+              _liveState: (proc.isFailed as boolean) ? 'failed' : 'completing',
             });
             const expiry = createdAt! + MIN_LIVE_EXPOSURE_MS;
             if (computedNextExpiry === null || expiry < computedNextExpiry) {

--- a/web/src/pages/ChatAgent/components/RightPanel.tsx
+++ b/web/src/pages/ChatAgent/components/RightPanel.tsx
@@ -3,6 +3,7 @@ import { X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { AnimatedTabs } from '@/components/ui/animated-tabs';
 import type { ContextPayload } from './FilePanel';
+import type { MemoryTier } from '../utils/agentPaths';
 
 const FilePanel = React.lazy(() => import('./FilePanel'));
 const MemoryPanel = React.lazy(() => import('./MemoryPanel'));
@@ -17,6 +18,17 @@ interface RightPanelProps {
   onTargetFileHandled?: () => void;
   targetDirectory?: string | null;
   onTargetDirHandled?: () => void;
+  /** Memory entry to pre-select when the Memory tab opens. */
+  targetMemoryKey?: string | null;
+  targetMemoryTier?: MemoryTier | null;
+  onTargetMemoryHandled?: () => void;
+  /** Memo entry to pre-select when the Memo tab opens. */
+  targetMemoKey?: string | null;
+  onTargetMemoHandled?: () => void;
+  /** Routes a clicked file/memory/memo path through ChatView's path-aware
+   * router. Lets in-panel markdown links (e.g., a sibling memory entry
+   * referenced from memory.md) jump to the right tab + entry. */
+  onOpenFile?: (path: string, workspaceId?: string) => void;
   files?: string[];
   filesLoading?: boolean;
   filesError?: string | null;
@@ -37,6 +49,12 @@ export default function RightPanel({
   onTargetFileHandled,
   targetDirectory,
   onTargetDirHandled,
+  targetMemoryKey,
+  targetMemoryTier,
+  onTargetMemoryHandled,
+  targetMemoKey,
+  onTargetMemoHandled,
+  onOpenFile,
   files,
   filesLoading,
   filesError,
@@ -60,11 +78,15 @@ export default function RightPanel({
     [t],
   );
 
-  // If the caller navigates to a specific file while the Memory tab is active,
-  // snap back to Files so the user sees what they asked for.
+  // Snap-back precedence: memory > memo > file. The parent (ChatView) clears
+  // sibling targets before setting one, so in steady state only one branch
+  // fires; this effect is the second line of defense if multiple are set
+  // in the same render.
   React.useEffect(() => {
-    if (targetFile || targetDirectory) setTab('files');
-  }, [targetFile, targetDirectory]);
+    if (targetMemoryKey != null) setTab('memory');
+    else if (targetMemoKey != null) setTab('memo');
+    else if (targetFile || targetDirectory) setTab('files');
+  }, [targetMemoryKey, targetMemoKey, targetFile, targetDirectory]);
 
   return (
     <div
@@ -118,8 +140,22 @@ export default function RightPanel({
               onSwitchToMemoTab={() => setTab('memo')}
             />
           )}
-          {tab === 'memory' && <MemoryPanel workspaceId={workspaceId} />}
-          {tab === 'memo' && <MemoPanel />}
+          {tab === 'memory' && (
+            <MemoryPanel
+              workspaceId={workspaceId}
+              targetKey={targetMemoryKey ?? null}
+              targetTier={targetMemoryTier ?? null}
+              onTargetHandled={onTargetMemoryHandled}
+              onOpenFile={onOpenFile}
+            />
+          )}
+          {tab === 'memo' && (
+            <MemoPanel
+              targetKey={targetMemoKey ?? null}
+              onTargetHandled={onTargetMemoHandled}
+              onOpenFile={onOpenFile}
+            />
+          )}
         </Suspense>
       </div>
     </div>

--- a/web/src/pages/ChatAgent/components/ToolCallMessageContent.tsx
+++ b/web/src/pages/ChatAgent/components/ToolCallMessageContent.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
 import { ChevronDown, ChevronUp, FileText } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { TextShimmer } from '@/components/ui/text-shimmer';
-import { getDisplayName, getToolIcon, getInProgressText, stripLineNumbers, parseTruncatedResult } from './toolDisplayConfig';
+import { getDisplayName, getToolIcon, getActiveLabel, stripLineNumbers, parseTruncatedResult } from './toolDisplayConfig';
 import Markdown from './Markdown';
 import { parseDisplayableResults, buildRichResultMap, resolveSnippet } from './webSearchUtils';
 
@@ -180,10 +181,8 @@ interface ToolCallMessageContentProps {
 }
 
 /**
- * ToolCallMessageContent Component
- *
- * Renders tool call information. Used in the agent panel (non-textOnly mode).
- * In the main chat textOnly mode, tool calls are rendered via ActivityAccordion/LiveActivity instead.
+ * ToolCallMessageContent -- used in the subagent/detail panel.
+ * In the main chat view, tool calls are rendered by ActivityBlock instead.
  */
 function ToolCallMessageContent({
   toolCallId: _toolCallId,
@@ -197,6 +196,7 @@ function ToolCallMessageContent({
   onDetailClick,
   mergedProcesses
 }: ToolCallMessageContentProps): React.ReactElement | null {
+  const { t } = useTranslation();
   const [isExpanded, setIsExpanded] = useState(false);
 
   // Resolve display data: single from props or last of merged
@@ -205,7 +205,8 @@ function ToolCallMessageContent({
     : [{ toolName, toolCall, toolCallResult, isInProgress, isComplete, isFailed }];
   const displayProcess = processes[processes.length - 1];
   const rawToolName = displayProcess.toolName || displayProcess.toolCall?.name || 'Tool Call';
-  const displayName = getDisplayName(rawToolName);
+  const displayArgs = displayProcess.toolCall?.args;
+  const displayName = getDisplayName(rawToolName, t, displayArgs);
   const isFileTool = FILE_TOOLS.includes(rawToolName);
   const filePath = isFileTool ? getFilePathFromToolCall(displayProcess.toolCall) : null;
 
@@ -226,7 +227,7 @@ function ToolCallMessageContent({
     : [];
   const hasInlineResult = inlineSummaries.length > 0;
 
-  const IconComponent = getToolIcon(rawToolName);
+  const IconComponent = getToolIcon(rawToolName, displayArgs);
 
   // Inline tool rendering — compact row with summary
   if (isInlineTool) {
@@ -280,7 +281,7 @@ function ToolCallMessageContent({
                 className="font-medium text-[13px] [--base-color:var(--Labels-Secondary)] [--base-gradient-color:var(--color-text-primary)]"
                 duration={1.5}
               >
-                {`${displayName} ${getInProgressText(rawToolName, displayProcess.toolCall) || ''}`}
+                {getActiveLabel(rawToolName, displayProcess.toolCall, t)}
               </TextShimmer>
             ) : (
               <span style={{ fontWeight: 500 }}>{displayName}</span>
@@ -347,7 +348,7 @@ function ToolCallMessageContent({
             className="font-medium text-[13px] [--base-color:var(--Labels-Secondary)] [--base-gradient-color:var(--color-text-primary)]"
             duration={1.5}
           >
-            {`${displayName} ${getInProgressText(rawToolName, displayProcess.toolCall) || ''}`}
+            {getActiveLabel(rawToolName, displayProcess.toolCall, t)}
           </TextShimmer>
         ) : (
           <span style={{ color: 'inherit' }}>{displayName}</span>

--- a/web/src/pages/ChatAgent/components/ToolCallMessageContent.tsx
+++ b/web/src/pages/ChatAgent/components/ToolCallMessageContent.tsx
@@ -8,10 +8,9 @@ import { parseDisplayableResults, buildRichResultMap, resolveSnippet } from './w
 
 /**
  * File-related tool names that support opening in the file panel.
- * Backend uses PascalCase (LangChain SDK convention). Include both for backward compatibility
- * with older history that may have snake_case tool names.
+ * Mirrors the agent's @tool decorators in src/ptc_agent/agent/tools/file_ops.py.
  */
-const FILE_TOOLS = ['Write', 'Edit', 'Read', 'Save', 'write_file', 'edit_file', 'read_file', 'save_file'];
+const FILE_TOOLS = ['Write', 'Edit', 'Read'];
 
 /**
  * Inline tools — results are shown as a one-line summary directly in the row.

--- a/web/src/pages/ChatAgent/components/__tests__/ActivityBlock.failed.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/ActivityBlock.failed.test.tsx
@@ -1,0 +1,308 @@
+/**
+ * Coverage for the failed-tool-call surfacing logic added in Fix #3, the
+ * memo-write classification surfacing in Fix #4, and the priority-fragment
+ * cap in Fix #14.
+ *
+ * Strategy: render `ActivityBlock` directly with a small set of synthesized
+ * `_liveState: 'completed'` items, and assert against the rendered DOM. The
+ * t() identity mock returns the i18n key as-is so the assertions can pin
+ * the exact branch (e.g. `categoryCount.failed`, `categoryCount.memoWrite`)
+ * without depending on the bundled English copy.
+ */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, within, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ActivityBlock from '../ActivityBlock';
+
+// ---------------------------------------------------------------------------
+// Mocks — keep the component mountable in jsdom and surface i18n keys.
+// ---------------------------------------------------------------------------
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (opts && typeof opts === 'object') {
+        let out = key;
+        for (const [k, v] of Object.entries(opts)) {
+          out = out.replace(new RegExp(`{{\\s*${k}\\s*}}`, 'g'), String(v));
+        }
+        return out;
+      }
+      return key;
+    },
+  }),
+}));
+
+// Markdown is heavy and irrelevant to these tests.
+vi.mock('../Markdown', () => ({
+  default: ({ content }: { content: string }) => (
+    <div data-testid="markdown-content">{content}</div>
+  ),
+}));
+
+// Inline artifact cards aren't used by these test items but are imported by
+// ActivityBlock — stub them so the module graph stays light.
+vi.mock('../charts/InlineArtifactCards', () => ({
+  INLINE_ARTIFACT_TOOLS: new Set<string>(),
+  InlineStockPriceCard: () => null,
+  InlineCompanyOverviewCard: () => null,
+  InlineMarketIndicesCard: () => null,
+  InlineSectorPerformanceCard: () => null,
+  InlineSecFilingCard: () => null,
+  InlineStockScreenerCard: () => null,
+  InlineWebSearchCard: () => null,
+}));
+
+vi.mock('../charts/InlineAutomationCards', () => ({
+  InlineAutomationCard: () => null,
+}));
+
+vi.mock('../charts/InlinePreviewCard', () => ({
+  InlinePreviewCard: () => null,
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type ActivityItem = Parameters<typeof ActivityBlock>[0]['items'][number];
+
+function completedTool(toolName: string, opts: Partial<ActivityItem> = {}): ActivityItem {
+  return {
+    type: 'tool_call',
+    id: opts.id ?? `${toolName}-${Math.random().toString(36).slice(2, 8)}`,
+    toolName,
+    toolCall: opts.toolCall ?? { args: {} },
+    isComplete: true,
+    _liveState: 'completed',
+    ...opts,
+  } as ActivityItem;
+}
+
+// ---------------------------------------------------------------------------
+// Fix #3 — failed-call surfacing
+// ---------------------------------------------------------------------------
+
+// `summaryLabel` is title-cased before render (charAt(0).toUpperCase()), so
+// the accessible name comes through with a leading capital. Use a
+// case-insensitive regex when looking up the toggle by name.
+const SUMMARY_BUTTON_RE = /toolArtifact/i;
+
+describe('ActivityBlock — failed tool calls (Fix #3)', () => {
+  it('appends a "failed" fragment to the folded accordion summary when an item is failed', () => {
+    const items: ActivityItem[] = [
+      completedTool('Read', {
+        id: 'r-1',
+        isFailed: true,
+        toolCall: { args: { file_path: 'work/scratch.md' } },
+      }),
+    ];
+
+    render(<ActivityBlock items={items} isStreaming={false} />);
+
+    // Folded summary contains the failed fragment.
+    const summary = screen.getByRole('button', { name: SUMMARY_BUTTON_RE });
+    expect(summary).toHaveTextContent(/toolArtifact\.categoryCount\.failed/i);
+  });
+
+  it('renders the failed badge on the timeline icon when the accordion is expanded', () => {
+    const items: ActivityItem[] = [
+      completedTool('Read', {
+        id: 'r-1',
+        isFailed: true,
+        toolCall: { args: { file_path: 'work/scratch.md' } },
+      }),
+    ];
+
+    const { container } = render(<ActivityBlock items={items} isStreaming={false} />);
+
+    // Expand the accordion.
+    fireEvent.click(screen.getByRole('button', { name: SUMMARY_BUTTON_RE }));
+
+    // The failed item gets the .failed class hook + a badge with the
+    // toolCallFailed a11y label.
+    const failedRow = container.querySelector('.titem.failed');
+    expect(failedRow).not.toBeNull();
+    const badge = failedRow!.querySelector('.nrow-badge');
+    expect(badge).not.toBeNull();
+    expect(badge!.getAttribute('aria-label')).toBe('toolArtifact.a11y.toolCallFailed');
+  });
+
+  it('renders the failed badge on an Edit row (EditToolRow path)', () => {
+    const items: ActivityItem[] = [
+      completedTool('Edit', {
+        id: 'e-1',
+        isFailed: true,
+        toolCall: {
+          args: {
+            file_path: 'work/scratch.md',
+            old_string: 'foo',
+            new_string: 'bar',
+          },
+        },
+      }),
+    ];
+
+    const { container } = render(<ActivityBlock items={items} isStreaming={false} />);
+    fireEvent.click(screen.getByRole('button', { name: SUMMARY_BUTTON_RE }));
+
+    const failedRow = container.querySelector('.titem.failed');
+    expect(failedRow).not.toBeNull();
+    expect(failedRow!.querySelector('.nrow-badge')).not.toBeNull();
+  });
+
+  it('counts successful and failed reads distinctly in the folded summary', () => {
+    const items: ActivityItem[] = [
+      completedTool('Read', { id: 'r-1', toolCall: { args: { file_path: 'a.md' } } }),
+      completedTool('Read', { id: 'r-2', toolCall: { args: { file_path: 'b.md' } } }),
+      completedTool('Read', {
+        id: 'r-3',
+        isFailed: true,
+        toolCall: { args: { file_path: 'c.md' } },
+      }),
+    ];
+
+    render(<ActivityBlock items={items} isStreaming={false} />);
+    const summary = screen.getByRole('button', { name: SUMMARY_BUTTON_RE });
+    // Three reads in the fileRead bucket (orthogonal to failure axis).
+    expect(summary).toHaveTextContent(/toolArtifact\.categoryCount.fileRead/i);
+    // ...and one failed fragment alongside it.
+    expect(summary).toHaveTextContent(/toolArtifact\.categoryCount.failed/i);
+  });
+
+  it('does not render any failed badge when no item is failed', () => {
+    const items: ActivityItem[] = [
+      completedTool('Read', {
+        id: 'r-1',
+        toolCall: { args: { file_path: 'work/scratch.md' } },
+      }),
+    ];
+
+    const { container } = render(<ActivityBlock items={items} isStreaming={false} />);
+    fireEvent.click(screen.getByRole('button', { name: SUMMARY_BUTTON_RE }));
+    expect(container.querySelector('.titem.failed')).toBeNull();
+    expect(container.querySelector('.nrow-badge')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix #4 — memo write/edit classification in the summary
+// ---------------------------------------------------------------------------
+
+describe('ActivityBlock — memo write/edit fragment (Fix #4)', () => {
+  it('emits a memoWrite fragment when the agent writes a memo', () => {
+    const items: ActivityItem[] = [
+      completedTool('Write', {
+        id: 'w-1',
+        toolCall: { args: { file_path: '.agents/user/memo/notes.md' } },
+      }),
+    ];
+
+    render(<ActivityBlock items={items} isStreaming={false} />);
+    const summary = screen.getByRole('button', { name: SUMMARY_BUTTON_RE });
+    expect(summary).toHaveTextContent(/toolArtifact\.categoryCount.memoWrite/i);
+    // It must NOT show as a memo read.
+    expect(summary).not.toHaveTextContent(/toolArtifact\.categoryCount.memo /i);
+  });
+
+  it('keeps memo reads in the existing memo fragment', () => {
+    const items: ActivityItem[] = [
+      completedTool('Read', {
+        id: 'r-1',
+        toolCall: { args: { file_path: '.agents/user/memo/notes.md' } },
+      }),
+    ];
+
+    render(<ActivityBlock items={items} isStreaming={false} />);
+    const summary = screen.getByRole('button', { name: SUMMARY_BUTTON_RE });
+    expect(summary).toHaveTextContent(/toolArtifact\.categoryCount.memo/i);
+    expect(summary).not.toHaveTextContent(/toolArtifact\.categoryCount.memoWrite/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix #14 — priority fragments survive the FOLDED_MAX cap
+// ---------------------------------------------------------------------------
+
+describe('ActivityBlock — priority fragments survive the cap (Fix #14)', () => {
+  it('keeps memoryWrite visible even with 4+ categories present', () => {
+    const items: ActivityItem[] = [
+      // A memory write — the high-signal fragment we don't want to hide.
+      completedTool('Write', {
+        id: 'mw-1',
+        toolCall: { args: { file_path: '.agents/user/memory/risk.md' } },
+      }),
+      // Pad with three other categories so the cap kicks in.
+      completedTool('ExecuteCode', { id: 'c-1' }),
+      completedTool('WebSearch', { id: 'wb-1' }),
+      completedTool('Glob', { id: 'g-1' }),
+      completedTool('Read', { id: 'r-1', toolCall: { args: { file_path: 'work/scratch.md' } } }),
+    ];
+
+    render(<ActivityBlock items={items} isStreaming={false} />);
+    const summary = screen.getByRole('button', { name: SUMMARY_BUTTON_RE });
+    // memoryUpdated must be in the visible 3 even with overflow.
+    expect(summary).toHaveTextContent(/toolArtifact\.categoryCount.memoryUpdated/i);
+    // The "and more" suffix indicates the cap fired.
+    expect(summary).toHaveTextContent(/toolArtifact\.andMore/i);
+  });
+
+  it('keeps a failed fragment visible even with 4+ categories present', () => {
+    const items: ActivityItem[] = [
+      completedTool('Read', {
+        id: 'r-fail',
+        isFailed: true,
+        toolCall: { args: { file_path: 'work/scratch.md' } },
+      }),
+      completedTool('ExecuteCode', { id: 'c-1' }),
+      completedTool('WebSearch', { id: 'wb-1' }),
+      completedTool('Glob', { id: 'g-1' }),
+      // A second non-priority bucket to overflow past the cap.
+      completedTool('Read', { id: 'r-2', toolCall: { args: { file_path: 'work/other.md' } } }),
+    ];
+
+    render(<ActivityBlock items={items} isStreaming={false} />);
+    const summary = screen.getByRole('button', { name: SUMMARY_BUTTON_RE });
+    expect(summary).toHaveTextContent(/toolArtifact\.categoryCount.failed/i);
+    expect(summary).toHaveTextContent(/toolArtifact\.andMore/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix #16 — accordion accessibility
+// ---------------------------------------------------------------------------
+
+describe('ActivityBlock — accordion a11y (Fix #16)', () => {
+  it('toggles aria-expanded on the summary button', () => {
+    const items: ActivityItem[] = [
+      completedTool('Read', { id: 'r-1', toolCall: { args: { file_path: 'work/scratch.md' } } }),
+    ];
+
+    render(<ActivityBlock items={items} isStreaming={false} />);
+    const summary = screen.getByRole('button', { name: SUMMARY_BUTTON_RE });
+    expect(summary).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(summary);
+    expect(summary).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('points aria-controls at the timeline region with matching aria-labelledby', () => {
+    const items: ActivityItem[] = [
+      completedTool('Read', { id: 'r-1', toolCall: { args: { file_path: 'work/scratch.md' } } }),
+    ];
+
+    const { container } = render(<ActivityBlock items={items} isStreaming={false} />);
+    const summary = screen.getByRole('button', { name: SUMMARY_BUTTON_RE });
+    fireEvent.click(summary);
+
+    const controlsId = summary.getAttribute('aria-controls');
+    expect(controlsId).toBeTruthy();
+    const region = container.querySelector(`#${CSS.escape(controlsId!)}`);
+    expect(region).not.toBeNull();
+    expect(region!.getAttribute('role')).toBe('region');
+    expect(region!.getAttribute('aria-labelledby')).toBe(summary.id);
+    // The timeline region holds at least one row.
+    expect(within(region as HTMLElement).getAllByRole('listitem').length).toBeGreaterThan(0);
+  });
+});

--- a/web/src/pages/ChatAgent/components/__tests__/ChatView.routing.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/ChatView.routing.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * ChatView routing — verifies the pure routing function used by
+ * `handleOpenAgentArtifactFromChat`. Critical regressions:
+ *  - all targets are cleared per call (no stale-target hijacking)
+ *  - memo index opens to LIST view (empty-string targetMemoKey sentinel)
+ *  - user-scoped artifacts (memo, user-tier memory) clear filePanelWorkspaceId
+ *  - cross-workspace ws:// links pass through targetWorkspaceId
+ */
+import { describe, it, expect } from 'vitest';
+import { computeAgentArtifactRouting } from '../../utils/agentPaths';
+
+describe('computeAgentArtifactRouting — per-kind routing', () => {
+  it('routes user memory entry → Memory tab + tier user + clears workspace id', () => {
+    const r = computeAgentArtifactRouting('.agents/user/memory/risk-preferences.md');
+    expect(r).toEqual({
+      targetFile: null,
+      targetMemoryKey: 'risk-preferences.md',
+      targetMemoryTier: 'user',
+      targetMemoKey: null,
+      clearWorkspaceId: true,
+      setWorkspaceId: null,
+    });
+  });
+
+  it('routes workspace memory without a wsid → clears stale filePanelWorkspaceId (flash-mode wsid leak guard)', () => {
+    // Regression: prior versions left clearWorkspaceId=false, leaking a stale
+    // ws id from a prior cross-workspace click into the new memory query.
+    const r = computeAgentArtifactRouting('.agents/workspace/memory/foo.md');
+    expect(r.targetMemoryKey).toBe('foo.md');
+    expect(r.targetMemoryTier).toBe('workspace');
+    expect(r.clearWorkspaceId).toBe(true);
+    expect(r.setWorkspaceId).toBeNull();
+    expect(r.targetFile).toBeNull();
+    expect(r.targetMemoKey).toBeNull();
+  });
+
+  it('routes a memo entry → Memo tab + slug + clears workspace id', () => {
+    const r = computeAgentArtifactRouting('.agents/user/memo/my-report.pdf');
+    expect(r).toEqual({
+      targetFile: null,
+      targetMemoryKey: null,
+      targetMemoryTier: null,
+      targetMemoKey: 'my-report.pdf',
+      clearWorkspaceId: true,
+      setWorkspaceId: null,
+    });
+  });
+
+  it('routes the memo index → Memo tab to LIST (empty-string sentinel, no entry pre-select)', () => {
+    const r = computeAgentArtifactRouting('.agents/user/memo/memo.md');
+    expect(r.targetMemoKey).toBe('');
+    expect(r.targetMemoryKey).toBeNull();
+    expect(r.targetFile).toBeNull();
+    expect(r.clearWorkspaceId).toBe(true);
+  });
+
+  it('routes a skill activation → Files tab with full path', () => {
+    const r = computeAgentArtifactRouting('.agents/skills/investigate/SKILL.md');
+    expect(r.targetFile).toBe('.agents/skills/investigate/SKILL.md');
+    expect(r.targetMemoryKey).toBeNull();
+    expect(r.targetMemoKey).toBeNull();
+    expect(r.clearWorkspaceId).toBe(false);
+  });
+
+  it('routes a regular file → Files tab and preserves workspace id when provided', () => {
+    const r = computeAgentArtifactRouting('work/notes.md', 'ws-other');
+    expect(r.targetFile).toBe('work/notes.md');
+    expect(r.setWorkspaceId).toBe('ws-other');
+    expect(r.clearWorkspaceId).toBe(false);
+  });
+
+  it('propagates targetWorkspaceId for workspace-tier memory (cross-workspace __wsref__ links)', () => {
+    // Regression guard: when a markdown link reaches into another workspace's
+    // memory (`__wsref__/ws-other/.agents/workspace/memory/notes.md`), the
+    // routing must hand the linked workspace id to MemoryPanel so it queries
+    // the correct workspace, not the chat's current one.
+    const r = computeAgentArtifactRouting('.agents/workspace/memory/notes.md', 'ws-other');
+    expect(r.targetMemoryKey).toBe('notes.md');
+    expect(r.targetMemoryTier).toBe('workspace');
+    expect(r.setWorkspaceId).toBe('ws-other');
+    expect(r.clearWorkspaceId).toBe(false);
+  });
+
+  it('extracts wsid from a __wsref__/<wsid>/... path even without an explicit targetWorkspaceId arg', () => {
+    // The path itself carries the workspace context; MemoryPanel must wire to
+    // ws-X before it mounts. clearWorkspaceId stays false because we are SETTING.
+    const r = computeAgentArtifactRouting('__wsref__/ws-X/.agents/user/memory/foo.md');
+    expect(r.targetMemoryKey).toBe('foo.md');
+    expect(r.targetMemoryTier).toBe('user');
+    // User-tier memory always clears workspace id regardless of __wsref__.
+    expect(r.clearWorkspaceId).toBe(true);
+    expect(r.setWorkspaceId).toBeNull();
+  });
+
+  it('extracts wsid from __wsref__ for workspace-tier memory and sets it on the panel', () => {
+    const r = computeAgentArtifactRouting('__wsref__/ws-X/.agents/workspace/memory/foo.md');
+    expect(r.targetMemoryKey).toBe('foo.md');
+    expect(r.targetMemoryTier).toBe('workspace');
+    expect(r.setWorkspaceId).toBe('ws-X');
+    expect(r.clearWorkspaceId).toBe(false);
+  });
+
+  it('user-tier memory always clears workspace id, even when one is provided', () => {
+    // User memory is global — a stale ws id from a flash ws:// link must be
+    // cleared so the memory list doesn't leak into the wrong workspace.
+    const r = computeAgentArtifactRouting('.agents/user/memory/foo.md', 'ws-other');
+    expect(r.targetMemoryTier).toBe('user');
+    expect(r.clearWorkspaceId).toBe(true);
+    expect(r.setWorkspaceId).toBeNull();
+  });
+
+  it('clears every other target on every call (no stale hijacking)', () => {
+    // The function returns a fresh object every time; sibling fields are null.
+    const memo = computeAgentArtifactRouting('.agents/user/memo/foo.pdf');
+    expect(memo.targetFile).toBeNull();
+    expect(memo.targetMemoryKey).toBeNull();
+
+    const memory = computeAgentArtifactRouting('.agents/user/memory/foo.md');
+    expect(memory.targetFile).toBeNull();
+    expect(memory.targetMemoKey).toBeNull();
+
+    const file = computeAgentArtifactRouting('work/x.md');
+    expect(file.targetMemoryKey).toBeNull();
+    expect(file.targetMemoKey).toBeNull();
+    expect(file.targetMemoryTier).toBeNull();
+  });
+
+  it('handles leading slash and sandbox-root prefix (path normalization)', () => {
+    const a = computeAgentArtifactRouting('/.agents/user/memory/foo.md');
+    const b = computeAgentArtifactRouting('home/workspace/.agents/user/memory/foo.md');
+    expect(a.targetMemoryKey).toBe('foo.md');
+    expect(b.targetMemoryKey).toBe('foo.md');
+  });
+
+  it('falls back to file routing for unknown agent paths', () => {
+    const r = computeAgentArtifactRouting('something/random.json');
+    expect(r.targetFile).toBe('something/random.json');
+    expect(r.targetMemoKey).toBeNull();
+    expect(r.targetMemoryKey).toBeNull();
+  });
+});

--- a/web/src/pages/ChatAgent/components/__tests__/MemoPanelRace.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/MemoPanelRace.test.tsx
@@ -1,0 +1,521 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { renderWithProviders } from '@/test/utils';
+
+// ---------------------------------------------------------------------------
+// These tests exercise the cache-refetch race + body-link rewrite + unsaved-
+// edit confirmation behaviour. We stub the data hooks directly (rather than
+// the api layer) so we can deterministically control `isLoading` /
+// `isFetching` transitions without spinning a real react-query lifecycle.
+// ---------------------------------------------------------------------------
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      // Mirror the i18next defaultValue fallback so the unsaved-edit prompt
+      // reads naturally when the test inspects window.confirm's argument.
+      if (opts && typeof opts === 'object' && 'defaultValue' in opts) {
+        return String((opts as { defaultValue: unknown }).defaultValue);
+      }
+      if (opts && typeof opts === 'object') {
+        let out = key;
+        for (const [k, v] of Object.entries(opts)) {
+          out = out.replace(new RegExp(`{{\\s*${k}\\s*}}`, 'g'), String(v));
+        }
+        return out;
+      }
+      return key;
+    },
+  }),
+}));
+
+vi.mock('../Markdown', () => ({
+  default: ({
+    content,
+    onOpenFile,
+  }: {
+    content: string;
+    onOpenFile?: (href: string, wsId?: string) => void;
+  }) => (
+    <div data-testid="markdown-content">
+      {content}
+      {/* Expose the link-router so tests can assert how hrefs are rewritten. */}
+      <button
+        type="button"
+        data-testid="md-link-md"
+        onClick={() => onOpenFile?.('siblings.md')}
+      >
+        siblings.md
+      </button>
+      <button
+        type="button"
+        data-testid="md-link-md-dotslash"
+        onClick={() => onOpenFile?.('./other.md')}
+      >
+        ./other.md
+      </button>
+      <button
+        type="button"
+        data-testid="md-link-pdf"
+        onClick={() => onOpenFile?.('reports/q1.pdf')}
+      >
+        reports/q1.pdf
+      </button>
+      <button
+        type="button"
+        data-testid="md-link-bare-pdf"
+        onClick={() => onOpenFile?.('attached.pdf')}
+      >
+        attached.pdf
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
+    open ? <div data-testid="dialog">{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="dialog-content">{children}</div>
+  ),
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock('@/components/ui/hover-card', () => ({
+  HoverCard: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  HoverCardTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  HoverCardContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/hooks/useWorkspaces', () => ({
+  useWorkspaces: () => ({ data: { workspaces: [] } }),
+}));
+
+// Stub the api module wholesale — the hooks below are mocked but the panel
+// still imports a couple of helpers (download, deleteUserMemo for bulk).
+vi.mock('@/pages/ChatAgent/utils/api', () => ({
+  listUserMemos: vi.fn(),
+  readUserMemo: vi.fn(),
+  uploadUserMemo: vi.fn(),
+  writeUserMemo: vi.fn(),
+  deleteUserMemo: vi.fn(),
+  regenerateUserMemo: vi.fn(),
+  triggerUserMemoDownload: vi.fn(),
+  downloadUserMemoBlobUrl: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Hook stubs — we drive the list/read state directly so each test can
+// control the loading / refetching / data transitions without timing.
+// ---------------------------------------------------------------------------
+
+interface ListState {
+  data: { entries: Array<{ key: string; original_filename: string | null; mime_type: string | null; size_bytes: number; description: string | null; metadata_status: 'ready' | 'pending' | 'failed' | null; created_at: string | null; modified_at: string | null; source_kind: string | null; source_workspace_id: string | null; source_path: string | null; sha256: string | null }>; truncated: boolean } | undefined;
+  isLoading: boolean;
+  isFetching: boolean;
+  error: unknown;
+  refetch: () => void;
+}
+
+interface ReadState {
+  data:
+    | {
+        key: string;
+        content: string;
+        encoding: string;
+        mime_type: string | null;
+        size_bytes: number;
+        original_filename: string | null;
+        description: string | null;
+        summary: string | null;
+        metadata_status: 'ready' | 'pending' | 'failed' | null;
+        metadata_error: string | null;
+        created_at: string | null;
+        modified_at: string | null;
+        source_kind: string | null;
+        source_workspace_id: string | null;
+        source_path: string | null;
+      }
+    | undefined;
+  isLoading: boolean;
+  error: unknown;
+}
+
+let listState: ListState;
+let readState: ReadState;
+
+vi.mock('../../hooks/useMemo', () => ({
+  useUserMemoList: () => listState,
+  useReadUserMemo: () => readState,
+  useUploadUserMemo: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useDeleteUserMemo: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useWriteUserMemo: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useRegenerateUserMemo: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+import MemoPanel from '../MemoPanel';
+
+const baseEntry = {
+  key: 'note.md',
+  original_filename: 'note.md',
+  mime_type: 'text/markdown',
+  size_bytes: 12,
+  description: null,
+  metadata_status: 'ready' as const,
+  created_at: '2026-01-01T00:00:00Z',
+  modified_at: null,
+  source_kind: null,
+  source_workspace_id: null,
+  source_path: null,
+  sha256: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listState = {
+    data: { entries: [], truncated: false },
+    isLoading: false,
+    isFetching: false,
+    error: null,
+    refetch: vi.fn(),
+  };
+  readState = {
+    data: undefined,
+    isLoading: false,
+    error: null,
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Fix #5 — race: stale list + targetKey arrives while refetch is in flight
+// ---------------------------------------------------------------------------
+
+describe('MemoPanel — cache-refetch race (Fix #5)', () => {
+  it('does not flash the not-found banner while a background refetch is in flight, and opens the entry once it lands', async () => {
+    // Stale list (no target) + refetch in flight.
+    listState = {
+      data: { entries: [], truncated: false },
+      isLoading: false,
+      isFetching: true,
+      error: null,
+      refetch: vi.fn(),
+    };
+
+    const { rerender } = renderWithProviders(
+      <MemoPanel targetKey="fresh-memo.md" onTargetHandled={() => {}} />,
+    );
+
+    // Banner must NOT appear while we're still fetching the fresh list.
+    await waitFor(() => {
+      expect(
+        screen.queryByText('memoPanel.notFound'),
+      ).not.toBeInTheDocument();
+    });
+
+    // Refetch lands — fresh list now contains the target.
+    listState = {
+      data: {
+        entries: [
+          { ...baseEntry, key: 'fresh-memo.md', original_filename: 'fresh-memo.md' },
+        ],
+        truncated: false,
+      },
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refetch: vi.fn(),
+    };
+    readState = {
+      data: {
+        key: 'fresh-memo.md',
+        content: '# fresh',
+        encoding: 'utf-8',
+        mime_type: 'text/markdown',
+        size_bytes: 7,
+        original_filename: 'fresh-memo.md',
+        description: null,
+        summary: null,
+        metadata_status: 'ready',
+        metadata_error: null,
+        created_at: null,
+        modified_at: null,
+        source_kind: null,
+        source_workspace_id: null,
+        source_path: null,
+      },
+      isLoading: false,
+      error: null,
+    };
+
+    rerender(<MemoPanel targetKey="fresh-memo.md" onTargetHandled={() => {}} />);
+
+    // Viewer mounted with the fresh content; no not-found banner ever rendered.
+    await waitFor(() =>
+      expect(screen.getByTestId('markdown-content')).toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByText(/memoPanel\.notFound/),
+    ).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix #6 — body link rewrite heuristic
+// ---------------------------------------------------------------------------
+
+describe('MemoPanel — body link routing (Fix #6)', () => {
+  it('rewrites bare slug hrefs into the memo dir, but passes hrefs containing a "/" through unchanged', async () => {
+    const onOpenFile = vi.fn();
+
+    listState = {
+      data: { entries: [{ ...baseEntry }], truncated: false },
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refetch: vi.fn(),
+    };
+    readState = {
+      data: {
+        key: 'note.md',
+        content: '# n',
+        encoding: 'utf-8',
+        mime_type: 'text/markdown',
+        size_bytes: 3,
+        original_filename: 'note.md',
+        description: null,
+        summary: null,
+        metadata_status: 'ready',
+        metadata_error: null,
+        created_at: null,
+        modified_at: null,
+        source_kind: null,
+        source_workspace_id: null,
+        source_path: null,
+      },
+      isLoading: false,
+      error: null,
+    };
+
+    renderWithProviders(<MemoPanel onOpenFile={onOpenFile} />);
+    const user = userEvent.setup();
+
+    await user.click(await screen.findByText('note.md'));
+    await screen.findByTestId('markdown-content');
+
+    // Bare slug `siblings.md` → resolves against the memo dir.
+    await user.click(screen.getByTestId('md-link-md'));
+    expect(onOpenFile).toHaveBeenLastCalledWith(
+      '.agents/user/memo/siblings.md',
+      undefined,
+    );
+
+    // `./other.md` → leading `./` stripped, resolved against memo dir.
+    await user.click(screen.getByTestId('md-link-md-dotslash'));
+    expect(onOpenFile).toHaveBeenLastCalledWith(
+      '.agents/user/memo/other.md',
+      undefined,
+    );
+
+    // `reports/q1.pdf` → has a subdir → passes through verbatim.
+    await user.click(screen.getByTestId('md-link-pdf'));
+    expect(onOpenFile).toHaveBeenLastCalledWith('reports/q1.pdf', undefined);
+
+    // Bare `attached.pdf` (no subdir) → still resolved against memo dir
+    // because PDFs are valid memo entries.
+    await user.click(screen.getByTestId('md-link-bare-pdf'));
+    expect(onOpenFile).toHaveBeenLastCalledWith(
+      '.agents/user/memo/attached.pdf',
+      undefined,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix #8 — unsaved edit + empty-string targetKey sentinel
+// ---------------------------------------------------------------------------
+
+describe('MemoPanel — unsaved edit guard on empty targetKey (Fix #8)', () => {
+  it('prompts before discarding when the user cancels, and keeps the editor mounted', async () => {
+    listState = {
+      data: { entries: [{ ...baseEntry }], truncated: false },
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refetch: vi.fn(),
+    };
+    readState = {
+      data: {
+        key: 'note.md',
+        content: 'old content',
+        encoding: 'utf-8',
+        mime_type: 'text/markdown',
+        size_bytes: 11,
+        original_filename: 'note.md',
+        description: null,
+        summary: null,
+        metadata_status: 'ready',
+        metadata_error: null,
+        created_at: null,
+        modified_at: null,
+        source_kind: null,
+        source_workspace_id: null,
+        source_path: null,
+      },
+      isLoading: false,
+      error: null,
+    };
+
+    const onTargetHandled = vi.fn();
+
+    const { rerender } = renderWithProviders(
+      <MemoPanel onTargetHandled={onTargetHandled} />,
+    );
+    const user = userEvent.setup();
+
+    // Open the entry, enter edit mode, dirty the buffer.
+    await user.click(await screen.findByText('note.md'));
+    await screen.findByTestId('markdown-content');
+    await user.click(screen.getByTitle('memoPanel.actions.edit'));
+    const textarea = await screen.findByDisplayValue('old content');
+    await user.type(textarea, ' + my unsaved work');
+
+    // Stub confirm → user cancels.
+    const confirmSpy = vi
+      .spyOn(window, 'confirm')
+      .mockImplementation(() => false);
+
+    // Empty-string sentinel arrives (e.g. agent wrote memo.md index).
+    rerender(
+      <MemoPanel targetKey="" onTargetHandled={onTargetHandled} />,
+    );
+
+    await waitFor(() => expect(confirmSpy).toHaveBeenCalled());
+
+    // Editor still mounted with the dirty buffer intact.
+    expect(
+      screen.getByDisplayValue('old content + my unsaved work'),
+    ).toBeInTheDocument();
+
+    // Sentinel was acked so we don't loop on every render.
+    expect(onTargetHandled).toHaveBeenCalled();
+
+    confirmSpy.mockRestore();
+  });
+
+  it('clears the editor when the user confirms the discard', async () => {
+    listState = {
+      data: { entries: [{ ...baseEntry }], truncated: false },
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refetch: vi.fn(),
+    };
+    readState = {
+      data: {
+        key: 'note.md',
+        content: 'old content',
+        encoding: 'utf-8',
+        mime_type: 'text/markdown',
+        size_bytes: 11,
+        original_filename: 'note.md',
+        description: null,
+        summary: null,
+        metadata_status: 'ready',
+        metadata_error: null,
+        created_at: null,
+        modified_at: null,
+        source_kind: null,
+        source_workspace_id: null,
+        source_path: null,
+      },
+      isLoading: false,
+      error: null,
+    };
+
+    const { rerender } = renderWithProviders(
+      <MemoPanel onTargetHandled={() => {}} />,
+    );
+    const user = userEvent.setup();
+
+    await user.click(await screen.findByText('note.md'));
+    await screen.findByTestId('markdown-content');
+    await user.click(screen.getByTitle('memoPanel.actions.edit'));
+    const textarea = await screen.findByDisplayValue('old content');
+    await user.type(textarea, ' dirty');
+
+    const confirmSpy = vi
+      .spyOn(window, 'confirm')
+      .mockImplementation(() => true);
+
+    rerender(<MemoPanel targetKey="" onTargetHandled={() => {}} />);
+
+    await waitFor(() => expect(confirmSpy).toHaveBeenCalled());
+
+    // Back on the list view (no editor mounted).
+    await waitFor(() =>
+      expect(
+        screen.queryByDisplayValue('old content dirty'),
+      ).not.toBeInTheDocument(),
+    );
+
+    confirmSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix #9 — banner clears on equal-length membership change
+// ---------------------------------------------------------------------------
+
+describe('MemoPanel — not-found banner clears on key-set change (Fix #9)', () => {
+  it('clears the banner when the missing key replaces another entry (length unchanged)', async () => {
+    // Initial: list has [a.md], target b.md → banner.
+    listState = {
+      data: {
+        entries: [
+          { ...baseEntry, key: 'a.md', original_filename: 'a.md' },
+        ],
+        truncated: false,
+      },
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refetch: vi.fn(),
+    };
+
+    const { rerender } = renderWithProviders(
+      <MemoPanel targetKey="b.md" onTargetHandled={() => {}} />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText(/memoPanel\.notFound/)).toBeInTheDocument(),
+    );
+
+    // Same length, different membership: drop a.md, add b.md.
+    await act(async () => {
+      listState = {
+        data: {
+          entries: [
+            { ...baseEntry, key: 'b.md', original_filename: 'b.md' },
+          ],
+          truncated: false,
+        },
+        isLoading: false,
+        isFetching: false,
+        error: null,
+        refetch: vi.fn(),
+      };
+      rerender(<MemoPanel targetKey={null} onTargetHandled={() => {}} />);
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText(/memoPanel\.notFound/),
+      ).not.toBeInTheDocument(),
+    );
+  });
+});

--- a/web/src/pages/ChatAgent/components/__tests__/MemoPanelRace.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/MemoPanelRace.test.tsx
@@ -14,8 +14,7 @@ import { renderWithProviders } from '@/test/utils';
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string, opts?: Record<string, unknown>) => {
-      // Mirror the i18next defaultValue fallback so the unsaved-edit prompt
-      // reads naturally when the test inspects window.confirm's argument.
+      // Mirror the i18next defaultValue fallback for any keys still using it.
       if (opts && typeof opts === 'object' && 'defaultValue' in opts) {
         return String((opts as { defaultValue: unknown }).defaultValue);
       }
@@ -384,17 +383,16 @@ describe('MemoPanel — unsaved edit guard on empty targetKey (Fix #8)', () => {
     const textarea = await screen.findByDisplayValue('old content');
     await user.type(textarea, ' + my unsaved work');
 
-    // Stub confirm → user cancels.
-    const confirmSpy = vi
-      .spyOn(window, 'confirm')
-      .mockImplementation(() => false);
-
     // Empty-string sentinel arrives (e.g. agent wrote memo.md index).
+    // The non-blocking discard-confirm dialog should open instead of the
+    // synchronous window.confirm() that would freeze the SSE event loop.
     rerender(
       <MemoPanel targetKey="" onTargetHandled={onTargetHandled} />,
     );
 
-    await waitFor(() => expect(confirmSpy).toHaveBeenCalled());
+    // Dialog title appears (translation mock returns the key verbatim).
+    const cancelBtn = await screen.findByRole('button', { name: 'common.cancel' });
+    await user.click(cancelBtn);
 
     // Editor still mounted with the dirty buffer intact.
     expect(
@@ -403,8 +401,6 @@ describe('MemoPanel — unsaved edit guard on empty targetKey (Fix #8)', () => {
 
     // Sentinel was acked so we don't loop on every render.
     expect(onTargetHandled).toHaveBeenCalled();
-
-    confirmSpy.mockRestore();
   });
 
   it('clears the editor when the user confirms the discard', async () => {
@@ -448,13 +444,11 @@ describe('MemoPanel — unsaved edit guard on empty targetKey (Fix #8)', () => {
     const textarea = await screen.findByDisplayValue('old content');
     await user.type(textarea, ' dirty');
 
-    const confirmSpy = vi
-      .spyOn(window, 'confirm')
-      .mockImplementation(() => true);
-
     rerender(<MemoPanel targetKey="" onTargetHandled={() => {}} />);
 
-    await waitFor(() => expect(confirmSpy).toHaveBeenCalled());
+    // The discard-confirm dialog opens; click the destructive Discard button.
+    const discardBtn = await screen.findByRole('button', { name: 'memoPanel.discardEdits' });
+    await user.click(discardBtn);
 
     // Back on the list view (no editor mounted).
     await waitFor(() =>
@@ -462,8 +456,6 @@ describe('MemoPanel — unsaved edit guard on empty targetKey (Fix #8)', () => {
         screen.queryByDisplayValue('old content dirty'),
       ).not.toBeInTheDocument(),
     );
-
-    confirmSpy.mockRestore();
   });
 });
 

--- a/web/src/pages/ChatAgent/components/__tests__/MemoryPanel.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/MemoryPanel.test.tsx
@@ -1,0 +1,312 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { renderWithProviders } from '@/test/utils';
+
+// ---------------------------------------------------------------------------
+// MemoryPanel tests for fixes #5, #6, #9. We stub the memory hooks directly
+// so each test deterministically controls loading / refetching transitions.
+// ---------------------------------------------------------------------------
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (opts && typeof opts === 'object') {
+        let out = key;
+        for (const [k, v] of Object.entries(opts)) {
+          out = out.replace(new RegExp(`{{\\s*${k}\\s*}}`, 'g'), String(v));
+        }
+        return out;
+      }
+      return key;
+    },
+  }),
+}));
+
+vi.mock('../Markdown', () => ({
+  default: ({
+    content,
+    onOpenFile,
+  }: {
+    content: string;
+    onOpenFile?: (href: string, wsId?: string) => void;
+  }) => (
+    <div data-testid="markdown-content">
+      {content}
+      <button
+        type="button"
+        data-testid="md-link-md"
+        onClick={() => onOpenFile?.('feedback_visualization_preference.md')}
+      >
+        feedback.md
+      </button>
+      <button
+        type="button"
+        data-testid="md-link-md-dotslash"
+        onClick={() => onOpenFile?.('./other-note.md')}
+      >
+        ./other-note.md
+      </button>
+      <button
+        type="button"
+        data-testid="md-link-pdf"
+        onClick={() => onOpenFile?.('reports/q1.pdf')}
+      >
+        reports/q1.pdf
+      </button>
+      <button
+        type="button"
+        data-testid="md-link-bare-pdf"
+        onClick={() => onOpenFile?.('attached.pdf')}
+      >
+        attached.pdf
+      </button>
+      <button
+        type="button"
+        data-testid="md-link-qualified"
+        onClick={() => onOpenFile?.('.agents/skills/foo/skill.md')}
+      >
+        skill ref
+      </button>
+    </div>
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Hook stubs
+// ---------------------------------------------------------------------------
+
+interface ListState {
+  entries: Array<{
+    key: string;
+    size: number;
+    modified_at: string | null;
+  }>;
+  loading: boolean;
+  isFetching: boolean;
+  error: string | null;
+  refresh: () => void;
+}
+
+interface ReadState {
+  data: { content: string; key: string; encoding?: string; size?: number } | undefined;
+  loading: boolean;
+  error: string | null;
+}
+
+let userListState: ListState;
+let wsListState: ListState;
+let userReadState: ReadState;
+let wsReadState: ReadState;
+
+vi.mock('../../hooks/useMemory', () => ({
+  useUserMemory: () => userListState,
+  useWorkspaceMemory: () => wsListState,
+  useReadUserMemory: () => userReadState,
+  useReadWorkspaceMemory: () => wsReadState,
+}));
+
+import MemoryPanel from '../MemoryPanel';
+
+const baseEntry = (key: string) => ({
+  key,
+  size: 100,
+  modified_at: '2026-01-01T00:00:00Z',
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  userListState = {
+    entries: [],
+    loading: false,
+    isFetching: false,
+    error: null,
+    refresh: vi.fn(),
+  };
+  wsListState = {
+    entries: [],
+    loading: false,
+    isFetching: false,
+    error: null,
+    refresh: vi.fn(),
+  };
+  userReadState = { data: undefined, loading: false, error: null };
+  wsReadState = { data: undefined, loading: false, error: null };
+});
+
+// ---------------------------------------------------------------------------
+// Fix #5 — race
+// ---------------------------------------------------------------------------
+
+describe('MemoryPanel — cache-refetch race (Fix #5)', () => {
+  it('does not flash not-found while a background refetch is in flight; opens entry once it lands', async () => {
+    // Stale list with no target, refetch in flight.
+    userListState = {
+      entries: [],
+      loading: false,
+      isFetching: true,
+      error: null,
+      refresh: vi.fn(),
+    };
+
+    const { rerender } = renderWithProviders(
+      <MemoryPanel
+        workspaceId={null}
+        targetKey="just-written.md"
+        targetTier="user"
+      />,
+    );
+
+    // No banner while refetching — give react a tick to settle.
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/memoryPanel\.notFound/),
+      ).not.toBeInTheDocument();
+    });
+
+    // Refresh lands with the target entry.
+    userListState = {
+      entries: [baseEntry('just-written.md')],
+      loading: false,
+      isFetching: false,
+      error: null,
+      refresh: vi.fn(),
+    };
+    userReadState = {
+      data: { key: 'just-written.md', content: '# fresh', size: 7, encoding: 'utf-8' },
+      loading: false,
+      error: null,
+    };
+
+    rerender(
+      <MemoryPanel
+        workspaceId={null}
+        targetKey="just-written.md"
+        targetTier="user"
+      />,
+    );
+
+    // Viewer mounted with content; banner never appeared.
+    await waitFor(() =>
+      expect(screen.getByTestId('markdown-content')).toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByText(/memoryPanel\.notFound/),
+    ).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix #6 — body link rewrite heuristic
+// ---------------------------------------------------------------------------
+
+describe('MemoryPanel — body link routing (Fix #6)', () => {
+  it('rewrites `.md` siblings into the memory dir but passes other extensions through unchanged', async () => {
+    const onOpenFile = vi.fn();
+    userListState = {
+      entries: [baseEntry('memory.md')],
+      loading: false,
+      isFetching: false,
+      error: null,
+      refresh: vi.fn(),
+    };
+    userReadState = {
+      data: { key: 'memory.md', content: '# memory', size: 8 },
+      loading: false,
+      error: null,
+    };
+
+    renderWithProviders(
+      <MemoryPanel
+        workspaceId={null}
+        onOpenFile={onOpenFile}
+      />,
+    );
+    const user = userEvent.setup();
+
+    await user.click(await screen.findByText('memory.md'));
+    await screen.findByTestId('markdown-content');
+
+    // Bare `.md` → resolved against user memory dir.
+    await user.click(screen.getByTestId('md-link-md'));
+    expect(onOpenFile).toHaveBeenLastCalledWith(
+      '.agents/user/memory/feedback_visualization_preference.md',
+      undefined,
+    );
+
+    // `./other-note.md` → leading `./` stripped, then resolved.
+    await user.click(screen.getByTestId('md-link-md-dotslash'));
+    expect(onOpenFile).toHaveBeenLastCalledWith(
+      '.agents/user/memory/other-note.md',
+      undefined,
+    );
+
+    // `reports/q1.pdf` (non-md) → passes through verbatim, stripped of any `./`.
+    await user.click(screen.getByTestId('md-link-pdf'));
+    expect(onOpenFile).toHaveBeenLastCalledWith('reports/q1.pdf', undefined);
+
+    // Bare `attached.pdf` → still passes through (not a memory entry).
+    await user.click(screen.getByTestId('md-link-bare-pdf'));
+    expect(onOpenFile).toHaveBeenLastCalledWith('attached.pdf', undefined);
+
+    // Already-qualified `.agents/...` → passes through verbatim.
+    await user.click(screen.getByTestId('md-link-qualified'));
+    expect(onOpenFile).toHaveBeenLastCalledWith(
+      '.agents/skills/foo/skill.md',
+      undefined,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix #9 — banner clears on equal-length membership change
+// ---------------------------------------------------------------------------
+
+describe('MemoryPanel — not-found banner clears on key-set change (Fix #9)', () => {
+  it('clears the banner when the missing key replaces another entry (length unchanged)', async () => {
+    userListState = {
+      entries: [baseEntry('a.md')],
+      loading: false,
+      isFetching: false,
+      error: null,
+      refresh: vi.fn(),
+    };
+
+    const { rerender } = renderWithProviders(
+      <MemoryPanel
+        workspaceId={null}
+        targetKey="b.md"
+        targetTier="user"
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText(/memoryPanel\.notFound/)).toBeInTheDocument(),
+    );
+
+    // Same length; swap a.md → b.md.
+    await act(async () => {
+      userListState = {
+        entries: [baseEntry('b.md')],
+        loading: false,
+        isFetching: false,
+        error: null,
+        refresh: vi.fn(),
+      };
+      rerender(
+        <MemoryPanel
+          workspaceId={null}
+          targetKey={null}
+          targetTier="user"
+        />,
+      );
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText(/memoryPanel\.notFound/),
+      ).not.toBeInTheDocument(),
+    );
+  });
+});

--- a/web/src/pages/ChatAgent/components/__tests__/RightPanel.snapBack.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/RightPanel.snapBack.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * RightPanel snap-back precedence: when multiple target props are set in one
+ * render, the panel must converge on memory > memo > file. The parent
+ * (ChatView) clears siblings before setting one, but this effect is the
+ * second line of defense.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { renderWithProviders } from '@/test/utils';
+import RightPanel from '../RightPanel';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+// Replace lazy children with cheap stubs so we can assert which one renders.
+vi.mock('../FilePanel', () => ({
+  default: () => <div data-testid="file-panel">files</div>,
+}));
+vi.mock('../MemoryPanel', () => ({
+  default: () => <div data-testid="memory-panel">memory</div>,
+}));
+vi.mock('../MemoPanel', () => ({
+  default: () => <div data-testid="memo-panel">memo</div>,
+}));
+
+vi.mock('@/components/ui/animated-tabs', () => ({
+  AnimatedTabs: ({ tabs, value, onChange }: {
+    tabs: { id: string; label: string }[];
+    value: string;
+    onChange: (id: string) => void;
+  }) => (
+    <div data-testid="tabs" data-active={value}>
+      {tabs.map((t) => (
+        <button key={t.id} data-tab={t.id} onClick={() => onChange(t.id)}>
+          {t.label}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+const baseProps = {
+  workspaceId: 'ws-1',
+  onClose: () => {},
+};
+
+describe('RightPanel snap-back precedence', () => {
+  it('starts on the initialTab when no targets are set', async () => {
+    renderWithProviders(<RightPanel {...baseProps} initialTab="memory" />);
+    await waitFor(() => {
+      expect(screen.getByTestId('tabs').getAttribute('data-active')).toBe('memory');
+    });
+  });
+
+  it('snaps to Files when targetFile is set', async () => {
+    renderWithProviders(
+      <RightPanel
+        {...baseProps}
+        initialTab="memory"
+        targetFile="work/notes.md"
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('tabs').getAttribute('data-active')).toBe('files');
+    });
+  });
+
+  it('snaps to Memo when targetMemoKey is set', async () => {
+    renderWithProviders(
+      <RightPanel
+        {...baseProps}
+        initialTab="files"
+        targetMemoKey="report.pdf"
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('tabs').getAttribute('data-active')).toBe('memo');
+    });
+  });
+
+  it('snaps to Memory when targetMemoryKey is set', async () => {
+    renderWithProviders(
+      <RightPanel
+        {...baseProps}
+        initialTab="files"
+        targetMemoryKey="risk-preferences.md"
+        targetMemoryTier="user"
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('tabs').getAttribute('data-active')).toBe('memory');
+    });
+  });
+
+  it('honors precedence (memory > memo > file) when all three are set', async () => {
+    renderWithProviders(
+      <RightPanel
+        {...baseProps}
+        initialTab="files"
+        targetFile="work/notes.md"
+        targetMemoKey="report.pdf"
+        targetMemoryKey="risk-preferences.md"
+        targetMemoryTier="user"
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('tabs').getAttribute('data-active')).toBe('memory');
+    });
+  });
+
+  it('honors precedence (memo > file) when memory is null', async () => {
+    renderWithProviders(
+      <RightPanel
+        {...baseProps}
+        initialTab="files"
+        targetFile="work/notes.md"
+        targetMemoKey="report.pdf"
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('tabs').getAttribute('data-active')).toBe('memo');
+    });
+  });
+
+  it('treats empty-string targetMemoKey as a memo-tab open (no entry)', async () => {
+    // Used by ChatView for memo-index routing.
+    renderWithProviders(
+      <RightPanel
+        {...baseProps}
+        initialTab="files"
+        targetMemoKey=""
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('tabs').getAttribute('data-active')).toBe('memo');
+    });
+  });
+});

--- a/web/src/pages/ChatAgent/components/__tests__/extractLeadingBoldHeader.test.ts
+++ b/web/src/pages/ChatAgent/components/__tests__/extractLeadingBoldHeader.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Reasoning-row subtitle promotion: confirms we only swap the generic
+ * "Reasoning" label when the content really begins with a `**heading**\n\nbody`
+ * shape, and we leave every other reasoning untouched.
+ */
+import { describe, it, expect } from 'vitest';
+import { extractLeadingBoldHeader } from '../ActivityBlock';
+
+describe('extractLeadingBoldHeader', () => {
+  it('promotes a leading bold heading + blank line + body', () => {
+    const r = extractLeadingBoldHeader('**Considering task organization**\n\nI think this task is simple.');
+    expect(r.title).toBe('Considering task organization');
+    expect(r.body).toBe('I think this task is simple.');
+  });
+
+  it('promotes when only one newline separates header and body', () => {
+    const r = extractLeadingBoldHeader('**Header**\nBody starts here.');
+    expect(r.title).toBe('Header');
+    expect(r.body).toBe('Body starts here.');
+  });
+
+  it('tolerates leading whitespace before the bold marker', () => {
+    const r = extractLeadingBoldHeader('   **Title**\n\nBody.');
+    expect(r.title).toBe('Title');
+    expect(r.body).toBe('Body.');
+  });
+
+  it('leaves plain paragraph reasoning alone', () => {
+    const original = 'I need to figure out where this comes from. Let me read the file first.';
+    const r = extractLeadingBoldHeader(original);
+    expect(r.title).toBeNull();
+    expect(r.body).toBe(original);
+  });
+
+  it('does not promote inline bold mid-sentence', () => {
+    const original = 'I think **this** is a problem worth investigating.';
+    const r = extractLeadingBoldHeader(original);
+    expect(r.title).toBeNull();
+    expect(r.body).toBe(original);
+  });
+
+  it('does not promote when bold runs into the body without a newline', () => {
+    const original = '**Note:** the user wants to remove their preference.';
+    const r = extractLeadingBoldHeader(original);
+    expect(r.title).toBeNull();
+    expect(r.body).toBe(original);
+  });
+
+  it('does not promote a bold-only paragraph with no body', () => {
+    const r = extractLeadingBoldHeader('**Just a bold line, nothing follows**\n\n');
+    expect(r.title).toBeNull();
+  });
+
+  it('rejects an over-long candidate (looks like a sentence, not a heading)', () => {
+    const longBold = '**' + 'word '.repeat(30).trim() + '**\n\nBody.';
+    const r = extractLeadingBoldHeader(longBold);
+    expect(r.title).toBeNull();
+  });
+
+  it('returns null safely for empty content', () => {
+    const r = extractLeadingBoldHeader('');
+    expect(r.title).toBeNull();
+    expect(r.body).toBe('');
+  });
+
+  it('does not match nested asterisks inside the bold span', () => {
+    // The capture group rejects internal `*` so the sequence below can\'t be parsed
+    // as a clean heading; we play safe and leave content as-is.
+    const original = '**A *nested* asterisk title**\n\nBody.';
+    const r = extractLeadingBoldHeader(original);
+    expect(r.title).toBeNull();
+    expect(r.body).toBe(original);
+  });
+});

--- a/web/src/pages/ChatAgent/components/__tests__/toolDisplayConfig.test.ts
+++ b/web/src/pages/ChatAgent/components/__tests__/toolDisplayConfig.test.ts
@@ -40,21 +40,9 @@ describe('categorizeTool — memo classification', () => {
     ).toBe('memoWrite');
   });
 
-  it('classifies the snake_case write_file alias as memoWrite', () => {
-    expect(
-      categorizeTool('write_file', { args: { file_path: '.agents/user/memo/x.md' } })
-    ).toBe('memoWrite');
-  });
-
   it('keeps a Read on a memo path as memo (read bucket)', () => {
     expect(
       categorizeTool('Read', { args: { file_path: '.agents/user/memo/x.md' } })
-    ).toBe('memo');
-  });
-
-  it('keeps the snake_case read_file alias as memo', () => {
-    expect(
-      categorizeTool('read_file', { args: { file_path: '.agents/user/memo/x.md' } })
     ).toBe('memo');
   });
 

--- a/web/src/pages/ChatAgent/components/__tests__/toolDisplayConfig.test.ts
+++ b/web/src/pages/ChatAgent/components/__tests__/toolDisplayConfig.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Pure-function coverage for the tool classification + label helpers.
+ * Focus is on the memo write/edit branch added for Fix #4 — confirming
+ * `categorizeTool` distinguishes a memo `Write/Edit` from a memo `Read`,
+ * and that the completed-row title surfaces the right verb so a future
+ * regression letting the agent mutate memos doesn't render as "Read memo".
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  categorizeTool,
+  getCompletedRowTitle,
+  getInProgressText,
+  getToolIcon,
+} from '../toolDisplayConfig';
+
+// Identity translator — surfaces the i18n key so we can assert which
+// branch fired without depending on an actual locale bundle. Mirrors the
+// pattern used in MemoPanel.test.tsx.
+const tIdentity = (key: string, opts?: Record<string, unknown>) => {
+  if (opts && typeof opts === 'object') {
+    let out = key;
+    for (const [k, v] of Object.entries(opts)) {
+      out = out.replace(new RegExp(`{{\\s*${k}\\s*}}`, 'g'), String(v));
+    }
+    return out;
+  }
+  return key;
+};
+
+describe('categorizeTool — memo classification', () => {
+  it('classifies a Write to a memo path as memoWrite', () => {
+    expect(
+      categorizeTool('Write', { args: { file_path: '.agents/user/memo/x.md' } })
+    ).toBe('memoWrite');
+  });
+
+  it('classifies an Edit to a memo path (with sandbox-root prefix) as memoWrite', () => {
+    expect(
+      categorizeTool('Edit', { args: { file_path: '/home/workspace/.agents/user/memo/x.md' } })
+    ).toBe('memoWrite');
+  });
+
+  it('classifies the snake_case write_file alias as memoWrite', () => {
+    expect(
+      categorizeTool('write_file', { args: { file_path: '.agents/user/memo/x.md' } })
+    ).toBe('memoWrite');
+  });
+
+  it('keeps a Read on a memo path as memo (read bucket)', () => {
+    expect(
+      categorizeTool('Read', { args: { file_path: '.agents/user/memo/x.md' } })
+    ).toBe('memo');
+  });
+
+  it('keeps the snake_case read_file alias as memo', () => {
+    expect(
+      categorizeTool('read_file', { args: { file_path: '.agents/user/memo/x.md' } })
+    ).toBe('memo');
+  });
+
+  it('does not change file/memory categorization', () => {
+    expect(
+      categorizeTool('Read', { args: { file_path: 'work/scratch.md' } })
+    ).toBe('fileRead');
+    expect(
+      categorizeTool('Write', { args: { file_path: '.agents/user/memory/risk.md' } })
+    ).toBe('memoryWrite');
+    expect(
+      categorizeTool('Read', { args: { file_path: '.agents/user/memory/memory.md' } })
+    ).toBe('memoryRead');
+  });
+});
+
+describe('getCompletedRowTitle — memo write/edit verbs', () => {
+  it('returns the wroteMemo i18n key for Write on a memo path', () => {
+    const title = getCompletedRowTitle(
+      'Write',
+      { args: { file_path: '.agents/user/memo/x.md' } },
+      tIdentity,
+    );
+    expect(title).toBe('toolArtifact.completed.wroteMemo');
+  });
+
+  it('returns the updatedMemo i18n key for Edit on a memo path', () => {
+    const title = getCompletedRowTitle(
+      'Edit',
+      { args: { file_path: '.agents/user/memo/x.md' } },
+      tIdentity,
+    );
+    expect(title).toBe('toolArtifact.completed.updatedMemo');
+  });
+
+  it('still returns the readMemo key for Read on a memo path', () => {
+    const title = getCompletedRowTitle(
+      'Read',
+      { args: { file_path: '.agents/user/memo/x.md' } },
+      tIdentity,
+    );
+    expect(title).toBe('toolArtifact.completed.readMemo');
+  });
+});
+
+describe('getInProgressText — memo write/edit progress phrases', () => {
+  it('emits writingMemoSlug for Write on a memo path', () => {
+    const out = getInProgressText(
+      'Write',
+      { args: { file_path: '.agents/user/memo/notes.md' } },
+      tIdentity,
+    );
+    expect(out).toBe('toolArtifact.inProgress.writingMemoSlug');
+  });
+
+  it('emits updatingMemoSlug for Edit on a memo path', () => {
+    const out = getInProgressText(
+      'Edit',
+      { args: { file_path: '.agents/user/memo/notes.md' } },
+      tIdentity,
+    );
+    expect(out).toBe('toolArtifact.inProgress.updatingMemoSlug');
+  });
+});
+
+describe('getToolIcon — memo write/edit icon variant', () => {
+  it('uses a different icon for memo writes vs memo reads', () => {
+    const readIcon = getToolIcon('Read', { file_path: '.agents/user/memo/x.md' });
+    const writeIcon = getToolIcon('Write', { file_path: '.agents/user/memo/x.md' });
+    expect(readIcon).not.toBe(writeIcon);
+  });
+
+  it('uses the same icon for both Edit and Write on memo paths', () => {
+    const editIcon = getToolIcon('Edit', { file_path: '.agents/user/memo/x.md' });
+    const writeIcon = getToolIcon('Write', { file_path: '.agents/user/memo/x.md' });
+    expect(editIcon).toBe(writeIcon);
+  });
+});

--- a/web/src/pages/ChatAgent/components/toolDisplayConfig.ts
+++ b/web/src/pages/ChatAgent/components/toolDisplayConfig.ts
@@ -3,7 +3,9 @@ import {
   TrendingUp, Building2, BarChart3, PieChart, Search, Globe,
   FilePlus, FileText, FilePen, FolderSearch, SquareChevronRight, Wrench,
   Newspaper, Brain, User, FileBarChart, Clock, ClipboardList, Zap, Settings, Terminal,
+  Sparkles, BookText, BookMarked, BookPlus,
 } from 'lucide-react';
+import { classifyAgentPath, topicFromMemoryKey, type AgentPathInfo } from '../utils/agentPaths';
 
 /** Translation function signature compatible with i18next's t() */
 type TFn = (key: string, opts?: Record<string, unknown>) => string;
@@ -89,19 +91,125 @@ export const TOOL_DISPLAY_CONFIG: Record<string, ToolDisplayEntry> = {
   manage_automation:        { displayName: 'Manage Automation',    i18nKey: 'manageAutomation',    icon: Settings },
 };
 
-export function getDisplayName(rawToolName: string, t?: TFn): string {
+/** Classifies the file_path arg for Read/Write/Edit and their snake_case aliases. Returns null for all other tools. */
+function classifyFromArgs(toolName: string, args: ToolCallArgs | undefined): AgentPathInfo | null {
+  if (!args) return null;
+  if (toolName !== 'Read' && toolName !== 'Write' && toolName !== 'Edit' &&
+      toolName !== 'read_file' && toolName !== 'write_file' && toolName !== 'edit_file' &&
+      toolName !== 'Save' && toolName !== 'save_file') {
+    return null;
+  }
+  const fp = (args.file_path || args.filePath) as string | undefined;
+  if (!fp) return null;
+  return classifyAgentPath(fp);
+}
+
+// Defined above the icon/label helpers (which now reference it) and reused by
+// `categorizeTool` further down. Single source of truth for "what tool name
+// indicates a write/edit?" — keep both entries in sync if a new alias appears.
+const FILE_WRITE_TOOLS = new Set(['Write', 'write_file', 'Save', 'save_file', 'Edit', 'edit_file']);
+const FILE_READ_TOOLS = new Set(['Read', 'read_file']);
+
+export function getDisplayName(rawToolName: string, t?: TFn, args?: ToolCallArgs): string {
+  const info = classifyFromArgs(rawToolName, args);
+  if (info) {
+    if (info.kind === 'skill') {
+      return t ? t('toolArtifact.tool.skill') : 'Skill';
+    }
+    if (info.kind === 'memory') {
+      const isWorkspaceTier = info.tier === 'workspace';
+      if (isWorkspaceTier) return t ? t('toolArtifact.tool.workspaceMemory') : 'Workspace Memory';
+      return t ? t('toolArtifact.tool.memory') : 'Memory';
+    }
+    if (info.kind === 'memo') {
+      return t ? t('toolArtifact.tool.memo') : 'Memo';
+    }
+  }
   const config = TOOL_DISPLAY_CONFIG[rawToolName];
   if (t && config?.i18nKey) return t(`toolArtifact.tool.${config.i18nKey}`);
   return config?.displayName || rawToolName;
 }
 
-export function getToolIcon(rawToolName: string): LucideIcon {
+export function getToolIcon(rawToolName: string, args?: ToolCallArgs): LucideIcon {
+  const info = classifyFromArgs(rawToolName, args);
+  if (info) {
+    if (info.kind === 'skill') return Sparkles;
+    if (info.kind === 'memory') return BookMarked;
+    if (info.kind === 'memo') {
+      // Distinguish memo writes/edits from reads with a "book + plus" glyph
+      // so the timeline row hints that the agent modified the memo (even
+      // though current backend rules make this read-only by design).
+      return FILE_WRITE_TOOLS.has(rawToolName) ? BookPlus : BookText;
+    }
+  }
   return TOOL_DISPLAY_CONFIG[rawToolName]?.icon || Wrench;
 }
 
 export function getInProgressText(rawToolName: string, toolCall: ToolCall | undefined, t?: TFn): string {
   const args = toolCall?.args;
   const tr = t ? (key: string, opts?: Record<string, unknown>) => t(`toolArtifact.inProgress.${key}`, opts) : null;
+
+  // Path-aware variants for store-backed paths. These short-circuit the
+  // generic Read/Write/Edit branches below.
+  const info = classifyFromArgs(rawToolName, args);
+  if (info) {
+    if (info.kind === 'skill' && (rawToolName === 'Read' || rawToolName === 'read_file')) {
+      return info.name
+        ? (tr?.('activatingSkillName', { name: info.name }) ?? `activating skill ${info.name}...`)
+        : (tr?.('activatingSkill') ?? 'activating skill...');
+    }
+    if (info.kind === 'memory') {
+      const topic = topicFromMemoryKey(info.key);
+      const ws = info.tier === 'workspace';
+      if (rawToolName === 'Read' || rawToolName === 'read_file') {
+        if (info.isIndex) {
+          return ws
+            ? (tr?.('readingWorkspaceMemory') ?? 'reading workspace memory...')
+            : (tr?.('readingMemory') ?? 'reading memory...');
+        }
+        return ws
+          ? (tr?.('readingWorkspaceMemoryTopic', { topic }) ?? `reading workspace memory about ${topic}...`)
+          : (tr?.('readingMemoryTopic', { topic }) ?? `reading memory about ${topic}...`);
+      }
+      if (rawToolName === 'Write' || rawToolName === 'write_file' || rawToolName === 'Save' || rawToolName === 'save_file') {
+        // Index writes shouldn't render the topic — `topicFromMemoryKey('memory.md')`
+        // returns 'memory', which would print "adding memory memory...".
+        if (info.isIndex) {
+          return ws
+            ? (tr?.('addingWorkspaceMemory') ?? 'adding workspace memory...')
+            : (tr?.('addingMemory') ?? 'adding memory...');
+        }
+        return ws
+          ? (tr?.('addingWorkspaceMemoryTopic', { topic }) ?? `adding workspace memory ${topic}...`)
+          : (tr?.('addingMemoryTopic', { topic }) ?? `adding memory ${topic}...`);
+      }
+      if (rawToolName === 'Edit' || rawToolName === 'edit_file') {
+        if (info.isIndex) {
+          return ws
+            ? (tr?.('updatingWorkspaceMemory') ?? 'updating workspace memory...')
+            : (tr?.('updatingMemory') ?? 'updating memory...');
+        }
+        return ws
+          ? (tr?.('updatingWorkspaceMemoryTopic', { topic }) ?? `updating workspace memory ${topic}...`)
+          : (tr?.('updatingMemoryTopic', { topic }) ?? `updating memory ${topic}...`);
+      }
+    }
+    if (info.kind === 'memo') {
+      if (rawToolName === 'Read' || rawToolName === 'read_file') {
+        if (info.isIndex) {
+          return tr?.('readingMemoIndex') ?? 'reading memo index...';
+        }
+        return tr?.('readingMemoSlug', { slug: info.key }) ?? `reading memo ${info.key}...`;
+      }
+      if (rawToolName === 'Write' || rawToolName === 'Save' || rawToolName === 'write_file' || rawToolName === 'save_file') {
+        return tr?.('writingMemoSlug', { slug: info.key }) ?? `writing memo ${info.key}...`;
+      }
+      if (rawToolName === 'Edit' || rawToolName === 'edit_file') {
+        return tr?.('updatingMemoSlug', { slug: info.key }) ?? `updating memo ${info.key}...`;
+      }
+    }
+  }
+
   switch (rawToolName) {
     case 'get_stock_daily_prices':
       return args?.symbol
@@ -194,12 +302,30 @@ export function getInProgressText(rawToolName: string, toolCall: ToolCall | unde
 }
 
 /**
- * Extracts a short completed-state summary from tool call args.
- * Used in both live zone (completed but not yet in accordion) and accordion rows.
+ * `_t` (optional, currently unused) is accepted for parity with sibling
+ * helpers — the summary is a bare noun (topic / slug / skill name) that
+ * doesn't need localization today, but the param keeps call sites symmetric
+ * and reserves space for future translated variants.
  */
-export function getCompletedSummary(toolName: string, toolCall: ToolCall | undefined): string | null {
+export function getCompletedSummary(toolName: string, toolCall: ToolCall | undefined, _t?: TFn): string | null {
   const args = toolCall?.args;
   if (!args) return null;
+  // Path-aware summaries: emit just the meaningful object (skill name, topic,
+  // memo slug). The verb is carried by getDisplayName / row label.
+  const info = classifyFromArgs(toolName, args);
+  if (info) {
+    if (info.kind === 'skill') return info.name || null;
+    if (info.kind === 'memory') {
+      // Index files: no pill — the row title already says "Read memory" /
+      // "Added memory" etc., and the row itself becomes the click target.
+      if (info.isIndex) return null;
+      return topicFromMemoryKey(info.key) || null;
+    }
+    if (info.kind === 'memo') {
+      if (info.isIndex) return null;
+      return info.key || null;
+    }
+  }
   if (args.description) return args.description;
   if (args.symbol) return args.symbol;
   if (args.query) return args.query;
@@ -216,6 +342,112 @@ export function getCompletedSummary(toolName: string, toolCall: ToolCall | undef
     return fp!.split('/').pop() || null;
   }
   return null;
+}
+
+/**
+ * Full live-row label for the Active state. For path-aware tools this is a
+ * single coherent phrase ("Reading memory about <topic>") with no leading
+ * noun; for generic tools we fall back to the historic
+ * `${displayName} ${progressText}` concat.
+ */
+export function getActiveLabel(toolName: string, toolCall: ToolCall | undefined, t?: TFn): string {
+  const args = toolCall?.args;
+  const info = classifyFromArgs(toolName, args);
+  if (info && info.kind !== 'file') {
+    // getInProgressText already produces the full phrase for path-aware paths.
+    return getInProgressText(toolName, toolCall, t);
+  }
+  const dn = getDisplayName(toolName, t, args);
+  const pt = getInProgressText(toolName, toolCall, t);
+  return pt ? `${dn} ${pt}` : dn;
+}
+
+/**
+ * Title for completed timeline rows. Returns the past-tense verb phrase for
+ * path-aware tools ("Read memory", "Added memory", "Activated skill") and the
+ * generic displayName otherwise.
+ */
+export function getCompletedRowTitle(toolName: string, toolCall: ToolCall | undefined, t?: TFn): string {
+  const args = toolCall?.args;
+  const info = classifyFromArgs(toolName, args);
+  if (info) {
+    if (info.kind === 'skill' && (toolName === 'Read' || toolName === 'read_file')) {
+      return t ? t('toolArtifact.completed.activatedSkill') : 'Activated skill';
+    }
+    if (info.kind === 'memory') {
+      const ws = info.tier === 'workspace';
+      if (toolName === 'Write' || toolName === 'Save' || toolName === 'write_file' || toolName === 'save_file') {
+        return t ? t('toolArtifact.completed.addedMemory') : 'Added memory';
+      }
+      if (toolName === 'Edit' || toolName === 'edit_file') {
+        return t ? t('toolArtifact.completed.updatedMemory') : 'Updated memory';
+      }
+      if (toolName === 'Read' || toolName === 'read_file') {
+        if (ws) return t ? t('toolArtifact.completed.readWorkspaceMemory') : 'Read workspace memory';
+        return t ? t('toolArtifact.completed.readMemory') : 'Read memory';
+      }
+    }
+    if (info.kind === 'memo') {
+      if (toolName === 'Read' || toolName === 'read_file') {
+        if (info.isIndex) return t ? t('toolArtifact.completed.readMemoIndex') : 'Read memo index';
+        return t ? t('toolArtifact.completed.readMemo') : 'Read memo';
+      }
+      // Distinguish Write vs Edit verbs so a regression that lets the agent
+      // mutate a memo surfaces with the correct framing instead of "Read memo".
+      if (toolName === 'Write' || toolName === 'Save' || toolName === 'write_file' || toolName === 'save_file') {
+        return t ? t('toolArtifact.completed.wroteMemo') : 'Wrote memo';
+      }
+      if (toolName === 'Edit' || toolName === 'edit_file') {
+        return t ? t('toolArtifact.completed.updatedMemo') : 'Updated memo';
+      }
+    }
+  }
+  return getDisplayName(toolName, t, args);
+}
+
+/**
+ * Discriminator used by the content-aware accordion header. Maps a completed
+ * tool call to a coarse category for counting. Memory is split into read vs
+ * write so the header can collapse a mixed sequence into a single fragment
+ * whose verb reflects whether anything was modified.
+ */
+export type ToolCategory =
+  | 'skill'
+  | 'memoryRead'
+  | 'memoryWrite'
+  | 'memo'        // Read on a memo path
+  | 'memoWrite'   // Write/Edit/Save on a memo path (rare — backend currently
+                  // restricts agents to read-only memo access — but we
+                  // surface modifications distinctly so any future regression
+                  // is visible to the user instead of being hidden behind the
+                  // generic "read N memos" framing.)
+  | 'code'
+  | 'web'
+  | 'search'      // Glob, Grep
+  | 'fileRead'    // Read on a non-store path
+  | 'fileEdit'    // Write/Edit/Save on a non-store path
+  | 'generic';    // anything else (TaskOutput, MCP tools without artifacts, ...)
+
+export function categorizeTool(toolName: string, toolCall: ToolCall | undefined): ToolCategory {
+  const args = toolCall?.args;
+  const info = classifyFromArgs(toolName, args);
+  if (info) {
+    if (info.kind === 'skill') return 'skill';
+    if (info.kind === 'memory') {
+      return FILE_WRITE_TOOLS.has(toolName) ? 'memoryWrite' : 'memoryRead';
+    }
+    if (info.kind === 'memo') {
+      return FILE_WRITE_TOOLS.has(toolName) ? 'memoWrite' : 'memo';
+    }
+    // info.kind === 'file' (a known file tool but path is generic) falls
+    // through to the per-tool bucketing below.
+  }
+  if (toolName === 'ExecuteCode' || toolName === 'Bash') return 'code';
+  if (toolName === 'WebSearch' || toolName === 'WebFetch') return 'web';
+  if (toolName === 'Glob' || toolName === 'Grep') return 'search';
+  if (FILE_READ_TOOLS.has(toolName)) return 'fileRead';
+  if (FILE_WRITE_TOOLS.has(toolName)) return 'fileEdit';
+  return 'generic';
 }
 
 function formatByteSize(bytes: number, t?: TFn): string | null {

--- a/web/src/pages/ChatAgent/components/toolDisplayConfig.ts
+++ b/web/src/pages/ChatAgent/components/toolDisplayConfig.ts
@@ -91,24 +91,22 @@ export const TOOL_DISPLAY_CONFIG: Record<string, ToolDisplayEntry> = {
   manage_automation:        { displayName: 'Manage Automation',    i18nKey: 'manageAutomation',    icon: Settings },
 };
 
-/** Classifies the file_path arg for Read/Write/Edit and their snake_case aliases. Returns null for all other tools. */
+// Single source of truth for "what tool name indicates a file
+// write/edit/read?" — these are the only tool decorators registered in the
+// agent (see src/ptc_agent/agent/tools/file_ops.py: @tool("Read"),
+// @tool("Write"), @tool("Edit")). Used by classifyFromArgs and categorizeTool.
+const FILE_WRITE_TOOLS = new Set(['Write', 'Edit']);
+const FILE_READ_TOOLS = new Set(['Read']);
+const FILE_PATH_TOOLS = new Set([...FILE_WRITE_TOOLS, ...FILE_READ_TOOLS]);
+
+/** Classifies the file_path arg for Read/Write/Edit. Returns null for all other tools. */
 function classifyFromArgs(toolName: string, args: ToolCallArgs | undefined): AgentPathInfo | null {
   if (!args) return null;
-  if (toolName !== 'Read' && toolName !== 'Write' && toolName !== 'Edit' &&
-      toolName !== 'read_file' && toolName !== 'write_file' && toolName !== 'edit_file' &&
-      toolName !== 'Save' && toolName !== 'save_file') {
-    return null;
-  }
+  if (!FILE_PATH_TOOLS.has(toolName)) return null;
   const fp = (args.file_path || args.filePath) as string | undefined;
   if (!fp) return null;
   return classifyAgentPath(fp);
 }
-
-// Defined above the icon/label helpers (which now reference it) and reused by
-// `categorizeTool` further down. Single source of truth for "what tool name
-// indicates a write/edit?" — keep both entries in sync if a new alias appears.
-const FILE_WRITE_TOOLS = new Set(['Write', 'write_file', 'Save', 'save_file', 'Edit', 'edit_file']);
-const FILE_READ_TOOLS = new Set(['Read', 'read_file']);
 
 export function getDisplayName(rawToolName: string, t?: TFn, args?: ToolCallArgs): string {
   const info = classifyFromArgs(rawToolName, args);
@@ -153,7 +151,7 @@ export function getInProgressText(rawToolName: string, toolCall: ToolCall | unde
   // generic Read/Write/Edit branches below.
   const info = classifyFromArgs(rawToolName, args);
   if (info) {
-    if (info.kind === 'skill' && (rawToolName === 'Read' || rawToolName === 'read_file')) {
+    if (info.kind === 'skill' && rawToolName === 'Read') {
       return info.name
         ? (tr?.('activatingSkillName', { name: info.name }) ?? `activating skill ${info.name}...`)
         : (tr?.('activatingSkill') ?? 'activating skill...');
@@ -161,7 +159,7 @@ export function getInProgressText(rawToolName: string, toolCall: ToolCall | unde
     if (info.kind === 'memory') {
       const topic = topicFromMemoryKey(info.key);
       const ws = info.tier === 'workspace';
-      if (rawToolName === 'Read' || rawToolName === 'read_file') {
+      if (rawToolName === 'Read') {
         if (info.isIndex) {
           return ws
             ? (tr?.('readingWorkspaceMemory') ?? 'reading workspace memory...')
@@ -171,7 +169,7 @@ export function getInProgressText(rawToolName: string, toolCall: ToolCall | unde
           ? (tr?.('readingWorkspaceMemoryTopic', { topic }) ?? `reading workspace memory about ${topic}...`)
           : (tr?.('readingMemoryTopic', { topic }) ?? `reading memory about ${topic}...`);
       }
-      if (rawToolName === 'Write' || rawToolName === 'write_file' || rawToolName === 'Save' || rawToolName === 'save_file') {
+      if (rawToolName === 'Write') {
         // Index writes shouldn't render the topic — `topicFromMemoryKey('memory.md')`
         // returns 'memory', which would print "adding memory memory...".
         if (info.isIndex) {
@@ -183,7 +181,7 @@ export function getInProgressText(rawToolName: string, toolCall: ToolCall | unde
           ? (tr?.('addingWorkspaceMemoryTopic', { topic }) ?? `adding workspace memory ${topic}...`)
           : (tr?.('addingMemoryTopic', { topic }) ?? `adding memory ${topic}...`);
       }
-      if (rawToolName === 'Edit' || rawToolName === 'edit_file') {
+      if (rawToolName === 'Edit') {
         if (info.isIndex) {
           return ws
             ? (tr?.('updatingWorkspaceMemory') ?? 'updating workspace memory...')
@@ -195,16 +193,16 @@ export function getInProgressText(rawToolName: string, toolCall: ToolCall | unde
       }
     }
     if (info.kind === 'memo') {
-      if (rawToolName === 'Read' || rawToolName === 'read_file') {
+      if (rawToolName === 'Read') {
         if (info.isIndex) {
           return tr?.('readingMemoIndex') ?? 'reading memo index...';
         }
         return tr?.('readingMemoSlug', { slug: info.key }) ?? `reading memo ${info.key}...`;
       }
-      if (rawToolName === 'Write' || rawToolName === 'Save' || rawToolName === 'write_file' || rawToolName === 'save_file') {
+      if (rawToolName === 'Write') {
         return tr?.('writingMemoSlug', { slug: info.key }) ?? `writing memo ${info.key}...`;
       }
-      if (rawToolName === 'Edit' || rawToolName === 'edit_file') {
+      if (rawToolName === 'Edit') {
         return tr?.('updatingMemoSlug', { slug: info.key }) ?? `updating memo ${info.key}...`;
       }
     }
@@ -371,33 +369,33 @@ export function getCompletedRowTitle(toolName: string, toolCall: ToolCall | unde
   const args = toolCall?.args;
   const info = classifyFromArgs(toolName, args);
   if (info) {
-    if (info.kind === 'skill' && (toolName === 'Read' || toolName === 'read_file')) {
+    if (info.kind === 'skill' && toolName === 'Read') {
       return t ? t('toolArtifact.completed.activatedSkill') : 'Activated skill';
     }
     if (info.kind === 'memory') {
       const ws = info.tier === 'workspace';
-      if (toolName === 'Write' || toolName === 'Save' || toolName === 'write_file' || toolName === 'save_file') {
+      if (toolName === 'Write') {
         return t ? t('toolArtifact.completed.addedMemory') : 'Added memory';
       }
-      if (toolName === 'Edit' || toolName === 'edit_file') {
+      if (toolName === 'Edit') {
         return t ? t('toolArtifact.completed.updatedMemory') : 'Updated memory';
       }
-      if (toolName === 'Read' || toolName === 'read_file') {
+      if (toolName === 'Read') {
         if (ws) return t ? t('toolArtifact.completed.readWorkspaceMemory') : 'Read workspace memory';
         return t ? t('toolArtifact.completed.readMemory') : 'Read memory';
       }
     }
     if (info.kind === 'memo') {
-      if (toolName === 'Read' || toolName === 'read_file') {
+      if (toolName === 'Read') {
         if (info.isIndex) return t ? t('toolArtifact.completed.readMemoIndex') : 'Read memo index';
         return t ? t('toolArtifact.completed.readMemo') : 'Read memo';
       }
       // Distinguish Write vs Edit verbs so a regression that lets the agent
       // mutate a memo surfaces with the correct framing instead of "Read memo".
-      if (toolName === 'Write' || toolName === 'Save' || toolName === 'write_file' || toolName === 'save_file') {
+      if (toolName === 'Write') {
         return t ? t('toolArtifact.completed.wroteMemo') : 'Wrote memo';
       }
-      if (toolName === 'Edit' || toolName === 'edit_file') {
+      if (toolName === 'Edit') {
         return t ? t('toolArtifact.completed.updatedMemo') : 'Updated memo';
       }
     }

--- a/web/src/pages/ChatAgent/hooks/useMemory.ts
+++ b/web/src/pages/ChatAgent/hooks/useMemory.ts
@@ -13,6 +13,9 @@ import {
 interface ListResult {
   entries: MemoryEntry[];
   loading: boolean;
+  /** True while a background refetch is in flight (e.g. after invalidation).
+   *  Distinct from `loading`, which is only true on the very first fetch. */
+  isFetching: boolean;
   error: string | null;
   refresh: () => void;
 }
@@ -20,7 +23,7 @@ interface ListResult {
 /** List the user-tier memory entries for the current user. */
 export function useUserMemory(enabled: boolean = true): ListResult {
   const queryClient = useQueryClient();
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, isFetching, error } = useQuery({
     queryKey: queryKeys.memory.user(),
     queryFn: listUserMemory,
     enabled,
@@ -34,6 +37,7 @@ export function useUserMemory(enabled: boolean = true): ListResult {
   return {
     entries: data?.entries ?? [],
     loading: isLoading,
+    isFetching,
     error: error ? (error as Error).message || 'Failed to load memory' : null,
     refresh,
   };
@@ -45,7 +49,7 @@ export function useWorkspaceMemory(
   enabled: boolean = true,
 ): ListResult {
   const queryClient = useQueryClient();
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, isFetching, error } = useQuery({
     queryKey: queryKeys.memory.workspace(workspaceId ?? ''),
     queryFn: () => listWorkspaceMemory(workspaceId!),
     enabled: enabled && !!workspaceId,
@@ -60,6 +64,7 @@ export function useWorkspaceMemory(
   return {
     entries: data?.entries ?? [],
     loading: isLoading,
+    isFetching,
     error: error ? (error as Error).message || 'Failed to load memory' : null,
     refresh,
   };

--- a/web/src/pages/ChatAgent/utils/__tests__/agentPaths.test.ts
+++ b/web/src/pages/ChatAgent/utils/__tests__/agentPaths.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import { classifyAgentPath, topicFromMemoryKey } from '../agentPaths';
+
+describe('classifyAgentPath', () => {
+  it('classifies a user memory entry', () => {
+    const r = classifyAgentPath('.agents/user/memory/risk-preferences.md');
+    expect(r.kind).toBe('memory');
+    if (r.kind === 'memory') {
+      expect(r.tier).toBe('user');
+      expect(r.key).toBe('risk-preferences.md');
+      expect(r.isIndex).toBe(false);
+    }
+  });
+
+  it('flags the user memory index', () => {
+    const r = classifyAgentPath('.agents/user/memory/memory.md');
+    expect(r.kind).toBe('memory');
+    if (r.kind === 'memory') {
+      expect(r.tier).toBe('user');
+      expect(r.isIndex).toBe(true);
+    }
+  });
+
+  it('classifies a workspace memory entry', () => {
+    const r = classifyAgentPath('.agents/workspace/memory/foo.md');
+    expect(r.kind).toBe('memory');
+    if (r.kind === 'memory') expect(r.tier).toBe('workspace');
+  });
+
+  it('classifies a memo entry, slug opaque', () => {
+    const r = classifyAgentPath('.agents/user/memo/my-report.pdf');
+    expect(r.kind).toBe('memo');
+    if (r.kind === 'memo') {
+      expect(r.key).toBe('my-report.pdf');
+      expect(r.isIndex).toBe(false);
+    }
+  });
+
+  it('flags the memo index', () => {
+    const r = classifyAgentPath('.agents/user/memo/memo.md');
+    expect(r.kind).toBe('memo');
+    if (r.kind === 'memo') expect(r.isIndex).toBe(true);
+  });
+
+  it('classifies a skill activation', () => {
+    const r = classifyAgentPath('.agents/skills/investigate/SKILL.md');
+    expect(r.kind).toBe('skill');
+    if (r.kind === 'skill') expect(r.name).toBe('investigate');
+  });
+
+  it('strips the leading slash', () => {
+    const r = classifyAgentPath('/.agents/user/memory/foo.md');
+    expect(r.kind).toBe('memory');
+  });
+
+  it('strips the home/workspace/ sandbox-root prefix', () => {
+    const r = classifyAgentPath('home/workspace/.agents/user/memory/foo.md');
+    expect(r.kind).toBe('memory');
+  });
+
+  it('treats every well-formed shape identically', () => {
+    const variants = [
+      '.agents/user/memory/memory.md',
+      '/.agents/user/memory/memory.md',
+      'home/workspace/.agents/user/memory/memory.md',
+    ];
+    const kinds = variants.map((p) => classifyAgentPath(p).kind);
+    expect(new Set(kinds)).toEqual(new Set(['memory']));
+  });
+
+  it('falls back to file for unknown paths', () => {
+    expect(classifyAgentPath('work/notes.md').kind).toBe('file');
+    expect(classifyAgentPath('').kind).toBe('file');
+  });
+
+  it('treats bare memory.md / memo.md (no prefix) as a regular file', () => {
+    // Agent middleware always emits the full prefix; bare names are user files.
+    expect(classifyAgentPath('memory.md').kind).toBe('file');
+    expect(classifyAgentPath('memo.md').kind).toBe('file');
+  });
+
+  it('unwraps __wsref__/<wsid>/... and decorates with crossWorkspaceId', () => {
+    const r = classifyAgentPath('__wsref__/abc-123/.agents/user/memory/risk.md');
+    expect(r.kind).toBe('memory');
+    if (r.kind === 'memory') {
+      expect(r.tier).toBe('user');
+      expect(r.key).toBe('risk.md');
+      expect(r.crossWorkspaceId).toBe('abc-123');
+    }
+  });
+
+  it('unwraps __wsref__ for workspace memory and propagates the wsid', () => {
+    const r = classifyAgentPath('__wsref__/ws-X/.agents/workspace/memory/notes.md');
+    expect(r.kind).toBe('memory');
+    if (r.kind === 'memory') {
+      expect(r.tier).toBe('workspace');
+      expect(r.key).toBe('notes.md');
+      expect(r.crossWorkspaceId).toBe('ws-X');
+    }
+  });
+
+  it('strips the file:///home/workspace/ markdown auto-link prefix', () => {
+    const r = classifyAgentPath('file:///home/workspace/.agents/user/memo/x.md');
+    expect(r.kind).toBe('memo');
+    if (r.kind === 'memo') {
+      expect(r.key).toBe('x.md');
+    }
+  });
+
+  it('strips the bare /home/daytona/ sandbox-absolute prefix', () => {
+    const r = classifyAgentPath('/home/daytona/.agents/skills/foo/SKILL.md');
+    expect(r.kind).toBe('skill');
+    if (r.kind === 'skill') {
+      expect(r.name).toBe('foo');
+    }
+  });
+
+  it('strips a leading ./ before classification', () => {
+    const r = classifyAgentPath('./.agents/user/memory/foo.md');
+    expect(r.kind).toBe('memory');
+  });
+
+  it('strips trailing ?query and #fragment before classification', () => {
+    const r = classifyAgentPath('.agents/user/memo/foo.md?ts=1#sec');
+    expect(r.kind).toBe('memo');
+    if (r.kind === 'memo') {
+      expect(r.key).toBe('foo.md');
+    }
+  });
+
+  it('falls back to file for malformed memory dir paths (trailing slash)', () => {
+    // `.agents/user/memory/` has empty key — would trigger MemoryPanel's
+    // not-found banner. Treat as a Files-tab dir reference instead.
+    expect(classifyAgentPath('.agents/user/memory/').kind).toBe('file');
+    expect(classifyAgentPath('.agents/workspace/memory/').kind).toBe('file');
+  });
+});
+
+describe('topicFromMemoryKey', () => {
+  it('strips .md and replaces dashes/underscores', () => {
+    expect(topicFromMemoryKey('risk-preferences.md')).toBe('risk preferences');
+    expect(topicFromMemoryKey('my_topic.md')).toBe('my topic');
+    expect(topicFromMemoryKey('plain.md')).toBe('plain');
+  });
+
+  it('handles edge cases', () => {
+    expect(topicFromMemoryKey('')).toBe('');
+    expect(topicFromMemoryKey('mixed-with_both.md')).toBe('mixed with both');
+    expect(topicFromMemoryKey('NoExt')).toBe('NoExt');
+  });
+});

--- a/web/src/pages/ChatAgent/utils/agentPaths.ts
+++ b/web/src/pages/ChatAgent/utils/agentPaths.ts
@@ -1,0 +1,298 @@
+// Source of truth for memory/memo dirs: src/ptc_agent/core/paths.py.
+// SKILLS_DIR is hardcoded here; the same '.agents/skills' literal is
+// duplicated across several backend files (sandbox builder, agent config
+// loader, skills middleware) — there's no shared constant yet, so any
+// rename has to touch the literal in each place.
+export const MEMORY_USER_DIR = '.agents/user/memory';
+export const MEMORY_WORKSPACE_DIR = '.agents/workspace/memory';
+export const MEMO_USER_DIR = '.agents/user/memo';
+export const SKILLS_DIR = '.agents/skills';
+export const MEMORY_INDEX_FILENAME = 'memory.md';
+export const MEMO_INDEX_FILENAME = 'memo.md';
+
+// Sandbox roots the agent sometimes emits as either bare absolute or
+// `file:///`-wrapped paths (see normalizeFileRefs.ts). Both `workspace` and
+// `daytona` variants appear in the wild.
+const SANDBOX_ROOT_PREFIXES = [
+  'home/workspace/',
+  'home/daytona/',
+];
+const FILE_PROTO_PREFIX = 'file:///';
+const WSREF_PREFIX = '__wsref__/';
+
+export type AgentPathKind = 'memory' | 'memo' | 'skill' | 'file';
+export type MemoryTier = 'user' | 'workspace';
+
+export interface MemoryPathInfo {
+  kind: 'memory';
+  tier: MemoryTier;
+  /** Bare filename, e.g. "memory.md" or "risk-preferences.md". */
+  key: string;
+  isIndex: boolean;
+  /** Original (unnormalized) path for display. */
+  rawPath: string;
+  /** Workspace id extracted from a `__wsref__/<wsid>/...` cross-workspace ref. */
+  crossWorkspaceId?: string;
+}
+
+export interface MemoPathInfo {
+  kind: 'memo';
+  /** Slug from the memo entry (opaque to the frontend; matches MemoEntry.key with ===). */
+  key: string;
+  isIndex: boolean;
+  rawPath: string;
+  /** Workspace id extracted from a `__wsref__/<wsid>/...` cross-workspace ref. */
+  crossWorkspaceId?: string;
+}
+
+export interface SkillPathInfo {
+  kind: 'skill';
+  /** Directory segment after `.agents/skills/`. */
+  name: string;
+  rawPath: string;
+  /** Workspace id extracted from a `__wsref__/<wsid>/...` cross-workspace ref. */
+  crossWorkspaceId?: string;
+}
+
+export interface FilePathInfo {
+  kind: 'file';
+  rawPath: string;
+}
+
+export type AgentPathInfo =
+  | MemoryPathInfo
+  | MemoPathInfo
+  | SkillPathInfo
+  | FilePathInfo;
+
+/**
+ * Canonicalize the various path shapes the agent emits before classification:
+ *   - leading `/`, `./`, double-slashes
+ *   - `file:///home/(workspace|daytona)/...` → relative
+ *   - `/home/(workspace|daytona)/...` → relative
+ *   - trailing `?query` / `#fragment` stripped
+ *
+ * `__wsref__/<wsid>/...` is handled at the classifier layer (it needs to
+ * extract the wsid before recursing on the inner path).
+ */
+function normalizePath(rawPath: string): string {
+  let p = rawPath;
+
+  // Strip query string and fragment first — they don't affect classification
+  // but break suffix checks like `.endsWith('.md')`.
+  p = p.split(/[?#]/)[0];
+
+  // Unwrap file:/// prefix (markdown auto-link form).
+  if (p.startsWith(FILE_PROTO_PREFIX)) {
+    p = p.slice(FILE_PROTO_PREFIX.length);
+  }
+
+  // Strip leading slashes (covers absolute `/home/...` and `/.agents/...`),
+  // iteratively strip leading `./`, and collapse double-slashes from path joins.
+  p = p.replace(/^\/+/, '');
+  while (p.startsWith('./')) {
+    p = p.slice(2);
+  }
+  p = p.replace(/\/{2,}/g, '/');
+
+  // Strip the sandbox-root prefix the agent sometimes emits.
+  for (const prefix of SANDBOX_ROOT_PREFIXES) {
+    if (p.startsWith(prefix)) {
+      p = p.slice(prefix.length);
+      break;
+    }
+  }
+
+  return p;
+}
+
+/**
+ * Classify an agent file path into its semantic domain.
+ *
+ * Bare names like `memory.md` or `memo.md` (no prefix) fall to `kind: 'file'`
+ * because the agent middleware emits the full prefix for store-backed paths.
+ *
+ * `__wsref__/<wsid>/<rest>` is unwrapped: the inner `<rest>` is re-classified
+ * and the extracted `<wsid>` is attached as `crossWorkspaceId` so callers can
+ * propagate the workspace context to MemoryPanel/MemoPanel/FilePanel.
+ */
+export function classifyAgentPath(rawPath: string): AgentPathInfo {
+  if (!rawPath) return { kind: 'file', rawPath };
+
+  // Unwrap `__wsref__/<wsid>/<rest>` first. Handles a leading `/` before the
+  // marker too (some agent variants emit `/__wsref__/...`).
+  const wsrefStripped = rawPath.replace(/^\/+/, '');
+  if (wsrefStripped.startsWith(WSREF_PREFIX)) {
+    const tail = wsrefStripped.slice(WSREF_PREFIX.length);
+    const slashIdx = tail.indexOf('/');
+    if (slashIdx > 0) {
+      const wsid = tail.slice(0, slashIdx);
+      const inner = tail.slice(slashIdx + 1);
+      const innerInfo = classifyAgentPath(inner);
+      // Re-attach the original rawPath (so display layers show the full link)
+      // and decorate with the extracted workspace id. `kind: 'file'` doesn't
+      // need the marker — Files tab routing pipes setWorkspaceId through the
+      // routing function's targetWorkspaceId arg.
+      if (innerInfo.kind === 'memory' || innerInfo.kind === 'memo' || innerInfo.kind === 'skill') {
+        return { ...innerInfo, rawPath, crossWorkspaceId: wsid };
+      }
+      return { ...innerInfo, rawPath };
+    }
+  }
+
+  const norm = normalizePath(rawPath);
+
+  if (norm.startsWith(`${MEMORY_USER_DIR}/`)) {
+    const key = norm.slice(MEMORY_USER_DIR.length + 1);
+    // Trailing-slash dir paths (e.g. `.agents/user/memory/`) yield key === ''
+    // which would trigger MemoryPanel's not-found banner. Treat as malformed
+    // and fall through to Files tab — Glob/bash artifacts emit dir paths there.
+    if (!key) {
+      return { kind: 'file', rawPath };
+    }
+    return {
+      kind: 'memory',
+      tier: 'user',
+      key,
+      isIndex: key === MEMORY_INDEX_FILENAME,
+      rawPath,
+    };
+  }
+  if (norm.startsWith(`${MEMORY_WORKSPACE_DIR}/`)) {
+    const key = norm.slice(MEMORY_WORKSPACE_DIR.length + 1);
+    if (!key) {
+      return { kind: 'file', rawPath };
+    }
+    return {
+      kind: 'memory',
+      tier: 'workspace',
+      key,
+      isIndex: key === MEMORY_INDEX_FILENAME,
+      rawPath,
+    };
+  }
+  if (norm.startsWith(`${MEMO_USER_DIR}/`)) {
+    const key = norm.slice(MEMO_USER_DIR.length + 1);
+    // Empty-string memo key remains the documented LIST-view sentinel
+    // (`computeAgentArtifactRouting` maps it to `targetMemoKey: ''`).
+    return {
+      kind: 'memo',
+      key,
+      isIndex: key === MEMO_INDEX_FILENAME,
+      rawPath,
+    };
+  }
+  if (norm.startsWith(`${SKILLS_DIR}/`)) {
+    const tail = norm.slice(SKILLS_DIR.length + 1);
+    const name = tail.split('/')[0] || '';
+    return { kind: 'skill', name, rawPath };
+  }
+  return { kind: 'file', rawPath };
+}
+
+/** Strip `.md` and turn `risk-preferences` / `risk_preferences` into `risk preferences`. */
+export function topicFromMemoryKey(key: string): string {
+  if (!key) return '';
+  let topic = key;
+  if (topic.toLowerCase().endsWith('.md')) topic = topic.slice(0, -3);
+  return topic.replace(/[-_]+/g, ' ').trim();
+}
+
+/**
+ * Routing decision returned by `computeAgentArtifactRouting`. The ChatView
+ * routing handler applies these by clearing all four target fields first and
+ * then assigning whichever the routing returned. Empty-string targetMemoKey
+ * means "open Memo tab to LIST view (no entry pre-select)" — used for the
+ * memo index path.
+ */
+export interface AgentArtifactRouting {
+  targetFile: string | null;
+  targetMemoryKey: string | null;
+  targetMemoryTier: MemoryTier | null;
+  /** `''` (empty string) means open Memo tab without selecting; null means no memo target. */
+  targetMemoKey: string | null;
+  /** True when the routing must clear filePanelWorkspaceId (user-scoped artifact). */
+  clearWorkspaceId: boolean;
+  /** Workspace id to set on filePanelWorkspaceId (only for cross-workspace file links). */
+  setWorkspaceId: string | null;
+}
+
+/**
+ * Pure routing decision. Caller (ChatView) applies the resulting state
+ * transitions atomically. Centralized here so it's testable without mounting
+ * the whole chat shell.
+ *
+ * `targetWorkspaceId` takes precedence over a `__wsref__/<wsid>/...` embedded
+ * id — caller-supplied context wins. When neither is provided for a workspace-
+ * tier memory path, we emit `clearWorkspaceId: true` so a stale
+ * filePanelWorkspaceId from a prior cross-workspace click doesn't leak into
+ * the new query (flash-mode regression guard).
+ */
+export function computeAgentArtifactRouting(
+  rawPath: string,
+  targetWorkspaceId?: string,
+): AgentArtifactRouting {
+  const info = classifyAgentPath(rawPath);
+  // Caller-supplied wsid wins; otherwise fall back to the wsid extracted from
+  // a `__wsref__/...` marker in the path itself.
+  const embeddedWsid =
+    info.kind === 'memory' || info.kind === 'memo' || info.kind === 'skill'
+      ? info.crossWorkspaceId
+      : undefined;
+  const resolvedWsid = targetWorkspaceId ?? embeddedWsid ?? null;
+
+  const base: AgentArtifactRouting = {
+    targetFile: null,
+    targetMemoryKey: null,
+    targetMemoryTier: null,
+    targetMemoKey: null,
+    clearWorkspaceId: false,
+    setWorkspaceId: null,
+  };
+  if (info.kind === 'memory') {
+    if (info.tier === 'user') {
+      // User memory is global to the user — workspace context is meaningless,
+      // and any stale ws id from a flash `ws://` link must be cleared so the
+      // memory query doesn't leak into the wrong workspace.
+      return {
+        ...base,
+        targetMemoryKey: info.key,
+        targetMemoryTier: 'user',
+        clearWorkspaceId: true,
+      };
+    }
+    // Workspace memory:
+    //  - With a resolved wsid (caller-supplied OR embedded `__wsref__`), set
+    //    it on the panel so MemoryPanel queries the correct workspace.
+    //  - Without one, clear filePanelWorkspaceId. Flash mode previously left
+    //    it as-is, leaking a stale wsid from a prior cross-workspace click
+    //    into the new memory list query.
+    if (resolvedWsid) {
+      return {
+        ...base,
+        targetMemoryKey: info.key,
+        targetMemoryTier: 'workspace',
+        setWorkspaceId: resolvedWsid,
+      };
+    }
+    return {
+      ...base,
+      targetMemoryKey: info.key,
+      targetMemoryTier: 'workspace',
+      clearWorkspaceId: true,
+    };
+  }
+  if (info.kind === 'memo') {
+    return {
+      ...base,
+      targetMemoKey: info.isIndex ? '' : info.key,
+      clearWorkspaceId: true,
+    };
+  }
+  // skill / file → Files tab; pass-through workspace id for cross-workspace links.
+  return {
+    ...base,
+    targetFile: rawPath,
+    setWorkspaceId: resolvedWsid,
+  };
+}


### PR DESCRIPTION
## Summary

Refreshes the chat agent's tool-call UX so path semantics are visible, the right panel routes to the correct tab, and the visual treatment is monochrome and intentional.

- **Path-aware labels.** `read_file('.agents/skills/...')`, `.agents/user/memory/...`, `.agents/user/memo/...`, and ordinary workspace files no longer flatten into one generic "Read filename". Skills become *"Activated skill X"*, memory becomes *"Read memory about <topic>"*, memos become *"Read memo <slug>"*, etc.
- **Correct tab routing.** Clicking a tool-call object pill now opens the **Memory** or **Memo** tab (with the entry pre-selected) instead of dropping every artifact into the Files tab. New `agentPaths.ts` is the single source of truth — normalizes `file://`, `home/(workspace|daytona)/`, leading slashes, query/hash, and `__wsref__/<wsid>/<rest>` cross-workspace refs.
- **Monochrome timeline.** Live zone gets a 2px left rule + label shimmer; completing/failed states get neutral gray ✓/✕ badges. Accordion body becomes a real timeline (`<ol role="region">` with vertical rule) instead of a stack of icon rows.
- **Right-panel snap-back precedence.** memory > memo > file. Cleared all sibling target props before setting the new one — eliminates the silent-failure scenario where stale state hijacks the snap.
- **Failure surfaced consistently.** Failed tool calls now render with a gray ✕ badge in the activity block (was previously a neutral row, only `ToolCallMessageContent` showed failure).
- **a11y.** `aria-live="polite"` region in `ChatView` announces tool-call completions; accordion uses `aria-expanded` + `aria-controls`; pill chip is a real `<button>` with focus ring.

## Test plan

- [x] `pnpm vitest run` — 915/915 (was 874 → +41 new tests)
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm lint` — 0 errors / 94 pre-existing warnings
- [x] Manual QA: trigger skill activation, memory read/write, memo read, ordinary file read, failed tool call. Verify pill click routes to the correct tab in each case.
- [x] Manual QA: open Memory tab, click a memo path → snaps to Memo. Click a regular file → snaps to Files. Snap-back precedence honored.
- [x] Manual QA: flash-mode `ws://` link, then memory pill in same session → no stale workspace id leakage.
- [x] Visual QA in dark mode: timeline rule, badges, pills all legible.

## New files

- `web/src/pages/ChatAgent/utils/agentPaths.ts` — `classifyAgentPath`, `topicFromMemoryKey`, `computeAgentArtifactRouting`
- `web/src/pages/ChatAgent/components/ActivityBlock.css` — timeline + state cues, mobile + a11y rules
- 8 new `__tests__/` files covering classification, routing, snap-back precedence, failed-state styling, refetch race, and tool display config

## Reviewer notes

- The `.nrow.failed` red rule in the original HTML preview is **not** what shipped — locked monochrome decision means failed badge is gray (`var(--color-border-strong)`).
- Two `a11y.*` locale namespaces exist (`chat.a11y.*` from this PR + pre-existing `toolArtifact.a11y.*`). Cosmetic, deferred consolidation.
- Cross-workspace flash-mode routing is unit-tested only; no manual coverage yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)