### PR TITLE
fix(byok): rewrite custom provider to parent_provider so SDK resolves correctly`

### DIFF
--- a/src/server/handlers/chat/llm_config.py
+++ b/src/server/handlers/chat/llm_config.py
@@ -56,9 +56,15 @@ async def _resolve_custom_model_byok(
     if cp_by_name:
         byok_config = await get_byok_config_for_provider(user_id, model_name)
         if byok_config:
-            base_url = byok_config.get("base_url") or mc.get_provider_info(cp_by_name["parent_provider"]).get("base_url")
+            parent = cp_by_name["parent_provider"]
+            base_url = byok_config.get("base_url") or mc.get_provider_info(parent).get("base_url")
             if cp_by_name.get("use_response_api"):
                 custom_config = {**custom_config, "_use_response_api": True}
+            # Rewrite provider to parent so ``from_custom_config`` reads SDK /
+            # default_headers from the manifest. Without this, an Anthropic-
+            # parented custom provider (e.g. matrixllm) defaults to sdk="openai"
+            # and POSTs /chat/completions to an Anthropic /v1/messages endpoint.
+            custom_config = {**custom_config, "provider": parent}
             return byok_config, base_url, custom_config
 
     # 2. Provider field is a custom sub-provider
@@ -66,9 +72,11 @@ async def _resolve_custom_model_byok(
     if cp_by_provider:
         byok_config = await get_byok_config_for_provider(user_id, provider)
         if byok_config:
-            base_url = byok_config.get("base_url") or mc.get_provider_info(cp_by_provider["parent_provider"]).get("base_url")
+            parent = cp_by_provider["parent_provider"]
+            base_url = byok_config.get("base_url") or mc.get_provider_info(parent).get("base_url")
             if cp_by_provider.get("use_response_api"):
                 custom_config = {**custom_config, "_use_response_api": True}
+            custom_config = {**custom_config, "provider": parent}
             return byok_config, base_url, custom_config
 
     # 3. System provider — try the provider's own slug first (variants like

--- a/src/server/handlers/chat/llm_config.py
+++ b/src/server/handlers/chat/llm_config.py
@@ -58,8 +58,13 @@ async def _resolve_custom_model_byok(
         if byok_config:
             parent = cp_by_name["parent_provider"]
             base_url = byok_config.get("base_url") or mc.get_provider_info(parent).get("base_url")
-            if cp_by_name.get("use_response_api"):
-                custom_config = {**custom_config, "_use_response_api": True}
+            # Forward user's explicit setting (truthy OR falsy) so it can
+            # override the parent manifest's default. Truthy-only check would
+            # silently lose a user's ``false`` and re-inherit the parent's
+            # ``true`` — breaking OpenAI-compat gateways that don't ship
+            # ``/v1/responses``.
+            if "use_response_api" in cp_by_name:
+                custom_config = {**custom_config, "_use_response_api": cp_by_name["use_response_api"]}
             # Rewrite provider to parent so ``from_custom_config`` reads SDK /
             # default_headers from the manifest. Without this, an Anthropic-
             # parented custom provider (e.g. matrixllm) defaults to sdk="openai"
@@ -74,8 +79,8 @@ async def _resolve_custom_model_byok(
         if byok_config:
             parent = cp_by_provider["parent_provider"]
             base_url = byok_config.get("base_url") or mc.get_provider_info(parent).get("base_url")
-            if cp_by_provider.get("use_response_api"):
-                custom_config = {**custom_config, "_use_response_api": True}
+            if "use_response_api" in cp_by_provider:
+                custom_config = {**custom_config, "_use_response_api": cp_by_provider["use_response_api"]}
             custom_config = {**custom_config, "provider": parent}
             return byok_config, base_url, custom_config
 


### PR DESCRIPTION

Fixes #221 
### Summary

Fixes the missing provider rewrite in `_resolve_custom_model_byok` paths 1 and 2. With the rewrite in place, `from_custom_config` picks up SDK / default_headers / `use_response_api` from `providers.json` correctly, so Anthropic-parented custom providers no longer default to the OpenAI SDK.

### Changes

`src/server/handlers/chat/llm_config.py`: after locating the BYOK key in path 1 and path 2, rewrite `custom_config["provider"]` to `parent_provider`. This mirrors the sibling-rewrite already in path 3.

```python
# path 1
parent = cp_by_name["parent_provider"]
base_url = byok_config.get("base_url") or mc.get_provider_info(parent).get("base_url")
if cp_by_name.get("use_response_api"):
    custom_config = {**custom_config, "_use_response_api": True}
custom_config = {**custom_config, "provider": parent}
return byok_config, base_url, custom_config

# path 2 follows the same shape
```

### Rationale

`from_custom_config` resolves the SDK by looking up `custom_config["provider"]` in the manifest. User-defined slugs are not in the manifest, so it falls back to `"openai"` — a deliberate default for unknown providers. The right place to fix this is the call site: once `_resolve_custom_model_byok` knows the parent, it should point `provider` at the parent so the manifest lookup hits. Path 3 already does this after its sibling fan-out; paths 1 and 2 were simply missing the same step.

`from_custom_config` is kept as a pure config-in / client-out function — it deliberately does not reach back into user preferences. Semantic boundary stays at the caller.

### Testing

- Manual repro: configure a `parent_provider: anthropic` custom provider with a BYOK `base_url` pointing at an Anthropic-compatible proxy and send a chat request. Before the fix: 404 with `provider_module: openai`. After the fix: succeeds with `provider_module: anthropic`.
- Path 3 (sibling fan-out) is unaffected: it already does its own rewrite via `candidate`; this PR only appends the same semantic rewrite at the end of paths 1 and 2.

### Note for users

The Anthropic SDK appends `/v1/messages` to `base_url`, so BYOK `base_url` must not include a trailing `/v1`. This is SDK behavior independent of the patch; writing `https://example.com/anthropic/v1` would produce `/anthropic/v1/v1/messages`. The convention matches existing manifest entries (`https://api.moonshot.ai/anthropic`, `https://api.z.ai/api/anthropic`, etc.).
