### PR TITLE
fix(build): default PROVIDER=docker so 'make up' builds sandbox image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,11 @@ config: ## Interactive setup wizard (LLM, data, sandbox, search)
 # ---------------------------------------------------------------------------
 # Docker Compose (full-stack)
 # ---------------------------------------------------------------------------
-up: _sandbox-prepare ## Start full stack (PROVIDER=docker|daytona)
+# Default to the docker sandbox provider so plain `make up` works out of the
+# box. Override with `make up PROVIDER=daytona` to skip the sandbox image build.
+PROVIDER ?= docker
+
+up: _sandbox-prepare ## Start full stack (PROVIDER=docker|daytona, default docker)
 	SANDBOX_PROVIDER=$(PROVIDER) docker compose up --build
 
 down: ## Stop all Docker Compose services
@@ -19,11 +23,16 @@ clean: down ## Stop everything and remove stale sandbox containers
 	@docker rm -f $$(docker ps -aq --filter "name=langalpha-sandbox") 2>/dev/null || true
 	@echo "Clean."
 
-# Build sandbox image only when provider needs it (docker)
+# Build sandbox image only when provider needs it (docker), and only if the
+# image isn't already present locally — avoids a ~25 min rebuild on every `up`.
 _sandbox-prepare:
 ifeq ($(PROVIDER),docker)
-	@echo "Building sandbox image for docker provider..."
-	docker build -f Dockerfile.sandbox -t langalpha-sandbox:latest .
+	@if ! docker image inspect langalpha-sandbox:latest >/dev/null 2>&1; then \
+		echo "Building sandbox image for docker provider..."; \
+		docker build -f Dockerfile.sandbox -t langalpha-sandbox:latest .; \
+	else \
+		echo "Sandbox image langalpha-sandbox:latest already present, skipping build."; \
+	fi
 endif
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Default `PROVIDER` to `docker` in the Makefile so plain `make up` triggers `_sandbox-prepare`.
- Skip the sandbox image rebuild when `langalpha-sandbox:latest` already exists (~25 min saved per `make up`).
- No behavior change for `make up PROVIDER=daytona` — Daytona users still opt out of the local image build.

## Bug
Plain `make up` (no `PROVIDER` argument) silently skips `_sandbox-prepare` because `ifeq ($(PROVIDER),docker)` is false when `PROVIDER` is unset. The runtime, however, defaults to the docker sandbox provider via `SANDBOX_PROVIDER` in `.env`, so the first workspace creation 500s with:

> Docker image 'langalpha-sandbox:latest' not found and Dockerfile.sandbox not found in any search path

`Dockerfile.sandbox` isn't bind-mounted into the backend container, so the runtime can't lazy-build it either — the host has to build it ahead of time. README and the `make up` help text both imply `make up` is sufficient on its own.

## Test plan
- [ ] `docker rmi langalpha-sandbox:latest && make up` — should build the sandbox image then start the stack
- [ ] `make up` (image already present) — should print "skipping build" and start the stack quickly
- [ ] `make up PROVIDER=daytona` — should NOT build the sandbox image
- [ ] First workspace creation succeeds (no 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)