### PR TITLE
fix(persistence): strip NUL bytes from tool results and Postgres TEXT/JSONB binds

### DIFF
--- a/scripts/ops/scrub_nul_checkpoint.py
+++ b/scripts/ops/scrub_nul_checkpoint.py
@@ -1,0 +1,232 @@
+"""Scrub NUL bytes from a LangGraph checkpoint that has become unresumable.
+
+A ToolMessage with a `\\x00` byte in its content gets serialized into
+`checkpoint_blobs.blob` (BYTEA — accepts NUL fine). On every resume the
+message rehydrates and downstream code that re-serializes it to JSONB fails
+with `psycopg.errors.UntranslatableCharacter`, making the thread permanently
+unresumable.
+
+This script identifies poisoned blobs for a given thread, deserializes via
+LangGraph's own serde so message types are preserved, walks the structure
+stripping NUL from every string, and rewrites the blob.
+
+Usage:
+    uv run python scripts/ops/scrub_nul_checkpoint.py THREAD_ID            # dry-run
+    uv run python scripts/ops/scrub_nul_checkpoint.py THREAD_ID --apply    # mutate
+
+Idempotent. Connects via the same MEMORY_DB_* env vars used by the
+checkpointer (`src/server/utils/checkpointer.py`).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+from typing import Any
+from urllib.parse import quote_plus
+
+import psycopg
+from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("scrub_nul_checkpoint")
+
+
+def _strip_nul(value: Any) -> tuple[Any, int]:
+    """Recursively strip NUL bytes from any string in `value`.
+
+    Returns (cleaned_value, count) where count is the number of strings
+    that had at least one NUL stripped.
+    """
+    if isinstance(value, str):
+        if "\x00" in value:
+            return value.replace("\x00", ""), 1
+        return value, 0
+    if isinstance(value, bytes):
+        if b"\x00" in value:
+            # Bytes are legal — leave them alone. They never bind to TEXT.
+            return value, 0
+        return value, 0
+    if isinstance(value, dict):
+        out: dict = {}
+        n = 0
+        for k, v in value.items():
+            new_k, kc = _strip_nul(k)
+            new_v, vc = _strip_nul(v)
+            out[new_k] = new_v
+            n += kc + vc
+        return out, n
+    if isinstance(value, list):
+        out_list = []
+        n = 0
+        for item in value:
+            new_item, ic = _strip_nul(item)
+            out_list.append(new_item)
+            n += ic
+        return out_list, n
+    if isinstance(value, tuple):
+        cleaned = [_strip_nul(item) for item in value]
+        return tuple(c for c, _ in cleaned), sum(n for _, n in cleaned)
+    # Pydantic/LangChain message objects: walk attributes that look textual.
+    # `content` is the dominant carrier. Other str attributes get same treatment.
+    if hasattr(value, "__dict__"):
+        n = 0
+        for attr_name, attr_val in list(vars(value).items()):
+            new_val, c = _strip_nul(attr_val)
+            if c:
+                try:
+                    setattr(value, attr_name, new_val)
+                    n += c
+                except (AttributeError, TypeError):
+                    # Slot/frozen — skip.
+                    pass
+        return value, n
+    return value, 0
+
+
+def _build_db_uri() -> str:
+    db_host = os.getenv("MEMORY_DB_HOST", "localhost")
+    db_port = os.getenv("MEMORY_DB_PORT", "5432")
+    db_name = os.getenv("MEMORY_DB_NAME", "postgres")
+    db_user = os.getenv("MEMORY_DB_USER", "postgres")
+    db_password = os.getenv("MEMORY_DB_PASSWORD", "postgres")
+    sslmode = "require" if "supabase.com" in db_host else "disable"
+    return (
+        f"postgresql://{quote_plus(db_user)}:{quote_plus(db_password)}"
+        f"@{db_host}:{db_port}/{db_name}?sslmode={sslmode}"
+    )
+
+
+async def _scrub_table(
+    conn: psycopg.AsyncConnection,
+    serde: JsonPlusSerializer,
+    table: str,
+    key_cols: list[str],
+    thread_id: str,
+    apply_changes: bool,
+) -> tuple[int, int]:
+    """Scrub one table. Returns (rows_inspected, rows_modified).
+
+    SELECT runs through a server-side cursor with `fetchmany` so peak memory
+    stays bounded by the chunk size regardless of thread history depth. When
+    applying changes, the SELECT is `FOR UPDATE` and UPDATEs run inside the
+    same transaction, serializing against any concurrent checkpoint write.
+    """
+    select_cols = ", ".join(key_cols + ["type", "blob"])
+    where_keys = " AND ".join(f"{c} = %s" for c in key_cols)
+    select_sql = f"SELECT {select_cols} FROM {table} WHERE thread_id = %s"
+    if apply_changes:
+        select_sql += " FOR UPDATE"
+    update_sql = f"UPDATE {table} SET blob = %s, type = %s WHERE {where_keys}"
+
+    inspected = 0
+    modified = 0
+
+    async with conn.transaction():
+        # Server-side cursor name: scoped to table to stay unique within the tx.
+        async with conn.cursor(name=f"scrub_{table}") as cur_read:
+            await cur_read.execute(select_sql, (thread_id,))
+            async with conn.cursor() as cur_write:
+                while True:
+                    rows = await cur_read.fetchmany(100)
+                    if not rows:
+                        break
+                    for row in rows:
+                        inspected += 1
+                        *key_vals, type_str, blob = row
+                        if blob is None:
+                            continue
+                        # Quick byte-level check: skip blobs that obviously have no NUL inside
+                        # any string field. A NUL byte CAN legally appear in msgpack framing
+                        # bytes (length prefixes, type codes), so this is a heuristic; only
+                        # blobs without ANY 0x00 are safe to skip without deserializing.
+                        if b"\x00" not in bytes(blob):
+                            continue
+                        try:
+                            value = serde.loads_typed((type_str, bytes(blob)))
+                        except Exception as e:
+                            logger.warning(
+                                "Skipping unparseable blob in %s key=%s type=%s err=%s",
+                                table, dict(zip(key_cols, key_vals)), type_str, e,
+                            )
+                            continue
+                        cleaned, count = _strip_nul(value)
+                        if count == 0:
+                            continue
+                        try:
+                            new_type, new_blob = serde.dumps_typed(cleaned)
+                        except Exception as e:
+                            logger.warning(
+                                "Failed to re-serialize cleaned blob in %s key=%s err=%s",
+                                table, dict(zip(key_cols, key_vals)), e,
+                            )
+                            continue
+                        modified += 1
+                        logger.info(
+                            "Scrubbed %d strings in %s key=%s (was %d bytes, now %d)",
+                            count, table, dict(zip(key_cols, key_vals)),
+                            len(bytes(blob)), len(new_blob),
+                        )
+                        if apply_changes:
+                            await cur_write.execute(
+                                update_sql, (new_blob, new_type, *key_vals),
+                            )
+
+    if modified:
+        if apply_changes:
+            logger.info("Committed %d UPDATE(s) on %s", modified, table)
+        else:
+            logger.info(
+                "Dry-run: would UPDATE %d row(s) on %s. Re-run with --apply to mutate.",
+                modified, table,
+            )
+
+    return inspected, modified
+
+
+async def main(thread_id: str, apply_changes: bool) -> int:
+    serde = JsonPlusSerializer()
+    db_uri = _build_db_uri()
+
+    logger.info("Connecting to checkpoint DB: %s", db_uri.split("@")[-1])
+    async with await psycopg.AsyncConnection.connect(db_uri) as conn:
+        # checkpoint_blobs holds the channel values (incl. messages list).
+        # checkpoint_writes holds pending writes from interrupted runs.
+        b_inspected, b_modified = await _scrub_table(
+            conn,
+            serde,
+            "checkpoint_blobs",
+            ["thread_id", "checkpoint_ns", "channel", "version"],
+            thread_id,
+            apply_changes,
+        )
+        w_inspected, w_modified = await _scrub_table(
+            conn,
+            serde,
+            "checkpoint_writes",
+            ["thread_id", "checkpoint_ns", "checkpoint_id", "task_id", "idx"],
+            thread_id,
+            apply_changes,
+        )
+
+    logger.info(
+        "Done. checkpoint_blobs: %d inspected, %d %s. checkpoint_writes: %d inspected, %d %s.",
+        b_inspected, b_modified, "modified" if apply_changes else "would be modified",
+        w_inspected, w_modified, "modified" if apply_changes else "would be modified",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("thread_id", help="Thread UUID to scrub.")
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually write the scrubbed blobs back. Default is dry-run.",
+    )
+    args = parser.parse_args()
+    sys.exit(asyncio.run(main(args.thread_id, args.apply)))

--- a/scripts/ops/scrub_nul_checkpoint.py
+++ b/scripts/ops/scrub_nul_checkpoint.py
@@ -46,9 +46,7 @@ def _strip_nul(value: Any) -> tuple[Any, int]:
             return value.replace("\x00", ""), 1
         return value, 0
     if isinstance(value, bytes):
-        if b"\x00" in value:
-            # Bytes are legal — leave them alone. They never bind to TEXT.
-            return value, 0
+        # Bytes are legal — they never bind to TEXT.
         return value, 0
     if isinstance(value, dict):
         out: dict = {}

--- a/src/ptc_agent/agent/middleware/tool/result_normalization.py
+++ b/src/ptc_agent/agent/middleware/tool/result_normalization.py
@@ -1,6 +1,7 @@
 """Tool result normalization middleware.
 
-Ensures all tool results are strings for LLM compatibility.
+Coerces tool results to strings for LLM compatibility and strips NUL bytes so
+the content is safe to persist into Postgres TEXT/JSONB columns downstream.
 """
 import json
 import logging
@@ -13,49 +14,70 @@ logger = logging.getLogger(__name__)
 
 
 class ToolResultNormalizationMiddleware(AgentMiddleware):
-    """Middleware that normalizes tool results to strings for LLM compatibility.
+    """Normalize tool results to LLM-compatible strings and scrub NUL bytes.
 
-    This middleware ensures all tool results are returned as strings for LLM compatibility.
-    Some tools may return Python objects (lists, dicts, None, etc.) that cause type errors
-    when sent to LLM APIs that expect ToolMessage content to be a string.
+    Two concerns, one chokepoint:
 
-    Common issue: OpenAI API returns BadRequestError when ToolMessage content is an array:
-    "The parameter `input` specified in the request are not valid: `Mismatch type string with value array`"
+    1. **Type coercion** — some tools return Python objects (lists, dicts, None)
+       that LLM APIs reject. OpenAI for example raises BadRequestError on array
+       ToolMessage content: "Mismatch type string with value array". We coerce
+       to a string here so every downstream consumer sees a uniform shape.
 
-    This middleware normalizes all tool results:
-    - Strings: Pass through unchanged
-    - Lists/Dicts: Convert to JSON string using json.dumps()
-    - None: Convert to empty string ""
-    - Other types: Convert to string using str()
+    2. **NUL safety** — sandbox stdout, file reads, web-fetch markdown, etc. can
+       carry literal `\\x00` bytes. Postgres rejects these in TEXT (`cannot
+       contain NUL`) and JSONB (`UntranslatableCharacter` on the `\\u0000`
+       escape), making affected threads permanently unresumable. Stripping at
+       this single point keeps the rest of the system — agent state, SSE
+       events, LangSmith traces, msgpack checkpoints — clean.
     """
 
     def _normalize_result(self, result: Any) -> str:
-        """Normalize tool result to a string.
+        """Normalize tool result to a NUL-free string.
 
         Args:
             result: The result from tool execution (any type)
 
         Returns:
-            Normalized string representation
+            Normalized string representation with NUL bytes stripped.
         """
         # Already a string - pass through
         if isinstance(result, str):
-            return result
+            s = result
 
         # None - return empty JSON array
-        if result is None:
-            return json.dumps([])
+        elif result is None:
+            s = json.dumps([])
 
         # Lists and dicts - convert to JSON string
-        if isinstance(result, (list, dict)):
+        elif isinstance(result, (list, dict)):
             try:
-                return json.dumps(result, ensure_ascii=False)
+                s = json.dumps(result, ensure_ascii=False)
             except (TypeError, ValueError) as e:
                 logger.warning(f"Failed to JSON serialize tool result: {e}, falling back to str()")
-                return str(result)
+                s = str(result)
 
         # Other types - convert to string
-        return str(result)
+        else:
+            s = str(result)
+
+        # Strip NUL bytes so the result is safe to persist to PG TEXT/JSONB.
+        # Two forms to catch:
+        #   - Literal `\x00` byte (string-passthrough path: tool returned a str
+        #     with embedded NUL, e.g. sandbox stdout).
+        #   - JSON unicode-escape sequence (dict/list path: json.dumps always
+        #     escapes control chars regardless of ensure_ascii — so a NUL
+        #     inside a dict value re-emerges as a six-char escape here).
+        # Both `in` checks are C-level and short-circuit the no-op case
+        # without allocating a new string.
+        has_raw = "\x00" in s
+        has_esc = "\\u0000" in s
+        if has_raw or has_esc:
+            logger.warning("Stripped NUL bytes from tool result")
+            if has_raw:
+                s = s.replace("\x00", "")
+            if has_esc:
+                s = s.replace("\\u0000", "")
+        return s
 
     def wrap_tool_call(self, request, handler):
         """Synchronous tool result normalizer."""

--- a/src/ptc_agent/agent/middleware/tool/result_normalization.py
+++ b/src/ptc_agent/agent/middleware/tool/result_normalization.py
@@ -40,37 +40,34 @@ class ToolResultNormalizationMiddleware(AgentMiddleware):
         Returns:
             Normalized string representation with NUL bytes stripped.
         """
-        # Already a string - pass through
+        # Track whether `s` came from json.dumps so the `\u0000` escape check
+        # only runs on serialized output. On the string-passthrough path the
+        # literal six-char sequence `\u0000` is just text and Postgres TEXT
+        # accepts it fine — stripping it there would mangle docs/LLM output
+        # that happens to mention the escape.
+        from_dumps = False
+
         if isinstance(result, str):
             s = result
-
-        # None - return empty JSON array
         elif result is None:
             s = json.dumps([])
-
-        # Lists and dicts - convert to JSON string
         elif isinstance(result, (list, dict)):
             try:
                 s = json.dumps(result, ensure_ascii=False)
+                from_dumps = True
             except (TypeError, ValueError) as e:
                 logger.warning(f"Failed to JSON serialize tool result: {e}, falling back to str()")
                 s = str(result)
-
-        # Other types - convert to string
         else:
             s = str(result)
 
         # Strip NUL bytes so the result is safe to persist to PG TEXT/JSONB.
-        # Two forms to catch:
-        #   - Literal `\x00` byte (string-passthrough path: tool returned a str
-        #     with embedded NUL, e.g. sandbox stdout).
-        #   - JSON unicode-escape sequence (dict/list path: json.dumps always
-        #     escapes control chars regardless of ensure_ascii — so a NUL
-        #     inside a dict value re-emerges as a six-char escape here).
-        # Both `in` checks are C-level and short-circuit the no-op case
-        # without allocating a new string.
+        # Raw `\x00` is the only form that reaches a TEXT bind; the `\u0000`
+        # escape is what json.dumps emits for an embedded NUL, which JSONB
+        # then rejects. Both `in` checks are C-level so the clean path costs
+        # one scan and no allocation.
         has_raw = "\x00" in s
-        has_esc = "\\u0000" in s
+        has_esc = from_dumps and "\\u0000" in s
         if has_raw or has_esc:
             logger.warning("Stripped NUL bytes from tool result")
             if has_raw:

--- a/src/server/database/conversation.py
+++ b/src/server/database/conversation.py
@@ -16,6 +16,7 @@ from psycopg.types.json import Json
 from psycopg_pool import AsyncConnectionPool
 
 from src.config.settings import get_conversation_pool_max
+from src.server.utils.pg_sanitize import SafeJson, strip_pg_nul_str
 
 logger = logging.getLogger(__name__)
 
@@ -802,6 +803,11 @@ async def create_query(
     if created_at is None:
         created_at = datetime.now(timezone.utc)
 
+    # Sanitize user-typed input — `content` is a TEXT column, `metadata` is JSONB.
+    # User can paste anything (binary copy/paste, terminal escapes), so adversarial
+    # NUL bytes are realistic here. Strip once so all code paths below see clean data.
+    content = strip_pg_nul_str(content)
+
     try:
         if conn:
             # Reuse provided connection
@@ -831,7 +837,7 @@ async def create_query(
                             content,
                             query_type,
                             feedback_action,
-                            Json(metadata or {}),
+                            SafeJson(metadata or {}),
                             created_at,
                         ),
                     )
@@ -854,7 +860,7 @@ async def create_query(
                             content,
                             query_type,
                             feedback_action,
-                            Json(metadata or {}),
+                            SafeJson(metadata or {}),
                             created_at,
                         ),
                     )
@@ -892,7 +898,7 @@ async def create_query(
                                 content,
                                 query_type,
                                 feedback_action,
-                                Json(metadata or {}),
+                                SafeJson(metadata or {}),
                                 created_at,
                             ),
                         )
@@ -915,7 +921,7 @@ async def create_query(
                                 content,
                                 query_type,
                                 feedback_action,
-                                Json(metadata or {}),
+                                SafeJson(metadata or {}),
                                 created_at,
                             ),
                         )
@@ -1059,12 +1065,12 @@ async def create_response(
                             turn_index,
                             status,
                             interrupt_reason,
-                            Json(metadata or {}),
+                            SafeJson(metadata or {}),
                             warnings or [],
                             errors or [],
                             execution_time,
                             created_at,
-                            Json(sse_events) if sse_events else None,
+                            SafeJson(sse_events) if sse_events else None,
                         ),
                     )
                 else:
@@ -1089,12 +1095,12 @@ async def create_response(
                             turn_index,
                             status,
                             interrupt_reason,
-                            Json(metadata or {}),
+                            SafeJson(metadata or {}),
                             warnings or [],
                             errors or [],
                             execution_time,
                             created_at,
-                            Json(sse_events) if sse_events else None,
+                            SafeJson(sse_events) if sse_events else None,
                         ),
                     )
                 result = await cur.fetchone()
@@ -1137,12 +1143,12 @@ async def create_response(
                                 turn_index,
                                 status,
                                 interrupt_reason,
-                                Json(metadata or {}),
+                                SafeJson(metadata or {}),
                                 warnings or [],
                                 errors or [],
                                 execution_time,
                                 created_at,
-                                Json(sse_events) if sse_events else None,
+                                SafeJson(sse_events) if sse_events else None,
                             ),
                         )
                     else:
@@ -1167,12 +1173,12 @@ async def create_response(
                                 turn_index,
                                 status,
                                 interrupt_reason,
-                                Json(metadata or {}),
+                                SafeJson(metadata or {}),
                                 warnings or [],
                                 errors or [],
                                 execution_time,
                                 created_at,
-                                Json(sse_events) if sse_events else None,
+                                SafeJson(sse_events) if sse_events else None,
                             ),
                         )
                     result = await cur.fetchone()
@@ -1214,7 +1220,7 @@ async def update_sse_events(
                     SET sse_events = %s
                     WHERE conversation_response_id = %s
                     """,
-                    (Json(sse_events), conversation_response_id),
+                    (SafeJson(sse_events), conversation_response_id),
                 )
                 updated = cur.rowcount > 0
         else:
@@ -1226,7 +1232,7 @@ async def update_sse_events(
                         SET sse_events = %s
                         WHERE conversation_response_id = %s
                         """,
-                        (Json(sse_events), conversation_response_id),
+                        (SafeJson(sse_events), conversation_response_id),
                     )
                     updated = cur.rowcount > 0
 

--- a/src/server/database/workspace_file.py
+++ b/src/server/database/workspace_file.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List, Optional
 from psycopg.rows import dict_row
 
 from src.server.database.conversation import get_db_connection
+from src.server.utils.pg_sanitize import strip_pg_nul_str
 
 logger = logging.getLogger(__name__)
 
@@ -66,18 +67,22 @@ async def bulk_upsert_files(
             updated_at = NOW()
     """
 
+    # Strip NUL bytes from any string bound to a TEXT/VARCHAR column. Sandbox
+    # files (and the find listings that name them) can carry `\x00` which
+    # Postgres rejects with `cannot contain NUL`, killing the whole 50-row
+    # transaction. content_binary is BYTEA and accepts NUL fine.
     params_list = [
         (
             workspace_id,
-            f["file_path"],
-            f["file_name"],
+            strip_pg_nul_str(f["file_path"]),
+            strip_pg_nul_str(f["file_name"]),
             f["file_size"],
             f.get("content_hash"),
-            f.get("content_text"),
+            strip_pg_nul_str(f.get("content_text")),
             f.get("content_binary"),
-            f.get("mime_type"),
+            strip_pg_nul_str(f.get("mime_type")),
             f.get("is_binary", False),
-            f.get("permissions"),
+            strip_pg_nul_str(f.get("permissions")),
             f.get("sandbox_modified_at"),
         )
         for f in files

--- a/src/server/services/persistence/file.py
+++ b/src/server/services/persistence/file.py
@@ -87,11 +87,10 @@ def _detect_is_binary(file_path: str, content: bytes) -> bool:
     """Detect whether file content is binary."""
     if _is_binary_extension(file_path):
         return True
-    sample = content[:8192]
-    if b"\x00" in sample:
+    if b"\x00" in content[:65536]:
         return True
     try:
-        sample.decode("utf-8")
+        content[:8192].decode("utf-8")
         return False
     except UnicodeDecodeError:
         return True

--- a/src/server/utils/pg_sanitize.py
+++ b/src/server/utils/pg_sanitize.py
@@ -1,0 +1,49 @@
+"""Sanitize values bound to Postgres TEXT/JSONB columns.
+
+Postgres rejects NUL (`\\x00`) in TEXT/VARCHAR and the `\\u0000` escape in JSONB
+text content (psycopg surfaces these as `cannot contain NUL` /
+`UntranslatableCharacter`). This module is the single shared helper for
+stripping those bytes at the persistence boundary.
+
+Use `strip_pg_nul_str` for plain TEXT binds. Use `SafeJson` as a drop-in
+replacement for `psycopg.types.json.Json` when binding JSONB.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from psycopg.types.json import Json
+
+
+def strip_pg_nul_str(value: str | None) -> str | None:
+    """Strip NUL bytes from a string before it's bound to a TEXT/VARCHAR column."""
+    if not value or "\x00" not in value:
+        return value
+    return value.replace("\x00", "")
+
+
+def _safe_dumps(value: Any) -> str:
+    """JSON-serialize for psycopg JSONB bind, stripping any `\\u0000` escape.
+
+    Piggybacks on the dumps psycopg already performs at bind time. The strip is a
+    single C-level `str.replace` on the serialized text — no extra Python-level
+    walks of the value tree.
+    """
+    s = json.dumps(value, ensure_ascii=False)
+    if "\\u0000" not in s:
+        return s
+    return s.replace("\\u0000", "")
+
+
+class SafeJson(Json):
+    """Drop-in replacement for `psycopg.types.json.Json` that strips `\\u0000`.
+
+    psycopg already calls `dumps()` once per `Json` bind. Overriding `dumps`
+    here adds zero extra traversal — only one extra C-level scan on the
+    serialized JSON for the escape sequence.
+    """
+
+    def __init__(self, value: Any):
+        super().__init__(value, dumps=_safe_dumps)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -214,31 +214,29 @@ async def patched_get_db_connection(test_db_pool):
         async with test_db_pool.connection() as conn:
             yield conn
 
-    with patch(
+    # Every module that does a module-level `from .conversation import
+    # get_db_connection` holds its own local reference, so each one needs
+    # its own patch target. Modules that import lazily inside a function
+    # (market_insight, services.workspace_manager) automatically pick up
+    # the source patch on conversation.get_db_connection.
+    targets = [
         "src.server.database.conversation.get_db_connection",
-        _test_get_db_connection,
-    ):
-        # Also patch the re-export in every database module that imports it
-        with patch(
-            "src.server.database.workspace.get_db_connection",
-            _test_get_db_connection,
-        ), patch(
-            "src.server.database.user.get_db_connection",
-            _test_get_db_connection,
-        ), patch(
-            "src.server.database.watchlist.get_db_connection",
-            _test_get_db_connection,
-        ), patch(
-            "src.server.database.portfolio.get_db_connection",
-            _test_get_db_connection,
-        ), patch(
-            "src.server.database.api_keys.get_db_connection",
-            _test_get_db_connection,
-        ), patch(
-            "src.server.database.automation.get_db_connection",
-            _test_get_db_connection,
-        ):
-            yield _test_get_db_connection
+        "src.server.database.workspace.get_db_connection",
+        "src.server.database.workspace_file.get_db_connection",
+        "src.server.database.user.get_db_connection",
+        "src.server.database.watchlist.get_db_connection",
+        "src.server.database.portfolio.get_db_connection",
+        "src.server.database.api_keys.get_db_connection",
+        "src.server.database.automation.get_db_connection",
+        "src.server.database.oauth_tokens.get_db_connection",
+        "src.server.database.vault_secrets.get_db_connection",
+    ]
+    from contextlib import ExitStack
+
+    with ExitStack() as stack:
+        for target in targets:
+            stack.enter_context(patch(target, _test_get_db_connection))
+        yield _test_get_db_connection
 
 
 @pytest.fixture

--- a/tests/integration/test_pg_nul_persistence.py
+++ b/tests/integration/test_pg_nul_persistence.py
@@ -1,0 +1,183 @@
+"""Integration tests for PG NUL/`\\u0000` persistence safety.
+
+With sanitization in place at the persistence boundary (`SafeJson` +
+`strip_pg_nul_str`) and at the source (tool-result middleware), these tests
+pin the contracted behavior:
+
+- `workspace_files.content_text` accepts NUL-bearing input without aborting
+  the whole batch (sandbox files can carry `\\x00` in binary-looking text).
+- `conversation_responses.sse_events` JSONB accepts a tool-result event with
+  embedded NUL (defense-in-depth at the persistence layer).
+- `conversation_queries.content` accepts NUL in user-typed input.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+class TestWorkspaceFileBulkUpsert:
+    async def test_content_text_with_nul_inserts_cleanly(
+        self, seed_workspace, patched_get_db_connection
+    ):
+        """bulk_upsert must not abort the whole batch when one file contains NUL bytes."""
+        from src.server.database.workspace_file import (
+            bulk_upsert_files,
+            get_file,
+        )
+
+        ws_id = str(seed_workspace["workspace_id"])
+
+        files = [
+            {
+                "file_path": "work/clean.txt",
+                "file_name": "clean.txt",
+                "file_size": 5,
+                "content_text": "hello",
+                "is_binary": False,
+            },
+            {
+                "file_path": "work/nulfile.txt",
+                "file_name": "nulfile.txt",
+                "file_size": 7,
+                "content_text": "pre\x00post",
+                "is_binary": False,
+            },
+        ]
+
+        count = await bulk_upsert_files(ws_id, files)
+
+        # Both rows must insert; the NUL-bearing row's content must be stripped.
+        assert count == 2
+
+        clean = await get_file(ws_id, "work/clean.txt")
+        assert clean is not None
+        assert clean["content_text"] == "hello"
+
+        scrubbed = await get_file(ws_id, "work/nulfile.txt")
+        assert scrubbed is not None
+        assert "\x00" not in scrubbed["content_text"]
+        assert scrubbed["content_text"] == "prepost"
+
+    async def test_nul_in_path_components_does_not_break_batch(
+        self, seed_workspace, patched_get_db_connection
+    ):
+        """Defense in depth — file_path/file_name are also TEXT columns."""
+        from src.server.database.workspace_file import (
+            bulk_upsert_files,
+            get_files_for_workspace,
+        )
+
+        ws_id = str(seed_workspace["workspace_id"])
+
+        # Stripped path becomes "work/odd.txt".
+        files = [
+            {
+                "file_path": "work/odd\x00.txt",
+                "file_name": "odd\x00.txt",
+                "file_size": 0,
+                "content_text": "",
+                "is_binary": False,
+            },
+        ]
+
+        count = await bulk_upsert_files(ws_id, files)
+        assert count == 1
+
+        rows = await get_files_for_workspace(ws_id)
+        assert any(r["file_path"] == "work/odd.txt" for r in rows)
+
+
+class TestConversationResponseSseEvents:
+    async def test_sse_events_with_nul_in_tool_result_persists(
+        self, seed_workspace, patched_get_db_connection
+    ):
+        """JSONB must accept a tool-result event payload that contains NUL bytes."""
+        from src.server.database.conversation import (
+            create_response,
+            create_thread,
+            get_responses_for_thread,
+        )
+
+        ws_id = str(seed_workspace["workspace_id"])
+        thread_id = str(uuid.uuid4())
+        await create_thread(
+            conversation_thread_id=thread_id,
+            workspace_id=ws_id,
+            current_status="in_progress",
+            msg_type="ptc",
+        )
+
+        # Simulates a tool_call_result event whose content slipped past the
+        # middleware (defense-in-depth scenario).
+        sse_events = [
+            {
+                "event": "tool_call_result",
+                "data": {
+                    "tool": "execute_code",
+                    "content": "stdout-line\x00trailing",
+                },
+            }
+        ]
+
+        response_id = str(uuid.uuid4())
+        await create_response(
+            conversation_response_id=response_id,
+            conversation_thread_id=thread_id,
+            turn_index=0,
+            status="completed",
+            sse_events=sse_events,
+        )
+
+        responses, total = await get_responses_for_thread(thread_id)
+        assert total == 1
+        loaded = responses[0]
+        events = loaded.get("sse_events") or []
+        assert len(events) == 1
+        content = events[0]["data"]["content"]
+        # JSONB round-trip: the \\u0000 escape is stripped at bind time,
+        # so the deserialized string contains no NUL.
+        assert "\x00" not in content
+        assert content == "stdout-linetrailing"
+
+
+class TestConversationQueryUserInput:
+    async def test_user_input_with_nul_persists(
+        self, seed_workspace, patched_get_db_connection
+    ):
+        """User pastes binary noise — server must not 500."""
+        from src.server.database.conversation import (
+            create_query,
+            create_thread,
+            get_queries_for_thread,
+        )
+
+        ws_id = str(seed_workspace["workspace_id"])
+        thread_id = str(uuid.uuid4())
+        await create_thread(
+            conversation_thread_id=thread_id,
+            workspace_id=ws_id,
+            current_status="in_progress",
+            msg_type="ptc",
+        )
+
+        await create_query(
+            conversation_query_id=str(uuid.uuid4()),
+            conversation_thread_id=thread_id,
+            turn_index=0,
+            content="What is\x00 going on?",
+            query_type="initial",
+            metadata={"hint": "weird\x00paste"},
+        )
+
+        queries, total = await get_queries_for_thread(thread_id)
+        assert total == 1
+        assert "\x00" not in queries[0]["content"]
+        assert queries[0]["content"] == "What is going on?"
+        # metadata JSONB also clean
+        meta = queries[0]["metadata"] or {}
+        assert "\x00" not in (meta.get("hint") or "")

--- a/tests/unit/ptc_agent/middleware/tool/test_result_normalization.py
+++ b/tests/unit/ptc_agent/middleware/tool/test_result_normalization.py
@@ -1,0 +1,133 @@
+"""Tests for ToolResultNormalizationMiddleware.
+
+This middleware is the single chokepoint where every tool result becomes a
+NUL-free string. It serves two concerns:
+
+1. Type coercion — non-string results become strings so LLM APIs that require
+   string ToolMessage content don't error out.
+2. NUL stripping — a `\\x00` byte in tool output would break Postgres
+   TEXT/JSONB binds, making affected threads permanently unresumable.
+
+Both behaviors are pinned here.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from langchain_core.messages import ToolMessage
+
+from ptc_agent.agent.middleware.tool.result_normalization import (
+    ToolResultNormalizationMiddleware,
+)
+
+
+@pytest.fixture
+def mw() -> ToolResultNormalizationMiddleware:
+    return ToolResultNormalizationMiddleware()
+
+
+# ---------------------------------------------------------------------------
+# _normalize_result — type coercion
+# ---------------------------------------------------------------------------
+
+
+class TestTypeCoercion:
+    def test_string_passthrough(self, mw):
+        assert mw._normalize_result("hello") == "hello"
+
+    def test_none_becomes_empty_json_array(self, mw):
+        assert mw._normalize_result(None) == "[]"
+
+    def test_dict_becomes_json(self, mw):
+        out = mw._normalize_result({"k": "v"})
+        assert json.loads(out) == {"k": "v"}
+
+    def test_list_becomes_json(self, mw):
+        out = mw._normalize_result([1, "two", {"three": 3}])
+        assert json.loads(out) == [1, "two", {"three": 3}]
+
+    def test_other_type_via_str(self, mw):
+        assert mw._normalize_result(42) == "42"
+
+    def test_unicode_preserved(self, mw):
+        # ensure_ascii=False — Chinese characters etc. survive intact.
+        out = mw._normalize_result({"msg": "你好"})
+        assert "你好" in out
+
+
+# ---------------------------------------------------------------------------
+# _normalize_result — NUL stripping
+# ---------------------------------------------------------------------------
+
+
+class TestNulStripping:
+    def test_strips_nul_from_string(self, mw, caplog):
+        out = mw._normalize_result("ok\x00bad")
+        assert out == "okbad"
+        # Warning fires so logs make NUL occurrences observable.
+        assert any("Stripped NUL" in r.message for r in caplog.records)
+
+    def test_strips_nul_inside_dict_value(self, mw):
+        # Dict path goes through json.dumps first; the resulting string
+        # contains the JSON `\\u0000` escape which we then strip.
+        out = mw._normalize_result({"content": "stdout\x00"})
+        # Either form is unacceptable in Postgres JSONB.
+        assert "\\u0000" not in out
+        assert "\x00" not in out
+
+    def test_strips_nul_inside_list(self, mw):
+        out = mw._normalize_result(["a\x00", "b"])
+        assert "\\u0000" not in out
+        assert "\x00" not in out
+
+    def test_clean_string_does_not_emit_warning(self, mw, caplog):
+        out = mw._normalize_result("clean output")
+        assert out == "clean output"
+        assert not any("Stripped NUL" in r.message for r in caplog.records)
+
+    def test_multiple_nuls_all_stripped(self, mw):
+        assert mw._normalize_result("\x00a\x00b\x00c\x00") == "abc"
+
+
+# ---------------------------------------------------------------------------
+# wrap_tool_call / awrap_tool_call — integration with ToolMessage
+# ---------------------------------------------------------------------------
+
+
+class TestWrapToolCall:
+    def test_sync_path_strips_nul_in_toolmessage(self, mw):
+        msg = ToolMessage(content="hello\x00world", tool_call_id="call-1")
+        handler = MagicMock(return_value=msg)
+        out = mw.wrap_tool_call(request=MagicMock(), handler=handler)
+        assert out is msg
+        assert msg.content == "helloworld"
+
+    def test_sync_path_passthrough_for_non_toolmessage(self, mw):
+        # If something other than a ToolMessage comes back, leave it alone.
+        sentinel = object()
+        handler = MagicMock(return_value=sentinel)
+        assert mw.wrap_tool_call(request=MagicMock(), handler=handler) is sentinel
+
+    @pytest.mark.asyncio
+    async def test_async_path_strips_nul_in_toolmessage(self, mw):
+        msg = ToolMessage(content="hello\x00world", tool_call_id="call-1")
+        handler = AsyncMock(return_value=msg)
+        out = await mw.awrap_tool_call(request=MagicMock(), handler=handler)
+        assert out is msg
+        assert msg.content == "helloworld"
+
+    @pytest.mark.asyncio
+    async def test_async_path_coerces_dict_then_strips(self, mw):
+        # Tool returns a dict directly into ToolMessage.content (some tools do
+        # this before LangChain wraps it). Middleware coerces to JSON string,
+        # then strips the \\u0000 escape that the dict's NUL-bearing value
+        # would have produced.
+        msg = ToolMessage(content={"data": "stdout\x00"}, tool_call_id="call-2")
+        handler = AsyncMock(return_value=msg)
+        await mw.awrap_tool_call(request=MagicMock(), handler=handler)
+        assert isinstance(msg.content, str)
+        assert "\\u0000" not in msg.content
+        assert "\x00" not in msg.content

--- a/tests/unit/ptc_agent/middleware/tool/test_result_normalization.py
+++ b/tests/unit/ptc_agent/middleware/tool/test_result_normalization.py
@@ -91,6 +91,14 @@ class TestNulStripping:
     def test_multiple_nuls_all_stripped(self, mw):
         assert mw._normalize_result("\x00a\x00b\x00c\x00") == "abc"
 
+    def test_literal_unicode_escape_in_string_preserved(self, mw, caplog):
+        # On the string-passthrough path, the six-char sequence `\u0000` is
+        # just text — Postgres TEXT accepts it. Stripping would mangle docs
+        # or LLM output that explains Unicode escapes literally.
+        text = "the unicode escape \\u0000 represents NUL"
+        assert mw._normalize_result(text) == text
+        assert not any("Stripped NUL" in r.message for r in caplog.records)
+
 
 # ---------------------------------------------------------------------------
 # wrap_tool_call / awrap_tool_call — integration with ToolMessage

--- a/tests/unit/server/utils/test_pg_sanitize.py
+++ b/tests/unit/server/utils/test_pg_sanitize.py
@@ -1,0 +1,96 @@
+"""Tests for src.server.utils.pg_sanitize.
+
+`pg_sanitize` is the shared helper that strips NUL bytes / `\\u0000` escapes
+before values are bound to Postgres TEXT/JSONB columns. These tests pin its
+behavior so future changes don't silently re-expose the persistence boundary
+to NUL-bearing input.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from src.server.utils.pg_sanitize import SafeJson, _safe_dumps, strip_pg_nul_str
+
+
+class TestStripPgNulStr:
+    def test_strips_embedded_nul(self):
+        assert strip_pg_nul_str("a\x00b") == "ab"
+
+    def test_strips_multiple_nuls(self):
+        assert strip_pg_nul_str("\x00a\x00b\x00") == "ab"
+
+    def test_passthrough_when_no_nul_returns_same_object(self):
+        # Critical for hot path: no allocation when input is clean.
+        s = "hello world"
+        assert strip_pg_nul_str(s) is s
+
+    def test_empty_passthrough(self):
+        assert strip_pg_nul_str("") == ""
+
+    def test_none_passthrough(self):
+        assert strip_pg_nul_str(None) is None
+
+
+class TestSafeDumps:
+    def test_strips_unicode_escape_in_string_value(self):
+        out = _safe_dumps({"k": "a\x00b"})
+        assert "\\u0000" not in out
+        # Round-trip should give back the cleaned value.
+        assert json.loads(out) == {"k": "ab"}
+
+    def test_clean_input_is_unchanged_aside_from_serialization(self):
+        out = _safe_dumps({"k": "v"})
+        assert json.loads(out) == {"k": "v"}
+
+    def test_handles_nested_structures(self):
+        out = _safe_dumps({"k": "a\x00b", "n": [1, "c\x00", {"deep": "d\x00"}]})
+        roundtrip = json.loads(out)
+        assert roundtrip == {"k": "ab", "n": [1, "c", {"deep": "d"}]}
+
+    def test_unserializable_raises_typeerror(self):
+        # No `default=` fallback — non-JSON types must surface as TypeError so
+        # accidental datetime/UUID/Pydantic-object binds don't get silently
+        # stringified into JSONB.
+        class Custom:
+            pass
+
+        with pytest.raises(TypeError):
+            _safe_dumps({"x": Custom()})
+
+    def test_strips_nul_in_dict_keys(self):
+        out = _safe_dumps({"k\x00": 1})
+        assert json.loads(out) == {"k": 1}
+
+
+class TestSafeJson:
+    def test_is_a_psycopg_Json_subclass(self):
+        from psycopg.types.json import Json
+
+        assert isinstance(SafeJson({}), Json)
+
+    def test_dumps_strips_nul(self):
+        wrapped = SafeJson({"a": "x\x00", "b": ["y\x00z"]})
+        # psycopg calls dumps() on the wrapped value at bind time. Replicate.
+        rendered = wrapped.dumps(wrapped.obj)
+        assert "\\u0000" not in rendered
+        assert json.loads(rendered) == {"a": "x", "b": ["yz"]}
+
+
+@pytest.mark.parametrize("size_mb", [1, 10])
+def test_safe_dumps_performance_smoke(size_mb: int):
+    """Catch accidental Python-level walks if someone "improves" _safe_dumps.
+
+    With the current dumps-based approach, a 10 MB nested dict should
+    serialize+strip in well under 1 second on any modern machine. The bound
+    is generous to keep the test stable on shared CI runners.
+    """
+    chunk = "x" * 1024  # 1 KB strings
+    blob = {"items": [{"i": i, "data": chunk} for i in range(size_mb * 1024)]}
+    start = time.perf_counter()
+    _safe_dumps(blob)
+    elapsed = time.perf_counter() - start
+    assert elapsed < 5.0, f"_safe_dumps too slow: {elapsed:.2f}s for {size_mb} MB"


### PR DESCRIPTION
## Summary

A tool result containing a NUL byte (`0x00`) — common in sandbox stdout, file reads, and web-fetch markdown — poisons two persistence paths:

- `conversation_responses.sse_events` JSONB rejects the ` ` escape with `psycopg.errors.UntranslatableCharacter`.
- `workspace_files.content_text` TEXT rejects raw NUL with `cannot contain NUL (0x00) bytes`, aborting the whole bulk upsert batch.

The thread-level failure mode is the worst part: the bad `ToolMessage` lands in LangGraph's `checkpoint_blobs.blob` (BYTEA, accepts NUL fine), so on every resume the message rehydrates and re-fails on the JSONB write. The thread becomes permanently unresumable.

## Fix

**Source layer.** `ToolResultNormalizationMiddleware._normalize_result` strips both the literal NUL byte (from the string-passthrough path) and the ` ` JSON escape (from the dict/list path that goes through `json.dumps`). One chokepoint covers PTC, Flash, and every subagent built through the same factory.

**Boundary layer.** New `src/server/utils/pg_sanitize.py` exports `strip_pg_nul_str` for plain TEXT binds and `SafeJson` as a drop-in for `psycopg.types.json.Json` that piggybacks on the `dumps` psycopg already performs at bind time, no extra Python-level walks. Wired into:

- `workspace_file.bulk_upsert_files` — `file_path`, `file_name`, `content_text`, `mime_type`, `permissions` all stripped per row before `executemany`.
- `conversation.create_query` — `content` stripped, `metadata` wrapped in `SafeJson`.
- `conversation.create_response` and `update_sse_events` — `metadata` and `sse_events` wrapped in `SafeJson`.

**Detection hardening.** `_detect_is_binary` now scans the first 64 KB for NUL (was only the first 8 KB), so a NUL-bearing file is correctly routed to `content_binary` BYTEA. The boundary `strip_pg_nul_str` catches anything past 64 KB.

**Recovery script.** `scripts/ops/scrub_nul_checkpoint.py` takes a thread UUID and round-trips its `checkpoint_blobs` and `checkpoint_writes` rows through `JsonPlusSerializer` so message types are preserved, recursively strips NUL from every string field, and rewrites the blobs. Server-side streaming cursor keeps peak memory bounded regardless of thread depth; `FOR UPDATE` (apply path only) serializes against any concurrent checkpoint write. Dry-run by default, requires `--apply` to mutate. Idempotent.

## What changed

| File | Change |
|---|---|
| `src/ptc_agent/agent/middleware/tool/result_normalization.py` | Strip both raw NUL and the ` ` escape after string normalization, log when stripping fires |
| `src/server/utils/pg_sanitize.py` (new) | `strip_pg_nul_str` + `_safe_dumps` + `SafeJson` |
| `src/server/database/workspace_file.py` | TEXT columns stripped in `bulk_upsert_files` |
| `src/server/database/conversation.py` | `Json(...)` → `SafeJson(...)` for metadata + sse_events; `content` stripped in `create_query` |
| `src/server/services/persistence/file.py` | `_detect_is_binary` scans 64 KB instead of 8 KB |
| `scripts/ops/scrub_nul_checkpoint.py` (new) | One-shot checkpoint scrubber for already-poisoned threads |

## Tests

- `tests/unit/server/utils/test_pg_sanitize.py` — 14 tests: NUL stripping, JSONB safety, performance smoke up to 10 MB, asserts non-JSON-serializable types raise `TypeError` (no silent stringification).
- `tests/unit/ptc_agent/middleware/tool/test_result_normalization.py` — 15 tests: type coercion, NUL stripping (string/dict/list paths), sync + async `wrap_tool_call`.
- `tests/integration/test_pg_nul_persistence.py` — 4 tests: `bulk_upsert_files` survives NUL in content + path components, `sse_events` JSONB persists with NUL-bearing tool result, user-typed query content with NUL persists clean.

## Verification

- Unit: `uv run pytest tests/unit/server/utils/test_pg_sanitize.py tests/unit/ptc_agent/middleware/tool/test_result_normalization.py` — 29/29 passing.
- Integration: 4 new pg_nul_persistence tests + 11 conversation_persistence + 18 workspace_lifecycle regression — 33/33 passing.
- Lint: `uv run ruff check` clean.

## Recovery

For any thread that's already stuck:

```
uv run python scripts/ops/scrub_nul_checkpoint.py <thread-uuid>            # dry-run
uv run python scripts/ops/scrub_nul_checkpoint.py <thread-uuid> --apply    # mutate
```

## Test plan

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Lint clean
- [ ] Smoke: emit a NUL through `execute_code` and verify the chat completes (no 500); look for the new `Stripped NUL bytes from tool result` warning fired once.
- [ ] Smoke: write a NUL-bearing file in a sandbox, hit the workspace files backup endpoint, verify 200 and a `workspace_files` row (either `is_binary=true` or content stripped).
