### PR TITLE
fix(sse,persistence): reset per-turn state at workflow start

### DIFF
--- a/src/server/services/background_task_manager.py
+++ b/src/server/services/background_task_manager.py
@@ -440,6 +440,41 @@ class BackgroundTaskManager:
                 f"[BackgroundTaskManager] Cleaned up {len(to_remove)} tasks: {to_remove}"
             )
 
+    async def _reset_event_buffer_state(self, thread_id: str) -> None:
+        """Drop stale Redis Stream state from a prior workflow execution.
+
+        Called before each fresh workflow turn. Without this, a new SSE
+        consumer attaches with ``cursor=0`` and replays the previous
+        turn's events because the producer-side dirty-resume guard in
+        ``pipelined_event_buffer`` only fires after the first new event
+        lands — by then the consumer has already pulled the stale data
+        and advanced its cursor past where the new entries land.
+        """
+        if self.event_storage_backend != "redis":
+            return
+        try:
+            cache = get_cache_client()
+        except Exception as e:
+            logger.warning(
+                f"[BackgroundTaskManager] Cache unavailable while resetting "
+                f"event buffer for {thread_id}: {e}"
+            )
+            return
+        if not cache.enabled or not cache.client:
+            return
+        try:
+            stream_key = f"workflow:stream:{thread_id}"
+            meta_key = f"workflow:events:meta:{thread_id}"
+            pipe = cache.client.pipeline(transaction=False)
+            pipe.delete(stream_key)
+            pipe.delete(meta_key)
+            await pipe.execute()
+        except Exception as e:
+            logger.warning(
+                f"[BackgroundTaskManager] Failed to reset event buffer for "
+                f"{thread_id}: {e}"
+            )
+
     async def pre_register(self, thread_id: str) -> None:
         """Pre-register a thread as QUEUED before the workflow generator starts.
 
@@ -448,6 +483,10 @@ class BackgroundTaskManager:
         Reconnecting clients see a QUEUED TaskInfo and attach to
         ``workflow:stream:{thread_id}`` (initially empty) instead of a 404.
         """
+        # Wipe any stale stream/meta from a prior turn before any consumer
+        # can attach to the placeholder.
+        await self._reset_event_buffer_state(thread_id)
+
         async with self.task_lock:
             if thread_id in self.tasks:
                 existing = self.tasks[thread_id]
@@ -491,6 +530,12 @@ class BackgroundTaskManager:
             ValueError: If max concurrent workflows exceeded
             RuntimeError: If workflow already exists for thread_id
         """
+        # Wipe stale stream/meta from a prior turn before the new asyncio
+        # task starts writing — the upgrade path is redundant here because
+        # pre_register already cleared, but the fresh-start path absolutely
+        # needs this to avoid replay of the previous turn's events.
+        await self._reset_event_buffer_state(thread_id)
+
         async with self.task_lock:
             # Check if already exists
             if thread_id in self.tasks:

--- a/src/server/services/persistence/conversation.py
+++ b/src/server/services/persistence/conversation.py
@@ -167,7 +167,14 @@ class ConversationPersistenceService:
             )
 
     async def _finalize_pair(self):
-        """Increment turn index and run post-persist hook (clear event buffer, etc.)."""
+        """Increment turn index, run post-persist hook, then release the singleton.
+
+        The class is documented as "one service instance per workflow execution"
+        but cleanup was historically never reached, so the singleton accumulated
+        ``_persisted_queries`` / ``_turn_index_cache`` across turns and silently
+        skipped new query persists when the cached state diverged from the DB.
+        Releasing here makes the next workflow turn build a fresh instance.
+        """
         self.increment_turn_index()
         if self._on_pair_persisted:
             try:
@@ -177,6 +184,7 @@ class ConversationPersistenceService:
                     f"[ConversationPersistence] _on_pair_persisted callback failed "
                     f"for thread_id={self.thread_id}: {e}"
                 )
+        await self.cleanup()
 
     async def _get_latest_checkpoint_id(self) -> str | None:
         """Best-effort: get latest checkpoint_id from the checkpointer.
@@ -230,17 +238,16 @@ class ConversationPersistenceService:
         """
         turn_index = await self.get_or_calculate_turn_index()
 
-        if turn_index in self._persisted_queries:
-            logger.warning(
-                f"[ConversationPersistence] Query already created for thread_id={self.thread_id} "
-                f"turn_index={turn_index}, skipping"
-            )
-            return self._current_query_id
-
         try:
             query_id = str(uuid4())
 
-            await qr_db.create_query(
+            # ``qr_db.create_query`` is idempotent via
+            # ``ON CONFLICT (conversation_thread_id, turn_index) DO UPDATE`` —
+            # don't gate on the in-memory ``_persisted_queries`` set, that gate
+            # silently dropped new turns when the singleton's state diverged
+            # from the DB across workflow executions. Let the DB tell us
+            # whether the row already exists.
+            row = await qr_db.create_query(
                 conversation_query_id=query_id,
                 conversation_thread_id=self.thread_id,
                 turn_index=turn_index,
@@ -251,15 +258,24 @@ class ConversationPersistenceService:
                 created_at=timestamp
             )
 
-            self._persisted_queries.add(turn_index)
-            self._current_query_id = query_id
-
-            logger.debug(
-                f"[ConversationPersistence] Created query for thread_id={self.thread_id} "
-                f"turn_index={turn_index} query_id={query_id}"
+            # ON CONFLICT DO UPDATE keeps the existing primary key, so the
+            # row's actual ``conversation_query_id`` may differ from the
+            # freshly-generated UUID we sent. Trust the RETURNING value.
+            stored_query_id = (
+                row.get("conversation_query_id", query_id)
+                if isinstance(row, dict)
+                else query_id
             )
 
-            return query_id
+            self._persisted_queries.add(turn_index)
+            self._current_query_id = stored_query_id
+
+            logger.debug(
+                f"[ConversationPersistence] Persisted query for thread_id={self.thread_id} "
+                f"turn_index={turn_index} query_id={stored_query_id}"
+            )
+
+            return stored_query_id
 
         except Exception as e:
             logger.error(

--- a/tests/unit/server/services/test_per_turn_state_reset.py
+++ b/tests/unit/server/services/test_per_turn_state_reset.py
@@ -1,0 +1,198 @@
+"""Tests for per-turn state reset across workflow executions.
+
+Two related fixes covered here:
+
+1. ``BackgroundTaskManager._reset_event_buffer_state`` drops
+   ``workflow:stream:{thread_id}`` + ``workflow:events:meta:{thread_id}``
+   at the start of every fresh turn so a new SSE consumer can't replay
+   stale events from a previous turn.
+
+2. ``ConversationPersistenceService._finalize_pair`` now releases the
+   thread's singleton from the module cache (matching the documented
+   "one instance per workflow execution" lifecycle), and
+   ``persist_query_start`` no longer gates on the in-memory
+   ``_persisted_queries`` set — the DB's
+   ``ON CONFLICT (conversation_thread_id, turn_index)`` is the source
+   of truth for idempotency.
+
+Together these stop a turn-2 query from rendering the turn-1 response
+even when the previous turn's terminal cleanup didn't run cleanly.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.server.services.background_task_manager import BackgroundTaskManager
+from src.server.services.persistence import conversation as persistence_module
+from src.server.services.persistence.conversation import (
+    ConversationPersistenceService,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fix #1 — BTM proactive event-buffer reset
+# ---------------------------------------------------------------------------
+
+
+def _make_btm_redis_backend() -> BackgroundTaskManager:
+    """BackgroundTaskManager configured with the redis event backend."""
+    with patch("src.server.services.background_task_manager.get_max_concurrent_workflows", return_value=10), \
+         patch("src.server.services.background_task_manager.get_workflow_result_ttl", return_value=3600), \
+         patch("src.server.services.background_task_manager.get_abandoned_workflow_timeout", return_value=3600), \
+         patch("src.server.services.background_task_manager.get_cleanup_interval", return_value=60), \
+         patch("src.server.services.background_task_manager.is_intermediate_storage_enabled", return_value=False), \
+         patch("src.server.services.background_task_manager.get_max_stored_messages_per_agent", return_value=1000), \
+         patch("src.server.services.background_task_manager.get_event_storage_backend", return_value="redis"), \
+         patch("src.server.services.background_task_manager.get_redis_ttl_workflow_events", return_value=86400):
+        return BackgroundTaskManager()
+
+
+def _patch_cache(client_mock: MagicMock):
+    """Patch ``get_cache_client`` to return an enabled cache with the given client."""
+    cache = MagicMock()
+    cache.enabled = True
+    cache.client = client_mock
+    return patch(
+        "src.server.services.background_task_manager.get_cache_client",
+        return_value=cache,
+    )
+
+
+@pytest.mark.asyncio
+async def test_reset_event_buffer_deletes_stream_and_meta():
+    """``_reset_event_buffer_state`` pipelines DEL on stream + meta keys."""
+    btm = _make_btm_redis_backend()
+
+    pipe = MagicMock()
+    pipe.delete = MagicMock(return_value=pipe)
+    pipe.execute = AsyncMock(return_value=[1, 1])
+
+    client = MagicMock()
+    client.pipeline = MagicMock(return_value=pipe)
+
+    with _patch_cache(client):
+        await btm._reset_event_buffer_state("thread-X")
+
+    # Both keys queued for DEL on the pipeline before the single execute().
+    deleted_keys = [call.args[0] for call in pipe.delete.call_args_list]
+    assert "workflow:stream:thread-X" in deleted_keys
+    assert "workflow:events:meta:thread-X" in deleted_keys
+    pipe.execute.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_reset_event_buffer_noop_for_non_redis_backend():
+    """Memory backend never touches Redis."""
+    with patch("src.server.services.background_task_manager.get_max_concurrent_workflows", return_value=10), \
+         patch("src.server.services.background_task_manager.get_workflow_result_ttl", return_value=3600), \
+         patch("src.server.services.background_task_manager.get_abandoned_workflow_timeout", return_value=3600), \
+         patch("src.server.services.background_task_manager.get_cleanup_interval", return_value=60), \
+         patch("src.server.services.background_task_manager.is_intermediate_storage_enabled", return_value=False), \
+         patch("src.server.services.background_task_manager.get_max_stored_messages_per_agent", return_value=1000), \
+         patch("src.server.services.background_task_manager.get_event_storage_backend", return_value="memory"), \
+         patch("src.server.services.background_task_manager.get_redis_ttl_workflow_events", return_value=86400):
+        btm = BackgroundTaskManager()
+
+    with patch(
+        "src.server.services.background_task_manager.get_cache_client",
+        side_effect=AssertionError("should not be called for memory backend"),
+    ):
+        await btm._reset_event_buffer_state("thread-X")
+
+
+@pytest.mark.asyncio
+async def test_pre_register_calls_reset_event_buffer():
+    """``pre_register`` resets the buffer before any consumer can attach to the placeholder."""
+    btm = _make_btm_redis_backend()
+
+    with patch.object(btm, "_reset_event_buffer_state", new_callable=AsyncMock) as mock_reset:
+        await btm.pre_register("thread-Y")
+
+    mock_reset.assert_awaited_once_with("thread-Y")
+    assert "thread-Y" in btm.tasks
+
+
+# ---------------------------------------------------------------------------
+# Fix #2 — Persistence singleton lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_persistence_singleton_cache():
+    """Each test gets a clean module-level singleton cache."""
+    persistence_module._service_instances.clear()
+    yield
+    persistence_module._service_instances.clear()
+
+
+@pytest.mark.asyncio
+async def test_finalize_pair_releases_singleton_from_cache():
+    """After ``_finalize_pair`` runs, the next ``get_instance`` returns a fresh object."""
+    svc = ConversationPersistenceService.get_instance("thread-Z")
+    assert persistence_module._service_instances.get("thread-Z") is svc
+
+    # ``_finalize_pair`` increments turn_index, fires the hook, then cleanups.
+    svc._turn_index_cache = 3
+    await svc._finalize_pair()
+
+    # Singleton dropped from cache.
+    assert "thread-Z" not in persistence_module._service_instances
+    # The next get_instance builds a fresh object — separate identity.
+    fresh = ConversationPersistenceService.get_instance("thread-Z")
+    assert fresh is not svc
+
+
+@pytest.mark.asyncio
+async def test_persist_query_start_does_not_gate_on_stale_set():
+    """Even when the in-memory set already contains the turn_index (simulating
+    stale state from a prior workflow execution that didn't reach
+    ``_finalize_pair``), persist_query_start must still call create_query —
+    the DB's ON CONFLICT is the canonical idempotency check."""
+    svc = ConversationPersistenceService.get_instance("thread-Q")
+    # Simulate stale carry-over: previous turn left turn_index=1 in the set.
+    svc._persisted_queries.add(1)
+    svc._turn_index_cache = 1
+
+    db_returned_uuid = "11111111-1111-1111-1111-111111111111"
+    create_query_mock = AsyncMock(
+        return_value={"conversation_query_id": db_returned_uuid, "turn_index": 1}
+    )
+
+    with patch(
+        "src.server.services.persistence.conversation.qr_db.create_query",
+        create_query_mock,
+    ):
+        returned = await svc.persist_query_start(
+            content="hello",
+            query_type="initial",
+        )
+
+    create_query_mock.assert_awaited_once()
+    kwargs = create_query_mock.call_args.kwargs
+    assert kwargs["conversation_thread_id"] == "thread-Q"
+    assert kwargs["turn_index"] == 1
+    assert returned == db_returned_uuid
+    assert svc._current_query_id == db_returned_uuid
+
+
+@pytest.mark.asyncio
+async def test_persist_query_start_uses_freshly_generated_id_when_row_lacks_one():
+    """If the DB layer returns a dict without ``conversation_query_id`` (defensive
+    path), fall back to the freshly generated UUID we sent."""
+    svc = ConversationPersistenceService.get_instance("thread-R")
+    svc._turn_index_cache = 0
+
+    create_query_mock = AsyncMock(return_value={"turn_index": 0})
+
+    with patch(
+        "src.server.services.persistence.conversation.qr_db.create_query",
+        create_query_mock,
+    ):
+        returned = await svc.persist_query_start(content="hi", query_type="initial")
+
+    sent_id = create_query_mock.call_args.kwargs["conversation_query_id"]
+    assert returned == sent_id
+    assert svc._current_query_id == sent_id


### PR DESCRIPTION
## Summary

Two cross-turn state leaks in the SSE delivery + persistence layers were letting turn N+1 render turn N's response on the same thread.

- **Redis Stream leak:** `workflow:stream:{thread_id}` is keyed per-thread with a 24h TTL. Cleanup runs only via `_on_pair_persisted` after a successful terminal persist — any path that misses (cancellation, crash, abandoned-task cleanup, persistence errors) leaves the stale events in place. The next turn's SSE consumer attaches with `cursor=0`, replays them, then freezes because its cursor advances past the new entries' explicit `<seq>-0` IDs.
- **Persistence singleton leak:** `ConversationPersistenceService` is documented as one-instance-per-workflow-execution, but `cleanup()` was never called from production code. The module-level singleton accumulated `_persisted_queries` and `_turn_index_cache` across turns. When a prior turn's `_finalize_pair` didn't run, the next turn's `persist_query_start` matched the stale `turn_index` in the set and silently dropped the insert.

These compound: the visible symptom is a "completed" turn whose query row never made it to the DB and whose SSE stream replays the previous response.

## Fix

**Proactive event-buffer reset at workflow start** — new `BackgroundTaskManager._reset_event_buffer_state(thread_id)` pipelines `DEL workflow:stream:{thread_id}` and `DEL workflow:events:meta:{thread_id}`. Called from `pre_register` and the top of `start_workflow` *before* the asyncio task is created and *before* the HTTP response returns — closing the race against an attaching SSE consumer.

**Persistence singleton respects its documented lifecycle** — `_finalize_pair` now releases the singleton from the module cache after every successful terminal persist. The next turn calls `get_instance` and gets a fresh object that re-reads `turn_index` from the DB.

**`persist_query_start` trusts the DB** — drops the in-memory `_persisted_queries` gate. `qr_db.create_query` already uses `ON CONFLICT (conversation_thread_id, turn_index) DO UPDATE`, which is the canonical idempotency check. The new code also threads the DB-returned `conversation_query_id` so subsequent operations link to the row that actually exists (the freshly-generated UUID was being stored even on ON CONFLICT — a latent bug the gate had masked).

Both halves of the fix are independent and defense-in-depth: cleanup at the end of `_finalize_pair` handles the happy path; dropping the gate handles the case where `_finalize_pair` never runs.

## Why this location

| Place | Why rejected |
|---|---|
| Producer-side dirty-resume guard inside `pipelined_event_buffer` | Already exists, fires *after* the first new event lands — consumer's XRANGE can win the race. |
| Consumer-side DEL on SSE attach | Producer should own lifecycle. Consumer-side DEL would wipe live streams when reconnecting mid-turn. |
| Per-turn stream keys (`workflow:stream:{thread_id}:{turn_index}`) | Bigger contract change; frontend keys by thread_id. Reset-at-start is strictly cheaper. |

The chosen location runs at the producer's commit point before the asyncio task exists. By the time the HTTP response goes back to the client and the SSE GET fires, the stream is provably empty. Zero race window.

## Context

Surfaces post-Streams cutover (#192 / #196 / #213). The cutover migrated SSE delivery from per-task in-memory deques to Redis Streams keyed by thread; the in-memory deques implicitly reset per turn, the new Stream does not. Cleanup-at-terminal was the intended mechanism but couldn't reliably guarantee a clean slate.

## Test plan

- [ ] Send query, let it complete, send a second query on the same thread → second query renders its own response (not the first's replay).
- [ ] Repro the persistence half: Ctrl-C the dev server mid-stream during turn 1, restart, send turn 2 on the same thread → turn 2 query row lands in Postgres (`SELECT turn_index FROM conversation_queries WHERE conversation_thread_id = '<id>'` shows both turns).
- [ ] `uv run pytest tests/unit/` — 3327 pass (+6 new in `test_per_turn_state_reset.py`).
- [ ] `uv run ruff check src/server/services/background_task_manager.py src/server/services/persistence/conversation.py` — clean.