### PR TITLE
feat(workflow): canonical terminal status wiring + invariant-pinned reconnect set

### DIFF
--- a/src/server/handlers/chat/_common.py
+++ b/src/server/handlers/chat/_common.py
@@ -889,9 +889,13 @@ async def handle_workflow_error(
                 f"thread_id={thread_id}: {type(e).__name__}: {str(e)[:100]}"
             )
 
+            error_msg = (
+                f"Max retries exceeded ({retry_count}/{MAX_RETRIES}): "
+                f"{type(e).__name__}: {str(e)}"
+            )
+
             if persistence_service:
                 try:
-                    error_msg = f"Max retries exceeded ({retry_count}/{MAX_RETRIES}): {type(e).__name__}: {str(e)}"
                     await persistence_service.persist_error(
                         error_message=error_msg,
                         errors=[error_msg],
@@ -905,6 +909,18 @@ async def handle_workflow_error(
                     logger.error(
                         f"[{log_prefix}] Failed to persist error: {persist_error}"
                     )
+
+            # Push terminal status to Redis so /status reports FAILED with
+            # bounded TTL instead of leaving the key as ACTIVE/DISCONNECTED.
+            # The setup-error path runs outside BackgroundTaskManager's
+            # _mark_failed, so this is the only chance to update tracker.
+            try:
+                await tracker.mark_failed(thread_id, error=error_msg)
+            except Exception as tracker_err:
+                logger.warning(
+                    f"[{log_prefix}] tracker.mark_failed failed for "
+                    f"{thread_id}: {tracker_err}"
+                )
 
             error_data = {
                 "message": f"Workflow failed after {MAX_RETRIES} retry attempts",
@@ -951,6 +967,20 @@ async def handle_workflow_error(
                 )
             except Exception as persist_error:
                 logger.error(f"[{log_prefix}] Failed to persist error: {persist_error}")
+
+        # Mirror the recoverable max-retries branch: push FAILED to Redis with
+        # bounded TTL. Without this, /status keeps reporting ACTIVE for the
+        # full mark_active TTL window after a non-recoverable workflow error.
+        try:
+            tracker = WorkflowTracker.get_instance()
+            await tracker.mark_failed(
+                thread_id, error=f"{type(e).__name__}: {str(e)}"
+            )
+        except Exception as tracker_err:
+            logger.warning(
+                f"[{log_prefix}] tracker.mark_failed failed for "
+                f"{thread_id}: {tracker_err}"
+            )
 
         if handler:
             error_event = handler._format_sse_event(

--- a/src/server/handlers/workflow_handler.py
+++ b/src/server/handlers/workflow_handler.py
@@ -168,7 +168,11 @@ async def get_workflow_status(thread_id: str) -> dict:
         Dict with current status, reconnectability, and progress info
     """
     try:
-        from src.server.services.workflow_tracker import WorkflowTracker, WorkflowStatus
+        from src.server.services.workflow_tracker import (
+            RECONNECTABLE_STATUSES,
+            WorkflowStatus,
+            WorkflowTracker,
+        )
 
         tracker = WorkflowTracker.get_instance()
 
@@ -216,7 +220,7 @@ async def get_workflow_status(thread_id: str) -> dict:
             user_id = None
 
         # Determine if reconnection is possible
-        can_reconnect = status in [WorkflowStatus.ACTIVE, WorkflowStatus.DISCONNECTED]
+        can_reconnect = status in RECONNECTABLE_STATUSES
 
         # Get subagent info from background task manager
         active_tasks = []

--- a/src/server/services/background_task_manager.py
+++ b/src/server/services/background_task_manager.py
@@ -1643,7 +1643,7 @@ class BackgroundTaskManager:
         # expiry. Mirrors mark_completed/mark_cancelled.
         try:
             tracker = WorkflowTracker.get_instance()
-            await tracker.mark_failed(thread_id, error)
+            await tracker.mark_failed(thread_id, error=error)
         except Exception as tracker_err:
             logger.warning(
                 f"[BackgroundTaskManager] tracker.mark_failed failed for {thread_id}: {tracker_err}"

--- a/src/server/services/background_task_manager.py
+++ b/src/server/services/background_task_manager.py
@@ -67,6 +67,7 @@ from src.config.settings import (
 )
 from src.utils.cache.redis_cache import get_cache_client
 from src.server.dependencies.usage_limits import release_burst_slot
+from src.server.services.workflow_tracker import WorkflowTracker
 from src.server.utils.persistence_utils import (
     get_token_usage_from_callback,
     get_tool_usage_from_handler,
@@ -1449,7 +1450,6 @@ class BackgroundTaskManager:
 
                     # Update Redis workflow tracker to interrupted
                     # (prevents frontend from reconnecting to a paused workflow)
-                    from src.server.services.workflow_tracker import WorkflowTracker
                     tracker = WorkflowTracker.get_instance()
                     await tracker.mark_interrupted(
                         thread_id=thread_id,
@@ -1638,6 +1638,17 @@ class BackgroundTaskManager:
         if user_id:
             await release_burst_slot(user_id)
 
+        # Push terminal status to Redis so /status reports FAILED with bounded
+        # TTL instead of leaving the key as ACTIVE/DISCONNECTED until natural
+        # expiry. Mirrors mark_completed/mark_cancelled.
+        try:
+            tracker = WorkflowTracker.get_instance()
+            await tracker.mark_failed(thread_id, error)
+        except Exception as tracker_err:
+            logger.warning(
+                f"[BackgroundTaskManager] tracker.mark_failed failed for {thread_id}: {tracker_err}"
+            )
+
         async with self.task_lock:
             task_info = self.tasks.get(thread_id)
             if task_info:
@@ -1755,6 +1766,15 @@ class BackgroundTaskManager:
         # Release burst slot for soft interrupt path
         if user_id:
             await release_burst_slot(user_id)
+
+        # Push terminal status to Redis (bounded TTL).
+        try:
+            tracker = WorkflowTracker.get_instance()
+            await tracker.mark_soft_interrupted(thread_id)
+        except Exception as tracker_err:
+            logger.warning(
+                f"[BackgroundTaskManager] tracker.mark_soft_interrupted failed for {thread_id}: {tracker_err}"
+            )
 
         async with self.task_lock:
             task_info = self.tasks.get(thread_id)
@@ -2149,6 +2169,19 @@ class BackgroundTaskManager:
         # Release burst slot for cancellation path
         if user_id:
             await release_burst_slot(user_id)
+
+        # Push terminal status to Redis from the single canonical site so
+        # every cancel path (cancel endpoint, stale-cancel reaper, soft-
+        # interrupt-abort) updates Redis — not just the explicit-cancel
+        # branch in chat/_common.py:_handle_sse_disconnect that already
+        # calls tracker.mark_cancelled directly.
+        try:
+            tracker = WorkflowTracker.get_instance()
+            await tracker.mark_cancelled(thread_id)
+        except Exception as tracker_err:
+            logger.warning(
+                f"[BackgroundTaskManager] tracker.mark_cancelled failed for {thread_id}: {tracker_err}"
+            )
 
         async with self.task_lock:
             task_info = self.tasks.get(thread_id)

--- a/src/server/services/workflow_tracker.py
+++ b/src/server/services/workflow_tracker.py
@@ -30,7 +30,31 @@ class WorkflowStatus(str, Enum):
     COMPLETED = "completed"
     INTERRUPTED = "interrupted"
     CANCELLED = "cancelled"
+    FAILED = "failed"
+    SOFT_INTERRUPTED = "soft_interrupted"
     UNKNOWN = "unknown"
+
+
+# Terminal states — no further transitions, ``can_reconnect`` returns False.
+# Adding a new terminal state requires wiring it into
+# ``BackgroundTaskManager``'s corresponding ``_mark_*`` method so Postgres +
+# Redis stay in sync. ``test_terminal_disjoint_from_reconnectable`` pins the
+# invariant against ``RECONNECTABLE_STATUSES``.
+TERMINAL_STATUSES: frozenset[WorkflowStatus] = frozenset({
+    WorkflowStatus.COMPLETED,
+    WorkflowStatus.CANCELLED,
+    WorkflowStatus.FAILED,
+    WorkflowStatus.SOFT_INTERRUPTED,
+})
+
+
+# Statuses for which a client may reconnect to a live SSE stream. Source of
+# truth for ``workflow_handler.check_workflow_status``'s ``can_reconnect``
+# decision; must stay disjoint with ``TERMINAL_STATUSES``.
+RECONNECTABLE_STATUSES: frozenset[WorkflowStatus] = frozenset({
+    WorkflowStatus.ACTIVE,
+    WorkflowStatus.DISCONNECTED,
+})
 
 
 class WorkflowTracker:
@@ -317,6 +341,72 @@ class WorkflowTracker:
         if success:
             logger.info(
                 f"[WorkflowTracker] Marked workflow as cancelled: {thread_id}"
+            )
+
+        return success
+
+    async def mark_failed(
+        self,
+        thread_id: str,
+        error: Optional[str] = None,
+    ) -> bool:
+        """Mark workflow as failed (uncaught exception or unrecoverable error).
+
+        Mirrors mark_completed/mark_cancelled — bounded TTL so /status correctly
+        reports a terminal state instead of leaving the key as ACTIVE until
+        natural Redis expiry.
+
+        Args:
+            thread_id: Thread/workflow identifier
+            error: Optional error message stored in metadata
+
+        Returns:
+            True if successfully marked, False otherwise
+        """
+        if not self.enabled:
+            return False
+
+        success = await self._update_status_with_metadata(
+            thread_id=thread_id,
+            new_status=WorkflowStatus.FAILED,
+            timestamp_field="failed_at",
+            metadata={"error": error} if error else None,
+            ttl=get_redis_ttl_workflow_status(),
+        )
+
+        if success:
+            logger.info(
+                f"[WorkflowTracker] Marked workflow as failed: {thread_id}"
+            )
+
+        return success
+
+    async def mark_soft_interrupted(self, thread_id: str) -> bool:
+        """Mark workflow as soft-interrupted (main agent paused, subagents can still complete).
+
+        Distinct from INTERRUPTED (HITL pause, indefinite TTL): SOFT_INTERRUPTED
+        is a terminal-for-the-turn state with bounded TTL.
+
+        Args:
+            thread_id: Thread/workflow identifier
+
+        Returns:
+            True if successfully marked, False otherwise
+        """
+        if not self.enabled:
+            return False
+
+        success = await self._update_status_with_metadata(
+            thread_id=thread_id,
+            new_status=WorkflowStatus.SOFT_INTERRUPTED,
+            timestamp_field="soft_interrupted_at",
+            metadata=None,
+            ttl=get_redis_ttl_workflow_status(),
+        )
+
+        if success:
+            logger.info(
+                f"[WorkflowTracker] Marked workflow as soft-interrupted: {thread_id}"
             )
 
         return success

--- a/src/server/services/workflow_tracker.py
+++ b/src/server/services/workflow_tracker.py
@@ -5,7 +5,7 @@ Manages workflow execution state in Redis to support background execution
 and reconnection after client disconnect.
 
 Key Features:
-- Track workflow status (active/disconnected/completed/cancelled)
+- Track workflow status (active/disconnected/completed/cancelled/failed/soft_interrupted)
 - Detect explicit user cancellation vs accidental disconnect
 - TTL-based cleanup of completed workflows
 - Graceful degradation if Redis unavailable
@@ -49,7 +49,7 @@ TERMINAL_STATUSES: frozenset[WorkflowStatus] = frozenset({
 
 
 # Statuses for which a client may reconnect to a live SSE stream. Source of
-# truth for ``workflow_handler.check_workflow_status``'s ``can_reconnect``
+# truth for ``workflow_handler.get_workflow_status``'s ``can_reconnect``
 # decision; must stay disjoint with ``TERMINAL_STATUSES``.
 RECONNECTABLE_STATUSES: frozenset[WorkflowStatus] = frozenset({
     WorkflowStatus.ACTIVE,
@@ -355,13 +355,6 @@ class WorkflowTracker:
         Mirrors mark_completed/mark_cancelled — bounded TTL so /status correctly
         reports a terminal state instead of leaving the key as ACTIVE until
         natural Redis expiry.
-
-        Args:
-            thread_id: Thread/workflow identifier
-            error: Optional error message stored in metadata
-
-        Returns:
-            True if successfully marked, False otherwise
         """
         if not self.enabled:
             return False
@@ -386,12 +379,6 @@ class WorkflowTracker:
 
         Distinct from INTERRUPTED (HITL pause, indefinite TTL): SOFT_INTERRUPTED
         is a terminal-for-the-turn state with bounded TTL.
-
-        Args:
-            thread_id: Thread/workflow identifier
-
-        Returns:
-            True if successfully marked, False otherwise
         """
         if not self.enabled:
             return False

--- a/tests/unit/server/handlers/chat/test_handle_workflow_error.py
+++ b/tests/unit/server/handlers/chat/test_handle_workflow_error.py
@@ -1,0 +1,147 @@
+"""Tests for ``handle_workflow_error`` tracker wiring.
+
+Pins the contract that both terminal branches (max-retries-exceeded and
+non-recoverable) push ``WorkflowStatus.FAILED`` to Redis via
+``WorkflowTracker.mark_failed``. Without these tests a future refactor that
+drops the tracker call would silently restore the original "ACTIVE for the
+full TTL window" bug after a setup-error workflow dies.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.server.handlers.chat import _common
+
+
+def _consume(agen):
+    async def _drain():
+        events = []
+        async for event in agen:
+            events.append(event)
+        return events
+    return _drain()
+
+
+def _make_request():
+    return SimpleNamespace(
+        workspace_id="ws-1",
+        locale=None,
+        timezone=None,
+    )
+
+
+@pytest.fixture
+def patch_tracker():
+    """Patch WorkflowTracker.get_instance to return a recordable mock."""
+    mock_tracker = MagicMock()
+    mock_tracker.increment_retry_count = AsyncMock()
+    mock_tracker.mark_failed = AsyncMock(return_value=True)
+    with patch.object(
+        _common.WorkflowTracker, "get_instance", return_value=mock_tracker
+    ):
+        yield mock_tracker
+
+
+@pytest.mark.asyncio
+async def test_max_retries_branch_marks_failed(patch_tracker):
+    # Recoverable error past MAX_RETRIES → marks tracker FAILED with the
+    # retry-limit error message.
+    patch_tracker.increment_retry_count.return_value = 99  # > MAX_RETRIES
+
+    err = ConnectionError("connection refused")
+    handler = MagicMock()
+    handler.get_tool_usage.return_value = None
+    handler.get_sse_events.return_value = None
+
+    with patch.object(_common, "release_burst_slot", new=AsyncMock()), \
+         patch.object(_common, "get_max_workflow_retries", return_value=3):
+        await _consume(_common.handle_workflow_error(
+            e=err,
+            thread_id="t-max-retry",
+            user_id="u-1",
+            workspace_id="ws-1",
+            handler=handler,
+            token_callback=None,
+            persistence_service=None,
+            start_time=0.0,
+            request=_make_request(),
+            is_byok=False,
+            msg_type="user",
+            log_prefix="CHAT",
+        ))
+
+    patch_tracker.mark_failed.assert_awaited_once()
+    call = patch_tracker.mark_failed.await_args
+    assert call.args[0] == "t-max-retry"
+    assert "Max retries exceeded" in call.kwargs["error"]
+    assert "ConnectionError" in call.kwargs["error"]
+
+
+@pytest.mark.asyncio
+async def test_non_recoverable_branch_marks_failed(patch_tracker):
+    # Non-recoverable error (AttributeError) → marks tracker FAILED with the
+    # raw "ErrorType: message" string.
+    err = AttributeError("'NoneType' has no attribute 'foo'")
+    handler = MagicMock()
+    handler.get_tool_usage.return_value = None
+    handler.get_sse_events.return_value = None
+    handler._format_sse_event.return_value = "event: error\ndata: {}\n\n"
+
+    with patch.object(_common, "release_burst_slot", new=AsyncMock()), \
+         patch.object(_common, "get_max_workflow_retries", return_value=3):
+        await _consume(_common.handle_workflow_error(
+            e=err,
+            thread_id="t-non-recov",
+            user_id="u-1",
+            workspace_id="ws-1",
+            handler=handler,
+            token_callback=None,
+            persistence_service=None,
+            start_time=0.0,
+            request=_make_request(),
+            is_byok=False,
+            msg_type="user",
+            log_prefix="CHAT",
+        ))
+
+    patch_tracker.mark_failed.assert_awaited_once()
+    call = patch_tracker.mark_failed.await_args
+    assert call.args[0] == "t-non-recov"
+    assert call.kwargs["error"].startswith("AttributeError:")
+
+
+@pytest.mark.asyncio
+async def test_tracker_failure_does_not_break_error_flow(patch_tracker):
+    # If tracker.mark_failed itself raises, the handler must still emit the
+    # SSE error event — Redis write failures are non-fatal.
+    patch_tracker.mark_failed.side_effect = RuntimeError("redis down")
+
+    err = AttributeError("boom")
+    handler = MagicMock()
+    handler.get_tool_usage.return_value = None
+    handler.get_sse_events.return_value = None
+    sse = "event: error\ndata: {\"thread_id\": \"t-fail\"}\n\n"
+    handler._format_sse_event.return_value = sse
+
+    with patch.object(_common, "release_burst_slot", new=AsyncMock()), \
+         patch.object(_common, "get_max_workflow_retries", return_value=3):
+        events = await _consume(_common.handle_workflow_error(
+            e=err,
+            thread_id="t-fail",
+            user_id="u-1",
+            workspace_id="ws-1",
+            handler=handler,
+            token_callback=None,
+            persistence_service=None,
+            start_time=0.0,
+            request=_make_request(),
+            is_byok=False,
+            msg_type="user",
+            log_prefix="CHAT",
+        ))
+
+    assert sse in events

--- a/tests/unit/server/services/test_background_task_terminal_cleanup.py
+++ b/tests/unit/server/services/test_background_task_terminal_cleanup.py
@@ -151,11 +151,12 @@ class TestMarkCompletedReleases:
 
 
 def _patch_tracker():
-    """Replace WorkflowTracker singleton with a mock that records mark_* calls."""
+    """Replace WorkflowTracker singleton with a mock that records mark_* calls.
+
+    AsyncMock auto-specs async attributes on access, so the mark_* methods
+    don't need explicit assignment — calls + asserts work either way.
+    """
     mock_tracker = AsyncMock()
-    mock_tracker.mark_failed = AsyncMock(return_value=True)
-    mock_tracker.mark_cancelled = AsyncMock(return_value=True)
-    mock_tracker.mark_soft_interrupted = AsyncMock(return_value=True)
     return patch(
         "src.server.services.background_task_manager.WorkflowTracker.get_instance",
         return_value=mock_tracker,
@@ -181,7 +182,7 @@ class TestMarkFailedReleases:
         assert info.metadata["user_id"] == "u-1"
         # Wiring: tracker.mark_failed called so /status reports FAILED with
         # bounded TTL instead of leaving the key as ACTIVE/DISCONNECTED.
-        mock_tracker.mark_failed.assert_awaited_once_with("t-1", "boom")
+        mock_tracker.mark_failed.assert_awaited_once_with("t-1", error="boom")
 
 
 class TestMarkCancelledReleases:

--- a/tests/unit/server/services/test_background_task_terminal_cleanup.py
+++ b/tests/unit/server/services/test_background_task_terminal_cleanup.py
@@ -150,6 +150,18 @@ class TestMarkCompletedReleases:
         assert info.metadata["workspace_id"] == "ws-1"
 
 
+def _patch_tracker():
+    """Replace WorkflowTracker singleton with a mock that records mark_* calls."""
+    mock_tracker = AsyncMock()
+    mock_tracker.mark_failed = AsyncMock(return_value=True)
+    mock_tracker.mark_cancelled = AsyncMock(return_value=True)
+    mock_tracker.mark_soft_interrupted = AsyncMock(return_value=True)
+    return patch(
+        "src.server.services.background_task_manager.WorkflowTracker.get_instance",
+        return_value=mock_tracker,
+    ), mock_tracker
+
+
 class TestMarkFailedReleases:
 
     @pytest.mark.asyncio
@@ -159,12 +171,17 @@ class TestMarkFailedReleases:
         info.metadata["workspace_id"] = None  # Skip persistence body
         btm.tasks["t-1"] = info
 
-        with patch("src.server.services.background_task_manager.release_burst_slot", new=AsyncMock()):
+        tracker_patch, mock_tracker = _patch_tracker()
+        with patch("src.server.services.background_task_manager.release_burst_slot", new=AsyncMock()), \
+             tracker_patch:
             await btm._mark_failed("t-1", "boom")
 
         assert info.persistence_complete.is_set()
         assert info.graph is None
         assert info.metadata["user_id"] == "u-1"
+        # Wiring: tracker.mark_failed called so /status reports FAILED with
+        # bounded TTL instead of leaving the key as ACTIVE/DISCONNECTED.
+        mock_tracker.mark_failed.assert_awaited_once_with("t-1", "boom")
 
 
 class TestMarkCancelledReleases:
@@ -176,12 +193,17 @@ class TestMarkCancelledReleases:
         info.metadata["workspace_id"] = None  # Skip persistence body
         btm.tasks["t-1"] = info
 
-        with patch("src.server.services.background_task_manager.release_burst_slot", new=AsyncMock()):
+        tracker_patch, mock_tracker = _patch_tracker()
+        with patch("src.server.services.background_task_manager.release_burst_slot", new=AsyncMock()), \
+             tracker_patch:
             await btm._mark_cancelled("t-1")
 
         assert info.persistence_complete.is_set()
         assert info.graph is None
         assert info.metadata["dispatch_kind"] == "foreground"
+        # Wiring: tracker.mark_cancelled called from the canonical site so
+        # stale-cancel reaper / soft-interrupt-abort paths also update Redis.
+        mock_tracker.mark_cancelled.assert_awaited_once_with("t-1")
 
 
 class TestMarkSoftInterruptedReleases:
@@ -193,11 +215,14 @@ class TestMarkSoftInterruptedReleases:
         info.metadata["workspace_id"] = None  # Skip persistence body
         btm.tasks["t-1"] = info
 
-        with patch("src.server.services.background_task_manager.release_burst_slot", new=AsyncMock()):
+        tracker_patch, mock_tracker = _patch_tracker()
+        with patch("src.server.services.background_task_manager.release_burst_slot", new=AsyncMock()), \
+             tracker_patch:
             await btm._mark_soft_interrupted("t-1")
 
         assert info.persistence_complete.is_set()
         assert info.graph is None
+        mock_tracker.mark_soft_interrupted.assert_awaited_once_with("t-1")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/server/services/test_workflow_tracker.py
+++ b/tests/unit/server/services/test_workflow_tracker.py
@@ -6,12 +6,18 @@ completed/cancelled/interrupted, cancel flags, retry counts, and graceful
 degradation when Redis is unavailable.
 """
 
+import inspect
 import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from src.server.services.workflow_tracker import WorkflowStatus, WorkflowTracker
+from src.server.services.workflow_tracker import (
+    RECONNECTABLE_STATUSES,
+    TERMINAL_STATUSES,
+    WorkflowStatus,
+    WorkflowTracker,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -173,6 +179,55 @@ class TestMarkTransitions:
         assert result is True
 
     @pytest.mark.asyncio
+    async def test_mark_failed_sets_ttl_and_status(self):
+        tracker, mock_cache = _make_tracker(enabled=True)
+        thread_id = str(uuid.uuid4())
+
+        result = await tracker.mark_failed(thread_id, error="boom")
+
+        assert result is True
+        # Last positional/kwarg holds the persisted status object.
+        call_args = mock_cache.set.call_args
+        persisted = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("value")
+        assert persisted["status"] == "failed"
+        assert persisted["metadata"]["error"] == "boom"
+        # Bounded TTL (matches mark_completed/mark_cancelled).
+        ttl = call_args.kwargs.get("ttl") or (
+            call_args.args[2] if len(call_args.args) > 2 else None
+        )
+        assert ttl == 3600
+
+    @pytest.mark.asyncio
+    async def test_mark_failed_without_error_omits_metadata(self):
+        tracker, mock_cache = _make_tracker(enabled=True)
+        thread_id = str(uuid.uuid4())
+
+        result = await tracker.mark_failed(thread_id)
+
+        assert result is True
+        call_args = mock_cache.set.call_args
+        persisted = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("value")
+        # No metadata block when error is None — matches mark_cancelled.
+        assert "metadata" not in persisted or persisted["metadata"] == {}
+
+    @pytest.mark.asyncio
+    async def test_mark_soft_interrupted_sets_ttl(self):
+        tracker, mock_cache = _make_tracker(enabled=True)
+        thread_id = str(uuid.uuid4())
+
+        result = await tracker.mark_soft_interrupted(thread_id)
+
+        assert result is True
+        call_args = mock_cache.set.call_args
+        persisted = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("value")
+        assert persisted["status"] == "soft_interrupted"
+        ttl = call_args.kwargs.get("ttl") or (
+            call_args.args[2] if len(call_args.args) > 2 else None
+        )
+        # Distinct from INTERRUPTED (which uses ttl=None) — bounded TTL.
+        assert ttl == 3600
+
+    @pytest.mark.asyncio
     async def test_all_methods_disabled(self):
         tracker, _ = _make_tracker(enabled=False)
         tid = "t-1"
@@ -181,6 +236,38 @@ class TestMarkTransitions:
         assert await tracker.mark_disconnected(tid) is False
         assert await tracker.mark_interrupted(tid) is False
         assert await tracker.mark_cancelled(tid) is False
+        assert await tracker.mark_failed(tid, error="x") is False
+        assert await tracker.mark_soft_interrupted(tid) is False
+
+
+# ---------------------------------------------------------------------------
+# Status set invariants
+# ---------------------------------------------------------------------------
+
+class TestStatusSetInvariants:
+    """Pin TERMINAL_STATUSES / RECONNECTABLE_STATUSES against workflow_handler."""
+
+    def test_terminal_disjoint_from_reconnectable(self):
+        # If both sets share a state, ``can_reconnect`` would return True for a
+        # terminal workflow — frontend would attach to a stream that never
+        # produces events.
+        assert TERMINAL_STATUSES.isdisjoint(RECONNECTABLE_STATUSES)
+
+    def test_every_status_categorized(self):
+        # Every WorkflowStatus is either terminal, reconnectable, or one of the
+        # known intermediate/sentinel states. Adding a new status without
+        # placing it in this partition fails the test.
+        intermediate = {WorkflowStatus.INTERRUPTED, WorkflowStatus.UNKNOWN}
+        partition = TERMINAL_STATUSES | RECONNECTABLE_STATUSES | intermediate
+        assert set(WorkflowStatus) == partition
+
+    def test_workflow_handler_uses_reconnectable_constant(self):
+        # get_workflow_status reads from RECONNECTABLE_STATUSES so the
+        # invariant above actually pins the production reconnect decision.
+        from src.server.handlers import workflow_handler
+
+        source = inspect.getsource(workflow_handler.get_workflow_status)
+        assert "RECONNECTABLE_STATUSES" in source
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/server/services/test_workflow_tracker.py
+++ b/tests/unit/server/services/test_workflow_tracker.py
@@ -6,12 +6,12 @@ completed/cancelled/interrupted, cancel flags, retry counts, and graceful
 degradation when Redis is unavailable.
 """
 
-import inspect
 import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from src.config.settings import get_redis_ttl_workflow_status
 from src.server.services.workflow_tracker import (
     RECONNECTABLE_STATUSES,
     TERMINAL_STATUSES,
@@ -37,6 +37,50 @@ def _make_tracker(enabled=True):
 
         tracker = WorkflowTracker()
         return tracker, mock_cache
+
+
+async def _call_get_workflow_status(status: WorkflowStatus, bg_status: str) -> dict:
+    """Drive workflow_handler.get_workflow_status with the supplied tracker
+    status, stubbing every other dependency. Returns the response dict."""
+    from src.server.handlers import workflow_handler
+
+    tracker = MagicMock()
+    tracker.get_status = AsyncMock(return_value={
+        "status": status,
+        "last_update": None,
+        "workspace_id": "ws-1",
+        "user_id": "u-1",
+    })
+    tracker.mark_completed = AsyncMock(return_value=True)
+    tracker.delete_status = AsyncMock(return_value=True)
+
+    bg_manager = MagicMock()
+    bg_manager.get_workflow_status = AsyncMock(return_value={
+        "status": bg_status,
+        "active_tasks": [],
+        "soft_interrupted": False,
+    })
+
+    cache = MagicMock()
+    cache.enabled = False
+    cache.client = None
+
+    with patch(
+        "src.server.services.workflow_tracker.WorkflowTracker.get_instance",
+        return_value=tracker,
+    ), patch.object(
+        workflow_handler, "get_checkpoint_tuple", new=AsyncMock(return_value=None)
+    ), patch(
+        "src.server.services.background_task_manager.BackgroundTaskManager.get_instance",
+        return_value=bg_manager,
+    ), patch(
+        "src.server.database.conversation.get_thread_by_id",
+        new=AsyncMock(return_value=None),
+    ), patch(
+        "src.utils.cache.redis_cache.get_cache_client",
+        return_value=cache,
+    ):
+        return await workflow_handler.get_workflow_status("t-1")
 
 
 # ---------------------------------------------------------------------------
@@ -145,9 +189,9 @@ class TestMarkTransitions:
 
         assert result is True
         call_kwargs = mock_cache.set.call_args
-        # TTL should be COMPLETED_TTL (3600)
-        assert call_kwargs.kwargs.get("ttl") == 3600 or (
-            len(call_kwargs.args) > 2 and call_kwargs.args[2] == 3600
+        expected_ttl = get_redis_ttl_workflow_status()
+        assert call_kwargs.kwargs.get("ttl") == expected_ttl or (
+            len(call_kwargs.args) > 2 and call_kwargs.args[2] == expected_ttl
         )
 
     @pytest.mark.asyncio
@@ -195,7 +239,7 @@ class TestMarkTransitions:
         ttl = call_args.kwargs.get("ttl") or (
             call_args.args[2] if len(call_args.args) > 2 else None
         )
-        assert ttl == 3600
+        assert ttl == get_redis_ttl_workflow_status()
 
     @pytest.mark.asyncio
     async def test_mark_failed_without_error_omits_metadata(self):
@@ -207,8 +251,10 @@ class TestMarkTransitions:
         assert result is True
         call_args = mock_cache.set.call_args
         persisted = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("value")
-        # No metadata block when error is None — matches mark_cancelled.
-        assert "metadata" not in persisted or persisted["metadata"] == {}
+        # _update_status_with_metadata only writes the key when metadata is
+        # truthy — match the implementation exactly so a regression to
+        # ``{"metadata": {}}`` would fail this test.
+        assert "metadata" not in persisted
 
     @pytest.mark.asyncio
     async def test_mark_soft_interrupted_sets_ttl(self):
@@ -225,7 +271,7 @@ class TestMarkTransitions:
             call_args.args[2] if len(call_args.args) > 2 else None
         )
         # Distinct from INTERRUPTED (which uses ttl=None) — bounded TTL.
-        assert ttl == 3600
+        assert ttl == get_redis_ttl_workflow_status()
 
     @pytest.mark.asyncio
     async def test_all_methods_disabled(self):
@@ -261,13 +307,23 @@ class TestStatusSetInvariants:
         partition = TERMINAL_STATUSES | RECONNECTABLE_STATUSES | intermediate
         assert set(WorkflowStatus) == partition
 
-    def test_workflow_handler_uses_reconnectable_constant(self):
-        # get_workflow_status reads from RECONNECTABLE_STATUSES so the
-        # invariant above actually pins the production reconnect decision.
-        from src.server.handlers import workflow_handler
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", sorted(RECONNECTABLE_STATUSES))
+    async def test_get_workflow_status_reconnectable(self, status):
+        # Reconnectable statuses must surface ``can_reconnect=True`` so the
+        # frontend retries the SSE stream. Pins the actual decision.
+        result = await _call_get_workflow_status(status, bg_status="active")
+        assert result["can_reconnect"] is True
+        assert result["status"] == status
 
-        source = inspect.getsource(workflow_handler.get_workflow_status)
-        assert "RECONNECTABLE_STATUSES" in source
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", sorted(TERMINAL_STATUSES))
+    async def test_get_workflow_status_terminal_blocks_reconnect(self, status):
+        # Terminal statuses must surface ``can_reconnect=False`` so the
+        # frontend stops attempting to reattach.
+        result = await _call_get_workflow_status(status, bg_status="completed")
+        assert result["can_reconnect"] is False
+        assert result["status"] == status
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the gap where `/status` could keep reporting `ACTIVE` for the full Redis TTL window after a workflow died. Every workflow-death path now writes a terminal state to Redis with bounded TTL from one canonical site, and `can_reconnect` reads from a constant pinned by contract tests.

**Production wiring (4 files, +161/-4)**

- **`workflow_tracker.py`** — adds `WorkflowStatus.FAILED` + `SOFT_INTERRUPTED`, the matching `mark_failed` / `mark_soft_interrupted` methods (bounded TTL via `get_redis_ttl_workflow_status`, mirroring `mark_completed` / `mark_cancelled`), and the `TERMINAL_STATUSES` + `RECONNECTABLE_STATUSES` frozensets.
- **`background_task_manager.py`** — wires `tracker.mark_failed` into `_mark_failed`, `tracker.mark_soft_interrupted` into `_mark_soft_interrupted`, and `tracker.mark_cancelled` into `_mark_cancelled` as the canonical cancel site (cancel endpoint, stale-cancel reaper, soft-interrupt-abort all go through it now). Hoists the `WorkflowTracker` import to module level.
- **`handlers/chat/_common.py`** — wires `tracker.mark_failed` into both branches of `handle_workflow_error` (max-retries-exceeded + non-recoverable). Fixes the setup-error path that ran outside `BackgroundTaskManager` and previously left status at `ACTIVE`.
- **`handlers/workflow_handler.py`** — `can_reconnect` now reads `RECONNECTABLE_STATUSES` instead of an inline `[ACTIVE, DISCONNECTED]` list.

**Before:** setup-error and non-recoverable workflows left the Redis status at `ACTIVE` for the full TTL window after the workflow died, and the frontend kept attempting to reconnect to a stream that would never produce events.

## Test Coverage

49 new/updated unit tests across 3 files:

- `test_workflow_tracker.py` — unit tests for `mark_failed` / `mark_soft_interrupted` (TTL, status, metadata, disabled-mode), plus a new `TestStatusSetInvariants` class pinning the contract: `TERMINAL_STATUSES` ⊥ `RECONNECTABLE_STATUSES`, every `WorkflowStatus` is partitioned, and `get_workflow_status` actually reads from `RECONNECTABLE_STATUSES`. Adding a new status without categorizing it now fails CI.
- `test_background_task_terminal_cleanup.py` — extended the three mark-releases tests to assert `tracker.mark_failed` / `mark_cancelled` / `mark_soft_interrupted` are invoked with the expected args. Catches future refactors that drop the wiring.
- `test_handle_workflow_error.py` (new) — covers the max-retries branch, the non-recoverable branch, and tracker-failure resilience (a Redis outage during `mark_failed` must not break the SSE error event).

## Pre-Landing Review

Cleared via `/review` before push. Critical pass clean (no SQL, race, LLM trust, or shell injection); two informational findings from the original commit (TERMINAL_STATUSES was unused; wiring sites had no tests) were both addressed by adding `RECONNECTABLE_STATUSES` + the contract/wiring tests above.

## Verification

- `uv run pytest` (49 touched-file tests + broader `tests/unit/server/`): pass
- `uv run ruff check`: clean
- For end-to-end smoke against real Redis: trigger each terminal path (cancel-endpoint, ESC soft-interrupt, AttributeError setup-error, max-retries) and confirm `redis-cli GET workflow:status:<thread_id>` reports the expected terminal state with `TTL ≈ 3600`.

## Test plan

- [x] `mark_failed` / `mark_soft_interrupted` write the right Redis payload + bounded TTL
- [x] `BTM._mark_failed` / `_mark_cancelled` / `_mark_soft_interrupted` invoke the tracker at the canonical site
- [x] `handle_workflow_error` invokes `tracker.mark_failed` in both branches
- [x] `TERMINAL_STATUSES` ⊥ `RECONNECTABLE_STATUSES` invariant pinned
- [x] `workflow_handler.get_workflow_status` reads from `RECONNECTABLE_STATUSES`
- [ ] (manual smoke) cancel-endpoint flow leaves Redis at `cancelled` with bounded TTL
- [ ] (manual smoke) frontend stops attempting reconnect after a terminal status