### PR TITLE
feat(chat-agent): subagent telemetry surfaces, nav redesign, and steering rollback fix

### DIFF
--- a/src/ptc_agent/agent/middleware/background_subagent/event_capture.py
+++ b/src/ptc_agent/agent/middleware/background_subagent/event_capture.py
@@ -200,6 +200,7 @@ class SubagentEventCaptureMiddleware(AgentMiddleware):
                                 "ts": time.time(),
                             },
                         )
+
             except Exception as e:
                 # Never break the agent for capture failures, but leave a
                 # breadcrumb so capture regressions are debuggable.

--- a/src/ptc_agent/agent/middleware/background_subagent/subagent.py
+++ b/src/ptc_agent/agent/middleware/background_subagent/subagent.py
@@ -32,6 +32,14 @@ from src.server.utils.content_normalizer import normalize_text_content
 logger = structlog.get_logger(__name__)
 
 
+# Custom-mode SSE events we actually want forwarded from a subagent's
+# astream. Anything else (file_operations, todo_operations, show_widget,
+# etc. payloads) is dropped to keep the per-task buffer focused on
+# telemetry and to close protocol-injection vectors against the frontend's
+# subagent SSE handler.
+_ALLOWED_CUSTOM_EVENT_TYPES = frozenset({"context_window"})
+
+
 class _SubagentTokenForwarder:
     """Forward per-token ``messages``-mode chunks from subagent.astream into
     captured-event records on the registry.
@@ -170,10 +178,20 @@ class _SubagentTokenForwarder:
         the subagent's ``stream_mode``, those would die at the astream
         boundary. We tag with the stable ``task:{task_id}`` agent_id so the
         per-task SSE consumer and frontend can route the event.
+
+        Other middleware (file_operations, todo_operations, show_widget) also
+        emits via the same writer with potentially large payloads. We
+        whitelist the event types we actually want to forward to avoid
+        bloating the per-task buffer / Redis stream and to close a protocol
+        injection path — without the whitelist, a custom payload with
+        ``type: "message_chunk"`` would spoof a real subagent SSE event on
+        the frontend.
         """
         if not isinstance(data, dict):
             return
-        event_type = data.get("type") or "custom"
+        event_type = data.get("type")
+        if event_type not in _ALLOWED_CUSTOM_EVENT_TYPES:
+            return
         payload = {k: v for k, v in data.items() if k != "type"}
         payload["agent"] = self.agent_id
         await self.registry.append_captured_event(

--- a/src/ptc_agent/agent/middleware/background_subagent/subagent.py
+++ b/src/ptc_agent/agent/middleware/background_subagent/subagent.py
@@ -219,7 +219,15 @@ class _SubagentTokenForwarder:
         try:
             await self.registry.append_sentinel_to_stream(self.tool_call_id)
         except Exception:
-            pass
+            # Best-effort: degraded Redis falls back to the polling path
+            # (XREAD BLOCK timeout + asyncio_task.done()). Log so an oncall
+            # has a breadcrumb when "subagents close slowly" — without it
+            # the failure is invisible.
+            logger.warning(
+                "subagent_sentinel_write_failed",
+                tool_call_id=self.tool_call_id,
+                exc_info=True,
+            )
 
 
 class SubAgent(TypedDict):

--- a/src/ptc_agent/agent/middleware/background_subagent/subagent.py
+++ b/src/ptc_agent/agent/middleware/background_subagent/subagent.py
@@ -161,6 +161,26 @@ class _SubagentTokenForwarder:
 
         self._last_msg_id = msg_id
 
+    async def forward_custom(self, data: Any) -> None:
+        """Forward a ``custom``-mode event from inside the subagent's astream
+        into the per-task captured-event buffer.
+
+        Compaction middleware emits ``context_window`` events (token_usage,
+        summarize, offload) via ``get_stream_writer``. Without ``custom`` in
+        the subagent's ``stream_mode``, those would die at the astream
+        boundary. We tag with the stable ``task:{task_id}`` agent_id so the
+        per-task SSE consumer and frontend can route the event.
+        """
+        if not isinstance(data, dict):
+            return
+        event_type = data.get("type") or "custom"
+        payload = {k: v for k, v in data.items() if k != "type"}
+        payload["agent"] = self.agent_id
+        await self.registry.append_captured_event(
+            self.tool_call_id,
+            {"event": event_type, "data": payload, "ts": time.time()},
+        )
+
     async def finalize(self) -> None:
         """Close any still-open reasoning lifecycle and signal stream-end.
 
@@ -399,16 +419,16 @@ def _create_task_tool(
         state: dict,
         config: dict,
     ) -> dict:
-        """Drive the subagent through ``astream`` with combined ``values`` and
-        ``messages`` modes; return the final state.
+        """Drive the subagent through ``astream`` with combined ``values``,
+        ``messages``, and ``custom`` modes; return the final state.
 
         ``values`` mode yields full state snapshots; the last one is the
         tool's return value. ``messages`` mode yields per-token
         ``AIMessageChunk`` deltas forwarded to the registry as
-        ``message_chunk`` records for per-task SSE granularity.
-
-        ``stream_mode=["values", "messages"]`` yields ``(mode, data)`` tuples;
-        ``messages`` data is ``(message_chunk, metadata)``.
+        ``message_chunk`` records for per-task SSE granularity. ``custom``
+        mode surfaces ``get_stream_writer()`` events emitted from inside the
+        subagent (e.g. compaction's ``context_window`` token_usage / summarize
+        / offload signals) which would otherwise die at the astream boundary.
         """
         last_state: dict | None = None
         forwarder: _SubagentTokenForwarder | None = None
@@ -426,7 +446,7 @@ def _create_task_tool(
 
         try:
             async for mode, data in subagent.astream(
-                state, config, stream_mode=["values", "messages"]
+                state, config, stream_mode=["values", "messages", "custom"]
             ):
                 if mode == "values":
                     last_state = data
@@ -455,6 +475,14 @@ def _create_task_tool(
                                 "Subagent token forwarding failed",
                                 error=str(exc),
                             )
+                elif mode == "custom" and forwarder is not None:
+                    try:
+                        await forwarder.forward_custom(data)
+                    except Exception as exc:
+                        logger.debug(
+                            "Subagent custom-event forwarding failed",
+                            error=str(exc),
+                        )
         finally:
             if forwarder is not None:
                 try:

--- a/tests/unit/middleware/test_subagent_token_forwarder.py
+++ b/tests/unit/middleware/test_subagent_token_forwarder.py
@@ -396,3 +396,143 @@ async def test_atask_pipeline_forwards_messages_chunks_to_registry(monkeypatch):
     ]
     assert [e["data"]["content"] for e in text_chunks] == ["Hel", "lo", ", world"]
     assert {e["data"]["agent"] for e in text_chunks} == {"task:taskpipe"}
+
+
+# ---------------------------------------------------------------------------
+# custom-mode forwarding — surfaces compaction's get_stream_writer events
+# (context_window token_usage / summarize / offload) that ride a separate
+# stream channel from messages-mode chunks.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_forward_custom_appends_context_window_event() -> None:
+    """A ``custom``-mode dict with ``type=context_window`` lands as a captured
+    record with the stable ``task:{task_id}`` agent_id."""
+    registry = BackgroundTaskRegistry()
+    task = await _register(registry, task_id_override="abc123")
+    fwd = _SubagentTokenForwarder(registry, task.tool_call_id, "task:abc123")
+
+    await fwd.forward_custom(
+        {
+            "type": "context_window",
+            "action": "token_usage",
+            "signal": "complete",
+            "input_tokens": 100,
+            "output_tokens": 40,
+            "total_tokens": 140,
+        }
+    )
+
+    records = list(task.captured_events_tail)
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["event"] == "context_window"
+    data = rec["data"]
+    assert data["agent"] == "task:abc123"
+    assert data["action"] == "token_usage"
+    assert data["input_tokens"] == 100
+    assert data["output_tokens"] == 40
+    assert data["total_tokens"] == 140
+    # ``type`` is consumed as the event name and stripped from data.
+    assert "type" not in data
+
+
+@pytest.mark.asyncio
+async def test_forward_custom_ignores_non_dict() -> None:
+    """Non-dict custom payloads (e.g. legacy strings) are dropped silently."""
+    registry = BackgroundTaskRegistry()
+    task = await _register(registry, task_id_override="abc")
+    fwd = _SubagentTokenForwarder(registry, task.tool_call_id, "task:abc")
+
+    await fwd.forward_custom("not-a-dict")
+    await fwd.forward_custom(None)
+    await fwd.forward_custom(42)
+
+    assert list(task.captured_events_tail) == []
+
+
+@pytest.mark.asyncio
+async def test_atask_pipeline_forwards_custom_events_to_registry(monkeypatch):
+    """End-to-end: when the subagent emits a ``custom``-mode payload, the
+    Task-tool driver routes it through ``forward_custom`` so the per-task
+    buffer carries it for SSE replay."""
+    from ptc_agent.agent.middleware.background_subagent import subagent as sa
+    from ptc_agent.agent.middleware.background_subagent.middleware import (
+        current_background_tool_call_id,
+    )
+
+    parent_config = {"configurable": {"thread_id": "t1"}}
+    monkeypatch.setattr(
+        "ptc_agent.agent.middleware.background_subagent.subagent.get_config",
+        lambda: parent_config,
+    )
+
+    registry = BackgroundTaskRegistry()
+    task = await _register(registry, task_id_override="custompipe")
+
+    async def fake_astream(state, config, stream_mode=None):
+        # The driver must subscribe to ``custom`` for this to surface.
+        assert "custom" in (stream_mode or [])
+        yield (
+            "custom",
+            {
+                "type": "context_window",
+                "action": "token_usage",
+                "signal": "complete",
+                "input_tokens": 50,
+                "output_tokens": 10,
+                "total_tokens": 60,
+            },
+        )
+        yield ("values", {"messages": [MagicMock(text="final")]})
+
+    fake_subagent = MagicMock()
+    fake_subagent.astream = fake_astream
+
+    tool = sa._create_task_tool(
+        default_model=MagicMock(),
+        default_tools=[],
+        default_middleware=[],
+        default_interrupt_on=None,
+        subagents=[],
+        general_purpose_agent=False,
+        registry=registry,
+        checkpointer=None,
+    )
+    coroutine = tool.coroutine
+    closure_vars = {
+        cell_name: cell.cell_contents
+        for cell_name, cell in zip(
+            coroutine.__code__.co_freevars,
+            coroutine.__closure__ or (),
+        )
+    }
+    sg = closure_vars["subagent_graphs"]
+    sg["general-purpose"] = fake_subagent
+
+    runtime = MagicMock()
+    runtime.state = {"messages": []}
+    runtime.tool_call_id = "tc-pipe"
+
+    token = current_background_tool_call_id.set(task.tool_call_id)
+    try:
+        await coroutine(
+            description="d",
+            prompt="p",
+            subagent_type="general-purpose",
+            action="init",
+            task_id=None,
+            runtime=runtime,
+        )
+    finally:
+        current_background_tool_call_id.reset(token)
+
+    cw_events = [
+        e for e in task.captured_events_tail if e["event"] == "context_window"
+    ]
+    assert len(cw_events) == 1
+    data = cw_events[0]["data"]
+    assert data["agent"] == "task:custompipe"
+    assert data["action"] == "token_usage"
+    assert data["total_tokens"] == 60

--- a/tests/unit/middleware/test_subagent_token_forwarder.py
+++ b/tests/unit/middleware/test_subagent_token_forwarder.py
@@ -453,6 +453,29 @@ async def test_forward_custom_ignores_non_dict() -> None:
 
 
 @pytest.mark.asyncio
+async def test_forward_custom_drops_non_whitelisted_event_types() -> None:
+    """Custom payloads with unrecognized ``type`` values are dropped to avoid
+    bloating the per-task buffer with file-op / widget payloads and to close
+    a frontend protocol-injection vector — a custom emitter could otherwise
+    send ``type: "message_chunk"`` and spoof a real subagent SSE event."""
+    registry = BackgroundTaskRegistry()
+    task = await _register(registry, task_id_override="wl")
+    fwd = _SubagentTokenForwarder(registry, task.tool_call_id, "task:wl")
+
+    # Frontend protocol events — must not pass through.
+    await fwd.forward_custom({"type": "message_chunk", "content": "boo"})
+    await fwd.forward_custom({"type": "tool_call_result", "result": "x"})
+    await fwd.forward_custom({"type": "tool_calls", "tool_calls": []})
+    # File-op / widget-style payloads — must not pass through.
+    await fwd.forward_custom({"type": "file_op", "old_string": "a" * 10000})
+    await fwd.forward_custom({"type": "widget", "html": "<div/>"})
+    # Missing ``type`` entirely — must not pass through (no implicit "custom").
+    await fwd.forward_custom({"foo": "bar"})
+
+    assert list(task.captured_events_tail) == []
+
+
+@pytest.mark.asyncio
 async def test_atask_pipeline_forwards_custom_events_to_registry(monkeypatch):
     """End-to-end: when the subagent emits a ``custom``-mode payload, the
     Task-tool driver routes it through ``forward_custom`` so the per-task

--- a/tests/unit/middleware/test_subagent_tracer_isolation.py
+++ b/tests/unit/middleware/test_subagent_tracer_isolation.py
@@ -182,14 +182,16 @@ async def test_subagent_does_not_inherit_parent_token_tracker(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_subagent_uses_astream_with_values_and_messages_modes(
+async def test_subagent_uses_astream_with_values_messages_and_custom_modes(
     monkeypatch,
 ):
     """The Task tool drives the subagent through
-    ``astream(stream_mode=["values", "messages"])``. The LAST ``values``
-    yield is the tool's return; ``messages`` yields are forwarded as per-token
-    captured events on the registry. Earlier ``values`` yields are
-    intermediate snapshots that must NOT propagate."""
+    ``astream(stream_mode=["values", "messages", "custom"])``. The LAST
+    ``values`` yield is the tool's return; ``messages`` yields are forwarded
+    as per-token captured events on the registry; ``custom`` yields surface
+    compaction's ``get_stream_writer`` events (token_usage / summarize /
+    offload) so they reach the per-task SSE consumer. Earlier ``values``
+    yields are intermediate snapshots that must NOT propagate."""
     from ptc_agent.agent.middleware.background_subagent import subagent as sa
 
     parent_config = {"configurable": {"thread_id": "t1"}}
@@ -246,9 +248,9 @@ async def test_subagent_uses_astream_with_values_and_messages_modes(
         runtime=runtime,
     )
 
-    # Driver requests both modes — values for the final-state return,
-    # messages for per-token forwarding.
-    assert seen_stream_modes == [["values", "messages"]]
+    # Driver requests three modes — values for the final-state return,
+    # messages for per-token forwarding, custom for get_stream_writer events.
+    assert seen_stream_modes == [["values", "messages", "custom"]]
 
     # Only the LAST values yield propagates as the tool's return.
     msg = cmd.update["messages"][-1]

--- a/web/src/lib/__tests__/format.test.ts
+++ b/web/src/lib/__tests__/format.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import i18n from '@/i18n';
-import { createFormatter, createDateFormatter } from '@/lib/format';
+import { createFormatter, createDateFormatter, compactNumber } from '@/lib/format';
 
 describe('createFormatter', () => {
   beforeEach(() => {
@@ -50,6 +50,25 @@ describe('createDateFormatter', () => {
     i18n.changeLanguage('zh-CN');
     const zh = fmt(new Date('2026-04-25T00:00:00Z'));
     expect(en).not.toBe(zh);
+  });
+});
+
+describe('compactNumber', () => {
+  beforeEach(() => {
+    i18n.changeLanguage('en-US');
+  });
+
+  it('renders sub-thousand values verbatim (no suffix)', () => {
+    expect(compactNumber(0)).toBe('0');
+    expect(compactNumber(7)).toBe('7');
+    expect(compactNumber(999)).toBe('999');
+  });
+
+  it('compacts 4-digit-and-up values with locale suffix', () => {
+    expect(compactNumber(1000)).toMatch(/^1K$/);
+    expect(compactNumber(1234)).toMatch(/^1\.2K$/);
+    expect(compactNumber(5142)).toMatch(/^5\.1K$/);
+    expect(compactNumber(1_500_000)).toMatch(/^1\.5M$/);
   });
 });
 

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -60,3 +60,8 @@ export function createDateFormatter(opts: Intl.DateTimeFormatOptions): (d: Date 
     return fmt.format(d);
   };
 }
+
+// Compact short-form integer formatter — `1234 → "1.2K"`, `5_142 → "5.1K"`,
+// `1_500_000 → "1.5M"`. Locale-aware via Intl. Numbers under 1000 render in
+// full; suffix style follows the active locale (en `K`, zh `万`, etc).
+export const compactNumber = createFormatter({ notation: 'compact', maximumFractionDigits: 1 });

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -1730,8 +1730,6 @@
       "memo_other": "read {{count}} memos",
       "memoWrite": "wrote {{count}} memo",
       "memoWrite_other": "wrote {{count}} memos",
-      "failed": "{{count}} failed",
-      "failed_other": "{{count}} failed",
       "code": "executed {{count}} code block",
       "code_other": "executed {{count}} code blocks",
       "web": "made {{count}} web call",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -1716,7 +1716,6 @@
       "memoryUpdated": "更新记忆",
       "memo": "读取 {{count}} 份备忘",
       "memoWrite": "写入 {{count}} 份备忘",
-      "failed": "{{count}} 个失败",
       "code": "执行 {{count}} 段代码",
       "web": "发起 {{count}} 次网络请求",
       "search": "执行 {{count}} 次搜索",

--- a/web/src/pages/ChatAgent/components/ActivityBlock.tsx
+++ b/web/src/pages/ChatAgent/components/ActivityBlock.tsx
@@ -159,17 +159,15 @@ const ActivityBlock = memo(function ActivityBlock({ items, preparingToolCall, is
   // emit `<count> <label>` fragments. Computed BEFORE any early-return so
   // hook order stays stable.
   //
-  // Fingerprint includes the file_path arg AND `isFailed` per item so the
-  // breakdown re-walks when an item's args arrive late (a common SSE pattern:
-  // row created with empty args, file_path patched in a later chunk) or when
-  // a failure flag flips after the initial completed render. The earlier
-  // `[length, lastId]` key silently froze the category counts in both cases.
+  // Fingerprint includes the file_path arg per item so the breakdown
+  // re-walks when an item's args arrive late (a common SSE pattern: row
+  // created with empty args, file_path patched in a later chunk). The
+  // earlier `[length, lastId]` key silently froze the category counts.
   const summaryFingerprint = completedItems
     .map((i) => {
       const args = i.toolCall?.args as Record<string, unknown> | undefined;
       const fp = (args?.file_path || args?.filePath || '') as string;
-      const failed = i.isFailed ? '1' : '0';
-      return `${i.id || i.toolCallId || ''}:${i.type}:${i.toolName || ''}:${fp}:${failed}`;
+      return `${i.id || i.toolCallId || ''}:${i.type}:${i.toolName || ''}:${fp}`;
     })
     .join('|');
   // Slot = what we emit in the header. `memory` collapses read+write into one
@@ -177,21 +175,15 @@ const ActivityBlock = memo(function ActivityBlock({ items, preparingToolCall, is
   // surface). `fileRead`/`fileEdit` and `memo`/`memoWrite` stay separate —
   // distinct file/memo paths shouldn't collide under one label, and any
   // memo modification is surfaced distinctly so a future regression letting
-  // the agent mutate a memo is visible. `failed` is orthogonal to the
-  // category axis but is its own fragment so the user sees that the
-  // accordion contains failures even before expanding (otherwise a failed
-  // read counts identically to a successful one once `_liveState` flips to
-  // 'completed').
-  type SummarySlot = 'skill' | 'memory' | 'memo' | 'memoWrite' | 'code' | 'web' | 'search' | 'fileRead' | 'fileEdit' | 'reasoning' | 'generic' | 'failed';
+  // the agent mutate a memo is visible.
+  type SummarySlot = 'skill' | 'memory' | 'memo' | 'memoWrite' | 'code' | 'web' | 'search' | 'fileRead' | 'fileEdit' | 'reasoning' | 'generic';
   const summaryFragments = useMemo<{ slot: SummarySlot; count: number; modified?: boolean }[]>(() => {
     const counts = new Map<ToolCategory | 'reasoning', number>();
-    let failedCount = 0;
     for (const item of completedItems) {
       const key: ToolCategory | 'reasoning' = item.type === 'reasoning'
         ? 'reasoning'
         : categorizeTool(item.toolName || '', item.toolCall);
       counts.set(key, (counts.get(key) ?? 0) + 1);
-      if (item.isFailed) failedCount += 1;
     }
     const memReads = counts.get('memoryRead') ?? 0;
     const memWrites = counts.get('memoryWrite') ?? 0;
@@ -205,7 +197,6 @@ const ActivityBlock = memo(function ActivityBlock({ items, preparingToolCall, is
         out.push({ slot, count: counts.get(slot as ToolCategory | 'reasoning')! });
       }
     }
-    if (failedCount > 0) out.push({ slot: 'failed', count: failedCount });
     return out;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [summaryFingerprint]);
@@ -222,14 +213,14 @@ const ActivityBlock = memo(function ActivityBlock({ items, preparingToolCall, is
     // When folded, cap the breakdown at 3 fragments + "…" so the header stays
     // scannable on turns with many tool categories. Expanding the accordion
     // reveals the full breakdown alongside the per-step rows.
-    // High-signal fragments (memory writes, memo writes, failures) get
-    // priority: they're information the user specifically needs to see and
-    // shouldn't drop into the "and more …" tail when 4+ categories are
-    // present. We hoist them to the front of the visible slice while
-    // preserving the relative order of everything else.
+    // High-signal fragments (memory writes, memo writes) get priority:
+    // they're information the user specifically needs to see and shouldn't
+    // drop into the "and more …" tail when 4+ categories are present.
+    // We hoist them to the front of the visible slice while preserving the
+    // relative order of everything else.
     const FOLDED_MAX = 3;
     const isPriority = (f: { slot: SummarySlot; modified?: boolean }) =>
-      f.slot === 'failed' || f.slot === 'memoWrite' || (f.slot === 'memory' && f.modified === true);
+      f.slot === 'memoWrite' || (f.slot === 'memory' && f.modified === true);
     const priority = summaryFragments.filter(isPriority);
     const rest = summaryFragments.filter((f) => !isPriority(f));
     const ordered = [...priority, ...rest];
@@ -250,7 +241,6 @@ const ActivityBlock = memo(function ActivityBlock({ items, preparingToolCall, is
         if (f.slot === 'code') return t('toolArtifact.categoryCount.code', { count: f.count });
         if (f.slot === 'web') return t('toolArtifact.categoryCount.web', { count: f.count });
         if (f.slot === 'search') return t('toolArtifact.categoryCount.search', { count: f.count });
-        if (f.slot === 'failed') return t('toolArtifact.categoryCount.failed', { count: f.count });
         return t('toolArtifact.categoryCount.generic', { count: f.count });
       });
     summaryLabel = labels.join(' \u00b7 ');

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -134,6 +134,7 @@ interface SubagentUpdateData {
   status?: string;
   currentTool?: string;
   messages?: SubagentMessage[];
+  tokenUsage?: SubagentTokenUsage;
   [key: string]: unknown;
 }
 
@@ -1454,6 +1455,11 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     }
     if (history) {
       updateData.messages = (history.messages || []) as SubagentMessage[];
+      // Also seed tokenUsage from history. Without this, clicking a replayed
+      // subagent card creates the live card with tokenUsage=ZERO_USAGE, and
+      // the telemetry resolver's "card path" wins on return (messages.length > 0)
+      // and reports zero tokens — even though history still has the real total.
+      updateData.tokenUsage = (history.tokenUsage as SubagentTokenUsage) ?? ZERO_USAGE;
     }
 
     updateSubagentCard(agentId, updateData);

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -874,19 +874,43 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
 
   // Per-subagent telemetry resolver consumed by MessageList. Maps a message
   // segment's `subagentId` (a toolCallId) through `resolveSubagentIdToAgentId`
-  // and reads tool count + token usage off the matching card. Keeping the
-  // resolution in this closure means MessageList never touches the cards or
-  // the toolCallId map directly.
+  // and reads tool count + token usage off the matching card. Falls back to
+  // the history entry on a fresh load — cards are created lazily on click,
+  // so without this fallback the inline row would stay hidden after refresh
+  // until the user clicks into the subagent. Keeping the resolution in this
+  // closure means MessageList never touches the cards or the toolCallId map
+  // directly.
   const resolveSubagentTelemetry = useCallback((subagentId: string) => {
-    const agentId = resolveSubagentIdToAgentId(subagentId);
-    const card = cards[`subagent-${agentId}`];
+    const card = cards[`subagent-${resolveSubagentIdToAgentId(subagentId)}`];
     const sd = card?.subagentData as Record<string, unknown> | undefined;
+    const sdMessages = sd?.messages as SubagentMessage[] | undefined;
+    const sdTokenUsage = sd?.tokenUsage as SubagentTokenUsage | undefined;
+
+    // Card path: prefer live state, but only when it has actually been
+    // populated. A click-created card with empty messages should still
+    // pull from history below.
+    if (sd && (sdMessages?.length || (sdTokenUsage?.total ?? 0) > 0)) {
+      return {
+        toolCalls: countToolCalls(sdMessages),
+        tokenUsage: sdTokenUsage ?? ZERO_USAGE,
+      };
+    }
+
+    // History fallback: post-refresh path before the user opens the card.
+    const history = getSubagentHistory?.(subagentId);
+    if (history) {
+      return {
+        toolCalls: history.toolCalls ?? countToolCalls(history.messages as SubagentMessage[] | undefined),
+        tokenUsage: (history.tokenUsage as SubagentTokenUsage | undefined) ?? ZERO_USAGE,
+      };
+    }
+
     if (!sd) return undefined;
     return {
-      toolCalls: countToolCalls(sd.messages as SubagentMessage[] | undefined),
-      tokenUsage: (sd.tokenUsage as SubagentTokenUsage | undefined) ?? ZERO_USAGE,
+      toolCalls: countToolCalls(sdMessages),
+      tokenUsage: sdTokenUsage ?? ZERO_USAGE,
     };
-  }, [cards, resolveSubagentIdToAgentId]);
+  }, [cards, resolveSubagentIdToAgentId, getSubagentHistory]);
 
   // Auto-hide excess agents (beyond 11 subagents)
   const excessIds = useMemo(() => excessSubagents.map(a => a.id).join(','), [excessSubagents]);

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -17,6 +17,8 @@ import { clampPanelWidth as clampPanelWidthUtil } from '@/lib/panelUtils';
 import { useCardState } from '../hooks/useCardState';
 import { useWorkspaceFiles } from '../hooks/useWorkspaceFiles';
 import { classifyAgentPath, computeAgentArtifactRouting, type MemoryTier } from '../utils/agentPaths';
+import { countToolCalls } from '../utils/subagentMetrics';
+import { type SubagentTokenUsage, ZERO_USAGE } from '../utils/tokenUsage';
 import { getCompletedRowTitle } from './toolDisplayConfig';
 import './FilePanel.css';
 import ChatInput, { type ChatInputHandle } from '../../../components/ui/chat-input';
@@ -112,6 +114,7 @@ interface AgentInfo {
   type: string;
   status: string;
   toolCalls: number;
+  tokenUsage: SubagentTokenUsage;
   currentTool: string;
   messages: SubagentMessage[];
   isActive: boolean;
@@ -129,7 +132,6 @@ interface SubagentUpdateData {
   isHistory: boolean;
   isActive: boolean;
   status?: string;
-  toolCalls?: number;
   currentTool?: string;
   messages?: SubagentMessage[];
   [key: string]: unknown;
@@ -211,6 +213,7 @@ const MAIN_AGENT: AgentInfo = {
   type: 'main',
   status: 'active',
   toolCalls: 0,
+  tokenUsage: ZERO_USAGE,
   currentTool: '',
   messages: [],
   isActive: true,
@@ -853,7 +856,8 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
           prompt: (sd?.prompt as string) || '',
           type: (sd?.type as string) || 'general-purpose',
           status: (sd?.status as string) || 'active',
-          toolCalls: (sd?.toolCalls as number) || 0,
+          toolCalls: countToolCalls(sd?.messages as SubagentMessage[] | undefined),
+          tokenUsage: (sd?.tokenUsage as SubagentTokenUsage | undefined) ?? ZERO_USAGE,
           currentTool: (sd?.currentTool as string) || '',
           messages: (sd?.messages as SubagentMessage[]) || [],
           isActive: sd?.isActive !== false,
@@ -867,6 +871,22 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
       excessSubagents: visible.slice(maxSubagents),
     };
   }, [cards, hiddenAgentIds, t]);
+
+  // Per-subagent telemetry resolver consumed by MessageList. Maps a message
+  // segment's `subagentId` (a toolCallId) through `resolveSubagentIdToAgentId`
+  // and reads tool count + token usage off the matching card. Keeping the
+  // resolution in this closure means MessageList never touches the cards or
+  // the toolCallId map directly.
+  const resolveSubagentTelemetry = useCallback((subagentId: string) => {
+    const agentId = resolveSubagentIdToAgentId(subagentId);
+    const card = cards[`subagent-${agentId}`];
+    const sd = card?.subagentData as Record<string, unknown> | undefined;
+    if (!sd) return undefined;
+    return {
+      toolCalls: countToolCalls(sd.messages as SubagentMessage[] | undefined),
+      tokenUsage: (sd.tokenUsage as SubagentTokenUsage | undefined) ?? ZERO_USAGE,
+    };
+  }, [cards, resolveSubagentIdToAgentId]);
 
   // Auto-hide excess agents (beyond 11 subagents)
   const excessIds = useMemo(() => excessSubagents.map(a => a.id).join(','), [excessSubagents]);
@@ -1402,11 +1422,10 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
       isActive: !history,
     };
     if (isLive) {
-      // Card is actively streaming — preserve its current status, toolCalls, and currentTool.
+      // Card is actively streaming — preserve its current status and currentTool.
       // Overwriting these causes a brief "completed" flash in the SubagentStatusBar.
     } else {
       updateData.status = finalStatus;
-      updateData.toolCalls = 0;
       updateData.currentTool = '';
     }
     if (history) {
@@ -2058,6 +2077,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
                           handleSendMessage(`/self-improve ${instruction}`);
                         }}
                         onWidgetSendPrompt={handleSendMessage}
+                        resolveSubagentTelemetry={resolveSubagentTelemetry}
                       />
                     </div>
                   </div>
@@ -2106,6 +2126,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
                             hideAvatar={true}
                             onOpenFile={handleOpenFileFromChat}
                             onToolCallDetailClick={handleToolCallDetailClick}
+                            resolveSubagentTelemetry={resolveSubagentTelemetry}
                           />
                         </div>
                       )}

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -30,6 +30,7 @@ import ChatInput, { type ChatInputHandle } from '../../../components/ui/chat-inp
 import { attachmentsToContexts, widgetSnapshotsToContexts, type Attachment } from '../utils/fileUpload';
 import type { WidgetContextSnapshot } from '@/pages/Dashboard/widgets/framework/contextSnapshot';
 import MessageList, { normalizeSubagentText } from './MessageList';
+import { SubagentTelemetryContext } from './SubagentTelemetryContext';
 import Markdown from './Markdown';
 import NavigationPanel from './NavigationPanel';
 import ChatMinimap from './ChatMinimap';
@@ -2024,6 +2025,11 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
             }}
           >
             {/* Messages Area - Fixed height, scrollable */}
+            {/* Subscribe inline subagent cards directly to live telemetry. The
+                resolver identity changes on every SSE token (cards is a dep),
+                but only context consumers re-render — MessageBubble /
+                MessageContentSegments stay React.memo'd. */}
+            <SubagentTelemetryContext.Provider value={resolveSubagentTelemetry}>
             <div
               ref={msgAreaRef}
               className="flex-1 overflow-hidden"
@@ -2087,7 +2093,6 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
                           handleSendMessage(`/self-improve ${instruction}`);
                         }}
                         onWidgetSendPrompt={handleSendMessage}
-                        resolveSubagentTelemetry={resolveSubagentTelemetry}
                       />
                     </div>
                   </div>
@@ -2136,7 +2141,6 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
                             hideAvatar={true}
                             onOpenFile={handleOpenFileFromChat}
                             onToolCallDetailClick={handleToolCallDetailClick}
-                            resolveSubagentTelemetry={resolveSubagentTelemetry}
                           />
                         </div>
                       )}
@@ -2159,6 +2163,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
                 />
               )}
             </div>
+            </SubagentTelemetryContext.Provider>
 
             {/* Input Area */}
             <div className={`flex-shrink-0 ${isMobile ? 'p-3' : 'p-4'} flex justify-center`}>

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -19,6 +19,11 @@ import { useWorkspaceFiles } from '../hooks/useWorkspaceFiles';
 import { classifyAgentPath, computeAgentArtifactRouting, type MemoryTier } from '../utils/agentPaths';
 import { countToolCalls } from '../utils/subagentMetrics';
 import { type SubagentTokenUsage, ZERO_USAGE } from '../utils/tokenUsage';
+import {
+  resolveSubagentTelemetry as resolveSubagentTelemetryPure,
+  type SubagentDataLike,
+  type SubagentHistoryLike,
+} from '../utils/resolveSubagentTelemetry';
 import { getCompletedRowTitle } from './toolDisplayConfig';
 import './FilePanel.css';
 import ChatInput, { type ChatInputHandle } from '../../../components/ui/chat-input';
@@ -883,34 +888,9 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
   // directly.
   const resolveSubagentTelemetry = useCallback((subagentId: string) => {
     const card = cards[`subagent-${resolveSubagentIdToAgentId(subagentId)}`];
-    const sd = card?.subagentData as Record<string, unknown> | undefined;
-    const sdMessages = sd?.messages as SubagentMessage[] | undefined;
-    const sdTokenUsage = sd?.tokenUsage as SubagentTokenUsage | undefined;
-
-    // Card path: prefer live state, but only when it has actually been
-    // populated. A click-created card with empty messages should still
-    // pull from history below.
-    if (sd && (sdMessages?.length || (sdTokenUsage?.total ?? 0) > 0)) {
-      return {
-        toolCalls: countToolCalls(sdMessages),
-        tokenUsage: sdTokenUsage ?? ZERO_USAGE,
-      };
-    }
-
-    // History fallback: post-refresh path before the user opens the card.
-    const history = getSubagentHistory?.(subagentId);
-    if (history) {
-      return {
-        toolCalls: history.toolCalls ?? countToolCalls(history.messages as SubagentMessage[] | undefined),
-        tokenUsage: (history.tokenUsage as SubagentTokenUsage | undefined) ?? ZERO_USAGE,
-      };
-    }
-
-    if (!sd) return undefined;
-    return {
-      toolCalls: countToolCalls(sdMessages),
-      tokenUsage: sdTokenUsage ?? ZERO_USAGE,
-    };
+    const sd = card?.subagentData as SubagentDataLike | undefined;
+    const history = getSubagentHistory?.(subagentId) as SubagentHistoryLike | undefined;
+    return resolveSubagentTelemetryPure(sd, history);
   }, [cards, resolveSubagentIdToAgentId, getSubagentHistory]);
 
   // Auto-hide excess agents (beyond 11 subagents)

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -204,7 +204,7 @@ const _sharedNav = { visible: false, locked: false };
 // Static main agent object — never changes, so defined once at module level
 const MAIN_AGENT: AgentInfo = {
   id: 'main',
-  name: 'Boss',
+  name: 'Lead Agent',
   displayName: 'LangAlpha',
   taskId: '',
   description: '',

--- a/web/src/pages/ChatAgent/components/MessageList.tsx
+++ b/web/src/pages/ChatAgent/components/MessageList.tsx
@@ -34,7 +34,6 @@ import StartQuestionCard from './StartQuestionCard';
 import PTCAgentCard from './PTCAgentCard';
 import SecretaryConfirmCard from './SecretaryConfirmCard';
 import SubagentTaskMessageContent from './SubagentTaskMessageContent';
-import type { SubagentTelemetry } from '../utils/resolveSubagentTelemetry';
 import TextMessageContent from './TextMessageContent';
 import InlineWidget from './viewers/InlineWidget';
 import ToolCallMessageContent from './ToolCallMessageContent';
@@ -46,8 +45,6 @@ import { TextShimmer } from '@/components/ui/text-shimmer';
 const EMPTY_OBJ = {} as Record<string, never>;
 
 // --- Shared Types ---
-
-type ResolveSubagentTelemetry = (subagentId: string) => SubagentTelemetry | undefined;
 
 /** Loosely typed message record from SSE/API */
 type MessageRecord = Record<string, unknown>;
@@ -354,13 +351,9 @@ interface MessageListProps {
   onReportWithAgent?: (instruction: string) => void;
   onWidgetSendPrompt?: (text: string) => void;
   flashContext?: { threadId: string; workspaceId: string } | null;
-  /** Resolves a `segment.subagentId` (toolCallId) to the live telemetry of
-   *  the underlying subagent — handles toolCallId → agentId resolution
-   *  and the cards lookup in one closure. */
-  resolveSubagentTelemetry?: ResolveSubagentTelemetry;
 }
 
-function MessageList({ messages, isLoading, isLoadingHistory, hideAvatar, compactToolCalls, isSubagentView, readOnly, allowFiles, onOpenSubagentTask, onOpenFile, onOpenDir, onToolCallDetailClick, onApprovePlan, onRejectPlan, onPlanDetailClick, onAnswerQuestion, onSkipQuestion, onApproveCreateWorkspace, onRejectCreateWorkspace, onApproveStartQuestion, onRejectStartQuestion, onApprovePTCAgent, onRejectPTCAgent, onApproveSecretaryAction, onRejectSecretaryAction, onEditMessage, onRegenerate, onRetry, onThumbUp, onThumbDown, getFeedbackForMessage, onReportWithAgent, onWidgetSendPrompt, flashContext, resolveSubagentTelemetry }: MessageListProps): React.ReactElement | null {
+function MessageList({ messages, isLoading, isLoadingHistory, hideAvatar, compactToolCalls, isSubagentView, readOnly, allowFiles, onOpenSubagentTask, onOpenFile, onOpenDir, onToolCallDetailClick, onApprovePlan, onRejectPlan, onPlanDetailClick, onAnswerQuestion, onSkipQuestion, onApproveCreateWorkspace, onRejectCreateWorkspace, onApproveStartQuestion, onRejectStartQuestion, onApprovePTCAgent, onRejectPTCAgent, onApproveSecretaryAction, onRejectSecretaryAction, onEditMessage, onRegenerate, onRetry, onThumbUp, onThumbDown, getFeedbackForMessage, onReportWithAgent, onWidgetSendPrompt, flashContext }: MessageListProps): React.ReactElement | null {
   const isMobile = useIsMobile();
 
   // Empty state - show when no messages exist (hidden in subagent view)
@@ -450,7 +443,6 @@ function MessageList({ messages, isLoading, isLoadingHistory, hideAvatar, compac
             onReportWithAgent={onReportWithAgent}
             onWidgetSendPrompt={onWidgetSendPrompt}
             flashContext={flashContext}
-            resolveSubagentTelemetry={resolveSubagentTelemetry}
           />
         )
       )}
@@ -495,14 +487,13 @@ interface MessageBubbleProps {
   onWidgetSendPrompt?: (text: string) => void;
   isMobile?: boolean;
   flashContext?: { threadId: string; workspaceId: string } | null;
-  resolveSubagentTelemetry?: ResolveSubagentTelemetry;
 }
 
 /**
  * Wrapped with React.memo — safe because updateMessage() in messageHelpers.ts
  * returns the same object reference for unchanged messages.
  */
-const MessageBubble = memo(function MessageBubble({ message, isLoading, hideAvatar, compactToolCalls, isSubagentView, readOnly, allowFiles, onOpenSubagentTask, onOpenFile, onOpenDir, onToolCallDetailClick, onApprovePlan, onRejectPlan, onPlanDetailClick, onAnswerQuestion, onSkipQuestion, onApproveCreateWorkspace, onRejectCreateWorkspace, onApproveStartQuestion, onRejectStartQuestion, onApprovePTCAgent, onRejectPTCAgent, onApproveSecretaryAction, onRejectSecretaryAction, onEditMessage, onRegenerate, onRetry, onThumbUp, onThumbDown, getFeedbackForMessage, onReportWithAgent, onWidgetSendPrompt, isMobile, flashContext, resolveSubagentTelemetry }: MessageBubbleProps): React.ReactElement {
+const MessageBubble = memo(function MessageBubble({ message, isLoading, hideAvatar, compactToolCalls, isSubagentView, readOnly, allowFiles, onOpenSubagentTask, onOpenFile, onOpenDir, onToolCallDetailClick, onApprovePlan, onRejectPlan, onPlanDetailClick, onAnswerQuestion, onSkipQuestion, onApproveCreateWorkspace, onRejectCreateWorkspace, onApproveStartQuestion, onRejectStartQuestion, onApprovePTCAgent, onRejectPTCAgent, onApproveSecretaryAction, onRejectSecretaryAction, onEditMessage, onRegenerate, onRetry, onThumbUp, onThumbDown, getFeedbackForMessage, onReportWithAgent, onWidgetSendPrompt, isMobile, flashContext }: MessageBubbleProps): React.ReactElement {
   const { user } = useUser();
   const { theme } = useTheme();
   const logo = theme === 'light' ? logoDark : logoLight;
@@ -730,7 +721,6 @@ const MessageBubble = memo(function MessageBubble({ message, isLoading, hideAvat
               toolCallProcesses={(message.toolCallProcesses as Record<string, ToolCallProcessRecord>) || EMPTY_OBJ}
               todoListProcesses={(message.todoListProcesses as Record<string, Record<string, unknown>>) || EMPTY_OBJ}
               subagentTasks={(message.subagentTasks as Record<string, Record<string, unknown>>) || EMPTY_OBJ}
-              resolveSubagentTelemetry={resolveSubagentTelemetry}
               planApprovals={(message.planApprovals as Record<string, Record<string, unknown>>) || EMPTY_OBJ}
               userQuestions={(message.userQuestions as Record<string, Record<string, unknown>>) || EMPTY_OBJ}
               workspaceProposals={(message.workspaceProposals as Record<string, Record<string, unknown>>) || EMPTY_OBJ}
@@ -936,7 +926,6 @@ interface MessageContentSegmentsProps {
   toolCallProcesses: Record<string, ToolCallProcessRecord>;
   todoListProcesses: Record<string, Record<string, unknown>>;
   subagentTasks: Record<string, Record<string, unknown>>;
-  resolveSubagentTelemetry?: ResolveSubagentTelemetry;
   planApprovals?: Record<string, Record<string, unknown>>;
   userQuestions?: Record<string, Record<string, unknown>>;
   workspaceProposals?: Record<string, Record<string, unknown>>;
@@ -1091,7 +1080,7 @@ function TextBlock({ block, isFirst, isStreaming, hasError, structuredError, isS
   return isFirst && textContent ? <div className="-mt-1">{textEl}</div> : textEl;
 }
 
-const MessageContentSegments = memo(function MessageContentSegments({ segments, reasoningProcesses, toolCallProcesses, todoListProcesses, subagentTasks, resolveSubagentTelemetry, planApprovals = EMPTY_OBJ, userQuestions = EMPTY_OBJ, workspaceProposals = EMPTY_OBJ, questionProposals = EMPTY_OBJ, pendingToolCallChunks = EMPTY_OBJ, isStreaming, hasError, structuredError, isAssistant = false, compactToolCalls = false, isSubagentView = false, readOnly = false, allowFiles = false, onOpenSubagentTask, onOpenFile, onOpenDir, onToolCallDetailClick, onApprovePlan, onRejectPlan, onPlanDetailClick, onAnswerQuestion, onSkipQuestion, onApproveCreateWorkspace, onRejectCreateWorkspace, onApproveStartQuestion, onRejectStartQuestion, onApprovePTCAgent, onRejectPTCAgent, onApproveSecretaryAction, onRejectSecretaryAction, ptcAgentProposals = EMPTY_OBJ, secretaryActionProposals = EMPTY_OBJ, onWidgetSendPrompt, htmlWidgetProcesses = EMPTY_OBJ, textOnly = false, flashContext }: MessageContentSegmentsProps): React.ReactElement {
+const MessageContentSegments = memo(function MessageContentSegments({ segments, reasoningProcesses, toolCallProcesses, todoListProcesses, subagentTasks, planApprovals = EMPTY_OBJ, userQuestions = EMPTY_OBJ, workspaceProposals = EMPTY_OBJ, questionProposals = EMPTY_OBJ, pendingToolCallChunks = EMPTY_OBJ, isStreaming, hasError, structuredError, isAssistant = false, compactToolCalls = false, isSubagentView = false, readOnly = false, allowFiles = false, onOpenSubagentTask, onOpenFile, onOpenDir, onToolCallDetailClick, onApprovePlan, onRejectPlan, onPlanDetailClick, onAnswerQuestion, onSkipQuestion, onApproveCreateWorkspace, onRejectCreateWorkspace, onApproveStartQuestion, onRejectStartQuestion, onApprovePTCAgent, onRejectPTCAgent, onApproveSecretaryAction, onRejectSecretaryAction, ptcAgentProposals = EMPTY_OBJ, secretaryActionProposals = EMPTY_OBJ, onWidgetSendPrompt, htmlWidgetProcesses = EMPTY_OBJ, textOnly = false, flashContext }: MessageContentSegmentsProps): React.ReactElement {
   // Force re-render timer for recently-completed tool calls that need minimum exposure
   const [tick, setTick] = useState(0);
   const expiryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -1483,7 +1472,6 @@ const MessageContentSegments = memo(function MessageContentSegments({ segments, 
               _subagentResult: (task.result as string) || null,
               _subagentStatus: (task.status as string) || null,
             } : undefined;
-            const telemetry = resolveSubagentTelemetry?.(subId);
             return (
               <SubagentTaskMessageContent
                 key={block.key}
@@ -1496,8 +1484,6 @@ const MessageContentSegments = memo(function MessageContentSegments({ segments, 
                 onOpen={readOnly ? undefined : onOpenSubagentTask}
                 onDetailOpen={readOnly ? undefined : (onToolCallDetailClick as any)} // TODO: type properly
                 toolCallProcess={toolCallProcess as any} // TODO: type properly — ToolCallProcess not exported
-                toolCalls={telemetry?.toolCalls}
-                tokenUsage={telemetry?.tokenUsage}
               />
             );
           }
@@ -1654,7 +1640,6 @@ const MessageContentSegments = memo(function MessageContentSegments({ segments, 
           const subId = segment.subagentId!;
           const task = subagentTasks[subId];
           if (task) {
-            const telemetry = resolveSubagentTelemetry?.(subId);
             return (
               <SubagentTaskMessageContent
                 key={`subagent-task-${subId}`}
@@ -1665,8 +1650,6 @@ const MessageContentSegments = memo(function MessageContentSegments({ segments, 
                 action={task.action as 'init' | 'update' | 'resume' | undefined}
                 resumeTargetId={task.resumeTargetId as string}
                 onOpen={onOpenSubagentTask}
-                toolCalls={telemetry?.toolCalls}
-                tokenUsage={telemetry?.tokenUsage}
               />
             );
           }

--- a/web/src/pages/ChatAgent/components/MessageList.tsx
+++ b/web/src/pages/ChatAgent/components/MessageList.tsx
@@ -34,7 +34,7 @@ import StartQuestionCard from './StartQuestionCard';
 import PTCAgentCard from './PTCAgentCard';
 import SecretaryConfirmCard from './SecretaryConfirmCard';
 import SubagentTaskMessageContent from './SubagentTaskMessageContent';
-import type { SubagentTokenUsage } from '../utils/tokenUsage';
+import type { SubagentTelemetry } from '../utils/resolveSubagentTelemetry';
 import TextMessageContent from './TextMessageContent';
 import InlineWidget from './viewers/InlineWidget';
 import ToolCallMessageContent from './ToolCallMessageContent';
@@ -47,7 +47,6 @@ const EMPTY_OBJ = {} as Record<string, never>;
 
 // --- Shared Types ---
 
-type SubagentTelemetry = { toolCalls: number; tokenUsage: SubagentTokenUsage };
 type ResolveSubagentTelemetry = (subagentId: string) => SubagentTelemetry | undefined;
 
 /** Loosely typed message record from SSE/API */

--- a/web/src/pages/ChatAgent/components/MessageList.tsx
+++ b/web/src/pages/ChatAgent/components/MessageList.tsx
@@ -34,6 +34,10 @@ import StartQuestionCard from './StartQuestionCard';
 import PTCAgentCard from './PTCAgentCard';
 import SecretaryConfirmCard from './SecretaryConfirmCard';
 import SubagentTaskMessageContent from './SubagentTaskMessageContent';
+import type { SubagentTokenUsage } from '../utils/tokenUsage';
+
+type SubagentTelemetry = { toolCalls: number; tokenUsage: SubagentTokenUsage };
+type ResolveSubagentTelemetry = (subagentId: string) => SubagentTelemetry | undefined;
 import TextMessageContent from './TextMessageContent';
 import InlineWidget from './viewers/InlineWidget';
 import ToolCallMessageContent from './ToolCallMessageContent';
@@ -351,9 +355,13 @@ interface MessageListProps {
   onReportWithAgent?: (instruction: string) => void;
   onWidgetSendPrompt?: (text: string) => void;
   flashContext?: { threadId: string; workspaceId: string } | null;
+  /** Resolves a `segment.subagentId` (toolCallId) to the live telemetry of
+   *  the underlying subagent — handles toolCallId → agentId resolution
+   *  and the cards lookup in one closure. */
+  resolveSubagentTelemetry?: ResolveSubagentTelemetry;
 }
 
-function MessageList({ messages, isLoading, isLoadingHistory, hideAvatar, compactToolCalls, isSubagentView, readOnly, allowFiles, onOpenSubagentTask, onOpenFile, onOpenDir, onToolCallDetailClick, onApprovePlan, onRejectPlan, onPlanDetailClick, onAnswerQuestion, onSkipQuestion, onApproveCreateWorkspace, onRejectCreateWorkspace, onApproveStartQuestion, onRejectStartQuestion, onApprovePTCAgent, onRejectPTCAgent, onApproveSecretaryAction, onRejectSecretaryAction, onEditMessage, onRegenerate, onRetry, onThumbUp, onThumbDown, getFeedbackForMessage, onReportWithAgent, onWidgetSendPrompt, flashContext }: MessageListProps): React.ReactElement | null {
+function MessageList({ messages, isLoading, isLoadingHistory, hideAvatar, compactToolCalls, isSubagentView, readOnly, allowFiles, onOpenSubagentTask, onOpenFile, onOpenDir, onToolCallDetailClick, onApprovePlan, onRejectPlan, onPlanDetailClick, onAnswerQuestion, onSkipQuestion, onApproveCreateWorkspace, onRejectCreateWorkspace, onApproveStartQuestion, onRejectStartQuestion, onApprovePTCAgent, onRejectPTCAgent, onApproveSecretaryAction, onRejectSecretaryAction, onEditMessage, onRegenerate, onRetry, onThumbUp, onThumbDown, getFeedbackForMessage, onReportWithAgent, onWidgetSendPrompt, flashContext, resolveSubagentTelemetry }: MessageListProps): React.ReactElement | null {
   const isMobile = useIsMobile();
 
   // Empty state - show when no messages exist (hidden in subagent view)
@@ -443,6 +451,7 @@ function MessageList({ messages, isLoading, isLoadingHistory, hideAvatar, compac
             onReportWithAgent={onReportWithAgent}
             onWidgetSendPrompt={onWidgetSendPrompt}
             flashContext={flashContext}
+            resolveSubagentTelemetry={resolveSubagentTelemetry}
           />
         )
       )}
@@ -487,13 +496,14 @@ interface MessageBubbleProps {
   onWidgetSendPrompt?: (text: string) => void;
   isMobile?: boolean;
   flashContext?: { threadId: string; workspaceId: string } | null;
+  resolveSubagentTelemetry?: ResolveSubagentTelemetry;
 }
 
 /**
  * Wrapped with React.memo — safe because updateMessage() in messageHelpers.ts
  * returns the same object reference for unchanged messages.
  */
-const MessageBubble = memo(function MessageBubble({ message, isLoading, hideAvatar, compactToolCalls, isSubagentView, readOnly, allowFiles, onOpenSubagentTask, onOpenFile, onOpenDir, onToolCallDetailClick, onApprovePlan, onRejectPlan, onPlanDetailClick, onAnswerQuestion, onSkipQuestion, onApproveCreateWorkspace, onRejectCreateWorkspace, onApproveStartQuestion, onRejectStartQuestion, onApprovePTCAgent, onRejectPTCAgent, onApproveSecretaryAction, onRejectSecretaryAction, onEditMessage, onRegenerate, onRetry, onThumbUp, onThumbDown, getFeedbackForMessage, onReportWithAgent, onWidgetSendPrompt, isMobile, flashContext }: MessageBubbleProps): React.ReactElement {
+const MessageBubble = memo(function MessageBubble({ message, isLoading, hideAvatar, compactToolCalls, isSubagentView, readOnly, allowFiles, onOpenSubagentTask, onOpenFile, onOpenDir, onToolCallDetailClick, onApprovePlan, onRejectPlan, onPlanDetailClick, onAnswerQuestion, onSkipQuestion, onApproveCreateWorkspace, onRejectCreateWorkspace, onApproveStartQuestion, onRejectStartQuestion, onApprovePTCAgent, onRejectPTCAgent, onApproveSecretaryAction, onRejectSecretaryAction, onEditMessage, onRegenerate, onRetry, onThumbUp, onThumbDown, getFeedbackForMessage, onReportWithAgent, onWidgetSendPrompt, isMobile, flashContext, resolveSubagentTelemetry }: MessageBubbleProps): React.ReactElement {
   const { user } = useUser();
   const { theme } = useTheme();
   const logo = theme === 'light' ? logoDark : logoLight;
@@ -721,6 +731,7 @@ const MessageBubble = memo(function MessageBubble({ message, isLoading, hideAvat
               toolCallProcesses={(message.toolCallProcesses as Record<string, ToolCallProcessRecord>) || EMPTY_OBJ}
               todoListProcesses={(message.todoListProcesses as Record<string, Record<string, unknown>>) || EMPTY_OBJ}
               subagentTasks={(message.subagentTasks as Record<string, Record<string, unknown>>) || EMPTY_OBJ}
+              resolveSubagentTelemetry={resolveSubagentTelemetry}
               planApprovals={(message.planApprovals as Record<string, Record<string, unknown>>) || EMPTY_OBJ}
               userQuestions={(message.userQuestions as Record<string, Record<string, unknown>>) || EMPTY_OBJ}
               workspaceProposals={(message.workspaceProposals as Record<string, Record<string, unknown>>) || EMPTY_OBJ}
@@ -926,6 +937,7 @@ interface MessageContentSegmentsProps {
   toolCallProcesses: Record<string, ToolCallProcessRecord>;
   todoListProcesses: Record<string, Record<string, unknown>>;
   subagentTasks: Record<string, Record<string, unknown>>;
+  resolveSubagentTelemetry?: ResolveSubagentTelemetry;
   planApprovals?: Record<string, Record<string, unknown>>;
   userQuestions?: Record<string, Record<string, unknown>>;
   workspaceProposals?: Record<string, Record<string, unknown>>;
@@ -1080,7 +1092,7 @@ function TextBlock({ block, isFirst, isStreaming, hasError, structuredError, isS
   return isFirst && textContent ? <div className="-mt-1">{textEl}</div> : textEl;
 }
 
-const MessageContentSegments = memo(function MessageContentSegments({ segments, reasoningProcesses, toolCallProcesses, todoListProcesses, subagentTasks, planApprovals = EMPTY_OBJ, userQuestions = EMPTY_OBJ, workspaceProposals = EMPTY_OBJ, questionProposals = EMPTY_OBJ, pendingToolCallChunks = EMPTY_OBJ, isStreaming, hasError, structuredError, isAssistant = false, compactToolCalls = false, isSubagentView = false, readOnly = false, allowFiles = false, onOpenSubagentTask, onOpenFile, onOpenDir, onToolCallDetailClick, onApprovePlan, onRejectPlan, onPlanDetailClick, onAnswerQuestion, onSkipQuestion, onApproveCreateWorkspace, onRejectCreateWorkspace, onApproveStartQuestion, onRejectStartQuestion, onApprovePTCAgent, onRejectPTCAgent, onApproveSecretaryAction, onRejectSecretaryAction, ptcAgentProposals = EMPTY_OBJ, secretaryActionProposals = EMPTY_OBJ, onWidgetSendPrompt, htmlWidgetProcesses = EMPTY_OBJ, textOnly = false, flashContext }: MessageContentSegmentsProps): React.ReactElement {
+const MessageContentSegments = memo(function MessageContentSegments({ segments, reasoningProcesses, toolCallProcesses, todoListProcesses, subagentTasks, resolveSubagentTelemetry, planApprovals = EMPTY_OBJ, userQuestions = EMPTY_OBJ, workspaceProposals = EMPTY_OBJ, questionProposals = EMPTY_OBJ, pendingToolCallChunks = EMPTY_OBJ, isStreaming, hasError, structuredError, isAssistant = false, compactToolCalls = false, isSubagentView = false, readOnly = false, allowFiles = false, onOpenSubagentTask, onOpenFile, onOpenDir, onToolCallDetailClick, onApprovePlan, onRejectPlan, onPlanDetailClick, onAnswerQuestion, onSkipQuestion, onApproveCreateWorkspace, onRejectCreateWorkspace, onApproveStartQuestion, onRejectStartQuestion, onApprovePTCAgent, onRejectPTCAgent, onApproveSecretaryAction, onRejectSecretaryAction, ptcAgentProposals = EMPTY_OBJ, secretaryActionProposals = EMPTY_OBJ, onWidgetSendPrompt, htmlWidgetProcesses = EMPTY_OBJ, textOnly = false, flashContext }: MessageContentSegmentsProps): React.ReactElement {
   // Force re-render timer for recently-completed tool calls that need minimum exposure
   const [tick, setTick] = useState(0);
   const expiryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -1463,18 +1475,20 @@ const MessageContentSegments = memo(function MessageContentSegments({ segments, 
           }
 
           if (block.type === 'subagent_task') {
-            const task = subagentTasks[(block as SubagentTaskRenderBlock).segment.subagentId!];
+            const subId = (block as SubagentTaskRenderBlock).segment.subagentId!;
+            const task = subagentTasks[subId];
             if (!task) return null;
-            const rawToolCallProcess = toolCallProcesses[(block as SubagentTaskRenderBlock).segment.subagentId!] || undefined;
+            const rawToolCallProcess = toolCallProcesses[subId] || undefined;
             const toolCallProcess = rawToolCallProcess ? {
               ...rawToolCallProcess,
               _subagentResult: (task.result as string) || null,
               _subagentStatus: (task.status as string) || null,
             } : undefined;
+            const telemetry = resolveSubagentTelemetry?.(subId);
             return (
               <SubagentTaskMessageContent
                 key={block.key}
-                subagentId={(block as SubagentTaskRenderBlock).segment.subagentId!}
+                subagentId={subId}
                 description={task.description as string}
                 type={task.type as string}
                 status={task.status as string}
@@ -1483,6 +1497,8 @@ const MessageContentSegments = memo(function MessageContentSegments({ segments, 
                 onOpen={readOnly ? undefined : onOpenSubagentTask}
                 onDetailOpen={readOnly ? undefined : (onToolCallDetailClick as any)} // TODO: type properly
                 toolCallProcess={toolCallProcess as any} // TODO: type properly — ToolCallProcess not exported
+                toolCalls={telemetry?.toolCalls}
+                tokenUsage={telemetry?.tokenUsage}
               />
             );
           }
@@ -1636,18 +1652,22 @@ const MessageContentSegments = memo(function MessageContentSegments({ segments, 
             />
           );
         } else if (segment.type === 'subagent_task') {
-          const task = subagentTasks[segment.subagentId!];
+          const subId = segment.subagentId!;
+          const task = subagentTasks[subId];
           if (task) {
+            const telemetry = resolveSubagentTelemetry?.(subId);
             return (
               <SubagentTaskMessageContent
-                key={`subagent-task-${segment.subagentId}`}
-                subagentId={segment.subagentId!}
+                key={`subagent-task-${subId}`}
+                subagentId={subId}
                 description={task.description as string}
                 type={task.type as string}
                 status={task.status as string}
                 action={task.action as 'init' | 'update' | 'resume' | undefined}
                 resumeTargetId={task.resumeTargetId as string}
                 onOpen={onOpenSubagentTask}
+                toolCalls={telemetry?.toolCalls}
+                tokenUsage={telemetry?.tokenUsage}
               />
             );
           }

--- a/web/src/pages/ChatAgent/components/MessageList.tsx
+++ b/web/src/pages/ChatAgent/components/MessageList.tsx
@@ -35,9 +35,6 @@ import PTCAgentCard from './PTCAgentCard';
 import SecretaryConfirmCard from './SecretaryConfirmCard';
 import SubagentTaskMessageContent from './SubagentTaskMessageContent';
 import type { SubagentTokenUsage } from '../utils/tokenUsage';
-
-type SubagentTelemetry = { toolCalls: number; tokenUsage: SubagentTokenUsage };
-type ResolveSubagentTelemetry = (subagentId: string) => SubagentTelemetry | undefined;
 import TextMessageContent from './TextMessageContent';
 import InlineWidget from './viewers/InlineWidget';
 import ToolCallMessageContent from './ToolCallMessageContent';
@@ -49,6 +46,9 @@ import { TextShimmer } from '@/components/ui/text-shimmer';
 const EMPTY_OBJ = {} as Record<string, never>;
 
 // --- Shared Types ---
+
+type SubagentTelemetry = { toolCalls: number; tokenUsage: SubagentTokenUsage };
+type ResolveSubagentTelemetry = (subagentId: string) => SubagentTelemetry | undefined;
 
 /** Loosely typed message record from SSE/API */
 type MessageRecord = Record<string, unknown>;

--- a/web/src/pages/ChatAgent/components/NavigationPanel.css
+++ b/web/src/pages/ChatAgent/components/NavigationPanel.css
@@ -68,6 +68,22 @@
   background-color: var(--color-border-muted);
 }
 
+/* Hierarchy glyph for subagent rows. Width is glyph (text-xs ~12px) + 2px
+   optical correction so the label column aligns with main-agent rows. The
+   monospace stack guards against system fonts missing U+2514 / U+2500. */
+.nav-panel-agent-glyph {
+  width: 14px;
+  flex-shrink: 0;
+  color: var(--color-icon-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+}
+
+/* Lift the glyph one shade when its row is selected so the connector
+   participates in the selection state alongside the label. */
+.nav-panel-agent-row.is-selected .nav-panel-agent-glyph {
+  color: var(--color-text-secondary);
+}
+
 /* Dismiss buttons (minimize + fold) */
 .nav-panel-dismiss-btn {
   opacity: 0.4;

--- a/web/src/pages/ChatAgent/components/NavigationPanel.tsx
+++ b/web/src/pages/ChatAgent/components/NavigationPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useMemo } from 'react';
 import {
   ChevronRight, ChevronDown, Folder, Zap, Pin, MessageSquareText,
-  Crown, Bot, Check, Circle, Loader2, X, ChevronsDown,
+  Check, Circle, Loader2, X, ChevronsDown,
 } from 'lucide-react';
 import { ScrollArea } from '../../../components/ui/scroll-area';
 import { useIsMobile } from '@/hooks/useIsMobile';
@@ -37,6 +37,7 @@ interface AgentMessage {
 interface AgentEntry {
   id: string;
   name: string;
+  description?: string;
   isMainAgent?: boolean;
   status?: string;
   messages?: AgentMessage[];
@@ -278,26 +279,35 @@ function NavigationPanel({
                                 const isActive = status === 'active';
                                 const isCompleted = status === 'completed';
 
+                                const trimmedDescription = typeof agent.description === 'string' ? agent.description.trim() : '';
+                                const rowLabel = !isMainAgent && trimmedDescription
+                                  ? trimmedDescription
+                                  : agent.name;
+
                                 return (
                                   <div
                                     key={agent.id}
-                                    className={`nav-panel-agent-row group ${isActive && !isMainAgent ? 'nav-panel-agent-pulse' : ''}`}
+                                    data-testid="agent-row"
+                                    data-agent-role={isMainAgent ? 'main' : 'sub'}
+                                    className={`nav-panel-agent-row group ${isActive && !isMainAgent ? 'nav-panel-agent-pulse' : ''}${isSelected ? ' is-selected' : ''}`}
                                     style={{
                                       backgroundColor: isSelected ? 'var(--color-border-muted)' : undefined,
                                     }}
                                     onClick={() => onSelectAgent(agent.id)}
                                   >
-                                    {/* Agent icon */}
-                                    {isMainAgent
-                                      ? <Crown className="h-3.5 w-3.5 flex-shrink-0" style={{ color: 'var(--color-text-tertiary)' }} />
-                                      : <Bot className="h-3.5 w-3.5 flex-shrink-0" style={{ color: 'var(--color-text-tertiary)' }} />
-                                    }
-                                    {/* Agent name */}
+                                    {/* Hierarchy indicator: subagents render `└─` to descend visually under the main agent's text column */}
+                                    {!isMainAgent && (
+                                      <span aria-hidden="true" className="nav-panel-agent-glyph text-xs">
+                                        └─
+                                      </span>
+                                    )}
+                                    {/* Agent label: subagent description when available, else fallback name */}
                                     <span
                                       className="text-xs truncate"
                                       style={{ color: isSelected ? 'var(--color-text-primary)' : 'var(--color-text-tertiary)' }}
+                                      title={rowLabel}
                                     >
-                                      {agent.name}
+                                      {rowLabel}
                                     </span>
                                     {/* Status badge */}
                                     {!isMainAgent && (

--- a/web/src/pages/ChatAgent/components/SubagentTaskMessageContent.tsx
+++ b/web/src/pages/ChatAgent/components/SubagentTaskMessageContent.tsx
@@ -117,8 +117,17 @@ function SubagentTaskMessageContent({
     }
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>): void => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleCardClick();
+    }
+  };
+
   return (
     <div
+      role="button"
+      tabIndex={0}
       style={{
         background: 'var(--color-bg-tool-card)',
         border: '1px solid var(--color-border-muted)',
@@ -129,6 +138,7 @@ function SubagentTaskMessageContent({
         transition: 'border-color 0.15s',
       }}
       onClick={handleCardClick}
+      onKeyDown={handleKeyDown}
       onMouseEnter={(e: React.MouseEvent<HTMLDivElement>) => (e.currentTarget.style.borderColor = 'var(--color-border-default)')}
       onMouseLeave={(e: React.MouseEvent<HTMLDivElement>) => (e.currentTarget.style.borderColor = 'var(--color-border-muted)')}
       title={
@@ -188,17 +198,26 @@ function SubagentTaskMessageContent({
           {statusLabel}
         </span>
         {hasResult ? (
-          <ArrowRight
-            style={{
-              width: 14,
-              height: 14,
-              flexShrink: 0,
-              color: 'var(--color-accent-primary)',
-            }}
+          <button
+            type="button"
+            aria-label="View subagent output"
             onClick={handleViewOutput}
-          />
+            style={{
+              background: 'transparent',
+              border: 'none',
+              padding: 0,
+              display: 'inline-flex',
+              alignItems: 'center',
+              cursor: 'pointer',
+              color: 'var(--color-accent-primary)',
+              flexShrink: 0,
+            }}
+          >
+            <ArrowRight style={{ width: 14, height: 14 }} />
+          </button>
         ) : (
           <ChevronRight
+            aria-hidden="true"
             style={{
               width: 14,
               height: 14,

--- a/web/src/pages/ChatAgent/components/SubagentTaskMessageContent.tsx
+++ b/web/src/pages/ChatAgent/components/SubagentTaskMessageContent.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import { Check, Loader2, ArrowRight, RotateCw, RefreshCw } from 'lucide-react';
-import iconRobo from '../../../assets/img/icon-robo.png';
-import iconRoboSing from '../../../assets/img/icon-robo-sing.png';
+import { Check, Loader2, ArrowRight, ChevronRight, RotateCw, RefreshCw } from 'lucide-react';
 import { compactNumber } from '@/lib/format';
 import { type SubagentTokenUsage } from '../utils/tokenUsage';
-import './NavigationPanel.css';
+
+const MONO_STACK = 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace';
 
 /**
  * Extract a short one-line summary from a full task description.
@@ -12,15 +11,11 @@ import './NavigationPanel.css';
  */
 function summarize(text: string | undefined, maxLen = 100): string {
   if (!text || typeof text !== 'string') return '';
-  // Take first line only
   const firstLine = text.split(/\n/)[0].trim();
-  // Remove trailing colon (often "Research X comprehensively. Cover:")
   const cleaned = firstLine.replace(/:$/, '');
   if (cleaned.length <= maxLen) return cleaned;
-  return cleaned.slice(0, maxLen).replace(/\s+\S*$/, '') + '\u2026';
+  return cleaned.slice(0, maxLen).replace(/\s+\S*$/, '') + '…';
 }
-
-const CARD_BORDER = 'var(--color-border-muted)';
 
 interface ToolCallProcess {
   toolCallResult?: {
@@ -54,11 +49,9 @@ interface SubagentTaskMessageContentProps {
 }
 
 /**
- * SubagentTaskMessageContent Component
- *
- * Renders a compact, clickable card in the main chat view to indicate that
- * a background subagent task was launched or resumed (via the `task` tool).
- * Uses the same visual style as inline artifact cards (company overview, etc.).
+ * Inline subagent card. Trading-terminal-style row: agent type on the left of
+ * the rule, semantic status on the right, description and live telemetry
+ * (tools / tokens) in the body. Adapts to light/dark via design tokens.
  */
 function SubagentTaskMessageContent({
   subagentId,
@@ -82,9 +75,37 @@ function SubagentTaskMessageContent({
   const hasResult = isCompleted && toolCallProcess?.toolCallResult?.content;
   const summary = summarize(description);
 
+  // Status discriminator — drives icon, label, and accent color.
+  // Updated/Resumed share the warning-amber treatment with Running because
+  // those are all "in-flight or recent change" states; Completed is success.
+  const statusKind: 'completed' | 'running' | 'updated' | 'resumed' | 'unknown' =
+    action === 'update' ? 'updated'
+    : action === 'resume' ? 'resumed'
+    : action === 'init' && isRunning ? 'running'
+    : action === 'init' && isCompleted ? 'completed'
+    : 'unknown';
+
+  const statusColor =
+    statusKind === 'completed' ? 'var(--color-success)'
+    : statusKind === 'unknown' ? 'var(--color-text-tertiary)'
+    : 'var(--color-warning)';
+
+  const statusLabel =
+    statusKind === 'completed' ? 'Completed'
+    : statusKind === 'running' ? 'Running'
+    : statusKind === 'updated' ? 'Updated'
+    : statusKind === 'resumed' ? 'Resumed'
+    : status;
+
+  const StatusIcon =
+    statusKind === 'completed' ? Check
+    : statusKind === 'running' ? Loader2
+    : statusKind === 'updated' ? RefreshCw
+    : statusKind === 'resumed' ? RotateCw
+    : null;
+
   const handleCardClick = (): void => {
     if (onOpen) {
-      // For resume cards, open the original subagent's tab if possible
       onOpen({ subagentId: resumeTargetId || subagentId || '', description: description || '', type, status });
     }
   };
@@ -100,83 +121,142 @@ function SubagentTaskMessageContent({
     <div
       style={{
         background: 'var(--color-bg-tool-card)',
-        border: `1px solid ${CARD_BORDER}`,
-        borderRadius: 8,
-        padding: '12px 14px',
+        border: '1px solid var(--color-border-muted)',
+        borderRadius: 12,
+        overflow: 'hidden',
         cursor: 'pointer',
+        fontFamily: MONO_STACK,
         transition: 'border-color 0.15s',
       }}
       onClick={handleCardClick}
-      onMouseEnter={(e: React.MouseEvent<HTMLDivElement>) => (e.currentTarget.style.borderColor = 'var(--color-border-muted)')}
-      onMouseLeave={(e: React.MouseEvent<HTMLDivElement>) => (e.currentTarget.style.borderColor = CARD_BORDER)}
-      title={action === 'update' ? 'Click to view updated subagent' : action === 'resume' ? 'Click to view resumed subagent' : isRunning ? 'Click to view running subagent' : 'Click to view subagent details'}
+      onMouseEnter={(e: React.MouseEvent<HTMLDivElement>) => (e.currentTarget.style.borderColor = 'var(--color-border-default)')}
+      onMouseLeave={(e: React.MouseEvent<HTMLDivElement>) => (e.currentTarget.style.borderColor = 'var(--color-border-muted)')}
+      title={
+        action === 'update' ? 'Click to view updated subagent'
+        : action === 'resume' ? 'Click to view resumed subagent'
+        : isRunning ? 'Click to view running subagent'
+        : 'Click to view subagent details'
+      }
     >
-      {/* Top row: icon + summary text */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 8 }}>
-        <div style={{ position: 'relative', flexShrink: 0 }}>
-          <img
-            src={isCompleted ? iconRobo : iconRoboSing}
-            alt="Subagent"
-            className={isRunning ? 'nav-panel-agent-pulse' : ''}
-            style={{ width: 20, height: 20 }}
-          />
-          {isRunning && (
-            <Loader2
+      {/* Rule: agent type · status · affordance */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+          padding: '10px 12px 8px 14px',
+          borderBottom: '1px solid var(--color-border-subtle)',
+          fontSize: 12,
+        }}
+      >
+        <span
+          style={{
+            color: 'var(--color-text-secondary)',
+            fontWeight: 500,
+            textTransform: 'lowercase',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            minWidth: 0,
+            flex: '0 1 auto',
+          }}
+        >
+          {type}
+        </span>
+        <span style={{ flex: 1 }} />
+        <span
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 5,
+            color: statusColor,
+            fontSize: 11,
+            letterSpacing: '0.04em',
+            fontWeight: 500,
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {StatusIcon && (
+            <StatusIcon
               style={{
-                width: 10, height: 10,
-                position: 'absolute', bottom: -2, right: -2,
-                color: 'var(--color-accent-primary)',
-                animation: 'spin 1s linear infinite',
+                width: 11,
+                height: 11,
+                animation: statusKind === 'running' ? 'spin 1s linear infinite' : undefined,
               }}
             />
           )}
-        </div>
-        <span style={{ fontWeight: 600, color: 'var(--color-text-primary)', fontSize: 14, flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-          {summary || 'Subagent Task'}
+          {statusLabel}
         </span>
-        {!!hasResult && (
+        {hasResult ? (
           <ArrowRight
-            style={{ width: 14, height: 14, flexShrink: 0, color: 'var(--color-accent-primary)' }}
+            style={{
+              width: 14,
+              height: 14,
+              flexShrink: 0,
+              color: 'var(--color-accent-primary)',
+            }}
             onClick={handleViewOutput}
+          />
+        ) : (
+          <ChevronRight
+            style={{
+              width: 14,
+              height: 14,
+              flexShrink: 0,
+              color: 'var(--color-text-quaternary)',
+            }}
           />
         )}
       </div>
 
-      {/* Bottom row: type badge + status */}
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-        <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>
-          {type}
-        </span>
-        <span style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 12, color: (action === 'update' || action === 'resume') ? 'var(--color-warning)' : isRunning ? 'var(--color-accent-primary)' : isCompleted ? 'var(--color-accent-primary)' : 'var(--color-text-tertiary)' }}>
-          {action === 'update' && <RefreshCw style={{ width: 12, height: 12 }} />}
-          {action === 'resume' && <RotateCw style={{ width: 12, height: 12 }} />}
-          {action === 'init' && isRunning && <Loader2 style={{ width: 12, height: 12, animation: 'spin 1s linear infinite' }} />}
-          {action === 'init' && isCompleted && <Check style={{ width: 12, height: 12 }} />}
-          {action === 'update' ? 'Updated' : action === 'resume' ? 'Resumed' : isRunning ? 'Running' : isCompleted ? 'Completed' : status}
-        </span>
-      </div>
-      {/* Telemetry row: live tool-call count + cumulative token total. Hidden
-          when both are zero so freshly-spawned cards stay visually quiet. */}
-      {(toolCalls > 0 || (tokenUsage?.total ?? 0) > 0) && (
+      {/* Body: description + telemetry */}
+      <div style={{ padding: '12px 14px 14px' }}>
         <div
-          data-testid="subagent-telemetry"
           style={{
-            marginTop: 6,
-            display: 'flex',
-            gap: 10,
-            fontSize: 11,
-            fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
-            color: 'var(--color-text-tertiary)',
+            fontFamily:
+              "'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+            fontSize: 14,
+            fontWeight: 500,
+            color: 'var(--color-text-primary)',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            marginBottom: (toolCalls > 0 || (tokenUsage?.total ?? 0) > 0) ? 8 : 0,
           }}
         >
-          {toolCalls > 0 && <span>{toolCalls} {toolCalls === 1 ? 'tool' : 'tools'}</span>}
-          {(tokenUsage?.total ?? 0) > 0 && (
-            <span title={`${tokenUsage!.input} in · ${tokenUsage!.output} out`}>
-              {toolCalls > 0 ? '· ' : ''}{compactNumber(tokenUsage!.total)} tokens
-            </span>
-          )}
+          {summary || 'Subagent Task'}
         </div>
-      )}
+
+        {(toolCalls > 0 || (tokenUsage?.total ?? 0) > 0) && (
+          <div
+            data-testid="subagent-telemetry"
+            style={{
+              display: 'flex',
+              gap: 8,
+              fontSize: 11,
+              color: 'var(--color-text-tertiary)',
+              fontFamily: MONO_STACK,
+              letterSpacing: '0.02em',
+            }}
+          >
+            {toolCalls > 0 && (
+              <span>
+                <strong style={{ color: 'var(--color-text-secondary)', fontWeight: 600 }}>{toolCalls}</strong>
+                {' '}
+                {toolCalls === 1 ? 'tool' : 'tools'}
+              </span>
+            )}
+            {(tokenUsage?.total ?? 0) > 0 && (
+              <span title={`${tokenUsage!.input} in · ${tokenUsage!.output} out`}>
+                {toolCalls > 0 ? '· ' : ''}
+                <strong style={{ color: 'var(--color-text-secondary)', fontWeight: 600 }}>{compactNumber(tokenUsage!.total)}</strong>
+                {' '}
+                tokens
+              </span>
+            )}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/web/src/pages/ChatAgent/components/SubagentTaskMessageContent.tsx
+++ b/web/src/pages/ChatAgent/components/SubagentTaskMessageContent.tsx
@@ -118,6 +118,10 @@ function SubagentTaskMessageContent({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>): void => {
+    // Ignore keystrokes that originated on a descendant control (e.g. the
+    // "View subagent output" button) — the descendant handles its own
+    // activation, and the keydown shouldn't double-fire as a card click.
+    if (e.target !== e.currentTarget) return;
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
       handleCardClick();

--- a/web/src/pages/ChatAgent/components/SubagentTaskMessageContent.tsx
+++ b/web/src/pages/ChatAgent/components/SubagentTaskMessageContent.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Check, Loader2, ArrowRight, ChevronRight, RotateCw, RefreshCw } from 'lucide-react';
 import { compactNumber } from '@/lib/format';
 import { type SubagentTokenUsage } from '../utils/tokenUsage';
+import { useSubagentTelemetry } from './SubagentTelemetryContext';
 
 const MONO_STACK = 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace';
 
@@ -63,9 +64,17 @@ function SubagentTaskMessageContent({
   onOpen,
   onDetailOpen,
   toolCallProcess,
-  toolCalls = 0,
-  tokenUsage,
+  toolCalls: toolCallsProp,
+  tokenUsage: tokenUsageProp,
 }: SubagentTaskMessageContentProps): React.ReactElement | null {
+  // Subscribe to live telemetry at the leaf so token-tick re-renders bypass
+  // the memoized MessageBubble / MessageContentSegments above us. Direct
+  // props (used by tests and any explicit caller) take precedence over the
+  // context lookup so call sites can still override or stub.
+  const ctxTelemetry = useSubagentTelemetry(subagentId);
+  const toolCalls = toolCallsProp ?? ctxTelemetry?.toolCalls ?? 0;
+  const tokenUsage = tokenUsageProp ?? ctxTelemetry?.tokenUsage;
+
   if (!subagentId && !description) {
     return null;
   }

--- a/web/src/pages/ChatAgent/components/SubagentTaskMessageContent.tsx
+++ b/web/src/pages/ChatAgent/components/SubagentTaskMessageContent.tsx
@@ -119,7 +119,7 @@ function SubagentTaskMessageContent({
     }
   };
 
-  const handleViewOutput = (e: React.MouseEvent): void => {
+  const handleViewOutput = (e: React.MouseEvent<HTMLButtonElement>): void => {
     e.stopPropagation();
     if (onDetailOpen && toolCallProcess) {
       onDetailOpen(toolCallProcess);

--- a/web/src/pages/ChatAgent/components/SubagentTaskMessageContent.tsx
+++ b/web/src/pages/ChatAgent/components/SubagentTaskMessageContent.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Check, Loader2, ArrowRight, RotateCw, RefreshCw } from 'lucide-react';
 import iconRobo from '../../../assets/img/icon-robo.png';
 import iconRoboSing from '../../../assets/img/icon-robo-sing.png';
+import { compactNumber } from '@/lib/format';
+import { type SubagentTokenUsage } from '../utils/tokenUsage';
 import './NavigationPanel.css';
 
 /**
@@ -45,6 +47,10 @@ interface SubagentTaskMessageContentProps {
   onOpen?: (info: SubagentInfo) => void;
   onDetailOpen?: (process: ToolCallProcess) => void;
   toolCallProcess?: ToolCallProcess;
+  /** Live tool-call count for this subagent — derived from card state at the call site. */
+  toolCalls?: number;
+  /** Live cumulative token usage for this subagent — derived from card state at the call site. */
+  tokenUsage?: SubagentTokenUsage;
 }
 
 /**
@@ -64,6 +70,8 @@ function SubagentTaskMessageContent({
   onOpen,
   onDetailOpen,
   toolCallProcess,
+  toolCalls = 0,
+  tokenUsage,
 }: SubagentTaskMessageContentProps): React.ReactElement | null {
   if (!subagentId && !description) {
     return null;
@@ -147,6 +155,28 @@ function SubagentTaskMessageContent({
           {action === 'update' ? 'Updated' : action === 'resume' ? 'Resumed' : isRunning ? 'Running' : isCompleted ? 'Completed' : status}
         </span>
       </div>
+      {/* Telemetry row: live tool-call count + cumulative token total. Hidden
+          when both are zero so freshly-spawned cards stay visually quiet. */}
+      {(toolCalls > 0 || (tokenUsage?.total ?? 0) > 0) && (
+        <div
+          data-testid="subagent-telemetry"
+          style={{
+            marginTop: 6,
+            display: 'flex',
+            gap: 10,
+            fontSize: 11,
+            fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+            color: 'var(--color-text-tertiary)',
+          }}
+        >
+          {toolCalls > 0 && <span>{toolCalls} {toolCalls === 1 ? 'tool' : 'tools'}</span>}
+          {(tokenUsage?.total ?? 0) > 0 && (
+            <span title={`${tokenUsage!.input} in · ${tokenUsage!.output} out`}>
+              {toolCalls > 0 ? '· ' : ''}{compactNumber(tokenUsage!.total)} tokens
+            </span>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/pages/ChatAgent/components/SubagentTelemetryContext.tsx
+++ b/web/src/pages/ChatAgent/components/SubagentTelemetryContext.tsx
@@ -1,0 +1,15 @@
+import { createContext, useContext } from 'react';
+import type { SubagentTelemetry } from '../utils/resolveSubagentTelemetry';
+
+export type SubagentTelemetryResolver = (subagentId: string) => SubagentTelemetry | undefined;
+
+// Consumed at the leaf (SubagentTaskMessageContent) so live token-tick
+// re-renders bypass the memoized MessageBubble / MessageContentSegments
+// trees instead of busting their memo on every SSE event.
+export const SubagentTelemetryContext = createContext<SubagentTelemetryResolver | null>(null);
+
+export function useSubagentTelemetry(subagentId: string | undefined): SubagentTelemetry | undefined {
+  const resolver = useContext(SubagentTelemetryContext);
+  if (!resolver || !subagentId) return undefined;
+  return resolver(subagentId);
+}

--- a/web/src/pages/ChatAgent/components/__tests__/ActivityBlock.failed.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/ActivityBlock.failed.test.tsx
@@ -1,13 +1,18 @@
 /**
- * Coverage for the failed-tool-call surfacing logic added in Fix #3, the
- * memo-write classification surfacing in Fix #4, and the priority-fragment
- * cap in Fix #14.
+ * Coverage for the per-row failed-tool-call rendering, the memo-write
+ * classification surfacing in the folded summary, and the priority-fragment
+ * cap that protects high-signal slots (memoWrite, memoryUpdated) from being
+ * truncated when many tool categories are present.
+ *
+ * Failed tool calls are rendered per-row only — the folded summary intentionally
+ * does NOT include a "{N} failed" fragment. The negative assertions below
+ * lock that contract in.
  *
  * Strategy: render `ActivityBlock` directly with a small set of synthesized
  * `_liveState: 'completed'` items, and assert against the rendered DOM. The
  * t() identity mock returns the i18n key as-is so the assertions can pin
- * the exact branch (e.g. `categoryCount.failed`, `categoryCount.memoWrite`)
- * without depending on the bundled English copy.
+ * the exact branch (e.g. `categoryCount.memoWrite`) without depending on the
+ * bundled English copy.
  */
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
@@ -81,7 +86,7 @@ function completedTool(toolName: string, opts: Partial<ActivityItem> = {}): Acti
 }
 
 // ---------------------------------------------------------------------------
-// Fix #3 — failed-call surfacing
+// Failed tool calls — per-row rendering, no summary fragment
 // ---------------------------------------------------------------------------
 
 // `summaryLabel` is title-cased before render (charAt(0).toUpperCase()), so
@@ -89,8 +94,8 @@ function completedTool(toolName: string, opts: Partial<ActivityItem> = {}): Acti
 // case-insensitive regex when looking up the toggle by name.
 const SUMMARY_BUTTON_RE = /toolArtifact/i;
 
-describe('ActivityBlock — failed tool calls (Fix #3)', () => {
-  it('appends a "failed" fragment to the folded accordion summary when an item is failed', () => {
+describe('ActivityBlock — failed tool calls', () => {
+  it('does NOT add a failed fragment to the folded accordion summary when an item is failed', () => {
     const items: ActivityItem[] = [
       completedTool('Read', {
         id: 'r-1',
@@ -101,9 +106,10 @@ describe('ActivityBlock — failed tool calls (Fix #3)', () => {
 
     render(<ActivityBlock items={items} isStreaming={false} />);
 
-    // Folded summary contains the failed fragment.
+    // Folded summary intentionally omits the failed count — failure
+    // visibility lives on the per-row badge instead.
     const summary = screen.getByRole('button', { name: SUMMARY_BUTTON_RE });
-    expect(summary).toHaveTextContent(/toolArtifact\.categoryCount\.failed/i);
+    expect(summary).not.toHaveTextContent(/toolArtifact\.categoryCount\.failed/i);
   });
 
   it('renders the failed badge on the timeline icon when the accordion is expanded', () => {
@@ -152,7 +158,7 @@ describe('ActivityBlock — failed tool calls (Fix #3)', () => {
     expect(failedRow!.querySelector('.nrow-badge')).not.toBeNull();
   });
 
-  it('counts successful and failed reads distinctly in the folded summary', () => {
+  it('counts all reads in the fileRead bucket regardless of failure state', () => {
     const items: ActivityItem[] = [
       completedTool('Read', { id: 'r-1', toolCall: { args: { file_path: 'a.md' } } }),
       completedTool('Read', { id: 'r-2', toolCall: { args: { file_path: 'b.md' } } }),
@@ -165,10 +171,10 @@ describe('ActivityBlock — failed tool calls (Fix #3)', () => {
 
     render(<ActivityBlock items={items} isStreaming={false} />);
     const summary = screen.getByRole('button', { name: SUMMARY_BUTTON_RE });
-    // Three reads in the fileRead bucket (orthogonal to failure axis).
+    // Three reads in the fileRead bucket (failures don't split the count).
     expect(summary).toHaveTextContent(/toolArtifact\.categoryCount.fileRead/i);
-    // ...and one failed fragment alongside it.
-    expect(summary).toHaveTextContent(/toolArtifact\.categoryCount.failed/i);
+    // No standalone failed fragment.
+    expect(summary).not.toHaveTextContent(/toolArtifact\.categoryCount.failed/i);
   });
 
   it('does not render any failed badge when no item is failed', () => {
@@ -187,10 +193,10 @@ describe('ActivityBlock — failed tool calls (Fix #3)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Fix #4 — memo write/edit classification in the summary
+// Memo write/edit classification in the summary
 // ---------------------------------------------------------------------------
 
-describe('ActivityBlock — memo write/edit fragment (Fix #4)', () => {
+describe('ActivityBlock — memo write/edit fragment', () => {
   it('emits a memoWrite fragment when the agent writes a memo', () => {
     const items: ActivityItem[] = [
       completedTool('Write', {
@@ -222,10 +228,10 @@ describe('ActivityBlock — memo write/edit fragment (Fix #4)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Fix #14 — priority fragments survive the FOLDED_MAX cap
+// Priority fragments survive the FOLDED_MAX cap
 // ---------------------------------------------------------------------------
 
-describe('ActivityBlock — priority fragments survive the cap (Fix #14)', () => {
+describe('ActivityBlock — priority fragments survive the cap', () => {
   it('keeps memoryWrite visible even with 4+ categories present', () => {
     const items: ActivityItem[] = [
       // A memory write — the high-signal fragment we don't want to hide.
@@ -247,33 +253,13 @@ describe('ActivityBlock — priority fragments survive the cap (Fix #14)', () =>
     // The "and more" suffix indicates the cap fired.
     expect(summary).toHaveTextContent(/toolArtifact\.andMore/i);
   });
-
-  it('keeps a failed fragment visible even with 4+ categories present', () => {
-    const items: ActivityItem[] = [
-      completedTool('Read', {
-        id: 'r-fail',
-        isFailed: true,
-        toolCall: { args: { file_path: 'work/scratch.md' } },
-      }),
-      completedTool('ExecuteCode', { id: 'c-1' }),
-      completedTool('WebSearch', { id: 'wb-1' }),
-      completedTool('Glob', { id: 'g-1' }),
-      // A second non-priority bucket to overflow past the cap.
-      completedTool('Read', { id: 'r-2', toolCall: { args: { file_path: 'work/other.md' } } }),
-    ];
-
-    render(<ActivityBlock items={items} isStreaming={false} />);
-    const summary = screen.getByRole('button', { name: SUMMARY_BUTTON_RE });
-    expect(summary).toHaveTextContent(/toolArtifact\.categoryCount.failed/i);
-    expect(summary).toHaveTextContent(/toolArtifact\.andMore/i);
-  });
 });
 
 // ---------------------------------------------------------------------------
-// Fix #16 — accordion accessibility
+// Accordion accessibility
 // ---------------------------------------------------------------------------
 
-describe('ActivityBlock — accordion a11y (Fix #16)', () => {
+describe('ActivityBlock — accordion a11y', () => {
   it('toggles aria-expanded on the summary button', () => {
     const items: ActivityItem[] = [
       completedTool('Read', { id: 'r-1', toolCall: { args: { file_path: 'work/scratch.md' } } }),

--- a/web/src/pages/ChatAgent/components/__tests__/NavigationPanel.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/NavigationPanel.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * Coverage for the agent-row rendering changes:
+ *  - subagents prefer their description over the displayId / "Worker" name.
+ *  - main agent renders without a leading icon; subagents render `└─`.
+ *  - long descriptions clip with truncate + reveal full text via title.
+ *
+ * The panel renders agent rows only when (workspace expanded) AND (thread is
+ * the current thread, expanded). Each test wires currentWorkspaceId +
+ * currentThreadId so the rows mount on first render.
+ */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import NavigationPanel from '../NavigationPanel';
+
+// `t()` identity mock — we don't depend on bundled English copy here, but
+// the component reads i18n keys for some labels and we want the fallback
+// strings ("Worker") to come from the agents array, not from t().
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const WS_ID = 'ws-1';
+const THREAD_ID = 'thread-1';
+
+interface RenderOpts {
+  agents: React.ComponentProps<typeof NavigationPanel>['agents'];
+}
+
+function renderPanel({ agents }: RenderOpts) {
+  return render(
+    <NavigationPanel
+      workspaces={[{ workspace_id: WS_ID, name: 'Test workspace' }]}
+      workspaceThreads={{
+        [WS_ID]: {
+          threads: [{ thread_id: THREAD_ID, title: 'Test thread' }],
+          loading: false,
+        },
+      }}
+      currentWorkspaceId={WS_ID}
+      currentThreadId={THREAD_ID}
+      agents={agents}
+      activeAgentId={null}
+      expandWorkspace={vi.fn()}
+      onSelectAgent={vi.fn()}
+      onRemoveAgent={vi.fn()}
+      onNavigateThread={vi.fn()}
+    />,
+  );
+}
+
+describe('NavigationPanel — subagent description fallback', () => {
+  it('renders the trimmed description in place of the displayId / Worker name', () => {
+    renderPanel({
+      agents: [
+        { id: 'main', name: 'Lead Agent', isMainAgent: true },
+        {
+          id: 'sub-1',
+          name: 'Task-k7Xm2p',
+          description: 'Research AAPL Q3 revenue drivers',
+          isMainAgent: false,
+        },
+      ],
+    });
+
+    expect(screen.getByText('Research AAPL Q3 revenue drivers')).toBeInTheDocument();
+    expect(screen.queryByText('Task-k7Xm2p')).toBeNull();
+  });
+
+  it('falls back to agent.name when description is empty / whitespace-only / null', () => {
+    renderPanel({
+      agents: [
+        { id: 'main', name: 'Lead Agent', isMainAgent: true },
+        { id: 'sub-1', name: 'Worker', description: '   ', isMainAgent: false },
+        { id: 'sub-2', name: 'Worker', description: undefined, isMainAgent: false },
+        // JSON wire shape: backend may emit `null` rather than omit the field.
+        // The runtime guard is `typeof agent.description === 'string'`, which
+        // correctly rejects null — pinning that contract here so a future
+        // refactor to a truthy check (`agent.description?.trim()`) doesn't
+        // silently break for `description: 0` or other falsy non-strings.
+        { id: 'sub-3', name: 'Worker', description: null as unknown as undefined, isMainAgent: false },
+      ],
+    });
+
+    expect(screen.getAllByText('Worker').length).toBe(3);
+  });
+
+  it('ignores description on the main agent row and always renders agent.name', () => {
+    renderPanel({
+      agents: [
+        // A main agent that carries a description should still render as
+        // 'Lead Agent' — the description fallback is gated on !isMainAgent.
+        { id: 'main', name: 'Lead Agent', description: 'should be ignored', isMainAgent: true },
+        { id: 'sub-1', name: 'Worker', description: 'visible sub label', isMainAgent: false },
+      ],
+    });
+
+    expect(screen.getByText('Lead Agent')).toBeInTheDocument();
+    expect(screen.queryByText('should be ignored')).toBeNull();
+    expect(screen.getByText('visible sub label')).toBeInTheDocument();
+  });
+
+  it('exposes the full description via the title attribute for hover-reveal', () => {
+    const long = 'a'.repeat(300);
+    renderPanel({
+      agents: [
+        { id: 'main', name: 'Lead Agent', isMainAgent: true },
+        { id: 'sub-1', name: 'Worker', description: long, isMainAgent: false },
+      ],
+    });
+
+    const label = screen.getByTitle(long);
+    expect(label).toBeInTheDocument();
+    expect(label.textContent).toBe(long);
+  });
+});
+
+describe('NavigationPanel — hierarchy markers', () => {
+  // Rows are queried via `data-testid="agent-row"` + `data-agent-role` rather
+  // than the styling-hook class `.nav-panel-agent-row` so that a CSS refactor
+  // can rename the class without silently breaking these tests.
+  function findRows() {
+    const rows = screen.getAllByTestId('agent-row');
+    const mainRow = rows.find((r) => r.dataset.agentRole === 'main') as HTMLElement;
+    const subRow = rows.find((r) => r.dataset.agentRole === 'sub') as HTMLElement;
+    return { rows, mainRow, subRow };
+  }
+
+  it('renders the └─ glyph for subagent rows but not for the main agent row', () => {
+    renderPanel({
+      agents: [
+        { id: 'main', name: 'Lead Agent', isMainAgent: true },
+        { id: 'sub-1', name: 'Worker', description: 'Build DCF', isMainAgent: false },
+      ],
+    });
+
+    const { rows, mainRow, subRow } = findRows();
+    expect(rows.length).toBe(2);
+
+    // Main-agent row: no glyph in its DOM subtree.
+    expect(mainRow.textContent).not.toContain('└─');
+    expect(within(mainRow).queryByText('Lead Agent')).toBeInTheDocument();
+
+    // Subagent row: glyph appears as its own aria-hidden inline span.
+    expect(subRow.textContent).toContain('└─');
+    expect(within(subRow).queryByText('Build DCF')).toBeInTheDocument();
+  });
+
+  it('marks the hierarchy glyph aria-hidden so screen readers ignore it', () => {
+    renderPanel({
+      agents: [
+        { id: 'main', name: 'Lead Agent', isMainAgent: true },
+        { id: 'sub-1', name: 'Worker', description: 'Build DCF', isMainAgent: false },
+      ],
+    });
+
+    const { subRow } = findRows();
+    const glyph = Array.from(subRow.children).find((c) => c.textContent === '└─');
+    expect(glyph).toBeTruthy();
+    expect(glyph!.getAttribute('aria-hidden')).toBe('true');
+  });
+});

--- a/web/src/pages/ChatAgent/components/__tests__/SubagentTaskMessageContent.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/SubagentTaskMessageContent.test.tsx
@@ -12,6 +12,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import SubagentTaskMessageContent from '../SubagentTaskMessageContent';
+import { SubagentTelemetryContext } from '../SubagentTelemetryContext';
 
 const baseProps = {
   subagentId: 'tc-abc',
@@ -169,6 +170,48 @@ describe('SubagentTaskMessageContent — status discriminator', () => {
     // Neither Completed/Running/Updated/Resumed matches, so the raw status
     // string survives as the fallback label.
     expect(screen.getByText('something-else')).toBeInTheDocument();
+  });
+});
+
+describe('SubagentTaskMessageContent — telemetry context fallback', () => {
+  it('reads telemetry from context when toolCalls / tokenUsage props are absent', () => {
+    // The leaf subscribes to SubagentTelemetryContext so live token-tick
+    // re-renders bypass the memoized MessageBubble / MessageContentSegments
+    // tree. This is the perf path; props are still the override for tests
+    // and any explicit caller.
+    const resolver = vi.fn(() => ({
+      toolCalls: 5,
+      tokenUsage: { input: 1000, output: 234, total: 1234 },
+    }));
+    render(
+      <SubagentTelemetryContext.Provider value={resolver}>
+        <SubagentTaskMessageContent {...baseProps} />
+      </SubagentTelemetryContext.Provider>,
+    );
+    expect(resolver).toHaveBeenCalledWith('tc-abc');
+    const row = screen.getByTestId('subagent-telemetry');
+    expect(row).toHaveTextContent('5 tools');
+    expect(row.textContent).toMatch(/1\.2K\s+tokens/i);
+  });
+
+  it('explicit props still override the context value', () => {
+    const resolver = vi.fn(() => ({
+      toolCalls: 99,
+      tokenUsage: { input: 1, output: 1, total: 99999 },
+    }));
+    render(
+      <SubagentTelemetryContext.Provider value={resolver}>
+        <SubagentTaskMessageContent
+          {...baseProps}
+          toolCalls={2}
+          tokenUsage={{ input: 0, output: 0, total: 0 }}
+        />
+      </SubagentTelemetryContext.Provider>,
+    );
+    // Props win: 2 tools, no tokens row.
+    const row = screen.getByTestId('subagent-telemetry');
+    expect(row).toHaveTextContent('2 tools');
+    expect(row).not.toHaveTextContent(/tokens/i);
   });
 });
 

--- a/web/src/pages/ChatAgent/components/__tests__/SubagentTaskMessageContent.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/SubagentTaskMessageContent.test.tsx
@@ -8,8 +8,8 @@
  *  - title attribute on the tokens segment exposes the input/output split
  */
 import React from 'react';
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import SubagentTaskMessageContent from '../SubagentTaskMessageContent';
 
@@ -205,5 +205,48 @@ describe('SubagentTaskMessageContent — accessibility', () => {
     expect(viewButton).toBeInTheDocument();
     viewButton.click();
     expect(captured).toEqual({ toolCallResult: { content: 'output text' } });
+  });
+
+  it('keyboard activation of view-output button does not also fire the card click', () => {
+    // Regression: outer `<div role="button" onKeyDown=...>` and inner
+    // `<button>` are nested. A keydown on the inner button bubbles, so
+    // without a target/currentTarget guard the outer keydown handler used
+    // to fire `onOpen` in addition to the inner button's `onDetailOpen`,
+    // opening two panels on a single Enter press.
+    const onOpen = vi.fn();
+    const onDetailOpen = vi.fn();
+    render(
+      <SubagentTaskMessageContent
+        subagentId="tc-kbd"
+        description="Done"
+        type="research"
+        status="completed"
+        toolCallProcess={{ toolCallResult: { content: 'output text' } }}
+        onOpen={onOpen}
+        onDetailOpen={onDetailOpen}
+      />,
+    );
+    const viewButton = screen.getByRole('button', { name: 'View subagent output' });
+    // Simulate keyboard activation: keydown on the inner button bubbles to
+    // the outer card, but the guard should prevent handleCardClick from running.
+    fireEvent.keyDown(viewButton, { key: 'Enter' });
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it('keyboard activation on the card itself still fires onOpen', () => {
+    const onOpen = vi.fn();
+    render(
+      <SubagentTaskMessageContent
+        subagentId="tc-kbd-card"
+        description="Done"
+        type="research"
+        status="completed"
+        onOpen={onOpen}
+      />,
+    );
+    // Without a hasResult body there's only one role=button — the card root.
+    const card = screen.getByRole('button');
+    fireEvent.keyDown(card, { key: 'Enter' });
+    expect(onOpen).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/src/pages/ChatAgent/components/__tests__/SubagentTaskMessageContent.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/SubagentTaskMessageContent.test.tsx
@@ -102,3 +102,108 @@ describe('SubagentTaskMessageContent — telemetry row', () => {
     expect(tokensSpan).toBeInTheDocument();
   });
 });
+
+describe('SubagentTaskMessageContent — status discriminator', () => {
+  it('renders Running label with spin animation for action=init + status=running', () => {
+    render(
+      <SubagentTaskMessageContent
+        subagentId="tc-r"
+        description="Long-running task"
+        type="research"
+        status="running"
+        action="init"
+      />,
+    );
+    expect(screen.getByText('Running')).toBeInTheDocument();
+  });
+
+  it('renders Completed label for action=init + status=completed', () => {
+    render(
+      <SubagentTaskMessageContent
+        subagentId="tc-c"
+        description="Done task"
+        type="research"
+        status="completed"
+        action="init"
+      />,
+    );
+    expect(screen.getByText('Completed')).toBeInTheDocument();
+  });
+
+  it('renders Updated label for action=update', () => {
+    render(
+      <SubagentTaskMessageContent
+        subagentId="tc-u"
+        description="Steered task"
+        type="research"
+        status="running"
+        action="update"
+      />,
+    );
+    expect(screen.getByText('Updated')).toBeInTheDocument();
+  });
+
+  it('renders Resumed label for action=resume', () => {
+    render(
+      <SubagentTaskMessageContent
+        subagentId="tc-rs"
+        description="Resumed task"
+        type="research"
+        status="running"
+        action="resume"
+      />,
+    );
+    expect(screen.getByText('Resumed')).toBeInTheDocument();
+  });
+
+  it('falls through to raw status text for unknown discriminator', () => {
+    render(
+      <SubagentTaskMessageContent
+        subagentId="tc-x"
+        description="Edge case"
+        type="research"
+        status="something-else"
+        action="init"
+      />,
+    );
+    // Neither Completed/Running/Updated/Resumed matches, so the raw status
+    // string survives as the fallback label.
+    expect(screen.getByText('something-else')).toBeInTheDocument();
+  });
+});
+
+describe('SubagentTaskMessageContent — accessibility', () => {
+  it('exposes the card as a keyboard-focusable button', () => {
+    render(
+      <SubagentTaskMessageContent
+        subagentId="tc-a11y"
+        description="Click me"
+        type="research"
+        status="completed"
+      />,
+    );
+    // Without a hasResult body, the card root is the only role=button.
+    // Without aria-label/title-as-accessible-name we just look up by role.
+    const card = screen.getByRole('button');
+    expect(card).toHaveAttribute('tabIndex', '0');
+    expect(card).toHaveAttribute('title');
+  });
+
+  it('opens the secondary view-output action via an accessible button', () => {
+    let captured: unknown = null;
+    render(
+      <SubagentTaskMessageContent
+        subagentId="tc-output"
+        description="Done"
+        type="research"
+        status="completed"
+        toolCallProcess={{ toolCallResult: { content: 'output text' } }}
+        onDetailOpen={(p) => { captured = p; }}
+      />,
+    );
+    const viewButton = screen.getByRole('button', { name: 'View subagent output' });
+    expect(viewButton).toBeInTheDocument();
+    viewButton.click();
+    expect(captured).toEqual({ toolCallResult: { content: 'output text' } });
+  });
+});

--- a/web/src/pages/ChatAgent/components/__tests__/SubagentTaskMessageContent.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/SubagentTaskMessageContent.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Coverage for the inline-card telemetry row added below the existing
+ * type-badge / status row:
+ *  - hidden when both toolCalls === 0 and tokenUsage.total === 0
+ *  - shows tools count when only toolCalls > 0
+ *  - shows compact-formatted tokens when only tokenUsage.total > 0
+ *  - both segments rendered (separator dot) when both > 0
+ *  - title attribute on the tokens segment exposes the input/output split
+ */
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import SubagentTaskMessageContent from '../SubagentTaskMessageContent';
+
+const baseProps = {
+  subagentId: 'tc-abc',
+  description: 'Research AAPL Q3',
+  type: 'research',
+  status: 'completed' as const,
+};
+
+describe('SubagentTaskMessageContent — telemetry row', () => {
+  it('hides the row when both metrics are zero', () => {
+    render(
+      <SubagentTaskMessageContent
+        {...baseProps}
+        toolCalls={0}
+        tokenUsage={{ input: 0, output: 0, total: 0 }}
+      />,
+    );
+    expect(screen.queryByTestId('subagent-telemetry')).toBeNull();
+  });
+
+  it('hides the row when telemetry props are omitted entirely', () => {
+    render(<SubagentTaskMessageContent {...baseProps} />);
+    expect(screen.queryByTestId('subagent-telemetry')).toBeNull();
+  });
+
+  it('shows only the tool count when tokens are zero', () => {
+    render(
+      <SubagentTaskMessageContent
+        {...baseProps}
+        toolCalls={4}
+        tokenUsage={{ input: 0, output: 0, total: 0 }}
+      />,
+    );
+    const row = screen.getByTestId('subagent-telemetry');
+    expect(row).toHaveTextContent('4 tools');
+    expect(row).not.toHaveTextContent(/tokens/i);
+  });
+
+  it('uses the singular "tool" label when count is exactly 1', () => {
+    render(
+      <SubagentTaskMessageContent
+        {...baseProps}
+        toolCalls={1}
+        tokenUsage={{ input: 0, output: 0, total: 0 }}
+      />,
+    );
+    expect(screen.getByTestId('subagent-telemetry')).toHaveTextContent(/^1 tool$/);
+  });
+
+  it('shows only compact tokens when tool count is zero', () => {
+    render(
+      <SubagentTaskMessageContent
+        {...baseProps}
+        toolCalls={0}
+        tokenUsage={{ input: 4000, output: 1142, total: 5142 }}
+      />,
+    );
+    const row = screen.getByTestId('subagent-telemetry');
+    // compactNumber locale-formats 5142 → "5.1K" — case-insensitive match
+    // because Intl emits uppercase suffixes; the code does not lowercase.
+    expect(row.textContent).toMatch(/5\.1K\s+tokens/i);
+    expect(row).not.toHaveTextContent(/tools/);
+  });
+
+  it('renders both segments with a separator dot when both are non-zero', () => {
+    render(
+      <SubagentTaskMessageContent
+        {...baseProps}
+        toolCalls={7}
+        tokenUsage={{ input: 4000, output: 1142, total: 5142 }}
+      />,
+    );
+    const row = screen.getByTestId('subagent-telemetry');
+    expect(row).toHaveTextContent('7 tools');
+    expect(row.textContent).toMatch(/5\.1K\s+tokens/i);
+    expect(row).toHaveTextContent('·');
+  });
+
+  it('exposes the input/output split via the title attribute on the tokens segment', () => {
+    render(
+      <SubagentTaskMessageContent
+        {...baseProps}
+        toolCalls={3}
+        tokenUsage={{ input: 4000, output: 1142, total: 5142 }}
+      />,
+    );
+    const tokensSpan = screen.getByTitle('4000 in · 1142 out');
+    expect(tokensSpan).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/ChatAgent/components/__tests__/SubagentTaskMessageContent.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/SubagentTaskMessageContent.test.tsx
@@ -207,6 +207,31 @@ describe('SubagentTaskMessageContent — accessibility', () => {
     expect(captured).toEqual({ toolCallResult: { content: 'output text' } });
   });
 
+  it('mouse click on view-output button does not also fire the card click', () => {
+    // Regression: outer card div has onClick=handleCardClick, inner button
+    // has onClick=handleViewOutput. handleViewOutput already calls
+    // stopPropagation, so the click should fire onDetailOpen exactly once
+    // and never fire onOpen. Pinning this to catch any future change that
+    // drops the stopPropagation.
+    const onOpen = vi.fn();
+    const onDetailOpen = vi.fn();
+    render(
+      <SubagentTaskMessageContent
+        subagentId="tc-mouse"
+        description="Done"
+        type="research"
+        status="completed"
+        toolCallProcess={{ toolCallResult: { content: 'output text' } }}
+        onOpen={onOpen}
+        onDetailOpen={onDetailOpen}
+      />,
+    );
+    const viewButton = screen.getByRole('button', { name: 'View subagent output' });
+    viewButton.click();
+    expect(onDetailOpen).toHaveBeenCalledTimes(1);
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
   it('keyboard activation of view-output button does not also fire the card click', () => {
     // Regression: outer `<div role="button" onKeyDown=...>` and inner
     // `<button>` are nested. A keydown on the inner button bubbles, so

--- a/web/src/pages/ChatAgent/hooks/useCardState.ts
+++ b/web/src/pages/ChatAgent/hooks/useCardState.ts
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { type SubagentTokenUsage, ZERO_USAGE } from '../utils/tokenUsage';
 
 // --- Card-level types ---
 
@@ -30,7 +31,7 @@ interface SubagentData {
   description?: string;
   prompt?: string;
   type?: string;
-  toolCalls?: number;
+  tokenUsage?: SubagentTokenUsage;
   currentTool?: string;
   status?: string;
   messages?: SubagentMessage[];
@@ -111,10 +112,15 @@ export function useCardState(initialCards: CardsMap = {}): UseCardStateResult {
         }
 
         // If card is inactive and not being reactivated, skip pure status updates.
-        // However, allow content updates (messages) through — trailing message_chunk
-        // and tool_call_result events can arrive after the completion signal due to
-        // the tail loop's polling interval.
-        const hasContentUpdate = subagentDataUpdate.messages !== undefined;
+        // However, allow content updates (messages, tokenUsage) through — trailing
+        // message_chunk / tool_call_result events arrive after the per-task stream
+        // closes due to the tail loop's polling interval, and token_usage events
+        // for the subagent's last LLM call are emitted on the MAIN stream which
+        // typically finishes draining slightly after the per-task stream marks the
+        // card inactive — dropping them here would zero out the displayed total.
+        const hasContentUpdate =
+          subagentDataUpdate.messages !== undefined ||
+          subagentDataUpdate.tokenUsage !== undefined;
         if (isCurrentlyInactive && !isBeingReactivated && !hasContentUpdate) {
           if (import.meta.env.DEV) {
             console.log('[updateSubagentCard] Skipping update to inactive card:', {
@@ -237,7 +243,7 @@ export function useCardState(initialCards: CardsMap = {}): UseCardStateResult {
               description: '',
               prompt: '',
               type: 'general-purpose',
-              toolCalls: 0,
+              tokenUsage: ZERO_USAGE,
               currentTool: '',
               status: 'active',
               messages: [],

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -15,6 +15,7 @@ import { buildRateLimitError, isUpstreamHint, type StructuredError } from '@/uti
 import { getStoredThreadId, setStoredThreadId } from './utils/threadStorage';
 import { countToolCalls } from '../utils/subagentMetrics';
 import { type SubagentTokenUsage, ZERO_USAGE, extractTokenUsageDelta, accumulateTokenUsage } from '../utils/tokenUsage';
+import { computeSteeringBoundary, shouldSkipSteeringRollback } from '../utils/steeringRollback';
 export { removeStoredThreadId } from './utils/threadStorage';
 import { createUserMessage, createAssistantMessage, createNotificationMessage, appendMessage, updateMessage, type AttachmentMeta } from './utils/messageHelpers';
 import type { ChatMessage, AssistantMessage } from '@/types/chat';
@@ -2636,9 +2637,7 @@ export function useChatMessages(
         // has a larger id. Use it directly so the rollback filter knows what
         // to keep vs. drop. Fall back to the local counter for tests/legacy
         // flows where SSE events carry no `_eventId`.
-        const boundary = event._eventId != null
-          ? Number(event._eventId)
-          : refs.contentOrderCounterRef.current;
+        const boundary = computeSteeringBoundary(event, refs.contentOrderCounterRef.current);
         steeringAtOrder = boundary;
         if (refs.steeringAtOrderRef) refs.steeringAtOrderRef.current = boundary;
         return;
@@ -2669,11 +2668,7 @@ export function useChatMessages(
             // was a non-numeric fallback) — skip the destructive filter and
             // just finalize. Real segment orders are always positive; any
             // other boundary would drop every segment, wiping the visible turn.
-            if (
-              effectiveSteeringAtOrder === null ||
-              !Number.isFinite(effectiveSteeringAtOrder) ||
-              effectiveSteeringAtOrder <= 0
-            ) {
+            if (shouldSkipSteeringRollback(effectiveSteeringAtOrder)) {
               const tp: typeof aMsg.toolCallProcesses = {};
               for (const [id, val] of Object.entries(aMsg.toolCallProcesses || {})) {
                 tp[id] = val.isInProgress ? { ...val, isInProgress: false, isComplete: true } : val;
@@ -2685,9 +2680,11 @@ export function useChatMessages(
               return { ...aMsg, isStreaming: false, toolCallProcesses: tp, reasoningProcesses: rp };
             }
 
-            // Keep only segments at or before the steering point
+            // Keep only segments at or before the steering point. Guard
+            // already proved boundary is a positive finite number.
+            const boundary = effectiveSteeringAtOrder as number;
             const keptSegments = (aMsg.contentSegments || []).filter(
-              (s) => s.order <= effectiveSteeringAtOrder
+              (s) => s.order <= boundary
             );
 
             // Rebuild plain-text content from kept text segments
@@ -3608,9 +3605,7 @@ export function useChatMessages(
             // handler can roll back leaked content. The event's own `_eventId`
             // is the natural boundary in the Redis stream; fall back to the
             // local counter for tests/legacy flows without `_eventId`.
-            steeringAtOrderRef.current = event._eventId != null
-              ? Number(event._eventId)
-              : contentOrderCounterRef.current;
+            steeringAtOrderRef.current = computeSteeringBoundary(event, contentOrderCounterRef.current);
             // Update the user message to reflect steering status
             setMessages((prev) =>
               updateMessage(prev,userMessage.id as string, (msg) => ({

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -2631,10 +2631,16 @@ export function useChatMessages(
       // Handle steering_accepted events for the MAIN agent (user sent a message while agent streams).
       // Subagent steering_accepted events are handled below in the isSubagent block.
       if (eventType === 'steering_accepted' && !isSubagent) {
-        // Record the content order counter so we can roll back leaked content
-        // when steering_delivered arrives (see handler below).
-        steeringAtOrder = refs.contentOrderCounterRef.current;
-        if (refs.steeringAtOrderRef) refs.steeringAtOrderRef.current = refs.contentOrderCounterRef.current;
+        // The steering_accepted event's own `_eventId` is the boundary: every
+        // earlier event in the Redis stream has a smaller id, every later one
+        // has a larger id. Use it directly so the rollback filter knows what
+        // to keep vs. drop. Fall back to the local counter for tests/legacy
+        // flows where SSE events carry no `_eventId`.
+        const boundary = event._eventId != null
+          ? Number(event._eventId)
+          : refs.contentOrderCounterRef.current;
+        steeringAtOrder = boundary;
+        if (refs.steeringAtOrderRef) refs.steeringAtOrderRef.current = boundary;
         return;
       }
 
@@ -2658,8 +2664,16 @@ export function useChatMessages(
             // ref is set by handleSendSteering on the secondary stream).
             const effectiveSteeringAtOrder = steeringAtOrder ?? refs.steeringAtOrderRef?.current ?? null;
 
-            // If no snapshot, just finalize (mark all in-progress processes as complete)
-            if (effectiveSteeringAtOrder === null) {
+            // If no snapshot — or snapshot is non-positive / NaN (steering
+            // arrived before any ordered content was emitted, or `_eventId`
+            // was a non-numeric fallback) — skip the destructive filter and
+            // just finalize. Real segment orders are always positive; any
+            // other boundary would drop every segment, wiping the visible turn.
+            if (
+              effectiveSteeringAtOrder === null ||
+              !Number.isFinite(effectiveSteeringAtOrder) ||
+              effectiveSteeringAtOrder <= 0
+            ) {
               const tp: typeof aMsg.toolCallProcesses = {};
               for (const [id, val] of Object.entries(aMsg.toolCallProcesses || {})) {
                 tp[id] = val.isInProgress ? { ...val, isInProgress: false, isComplete: true } : val;
@@ -3590,9 +3604,13 @@ export function useChatMessages(
         (event) => {
           const eventType = event.event || 'message_chunk';
           if (eventType === 'steering_accepted') {
-            // Snapshot the content order counter so the primary stream's
-            // steering_delivered handler can roll back leaked content.
-            steeringAtOrderRef.current = contentOrderCounterRef.current;
+            // Snapshot the boundary so the primary stream's steering_delivered
+            // handler can roll back leaked content. The event's own `_eventId`
+            // is the natural boundary in the Redis stream; fall back to the
+            // local counter for tests/legacy flows without `_eventId`.
+            steeringAtOrderRef.current = event._eventId != null
+              ? Number(event._eventId)
+              : contentOrderCounterRef.current;
             // Update the user message to reflect steering status
             setMessages((prev) =>
               updateMessage(prev,userMessage.id as string, (msg) => ({

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -2815,7 +2815,9 @@ export function useChatMessages(
             }
             return;
           }
-          if (taskId && event.action !== 'token_usage') {
+          // token_usage is handled and returned above; this branch is now
+          // for summarize / offload / future actions only.
+          if (taskId) {
             const action = event.action;
             let text;
             let detail: string | undefined;

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -13,6 +13,8 @@ import { useUser } from '@/hooks/useUser';
 import { sendChatMessageStream, replayThreadHistory, getWorkflowStatus, reconnectToWorkflowStream, sendHitlResponse, streamSubagentTaskEvents, fetchThreadTurns, submitFeedback, removeFeedback, getThreadFeedback, watchThread } from '../utils/api';
 import { buildRateLimitError, isUpstreamHint, type StructuredError } from '@/utils/rateLimitError';
 import { getStoredThreadId, setStoredThreadId } from './utils/threadStorage';
+import { countToolCalls } from '../utils/subagentMetrics';
+import { type SubagentTokenUsage, ZERO_USAGE, extractTokenUsageDelta, accumulateTokenUsage } from '../utils/tokenUsage';
 export { removeStoredThreadId } from './utils/threadStorage';
 import { createUserMessage, createAssistantMessage, createNotificationMessage, appendMessage, updateMessage, type AttachmentMeta } from './utils/messageHelpers';
 import type { ChatMessage, AssistantMessage } from '@/types/chat';
@@ -201,6 +203,7 @@ interface SubagentHistoryEntry {
   messages: Record<string, unknown>[];
   status: string;
   toolCalls: number;
+  tokenUsage: SubagentTokenUsage;
   currentTool: string;
 }
 
@@ -628,6 +631,14 @@ export function useChatMessages(
   // Persistent subagent state refs — survives across turns so resumed subagents
   // retain messages from previous runs. Keyed by taskId (e.g., "task:k7Xm2p").
   const subagentStateRefsRef = useRef<Record<string, TaskRefs>>({});
+
+  // Per-task running total of token usage. Backend emits per-call deltas via
+  // `context_window/token_usage` events; we sum here. The ref is the source
+  // of truth for accumulation; SubagentData.tokenUsage is overwritten with
+  // the running total on each update so the projection in ChatView reads it
+  // without needing direct ref access. Reconnect during an active subagent
+  // can double-count (event replay) — acceptable for a UI display surface.
+  const subagentTokenUsageRef = useRef<Record<string, SubagentTokenUsage>>({});
 
   // During history load: queue task tool call IDs until the matching artifact 'spawned' event drains them
   const historyPendingTaskToolCallIdsRef = useRef<string[]>([]);
@@ -1624,6 +1635,10 @@ export function useChatMessages(
           for (const [taskId, subagentHistory] of subagentHistoryByTaskId.entries()) {
             // Create temporary refs structure for processing
             let currentRunIndex = 0;
+            // Per-task token-usage accumulator: backend emits per-call deltas
+            // and we sum them into a running total before storing on the
+            // SubagentHistoryEntry below.
+            let tempTokenUsage: SubagentTokenUsage = ZERO_USAGE;
             const tempSubagentStateRefs: Record<string, TaskRefs> = {
               [taskId]: {
                 contentOrderCounterRef: { current: 0 },
@@ -1785,7 +1800,7 @@ export function useChatMessages(
                 // Embed notification as content segment in the assistant message
                 const action = event.action;
                 if (action === 'token_usage') {
-                  // Skip — no per-subagent token display
+                  tempTokenUsage = accumulateTokenUsage(tempTokenUsage, extractTokenUsageDelta(event));
                 } else {
                   let text;
                   let detail: string | undefined;
@@ -1865,7 +1880,8 @@ export function useChatMessages(
               type: taskMetadata?.type || 'general-purpose',
               messages: finalMessages,
               status: 'completed', // History events are always completed
-              toolCalls: 0,
+              toolCalls: countToolCalls(finalMessages),
+              tokenUsage: tempTokenUsage,
               currentTool: '',
             };
 
@@ -2037,6 +2053,10 @@ export function useChatMessages(
           const agentId = `task:${taskId}`;
           const historyData = subagentHistoryRef.current[agentId];
           if (historyData) {
+            // Seed the live token-usage ref from history so subsequent live
+            // deltas accumulate on top of the historical total instead of
+            // starting from zero.
+            subagentTokenUsageRef.current[agentId] = historyData.tokenUsage ?? ZERO_USAGE;
             updateSubagentCard(agentId, {
               agentId,
               displayId: `Task-${taskId}`,
@@ -2044,6 +2064,7 @@ export function useChatMessages(
               description: historyData.description || '',
               prompt: historyData.prompt || historyData.description || '',
               type: historyData.type || 'general-purpose',
+              tokenUsage: historyData.tokenUsage ?? ZERO_USAGE,
               status: 'active',
               isActive: true,
               isReconnect: true,
@@ -2341,6 +2362,7 @@ export function useChatMessages(
           const agentId = `task:${taskId}`;
           const historyData = subagentHistoryRef.current?.[agentId];
           if (updateSubagentCard && historyData) {
+            subagentTokenUsageRef.current[agentId] = historyData.tokenUsage ?? ZERO_USAGE;
             updateSubagentCard(agentId, {
               agentId,
               displayId: `Task-${taskId}`,
@@ -2348,6 +2370,7 @@ export function useChatMessages(
               description: historyData.description || '',
               prompt: historyData.prompt || historyData.description || '',
               type: historyData.type || 'general-purpose',
+              tokenUsage: historyData.tokenUsage ?? ZERO_USAGE,
               status: 'active',
               isActive: true,
               isReconnect: true,
@@ -2769,6 +2792,18 @@ export function useChatMessages(
           // segment inside the current assistant message (same as main chat) so
           // it appears at the correct chronological position.
           const taskId = getTaskIdFromEvent(event);
+          if (taskId && event.action === 'token_usage') {
+            // Sum per-call delta into the per-task running total, then push
+            // the new total onto SubagentData so the AgentInfo projection
+            // (and the inline subagent card) re-renders with it.
+            const prev = subagentTokenUsageRef.current[taskId] ?? ZERO_USAGE;
+            const next = accumulateTokenUsage(prev, extractTokenUsageDelta(event));
+            subagentTokenUsageRef.current[taskId] = next;
+            if (updateSubagentCard) {
+              updateSubagentCard(taskId, { tokenUsage: next });
+            }
+            return;
+          }
           if (taskId && event.action !== 'token_usage') {
             const action = event.action;
             let text;

--- a/web/src/pages/ChatAgent/utils/__tests__/resolveSubagentTelemetry.test.ts
+++ b/web/src/pages/ChatAgent/utils/__tests__/resolveSubagentTelemetry.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveSubagentTelemetry,
+  type SubagentDataLike,
+  type SubagentHistoryLike,
+} from '../resolveSubagentTelemetry';
+import { ZERO_USAGE } from '../tokenUsage';
+
+const msgWith = (tools: number) => ({
+  toolCallProcesses: Object.fromEntries(Array.from({ length: tools }, (_, i) => [`tc-${i}`, {}])),
+});
+
+describe('resolveSubagentTelemetry', () => {
+  it('returns undefined when neither card nor history is present', () => {
+    expect(resolveSubagentTelemetry(undefined, undefined)).toBeUndefined();
+  });
+
+  it('uses card state when populated with messages', () => {
+    const card: SubagentDataLike = {
+      messages: [msgWith(2), msgWith(3)],
+      tokenUsage: { input: 100, output: 50, total: 150 },
+    };
+    expect(resolveSubagentTelemetry(card, undefined)).toEqual({
+      toolCalls: 5,
+      tokenUsage: { input: 100, output: 50, total: 150 },
+    });
+  });
+
+  it('uses card state when messages are empty but tokenUsage.total > 0', () => {
+    // Live token_usage event landed before any tool call — card has tokens
+    // but no messages yet.
+    const card: SubagentDataLike = {
+      messages: [],
+      tokenUsage: { input: 10, output: 5, total: 15 },
+    };
+    expect(resolveSubagentTelemetry(card, undefined)).toEqual({
+      toolCalls: 0,
+      tokenUsage: { input: 10, output: 5, total: 15 },
+    });
+  });
+
+  it('falls back to history when card is present but empty (namespace-race fix)', () => {
+    // The exact scenario the click-replay path used to hit: a freshly
+    // created card with no live state should NOT shadow the history total.
+    const emptyCard: SubagentDataLike = { messages: [], tokenUsage: ZERO_USAGE };
+    const history: SubagentHistoryLike = {
+      messages: [msgWith(4)],
+      tokenUsage: { input: 200, output: 100, total: 300 },
+    };
+    expect(resolveSubagentTelemetry(emptyCard, history)).toEqual({
+      toolCalls: 4,
+      tokenUsage: { input: 200, output: 100, total: 300 },
+    });
+  });
+
+  it('falls back to history when no card exists at all (post-refresh path)', () => {
+    const history: SubagentHistoryLike = {
+      messages: [msgWith(7)],
+      tokenUsage: { input: 500, output: 250, total: 750 },
+    };
+    expect(resolveSubagentTelemetry(undefined, history)).toEqual({
+      toolCalls: 7,
+      tokenUsage: { input: 500, output: 250, total: 750 },
+    });
+  });
+
+  it('prefers explicit history.toolCalls over derived count', () => {
+    // History writers may stamp toolCalls explicitly; the resolver should
+    // trust that over re-deriving (avoids double-counting reconnect events).
+    const history: SubagentHistoryLike = {
+      messages: [msgWith(3)],
+      toolCalls: 99,
+      tokenUsage: { input: 0, output: 0, total: 1000 },
+    };
+    expect(resolveSubagentTelemetry(undefined, history)).toEqual({
+      toolCalls: 99,
+      tokenUsage: { input: 0, output: 0, total: 1000 },
+    });
+  });
+
+  it('history with missing tokenUsage falls through to ZERO_USAGE', () => {
+    const history: SubagentHistoryLike = { messages: [msgWith(2)] };
+    expect(resolveSubagentTelemetry(undefined, history)).toEqual({
+      toolCalls: 2,
+      tokenUsage: ZERO_USAGE,
+    });
+  });
+
+  it('card present but unpopulated AND no history → returns ZERO defaults from card path', () => {
+    // Edge case: the card was created (e.g. user clicked) but neither live
+    // events nor history exist yet. We still return a value so callers can
+    // render "0 tools · 0 tokens" without flickering through undefined.
+    const emptyCard: SubagentDataLike = { messages: [], tokenUsage: ZERO_USAGE };
+    expect(resolveSubagentTelemetry(emptyCard, undefined)).toEqual({
+      toolCalls: 0,
+      tokenUsage: ZERO_USAGE,
+    });
+  });
+
+  it('does not mutate inputs', () => {
+    const card: SubagentDataLike = { messages: [msgWith(1)], tokenUsage: { input: 1, output: 1, total: 2 } };
+    const history: SubagentHistoryLike = { messages: [msgWith(9)], tokenUsage: { input: 9, output: 9, total: 18 } };
+    const cardSnap = JSON.stringify(card);
+    const historySnap = JSON.stringify(history);
+    resolveSubagentTelemetry(card, history);
+    expect(JSON.stringify(card)).toBe(cardSnap);
+    expect(JSON.stringify(history)).toBe(historySnap);
+  });
+});

--- a/web/src/pages/ChatAgent/utils/__tests__/steeringRollback.test.ts
+++ b/web/src/pages/ChatAgent/utils/__tests__/steeringRollback.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { computeSteeringBoundary, shouldSkipSteeringRollback } from '../steeringRollback';
+
+describe('computeSteeringBoundary', () => {
+  it('returns numeric _eventId verbatim', () => {
+    expect(computeSteeringBoundary({ _eventId: 12345 }, 99)).toBe(12345);
+  });
+
+  it('coerces string _eventId via Number()', () => {
+    // Redis stream ids parse as numeric millisecond prefix in the SSE
+    // injection layer, but a defensive string fallback may slip through.
+    expect(computeSteeringBoundary({ _eventId: '67890' }, 99)).toBe(67890);
+  });
+
+  it('returns NaN for non-numeric string _eventId', () => {
+    // Non-numeric strings should yield NaN — caller MUST then call
+    // shouldSkipSteeringRollback to avoid wiping the visible turn.
+    expect(computeSteeringBoundary({ _eventId: '1759-0' }, 99)).toBeNaN();
+    expect(computeSteeringBoundary({ _eventId: 'abc' }, 99)).toBeNaN();
+  });
+
+  it('falls back to counter when _eventId is undefined', () => {
+    expect(computeSteeringBoundary({}, 42)).toBe(42);
+  });
+
+  it('falls back to counter when _eventId is null', () => {
+    expect(computeSteeringBoundary({ _eventId: null as unknown as undefined }, 7)).toBe(7);
+  });
+
+  it('treats _eventId === 0 as a real boundary, not a fallback trigger', () => {
+    // A literal 0 _eventId is rare but valid; the guard catches it
+    // separately. computeSteeringBoundary should not silently substitute
+    // the counter for it.
+    expect(computeSteeringBoundary({ _eventId: 0 }, 99)).toBe(0);
+  });
+});
+
+describe('shouldSkipSteeringRollback', () => {
+  it('skips when boundary is null', () => {
+    expect(shouldSkipSteeringRollback(null)).toBe(true);
+  });
+
+  it('skips when boundary is NaN', () => {
+    // The regression: a non-numeric string `_eventId` from a legacy or
+    // mis-tagged event yields NaN. Without this guard, every comparison
+    // `s.order <= NaN` is false and the filter wipes the entire turn.
+    expect(shouldSkipSteeringRollback(NaN)).toBe(true);
+  });
+
+  it('skips when boundary is 0', () => {
+    expect(shouldSkipSteeringRollback(0)).toBe(true);
+  });
+
+  it('skips when boundary is negative', () => {
+    expect(shouldSkipSteeringRollback(-1)).toBe(true);
+    expect(shouldSkipSteeringRollback(-12345)).toBe(true);
+  });
+
+  it('skips when boundary is Infinity / -Infinity', () => {
+    // Number.isFinite catches both infinities — Infinity boundary
+    // technically keeps everything but signals corrupt state.
+    expect(shouldSkipSteeringRollback(Infinity)).toBe(true);
+    expect(shouldSkipSteeringRollback(-Infinity)).toBe(true);
+  });
+
+  it('does NOT skip for any positive finite boundary', () => {
+    expect(shouldSkipSteeringRollback(1)).toBe(false);
+    expect(shouldSkipSteeringRollback(42)).toBe(false);
+    expect(shouldSkipSteeringRollback(1759000000000)).toBe(false); // realistic Redis ms id
+  });
+
+  it('does NOT skip for fractional positive boundaries', () => {
+    // Defensive: a non-integer boundary still keeps segments with
+    // smaller orders. Production never produces this, but the guard
+    // should not over-reject.
+    expect(shouldSkipSteeringRollback(0.5)).toBe(false);
+  });
+});
+
+describe('integration: compute → guard pipeline', () => {
+  it('numeric _eventId → boundary preserved → filter applies', () => {
+    const boundary = computeSteeringBoundary({ _eventId: 100 }, 0);
+    expect(shouldSkipSteeringRollback(boundary)).toBe(false);
+  });
+
+  it('non-numeric string _eventId → NaN → filter SKIPPED (regression)', () => {
+    // The exact regression this branch fixes: a non-numeric `_eventId`
+    // would have produced NaN and wiped the visible turn before the
+    // widened guard.
+    const boundary = computeSteeringBoundary({ _eventId: 'bad-id' }, 0);
+    expect(shouldSkipSteeringRollback(boundary)).toBe(true);
+  });
+
+  it('missing _eventId AND zero counter → 0 boundary → filter SKIPPED', () => {
+    // Steering arrived before any ordered content was emitted: counter
+    // is still 0, no segments to keep, finalize without a destructive
+    // filter that would otherwise drop everything.
+    const boundary = computeSteeringBoundary({}, 0);
+    expect(shouldSkipSteeringRollback(boundary)).toBe(true);
+  });
+
+  it('missing _eventId AND positive counter → counter boundary → filter applies', () => {
+    const boundary = computeSteeringBoundary({}, 17);
+    expect(shouldSkipSteeringRollback(boundary)).toBe(false);
+    expect(boundary).toBe(17);
+  });
+});

--- a/web/src/pages/ChatAgent/utils/__tests__/subagentMetrics.test.ts
+++ b/web/src/pages/ChatAgent/utils/__tests__/subagentMetrics.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { countToolCalls } from '../subagentMetrics';
+
+describe('countToolCalls', () => {
+  it('returns 0 for empty / nullish input', () => {
+    expect(countToolCalls(undefined)).toBe(0);
+    expect(countToolCalls(null)).toBe(0);
+    expect(countToolCalls([])).toBe(0);
+  });
+
+  it('counts toolCallProcesses keys across multiple messages', () => {
+    const messages = [
+      { toolCallProcesses: { a: {}, b: {} } },
+      { toolCallProcesses: { c: {} } },
+      { toolCallProcesses: { d: {}, e: {}, f: {} } },
+    ];
+    expect(countToolCalls(messages)).toBe(6);
+  });
+
+  it('skips messages without toolCallProcesses', () => {
+    const messages = [
+      { role: 'assistant' },
+      { toolCallProcesses: { a: {} } },
+      { reasoningProcesses: {} },
+      { toolCallProcesses: { b: {}, c: {} } },
+    ];
+    expect(countToolCalls(messages)).toBe(3);
+  });
+
+  it('treats duplicate keys across messages as separate (since maps live on each message)', () => {
+    // Documents the actual semantic: a re-emitted toolCallId on a later
+    // message would be a backend bug, not something we paper over.
+    const messages = [
+      { toolCallProcesses: { a: {} } },
+      { toolCallProcesses: { a: {} } },
+    ];
+    expect(countToolCalls(messages)).toBe(2);
+  });
+});

--- a/web/src/pages/ChatAgent/utils/__tests__/tokenUsage.test.ts
+++ b/web/src/pages/ChatAgent/utils/__tests__/tokenUsage.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ZERO_USAGE,
+  extractTokenUsageDelta,
+  accumulateTokenUsage,
+  type SubagentTokenUsage,
+} from '../tokenUsage';
+
+describe('extractTokenUsageDelta', () => {
+  it('reads input/output/total straight off a well-formed event', () => {
+    expect(extractTokenUsageDelta({ input_tokens: 100, output_tokens: 50, total_tokens: 150 }))
+      .toEqual({ input: 100, output: 50, total: 150 });
+  });
+
+  it('falls back to input + output when total_tokens is missing', () => {
+    expect(extractTokenUsageDelta({ input_tokens: 80, output_tokens: 20 }))
+      .toEqual({ input: 80, output: 20, total: 100 });
+  });
+
+  it('coerces stringified numbers (defensive against older SSE shapes)', () => {
+    expect(extractTokenUsageDelta({ input_tokens: '10', output_tokens: '5', total_tokens: '15' }))
+      .toEqual({ input: 10, output: 5, total: 15 });
+  });
+
+  it('treats missing/NaN/negative fields as zero', () => {
+    expect(extractTokenUsageDelta({})).toEqual(ZERO_USAGE);
+    expect(extractTokenUsageDelta({ input_tokens: NaN, output_tokens: -5 })).toEqual(ZERO_USAGE);
+    expect(extractTokenUsageDelta({ input_tokens: 'foo' })).toEqual(ZERO_USAGE);
+  });
+});
+
+describe('accumulateTokenUsage', () => {
+  it('adds delta into prev across all three axes', () => {
+    const prev: SubagentTokenUsage = { input: 100, output: 50, total: 150 };
+    const delta: SubagentTokenUsage = { input: 30, output: 20, total: 50 };
+    expect(accumulateTokenUsage(prev, delta)).toEqual({ input: 130, output: 70, total: 200 });
+  });
+
+  it('is commutative — order of equal events produces the same total', () => {
+    const a: SubagentTokenUsage = { input: 10, output: 5, total: 15 };
+    const b: SubagentTokenUsage = { input: 7, output: 3, total: 10 };
+    const ab = accumulateTokenUsage(accumulateTokenUsage(ZERO_USAGE, a), b);
+    const ba = accumulateTokenUsage(accumulateTokenUsage(ZERO_USAGE, b), a);
+    expect(ab).toEqual(ba);
+  });
+
+  it('ZERO_USAGE is the additive identity', () => {
+    const x: SubagentTokenUsage = { input: 42, output: 17, total: 59 };
+    expect(accumulateTokenUsage(ZERO_USAGE, x)).toEqual(x);
+    expect(accumulateTokenUsage(x, ZERO_USAGE)).toEqual(x);
+  });
+});

--- a/web/src/pages/ChatAgent/utils/resolveSubagentTelemetry.ts
+++ b/web/src/pages/ChatAgent/utils/resolveSubagentTelemetry.ts
@@ -1,0 +1,72 @@
+/**
+ * Pure resolver for inline-card subagent telemetry.
+ *
+ * Two writers feed the inline subagent card: the live `cards[...]` state
+ * (driven by SSE events) and the post-refresh `subagentHistoryRef`
+ * (driven by history replay). Either can be present, both can be present,
+ * or neither. The resolver picks the right source so the card renders
+ * the same numbers in every reconnect/refresh permutation.
+ *
+ * Extracted as a pure function so the namespace-race fallback (history
+ * fills in when the live card hasn't been hydrated yet) and the
+ * post-refresh ZERO_USAGE seeding can be regression-tested without
+ * mounting `ChatView`.
+ */
+import { countToolCalls } from './subagentMetrics';
+import { ZERO_USAGE, type SubagentTokenUsage } from './tokenUsage';
+
+export interface SubagentTelemetry {
+  toolCalls: number;
+  tokenUsage: SubagentTokenUsage;
+}
+
+interface MessageLike {
+  toolCallProcesses?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export interface SubagentDataLike {
+  messages?: MessageLike[];
+  tokenUsage?: SubagentTokenUsage;
+}
+
+export interface SubagentHistoryLike {
+  messages?: MessageLike[];
+  tokenUsage?: SubagentTokenUsage;
+  toolCalls?: number;
+}
+
+export function resolveSubagentTelemetry(
+  subagentData: SubagentDataLike | undefined,
+  history: SubagentHistoryLike | undefined,
+): SubagentTelemetry | undefined {
+  const sdMessages = subagentData?.messages;
+  const sdTokenUsage = subagentData?.tokenUsage;
+
+  // Card path: prefer live state, but only when the card has actually been
+  // populated. A click-created card with empty messages and zero tokens
+  // should still pull from history below — the bug we hit when post-refresh
+  // resolution returned zero even though history had the real total.
+  if (subagentData && (sdMessages?.length || (sdTokenUsage?.total ?? 0) > 0)) {
+    return {
+      toolCalls: countToolCalls(sdMessages),
+      tokenUsage: sdTokenUsage ?? ZERO_USAGE,
+    };
+  }
+
+  // History fallback: post-refresh path before the user opens the card,
+  // and the namespace-race fallback when SSE hydration hasn't caught up.
+  if (history) {
+    return {
+      toolCalls: history.toolCalls ?? countToolCalls(history.messages),
+      tokenUsage: history.tokenUsage ?? ZERO_USAGE,
+    };
+  }
+
+  if (!subagentData) return undefined;
+
+  return {
+    toolCalls: countToolCalls(sdMessages),
+    tokenUsage: sdTokenUsage ?? ZERO_USAGE,
+  };
+}

--- a/web/src/pages/ChatAgent/utils/steeringRollback.ts
+++ b/web/src/pages/ChatAgent/utils/steeringRollback.ts
@@ -1,0 +1,57 @@
+/**
+ * Steering rollback boundary helpers.
+ *
+ * When the user sends a steering message mid-turn, the backend emits
+ * `steering_accepted` carrying the cutoff `_eventId`. The frontend
+ * snapshots that id and, on the subsequent `steering_delivered` event,
+ * filters the assistant message's content segments to keep only those
+ * whose `order <= boundary`.
+ *
+ * Two pure helpers extracted from `useChatMessages.ts` so the boundary
+ * read and the destructive-filter guard can be regression-tested without
+ * mounting the hook:
+ *
+ *   • `computeSteeringBoundary` — read `_eventId` (numeric or coerced
+ *     numeric string), fall back to the local counter when absent.
+ *   • `shouldSkipSteeringRollback` — true when a non-positive, NaN, or
+ *     null boundary would wipe every segment if applied. Real segment
+ *     orders are always positive integers, so any other boundary is a
+ *     "no rollback" signal.
+ *
+ * Both are called from the primary stream's `steering_delivered` handler
+ * AND the secondary stream's `steering_accepted` handler. Keeping them
+ * pure means the two call sites cannot drift.
+ */
+
+/**
+ * Compute the rollback boundary from a steering_accepted event.
+ *
+ * Numeric `_eventId` (typical Redis stream id parsed as number) wins.
+ * String `_eventId` is coerced via `Number()` — non-numeric strings
+ * yield `NaN`, which `shouldSkipSteeringRollback` then catches.
+ * Missing `_eventId` falls back to the per-stream counter.
+ */
+export function computeSteeringBoundary(
+  event: { _eventId?: number | string },
+  counterFallback: number,
+): number {
+  if (event._eventId == null) return counterFallback;
+  return typeof event._eventId === 'number' ? event._eventId : Number(event._eventId);
+}
+
+/**
+ * Return true when the rollback filter should be SKIPPED — i.e. when the
+ * boundary would wipe every visible segment.
+ *
+ * Skip cases:
+ *   • `null` — steering arrived before any ordered content
+ *   • `NaN` — `_eventId` was a non-numeric string fallback
+ *   • `<= 0` — boundary predates the first segment (or is bogus)
+ *
+ * Real segment orders are always positive integers, so any other
+ * boundary value would drop everything and leave the user with an
+ * empty turn. The caller should finalize the message instead.
+ */
+export function shouldSkipSteeringRollback(boundary: number | null): boolean {
+  return boundary === null || !Number.isFinite(boundary) || boundary <= 0;
+}

--- a/web/src/pages/ChatAgent/utils/subagentMetrics.ts
+++ b/web/src/pages/ChatAgent/utils/subagentMetrics.ts
@@ -6,14 +6,6 @@
  * reconnect can't inflate the count, and the live and history-replay paths
  * don't need separate writers.
  */
-import type { SubagentTokenUsage } from './tokenUsage';
-
-/** Per-subagent telemetry map, keyed by subagent id (the short id, not the
- *  `task:` prefixed agent id). Threaded as a prop through MessageList so
- *  inline subagent cards can render their live counters without each
- *  component reaching back into the cards state itself. */
-export type SubagentTelemetryMap = Record<string, { toolCalls: number; tokenUsage: SubagentTokenUsage }>;
-
 interface MessageLike {
   toolCallProcesses?: Record<string, unknown>;
   [key: string]: unknown;

--- a/web/src/pages/ChatAgent/utils/subagentMetrics.ts
+++ b/web/src/pages/ChatAgent/utils/subagentMetrics.ts
@@ -1,0 +1,32 @@
+/**
+ * Pure derivations of subagent telemetry from the existing message tree.
+ *
+ * Tool-call count is derived (not stored) so there's only one source of truth
+ * (`toolCallProcesses` map keyed by tool_call_id) — re-emitted events on
+ * reconnect can't inflate the count, and the live and history-replay paths
+ * don't need separate writers.
+ */
+import type { SubagentTokenUsage } from './tokenUsage';
+
+/** Per-subagent telemetry map, keyed by subagent id (the short id, not the
+ *  `task:` prefixed agent id). Threaded as a prop through MessageList so
+ *  inline subagent cards can render their live counters without each
+ *  component reaching back into the cards state itself. */
+export type SubagentTelemetryMap = Record<string, { toolCalls: number; tokenUsage: SubagentTokenUsage }>;
+
+interface MessageLike {
+  toolCallProcesses?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export function countToolCalls(messages: MessageLike[] | undefined | null): number {
+  if (!messages || messages.length === 0) return 0;
+  let total = 0;
+  for (const m of messages) {
+    const procs = m?.toolCallProcesses;
+    if (procs && typeof procs === 'object') {
+      total += Object.keys(procs).length;
+    }
+  }
+  return total;
+}

--- a/web/src/pages/ChatAgent/utils/tokenUsage.ts
+++ b/web/src/pages/ChatAgent/utils/tokenUsage.ts
@@ -1,0 +1,43 @@
+/**
+ * Per-subagent token-usage accumulation.
+ *
+ * Backend emits one `context_window` `token_usage` SSE event per LLM call,
+ * carrying THIS-CALL deltas (input/output/total). The frontend accumulates
+ * deltas into a per-subagent running total and renders it on the inline
+ * subagent card (and any future telemetry surface).
+ *
+ * Splitting extract / accumulate into pure functions lets the live and
+ * history-replay handlers share one code path, and keeps the addition rule
+ * in one place if backend semantics ever flip from delta to cumulative.
+ */
+
+export type SubagentTokenUsage = {
+  input: number;
+  output: number;
+  total: number;
+};
+
+export const ZERO_USAGE: SubagentTokenUsage = { input: 0, output: 0, total: 0 };
+
+// Defensive against missing fields, NaN, and string-typed numbers from older
+// SSE shapes. `total` falls back to `input + output` if backend omitted it.
+export function extractTokenUsageDelta(event: Record<string, unknown>): SubagentTokenUsage {
+  const num = (v: unknown): number => {
+    const n = typeof v === 'number' ? v : typeof v === 'string' ? Number(v) : 0;
+    return Number.isFinite(n) && n > 0 ? n : 0;
+  };
+  const input = num(event.input_tokens);
+  const output = num(event.output_tokens);
+  const totalRaw = num(event.total_tokens);
+  return { input, output, total: totalRaw || input + output };
+}
+
+// Commutative addition — order of incoming events doesn't matter, so live
+// and history-replay produce the same total for the same set of events.
+export function accumulateTokenUsage(prev: SubagentTokenUsage, delta: SubagentTokenUsage): SubagentTokenUsage {
+  return {
+    input: prev.input + delta.input,
+    output: prev.output + delta.output,
+    total: prev.total + delta.total,
+  };
+}

--- a/web/src/pages/ChatAgent/utils/tokenUsage.ts
+++ b/web/src/pages/ChatAgent/utils/tokenUsage.ts
@@ -17,7 +17,9 @@ export type SubagentTokenUsage = {
   total: number;
 };
 
-export const ZERO_USAGE: SubagentTokenUsage = { input: 0, output: 0, total: 0 };
+// Frozen so the shared default can't be mutated by an accidental write at any
+// of the `?? ZERO_USAGE` call sites (TS `as` casts bypass type-level guards).
+export const ZERO_USAGE: SubagentTokenUsage = Object.freeze({ input: 0, output: 0, total: 0 });
 
 // Defensive against missing fields, NaN, and string-typed numbers from older
 // SSE shapes. `total` falls back to `input + output` if backend omitted it.


### PR DESCRIPTION
## Summary

Touches the inline subagent card, the nav rows, the activity-block summary, and the SSE telemetry pipeline that feeds them. Three buckets of work:

**Live subagent telemetry**
- Inline card now shows `N tools · N.NK tokens` ratcheting in real time and persisting through history replay.
- Tool-call count derived from `messages[].toolCallProcesses` at projection time (single source of truth, immune to event-replay double-counting).
- Token usage accumulates per-call deltas from the backend's `context_window/token_usage` SSE events that the frontend previously dropped.
- Backend `_SubagentTokenForwarder.forward_custom` subscribes to the subagent's `custom` stream-mode and tags compaction events with stable `task:{task_id}` agent_id so per-task SSE consumers can route them.

**UI redesigns + a11y**
- Inline subagent card: rule + body layout, status discriminator (running/completed/updated/resumed), `var(--color-warning)` accent, `MONO_STACK` font.
- Nav rows: subagent rows show task descriptions instead of \"Worker\" fallback; U+2514 U+2500 tree glyph replaces icons; main-agent label \"Boss\" → \"Lead Agent\".
- Inline card promoted to keyboard-focusable \`role=\"button\"\` with Enter/Space; secondary view-output ArrowRight wrapped in real \`<button aria-label>\`.
- Activity-block dropped the \`N failed\` aggregate fragment from folded summaries; per-row failed badges unchanged.

**Bug fixes**
- Steering rollback boundary now reads `event._eventId` directly (was always 0 in production), with widened guard (`null || NaN || <= 0` → skip destructive filter) so a non-numeric or unset boundary no longer wipes the visible turn.
- Card-refresh from history seeds `tokenUsage` (was creating live card with `ZERO_USAGE`, telemetry resolver's card-path winning, post-refresh threads showing 0 tokens).
- `forward_custom` now whitelists `context_window` only — earlier version forwarded any `data[\"type\"]` which let unrelated middleware (file_operations, todo_operations, show_widget) bloat the per-task buffer and gave a custom-mode emitter a path to spoof real frontend SSE event names.

## Diff Size
- Total: 25 files changed, 1530 insertions(+), 187 deletions(-)
- Net (excl. tests): 17 files changed, 770 insertions(+), 137 deletions(-)

## Test Coverage

Vitest: **1032/1032 pass** (96 files). Pytest backend subagent: **18/18 pass**.

Two regression-fix paths extracted into pure helpers and unit-tested:
- \`utils/resolveSubagentTelemetry.ts\` — 9 tests covering card-populated path, history fallback, namespace-race fix, undefined when neither present, no-mutation invariant.
- \`utils/steeringRollback.ts\` — 17 tests covering `_eventId` numeric/string/missing/null, NaN guard, `<=0` guard, infinity, fractional positive boundaries, and the integration pipeline (numeric → boundary preserved, non-numeric string → NaN → filter SKIPPED).

Status discriminator branches now have 5 dedicated tests (running/completed/updated/resumed/unknown). A11y: 2 tests (card focusable as button, view-output reachable as button with aria-label). Backend: protocol-injection rejection test (`test_forward_custom_drops_non_whitelisted_event_types`).

AI-assessed coverage on changed paths: 57% with 27 minor gaps, mostly informational paths inside the 2000+ line useChatMessages hook. The two highest-risk paths (steering rollback + history-seeded tokenUsage) are now locked in.

## Pre-Landing Review

22 findings across Testing/Maintainability/Security/Performance/Design specialists + Codex adversarial. Auto-fixed in this branch:

- **DESIGN [conf 9]** Inline card was clickable \`<div>\` with no keyboard support → now \`role=\"button\"\` + \`tabIndex={0}\` + Enter/Space handler.
- **DESIGN [conf 8]** ArrowRight onClick had no semantics or aria-label → wrapped in \`<button aria-label=\"View subagent output\">\`.
- **CODEX adversarial [confirmed]** \`forward_custom\` accepted any custom event type → whitelisted to \`context_window\` only with new injection-rejection test.
- **TESTING [conf 7]** Status discriminator branches (5 cases) untested → 5 tests added.

Deferred (informational, not blocking):

- **PERF [conf 8]** \`resolveSubagentTelemetry\` useCallback depends on \`cards\` which gets a fresh reference on every SSE event. Pre-existing rendering pattern across the chat — fixing it requires a larger refactor (ref-based pattern or precomputed Map at the parent). Tracked as P1 follow-up.
- **CODEX adversarial** Token usage replay on reconnect (per-task SSE doesn't pass \`last_event_id\`) — acknowledged in code comments, accepted as UI-display surface.
- Various lower-confidence design polish items (status colors, hover via JS vs CSS, └─ glyph cross-platform, typography mix), DRY duplication of history pre-seed helper, i18n on telemetry strings — all cosmetic / pattern-level, deferred.

PR Quality Score: 7.5/10. Security specialist: 0 findings.

## Design Review

Design Review (lite): 7 findings — 2 auto-fixed (a11y), 5 deferred (status color polish, hover-via-JS, hierarchy fallback, └─ glyph cross-platform risk, typography mix). AI Slop: clean.

Codex 7-litmus design check ran clean.

## Eval Results

No prompt-related files changed — evals skipped.

## Scope Drift

Scope Check: CLEAN. Intent (from commit history + plan file): subagent telemetry on inline cards plus UX cleanup. Delivered: all 10 commits map to that theme. Branch was renamed from \`feat/chat-agent-nav-cleanup\` to \`feat/chat-agent-subagent-surfaces\` mid-development to match the broader scope.

## Plan Completion

Plan file: \`/Users/chen/.claude/plans/quick-ui-change-1-sleepy-bengio.md\` (live tool-call count + token usage on inline subagent cards).

15/21 in-scope items DONE, 5 CHANGED (deliberate design pivots — same observable behavior), 1 DEFERRED (optional bonus per plan), 1 NOT DONE (\`useChatMessages.tokenUsage.test.ts\` history-replay total scenario — pure-function accumulation logic is covered by \`tokenUsage.test.ts\` directly, the missing piece is integration scaffolding).

Out-of-plan extras delivered: steering rollback fix, nav redesign, activity-block cleanup, history-seed bug fix, layout overhaul, backend custom-mode astream subscription with whitelist + protocol-injection guard.

## Verification Results

Skipped — plan's verification section is manual SSE/devtools inspection, not amenable to /qa-only browser automation. Manual UI verification recommended post-merge.

## Documentation

All documentation is up to date — no README/CLAUDE.md updates needed. Diff is internal chat-agent surface polish; no new commands, env vars, routes, or SSE event types beyond what's already documented.

## Known Follow-ups (P1)

- \`resolveSubagentTelemetry\` rendering perf: hoist into ref-based pattern or precompute telemetry as a stable Map at ChatView level so React.memo on \`MessageContentSegments\` short-circuits when only unrelated subagents update.
- Last-event-id on per-task SSE reconnect to avoid token-replay double-count.

## Test plan
- [x] All 1032 vitest tests pass
- [x] All 18 backend subagent pytest tests pass
- [x] tsc clean
- [ ] Manual: refresh thread mid-subagent, verify \`N tools · N.NK tokens\` row populates from history before user clicks card
- [ ] Manual: send steering message during streaming with rich content rendered, verify visible turn survives the rollback
- [ ] Manual: verify inline card is keyboard-reachable (Tab) and Enter/Space activates it