### PR TITLE
fix(yfinance): drop placeholder income-statement rows lacking revenue

### DIFF
--- a/src/data_client/yfinance/financial_source.py
+++ b/src/data_client/yfinance/financial_source.py
@@ -209,23 +209,26 @@ def _get_income_statements(
 ) -> list[dict[str, Any]]:
     ticker = yf.Ticker(symbol)
     df = ticker.quarterly_income_stmt if period == "quarter" else ticker.income_stmt
-    records = _dataframe_to_records(df, limit)
     result = []
-    for r in records:
+    for r in _dataframe_to_records(df):
         mapped = _remap_keys(r, _INCOME_STMT_KEY_MAP)
-        # Compute margin ratios (FMP provides these; yfinance only has absolute values)
         rev = mapped.get("revenue")
-        if rev and isinstance(rev, (int, float)) and rev != 0:
-            gp = mapped.get("grossProfit")
-            oi = mapped.get("operatingIncome")
-            ni = mapped.get("netIncome")
-            if isinstance(gp, (int, float)):
-                mapped["grossProfitRatio"] = round(gp / rev, 6)
-            if isinstance(oi, (int, float)):
-                mapped["operatingIncomeRatio"] = round(oi / rev, 6)
-            if isinstance(ni, (int, float)):
-                mapped["netIncomeRatio"] = round(ni / rev, 6)
+        # yfinance creates a row for each newly-reported quarter where only EPS
+        # is populated; income line items land later. FMP never returns such rows.
+        if not isinstance(rev, (int, float)) or rev == 0:
+            continue
+        gp = mapped.get("grossProfit")
+        oi = mapped.get("operatingIncome")
+        ni = mapped.get("netIncome")
+        if isinstance(gp, (int, float)):
+            mapped["grossProfitRatio"] = round(gp / rev, 6)
+        if isinstance(oi, (int, float)):
+            mapped["operatingIncomeRatio"] = round(oi / rev, 6)
+        if isinstance(ni, (int, float)):
+            mapped["netIncomeRatio"] = round(ni / rev, 6)
         result.append(mapped)
+        if len(result) >= limit:
+            break
     return result
 
 

--- a/src/data_client/yfinance/financial_source.py
+++ b/src/data_client/yfinance/financial_source.py
@@ -210,11 +210,14 @@ def _get_income_statements(
     ticker = yf.Ticker(symbol)
     df = ticker.quarterly_income_stmt if period == "quarter" else ticker.income_stmt
     result = []
+    # `limit` is applied after the placeholder filter below, not in
+    # _dataframe_to_records, so a limit=N request returns N complete quarters.
     for r in _dataframe_to_records(df):
         mapped = _remap_keys(r, _INCOME_STMT_KEY_MAP)
         rev = mapped.get("revenue")
         # yfinance creates a row for each newly-reported quarter where only EPS
-        # is populated; income line items land later. FMP never returns such rows.
+        # is populated; income line items land later. Treat any non-numeric or
+        # zero revenue as an unusable row — matches FMP, which never returns one.
         if not isinstance(rev, (int, float)) or rev == 0:
             continue
         gp = mapped.get("grossProfit")

--- a/tests/unit/data_client/test_yfinance_financial_source.py
+++ b/tests/unit/data_client/test_yfinance_financial_source.py
@@ -1,0 +1,130 @@
+"""Unit tests for yfinance financial source — synthetic dataframes, no network."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+def _make_income_stmt_df(rows: list[tuple[str, list]], dates: list[str]) -> pd.DataFrame:
+    """Build a yfinance-shaped income statement DataFrame.
+
+    yfinance returns metrics as rows, dates as columns (most recent first).
+    """
+    cols = [pd.Timestamp(d) for d in dates]
+    return pd.DataFrame({c: [vals[i] for _, vals in rows] for i, c in enumerate(cols)},
+                        index=[name for name, _ in rows])
+
+
+class TestGetIncomeStatementsPlaceholderRows:
+    """Regression: yfinance returns a placeholder row for newly-reported quarters
+    with only EPS populated (full income line items land later). These must be
+    skipped so callers see only complete rows — matching FMP behavior.
+    """
+
+    def _run(self, df, *, period="quarter", limit=4):
+        from src.data_client.yfinance.financial_source import _get_income_statements
+
+        with patch("src.data_client.yfinance.financial_source.yf.Ticker") as ticker_cls:
+            ticker = MagicMock()
+            ticker.quarterly_income_stmt = df
+            ticker.income_stmt = df
+            ticker_cls.return_value = ticker
+            return _get_income_statements("TEST", period, limit)
+
+    def test_skips_placeholder_row_with_nan_revenue(self):
+        df = _make_income_stmt_df(
+            rows=[
+                ("Total Revenue", [np.nan, 100.0, 90.0]),
+                ("Cost Of Revenue", [np.nan, 60.0, 55.0]),
+                ("Gross Profit", [np.nan, 40.0, 35.0]),
+                ("Net Income", [np.nan, 20.0, 18.0]),
+                ("Basic EPS", [2.02, 1.50, 1.40]),
+            ],
+            dates=["2026-03-31", "2025-12-31", "2025-09-30"],
+        )
+        result = self._run(df)
+
+        assert len(result) == 2
+        assert result[0]["date"] == "2025-12-31"
+        assert result[0]["revenue"] == 100.0
+        assert result[0]["grossProfitRatio"] == 0.4
+        assert result[0]["netIncomeRatio"] == 0.2
+
+    def test_keeps_all_rows_when_revenue_present(self):
+        df = _make_income_stmt_df(
+            rows=[
+                ("Total Revenue", [200.0, 100.0]),
+                ("Gross Profit", [80.0, 40.0]),
+            ],
+            dates=["2026-03-31", "2025-12-31"],
+        )
+        result = self._run(df)
+
+        assert len(result) == 2
+        assert [r["date"] for r in result] == ["2026-03-31", "2025-12-31"]
+        assert result[0]["grossProfitRatio"] == 0.4
+
+    def test_limit_applied_after_filtering(self):
+        df = _make_income_stmt_df(
+            rows=[
+                ("Total Revenue", [np.nan, 100.0, 90.0, 80.0, 70.0]),
+                ("Gross Profit", [np.nan, 40.0, 35.0, 32.0, 28.0]),
+            ],
+            dates=["2026-03-31", "2025-12-31", "2025-09-30", "2025-06-30", "2025-03-31"],
+        )
+        result = self._run(df, limit=3)
+
+        assert len(result) == 3
+        assert [r["date"] for r in result] == ["2025-12-31", "2025-09-30", "2025-06-30"]
+
+    def test_empty_dataframe_returns_empty(self):
+        result = self._run(pd.DataFrame())
+        assert result == []
+
+    def test_zero_revenue_row_skipped(self):
+        df = _make_income_stmt_df(
+            rows=[("Total Revenue", [0.0, 100.0]), ("Gross Profit", [0.0, 40.0])],
+            dates=["2026-03-31", "2025-12-31"],
+        )
+        result = self._run(df)
+        assert len(result) == 1
+        assert result[0]["date"] == "2025-12-31"
+
+
+@pytest.mark.parametrize(
+    "missing_metric",
+    ["Gross Profit", "Operating Income", "Net Income"],
+)
+def test_ratio_omitted_when_underlying_metric_missing(missing_metric):
+    """Margin ratios are only set when the underlying numerator is numeric.
+    Missing metrics shouldn't crash or produce bogus ratios.
+    """
+    from src.data_client.yfinance.financial_source import _get_income_statements
+
+    base_rows = {
+        "Total Revenue": 100.0,
+        "Gross Profit": 40.0,
+        "Operating Income": 30.0,
+        "Net Income": 20.0,
+    }
+    base_rows[missing_metric] = np.nan
+    df = _make_income_stmt_df(
+        rows=[(name, [val]) for name, val in base_rows.items()],
+        dates=["2025-12-31"],
+    )
+    with patch("src.data_client.yfinance.financial_source.yf.Ticker") as ticker_cls:
+        ticker = MagicMock()
+        ticker.quarterly_income_stmt = df
+        ticker_cls.return_value = ticker
+        result = _get_income_statements("TEST", "quarter", 4)
+
+    ratio_key = {
+        "Gross Profit": "grossProfitRatio",
+        "Operating Income": "operatingIncomeRatio",
+        "Net Income": "netIncomeRatio",
+    }[missing_metric]
+    assert ratio_key not in result[0]


### PR DESCRIPTION
## Summary

- Skip yfinance income-statement rows whose `revenue` isn't a usable number — Yahoo creates a row for each newly-reported quarter where only EPS and share counts are populated, and full income line items land later.
- Apply `limit` after filtering so a `limit=N` request always yields N complete quarters when the underlying data has them.
- Adds a unit-test suite at `tests/unit/data_client/test_yfinance_financial_source.py` that pins the regression with synthetic dataframes (no network), so this catches in CI even when Yahoo's data is fully populated.

## Why

The integration test `tests/integration/test_yfinance_live.py::test_get_income_statements` started failing this week with:

```
AssertionError: assert 'grossProfitRatio' in {'basicEps': 2.02, ..., 'costOfRevenue': None, 'date': '2026-03-31', ...}
```

Direct Yahoo query confirms the placeholder pattern for AAPL:

```
2026-03-31  rev=nan         gross_profit=nan         cost_of_revenue=nan
2025-12-31  rev=143,756M    gross_profit=69,231M     cost_of_revenue=74,525M
2025-09-30  rev=102,466M    gross_profit=48,341M     cost_of_revenue=54,125M
```

This isn't a code regression (last touch was 2026-03-19 in #?). It's Yahoo seeding the new quarter's row with EPS first; the rest follows later. FMP never returns rows like this — the source layer should match that contract.

## Shape (no time-mixing)

Each returned dict still represents exactly one quarter, with its own `date` field. Order is preserved (most recent first). The only behavioral change: when a placeholder exists, the returned window slides one quarter back so the agent gets older-but-complete data instead of newer-but-broken data.

## Test plan

- [x] `uv run pytest tests/unit/data_client/test_yfinance_financial_source.py -v` — 8/8 pass
- [x] `uv run pytest tests/integration/test_yfinance_live.py -v -m integration` — 27/27 pass (originally-failing test now green)
- [x] `uv run ruff check src/data_client/yfinance/financial_source.py tests/unit/data_client/test_yfinance_financial_source.py` — clean