### PR TITLE
feat(subagent): emit error event on per-task SSE when subagent crashes

### DIFF
--- a/src/ptc_agent/agent/middleware/background_subagent/subagent.py
+++ b/src/ptc_agent/agent/middleware/background_subagent/subagent.py
@@ -99,6 +99,17 @@ class _SubagentTokenForwarder:
             "ts": time.time(),
         }
 
+    def _error_record(self, message: str, error_type: str) -> dict[str, Any]:
+        return {
+            "event": "error",
+            "data": {
+                "agent": self.agent_id,
+                "message": message,
+                "error_type": error_type,
+            },
+            "ts": time.time(),
+        }
+
     async def forward(
         self,
         message_chunk: BaseMessage,
@@ -198,6 +209,30 @@ class _SubagentTokenForwarder:
             self.tool_call_id,
             {"event": event_type, "data": payload, "ts": time.time()},
         )
+
+    async def forward_error(self, exc: BaseException) -> None:
+        """Spill an ``error`` SSE record so per-task SSE consumers can
+        distinguish a crashed subagent from a clean completion.
+
+        Without this, both success and failure terminate the per-task stream
+        with only the ``subagent_stream_end`` sentinel — leaving downstream
+        trackers (ginlix-integration's Slack/Discord/Feishu task tracker, the
+        web frontend, ptc-cli) unable to surface failure to the user.
+
+        Best-effort: failures here are absorbed so they cannot mask the
+        original exception, which is always re-raised by the caller.
+        """
+        try:
+            await self.registry.append_captured_event(
+                self.tool_call_id,
+                self._error_record(str(exc) or repr(exc), type(exc).__name__),
+            )
+        except Exception:
+            logger.warning(
+                "subagent_error_event_write_failed",
+                tool_call_id=self.tool_call_id,
+                exc_info=True,
+            )
 
     async def finalize(self) -> None:
         """Close any still-open reasoning lifecycle and signal stream-end.
@@ -509,6 +544,15 @@ def _create_task_tool(
                             "Subagent custom-event forwarding failed",
                             error=str(exc),
                         )
+        except Exception as exc:
+            # Spill an ``error`` SSE record so per-task consumers can tell a
+            # crashed subagent apart from a clean completion. ``asyncio.CancelledError``
+            # (BaseException) skips this path on purpose — cancellation is an
+            # orderly stop, not a content-level error; the registry's ``cancelled``
+            # flag already distinguishes it.
+            if forwarder is not None:
+                await forwarder.forward_error(exc)
+            raise
         finally:
             if forwarder is not None:
                 try:

--- a/tests/unit/middleware/test_subagent_token_forwarder.py
+++ b/tests/unit/middleware/test_subagent_token_forwarder.py
@@ -190,6 +190,127 @@ async def test_finalize_sentinel_failure_does_not_propagate():
 
 
 @pytest.mark.asyncio
+async def test_forward_error_appends_error_record():
+    """forward_error spills an SSE error record with the canonical agent_id,
+    the exception message, and the exception type name. This is what lets
+    per-task SSE consumers distinguish a crashed subagent from a clean close.
+    """
+    registry = BackgroundTaskRegistry()
+    task = await _register(registry)
+    fw = _SubagentTokenForwarder(registry, task.tool_call_id, "task:abc")
+
+    await fw.forward_error(RuntimeError("upstream blew up"))
+
+    error_records = [e for e in task.captured_events_tail if e["event"] == "error"]
+    assert len(error_records) == 1
+    assert error_records[0]["data"] == {
+        "agent": "task:abc",
+        "message": "upstream blew up",
+        "error_type": "RuntimeError",
+    }
+
+
+@pytest.mark.asyncio
+async def test_forward_error_absorbs_registry_failure():
+    """If append_captured_event raises (degraded Redis), forward_error must
+    not propagate — it is always called inside an existing exception flow
+    and must not mask the original error.
+    """
+    registry = BackgroundTaskRegistry()
+    task = await _register(registry)
+    fw = _SubagentTokenForwarder(registry, task.tool_call_id, "task:abc")
+
+    async def boom(_tool_call_id, _record):
+        raise RuntimeError("registry on fire")
+
+    registry.append_captured_event = boom  # type: ignore[method-assign]
+
+    # Should not raise.
+    await fw.forward_error(ValueError("original error"))
+
+
+@pytest.mark.asyncio
+async def test_arun_subagent_streaming_emits_error_event_on_exception(monkeypatch):
+    """End-to-end: when the subagent.astream raises, the per-task SSE stream
+    sees an `error` event carrying the exception message + type before the
+    subagent_stream_end sentinel, and the original exception propagates out
+    of _arun_subagent_streaming so the registry's outer wrapper can record it
+    on task.error.
+    """
+    from ptc_agent.agent.middleware.background_subagent import subagent as sa
+    from ptc_agent.agent.middleware.background_subagent.middleware import (
+        current_background_tool_call_id,
+    )
+
+    parent_config = {"configurable": {"thread_id": "t1"}}
+    monkeypatch.setattr(
+        "ptc_agent.agent.middleware.background_subagent.subagent.get_config",
+        lambda: parent_config,
+    )
+
+    registry = BackgroundTaskRegistry()
+    task = await _register(registry, task_id_override="taskerr")
+
+    async def fake_astream(state, config, stream_mode=None):
+        yield ("messages", (_chunk("partial"), {}))
+        raise RuntimeError("model crashed mid-stream")
+
+    fake_subagent = MagicMock()
+    fake_subagent.astream = fake_astream
+
+    tool = sa._create_task_tool(
+        default_model=MagicMock(),
+        default_tools=[],
+        default_middleware=[],
+        default_interrupt_on=None,
+        subagents=[],
+        general_purpose_agent=False,
+        registry=registry,
+        checkpointer=None,
+    )
+    coroutine = tool.coroutine
+    closure_vars = {
+        cell_name: cell.cell_contents
+        for cell_name, cell in zip(
+            coroutine.__code__.co_freevars,
+            coroutine.__closure__ or (),
+        )
+    }
+    sg = closure_vars["subagent_graphs"]
+    sg["general-purpose"] = fake_subagent
+
+    runtime = MagicMock()
+    runtime.state = {"messages": []}
+    runtime.tool_call_id = "tc-err"
+
+    # The Task tool's "init" path awaits _arun_subagent_streaming directly
+    # rather than scheduling it as a background asyncio task, so the
+    # RuntimeError propagates out of the coroutine. The contract under test
+    # is that forward_error was called BEFORE the re-raise: the captured
+    # events on the registered task should already contain the error record.
+    token = current_background_tool_call_id.set(task.tool_call_id)
+    try:
+        with pytest.raises(RuntimeError, match="model crashed mid-stream"):
+            await coroutine(
+                description="d",
+                prompt="p",
+                subagent_type="general-purpose",
+                action="init",
+                task_id=None,
+                runtime=runtime,
+            )
+    finally:
+        current_background_tool_call_id.reset(token)
+
+    events = list(task.captured_events_tail)
+    error_records = [e for e in events if e["event"] == "error"]
+    assert len(error_records) == 1, f"expected 1 error event, got events={events}"
+    assert error_records[0]["data"]["message"] == "model crashed mid-stream"
+    assert error_records[0]["data"]["error_type"] == "RuntimeError"
+    assert error_records[0]["data"]["agent"] == "task:taskerr"
+
+
+@pytest.mark.asyncio
 async def test_message_id_change_closes_prior_reasoning():
     """A new message_id with reasoning still active means the prior LLM call
     finished mid-reasoning. Close the old lifecycle before starting fresh."""


### PR DESCRIPTION
## Summary

When a background subagent raises mid-execution, its per-task SSE stream previously closed with only the `subagent_stream_end` sentinel — leaving downstream consumers unable to distinguish a crash from a clean completion.

This PR spills an `event: error` record onto the per-task stream before finalization, carrying the exception type and message. Behavior is **additive**: consumers that don't subscribe to error events on the per-task stream silently ignore the new record.

### Changes

- `_SubagentTokenForwarder` gains:
  - `_error_record(message, error_type)` — pure data builder, mirrors the shape of existing `_chunk_record` / `_signal_record`.
  - `forward_error(exc)` — best-effort spill onto the per-task Redis stream; failures here are absorbed so they cannot mask the original exception.
- `_arun_subagent_streaming` catches `Exception` (deliberately **not** `BaseException` — `asyncio.CancelledError` remains an orderly stop, not a content-level error), spills the error event, then re-raises with the original traceback preserved.
- `finalize()` continues to run from the `finally` block, so the sentinel always fires after the error event.

### Record shape

```json
{
  "event": "error",
  "data": {
    "agent": "<agent_id>",
    "message": "<str(exc) or repr(exc)>",
    "error_type": "<exception class name>"
  },
  "ts": <unix_ts>
}
```

## Test plan

- [x] Unit: `forward_error` appends the error record with the correct shape
- [x] Unit: `forward_error` absorbs registry failures (best-effort, original exception preserved)
- [x] E2E: `_arun_subagent_streaming` emits the error event when `astream` raises, then re-raises
- [x] All 18 forwarder tests pass
- [x] Broader 46 subagent + per-task SSE tests still pass
- [x] `ruff check` clean on changed files

## Regression risk

Low. The change is additive on the SSE wire (new event type, ignored by consumers that don't expect it), preserves the original control flow on the unhappy path (exception still re-raises with original traceback, sentinel still fires from `finally`), and the new method is best-effort with internal exception absorption. `asyncio.CancelledError` is deliberately not caught so cancellation behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)