### PR TITLE
fix(agent): restore Anthropic thinking sanitizer wiring (regression from #150)

### DIFF
--- a/src/ptc_agent/agent/agent.py
+++ b/src/ptc_agent/agent/agent.py
@@ -51,6 +51,7 @@ from ptc_agent.agent.middleware import (
     MemoryContextMiddleware,
     # injects <memo-index count=N path=.../>
     MemoAwarenessMiddleware,
+    AnthropicThinkingSanitizerMiddleware,
 )
 from ptc_agent.core.paths import (
     MEMO_INDEX_FILENAME,
@@ -677,6 +678,7 @@ class PTCAgent:
                 AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
                 EmptyToolCallRetryMiddleware(),
                 PatchToolCallsMiddleware(),
+                AnthropicThinkingSanitizerMiddleware(),
             ]
             if m is not None
         ]
@@ -733,6 +735,7 @@ class PTCAgent:
                 *workspace_context_middleware,
                 *dynamic_context_middleware,
                 *runtime_context_middleware,
+                AnthropicThinkingSanitizerMiddleware(),
             ]
             if m is not None
         ]

--- a/src/ptc_agent/agent/middleware/anthropic_thinking_sanitizer.py
+++ b/src/ptc_agent/agent/middleware/anthropic_thinking_sanitizer.py
@@ -1,23 +1,14 @@
-"""Sanitize malformed Anthropic thinking blocks before they reach the API.
+"""Repair orphan Anthropic thinking blocks before the API call.
 
-On Claude Opus 4.7 with adaptive thinking + default `display: "omitted"`,
-the Anthropic stream only emits `signature_delta` events (no `thinking_delta`).
-langchain-anthropic's stream handler turns each delta into a standalone
-content block: `{"type": "thinking", "signature": "...", "index": N}` — with
-no `thinking` field. The merged AIMessage lands in LangGraph state that way,
-and the next turn replaying it to Anthropic fails with:
-
-    messages.<i>.content.<j>.thinking.thinking: Field required
-
-Anthropic's contract is that `type="thinking"` blocks must always carry a
-`thinking` field, even when omitted (empty string is valid). This middleware
-walks every AIMessage in the outgoing request and injects `thinking: ""` on
-blocks that have a signature but are missing the `thinking` key. Signature
-continuity is preserved; the schema is satisfied.
+langchain-anthropic streams `signature_delta` events into content blocks shaped
+`{"type": "thinking", "signature": "...", "index": N}` — no `thinking` field.
+LangGraph checkpoints them, and the next turn fails with
+`messages[i].content: missing field 'thinking'`. We inject `thinking: ""`
+on blocks that have a non-empty signature; blocks lacking a signature are
+unrecoverable corruption and are passed through so the API rejects them.
 """
 
 from collections.abc import Awaitable, Callable
-from copy import deepcopy
 import logging
 from typing import Any
 
@@ -28,18 +19,17 @@ logger = logging.getLogger(__name__)
 
 
 def _sanitize_thinking_block(block: dict[str, Any]) -> tuple[dict[str, Any], bool]:
-    """Return (block, changed). Injects thinking='' on orphan signature-only blocks."""
     if block.get("type") != "thinking":
         return block, False
-    thinking = block.get("thinking")
-    if isinstance(thinking, str):
+    if isinstance(block.get("thinking"), str):
         return block, False
-    repaired = {**block, "thinking": ""}
-    return repaired, True
+    signature = block.get("signature")
+    if not (isinstance(signature, str) and signature):
+        return block, False
+    return {**block, "thinking": ""}, True
 
 
 def _sanitize_message(msg: AnyMessage) -> tuple[AnyMessage, int]:
-    """Return (maybe-new message, count of blocks repaired)."""
     if not isinstance(msg, AIMessage):
         return msg, 0
     content = msg.content
@@ -63,13 +53,10 @@ def _sanitize_message(msg: AnyMessage) -> tuple[AnyMessage, int]:
     if not changed:
         return msg, 0
 
-    new_msg = deepcopy(msg)
-    new_msg.content = new_blocks
-    return new_msg, repaired_count
+    return msg.model_copy(update={"content": new_blocks}), repaired_count
 
 
 def _sanitize_messages(messages: list[AnyMessage]) -> tuple[list[AnyMessage], int]:
-    """Return (messages, total_blocks_repaired). Same list object if nothing changed."""
     result: list[AnyMessage] = []
     total = 0
     changed = False
@@ -83,13 +70,6 @@ def _sanitize_messages(messages: list[AnyMessage]) -> tuple[list[AnyMessage], in
 
 
 class AnthropicThinkingSanitizerMiddleware(AgentMiddleware):
-    """Repair orphan thinking blocks (missing `thinking` text) before the LLM call.
-
-    See module docstring for root cause. This middleware should run innermost so
-    it catches blocks introduced by any upstream middleware and it is the last
-    thing to touch messages before the API call.
-    """
-
     def wrap_model_call(
         self,
         request: ModelRequest,
@@ -98,9 +78,7 @@ class AnthropicThinkingSanitizerMiddleware(AgentMiddleware):
         sanitized, repaired = _sanitize_messages(request.messages)
         if repaired:
             logger.warning(
-                "[ThinkingSanitizer] Repaired %d orphan thinking block(s) "
-                "(injected thinking='') before Anthropic call",
-                repaired,
+                "[ThinkingSanitizer] repaired %d orphan thinking block(s)", repaired
             )
             request = request.override(messages=sanitized)
         return handler(request)
@@ -113,9 +91,7 @@ class AnthropicThinkingSanitizerMiddleware(AgentMiddleware):
         sanitized, repaired = _sanitize_messages(request.messages)
         if repaired:
             logger.warning(
-                "[ThinkingSanitizer] Repaired %d orphan thinking block(s) "
-                "(injected thinking='') before Anthropic call",
-                repaired,
+                "[ThinkingSanitizer] repaired %d orphan thinking block(s)", repaired
             )
             request = request.override(messages=sanitized)
         return await handler(request)

--- a/tests/unit/ptc_agent/middleware/test_anthropic_thinking_sanitizer.py
+++ b/tests/unit/ptc_agent/middleware/test_anthropic_thinking_sanitizer.py
@@ -72,6 +72,20 @@ class TestSanitizeBlock:
         assert changed is False
         assert out is block
 
+    @pytest.mark.parametrize(
+        "block",
+        [
+            {"type": "thinking"},
+            {"type": "thinking", "signature": ""},
+            {"type": "thinking", "signature": None},
+            {"type": "thinking", "thinking": None},
+        ],
+    )
+    def test_no_signature_blocks_left_alone(self, block):
+        out, changed = _sanitize_thinking_block(block)
+        assert changed is False
+        assert out is block
+
 
 # ---------------------------------------------------------------------------
 # _sanitize_message — whole-message scan


### PR DESCRIPTION
## Summary

- Restores `AnthropicThinkingSanitizerMiddleware()` as the innermost layer in both main and subagent middleware chains. The wiring landed in #145 (commit `a208c79`) but was silently dropped by #150 (commit `aa8167aa`, *"feat(sandbox-backend): conform to SandboxBackendProtocol"*) during the `deepagents` 0.3.5→0.5.3 bump. The sanitizer file has been on `main` but unused since 2026-04-20.
- Tightens `_sanitize_thinking_block` to require a non-empty `signature` before injecting `thinking=\"\"`. Signature-less thinking blocks are unrecoverable corruption — let the API reject them rather than smuggle them through silently.
- Switches the repair path from `deepcopy(msg)` to `msg.model_copy(update={\"content\": new_blocks})`. The sanitizer only owns `content`; other AIMessage attributes (`additional_kwargs`, `response_metadata`, `tool_calls`, etc.) are out of scope. Any future middleware that mutates those is responsible for its own copy — that's the LangChain convention.
- Trims module/function/class docstrings whose names already explain what they do.

## Why this matters

Without the sanitizer wired in, BYOK runs against Anthropic-compatible endpoints with adaptive thinking (e.g. DeepSeek's `https://api.deepseek.com/anthropic`, MiniMax, Z.AI) fail every turn after an orphan `signature_delta`-only thinking block lands in checkpoint state:

```
BadRequestError: messages[i].content: missing field 'thinking'
```

LangSmith trace `019dd4a5-1ecc-7fd3-aed3-e509c5247e12` shows 12 LLM calls × 4 retries each on a single PTC turn before the agent gave up. Restoring the wiring ends that.

## Test plan

- [x] `uv run pytest tests/unit/ptc_agent/middleware/test_anthropic_thinking_sanitizer.py -v` — 24/24 passing including 4 new parametrized no-signature cases.
- [x] `uv run ruff check src/ptc_agent/agent/middleware/anthropic_thinking_sanitizer.py src/ptc_agent/agent/agent.py tests/unit/ptc_agent/middleware/test_anthropic_thinking_sanitizer.py` — clean.
- [x] Replay the failing trace against a build with this branch and confirm no `missing field 'thinking'` errors.