### PR TITLE
fix(api): accept open-vocabulary instrument_type

### DIFF
--- a/skills/user-profile/SKILL.md
+++ b/skills/user-profile/SKILL.md
@@ -212,7 +212,7 @@ Add or update an item in a watchlist.
 |-------|------|----------|-------------|
 | `symbol` | str | Yes | Stock symbol (used as key) |
 | `watchlist_id` | str | No | Target watchlist (uses default if omitted) |
-| `instrument_type` | str | No | "stock", "etf", "index", "crypto" (default: "stock") |
+| `instrument_type` | str | No | Free-form. Common: "stock", "etf", "index", "crypto", "future", "commodity", "currency". Other values accepted (default: "stock") |
 | `exchange` | str | No | e.g., "NASDAQ" |
 | `name` | str | No | Company name |
 | `notes` | str | No | Why you're watching |
@@ -253,7 +253,7 @@ Add or update a portfolio holding.
 | `quantity` | float | Yes | Number of shares |
 | `average_cost` | float | No | Cost per share |
 | `account_name` | str | No | e.g., "Robinhood", "Fidelity IRA" (part of key) |
-| `instrument_type` | str | No | Default: "stock" |
+| `instrument_type` | str | No | Free-form. Common: "stock", "etf", "index", "crypto", "future", "commodity", "currency". Other values accepted (default: "stock") |
 | `currency` | str | No | Default: "USD" |
 | `notes` | str | No | Additional notes |
 

--- a/src/server/app/portfolio.py
+++ b/src/server/app/portfolio.py
@@ -80,7 +80,7 @@ async def add_portfolio_holding(
     holding, merge_details = await db_upsert_portfolio_holding(
         user_id=user_id,
         symbol=request.symbol,
-        instrument_type=request.instrument_type.value,
+        instrument_type=request.instrument_type,
         quantity=request.quantity,
         exchange=request.exchange,
         name=request.name,

--- a/src/server/app/watchlist.py
+++ b/src/server/app/watchlist.py
@@ -324,7 +324,7 @@ async def add_watchlist_item(
             user_id=user_id,
             watchlist_id=resolved_id,
             symbol=request.symbol,
-            instrument_type=request.instrument_type.value,
+            instrument_type=request.instrument_type,
             exchange=request.exchange,
             name=request.name,
             notes=request.notes,

--- a/src/server/models/user.py
+++ b/src/server/models/user.py
@@ -6,7 +6,6 @@ These models support the user onboarding flow and investment preferences.
 
 from datetime import datetime
 from decimal import Decimal
-from enum import Enum
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
@@ -37,20 +36,22 @@ def normalize_symbol(symbol: str) -> str:
 
 
 # =============================================================================
-# Enums
+# Instrument Types
 # =============================================================================
 
 
-class InstrumentType(str, Enum):
-    """Supported instrument types for watchlist and portfolio."""
+KNOWN_INSTRUMENT_TYPES: frozenset[str] = frozenset(
+    {"stock", "etf", "index", "crypto", "future", "commodity", "currency"}
+)
+"""Canonical instrument types. Extra values are accepted (the agent may classify
+holdings outside this set, e.g. 'cash_management') so the column is treated as
+an open vocabulary; this set documents the conventional values."""
 
-    STOCK = "stock"
-    ETF = "etf"
-    INDEX = "index"
-    CRYPTO = "crypto"
-    FUTURE = "future"
-    COMMODITY = "commodity"
-    CURRENCY = "currency"
+
+def normalize_instrument_type(v: Any) -> Any:
+    if isinstance(v, str):
+        return v.strip().lower()
+    return v
 
 
 # =============================================================================
@@ -278,7 +279,15 @@ class WatchlistItemBase(BaseModel):
     """Base watchlist item fields."""
 
     symbol: str = Field(..., max_length=50, description="Instrument symbol")
-    instrument_type: InstrumentType = Field(..., description="Type of instrument")
+    instrument_type: str = Field(
+        ...,
+        min_length=1,
+        max_length=30,
+        description=(
+            "Type of instrument. Common values: stock, etf, index, crypto, future, "
+            "commodity, currency. Other values are accepted."
+        ),
+    )
     exchange: Optional[str] = Field(
         None, max_length=50, description="Exchange (e.g., 'NASDAQ')"
     )
@@ -298,6 +307,11 @@ class WatchlistItemBase(BaseModel):
         if isinstance(v, str):
             return normalize_symbol(v)
         return v  # Let Pydantic handle type validation
+
+    @field_validator("instrument_type", mode="before")
+    @classmethod
+    def normalize_instrument_type_field(cls, v: Any) -> Any:
+        return normalize_instrument_type(v)
 
 
 class WatchlistItemCreate(WatchlistItemBase):
@@ -370,7 +384,15 @@ class PortfolioHoldingBase(BaseModel):
     """Base portfolio holding fields."""
 
     symbol: str = Field(..., max_length=50, description="Instrument symbol")
-    instrument_type: InstrumentType = Field(..., description="Type of instrument")
+    instrument_type: str = Field(
+        ...,
+        min_length=1,
+        max_length=30,
+        description=(
+            "Type of instrument. Common values: stock, etf, index, crypto, future, "
+            "commodity, currency. Other values are accepted."
+        ),
+    )
     exchange: Optional[str] = Field(
         None, max_length=50, description="Exchange (e.g., 'NASDAQ')"
     )
@@ -396,6 +418,11 @@ class PortfolioHoldingBase(BaseModel):
         if isinstance(v, str):
             return normalize_symbol(v)
         return v  # Let Pydantic handle type validation
+
+    @field_validator("instrument_type", mode="before")
+    @classmethod
+    def normalize_instrument_type_field(cls, v: Any) -> Any:
+        return normalize_instrument_type(v)
 
 
 class PortfolioHoldingCreate(PortfolioHoldingBase):

--- a/src/tools/user_profile/tools.py
+++ b/src/tools/user_profile/tools.py
@@ -22,6 +22,7 @@ from src.server.database import user as user_db
 from src.server.database import watchlist as watchlist_db
 from src.server.database import portfolio as portfolio_db
 from src.server.database.user import invalidate_user_prefs_cache
+from src.server.models.user import normalize_instrument_type
 from src.server.services.onboarding import maybe_complete_onboarding
 
 logger = logging.getLogger(__name__)
@@ -307,7 +308,7 @@ async def _upsert_watchlist_item(config: RunnableConfig, data: dict[str, Any], r
             user_id=user_id,
             watchlist_id=watchlist_id,
             symbol=symbol.upper(),
-            instrument_type=data.get("instrument_type", "stock"),
+            instrument_type=normalize_instrument_type(data.get("instrument_type", "stock")),
             exchange=data.get("exchange"),
             name=data.get("name"),
             notes=data.get("notes"),
@@ -343,7 +344,7 @@ async def _upsert_portfolio_holding(config: RunnableConfig, data: dict[str, Any]
     holding, merge_details = await portfolio_db.upsert_portfolio_holding(
         user_id=user_id,
         symbol=symbol.upper(),
-        instrument_type=data.get("instrument_type", "stock"),
+        instrument_type=normalize_instrument_type(data.get("instrument_type", "stock")),
         quantity=Decimal(str(quantity)),
         average_cost=Decimal(str(average_cost)) if average_cost else None,
         currency=data.get("currency", "USD"),

--- a/tests/unit/server/app/test_portfolio.py
+++ b/tests/unit/server/app/test_portfolio.py
@@ -100,6 +100,50 @@ async def test_list_portfolio_empty(client):
     assert resp.json()["total"] == 0
 
 
+@pytest.mark.asyncio
+async def test_list_portfolio_accepts_non_canonical_instrument_type(client):
+    # Regression: a holding with an instrument_type outside the conventional
+    # set (e.g. 'cash_management' written by the agent) used to 500 the
+    # entire endpoint via Pydantic enum validation on the response model.
+    h = _holding(symbol="VMFXX", instrument_type="cash_management")
+    with patch(
+        f"{DB}.db_get_user_portfolio",
+        new_callable=AsyncMock,
+        return_value=[h],
+    ):
+        resp = await client.get("/api/v1/users/me/portfolio")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["holdings"][0]["instrument_type"] == "cash_management"
+
+
+@pytest.mark.asyncio
+async def test_add_portfolio_holding_accepts_non_canonical_instrument_type(client):
+    h = _holding(symbol="VMFXX", instrument_type="cash_management")
+    upsert = AsyncMock(return_value=(h, None))
+    with (
+        patch(f"{DB}.db_upsert_portfolio_holding", upsert),
+        patch(
+            f"{DB}.maybe_complete_onboarding",
+            new_callable=AsyncMock,
+        ),
+    ):
+        resp = await client.post(
+            "/api/v1/users/me/portfolio",
+            json={
+                "symbol": "VMFXX",
+                "instrument_type": "Cash_Management",  # mixed case → normalized
+                "quantity": 1000,
+            },
+        )
+
+    assert resp.status_code == 201
+    assert resp.json()["instrument_type"] == "cash_management"
+    assert upsert.call_args.kwargs["instrument_type"] == "cash_management"
+
+
 # ---------------------------------------------------------------------------
 # POST /api/v1/users/me/portfolio
 # ---------------------------------------------------------------------------

--- a/tests/unit/server/app/test_watchlist.py
+++ b/tests/unit/server/app/test_watchlist.py
@@ -341,6 +341,58 @@ async def test_add_watchlist_item(client):
 
 
 @pytest.mark.asyncio
+async def test_list_watchlist_items_accepts_non_canonical_instrument_type(client):
+    # Regression companion to the portfolio version: the watchlist read
+    # path previously enforced the same closed enum on instrument_type
+    # and 500'd on agent-written rows with non-canonical values.
+    wl = _watchlist()
+    items = [_item(symbol="VMFXX", instrument_type="cash_management")]
+    with (
+        patch(f"{DB}.db_get_or_create_default_watchlist", new_callable=AsyncMock),
+        patch(f"{DB}.db_get_watchlist", new_callable=AsyncMock, return_value=wl),
+        patch(
+            f"{DB}.db_get_watchlist_items",
+            new_callable=AsyncMock,
+            return_value=items,
+        ),
+    ):
+        resp = await client.get(f"/api/v1/users/me/watchlists/{WL_ID}/items")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["items"][0]["instrument_type"] == "cash_management"
+
+
+@pytest.mark.asyncio
+async def test_add_watchlist_item_accepts_non_canonical_instrument_type(client):
+    item = _item(symbol="VMFXX", instrument_type="cash_management")
+    create = AsyncMock(return_value=item)
+    with (
+        patch(
+            f"{DB}.db_get_or_create_default_watchlist",
+            new_callable=AsyncMock,
+        ),
+        patch(f"{DB}.db_create_watchlist_item", create),
+        patch(
+            f"{DB}.maybe_complete_onboarding",
+            new_callable=AsyncMock,
+        ),
+    ):
+        resp = await client.post(
+            f"/api/v1/users/me/watchlists/{WL_ID}/items",
+            json={
+                "symbol": "VMFXX",
+                "instrument_type": "Cash_Management",  # mixed case → normalized
+            },
+        )
+
+    assert resp.status_code == 201
+    assert resp.json()["instrument_type"] == "cash_management"
+    assert create.call_args.kwargs["instrument_type"] == "cash_management"
+
+
+@pytest.mark.asyncio
 async def test_add_watchlist_item_duplicate_409(client):
     with (
         patch(f"{DB}.db_get_or_create_default_watchlist", new_callable=AsyncMock),


### PR DESCRIPTION
## Summary

`GET /api/v1/users/me/portfolio` and `GET /api/v1/users/me/watchlists/{id}/items` raised 500 whenever a stored row had an `instrument_type` outside a closed Pydantic enum. Agent-written rows can legitimately produce values outside the canonical seven (e.g. cash-sweep / money-market products that don't fit `stock|etf|index|crypto|future|commodity|currency`). One bad row used to 500 the entire portfolio fetch.

This widens the type to free-form 1-30 char `str` on the API contract, with lowercase + strip normalization at every entry point so existing data and new writes stay consistent.

## Changes

- `src/server/models/user.py` — Replace `InstrumentType(str, Enum)` with a `KNOWN_INSTRUMENT_TYPES` frozenset (guidance only, not enforced) plus a `normalize_instrument_type()` helper. Both `WatchlistItemBase.instrument_type` and `PortfolioHoldingBase.instrument_type` are now `str(min_length=1, max_length=30)` with a `mode="before"` validator that normalizes to lowercase + stripped.
- `src/server/app/portfolio.py`, `src/server/app/watchlist.py` — drop `.value` after the field type change.
- `src/tools/user_profile/tools.py` — mirror the same normalization on the agent's `_create_watchlist_item` and `_upsert_portfolio_holding` write paths so agent-written rows and API-written rows converge on the same casing.
- `skills/user-profile/SKILL.md` — describe `instrument_type` as free-form on both `watchlist_item` and `portfolio_holding` entity tables, with the canonical seven listed as guidance.

## Behavior change

- `POST /api/v1/users/me/portfolio` and `POST /api/v1/users/me/watchlists/{id}/items` previously returned 422 for any `instrument_type` outside the closed enum. They now accept any 1-30 char string. The auto-generated OpenAPI schema for these fields changes from a closed enum to a string.
- `GET` endpoints that previously raised 500 on existing rows with non-canonical `instrument_type` values now return them in the response, normalized to lowercase + stripped.
- DB columns `user_portfolios.instrument_type` and `watchlist_items.instrument_type` are unchanged (`VARCHAR(30) NOT NULL`); no migration.

## Diff Size

- Total: 7 files, +143/-19
- Net (excl. tests): 5 files, +47/-19

## Test plan

- [x] `uv run pytest tests/unit/server/app/test_portfolio.py tests/unit/server/app/test_watchlist.py -v` — 37 pass, including 3 new regressions covering the GET 500 path (portfolio + watchlist) and the POST normalization (portfolio + watchlist).
- [x] `uv run ruff check` clean on all changed files.
- [ ] Confirm the OpenAPI schema change is acceptable for any downstream client codegen consumers.