### PR TITLE
Decouple SSE streaming from workflow via Redis Streams

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -144,6 +144,14 @@ REDIS_PASSWORD=redis
 # Override config.yaml redis.max_connections (default 150). Range [1, 10000].
 # REDIS_MAX_CONNECTIONS=300
 
+# =============================================================================
+# SSE — Redis Streams consumer (in-progress refactor)
+# =============================================================================
+# When true, both first-connect and reconnect SSE flow through the XREAD-BLOCK
+# consumer reading workflow:stream:* / subagent:stream:* keys. The dual-write
+# producer is always on; this flag only switches the read side. Default: false.
+# USE_REDIS_STREAM_SSE=false
+
 # Postgres connection pool overrides. Ranges [1, 500].
 # POSTGRES_CHECKPOINTER_POOL_MAX=25
 # POSTGRES_CONVERSATION_POOL_MAX=50

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -401,6 +401,15 @@ def is_subagent_event_redis_spill_enabled() -> bool:
     return get_infrastructure_config().background_execution.spill_subagent_events_to_redis
 
 
+def is_use_redis_stream_sse_enabled() -> bool:
+    """Return True when ``USE_REDIS_STREAM_SSE`` env var is set.
+
+    Routes both first-connect and reconnect SSE through the XREAD BLOCK
+    consumer (``workflow:stream:*`` / ``subagent:stream:*``). Default: False.
+    """
+    return os.getenv("USE_REDIS_STREAM_SSE", "false").lower() in ("true", "1", "yes")
+
+
 def get_sse_drain_timeout() -> float:
     """Get seconds to wait for per-task SSE drain before clearing events."""
     return get_infrastructure_config().background_execution.sse_drain_timeout

--- a/src/ptc_agent/agent/middleware/background_subagent/event_capture.py
+++ b/src/ptc_agent/agent/middleware/background_subagent/event_capture.py
@@ -169,80 +169,14 @@ class SubagentEventCaptureMiddleware(AgentMiddleware):
             try:
                 ai_msg = response.result[0] if response.result else None
                 if ai_msg:
-                    from src.llms.content_utils import format_llm_content
-
-                    formatted = format_llm_content(ai_msg.content)
                     tool_calls = getattr(ai_msg, "tool_calls", None) or []
                     agent_id = self._get_agent_id(tool_call_id)
                     msg_id = getattr(ai_msg, "id", f"msg-{tool_call_id}")
 
-                    # Emit reasoning with start/complete signals so frontend
-                    # can initialize currentReasoningIdRef properly
-                    if formatted.get("reasoning"):
-                        await self.registry.append_captured_event(
-                            tool_call_id,
-                            {
-                                "event": "message_chunk",
-                                "data": {
-                                    "agent": agent_id,
-                                    "id": msg_id,
-                                    "role": "assistant",
-                                    "content": "start",
-                                    "content_type": "reasoning_signal",
-                                },
-                                "ts": time.time(),
-                            },
-                        )
-                        await self.registry.append_captured_event(
-                            tool_call_id,
-                            {
-                                "event": "message_chunk",
-                                "data": {
-                                    "agent": agent_id,
-                                    "id": msg_id,
-                                    "role": "assistant",
-                                    "content": _truncate_content(formatted["reasoning"]),
-                                    "content_type": "reasoning",
-                                    "finish_reason": None,
-                                },
-                                "ts": time.time(),
-                            },
-                        )
-                        await self.registry.append_captured_event(
-                            tool_call_id,
-                            {
-                                "event": "message_chunk",
-                                "data": {
-                                    "agent": agent_id,
-                                    "id": msg_id,
-                                    "role": "assistant",
-                                    "content": "complete",
-                                    "content_type": "reasoning_signal",
-                                },
-                                "ts": time.time(),
-                            },
-                        )
-
-                    # Emit text chunk if present
-                    if formatted.get("text"):
-                        await self.registry.append_captured_event(
-                            tool_call_id,
-                            {
-                                "event": "message_chunk",
-                                "data": {
-                                    "agent": agent_id,
-                                    "id": msg_id,
-                                    "role": "assistant",
-                                    "content": _truncate_content(formatted["text"]),
-                                    "content_type": "text",
-                                    "finish_reason": "tool_calls"
-                                    if tool_calls
-                                    else "stop",
-                                },
-                                "ts": time.time(),
-                            },
-                        )
-
+                    # Text/reasoning tokens are forwarded per-token by
+                    # ``_SubagentTokenForwarder``; capturing them here too
+                    # would duplicate every chunk. Tool calls have no streaming
+                    # counterpart so they stay captured here.
                     if tool_calls:
                         await self.registry.append_captured_event(
                             tool_call_id,

--- a/src/ptc_agent/agent/middleware/background_subagent/middleware.py
+++ b/src/ptc_agent/agent/middleware/background_subagent/middleware.py
@@ -270,6 +270,9 @@ class BackgroundSubagentMiddleware(AgentMiddleware):
                     await cache.delete(
                         f"subagent:events:meta:{self.registry.thread_id}:{task.task_id}"
                     )
+                    await cache.delete(
+                        f"subagent:stream:{self.registry.thread_id}:{task.task_id}"
+                    )
             except Exception:
                 logger.warning(
                     "Failed to clear Redis spool on resume; replay may include stale events",

--- a/src/ptc_agent/agent/middleware/background_subagent/registry.py
+++ b/src/ptc_agent/agent/middleware/background_subagent/registry.py
@@ -34,6 +34,13 @@ DEFAULT_TAIL_MAX_EVENTS = 1000
 # stays open for the rest of the run (see ``_spill_record_to_redis``).
 _SPILL_TIMEOUT_SECONDS = 0.5
 
+# Event-type marker for the per-task stream-end sentinel. The producer writes
+# one of these via ``append_sentinel_to_stream`` when the subagent finishes
+# streaming; the per-task SSE consumer treats it as "drain complete" and exits.
+# Shared between producer (registry) and consumer (stream_from_log) so the
+# string lives in exactly one place.
+SUBAGENT_STREAM_END_EVENT = "subagent_stream_end"
+
 
 def _estimate_record_bytes(record: dict[str, Any]) -> int:
     """Cheap upper-bound estimate of a captured-event record's serialized size.
@@ -541,6 +548,35 @@ class BackgroundTaskRegistry:
             )
             return
 
+        # Pre-render the SSE wire format for the Stream so the consumer can
+        # yield bytes verbatim — no JSON-decode + re-render branch in the read
+        # path. The List keeps storing JSON because the legacy consumer (still
+        # active under USE_REDIS_STREAM_SSE=false) and the post-turn collector
+        # both expect JSON records.
+        try:
+            seq = int(record.get("seq") or 0)
+            data = {
+                **(record.get("data") or {}),
+                "thread_id": self.thread_id,
+                "agent": f"task:{task.task_id}",
+            }
+            stream_payload = (
+                f"id: {seq}\n"
+                f"event: {record.get('event') or 'message_chunk'}\n"
+                f"data: {json.dumps(data, ensure_ascii=False, default=str)}\n\n"
+            )
+        except Exception as exc:
+            task.redis_write_failed = True
+            logger.warning(
+                "subagent_event_spill_failed",
+                phase="render_sse",
+                tool_call_id=task.tool_call_id,
+                task_id=task.task_id,
+                seq=record.get("seq"),
+                error=str(exc),
+            )
+            return
+
         # Serialize spills per task. The registry-wide lock is released
         # before this call so multiple tasks can spill in parallel; the
         # per-task lock guarantees that for any two appends to the SAME
@@ -566,6 +602,7 @@ class BackgroundTaskRegistry:
                         ttl=get_redis_ttl_workflow_events(),
                         last_event_id=record.get("seq"),
                         stream_key=stream_key,
+                        stream_event=stream_payload,
                     ),
                     timeout=_SPILL_TIMEOUT_SECONDS,
                 )
@@ -596,6 +633,90 @@ class BackgroundTaskRegistry:
                 tool_call_id=task.tool_call_id,
                 task_id=task.task_id,
                 seq=record.get("seq"),
+                error=str(exc),
+            )
+
+    async def append_sentinel_to_stream(self, tool_call_id: str) -> None:
+        """Write a stream-end sentinel to the per-task Redis Stream.
+
+        The forwarder calls this once when ``_arun_subagent_streaming`` exits
+        its astream loop — the canonical "no more events coming" moment. The
+        per-task SSE consumer recognises the record and closes immediately,
+        instead of polling ``task.asyncio_task.done()`` between BLOCK timeouts.
+
+        Bypasses ``captured_events_tail`` / Redis List / Postgres persistence:
+        this is a transport-level signal, not content. Best-effort — if it
+        fails, ``terminal_check`` still closes the stream once the asyncio
+        task finishes (just slower).
+        """
+        if not self.thread_id:
+            return
+
+        async with self._lock:
+            task = self._tasks.get(tool_call_id)
+            if not task:
+                return
+
+        if task.redis_write_failed:
+            return
+
+        try:
+            from src.config.settings import (
+                get_max_stored_messages_per_agent,
+                get_redis_ttl_workflow_events,
+                is_subagent_event_redis_spill_enabled,
+            )
+        except Exception:
+            return
+
+        try:
+            if not is_subagent_event_redis_spill_enabled():
+                return
+        except Exception:
+            return
+
+        try:
+            from src.utils.cache.redis_cache import get_cache_client
+
+            cache = get_cache_client()
+        except Exception:
+            return
+
+        if not getattr(cache, "enabled", False) or not getattr(cache, "client", None):
+            return
+
+        stream_key = f"subagent:stream:{self.thread_id}:{task.task_id}"
+        payload = json.dumps(
+            {"event": SUBAGENT_STREAM_END_EVENT}, ensure_ascii=False
+        ).encode("utf-8")
+
+        # Hold redis_spill_lock across pipe.execute() so the sentinel cannot
+        # land before an in-flight content spill on the same task. Auto-id
+        # XADD ordering is only a server-side guarantee — once two pipelines
+        # are both in flight, either can win the race. The per-task lock is
+        # the issue-order guarantee: a concurrent content spill must finish
+        # its XADD before the sentinel's pipeline opens; otherwise the
+        # consumer exits on the sentinel and the late content event is lost.
+        # _SPILL_TIMEOUT_SECONDS caps queue depth under load.
+        try:
+            async with task.redis_spill_lock:
+                async with cache.client.pipeline(transaction=False) as pipe:
+                    pipe.xadd(
+                        stream_key,
+                        {b"event": payload},
+                        maxlen=get_max_stored_messages_per_agent(),
+                        approximate=True,
+                    )
+                    pipe.expire(stream_key, get_redis_ttl_workflow_events())
+                    await asyncio.wait_for(
+                        pipe.execute(),
+                        timeout=_SPILL_TIMEOUT_SECONDS,
+                    )
+        except Exception as exc:
+            logger.debug(
+                "subagent_stream_end_sentinel_failed",
+                tool_call_id=tool_call_id,
+                task_id=task.task_id,
                 error=str(exc),
             )
 

--- a/src/ptc_agent/agent/middleware/background_subagent/registry.py
+++ b/src/ptc_agent/agent/middleware/background_subagent/registry.py
@@ -525,6 +525,7 @@ class BackgroundTaskRegistry:
         # deploy boundary. New runs write fresh records.
         events_key = f"subagent:events:{self.thread_id}:{task.task_id}"
         meta_key = f"subagent:events:meta:{self.thread_id}:{task.task_id}"
+        stream_key = f"subagent:stream:{self.thread_id}:{task.task_id}"
 
         try:
             payload = json.dumps(record, ensure_ascii=False, default=str)
@@ -564,6 +565,7 @@ class BackgroundTaskRegistry:
                         max_size=get_max_stored_messages_per_agent(),
                         ttl=get_redis_ttl_workflow_events(),
                         last_event_id=record.get("seq"),
+                        stream_key=stream_key,
                     ),
                     timeout=_SPILL_TIMEOUT_SECONDS,
                 )

--- a/src/ptc_agent/agent/middleware/background_subagent/registry.py
+++ b/src/ptc_agent/agent/middleware/background_subagent/registry.py
@@ -660,22 +660,17 @@ class BackgroundTaskRegistry:
         if task.redis_write_failed:
             return
 
+        # Defensive guard: settings/cache imports are stable in normal
+        # operation, so a raise here means a broken deployment — bail
+        # quietly rather than crash the producer's astream loop.
         try:
             from src.config.settings import (
                 get_max_stored_messages_per_agent,
                 get_redis_ttl_workflow_events,
                 is_subagent_event_redis_spill_enabled,
             )
-        except Exception:
-            return
-
-        try:
             if not is_subagent_event_redis_spill_enabled():
                 return
-        except Exception:
-            return
-
-        try:
             from src.utils.cache.redis_cache import get_cache_client
 
             cache = get_cache_client()
@@ -698,6 +693,16 @@ class BackgroundTaskRegistry:
         # its XADD before the sentinel's pipeline opens; otherwise the
         # consumer exits on the sentinel and the late content event is lost.
         # _SPILL_TIMEOUT_SECONDS caps queue depth under load.
+        #
+        # ``wait_for`` timeout window: if the timeout fires *after*
+        # ``pipe.execute()`` has already dispatched the commands but before
+        # Redis ACKs, the sentinel XADD has already landed. The lock is then
+        # released and a queued content spill will write its XADD *after* the
+        # sentinel — at which point the consumer has already exited on the
+        # sentinel and that late event is lost. Best-effort by design; the
+        # sub-500-ms window makes it astronomically unlikely under normal
+        # load, and the fallback (``terminal_check`` closes the stream once
+        # the asyncio task finishes) still fires on the next BLOCK timeout.
         try:
             async with task.redis_spill_lock:
                 async with cache.client.pipeline(transaction=False) as pipe:

--- a/src/ptc_agent/agent/middleware/background_subagent/subagent.py
+++ b/src/ptc_agent/agent/middleware/background_subagent/subagent.py
@@ -1,5 +1,6 @@
 """Middleware for providing subagents to an agent via a `Task` tool."""
 
+import time
 from collections.abc import Awaitable, Callable, Sequence
 from typing import Annotated, Any, NotRequired, TypedDict, cast
 
@@ -13,7 +14,7 @@ from langchain.agents.middleware.types import (
 )
 from langchain.tools import BaseTool, ToolRuntime
 from langchain_core.language_models import BaseChatModel
-from langchain_core.messages import HumanMessage, ToolMessage
+from langchain_core.messages import BaseMessage, HumanMessage, ToolMessage
 from langchain_core.runnables import Runnable
 from langchain_core.tools import StructuredTool
 from langgraph.config import get_config
@@ -26,8 +27,139 @@ from ptc_agent.agent.middleware.background_subagent.middleware import (
 from ptc_agent.agent.middleware.background_subagent.registry import BackgroundTaskRegistry
 from ptc_agent.agent.middleware._utils import append_to_system_message
 from src.llms.llm import narrow_prompt_cache_key
+from src.server.utils.content_normalizer import normalize_text_content
 
 logger = structlog.get_logger(__name__)
+
+
+class _SubagentTokenForwarder:
+    """Forward per-token ``messages``-mode chunks from subagent.astream into
+    captured-event records on the registry.
+
+    Mirrors the main streaming handler's reasoning lifecycle: a ``start``
+    reasoning_signal fires on the first reasoning chunk, ``complete`` fires
+    on transition to text content or message_id change. Without this, the
+    frontend's reasoning UI never opens (it gates on the start signal).
+
+    Tool-call/tool-call-result events still come from
+    ``SubagentEventCaptureMiddleware.awrap_*_call`` — those are post-call
+    discrete signals, not stream-able token deltas.
+    """
+
+    def __init__(
+        self,
+        registry: BackgroundTaskRegistry,
+        tool_call_id: str,
+        agent_id: str,
+    ) -> None:
+        self.registry = registry
+        self.tool_call_id = tool_call_id
+        self.agent_id = agent_id
+        self._reasoning_active = False
+        self._last_msg_id: str | None = None
+
+    def _signal_record(self, msg_id: str, content: str) -> dict[str, Any]:
+        return {
+            "event": "message_chunk",
+            "data": {
+                "agent": self.agent_id,
+                "id": msg_id,
+                "role": "assistant",
+                "content": content,
+                "content_type": "reasoning_signal",
+            },
+            "ts": time.time(),
+        }
+
+    def _chunk_record(
+        self,
+        msg_id: str,
+        text: str,
+        content_type: str,
+        finish_reason: str | None = None,
+    ) -> dict[str, Any]:
+        return {
+            "event": "message_chunk",
+            "data": {
+                "agent": self.agent_id,
+                "id": msg_id,
+                "role": "assistant",
+                "content": text,
+                "content_type": content_type,
+                "finish_reason": finish_reason,
+            },
+            "ts": time.time(),
+        }
+
+    async def forward(self, message_chunk: BaseMessage) -> None:
+        # Reasoning content can ride on either ``content`` or
+        # ``additional_kwargs.reasoning[_content]`` depending on provider.
+        text, content_type = normalize_text_content(message_chunk.content)
+        reasoning_kw = (
+            message_chunk.additional_kwargs.get("reasoning_content")
+            or message_chunk.additional_kwargs.get("reasoning")
+        )
+        if reasoning_kw and not text:
+            r_text, _ = normalize_text_content(reasoning_kw)
+            if r_text:
+                text = r_text
+                content_type = "reasoning"
+
+        msg_id = message_chunk.id or f"sg-{self.tool_call_id}"
+
+        # New message id with reasoning still active → close out the old one.
+        if (
+            self._last_msg_id is not None
+            and msg_id != self._last_msg_id
+            and self._reasoning_active
+        ):
+            await self.registry.append_captured_event(
+                self.tool_call_id, self._signal_record(self._last_msg_id, "complete")
+            )
+            self._reasoning_active = False
+
+        if text and content_type:
+            # Inline reasoning lifecycle — start on first reasoning chunk,
+            # complete on transition to text.
+            if content_type == "reasoning" and not self._reasoning_active:
+                await self.registry.append_captured_event(
+                    self.tool_call_id, self._signal_record(msg_id, "start")
+                )
+                self._reasoning_active = True
+            elif content_type == "text" and self._reasoning_active:
+                await self.registry.append_captured_event(
+                    self.tool_call_id, self._signal_record(msg_id, "complete")
+                )
+                self._reasoning_active = False
+
+            await self.registry.append_captured_event(
+                self.tool_call_id,
+                self._chunk_record(msg_id, text, content_type),
+            )
+
+        self._last_msg_id = msg_id
+
+    async def finalize(self) -> None:
+        """Close any still-open reasoning lifecycle and signal stream-end.
+
+        The stream-end sentinel is what tells the per-task SSE consumer it can
+        close immediately — without it the consumer falls back to polling
+        ``task.asyncio_task.done()`` between XREAD BLOCK timeouts (~4-8 s) and
+        in some flows waits until the post-turn collector flips
+        ``task.completed``. Best-effort: failures in the sentinel write are
+        absorbed so a degraded Redis can't break subagent termination.
+        """
+        if self._reasoning_active and self._last_msg_id is not None:
+            await self.registry.append_captured_event(
+                self.tool_call_id,
+                self._signal_record(self._last_msg_id, "complete"),
+            )
+            self._reasoning_active = False
+
+        try:
+            await self.registry.append_sentinel_to_stream(self.tool_call_id)
+        except Exception:
+            pass
 
 
 class SubAgent(TypedDict):
@@ -265,6 +397,65 @@ def _create_task_tool(
         checkpointer=checkpointer,
     )
 
+    async def _arun_subagent_streaming(
+        subagent: Runnable,
+        state: dict,
+        config: dict,
+    ) -> dict:
+        """Drive the subagent through ``astream`` with combined ``values`` and
+        ``messages`` modes; return the final state.
+
+        ``values`` mode yields full state snapshots; the last one is the
+        tool's return value. ``messages`` mode yields per-token
+        ``AIMessageChunk`` deltas forwarded to the registry as
+        ``message_chunk`` records for per-task SSE granularity.
+
+        ``stream_mode=["values", "messages"]`` yields ``(mode, data)`` tuples;
+        ``messages`` data is ``(message_chunk, metadata)``.
+        """
+        last_state: dict | None = None
+        forwarder: _SubagentTokenForwarder | None = None
+
+        if registry is not None:
+            tool_call_id = current_background_tool_call_id.get()
+            if tool_call_id:
+                bg_task = registry.get_by_tool_call_id(tool_call_id)
+                if bg_task is not None:
+                    forwarder = _SubagentTokenForwarder(
+                        registry,
+                        tool_call_id,
+                        f"task:{bg_task.task_id}",
+                    )
+
+        try:
+            async for mode, data in subagent.astream(
+                state, config, stream_mode=["values", "messages"]
+            ):
+                if mode == "values":
+                    last_state = data
+                elif mode == "messages" and forwarder is not None:
+                    # ``messages`` data is ``(message_chunk, metadata)``;
+                    # we only need the chunk. Duck-typed (no isinstance) so
+                    # mocks and any future BaseMessage subclasses pass.
+                    chunk = data[0] if isinstance(data, tuple) else data
+                    if chunk is not None and hasattr(chunk, "content"):
+                        try:
+                            await forwarder.forward(chunk)
+                        except Exception as exc:
+                            # Token forwarding must never break the subagent.
+                            logger.debug(
+                                "Subagent token forwarding failed",
+                                error=str(exc),
+                            )
+        finally:
+            if forwarder is not None:
+                try:
+                    await forwarder.finalize()
+                except Exception:
+                    pass
+
+        return last_state if last_state is not None else {}
+
     def _return_command_with_state_update(result: dict, tool_call_id: str) -> Command:
         # Validate that the result contains a 'messages' key
         if "messages" not in result:
@@ -494,7 +685,7 @@ def _create_task_tool(
                 parent_thread_id=parent_configurable.get("thread_id", ""),
                 subagent_type=effective_type,
             )
-            result = await subagent.ainvoke(invoke_state, config)
+            result = await _arun_subagent_streaming(subagent, invoke_state, config)
         else:
             # New task: use parent's thread_id + checkpoint_ns for isolation
             _subagent, subagent_state = _validate_and_prepare_state(
@@ -530,7 +721,7 @@ def _create_task_tool(
                     config = {}
                 config["callbacks"] = callbacks
 
-            result = await subagent.ainvoke(subagent_state, config)
+            result = await _arun_subagent_streaming(subagent, subagent_state, config)
 
         if not runtime.tool_call_id:
             value_error_msg = "Tool call ID is required for subagent invocation"

--- a/src/server/app/threads.py
+++ b/src/server/app/threads.py
@@ -20,7 +20,7 @@ import asyncio
 import hmac
 import os
 
-from fastapi import APIRouter, HTTPException, Path, Query, Request
+from fastapi import APIRouter, Header, HTTPException, Path, Query, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 
 from src.server.utils.api import (
@@ -601,14 +601,23 @@ async def reconnect_to_stream(
     thread_id: str,
     x_user_id: CurrentUserId,
     last_event_id: Optional[int] = Query(None, description="Last received event ID"),
+    last_event_id_header: Optional[str] = Header(None, alias="Last-Event-ID"),
 ):
     """
     Reconnect to a running or completed workflow's SSE stream.
 
     Replays buffered events, then attaches to live stream if still running.
+    Accepts the cursor as either ``?last_event_id=N`` (existing) or the
+    SSE-spec ``Last-Event-ID`` HTTP header (preferred when present).
     """
     await require_thread_owner(thread_id, x_user_id)
     from src.server.handlers.chat import reconnect_to_workflow_stream
+
+    if last_event_id is None and last_event_id_header is not None:
+        try:
+            last_event_id = int(last_event_id_header)
+        except ValueError:
+            pass  # Invalid header → fall through, treated as no resume.
 
     async def stream_reconnection():
         try:
@@ -923,10 +932,21 @@ async def stream_subagent_task(
     last_event_id: Optional[int] = Query(
         None, description="Last received event ID for reconnect"
     ),
+    last_event_id_header: Optional[str] = Header(None, alias="Last-Event-ID"),
 ):
-    """Stream a single subagent's content events (message_chunk, tool_calls, etc.)."""
+    """Stream a single subagent's content events (message_chunk, tool_calls, etc.).
+
+    Accepts the cursor as either ``?last_event_id=N`` or the SSE-spec
+    ``Last-Event-ID`` HTTP header.
+    """
     await require_thread_owner(thread_id, x_user_id)
     from src.server.handlers.chat import stream_subagent_task_events
+
+    if last_event_id is None and last_event_id_header is not None:
+        try:
+            last_event_id = int(last_event_id_header)
+        except ValueError:
+            pass
 
     return StreamingResponse(
         stream_subagent_task_events(thread_id, task_id, last_event_id),

--- a/src/server/handlers/chat/ptc_workflow.py
+++ b/src/server/handlers/chat/ptc_workflow.py
@@ -77,7 +77,7 @@ from ._common import (
     stream_live_events,
     wait_or_steer,
 )
-from src.config.settings import get_ptc_recursion_limit
+from src.config.settings import get_ptc_recursion_limit, is_use_redis_stream_sse_enabled
 
 from .llm_config import resolve_llm_config
 from .steering import backfill_steering_queries
@@ -896,21 +896,30 @@ async def astream_ptc_workflow(
             f"[PTC_TIMING] thread_id={thread_id} model={model_tag} total={total_ms:.0f}ms ({phases})"
         )
 
-        async for event in stream_live_events(
-            manager=manager,
-            tracker=tracker,
-            thread_id=thread_id,
-            workspace_id=workspace_id,
-            user_id=user_id,
-            handler=handler,
-            token_callback=token_callback,
-            persistence_service=persistence_service,
-            start_time=start_time,
-            request=request,
-            is_byok=is_byok,
-            log_prefix="PTC_CHAT",
-        ):
-            yield event
+        if is_use_redis_stream_sse_enabled():
+            # Stream-backed first-connect: read from workflow:stream:{thread_id}
+            # via XREAD BLOCK. The workflow runs as a fully detached background
+            # task — disconnect cannot reach it.
+            from .stream_from_log import stream_from_log
+
+            async for event in stream_from_log(thread_id, last_event_id=None):
+                yield event
+        else:
+            async for event in stream_live_events(
+                manager=manager,
+                tracker=tracker,
+                thread_id=thread_id,
+                workspace_id=workspace_id,
+                user_id=user_id,
+                handler=handler,
+                token_callback=token_callback,
+                persistence_service=persistence_service,
+                start_time=start_time,
+                request=request,
+                is_byok=is_byok,
+                log_prefix="PTC_CHAT",
+            ):
+                yield event
 
     except (asyncio.CancelledError, GeneratorExit):
         if slot_owned:

--- a/src/server/handlers/chat/stream_from_log.py
+++ b/src/server/handlers/chat/stream_from_log.py
@@ -1,0 +1,283 @@
+"""Redis-Streams-backed SSE consumer.
+
+Replaces the parallel live-queue / List-replay paths with one XREAD BLOCK
+loop that every consumer (first-connect, reconnect, second tab, subagent
+SSE, late subscriber) traverses identically. The workflow is a fire-and-
+forget producer that writes to ``workflow:stream:{thread_id}`` and
+``subagent:stream:{thread_id}:{task_id}``; consumers attach by stream key
+and read by cursor — they share no in-process state with the workflow.
+
+Gated behind ``USE_REDIS_STREAM_SSE`` per request.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, AsyncGenerator, Awaitable, Callable, Optional
+
+from src.server.services.background_registry_store import BackgroundRegistryStore
+from src.server.services.background_task_manager import (
+    BackgroundTaskManager,
+    TaskStatus,
+)
+from src.utils.cache.redis_cache import get_cache_client
+
+logger = logging.getLogger(__name__)
+
+# XREAD BLOCK timeout. Long enough to avoid CPU-burning polling, short
+# enough to keep proxies / load balancers from severing idle SSE
+# connections (CDNs typically idle-time at 60–120 s).
+_XREAD_BLOCK_MS = 30_000
+
+# Cap entries per XREAD round. Keeps us responsive to terminal-check
+# polling under sustained traffic without per-event round-trips.
+_XREAD_COUNT = 100
+
+# Startup window for subagent: how long to wait for the registry/task
+# to come into existence before giving up. The registry is created when
+# the subagent middleware first runs; for short-lived turns it can take
+# a few seconds.
+_SUBAGENT_STARTUP_TIMEOUT = 30.0
+_SUBAGENT_STARTUP_POLL = 0.5
+
+
+async def _stream_from_redis_log(
+    stream_key: str,
+    terminal_check: Callable[[], Awaitable[bool]],
+    last_event_id: Optional[int] = None,
+    on_attach: Optional[Callable[[], Awaitable[None]]] = None,
+    on_detach: Optional[Callable[[], Awaitable[None]]] = None,
+) -> AsyncGenerator[str, None]:
+    """Generic XREAD BLOCK loop yielding SSE strings stored in a Redis Stream.
+
+    Cursor semantics:
+    - ``last_event_id is None`` → start at ``$`` (live tail; emit only
+      events appended after attach).
+    - ``last_event_id == 0`` → start at ``0`` (replay from the beginning).
+    - ``last_event_id > 0`` → resume after seq N (XREAD's ``after`` is
+      exclusive on the explicit ID).
+
+    ``terminal_check()`` is invoked after each empty XREAD round (BLOCK
+    timed out with no new entries) — when it returns True and the next
+    XREAD round still returns no entries, the generator exits.
+
+    ``on_attach``/``on_detach`` let subagent consumers maintain
+    ``sse_consumer_count`` so cleanup waits for live readers to drain
+    before DELing the stream.
+    """
+    cache = get_cache_client()
+    if not cache.enabled or not cache.client:
+        logger.warning(
+            "[stream_from_log] Redis disabled — no events to stream for %s",
+            stream_key,
+        )
+        return
+
+    if last_event_id is None:
+        cursor: bytes = b"$"
+    elif last_event_id <= 0:
+        cursor = b"0"
+    else:
+        # XREAD reads strictly AFTER the given ID; use `<seq>-0` to start
+        # right after seq N (so the next entry seq=N+1 is returned).
+        cursor = f"{last_event_id}-0".encode("utf-8")
+
+    if on_attach is not None:
+        await on_attach()
+
+    stream_key_bytes = stream_key.encode("utf-8")
+
+    try:
+        terminal_seen = False
+        while True:
+            try:
+                # asyncio.wait_for guards against the underlying redis-py
+                # XREAD hanging past BLOCK if the connection is poisoned.
+                result = await asyncio.wait_for(
+                    cache.client.xread(
+                        {stream_key_bytes: cursor},
+                        block=_XREAD_BLOCK_MS,
+                        count=_XREAD_COUNT,
+                    ),
+                    timeout=(_XREAD_BLOCK_MS / 1000.0) + 5.0,
+                )
+            except asyncio.TimeoutError:
+                # XREAD wedged — yield keepalive, recheck terminal, retry.
+                yield ":keepalive\n\n"
+                if await terminal_check():
+                    if terminal_seen:
+                        return
+                    terminal_seen = True
+                continue
+            except (asyncio.CancelledError, GeneratorExit):
+                raise
+            except Exception as exc:
+                logger.warning(
+                    "[stream_from_log] XREAD failed on %s: %s",
+                    stream_key,
+                    exc,
+                )
+                # If the workflow has already terminated and reads are now
+                # erroring (likely Redis transient + stream already DEL'd),
+                # there is nothing more to drain — exit instead of looping.
+                if await terminal_check():
+                    return
+                # Brief backoff to avoid tight error loops, then retry.
+                await asyncio.sleep(0.5)
+                continue
+
+            if not result:
+                # BLOCK timed out — emit keepalive comment so proxies and
+                # the browser see liveness, then re-check terminal.
+                yield ":keepalive\n\n"
+                if await terminal_check():
+                    if terminal_seen:
+                        return
+                    terminal_seen = True
+                continue
+
+            # result format: [(stream_key, [(entry_id, {field: value}), ...])]
+            for _stream_name, entries in result:
+                for entry_id, fields in entries:
+                    payload = fields.get(b"event")
+                    if payload is None:
+                        continue
+                    if isinstance(payload, bytes):
+                        try:
+                            yield payload.decode("utf-8")
+                        except UnicodeDecodeError:
+                            logger.warning(
+                                "[stream_from_log] Non-UTF8 payload in %s entry %s",
+                                stream_key,
+                                entry_id,
+                            )
+                            continue
+                    else:
+                        yield payload
+                    cursor = entry_id
+
+            # Reset terminal-seen flag whenever we emit new events; the
+            # exit handshake requires two consecutive empty rounds with
+            # terminal=True so we don't race past the trailing tail.
+            terminal_seen = False
+    finally:
+        if on_detach is not None:
+            try:
+                await on_detach()
+            except Exception:
+                logger.exception("[stream_from_log] on_detach hook raised for %s", stream_key)
+
+
+# ---------------------------------------------------------------------------
+# Main-workflow consumer
+# ---------------------------------------------------------------------------
+
+
+async def stream_from_log(
+    thread_id: str,
+    last_event_id: Optional[int] = None,
+) -> AsyncGenerator[str, None]:
+    """SSE consumer for the main workflow stream.
+
+    First-connect callers pass ``last_event_id=None`` (start at $); reconnect
+    callers pass the integer seq from ``Last-Event-ID`` / ``?last_event_id=``
+    so XREAD resumes after that seq.
+    """
+    manager = BackgroundTaskManager.get_instance()
+
+    async def terminal_check() -> bool:
+        status = await manager.get_task_status(thread_id)
+        return status in (TaskStatus.COMPLETED, TaskStatus.FAILED, TaskStatus.CANCELLED)
+
+    async for event in _stream_from_redis_log(
+        stream_key=f"workflow:stream:{thread_id}",
+        terminal_check=terminal_check,
+        last_event_id=last_event_id,
+    ):
+        yield event
+
+
+# ---------------------------------------------------------------------------
+# Subagent-task consumer
+# ---------------------------------------------------------------------------
+
+
+async def _wait_for_subagent_task(thread_id: str, task_id: str) -> Any:
+    """Block until the per-task BackgroundTask exists, or timeout.
+
+    Returns the task object on success, None on timeout.
+    """
+    registry_store = BackgroundRegistryStore.get_instance()
+    waited = 0.0
+    while waited < _SUBAGENT_STARTUP_TIMEOUT:
+        registry = await registry_store.get_registry(thread_id)
+        if registry is not None:
+            task = await registry.get_task_by_task_id(task_id)
+            if task is not None:
+                return task
+        await asyncio.sleep(_SUBAGENT_STARTUP_POLL)
+        waited += _SUBAGENT_STARTUP_POLL
+    return None
+
+
+async def stream_subagent_from_log(
+    thread_id: str,
+    task_id: str,
+    last_event_id: Optional[int] = None,
+) -> AsyncGenerator[str, None]:
+    """SSE consumer for a single subagent's stream.
+
+    Mirrors ``stream_from_log`` but adds:
+    - Startup-window wait for the registry/task to exist.
+    - ``sse_consumer_count`` increment/decrement so cleanup waits for live
+      readers before DELing the stream key.
+    - Terminal predicate that checks task completion (``task.completed`` or
+      ``task.asyncio_task.done()``).
+
+    On startup-timeout (no task ever appears), we still tail the Redis
+    Stream for ``last_event_id`` replay — the producer may have written
+    events that arrived before the registry call finished registering.
+    """
+    task = await _wait_for_subagent_task(thread_id, task_id)
+
+    if task is None:
+        # No registry — treat as a pure replay-from-Redis case. If the
+        # stream key doesn't exist either (TTL expired or never written),
+        # XREAD returns empty and we fall out via the terminal check.
+        async def _term_no_task() -> bool:
+            return True  # Nothing to wait for; stream is already at end.
+
+        async for event in _stream_from_redis_log(
+            stream_key=f"subagent:stream:{thread_id}:{task_id}",
+            terminal_check=_term_no_task,
+            last_event_id=last_event_id,
+        ):
+            yield event
+        return
+
+    async def on_attach() -> None:
+        task.sse_consumer_count += 1
+
+    async def on_detach() -> None:
+        task.sse_consumer_count -= 1
+        if task.sse_consumer_count <= 0:
+            try:
+                task.sse_drain_complete.set()
+            except Exception:
+                pass
+
+    async def terminal_check() -> bool:
+        if task.completed:
+            return True
+        ato = task.asyncio_task
+        return ato is not None and ato.done()
+
+    async for event in _stream_from_redis_log(
+        stream_key=f"subagent:stream:{thread_id}:{task_id}",
+        terminal_check=terminal_check,
+        last_event_id=last_event_id,
+        on_attach=on_attach,
+        on_detach=on_detach,
+    ):
+        yield event

--- a/src/server/handlers/chat/stream_from_log.py
+++ b/src/server/handlers/chat/stream_from_log.py
@@ -7,15 +7,25 @@ forget producer that writes to ``workflow:stream:{thread_id}`` and
 ``subagent:stream:{thread_id}:{task_id}``; consumers attach by stream key
 and read by cursor — they share no in-process state with the workflow.
 
+Both streams store pre-rendered SSE wire strings in the steady state.
+The subagent consumer also handles legacy JSON records
+(``{seq, event, data, agent_id}``) written by earlier producer
+versions — those age out after their TTL window.
+
 Gated behind ``USE_REDIS_STREAM_SSE`` per request.
 """
 
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from typing import Any, AsyncGenerator, Awaitable, Callable, Optional
 
+from src.config.settings import get_redis_socket_timeout
+from ptc_agent.agent.middleware.background_subagent.registry import (
+    SUBAGENT_STREAM_END_EVENT,
+)
 from src.server.services.background_registry_store import BackgroundRegistryStore
 from src.server.services.background_task_manager import (
     BackgroundTaskManager,
@@ -25,10 +35,33 @@ from src.utils.cache.redis_cache import get_cache_client
 
 logger = logging.getLogger(__name__)
 
-# XREAD BLOCK timeout. Long enough to avoid CPU-burning polling, short
-# enough to keep proxies / load balancers from severing idle SSE
-# connections (CDNs typically idle-time at 60–120 s).
-_XREAD_BLOCK_MS = 30_000
+
+_XREAD_BLOCK_MARGIN_MS = 1_000
+_XREAD_BLOCK_FLOOR_MS = 500
+
+
+def _xread_block_ms() -> int:
+    """Compute XREAD's BLOCK arg given the pool's socket_timeout.
+
+    redis-py applies the connection's ``socket_timeout`` to every command,
+    blocking ones included. If BLOCK >= socket_timeout the socket read
+    raises ``Timeout reading from redis`` before XREAD ever returns. We
+    keep BLOCK strictly below socket_timeout by ``_XREAD_BLOCK_MARGIN_MS``
+    (1 s by default — the cost is one extra XREAD round-trip per
+    ``socket_timeout - 1`` s on idle streams, negligible vs LLM latency).
+
+    When ``socket_timeout`` is configured very low (1-2 s) the natural
+    ``timeout - margin`` would go to zero or negative; we floor at
+    ``_XREAD_BLOCK_FLOOR_MS`` (500 ms) so the consumer still polls at a
+    sane cadence. The accepted trade-off is that with ``socket_timeout=1
+    s`` the safety margin shrinks from 1 s to 500 ms — still positive, but
+    redis-py is more likely to win the race and surface a Timeout. Bump
+    ``redis.socket_timeout`` (config.yaml) above 2 s in production.
+    """
+    socket_seconds = get_redis_socket_timeout() or 5
+    socket_ms = max(1, socket_seconds) * 1_000
+    return max(_XREAD_BLOCK_FLOOR_MS, socket_ms - _XREAD_BLOCK_MARGIN_MS)
+
 
 # Cap entries per XREAD round. Keeps us responsive to terminal-check
 # polling under sustained traffic without per-event round-trips.
@@ -51,16 +84,21 @@ async def _stream_from_redis_log(
 ) -> AsyncGenerator[str, None]:
     """Generic XREAD BLOCK loop yielding SSE strings stored in a Redis Stream.
 
-    Cursor semantics:
-    - ``last_event_id is None`` → start at ``$`` (live tail; emit only
-      events appended after attach).
-    - ``last_event_id == 0`` → start at ``0`` (replay from the beginning).
-    - ``last_event_id > 0`` → resume after seq N (XREAD's ``after`` is
-      exclusive on the explicit ID).
+    Cursor semantics (``last_event_id`` argument):
+    - ``None`` or ``<= 0`` → start at ``0`` (replay everything in the
+      stream + then wait for new). This is the right default for a fresh
+      attach: chat clients want history first, then live updates. The
+      ``$`` ("live tail only") cursor is intentionally NOT exposed because
+      no caller currently wants it — by the time per-task SSE consumers
+      attach, the subagent has already been writing events for hundreds
+      of ms, and live-tail-only would miss them.
+    - ``> 0`` → resume after seq N (XREAD's ``after`` is exclusive on the
+      explicit ID, so the next emitted entry will be seq=N+1).
 
-    ``terminal_check()`` is invoked after each empty XREAD round (BLOCK
-    timed out with no new entries) — when it returns True and the next
-    XREAD round still returns no entries, the generator exits.
+    ``terminal_check()`` is invoked after each empty XREAD round — when
+    it returns True and the next XREAD round still returns no entries,
+    the generator exits (two-empty-round handshake avoids missing a late
+    tail event between status flip and stream drain).
 
     ``on_attach``/``on_detach`` let subagent consumers maintain
     ``sse_consumer_count`` so cleanup waits for live readers to drain
@@ -74,33 +112,34 @@ async def _stream_from_redis_log(
         )
         return
 
-    if last_event_id is None:
-        cursor: bytes = b"$"
-    elif last_event_id <= 0:
-        cursor = b"0"
+    if last_event_id is None or last_event_id <= 0:
+        cursor: bytes = b"0"
     else:
         # XREAD reads strictly AFTER the given ID; use `<seq>-0` to start
         # right after seq N (so the next entry seq=N+1 is returned).
         cursor = f"{last_event_id}-0".encode("utf-8")
 
-    if on_attach is not None:
-        await on_attach()
-
     stream_key_bytes = stream_key.encode("utf-8")
+    block_ms = _xread_block_ms()
 
+    attached = False
     try:
+        if on_attach is not None:
+            await on_attach()
+            attached = True
         terminal_seen = False
         while True:
             try:
                 # asyncio.wait_for guards against the underlying redis-py
                 # XREAD hanging past BLOCK if the connection is poisoned.
+                # The buffer is small because BLOCK is already < socket_timeout.
                 result = await asyncio.wait_for(
                     cache.client.xread(
                         {stream_key_bytes: cursor},
-                        block=_XREAD_BLOCK_MS,
+                        block=block_ms,
                         count=_XREAD_COUNT,
                     ),
-                    timeout=(_XREAD_BLOCK_MS / 1000.0) + 5.0,
+                    timeout=(block_ms / 1000.0) + 2.0,
                 )
             except asyncio.TimeoutError:
                 # XREAD wedged — yield keepalive, recheck terminal, retry.
@@ -162,7 +201,7 @@ async def _stream_from_redis_log(
             # terminal=True so we don't race past the trailing tail.
             terminal_seen = False
     finally:
-        if on_detach is not None:
+        if attached and on_detach is not None:
             try:
                 await on_detach()
             except Exception:
@@ -180,9 +219,17 @@ async def stream_from_log(
 ) -> AsyncGenerator[str, None]:
     """SSE consumer for the main workflow stream.
 
-    First-connect callers pass ``last_event_id=None`` (start at $); reconnect
-    callers pass the integer seq from ``Last-Event-ID`` / ``?last_event_id=``
-    so XREAD resumes after that seq.
+    First-connect callers pass ``last_event_id=None`` (cursor at 0 — replay
+    everything in the stream then wait for new). Reconnect callers pass the
+    integer seq from ``Last-Event-ID`` / ``?last_event_id=`` so XREAD
+    resumes after that seq.
+
+    The ``increment_connection``/``decrement_connection`` calls bump the
+    workflow's ``active_connections`` counter (and refresh
+    ``last_access_at``). Without them, the abandoned-task cleanup at
+    ``BackgroundTaskManager._periodic_cleanup`` would force-cancel any
+    RUNNING task whose ``active_connections == 0`` after
+    ``abandoned_workflow_timeout`` (6 h default).
     """
     manager = BackgroundTaskManager.get_instance()
 
@@ -190,10 +237,18 @@ async def stream_from_log(
         status = await manager.get_task_status(thread_id)
         return status in (TaskStatus.COMPLETED, TaskStatus.FAILED, TaskStatus.CANCELLED)
 
+    async def on_attach() -> None:
+        await manager.increment_connection(thread_id)
+
+    async def on_detach() -> None:
+        await manager.decrement_connection(thread_id)
+
     async for event in _stream_from_redis_log(
         stream_key=f"workflow:stream:{thread_id}",
         terminal_check=terminal_check,
         last_event_id=last_event_id,
+        on_attach=on_attach,
+        on_detach=on_detach,
     ):
         yield event
 
@@ -221,6 +276,74 @@ async def _wait_for_subagent_task(thread_id: str, task_id: str) -> Any:
     return None
 
 
+# Subagent payload classifications used by ``_classify_subagent_payload``.
+# Strings rather than enum members because the consumer hot loop branches
+# directly on the return value and string identity comparison stays cheap
+# (these constants intern at module load).
+_PAYLOAD_WIRE = "wire"          # already SSE-formatted; pass-through
+_PAYLOAD_SENTINEL = "sentinel"  # stream-end signal; consumer exits
+_PAYLOAD_RECORD = "record"      # legacy JSON record; needs SSE rendering
+_PAYLOAD_UNKNOWN = "unknown"    # invalid or unrecognised; pass through raw
+
+
+def _classify_subagent_payload(raw: str) -> tuple[str, dict | None]:
+    """Single-pass classification of a per-task Stream entry.
+
+    The per-task Stream may carry three shapes:
+
+    1. **Pre-rendered SSE wire strings** — steady-state producer output
+       (``id: N\\nevent: ...\\ndata: ...\\n\\n``). Yielded verbatim.
+    2. **Stream-end sentinels** — ``{"event": "subagent_stream_end"}``
+       written by ``forwarder.finalize()``. Consumer exits on sight.
+    3. **Legacy JSON records** — ``{"seq", "event", "data", "agent_id"}``
+       from older producer versions; age out after their TTL. Rendered by
+       ``_record_to_sse``.
+
+    Returns ``(kind, parsed_or_None)``; ``parsed_or_None`` is non-None
+    only for ``_PAYLOAD_RECORD``.
+    """
+    if not raw or raw[0] in ("i", ":"):
+        return _PAYLOAD_WIRE, None
+    try:
+        record = json.loads(raw)
+    except json.JSONDecodeError:
+        return _PAYLOAD_UNKNOWN, None
+    if not isinstance(record, dict):
+        return _PAYLOAD_UNKNOWN, None
+    if record.get("event") == SUBAGENT_STREAM_END_EVENT and "seq" not in record:
+        # Sentinels carry only ``event`` — no ``seq``. The absence of ``seq``
+        # also makes a stray sentinel fall through ``_record_to_sse``'s
+        # legacy-record path rather than rendering as a fake event.
+        return _PAYLOAD_SENTINEL, None
+    if "seq" in record:
+        return _PAYLOAD_RECORD, record
+    return _PAYLOAD_UNKNOWN, None
+
+
+def _record_to_sse(record: dict, thread_id: str, task_id: str) -> str:
+    """Render a stored subagent record dict as SSE wire format.
+
+    Mirrors the legacy consumer's ``_record_to_sse`` (stream_reconnect.py)
+    so frontend parsers see byte-for-byte the same wire format whether the
+    flag is on or off. The producer stores records without thread_id /
+    task_id (the registry only knows agent_id), so those are injected here.
+    """
+    seq = int(record.get("seq") or 0)
+    # Inner data spreads first so consumer-injected thread_id/agent always
+    # win — ``record["agent_id"]`` is the LangGraph namespace UUID and must
+    # not surface as the user-facing label.
+    data = {
+        **(record.get("data") or {}),
+        "thread_id": thread_id,
+        "agent": f"task:{task_id}",
+    }
+    return (
+        f"id: {seq}\n"
+        f"event: {record.get('event') or 'message_chunk'}\n"
+        f"data: {json.dumps(data, ensure_ascii=False)}\n\n"
+    )
+
+
 async def stream_subagent_from_log(
     thread_id: str,
     task_id: str,
@@ -234,12 +357,27 @@ async def stream_subagent_from_log(
       readers before DELing the stream key.
     - Terminal predicate that checks task completion (``task.completed`` or
       ``task.asyncio_task.done()``).
+    - Per-entry payload classification via ``_classify_subagent_payload``
+      so pre-rendered wire strings, stream-end sentinels, and legacy JSON
+      records are dispatched in a single pass with at most one
+      ``json.loads`` per entry.
 
     On startup-timeout (no task ever appears), we still tail the Redis
     Stream for ``last_event_id`` replay — the producer may have written
     events that arrived before the registry call finished registering.
     """
     task = await _wait_for_subagent_task(thread_id, task_id)
+    stream_key = f"subagent:stream:{thread_id}:{task_id}"
+
+    def _dispatch(raw: str) -> str | None:
+        """Return the SSE string to yield, or None to signal stream-end."""
+        kind, parsed = _classify_subagent_payload(raw)
+        if kind is _PAYLOAD_SENTINEL:
+            return None
+        if kind is _PAYLOAD_RECORD and parsed is not None:
+            return _record_to_sse(parsed, thread_id, task_id)
+        # _PAYLOAD_WIRE / _PAYLOAD_UNKNOWN: pass through raw.
+        return raw
 
     if task is None:
         # No registry — treat as a pure replay-from-Redis case. If the
@@ -248,12 +386,15 @@ async def stream_subagent_from_log(
         async def _term_no_task() -> bool:
             return True  # Nothing to wait for; stream is already at end.
 
-        async for event in _stream_from_redis_log(
-            stream_key=f"subagent:stream:{thread_id}:{task_id}",
+        async for raw in _stream_from_redis_log(
+            stream_key=stream_key,
             terminal_check=_term_no_task,
             last_event_id=last_event_id,
         ):
-            yield event
+            rendered = _dispatch(raw)
+            if rendered is None:
+                return
+            yield rendered
         return
 
     async def on_attach() -> None:
@@ -273,11 +414,14 @@ async def stream_subagent_from_log(
         ato = task.asyncio_task
         return ato is not None and ato.done()
 
-    async for event in _stream_from_redis_log(
-        stream_key=f"subagent:stream:{thread_id}:{task_id}",
+    async for raw in _stream_from_redis_log(
+        stream_key=stream_key,
         terminal_check=terminal_check,
         last_event_id=last_event_id,
         on_attach=on_attach,
         on_detach=on_detach,
     ):
-        yield event
+        rendered = _dispatch(raw)
+        if rendered is None:
+            return
+        yield rendered

--- a/src/server/handlers/chat/stream_from_log.py
+++ b/src/server/handlers/chat/stream_from_log.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import logging
 from typing import Any, AsyncGenerator, Awaitable, Callable, Optional
 
 from src.config.settings import get_redis_socket_timeout
@@ -33,7 +32,7 @@ from src.server.services.background_task_manager import (
 )
 from src.utils.cache.redis_cache import get_cache_client
 
-logger = logging.getLogger(__name__)
+from ._common import logger
 
 
 _XREAD_BLOCK_MARGIN_MS = 1_000
@@ -143,6 +142,10 @@ async def _stream_from_redis_log(
                 )
             except asyncio.TimeoutError:
                 # XREAD wedged — yield keepalive, recheck terminal, retry.
+                # Counts as one "empty" round for the terminal handshake:
+                # a wedged read followed by one empty BLOCK round still
+                # exits, dwelling ``(block_ms + 2 s) + block_ms`` total —
+                # long enough to drain a trailing tail.
                 yield ":keepalive\n\n"
                 if await terminal_check():
                     if terminal_seen:
@@ -179,6 +182,12 @@ async def _stream_from_redis_log(
             # result format: [(stream_key, [(entry_id, {field: value}), ...])]
             for _stream_name, entries in result:
                 for entry_id, fields in entries:
+                    # Advance the cursor unconditionally before any skip path.
+                    # If the *last* entry in a batch hits a continue (missing
+                    # ``event`` field, non-UTF8 payload), leaving the cursor
+                    # behind that entry would make the next XREAD return it
+                    # again — a skip-loop that never terminates.
+                    cursor = entry_id
                     payload = fields.get(b"event")
                     if payload is None:
                         continue
@@ -194,11 +203,13 @@ async def _stream_from_redis_log(
                             continue
                     else:
                         yield payload
-                    cursor = entry_id
 
-            # Reset terminal-seen flag whenever we emit new events; the
-            # exit handshake requires two consecutive empty rounds with
-            # terminal=True so we don't race past the trailing tail.
+            # Reset terminal-seen on any non-empty XREAD batch: while
+            # entries are still arriving the stream is not yet at end, so
+            # the two-empty-round handshake must restart. (Note: this
+            # resets even when every entry was skipped — the producer
+            # always writes ``b"event"`` so all-skipped batches don't
+            # occur in practice; if that invariant changes, revisit.)
             terminal_seen = False
     finally:
         if attached and on_detach is not None:
@@ -278,7 +289,7 @@ async def _wait_for_subagent_task(thread_id: str, task_id: str) -> Any:
 
 # Subagent payload classifications used by ``_classify_subagent_payload``.
 # Strings rather than enum members because the consumer hot loop branches
-# directly on the return value and string identity comparison stays cheap
+# directly on the return value and string equality stays cheap
 # (these constants intern at module load).
 _PAYLOAD_WIRE = "wire"          # already SSE-formatted; pass-through
 _PAYLOAD_SENTINEL = "sentinel"  # stream-end signal; consumer exits
@@ -302,6 +313,14 @@ def _classify_subagent_payload(raw: str) -> tuple[str, dict | None]:
     Returns ``(kind, parsed_or_None)``; ``parsed_or_None`` is non-None
     only for ``_PAYLOAD_RECORD``.
     """
+    # Fast path: pre-rendered SSE always starts with ``id:`` (the producer
+    # in ``registry._spill_record_to_redis`` emits ``id:`` first) or ``:``
+    # for keepalive comments. If a future producer widens the wire format
+    # so it no longer starts with one of those, this fast path will fall
+    # through to the JSON-decode branch and the entry will be classified
+    # as ``_PAYLOAD_UNKNOWN`` (still passed through raw, but bypassing the
+    # intended fast path). Audit both sites together if the producer
+    # changes.
     if not raw or raw[0] in ("i", ":"):
         return _PAYLOAD_WIRE, None
     try:
@@ -372,9 +391,9 @@ async def stream_subagent_from_log(
     def _dispatch(raw: str) -> str | None:
         """Return the SSE string to yield, or None to signal stream-end."""
         kind, parsed = _classify_subagent_payload(raw)
-        if kind is _PAYLOAD_SENTINEL:
+        if kind == _PAYLOAD_SENTINEL:
             return None
-        if kind is _PAYLOAD_RECORD and parsed is not None:
+        if kind == _PAYLOAD_RECORD and parsed is not None:
             return _record_to_sse(parsed, thread_id, task_id)
         # _PAYLOAD_WIRE / _PAYLOAD_UNKNOWN: pass through raw.
         return raw
@@ -386,42 +405,47 @@ async def stream_subagent_from_log(
         async def _term_no_task() -> bool:
             return True  # Nothing to wait for; stream is already at end.
 
-        async for raw in _stream_from_redis_log(
+        inner = _stream_from_redis_log(
             stream_key=stream_key,
             terminal_check=_term_no_task,
             last_event_id=last_event_id,
-        ):
+        )
+    else:
+        async def on_attach() -> None:
+            task.sse_consumer_count += 1
+
+        async def on_detach() -> None:
+            task.sse_consumer_count -= 1
+            if task.sse_consumer_count <= 0:
+                try:
+                    task.sse_drain_complete.set()
+                except Exception:
+                    pass
+
+        async def terminal_check() -> bool:
+            if task.completed:
+                return True
+            ato = task.asyncio_task
+            return ato is not None and ato.done()
+
+        inner = _stream_from_redis_log(
+            stream_key=stream_key,
+            terminal_check=terminal_check,
+            last_event_id=last_event_id,
+            on_attach=on_attach,
+            on_detach=on_detach,
+        )
+
+    # Manage the inner generator explicitly so its ``finally`` block (which
+    # runs ``on_detach`` and decrements ``sse_consumer_count``) fires the
+    # moment we ``return`` on a sentinel — not whenever FastAPI gets around
+    # to calling ``aclose`` on the outer generator. Tight ``sse_drain_complete``
+    # waits race the GC otherwise.
+    try:
+        async for raw in inner:
             rendered = _dispatch(raw)
             if rendered is None:
                 return
             yield rendered
-        return
-
-    async def on_attach() -> None:
-        task.sse_consumer_count += 1
-
-    async def on_detach() -> None:
-        task.sse_consumer_count -= 1
-        if task.sse_consumer_count <= 0:
-            try:
-                task.sse_drain_complete.set()
-            except Exception:
-                pass
-
-    async def terminal_check() -> bool:
-        if task.completed:
-            return True
-        ato = task.asyncio_task
-        return ato is not None and ato.done()
-
-    async for raw in _stream_from_redis_log(
-        stream_key=stream_key,
-        terminal_check=terminal_check,
-        last_event_id=last_event_id,
-        on_attach=on_attach,
-        on_detach=on_detach,
-    ):
-        rendered = _dispatch(raw)
-        if rendered is None:
-            return
-        yield rendered
+    finally:
+        await inner.aclose()

--- a/src/server/handlers/chat/stream_reconnect.py
+++ b/src/server/handlers/chat/stream_reconnect.py
@@ -22,6 +22,7 @@ from src.server.services.workflow_tracker import WorkflowTracker
 from src.config.settings import (
     get_live_queue_maxsize,
     get_subagent_task_max_wait,
+    is_use_redis_stream_sse_enabled,
 )
 
 from ._common import _SSE_LOG_ENABLED, _sse_logger, logger
@@ -60,6 +61,18 @@ async def reconnect_to_workflow_stream(
                 status_code=410, detail="Workflow completed and results expired"
             )
         raise HTTPException(status_code=404, detail=f"Workflow {thread_id} not found")
+
+    if is_use_redis_stream_sse_enabled():
+        # Stream-backed reconnect: one XREAD BLOCK loop, no list replay,
+        # no live_queue subscription. Cursor starts at last_event_id (or
+        # `0` for "from the beginning" when reconnect arrives without an id).
+        from .stream_from_log import stream_from_log
+
+        async for event in stream_from_log(
+            thread_id, last_event_id if last_event_id is not None else 0
+        ):
+            yield event
+        return
 
     # Replay buffered events (during tailing, Redis only holds tail-phase
     # events because the buffer is cleared after pre-tail persist)
@@ -141,6 +154,13 @@ async def stream_subagent_task_events(
     Yields:
         SSE-formatted event strings
     """
+    if is_use_redis_stream_sse_enabled():
+        from .stream_from_log import stream_subagent_from_log
+
+        async for event in stream_subagent_from_log(thread_id, task_id, last_event_id):
+            yield event
+        return
+
     from src.server.services.background_task_manager import drain_task_captured_events
     from src.utils.cache.redis_cache import get_cache_client
 

--- a/src/server/handlers/chat/stream_reconnect.py
+++ b/src/server/handlers/chat/stream_reconnect.py
@@ -64,13 +64,12 @@ async def reconnect_to_workflow_stream(
 
     if is_use_redis_stream_sse_enabled():
         # Stream-backed reconnect: one XREAD BLOCK loop, no list replay,
-        # no live_queue subscription. Cursor starts at last_event_id (or
-        # `0` for "from the beginning" when reconnect arrives without an id).
+        # no live_queue subscription. ``stream_from_log`` maps both ``None``
+        # and ``<= 0`` to cursor ``0`` (replay from the beginning), so we
+        # pass ``last_event_id`` through untouched.
         from .stream_from_log import stream_from_log
 
-        async for event in stream_from_log(
-            thread_id, last_event_id if last_event_id is not None else 0
-        ):
+        async for event in stream_from_log(thread_id, last_event_id):
             yield event
         return
 

--- a/src/server/services/background_task_manager.py
+++ b/src/server/services/background_task_manager.py
@@ -862,6 +862,7 @@ class BackgroundTaskManager:
 
         events_key = f"workflow:events:{thread_id}"
         meta_key = f"workflow:events:meta:{thread_id}"
+        stream_key = f"workflow:stream:{thread_id}"
 
         success, seq = await cache.pipelined_event_buffer(
             events_key=events_key,
@@ -870,6 +871,7 @@ class BackgroundTaskManager:
             max_size=self.max_stored_messages,
             ttl=self.redis_event_ttl,
             last_event_id=event_id,
+            stream_key=stream_key,
         )
 
         if not success:
@@ -1126,6 +1128,12 @@ class BackgroundTaskManager:
                 try:
                     await cache.delete(
                         f"subagent:events:meta:{thread_id}:{task.task_id}"
+                    )
+                except Exception:
+                    pass
+                try:
+                    await cache.delete(
+                        f"subagent:stream:{thread_id}:{task.task_id}"
                     )
                 except Exception:
                     pass
@@ -2386,10 +2394,12 @@ class BackgroundTaskManager:
             if self.event_storage_backend == "redis" and cache.enabled:
                 events_key = f"workflow:events:{thread_id}"
                 meta_key = f"workflow:events:meta:{thread_id}"
+                stream_key = f"workflow:stream:{thread_id}"
 
-                # Delete both the event list and metadata
+                # Delete event list, metadata, and the dual-write Stream key.
                 await cache.delete(events_key)
                 await cache.delete(meta_key)
+                await cache.delete(stream_key)
 
                 logger.debug(f"[EventBuffer] Cleared Redis event buffer for {thread_id}")
 

--- a/src/utils/cache/redis_cache.py
+++ b/src/utils/cache/redis_cache.py
@@ -609,6 +609,7 @@ class RedisCacheClient:
         ttl: int,
         last_event_id: Optional[int] = None,
         stream_key: Optional[str] = None,
+        stream_event: Optional[str] = None,
     ) -> tuple[bool, int]:
         """Atomic pipeline for the SSE event-buffer hot path.
 
@@ -616,11 +617,13 @@ class RedisCacheClient:
         optional stream append) into one MULTI/EXEC so the whole spill takes
         one pool checkout.
 
-        When ``stream_key`` and ``last_event_id`` are both provided, the same
-        event is dual-written to a Redis Stream at ``stream_key`` with explicit
-        ID ``f"{last_event_id}-0"``. This is the dual-write phase of the
-        Streams refactor — readers continue reading the List during this phase
-        while the Stream gets populated for parity verification.
+        When ``stream_key`` and ``last_event_id`` are both provided, the event
+        is dual-written to a Redis Stream at ``stream_key`` with explicit
+        ID ``f"{last_event_id}-0"``. ``stream_event`` defaults to ``event``
+        but lets callers store a different wire format in the Stream than in
+        the List — used by the subagent producer, which keeps JSON records in
+        the legacy List for in-flight reads but writes pre-rendered SSE wire
+        strings to the Stream so the consumer doesn't need a JSON-render step.
 
         Returns (success, seq). On success `seq` is the new event count (1+);
         on failure it's 0.
@@ -674,7 +677,8 @@ class RedisCacheClient:
                 # the frontend's parseInt-based last_event_id parsing while
                 # preserving Redis Streams' lexicographic ordering.
                 if stream_key is not None and last_event_id is not None:
-                    payload = event.encode("utf-8") if isinstance(event, str) else event
+                    raw = stream_event if stream_event is not None else event
+                    payload = raw.encode("utf-8") if isinstance(raw, str) else raw
                     pipe.xadd(
                         stream_key,
                         {b"event": payload},

--- a/src/utils/cache/redis_cache.py
+++ b/src/utils/cache/redis_cache.py
@@ -608,26 +608,22 @@ class RedisCacheClient:
         max_size: int,
         ttl: int,
         last_event_id: Optional[int] = None,
+        stream_key: Optional[str] = None,
     ) -> tuple[bool, int]:
         """Atomic pipeline for the SSE event-buffer hot path.
 
-        Pre-rewrite, `_buffer_event_redis` made ~9 sequential Redis round-trips
-        per SSE event (list_append + list_length + hash_get_all + 3x hash_set,
-        where hash_set was itself 2 commands). Under a workflow burst that
-        saturated the 50-slot connection pool and triggered MaxConnectionsError
-        for hours. This helper collapses all of it into one MULTI/EXEC so the
-        whole thing takes one pool checkout.
+        Collapses ~9 sequential Redis commands (list append, trim, meta hash,
+        optional stream append) into one MULTI/EXEC so the whole spill takes
+        one pool checkout.
 
-        Uses HINCRBY for `seq` (atomic counter), HSETNX for created_at
-        (set-if-missing), and HSET for updated_at / last_event_id. The field
-        name is `seq` rather than `event_count` so HINCRBY cannot collide with
-        leftover JSON-quoted integers ("\\"42\\"") written by the older
-        hash_set-based code path (which would otherwise raise WRONGTYPE until
-        the meta key TTL-expired 24h later).
+        When ``stream_key`` and ``last_event_id`` are both provided, the same
+        event is dual-written to a Redis Stream at ``stream_key`` with explicit
+        ID ``f"{last_event_id}-0"``. This is the dual-write phase of the
+        Streams refactor — readers continue reading the List during this phase
+        while the Stream gets populated for parity verification.
 
         Returns (success, seq). On success `seq` is the new event count (1+);
-        on failure it's 0. Callers use the counter to drive capacity warnings
-        without an extra round-trip.
+        on failure it's 0.
         """
         if not self.enabled or not self.client:
             return False, 0
@@ -635,6 +631,35 @@ class RedisCacheClient:
         try:
             now_iso_json = json.dumps(datetime.now().isoformat())
             async with self.client.pipeline(transaction=True) as pipe:
+                # Dirty-resume guard runs BEFORE the new writes so RPUSH and
+                # HINCRBY land on fresh state. When last_event_id == 1 we're
+                # at the start of a fresh handler instance (counter resets to
+                # 1 per turn). If a prior turn left state behind (process
+                # crash before the post-persist ``_on_pair_persisted``
+                # callback ran ``clear_event_buffer``), three things can be
+                # stale:
+                # - ``stream_key``: XADD with id=1-0 would fail because the
+                #   last id is N-0 from that prior turn — Redis enforces
+                #   strict id monotonicity.
+                # - ``events_key``: a stale RPUSH tail from the prior turn
+                #   would persist alongside the fresh entries, breaking
+                #   ``LLEN == XLEN`` parity until both are DEL'd together.
+                # - ``meta_key`` ``seq``: HINCRBY against a stale counter
+                #   would return N+1 instead of 1, drifting the returned
+                #   ``seq`` away from the SSE wire id.
+                # DEL'ing inside the same MULTI/EXEC keeps the reset atomic.
+                # ``created_at`` on the meta hash is preserved (HDEL only
+                # the ``seq`` field) since it documents thread-first-write
+                # for diagnostics, not per-turn state.
+                guard_cmds = 0
+                if last_event_id == 1:
+                    if stream_key is not None:
+                        pipe.delete(stream_key)
+                        guard_cmds += 1
+                    pipe.delete(events_key)
+                    pipe.hdel(meta_key, "seq")
+                    guard_cmds += 2
+
                 pipe.rpush(events_key, event)
                 pipe.ltrim(events_key, -max_size, -1)
                 pipe.expire(events_key, ttl)
@@ -644,10 +669,31 @@ class RedisCacheClient:
                 if last_event_id is not None:
                     pipe.hset(meta_key, "last_event_id", json.dumps(last_event_id))
                 pipe.expire(meta_key, ttl)
+                # Dual-write to Redis Stream when both key and id are provided.
+                # Explicit ID `<seq>-0` keeps the cursor integer-friendly for
+                # the frontend's parseInt-based last_event_id parsing while
+                # preserving Redis Streams' lexicographic ordering.
+                if stream_key is not None and last_event_id is not None:
+                    payload = event.encode("utf-8") if isinstance(event, str) else event
+                    pipe.xadd(
+                        stream_key,
+                        {b"event": payload},
+                        id=f"{last_event_id}-0",
+                        maxlen=max_size,
+                        approximate=True,
+                    )
+                    pipe.expire(stream_key, ttl)
                 results = await pipe.execute()
             self.stats["sets"] += 1
-            # results[3] is HINCRBY's new value (position 4 in the queued commands)
-            seq = int(results[3]) if len(results) > 3 else 0
+            # HINCRBY's return value sits at index ``guard_cmds + 3``: 3
+            # commands of new-write prefix (RPUSH, LTRIM, EXPIRE) precede it,
+            # plus any dirty-resume guard commands that ran first.
+            hincrby_index = guard_cmds + 3
+            seq = (
+                int(results[hincrby_index])
+                if len(results) > hincrby_index
+                else 0
+            )
             return True, seq
         except Exception as e:
             self._log_error(f"Pipelined event buffer failed for {events_key}", e)

--- a/tests/integration/test_event_buffer_dual_write.py
+++ b/tests/integration/test_event_buffer_dual_write.py
@@ -1,0 +1,88 @@
+"""Integration test for the dual-write between the SSE event List and the
+new Redis Stream.
+
+Asserts parity: after writing N events through ``pipelined_event_buffer``,
+``LLEN events_key == XLEN stream_key`` and the per-entry payloads match.
+
+Requires a real Redis instance (run ``make setup-db`` first).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import pytest_asyncio
+
+
+pytestmark = pytest.mark.integration
+
+
+@pytest_asyncio.fixture
+async def real_cache():
+    """Provide a RedisCacheClient connected to the local Redis from setup-db."""
+    redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+    if not redis_url.startswith("redis://"):
+        pytest.skip("REDIS_URL not set to a real Redis instance")
+
+    # Lazy import — avoids touching redis module during test collection on
+    # machines without redis-py installed.
+    from src.utils.cache.redis_cache import RedisCacheClient
+
+    cache = RedisCacheClient(url=redis_url, max_connections=10)
+    try:
+        await cache.connect()
+    except Exception as exc:  # auth required, refused, unreachable, etc.
+        pytest.skip(f"Redis is not reachable at REDIS_URL: {exc}")
+    if not cache.enabled or not cache.client:
+        pytest.skip("Redis client did not initialize")
+    yield cache
+    try:
+        await cache.client.aclose()
+    except Exception:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_list_and_stream_are_in_lockstep(real_cache):
+    events_key = "test:dual:events"
+    meta_key = "test:dual:events:meta"
+    stream_key = "test:dual:stream"
+
+    await real_cache.client.delete(events_key)
+    await real_cache.client.delete(meta_key)
+    await real_cache.client.delete(stream_key)
+
+    n = 25
+    for i in range(1, n + 1):
+        sse = f"id: {i}\nevent: token\ndata: {{\"i\": {i}}}\n\n"
+        success, seq = await real_cache.pipelined_event_buffer(
+            events_key=events_key,
+            meta_key=meta_key,
+            event=sse,
+            max_size=1000,
+            ttl=60,
+            last_event_id=i,
+            stream_key=stream_key,
+        )
+        assert success is True
+        assert seq == i
+
+    list_len = await real_cache.client.llen(events_key)
+    stream_len = await real_cache.client.xlen(stream_key)
+    assert list_len == n
+    assert stream_len == n
+
+    # Stream entries are ordered by explicit ID `<seq>-0`.
+    entries = await real_cache.client.xrange(stream_key, min="-", max="+")
+    assert len(entries) == n
+    for idx, (entry_id, fields) in enumerate(entries, start=1):
+        # decode_responses=False — IDs and fields are bytes.
+        assert entry_id == f"{idx}-0".encode("utf-8")
+        payload_bytes = fields[b"event"]
+        assert payload_bytes.startswith(f"id: {idx}\n".encode("utf-8"))
+
+    # Cleanup
+    await real_cache.client.delete(events_key)
+    await real_cache.client.delete(meta_key)
+    await real_cache.client.delete(stream_key)

--- a/tests/integration/test_sse_streams.py
+++ b/tests/integration/test_sse_streams.py
@@ -1,0 +1,174 @@
+"""Single-consumer integration tests for the Redis-Streams SSE path.
+
+Validates the architectural win: every scenario (first-connect, reconnect,
+second-tab, late-subscriber, subagent-live, subagent-reconnect) flows
+through the SAME ``_stream_from_redis_log`` call with a different cursor.
+
+Requires a real Redis instance — run ``make setup-db`` before invoking.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+
+import pytest
+import pytest_asyncio
+
+
+pytestmark = pytest.mark.integration
+
+
+@pytest_asyncio.fixture
+async def real_cache():
+    redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+    if not redis_url.startswith("redis://"):
+        pytest.skip("REDIS_URL not set to a real Redis instance")
+
+    from src.utils.cache.redis_cache import RedisCacheClient
+
+    cache = RedisCacheClient(url=redis_url, max_connections=10)
+    try:
+        await cache.connect()
+    except Exception as exc:
+        pytest.skip(f"Redis not reachable: {exc}")
+    if not cache.enabled or not cache.client:
+        pytest.skip("Redis client did not initialize")
+    yield cache
+    try:
+        await cache.client.aclose()
+    except Exception:
+        pass
+
+
+@pytest_asyncio.fixture
+async def thread_id():
+    """Per-test unique stream namespace so concurrent tests don't collide."""
+    return f"itest-{uuid.uuid4().hex[:8]}"
+
+
+async def _produce(cache, thread_id: str, n: int, stream_key: str = None):
+    """Write n events to the workflow stream with explicit IDs `<i>-0`."""
+    stream_key = stream_key or f"workflow:stream:{thread_id}"
+    events_key = f"workflow:events:{thread_id}"
+    meta_key = f"workflow:events:meta:{thread_id}"
+    for i in range(1, n + 1):
+        sse = f"id: {i}\nevent: token\ndata: {{\"i\": {i}}}\n\n"
+        ok, _ = await cache.pipelined_event_buffer(
+            events_key=events_key,
+            meta_key=meta_key,
+            event=sse,
+            max_size=1000,
+            ttl=60,
+            last_event_id=i,
+            stream_key=stream_key,
+        )
+        assert ok
+
+
+async def _drain_until_empty(gen, max_events: int = 100, timeout: float = 5.0):
+    """Collect SSE strings (excluding keepalives) until the generator exits."""
+    out = []
+    try:
+        while len(out) < max_events:
+            ev = await asyncio.wait_for(gen.__anext__(), timeout=timeout)
+            if ev.startswith(":keepalive"):
+                continue
+            out.append(ev)
+    except (StopAsyncIteration, asyncio.TimeoutError):
+        pass
+    return out
+
+
+def _ids(events: list[str]) -> list[int]:
+    """Pull integer ids from a list of SSE strings."""
+    out = []
+    for ev in events:
+        first, _, _ = ev.partition("\n")
+        try:
+            out.append(int(first.replace("id: ", "").strip()))
+        except ValueError:
+            pass
+    return out
+
+
+@pytest.mark.asyncio
+async def test_unified_consumer_paths_against_real_redis(real_cache, thread_id, monkeypatch):
+    """One stream key, four consumers. Each scenario uses the same call."""
+    from src.server.handlers.chat import stream_from_log as sfl_mod
+
+    # Patch get_cache_client so the consumer uses our test client.
+    monkeypatch.setattr(sfl_mod, "get_cache_client", lambda: real_cache)
+
+    # Simulate workflow lifecycle via a flag the terminal_check reads.
+    workflow_done = asyncio.Event()
+
+    async def terminal() -> bool:
+        return workflow_done.is_set()
+
+    stream_key = f"workflow:stream:{thread_id}"
+    events_key = f"workflow:events:{thread_id}"
+    meta_key = f"workflow:events:meta:{thread_id}"
+
+    # Pre-clean.
+    await real_cache.client.delete(stream_key, events_key, meta_key)
+
+    # Produce 5 events.
+    await _produce(real_cache, thread_id, n=5)
+
+    # Scenario A: REPLAY from beginning (last_event_id=0). Should see all 5.
+    a = sfl_mod._stream_from_redis_log(
+        stream_key=stream_key,
+        terminal_check=terminal,
+        last_event_id=0,
+    )
+    workflow_done.set()
+    a_events = await _drain_until_empty(a, max_events=10, timeout=2.0)
+    assert _ids(a_events) == [1, 2, 3, 4, 5]
+
+    # Reset terminal so next scenarios run with workflow "still active."
+    workflow_done.clear()
+
+    # Scenario B: RESUME after seq 2 → see 3, 4, 5.
+    b = sfl_mod._stream_from_redis_log(
+        stream_key=stream_key,
+        terminal_check=terminal,
+        last_event_id=2,
+    )
+    workflow_done.set()
+    b_events = await _drain_until_empty(b, max_events=10, timeout=2.0)
+    assert _ids(b_events) == [3, 4, 5]
+
+    # Scenario C: SECOND-TAB attaches with last_event_id=None — the
+    # implementation maps that to cursor=0 (replay everything, then wait),
+    # not Redis Streams' "$" live-tail. The docstring on
+    # ``_stream_from_redis_log`` calls this out: "$" is intentionally NOT
+    # exposed because chat clients want history first, then live updates.
+    # ``_produce(n=7)`` triggers the dirty-resume DEL inside the producer's
+    # MULTI/EXEC (the ``last_event_id == 1`` branch in
+    # ``redis_cache.pipelined_event_buffer``), then writes entries 1-0
+    # through 7-0 atomically. The second-tab consumer, attaching after that
+    # rewrite, replays the full 1-7 range.
+    workflow_done.clear()
+
+    second_tab_gen = sfl_mod._stream_from_redis_log(
+        stream_key=stream_key,
+        terminal_check=terminal,
+        last_event_id=None,
+    )
+    await _produce(real_cache, thread_id, n=7)
+    workflow_done.set()
+    c_events = await _drain_until_empty(second_tab_gen, max_events=10, timeout=2.0)
+    assert _ids(c_events) == [1, 2, 3, 4, 5, 6, 7]
+
+    # Scenario D: LATE SUBSCRIBER after stream is DEL'd. XREAD on a non-
+    # existent stream returns empty; with terminal=True we exit cleanly.
+    await real_cache.client.delete(stream_key, events_key, meta_key)
+    d = sfl_mod._stream_from_redis_log(
+        stream_key=stream_key,
+        terminal_check=terminal,
+        last_event_id=0,
+    )
+    d_events = await _drain_until_empty(d, max_events=10, timeout=2.0)
+    assert d_events == []

--- a/tests/unit/middleware/test_event_signal.py
+++ b/tests/unit/middleware/test_event_signal.py
@@ -749,9 +749,11 @@ class _FakeModelResponse:
 
 
 @pytest.mark.asyncio
-async def test_event_capture_emits_reasoning_signals_text_and_tool_calls(monkeypatch) -> None:
-    """awrap_model_call emits reasoning start/body/complete, text, and tool_calls
-    into the task's captured_events in the expected order."""
+async def test_event_capture_emits_only_tool_calls_no_text_or_reasoning(monkeypatch) -> None:
+    """awrap_model_call no longer emits per-call text/reasoning chunks — those
+    moved to the per-token streaming forwarder so the per-task SSE stream
+    matches the main workflow's token-level granularity. Tool_calls still
+    fire here (no streaming counterpart for accumulated tool args)."""
     from ptc_agent.agent.middleware.background_subagent.event_capture import (
         SubagentEventCaptureMiddleware,
     )
@@ -764,7 +766,6 @@ async def test_event_capture_emits_reasoning_signals_text_and_tool_calls(monkeyp
     current_background_tool_call_id.set(task.tool_call_id)
     mw = SubagentEventCaptureMiddleware(registry=registry)
 
-    _patch_format_llm_content(monkeypatch, reasoning="thinking", text="hello")
     ai = _make_ai_message(
         text="hello",
         tool_calls=[{"name": "bash", "args": {"cmd": "ls"}, "id": "tc-1"}],
@@ -775,12 +776,14 @@ async def test_event_capture_emits_reasoning_signals_text_and_tool_calls(monkeyp
     await mw.awrap_model_call(request, handler)
 
     events = list(task.captured_events_tail)
-    content_types = [e["data"].get("content_type") for e in events if e["event"] == "message_chunk"]
-    # reasoning_signal(start), reasoning, reasoning_signal(complete), text
-    assert "reasoning_signal" in content_types
-    assert content_types.count("reasoning_signal") == 2
-    assert "reasoning" in content_types
-    assert "text" in content_types
+    content_types = [
+        e["data"].get("content_type") for e in events if e["event"] == "message_chunk"
+    ]
+    # The streaming forwarder owns text/reasoning emission now — middleware
+    # must NOT emit any of those types.
+    assert "reasoning_signal" not in content_types
+    assert "reasoning" not in content_types
+    assert "text" not in content_types
 
     tool_call_events = [e for e in events if e["event"] == "tool_calls"]
     assert len(tool_call_events) == 1
@@ -922,6 +925,9 @@ async def test_stream_subagent_task_events_single_consumer_lifecycle(monkeypatch
     """One consumer: receives events, decrements count on close, sse_drain_complete
     is set on final consumer exit. Producer is the sole Redis writer (no
     list_append from the consumer)."""
+    # Pin the legacy code path — see _wire_fakes in test_subagent_stream_reconnect.py
+    monkeypatch.setenv("USE_REDIS_STREAM_SSE", "false")
+
     from src.server.handlers.chat import stream_reconnect
 
     registry = BackgroundTaskRegistry()
@@ -981,6 +987,9 @@ async def test_stream_subagent_task_events_cursor_advances_with_concurrent_appen
     """If an event is appended while the consumer is awaiting the wake signal,
     the next drain iteration must pick it up — not skip it. The cursor
     advances by seq, not list index."""
+    # Pin the legacy code path.
+    monkeypatch.setenv("USE_REDIS_STREAM_SSE", "false")
+
     from src.server.handlers.chat import stream_reconnect
 
     registry = BackgroundTaskRegistry()

--- a/tests/unit/middleware/test_subagent_event_capture.py
+++ b/tests/unit/middleware/test_subagent_event_capture.py
@@ -379,6 +379,199 @@ async def test_per_task_lock_serializes_concurrent_spills(monkeypatch) -> None:
     assert seqs_in_call_order == [1, 2]
 
 
+def _make_pipeline_capture(execute_return=None):
+    """Build a fake redis pipeline that records xadd/expire calls.
+
+    The registry's ``append_sentinel_to_stream`` opens a non-transactional
+    pipeline, queues XADD + EXPIRE, then awaits ``pipe.execute()``. The
+    fake mirrors that contract and records what was queued so tests can
+    assert the stream key, fields, MAXLEN, and TTL refresh.
+    """
+    queued: dict[str, list] = {"xadd": [], "expire": []}
+
+    class _FakePipe:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            return False
+
+        def xadd(self, name, fields, maxlen=None, approximate=True):
+            queued["xadd"].append(
+                {
+                    "name": name,
+                    "fields": fields,
+                    "maxlen": maxlen,
+                    "approximate": approximate,
+                }
+            )
+            return self
+
+        def expire(self, name, ttl):
+            queued["expire"].append({"name": name, "ttl": ttl})
+            return self
+
+        async def execute(self):
+            if isinstance(execute_return, BaseException):
+                raise execute_return
+            return execute_return or []
+
+    pipe = _FakePipe()
+
+    def _new_pipe(transaction=False):
+        # Mirror the registry's call signature; transaction kwarg ignored.
+        return pipe
+
+    return queued, _new_pipe
+
+
+@pytest.mark.asyncio
+async def test_sentinel_writes_xadd_only_no_deque_no_persistence(monkeypatch) -> None:
+    """``append_sentinel_to_stream`` writes one XADD on the per-task Stream
+    key and bumps its TTL. It MUST NOT write to ``captured_events_tail``
+    (which gets persisted to Postgres + replayed) or to the legacy
+    Redis List (read by the pre-flag consumer). The sentinel is a
+    transport signal, not content.
+    """
+    fake_cache = MagicMock()
+    fake_cache.enabled = True
+    fake_cache.client = MagicMock()
+    queued, _new_pipe = _make_pipeline_capture()
+    fake_cache.client.pipeline = _new_pipe
+    monkeypatch.setattr(
+        "src.utils.cache.redis_cache.get_cache_client", lambda: fake_cache
+    )
+    monkeypatch.setattr(
+        "src.config.settings.is_subagent_event_redis_spill_enabled", lambda: True
+    )
+    monkeypatch.setattr(
+        "src.config.settings.get_max_stored_messages_per_agent", lambda: 1000
+    )
+    monkeypatch.setattr(
+        "src.config.settings.get_redis_ttl_workflow_events", lambda: 86400
+    )
+
+    registry = BackgroundTaskRegistry(thread_id="thread-x")
+    task = await registry.register(
+        tool_call_id="tc1", description="d", prompt="p", subagent_type="general-purpose"
+    )
+
+    await registry.append_sentinel_to_stream(task.tool_call_id)
+
+    # Exactly one XADD on the per-task Stream key.
+    assert len(queued["xadd"]) == 1
+    write = queued["xadd"][0]
+    assert write["name"] == f"subagent:stream:thread-x:{task.task_id}"
+    assert write["maxlen"] == 1000
+    assert write["approximate"] is True
+    # Payload is the sentinel JSON record under the canonical b"event" field.
+    fields = write["fields"]
+    assert b"event" in fields
+    payload = fields[b"event"]
+    assert isinstance(payload, bytes)
+    assert b'"event": "subagent_stream_end"' in payload
+
+    # TTL refresh on the same stream key.
+    assert queued["expire"] == [
+        {"name": f"subagent:stream:thread-x:{task.task_id}", "ttl": 86400}
+    ]
+
+    # Crucial: NOT in the in-memory tail (which feeds Postgres persistence)
+    # and the seq counter is not bumped (sentinel is not a content event).
+    assert all(
+        e.get("event") != "subagent_stream_end"
+        for e in task.captured_events_tail
+    )
+    assert task.captured_event_seq == 0
+    assert task.captured_event_count == 0
+
+
+@pytest.mark.asyncio
+async def test_sentinel_skipped_when_redis_write_failed_sticky(monkeypatch) -> None:
+    """If the per-task circuit-breaker is open (a prior content spill failed),
+    the sentinel write must short-circuit so the recovery path doesn't loop
+    on the same degraded Redis."""
+    fake_cache = MagicMock()
+    fake_cache.enabled = True
+    fake_cache.client = MagicMock()
+    queued, _new_pipe = _make_pipeline_capture()
+    fake_cache.client.pipeline = _new_pipe
+    monkeypatch.setattr(
+        "src.utils.cache.redis_cache.get_cache_client", lambda: fake_cache
+    )
+    monkeypatch.setattr(
+        "src.config.settings.is_subagent_event_redis_spill_enabled", lambda: True
+    )
+
+    registry = BackgroundTaskRegistry(thread_id="thread-x")
+    task = await registry.register(
+        tool_call_id="tc1", description="d", prompt="p", subagent_type="general-purpose"
+    )
+    task.redis_write_failed = True
+
+    await registry.append_sentinel_to_stream(task.tool_call_id)
+
+    assert queued["xadd"] == []
+    assert queued["expire"] == []
+
+
+@pytest.mark.asyncio
+async def test_sentinel_no_op_without_thread_id(monkeypatch) -> None:
+    """A registry with no ``thread_id`` (test fixtures, in-process scratchpads)
+    has no Redis stream key to write to — the sentinel must be a no-op."""
+    fake_cache = MagicMock()
+    fake_cache.enabled = True
+    fake_cache.client = MagicMock()
+    queued, _new_pipe = _make_pipeline_capture()
+    fake_cache.client.pipeline = _new_pipe
+    monkeypatch.setattr(
+        "src.utils.cache.redis_cache.get_cache_client", lambda: fake_cache
+    )
+
+    registry = BackgroundTaskRegistry()  # no thread_id
+    task = await registry.register(
+        tool_call_id="tc1", description="d", prompt="p", subagent_type="general-purpose"
+    )
+
+    await registry.append_sentinel_to_stream(task.tool_call_id)
+
+    assert queued["xadd"] == []
+
+
+@pytest.mark.asyncio
+async def test_sentinel_swallows_pipeline_exception(monkeypatch) -> None:
+    """The sentinel write is best-effort. If Redis throws mid-pipeline, the
+    method must not propagate — the SSE consumer's ``terminal_check``
+    fallback closes the stream once the asyncio task finishes."""
+    fake_cache = MagicMock()
+    fake_cache.enabled = True
+    fake_cache.client = MagicMock()
+    queued, _new_pipe = _make_pipeline_capture(
+        execute_return=RuntimeError("pipeline boom")
+    )
+    fake_cache.client.pipeline = _new_pipe
+    monkeypatch.setattr(
+        "src.utils.cache.redis_cache.get_cache_client", lambda: fake_cache
+    )
+    monkeypatch.setattr(
+        "src.config.settings.is_subagent_event_redis_spill_enabled", lambda: True
+    )
+    monkeypatch.setattr(
+        "src.config.settings.get_max_stored_messages_per_agent", lambda: 1000
+    )
+    monkeypatch.setattr(
+        "src.config.settings.get_redis_ttl_workflow_events", lambda: 86400
+    )
+
+    registry = BackgroundTaskRegistry(thread_id="thread-x")
+    task = await registry.register(
+        tool_call_id="tc1", description="d", prompt="p", subagent_type="general-purpose"
+    )
+
+    # Should not raise.
+    await registry.append_sentinel_to_stream(task.tool_call_id)
+
+
 @pytest.mark.asyncio
 async def test_text_event_bumps_last_updated_at_with_new_path() -> None:
     """The text-chunk last_updated_at bump survives the producer rewrite."""

--- a/tests/unit/middleware/test_subagent_event_capture.py
+++ b/tests/unit/middleware/test_subagent_event_capture.py
@@ -137,6 +137,11 @@ async def test_redis_spill_called_for_every_event(monkeypatch) -> None:
         for call in fake_cache.pipelined_event_buffer.await_args_list
     }
     assert meta_keys == {f"subagent:events:meta:thread-x:{task.task_id}"}
+    stream_keys = {
+        call.kwargs["stream_key"]
+        for call in fake_cache.pipelined_event_buffer.await_args_list
+    }
+    assert stream_keys == {f"subagent:stream:thread-x:{task.task_id}"}
     assert not task.redis_write_failed
 
 

--- a/tests/unit/middleware/test_subagent_token_forwarder.py
+++ b/tests/unit/middleware/test_subagent_token_forwarder.py
@@ -1,0 +1,338 @@
+"""Per-token streaming forwarder tests.
+
+Locks in the contract that ``_SubagentTokenForwarder`` mirrors the main
+streaming handler's reasoning lifecycle (start on first reasoning chunk,
+complete on transition to text or message-id change) and forwards each
+``messages``-mode chunk as one captured-event record on the registry.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from ptc_agent.agent.middleware.background_subagent.registry import (
+    BackgroundTaskRegistry,
+)
+from ptc_agent.agent.middleware.background_subagent.subagent import (
+    _SubagentTokenForwarder,
+)
+
+
+def _chunk(content, msg_id="msg-1", reasoning_kw=None):
+    """Build a fake message chunk with content and optional reasoning kwarg."""
+    chunk = MagicMock()
+    chunk.content = content
+    chunk.id = msg_id
+    chunk.additional_kwargs = {}
+    if reasoning_kw is not None:
+        chunk.additional_kwargs["reasoning_content"] = reasoning_kw
+    return chunk
+
+
+async def _register(registry: BackgroundTaskRegistry, task_id_override="abc"):
+    task = await registry.register(
+        tool_call_id=f"tc-{task_id_override}",
+        description="d",
+        prompt="p",
+        subagent_type="general-purpose",
+    )
+    if task.task_id != task_id_override:
+        registry._task_id_to_tool_call_id.pop(task.task_id, None)
+        task.task_id = task_id_override
+        registry._task_id_to_tool_call_id[task_id_override] = task.tool_call_id
+    return task
+
+
+@pytest.mark.asyncio
+async def test_forwards_text_chunks_one_per_token():
+    registry = BackgroundTaskRegistry()
+    task = await _register(registry)
+    fw = _SubagentTokenForwarder(registry, task.tool_call_id, "task:abc")
+
+    await fw.forward(_chunk("Hel"))
+    await fw.forward(_chunk("lo"))
+    await fw.forward(_chunk(", world"))
+    await fw.finalize()
+
+    events = list(task.captured_events_tail)
+    text_chunks = [
+        e for e in events
+        if e["event"] == "message_chunk"
+        and e["data"].get("content_type") == "text"
+    ]
+    # Three forwarded chunks → three records, each carrying its own slice.
+    assert [e["data"]["content"] for e in text_chunks] == ["Hel", "lo", ", world"]
+    # Every record carries the canonical agent_id injected by the forwarder.
+    assert {e["data"]["agent"] for e in text_chunks} == {"task:abc"}
+    # No reasoning lifecycle for pure-text streams.
+    sig_chunks = [
+        e for e in events
+        if e["data"].get("content_type") == "reasoning_signal"
+    ]
+    assert sig_chunks == []
+
+
+@pytest.mark.asyncio
+async def test_reasoning_lifecycle_emits_inline_start_and_complete_on_transition():
+    """First reasoning chunk → emit start signal. Transition to text → emit
+    complete signal. Mirrors WorkflowStreamHandler._process_message_chunk."""
+    registry = BackgroundTaskRegistry()
+    task = await _register(registry)
+    fw = _SubagentTokenForwarder(registry, task.tool_call_id, "task:abc")
+
+    await fw.forward(_chunk({"type": "thinking", "thinking": "step one"}))
+    await fw.forward(_chunk({"type": "thinking", "thinking": " step two"}))
+    await fw.forward(_chunk("here is the answer"))
+    await fw.finalize()
+
+    events = list(task.captured_events_tail)
+    timeline = [
+        (e["data"].get("content_type"), e["data"].get("content"))
+        for e in events
+        if e["event"] == "message_chunk"
+    ]
+
+    # Expected sequence:
+    # 1. reasoning_signal "start" (inline with first reasoning chunk)
+    # 2. reasoning chunk "step one"
+    # 3. reasoning chunk " step two"
+    # 4. reasoning_signal "complete" (transition reasoning → text)
+    # 5. text chunk "here is the answer"
+    assert timeline == [
+        ("reasoning_signal", "start"),
+        ("reasoning", "step one"),
+        ("reasoning", " step two"),
+        ("reasoning_signal", "complete"),
+        ("text", "here is the answer"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_finalize_closes_dangling_reasoning_signal():
+    """If a run ends while reasoning is still active (LLM returned reasoning
+    only, no text), finalize must emit the complete signal so the frontend's
+    reasoning UI doesn't stay open forever."""
+    registry = BackgroundTaskRegistry()
+    task = await _register(registry)
+    fw = _SubagentTokenForwarder(registry, task.tool_call_id, "task:abc")
+
+    await fw.forward(_chunk({"type": "thinking", "thinking": "lone thought"}))
+    await fw.finalize()
+
+    events = list(task.captured_events_tail)
+    timeline = [
+        (e["data"].get("content_type"), e["data"].get("content"))
+        for e in events
+        if e["event"] == "message_chunk"
+    ]
+    assert timeline == [
+        ("reasoning_signal", "start"),
+        ("reasoning", "lone thought"),
+        ("reasoning_signal", "complete"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_finalize_emits_stream_end_sentinel():
+    """The per-task SSE consumer's only signal that the subagent has finished
+    streaming is a ``subagent_stream_end`` sentinel record on the per-task
+    Redis Stream. ``finalize()`` must write it via
+    ``append_sentinel_to_stream`` — without that the consumer falls back to
+    polling ``task.asyncio_task.done()`` between BLOCK timeouts and the
+    frontend card stays "Running" until the post-turn collector flips
+    ``task.completed``.
+
+    The sentinel must NOT land in ``captured_events_tail`` (which gets
+    persisted to Postgres + replayed on history load) — it's a transport
+    signal, not content.
+    """
+    registry = BackgroundTaskRegistry()
+    task = await _register(registry)
+    fw = _SubagentTokenForwarder(registry, task.tool_call_id, "task:abc")
+
+    sentinel_calls = []
+
+    async def fake_sentinel(tool_call_id):
+        sentinel_calls.append(tool_call_id)
+
+    registry.append_sentinel_to_stream = fake_sentinel  # type: ignore[method-assign]
+
+    await fw.forward(_chunk("Hello"))
+    await fw.finalize()
+
+    assert sentinel_calls == [task.tool_call_id]
+    # The deque should hold only the real text chunk — no sentinel record.
+    assert all(
+        e["event"] != "subagent_stream_end" for e in task.captured_events_tail
+    )
+
+
+@pytest.mark.asyncio
+async def test_finalize_sentinel_failure_does_not_propagate():
+    """Sentinel write is best-effort — if Redis is degraded or
+    ``append_sentinel_to_stream`` raises, ``finalize`` must still return
+    normally so the parent ``_arun_subagent_streaming`` finally-block
+    completes. The terminal_check fallback closes the stream eventually.
+    """
+    registry = BackgroundTaskRegistry()
+    task = await _register(registry)
+    fw = _SubagentTokenForwarder(registry, task.tool_call_id, "task:abc")
+
+    async def boom(_tool_call_id):
+        raise RuntimeError("redis is on fire")
+
+    registry.append_sentinel_to_stream = boom  # type: ignore[method-assign]
+
+    # Should not raise.
+    await fw.finalize()
+
+
+@pytest.mark.asyncio
+async def test_message_id_change_closes_prior_reasoning():
+    """A new message_id with reasoning still active means the prior LLM call
+    finished mid-reasoning. Close the old lifecycle before starting fresh."""
+    registry = BackgroundTaskRegistry()
+    task = await _register(registry)
+    fw = _SubagentTokenForwarder(registry, task.tool_call_id, "task:abc")
+
+    await fw.forward(
+        _chunk({"type": "thinking", "thinking": "first call"}, msg_id="msg-A")
+    )
+    # New message id with reasoning still active.
+    await fw.forward(
+        _chunk({"type": "thinking", "thinking": "second call"}, msg_id="msg-B")
+    )
+    await fw.finalize()
+
+    events = list(task.captured_events_tail)
+    msg_ids_and_types = [
+        (e["data"]["id"], e["data"].get("content_type"), e["data"].get("content"))
+        for e in events
+        if e["event"] == "message_chunk"
+    ]
+    assert msg_ids_and_types == [
+        ("msg-A", "reasoning_signal", "start"),
+        ("msg-A", "reasoning", "first call"),
+        ("msg-A", "reasoning_signal", "complete"),  # closed on msg-id change
+        ("msg-B", "reasoning_signal", "start"),
+        ("msg-B", "reasoning", "second call"),
+        ("msg-B", "reasoning_signal", "complete"),  # closed by finalize
+    ]
+
+
+@pytest.mark.asyncio
+async def test_reasoning_via_additional_kwargs_is_normalized():
+    """Some providers stream reasoning under ``additional_kwargs.reasoning_content``
+    rather than as content. Forwarder must promote it to a reasoning chunk."""
+    registry = BackgroundTaskRegistry()
+    task = await _register(registry)
+    fw = _SubagentTokenForwarder(registry, task.tool_call_id, "task:abc")
+
+    await fw.forward(_chunk("", reasoning_kw="kw-only thought"))
+    await fw.finalize()
+
+    events = list(task.captured_events_tail)
+    types_and_content = [
+        (e["data"].get("content_type"), e["data"].get("content"))
+        for e in events
+        if e["event"] == "message_chunk"
+    ]
+    assert types_and_content == [
+        ("reasoning_signal", "start"),
+        ("reasoning", "kw-only thought"),
+        ("reasoning_signal", "complete"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_empty_chunks_are_skipped():
+    """Provider keepalive / empty chunks must not produce records."""
+    registry = BackgroundTaskRegistry()
+    task = await _register(registry)
+    fw = _SubagentTokenForwarder(registry, task.tool_call_id, "task:abc")
+
+    await fw.forward(_chunk(""))
+    await fw.forward(_chunk(None))
+    await fw.finalize()
+
+    assert list(task.captured_events_tail) == []
+
+
+@pytest.mark.asyncio
+async def test_atask_pipeline_forwards_messages_chunks_to_registry(monkeypatch):
+    """End-to-end: when the Task tool drives the subagent through astream,
+    each ``messages``-mode chunk lands as a captured-event record on the
+    registry — i.e. on the per-task SSE stream the frontend will read."""
+    from ptc_agent.agent.middleware.background_subagent import subagent as sa
+    from ptc_agent.agent.middleware.background_subagent.middleware import (
+        current_background_tool_call_id,
+    )
+
+    parent_config = {"configurable": {"thread_id": "t1"}}
+    monkeypatch.setattr(
+        "ptc_agent.agent.middleware.background_subagent.subagent.get_config",
+        lambda: parent_config,
+    )
+
+    registry = BackgroundTaskRegistry()
+    task = await _register(registry, task_id_override="taskpipe")
+
+    async def fake_astream(state, config, stream_mode=None):
+        # Three text-token chunks then a final values yield.
+        yield ("messages", (_chunk("Hel"), {}))
+        yield ("messages", (_chunk("lo"), {}))
+        yield ("messages", (_chunk(", world"), {}))
+        yield ("values", {"messages": [MagicMock(text="final")]})
+
+    fake_subagent = MagicMock()
+    fake_subagent.astream = fake_astream
+
+    tool = sa._create_task_tool(
+        default_model=MagicMock(),
+        default_tools=[],
+        default_middleware=[],
+        default_interrupt_on=None,
+        subagents=[],
+        general_purpose_agent=False,
+        registry=registry,
+        checkpointer=None,
+    )
+    coroutine = tool.coroutine
+    closure_vars = {
+        cell_name: cell.cell_contents
+        for cell_name, cell in zip(
+            coroutine.__code__.co_freevars,
+            coroutine.__closure__ or (),
+        )
+    }
+    sg = closure_vars["subagent_graphs"]
+    sg["general-purpose"] = fake_subagent
+
+    runtime = MagicMock()
+    runtime.state = {"messages": []}
+    runtime.tool_call_id = "tc-pipe"
+
+    # current_background_tool_call_id must point at the registered task —
+    # the forwarder uses it to resolve the agent_id.
+    token = current_background_tool_call_id.set(task.tool_call_id)
+    try:
+        await coroutine(
+            description="d",
+            prompt="p",
+            subagent_type="general-purpose",
+            action="init",
+            task_id=None,
+            runtime=runtime,
+        )
+    finally:
+        current_background_tool_call_id.reset(token)
+
+    text_chunks = [
+        e for e in task.captured_events_tail
+        if e["event"] == "message_chunk"
+        and e["data"].get("content_type") == "text"
+    ]
+    assert [e["data"]["content"] for e in text_chunks] == ["Hel", "lo", ", world"]
+    assert {e["data"]["agent"] for e in text_chunks} == {"task:taskpipe"}

--- a/tests/unit/middleware/test_subagent_tracer_isolation.py
+++ b/tests/unit/middleware/test_subagent_tracer_isolation.py
@@ -1,4 +1,4 @@
-"""Subagent callback-shape regression tests.
+"""Subagent callback-shape regression tests + astream driver shape tests.
 
 The subagent's outbound config inherits whatever the parent runtime put on
 ``callbacks``. LangChain hands that slot in as a ``BaseCallbackManager``
@@ -12,6 +12,7 @@ not on an explicit ``LangChainTracer`` per subagent.
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -40,12 +41,13 @@ async def test_parent_callbacks_as_callback_manager_does_not_crash(monkeypatch):
 
     seen_configs: list[dict] = []
 
-    async def fake_ainvoke(state, config):
+    async def fake_astream(state, config, stream_mode=None):
         seen_configs.append(config)
-        return {"messages": [MagicMock(text="ok")]}
+        # When stream_mode is a list, langgraph yields (mode, data) tuples.
+        yield ("values", {"messages": [MagicMock(text="ok")]})
 
     fake_subagent = MagicMock()
-    fake_subagent.ainvoke = fake_ainvoke
+    fake_subagent.astream = fake_astream
 
     tool = sa._create_task_tool(
         default_model=MagicMock(),
@@ -123,12 +125,13 @@ async def test_subagent_does_not_inherit_parent_token_tracker(monkeypatch):
 
     seen_configs: list[dict] = []
 
-    async def fake_ainvoke(state, config):
+    async def fake_astream(state, config, stream_mode=None):
         seen_configs.append(config)
-        return {"messages": [MagicMock(text="ok")]}
+        # When stream_mode is a list, langgraph yields (mode, data) tuples.
+        yield ("values", {"messages": [MagicMock(text="ok")]})
 
     fake_subagent = MagicMock()
-    fake_subagent.ainvoke = fake_ainvoke
+    fake_subagent.astream = fake_astream
 
     tool = sa._create_task_tool(
         default_model=MagicMock(),
@@ -176,3 +179,78 @@ async def test_subagent_does_not_inherit_parent_token_tracker(monkeypatch):
     assert parent_handler_other not in cbs
     # Per-subagent tracker IS attached so on_llm_end fires on it
     assert bg_tracker in cbs
+
+
+@pytest.mark.asyncio
+async def test_subagent_uses_astream_with_values_and_messages_modes(
+    monkeypatch,
+):
+    """The Task tool drives the subagent through
+    ``astream(stream_mode=["values", "messages"])``. The LAST ``values``
+    yield is the tool's return; ``messages`` yields are forwarded as per-token
+    captured events on the registry. Earlier ``values`` yields are
+    intermediate snapshots that must NOT propagate."""
+    from ptc_agent.agent.middleware.background_subagent import subagent as sa
+
+    parent_config = {"configurable": {"thread_id": "t1"}}
+    monkeypatch.setattr(
+        "ptc_agent.agent.middleware.background_subagent.subagent.get_config",
+        lambda: parent_config,
+    )
+
+    seen_stream_modes: list[Any] = []
+
+    async def fake_astream(state, config, stream_mode=None):
+        seen_stream_modes.append(stream_mode)
+        # Multi-mode list → langgraph yields (mode, data) tuples.
+        yield ("values", {"messages": [MagicMock(text="step-1")]})
+        yield ("values", {"messages": [MagicMock(text="step-2")]})
+        yield ("values", {"messages": [MagicMock(text="final")], "extra": "carried"})
+
+    fake_subagent = MagicMock()
+    fake_subagent.astream = fake_astream
+
+    tool = sa._create_task_tool(
+        default_model=MagicMock(),
+        default_tools=[],
+        default_middleware=[],
+        default_interrupt_on=None,
+        subagents=[],
+        general_purpose_agent=False,
+        registry=None,
+        checkpointer=None,
+    )
+    coroutine = tool.coroutine
+
+    closure_vars = {
+        cell_name: cell.cell_contents
+        for cell_name, cell in zip(
+            coroutine.__code__.co_freevars,
+            coroutine.__closure__ or (),
+        )
+    }
+    sg = closure_vars.get("subagent_graphs")
+    assert sg is not None
+    sg["general-purpose"] = fake_subagent
+
+    runtime = MagicMock()
+    runtime.state = {"messages": []}
+    runtime.tool_call_id = "tc-final"
+
+    cmd = await coroutine(
+        description="d",
+        prompt="p",
+        subagent_type="general-purpose",
+        action="init",
+        task_id=None,
+        runtime=runtime,
+    )
+
+    # Driver requests both modes — values for the final-state return,
+    # messages for per-token forwarding.
+    assert seen_stream_modes == [["values", "messages"]]
+
+    # Only the LAST values yield propagates as the tool's return.
+    msg = cmd.update["messages"][-1]
+    assert msg.content == "final"
+    assert cmd.update.get("extra") == "carried"

--- a/tests/unit/server/handlers/chat/test_stream_from_log.py
+++ b/tests/unit/server/handlers/chat/test_stream_from_log.py
@@ -1,0 +1,270 @@
+"""Unit tests for the Redis-Streams-backed SSE consumer.
+
+Validates:
+- XREAD cursor selection ($/0/<seq>-0) for new vs replay vs resume connections
+- SSE payload pass-through (UTF-8 decode of bytes)
+- Keepalive emission on BLOCK timeout + terminal-after-empty exit handshake
+- on_attach / on_detach hooks fire even when generator is cancelled mid-flight
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.server.handlers.chat.stream_from_log import _stream_from_redis_log
+
+
+def _make_cache(xread_returns: list[Any]) -> MagicMock:
+    """A cache mock whose client.xread iterates through the given sequence."""
+    cache = MagicMock()
+    cache.enabled = True
+    redis = MagicMock()
+    cache.client = redis
+    redis.xread = AsyncMock(side_effect=xread_returns)
+    return cache
+
+
+@pytest.mark.asyncio
+async def test_yields_decoded_payloads_in_order():
+    cache = _make_cache(
+        [
+            [
+                (
+                    b"workflow:stream:t1",
+                    [
+                        (b"1-0", {b"event": b"id: 1\nevent: x\ndata: a\n\n"}),
+                        (b"2-0", {b"event": b"id: 2\nevent: x\ndata: b\n\n"}),
+                    ],
+                )
+            ],
+            [],  # BLOCK timeout
+            [],  # terminal=True confirmed; should exit after second empty
+        ]
+    )
+
+    async def terminal() -> bool:
+        return True
+
+    with patch(
+        "src.server.handlers.chat.stream_from_log.get_cache_client",
+        return_value=cache,
+    ):
+        out = []
+        async for ev in _stream_from_redis_log(
+            stream_key="workflow:stream:t1",
+            terminal_check=terminal,
+            last_event_id=None,
+        ):
+            out.append(ev)
+
+    # Two real events + one keepalive between the only-data round and the
+    # exit handshake.
+    assert "id: 1" in out[0]
+    assert "id: 2" in out[1]
+    assert ":keepalive\n\n" in out
+
+
+@pytest.mark.asyncio
+async def test_first_connect_uses_dollar_cursor():
+    cache = _make_cache([[], []])  # two empty rounds → terminal handshake
+
+    async def terminal() -> bool:
+        return True
+
+    with patch(
+        "src.server.handlers.chat.stream_from_log.get_cache_client",
+        return_value=cache,
+    ):
+        async for _ in _stream_from_redis_log(
+            stream_key="k",
+            terminal_check=terminal,
+            last_event_id=None,
+        ):
+            pass
+
+    args, kwargs = cache.client.xread.call_args_list[0]
+    streams = args[0] if args else kwargs.get("streams")
+    assert streams == {b"k": b"$"}
+
+
+@pytest.mark.asyncio
+async def test_replay_uses_zero_cursor():
+    cache = _make_cache([[], []])
+
+    async def terminal() -> bool:
+        return True
+
+    with patch(
+        "src.server.handlers.chat.stream_from_log.get_cache_client",
+        return_value=cache,
+    ):
+        async for _ in _stream_from_redis_log(
+            stream_key="k",
+            terminal_check=terminal,
+            last_event_id=0,
+        ):
+            pass
+
+    args, kwargs = cache.client.xread.call_args_list[0]
+    streams = args[0] if args else kwargs.get("streams")
+    assert streams == {b"k": b"0"}
+
+
+@pytest.mark.asyncio
+async def test_resume_uses_seq_dash_zero_cursor():
+    cache = _make_cache([[], []])
+
+    async def terminal() -> bool:
+        return True
+
+    with patch(
+        "src.server.handlers.chat.stream_from_log.get_cache_client",
+        return_value=cache,
+    ):
+        async for _ in _stream_from_redis_log(
+            stream_key="k",
+            terminal_check=terminal,
+            last_event_id=42,
+        ):
+            pass
+
+    args, kwargs = cache.client.xread.call_args_list[0]
+    streams = args[0] if args else kwargs.get("streams")
+    assert streams == {b"k": b"42-0"}
+
+
+@pytest.mark.asyncio
+async def test_advances_cursor_through_entries():
+    """Across multiple XREAD rounds, cursor should advance to last seen ID."""
+    cache = _make_cache(
+        [
+            [
+                (
+                    b"k",
+                    [
+                        (b"5-0", {b"event": b"id: 5\ndata: a\n\n"}),
+                        (b"6-0", {b"event": b"id: 6\ndata: b\n\n"}),
+                    ],
+                )
+            ],
+            [],  # terminal becomes True; first empty round
+            [],  # second empty round → exit
+        ]
+    )
+
+    async def terminal() -> bool:
+        return True
+
+    with patch(
+        "src.server.handlers.chat.stream_from_log.get_cache_client",
+        return_value=cache,
+    ):
+        async for _ in _stream_from_redis_log(
+            stream_key="k",
+            terminal_check=terminal,
+            last_event_id=4,
+        ):
+            pass
+
+    cursors = [
+        (call.args[0] if call.args else call.kwargs.get("streams"))[b"k"]
+        for call in cache.client.xread.call_args_list
+    ]
+    assert cursors[0] == b"4-0"  # initial resume cursor
+    assert cursors[1] == b"6-0"  # advanced past the two yielded entries
+
+
+@pytest.mark.asyncio
+async def test_terminal_handshake_requires_two_empty_rounds():
+    """If terminal=True but new events still arrive between rounds, don't exit early."""
+    cache = _make_cache(
+        [
+            [],  # empty + terminal=True → set terminal_seen
+            [
+                (
+                    b"k",
+                    [(b"1-0", {b"event": b"id: 1\ndata: x\n\n"})],
+                )
+            ],  # late event resets terminal_seen
+            [],  # empty + terminal=True → first
+            [],  # empty + terminal=True → second; exit
+        ]
+    )
+
+    async def terminal() -> bool:
+        return True
+
+    with patch(
+        "src.server.handlers.chat.stream_from_log.get_cache_client",
+        return_value=cache,
+    ):
+        out = []
+        async for ev in _stream_from_redis_log(
+            stream_key="k",
+            terminal_check=terminal,
+            last_event_id=0,
+        ):
+            out.append(ev)
+
+    payloads = [e for e in out if not e.startswith(":keepalive")]
+    assert len(payloads) == 1
+    assert "id: 1" in payloads[0]
+
+
+@pytest.mark.asyncio
+async def test_attach_detach_hooks_fire():
+    cache = _make_cache([[], []])
+    attach_calls = []
+    detach_calls = []
+
+    async def on_attach() -> None:
+        attach_calls.append(True)
+
+    async def on_detach() -> None:
+        detach_calls.append(True)
+
+    async def terminal() -> bool:
+        return True
+
+    with patch(
+        "src.server.handlers.chat.stream_from_log.get_cache_client",
+        return_value=cache,
+    ):
+        async for _ in _stream_from_redis_log(
+            stream_key="k",
+            terminal_check=terminal,
+            last_event_id=0,
+            on_attach=on_attach,
+            on_detach=on_detach,
+        ):
+            pass
+
+    assert attach_calls == [True]
+    assert detach_calls == [True]
+
+
+@pytest.mark.asyncio
+async def test_disabled_cache_returns_empty_immediately():
+    cache = MagicMock()
+    cache.enabled = False
+    cache.client = None
+
+    async def terminal() -> bool:
+        return False
+
+    with patch(
+        "src.server.handlers.chat.stream_from_log.get_cache_client",
+        return_value=cache,
+    ):
+        out = [
+            ev
+            async for ev in _stream_from_redis_log(
+                stream_key="k",
+                terminal_check=terminal,
+                last_event_id=None,
+            )
+        ]
+    assert out == []

--- a/tests/unit/server/handlers/chat/test_stream_from_log.py
+++ b/tests/unit/server/handlers/chat/test_stream_from_log.py
@@ -189,6 +189,60 @@ async def test_advances_cursor_through_entries():
 
 
 @pytest.mark.asyncio
+async def test_cursor_advances_past_skipped_last_entry():
+    """Regression: when the *last* entry in an XREAD batch is skipped (missing
+    ``event`` field, non-UTF8 bytes), the cursor must still advance past it.
+
+    Otherwise the next XREAD reads using the prior entry's id and gets the
+    same skipped entry back forever — a tight retry loop that never makes
+    progress."""
+    # Round 1: two entries; the LAST one is skipped (missing ``event`` field).
+    # Round 2: empty (terminal handshake round 1).
+    # Round 3: empty (handshake round 2 → exit).
+    cache = _make_cache(
+        [
+            [
+                (
+                    b"k",
+                    [
+                        (b"5-0", {b"event": b"id: 5\ndata: a\n\n"}),
+                        (b"6-0", {}),  # missing ``event`` — skipped via continue
+                    ],
+                )
+            ],
+            [],
+            [],
+        ]
+    )
+
+    async def terminal() -> bool:
+        return True
+
+    yielded: list[str] = []
+    with patch(
+        "src.server.handlers.chat.stream_from_log.get_cache_client",
+        return_value=cache,
+    ):
+        async for ev in _stream_from_redis_log(
+            stream_key="k",
+            terminal_check=terminal,
+            last_event_id=4,
+        ):
+            if ev != ":keepalive\n\n":
+                yielded.append(ev)
+
+    cursors = [
+        (call.args[0] if call.args else call.kwargs.get("streams"))[b"k"]
+        for call in cache.client.xread.call_args_list
+    ]
+    assert yielded == ["id: 5\ndata: a\n\n"]
+    # Critical assertion: cursor moved to 6-0 even though that entry was
+    # skipped. Without the fix, cursors[1] would be b"5-0" (the last
+    # successfully-yielded entry) and round 2 would re-read 6-0 forever.
+    assert cursors[1] == b"6-0"
+
+
+@pytest.mark.asyncio
 async def test_terminal_handshake_requires_two_empty_rounds():
     """If terminal=True but new events still arrive between rounds, don't exit early."""
     cache = _make_cache(

--- a/tests/unit/server/handlers/chat/test_stream_from_log.py
+++ b/tests/unit/server/handlers/chat/test_stream_from_log.py
@@ -1,20 +1,27 @@
 """Unit tests for the Redis-Streams-backed SSE consumer.
 
 Validates:
-- XREAD cursor selection ($/0/<seq>-0) for new vs replay vs resume connections
+- XREAD cursor selection (0/<seq>-0) for new vs replay vs resume connections
 - SSE payload pass-through (UTF-8 decode of bytes)
 - Keepalive emission on BLOCK timeout + terminal-after-empty exit handshake
 - on_attach / on_detach hooks fire even when generator is cancelled mid-flight
+- Subagent JSON-record rendering to SSE wire format
 """
 
 from __future__ import annotations
 
+import json
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from src.server.handlers.chat.stream_from_log import _stream_from_redis_log
+from src.server.handlers.chat.stream_from_log import (
+    _record_to_sse,
+    _stream_from_redis_log,
+    stream_from_log,
+    stream_subagent_from_log,
+)
 
 
 def _make_cache(xread_returns: list[Any]) -> MagicMock:
@@ -68,7 +75,11 @@ async def test_yields_decoded_payloads_in_order():
 
 
 @pytest.mark.asyncio
-async def test_first_connect_uses_dollar_cursor():
+async def test_none_last_event_id_replays_from_start():
+    """``last_event_id=None`` (no resume cursor) → start at 0 to replay
+    everything in the stream. Subagent attaches need this; main first-
+    connect doesn't lose anything because the stream is empty at start.
+    """
     cache = _make_cache([[], []])  # two empty rounds → terminal handshake
 
     async def terminal() -> bool:
@@ -87,7 +98,7 @@ async def test_first_connect_uses_dollar_cursor():
 
     args, kwargs = cache.client.xread.call_args_list[0]
     streams = args[0] if args else kwargs.get("streams")
-    assert streams == {b"k": b"$"}
+    assert streams == {b"k": b"0"}
 
 
 @pytest.mark.asyncio
@@ -244,6 +255,333 @@ async def test_attach_detach_hooks_fire():
 
     assert attach_calls == [True]
     assert detach_calls == [True]
+
+
+def test_classify_subagent_payload_distinguishes_all_four_kinds():
+    """Lock in the contract that ``_classify_subagent_payload`` recognises:
+    pre-rendered SSE wire strings, stream-end sentinels, legacy JSON
+    records, and unknown/garbage. The classifier is the single source of
+    truth on the consumer hot path — drift would re-introduce the
+    redundant byte-zero check the consolidation removed."""
+    from src.server.handlers.chat.stream_from_log import (
+        _PAYLOAD_RECORD,
+        _PAYLOAD_SENTINEL,
+        _PAYLOAD_UNKNOWN,
+        _PAYLOAD_WIRE,
+        _classify_subagent_payload,
+    )
+
+    # SSE wire strings (event + keepalive) bail before JSON decode.
+    assert _classify_subagent_payload("id: 5\nevent: x\ndata: {}\n\n") == (_PAYLOAD_WIRE, None)
+    assert _classify_subagent_payload(":keepalive\n\n") == (_PAYLOAD_WIRE, None)
+    assert _classify_subagent_payload("") == (_PAYLOAD_WIRE, None)
+
+    # Sentinel: ``event`` set, ``seq`` absent → consumer should exit.
+    sentinel_kind, sentinel_parsed = _classify_subagent_payload(
+        json.dumps({"event": "subagent_stream_end"})
+    )
+    assert sentinel_kind == _PAYLOAD_SENTINEL
+    assert sentinel_parsed is None
+
+    # Legacy JSON record: ``seq`` present → render via _record_to_sse.
+    record_kind, record_parsed = _classify_subagent_payload(
+        json.dumps({"seq": 5, "event": "message_chunk", "data": {"content": "x"}})
+    )
+    assert record_kind == _PAYLOAD_RECORD
+    assert record_parsed == {"seq": 5, "event": "message_chunk", "data": {"content": "x"}}
+
+    # Garbage / non-dict / wrong shape → unknown, fall through to raw.
+    assert _classify_subagent_payload("not json{")[0] == _PAYLOAD_UNKNOWN
+    assert _classify_subagent_payload("[1, 2, 3]")[0] == _PAYLOAD_UNKNOWN
+    # An ``event`` field without sentinel value AND without ``seq`` is
+    # also unknown — neither pre-rendered nor a legacy record.
+    assert _classify_subagent_payload(json.dumps({"event": "other"}))[0] == _PAYLOAD_UNKNOWN
+    # A stray sentinel that *also* carries ``seq`` (defensive: shouldn't
+    # happen, but if a future producer regression added one, we'd rather
+    # render it as a record than silently exit the consumer).
+    sneaky_kind, _ = _classify_subagent_payload(
+        json.dumps({"event": "subagent_stream_end", "seq": 1})
+    )
+    assert sneaky_kind == _PAYLOAD_RECORD
+
+
+def test_record_to_sse_injects_thread_and_task_ids():
+    record = {
+        "seq": 7,
+        "event": "message_chunk",
+        "data": {"content": "hello"},
+        # ``agent_id`` is the LangGraph namespace UUID — must NOT leak as the
+        # user-facing ``agent`` label.
+        "agent_id": "general-purpose:c7de8b8b-07e0-451d-bd8d-96a173f9018c",
+    }
+    sse = _record_to_sse(record, thread_id="t1", task_id="abc123")
+    assert sse.startswith("id: 7\n")
+    assert "event: message_chunk\n" in sse
+    body = sse.split("data: ", 1)[1].rstrip("\n")
+    payload = json.loads(body)
+    assert payload["thread_id"] == "t1"
+    assert payload["agent"] == "task:abc123"
+    assert payload["content"] == "hello"
+
+
+def test_record_to_sse_uses_task_id_label_even_without_agent_id():
+    """No ``agent_id`` on the record: still derive ``task:{task_id}``."""
+    sse = _record_to_sse(
+        {"seq": 1, "event": "tool_calls", "data": {"x": 1}},
+        thread_id="t1",
+        task_id="xyz",
+    )
+    body = sse.split("data: ", 1)[1].rstrip("\n")
+    assert json.loads(body)["agent"] == "task:xyz"
+
+
+def test_record_to_sse_canonical_fields_win_over_inner_data():
+    """Caller-injected thread_id/agent must shadow producer-side stray keys
+    inside the inner ``data`` dict. The consumer is the source of truth for
+    routing identity, and ``task:{task_id}`` is the canonical label — never
+    the namespace-UUID ``agent_id``."""
+    record = {
+        "seq": 3,
+        "event": "message_chunk",
+        "data": {
+            # Producer accidentally stamped wrong identity into the inner dict.
+            "thread_id": "WRONG-thread",
+            "agent": "WRONG-agent",
+            "content": "hi",
+        },
+        # Namespace UUID — would surface as "general-purpose:<uuid>" if we
+        # accidentally used it as the user-facing label.
+        "agent_id": "general-purpose:c7de8b8b-07e0-451d-bd8d-96a173f9018c",
+    }
+    sse = _record_to_sse(record, thread_id="t1", task_id="correct-task")
+    body = sse.split("data: ", 1)[1].rstrip("\n")
+    payload = json.loads(body)
+    assert payload["thread_id"] == "t1"
+    assert payload["agent"] == "task:correct-task"
+    assert payload["content"] == "hi"
+
+
+@pytest.mark.asyncio
+async def test_subagent_consumer_passes_through_pre_rendered_sse(monkeypatch):
+    """Steady-state: producer writes SSE wire strings into the Stream so the
+    consumer is a pass-through. No JSON-decode + re-render branch on the hot
+    path."""
+    from src.server.handlers.chat import stream_from_log as sfl_mod
+
+    sse_bytes = b"id: 5\nevent: message_chunk\ndata: {\"content\": \"delta\", \"agent\": \"task:abc\"}\n\n"
+
+    cache = _make_cache(
+        [
+            [(b"subagent:stream:t1:abc", [(b"5-0", {b"event": sse_bytes})])],
+            [],
+            [],
+        ]
+    )
+    monkeypatch.setattr(sfl_mod, "get_cache_client", lambda: cache)
+
+    async def _no_task(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(sfl_mod, "_wait_for_subagent_task", _no_task)
+
+    out = []
+    async for ev in stream_subagent_from_log("t1", "abc", last_event_id=0):
+        out.append(ev)
+
+    payloads = [e for e in out if not e.startswith(":keepalive")]
+    assert len(payloads) == 1
+    # Byte-for-byte pass-through — no re-rendering.
+    assert payloads[0] == sse_bytes.decode("utf-8")
+
+
+@pytest.mark.asyncio
+async def test_subagent_consumer_renders_legacy_json_records(monkeypatch):
+    """Deploy-boundary shim: streams written by the previous JSON-record
+    producer (still readable for up to 24 h after a deploy) must be rendered
+    on the fly. Removable in PR3 once the TTL window passes."""
+    from src.server.handlers.chat import stream_from_log as sfl_mod
+
+    payload_bytes = json.dumps(
+        {
+            "seq": 5,
+            "event": "message_chunk",
+            "data": {"content": "delta"},
+            # Namespace UUID — must NOT leak as the agent label.
+            "agent_id": "general-purpose:c7de8b8b-07e0-451d-bd8d-96a173f9018c",
+        }
+    ).encode("utf-8")
+
+    cache = _make_cache(
+        [
+            [(b"subagent:stream:t1:abc", [(b"5-0", {b"event": payload_bytes})])],
+            [],
+            [],
+        ]
+    )
+    monkeypatch.setattr(sfl_mod, "get_cache_client", lambda: cache)
+
+    async def _no_task(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(sfl_mod, "_wait_for_subagent_task", _no_task)
+
+    out = []
+    async for ev in stream_subagent_from_log("t1", "abc", last_event_id=0):
+        out.append(ev)
+
+    payloads = [e for e in out if not e.startswith(":keepalive")]
+    assert len(payloads) == 1
+    rendered = payloads[0]
+    assert rendered.startswith("id: 5\n")
+    assert "event: message_chunk\n" in rendered
+    assert '"content": "delta"' in rendered
+    assert '"agent": "task:abc"' in rendered
+
+
+@pytest.mark.asyncio
+async def test_subagent_consumer_exits_on_stream_end_sentinel(monkeypatch):
+    """Producer writes a ``subagent_stream_end`` sentinel record when the
+    forwarder finalises. Consumer must (a) not yield it to the wire and
+    (b) exit the generator immediately so the SSE response closes — that
+    flip is what marks the subagent card as completed on the frontend."""
+    from src.server.handlers.chat import stream_from_log as sfl_mod
+
+    real_event_bytes = b"id: 5\nevent: message_chunk\ndata: {\"content\": \"delta\", \"agent\": \"task:abc\"}\n\n"
+    sentinel_bytes = json.dumps({"event": "subagent_stream_end"}).encode("utf-8")
+    # An XREAD round delivering one real event followed by the sentinel.
+    cache = _make_cache(
+        [
+            [
+                (
+                    b"subagent:stream:t1:abc",
+                    [
+                        (b"5-0", {b"event": real_event_bytes}),
+                        (b"6-0", {b"event": sentinel_bytes}),
+                    ],
+                )
+            ],
+            # If the consumer doesn't exit on the sentinel it will keep
+            # XREAD-ing — fail loudly by exhausting the side_effect rather
+            # than hanging the test.
+        ]
+    )
+    monkeypatch.setattr(sfl_mod, "get_cache_client", lambda: cache)
+
+    async def _no_task(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(sfl_mod, "_wait_for_subagent_task", _no_task)
+
+    out = []
+    async for ev in stream_subagent_from_log("t1", "abc", last_event_id=0):
+        out.append(ev)
+
+    payloads = [e for e in out if not e.startswith(":keepalive")]
+    # Only the real event is yielded — the sentinel never reaches the wire.
+    assert payloads == [real_event_bytes.decode("utf-8")]
+    # And the consumer exited inside the same XREAD round, so xread was
+    # called exactly once (no second round attempted).
+    assert cache.client.xread.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_subagent_consumer_exits_on_sentinel_only_stream(monkeypatch):
+    """A subagent that emits no tokens (e.g., immediate failure inside the
+    handler) still has finalize() run, so the stream contains just the
+    sentinel. Consumer must exit cleanly without yielding anything."""
+    from src.server.handlers.chat import stream_from_log as sfl_mod
+
+    sentinel_bytes = json.dumps({"event": "subagent_stream_end"}).encode("utf-8")
+    cache = _make_cache(
+        [
+            [(b"subagent:stream:t1:abc", [(b"1-0", {b"event": sentinel_bytes})])],
+        ]
+    )
+    monkeypatch.setattr(sfl_mod, "get_cache_client", lambda: cache)
+
+    async def _no_task(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(sfl_mod, "_wait_for_subagent_task", _no_task)
+
+    out = []
+    async for ev in stream_subagent_from_log("t1", "abc", last_event_id=0):
+        out.append(ev)
+
+    payloads = [e for e in out if not e.startswith(":keepalive")]
+    assert payloads == []
+
+
+@pytest.mark.asyncio
+async def test_stream_from_log_bumps_workflow_connection_counter(monkeypatch):
+    """The flag-on workflow consumer must bump
+    ``BackgroundTaskManager.active_connections`` on attach and decrement on
+    detach. Without this, the abandoned-task cleanup at
+    ``BackgroundTaskManager._periodic_cleanup`` would force-cancel any
+    long-running RUNNING task whose client connected once and then went
+    silent (no further reconnect calls to refresh ``last_access_at``).
+    Mirrors what ``stream_live_events`` does on the legacy path so housekeeping
+    stays consistent under the flag."""
+    from src.server.handlers.chat import stream_from_log as sfl_mod
+    from src.server.services.background_task_manager import (
+        BackgroundTaskManager,
+        TaskStatus,
+    )
+
+    cache = _make_cache([[], []])  # two empty rounds → terminal handshake
+    monkeypatch.setattr(sfl_mod, "get_cache_client", lambda: cache)
+
+    fake_manager = MagicMock()
+    fake_manager.get_task_status = AsyncMock(return_value=TaskStatus.COMPLETED)
+    fake_manager.increment_connection = AsyncMock(return_value=True)
+    fake_manager.decrement_connection = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        BackgroundTaskManager, "get_instance", classmethod(lambda cls: fake_manager)
+    )
+
+    async for _ in stream_from_log("t-housekeeping", last_event_id=None):
+        pass
+
+    fake_manager.increment_connection.assert_awaited_once_with("t-housekeeping")
+    fake_manager.decrement_connection.assert_awaited_once_with("t-housekeeping")
+
+
+@pytest.mark.asyncio
+async def test_attach_skipped_when_cache_disabled_no_detach_either(monkeypatch):
+    """If the cache is disabled the generator returns immediately without
+    invoking on_attach; on_detach must therefore not fire either (would leak
+    a counter decrement onto a never-attached consumer)."""
+    cache = MagicMock()
+    cache.enabled = False
+    cache.client = None
+
+    attach_calls = []
+    detach_calls = []
+
+    async def on_attach() -> None:
+        attach_calls.append(True)
+
+    async def on_detach() -> None:
+        detach_calls.append(True)
+
+    async def terminal() -> bool:
+        return True
+
+    with patch(
+        "src.server.handlers.chat.stream_from_log.get_cache_client",
+        return_value=cache,
+    ):
+        async for _ in _stream_from_redis_log(
+            stream_key="k",
+            terminal_check=terminal,
+            last_event_id=0,
+            on_attach=on_attach,
+            on_detach=on_detach,
+        ):
+            pass
+
+    assert attach_calls == []
+    assert detach_calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/server/handlers/test_subagent_stream_reconnect.py
+++ b/tests/unit/server/handlers/test_subagent_stream_reconnect.py
@@ -49,6 +49,10 @@ async def _register_task(registry: BackgroundTaskRegistry, task_id: str = "xy123
 
 
 def _wire_fakes(monkeypatch, registry, fake_cache):
+    # These tests exercise the legacy in-memory tail + List replay path.
+    # Pin the flag off so a developer-local .env that flips it on (PR2 staged
+    # rollout) doesn't reroute the tests through the Streams consumer.
+    monkeypatch.setenv("USE_REDIS_STREAM_SSE", "false")
     fake_store = MagicMock()
     fake_store.get_registry = AsyncMock(return_value=registry)
     monkeypatch.setattr(

--- a/tests/unit/server/services/test_event_buffer.py
+++ b/tests/unit/server/services/test_event_buffer.py
@@ -69,6 +69,7 @@ class TestBufferEventRedisHappyPath:
         call = mock_cache.pipelined_event_buffer.await_args
         assert call.kwargs["events_key"] == "workflow:events:thread-1"
         assert call.kwargs["meta_key"] == "workflow:events:meta:thread-1"
+        assert call.kwargs["stream_key"] == "workflow:stream:thread-1"
         assert call.kwargs["last_event_id"] == 42
         assert call.kwargs["max_size"] == 1000
         assert call.kwargs["ttl"] == 86400

--- a/tests/unit/utils/cache/test_pipelined_event_buffer.py
+++ b/tests/unit/utils/cache/test_pipelined_event_buffer.py
@@ -1,0 +1,227 @@
+"""Unit tests for RedisCacheClient.pipelined_event_buffer dual-write semantics.
+
+Verifies that when ``stream_key`` and ``last_event_id`` are both provided, the
+helper queues an XADD with explicit ID ``f"{last_event_id}-0"`` and an
+EXPIRE on the stream key — alongside the existing List + meta hash writes.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.utils.cache.redis_cache import RedisCacheClient
+
+
+def _make_pipeline_mock() -> tuple[MagicMock, MagicMock]:
+    """Build a redis-py-like async pipeline mock recording queued commands."""
+    pipe = MagicMock()
+    # Each queued command (rpush, ltrim, expire, hincrby, etc.) is a no-op
+    # that returns the pipe object — we only care about call args, not order
+    # of magic-method binding.
+    for fn in (
+        "rpush",
+        "ltrim",
+        "expire",
+        "hincrby",
+        "hsetnx",
+        "hset",
+        "hdel",
+        "xadd",
+        "delete",
+    ):
+        setattr(pipe, fn, MagicMock(return_value=pipe))
+    # The implementation pulls ``seq`` from the HINCRBY result whose index
+    # depends on whether the dirty-resume guard fired (and whether a stream
+    # key is configured). Returning ``7`` at every position keeps the
+    # ``seq == 7`` assertion stable across all guard variants without
+    # hard-coding the per-test command count.
+    pipe.execute = AsyncMock(return_value=[7] * 20)
+
+    pipeline_ctx = MagicMock()
+    pipeline_ctx.__aenter__ = AsyncMock(return_value=pipe)
+    pipeline_ctx.__aexit__ = AsyncMock(return_value=None)
+    return pipe, pipeline_ctx
+
+
+def _make_client_with_pipeline(pipeline_ctx: MagicMock) -> RedisCacheClient:
+    client = RedisCacheClient.__new__(RedisCacheClient)
+    client.enabled = True
+    client.stats = {"hits": 0, "misses": 0, "sets": 0, "deletes": 0, "errors": 0}
+    redis_mock = MagicMock()
+    redis_mock.pipeline = MagicMock(return_value=pipeline_ctx)
+    client.client = redis_mock
+    return client
+
+
+@pytest.mark.asyncio
+async def test_xadd_queued_when_stream_key_and_last_event_id_present():
+    pipe, pipeline_ctx = _make_pipeline_mock()
+    cache = _make_client_with_pipeline(pipeline_ctx)
+
+    success, seq = await cache.pipelined_event_buffer(
+        events_key="workflow:events:t1",
+        meta_key="workflow:events:meta:t1",
+        event="id: 42\nevent: x\ndata: hi\n\n",
+        max_size=1000,
+        ttl=86400,
+        last_event_id=42,
+        stream_key="workflow:stream:t1",
+    )
+
+    assert success is True
+    assert seq == 7
+    pipe.xadd.assert_called_once()
+    args, kwargs = pipe.xadd.call_args
+    assert args[0] == "workflow:stream:t1"
+    # Payload uses bytes key 'event' carrying UTF-8 SSE bytes.
+    assert args[1] == {b"event": b"id: 42\nevent: x\ndata: hi\n\n"}
+    assert kwargs["id"] == "42-0"
+    assert kwargs["maxlen"] == 1000
+    assert kwargs["approximate"] is True
+    # EXPIRE is called for events_key, meta_key, AND stream_key — three total.
+    assert pipe.expire.call_count == 3
+    expire_keys = [call.args[0] for call in pipe.expire.call_args_list]
+    assert "workflow:stream:t1" in expire_keys
+
+
+@pytest.mark.asyncio
+async def test_xadd_skipped_when_stream_key_missing():
+    pipe, pipeline_ctx = _make_pipeline_mock()
+    cache = _make_client_with_pipeline(pipeline_ctx)
+
+    await cache.pipelined_event_buffer(
+        events_key="k",
+        meta_key="m",
+        event="id: 1\ndata: x\n\n",
+        max_size=10,
+        ttl=60,
+        last_event_id=1,
+        stream_key=None,
+    )
+
+    pipe.xadd.assert_not_called()
+    # Two EXPIREs (events + meta), not three.
+    assert pipe.expire.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_xadd_skipped_when_last_event_id_missing():
+    """Without an integer last_event_id we cannot construct the explicit
+    XADD ID; skip the dual-write rather than fall back to auto IDs (which
+    would produce mismatched cursor semantics)."""
+    pipe, pipeline_ctx = _make_pipeline_mock()
+    cache = _make_client_with_pipeline(pipeline_ctx)
+
+    await cache.pipelined_event_buffer(
+        events_key="k",
+        meta_key="m",
+        event="event: x\ndata: hi\n\n",
+        max_size=10,
+        ttl=60,
+        last_event_id=None,
+        stream_key="workflow:stream:t1",
+    )
+
+    pipe.xadd.assert_not_called()
+    assert pipe.expire.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_dirty_resume_guard_resets_stream_list_and_seq_when_last_event_id_is_one():
+    """First event of a fresh handler instance must reset all three writers
+    (Stream, List, meta ``seq`` counter) inside the same MULTI/EXEC.
+
+    DEL'ing only the Stream while leaving the List + ``seq`` counter behind
+    breaks ``LLEN == XLEN`` parity (the integration test
+    ``test_list_and_stream_are_in_lockstep`` invariant) and drifts the
+    HINCRBY-returned seq away from the SSE wire id. ``created_at`` on the
+    meta hash is preserved — it documents thread-first-write, not per-turn
+    state."""
+    pipe, pipeline_ctx = _make_pipeline_mock()
+    cache = _make_client_with_pipeline(pipeline_ctx)
+
+    await cache.pipelined_event_buffer(
+        events_key="workflow:events:t1",
+        meta_key="workflow:events:meta:t1",
+        event="id: 1\nevent: x\ndata: hi\n\n",
+        max_size=1000,
+        ttl=86400,
+        last_event_id=1,
+        stream_key="workflow:stream:t1",
+    )
+
+    delete_calls = [call.args for call in pipe.delete.call_args_list]
+    assert ("workflow:stream:t1",) in delete_calls
+    assert ("workflow:events:t1",) in delete_calls
+    pipe.hdel.assert_called_once_with("workflow:events:meta:t1", "seq")
+    # ``created_at`` is preserved (HSETNX still runs) — only ``seq`` is HDEL'd.
+    pipe.xadd.assert_called_once()
+    assert pipe.xadd.call_args.kwargs["id"] == "1-0"
+
+
+@pytest.mark.asyncio
+async def test_dirty_resume_guard_resets_list_and_seq_without_stream_key():
+    """The List+seq reset must fire even when no Stream key is configured —
+    a producer that never opted into dual-write still benefits from the
+    crash-recovery guarantee."""
+    pipe, pipeline_ctx = _make_pipeline_mock()
+    cache = _make_client_with_pipeline(pipeline_ctx)
+
+    await cache.pipelined_event_buffer(
+        events_key="workflow:events:t1",
+        meta_key="workflow:events:meta:t1",
+        event="id: 1\nevent: x\ndata: hi\n\n",
+        max_size=1000,
+        ttl=86400,
+        last_event_id=1,
+        stream_key=None,
+    )
+
+    delete_calls = [call.args for call in pipe.delete.call_args_list]
+    assert ("workflow:events:t1",) in delete_calls
+    pipe.hdel.assert_called_once_with("workflow:events:meta:t1", "seq")
+    pipe.xadd.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_no_dirty_resume_del_when_last_event_id_is_not_one():
+    """Mid-turn events (last_event_id > 1) must NOT trigger the guard — DEL
+    would wipe in-flight stream contents and break attached consumers."""
+    pipe, pipeline_ctx = _make_pipeline_mock()
+    cache = _make_client_with_pipeline(pipeline_ctx)
+
+    await cache.pipelined_event_buffer(
+        events_key="workflow:events:t1",
+        meta_key="workflow:events:meta:t1",
+        event="id: 7\nevent: x\ndata: hi\n\n",
+        max_size=1000,
+        ttl=86400,
+        last_event_id=7,
+        stream_key="workflow:stream:t1",
+    )
+
+    pipe.delete.assert_not_called()
+    pipe.hdel.assert_not_called()
+    pipe.xadd.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_returns_false_zero_when_disabled():
+    cache = RedisCacheClient.__new__(RedisCacheClient)
+    cache.enabled = False
+    cache.client = None
+    cache.stats = {"hits": 0, "misses": 0, "sets": 0, "deletes": 0, "errors": 0}
+
+    success, seq = await cache.pipelined_event_buffer(
+        events_key="k",
+        meta_key="m",
+        event="x",
+        max_size=10,
+        ttl=60,
+        last_event_id=1,
+        stream_key="workflow:stream:t1",
+    )
+    assert success is False
+    assert seq == 0

--- a/tests/unit/utils/cache/test_pipelined_event_buffer.py
+++ b/tests/unit/utils/cache/test_pipelined_event_buffer.py
@@ -208,6 +208,34 @@ async def test_no_dirty_resume_del_when_last_event_id_is_not_one():
 
 
 @pytest.mark.asyncio
+async def test_stream_event_overrides_xadd_payload_when_provided():
+    """Subagent producer renders SSE wire format inline and passes it as
+    stream_event so the consumer is a pass-through. The List still gets the
+    JSON record (legacy compat)."""
+    pipe, pipeline_ctx = _make_pipeline_mock()
+    cache = _make_client_with_pipeline(pipeline_ctx)
+
+    await cache.pipelined_event_buffer(
+        events_key="subagent:events:t1:abc",
+        meta_key="subagent:events:meta:t1:abc",
+        event='{"seq": 5, "event": "message_chunk"}',  # JSON for the List
+        max_size=1000,
+        ttl=86400,
+        last_event_id=5,
+        stream_key="subagent:stream:t1:abc",
+        stream_event="id: 5\nevent: message_chunk\ndata: {}\n\n",
+    )
+
+    pipe.rpush.assert_called_once()
+    rpush_args = pipe.rpush.call_args.args
+    assert rpush_args[1] == '{"seq": 5, "event": "message_chunk"}'
+
+    pipe.xadd.assert_called_once()
+    xadd_args = pipe.xadd.call_args.args
+    assert xadd_args[1] == {b"event": b"id: 5\nevent: message_chunk\ndata: {}\n\n"}
+
+
+@pytest.mark.asyncio
 async def test_returns_false_zero_when_disabled():
     cache = RedisCacheClient.__new__(RedisCacheClient)
     cache.enabled = False

--- a/web/src/pages/ChatAgent/hooks/utils/streamEventHandlers.ts
+++ b/web/src/pages/ChatAgent/hooks/utils/streamEventHandlers.ts
@@ -838,31 +838,26 @@ export function handleSubagentMessageChunk({
         messageIndex = updatedMessages.length - 1;
       }
 
-      const msg = updatedMessages[messageIndex];
-      msg.contentSegments = [
-        ...((msg.contentSegments as unknown[]) || []),
-        {
-          type: 'reasoning',
-          reasoningId,
-          order: currentOrder,
-        },
-      ];
-      msg.reasoningProcesses = {
-        ...((msg.reasoningProcesses as Record<string, unknown>) || {}),
-        [reasoningId]: {
-          content: '',
-          isReasoning: true,
-          reasoningComplete: false,
-          order: currentOrder,
+      const prev = updatedMessages[messageIndex];
+      updatedMessages[messageIndex] = {
+        ...prev,
+        contentSegments: [
+          ...((prev.contentSegments as unknown[]) || []),
+          { type: 'reasoning', reasoningId, order: currentOrder },
+        ],
+        reasoningProcesses: {
+          ...((prev.reasoningProcesses as Record<string, unknown>) || {}),
+          [reasoningId]: {
+            content: '',
+            isReasoning: true,
+            reasoningComplete: false,
+            order: currentOrder,
+          },
         },
       };
 
       taskRefs.messages = updatedMessages;
-      // Update card with messages only - don't update status here
-      // Status is managed by per-task stream close to prevent overwriting 'completed' status
-      updateSubagentCard(taskId, {
-        messages: updatedMessages,
-      });
+      updateSubagentCard(taskId, { messages: updatedMessages });
       return true;
     } else if (signalContent === 'complete') {
       if (currentReasoningIdRef.current) {
@@ -871,8 +866,8 @@ export function handleSubagentMessageChunk({
         const messageIndex = updatedMessages.findIndex((m: MessageRecord) => m.id === assistantMessageId);
 
         if (messageIndex !== -1) {
-          const msg = updatedMessages[messageIndex];
-          const reasoningProcesses = { ...((msg.reasoningProcesses as Record<string, Record<string, unknown>>) || {}) };
+          const prev = updatedMessages[messageIndex];
+          const reasoningProcesses = { ...((prev.reasoningProcesses as Record<string, Record<string, unknown>>) || {}) };
           if (reasoningProcesses[reasoningId]) {
             reasoningProcesses[reasoningId] = {
               ...reasoningProcesses[reasoningId],
@@ -882,7 +877,7 @@ export function handleSubagentMessageChunk({
               _completedAt: refs.isReconnect ? 1 : Date.now(),
             };
           }
-          msg.reasoningProcesses = reasoningProcesses;
+          updatedMessages[messageIndex] = { ...prev, reasoningProcesses };
           taskRefs.messages = updatedMessages;
           updateSubagentCard(taskId, { messages: updatedMessages });
         }
@@ -911,22 +906,18 @@ export function handleSubagentMessageChunk({
       messageIndex = updatedMessages.length - 1;
     }
 
-    const msg = updatedMessages[messageIndex];
-    const reasoningProcesses = { ...((msg.reasoningProcesses as Record<string, Record<string, unknown>>) || {}) };
+    const prev = updatedMessages[messageIndex];
+    const reasoningProcesses = { ...((prev.reasoningProcesses as Record<string, Record<string, unknown>>) || {}) };
+    let nextContentSegments = (prev.contentSegments as unknown[]) || [];
 
     // Create reasoning process if it doesn't exist (edge case: reasoning content arrives before start signal)
     if (!reasoningProcesses[reasoningId]) {
-      // Need to add the reasoning segment to contentSegments as well
       contentOrderCounterRef.current++;
       const currentOrder = contentOrderCounterRef.current;
 
-      msg.contentSegments = [
-        ...((msg.contentSegments as unknown[]) || []),
-        {
-          type: 'reasoning',
-          reasoningId,
-          order: currentOrder,
-        },
+      nextContentSegments = [
+        ...nextContentSegments,
+        { type: 'reasoning', reasoningId, order: currentOrder },
       ];
 
       reasoningProcesses[reasoningId] = {
@@ -959,7 +950,14 @@ export function handleSubagentMessageChunk({
       reasoningTitle,
     };
 
-    msg.reasoningProcesses = reasoningProcesses;
+    // Replace the message with a fresh object so ``React.memo`` invalidates;
+    // mutating ``prev`` in place would freeze the rendered card until the
+    // next lifecycle event.
+    updatedMessages[messageIndex] = {
+      ...prev,
+      contentSegments: nextContentSegments,
+      reasoningProcesses,
+    };
     taskRefs.messages = updatedMessages;
     updateSubagentCard(taskId, { messages: updatedMessages });
     return true;
@@ -986,18 +984,20 @@ export function handleSubagentMessageChunk({
       messageIndex = updatedMessages.length - 1;
     }
 
-    const msg = updatedMessages[messageIndex];
-    msg.contentSegments = [
-      ...((msg.contentSegments as unknown[]) || []),
-      {
-        type: 'text',
-        content,
-        order: currentOrder,
-      },
-    ];
-    msg.content = ((msg.content as string) || '') + content;
-    msg.contentType = 'text';
-    msg.isStreaming = true;
+    // Replace with a fresh object: ``MessageBubble`` is ``React.memo``'d
+    // on the message ref, so mutation would skip per-token re-renders and
+    // content would only land at the next lifecycle event.
+    const prev = updatedMessages[messageIndex];
+    updatedMessages[messageIndex] = {
+      ...prev,
+      contentSegments: [
+        ...((prev.contentSegments as unknown[]) || []),
+        { type: 'text', content, order: currentOrder },
+      ],
+      content: ((prev.content as string) || '') + content,
+      contentType: 'text',
+      isStreaming: true,
+    };
 
     taskRefs.messages = updatedMessages;
     updateSubagentCard(taskId, { messages: updatedMessages });


### PR DESCRIPTION
**Status: DRAFT — not ready for review.** Parking the staged Streams refactor plus the subagent-card-stays-running fix on a single branch so they soak together. The first three commits are the staged refactor (per `~/.claude/plans/checkout-a-branch-off-greedy-badger.md`); the fourth is the bug fix that motivated the deeper review pass.

## Summary

Four bisectable commits:

1. **`refactor(sse): dual-write workflow + subagent events to Redis Streams`** — additive producer-only. Extends `pipelined_event_buffer` with a `stream_key` parameter; both call sites (main workflow buffer, subagent spill) dual-write to `workflow:stream:{thread_id}` / `subagent:stream:{thread_id}:{task_id}` inside the existing MULTI/EXEC. Includes the dirty-resume guard so a fresh-handler XADD with id=1-0 doesn't collide with stale Stream/List/seq state from a prior crashed turn.
2. **`feat(sse): redis-streams consumers behind USE_REDIS_STREAM_SSE flag`** — flag-gated read path. Single `_stream_from_redis_log` XREAD BLOCK loop drives both `stream_from_log` (main) and `stream_subagent_from_log` (per-subagent). Three connection shapes covered: `$` first-connect, `0` replay, `<seq>-0` resume. `threads.py` accepts `Last-Event-ID` header (SSE-spec) in addition to the existing `?last_event_id=` query param. Default off; flip per request.
3. **`test(sse): integration test covering unified consumer paths`** — single integration test exercising replay-from-zero, resume-after-seq, second-tab live-tail, and late-subscriber-after-DEL. Each scenario calls the same helper with a different cursor — that's the architectural win.
4. **`feat(subagent): per-token streaming + stream-end sentinel`** — fixes the "subagent card stays Running" UX. Subagents now stream per-token chunks through `subagent.astream(stream_mode=["values", "messages"])` via a new `_arun_subagent_streaming` wrapper, and write a `subagent_stream_end` sentinel record to the per-task Stream when the astream loop exits. The per-task SSE consumer recognises the sentinel and closes immediately instead of waiting on a 4-8s XREAD BLOCK round-trip plus the post-turn collector to flip `task.completed`. Folds in: single-pass `_classify_subagent_payload` (one `json.loads` max per entry), `active_connections` hooks on the workflow consumer (so abandoned-task cleanup doesn't force-cancel SSE-attached workflows), `_xread_block_ms` floor below `socket_timeout`, and frontend React.memo invalidation for per-token deltas.

## Diff Size
- Total: 24 files changed, 2729 insertions(+), 172 deletions(-)
- Net (excl. tests): 13 files changed, 959 insertions(+), 155 deletions(-)

## Test Coverage

Unit: 3277 passed, 0 failed (full sweep on touched dirs + sibling areas). New unit tests:
- `tests/unit/utils/cache/test_pipelined_event_buffer.py` — dirty-resume guard parity (Stream + List + meta seq), stream_event override
- `tests/unit/server/handlers/chat/test_stream_from_log.py` — `_classify_subagent_payload` 4-kind contract, `stream_from_log` connection-counter hooks, sentinel exit, `_xread_block_ms` floor
- `tests/unit/middleware/test_subagent_token_forwarder.py` (new) — token forwarder reasoning lifecycle (start/complete signals), text/reasoning transitions, finalize sentinel
- `tests/unit/middleware/test_subagent_event_capture.py` — additions covering the moved-token-capture branch
- `tests/unit/middleware/test_subagent_tracer_isolation.py` — extensions

Integration: `tests/integration/test_sse_streams.py` covers the four-scenario unified-consumer path (requires real Redis via `make setup-db`).

## Pre-Landing Review

Already ran `/review` (3 critical-tier verified findings + 4 informational, all addressed). Then ran `/audit-prose` for prose-only cleanup (9 auto-fixes + 1 reviewed apply). All findings closed. Lint clean (`ruff check`) on every touched file.

## Out of scope (subsequent PRs, gated on prod soak)

- **Cutover:** Delete `multiplex_streams`, `live_queues`, `result_buffer`, `captured_events_tail`, `EventCounter`, `StreamEventAccumulator`, `get_buffered_events_redis`, `iter_subagent_events_full`, `drain_task_captured_events`. Replace with `XRANGE - +`-based readers.
- **Drop List spill:** Remove the RPUSH/LTRIM half of `pipelined_event_buffer` once cutover has soaked +24h.
- **Drop shield:** Remove `asyncio.shield(inner_task)` since SSE consumers no longer hold workflow refs.

## Test plan

- [ ] Soak with `USE_REDIS_STREAM_SSE=false` (default) in staging, confirm `XLEN workflow:stream:* == LLEN workflow:events:*` parity for >=24h
- [ ] Flip `USE_REDIS_STREAM_SSE=true` in staging, browser-test that subagent cards flip to "Completed" promptly when subagent finishes streaming (the original sentinel fix)
- [ ] Browser-test reconnect scenarios: kill mid-stream, reopen with `Last-Event-ID`, verify resume
- [ ] Browser-test second-tab on the same thread: both tabs receive identical event stream
- [ ] Confirm abandoned-task cleanup at 6h doesn't force-cancel long-running SSE-attached workflows