### PR TITLE
fix(ci): scope scrapling docker tests to sandbox-integration tier

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,9 @@ jobs:
           version: "latest"
       - run: uv sync --group dev --extra test
       - run: sudo apt-get install -y ripgrep
-      - run: uv run pytest tests/integration/ -v --tb=short -m integration --junitxml=test-results/backend-integration.xml --sandbox-metrics --sandbox-metrics-file test-results/session_metrics.json
+      # Skip docker-provider sandbox tests; they need GHCR auth + buildx
+      # and are owned by the sandbox-integration workflow's docker tier.
+      - run: uv run pytest tests/integration/ -v --tb=short -m integration --ignore=tests/integration/sandbox/providers --junitxml=test-results/backend-integration.xml --sandbox-metrics --sandbox-metrics-file test-results/session_metrics.json
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/tests/integration/sandbox/providers/test_scrapling_docker.py
+++ b/tests/integration/sandbox/providers/test_scrapling_docker.py
@@ -4,9 +4,12 @@ Builds the sandbox Docker image and verifies Scrapling, yfinance, and
 related tools work correctly inside the container environment.
 
 Run with:
-    uv run pytest tests/integration/tools/test_scrapling_docker.py -m integration -v --timeout=300
+    SANDBOX_TEST_PROVIDERS=docker uv run pytest \\
+        tests/integration/sandbox/providers/test_scrapling_docker.py -v
 
-Requires: Docker daemon running.
+Requires: Docker daemon running and ``docker`` selected in
+``SANDBOX_TEST_PROVIDERS`` (or the legacy ``SANDBOX_TEST_PROVIDER``).
+The sandbox-integration workflow's docker tier sets both.
 """
 
 from __future__ import annotations
@@ -15,7 +18,16 @@ import os
 import subprocess
 import pytest
 
-pytestmark = [pytest.mark.integration]
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        "docker" not in os.getenv(
+            "SANDBOX_TEST_PROVIDERS",
+            os.getenv("SANDBOX_TEST_PROVIDER", "memory"),
+        ).lower().split(","),
+        reason="Docker tests require docker in SANDBOX_TEST_PROVIDERS",
+    ),
+]
 
 _GHCR_IMAGE = "ghcr.io/ginlix-ai/langalpha/sandbox:latest"
 _IMAGE = "langalpha-sandbox:test-scrapling"
@@ -45,9 +57,10 @@ def _run_in_container(cmd: str, timeout: int = _TIMEOUT) -> subprocess.Completed
 def docker_image():
     """Resolve the sandbox Docker image once for all tests in this module.
 
-    Prefers the pre-built GHCR image (fast pull) and falls back to a local
-    ``docker build`` when the registry image is unavailable.  Set
-    ``DOCKER_SANDBOX_IMAGE`` to force a specific image tag.
+    Resolution order: ``DOCKER_SANDBOX_IMAGE`` env override → GHCR pull →
+    skip in CI / local build outside CI. ``DOCKER_SANDBOX_IMAGE`` is the
+    intended path for CI (sandbox-integration workflow sets it after a
+    cached pull/build).
     """
     if not _docker_available():
         pytest.skip("Docker not available")
@@ -73,7 +86,17 @@ def docker_image():
         yield _IMAGE
         return
 
-    # Fallback: build locally.
+    # In CI, never fall back to a local build: the Dockerfile takes ~20 min
+    # and easily blows past job timeouts when GHCR pulls flake. Skip instead
+    # so the failure mode is a clear "image unavailable" rather than 11
+    # tests timing out at 30 minutes apiece.
+    if os.environ.get("CI"):
+        pytest.skip(
+            f"GHCR pull of {_GHCR_IMAGE} failed; set DOCKER_SANDBOX_IMAGE "
+            "or run via the sandbox-integration workflow which authenticates to GHCR"
+        )
+
+    # Local dev fallback: build locally.
     result = subprocess.run(
         ["docker", "build", "-f", _DOCKERFILE, "-t", _IMAGE, "."],
         capture_output=True,


### PR DESCRIPTION
## Summary
- Move `tests/integration/tools/test_scrapling_docker.py` → `tests/integration/sandbox/providers/test_scrapling_docker.py` so the sandbox-integration workflow's docker tier owns it (already has GHCR auth, buildx, and path-filter gating).
- Add module-level `pytestmark` skipif on `SANDBOX_TEST_PROVIDERS` mirroring `test_docker_modes.py`, so non-docker tiers skip the file without doing any docker work.
- Skip in CI instead of falling back to a 30-min local `docker build` when the GHCR pull fails — the fallback is a local-dev convenience, not a CI strategy.
- `--ignore=tests/integration/sandbox/providers` in `test.yml` so the routing is explicit at the workflow level too.

## Why
`test.yml`'s `backend-integration` job has no GHCR login. Anonymous GHCR pulls of the prebuilt sandbox image flake; when the pull fails the fixture falls back to a local Dockerfile build that exceeds the 30-min timeout, erroring all 11 scrapling docker tests. Same PR passed at 11:49 UTC (pull worked, ~12 min), failed at 13:51 UTC (pull failed, ~37 min build timeout).

After this change, the scrapling docker tests run only when sandbox-integration.yml's docker path filter triggers.

## Test plan
- [x] daytona env: 11 skip, no docker work
- [x] backend-integration collection excludes providers/, 433 other tests collected
- [x] ruff clean
- [ ] CI green on this PR