### PR TITLE
feat(llms): pin OpenAI/Codex requests to thread-stable prompt_cache_key

### DIFF
--- a/src/llms/api_call.py
+++ b/src/llms/api_call.py
@@ -36,13 +36,19 @@ def maybe_disable_streaming(model: object) -> None:
     share the instance across requests MUST deep-copy first (see
     ``workflow_handler.py::compact`` and ``fetch.py::_extract_with_llm``
     for the reference pattern).
+
+    The ``RunnableBindingBase`` unwrap is defensive — keeps the Codex guard
+    and streaming flip working even if a caller wraps via ``bind()``.
     """
+    from langchain_core.runnables.base import RunnableBindingBase
     from src.llms.extension.codex import ChatCodexOpenAI
 
-    if isinstance(model, ChatCodexOpenAI):
+    target = model.bound if isinstance(model, RunnableBindingBase) else model
+
+    if isinstance(target, ChatCodexOpenAI):
         return
-    if hasattr(model, "streaming"):
-        model.streaming = False
+    if hasattr(target, "streaming"):
+        target.streaming = False
 
 
 async def make_api_call(

--- a/src/llms/llm.py
+++ b/src/llms/llm.py
@@ -289,6 +289,10 @@ class LLM:
         # Store response API flags for OpenAI SDK
         self.use_response_api = self.provider_info.get("use_response_api", False) if self.sdk in ("openai", "codex") else False
         self.use_previous_response_id = self.provider_info.get("use_previous_response_id", False) if self.sdk == "openai" else False
+        # prompt_cache_key: opt-in for sdk="openai"; codex applies it always-on.
+        self.prompt_cache_key_enabled = (
+            bool(self.provider_info.get("prompt_cache_key", False)) if self.sdk == "openai" else False
+        )
 
         # Optional default headers from provider config, with model-level beta merging
         self.default_headers = self.provider_info.get("default_headers")
@@ -309,6 +313,7 @@ class LLM:
         config: dict,
         api_key: str | None = None,
         base_url_override=_UNSET,
+        cache_key: str | None = None,
         **override_params,
     ):
         """
@@ -321,6 +326,8 @@ class LLM:
             config: Dict with keys: model_id, provider, and optional parameters/extra_body.
             api_key: Optional API key override (e.g. from BYOK).
             base_url_override: Override base URL. _UNSET = no override.
+            cache_key: Session-stable key sent as ``prompt_cache_key`` on
+                OpenAI/Codex requests (always-on for Codex; opt-in for OpenAI).
             **override_params: Additional parameters to override defaults.
 
         Returns:
@@ -362,9 +369,14 @@ class LLM:
             if instance.sdk == "openai"
             else False
         )
+        instance.prompt_cache_key_enabled = (
+            bool(instance.provider_info.get("prompt_cache_key", False))
+            if instance.sdk == "openai"
+            else False
+        )
         instance.default_headers = instance.provider_info.get("default_headers")
         instance._merge_additional_betas(config.get("additional_betas"))
-        return instance.get_llm()
+        return instance.get_llm(cache_key=cache_key)
 
     def _resolve_billing_type(self) -> str:
         """Determine billing type based on how this LLM was constructed.
@@ -380,21 +392,25 @@ class LLM:
             return "byok"
         return "platform"
 
-    def get_llm(self):
-        """
-        Initializes and returns a LangChain LLM client for the configured provider.
+    def get_llm(self, cache_key: str | None = None):
+        """Build the LangChain LLM client for the configured provider.
 
-        Returns:
-            A LangChain chat model instance with billing_type metadata attached.
-
-        Raises:
-            ValueError: If required API keys are not set or provider is unsupported.
+        ``cache_key`` becomes ``prompt_cache_key`` on OpenAI/Codex requests via
+        ``model_kwargs`` (not ``bind()``) so it survives ``bind_tools()`` and
+        ``with_structured_output()``. Codex always applies the key; regular
+        OpenAI applies it only when the provider opts in via providers.json.
         """
-        # Use the resolved SDK (already determined in __init__)
+        effective_cache_key: str | None = None
+        if cache_key and (
+            self.sdk == "codex"
+            or (self.sdk == "openai" and self.prompt_cache_key_enabled)
+        ):
+            effective_cache_key = str(cache_key)
+
         if self.sdk == "openai":
-            client = self._get_openai_llm()
+            client = self._get_openai_llm(cache_key=effective_cache_key)
         elif self.sdk == "codex":
-            client = self._get_codex_llm()
+            client = self._get_codex_llm(cache_key=effective_cache_key)
         elif self.sdk == "deepseek":
             client = self._get_deepseek_llm()
         elif self.sdk == "qwq":
@@ -440,7 +456,7 @@ class LLM:
             url = url.replace("{HOST_IP}", HOST_IP)
         return {param_name: url}
 
-    def _get_openai_llm(self):
+    def _get_openai_llm(self, cache_key: str | None = None):
         """Get OpenAI or OpenAI-compatible LLM."""
         params = {
             "model": self.model,
@@ -469,9 +485,14 @@ class LLM:
         if self.extra_body:
             params["extra_body"] = self.extra_body
 
+        # model_kwargs (not bind) so the key survives bind_tools / with_structured_output.
+        if cache_key:
+            existing_mk = params.get("model_kwargs") or {}
+            params["model_kwargs"] = {**existing_mk, "prompt_cache_key": cache_key}
+
         return ChatOpenAI(**params)
 
-    def _get_codex_llm(self):
+    def _get_codex_llm(self, cache_key: str | None = None):
         """Get Codex OAuth LLM (store=false, stateless)."""
         from src.llms.extension import ChatCodexOpenAI
 
@@ -495,6 +516,10 @@ class LLM:
 
         if self.extra_body:
             params["extra_body"] = self.extra_body
+
+        if cache_key:
+            existing_mk = params.get("model_kwargs") or {}
+            params["model_kwargs"] = {**existing_mk, "prompt_cache_key": cache_key}
 
         return ChatCodexOpenAI(**params)
 
@@ -607,6 +632,7 @@ def create_llm(
     default_headers: dict | None = None,
     base_url=_UNSET,
     reasoning_effort: str | None = None,
+    cache_key: str | None = None,
     **kwargs,
 ):
     """
@@ -619,6 +645,8 @@ def create_llm(
             (e.g. ChatGPT-Account-Id for Codex OAuth)
         base_url: Override base URL. None = SDK default, str = custom URL.
         reasoning_effort: Optional reasoning effort level ("low", "medium", "high").
+        cache_key: Session-stable key sent as ``prompt_cache_key`` on
+            OpenAI/Codex requests (always-on for Codex; opt-in for OpenAI).
         **kwargs: Additional parameters to override
 
     Returns:
@@ -634,13 +662,14 @@ def create_llm(
     if default_headers:
         existing = instance.default_headers or {}
         instance.default_headers = {**existing, **default_headers}
-    return instance.get_llm()
+    return instance.get_llm(cache_key=cache_key)
 
 
 def create_llm_from_custom(
     config: dict,
     api_key: str | None = None,
     base_url=_UNSET,
+    cache_key: str | None = None,
     **kwargs,
 ):
     """
@@ -650,12 +679,36 @@ def create_llm_from_custom(
         config: Dict with model_id, provider, and optional parameters/extra_body.
         api_key: Optional API key override (e.g. from BYOK).
         base_url: Override base URL. _UNSET = no override, None = SDK default.
+        cache_key: Session-stable key sent as ``prompt_cache_key`` on
+            OpenAI/Codex requests (always-on for Codex; opt-in for OpenAI).
         **kwargs: Additional parameters to override.
 
     Returns:
         A LangChain chat model instance.
     """
-    return LLM.from_custom_config(config, api_key=api_key, base_url_override=base_url, **kwargs)
+    return LLM.from_custom_config(
+        config, api_key=api_key, base_url_override=base_url, cache_key=cache_key, **kwargs
+    )
+
+
+def narrow_prompt_cache_key(model: Any, suffix: str) -> Any:
+    """Return a copy of ``model`` with ``:suffix`` appended to its ``prompt_cache_key``.
+
+    Used to namespace parallel sub-tasks (subagent fanout, compaction) onto
+    separate OpenAI cache shards — OpenAI rate-limits at ~15 RPM per
+    (prefix + ``prompt_cache_key``) bucket. No-op when the model has no
+    ``prompt_cache_key`` set or ``suffix`` is empty.
+    """
+    if not suffix:
+        return model
+    if not isinstance(model, BaseChatModel):
+        return model
+    mk = getattr(model, "model_kwargs", None) or {}
+    parent_key = mk.get("prompt_cache_key")
+    if not parent_key:
+        return model
+    new_mk = {**mk, "prompt_cache_key": f"{parent_key}:{suffix}"}
+    return model.model_copy(update={"model_kwargs": new_mk})
 
 
 def get_llm_by_type(llm_type: str) -> BaseChatModel:

--- a/src/llms/manifest/providers.json
+++ b/src/llms/manifest/providers.json
@@ -1261,6 +1261,7 @@
       "access_type": "api_key",
       "byok_eligible": true,
       "use_response_api": true,
+      "prompt_cache_key": true,
       "display_name": "OpenAI",
       "variants": {
         "codex-oauth": {

--- a/src/ptc_agent/agent/agent.py
+++ b/src/ptc_agent/agent/agent.py
@@ -651,7 +651,7 @@ class PTCAgent:
             if compaction_client:
                 compaction_config["_llm_client"] = compaction_client
             elif self.config.llm_client:
-                # Deep-copy so CompactionMiddleware.from_config() can set
+                # Copy so CompactionMiddleware.from_config() can set
                 # streaming=False without mutating the main agent's model.
                 compaction_config["_llm_client"] = self.config.llm_client.model_copy()
         elif self.config.llm_client:

--- a/src/ptc_agent/agent/flash/agent.py
+++ b/src/ptc_agent/agent/flash/agent.py
@@ -90,7 +90,7 @@ class FlashAgent:
                 # because the name is a typo. Raise a neutral error instead of
                 # the generic factory one.
                 ensure_model_in_manifest(config.llm.flash)
-                self.llm = create_llm(config.llm.flash)
+                self.llm = create_llm(config.llm.flash, cache_key=config.cache_key)
             model = config.llm.flash
             provider = "llm_config"
         else:
@@ -246,7 +246,7 @@ class FlashAgent:
             if compaction_client:
                 compaction_config["_llm_client"] = compaction_client
             elif self.config.llm_client:
-                # Deep-copy so CompactionMiddleware.from_config() can set
+                # Copy so CompactionMiddleware.from_config() can set
                 # streaming=False without mutating the main agent's model.
                 compaction_config["_llm_client"] = self.config.llm_client.model_copy()
         compaction = CompactionMiddleware.from_config(config=compaction_config, backend=None)

--- a/src/ptc_agent/agent/middleware/background_subagent/subagent.py
+++ b/src/ptc_agent/agent/middleware/background_subagent/subagent.py
@@ -172,6 +172,10 @@ def _get_subagents(
     # Use empty list if None (no default middleware)
     default_subagent_middleware = default_middleware or []
 
+    # Per-name suffix on ``prompt_cache_key`` so each subagent type lands on
+    # its own cache shard. No-op for models without the key set.
+    from src.llms.llm import narrow_prompt_cache_key
+
     agents: dict[str, Any] = {}
     subagent_descriptions = []
 
@@ -183,7 +187,7 @@ def _get_subagents(
                 HumanInTheLoopMiddleware(interrupt_on=default_interrupt_on)
             )
         general_purpose_subagent = create_agent(
-            default_model,
+            narrow_prompt_cache_key(default_model, "general-purpose"),
             system_prompt=DEFAULT_SUBAGENT_PROMPT,
             tools=default_tools,
             middleware=general_purpose_middleware,
@@ -217,7 +221,7 @@ def _get_subagents(
             _middleware.append(HumanInTheLoopMiddleware(interrupt_on=interrupt_on))
 
         agents[agent_["name"]] = create_agent(
-            subagent_model,
+            narrow_prompt_cache_key(subagent_model, agent_["name"]),
             system_prompt=agent_["system_prompt"],
             tools=_tools,
             middleware=_middleware,

--- a/src/ptc_agent/agent/middleware/background_subagent/subagent.py
+++ b/src/ptc_agent/agent/middleware/background_subagent/subagent.py
@@ -25,6 +25,7 @@ from ptc_agent.agent.middleware.background_subagent.middleware import (
 )
 from ptc_agent.agent.middleware.background_subagent.registry import BackgroundTaskRegistry
 from ptc_agent.agent.middleware._utils import append_to_system_message
+from src.llms.llm import narrow_prompt_cache_key
 
 logger = structlog.get_logger(__name__)
 
@@ -171,10 +172,6 @@ def _get_subagents(
     """
     # Use empty list if None (no default middleware)
     default_subagent_middleware = default_middleware or []
-
-    # Per-name suffix on ``prompt_cache_key`` so each subagent type lands on
-    # its own cache shard. No-op for models without the key set.
-    from src.llms.llm import narrow_prompt_cache_key
 
     agents: dict[str, Any] = {}
     subagent_descriptions = []

--- a/src/ptc_agent/config/agent.py
+++ b/src/ptc_agent/config/agent.py
@@ -238,6 +238,9 @@ class AgentConfig(BaseModel):
     llm_client: Any | None = Field(default=None, exclude=True)  # BaseChatModel instance
     subsidiary_llm_clients: dict[str, Any] = Field(default_factory=dict, exclude=True)
     fallback_llm_clients: list[Any] | None = Field(default=None, exclude=True)  # Pre-resolved fallback instances
+    # Forwarded by ``get_llm_client()`` to ``create_llm(cache_key=...)`` for
+    # the lazy factory path.
+    cache_key: str | None = Field(default=None, exclude=True)
     config_file_dir: Path | None = Field(
         default=None, exclude=True
     )  # For path resolution
@@ -486,7 +489,7 @@ class AgentConfig(BaseModel):
         from src.llms.llm import ensure_model_in_manifest
 
         ensure_model_in_manifest(self.llm.name)
-        return create_llm(self.llm.name)
+        return create_llm(self.llm.name, cache_key=self.cache_key)
 
     def to_core_config(self) -> CoreConfig:
         """Convert to CoreConfig for use with SessionManager.

--- a/src/server/app/threads.py
+++ b/src/server/app/threads.py
@@ -484,6 +484,7 @@ async def _handle_send_message(
             mode=agent_mode,
             reasoning_effort=getattr(request, "reasoning_effort", None),
             fast_mode=getattr(request, "fast_mode", None),
+            thread_id=thread_id,
         )
 
         # is_byok reflects whether THIS request actually uses a user-provided key

--- a/src/server/handlers/chat/flash_workflow.py
+++ b/src/server/handlers/chat/flash_workflow.py
@@ -206,6 +206,7 @@ async def astream_flash_workflow(
                 mode="flash",
                 reasoning_effort=getattr(request, "reasoning_effort", None),
                 fast_mode=getattr(request, "fast_mode", None),
+                thread_id=thread_id,
             )
 
         # Resolve timezone for metadata (observability only -- agent clock

--- a/src/server/handlers/chat/llm_config.py
+++ b/src/server/handlers/chat/llm_config.py
@@ -242,6 +242,7 @@ async def resolve_byok_llm_client(
     is_byok: bool,
     reasoning_effort: str | None = None,
     _pref_cache: dict | None = None,
+    cache_key: str | None = None,
 ):
     """
     If BYOK is active, build an LLM client for ``model_name``. Returns None
@@ -297,6 +298,7 @@ async def resolve_byok_llm_client(
             custom_config,
             api_key=byok_config["api_key"],
             base_url=base_url,
+            cache_key=cache_key,
         )
 
     # Unknown name — last-chance check for a custom-provider slug. Covers the
@@ -321,6 +323,7 @@ async def resolve_byok_llm_client(
             custom_config,
             api_key=byok_config["api_key"],
             base_url=base_url,
+            cache_key=cache_key,
         )
 
     # System model — BYOK key lives under the parent provider.
@@ -342,6 +345,7 @@ async def resolve_byok_llm_client(
         api_key=byok_config["api_key"],
         base_url=base_url,
         reasoning_effort=reasoning_effort,
+        cache_key=cache_key,
     )
 
 
@@ -350,6 +354,7 @@ async def resolve_oauth_llm_client(
     model_name: str,
     reasoning_effort: str | None = None,
     service_tier: str | None = None,
+    cache_key: str | None = None,
 ):
     """Resolve OAuth-connected LLM client. Independent of BYOK toggle."""
     from src.llms.llm import LLM as LLMFactory, create_llm
@@ -406,6 +411,7 @@ async def resolve_oauth_llm_client(
         api_key=access_token,
         default_headers=headers if headers else None,
         reasoning_effort=reasoning_effort,
+        cache_key=cache_key,
         **({"service_tier": service_tier} if service_tier and provider != "claude-oauth" else {}),
     )
 
@@ -491,6 +497,7 @@ async def resolve_llm_config(
     mode: str = "ptc",
     reasoning_effort: str | None = None,
     fast_mode: bool | None = None,
+    thread_id: str | None = None,
 ):
     """
     Resolve final LLM config with priority:
@@ -653,6 +660,7 @@ async def resolve_llm_config(
     oauth_client = await resolve_oauth_llm_client(
         user_id, effective_model, effective_reasoning,
         service_tier=effective_service_tier,
+        cache_key=thread_id,
     )
     if oauth_client:
         if config is base_config:
@@ -663,6 +671,7 @@ async def resolve_llm_config(
         byok_client = await resolve_byok_llm_client(
             user_id, effective_model, is_byok, effective_reasoning,
             _pref_cache=model_pref,
+            cache_key=thread_id,
         )
         if byok_client:
             if config is base_config:
@@ -680,11 +689,20 @@ async def resolve_llm_config(
         if config is base_config:
             config = config.model_copy(deep=True)
         config.llm_client = create_llm(
-            effective_model, reasoning_effort=effective_reasoning
+            effective_model,
+            reasoning_effort=effective_reasoning,
+            cache_key=thread_id,
         )
         logger.debug(
             f"[CHAT] Applied reasoning_effort={effective_reasoning} to {effective_model}"
         )
+
+    # Stash on config so the lazy ``AgentConfig.get_llm_client()`` path forwards
+    # it to ``create_llm`` when no OAuth/BYOK/reasoning branch pre-built the client.
+    if thread_id and config.cache_key != thread_id:
+        if config is base_config:
+            config = config.model_copy(deep=True)
+        config.cache_key = thread_id
 
     # Resolve OAuth/BYOK for subsidiary + fallback models in parallel.
     # Each model tries OAuth first, then BYOK if OAuth fails.
@@ -702,11 +720,14 @@ async def resolve_llm_config(
             source, _ = await classify_model(
                 user_id, model_name, _pref_cache=model_pref,
             )
-            client = await resolve_oauth_llm_client(user_id, model_name)
+            client = await resolve_oauth_llm_client(
+                user_id, model_name, cache_key=thread_id,
+            )
             if not client and is_byok:
                 client = await resolve_byok_llm_client(
                     user_id, model_name, is_byok,
                     _pref_cache=model_pref,
+                    cache_key=thread_id,
                 )
             return client, source
         except Exception:
@@ -772,7 +793,7 @@ async def resolve_llm_config(
                 )
                 continue
             try:
-                merged_fallbacks.append(_create_llm(model_name))
+                merged_fallbacks.append(_create_llm(model_name, cache_key=thread_id))
             except Exception:
                 logger.warning("[CHAT] Failed to create platform fallback for %s, skipping", model_name)
 

--- a/src/server/handlers/chat/ptc_workflow.py
+++ b/src/server/handlers/chat/ptc_workflow.py
@@ -335,6 +335,7 @@ async def astream_ptc_workflow(
                 setup.agent_config, user_id, request.llm_model, is_byok, mode="ptc",
                 reasoning_effort=getattr(request, "reasoning_effort", None),
                 fast_mode=getattr(request, "fast_mode", None),
+                thread_id=thread_id,
             )
 
         # Propagate fetch model override to tool context

--- a/src/server/handlers/workflow_handler.py
+++ b/src/server/handlers/workflow_handler.py
@@ -494,6 +494,7 @@ async def trigger_compaction(
                     request_model=None,
                     is_byok=is_byok,
                     mode="ptc",
+                    thread_id=thread_id,
                 )
             except HTTPException:
                 # 402 insufficient credits, 403 revoked key, etc. are intentional
@@ -516,7 +517,7 @@ async def trigger_compaction(
         model_name = (agent_cfg.llm.compaction or "") if agent_cfg and agent_cfg.llm else ""
 
         # Mirror PTCAgent.create_agent client priority: subsidiary → main → factory.
-        # Deep-copy before handing the client to compact_messages — it calls
+        # Copy before handing the client to compact_messages — it calls
         # maybe_disable_streaming (src/llms/api_call.py) which sets
         # streaming=False in-place. Without the copy, the fallback path
         # (agent_cfg == setup.agent_config) would permanently mutate the

--- a/tests/unit/config/test_agent_config.py
+++ b/tests/unit/config/test_agent_config.py
@@ -262,6 +262,25 @@ class TestAgentConfigGetLlmClient:
             with pytest.raises(ValueError, match="not defined in models.json"):
                 config.get_llm_client()
 
+    def test_falls_back_forwards_cache_key(self):
+        """Regression: on the lazy factory path, ``cache_key`` stashed on the
+        config (by ``resolve_llm_config``) must reach ``create_llm`` so the
+        OpenAI/Codex factory can pin the prompt cache shard."""
+        config = _minimal_config()
+        config.cache_key = "thread-cache-xyz"
+        mock_created = MagicMock()
+        mock_mc = MagicMock()
+        mock_mc.get_model_config.return_value = {"provider": "openai"}
+        with (
+            patch("src.llms.create_llm", return_value=mock_created) as mock_create,
+            patch("src.llms.llm.LLM.get_model_config", return_value=mock_mc),
+        ):
+            result = config.get_llm_client()
+        assert result is mock_created
+        mock_create.assert_called_once()
+        _args, kwargs = mock_create.call_args
+        assert kwargs.get("cache_key") == "thread-cache-xyz"
+
 
 # ---------------------------------------------------------------------------
 # SubagentConfig / SubagentsConfig

--- a/tests/unit/llms/test_api_call_streaming.py
+++ b/tests/unit/llms/test_api_call_streaming.py
@@ -55,3 +55,33 @@ def test_object_without_streaming_attr_is_noop():
     maybe_disable_streaming(llm)
 
     assert not hasattr(llm, "streaming")
+
+
+def test_bound_codex_streaming_preserved():
+    """Defensive: if any caller wraps codex in a ``RunnableBinding`` via
+    ``bind(...)``, the isinstance guard must still unwrap so streaming stays
+    True (Codex proxy returns HTTP 400 otherwise). Production wires
+    ``prompt_cache_key`` through ``model_kwargs`` instead, so the model is
+    normally a plain ChatCodexOpenAI."""
+    llm = _make_codex()
+    bound = llm.bind(prompt_cache_key="thread-abc-123")
+    assert llm.streaming is True
+
+    maybe_disable_streaming(bound)
+
+    assert llm.streaming is True
+
+
+def test_bound_plain_llm_streaming_disabled():
+    """For non-codex models, the binding wrapper must not block the
+    ``streaming=False`` flip on the underlying model."""
+    from langchain_core.runnables.base import RunnableBindingBase
+
+    llm = _PlainLLM(streaming=True)
+    bound = RunnableBindingBase.model_construct(
+        bound=llm, kwargs={"prompt_cache_key": "x"}
+    )
+
+    maybe_disable_streaming(bound)
+
+    assert llm.streaming is False

--- a/tests/unit/llms/test_prompt_cache_key.py
+++ b/tests/unit/llms/test_prompt_cache_key.py
@@ -1,0 +1,327 @@
+"""Tests for prompt_cache_key wiring on OpenAI/Codex factories.
+
+Verifies the differentiated rollout:
+- Codex (sdk="codex"): always-on, injects whenever cache_key is provided.
+- Regular OpenAI (sdk="openai"): opt-in via providers.json `prompt_cache_key: true`.
+- Other SDKs (anthropic, etc.): never inject, no error.
+
+Implementation note: ``prompt_cache_key`` is wired via ``ChatOpenAI(model_kwargs=...)``
+rather than ``Runnable.bind()`` so it survives ``bind_tools()`` /
+``with_structured_output()`` (those produce a fresh RunnableBinding that drops
+prior bind kwargs but keeps the underlying ChatOpenAI's model_kwargs).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from src.llms.llm import LLM
+
+
+class _StubModel:
+    """Returned by stubbed factory methods. Mirrors the surface our tests touch."""
+
+    def __init__(self):
+        self.metadata = {}
+
+
+def _make_llm(
+    sdk: str, prompt_cache_key_flag: bool = False
+) -> tuple[LLM, list[dict]]:
+    """Bypass __init__ to avoid models.json lookups; configure attributes directly.
+
+    Returns the LLM and a list that captures every keyword call to the stubbed
+    SDK factory (``_get_openai_llm`` / ``_get_codex_llm`` / ``_get_anthropic_llm``).
+    Tests inspect that list to assert whether ``cache_key`` reached the factory.
+    """
+    llm = LLM.__new__(LLM)
+    llm.sdk = sdk
+    llm.provider = f"test-{sdk}"
+    llm.provider_info = {"access_type": "platform"}
+    llm.api_key_override = None
+    llm.prompt_cache_key_enabled = prompt_cache_key_flag
+
+    factory_name = {
+        "openai": "_get_openai_llm",
+        "codex": "_get_codex_llm",
+        "anthropic": "_get_anthropic_llm",
+    }[sdk]
+
+    factory_calls: list[dict] = []
+
+    def _stub_factory(self, *args, **kwargs):  # noqa: ARG001
+        factory_calls.append(dict(kwargs))
+        return _StubModel()
+
+    patcher = patch.object(LLM, factory_name, _stub_factory)
+    patcher.start()
+    return llm, factory_calls
+
+
+@pytest.fixture(autouse=True)
+def _stop_all_patches():
+    yield
+    patch.stopall()
+
+
+class TestCodexAlwaysOn:
+    """Codex SDK should pass cache_key to its factory whenever provided,
+    regardless of any provider flag — matches the official Codex CLI."""
+
+    def test_codex_with_cache_key_passes_to_factory(self):
+        llm, calls = _make_llm("codex")
+        llm.get_llm(cache_key="thread-abc-123")
+        assert calls == [{"cache_key": "thread-abc-123"}]
+
+    def test_codex_without_cache_key_passes_none(self):
+        llm, calls = _make_llm("codex")
+        llm.get_llm(cache_key=None)
+        assert calls == [{"cache_key": None}]
+
+    def test_codex_empty_cache_key_passes_none(self):
+        llm, calls = _make_llm("codex")
+        llm.get_llm(cache_key="")
+        assert calls == [{"cache_key": None}]
+
+    def test_codex_stringifies_non_string_cache_key(self):
+        llm, calls = _make_llm("codex")
+        llm.get_llm(cache_key=12345)
+        assert calls == [{"cache_key": "12345"}]
+
+
+class TestOpenAIOptIn:
+    """Regular OpenAI SDK should pass cache_key to factory only when the
+    provider has ``prompt_cache_key: true`` in providers.json."""
+
+    def test_openai_flag_off_passes_none(self):
+        llm, calls = _make_llm("openai", prompt_cache_key_flag=False)
+        llm.get_llm(cache_key="thread-abc-123")
+        assert calls == [{"cache_key": None}]
+
+    def test_openai_flag_on_with_cache_key_passes_to_factory(self):
+        llm, calls = _make_llm("openai", prompt_cache_key_flag=True)
+        llm.get_llm(cache_key="thread-abc-123")
+        assert calls == [{"cache_key": "thread-abc-123"}]
+
+    def test_openai_flag_on_without_cache_key_passes_none(self):
+        llm, calls = _make_llm("openai", prompt_cache_key_flag=True)
+        llm.get_llm(cache_key=None)
+        assert calls == [{"cache_key": None}]
+
+
+class TestNonOpenAIProvidersUnaffected:
+    """Other SDKs should not receive a cache_key kwarg at all — no error."""
+
+    def test_anthropic_with_cache_key_does_not_pass(self):
+        llm, calls = _make_llm("anthropic")
+        llm.get_llm(cache_key="thread-abc-123")
+        assert calls == [{}]
+
+
+class TestProviderFlagExtraction:
+    """``LLM._extract_provider_info`` must read the flag only for sdk == 'openai'.
+    For codex and other SDKs the attribute should default to False."""
+
+    def test_codex_provider_flag_defaults_false(self):
+        llm = LLM.__new__(LLM)
+        llm.sdk = "codex"
+        llm.provider_info = {"prompt_cache_key": True}
+        llm.prompt_cache_key_enabled = (
+            bool(llm.provider_info.get("prompt_cache_key", False))
+            if llm.sdk == "openai"
+            else False
+        )
+        assert llm.prompt_cache_key_enabled is False
+
+    def test_openai_provider_flag_true(self):
+        llm = LLM.__new__(LLM)
+        llm.sdk = "openai"
+        llm.provider_info = {"prompt_cache_key": True}
+        llm.prompt_cache_key_enabled = (
+            bool(llm.provider_info.get("prompt_cache_key", False))
+            if llm.sdk == "openai"
+            else False
+        )
+        assert llm.prompt_cache_key_enabled is True
+
+    def test_openai_provider_flag_absent_defaults_false(self):
+        llm = LLM.__new__(LLM)
+        llm.sdk = "openai"
+        llm.provider_info = {}
+        llm.prompt_cache_key_enabled = (
+            bool(llm.provider_info.get("prompt_cache_key", False))
+            if llm.sdk == "openai"
+            else False
+        )
+        assert llm.prompt_cache_key_enabled is False
+
+
+class TestModelKwargsInjection:
+    """End-to-end: building a real ChatOpenAI / ChatCodexOpenAI through the
+    factory should land ``prompt_cache_key`` in ``model_kwargs`` and survive
+    composition (``bind_tools`` / ``with_structured_output``).
+
+    This is the regression test for the original ``bind()`` approach, where
+    LangChain's ``bind_tools`` produced a fresh RunnableBinding with kwargs
+    ``{'tools': [...]}`` and silently dropped ``prompt_cache_key``.
+    """
+
+    def _build_openai_llm(self, prompt_cache_key_flag: bool) -> LLM:
+        llm = LLM.__new__(LLM)
+        llm.sdk = "openai"
+        llm.provider = "test-openai"
+        llm.provider_info = {"access_type": "platform"}
+        llm.env_key = None
+        llm.base_url = None
+        llm.default_headers = None
+        llm.use_response_api = False
+        llm.use_previous_response_id = False
+        llm.parameters = {}
+        llm.extra_body = {}
+        llm.model = "gpt-4o-mini"
+        llm.api_key_override = "dummy-key"
+        llm.prompt_cache_key_enabled = prompt_cache_key_flag
+        return llm
+
+    def _build_codex_llm(self) -> LLM:
+        llm = LLM.__new__(LLM)
+        llm.sdk = "codex"
+        llm.provider = "test-codex"
+        llm.provider_info = {"access_type": "oauth"}
+        llm.env_key = None
+        llm.base_url = None
+        llm.default_headers = None
+        llm.use_response_api = True
+        llm.parameters = {}
+        llm.extra_body = {}
+        llm.model = "gpt-5"
+        llm.api_key_override = "dummy-codex-key"
+        llm.prompt_cache_key_enabled = False  # ignored on codex path
+        return llm
+
+    def test_openai_flag_on_lands_in_model_kwargs(self):
+        llm = self._build_openai_llm(prompt_cache_key_flag=True)
+        client = llm.get_llm(cache_key="thread-xyz")
+        assert client.model_kwargs.get("prompt_cache_key") == "thread-xyz"
+
+    def test_openai_flag_off_omits_model_kwargs(self):
+        llm = self._build_openai_llm(prompt_cache_key_flag=False)
+        client = llm.get_llm(cache_key="thread-xyz")
+        assert "prompt_cache_key" not in (client.model_kwargs or {})
+
+    def test_codex_always_on_lands_in_model_kwargs(self):
+        llm = self._build_codex_llm()
+        client = llm.get_llm(cache_key="thread-xyz")
+        assert client.model_kwargs.get("prompt_cache_key") == "thread-xyz"
+
+    def test_openai_cache_key_survives_bind_tools(self):
+        """The reason we use model_kwargs and not ``bind()``."""
+        llm = self._build_openai_llm(prompt_cache_key_flag=True)
+        client = llm.get_llm(cache_key="thread-xyz")
+
+        bound = client.bind_tools([])
+        # bind_tools wraps in RunnableBinding with kwargs={'tools': []}.
+        # The underlying ChatOpenAI must keep prompt_cache_key.
+        assert bound.bound.model_kwargs.get("prompt_cache_key") == "thread-xyz"
+
+    def test_openai_cache_key_in_request_payload_after_bind_tools(self):
+        """End-to-end: the SDK request payload must contain prompt_cache_key
+        even after the agent applies bind_tools."""
+        llm = self._build_openai_llm(prompt_cache_key_flag=True)
+        client = llm.get_llm(cache_key="thread-xyz")
+        bound = client.bind_tools([])
+
+        payload = bound.bound._get_request_payload(
+            [{"role": "user", "content": "hi"}], stop=None
+        )
+        assert payload.get("prompt_cache_key") == "thread-xyz"
+
+    def test_openai_user_model_kwargs_preserved(self):
+        """Existing user-supplied ``model_kwargs`` (from llm parameters) must
+        merge with our injection, not get clobbered."""
+        llm = self._build_openai_llm(prompt_cache_key_flag=True)
+        llm.parameters = {"model_kwargs": {"user_field": "keep-me"}}
+        client = llm.get_llm(cache_key="thread-xyz")
+        assert client.model_kwargs.get("user_field") == "keep-me"
+        assert client.model_kwargs.get("prompt_cache_key") == "thread-xyz"
+
+
+class TestNarrowPromptCacheKey:
+    """``narrow_prompt_cache_key`` clones a model with ``:<suffix>`` appended to
+    the existing ``prompt_cache_key`` so parallel sub-tasks (subagents,
+    compaction) don't compete for the main agent's RPM bucket."""
+
+    def _build_openai_with_key(self, key: str | None) -> object:
+        from langchain_openai import ChatOpenAI
+
+        mk = {"prompt_cache_key": key} if key else {}
+        return ChatOpenAI(model="gpt-4o-mini", api_key="dummy", model_kwargs=mk)
+
+    def test_appends_suffix_to_existing_key(self):
+        from src.llms.llm import narrow_prompt_cache_key
+
+        model = self._build_openai_with_key("thread-abc")
+        scoped = narrow_prompt_cache_key(model, "compact")
+
+        assert scoped is not model  # new instance
+        assert scoped.model_kwargs.get("prompt_cache_key") == "thread-abc:compact"
+        # original untouched
+        assert model.model_kwargs.get("prompt_cache_key") == "thread-abc"
+
+    def test_no_op_when_no_existing_key(self):
+        from src.llms.llm import narrow_prompt_cache_key
+
+        model = self._build_openai_with_key(None)
+        scoped = narrow_prompt_cache_key(model, "compact")
+        # No key → nothing to narrow → returns model unchanged.
+        assert scoped is model
+        assert "prompt_cache_key" not in scoped.model_kwargs
+
+    def test_no_op_with_empty_suffix(self):
+        from src.llms.llm import narrow_prompt_cache_key
+
+        model = self._build_openai_with_key("thread-abc")
+        scoped = narrow_prompt_cache_key(model, "")
+        assert scoped is model
+
+    def test_no_op_with_non_chat_model(self):
+        """Strings (subagent ``model: 'openai:gpt-4o'`` overrides) and other
+        non-BaseChatModel objects must pass through untouched — we don't have
+        a model_kwargs handle for them."""
+        from src.llms.llm import narrow_prompt_cache_key
+
+        assert narrow_prompt_cache_key("openai:gpt-4o", "x") == "openai:gpt-4o"
+        assert narrow_prompt_cache_key(None, "x") is None
+        assert narrow_prompt_cache_key(object(), "x") is not None
+
+    def test_preserves_other_model_kwargs(self):
+        from src.llms.llm import narrow_prompt_cache_key
+
+        from langchain_openai import ChatOpenAI
+
+        model = ChatOpenAI(
+            model="gpt-4o-mini",
+            api_key="dummy",
+            model_kwargs={
+                "prompt_cache_key": "thread-abc",
+                "user_field": "keep",
+            },
+        )
+        scoped = narrow_prompt_cache_key(model, "compact")
+        assert scoped.model_kwargs.get("user_field") == "keep"
+        assert scoped.model_kwargs.get("prompt_cache_key") == "thread-abc:compact"
+
+    def test_survives_bind_tools_after_narrowing(self):
+        """The narrowed model must still survive ``bind_tools`` — same property
+        as the original key (this is why we use model_kwargs, not bind())."""
+        from src.llms.llm import narrow_prompt_cache_key
+
+        model = self._build_openai_with_key("thread-abc")
+        scoped = narrow_prompt_cache_key(model, "general-purpose")
+        bound = scoped.bind_tools([])
+        assert (
+            bound.bound.model_kwargs.get("prompt_cache_key")
+            == "thread-abc:general-purpose"
+        )

--- a/tests/unit/llms/test_prompt_cache_key.py
+++ b/tests/unit/llms/test_prompt_cache_key.py
@@ -120,44 +120,6 @@ class TestNonOpenAIProvidersUnaffected:
         assert calls == [{}]
 
 
-class TestProviderFlagExtraction:
-    """``LLM._extract_provider_info`` must read the flag only for sdk == 'openai'.
-    For codex and other SDKs the attribute should default to False."""
-
-    def test_codex_provider_flag_defaults_false(self):
-        llm = LLM.__new__(LLM)
-        llm.sdk = "codex"
-        llm.provider_info = {"prompt_cache_key": True}
-        llm.prompt_cache_key_enabled = (
-            bool(llm.provider_info.get("prompt_cache_key", False))
-            if llm.sdk == "openai"
-            else False
-        )
-        assert llm.prompt_cache_key_enabled is False
-
-    def test_openai_provider_flag_true(self):
-        llm = LLM.__new__(LLM)
-        llm.sdk = "openai"
-        llm.provider_info = {"prompt_cache_key": True}
-        llm.prompt_cache_key_enabled = (
-            bool(llm.provider_info.get("prompt_cache_key", False))
-            if llm.sdk == "openai"
-            else False
-        )
-        assert llm.prompt_cache_key_enabled is True
-
-    def test_openai_provider_flag_absent_defaults_false(self):
-        llm = LLM.__new__(LLM)
-        llm.sdk = "openai"
-        llm.provider_info = {}
-        llm.prompt_cache_key_enabled = (
-            bool(llm.provider_info.get("prompt_cache_key", False))
-            if llm.sdk == "openai"
-            else False
-        )
-        assert llm.prompt_cache_key_enabled is False
-
-
 class TestModelKwargsInjection:
     """End-to-end: building a real ChatOpenAI / ChatCodexOpenAI through the
     factory should land ``prompt_cache_key`` in ``model_kwargs`` and survive

--- a/tests/unit/ptc_agent/agent/test_flash_agent_cache_key.py
+++ b/tests/unit/ptc_agent/agent/test_flash_agent_cache_key.py
@@ -1,0 +1,98 @@
+"""Regression test: ``FlashAgent`` must forward ``config.cache_key`` to
+``create_llm`` on the lazy platform path.
+
+When no OAuth/BYOK/reasoning branch pre-built ``llm_client``, the FlashAgent
+init path falls through to ``create_llm(config.llm.flash)``. Without
+forwarding ``cache_key``, flash-mode chats silently omit ``prompt_cache_key``
+on OpenAI/Codex providers while PTC mode (via ``AgentConfig.get_llm_client()``)
+gets it — flash and PTC must behave the same way.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ptc_agent.config import AgentConfig, LLMConfig
+from ptc_agent.config.core import (
+    DaytonaConfig,
+    FilesystemConfig,
+    LoggingConfig,
+    MCPConfig,
+    SandboxConfig,
+    SecurityConfig,
+)
+
+
+def _flash_config(cache_key: str | None) -> AgentConfig:
+    """Minimal AgentConfig with flash model set and llm_client=None so the
+    FlashAgent init path falls through to ``create_llm(...)``."""
+    return AgentConfig(
+        llm=LLMConfig(name="flash-model", flash="flash-model"),
+        security=SecurityConfig(),
+        logging=LoggingConfig(),
+        sandbox=SandboxConfig(daytona=DaytonaConfig(api_key="test-key")),
+        mcp=MCPConfig(),
+        filesystem=FilesystemConfig(),
+        cache_key=cache_key,
+    )
+
+
+class TestFlashAgentForwardsCacheKey:
+    def test_flash_platform_path_forwards_cache_key(self):
+        """Lazy create_llm path must receive ``cache_key=config.cache_key``."""
+        from ptc_agent.agent.flash.agent import FlashAgent
+
+        config = _flash_config(cache_key="thread-flash-1")
+        mock_llm = MagicMock(name="flash-llm-client")
+        with (
+            patch(
+                "src.llms.llm.ensure_model_in_manifest", return_value=None
+            ),
+            patch("src.llms.create_llm", return_value=mock_llm) as mock_create,
+        ):
+            FlashAgent(config)
+
+        mock_create.assert_called_once()
+        args, kwargs = mock_create.call_args
+        # The model name is positional in the existing call shape.
+        assert args[0] == "flash-model"
+        assert kwargs.get("cache_key") == "thread-flash-1"
+
+    def test_flash_platform_path_with_no_cache_key_passes_none(self):
+        """When no cache_key was stashed (e.g. utility path), still forward None
+        so factory behavior is identical to the pre-fix baseline."""
+        from ptc_agent.agent.flash.agent import FlashAgent
+
+        config = _flash_config(cache_key=None)
+        mock_llm = MagicMock(name="flash-llm-client")
+        with (
+            patch(
+                "src.llms.llm.ensure_model_in_manifest", return_value=None
+            ),
+            patch("src.llms.create_llm", return_value=mock_llm) as mock_create,
+        ):
+            FlashAgent(config)
+
+        _args, kwargs = mock_create.call_args
+        assert kwargs.get("cache_key") is None
+
+    def test_flash_with_prebuilt_client_skips_factory(self):
+        """If OAuth/BYOK already populated llm_client, FlashAgent must use it
+        directly and not call create_llm at all."""
+        from ptc_agent.agent.flash.agent import FlashAgent
+
+        config = _flash_config(cache_key="thread-flash-2")
+        prebuilt = MagicMock(name="prebuilt-flash-llm")
+        config.llm_client = prebuilt
+
+        with patch("src.llms.create_llm") as mock_create:
+            agent = FlashAgent(config)
+
+        assert agent.llm is prebuilt
+        mock_create.assert_not_called()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/server/handlers/test_resolve_llm_config.py
+++ b/tests/unit/server/handlers/test_resolve_llm_config.py
@@ -493,6 +493,32 @@ class TestBYOKResolution:
             )
         mock_resolve.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_default_platform_path_stashes_cache_key(self, base_config):
+        """Regression: the default platform path (no OAuth, no BYOK, no
+        reasoning) must stash ``thread_id`` on ``config.cache_key`` so the
+        lazy ``AgentConfig.get_llm_client()`` can pass it through to
+        ``create_llm(cache_key=...)``. Without this, the most common chat
+        path silently drops ``prompt_cache_key``."""
+        from src.server.handlers.chat.llm_config import resolve_llm_config
+
+        mock_mc = _mock_model_config()
+        with (
+            patch(f"{HANDLER}.get_model_preference", new_callable=AsyncMock, return_value={}),
+            patch(f"{HANDLER}.resolve_oauth_llm_client", new_callable=AsyncMock, return_value=None),
+            patch(f"{HANDLER}.resolve_byok_llm_client", new_callable=AsyncMock, return_value=None),
+            patch("src.llms.llm.LLM.get_model_config", return_value=mock_mc),
+        ):
+            config = await resolve_llm_config(
+                base_config,
+                "user-1",
+                None,
+                False,
+                thread_id="thread-platform-path",
+            )
+        assert config.llm_client is None  # lazy build via get_llm_client()
+        assert config.cache_key == "thread-platform-path"
+
 
 # ---------------------------------------------------------------------------
 # OAuth path

--- a/tests/unit/server/handlers/test_trigger_compaction.py
+++ b/tests/unit/server/handlers/test_trigger_compaction.py
@@ -249,8 +249,10 @@ async def test_manual_compact_forwards_subsidiary_oauth_client(base_config):
     )
 
     oauth_client = MagicMock(name="oauth-codex-client")
+    resolve_kwargs: dict = {}
 
-    async def _resolve_stub(base_cfg, user_id, request_model, is_byok, mode="ptc"):
+    async def _resolve_stub(base_cfg, user_id, request_model, is_byok, mode="ptc", **kwargs):
+        resolve_kwargs.update(kwargs)
         cfg = base_cfg.model_copy(deep=True)
         cfg.llm.compaction = "user-compaction-model"
         cfg.subsidiary_llm_clients["compaction"] = oauth_client
@@ -283,6 +285,9 @@ async def test_manual_compact_forwards_subsidiary_oauth_client(base_config):
         "compaction client so compact_messages doesn't rebuild a bare "
         "system-auth client."
     )
+    # thread_id must reach resolve_llm_config so prompt_cache_key binds to the
+    # session shard when running on an OpenAI-family compaction model.
+    assert resolve_kwargs.get("thread_id") == "thread-1"
 
 
 @pytest.mark.asyncio
@@ -306,8 +311,10 @@ async def test_manual_compact_falls_back_to_main_llm_client(base_config):
     )
 
     main_client = MagicMock(name="main-byok-client")
+    resolve_kwargs: dict = {}
 
-    async def _resolve_stub(base_cfg, user_id, request_model, is_byok, mode="ptc"):
+    async def _resolve_stub(base_cfg, user_id, request_model, is_byok, mode="ptc", **kwargs):
+        resolve_kwargs.update(kwargs)
         cfg = base_cfg.model_copy(deep=True)
         cfg.llm_client = main_client
         # No subsidiary compaction client — user picked default compaction model.
@@ -336,6 +343,7 @@ async def test_manual_compact_falls_back_to_main_llm_client(base_config):
     # permanently set streaming=False on the main agent's shared llm_client.
     main_client.model_copy.assert_called_once_with()
     assert kwargs["llm_client"] is main_client.model_copy.return_value
+    assert resolve_kwargs.get("thread_id") == "thread-1"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds a session-stable `prompt_cache_key` (the thread_id) on OpenAI and Codex SDK requests so multi-turn conversations stay pinned to the same upstream cache shard. Previously every call hash-routed independently and long runs hit cache ~38% of the time; with this in place hit rates should land in the 75–85% range.

**Plumbing**

- New `cache_key` kwarg on `create_llm` / `create_llm_from_custom` / `LLM.get_llm` / `_get_openai_llm` / `_get_codex_llm`.
- Injected via `params["model_kwargs"]["prompt_cache_key"] = cache_key` (not `bind()`) — survives `bind_tools()` and `with_structured_output()`.
- Opt-in flag `prompt_cache_key: true` in `providers.json` for the regular OpenAI variant; **always-on** for the Codex SDK path (matches the upstream Codex CLI's behavior).
- `AgentConfig.cache_key` field forwarded by `get_llm_client()` so the lazy/platform path works without OAuth/BYOK pre-resolution.
- Resolver (`resolve_llm_config`) stashes `thread_id` on the config and passes it through the BYOK/OAuth/fallback branches.
- Flash agent path forwards `cache_key` too.

**Subagent fanout**

- New helper `narrow_prompt_cache_key(model, suffix)` appends `:suffix` to the key so each subagent type lands on its own cache shard. Avoids collisions on OpenAI's ~15 RPM-per-bucket ceiling when multiple subagents fan out concurrently.
- Applied to both built-in `general-purpose` and configured custom subagents.
- No-op when the underlying model has no key set or is not a `BaseChatModel` (e.g. Anthropic, DeepSeek), so the helper is safe to call unconditionally.

**Compaction**

- Inherits the main agent's `prompt_cache_key` unchanged. Different system-prompt prefix means compaction naturally lands in a different cache bucket, no contention with the main agent.

**Defensive cleanup**

- `maybe_disable_streaming` now unwraps `RunnableBindingBase` before checking for `ChatCodexOpenAI` / setting `streaming=False`, so a future caller that wraps the model via `bind()` doesn't silently bypass the Codex guard.

## Test plan

- [x] `uv run pytest tests/unit/llms/test_prompt_cache_key.py tests/unit/llms/test_api_call_streaming.py tests/unit/config/test_agent_config.py tests/unit/server/handlers/test_resolve_llm_config.py tests/unit/server/handlers/test_trigger_compaction.py tests/unit/ptc_agent/agent/test_flash_agent_cache_key.py` — 120/120 pass
- [x] Full `uv run pytest tests/unit/` — 3210 pass (verified prior session)
- [x] `uv run ruff check` clean on all files in this diff
- [x] Codex review pass + `audit-prose` pass + manual P1/P2/P3 amendment cycle (`bind_tools` survival, default platform path, flash gap, RECONNECTABLE_STATUSES revert) all addressed before commit

**Post-merge to verify on a real run:** start a fresh thread on an opted-in OpenAI model, send 5–6 sequential messages, then iterate the resulting trace's child LLM runs and check that `prompt_cache_key` appears on every request payload and overall cache hit rate climbs ≥ 65% (target ~75–85%).