### PR TITLE
fix(i18n): prevent locale sync race that flipped localStorage between languages

### DIFF
--- a/web/src/hooks/__tests__/useSyncUserLocale.test.ts
+++ b/web/src/hooks/__tests__/useSyncUserLocale.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useSyncUserLocale } from '../useSyncUserLocale';
+
+vi.mock('../useUser', () => ({
+  useUser: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: vi.fn(),
+}));
+
+import { useUser } from '../useUser';
+import { useTranslation } from 'react-i18next';
+
+const mockUseUser = useUser as Mock;
+const mockUseTranslation = useTranslation as unknown as Mock;
+
+type I18nStub = { language: string; changeLanguage: Mock };
+
+function makeI18n(language = 'en-US'): I18nStub {
+  const stub: I18nStub = {
+    language,
+    changeLanguage: vi.fn((lang: string) => {
+      // Mirror real i18next behavior so subsequent reads see the new language.
+      stub.language = lang;
+      return Promise.resolve();
+    }),
+  };
+  return stub;
+}
+
+let mockI18n: I18nStub;
+
+describe('useSyncUserLocale', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    mockI18n = makeI18n('en-US');
+    mockUseTranslation.mockReturnValue({ i18n: mockI18n });
+  });
+
+  it('applies the server locale on first render', () => {
+    mockUseUser.mockReturnValue({ user: { locale: 'zh-CN' } });
+
+    renderHook(() => useSyncUserLocale());
+
+    expect(mockI18n.changeLanguage).toHaveBeenCalledTimes(1);
+    expect(mockI18n.changeLanguage).toHaveBeenCalledWith('zh-CN');
+    expect(localStorage.getItem('locale')).toBe('zh-CN');
+  });
+
+  it('does not re-apply when user.locale changes after the first sync (regression: locale race)', () => {
+    mockUseUser.mockReturnValue({ user: { locale: 'zh-CN' } });
+
+    const { rerender } = renderHook(() => useSyncUserLocale());
+
+    expect(mockI18n.changeLanguage).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem('locale')).toBe('zh-CN');
+
+    // Simulate a stale /users/me refetch returning the prior server value while
+    // the user has just picked a different locale locally.
+    mockUseUser.mockReturnValue({ user: { locale: 'en-US' } });
+    rerender();
+
+    // Latch must hold: no second changeLanguage, localStorage untouched.
+    expect(mockI18n.changeLanguage).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem('locale')).toBe('zh-CN');
+  });
+
+  it('latches even when the first render is a no-op (user.locale already matches i18n.language)', () => {
+    mockI18n = makeI18n('en-US');
+    mockUseTranslation.mockReturnValue({ i18n: mockI18n });
+    mockUseUser.mockReturnValue({ user: { locale: 'en-US' } });
+
+    const { rerender } = renderHook(() => useSyncUserLocale());
+
+    // First render: locale matches i18n.language, so changeLanguage is not
+    // called, but the latch must still trip.
+    expect(mockI18n.changeLanguage).not.toHaveBeenCalled();
+    expect(localStorage.getItem('locale')).toBeNull();
+
+    // Later refetch returns a different locale: latch must block the sync.
+    mockUseUser.mockReturnValue({ user: { locale: 'zh-CN' } });
+    rerender();
+
+    expect(mockI18n.changeLanguage).not.toHaveBeenCalled();
+    expect(localStorage.getItem('locale')).toBeNull();
+  });
+});

--- a/web/src/hooks/useSyncUserLocale.ts
+++ b/web/src/hooks/useSyncUserLocale.ts
@@ -1,20 +1,24 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useUser } from './useUser';
 
 const SUPPORTED = new Set(['en-US', 'zh-CN']);
 
 /**
- * Apply the user's DB-stored locale on app load so cross-device language
- * preference sticks (i18n's detector only sees localStorage + navigator).
+ * Apply the user's DB-stored locale once, on the first user payload we see.
+ * Subsequent refetches must not override the local value — otherwise a stale
+ * /users/me response can clobber a locale the user just picked in Settings.
  */
 export function useSyncUserLocale() {
   const { user } = useUser();
   const { i18n } = useTranslation();
+  const synced = useRef(false);
 
   useEffect(() => {
+    if (synced.current) return;
     const stored = user?.locale as string | undefined;
     if (!stored || !SUPPORTED.has(stored)) return;
+    synced.current = true; // latch even if no-op, so a later refetch can't trigger sync
     if (i18n.language === stored) return;
     i18n.changeLanguage(stored);
     if (typeof localStorage !== 'undefined') {


### PR DESCRIPTION
## Summary

Fix a race between two writers to `localStorage['locale']` that caused the saved language
to oscillate between values when changing the locale in Settings.

## Problem

Two places write `localStorage['locale']`:

1. **`Settings.handleLocaleChange`** (`web/src/pages/Settings/Settings.tsx:507`) — when
   the locale dropdown changes, it sets `i18n.language` + `localStorage`, then PATCHes
   `/users/me` and invalidates the React Query cache for `user.me`.
2. **`useSyncUserLocale`** (`web/src/hooks/useSyncUserLocale.ts`) — a `useEffect` keyed
   on `user?.locale` that re-fired on every refetch, unconditionally overwriting both
   `i18n.language` and `localStorage` whenever the server-returned value differed from
   the current `i18n.language`.

Because `user.me` is invalidated from 14 places across the app (avatar upload,
AuthContext sign-in, Setup flows, OAuth flows, ChatView onboarding, etc.), a stale or
out-of-order `/users/me` refetch could land between the user's pick and the PATCH
commit. The hook would see the old server value, write it back, and the locale would
visibly flip. A subsequent refetch with the new value flipped it again.

The hook's own docstring already promised one-time-on-app-load behavior — the
implementation just didn't enforce it.

## Fix

Add a `useRef` one-shot latch in `useSyncUserLocale`. The first valid `user.locale`
payload syncs `i18n` and `localStorage`; every subsequent change is a no-op.

Key detail: `synced.current = true` flips **before** the `i18n.language === stored`
early-return. This means even a first-render no-op (when the server value already
matches `i18n.language`) latches the hook, so a later refetch with a different value
can't trigger a sync.

Cross-device sync still works: changing the locale on one device → server updates →
the other device picks it up on next mount (fresh component, fresh ref). Logout/login
as a different account works the same way — `AuthenticatedShell` (App.tsx:762)
unmounts the hook on `!isLoggedIn` and remounts it fresh on re-login.

## Test plan

- [x] Unit test — applies server locale on first render
- [x] Unit test (regression) — subsequent `user.locale` changes after first sync are
      no-ops; `localStorage` stays untouched
- [x] Unit test — latch trips even when the first render is a no-op
      (`user.locale === i18n.language`)
- [x] `pnpm vitest run src/hooks/` — 79/79 pass
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` — no new warnings