### PR TITLE
fix(chat): emit structured error_type on non-recoverable workflow errors

### DIFF
--- a/src/server/handlers/chat/_common.py
+++ b/src/server/handlers/chat/_common.py
@@ -201,6 +201,27 @@ async def _is_plan_interrupt_pending(thread_id: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
+def _classify_non_recoverable_error_type(e: Exception) -> str:
+    """Map a non-recoverable exception to a structured ``error_type`` label.
+
+    Channel gateways switch on this label to surface user-actionable
+    messages (e.g. "this thread's workspace is gone — start fresh") instead
+    of opaque tracebacks. Defaults to ``"workflow_error"`` for unrecognized
+    cases so existing consumers keep working.
+    """
+    if isinstance(e, (ValueError, RuntimeError)):
+        msg = str(e)
+        if "Workspace" in msg:
+            if "not found" in msg:
+                return "workspace_not_found"
+            if "has been deleted" in msg:
+                return "workspace_deleted"
+            if "error state" in msg:
+                return "workspace_error_state"
+            return "workspace_unavailable"
+    return "workflow_error"
+
+
 def classify_error(e: Exception) -> dict:
     """Classify an exception as recoverable or non-recoverable.
 
@@ -803,22 +824,16 @@ async def handle_workflow_error(
                 f"{thread_id}: {tracker_err}"
             )
 
+        error_type_label = _classify_non_recoverable_error_type(e)
+        error_payload = {
+            "thread_id": thread_id,
+            "error": str(e),
+            "type": "workflow_error",
+            "error_type": error_type_label,
+            "error_class": type(e).__name__,
+        }
         if handler:
-            error_event = handler._format_sse_event(
-                "error",
-                {
-                    "thread_id": thread_id,
-                    "error": str(e),
-                    "type": "workflow_error",
-                },
-            )
+            error_event = handler._format_sse_event("error", error_payload)
             yield error_event
         else:
-            error_event = json.dumps(
-                {
-                    "thread_id": thread_id,
-                    "error": str(e),
-                    "type": "workflow_error",
-                }
-            )
-            yield f"event: error\ndata: {error_event}\n\n"
+            yield f"event: error\ndata: {json.dumps(error_payload)}\n\n"

--- a/tests/unit/server/handlers/test_chat_common.py
+++ b/tests/unit/server/handlers/test_chat_common.py
@@ -133,6 +133,55 @@ class TestClassifyError:
 
 
 # ---------------------------------------------------------------------------
+# _classify_non_recoverable_error_type
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyNonRecoverableErrorType:
+    """Maps workspace-lifecycle errors to structured ``error_type`` labels
+    so channel gateways can render user-actionable messages instead of
+    raw traceback strings."""
+
+    def _classify(self, e):
+        from src.server.handlers.chat._common import (
+            _classify_non_recoverable_error_type,
+        )
+        return _classify_non_recoverable_error_type(e)
+
+    def test_workspace_not_found_value_error(self):
+        result = self._classify(ValueError("Workspace abc123 not found"))
+        assert result == "workspace_not_found"
+
+    def test_workspace_deleted_runtime_error(self):
+        result = self._classify(
+            RuntimeError("Workspace abc123 has been deleted"),
+        )
+        assert result == "workspace_deleted"
+
+    def test_workspace_error_state_runtime_error(self):
+        result = self._classify(
+            RuntimeError(
+                "Workspace abc123 is in error state. Please delete and recreate."
+            ),
+        )
+        assert result == "workspace_error_state"
+
+    def test_workspace_generic_runtime_error_falls_to_unavailable(self):
+        """Unknown workspace error wording still gets the workspace bucket
+        so consumers can show a workspace-shaped notice."""
+        result = self._classify(RuntimeError("Workspace abc123 went sideways"))
+        assert result == "workspace_unavailable"
+
+    def test_non_workspace_error_defaults_to_workflow_error(self):
+        result = self._classify(RuntimeError("LLM provider quota exceeded"))
+        assert result == "workflow_error"
+
+    def test_unrelated_value_error_defaults_to_workflow_error(self):
+        result = self._classify(ValueError("invalid agent_mode"))
+        assert result == "workflow_error"
+
+
+# ---------------------------------------------------------------------------
 # process_hitl_response
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

The non-recoverable branch of `handle_workflow_error` previously emitted an SSE error event with only `{thread_id, error, type: workflow_error}`. Downstream channel gateways had no structured signal to distinguish user-actionable errors (sandbox deleted, workspace missing) from generic workflow failures, forcing them to substring-match the error message.

This adds `_classify_non_recoverable_error_type` which derives a stable label from the exception:

- `ValueError "Workspace ... not found"` → `workspace_not_found`
- `RuntimeError "Workspace ... has been deleted"` → `workspace_deleted`
- `RuntimeError "Workspace ... is in error state"` → `workspace_error_state`
- Other `ValueError`/`RuntimeError` mentioning Workspace → `workspace_unavailable`

Everything else stays at the default `workflow_error` so existing consumers are unaffected. The emitted error payload now also carries `error_class` so channel handlers can surface the exception class name without re-deriving it from the message.

## Diff Size

- Total: 2 files changed, 80 insertions(+), 16 deletions(-)
- Net (excl. tests): 1 file changed, 31 insertions(+), 16 deletions(-)

## Test plan

- [x] 6 new unit tests cover the label mapping
- [x] Existing `handle_workflow_error` tests still pass
- [x] Full `tests/unit/server/handlers/test_chat_common.py` suite: 70 passed in 1.70s