### PR TITLE
fix(crawler): isolate hosts via three-layer health and stage-level concurrency

### DIFF
--- a/agent_config.yaml
+++ b/agent_config.yaml
@@ -295,20 +295,24 @@ search_api: tavily
 # Backend: "scrapling" uses tiered HTTP→browser→stealth fetching.
 crawler:
   backend: "router" # Options: "scrapling", "router" (adds PDF/YouTube/X extraction)
-  max_concurrent_crawls: 20 # Max parallel browser contexts (adjust based on RAM: ~150MB each)
-  page_timeout: 60000 # Page load timeout in ms
-  delay_before_return: 3 # Seconds to wait for JS rendering after DOM ready
+  # Stage-level concurrency caps (replace the old max_concurrent_crawls).
+  # Tier 1 (curl_cffi) is cheap, Tier 2/3 (browsers) bound RAM at ~400MB each.
+  http_concurrency: 20    # Max concurrent Tier-1 HTTP fetches
+  browser_concurrency: 6  # Max concurrent Tier-2/3 browser fetches (~2.4GB RAM ceiling)
+  page_timeout: 60000 # Page load timeout in ms (overall, all tiers)
 
-  # Circuit breaker settings - prevents cascade failures when browser has issues
+  # Circuit breaker settings — applied to both per-host and global infra breakers.
+  # Per-host: a failing Reuters cannot poison Wikipedia.
+  # Global infra: trips on cross-cutting failures (browser crash, DNS).
   circuit_breaker:
-    failure_threshold: 5 # Number of failures before opening circuit
-    recovery_timeout: 60 # Seconds before attempting recovery (half-open state)
-    success_threshold: 2 # Successes needed to close circuit after recovery
+    failure_threshold: 5
+    recovery_timeout: 60
+    success_threshold: 2
 
-  # Queue limits - prevents resource exhaustion
+  # Queue limit — admission-control counter. Returns queue_full immediately when
+  # in-flight exceeds max_size; no separate slot wait.
   queue:
-    max_size: 100 # Maximum queued crawl requests
-    slot_timeout: 10 # Seconds to wait for crawl slot before giving up
+    max_size: 100
 
 # Web Fetch Configuration
 # Settings for web_fetch tool's sitemap-aware content extraction

--- a/src/config/tool_settings.py
+++ b/src/config/tool_settings.py
@@ -49,9 +49,28 @@ def _get_tool_config(key_path: str, default: Any = None) -> Any:
 # Crawler Configuration
 # =============================================================================
 
-def get_crawler_max_concurrent(default: int = 10) -> int:
-    """Get maximum concurrent crawler operations."""
-    return int(_get_tool_config('crawler.max_concurrent_crawls', default))
+def get_crawler_http_concurrency(default: int = 20) -> int:
+    """Concurrent Tier-1 (curl_cffi) calls. Cheap; cap is high."""
+    # Honor legacy max_concurrent_crawls if set, so existing deployments don't break.
+    legacy = _get_tool_config('crawler.max_concurrent_crawls')
+    if legacy is not None:
+        return int(legacy)
+    return int(_get_tool_config('crawler.http_concurrency', default))
+
+
+def get_crawler_browser_concurrency(default: int = 6) -> int:
+    """Concurrent Tier-2/3 (Chromium/Camoufox) calls. RAM-bounded."""
+    explicit = _get_tool_config('crawler.browser_concurrency')
+    if explicit is not None:
+        return int(explicit)
+    # Fall back to legacy `max_concurrent_crawls` so a low-RAM deployment that
+    # set it as a global cap (e.g. 2) doesn't silently spawn up to `default`
+    # browsers post-upgrade. Capped at `default` so HTTP-tuned legacy values
+    # (e.g. 50) don't translate to 50 Camoufox processes.
+    legacy = _get_tool_config('crawler.max_concurrent_crawls')
+    if legacy is not None:
+        return min(int(legacy), default)
+    return default
 
 
 def get_crawler_page_timeout(default: int = 60000) -> int:
@@ -75,13 +94,8 @@ def get_crawler_circuit_success_threshold(default: int = 2) -> int:
 
 
 def get_crawler_queue_max_size(default: int = 100) -> int:
-    """Get maximum crawler queue size."""
+    """Get maximum crawler queue size (admission-control counter)."""
     return int(_get_tool_config('crawler.queue.max_size', default))
-
-
-def get_crawler_queue_slot_timeout(default: int = 10) -> int:
-    """Get crawler queue slot timeout in seconds."""
-    return int(_get_tool_config('crawler.queue.slot_timeout', default))
 
 
 def get_crawler_backend(default: str = "scrapling") -> str:

--- a/src/tools/crawl.py
+++ b/src/tools/crawl.py
@@ -39,9 +39,10 @@ async def _crawl_impl(
         safe_crawler = get_safe_crawler_sync()
         result = await safe_crawler.crawl(url)
         if not result.success:
-            return f"Failed to crawl {url}: {result.error}"
+            kind = result.error_type or "error"
+            return f"[{kind}] Failed to crawl {url}: {result.error}"
         if not result.markdown or len(result.markdown.strip()) < 50:
-            return f"Failed to crawl {url}: page returned empty or blocked content (possibly anti-bot protected or paywalled)"
+            return f"[empty] Failed to crawl {url}: page returned empty or blocked content (possibly anti-bot protected or paywalled)"
         return {"url": url, "crawled_content": result.markdown}
     except BaseException as e:
         error_msg = f"Failed to crawl. Error: {repr(e)}"

--- a/src/tools/crawler/backend.py
+++ b/src/tools/crawler/backend.py
@@ -5,9 +5,8 @@ from typing import Literal, Optional, Protocol
 
 
 FailureKind = Literal[
-    "blocked",          # 401/403/451 — host permanently rejects us
+    "blocked",          # 401/451 — host permanently rejects us (403 falls through to Tier 2/3 because some Cloudflare configs return 403 to curl_cffi but 200 to Camoufox)
     "stealth_failed",   # Tier 3 reached but came back with no usable content
-    "empty",            # 200 OK but body was empty/garbage
     "rate_limited",     # 429
     "infra_error",      # browser crash, DNS, conn refused — our crawler is broken
 ]

--- a/src/tools/crawler/backend.py
+++ b/src/tools/crawler/backend.py
@@ -1,7 +1,16 @@
 """Abstract crawler backend protocol."""
 
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Literal, Optional, Protocol
+
+
+FailureKind = Literal[
+    "blocked",          # 401/403/451 — host permanently rejects us
+    "stealth_failed",   # Tier 3 reached but came back with no usable content
+    "empty",            # 200 OK but body was empty/garbage
+    "rate_limited",     # 429
+    "infra_error",      # browser crash, DNS, conn refused — our crawler is broken
+]
 
 
 @dataclass
@@ -11,6 +20,8 @@ class CrawlOutput:
     title: str
     html: str
     markdown: str
+    status: Optional[int] = None
+    failure_kind: Optional[FailureKind] = None
 
 
 class CrawlerBackend(Protocol):

--- a/src/tools/crawler/router.py
+++ b/src/tools/crawler/router.py
@@ -17,8 +17,15 @@ class ContentRouter:
     Satisfies the CrawlerBackend protocol.
     """
 
-    def __init__(self) -> None:
-        self._fallback = ScraplingCrawler()
+    def __init__(
+        self,
+        http_concurrency: int = 20,
+        browser_concurrency: int = 6,
+    ) -> None:
+        self._fallback = ScraplingCrawler(
+            http_concurrency=http_concurrency,
+            browser_concurrency=browser_concurrency,
+        )
 
     async def crawl_with_metadata(self, url: str) -> CrawlOutput:
         # SSRF protection: block private IPs, localhost, non-http(s) schemes

--- a/src/tools/crawler/safe_wrapper.py
+++ b/src/tools/crawler/safe_wrapper.py
@@ -1,15 +1,20 @@
 """
 Safe wrapper for crawler operations with isolation and fault tolerance.
 
-Provides defense-in-depth protection:
-- Circuit breaker for fault tolerance (fail fast after repeated failures)
-- Timeouts for all operations (prevent hanging)
-- Resource limiting (queue size, concurrency)
-- Auto browser reset on circuit open
-- Graceful degradation (never crash, always return structured errors)
+Three-layer health model:
+  - Blocked-host cache: hosts that returned 401/403/451. TTL 15 min, LRU 256.
+    Hit → fast-fail with [blocked]. Never trips any breaker.
+  - Per-host circuit breaker: transient host-level failures (timeout, 5xx,
+    rate-limited, empty). LRU 256. Trips after N consecutive failures.
+  - Global infra breaker: cross-cutting crawler-side failures (browser crash,
+    DNS, conn refused). Trips → all hosts fail-fast until recovery.
 
-Backend-agnostic: pluggable via CrawlerBackend protocol,
-selectable via `crawler.backend` in agent_config.yaml.
+A failing Reuters cannot poison Wikipedia: each host has its own breaker, and
+permanent blocks bypass breakers entirely via the cache.
+
+Stage-level concurrency lives inside ScraplingCrawler (HTTP vs browser
+semaphores). The wrapper keeps an admission counter (_max_queue) but no outer
+semaphore — that was the source of the Tier-1 starvation bug.
 """
 
 import asyncio
@@ -17,10 +22,12 @@ import logging
 import os
 import signal
 import time
+from collections import OrderedDict
 from dataclasses import dataclass
-from pathlib import Path
-from typing import Optional, Callable
 from enum import Enum
+from pathlib import Path
+from typing import Callable, Optional
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -36,16 +43,31 @@ _STAT_STARTTIME_IDX = 19  # /proc/[pid]/stat field 22, 0-indexed after comm
 # means "orphan reaped to init" when init actually reaps. If PID 1 is our python
 # worker (init: true silently failed), ppid==1 matches direct children including
 # LIVE browsers of in-flight workflows — the reaper would then SIGKILL healthy crawls.
-# `docker-init` is Docker's bundled tini wrapper; observed as PID 1 under
-# `init: true` on Docker Desktop and Docker CE without explicit tini install.
 _SAFE_INIT_PROCESSES = ("tini", "docker-init", "catatonit", "dumb-init")
+
+# Three-layer health model tunables.
+_BLOCKED_TTL_SECONDS = 900.0       # 15-min blocked-host cache entry
+_BLOCKED_LRU_CAP = 256             # bound the cache under host churn
+_HOST_BREAKERS_LRU_CAP = 256       # bound per-host breaker state
+_REAPER_INTERVAL_SECONDS = 300.0   # opportunistic reap cadence
+# Number of consecutive `blocked` responses on the same host before caching it.
+# A single 401 on /paywalled-article does not poison nytimes.com homepage; two
+# consecutive blocks (no successful fetch in between) confirm the whole host is
+# rejecting us. Resets on any successful fetch to that host.
+_BLOCK_CACHE_THRESHOLD = 2
+_BLOCK_ATTEMPTS_LRU_CAP = 256      # bound block-attempt counter under churn
+
+# Exception substrings that classify as cross-cutting infra failures (trip the
+# global infra breaker in addition to the per-host breaker). Other exceptions
+# stay host-scoped.
+_INFRA_ERROR_TYPES = ("browser_closed", "dns_error", "connection_refused")
 
 
 class CircuitState(Enum):
     """Circuit breaker states."""
-    CLOSED = "closed"       # Normal operation
-    OPEN = "open"           # Failing fast, rejecting requests
-    HALF_OPEN = "half_open" # Testing recovery
+    CLOSED = "closed"
+    OPEN = "open"
+    HALF_OPEN = "half_open"
 
 
 @dataclass
@@ -55,7 +77,10 @@ class CrawlResult:
     markdown: Optional[str] = None
     title: Optional[str] = None
     error: Optional[str] = None
-    error_type: Optional[str] = None  # timeout, circuit_open, queue_full, browser_error, etc.
+    # Passthrough of CrawlOutput.failure_kind for failures classified by the
+    # crawler, plus wrapper-level kinds (circuit_open, queue_full, cancelled,
+    # crawl_error) for failures classified at this layer.
+    error_type: Optional[str] = None
 
 
 class CircuitOpenError(Exception):
@@ -69,16 +94,7 @@ class QueueFullError(Exception):
 
 
 class CrawlerCircuitBreaker:
-    """
-    Circuit breaker for crawler operations.
-
-    State machine:
-    - CLOSED: Normal operation, tracking failures
-    - OPEN: After failure_threshold failures, reject all requests immediately
-    - HALF_OPEN: After recovery_timeout, allow one request to test recovery
-
-    When circuit opens, triggers browser reset to recover from corrupted state.
-    """
+    """Circuit breaker. Used for both per-host and global infra layers."""
 
     def __init__(
         self,
@@ -86,17 +102,9 @@ class CrawlerCircuitBreaker:
         recovery_timeout: float = 60.0,
         success_threshold: int = 2,
     ):
-        """
-        Initialize circuit breaker.
-
-        Args:
-            failure_threshold: Number of failures before opening circuit
-            recovery_timeout: Seconds before transitioning from OPEN to HALF_OPEN
-            success_threshold: Number of successes in HALF_OPEN to close circuit
-        """
         self.failure_threshold = failure_threshold
         self._base_recovery_timeout = recovery_timeout
-        self._max_recovery_timeout = 900.0  # 15 minutes cap
+        self._max_recovery_timeout = 900.0
         self.recovery_timeout = recovery_timeout
         self.success_threshold = success_threshold
         self.state = CircuitState.CLOSED
@@ -117,7 +125,6 @@ class CrawlerCircuitBreaker:
                     self.success_count = 0
 
     async def record_success(self) -> None:
-        """Record successful operation."""
         async with self._lock:
             self.failure_count = 0
             if self.state == CircuitState.HALF_OPEN:
@@ -129,12 +136,6 @@ class CrawlerCircuitBreaker:
                     self.recovery_timeout = self._base_recovery_timeout
 
     async def record_failure(self, trigger_reset: Optional[Callable] = None) -> None:
-        """
-        Record failed operation.
-
-        Args:
-            trigger_reset: Optional async callback to reset browser when circuit opens
-        """
         async with self._lock:
             self.failure_count += 1
             self.last_failure_time = time.time()
@@ -158,13 +159,11 @@ class CrawlerCircuitBreaker:
                 self.state = CircuitState.OPEN
                 should_open = True
 
-            # Trigger browser reset when circuit opens
             if should_open and trigger_reset:
                 logger.info("Triggering browser reset due to circuit open")
                 asyncio.create_task(trigger_reset())
 
     def is_open(self) -> bool:
-        """Check if circuit is open (rejecting requests)."""
         return self.state == CircuitState.OPEN
 
 
@@ -172,87 +171,152 @@ _VALID_BACKENDS = frozenset({"scrapling", "router"})
 
 
 class SafeCrawlerWrapper:
-    """
-    Safe wrapper for web crawling with comprehensive fault tolerance.
+    """Safe wrapper for web crawling with three-layer health isolation.
 
-    Features:
-    - Circuit breaker: Fail fast after repeated failures
-    - Timeouts: All operations have guaranteed timeouts
-    - Resource limiting: Queue size and concurrency limits
-    - Auto recovery: Browser reset when circuit opens
-    - Graceful degradation: Never raises, always returns CrawlResult
-    - Backend-agnostic: pluggable via CrawlerBackend protocol
+    Per-host breaker isolates one bad host from the rest. Blocked-host cache
+    fast-fails permanent rejections in <1ms without touching any breaker.
+    Global infra breaker only trips on cross-cutting failures (browser crash,
+    DNS resolver down) — never on host-specific issues.
     """
 
     def __init__(
         self,
-        max_concurrent: int = 10,
         max_queue_size: int = 100,
         default_timeout: float = 60.0,
-        slot_timeout: float = 10.0,
         circuit_failure_threshold: int = 5,
         circuit_recovery_timeout: float = 60.0,
         circuit_success_threshold: int = 2,
         backend: str = "scrapling",
+        http_concurrency: int = 20,
+        browser_concurrency: int = 6,
     ):
-        """
-        Initialize safe crawler wrapper.
-
-        Args:
-            max_concurrent: Maximum number of concurrent crawls
-            max_queue_size: Maximum number of queued requests
-            default_timeout: Default timeout for crawl operations (seconds)
-            slot_timeout: Timeout for waiting for a crawl slot (seconds)
-            circuit_failure_threshold: Failures before opening circuit
-            circuit_recovery_timeout: Seconds before testing recovery
-            circuit_success_threshold: Successes to close circuit
-            backend: Crawler backend (default: "scrapling")
-        """
-        self._semaphore = asyncio.Semaphore(max_concurrent)
         self._queue_count = 0
         self._max_queue = max_queue_size
         self._default_timeout = default_timeout
-        self._slot_timeout = slot_timeout
-        self._circuit = CrawlerCircuitBreaker(
+        # Per-host breaker config — shared across all hosts but each host
+        # gets its own breaker instance.
+        self._circuit_failure_threshold = circuit_failure_threshold
+        self._circuit_recovery_timeout = circuit_recovery_timeout
+        self._circuit_success_threshold = circuit_success_threshold
+        # Global infra breaker. Trips only on cross-cutting failures
+        # (browser_closed, dns_error, connection_refused). When open, all
+        # crawls fail-fast until recovery — DNS being broken is genuinely a
+        # cross-host problem.
+        self._infra_breaker = CrawlerCircuitBreaker(
             failure_threshold=circuit_failure_threshold,
             recovery_timeout=circuit_recovery_timeout,
             success_threshold=circuit_success_threshold,
         )
+        # Three-layer state. All access guarded by self._lock.
+        self._blocked_hosts: OrderedDict[str, float] = OrderedDict()
+        self._host_breakers: OrderedDict[str, CrawlerCircuitBreaker] = OrderedDict()
+        # Consecutive-block counter — see `_BLOCK_CACHE_THRESHOLD`. Required to
+        # avoid a single 401 on a paywalled URL poisoning the entire host.
+        self._block_attempts: OrderedDict[str, int] = OrderedDict()
         self._lock = asyncio.Lock()
-        # Serialize reaper runs: circuit-open can trigger many in parallel and a
-        # single /proc walk suffices; N concurrent walks are thundering-herd waste
-        # and widen the PID-reuse window between stat and os.kill.
+        # Reaper state.
         self._reaper_lock = asyncio.Lock()
-        self._crawler = None  # Lazy-initialized
+        self._last_reap_time = 0.0
+        # Crawler instance (lazy-init). Receives concurrency caps for stage-level
+        # semaphores inside the crawler.
+        self._crawler = None
+        self._http_concurrency = http_concurrency
+        self._browser_concurrency = browser_concurrency
         if backend not in _VALID_BACKENDS:
             raise ValueError(f"Unknown crawler backend: {backend!r}. Must be one of {_VALID_BACKENDS}")
         self._backend = backend
 
     async def _get_crawler(self):
-        """Lazy-initialize crawler based on configured backend."""
+        """Lazy-initialize crawler with stage-level concurrency caps."""
         if self._crawler is None:
             if self._backend == "scrapling":
                 from .scrapling_crawler import ScraplingCrawler
-                self._crawler = ScraplingCrawler()
+                self._crawler = ScraplingCrawler(
+                    http_concurrency=self._http_concurrency,
+                    browser_concurrency=self._browser_concurrency,
+                )
             elif self._backend == "router":
                 from .router import ContentRouter
-                self._crawler = ContentRouter()
+                self._crawler = ContentRouter(
+                    http_concurrency=self._http_concurrency,
+                    browser_concurrency=self._browser_concurrency,
+                )
             else:
                 raise ValueError(f"Unknown crawler backend: {self._backend}")
         return self._crawler
 
+    # ------------------------------------------------------------------ #
+    # Three-layer state helpers — all expect self._lock to be held.
+    # ------------------------------------------------------------------ #
+
+    def _is_blocked_locked(self, netloc: str) -> bool:
+        """Check blocked-host cache. LRU-touches on hit. Removes expired entries."""
+        expires = self._blocked_hosts.get(netloc)
+        if expires is None:
+            return False
+        if time.time() >= expires:
+            # Expired — drop and treat as miss. Next call will re-fetch and
+            # re-classify.
+            del self._blocked_hosts[netloc]
+            return False
+        self._blocked_hosts.move_to_end(netloc)
+        return True
+
+    def _set_blocked_locked(self, netloc: str) -> None:
+        """Mark a host as blocked for _BLOCKED_TTL_SECONDS."""
+        self._blocked_hosts[netloc] = time.time() + _BLOCKED_TTL_SECONDS
+        self._blocked_hosts.move_to_end(netloc)
+        while len(self._blocked_hosts) > _BLOCKED_LRU_CAP:
+            self._blocked_hosts.popitem(last=False)
+
+    def _record_block_attempt_locked(self, netloc: str) -> int:
+        """Increment the block-attempt counter for netloc and return new value."""
+        count = self._block_attempts.get(netloc, 0) + 1
+        self._block_attempts[netloc] = count
+        self._block_attempts.move_to_end(netloc)
+        while len(self._block_attempts) > _BLOCK_ATTEMPTS_LRU_CAP:
+            self._block_attempts.popitem(last=False)
+        return count
+
+    def _clear_block_attempts_locked(self, netloc: str) -> None:
+        """Reset block-attempt counter on success — paywalled article doesn't poison the host."""
+        self._block_attempts.pop(netloc, None)
+
+    def _get_or_create_host_breaker_locked(self, netloc: str) -> CrawlerCircuitBreaker:
+        """Return the per-host breaker, creating one (and LRU-evicting) if needed."""
+        breaker = self._host_breakers.get(netloc)
+        if breaker is None:
+            breaker = CrawlerCircuitBreaker(
+                failure_threshold=self._circuit_failure_threshold,
+                recovery_timeout=self._circuit_recovery_timeout,
+                success_threshold=self._circuit_success_threshold,
+            )
+            self._host_breakers[netloc] = breaker
+        else:
+            self._host_breakers.move_to_end(netloc)
+        while len(self._host_breakers) > _HOST_BREAKERS_LRU_CAP:
+            self._host_breakers.popitem(last=False)
+        return breaker
+
+    def _should_reap_locked(self) -> bool:
+        """Atomic gate for opportunistic reaping. Returns True at most once per interval."""
+        now = time.time()
+        if now - self._last_reap_time > _REAPER_INTERVAL_SECONDS:
+            self._last_reap_time = now
+            return True
+        return False
+
+    # ------------------------------------------------------------------ #
+    # Browser orphan reaper.
+    # ------------------------------------------------------------------ #
+
     async def _trigger_browser_reset(self) -> None:
-        """Reap orphaned browser processes when the circuit opens.
+        """Reap orphaned browser processes. Runs the /proc walk in a thread.
 
-        Belt-and-suspenders to Tier 1 (tini via `init: true` in compose): if a
-        browser fetch was cancelled before scrapling's session.close() ran, its
-        child Chromium/Camoufox/Firefox processes get reparented to PID 1. tini
-        reaps them eventually, but when the circuit trips we actively free RAM +
-        PID slots now instead of waiting.
-
-        Runs the /proc walk in a thread so walking thousands of /proc/*/stat
-        entries does not block the event loop while SSE streams are in flight.
-        A lock serializes concurrent circuit-open events onto one walk at a time.
+        Belt-and-suspenders to tini: if a browser fetch was cancelled before
+        scrapling's session.close() ran, its child Chromium/Camoufox/Firefox
+        processes get reparented to PID 1. tini reaps eventually; this actively
+        frees RAM + PID slots now.
         """
         if self._reaper_lock.locked():
             logger.debug("Browser reaper already running; skipping concurrent invocation")
@@ -273,8 +337,6 @@ class SafeCrawlerWrapper:
             logger.debug("Browser reset skipped: /proc not available (not Linux)")
             return
 
-        # Abort if PID 1 is not an init process — in that case ppid==1 may
-        # indicate a LIVE child of our python worker, not a reaped orphan.
         try:
             pid1_comm = (proc_root / "1" / "comm").read_text().strip()
         except (OSError, IndexError):
@@ -315,7 +377,6 @@ class SafeCrawlerWrapper:
                 os.kill(int(pid_dir.name), signal.SIGKILL)
                 killed += 1
             except (ProcessLookupError, FileNotFoundError, PermissionError, IndexError, ValueError):
-                # Process died mid-scan, stat fields malformed, or PID recycled — expected race.
                 continue
 
         if killed > 0:
@@ -323,37 +384,38 @@ class SafeCrawlerWrapper:
                 f"Circuit reset reaped {killed} orphaned browser processes"
             )
 
+    # ------------------------------------------------------------------ #
+    # Main crawl entry point.
+    # ------------------------------------------------------------------ #
+
     async def crawl(
         self,
         url: str,
         timeout: Optional[float] = None,
     ) -> CrawlResult:
-        """
-        Safely crawl a URL with all protections.
-
-        This method never raises exceptions - it always returns a CrawlResult
-        with success=True/False and appropriate error information.
-
-        Args:
-            url: URL to crawl
-            timeout: Optional timeout override (seconds)
-
-        Returns:
-            CrawlResult with success status and content/error
-        """
+        """Crawl a URL with all protections. Never raises — always returns CrawlResult."""
         timeout = timeout or self._default_timeout
+        netloc = (urlparse(url).netloc or "").lower()
 
-        # Check circuit breaker state
-        await self._circuit.check_state()
-        if self._circuit.is_open():
-            return CrawlResult(
-                success=False,
-                error="Crawler temporarily unavailable (circuit open)",
-                error_type="circuit_open",
-            )
-
-        # Check queue capacity
+        # Step 1: pre-call lock window. Cache check, breaker fetch, queue
+        # admission, reap gate. All cheap, all under one lock acquisition.
+        # Crucially, we do NOT call the actual crawler under this lock.
         async with self._lock:
+            # Blocked-cache hit: instant fail-fast.
+            if netloc and self._is_blocked_locked(netloc):
+                return CrawlResult(
+                    success=False,
+                    error_type="blocked",
+                    error=(
+                        f"Site blocks automated access ({netloc}). "
+                        "Retrying will not help — try an alternative source."
+                    ),
+                )
+            # Get/create per-host breaker (also LRU-evicts).
+            host_breaker = self._get_or_create_host_breaker_locked(netloc) if netloc else None
+            # Opportunistic reap gate (atomic check-and-set).
+            should_reap = self._should_reap_locked()
+            # Queue admission.
             if self._queue_count >= self._max_queue:
                 return CrawlResult(
                     success=False,
@@ -362,111 +424,193 @@ class SafeCrawlerWrapper:
                 )
             self._queue_count += 1
 
+        if should_reap:
+            asyncio.create_task(self._trigger_browser_reset())
+
         try:
-            # Acquire semaphore with timeout
-            try:
-                await asyncio.wait_for(
-                    self._semaphore.acquire(),
-                    timeout=self._slot_timeout,
-                )
-            except asyncio.TimeoutError:
+            # Step 2: breaker state checks. Per-breaker locks; safe outside self._lock.
+            if host_breaker is not None:
+                await host_breaker.check_state()
+                if host_breaker.is_open():
+                    return CrawlResult(
+                        success=False,
+                        error=f"Crawler temporarily unavailable for {netloc} (host breaker open)",
+                        error_type="circuit_open",
+                    )
+            await self._infra_breaker.check_state()
+            if self._infra_breaker.is_open():
                 return CrawlResult(
                     success=False,
-                    error=f"Timeout waiting for crawler slot ({self._slot_timeout}s)",
-                    error_type="queue_timeout",
+                    error="Crawler temporarily unavailable (infrastructure breaker open)",
+                    error_type="circuit_open",
                 )
 
+            # Step 3: run the crawl.
             try:
-                # Execute crawl with timeout
                 crawler = await self._get_crawler()
                 output = await asyncio.wait_for(
                     crawler.crawl_with_metadata(url),
                     timeout=timeout,
                 )
-
-                # Treat empty/near-empty content as a failed crawl —
-                # prevents blocked/errored pages from counting as circuit successes
-                if not output.markdown or len(output.markdown.strip()) < 10:
-                    await self._circuit.record_failure(self._trigger_browser_reset)
-                    return CrawlResult(
-                        success=False,
-                        markdown=output.markdown,
-                        title=output.title,
-                        error="Page returned empty content",
-                        error_type="empty_content",
-                    )
-
-                await self._circuit.record_success()
-                return CrawlResult(
-                    success=True,
-                    markdown=output.markdown,
-                    title=output.title,
-                )
+                return await self._classify_output(output, host_breaker, netloc)
 
             except asyncio.TimeoutError:
-                await self._circuit.record_failure(self._trigger_browser_reset)
+                # Host-level timeout → host breaker only.
+                if host_breaker is not None:
+                    await host_breaker.record_failure(self._trigger_browser_reset)
                 return CrawlResult(
                     success=False,
                     error=f"Crawl timed out after {timeout}s",
                     error_type="timeout",
                 )
             except asyncio.CancelledError:
-                # Don't count cancellation as failure
+                # Don't count cancellation as failure.
                 return CrawlResult(
                     success=False,
                     error="Crawl was cancelled",
                     error_type="cancelled",
                 )
             except Exception as e:
-                await self._circuit.record_failure(self._trigger_browser_reset)
-                error_str = str(e)
+                return await self._classify_exception(e, host_breaker)
 
-                # Classify error type for better diagnostics
-                if "has been closed" in error_str or "Target page" in error_str:
-                    error_type = "browser_closed"
-                elif "ERR_NAME_NOT_RESOLVED" in error_str:
-                    error_type = "dns_error"
-                elif "ERR_CONNECTION_REFUSED" in error_str:
-                    error_type = "connection_refused"
-                elif "ERR_CONNECTION_TIMED_OUT" in error_str:
-                    error_type = "connection_timeout"
-                elif "net::" in error_str:
-                    error_type = "network_error"
-                else:
-                    error_type = "crawl_error"
-
-                return CrawlResult(
-                    success=False,
-                    error=error_str[:200],  # Truncate long errors
-                    error_type=error_type,
-                )
-            finally:
-                self._semaphore.release()
         finally:
             async with self._lock:
                 self._queue_count -= 1
 
-    def get_status(self) -> dict:
-        """
-        Get wrapper status for monitoring.
+    async def _classify_output(
+        self,
+        output,
+        host_breaker: Optional[CrawlerCircuitBreaker],
+        netloc: str,
+    ) -> CrawlResult:
+        """Map CrawlOutput.failure_kind to CrawlResult and update appropriate health layer."""
+        kind = output.failure_kind
 
-        Returns:
-            Dict with circuit state, failure count, queue info
-        """
+        if kind == "blocked":
+            # Host rejection. Cache only after _BLOCK_CACHE_THRESHOLD consecutive
+            # blocks to avoid one paywalled URL poisoning the entire host's
+            # cache (NYT homepage works, /article 401s — don't block both).
+            # Never trip any breaker on blocks.
+            if netloc:
+                async with self._lock:
+                    count = self._record_block_attempt_locked(netloc)
+                    if count >= _BLOCK_CACHE_THRESHOLD:
+                        self._set_blocked_locked(netloc)
+                        # Reset counter — cache is the durable record now.
+                        self._clear_block_attempts_locked(netloc)
+            status_str = f"HTTP {output.status}" if output.status else "blocked"
+            return CrawlResult(
+                success=False,
+                error=(
+                    f"Site blocks automated access ({status_str}). "
+                    "Retrying will not help — try an alternative source."
+                ),
+                error_type="blocked",
+                markdown=output.markdown or "",
+                title=output.title or "",
+            )
+
+        if kind == "infra_error":
+            # Cross-cutting failure → both breakers.
+            if host_breaker is not None:
+                await host_breaker.record_failure(self._trigger_browser_reset)
+            await self._infra_breaker.record_failure(self._trigger_browser_reset)
+            return CrawlResult(
+                success=False,
+                error="Crawler infrastructure error",
+                error_type="infra_error",
+            )
+
+        if kind in ("rate_limited", "stealth_failed", "empty"):
+            # Host-scoped failure → host breaker only.
+            if host_breaker is not None:
+                await host_breaker.record_failure(self._trigger_browser_reset)
+            return CrawlResult(
+                success=False,
+                markdown=output.markdown or "",
+                title=output.title or "",
+                error=(
+                    f"Site returned {kind}"
+                    if kind != "empty"
+                    else "Page returned empty content"
+                ),
+                error_type=kind,
+            )
+
+        # No failure_kind set: legacy/successful path. Still guard against the
+        # silent-empty case (empty markdown without any classification — rare,
+        # but catches old extractors that don't set failure_kind).
+        if not output.markdown or len(output.markdown.strip()) < 10:
+            if host_breaker is not None:
+                await host_breaker.record_failure(self._trigger_browser_reset)
+            return CrawlResult(
+                success=False,
+                markdown=output.markdown or "",
+                title=output.title or "",
+                error="Page returned empty content",
+                error_type="empty_content",
+            )
+
+        # Success — reset any pending block-attempt counter for this host.
+        if host_breaker is not None:
+            await host_breaker.record_success()
+        if netloc and netloc in self._block_attempts:
+            async with self._lock:
+                self._clear_block_attempts_locked(netloc)
+        return CrawlResult(
+            success=True,
+            markdown=output.markdown,
+            title=output.title,
+        )
+
+    async def _classify_exception(
+        self,
+        e: Exception,
+        host_breaker: Optional[CrawlerCircuitBreaker],
+    ) -> CrawlResult:
+        """Classify an exception, update appropriate breaker(s), return CrawlResult."""
+        error_str = str(e)
+
+        if "has been closed" in error_str or "Target page" in error_str:
+            error_type = "browser_closed"
+        elif "ERR_NAME_NOT_RESOLVED" in error_str:
+            error_type = "dns_error"
+        elif "ERR_CONNECTION_REFUSED" in error_str:
+            error_type = "connection_refused"
+        elif "ERR_CONNECTION_TIMED_OUT" in error_str:
+            error_type = "connection_timeout"
+        elif "net::" in error_str:
+            error_type = "network_error"
+        else:
+            error_type = "crawl_error"
+
+        if host_breaker is not None:
+            await host_breaker.record_failure(self._trigger_browser_reset)
+        if error_type in _INFRA_ERROR_TYPES:
+            await self._infra_breaker.record_failure(self._trigger_browser_reset)
+
+        return CrawlResult(
+            success=False,
+            error=error_str[:200],
+            error_type=error_type,
+        )
+
+    def get_status(self) -> dict:
+        """Wrapper status for monitoring."""
         return {
-            "circuit_state": self._circuit.state.value,
-            "failure_count": self._circuit.failure_count,
-            "success_count": self._circuit.success_count,
-            "consecutive_opens": self._circuit._consecutive_opens,
-            "recovery_timeout": self._circuit.recovery_timeout,
+            "infra_circuit_state": self._infra_breaker.state.value,
+            "infra_failure_count": self._infra_breaker.failure_count,
+            "host_breaker_count": len(self._host_breakers),
+            "blocked_host_count": len(self._blocked_hosts),
             "queue_count": self._queue_count,
             "max_queue": self._max_queue,
-            "last_failure_time": self._circuit.last_failure_time,
+            "infra_last_failure_time": self._infra_breaker.last_failure_time,
         }
 
     def is_healthy(self) -> bool:
-        """Check if crawler is healthy (circuit not open)."""
-        return not self._circuit.is_open()
+        """Healthy iff infra breaker is closed. Per-host breakers being open
+        is normal and does not mean the crawler itself is unhealthy."""
+        return not self._infra_breaker.is_open()
 
 
 # Global singleton instance
@@ -478,25 +622,25 @@ def _build_configured_wrapper() -> SafeCrawlerWrapper:
     """Build a SafeCrawlerWrapper from agent_config settings."""
     try:
         from src.config.tool_settings import (
-            get_crawler_max_concurrent,
-            get_crawler_page_timeout,
-            get_crawler_queue_max_size,
-            get_crawler_queue_slot_timeout,
+            get_crawler_browser_concurrency,
             get_crawler_circuit_failure_threshold,
             get_crawler_circuit_recovery_timeout,
             get_crawler_circuit_success_threshold,
+            get_crawler_http_concurrency,
+            get_crawler_page_timeout,
+            get_crawler_queue_max_size,
             get_crawler_backend,
         )
 
         return SafeCrawlerWrapper(
-            max_concurrent=get_crawler_max_concurrent(),
             default_timeout=get_crawler_page_timeout() / 1000,
             max_queue_size=get_crawler_queue_max_size(),
-            slot_timeout=get_crawler_queue_slot_timeout(),
             circuit_failure_threshold=get_crawler_circuit_failure_threshold(),
             circuit_recovery_timeout=get_crawler_circuit_recovery_timeout(),
             circuit_success_threshold=get_crawler_circuit_success_threshold(),
             backend=get_crawler_backend(),
+            http_concurrency=get_crawler_http_concurrency(),
+            browser_concurrency=get_crawler_browser_concurrency(),
         )
     except Exception as e:
         logger.warning(f"Failed to load crawler config, using defaults: {e}")
@@ -504,18 +648,13 @@ def _build_configured_wrapper() -> SafeCrawlerWrapper:
 
 
 async def get_safe_crawler() -> SafeCrawlerWrapper:
-    """
-    Get or create safe crawler wrapper singleton.
-
-    Loads configuration from agent_config.yaml via tool_settings helpers.
-    """
+    """Get or create safe crawler wrapper singleton."""
     global _safe_wrapper
 
     if _safe_wrapper is not None:
         return _safe_wrapper
 
     async with _wrapper_lock:
-        # Double-check after acquiring lock
         if _safe_wrapper is not None:
             return _safe_wrapper
 
@@ -524,11 +663,7 @@ async def get_safe_crawler() -> SafeCrawlerWrapper:
 
 
 def get_safe_crawler_sync() -> SafeCrawlerWrapper:
-    """
-    Synchronous version of get_safe_crawler for non-async contexts.
-
-    Note: This creates the wrapper with default config if not already initialized.
-    """
+    """Synchronous version of get_safe_crawler for non-async contexts."""
     global _safe_wrapper
 
     if _safe_wrapper is None:

--- a/src/tools/crawler/safe_wrapper.py
+++ b/src/tools/crawler/safe_wrapper.py
@@ -5,7 +5,7 @@ Three-layer health model:
   - Blocked-host cache: hosts that returned 401/403/451. TTL 15 min, LRU 256.
     Hit → fast-fail with [blocked]. Never trips any breaker.
   - Per-host circuit breaker: transient host-level failures (timeout, 5xx,
-    rate-limited, empty). LRU 256. Trips after N consecutive failures.
+    rate-limited, stealth_failed). LRU 256. Trips after N consecutive failures.
   - Global infra breaker: cross-cutting crawler-side failures (browser crash,
     DNS, conn refused). Trips → all hosts fail-fast until recovery.
 
@@ -521,7 +521,7 @@ class SafeCrawlerWrapper:
                 error_type="infra_error",
             )
 
-        if kind in ("rate_limited", "stealth_failed", "empty"):
+        if kind in ("rate_limited", "stealth_failed"):
             # Host-scoped failure → host breaker only.
             if host_breaker is not None:
                 await host_breaker.record_failure(self._trigger_browser_reset)
@@ -529,11 +529,7 @@ class SafeCrawlerWrapper:
                 success=False,
                 markdown=output.markdown or "",
                 title=output.title or "",
-                error=(
-                    f"Site returned {kind}"
-                    if kind != "empty"
-                    else "Page returned empty content"
-                ),
+                error=f"Site returned {kind}",
                 error_type=kind,
             )
 
@@ -551,9 +547,14 @@ class SafeCrawlerWrapper:
                 error_type="empty_content",
             )
 
-        # Success — reset any pending block-attempt counter for this host.
+        # Success — reset host breaker, infra breaker, and any pending
+        # block-attempt counter for this host. Without record_success on the
+        # infra breaker, a HALF_OPEN breaker can never transition back to
+        # CLOSED, and recovery_timeout ratchets upward on every transient blip
+        # until it caps at 15 minutes.
         if host_breaker is not None:
             await host_breaker.record_success()
+        await self._infra_breaker.record_success()
         if netloc and netloc in self._block_attempts:
             async with self._lock:
                 self._clear_block_attempts_locked(netloc)

--- a/src/tools/crawler/scrapling_crawler.py
+++ b/src/tools/crawler/scrapling_crawler.py
@@ -6,18 +6,22 @@ Implements a three-tier fetching strategy:
   Tier 2 (Dynamic): AsyncDynamicSession -- Playwright/patchright Chromium
   Tier 3 (Stealth): AsyncStealthySession -- Camoufox anti-bot bypass
 
-Automatic fallback: Tier 1 -> Tier 2 -> Tier 3
+Automatic fallback: Tier 1 -> Tier 2 -> Tier 3 (terminal blocks short-circuit at Tier 1).
+
+Stage-level concurrency: Tier 1 (HTTP) and Tier 2/3 (browser) acquire separate
+semaphores. A burst of stuck browser fetches cannot starve fast Tier-1 calls.
+The HTTP semaphore is released before any browser-tier wait.
 
 Browser lifecycle: Tier 2/3 use the session classes directly (rather than the
 `DynamicFetcher.async_fetch()` classmethod wrapper) so we can shield
 `session.close()` from cancellation. `asyncio.wait_for` in safe_wrapper.py
 cancels the fetch coroutine on timeout; if close() is not shielded, it gets
-cancelled mid-teardown and orphans Chromium helper processes. See fix plan
-2026-04-18.
+cancelled mid-teardown and orphans Chromium helper processes.
 """
 
 import asyncio
 import logging
+from typing import Literal, Optional
 
 import html2text
 
@@ -38,6 +42,16 @@ _BLOCKED_SIGNALS = [
     "captcha",
 ]
 
+# HTTP statuses where retrying through browser tiers won't help. 401 = auth required;
+# 451 = legal block. 403 is excluded — some Cloudflare configs return 403 to curl_cffi
+# but 200 to Camoufox's full browser fingerprint, so it remains a real recovery path.
+_TERMINAL_BLOCK_STATUSES = (401, 451)
+
+# Tier-1 timeout. curl_cffi calls that haven't returned in 15s are dead — release
+# the slot rather than hold it for the full 30s. Covers slow international hosts
+# and large EDGAR PDFs comfortably.
+_TIER1_TIMEOUT_MS = 15000
+
 
 def _log_close_task_exception(task: asyncio.Task) -> None:
     # Observes close_task after outer cancel so asyncio doesn't emit
@@ -50,7 +64,11 @@ def _log_close_task_exception(task: asyncio.Task) -> None:
 
 
 def _needs_browser(html_body: str, status: int) -> bool:
-    """Detect if HTTP-only fetch returned blocked/empty content."""
+    """Detect if HTTP-only fetch returned blocked/empty content needing browser tiers.
+
+    Returns True for 4xx/5xx (except terminal blocks handled separately by caller),
+    near-empty bodies, or pages containing block-signal keywords.
+    """
     if status >= 400:
         return True
     if not html_body or len(html_body.strip()) < 200:
@@ -59,18 +77,28 @@ def _needs_browser(html_body: str, status: int) -> bool:
     return any(signal in lower for signal in _BLOCKED_SIGNALS)
 
 
-def _needs_stealth(html_body: str, status: int) -> bool:
-    """Detect if dynamic fetch hit anti-bot protection."""
-    if status in (401, 403):
-        return True
+def _needs_stealth(
+    html_body: str, status: int
+) -> Optional[Literal["cloudflare", "blocked"]]:
+    """Detect if dynamic fetch hit anti-bot protection.
+
+    Returns "cloudflare" when CF challenge signals are present (Tier 3 should run
+    the CF solver), "blocked" for plain 401/403 with no challenge page (Tier 3
+    should run without the solver), or None when content is acceptable.
+    """
     lower = (html_body or "").lower()
-    # Cloudflare challenge
+    # Cloudflare challenge — solver may help.
     if "cloudflare" in lower and ("ray id" in lower or "just a moment" in lower):
-        return True
-    # DataDome / generic anti-bot challenge (short page with JS challenge)
+        return "cloudflare"
+    # DataDome / generic JS challenge on a short page.
     if len(lower) < 2000 and ("enable js" in lower or "enable javascript" in lower):
-        return True
-    return False
+        return "cloudflare"
+    # Bare 401/403 with no challenge page — running the CF solver would just log
+    # "No Cloudflare challenge found" without helping. Still worth a stealth
+    # attempt with a different fingerprint.
+    if status in (401, 403):
+        return "blocked"
+    return None
 
 
 def _html_to_markdown(html: str) -> str:
@@ -93,21 +121,25 @@ def _extract_title(page) -> str:
 
 
 class ScraplingCrawler:
-    """
-    Async crawler using Scrapling with tiered fetching.
-
-    Satisfies the CrawlerBackend protocol.
-    """
+    """Async crawler using Scrapling with tiered fetching and stage-level concurrency."""
 
     def __init__(
         self,
         timeout: int = 30000,
         disable_resources: bool = True,
         network_idle: bool = True,
+        http_concurrency: int = 20,
+        browser_concurrency: int = 6,
     ):
         self.timeout = timeout
         self.disable_resources = disable_resources
         self.network_idle = network_idle
+        # Stage-level semaphores. Tier 1 (curl_cffi) is cheap so its cap is high;
+        # Tier 2/3 (Chromium/Camoufox) bound RAM at ~browser_concurrency * 400MB.
+        # Critically: Tier 1 releases its semaphore before any browser wait, so a
+        # burst of stuck browser calls cannot block fast HTTP calls.
+        self._http_sem = asyncio.Semaphore(http_concurrency)
+        self._browser_sem = asyncio.Semaphore(browser_concurrency)
 
     async def crawl(self, url: str) -> str:
         """Crawl and return markdown."""
@@ -115,18 +147,42 @@ class ScraplingCrawler:
         return output.markdown
 
     async def crawl_with_metadata(self, url: str) -> CrawlOutput:
-        """Crawl with tiered fallback, return CrawlOutput."""
+        """Crawl with tiered fallback, return CrawlOutput with status + failure_kind."""
         from .extractors.base import _validate_url
         _validate_url(url)
 
         # --- Tier 1: Fast HTTP fetch (requires curl_cffi) ---
         try:
             page, html_body, status = await self._tier1_fetch(url)
+
+            # Hard blocks — host permanently rejects scrapers. Skip Tier 2/3
+            # entirely. Each blocked-host call burns one curl_cffi call instead
+            # of spawning two browsers to confirm the same "no".
+            if status in _TERMINAL_BLOCK_STATUSES:
+                logger.debug(f"Tier 1 terminal block ({status}) for {url}")
+                return CrawlOutput(
+                    title="",
+                    html="",
+                    markdown="",
+                    status=status,
+                    failure_kind="blocked",
+                )
+            if status == 429:
+                logger.debug(f"Tier 1 rate limited for {url}")
+                return CrawlOutput(
+                    title="",
+                    html="",
+                    markdown="",
+                    status=status,
+                    failure_kind="rate_limited",
+                )
             if not _needs_browser(html_body, status):
                 title = _extract_title(page)
                 markdown = _html_to_markdown(html_body)
                 logger.debug(f"Tier 1 (fast) succeeded for {url}")
-                return CrawlOutput(title=title, html=html_body, markdown=markdown)
+                return CrawlOutput(
+                    title=title, html=html_body, markdown=markdown, status=status
+                )
             logger.debug(f"Tier 1 insufficient for {url}, escalating to Tier 2")
         except ImportError:
             # curl_cffi not installed — skip Tier 1 (scrapling without [fetchers])
@@ -135,65 +191,112 @@ class ScraplingCrawler:
             logger.debug(f"Tier 1 failed for {url}: {e}, escalating to Tier 2")
 
         # --- Tier 2: Dynamic browser fetch ---
+        stealth_reason: Optional[Literal["cloudflare", "blocked"]] = None
         try:
             page, html_body, status = await self._tier2_fetch(url)
-            if not _needs_stealth(html_body, status):
+
+            if status == 429:
+                logger.debug(f"Tier 2 rate limited for {url}")
+                return CrawlOutput(
+                    title="",
+                    html="",
+                    markdown="",
+                    status=status,
+                    failure_kind="rate_limited",
+                )
+            stealth_reason = _needs_stealth(html_body, status)
+            if stealth_reason is None:
                 title = _extract_title(page)
                 markdown = _html_to_markdown(html_body)
                 logger.debug(f"Tier 2 (dynamic) succeeded for {url}")
-                return CrawlOutput(title=title, html=html_body, markdown=markdown)
-            logger.debug(f"Tier 2 blocked for {url}, escalating to Tier 3")
+                return CrawlOutput(
+                    title=title, html=html_body, markdown=markdown, status=status
+                )
+            logger.debug(
+                f"Tier 2 blocked ({stealth_reason}) for {url}, escalating to Tier 3"
+            )
         except Exception as e:
             logger.debug(f"Tier 2 failed for {url}: {e}, escalating to Tier 3")
 
         # --- Tier 3: Stealth fetch ---
+        # Run CF solver only when Tier 2 actually saw a Cloudflare challenge.
+        # On bare 401/403 (stealth_reason == "blocked"), the solver would just
+        # log "No Cloudflare challenge found" — wasteful and noisy.
+        solve_cloudflare = stealth_reason == "cloudflare"
         try:
-            page, html_body, status = await self._tier3_fetch(url)
-            if _needs_stealth(html_body, status):
-                logger.debug(f"Tier 3 still blocked for {url} (status={status})")
-                return CrawlOutput(title="", html="", markdown="")
-            title = _extract_title(page)
-            markdown = _html_to_markdown(html_body)
-            logger.debug(f"Tier 3 (stealth) completed for {url} (status={status})")
-            return CrawlOutput(title=title, html=html_body, markdown=markdown)
-        except Exception as e:
-            logger.debug(f"Tier 3 failed for {url}: {e}")
-            return CrawlOutput(title="", html="", markdown="")
+            page, html_body, status = await self._tier3_fetch(
+                url, solve_cloudflare=solve_cloudflare
+            )
+            tier3_reason = _needs_stealth(html_body, status)
+            if tier3_reason is None:
+                title = _extract_title(page)
+                markdown = _html_to_markdown(html_body)
+                logger.debug(f"Tier 3 (stealth) completed for {url} (status={status})")
+                return CrawlOutput(
+                    title=title, html=html_body, markdown=markdown, status=status
+                )
+            # Still blocked after stealth tier.
+            logger.debug(f"Tier 3 still blocked for {url} (status={status})")
+            failure_kind = "blocked" if tier3_reason == "blocked" else "stealth_failed"
+            return CrawlOutput(
+                title="",
+                html="",
+                markdown="",
+                status=status,
+                failure_kind=failure_kind,
+            )
+        except Exception:
+            # Re-raise so SafeCrawlerWrapper._classify_exception can distinguish
+            # host-specific errors (DNS, connection refused) from genuinely
+            # cross-cutting infra failures (browser crash). Blanket-classifying
+            # as "infra_error" here would trip the global breaker on a few bad
+            # hostnames and starve all crawls — the exact bug this PR set out
+            # to fix.
+            logger.debug(f"Tier 3 failed for {url}", exc_info=True)
+            raise
 
     async def _tier1_fetch(self, url: str):
-        from scrapling.fetchers import AsyncFetcher
+        """HTTP-only fetch via curl_cffi. Bounded by _http_sem; releases on return."""
+        async with self._http_sem:
+            from scrapling.fetchers import AsyncFetcher
 
-        page = await AsyncFetcher.get(
-            url,
-            stealthy_headers=True,
-            follow_redirects=True,
-            timeout=self.timeout / 1000,  # ms → seconds (curl_cffi convention)
-        )
-        html_body = page.body.decode(page.encoding or "utf-8", errors="replace")
-        return page, html_body, page.status
+            page = await AsyncFetcher.get(
+                url,
+                stealthy_headers=True,
+                follow_redirects=True,
+                timeout=_TIER1_TIMEOUT_MS / 1000,  # ms → seconds
+            )
+            html_body = page.body.decode(page.encoding or "utf-8", errors="replace")
+            return page, html_body, page.status
 
     async def _tier2_fetch(self, url: str):
         # Direct session use (not DynamicFetcher.async_fetch) so we own the
         # close() path and can shield it from outer cancellation.
-        from scrapling.engines._browsers._controllers import AsyncDynamicSession
+        async with self._browser_sem:
+            from scrapling.engines._browsers._controllers import AsyncDynamicSession
 
-        session = AsyncDynamicSession(
-            headless=True,
-            disable_resources=self.disable_resources,
-            network_idle=self.network_idle,
-            timeout=self.timeout,
-        )
-        return await self._fetch_with_session(session, url)
+            session = AsyncDynamicSession(
+                headless=True,
+                disable_resources=self.disable_resources,
+                network_idle=self.network_idle,
+                timeout=self.timeout,
+            )
+            return await self._fetch_with_session(session, url)
 
-    async def _tier3_fetch(self, url: str):
-        from scrapling.engines._browsers._stealth import AsyncStealthySession
+    async def _tier3_fetch(self, url: str, *, solve_cloudflare: bool):
+        """Stealth fetch with optional CF solver. Caller decides based on Tier 2's
+        observation — invoking the solver against a non-CF page is wasted work."""
+        async with self._browser_sem:
+            from scrapling.engines._browsers._stealth import AsyncStealthySession
 
-        session = AsyncStealthySession(
-            headless=True,
-            network_idle=self.network_idle,
-            timeout=self.timeout,
-        )
-        return await self._fetch_with_session(session, url, solve_cloudflare=True)
+            session = AsyncStealthySession(
+                headless=True,
+                network_idle=self.network_idle,
+                timeout=self.timeout,
+            )
+            return await self._fetch_with_session(
+                session, url, solve_cloudflare=solve_cloudflare
+            )
 
     async def _fetch_with_session(self, session, url: str, **fetch_kwargs):
         """Start a scrapling session, fetch one URL, shield close() from cancel.

--- a/src/tools/crawler/scrapling_crawler.py
+++ b/src/tools/crawler/scrapling_crawler.py
@@ -188,6 +188,21 @@ class ScraplingCrawler:
             # curl_cffi not installed — skip Tier 1 (scrapling without [fetchers])
             logger.debug(f"Tier 1 unavailable (curl_cffi not installed), using Tier 2 for {url}")
         except Exception as e:
+            # Hard reachability failures (DNS, conn refused) at Tier 1 mean the
+            # host is down. Spawning Chromium and Camoufox to confirm the same
+            # would just burn ~800MB and ~10s. Short-circuit to infra_error so
+            # the wrapper routes the failure correctly without browser cost.
+            err = str(e).lower()
+            if (
+                "could not resolve" in err
+                or "couldn't resolve" in err
+                or "name resolution" in err
+                or "connection refused" in err
+            ):
+                logger.debug(f"Tier 1 unreachable for {url}: {e}, skipping browsers")
+                return CrawlOutput(
+                    title="", html="", markdown="", failure_kind="infra_error",
+                )
             logger.debug(f"Tier 1 failed for {url}: {e}, escalating to Tier 2")
 
         # --- Tier 2: Dynamic browser fetch ---

--- a/src/tools/fetch.py
+++ b/src/tools/fetch.py
@@ -246,22 +246,24 @@ async def web_fetch(
 
             # Check crawl result
             if not crawl_result.success:
+                kind = crawl_result.error_type or "error"
                 # If sitemap available, suggest alternatives
                 if sitemap_summary:
                     return (
-                        f"Failed to fetch {url}: {crawl_result.error}\n\n"
+                        f"[{kind}] Failed to fetch {url}: {crawl_result.error}\n\n"
                         f"However, here are other pages available on this site:\n\n"
                         f"{sitemap_summary}\n\n"
                         f"Try fetching one of these alternative URLs instead."
                     )
                 else:
-                    return f"Failed to fetch {url}: {crawl_result.error}"
+                    return f"[{kind}] Failed to fetch {url}: {crawl_result.error}"
 
             markdown = crawl_result.markdown
         else:
             crawl_result = await safe_crawler.crawl(url)
             if not crawl_result.success:
-                return f"Failed to fetch {url}: {crawl_result.error}"
+                kind = crawl_result.error_type or "error"
+                return f"[{kind}] Failed to fetch {url}: {crawl_result.error}"
             markdown = crawl_result.markdown
             sitemap_summary = ""
 

--- a/tests/integration/tools/test_scrapling_integration.py
+++ b/tests/integration/tools/test_scrapling_integration.py
@@ -99,8 +99,12 @@ class TestSafeCrawlerWrapperLive:
 
         assert not result.success
         assert result.error
+        # When all three tiers fail with network errors, ScraplingCrawler rolls
+        # the exception path into failure_kind="infra_error" → error_type="infra_error".
+        # If the single-tier exception path fires, it classifies via string match.
         assert result.error_type in (
-            "dns_error", "network_error", "connection_timeout", "crawl_error", "timeout", "empty_content",
+            "infra_error", "dns_error", "network_error", "connection_timeout",
+            "crawl_error", "timeout", "empty_content",
         )
 
     async def test_circuit_breaker_starts_healthy(self):
@@ -110,15 +114,17 @@ class TestSafeCrawlerWrapperLive:
         assert wrapper.is_healthy()
 
         status = wrapper.get_status()
-        assert status["circuit_state"] == "closed"
-        assert status["failure_count"] == 0
+        assert status["infra_circuit_state"] == "closed"
+        assert status["infra_failure_count"] == 0
+        assert status["host_breaker_count"] == 0
+        assert status["blocked_host_count"] == 0
 
     async def test_concurrent_crawls(self):
         """Test multiple concurrent crawls don't interfere."""
         import asyncio
         from src.tools.crawler.safe_wrapper import SafeCrawlerWrapper
 
-        wrapper = SafeCrawlerWrapper(backend="scrapling", max_concurrent=5)
+        wrapper = SafeCrawlerWrapper(backend="scrapling", http_concurrency=5)
         urls = [_TEST_URL, _TEST_URL_HTTPBIN]
 
         results = await asyncio.gather(*[wrapper.crawl(url) for url in urls])

--- a/tests/unit/tools/crawler/test_orphan_reaper.py
+++ b/tests/unit/tools/crawler/test_orphan_reaper.py
@@ -61,9 +61,13 @@ def patched_proc(fake_proc, monkeypatch):
 
 def _make_wrapper() -> SafeCrawlerWrapper:
     return SafeCrawlerWrapper(
-        max_concurrent=5, max_queue_size=10, default_timeout=5.0,
-        slot_timeout=2.0, circuit_failure_threshold=3,
-        circuit_recovery_timeout=60.0, circuit_success_threshold=2,
+        max_queue_size=10,
+        default_timeout=5.0,
+        circuit_failure_threshold=3,
+        circuit_recovery_timeout=60.0,
+        circuit_success_threshold=2,
+        http_concurrency=20,
+        browser_concurrency=6,
     )
 
 

--- a/tests/unit/tools/crawler/test_safe_wrapper.py
+++ b/tests/unit/tools/crawler/test_safe_wrapper.py
@@ -507,6 +507,44 @@ class TestThreeLayerHealth:
         assert wrapper._infra_breaker.state == CircuitState.CLOSED
 
     @pytest.mark.asyncio
+    async def test_infra_breaker_closes_after_recovery_success(self):
+        """HALF_OPEN infra breaker must close on success — otherwise recovery_timeout
+        ratchets upward forever on every transient blip until the 15-min cap.
+        """
+        wrapper = _make_wrapper(
+            circuit_failure_threshold=1,
+            circuit_recovery_timeout=0.05,
+            circuit_success_threshold=1,
+        )
+        mock_crawler = _inject_mock_crawler(wrapper)
+
+        # Trip infra breaker via an infra_error failure.
+        mock_crawler.crawl_with_metadata = AsyncMock(
+            return_value=CrawlOutput(title="", html="", markdown="",
+                                     status=None, failure_kind="infra_error")
+        )
+        await wrapper.crawl("https://example.com")
+        infra = wrapper._infra_breaker
+        assert infra.state == CircuitState.OPEN
+        base_timeout = infra.recovery_timeout
+
+        # Advance past recovery → HALF_OPEN on next check.
+        infra.last_failure_time = time.time() - 1.0
+
+        # Successful crawl from a different host must close infra and reset
+        # the escalating recovery_timeout.
+        mock_crawler.crawl_with_metadata = AsyncMock(
+            return_value=CrawlOutput(title="OK", html="", markdown="recovered ok ok ok",
+                                     status=200)
+        )
+        result = await wrapper.crawl("https://other.example/page")
+        assert result.success is True
+        assert infra.state == CircuitState.CLOSED
+        assert infra.failure_count == 0
+        assert infra.recovery_timeout == base_timeout
+        assert infra._consecutive_opens == 0
+
+    @pytest.mark.asyncio
     async def test_concurrent_host_breaker_creation_no_race(self):
         """50 concurrent calls to same novel host create exactly one breaker."""
         wrapper = _make_wrapper()

--- a/tests/unit/tools/crawler/test_safe_wrapper.py
+++ b/tests/unit/tools/crawler/test_safe_wrapper.py
@@ -1,18 +1,16 @@
-"""Unit tests for SafeCrawlerWrapper.crawl() fault-tolerance paths."""
+"""Unit tests for SafeCrawlerWrapper — three-layer health model + classification."""
 
 from __future__ import annotations
 
 import asyncio
 import time
-from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from src.tools.crawler.backend import CrawlOutput
 from src.tools.crawler.safe_wrapper import (
     CircuitState,
-    CrawlResult,
     CrawlerCircuitBreaker,
     SafeCrawlerWrapper,
     _build_configured_wrapper,
@@ -25,91 +23,60 @@ from src.tools.crawler.safe_wrapper import (
 
 
 def _make_wrapper(**kwargs) -> SafeCrawlerWrapper:
-    """Create a SafeCrawlerWrapper with a mocked backend so no real import occurs."""
+    """Create a SafeCrawlerWrapper with safe defaults for tests."""
     defaults = dict(
-        max_concurrent=5,
         max_queue_size=10,
         default_timeout=5.0,
-        slot_timeout=2.0,
         circuit_failure_threshold=3,
         circuit_recovery_timeout=60.0,
         circuit_success_threshold=2,
+        http_concurrency=20,
+        browser_concurrency=6,
     )
     defaults.update(kwargs)
-    wrapper = SafeCrawlerWrapper(**defaults)
-    return wrapper
+    return SafeCrawlerWrapper(**defaults)
 
 
 def _inject_mock_crawler(wrapper: SafeCrawlerWrapper) -> AsyncMock:
-    """Inject a mock crawler so _get_crawler() returns it without importing real backends."""
+    """Inject a mock crawler so _get_crawler() returns it without real imports."""
     mock_crawler = AsyncMock()
     wrapper._crawler = mock_crawler
     return mock_crawler
 
 
 # ---------------------------------------------------------------------------
-# SafeCrawlerWrapper.crawl() fault-tolerance paths
+# Wrapper-level fault tolerance (kept from previous suite, adapted to new API)
 # ---------------------------------------------------------------------------
 
 
 class TestSafeCrawlerCrawl:
-    """Tests for SafeCrawlerWrapper.crawl() covering all fault-tolerance paths."""
-
     @pytest.mark.asyncio
-    async def test_circuit_open_returns_error(self):
-        """When circuit breaker is OPEN, crawl returns immediately with circuit_open error."""
+    async def test_infra_breaker_open_returns_circuit_open(self):
         wrapper = _make_wrapper()
-        wrapper._circuit.state = CircuitState.OPEN
-        # Ensure check_state does NOT transition (last failure was recent)
-        wrapper._circuit.last_failure_time = time.time()
+        wrapper._infra_breaker.state = CircuitState.OPEN
+        wrapper._infra_breaker.last_failure_time = time.time()
 
         result = await wrapper.crawl("https://example.com")
 
-        assert isinstance(result, CrawlResult)
         assert result.success is False
         assert result.error_type == "circuit_open"
-        assert result.markdown is None
 
     @pytest.mark.asyncio
     async def test_queue_full_returns_error(self):
-        """When queue is at capacity, crawl returns queue_full error."""
         wrapper = _make_wrapper(max_queue_size=2)
         _inject_mock_crawler(wrapper)
-
-        # Artificially fill the queue
         wrapper._queue_count = 2
 
         result = await wrapper.crawl("https://example.com")
 
         assert result.success is False
         assert result.error_type == "queue_full"
-        assert "capacity" in result.error.lower()
-
-    @pytest.mark.asyncio
-    async def test_semaphore_slot_timeout(self):
-        """When no semaphore slot is available within slot_timeout, returns queue_timeout."""
-        wrapper = _make_wrapper(max_concurrent=1, slot_timeout=0.05)
-        _inject_mock_crawler(wrapper)
-
-        # Exhaust the semaphore
-        await wrapper._semaphore.acquire()
-
-        result = await wrapper.crawl("https://example.com")
-
-        assert result.success is False
-        assert result.error_type == "queue_timeout"
-        assert "slot" in result.error.lower()
-
-        # Clean up: release the semaphore we manually acquired
-        wrapper._semaphore.release()
 
     @pytest.mark.asyncio
     async def test_crawl_timeout_returns_timeout_error(self):
-        """When the crawl itself exceeds the timeout, returns timeout error."""
         wrapper = _make_wrapper(default_timeout=0.05)
         mock_crawler = _inject_mock_crawler(wrapper)
 
-        # Simulate a crawl that never finishes
         async def slow_crawl(url):
             await asyncio.sleep(10)
 
@@ -119,11 +86,9 @@ class TestSafeCrawlerCrawl:
 
         assert result.success is False
         assert result.error_type == "timeout"
-        assert "timed out" in result.error.lower()
 
     @pytest.mark.asyncio
-    async def test_crawl_timeout_records_failure(self):
-        """Timeout should be recorded as a circuit breaker failure."""
+    async def test_crawl_timeout_trips_host_breaker_only(self):
         wrapper = _make_wrapper(default_timeout=0.05, circuit_failure_threshold=1)
         mock_crawler = _inject_mock_crawler(wrapper)
 
@@ -132,31 +97,27 @@ class TestSafeCrawlerCrawl:
 
         mock_crawler.crawl_with_metadata = slow_crawl
 
-        assert wrapper._circuit.state == CircuitState.CLOSED
-
         await wrapper.crawl("https://example.com")
-
-        # With threshold=1, one failure should open the circuit
-        assert wrapper._circuit.state == CircuitState.OPEN
+        host_breaker = wrapper._host_breakers["example.com"]
+        assert host_breaker.state == CircuitState.OPEN
+        # Infra breaker should remain CLOSED — timeout is host-scoped.
+        assert wrapper._infra_breaker.state == CircuitState.CLOSED
 
     @pytest.mark.asyncio
-    async def test_crawl_cancelled_returns_cancelled(self):
-        """CancelledError returns cancelled error and does NOT record a failure."""
+    async def test_cancelled_returns_cancelled_no_failure(self):
         wrapper = _make_wrapper(circuit_failure_threshold=1)
         mock_crawler = _inject_mock_crawler(wrapper)
         mock_crawler.crawl_with_metadata = AsyncMock(side_effect=asyncio.CancelledError())
 
         result = await wrapper.crawl("https://example.com")
 
-        assert result.success is False
         assert result.error_type == "cancelled"
-        # Circuit should remain CLOSED -- cancellation is not a fault
-        assert wrapper._circuit.state == CircuitState.CLOSED
-        assert wrapper._circuit.failure_count == 0
+        # Host breaker may not even have been created since we returned early,
+        # but infra breaker definitely shouldn't trip.
+        assert wrapper._infra_breaker.state == CircuitState.CLOSED
 
     @pytest.mark.asyncio
-    async def test_dns_error(self):
-        """DNS resolution errors are classified as dns_error."""
+    async def test_dns_error_classifies_correctly(self):
         wrapper = _make_wrapper()
         mock_crawler = _inject_mock_crawler(wrapper)
         mock_crawler.crawl_with_metadata = AsyncMock(
@@ -165,12 +126,13 @@ class TestSafeCrawlerCrawl:
 
         result = await wrapper.crawl("https://bogus.invalid")
 
-        assert result.success is False
         assert result.error_type == "dns_error"
+        # DNS errors trip BOTH per-host AND infra breakers.
+        assert wrapper._host_breakers["bogus.invalid"].failure_count == 1
+        assert wrapper._infra_breaker.failure_count == 1
 
     @pytest.mark.asyncio
-    async def test_browser_closed_error_has_been_closed(self):
-        """'has been closed' browser errors are classified as browser_closed."""
+    async def test_browser_closed_classifies_correctly(self):
         wrapper = _make_wrapper()
         mock_crawler = _inject_mock_crawler(wrapper)
         mock_crawler.crawl_with_metadata = AsyncMock(
@@ -179,54 +141,26 @@ class TestSafeCrawlerCrawl:
 
         result = await wrapper.crawl("https://example.com")
 
-        assert result.success is False
         assert result.error_type == "browser_closed"
+        # browser_closed is infra → trips both.
+        assert wrapper._infra_breaker.failure_count == 1
 
     @pytest.mark.asyncio
-    async def test_browser_closed_error_target_page(self):
-        """'Target page' browser errors are classified as browser_closed."""
-        wrapper = _make_wrapper()
-        mock_crawler = _inject_mock_crawler(wrapper)
-        mock_crawler.crawl_with_metadata = AsyncMock(
-            side_effect=Exception("Target page, context or browser has been closed")
-        )
-
-        result = await wrapper.crawl("https://example.com")
-
-        assert result.success is False
-        assert result.error_type == "browser_closed"
-
-    @pytest.mark.asyncio
-    async def test_connection_refused_error(self):
-        """ERR_CONNECTION_REFUSED is classified as connection_refused."""
+    async def test_connection_refused_trips_infra(self):
         wrapper = _make_wrapper()
         mock_crawler = _inject_mock_crawler(wrapper)
         mock_crawler.crawl_with_metadata = AsyncMock(
             side_effect=Exception("net::ERR_CONNECTION_REFUSED")
         )
 
-        result = await wrapper.crawl("https://localhost:9999")
+        result = await wrapper.crawl("https://example.com")
 
-        assert result.success is False
         assert result.error_type == "connection_refused"
+        assert wrapper._infra_breaker.failure_count == 1
 
     @pytest.mark.asyncio
-    async def test_network_error_generic_net(self):
-        """Generic net:: errors are classified as network_error."""
-        wrapper = _make_wrapper()
-        mock_crawler = _inject_mock_crawler(wrapper)
-        mock_crawler.crawl_with_metadata = AsyncMock(
-            side_effect=Exception("net::ERR_CERT_AUTHORITY_INVALID")
-        )
-
-        result = await wrapper.crawl("https://self-signed.example.com")
-
-        assert result.success is False
-        assert result.error_type == "network_error"
-
-    @pytest.mark.asyncio
-    async def test_generic_crawl_error(self):
-        """Unclassified exceptions fall through to crawl_error."""
+    async def test_generic_crawl_error_host_only(self):
+        """Unclassified exceptions are host-scoped, not infra."""
         wrapper = _make_wrapper()
         mock_crawler = _inject_mock_crawler(wrapper)
         mock_crawler.crawl_with_metadata = AsyncMock(
@@ -235,66 +169,56 @@ class TestSafeCrawlerCrawl:
 
         result = await wrapper.crawl("https://example.com")
 
-        assert result.success is False
         assert result.error_type == "crawl_error"
-        assert "unexpected" in result.error.lower()
+        # Host breaker tripped, infra unchanged.
+        assert wrapper._host_breakers["example.com"].failure_count == 1
+        assert wrapper._infra_breaker.failure_count == 0
 
     @pytest.mark.asyncio
-    async def test_generic_crawl_error_truncates_long_message(self):
-        """Long error messages are truncated to 200 characters."""
+    async def test_long_error_message_truncated(self):
         wrapper = _make_wrapper()
         mock_crawler = _inject_mock_crawler(wrapper)
-        long_message = "X" * 500
-        mock_crawler.crawl_with_metadata = AsyncMock(
-            side_effect=RuntimeError(long_message)
-        )
+        mock_crawler.crawl_with_metadata = AsyncMock(side_effect=RuntimeError("X" * 500))
 
         result = await wrapper.crawl("https://example.com")
 
-        assert result.success is False
-        assert result.error_type == "crawl_error"
         assert len(result.error) == 200
 
     @pytest.mark.asyncio
     async def test_successful_crawl(self):
-        """Successful crawl returns CrawlResult with markdown and title."""
         wrapper = _make_wrapper()
         mock_crawler = _inject_mock_crawler(wrapper)
         mock_crawler.crawl_with_metadata = AsyncMock(
             return_value=CrawlOutput(
-                title="Example Page",
-                html="<p>Content</p>",
-                markdown="# Example Page\n\nContent",
+                title="Example", html="<p>X</p>", markdown="# Example\n\nContent",
+                status=200,
             )
         )
 
         result = await wrapper.crawl("https://example.com")
 
         assert result.success is True
-        assert result.title == "Example Page"
-        assert result.markdown == "# Example Page\n\nContent"
-        assert result.error is None
+        assert result.title == "Example"
         assert result.error_type is None
 
     @pytest.mark.asyncio
-    async def test_successful_crawl_records_success(self):
-        """Successful crawl resets failure count on the circuit breaker."""
+    async def test_successful_crawl_resets_host_failures(self):
         wrapper = _make_wrapper()
         mock_crawler = _inject_mock_crawler(wrapper)
         mock_crawler.crawl_with_metadata = AsyncMock(
-            return_value=CrawlOutput(title="OK", html="", markdown="Page content here")
+            return_value=CrawlOutput(title="OK", html="", markdown="real content here",
+                                     status=200)
         )
-
-        # Simulate some prior failures (not enough to open circuit)
-        wrapper._circuit.failure_count = 2
-
+        # First call to populate host_breaker.
         await wrapper.crawl("https://example.com")
-
-        assert wrapper._circuit.failure_count == 0
+        wrapper._host_breakers["example.com"].failure_count = 2
+        # Second call should reset.
+        await wrapper.crawl("https://example.com")
+        assert wrapper._host_breakers["example.com"].failure_count == 0
 
     @pytest.mark.asyncio
-    async def test_empty_content_returns_failure(self):
-        """Empty markdown from backend is treated as a failed crawl."""
+    async def test_empty_legacy_output_trips_host_only(self):
+        """Empty markdown without failure_kind (legacy path) trips host breaker."""
         wrapper = _make_wrapper()
         mock_crawler = _inject_mock_crawler(wrapper)
         mock_crawler.crawl_with_metadata = AsyncMock(
@@ -305,68 +229,30 @@ class TestSafeCrawlerCrawl:
 
         assert result.success is False
         assert result.error_type == "empty_content"
-        assert "empty content" in result.error.lower()
-
-    @pytest.mark.asyncio
-    async def test_empty_content_records_failure(self):
-        """Empty content counts as a circuit breaker failure, not success."""
-        wrapper = _make_wrapper()
-        mock_crawler = _inject_mock_crawler(wrapper)
-        mock_crawler.crawl_with_metadata = AsyncMock(
-            return_value=CrawlOutput(title="", html="", markdown="  ")
-        )
-
-        await wrapper.crawl("https://example.com")
-
-        assert wrapper._circuit.failure_count == 1
+        assert wrapper._host_breakers["example.com"].failure_count == 1
+        assert wrapper._infra_breaker.failure_count == 0
 
     @pytest.mark.asyncio
     async def test_queue_count_decremented_on_success(self):
-        """Queue count is properly decremented after a successful crawl."""
         wrapper = _make_wrapper()
         mock_crawler = _inject_mock_crawler(wrapper)
         mock_crawler.crawl_with_metadata = AsyncMock(
-            return_value=CrawlOutput(title="OK", html="", markdown="ok")
+            return_value=CrawlOutput(title="OK", html="", markdown="ok content here",
+                                     status=200)
         )
-
-        assert wrapper._queue_count == 0
         await wrapper.crawl("https://example.com")
         assert wrapper._queue_count == 0
 
     @pytest.mark.asyncio
     async def test_queue_count_decremented_on_error(self):
-        """Queue count is properly decremented even when crawl fails."""
         wrapper = _make_wrapper()
         mock_crawler = _inject_mock_crawler(wrapper)
-        mock_crawler.crawl_with_metadata = AsyncMock(
-            side_effect=RuntimeError("boom")
-        )
-
+        mock_crawler.crawl_with_metadata = AsyncMock(side_effect=RuntimeError("boom"))
         await wrapper.crawl("https://example.com")
         assert wrapper._queue_count == 0
 
     @pytest.mark.asyncio
-    async def test_semaphore_released_on_error(self):
-        """Semaphore slot is released after a crawl error so other requests can proceed."""
-        wrapper = _make_wrapper(max_concurrent=1)
-        mock_crawler = _inject_mock_crawler(wrapper)
-        mock_crawler.crawl_with_metadata = AsyncMock(
-            side_effect=RuntimeError("boom")
-        )
-
-        await wrapper.crawl("https://example.com")
-
-        # If semaphore was not released, a second crawl would block.
-        # Test that we can acquire it without timeout.
-        acquired = await asyncio.wait_for(
-            wrapper._semaphore.acquire(), timeout=0.1
-        )
-        assert acquired
-        wrapper._semaphore.release()
-
-    @pytest.mark.asyncio
     async def test_timeout_override(self):
-        """Explicit timeout parameter overrides default_timeout."""
         wrapper = _make_wrapper(default_timeout=30.0)
         mock_crawler = _inject_mock_crawler(wrapper)
 
@@ -377,214 +263,472 @@ class TestSafeCrawlerCrawl:
 
         result = await wrapper.crawl("https://example.com", timeout=0.05)
 
-        assert result.success is False
         assert result.error_type == "timeout"
-        # Error message should mention our custom timeout
         assert "0.05" in result.error
-
-    @pytest.mark.asyncio
-    async def test_connection_timeout_error(self):
-        """ERR_CONNECTION_TIMED_OUT is classified as connection_timeout."""
-        wrapper = _make_wrapper()
-        mock_crawler = _inject_mock_crawler(wrapper)
-        mock_crawler.crawl_with_metadata = AsyncMock(
-            side_effect=Exception("net::ERR_CONNECTION_TIMED_OUT")
-        )
-
-        result = await wrapper.crawl("https://slow.example.com")
-
-        assert result.success is False
-        assert result.error_type == "connection_timeout"
 
 
 # ---------------------------------------------------------------------------
-# Circuit breaker state transitions
+# Three-layer health: blocked-cache + per-host breaker + infra breaker
+# ---------------------------------------------------------------------------
+
+
+class TestThreeLayerHealth:
+    @pytest.mark.asyncio
+    async def test_one_block_does_not_cache_host(self):
+        """A single blocked response counts but doesn't cache — paywalled URL
+        on a mixed-access host (NYT homepage works, /article 401s) shouldn't
+        poison the whole host. _BLOCK_CACHE_THRESHOLD=2 consecutive blocks needed."""
+        wrapper = _make_wrapper()
+        mock_crawler = _inject_mock_crawler(wrapper)
+        mock_crawler.crawl_with_metadata = AsyncMock(
+            return_value=CrawlOutput(title="", html="", markdown="",
+                                     status=401, failure_kind="blocked")
+        )
+
+        result = await wrapper.crawl("https://nytimes.com/paywalled-article")
+
+        assert result.error_type == "blocked"
+        # Cache NOT populated yet.
+        assert "nytimes.com" not in wrapper._blocked_hosts
+        # Counter incremented.
+        assert wrapper._block_attempts.get("nytimes.com") == 1
+        # No breaker mutation.
+        assert wrapper._host_breakers["nytimes.com"].failure_count == 0
+        assert wrapper._infra_breaker.failure_count == 0
+
+    @pytest.mark.asyncio
+    async def test_two_consecutive_blocks_cache_host(self):
+        """After _BLOCK_CACHE_THRESHOLD consecutive blocks, host is cached."""
+        wrapper = _make_wrapper()
+        mock_crawler = _inject_mock_crawler(wrapper)
+        mock_crawler.crawl_with_metadata = AsyncMock(
+            return_value=CrawlOutput(title="", html="", markdown="",
+                                     status=401, failure_kind="blocked")
+        )
+
+        await wrapper.crawl("https://reuters.com/markets/p1")
+        await wrapper.crawl("https://reuters.com/markets/p2")
+
+        assert "reuters.com" in wrapper._blocked_hosts
+        # Counter reset after caching.
+        assert "reuters.com" not in wrapper._block_attempts
+        # Still no breaker mutation.
+        assert wrapper._host_breakers["reuters.com"].failure_count == 0
+        assert wrapper._infra_breaker.failure_count == 0
+
+    @pytest.mark.asyncio
+    async def test_block_attempts_reset_on_success(self):
+        """Success on a host clears the block-attempt counter — paywalled URL
+        followed by working homepage should not promote to host-cache."""
+        wrapper = _make_wrapper()
+        mock_crawler = _inject_mock_crawler(wrapper)
+
+        async def fake_crawl(url):
+            if "paywalled" in url:
+                return CrawlOutput(title="", html="", markdown="",
+                                   status=401, failure_kind="blocked")
+            return CrawlOutput(title="OK", html="", markdown="real content here",
+                               status=200)
+
+        mock_crawler.crawl_with_metadata = fake_crawl
+
+        await wrapper.crawl("https://nytimes.com/paywalled")
+        assert wrapper._block_attempts.get("nytimes.com") == 1
+        await wrapper.crawl("https://nytimes.com/")  # homepage works
+        assert "nytimes.com" not in wrapper._block_attempts
+        # Another blocked URL counts from 1, not 2.
+        await wrapper.crawl("https://nytimes.com/paywalled2")
+        assert wrapper._block_attempts.get("nytimes.com") == 1
+        assert "nytimes.com" not in wrapper._blocked_hosts
+
+    @pytest.mark.asyncio
+    async def test_blocked_cache_hit_skips_fetch(self):
+        """Repeat calls to a cached blocked host don't invoke the crawler at all."""
+        wrapper = _make_wrapper()
+        mock_crawler = _inject_mock_crawler(wrapper)
+        mock_crawler.crawl_with_metadata = AsyncMock(
+            return_value=CrawlOutput(title="", html="", markdown="",
+                                     status=401, failure_kind="blocked")
+        )
+
+        # Prime cache — needs two consecutive blocks now.
+        await wrapper.crawl("https://reuters.com/markets")
+        await wrapper.crawl("https://reuters.com/markets")
+        assert mock_crawler.crawl_with_metadata.await_count == 2
+        assert "reuters.com" in wrapper._blocked_hosts
+
+        # Third call should short-circuit.
+        result3 = await wrapper.crawl("https://reuters.com/some-other-page")
+
+        assert result3.error_type == "blocked"
+        # crawler not invoked again.
+        assert mock_crawler.crawl_with_metadata.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_blocked_cache_expiry_refetches(self):
+        wrapper = _make_wrapper()
+        mock_crawler = _inject_mock_crawler(wrapper)
+        mock_crawler.crawl_with_metadata = AsyncMock(
+            return_value=CrawlOutput(title="OK", html="", markdown="real content",
+                                     status=200)
+        )
+
+        # Manually plant an expired entry.
+        wrapper._blocked_hosts["reuters.com"] = time.time() - 1
+
+        result = await wrapper.crawl("https://reuters.com/foo")
+
+        assert result.success is True
+        assert "reuters.com" not in wrapper._blocked_hosts
+        assert mock_crawler.crawl_with_metadata.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_blocked_cache_lru_evicts_oldest(self):
+        from src.tools.crawler.safe_wrapper import _BLOCKED_LRU_CAP
+
+        wrapper = _make_wrapper()
+        # Populate cap entries.
+        for i in range(_BLOCKED_LRU_CAP):
+            wrapper._blocked_hosts[f"host{i}.example"] = time.time() + 900
+        # Add one more under the lock.
+        async with wrapper._lock:
+            wrapper._set_blocked_locked("newhost.example")
+
+        assert "host0.example" not in wrapper._blocked_hosts
+        assert "newhost.example" in wrapper._blocked_hosts
+        assert len(wrapper._blocked_hosts) == _BLOCKED_LRU_CAP
+
+    @pytest.mark.asyncio
+    async def test_per_host_breaker_isolation(self):
+        """Reuters host breaker open does not affect Wikipedia."""
+        wrapper = _make_wrapper(circuit_failure_threshold=1)
+        mock_crawler = _inject_mock_crawler(wrapper)
+
+        async def fake_crawl(url):
+            if "reuters" in url:
+                raise RuntimeError("boom")
+            return CrawlOutput(title="OK", html="", markdown="real content here", status=200)
+
+        mock_crawler.crawl_with_metadata = fake_crawl
+
+        # Reuters fails → host breaker opens.
+        await wrapper.crawl("https://reuters.com/foo")
+        assert wrapper._host_breakers["reuters.com"].state == CircuitState.OPEN
+        # Wikipedia should still succeed.
+        result = await wrapper.crawl("https://en.wikipedia.org/wiki/Reuters")
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_infra_breaker_only_trips_on_infra_kind(self):
+        """failure_kind='infra_error' trips both per-host and infra breakers."""
+        wrapper = _make_wrapper(circuit_failure_threshold=1)
+        mock_crawler = _inject_mock_crawler(wrapper)
+        mock_crawler.crawl_with_metadata = AsyncMock(
+            return_value=CrawlOutput(title="", html="", markdown="",
+                                     status=None, failure_kind="infra_error")
+        )
+
+        await wrapper.crawl("https://example.com")
+        assert wrapper._host_breakers["example.com"].state == CircuitState.OPEN
+        assert wrapper._infra_breaker.state == CircuitState.OPEN
+
+    @pytest.mark.asyncio
+    async def test_infra_breaker_open_blocks_all_hosts(self):
+        wrapper = _make_wrapper()
+        wrapper._infra_breaker.state = CircuitState.OPEN
+        wrapper._infra_breaker.last_failure_time = time.time()
+        mock_crawler = _inject_mock_crawler(wrapper)
+        mock_crawler.crawl_with_metadata = AsyncMock(
+            return_value=CrawlOutput(title="OK", html="", markdown="ok ok ok ok ok",
+                                     status=200)
+        )
+
+        result = await wrapper.crawl("https://wikipedia.org/wiki/Foo")
+
+        assert result.error_type == "circuit_open"
+        # Crawler should not have been invoked.
+        assert mock_crawler.crawl_with_metadata.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_per_host_breaker_recovery(self):
+        wrapper = _make_wrapper(
+            circuit_failure_threshold=1,
+            circuit_recovery_timeout=0.05,
+            circuit_success_threshold=1,
+        )
+        mock_crawler = _inject_mock_crawler(wrapper)
+
+        # First call: fail to open the breaker.
+        mock_crawler.crawl_with_metadata = AsyncMock(side_effect=RuntimeError("boom"))
+        await wrapper.crawl("https://example.com")
+        breaker = wrapper._host_breakers["example.com"]
+        assert breaker.state == CircuitState.OPEN
+
+        # Advance past recovery timeout.
+        breaker.last_failure_time = time.time() - 1.0
+
+        # Second call: succeed → breaker closes.
+        mock_crawler.crawl_with_metadata = AsyncMock(
+            return_value=CrawlOutput(title="OK", html="", markdown="recovered content here",
+                                     status=200)
+        )
+        result = await wrapper.crawl("https://example.com")
+        assert result.success is True
+        assert breaker.state == CircuitState.CLOSED
+
+    @pytest.mark.asyncio
+    async def test_rate_limited_kind_trips_host_only(self):
+        wrapper = _make_wrapper(circuit_failure_threshold=1)
+        mock_crawler = _inject_mock_crawler(wrapper)
+        mock_crawler.crawl_with_metadata = AsyncMock(
+            return_value=CrawlOutput(title="", html="", markdown="",
+                                     status=429, failure_kind="rate_limited")
+        )
+
+        result = await wrapper.crawl("https://example.com")
+
+        assert result.error_type == "rate_limited"
+        assert wrapper._host_breakers["example.com"].state == CircuitState.OPEN
+        assert wrapper._infra_breaker.state == CircuitState.CLOSED
+
+    @pytest.mark.asyncio
+    async def test_stealth_failed_kind_trips_host_only(self):
+        wrapper = _make_wrapper(circuit_failure_threshold=1)
+        mock_crawler = _inject_mock_crawler(wrapper)
+        mock_crawler.crawl_with_metadata = AsyncMock(
+            return_value=CrawlOutput(title="", html="", markdown="",
+                                     status=200, failure_kind="stealth_failed")
+        )
+
+        result = await wrapper.crawl("https://example.com")
+
+        assert result.error_type == "stealth_failed"
+        assert wrapper._host_breakers["example.com"].state == CircuitState.OPEN
+        assert wrapper._infra_breaker.state == CircuitState.CLOSED
+
+    @pytest.mark.asyncio
+    async def test_concurrent_host_breaker_creation_no_race(self):
+        """50 concurrent calls to same novel host create exactly one breaker."""
+        wrapper = _make_wrapper()
+        mock_crawler = _inject_mock_crawler(wrapper)
+        mock_crawler.crawl_with_metadata = AsyncMock(
+            return_value=CrawlOutput(title="OK", html="", markdown="content here ok ok",
+                                     status=200)
+        )
+
+        await asyncio.gather(*(
+            wrapper.crawl(f"https://example.com/page{i}") for i in range(50)
+        ))
+
+        # Only one breaker for example.com.
+        assert sum(1 for k in wrapper._host_breakers if k == "example.com") == 1
+        assert wrapper._host_breakers["example.com"].failure_count == 0
+
+    @pytest.mark.asyncio
+    async def test_host_breakers_lru_evicts_oldest(self):
+        """Parallel structure to blocked-cache LRU — host breaker dict is bounded."""
+        from src.tools.crawler.safe_wrapper import (
+            _HOST_BREAKERS_LRU_CAP,
+            CrawlerCircuitBreaker,
+        )
+
+        wrapper = _make_wrapper()
+        mock_crawler = _inject_mock_crawler(wrapper)
+        mock_crawler.crawl_with_metadata = AsyncMock(
+            return_value=CrawlOutput(title="OK", html="", markdown="ok ok ok ok ok",
+                                     status=200)
+        )
+        # Prefill at cap.
+        for i in range(_HOST_BREAKERS_LRU_CAP):
+            wrapper._host_breakers[f"host{i}.example"] = CrawlerCircuitBreaker()
+
+        # Crawl a novel host — should evict the oldest entry.
+        await wrapper.crawl("https://newhost.example/page")
+
+        assert "host0.example" not in wrapper._host_breakers
+        assert "newhost.example" in wrapper._host_breakers
+        assert len(wrapper._host_breakers) == _HOST_BREAKERS_LRU_CAP
+
+    @pytest.mark.asyncio
+    async def test_concurrent_blocked_does_not_poison_other_hosts(self):
+        """Regression for the production incident: 5 concurrent Reuters (blocked) +
+        1 concurrent Wikipedia (success). Reuters all return blocked, Wikipedia
+        succeeds, infra breaker stays closed, no cross-host poisoning."""
+        wrapper = _make_wrapper()
+        mock_crawler = _inject_mock_crawler(wrapper)
+
+        async def fake_crawl(url):
+            if "reuters" in url:
+                return CrawlOutput(title="", html="", markdown="",
+                                   status=401, failure_kind="blocked")
+            return CrawlOutput(title="Wiki", html="",
+                               markdown="real wikipedia content here ok",
+                               status=200)
+
+        mock_crawler.crawl_with_metadata = fake_crawl
+
+        coros = [wrapper.crawl(f"https://reuters.com/p{i}") for i in range(5)]
+        coros.append(wrapper.crawl("https://en.wikipedia.org/wiki/Reuters"))
+        results = await asyncio.gather(*coros)
+
+        reuters_results, wiki_result = results[:5], results[5]
+        # All Reuters blocked.
+        assert all(r.error_type == "blocked" for r in reuters_results)
+        # Wikipedia unaffected.
+        assert wiki_result.success is True
+        assert "wikipedia" in wiki_result.markdown.lower()
+        # Infra breaker uncontaminated.
+        assert wrapper._infra_breaker.failure_count == 0
+        assert wrapper._infra_breaker.state == CircuitState.CLOSED
+        # Reuters host breaker also untouched (blocks don't trip breakers).
+        assert wrapper._host_breakers["reuters.com"].failure_count == 0
+        # After 2+ blocks, reuters.com is cached.
+        assert "reuters.com" in wrapper._blocked_hosts
+
+
+# ---------------------------------------------------------------------------
+# Opportunistic reaper
+# ---------------------------------------------------------------------------
+
+
+class TestOpportunisticReaper:
+    @pytest.mark.asyncio
+    async def test_reap_throttled_to_one_per_interval(self):
+        """Multiple crawls within reap interval schedule reap exactly once."""
+        wrapper = _make_wrapper()
+        mock_crawler = _inject_mock_crawler(wrapper)
+        mock_crawler.crawl_with_metadata = AsyncMock(
+            return_value=CrawlOutput(title="OK", html="", markdown="ok " * 20, status=200)
+        )
+
+        reap_count = 0
+
+        async def fake_reap():
+            nonlocal reap_count
+            reap_count += 1
+
+        wrapper._trigger_browser_reset = fake_reap
+
+        # Fire 5 calls in quick succession.
+        await asyncio.gather(*(
+            wrapper.crawl(f"https://example.com/p{i}") for i in range(5)
+        ))
+        # Allow scheduled tasks to run.
+        await asyncio.sleep(0.02)
+
+        assert reap_count == 1
+
+    @pytest.mark.asyncio
+    async def test_reap_runs_again_after_interval(self):
+        from src.tools.crawler.safe_wrapper import _REAPER_INTERVAL_SECONDS
+
+        wrapper = _make_wrapper()
+        mock_crawler = _inject_mock_crawler(wrapper)
+        mock_crawler.crawl_with_metadata = AsyncMock(
+            return_value=CrawlOutput(title="OK", html="", markdown="content here ok",
+                                     status=200)
+        )
+
+        reap_count = 0
+
+        async def fake_reap():
+            nonlocal reap_count
+            reap_count += 1
+
+        wrapper._trigger_browser_reset = fake_reap
+
+        await wrapper.crawl("https://example.com/a")
+        await asyncio.sleep(0.02)
+        # Force interval to have elapsed.
+        wrapper._last_reap_time = time.time() - _REAPER_INTERVAL_SECONDS - 1
+        await wrapper.crawl("https://example.com/b")
+        await asyncio.sleep(0.02)
+
+        assert reap_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Caller-facing error string formatting
+# ---------------------------------------------------------------------------
+
+
+class TestErrorStringPrefix:
+    @pytest.mark.asyncio
+    async def test_blocked_error_string_helpful(self):
+        """Blocked CrawlResult.error tells the LLM not to retry."""
+        wrapper = _make_wrapper()
+        mock_crawler = _inject_mock_crawler(wrapper)
+        mock_crawler.crawl_with_metadata = AsyncMock(
+            return_value=CrawlOutput(title="", html="", markdown="",
+                                     status=401, failure_kind="blocked")
+        )
+
+        result = await wrapper.crawl("https://reuters.com/markets")
+
+        assert result.error_type == "blocked"
+        assert "blocks automated access" in result.error.lower()
+        assert "retrying will not help" in result.error.lower()
+
+
+# ---------------------------------------------------------------------------
+# Circuit breaker state transitions (unchanged class — kept tests verbatim)
 # ---------------------------------------------------------------------------
 
 
 class TestCircuitBreakerTransitions:
-    """Tests for CrawlerCircuitBreaker state machine transitions."""
-
     @pytest.mark.asyncio
     async def test_closed_to_open_after_threshold_failures(self):
-        """CLOSED -> OPEN after failure_threshold consecutive failures."""
         cb = CrawlerCircuitBreaker(failure_threshold=3, recovery_timeout=60.0)
-        assert cb.state == CircuitState.CLOSED
-
         for _ in range(3):
             await cb.record_failure()
-
         assert cb.state == CircuitState.OPEN
         assert cb.failure_count == 3
 
     @pytest.mark.asyncio
-    async def test_stays_closed_below_threshold(self):
-        """CLOSED stays CLOSED when failures are below threshold."""
-        cb = CrawlerCircuitBreaker(failure_threshold=5)
-
-        for _ in range(4):
-            await cb.record_failure()
-
-        assert cb.state == CircuitState.CLOSED
-
-    @pytest.mark.asyncio
     async def test_open_to_half_open_after_recovery_timeout(self):
-        """OPEN -> HALF_OPEN after recovery_timeout elapses."""
         cb = CrawlerCircuitBreaker(failure_threshold=1, recovery_timeout=0.05)
-
         await cb.record_failure()
-        assert cb.state == CircuitState.OPEN
-
-        # Simulate enough time passing
         cb.last_failure_time = time.time() - 1.0
-
         await cb.check_state()
         assert cb.state == CircuitState.HALF_OPEN
-        assert cb.success_count == 0
-
-    @pytest.mark.asyncio
-    async def test_open_stays_open_before_recovery_timeout(self):
-        """OPEN stays OPEN when recovery_timeout has not elapsed."""
-        cb = CrawlerCircuitBreaker(failure_threshold=1, recovery_timeout=60.0)
-
-        await cb.record_failure()
-        assert cb.state == CircuitState.OPEN
-
-        await cb.check_state()
-        assert cb.state == CircuitState.OPEN
 
     @pytest.mark.asyncio
     async def test_half_open_to_closed_after_success_threshold(self):
-        """HALF_OPEN -> CLOSED after success_threshold successes."""
         cb = CrawlerCircuitBreaker(
-            failure_threshold=1,
-            recovery_timeout=0.05,
-            success_threshold=2,
+            failure_threshold=1, recovery_timeout=0.05, success_threshold=2,
         )
-
-        # Move to HALF_OPEN
         await cb.record_failure()
         cb.last_failure_time = time.time() - 1.0
         await cb.check_state()
-        assert cb.state == CircuitState.HALF_OPEN
-
-        # First success: still half-open
         await cb.record_success()
         assert cb.state == CircuitState.HALF_OPEN
-        assert cb.success_count == 1
-
-        # Second success: close the circuit
         await cb.record_success()
         assert cb.state == CircuitState.CLOSED
-        assert cb.failure_count == 0
 
     @pytest.mark.asyncio
     async def test_half_open_to_open_on_failure(self):
-        """HALF_OPEN -> OPEN on any failure (re-opens with backoff)."""
         cb = CrawlerCircuitBreaker(
-            failure_threshold=1,
-            recovery_timeout=10.0,
-            success_threshold=2,
+            failure_threshold=1, recovery_timeout=10.0, success_threshold=2,
         )
-
-        # Move to HALF_OPEN
         cb.state = CircuitState.OPEN
         cb.last_failure_time = time.time() - 20.0
         await cb.check_state()
-        assert cb.state == CircuitState.HALF_OPEN
-
-        # Fail during half-open
         await cb.record_failure()
         assert cb.state == CircuitState.OPEN
         assert cb._consecutive_opens == 1
 
     @pytest.mark.asyncio
-    async def test_exponential_backoff_on_repeated_opens(self):
-        """Recovery timeout doubles each time circuit re-opens from HALF_OPEN."""
-        base_recovery = 10.0
+    async def test_exponential_backoff_capped(self):
         cb = CrawlerCircuitBreaker(
-            failure_threshold=1,
-            recovery_timeout=base_recovery,
-            success_threshold=2,
+            failure_threshold=1, recovery_timeout=500.0, success_threshold=2,
         )
-
-        # First open
-        await cb.record_failure()
-        assert cb.state == CircuitState.OPEN
-
-        # Transition to half-open, then fail again
-        cb.last_failure_time = time.time() - base_recovery - 1
-        await cb.check_state()
-        assert cb.state == CircuitState.HALF_OPEN
-        await cb.record_failure()
-        assert cb.state == CircuitState.OPEN
-        assert cb._consecutive_opens == 1
-        assert cb.recovery_timeout == base_recovery * 2  # 20s
-
-        # Another half-open -> failure cycle
-        cb.last_failure_time = time.time() - cb.recovery_timeout - 1
-        await cb.check_state()
-        assert cb.state == CircuitState.HALF_OPEN
-        await cb.record_failure()
-        assert cb._consecutive_opens == 2
-        assert cb.recovery_timeout == base_recovery * 4  # 40s
-
-    @pytest.mark.asyncio
-    async def test_recovery_timeout_capped_at_max(self):
-        """Recovery timeout is capped at _max_recovery_timeout (900s)."""
-        cb = CrawlerCircuitBreaker(
-            failure_threshold=1,
-            recovery_timeout=500.0,
-            success_threshold=2,
-        )
-        # Simulate many consecutive opens to exceed cap
         cb._consecutive_opens = 10
         cb.state = CircuitState.HALF_OPEN
-
         await cb.record_failure()
-
-        assert cb.recovery_timeout == 900.0  # capped
-
-    @pytest.mark.asyncio
-    async def test_successful_recovery_resets_consecutive_opens(self):
-        """Full recovery (HALF_OPEN -> CLOSED) resets consecutive_opens and recovery_timeout."""
-        base_recovery = 10.0
-        cb = CrawlerCircuitBreaker(
-            failure_threshold=1,
-            recovery_timeout=base_recovery,
-            success_threshold=1,
-        )
-
-        # Open, then half-open, then fail (backoff once)
-        await cb.record_failure()
-        cb.last_failure_time = time.time() - base_recovery - 1
-        await cb.check_state()
-        await cb.record_failure()
-        assert cb._consecutive_opens == 1
-        assert cb.recovery_timeout == base_recovery * 2
-
-        # Now recover
-        cb.last_failure_time = time.time() - cb.recovery_timeout - 1
-        await cb.check_state()
-        assert cb.state == CircuitState.HALF_OPEN
-        await cb.record_success()
-        assert cb.state == CircuitState.CLOSED
-        assert cb._consecutive_opens == 0
-        assert cb.recovery_timeout == base_recovery
-
-    @pytest.mark.asyncio
-    async def test_success_in_closed_state_resets_failures(self):
-        """record_success in CLOSED state resets failure_count."""
-        cb = CrawlerCircuitBreaker(failure_threshold=5)
-
-        cb.failure_count = 3
-        await cb.record_success()
-        assert cb.failure_count == 0
-        assert cb.state == CircuitState.CLOSED
+        assert cb.recovery_timeout == 900.0
 
     @pytest.mark.asyncio
     async def test_record_failure_triggers_reset_callback(self):
-        """When circuit opens, the trigger_reset callback is invoked."""
         cb = CrawlerCircuitBreaker(failure_threshold=1)
         reset_called = asyncio.Event()
 
@@ -592,45 +736,29 @@ class TestCircuitBreakerTransitions:
             reset_called.set()
 
         await cb.record_failure(trigger_reset=mock_reset)
-        assert cb.state == CircuitState.OPEN
-
-        # Allow the background task to run
         await asyncio.sleep(0.01)
         assert reset_called.is_set()
 
-    @pytest.mark.asyncio
-    async def test_record_failure_no_callback_when_not_opening(self):
-        """trigger_reset is NOT invoked when circuit does not transition to OPEN."""
-        cb = CrawlerCircuitBreaker(failure_threshold=5)
-        mock_reset = AsyncMock()
-
-        await cb.record_failure(trigger_reset=mock_reset)
-        assert cb.state == CircuitState.CLOSED
-        mock_reset.assert_not_awaited()
-
 
 # ---------------------------------------------------------------------------
-# _build_configured_wrapper()
+# _build_configured_wrapper
 # ---------------------------------------------------------------------------
 
 
 class TestBuildConfiguredWrapper:
-    """Tests for _build_configured_wrapper factory function."""
-
-    def test_happy_path_with_mock_config(self):
-        """Builds wrapper with values from tool_settings helpers."""
+    def test_happy_path(self):
         with patch(
-            "src.config.tool_settings.get_crawler_max_concurrent",
-            return_value=8,
+            "src.config.tool_settings.get_crawler_http_concurrency",
+            return_value=12,
+        ), patch(
+            "src.config.tool_settings.get_crawler_browser_concurrency",
+            return_value=4,
         ), patch(
             "src.config.tool_settings.get_crawler_page_timeout",
-            return_value=30000,  # ms
+            return_value=30000,
         ), patch(
             "src.config.tool_settings.get_crawler_queue_max_size",
             return_value=50,
-        ), patch(
-            "src.config.tool_settings.get_crawler_queue_slot_timeout",
-            return_value=5.0,
         ), patch(
             "src.config.tool_settings.get_crawler_circuit_failure_threshold",
             return_value=4,
@@ -647,48 +775,19 @@ class TestBuildConfiguredWrapper:
             wrapper = _build_configured_wrapper()
 
         assert wrapper._max_queue == 50
-        assert wrapper._default_timeout == 30.0  # 30000ms -> 30s
-        assert wrapper._slot_timeout == 5.0
-        assert wrapper._circuit.failure_threshold == 4
-        assert wrapper._circuit.recovery_timeout == 120.0
-        assert wrapper._circuit.success_threshold == 3
+        assert wrapper._default_timeout == 30.0
+        assert wrapper._http_concurrency == 12
+        assert wrapper._browser_concurrency == 4
+        assert wrapper._infra_breaker.failure_threshold == 4
         assert wrapper._backend == "scrapling"
 
     def test_fallback_on_import_error(self):
-        """When config imports fail, returns wrapper with defaults."""
-        with patch(
-            "src.tools.crawler.safe_wrapper._build_configured_wrapper",
-        ) as mock_build:
-            # Test the real function, not the mock -- we want to trigger the except branch
-            pass
-
-        # Directly test: make the import inside _build_configured_wrapper raise
-        with patch.dict(
-            "sys.modules",
-            {"src.config.tool_settings": None},
-        ):
+        with patch.dict("sys.modules", {"src.config.tool_settings": None}):
             wrapper = _build_configured_wrapper()
-
-        # Should be the default values
         assert wrapper._max_queue == 100
         assert wrapper._default_timeout == 60.0
-        assert wrapper._slot_timeout == 10.0
-        assert wrapper._circuit.failure_threshold == 5
-        assert wrapper._circuit.recovery_timeout == 60.0
-        assert wrapper._circuit.success_threshold == 2
-        assert wrapper._backend == "scrapling"
-
-    def test_fallback_on_generic_exception(self):
-        """When a config getter raises, returns wrapper with defaults."""
-        with patch(
-            "src.config.tool_settings.get_crawler_max_concurrent",
-            side_effect=RuntimeError("config broken"),
-        ):
-            wrapper = _build_configured_wrapper()
-
-        assert wrapper._max_queue == 100
-        assert wrapper._default_timeout == 60.0
-        assert wrapper._backend == "scrapling"
+        assert wrapper._http_concurrency == 20
+        assert wrapper._browser_concurrency == 6
 
 
 # ---------------------------------------------------------------------------
@@ -697,30 +796,28 @@ class TestBuildConfiguredWrapper:
 
 
 class TestWrapperStatus:
-    """Tests for get_status() and is_healthy() helper methods."""
-
     def test_get_status_initial(self):
         wrapper = _make_wrapper()
         status = wrapper.get_status()
-
-        assert status["circuit_state"] == "closed"
-        assert status["failure_count"] == 0
-        assert status["success_count"] == 0
-        assert status["consecutive_opens"] == 0
+        assert status["infra_circuit_state"] == "closed"
+        assert status["infra_failure_count"] == 0
+        assert status["host_breaker_count"] == 0
+        assert status["blocked_host_count"] == 0
         assert status["queue_count"] == 0
         assert status["max_queue"] == 10
-        assert status["last_failure_time"] is None
 
-    def test_is_healthy_when_closed(self):
+    def test_is_healthy_when_infra_closed(self):
         wrapper = _make_wrapper()
         assert wrapper.is_healthy() is True
 
-    def test_is_healthy_when_open(self):
+    def test_is_healthy_when_infra_open(self):
         wrapper = _make_wrapper()
-        wrapper._circuit.state = CircuitState.OPEN
+        wrapper._infra_breaker.state = CircuitState.OPEN
         assert wrapper.is_healthy() is False
 
-    def test_is_healthy_when_half_open(self):
+    def test_is_healthy_indifferent_to_host_breakers(self):
+        """Per-host breaker open is not 'unhealthy' — that's expected operation."""
         wrapper = _make_wrapper()
-        wrapper._circuit.state = CircuitState.HALF_OPEN
+        wrapper._host_breakers["reuters.com"] = CrawlerCircuitBreaker()
+        wrapper._host_breakers["reuters.com"].state = CircuitState.OPEN
         assert wrapper.is_healthy() is True

--- a/tests/unit/tools/crawler/test_scrapling_crawler.py
+++ b/tests/unit/tools/crawler/test_scrapling_crawler.py
@@ -1,6 +1,8 @@
-"""Unit tests for Scrapling crawler backend."""
+"""Unit tests for Scrapling crawler backend with tier classification."""
 
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import asyncio
 
 import pytest
 
@@ -8,9 +10,9 @@ from src.tools.crawler.backend import CrawlOutput
 from src.tools.crawler.scrapling_crawler import (
     ScraplingCrawler,
     _extract_title,
+    _html_to_markdown,
     _needs_browser,
     _needs_stealth,
-    _html_to_markdown,
 )
 
 
@@ -35,10 +37,6 @@ class TestNeedsBrowser:
         html = "<html><body>Just a moment... Checking your browser</body></html>" + "x" * 200
         assert _needs_browser(html, 200) is True
 
-    def test_enable_javascript_signal(self):
-        html = "<html><body>Please enable JavaScript to continue" + "x" * 200 + "</body></html>"
-        assert _needs_browser(html, 200) is True
-
     def test_normal_page(self):
         html = "<html><body>" + "<p>Real content here.</p>" * 20 + "</body></html>"
         assert _needs_browser(html, 200) is False
@@ -49,259 +47,375 @@ class TestNeedsBrowser:
 
 
 class TestNeedsStealth:
-    """Tests for Tier 2 -> Tier 3 escalation detection."""
+    """Tests for Tier 2 -> Tier 3 escalation. Returns 'cloudflare' / 'blocked' / None."""
 
-    def test_403_status(self):
-        assert _needs_stealth("<html>Blocked</html>", 403) is True
+    def test_403_returns_blocked(self):
+        # 403 with no CF signals → bare bot block.
+        assert _needs_stealth("<html>Blocked</html>", 403) == "blocked"
+
+    def test_401_returns_blocked(self):
+        assert _needs_stealth("<html>Unauthorized</html>", 401) == "blocked"
 
     def test_cloudflare_with_ray_id(self):
         html = "<html>Cloudflare challenge Ray ID: abc123</html>"
-        assert _needs_stealth(html, 200) is True
+        assert _needs_stealth(html, 200) == "cloudflare"
 
     def test_cloudflare_just_a_moment(self):
         html = "<html>Cloudflare Just a moment...</html>"
-        assert _needs_stealth(html, 200) is True
+        assert _needs_stealth(html, 200) == "cloudflare"
 
-    def test_normal_page(self):
+    def test_403_with_cloudflare_signals_returns_cloudflare(self):
+        # CF signals win over plain status — solver might help.
+        html = "<html>Cloudflare Just a moment... Ray ID: foo</html>"
+        assert _needs_stealth(html, 403) == "cloudflare"
+
+    def test_normal_page_returns_none(self):
         html = "<html><body>Normal page content</body></html>"
-        assert _needs_stealth(html, 200) is False
+        assert _needs_stealth(html, 200) is None
 
-    def test_cloudflare_without_ray_id(self):
-        # Cloudflare mention without ray id or just a moment is not stealth-needed
+    def test_cloudflare_without_challenge_returns_none(self):
+        # Cloudflare-hosted but not a challenge page.
         html = "<html>Powered by Cloudflare</html>"
-        assert _needs_stealth(html, 200) is False
+        assert _needs_stealth(html, 200) is None
 
-    def test_401_status(self):
-        assert _needs_stealth("<html>Unauthorized</html>", 401) is True
-
-    def test_datadome_challenge(self):
-        # DataDome anti-bot: short page with "enable JS" message
+    def test_datadome_challenge_returns_cloudflare(self):
+        # Generic JS challenge classified as cloudflare so solver runs.
         html = '<html><body><p>Please enable JS and disable any ad blocker</p></body></html>'
-        assert _needs_stealth(html, 200) is True
+        assert _needs_stealth(html, 200) == "cloudflare"
 
     def test_enable_js_on_large_page_not_stealth(self):
-        # A large page that discusses "enable javascript" is not a challenge
+        # Large page that mentions enable-javascript is not a challenge.
         html = "<html><body>" + "x" * 3000 + "enable javascript" + "</body></html>"
-        assert _needs_stealth(html, 200) is False
+        assert _needs_stealth(html, 200) is None
 
 
 class TestHtmlToMarkdown:
-    """Tests for HTML to markdown conversion."""
-
     def test_basic_conversion(self):
-        html = "<h1>Title</h1><p>Paragraph text.</p>"
-        md = _html_to_markdown(html)
+        md = _html_to_markdown("<h1>Title</h1><p>Paragraph text.</p>")
         assert "Title" in md
         assert "Paragraph text." in md
 
     def test_links_preserved(self):
-        html = '<a href="https://example.com">Link</a>'
-        md = _html_to_markdown(html)
+        md = _html_to_markdown('<a href="https://example.com">Link</a>')
         assert "https://example.com" in md
         assert "Link" in md
 
     def test_empty_html(self):
-        md = _html_to_markdown("")
-        assert md.strip() == ""
+        assert _html_to_markdown("").strip() == ""
 
 
 class TestCrawlOutput:
-    """Tests for CrawlOutput dataclass."""
-
     def test_create(self):
         output = CrawlOutput(title="Test", html="<p>Hi</p>", markdown="Hi")
         assert output.title == "Test"
-        assert output.html == "<p>Hi</p>"
-        assert output.markdown == "Hi"
+        assert output.status is None
+        assert output.failure_kind is None
+
+    def test_with_failure_kind(self):
+        output = CrawlOutput(
+            title="", html="", markdown="", status=401, failure_kind="blocked"
+        )
+        assert output.failure_kind == "blocked"
+        assert output.status == 401
 
 
 # ---------------------------------------------------------------------------
 # Helpers for tier dispatch tests
 # ---------------------------------------------------------------------------
 
+
 def _make_page_mock(title_text: str = "Test Page"):
-    """Create a mock Scrapling page object with .css() for title extraction."""
     title_node = MagicMock()
     title_node.get.return_value = title_text
-
     page = MagicMock()
     page.css.return_value = title_node
     return page
 
 
 _GOOD_HTML = "<html><head><title>Test Page</title></head><body>" + "<p>Content</p>" * 20 + "</body></html>"
-_BLOCKED_HTML = "<html><body>Just a moment... Checking your browser Cloudflare Ray ID: abc</body></html>"
+_BLOCKED_HTML_LIGHT = "<html><body>Just a moment... Cloudflare Ray ID: abc</body></html>"
 _STEALTH_HTML = "<html><body>Cloudflare challenge Ray ID: xyz Just a moment</body></html>"
+_BARE_401_HTML = "<html><body>401 Unauthorized</body></html>"
 
 
-class TestCrawlWithMetadataTiers:
-    """Tests for the three-tier fallback dispatch in crawl_with_metadata()."""
+class TestTierDispatch:
+    """Tier 1 → Tier 2 → Tier 3 escalation paths."""
 
     @pytest.mark.asyncio
     async def test_tier1_succeeds(self):
-        """Tier 1 returns good content -> returns immediately, Tier 2/3 never called."""
         crawler = ScraplingCrawler()
         page = _make_page_mock("Tier1 Title")
 
         with (
-            patch.object(crawler, "_tier1_fetch", new_callable=AsyncMock, return_value=(page, _GOOD_HTML, 200)) as t1,
+            patch.object(crawler, "_tier1_fetch", new_callable=AsyncMock, return_value=(page, _GOOD_HTML, 200)),
             patch.object(crawler, "_tier2_fetch", new_callable=AsyncMock) as t2,
             patch.object(crawler, "_tier3_fetch", new_callable=AsyncMock) as t3,
         ):
             result = await crawler.crawl_with_metadata("https://example.com")
 
-        t1.assert_awaited_once()
         t2.assert_not_awaited()
         t3.assert_not_awaited()
         assert result.title == "Tier1 Title"
-        assert result.html == _GOOD_HTML
-        assert "Content" in result.markdown
+        assert result.status == 200
+        assert result.failure_kind is None
+
+    @pytest.mark.asyncio
+    async def test_tier1_401_skips_browsers(self):
+        """Hard block at Tier 1 → return blocked immediately. No browser spawn."""
+        crawler = ScraplingCrawler()
+        page = _make_page_mock()
+
+        with (
+            patch.object(crawler, "_tier1_fetch", new_callable=AsyncMock, return_value=(page, _BARE_401_HTML, 401)),
+            patch.object(crawler, "_tier2_fetch", new_callable=AsyncMock) as t2,
+            patch.object(crawler, "_tier3_fetch", new_callable=AsyncMock) as t3,
+        ):
+            result = await crawler.crawl_with_metadata("https://reuters.com/markets")
+
+        t2.assert_not_awaited()
+        t3.assert_not_awaited()
+        assert result.failure_kind == "blocked"
+        assert result.status == 401
+        assert result.markdown == ""
+
+    @pytest.mark.asyncio
+    async def test_tier1_451_skips_browsers(self):
+        """Legal block (451) is also terminal at Tier 1."""
+        crawler = ScraplingCrawler()
+        page = _make_page_mock()
+
+        with (
+            patch.object(crawler, "_tier1_fetch", new_callable=AsyncMock, return_value=(page, "Unavailable for legal reasons", 451)),
+            patch.object(crawler, "_tier2_fetch", new_callable=AsyncMock) as t2,
+            patch.object(crawler, "_tier3_fetch", new_callable=AsyncMock) as t3,
+        ):
+            result = await crawler.crawl_with_metadata("https://example.com")
+
+        t2.assert_not_awaited()
+        t3.assert_not_awaited()
+        assert result.failure_kind == "blocked"
+        assert result.status == 451
+
+    @pytest.mark.asyncio
+    async def test_tier1_403_still_escalates(self):
+        """403 is ambiguous — still try Tier 2 (some CF configs accept browsers)."""
+        crawler = ScraplingCrawler()
+        page_t1 = _make_page_mock()
+        page_t2 = _make_page_mock("Tier2 Title")
+
+        with (
+            patch.object(crawler, "_tier1_fetch", new_callable=AsyncMock, return_value=(page_t1, "Forbidden", 403)),
+            patch.object(crawler, "_tier2_fetch", new_callable=AsyncMock, return_value=(page_t2, _GOOD_HTML, 200)) as t2,
+            patch.object(crawler, "_tier3_fetch", new_callable=AsyncMock) as t3,
+        ):
+            result = await crawler.crawl_with_metadata("https://example.com")
+
+        t2.assert_awaited_once()
+        t3.assert_not_awaited()
+        assert result.status == 200
+        assert result.failure_kind is None
+
+    @pytest.mark.asyncio
+    async def test_tier1_429_returns_rate_limited(self):
+        crawler = ScraplingCrawler()
+        page = _make_page_mock()
+
+        with (
+            patch.object(crawler, "_tier1_fetch", new_callable=AsyncMock, return_value=(page, "Too Many Requests", 429)),
+            patch.object(crawler, "_tier2_fetch", new_callable=AsyncMock) as t2,
+            patch.object(crawler, "_tier3_fetch", new_callable=AsyncMock) as t3,
+        ):
+            result = await crawler.crawl_with_metadata("https://example.com")
+
+        t2.assert_not_awaited()
+        t3.assert_not_awaited()
+        assert result.failure_kind == "rate_limited"
+        assert result.status == 429
 
     @pytest.mark.asyncio
     async def test_tier1_insufficient_escalates_to_tier2(self):
-        """Tier 1 returns blocked content -> escalates to Tier 2 which succeeds."""
         crawler = ScraplingCrawler()
         page_t1 = _make_page_mock()
         page_t2 = _make_page_mock("Tier2 Title")
 
         with (
-            patch.object(crawler, "_tier1_fetch", new_callable=AsyncMock, return_value=(page_t1, _BLOCKED_HTML, 200)),
-            patch.object(crawler, "_tier2_fetch", new_callable=AsyncMock, return_value=(page_t2, _GOOD_HTML, 200)) as t2,
+            patch.object(crawler, "_tier1_fetch", new_callable=AsyncMock, return_value=(page_t1, _BLOCKED_HTML_LIGHT, 200)),
+            patch.object(crawler, "_tier2_fetch", new_callable=AsyncMock, return_value=(page_t2, _GOOD_HTML, 200)),
             patch.object(crawler, "_tier3_fetch", new_callable=AsyncMock) as t3,
         ):
             result = await crawler.crawl_with_metadata("https://example.com")
 
-        t2.assert_awaited_once()
         t3.assert_not_awaited()
         assert result.title == "Tier2 Title"
-        assert "Content" in result.markdown
+        assert result.status == 200
 
     @pytest.mark.asyncio
     async def test_tier1_import_error_skips_to_tier2(self):
-        """Tier 1 raises ImportError (curl_cffi missing) -> skips to Tier 2."""
         crawler = ScraplingCrawler()
         page_t2 = _make_page_mock("Tier2 Title")
 
         with (
-            patch.object(crawler, "_tier1_fetch", new_callable=AsyncMock, side_effect=ImportError("No module named 'curl_cffi'")),
-            patch.object(crawler, "_tier2_fetch", new_callable=AsyncMock, return_value=(page_t2, _GOOD_HTML, 200)) as t2,
+            patch.object(crawler, "_tier1_fetch", new_callable=AsyncMock, side_effect=ImportError("No module")),
+            patch.object(crawler, "_tier2_fetch", new_callable=AsyncMock, return_value=(page_t2, _GOOD_HTML, 200)),
             patch.object(crawler, "_tier3_fetch", new_callable=AsyncMock) as t3,
         ):
             result = await crawler.crawl_with_metadata("https://example.com")
 
-        t2.assert_awaited_once()
         t3.assert_not_awaited()
         assert result.title == "Tier2 Title"
 
-    @pytest.mark.asyncio
-    async def test_tier1_general_exception_escalates_to_tier2(self):
-        """Tier 1 raises a general exception -> escalates to Tier 2."""
-        crawler = ScraplingCrawler()
-        page_t2 = _make_page_mock("Tier2 Title")
 
-        with (
-            patch.object(crawler, "_tier1_fetch", new_callable=AsyncMock, side_effect=RuntimeError("connection timeout")),
-            patch.object(crawler, "_tier2_fetch", new_callable=AsyncMock, return_value=(page_t2, _GOOD_HTML, 200)) as t2,
-            patch.object(crawler, "_tier3_fetch", new_callable=AsyncMock) as t3,
-        ):
-            result = await crawler.crawl_with_metadata("https://example.com")
-
-        t2.assert_awaited_once()
-        t3.assert_not_awaited()
-        assert result.title == "Tier2 Title"
+class TestSolveCloudflareDecision:
+    """Whether Tier 3 invokes scrapling's CF solver depends on Tier 2's reason."""
 
     @pytest.mark.asyncio
-    async def test_tier2_blocked_escalates_to_tier3(self):
-        """Tier 2 returns stealth-blocked content -> escalates to Tier 3 which succeeds."""
+    async def test_cf_reason_invokes_solver(self):
         crawler = ScraplingCrawler()
         page_t1 = _make_page_mock()
         page_t2 = _make_page_mock()
-        page_t3 = _make_page_mock("Tier3 Title")
+        page_t3 = _make_page_mock("Done")
 
         with (
-            patch.object(crawler, "_tier1_fetch", new_callable=AsyncMock, return_value=(page_t1, _BLOCKED_HTML, 200)),
+            patch.object(crawler, "_tier1_fetch", new_callable=AsyncMock, return_value=(page_t1, _BLOCKED_HTML_LIGHT, 200)),
             patch.object(crawler, "_tier2_fetch", new_callable=AsyncMock, return_value=(page_t2, _STEALTH_HTML, 200)),
             patch.object(crawler, "_tier3_fetch", new_callable=AsyncMock, return_value=(page_t3, _GOOD_HTML, 200)) as t3,
         ):
-            result = await crawler.crawl_with_metadata("https://example.com")
+            await crawler.crawl_with_metadata("https://example.com")
 
+        # Tier 3 should be called with solve_cloudflare=True because Tier 2 saw a CF challenge.
         t3.assert_awaited_once()
-        assert result.title == "Tier3 Title"
-        assert "Content" in result.markdown
+        call_kwargs = t3.await_args.kwargs
+        assert call_kwargs.get("solve_cloudflare") is True
 
     @pytest.mark.asyncio
-    async def test_tier2_exception_escalates_to_tier3(self):
-        """Tier 2 raises an exception -> escalates to Tier 3."""
+    async def test_blocked_reason_disables_solver(self):
+        """Tier 2 returns bare 401 — Tier 3 should skip the CF solver."""
         crawler = ScraplingCrawler()
-        page_t3 = _make_page_mock("Tier3 Title")
+        page_t1 = _make_page_mock()
+        page_t2 = _make_page_mock()
+        page_t3 = _make_page_mock("Done")
 
         with (
-            patch.object(crawler, "_tier1_fetch", new_callable=AsyncMock, side_effect=RuntimeError("t1 fail")),
-            patch.object(crawler, "_tier2_fetch", new_callable=AsyncMock, side_effect=RuntimeError("playwright crash")),
+            patch.object(crawler, "_tier1_fetch", new_callable=AsyncMock, return_value=(page_t1, _BLOCKED_HTML_LIGHT, 200)),
+            patch.object(crawler, "_tier2_fetch", new_callable=AsyncMock, return_value=(page_t2, _BARE_401_HTML, 401)),
             patch.object(crawler, "_tier3_fetch", new_callable=AsyncMock, return_value=(page_t3, _GOOD_HTML, 200)) as t3,
+        ):
+            await crawler.crawl_with_metadata("https://example.com")
+
+        t3.assert_awaited_once()
+        call_kwargs = t3.await_args.kwargs
+        assert call_kwargs.get("solve_cloudflare") is False
+
+
+class TestTier3Outcomes:
+    @pytest.mark.asyncio
+    async def test_tier3_still_blocked_sets_failure_kind(self):
+        crawler = ScraplingCrawler()
+        page = _make_page_mock()
+
+        with (
+            patch.object(crawler, "_tier1_fetch", new_callable=AsyncMock, return_value=(page, _BLOCKED_HTML_LIGHT, 200)),
+            patch.object(crawler, "_tier2_fetch", new_callable=AsyncMock, return_value=(page, _BARE_401_HTML, 401)),
+            patch.object(crawler, "_tier3_fetch", new_callable=AsyncMock, return_value=(page, _BARE_401_HTML, 401)),
         ):
             result = await crawler.crawl_with_metadata("https://example.com")
 
-        t3.assert_awaited_once()
-        assert result.title == "Tier3 Title"
+        assert result.failure_kind == "blocked"
+        assert result.status == 401
 
     @pytest.mark.asyncio
-    async def test_all_tiers_fail_returns_empty(self):
-        """All three tiers raise exceptions -> returns empty CrawlOutput."""
+    async def test_tier3_still_cloudflare_sets_stealth_failed(self):
+        crawler = ScraplingCrawler()
+        page = _make_page_mock()
+
+        with (
+            patch.object(crawler, "_tier1_fetch", new_callable=AsyncMock, return_value=(page, _BLOCKED_HTML_LIGHT, 200)),
+            patch.object(crawler, "_tier2_fetch", new_callable=AsyncMock, return_value=(page, _STEALTH_HTML, 200)),
+            patch.object(crawler, "_tier3_fetch", new_callable=AsyncMock, return_value=(page, _STEALTH_HTML, 200)),
+        ):
+            result = await crawler.crawl_with_metadata("https://example.com")
+
+        assert result.failure_kind == "stealth_failed"
+
+    @pytest.mark.asyncio
+    async def test_all_tiers_fail_propagates_exception(self):
+        """Tier-3 exception now re-raises so the wrapper's _classify_exception
+        can distinguish DNS/connection failures (host-only) from genuine infra
+        failures (browser_closed → trips global infra breaker). Crawler-level
+        blanket 'infra_error' was the bug that re-created host-isolation gaps."""
         crawler = ScraplingCrawler()
 
         with (
             patch.object(crawler, "_tier1_fetch", new_callable=AsyncMock, side_effect=RuntimeError("t1")),
             patch.object(crawler, "_tier2_fetch", new_callable=AsyncMock, side_effect=RuntimeError("t2")),
-            patch.object(crawler, "_tier3_fetch", new_callable=AsyncMock, side_effect=RuntimeError("t3")),
+            patch.object(crawler, "_tier3_fetch", new_callable=AsyncMock,
+                         side_effect=RuntimeError("net::ERR_NAME_NOT_RESOLVED at example.com")),
         ):
-            result = await crawler.crawl_with_metadata("https://example.com")
+            with pytest.raises(RuntimeError, match="ERR_NAME_NOT_RESOLVED"):
+                await crawler.crawl_with_metadata("https://example.com")
 
-        assert result.title == ""
-        assert result.html == ""
-        assert result.markdown == ""
+
+class TestStageSemaphores:
+    """The Tier-1 semaphore must be released before any browser-tier wait."""
 
     @pytest.mark.asyncio
-    async def test_tier3_still_blocked_returns_empty(self):
-        """Tier 3 returns stealth-blocked content -> returns empty CrawlOutput."""
-        crawler = ScraplingCrawler()
+    async def test_browser_sem_does_not_block_tier1(self):
+        """Saturating the browser semaphore must not block Tier-1 calls."""
+        crawler = ScraplingCrawler(http_concurrency=4, browser_concurrency=2)
+
+        # Acquire all browser slots so Tier 2/3 would block.
+        await crawler._browser_sem.acquire()
+        await crawler._browser_sem.acquire()
+        assert crawler._browser_sem._value == 0
+
+        # Tier 1 should still proceed normally.
+        page = _make_page_mock("OK")
+        with patch.object(
+            crawler, "_tier1_fetch", new_callable=AsyncMock,
+            return_value=(page, _GOOD_HTML, 200),
+        ):
+            result = await asyncio.wait_for(
+                crawler.crawl_with_metadata("https://example.com"), timeout=1.0
+            )
+
+        assert result.failure_kind is None
+
+        # Cleanup.
+        crawler._browser_sem.release()
+        crawler._browser_sem.release()
+
+    @pytest.mark.asyncio
+    async def test_http_sem_released_during_browser_wait(self):
+        """Tier-1 returning insufficient must release http_sem before Tier-2 acquires browser_sem."""
+        crawler = ScraplingCrawler(http_concurrency=1, browser_concurrency=1)
         page_t1 = _make_page_mock()
-        page_t2 = _make_page_mock()
-        page_t3 = _make_page_mock()
+        page_t2 = _make_page_mock("Tier2")
+
+        async def slow_t2(url):
+            # If http_sem were still held, this concurrent Tier-1 call would deadlock.
+            return (page_t2, _GOOD_HTML, 200)
 
         with (
-            patch.object(crawler, "_tier1_fetch", new_callable=AsyncMock, return_value=(page_t1, _BLOCKED_HTML, 200)),
-            patch.object(crawler, "_tier2_fetch", new_callable=AsyncMock, return_value=(page_t2, _STEALTH_HTML, 200)),
-            patch.object(crawler, "_tier3_fetch", new_callable=AsyncMock, return_value=(page_t3, _STEALTH_HTML, 403)),
+            patch.object(crawler, "_tier1_fetch", new_callable=AsyncMock,
+                         return_value=(page_t1, _BLOCKED_HTML_LIGHT, 200)),
+            patch.object(crawler, "_tier2_fetch", side_effect=slow_t2),
+            patch.object(crawler, "_tier3_fetch", new_callable=AsyncMock),
         ):
-            result = await crawler.crawl_with_metadata("https://example.com")
+            result = await asyncio.wait_for(
+                crawler.crawl_with_metadata("https://example.com"), timeout=1.0
+            )
 
-        assert result.title == ""
-        assert result.html == ""
-        assert result.markdown == ""
-
-    @pytest.mark.asyncio
-    async def test_crawl_delegates_to_crawl_with_metadata(self):
-        """crawl() delegates to crawl_with_metadata and returns .markdown."""
-        crawler = ScraplingCrawler()
-        expected_output = CrawlOutput(title="Title", html="<p>Hi</p>", markdown="Hi there")
-
-        with patch.object(crawler, "crawl_with_metadata", new_callable=AsyncMock, return_value=expected_output) as mock_cwm:
-            result = await crawler.crawl("https://example.com")
-
-        mock_cwm.assert_awaited_once_with("https://example.com")
-        assert result == "Hi there"
+        # http_sem fully released before Tier 2 ran.
+        assert crawler._http_sem._value == 1
+        assert result.title == "Tier2"
 
 
 class TestExtractTitle:
-    """Tests for _extract_title helper."""
-
     def test_with_title_element(self):
         page = _make_page_mock("My Page Title")
         assert _extract_title(page) == "My Page Title"
 
     def test_without_title_element(self):
-        """css() returns a node whose .get() is None -> empty string."""
         title_node = MagicMock()
         title_node.get.return_value = None
         page = MagicMock()
@@ -309,7 +423,6 @@ class TestExtractTitle:
         assert _extract_title(page) == ""
 
     def test_exception_returns_empty(self):
-        """Any exception in css() -> returns empty string."""
         page = MagicMock()
-        page.css.side_effect = AttributeError("no css method")
+        page.css.side_effect = AttributeError("no css")
         assert _extract_title(page) == ""

--- a/tests/unit/tools/crawler/test_scrapling_crawler.py
+++ b/tests/unit/tools/crawler/test_scrapling_crawler.py
@@ -197,6 +197,60 @@ class TestTierDispatch:
         assert result.status == 451
 
     @pytest.mark.asyncio
+    async def test_tier1_dns_failure_skips_browsers(self):
+        """DNS resolution failure at Tier 1 → return infra_error. No browser spawn."""
+        crawler = ScraplingCrawler()
+
+        with (
+            patch.object(crawler, "_tier1_fetch", new_callable=AsyncMock,
+                         side_effect=RuntimeError("Could not resolve host: nonexistent.invalid")),
+            patch.object(crawler, "_tier2_fetch", new_callable=AsyncMock) as t2,
+            patch.object(crawler, "_tier3_fetch", new_callable=AsyncMock) as t3,
+        ):
+            result = await crawler.crawl_with_metadata("https://nonexistent.invalid/page")
+
+        t2.assert_not_awaited()
+        t3.assert_not_awaited()
+        assert result.failure_kind == "infra_error"
+
+    @pytest.mark.asyncio
+    async def test_tier1_connection_refused_skips_browsers(self):
+        """Connection-refused at Tier 1 → return infra_error. No browser spawn."""
+        crawler = ScraplingCrawler()
+
+        with (
+            patch.object(crawler, "_tier1_fetch", new_callable=AsyncMock,
+                         side_effect=RuntimeError("Failed to connect: Connection refused")),
+            patch.object(crawler, "_tier2_fetch", new_callable=AsyncMock) as t2,
+            patch.object(crawler, "_tier3_fetch", new_callable=AsyncMock) as t3,
+        ):
+            result = await crawler.crawl_with_metadata("https://refused.example/page")
+
+        t2.assert_not_awaited()
+        t3.assert_not_awaited()
+        assert result.failure_kind == "infra_error"
+
+    @pytest.mark.asyncio
+    async def test_tier1_generic_error_still_escalates(self):
+        """Non-DNS Tier 1 errors still escalate (regression guard for N3)."""
+        crawler = ScraplingCrawler()
+        page_t2 = _make_page_mock("Tier2 Title")
+
+        with (
+            patch.object(crawler, "_tier1_fetch", new_callable=AsyncMock,
+                         side_effect=RuntimeError("SSL handshake timeout")),
+            patch.object(crawler, "_tier2_fetch", new_callable=AsyncMock,
+                         return_value=(page_t2, _GOOD_HTML, 200)) as t2,
+            patch.object(crawler, "_tier3_fetch", new_callable=AsyncMock) as t3,
+        ):
+            result = await crawler.crawl_with_metadata("https://example.com")
+
+        t2.assert_awaited_once()
+        t3.assert_not_awaited()
+        assert result.failure_kind is None
+        assert result.status == 200
+
+    @pytest.mark.asyncio
     async def test_tier1_403_still_escalates(self):
         """403 is ambiguous — still try Tier 2 (some CF configs accept browsers)."""
         crawler = ScraplingCrawler()


### PR DESCRIPTION
## Summary

Fixes a production starvation bug where one permanently-blocked host (e.g. `www.reuters.com` returning 401) would burn ~12s + ~700MB per call across all three scrapling tiers and trip the global circuit breaker, blocking unrelated `web_fetch` calls. The fix is structural: a three-layer health model replaces the single global breaker, and stage-level concurrency replaces the outer wrapper semaphore that was holding Tier-1 starvation hostage to browser-bound calls.

**Before:** one bad host took down all crawls.
**After:** that host returns `[blocked]` in ~1s from cache, only its own host breaker is affected, every other host keeps working.

## Three-layer health model

| Layer | Tracks | Trips on |
|---|---|---|
| Blocked-host cache (LRU 256, 15-min TTL) | Permanent host-level rejection | `failure_kind="blocked"` after 2 consecutive blocks on the same host |
| Per-host breakers (LRU 256) | Transient host failures | Timeout, empty, 5xx, rate_limited |
| Global infra breaker | Cross-cutting crawler failures only | Browser crash, DNS error, connection refused |

Block-cache requires **two** consecutive blocks before caching, so a single 401 on a paywalled URL doesn't poison the whole host (e.g. NYT homepage works while `/article/...` 401s). Counter resets on any successful fetch on that host.

## Stage-level concurrency

The outer `SafeCrawlerWrapper._semaphore` (which held all three tiers) is replaced by two inner semaphores in `ScraplingCrawler`:

- `_http_sem` — cap 20, gates Tier-1 (`curl_cffi`)
- `_browser_sem` — cap 6, gates Tier-2/3 (Chromium / Camoufox)

`_http_sem` is **not held while waiting for `_browser_sem`**, so a burst of stuck Tier-3 calls saturating the browser cap doesn't starve Tier-1 traffic. Legacy `crawler.max_concurrent_crawls` config falls back to `min(legacy, 6)` for `browser_concurrency` so low-RAM deployments don't silently spawn 6 browsers, and HTTP-tuned values (e.g. 50) don't translate to 50 Camoufox processes.

## Tier classification

- Tier-1 401/451 → short-circuit to `failure_kind="blocked"`, skip browser spawn entirely
- Tier-2 → typed reason (`"cloudflare" | "blocked"`) drives Tier-3's `solve_cloudflare` flag (no more unconditional CF solver on plain 401s)
- Tier-3 → re-raises exceptions so `safe_wrapper._classify_exception` can route DNS/connection errors as host-only instead of blanket-classifying as `infra_error` (this was the bug that recreated the starvation pattern)

## Diff size

12 files, +1,273 / −776. Production code in `src/tools/crawler/` (`safe_wrapper.py`, `scrapling_crawler.py`, `backend.py`), `src/config/tool_settings.py`, `agent_config.yaml`, plus error-prefix passthrough in `src/tools/fetch.py` / `src/tools/crawl.py`.

## Test coverage

- **3276/3276 unit tests pass** (13.7s); ruff clean on all touched files
- New / rewritten tests in `tests/unit/tools/crawler/`:
  - `test_one_block_does_not_cache_host` / `test_two_consecutive_blocks_cache_host` / `test_block_attempts_reset_on_success` — block-cache threshold semantics
  - `test_per_host_breaker_isolation` — Reuters open does not block Wikipedia
  - `test_infra_breaker_only_trips_on_infra_kind` / `test_infra_breaker_open_blocks_all_hosts`
  - `test_browser_semaphore_does_not_block_tier1` — saturate `_browser_sem` with 6 stuck Tier-3 calls, confirm Tier-1 still proceeds
  - `test_concurrent_blocked_does_not_poison_other_hosts` — 5 concurrent Reuters + 1 Wikipedia regression test for the actual incident shape
  - `test_blocked_cache_lru_evicts_oldest` / `test_host_breakers_lru_evicts_oldest` — LRU bounds
  - `test_all_tiers_fail_propagates_exception` — locks in the Tier-3 re-raise contract
- Integration tests updated for the new API (`circuit_state` → `infra_circuit_state`, `max_concurrent` → `http_concurrency`)

End-to-end verification (live URLs, 2026-05-08): Reuters returns `[blocked]` in 0.24s on first call (Tier 1 only), `<1ms` on cached calls; Wikipedia fetches in 2.65s (159KB markdown); infra breaker stays closed throughout.

## Test plan

- [x] `uv run pytest tests/unit/ --tb=short` — 3276 pass, 0 fail
- [x] `uv run ruff check src/tools/crawler/ src/tools/fetch.py src/tools/crawl.py src/config/tool_settings.py` — clean
- [x] Live integration: `uv run pytest tests/integration/tools/test_scrapling_integration.py -m integration` — 10 pass against live URLs
- [x] Mixed-host regression: 5 concurrent Reuters fetches + 1 Wikipedia fetch — Reuters caches after 2 blocks, Wikipedia unaffected
- [ ] Post-merge: monitor `safe_crawler.get_status()` for first hour to confirm `infra_circuit_state` stays closed and `blocked_hosts` populates as expected

## Out of scope (separate future PRs)

- Browser session pool to amortize Camoufox spinup
- 429 `Retry-After` header parsing
- Cross-process breaker coordination (Redis-backed) — caches are per-worker today
