### PR TITLE
fix(chat-agent): decode percent-encoded paths in markdown file links

### DIFF
--- a/web/src/pages/ChatAgent/components/FileCard.tsx
+++ b/web/src/pages/ChatAgent/components/FileCard.tsx
@@ -65,12 +65,22 @@ export function isFilePath(href: string | undefined): boolean {
 /**
  * Normalize a file path for API calls: strip __wsref__ prefix, return relative path.
  *
+ * Also percent-decodes the path so an LLM-emitted markdown link like
+ * `[name](results/%E9%95%BF...md)` reaches the API as raw Unicode and gets
+ * encoded exactly once by the HTTP layer. Without this, Axios re-encodes the
+ * leading `%` to `%25` and the backend's single `unquote` decodes to a
+ * literal `%XX` path that doesn't exist on disk.
+ *
  * Expects pre-normalized input (no file:// or /home/workspace/ prefixes).
  */
 export function normalizeFilePath(path: string): string {
   const ws = parseWsPath(path);
-  if (ws) return ws.path;
-  return path;
+  const raw = ws ? ws.path : path;
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
 }
 
 const IMAGE_EXTS = new Set(['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'bmp']);

--- a/web/src/pages/ChatAgent/components/WorkspaceImage.tsx
+++ b/web/src/pages/ChatAgent/components/WorkspaceImage.tsx
@@ -34,9 +34,7 @@ function WorkspaceImage({ src, alt, ...props }: WorkspaceImageProps) {
   // Decode LLM-emitted percent-encoded paths (e.g. ![](.../%E5%9B%BE%E8%A1%A8.png))
   // so Axios doesn't re-encode the leading `%` to `%25`. Idempotent on raw paths.
   let normalizedPath = rawPath;
-  if (rawPath) {
-    try { normalizedPath = decodeURIComponent(rawPath); } catch { /* malformed %XX — pass through */ }
-  }
+  try { normalizedPath = decodeURIComponent(rawPath); } catch { /* malformed %XX — pass through */ }
   const cacheKey = canFetch ? `${workspaceId || 'shared'}:${normalizedPath}` : '';
 
   const [state, setState] = useState<LoadState>(() =>

--- a/web/src/pages/ChatAgent/components/WorkspaceImage.tsx
+++ b/web/src/pages/ChatAgent/components/WorkspaceImage.tsx
@@ -30,7 +30,13 @@ function WorkspaceImage({ src, alt, ...props }: WorkspaceImageProps) {
   const effectiveDownloadFn = wsRef ? null : downloadFileFn;
 
   const canFetch = !!(src && !isExternalUrl(src) && (workspaceId || effectiveDownloadFn));
-  const normalizedPath = canFetch ? (wsRef ? wsRef.path : src!) : '';
+  const rawPath = canFetch ? (wsRef ? wsRef.path : src!) : '';
+  // Decode LLM-emitted percent-encoded paths (e.g. ![](.../%E5%9B%BE%E8%A1%A8.png))
+  // so Axios doesn't re-encode the leading `%` to `%25`. Idempotent on raw paths.
+  let normalizedPath = rawPath;
+  if (rawPath) {
+    try { normalizedPath = decodeURIComponent(rawPath); } catch { /* malformed %XX — pass through */ }
+  }
   const cacheKey = canFetch ? `${workspaceId || 'shared'}:${normalizedPath}` : '';
 
   const [state, setState] = useState<LoadState>(() =>

--- a/web/src/pages/ChatAgent/components/__tests__/FileCard.test.ts
+++ b/web/src/pages/ChatAgent/components/__tests__/FileCard.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeFilePath, parseWsPath } from '../FileCard';
+
+describe('normalizeFilePath', () => {
+  it('returns ASCII paths unchanged', () => {
+    expect(normalizeFilePath('results/amd_dcf_analysis.md')).toBe('results/amd_dcf_analysis.md');
+  });
+
+  it('returns raw Unicode paths unchanged', () => {
+    expect(normalizeFilePath('results/长飞光纤_短线分析_20260511.md')).toBe(
+      'results/长飞光纤_短线分析_20260511.md',
+    );
+  });
+
+  it('decodes percent-encoded CJK paths emitted by the LLM in markdown links', () => {
+    // LLM occasionally emits [name](results/%E9%95%BF...md) — the URL position
+    // in HTML/markdown is conventionally percent-encoded for non-ASCII chars.
+    const encoded =
+      'results/%E9%95%BF%E9%A3%9E%E5%85%89%E7%BA%A4_%E7%9F%AD%E7%BA%BF%E5%88%86%E6%9E%90_20260511.md';
+    expect(normalizeFilePath(encoded)).toBe('results/长飞光纤_短线分析_20260511.md');
+  });
+
+  it('strips the __wsref__ prefix', () => {
+    expect(normalizeFilePath('__wsref__/abc-123/results/report.md')).toBe('results/report.md');
+  });
+
+  it('strips __wsref__ and decodes the inner path in one pass', () => {
+    const encoded = '__wsref__/abc-123/results/%E6%8A%A5%E5%91%8A.md';
+    expect(normalizeFilePath(encoded)).toBe('results/报告.md');
+  });
+
+  it('falls through unchanged on malformed percent sequences', () => {
+    // `100%discount` is a legal filename — invalid as URI escape — decode throws.
+    expect(normalizeFilePath('results/100%discount.md')).toBe('results/100%discount.md');
+  });
+});
+
+describe('parseWsPath', () => {
+  it('parses __wsref__/{wsid}/path', () => {
+    expect(parseWsPath('__wsref__/ws-1/results/r.md')).toEqual({
+      workspaceId: 'ws-1',
+      path: 'results/r.md',
+    });
+  });
+
+  it('returns null for non-wsref paths', () => {
+    expect(parseWsPath('results/r.md')).toBeNull();
+    expect(parseWsPath(undefined)).toBeNull();
+  });
+});

--- a/web/src/pages/ChatAgent/components/__tests__/FileCard.test.ts
+++ b/web/src/pages/ChatAgent/components/__tests__/FileCard.test.ts
@@ -7,17 +7,15 @@ describe('normalizeFilePath', () => {
   });
 
   it('returns raw Unicode paths unchanged', () => {
-    expect(normalizeFilePath('results/长飞光纤_短线分析_20260511.md')).toBe(
-      'results/长飞光纤_短线分析_20260511.md',
-    );
+    expect(normalizeFilePath('results/示例_分析.md')).toBe('results/示例_分析.md');
   });
 
   it('decodes percent-encoded CJK paths emitted by the LLM in markdown links', () => {
-    // LLM occasionally emits [name](results/%E9%95%BF...md) — the URL position
+    // LLM occasionally emits [name](results/%XX%XX...md) — the URL position
     // in HTML/markdown is conventionally percent-encoded for non-ASCII chars.
-    const encoded =
-      'results/%E9%95%BF%E9%A3%9E%E5%85%89%E7%BA%A4_%E7%9F%AD%E7%BA%BF%E5%88%86%E6%9E%90_20260511.md';
-    expect(normalizeFilePath(encoded)).toBe('results/长飞光纤_短线分析_20260511.md');
+    // 示例_分析.md → %E7%A4%BA%E4%BE%8B_%E5%88%86%E6%9E%90.md
+    const encoded = 'results/%E7%A4%BA%E4%BE%8B_%E5%88%86%E6%9E%90.md';
+    expect(normalizeFilePath(encoded)).toBe('results/示例_分析.md');
   });
 
   it('strips the __wsref__ prefix', () => {
@@ -25,8 +23,9 @@ describe('normalizeFilePath', () => {
   });
 
   it('strips __wsref__ and decodes the inner path in one pass', () => {
-    const encoded = '__wsref__/abc-123/results/%E6%8A%A5%E5%91%8A.md';
-    expect(normalizeFilePath(encoded)).toBe('results/报告.md');
+    // 文件.md → %E6%96%87%E4%BB%B6.md
+    const encoded = '__wsref__/abc-123/results/%E6%96%87%E4%BB%B6.md';
+    expect(normalizeFilePath(encoded)).toBe('results/文件.md');
   });
 
   it('falls through unchanged on malformed percent sequences', () => {


### PR DESCRIPTION
## Summary

The LLM occasionally emits markdown links with already percent-encoded URLs for CJK filenames (e.g. `[报告](results/%E9%95%BF%E9%A3%9E...md)`). Because remark-parse preserves URLs verbatim and Axios's params serializer encodes once, the leading `%` gets re-encoded to `%25`, the backend's single `unquote()` decodes to a literal `%XX...` path, and `/files/read` / `/files/download` return 404.

Fix decodes the path with a try/catch `decodeURIComponent` at the two choke points before the API call:
- `normalizeFilePath` in `FileCard.tsx` — covers `fileAwareA` and the wsref backtick fallback in `Markdown.tsx`
- `WorkspaceImage.tsx` — bypasses `normalizeFilePath` and computes its own path, so it needs the same decode

Idempotent on raw Unicode paths (no `%XX` → no change) and on already-decoded paths. Malformed `%XX` sequences (e.g. a real filename like `100%discount.md`) fall through unchanged via the try/catch.

## Background

Issue 0044 surfaced 4 failing requests in a 33h window across 3 distinct workspaces, all on CJK filenames. Verified the chain end-to-end:

1. Reproduced the exact wire path from the issue by feeding a single-encoded CJK path through Axios — byte-for-byte match.
2. Confirmed `mdast-util-from-markdown` does NOT decode `%XX` in link destinations (it only decodes markdown escapes and HTML char refs).
3. Confirmed react-markdown's `defaultUrlTransform` is protocol-only — no encode/decode.
4. Swept the backend (`src/server/`, `src/ptc_agent/`, `src/tools/`) — zero `urllib.parse.quote` calls on chat content.
5. Swept the frontend chat rendering path — no `encodeURIComponent` on file paths anywhere.
6. SSE serializer uses `ensure_ascii=False` — raw UTF-8 over the wire, no encoding.

The only remaining source is the LLM stream itself. 1.3% failure rate (4/312) is consistent with intermittent non-determinism — models trained on web HTML sometimes emit URLs in encoded form even though our markdown handler accepts raw Unicode.

## Files changed

- `web/src/pages/ChatAgent/components/FileCard.tsx` — `normalizeFilePath` decodes via try/catch
- `web/src/pages/ChatAgent/components/WorkspaceImage.tsx` — same decode applied to image `src`
- `web/src/pages/ChatAgent/components/__tests__/FileCard.test.ts` — 8 new tests covering ASCII / raw CJK / percent-encoded CJK / `__wsref__` strip / combined / malformed `%` fallback

## Diff size

Total: 3 files changed, 68 insertions(+), 3 deletions(-)
Net (excl. tests): 2 files changed, 19 insertions(+), 3 deletions(-)

## Test plan

- [x] `pnpm vitest run src/pages/ChatAgent/` — 42 files, 424 tests pass (8 new in FileCard.test.ts)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — no new errors on changed files
- [ ] Smoke: open a workspace with a CJK filename, click the file in the tree → opens (regression check for the existing happy path)
- [ ] Smoke: ask the agent to write `results/分析.md` and have it embed a markdown link; click the link → opens (the bug's repro path)

## Related

- Issue 0044 (frontend double-URL-encoded CJK path → 404 on `/files/{read,download}`)
- PR #199 — backend CJK Content-Disposition + charset-detect on `/files/read` (different layer of the same general non-ASCII path family)