### PR TITLE
fix(sse,agent): recover malformed tool-call JSON + remediation hint on retry

### DIFF
--- a/src/ptc_agent/agent/middleware/tool/empty_call_retry.py
+++ b/src/ptc_agent/agent/middleware/tool/empty_call_retry.py
@@ -6,18 +6,31 @@ to call tools but the content was malformed/truncated and the SDK silently
 dropped it.  LangGraph sees empty tool_calls and routes to __END__, stopping
 the agent mid-task.
 
-This middleware detects that mismatch and retries the model call.
+This middleware detects that mismatch, injects a remediation hint into the
+message history so the model knows what went wrong, and retries the model call.
 """
 
 import logging
 
 from langchain.agents.middleware import AgentMiddleware
-from langchain_core.messages import AIMessage
+from langchain_core.messages import AIMessage, HumanMessage
 
 logger = logging.getLogger(__name__)
 
 # stop_reason values that indicate the model intended to call tools
 _TOOL_USE_STOP_REASONS = {"tool_use", "tool_calls"}
+
+_REMEDIATION_HINT = (
+    "Your previous response had stop_reason=tool_use but the tool_calls field "
+    "was empty. This typically means the JSON in the tool-call arguments was "
+    "malformed — most commonly an unescaped quote or control character inside "
+    "a long string value, or the response was truncated mid-token.\n\n"
+    "If you intended to call a tool, please retry now, paying special attention to:\n"
+    "- Every `\"` inside a string value must be escaped as `\\\"`\n"
+    "- Every `\\` inside a string value must be escaped as `\\\\`\n"
+    "- Raw newlines and control characters are not allowed inside JSON string values\n"
+    "- The full arguments object must be valid JSON end-to-end"
+)
 
 
 class EmptyToolCallRetryMiddleware(AgentMiddleware):
@@ -46,20 +59,39 @@ class EmptyToolCallRetryMiddleware(AgentMiddleware):
             self.max_retries,
         )
 
+    def _inject_hint(self, request, ai_msg: AIMessage) -> None:
+        """Append the broken AIMessage + a corrective HumanMessage to request.
+
+        Replaces ``request.messages`` with a new list so we don't mutate any
+        list the caller may still reference.
+        """
+        request.messages = list(request.messages) + [
+            ai_msg,
+            HumanMessage(content=_REMEDIATION_HINT),
+        ]
+
     def wrap_model_call(self, request, handler):
+        hint_injected = False
         for attempt in range(1 + self.max_retries):
             response = handler(request)
             ai_msg = response.result[0]
             if not self._should_retry(ai_msg):
                 return response
             self._log_retry(ai_msg, attempt)
+            if not hint_injected:
+                self._inject_hint(request, ai_msg)
+                hint_injected = True
         return response  # return last response even if still broken
 
     async def awrap_model_call(self, request, handler):
+        hint_injected = False
         for attempt in range(1 + self.max_retries):
             response = await handler(request)
             ai_msg = response.result[0]
             if not self._should_retry(ai_msg):
                 return response
             self._log_retry(ai_msg, attempt)
-        return response
+            if not hint_injected:
+                self._inject_hint(request, ai_msg)
+                hint_injected = True
+        return response  # return last response even if still broken

--- a/src/server/handlers/streaming_handler.py
+++ b/src/server/handlers/streaming_handler.py
@@ -13,6 +13,8 @@ import logging
 import re
 from typing import Any, AsyncGenerator, Dict, List, Optional, Set, cast
 
+import json_repair
+
 from langchain_core.messages import AIMessage, AIMessageChunk, BaseMessage, ToolMessage
 
 from src.server.utils.content_normalizer import (
@@ -35,6 +37,31 @@ WORKFLOW_TIMEOUT = get_workflow_timeout()  # seconds
 SSE_EVENT_LOG_ENABLED = is_sse_event_log_enabled()
 
 MERGED_STREAM_CHUNK_MAX_BYTES_DEFAULT = get_merged_chunk_max_bytes()
+
+
+def _parse_tool_args(raw: str) -> Optional[Dict[str, Any]]:
+    """Parse accumulated tool-call argument JSON, falling back to json_repair.
+
+    Frontier models occasionally emit nearly-valid JSON in tool-call args —
+    typically an unescaped quote or control char inside a long string value.
+    Strict ``json.loads`` rejects it and (without this fallback) the call is
+    silently dropped, triggering an empty-tool-call retry storm.
+
+    Returns the parsed dict, or ``None`` if both strict and tolerant parsing
+    fail. Tool-call args must be a JSON object per the LangChain contract;
+    non-dict results are rejected so downstream tool dispatch sees the same
+    shape it always has.
+    """
+    try:
+        parsed = json.loads(raw)
+        return parsed if isinstance(parsed, dict) else None
+    except json.JSONDecodeError:
+        pass
+    try:
+        repaired = json_repair.loads(raw)
+    except Exception:
+        return None
+    return repaired if isinstance(repaired, dict) else None
 
 
 # ---------------------------------------------------------------------------
@@ -1090,16 +1117,39 @@ class WorkflowStreamHandler:
                         )
                         continue
 
-                    try:
-                        # Parse accumulated JSON
-                        parsed_args = json.loads(state["args_accumulated"])
+                    raw_args = state["args_accumulated"]
+                    parsed_args = _parse_tool_args(raw_args)
 
-                        # Build complete tool_calls event (unified format for all providers)
-                        # Use provider-specific id field: "call_id" for Response API, "id" for Anthropic
+                    if parsed_args is None:
+                        # Both strict and tolerant parsers failed. Emit a window
+                        # around the strict-parse failure point to aid diagnosis.
+                        try:
+                            json.loads(raw_args)
+                            err_repr = "unknown"
+                            err_window = raw_args[:200]
+                        except json.JSONDecodeError as je:
+                            err_repr = str(je)
+                            start = max(0, je.pos - 80)
+                            end = min(len(raw_args), je.pos + 80)
+                            err_window = raw_args[start:end]
+                        logger.error(
+                            f"[TOOL_CALL_PARSE_ERROR] agent={agent_name} provider={provider_type} "
+                            f"name={state.get('name')} args_length={len(raw_args)} "
+                            f"error={err_repr} window={err_window!r}"
+                        )
+                        # Clear state so the broken call doesn't leak across turns.
+                        if provider_type == "response_api":
+                            self.function_call_state.pop(state_key, None)
+                        else:  # anthropic
+                            self.anthropic_tool_call_state.pop(state_key, None)
+                        continue
+
+                    try:
+                        # id field differs by provider: "call_id" for Response API, "id" for Anthropic.
                         tool_call_id = state.get("call_id") or state.get("id")
                         tool_calls = [{
                             "name": state["name"],
-                            "args": parsed_args,  # Parsed object, not JSON string
+                            "args": parsed_args,
                             "id": tool_call_id,
                             "type": "tool_call"
                         }]
@@ -1115,7 +1165,7 @@ class WorkflowStreamHandler:
 
                         logger.debug(
                             f"[TOOL_CALLS_COMPLETE] agent={agent_name} provider={provider_type} "
-                            f"name={state['name']} args_length={len(state['args_accumulated'])} "
+                            f"name={state['name']} args_length={len(raw_args)} "
                             f"id={tool_call_id}"
                         )
 
@@ -1127,11 +1177,6 @@ class WorkflowStreamHandler:
                         else:  # anthropic
                             self.anthropic_tool_call_state.pop(state_key, None)
 
-                    except json.JSONDecodeError as e:
-                        logger.error(
-                            f"[TOOL_CALL_PARSE_ERROR] agent={agent_name} provider={provider_type} "
-                            f"args={state['args_accumulated'][:200]} error={e}"
-                        )
                     except Exception as e:
                         logger.error(
                             f"[TOOL_CALL_ERROR] agent={agent_name} provider={provider_type} error={e}"

--- a/src/server/handlers/streaming_handler.py
+++ b/src/server/handlers/streaming_handler.py
@@ -11,7 +11,7 @@ import copy
 import json
 import logging
 import re
-from typing import Any, AsyncGenerator, Dict, List, Optional, Set, cast
+from typing import Any, AsyncGenerator, Dict, List, Optional, Set, Tuple, cast
 
 import json_repair
 
@@ -39,7 +39,9 @@ SSE_EVENT_LOG_ENABLED = is_sse_event_log_enabled()
 MERGED_STREAM_CHUNK_MAX_BYTES_DEFAULT = get_merged_chunk_max_bytes()
 
 
-def _parse_tool_args(raw: str) -> Optional[Dict[str, Any]]:
+def _parse_tool_args(
+    raw: str,
+) -> Tuple[Optional[Dict[str, Any]], str, str]:
     """Parse accumulated tool-call argument JSON, falling back to json_repair.
 
     Frontier models occasionally emit nearly-valid JSON in tool-call args —
@@ -47,21 +49,34 @@ def _parse_tool_args(raw: str) -> Optional[Dict[str, Any]]:
     Strict ``json.loads`` rejects it and (without this fallback) the call is
     silently dropped, triggering an empty-tool-call retry storm.
 
-    Returns the parsed dict, or ``None`` if both strict and tolerant parsing
-    fail. Tool-call args must be a JSON object per the LangChain contract;
-    non-dict results are rejected so downstream tool dispatch sees the same
-    shape it always has.
+    Returns ``(parsed_or_None, err_repr, err_window)``. On success the latter
+    two are empty strings. On failure they carry diagnostic context for the
+    caller's error log — the caller doesn't need to re-parse ``raw`` to build
+    a window around the failure point. Tool-call args must be a JSON object
+    per the LangChain contract; non-dict results are rejected so downstream
+    tool dispatch sees the same shape it always has.
     """
     try:
         parsed = json.loads(raw)
-        return parsed if isinstance(parsed, dict) else None
-    except json.JSONDecodeError:
-        pass
+        if isinstance(parsed, dict):
+            return parsed, "", ""
+        return (
+            None,
+            f"non-dict top-level JSON: {type(parsed).__name__}",
+            raw[:200],
+        )
+    except json.JSONDecodeError as je:
+        err_repr = str(je)
+        start = max(0, je.pos - 80)
+        end = min(len(raw), je.pos + 80)
+        err_window = raw[start:end]
     try:
         repaired = json_repair.loads(raw)
     except Exception:
-        return None
-    return repaired if isinstance(repaired, dict) else None
+        return None, err_repr, err_window
+    if isinstance(repaired, dict):
+        return repaired, "", ""
+    return None, err_repr, err_window
 
 
 # ---------------------------------------------------------------------------
@@ -1118,20 +1133,9 @@ class WorkflowStreamHandler:
                         continue
 
                     raw_args = state["args_accumulated"]
-                    parsed_args = _parse_tool_args(raw_args)
+                    parsed_args, err_repr, err_window = _parse_tool_args(raw_args)
 
                     if parsed_args is None:
-                        # Both strict and tolerant parsers failed. Emit a window
-                        # around the strict-parse failure point to aid diagnosis.
-                        try:
-                            json.loads(raw_args)
-                            err_repr = "unknown"
-                            err_window = raw_args[:200]
-                        except json.JSONDecodeError as je:
-                            err_repr = str(je)
-                            start = max(0, je.pos - 80)
-                            end = min(len(raw_args), je.pos + 80)
-                            err_window = raw_args[start:end]
                         logger.error(
                             f"[TOOL_CALL_PARSE_ERROR] agent={agent_name} provider={provider_type} "
                             f"name={state.get('name')} args_length={len(raw_args)} "

--- a/tests/unit/ptc_agent/middleware/tool/test_empty_call_retry.py
+++ b/tests/unit/ptc_agent/middleware/tool/test_empty_call_retry.py
@@ -1,0 +1,146 @@
+"""Tests for EmptyToolCallRetryMiddleware.
+
+When the model returns stop_reason=tool_use but tool_calls is empty (typically
+because the tool-call argument JSON was malformed and dropped upstream), the
+middleware should:
+
+1. Retry the model call up to max_retries times.
+2. On the first retry, inject the failing AIMessage plus a corrective
+   HumanMessage so the model gets a chance to see why it failed.
+3. Not inject the hint repeatedly.
+4. Stop retrying as soon as the model returns valid tool_calls.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+from ptc_agent.agent.middleware.tool.empty_call_retry import (
+    EmptyToolCallRetryMiddleware,
+    _REMEDIATION_HINT,
+)
+
+
+def _make_request(messages):
+    return SimpleNamespace(messages=list(messages))
+
+
+def _empty_call_ai_msg():
+    return AIMessage(
+        content="",
+        response_metadata={"stop_reason": "tool_use"},
+        tool_calls=[],
+    )
+
+
+def _good_ai_msg():
+    return AIMessage(
+        content="",
+        response_metadata={"stop_reason": "tool_use"},
+        tool_calls=[
+            {"name": "write_file", "args": {"file_path": "x.md", "content": "hi"}, "id": "1", "type": "tool_call"}
+        ],
+    )
+
+
+def _resp(ai_msg):
+    return SimpleNamespace(result=[ai_msg])
+
+
+class TestEmptyToolCallRetry:
+    def test_returns_immediately_on_valid_response(self):
+        mw = EmptyToolCallRetryMiddleware(max_retries=2)
+        request = _make_request([HumanMessage(content="hello")])
+        handler = MagicMock(return_value=_resp(_good_ai_msg()))
+
+        result = mw.wrap_model_call(request, handler)
+
+        assert handler.call_count == 1
+        assert result.result[0].tool_calls
+        # No hint injected on happy path.
+        assert len(request.messages) == 1
+
+    def test_injects_hint_on_first_retry(self):
+        mw = EmptyToolCallRetryMiddleware(max_retries=2)
+        request = _make_request([HumanMessage(content="hello")])
+        broken = _empty_call_ai_msg()
+        good = _good_ai_msg()
+        handler = MagicMock(side_effect=[_resp(broken), _resp(good)])
+
+        result = mw.wrap_model_call(request, handler)
+
+        assert handler.call_count == 2
+        assert result.result[0].tool_calls
+        # Hint is now in the request messages: original + broken AIMessage + HumanMessage hint.
+        assert len(request.messages) == 3
+        assert isinstance(request.messages[-1], HumanMessage)
+        assert request.messages[-1].content == _REMEDIATION_HINT
+        # The broken AIMessage was included so the model can see what it said.
+        assert request.messages[-2] is broken
+
+    def test_hint_injected_only_once_across_retries(self):
+        mw = EmptyToolCallRetryMiddleware(max_retries=3)
+        request = _make_request([HumanMessage(content="hello")])
+        broken1 = _empty_call_ai_msg()
+        broken2 = _empty_call_ai_msg()
+        good = _good_ai_msg()
+        handler = MagicMock(side_effect=[_resp(broken1), _resp(broken2), _resp(good)])
+
+        mw.wrap_model_call(request, handler)
+
+        assert handler.call_count == 3
+        # Only one hint message appended, not two — broken AIMessage from
+        # attempt #1 plus one HumanMessage hint. The second broken AIMessage
+        # does NOT re-trigger injection.
+        hint_count = sum(
+            1
+            for m in request.messages
+            if isinstance(m, HumanMessage) and m.content == _REMEDIATION_HINT
+        )
+        assert hint_count == 1
+
+    def test_exhausts_retries_when_always_broken(self):
+        mw = EmptyToolCallRetryMiddleware(max_retries=2)
+        request = _make_request([HumanMessage(content="hello")])
+        handler = MagicMock(side_effect=[_resp(_empty_call_ai_msg())] * 3)
+
+        result = mw.wrap_model_call(request, handler)
+
+        # 1 initial + 2 retries = 3 calls.
+        assert handler.call_count == 3
+        # Last response is still the broken one.
+        assert not result.result[0].tool_calls
+
+    def test_does_not_retry_when_not_tool_use_stop_reason(self):
+        mw = EmptyToolCallRetryMiddleware(max_retries=2)
+        request = _make_request([HumanMessage(content="hello")])
+        end_msg = AIMessage(
+            content="done",
+            response_metadata={"stop_reason": "end_turn"},
+            tool_calls=[],
+        )
+        handler = MagicMock(return_value=_resp(end_msg))
+
+        mw.wrap_model_call(request, handler)
+
+        assert handler.call_count == 1
+        assert len(request.messages) == 1
+
+    @pytest.mark.asyncio
+    async def test_async_path_injects_hint(self):
+        mw = EmptyToolCallRetryMiddleware(max_retries=2)
+        request = _make_request([HumanMessage(content="hello")])
+        broken = _empty_call_ai_msg()
+        good = _good_ai_msg()
+        handler = AsyncMock(side_effect=[_resp(broken), _resp(good)])
+
+        result = await mw.awrap_model_call(request, handler)
+
+        assert handler.await_count == 2
+        assert result.result[0].tool_calls
+        assert isinstance(request.messages[-1], HumanMessage)
+        assert request.messages[-1].content == _REMEDIATION_HINT

--- a/tests/unit/server/handlers/test_streaming_handler_parse.py
+++ b/tests/unit/server/handlers/test_streaming_handler_parse.py
@@ -11,21 +11,25 @@ from src.server.handlers.streaming_handler import _parse_tool_args
 
 class TestParseToolArgs:
     def test_strict_valid_json(self):
-        parsed = _parse_tool_args(
+        parsed, err_repr, err_window = _parse_tool_args(
             '{"file_path": "results/note.md", "content": "hello"}'
         )
         assert parsed == {"file_path": "results/note.md", "content": "hello"}
+        assert err_repr == ""
+        assert err_window == ""
 
     def test_unescaped_quote_inside_content_repairs(self):
         # Dominant failure shape: literal `"` inside the content field that
         # the model didn't escape. Strict json.loads raises
         # "Expecting ',' delimiter".
-        parsed = _parse_tool_args(
+        parsed, err_repr, err_window = _parse_tool_args(
             '{"file_path": "x.md", "content": "He said "hi" to me."}'
         )
         assert parsed is not None
         assert parsed.get("file_path") == "x.md"
         assert isinstance(parsed.get("content"), str)
+        assert err_repr == ""
+        assert err_window == ""
 
     def test_chinese_content_with_embedded_quote_repairs(self):
         # CJK content with an embedded unescaped quote — exercises multi-byte
@@ -34,22 +38,42 @@ class TestParseToolArgs:
             '{"file_path":"results/analysis.md",'
             '"content":"# 分析报告\\n标的"AMZN.US"表现良好。"}'
         )
-        parsed = _parse_tool_args(raw)
+        parsed, err_repr, err_window = _parse_tool_args(raw)
         assert parsed is not None
         assert parsed.get("file_path", "").endswith(".md")
         assert isinstance(parsed.get("content"), str)
+        assert err_repr == ""
 
-    def test_empty_string_returns_none(self):
-        assert _parse_tool_args("") is None
+    def test_empty_string_returns_none_with_error(self):
+        parsed, err_repr, err_window = _parse_tool_args("")
+        assert parsed is None
+        # Empty input is a JSONDecodeError, so err_repr carries the parser's message.
+        assert "Expecting" in err_repr or "char 0" in err_repr
+        assert err_window == ""
 
     def test_strict_valid_non_dict_is_rejected(self):
         # Bare strings/arrays/scalars parse via strict JSON but are not valid
-        # tool-call arg shapes (LangChain contract is a dict).
-        for raw in ('"just a string"', '[1, 2, 3]', 'null', '42'):
-            assert _parse_tool_args(raw) is None, f"unexpected parse for {raw!r}"
+        # tool-call arg shapes. err_repr should call out the shape mismatch
+        # explicitly so logs aren't misleading.
+        for raw, expected_type in (
+            ('"just a string"', "str"),
+            ("[1, 2, 3]", "list"),
+            ("null", "NoneType"),
+            ("42", "int"),
+        ):
+            parsed, err_repr, err_window = _parse_tool_args(raw)
+            assert parsed is None, f"unexpected parse for {raw!r}"
+            assert "non-dict" in err_repr, f"expected non-dict marker for {raw!r}, got {err_repr!r}"
+            assert expected_type in err_repr
+            assert err_window  # 200-char prefix carries the offending payload
 
     def test_repair_returning_non_dict_is_rejected(self):
         # json_repair will turn unstructured garbage into nested lists like
         # `[[["..."]]]`. Reject these so downstream tool dispatch never sees
-        # a non-dict args shape.
-        assert _parse_tool_args("{{{not json") is None
+        # a non-dict args shape. err_repr should carry the original
+        # JSONDecodeError context (not the post-repair shape) since the
+        # strict failure is what the caller cares about for diagnosis.
+        parsed, err_repr, err_window = _parse_tool_args("{{{not json")
+        assert parsed is None
+        assert err_repr  # carries the JSONDecodeError message
+        assert err_window  # carries bytes around the failure point

--- a/tests/unit/server/handlers/test_streaming_handler_parse.py
+++ b/tests/unit/server/handlers/test_streaming_handler_parse.py
@@ -1,0 +1,55 @@
+"""Tests for `_parse_tool_args` in `src/server/handlers/streaming_handler.py`.
+
+Frontier models occasionally emit tool-call argument JSON with an unescaped
+quote inside a long string value, causing strict `json.loads` to raise
+`Expecting ',' delimiter` and the call to be silently dropped. The fallback
+through `json_repair` recovers the dominant case.
+"""
+
+from src.server.handlers.streaming_handler import _parse_tool_args
+
+
+class TestParseToolArgs:
+    def test_strict_valid_json(self):
+        parsed = _parse_tool_args(
+            '{"file_path": "results/note.md", "content": "hello"}'
+        )
+        assert parsed == {"file_path": "results/note.md", "content": "hello"}
+
+    def test_unescaped_quote_inside_content_repairs(self):
+        # Dominant failure shape: literal `"` inside the content field that
+        # the model didn't escape. Strict json.loads raises
+        # "Expecting ',' delimiter".
+        parsed = _parse_tool_args(
+            '{"file_path": "x.md", "content": "He said "hi" to me."}'
+        )
+        assert parsed is not None
+        assert parsed.get("file_path") == "x.md"
+        assert isinstance(parsed.get("content"), str)
+
+    def test_chinese_content_with_embedded_quote_repairs(self):
+        # CJK content with an embedded unescaped quote — exercises multi-byte
+        # code-point handling in json_repair.
+        raw = (
+            '{"file_path":"results/analysis.md",'
+            '"content":"# 分析报告\\n标的"AMZN.US"表现良好。"}'
+        )
+        parsed = _parse_tool_args(raw)
+        assert parsed is not None
+        assert parsed.get("file_path", "").endswith(".md")
+        assert isinstance(parsed.get("content"), str)
+
+    def test_empty_string_returns_none(self):
+        assert _parse_tool_args("") is None
+
+    def test_strict_valid_non_dict_is_rejected(self):
+        # Bare strings/arrays/scalars parse via strict JSON but are not valid
+        # tool-call arg shapes (LangChain contract is a dict).
+        for raw in ('"just a string"', '[1, 2, 3]', 'null', '42'):
+            assert _parse_tool_args(raw) is None, f"unexpected parse for {raw!r}"
+
+    def test_repair_returning_non_dict_is_rejected(self):
+        # json_repair will turn unstructured garbage into nested lists like
+        # `[[["..."]]]`. Reject these so downstream tool dispatch never sees
+        # a non-dict args shape.
+        assert _parse_tool_args("{{{not json") is None


### PR DESCRIPTION
## Summary

Two-layer fix for the `[TOOL_CALL_PARSE_ERROR]` retry storm observed in production (recurring on both `provider=response_api` and `provider=anthropic` paths, multi-thousand-character Chinese `write_file` payloads, same byte offset reproducing deterministically across retries).

**Layer 1 — `streaming_handler.py`:** when accumulating tool-call argument JSON, try `json.loads` first, then fall back to `json_repair.loads` (already a project dependency). Most malformed-JSON cases — unescaped `\"` in long string values, raw newlines, stray backslashes — recover transparently. Only when both parsers fail does the call get dropped, with an enriched log line that includes an 80-char window around `je.pos` for future diagnosis.

**Layer 2 — `empty_call_retry.py`:** the downstream symptom of a dropped tool call is an `AIMessage` with `tool_calls=[]` but `stop_reason=tool_use`. The existing `EmptyToolCallRetryMiddleware` already retried this, but with identical context — the model deterministically re-emitted the same broken bytes. Now the retry path appends the broken `AIMessage` plus a `HumanMessage` with explicit JSON escape rules, giving the model a corrective feedback signal instead of a silent re-prompt.

## Key Changes

- `src/server/handlers/streaming_handler.py`: extract `_parse_tool_args()` with strict-then-repair fallback; replace bare `json.loads` + silent-drop with the new helper; enrich error logs with parse-error window
- `src/ptc_agent/agent/middleware/tool/empty_call_retry.py`: add `_REMEDIATION_HINT` constant and `_inject_hint()` method; inject hint on first retry only (subsequent retries do not grow context further)
- `tests/unit/ptc_agent/middleware/tool/test_empty_call_retry.py`: new — covers sync/async paths, hint-once invariant, retry exhaustion
- `tests/unit/server/handlers/test_streaming_handler_parse.py`: new — covers strict JSON, unescaped quotes, CJK content, empty string, non-dict rejection

## Trade-offs

- **Failure mode shifts from "noisy + dropped" to "quiet + executed."** A regression in model JSON quality won't trigger the old retry alarm — monitor via `[TOOL_CALL_PARSE_ERROR]` count instead.
- **`json_repair` is permissive.** It may produce tool args that are syntactically valid but semantically slightly off (e.g., truncates a string at the offending quote). For `write_file` this means "partial file > no file." Downstream Pydantic validation still catches type errors.
- **No new dependency.** `json_repair` (`json-repair>=0.7.0`) is already in `pyproject.toml` and used in `src/llms/content_utils.py`.
- **Happy path unchanged.** Strict `json.loads` runs first; only the fallback pays the `json_repair` cost.