### PR TITLE
feat(mcp): freeze global registry at startup, drop per-workspace cohorts

### DIFF
--- a/src/ptc_agent/core/mcp_registry.py
+++ b/src/ptc_agent/core/mcp_registry.py
@@ -23,7 +23,7 @@ _devnull = open(os.devnull, "w")  # noqa: SIM115
 
 
 class MCPToolInfo:
-    """Information about an MCP tool."""
+    """Snapshot of a single tool's schema as reported by its MCP server."""
 
     def __init__(
         self,
@@ -32,25 +32,13 @@ class MCPToolInfo:
         input_schema: dict[str, Any],
         server_name: str,
     ) -> None:
-        """Initialize tool info.
-
-        Args:
-            name: Tool name
-            description: Tool description
-            input_schema: JSON schema for tool input
-            server_name: Name of the MCP server providing this tool
-        """
         self.name = name
         self.description = description
         self.input_schema = input_schema
         self.server_name = server_name
 
     def get_parameters(self) -> dict[str, Any]:
-        """Extract parameter information from input schema.
-
-        Returns:
-            Dictionary mapping parameter names to their info
-        """
+        """Return ``{param_name: {type, description, required, default}}`` from input_schema."""
         params = {}
 
         if "properties" in self.input_schema:
@@ -129,11 +117,6 @@ class MCPServerConnector:
     """
 
     def __init__(self, config: MCPServerConfig) -> None:
-        """Initialize server connector.
-
-        Args:
-            config: Server configuration
-        """
         self.config = config
         self.session: ClientSession | None = None
         self.tools: list[MCPToolInfo] = []
@@ -180,7 +163,6 @@ class MCPServerConnector:
         if not self.config.env:
             return base_env
 
-        # Expand each configured env var and merge
         for key, value in self.config.env.items():
             if isinstance(value, str):
                 expanded_value = os.path.expandvars(value)
@@ -199,15 +181,10 @@ class MCPServerConnector:
         return base_env
 
     def _expand_url(self) -> str | None:
-        """Expand environment variable placeholders in URL.
-
-        Returns:
-            Expanded URL or None if no URL configured
-        """
+        """Return the URL with ``${VAR}`` placeholders expanded, or None if unconfigured."""
         if not self.config.url:
             return None
 
-        # Expand environment variable placeholders like ${VAR}
         expanded_url = os.path.expandvars(self.config.url)
 
         if "${" in self.config.url and expanded_url != self.config.url:
@@ -227,11 +204,7 @@ class MCPServerConnector:
         return expanded_url
 
     async def __aenter__(self) -> "MCPServerConnector":
-        """Enter async context manager - start connection task.
-
-        Returns:
-            Self for use in async with statement
-        """
+        """Start the background connection task and wait for it to be ready."""
         logger.debug("Connecting to MCP server", server=self.config.name)
 
         # Start background task that keeps nested contexts alive
@@ -243,7 +216,6 @@ class MCPServerConnector:
         await self._ready.wait()
 
         if self._connection_error:
-            # Connection failed, raise the error
             raise self._connection_error
 
         logger.debug(
@@ -366,7 +338,6 @@ class MCPServerConnector:
             self._connection_error = e
             self._ready.set()
 
-            # Log with full exception details
             import traceback
             error_details = traceback.format_exc()
 
@@ -384,7 +355,6 @@ class MCPServerConnector:
             raise RuntimeError("Not connected to server")
 
         try:
-            # List tools
             tools_response = await self.session.list_tools()
 
             self.tools = []
@@ -414,7 +384,6 @@ class MCPServerConnector:
     async def _discover_tools_http(self) -> None:
         """Discover available tools via HTTP transport."""
         try:
-            # Send tools/list request
             self._message_id += 1
             request = {
                 "jsonrpc": "2.0",
@@ -435,7 +404,6 @@ class MCPServerConnector:
                 msg = f"MCP error: {result['error']}"
                 raise RuntimeError(msg)
 
-            # Parse tools from response
             tools_data = result.get("result", {}).get("tools", [])
             self.tools = []
 
@@ -556,18 +524,17 @@ class MCPServerConnector:
         )
 
         try:
-            # Route to appropriate transport
             if self.config.transport == "http":
                 result = await self._call_tool_http(tool_name, arguments)
                 logger.debug("MCP tool call completed", server=self.config.name, tool=tool_name)
 
-                # HTTP returns dict directly
+                # HTTP returns dict directly; unwrap text content when present.
                 if isinstance(result, dict) and "content" in result:
                     content = result["content"]
                     if isinstance(content, list) and len(content) > 0:
-                        first = content[0]
-                        if isinstance(first, dict) and "text" in first:
-                            return first["text"]
+                        content_item = content[0]
+                        if isinstance(content_item, dict) and "text" in content_item:
+                            return content_item["text"]
                 return result
 
             # SSE/stdio transport uses session
@@ -578,9 +545,7 @@ class MCPServerConnector:
 
             logger.debug("MCP tool call completed", server=self.config.name, tool=tool_name)
 
-            # Extract content from result
             if hasattr(result, "content") and result.content and len(result.content) > 0:
-                # Return first content item's text
                 content_item = result.content[0]
                 if hasattr(content_item, "text"):
                     return content_item.text
@@ -603,13 +568,7 @@ class MCPServerConnector:
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:
-        """Exit async context manager - signal disconnect and wait for task.
-
-        Args:
-            exc_type: Exception type if an exception occurred
-            exc_val: Exception value if an exception occurred
-            exc_tb: Exception traceback if an exception occurred
-        """
+        """Signal the background task to disconnect and wait for it to finish."""
         logger.info("Disconnecting from MCP server", server=self.config.name)
 
         # Signal the background task to disconnect
@@ -637,27 +596,75 @@ class MCPServerConnector:
 
 
 class MCPRegistry:
-    """Registry of all configured MCP servers."""
+    """Registry of all configured MCP servers.
+
+    Connects to each server on startup, then optionally freezes (terminates
+    subprocesses, retains tool schema snapshot) for process-lifetime sharing.
+    """
 
     def __init__(self, config: CoreConfig) -> None:
-        """Initialize MCP registry.
-
-        Args:
-            config: Application configuration
-        """
         self.config = config
         self.connectors: dict[str, MCPServerConnector] = {}
+        self._frozen: bool = False
 
         logger.debug("Initialized MCPRegistry")
 
-    async def connect_all(self) -> None:
-        """Connect to all configured MCP servers.
+    @property
+    def frozen(self) -> bool:
+        """True once subprocesses are shut down but the tool snapshot is retained."""
+        return self._frozen
 
-        This method enters the async context for each connector,
-        following the proper async with pattern.
-        Disabled servers (enabled=False) are skipped.
+    # Bounded so a hanging stdio cleanup can't deadlock lifespan startup;
+    # any pending __aexit__ work is cancelled on expiry and subprocesses
+    # may leak (process exit reaps them).
+    FREEZE_TIMEOUT_S = 10.0
+
+    async def freeze(self) -> None:
+        """Terminate stdio subprocesses while preserving each connector's ``tools``.
+
+        After this returns, ``connect_all``/``disconnect_all`` are no-ops, so the
+        instance is safe to share across Sessions. Idempotent.
         """
-        # Filter to only enabled servers
+        if self._frozen:
+            return
+
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(
+                    *[
+                        connector.__aexit__(None, None, None)
+                        for connector in self.connectors.values()
+                    ],
+                    return_exceptions=True,
+                ),
+                timeout=self.FREEZE_TIMEOUT_S,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "MCP registry freeze timed out; pending __aexit__ tasks "
+                "cancelled, some stdio subprocesses may be leaked until "
+                "process exit",
+                timeout_s=self.FREEZE_TIMEOUT_S,
+                servers=len(self.connectors),
+            )
+
+        self._frozen = True
+
+        total_tools = sum(len(c.tools) for c in self.connectors.values())
+        logger.info(
+            "MCP registry frozen",
+            servers=len(self.connectors),
+            tools=total_tools,
+        )
+
+    async def connect_all(self) -> None:
+        """Connect to all configured MCP servers. Skips servers with enabled=False.
+
+        No-op when the registry is frozen.
+        """
+        if self._frozen:
+            return
+
         enabled_servers = [s for s in self.config.mcp.servers if s.enabled]
         disabled_count = len(self.config.mcp.servers) - len(enabled_servers)
 
@@ -673,38 +680,43 @@ class MCPRegistry:
             server_count=len(enabled_servers),
         )
 
-        # Create connectors for enabled servers only
         for server_config in enabled_servers:
             connector = MCPServerConnector(server_config)
             self.connectors[server_config.name] = connector
 
-        # Enter all connector contexts in parallel using proper async with pattern
-        # We collect the futures to handle errors properly
+        connector_names = list(self.connectors.keys())
         results = await asyncio.gather(
-            *[connector.__aenter__() for connector in self.connectors.values()],
+            *[self.connectors[name].__aenter__() for name in connector_names],
             return_exceptions=True,
         )
 
-        # Check for connection errors
-        errors = [r for r in results if isinstance(r, Exception)]
-        if errors:
+        # Drop connectors that failed to connect so a frozen snapshot never
+        # contains a server with empty tools. Pre-refactor, a per-workspace
+        # registry would retry on next workspace start; post-refactor, one bad
+        # boot would otherwise degrade the process for its lifetime.
+        failed: list[tuple[str, Exception]] = []
+        for name, result in zip(connector_names, results, strict=True):
+            if isinstance(result, Exception):
+                failed.append((name, result))
+                self.connectors.pop(name, None)
+
+        if failed:
             logger.warning(
-                "Some MCP servers failed to connect",
-                error_count=len(errors),
-                errors=[str(e) for e in errors],
+                "Some MCP servers failed to connect; dropped from registry",
+                error_count=len(failed),
+                failed_servers=[name for name, _ in failed],
+                errors=[str(exc) for _, exc in failed],
             )
 
         logger.debug("MCP servers connected", servers=list(self.connectors.keys()))
 
     async def disconnect_all(self) -> None:
-        """Disconnect from all MCP servers.
+        """Exit all connector contexts in parallel. No-op when frozen."""
+        if self._frozen:
+            return
 
-        This method exits the async context for each connector,
-        ensuring proper cleanup in reverse order.
-        """
         logger.info("Disconnecting from all MCP servers")
 
-        # Exit all connector contexts in parallel
         await asyncio.gather(
             *[
                 connector.__aexit__(None, None, None)
@@ -715,12 +727,27 @@ class MCPRegistry:
 
         self.connectors.clear()
 
-    def get_all_tools(self) -> dict[str, list[MCPToolInfo]]:
-        """Get all tools organized by server.
+    async def _force_disconnect_all(self) -> None:
+        """Tear down every connector regardless of ``_frozen`` state.
 
-        Returns:
-            Dictionary mapping server names to lists of tools
+        For lifespan-startup error rollback, where a partially-frozen registry
+        could otherwise leak its already-spawned subprocesses past the failure
+        point. Do not call from normal Session paths — use ``disconnect_all``.
         """
+        if not self.connectors:
+            return
+
+        await asyncio.gather(
+            *[
+                connector.__aexit__(None, None, None)
+                for connector in self.connectors.values()
+            ],
+            return_exceptions=True,
+        )
+        self.connectors.clear()
+
+    def get_all_tools(self) -> dict[str, list[MCPToolInfo]]:
+        """Return tools grouped by server name."""
         tools_by_server = {}
 
         for server_name, connector in self.connectors.items():
@@ -764,6 +791,11 @@ class MCPRegistry:
         Returns:
             Tool result
         """
+        if self._frozen:
+            raise RuntimeError(
+                "call_tool unsupported on frozen MCPRegistry; "
+                "route MCP calls via the sandbox-side cohort."
+            )
         connector = self.connectors.get(server_name)
         if not connector:
             msg = f"Server not found: {server_name}"
@@ -784,3 +816,37 @@ class MCPRegistry:
     ) -> None:
         """Async context manager exit."""
         await self.disconnect_all()
+
+
+# Process-global frozen registry installed at server lifespan startup
+# (see src/server/app/setup.py). Sessions borrow this snapshot; when None,
+# Session falls back to creating a per-instance registry (tests, standalone).
+#
+# TODO(option-c): eliminate the backend cohort by having the sandbox emit its
+# own tool schemas at boot via a one-shot ``--describe`` mode.
+_GLOBAL_REGISTRY: MCPRegistry | None = None
+
+
+def get_global_registry() -> MCPRegistry | None:
+    """Return the process-global frozen registry, or None if not installed."""
+    return _GLOBAL_REGISTRY
+
+
+def set_global_registry(registry: MCPRegistry) -> None:
+    """Install the process-global registry. The registry must be frozen so
+    Sessions borrowing it can rely on the snapshot invariant (no live stdio
+    subprocesses, schemas are immutable for the process lifetime).
+    """
+    if not registry.frozen:
+        raise ValueError(
+            "Global MCP registry must be frozen before installing; call "
+            "registry.freeze() first."
+        )
+    global _GLOBAL_REGISTRY
+    _GLOBAL_REGISTRY = registry
+
+
+def clear_global_registry() -> None:
+    """Drop the process-global registry reference."""
+    global _GLOBAL_REGISTRY
+    _GLOBAL_REGISTRY = None

--- a/src/ptc_agent/core/session.py
+++ b/src/ptc_agent/core/session.py
@@ -9,7 +9,7 @@ import structlog
 
 from ptc_agent.config.core import CoreConfig
 
-from .mcp_registry import MCPRegistry
+from .mcp_registry import MCPRegistry, get_global_registry
 from .sandbox import PTCSandbox
 
 logger = structlog.get_logger(__name__)
@@ -29,6 +29,9 @@ class Session:
         self.config = config
         self.sandbox: PTCSandbox | None = None
         self.mcp_registry: MCPRegistry | None = None
+        # False means we're borrowing the process-global frozen registry;
+        # stop/cleanup must NOT call disconnect_all on a borrowed instance.
+        self._owns_mcp_registry: bool = False
         self._initialized = False
 
         # agent.md cache with dirty flag (force first read)
@@ -90,16 +93,19 @@ class Session:
             reconnecting=sandbox_id is not None,
         )
 
-        # Initialize MCP registry
-        self.mcp_registry = MCPRegistry(self.config)
+        # Borrow the global frozen registry when available; otherwise own one.
+        global_registry = get_global_registry()
+        if global_registry is not None:
+            self.mcp_registry = global_registry
+            self._owns_mcp_registry = False
+        else:
+            self.mcp_registry = MCPRegistry(self.config)
+            self._owns_mcp_registry = True
 
         if sandbox_id:
             # RECONNECT MODE: Run MCP connections and sandbox start in parallel
-
-            # Create sandbox instance without mcp_registry
             self.sandbox = PTCSandbox(self.config, None)
 
-            # Run both operations in parallel
             try:
                 await asyncio.gather(
                     self.mcp_registry.connect_all(),
@@ -108,13 +114,13 @@ class Session:
                     ),
                 )
             except Exception:
-                # Clean up MCP connections to avoid leaks
-                if self.mcp_registry:
+                if self.mcp_registry and self._owns_mcp_registry:
                     try:
                         await self.mcp_registry.disconnect_all()
                     except Exception:
                         pass
-                    self.mcp_registry = None
+                self.mcp_registry = None
+                self._owns_mcp_registry = False
                 self.sandbox = None
                 raise
 
@@ -135,12 +141,13 @@ class Session:
                     self.mcp_registry.connect_all(),
                 )
             except Exception:
-                if self.mcp_registry:
+                if self.mcp_registry and self._owns_mcp_registry:
                     try:
                         await self.mcp_registry.disconnect_all()
                     except Exception:
                         pass
-                    self.mcp_registry = None
+                self.mcp_registry = None
+                self._owns_mcp_registry = False
                 self.sandbox = None
                 raise
 
@@ -194,10 +201,15 @@ class Session:
         self.sandbox = PTCSandbox(self.config, mcp_registry=None)
         self.sandbox.start_lazy_init(sandbox_id, on_state_observed=on_state_observed)
 
-        # Initialize MCP registry (required for system prompt) — runs in
-        # parallel with the Daytona sandbox start above.
-        self.mcp_registry = MCPRegistry(self.config)
-        await self.mcp_registry.connect_all()
+        # Borrow the global frozen registry when available; otherwise own one.
+        global_registry = get_global_registry()
+        if global_registry is not None:
+            self.mcp_registry = global_registry
+            self._owns_mcp_registry = False
+        else:
+            self.mcp_registry = MCPRegistry(self.config)
+            self._owns_mcp_registry = True
+            await self.mcp_registry.connect_all()
         mcp_ms = (time.time() - _t0) * 1000
 
         # Attach registry to sandbox (needed later for sync_sandbox_assets)
@@ -206,7 +218,8 @@ class Session:
         self._initialized = True
 
         logger.info(
-            f"[LAZY_INIT] sandbox_id={sandbox_id} mcp_connect={mcp_ms:.0f}ms",
+            f"[LAZY_INIT] sandbox_id={sandbox_id} mcp_connect={mcp_ms:.0f}ms "
+            f"borrowed_global={not self._owns_mcp_registry}",
         )
 
     async def get_sandbox(self) -> PTCSandbox | None:
@@ -228,9 +241,10 @@ class Session:
             await self.sandbox.cleanup()
             self.sandbox = None
 
-        if self.mcp_registry:
+        if self.mcp_registry and self._owns_mcp_registry:
             await self.mcp_registry.disconnect_all()
-            self.mcp_registry = None
+        self.mcp_registry = None
+        self._owns_mcp_registry = False
 
         self._initialized = False
         self._agent_md_dirty = True
@@ -259,7 +273,7 @@ class Session:
             except Exception:
                 pass
 
-        if self.mcp_registry:
+        if self.mcp_registry and self._owns_mcp_registry:
             await self.mcp_registry.disconnect_all()
 
         # Mark as uninitialized so the next restart will reconnect.
@@ -269,6 +283,7 @@ class Session:
         self._agent_md_dirty = True
         self.sandbox = None
         self.mcp_registry = None
+        self._owns_mcp_registry = False
 
         logger.info("Session stopped", conversation_id=self.conversation_id)
 

--- a/src/server/app/setup.py
+++ b/src/server/app/setup.py
@@ -199,6 +199,43 @@ async def lifespan(app: FastAPI):
         agent_config.validate_api_keys()
         logger.info("PTC Agent configuration loaded successfully")
 
+        # Connect once, freeze, install as the process-global registry so every
+        # Session borrows the same tool snapshot instead of spawning its own
+        # MCP cohort. Failures here are non-fatal: Sessions fall back to a
+        # per-instance registry.
+        from ptc_agent.core.mcp_registry import (
+            MCPRegistry,
+            set_global_registry,
+        )
+
+        mcp_registry = None
+        try:
+            core_config = agent_config.to_core_config()
+            mcp_registry = MCPRegistry(core_config)
+            await mcp_registry.connect_all()
+            await mcp_registry.freeze()
+            set_global_registry(mcp_registry)
+            logger.info(
+                "Global MCP registry frozen at startup (servers=%d)",
+                len(mcp_registry.connectors),
+            )
+        except Exception as exc:
+            # Tear down any subprocesses connect_all already spawned, regardless
+            # of how far freeze() got. ``disconnect_all`` short-circuits when
+            # _frozen=True, so use the force variant here to avoid leaks if the
+            # exception fired between freeze setting _frozen and the install.
+            if mcp_registry is not None:
+                try:
+                    await mcp_registry._force_disconnect_all()
+                except Exception:
+                    pass
+            logger.warning(
+                "Failed to install global MCP registry "
+                "(error_type=%s); sessions will fall back to per-instance "
+                "registries.",
+                type(exc).__name__,
+            )
+
         # Initialize generic one-shot LLM call wrapper. Constructed once so
         # every server-side utility LLM call (memo metadata, thread titles,
         # follow-up suggestions, etc.) shares a single BYOK/OAuth-aware entry
@@ -384,6 +421,15 @@ async def lifespan(app: FastAPI):
             logger.info("PTC Session Service shutdown complete")
         except Exception as e:
             logger.warning(f"Error during PTC Session Service shutdown: {e}")
+
+    # 4.5. Drop the global MCP registry reference (frozen snapshot — no
+    # subprocesses to terminate). Hygiene only.
+    try:
+        from ptc_agent.core.mcp_registry import clear_global_registry
+
+        clear_global_registry()
+    except Exception as e:
+        logger.debug(f"Error clearing global MCP registry: {e}")
 
     # 5. Close PTC Agent checkpointer pool
     if checkpointer is not None:

--- a/tests/unit/core/conftest.py
+++ b/tests/unit/core/conftest.py
@@ -1,0 +1,13 @@
+"""Shared fixtures for tests/unit/core."""
+
+import pytest
+
+from ptc_agent.core.mcp_registry import clear_global_registry
+
+
+@pytest.fixture(autouse=True)
+def _reset_mcp_global_registry():
+    """Module-level _GLOBAL_REGISTRY would otherwise leak across tests."""
+    clear_global_registry()
+    yield
+    clear_global_registry()

--- a/tests/unit/core/test_mcp_registry_env.py
+++ b/tests/unit/core/test_mcp_registry_env.py
@@ -5,10 +5,19 @@ instead of the full environment, preventing host secret leakage to
 MCP discovery subprocesses.
 """
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from ptc_agent.config.core import MCPServerConfig
-from ptc_agent.core.mcp_registry import MCPServerConnector
+from ptc_agent.core.mcp_registry import (
+    MCPRegistry,
+    MCPServerConnector,
+    MCPToolInfo,
+    clear_global_registry,
+    get_global_registry,
+    set_global_registry,
+)
 
 
 class TestPrepareEnvSafety:
@@ -140,3 +149,202 @@ class TestPrepareEnvSafety:
             result = connector._prepare_env()
 
         assert result == {"PATH": "/usr/bin"}
+
+
+class TestFreezeAndGlobalRegistry:
+    """Verify the frozen-snapshot path used at lifespan startup."""
+
+    def _make_connector_with_tools(
+        self, server_name: str, tool_names: list[str]
+    ) -> MCPServerConnector:
+        """Build a connector populated as if connect_all already ran."""
+        config = MCPServerConfig(
+            name=server_name, command="echo", args=["hi"], env={}
+        )
+        connector = MCPServerConnector(config)
+        connector.tools = [
+            MCPToolInfo(
+                name=name,
+                description=f"{name} desc",
+                input_schema={"type": "object"},
+                server_name=server_name,
+            )
+            for name in tool_names
+        ]
+        return connector
+
+    def _make_registry_with_servers(
+        self, servers: dict[str, list[str]]
+    ) -> MCPRegistry:
+        """Build a registry whose connectors look freshly connected."""
+        config = MagicMock()
+        config.mcp.servers = []  # not exercised by freeze() / connect_all no-op
+        registry = MCPRegistry(config)
+        for server_name, tool_names in servers.items():
+            registry.connectors[server_name] = self._make_connector_with_tools(
+                server_name, tool_names
+            )
+        return registry
+
+    @pytest.mark.asyncio
+    async def test_freeze_terminates_subprocesses_but_keeps_tools(self):
+        """freeze() exits each connector context and preserves the schema dict.
+
+        ``__aexit__`` is mocked to confirm it is awaited per connector;
+        ``connectors`` itself stays populated so consumers reading
+        ``get_all_tools`` still see the snapshot.
+        """
+        registry = self._make_registry_with_servers(
+            {"alpha": ["a1", "a2"], "beta": ["b1"]}
+        )
+        for connector in registry.connectors.values():
+            connector.__aexit__ = AsyncMock(return_value=None)
+
+        await registry.freeze()
+
+        for connector in registry.connectors.values():
+            connector.__aexit__.assert_awaited_once_with(None, None, None)
+        assert registry.frozen is True
+        assert set(registry.connectors.keys()) == {"alpha", "beta"}
+        assert {t.name for t in registry.connectors["alpha"].tools} == {"a1", "a2"}
+        assert {t.name for t in registry.connectors["beta"].tools} == {"b1"}
+
+    @pytest.mark.asyncio
+    async def test_freeze_is_idempotent(self):
+        """Calling freeze() twice doesn't double-call __aexit__."""
+        registry = self._make_registry_with_servers({"alpha": ["a1"]})
+        registry.connectors["alpha"].__aexit__ = AsyncMock(return_value=None)
+
+        await registry.freeze()
+        await registry.freeze()
+
+        registry.connectors["alpha"].__aexit__.assert_awaited_once()
+        assert registry.frozen is True
+
+    @pytest.mark.asyncio
+    async def test_connect_all_is_noop_when_frozen(self):
+        """A frozen registry never re-spawns subprocesses on connect_all().
+
+        This is what lets a Session that calls ``connect_all`` against the
+        shared global registry skip subprocess startup entirely.
+        """
+        registry = self._make_registry_with_servers({"alpha": ["a1"]})
+        registry.connectors["alpha"].__aexit__ = AsyncMock(return_value=None)
+        await registry.freeze()
+
+        # Stash a sentinel so we can prove connectors weren't replaced.
+        sentinel_connector = registry.connectors["alpha"]
+        await registry.connect_all()
+        assert registry.connectors["alpha"] is sentinel_connector
+        assert registry.frozen is True
+
+    @pytest.mark.asyncio
+    async def test_disconnect_all_is_noop_when_frozen(self):
+        """A frozen registry's disconnect_all preserves the snapshot.
+
+        Sessions that don't own the registry will still call
+        ``disconnect_all`` during stop/cleanup error paths; the no-op keeps
+        the shared snapshot intact.
+        """
+        registry = self._make_registry_with_servers({"alpha": ["a1"]})
+        registry.connectors["alpha"].__aexit__ = AsyncMock(return_value=None)
+        await registry.freeze()
+        # Reset the mock so we can detect any further __aexit__ calls.
+        registry.connectors["alpha"].__aexit__.reset_mock()
+
+        await registry.disconnect_all()
+
+        registry.connectors["alpha"].__aexit__.assert_not_called()
+        assert "alpha" in registry.connectors
+        assert registry.connectors["alpha"].tools[0].name == "a1"
+
+    def test_global_registry_lifecycle(self):
+        """get/set/clear preserve identity and clear actually clears."""
+        assert get_global_registry() is None
+
+        registry = MCPRegistry(MagicMock(mcp=MagicMock(servers=[])))
+        registry._frozen = True  # set_global_registry requires frozen
+        set_global_registry(registry)
+        assert get_global_registry() is registry
+
+        clear_global_registry()
+        assert get_global_registry() is None
+
+    def test_set_global_registry_rejects_unfrozen(self):
+        """Installing an unfrozen registry would defeat the snapshot
+        invariant — set_global_registry must raise."""
+        registry = MCPRegistry(MagicMock(mcp=MagicMock(servers=[])))
+        with pytest.raises(ValueError, match="frozen"):
+            set_global_registry(registry)
+        assert get_global_registry() is None
+
+    @pytest.mark.asyncio
+    async def test_connect_all_drops_failed_connectors(self):
+        """A connector whose __aenter__ raises must be removed from the
+        registry, not retained with empty tools. Otherwise the frozen
+        snapshot leaks a phantom server for the process lifetime."""
+        config = MagicMock()
+        config.mcp.servers = [
+            MCPServerConfig(name="alpha", command="echo", args=["hi"], env={}, enabled=True),
+            MCPServerConfig(name="beta", command="echo", args=["hi"], env={}, enabled=True),
+            MCPServerConfig(name="gamma", command="echo", args=["hi"], env={}, enabled=True),
+        ]
+        registry = MCPRegistry(config)
+
+        # Patch __aenter__ via MCPServerConnector creation hook
+        original_init = MCPServerConnector.__init__
+
+        def patched_init(self, cfg):
+            original_init(self, cfg)
+            should_fail = cfg.name == "beta"
+            if should_fail:
+                async def failing(*a, **kw):
+                    raise RuntimeError(f"{cfg.name} boot failed")
+                self.__aenter__ = failing  # type: ignore[method-assign]
+            else:
+                self.tools = [
+                    MCPToolInfo(
+                        name=f"{cfg.name}_tool",
+                        description="",
+                        input_schema={},
+                        server_name=cfg.name,
+                    )
+                ]
+                async def succeeding(*a, **kw):
+                    return self
+                self.__aenter__ = succeeding  # type: ignore[method-assign]
+
+        with patch.object(MCPServerConnector, "__init__", patched_init):
+            await registry.connect_all()
+
+        assert "alpha" in registry.connectors
+        assert "gamma" in registry.connectors
+        assert "beta" not in registry.connectors
+        assert len(registry.connectors) == 2
+
+    @pytest.mark.asyncio
+    async def test_force_disconnect_all_runs_when_frozen(self):
+        """_force_disconnect_all bypasses the frozen-state early-return so
+        lifespan-startup error rollback can drop subprocesses regardless of
+        how far freeze() got before raising."""
+        registry = self._make_registry_with_servers({"alpha": ["a1"]})
+        alpha_aexit = AsyncMock(return_value=None)
+        registry.connectors["alpha"].__aexit__ = alpha_aexit
+        await registry.freeze()
+        alpha_aexit.reset_mock()
+
+        await registry._force_disconnect_all()
+
+        alpha_aexit.assert_awaited_once_with(None, None, None)
+        assert registry.connectors == {}
+
+    @pytest.mark.asyncio
+    async def test_call_tool_raises_when_frozen(self):
+        """A frozen registry has no live sessions; call_tool must fail loud
+        instead of dispatching to a connector with session=None."""
+        registry = self._make_registry_with_servers({"alpha": ["a1"]})
+        registry.connectors["alpha"].__aexit__ = AsyncMock(return_value=None)
+        await registry.freeze()
+
+        with pytest.raises(RuntimeError, match="frozen"):
+            await registry.call_tool("alpha", "a1", {})

--- a/tests/unit/core/test_session_mcp_ownership.py
+++ b/tests/unit/core/test_session_mcp_ownership.py
@@ -1,0 +1,106 @@
+"""Verify Session borrow/own semantics for the process-global MCPRegistry.
+
+The borrow path is the load-bearing point of the global-frozen-registry
+refactor — every Session that finds an installed global must reuse it
+instead of spawning its own MCP cohort, and stop/cleanup must NEVER call
+disconnect_all on a borrowed instance.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ptc_agent.core.mcp_registry import (
+    MCPRegistry,
+    set_global_registry,
+)
+from ptc_agent.core.session import Session
+
+
+def _make_frozen_registry() -> MCPRegistry:
+    registry = MCPRegistry(MagicMock(mcp=MagicMock(servers=[])))
+    registry._frozen = True
+    return registry
+
+
+def _patch_session_init_collaborators():
+    """Patch sandbox + per-instance MCPRegistry so we don't hit Daytona."""
+    sandbox = MagicMock()
+    sandbox.setup_sandbox_workspace = AsyncMock(return_value=("snapshot", None))
+    sandbox.setup_tools_and_mcp = AsyncMock(return_value=None)
+    sandbox.cleanup = AsyncMock(return_value=None)
+    sandbox.stop_sandbox = AsyncMock(return_value=None)
+    sandbox.close = AsyncMock(return_value=None)
+    return sandbox
+
+
+@pytest.mark.asyncio
+async def test_initialize_borrows_global_when_installed():
+    """When a frozen global exists, Session reuses it and marks itself
+    as a non-owner — disconnect_all must never reach the global."""
+    global_registry = _make_frozen_registry()
+    set_global_registry(global_registry)
+    sandbox = _patch_session_init_collaborators()
+
+    session = Session("conv-1", MagicMock())
+
+    with patch("ptc_agent.core.session.PTCSandbox", return_value=sandbox):
+        await session.initialize()
+
+    assert session.mcp_registry is global_registry
+    assert session._owns_mcp_registry is False
+
+
+@pytest.mark.asyncio
+async def test_initialize_creates_own_registry_when_no_global():
+    """No global installed → Session creates a per-instance live registry
+    and takes ownership so cleanup tears it down."""
+    sandbox = _patch_session_init_collaborators()
+    fake_registry = MagicMock(spec=MCPRegistry)
+    fake_registry.connect_all = AsyncMock(return_value=None)
+    fake_registry.disconnect_all = AsyncMock(return_value=None)
+
+    session = Session("conv-2", MagicMock())
+
+    with patch("ptc_agent.core.session.PTCSandbox", return_value=sandbox), \
+         patch("ptc_agent.core.session.MCPRegistry", return_value=fake_registry):
+        await session.initialize()
+
+    assert session.mcp_registry is fake_registry
+    assert session._owns_mcp_registry is True
+    fake_registry.connect_all.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_skips_disconnect_for_borrowed_global():
+    """A borrowed global must survive any one Session's cleanup."""
+    global_registry = _make_frozen_registry()
+    global_registry.disconnect_all = AsyncMock(return_value=None)
+    set_global_registry(global_registry)
+    sandbox = _patch_session_init_collaborators()
+
+    session = Session("conv-3", MagicMock())
+
+    with patch("ptc_agent.core.session.PTCSandbox", return_value=sandbox):
+        await session.initialize()
+        await session.cleanup()
+
+    global_registry.disconnect_all.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_disconnects_owned_registry():
+    """Owned per-instance registry must be torn down on cleanup."""
+    sandbox = _patch_session_init_collaborators()
+    fake_registry = MagicMock(spec=MCPRegistry)
+    fake_registry.connect_all = AsyncMock(return_value=None)
+    fake_registry.disconnect_all = AsyncMock(return_value=None)
+
+    session = Session("conv-4", MagicMock())
+
+    with patch("ptc_agent.core.session.PTCSandbox", return_value=sandbox), \
+         patch("ptc_agent.core.session.MCPRegistry", return_value=fake_registry):
+        await session.initialize()
+        await session.cleanup()
+
+    fake_registry.disconnect_all.assert_awaited_once()


### PR DESCRIPTION
## Summary

- Lift `MCPRegistry` to a process-global frozen snapshot installed once at lifespan startup. After `connect_all` + `freeze`, the registry holds tool schemas in memory and all stdio subprocesses exit; `connect_all`/`disconnect_all` early-return so Sessions can safely share the snapshot.
- Each `Session` now borrows the global instance instead of spawning its own MCP cohort. Per-instance ownership is tracked so `cleanup`/`stop` only tear down what the Session created.
- Backend MCP cost drops from `len(enabled_servers)` per active workspace to **zero idle subprocesses after boot**. The agent's actual tool calls already run via the sandbox-side cohort emitted by `generate_mcp_client_code`, so the backend cohort was read-only after schema discovery.
- Boot-failure hardening: `freeze()` wraps connector teardown in a 10s timeout; `connect_all` drops connectors whose `__aenter__` raised so the snapshot can't carry phantom servers; `set_global_registry` rejects unfrozen instances; lifespan rollback uses `_force_disconnect_all()` so subprocesses are reaped regardless of how far `freeze()` got before raising; the failure log emits only `error_type` (no env-leak risk via raw exception text); `call_tool` raises post-freeze as a defensive guard against future regressions.
- Inline `TODO(option-c)` marks the long-term path: have the sandbox emit its own schemas via a one-shot `--describe` mode at boot, eliminating the backend cohort entirely.

## Test plan

- [x] `uv run pytest tests/unit/` — **3166 passed** (was 3160; +6 new tests)
- [x] `uv run ruff check` on touched files — clean
- [x] New tests cover: `freeze()` terminates subprocesses while keeping tools, `freeze()` idempotency, `connect_all`/`disconnect_all` no-op when frozen, `_force_disconnect_all` runs through frozen state, `call_tool` raises post-freeze, `set_global_registry` rejects unfrozen, `connect_all` drops failed connectors, global registry get/set/clear lifecycle.
- [x] Session borrow/own unit tests cover: borrows global when installed, creates own when no global, `cleanup` skips `disconnect_all` for borrowed global, `cleanup` does tear down owned registry.
- [x] Autouse fixture moved to `tests/unit/core/conftest.py` so `_GLOBAL_REGISTRY` cannot leak across tests outside the registry test class.

## Manual verification

After merge + redeploy, expect:
- Backend startup logs: one `MCP registry frozen servers=10 tools=69` line.
- `pgrep -af 'mcp_servers/' | wc -l` inside the backend container → 0 after boot (was N_workspaces × 10).
- Per-workspace startup latency drops the MCP-connect contribution to ~0ms; lazy log shows `borrowed_global=True`.