### PR TITLE
refactor(per-turn): adopt LangGraph run_id as first-class per-turn identity

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -75,7 +75,7 @@ curl -N -X POST "http://localhost:8000/api/v1/threads/messages" \
   }'
 ```
 
-The response includes a `thread_id` in SSE events for follow-up messages.
+The first SSE frame is `event: metadata` carrying `{thread_id, run_id}` — the canonical per-turn identity. The HTTP response also sets `Content-Location: /api/v1/threads/{thread_id}/messages/stream?run_id={run_id}` so the client knows the exact reconnect URL for this turn.
 
 ### Step 3: Continue the Conversation
 
@@ -90,8 +90,10 @@ curl -N -X POST "http://localhost:8000/api/v1/threads/THREAD_ID/messages" \
 
 ### Step 4: Reconnect if Disconnected
 
+Reconnect targets a specific run via `run_id`. If omitted, the server falls back to the latest run on the thread.
+
 ```bash
-curl -N "http://localhost:8000/api/v1/threads/THREAD_ID/messages/stream?last_event_id=42"
+curl -N "http://localhost:8000/api/v1/threads/THREAD_ID/messages/stream?run_id=RUN_ID&last_event_id=42"
 ```
 
 ### Step 5: Check Status
@@ -167,13 +169,16 @@ User identification is handled via:
 ## SSE Event Types
 
 The streaming endpoints emit Server-Sent Events. Key event types:
-- `message_chunk` — text/reasoning streaming
-- `tool_calls` / `tool_call_result` — tool execution
+- `metadata` — first frame of every stream, carries `{thread_id, run_id}` for reconnect/steering
+- `message_chunk` / `reasoning_content` / `reasoning_signal` — text + reasoning streaming
+- `tool_calls` / `tool_call_chunks` / `tool_call_result` — tool execution
 - `artifact` — file operations and outputs
-- `subagent_status` — background task status
+- `user_message` — echo of user input (including mid-turn steering)
+- `workflow_status` / `thread_created` — lifecycle signals
+- `steering_delivered` / `task_steering_accepted` — steering acknowledgements
 - `interrupt` — human-in-the-loop pause
-- `error` / `warning` / `keepalive` — control events
-- `done` — workflow completion
+- `error` / `keepalive` — control events
+- `finish` — workflow completion
 
 ## Versioning
 

--- a/src/ptc_agent/agent/middleware/background_subagent/middleware.py
+++ b/src/ptc_agent/agent/middleware/background_subagent/middleware.py
@@ -389,6 +389,16 @@ class BackgroundSubagentMiddleware(AgentMiddleware):
             else ""
         )
 
+        # Extract the current turn's run_id from the LangGraph config so the
+        # registry can stamp it on newly-spawned subagents without relying on
+        # ``registry.current_run_id`` (which races when two concurrent turns
+        # on the same thread share the per-thread registry).
+        current_run_id = (
+            request.runtime.config.get("run_id")
+            if request.runtime
+            else None
+        )
+
         # --- Action-based routing ---
         if action == "update":
             # --- UPDATE: Instruct a running task via Redis ---
@@ -579,6 +589,7 @@ class BackgroundSubagentMiddleware(AgentMiddleware):
                 prompt=prompt,
                 subagent_type=subagent_type,
                 asyncio_task=None,  # Will be set after task creation
+                run_id=current_run_id,
             )
             logger.info(
                 "Intercepting task tool call for background execution",

--- a/src/ptc_agent/agent/middleware/background_subagent/registry.py
+++ b/src/ptc_agent/agent/middleware/background_subagent/registry.py
@@ -143,6 +143,12 @@ class BackgroundTask:
     spawned_turn_index: int = 0
     """The turn_index of the parent turn that spawned this subagent."""
 
+    spawned_run_id: str | None = None
+    """The run_id of the parent turn that spawned this subagent. Set from
+    ``registry.current_run_id`` at register time. Collectors filter by this
+    so subagents from prior turns can't get claimed by a later turn's
+    collector after the registry is reused across turns."""
+
     per_call_records: list[dict[str, Any]] = field(default_factory=list)
     """Token usage records collected when subagent completes."""
 
@@ -202,6 +208,7 @@ class BackgroundTaskRegistry:
         self._lock = asyncio.Lock()
         self._results: dict[str, Any] = {}
         self.current_turn_index: int = 0
+        self.current_run_id: str | None = None
         self.thread_id: str = thread_id
 
     async def register(
@@ -227,6 +234,7 @@ class BackgroundTaskRegistry:
                 asyncio_task=asyncio_task,
                 agent_id=agent_id,
                 spawned_turn_index=self.current_turn_index,
+                spawned_run_id=self.current_run_id,
             )
             self._tasks[tool_call_id] = task
             self._task_id_to_tool_call_id[task_id] = tool_call_id
@@ -860,6 +868,26 @@ class BackgroundTaskRegistry:
             logger.info("Cancelled background tasks", count=cancelled, force=force)
 
         return cancelled
+
+    async def remove_task(self, tool_call_id: str) -> None:
+        """Remove a single task's registry entry and its lookup mappings.
+
+        Called by the BTM collector after ``_await_drain_and_cleanup_tasks``
+        finishes so the registry doesn't grow unboundedly across many turns
+        on a long-lived thread.
+        """
+        async with self._lock:
+            task = self._tasks.pop(tool_call_id, None)
+            if task is None:
+                return
+            self._task_id_to_tool_call_id.pop(task.task_id, None)
+            self._results.pop(tool_call_id, None)
+            stale_ns = [
+                ns for ns, tid in self._ns_uuid_to_tool_call_id.items()
+                if tid == tool_call_id
+            ]
+            for ns in stale_ns:
+                del self._ns_uuid_to_tool_call_id[ns]
 
     def clear(self) -> None:
         """Clear all tasks and results from the registry.

--- a/src/ptc_agent/agent/middleware/background_subagent/registry.py
+++ b/src/ptc_agent/agent/middleware/background_subagent/registry.py
@@ -218,8 +218,16 @@ class BackgroundTaskRegistry:
         prompt: str,
         subagent_type: str,
         asyncio_task: asyncio.Task | None = None,
+        run_id: str | None = None,
     ) -> BackgroundTask:
-        """Register a new background task and return it."""
+        """Register a new background task and return it.
+
+        ``run_id`` is the LangGraph run_id of the dispatching turn, stamped on
+        the task so the collector can filter prior-turn subagents. Callers
+        should always pass it explicitly (read from request config) rather
+        than relying on ``self.current_run_id``, which would race when two
+        concurrent turns share the registry.
+        """
         async with self._lock:
             # Generate short alphanumeric task_id
             task_id = secrets.token_urlsafe(4)[:6]
@@ -234,7 +242,7 @@ class BackgroundTaskRegistry:
                 asyncio_task=asyncio_task,
                 agent_id=agent_id,
                 spawned_turn_index=self.current_turn_index,
-                spawned_run_id=self.current_run_id,
+                spawned_run_id=run_id if run_id is not None else self.current_run_id,
             )
             self._tasks[tool_call_id] = task
             self._task_id_to_tool_call_id[task_id] = tool_call_id

--- a/src/server/app/threads.py
+++ b/src/server/app/threads.py
@@ -178,11 +178,13 @@ async def _consume_background_gen(
             status = await tracker.get_status(thread_id)
             if status and status.get("status") == "active":
                 meta = status.get("metadata", {})
-                if meta.get("dispatched") and meta.get("run_id") == run_id:
+                if meta.get("dispatched") and status.get("run_id") == run_id:
                     if _ok:
-                        await tracker.mark_completed(thread_id)
+                        await tracker.mark_completed(thread_id, run_id=run_id)
                     else:
-                        await tracker.mark_failed(thread_id, error=_error_text)
+                        await tracker.mark_failed(
+                            thread_id, error=_error_text, run_id=run_id
+                        )
         except Exception:
             pass
     return _ok

--- a/src/server/app/threads.py
+++ b/src/server/app/threads.py
@@ -83,30 +83,22 @@ def _track_task(task: asyncio.Task) -> None:
     task.add_done_callback(_background_tasks.discard)
 
 
-async def _consume_background_gen(gen, label: str, thread_id: str) -> bool:
-    """Drain an async generator in the background, cleaning up Redis on failure.
-
-    Returns True on success, False if the generator raised. Failures are logged
-    and Redis state cleaned up here; the exception is intentionally swallowed
-    so the caller can decide how to surface it (e.g. metric labeling).
-    """
+async def _consume_background_gen(
+    gen, label: str, thread_id: str, run_id: str
+) -> bool:
+    """Drain an async generator in the background, cleaning up Redis on failure."""
     _ok = True
+    _error_text: str | None = None
     try:
         async for _ in gen:
             pass
-    except Exception:
+    except Exception as exc:
         _ok = False
+        _error_text = f"{type(exc).__name__}: {exc}"
         logger.error(
-            f"[{label}] Background workflow failed: thread_id={thread_id}",
+            f"[{label}] Background workflow failed: thread_id={thread_id} run_id={run_id}",
             exc_info=True,
         )
-        # Clean up Redis state so the frontend doesn't show a permanent
-        # "pending" indicator for a dispatch that will never complete.
-        # NOTE: When called for the flash-side background task, ptc_origin
-        # is keyed by the PTC thread_id (not the flash thread_id passed here),
-        # so the lookup returns None and cleanup is a no-op. This is expected;
-        # _flash_report_back already handles ptc_origin cleanup before the
-        # flash workflow starts, and TTL covers any remaining edge cases.
         try:
             from src.utils.cache.redis_cache import get_cache_client
 
@@ -122,7 +114,6 @@ async def _consume_background_gen(gen, label: str, thread_id: str) -> bool:
                         remaining = await cache.client.scard(watch_key)
                         if remaining == 0:
                             await cache.client.delete(watch_key)
-                        # Notify frontend so the watch connection closes
                         await cache.client.publish(
                             f"thread:wake:{flash_tid}",
                             '{"error": "background_workflow_failed"}',
@@ -130,10 +121,41 @@ async def _consume_background_gen(gen, label: str, thread_id: str) -> bool:
         except Exception:
             logger.warning(f"[{label}] Redis cleanup after failure also failed", exc_info=True)
     finally:
-        # Clean up pre-registered dispatch state if the generator failed before
-        # reaching start_workflow().  The pre-registered TaskInfo is QUEUED with
-        # no asyncio task; once start_workflow() upgrades it, BackgroundTaskManager
-        # owns the lifecycle and this block is a no-op.
+        # When the generator raised before reaching start_workflow, the
+        # frontend already received {status: dispatched, run_id} and
+        # navigated to workflow:stream:{tid}:{rid} — but no events will
+        # ever land. Write a terminal `error` SSE so a reconnected client
+        # sees the failure instead of silently waiting on an empty stream.
+        # Wrapped in its own try/except so failure to emit never blocks
+        # the placeholder/tracker cleanup below.
+        if not _ok:
+            try:
+                from src.server.services.background_task_manager import stream_key
+                from src.utils.cache.redis_cache import get_cache_client
+
+                cache = get_cache_client()
+                if cache.enabled and cache.client:
+                    error_payload = {
+                        "thread_id": thread_id,
+                        "content": "background workflow failed",
+                        "error_type": "background_failure",
+                        "error": _error_text or "background workflow failed",
+                    }
+                    sse_wire = (
+                        f"event: error\n"
+                        f"data: {json.dumps(error_payload, ensure_ascii=False)}\n\n"
+                    )
+                    await cache.client.xadd(
+                        stream_key(thread_id, run_id),
+                        {b"event": sse_wire.encode("utf-8")},
+                    )
+            except Exception:
+                logger.warning(
+                    f"[{label}] Failed to emit terminal error SSE for "
+                    f"thread_id={thread_id} run_id={run_id}",
+                    exc_info=True,
+                )
+
         try:
             from src.server.services.background_task_manager import (
                 BackgroundTaskManager,
@@ -142,26 +164,25 @@ async def _consume_background_gen(gen, label: str, thread_id: str) -> bool:
             from src.server.services.workflow_tracker import WorkflowTracker
 
             manager = BackgroundTaskManager.get_instance()
+            key = (thread_id, run_id)
             async with manager.task_lock:
-                task_info = manager.tasks.get(thread_id)
+                task_info = manager.tasks.get(key)
                 if task_info and task_info.status == TaskStatus.QUEUED and task_info.task is None:
-                    # Workflow never started — drop the placeholder. Any
-                    # reconnect consumer attached to workflow:stream:* will
-                    # eventually exit via its terminal-check + handshake when
-                    # the missing TaskInfo flips it to a no-task state.
-                    del manager.tasks[thread_id]
+                    del manager.tasks[key]
                     logger.info(
                         f"[{label}] Cleaned up pre-registered placeholder "
-                        f"for {thread_id} (workflow never started)"
+                        f"for {key} (workflow never started)"
                     )
 
             tracker = WorkflowTracker.get_instance()
             status = await tracker.get_status(thread_id)
             if status and status.get("status") == "active":
-                # Only clean up if this was our pre-registration (metadata.dispatched)
                 meta = status.get("metadata", {})
-                if meta.get("dispatched"):
-                    await tracker.mark_completed(thread_id)
+                if meta.get("dispatched") and meta.get("run_id") == run_id:
+                    if _ok:
+                        await tracker.mark_completed(thread_id)
+                    else:
+                        await tracker.mark_failed(thread_id, error=_error_text)
         except Exception:
             pass
     return _ok
@@ -408,6 +429,14 @@ async def _handle_send_message(
 
     from src.server.database.workspace import get_workspace
 
+    # Canonical run_id generation site. Each POST gets a fresh UUID that
+    # flows through every downstream key: BTM ``(tid, rid)``, persistence
+    # service, ``workflow:stream:{tid}:{rid}``, LangGraph ``config["run_id"]``
+    # → ``CheckpointMetadata.run_id``, and the SSE ``metadata`` event the
+    # frontend sees as the first event of the stream. 1:1 with
+    # ``conversation_response_id``.
+    run_id = str(uuid4())
+
     user_id = auth.user_id
     is_byok = auth.is_byok
     agent_mode = request.agent_mode or "ptc"
@@ -532,37 +561,81 @@ async def _handle_send_message(
     _llm = getattr(config, "llm", None)
     _model = (getattr(_llm, "flash", None) if agent_mode == "flash" else getattr(_llm, "name", None)) or ""
 
+    # Content-Location header advertises the reconnect URL for this run.
+    # Mirrors langgraph_sdk's protocol so reconnects target the exact run.
+    sse_headers_with_loc = {
+        **SSE_HEADERS,
+        "Content-Location": f"/api/v1/threads/{thread_id}/messages/stream?run_id={run_id}",
+    }
+
     # Route to appropriate streaming function based on agent mode
     if agent_mode == "flash":
+        is_flash_dispatch = (
+            is_internal
+            and raw_request
+            and raw_request.headers.get("X-Dispatch") == "background"
+        )
         flash_gen = astream_flash_workflow(
             request=request,
             thread_id=thread_id,
+            run_id=run_id,
             user_input=user_input,
             user_id=user_id,
             is_byok=is_byok,
             config=config,
+            dispatched=is_flash_dispatch,
         )
 
-        # Background dispatch for flash (used by PTC completion report-back).
-        if is_internal and raw_request and raw_request.headers.get("X-Dispatch") == "background":
+        if is_flash_dispatch:
+            from src.server.services.background_task_manager import BackgroundTaskManager
+            manager = BackgroundTaskManager.get_instance()
+            # Fail-fast admission at the HTTP boundary: if another run is
+            # still active on this thread, wait for it to settle (up to
+            # the soft-interrupt timeout). If it doesn't settle, return
+            # 409 here rather than dispatching a doomed background task.
+            #
+            # The admission_lock is held across wait_for_soft_interrupted +
+            # pre_register so two concurrent dispatched POSTs on the same
+            # thread can't both pass the gate and start workflows on the
+            # same LangGraph thread_id (the foreground branch acquires
+            # this same lock inside its handler via wait_or_steer; the
+            # dispatched branch must do it here because it skips
+            # wait_or_steer entirely). Released before _track_task
+            # schedules the background workflow.
+            admission_lock = await manager.get_admission_lock(thread_id)
+            async with admission_lock:
+                settled = await manager.wait_for_soft_interrupted(
+                    thread_id, exclude_run_id=run_id
+                )
+                if not settled:
+                    await release_burst_slot(user_id)
+                    raise HTTPException(
+                        status_code=409,
+                        detail=(
+                            f"Workflow {thread_id} is still running; dispatched "
+                            "follow-up could not be admitted."
+                        ),
+                    )
+                await manager.pre_register(thread_id, run_id)
             _track_task(asyncio.create_task(
                 observe_background_chat_turn(
-                    _consume_background_gen(flash_gen, "FLASH_DISPATCH", thread_id),
+                    _consume_background_gen(flash_gen, "FLASH_DISPATCH", thread_id, run_id),
                     mode="flash",
                     model=_model,
                     user_id=user_id,
                     workspace_id=workspace_id,
                     thread_id=thread_id,
                 ),
-                name=f"flash-dispatch-{thread_id}",
+                name=f"flash-dispatch-{thread_id}-{run_id[:8]}",
             ))
             logger.info(
                 f"[FLASH_DISPATCH] Started background workflow: "
-                f"thread_id={thread_id}"
+                f"thread_id={thread_id} run_id={run_id}"
             )
             return JSONResponse({
                 "status": "dispatched",
                 "thread_id": thread_id,
+                "run_id": run_id,
             })
 
         return StreamingResponse(
@@ -575,61 +648,86 @@ async def _handle_send_message(
                 thread_id=thread_id,
             ),
             media_type="text/event-stream",
-            headers=SSE_HEADERS,
+            headers=sse_headers_with_loc,
         )
 
+    is_ptc_dispatch = (
+        is_internal
+        and raw_request
+        and raw_request.headers.get("X-Dispatch") == "background"
+    )
     ptc_gen = astream_ptc_workflow(
         request=request,
         thread_id=thread_id,
+        run_id=run_id,
         user_input=user_input,
         user_id=user_id,
         workspace_id=workspace_id,
         is_byok=is_byok,
         config=config,
+        dispatched=is_ptc_dispatch,
     )
 
-    # Internal dispatch mode: run the PTC workflow in a background task
-    # instead of streaming SSE.  The ptc_agent tool (secretary) uses this
-    # to avoid the generator being cancelled when the HTTP connection closes.
-    # Only honoured for internal service-to-service calls (X-Service-Token).
-    if is_internal and raw_request and raw_request.headers.get("X-Dispatch") == "background":
-        # Pre-register in WorkflowTracker and BackgroundTaskManager BEFORE the
-        # asyncio task starts.  This closes the timing gap where the frontend
-        # navigates to the new PTC workspace before the generator reaches
-        # tracker.mark_active() / manager.start_workflow() (~20 async ops later).
-        # Without this, /status returns {can_reconnect: false, status: unknown}
-        # and the frontend incorrectly marks the agent as completed.
+    if is_ptc_dispatch:
         from src.server.services.background_task_manager import BackgroundTaskManager
         from src.server.services.workflow_tracker import WorkflowTracker
 
         tracker = WorkflowTracker.get_instance()
         manager = BackgroundTaskManager.get_instance()
-        await tracker.mark_active(
-            thread_id=thread_id,
-            workspace_id=workspace_id,
-            user_id=user_id,
-            metadata={"type": "ptc_agent", "dispatched": True},
-        )
-        await manager.pre_register(thread_id)
+        # Fail-fast admission at the HTTP boundary: if another run is still
+        # active on this thread, wait for it to settle. If it doesn't,
+        # return 409 here rather than dispatching a doomed background task.
+        #
+        # The admission_lock is held across wait_for_soft_interrupted +
+        # mark_active + pre_register so two concurrent dispatched POSTs on
+        # the same thread can't both pass the gate and start workflows on
+        # the same LangGraph thread_id (the foreground branch acquires
+        # this same lock inside its handler via wait_or_steer; the
+        # dispatched branch must do it here because it skips
+        # wait_or_steer entirely). Released before _track_task schedules
+        # the background workflow.
+        admission_lock = await manager.get_admission_lock(thread_id)
+        async with admission_lock:
+            settled = await manager.wait_for_soft_interrupted(
+                thread_id, exclude_run_id=run_id
+            )
+            if not settled:
+                await release_burst_slot(user_id)
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"Workflow {thread_id} is still running; dispatched "
+                        "follow-up could not be admitted."
+                    ),
+                )
+            await tracker.mark_active(
+                thread_id=thread_id,
+                workspace_id=workspace_id,
+                user_id=user_id,
+                run_id=run_id,
+                metadata={"type": "ptc_agent", "dispatched": True},
+            )
+            await manager.pre_register(thread_id, run_id)
 
         _track_task(asyncio.create_task(
             observe_background_chat_turn(
-                _consume_background_gen(ptc_gen, "PTC_DISPATCH", thread_id),
+                _consume_background_gen(ptc_gen, "PTC_DISPATCH", thread_id, run_id),
                 mode="ptc",
                 model=_model,
                 user_id=user_id,
                 workspace_id=workspace_id,
                 thread_id=thread_id,
             ),
-            name=f"ptc-dispatch-{thread_id}",
+            name=f"ptc-dispatch-{thread_id}-{run_id[:8]}",
         ))
         logger.info(
             f"[PTC_DISPATCH] Started background workflow: "
-            f"thread_id={thread_id} workspace_id={workspace_id}"
+            f"thread_id={thread_id} run_id={run_id} workspace_id={workspace_id}"
         )
         return JSONResponse({
             "status": "dispatched",
             "thread_id": thread_id,
+            "run_id": run_id,
             "workspace_id": workspace_id,
         })
 
@@ -643,7 +741,7 @@ async def _handle_send_message(
             thread_id=thread_id,
         ),
         media_type="text/event-stream",
-        headers=SSE_HEADERS,
+        headers=sse_headers_with_loc,
     )
 
 
@@ -653,13 +751,12 @@ async def reconnect_to_stream(
     x_user_id: CurrentUserId,
     last_event_id: Optional[int] = Query(None, description="Last received event ID"),
     last_event_id_header: Optional[str] = Header(None, alias="Last-Event-ID"),
+    run_id: Optional[str] = Query(None, description="Specific run to reconnect to"),
 ):
-    """
-    Reconnect to a running or completed workflow's SSE stream.
+    """Reconnect to a running or completed workflow's SSE stream.
 
-    Replays buffered events, then attaches to live stream if still running.
-    Accepts the cursor as either ``?last_event_id=N`` (existing) or the
-    SSE-spec ``Last-Event-ID`` HTTP header (preferred when present).
+    ``run_id`` targets a specific turn. If omitted, falls back to the
+    latest run on the thread (matches the single-turn happy path).
     """
     await require_thread_owner(thread_id, x_user_id)
     from src.server.handlers.chat import reconnect_to_workflow_stream
@@ -670,11 +767,13 @@ async def reconnect_to_stream(
         try:
             last_event_id = int(last_event_id_header)
         except ValueError:
-            pass  # Invalid header → fall through, treated as no resume.
+            pass
 
     async def stream_reconnection():
         try:
-            async for event in reconnect_to_workflow_stream(thread_id, last_event_id):
+            async for event in reconnect_to_workflow_stream(
+                thread_id, run_id, last_event_id
+            ):
                 yield event
         except HTTPException:
             raise

--- a/src/server/database/conversation.py
+++ b/src/server/database/conversation.py
@@ -20,6 +20,28 @@ from src.server.utils.pg_sanitize import SafeJson, strip_pg_nul_str
 
 logger = logging.getLogger(__name__)
 
+
+class QueryConflictError(Exception):
+    """Raised when create_query (idempotent) collides with an existing
+    row whose content differs from the new write.
+
+    The idempotent ``ON CONFLICT DO UPDATE`` is gated on
+    ``content IS NOT DISTINCT FROM EXCLUDED.content``, so legitimate
+    retry-of-same-content stays a silent no-op while different-content
+    races (e.g. a concurrent POST that bypassed the in-process admission
+    lock) surface here instead of silently overwriting the loser's row.
+    """
+
+    def __init__(self, thread_id: str, turn_index: int, existing_content: Optional[str]):
+        self.thread_id = thread_id
+        self.turn_index = turn_index
+        self.existing_content = existing_content
+        super().__init__(
+            f"conversation_queries collision for thread_id={thread_id} "
+            f"turn_index={turn_index}: existing row has different content"
+        )
+
+
 # Cache key helpers — single source of truth for key format.
 # Invalidation sites import these instead of hardcoding the prefix.
 _EXISTS_TTL = 86400  # 24h — freshness via explicit invalidation
@@ -842,7 +864,15 @@ async def create_query(
             # Reuse provided connection
             async with conn.cursor(row_factory=dict_row) as cur:
                 if idempotent:
-                    # Idempotent: ON CONFLICT DO UPDATE for safe retries
+                    # Idempotent: ON CONFLICT DO UPDATE for safe retries.
+                    # The WHERE clause gates the UPDATE on content equality
+                    # so a legitimate retry-of-same-content (HITL resume,
+                    # network retry) succeeds silently while a concurrent
+                    # different-content INSERT collision (worker race that
+                    # bypassed the in-process admission lock) produces no
+                    # RETURNING row — we surface ``QueryConflictError``
+                    # instead of letting ``ON CONFLICT DO UPDATE`` silently
+                    # overwrite the loser's row.
                     await cur.execute(
                         """
                         INSERT INTO conversation_queries (
@@ -856,6 +886,7 @@ async def create_query(
                             feedback_action = EXCLUDED.feedback_action,
                             metadata = EXCLUDED.metadata,
                             created_at = EXCLUDED.created_at
+                        WHERE conversation_queries.content IS NOT DISTINCT FROM EXCLUDED.content
                         RETURNING conversation_query_id, conversation_thread_id, turn_index, content, type,
                                   feedback_action, metadata, created_at
                     """,
@@ -870,6 +901,23 @@ async def create_query(
                             created_at,
                         ),
                     )
+                    result = await cur.fetchone()
+                    if result is None:
+                        await cur.execute(
+                            "SELECT content FROM conversation_queries "
+                            "WHERE conversation_thread_id = %s AND turn_index = %s",
+                            (conversation_thread_id, turn_index),
+                        )
+                        existing = await cur.fetchone()
+                        raise QueryConflictError(
+                            thread_id=conversation_thread_id,
+                            turn_index=turn_index,
+                            existing_content=(existing or {}).get("content"),
+                        )
+                    logger.debug(
+                        f"[conversation_db] create_query query_id={conversation_query_id} thread_id={conversation_thread_id} turn_index={turn_index} type={query_type}"
+                    )
+                    return dict(result)
                 else:
                     # Non-idempotent: fail on conflict
                     await cur.execute(
@@ -903,7 +951,8 @@ async def create_query(
             async with get_db_connection() as conn:
                 async with conn.cursor(row_factory=dict_row) as cur:
                     if idempotent:
-                        # Idempotent: ON CONFLICT DO UPDATE for safe retries
+                        # Idempotent: ON CONFLICT DO UPDATE for safe retries.
+                        # See the parallel branch above for the WHERE gating.
                         await cur.execute(
                             """
                             INSERT INTO conversation_queries (
@@ -917,6 +966,7 @@ async def create_query(
                                 feedback_action = EXCLUDED.feedback_action,
                                 metadata = EXCLUDED.metadata,
                                 created_at = EXCLUDED.created_at
+                            WHERE conversation_queries.content IS NOT DISTINCT FROM EXCLUDED.content
                             RETURNING conversation_query_id, conversation_thread_id, turn_index, content, type,
                                       feedback_action, metadata, created_at
                         """,
@@ -931,6 +981,23 @@ async def create_query(
                                 created_at,
                             ),
                         )
+                        result = await cur.fetchone()
+                        if result is None:
+                            await cur.execute(
+                                "SELECT content FROM conversation_queries "
+                                "WHERE conversation_thread_id = %s AND turn_index = %s",
+                                (conversation_thread_id, turn_index),
+                            )
+                            existing = await cur.fetchone()
+                            raise QueryConflictError(
+                                thread_id=conversation_thread_id,
+                                turn_index=turn_index,
+                                existing_content=(existing or {}).get("content"),
+                            )
+                        logger.info(
+                            f"[conversation_db] create_query query_id={conversation_query_id} thread_id={conversation_thread_id} turn_index={turn_index} type={query_type}"
+                        )
+                        return dict(result)
                     else:
                         # Non-idempotent: fail on conflict
                         await cur.execute(

--- a/src/server/handlers/chat/_common.py
+++ b/src/server/handlers/chat/_common.py
@@ -755,7 +755,10 @@ async def handle_workflow_error(
             # error path runs outside BackgroundTaskManager's _mark_failed,
             # so this is the only chance to update tracker.
             try:
-                await tracker.mark_failed(thread_id, error=error_msg)
+                _expected = persistence_service.run_id if persistence_service else None
+                await tracker.mark_failed(
+                    thread_id, error=error_msg, run_id=_expected
+                )
             except Exception as tracker_err:
                 logger.warning(
                     f"[{log_prefix}] tracker.mark_failed failed for "

--- a/src/server/handlers/chat/_common.py
+++ b/src/server/handlers/chat/_common.py
@@ -97,15 +97,17 @@ async def _setup_fork_and_persistence(
     *,
     request: ChatRequest,
     thread_id: str,
+    run_id: str,
     workspace_id: str,
     user_id: str,
     log_prefix: str = "FORK",
 ) -> tuple[str, bool, ConversationPersistenceService]:
-    """Compute query_type, apply fork cleanup, and init persistence service.
+    """Compute query_type, apply fork cleanup, init per-run persistence service.
 
-    Shared by both flash and PTC handlers. Returns (query_type, is_fork, persistence_service).
+    Shared by flash and PTC handlers. Returns
+    ``(query_type, is_fork, persistence_service)``. Persistence is keyed
+    by ``(thread_id, run_id)`` — fresh per turn, no cross-turn aliasing.
     """
-    # Determine query type (allow explicit override for internal callers)
     if request.query_type:
         query_type = request.query_type
     else:
@@ -118,10 +120,8 @@ async def _setup_fork_and_persistence(
         else:
             query_type = "initial"
 
-    # Fork cleanup: truncate app DB when branching from a checkpoint
     is_fork = request.fork_from_turn is not None and request.checkpoint_id
     if is_fork:
-        # Parallelize the two DB operations (different tables, no dependency)
         deleted, _ = await asyncio.gather(
             qr_db.truncate_thread_from_turn(
                 thread_id,
@@ -134,19 +134,17 @@ async def _setup_fork_and_persistence(
             f"[{log_prefix}] Truncated {deleted} rows from turn_index>={request.fork_from_turn} "
             f"thread_id={thread_id} checkpoint_id={request.checkpoint_id}"
         )
-        # Clear Redis event buffer (stale events from old branch) — fault-tolerant
-        try:
-            manager = BackgroundTaskManager.get_instance()
-            await manager.clear_event_buffer(thread_id)
-        except Exception as e:
-            logger.warning(f"[{log_prefix}] Failed to clear event buffer: {e}")
+        # Fork buffer clearing now happens once the run starts emitting under
+        # the new per-run key; pre-clearing the legacy thread-keyed buffer
+        # is unnecessary because the new key didn't exist yet.
 
-    # Initialize persistence service
     persistence_service = ConversationPersistenceService.get_instance(
-        thread_id=thread_id, workspace_id=workspace_id, user_id=user_id
+        thread_id=thread_id,
+        run_id=run_id,
+        workspace_id=workspace_id,
+        user_id=user_id,
     )
 
-    # Reset persistence cache if forking, otherwise calculate from DB
     if is_fork:
         persistence_service.reset_for_fork(request.fork_from_turn)
     else:
@@ -486,9 +484,9 @@ async def persist_or_skip_replay(
 ) -> None:
     """Persist query start or skip persistence for checkpoint replay.
 
-    For checkpoint replays (regenerate/retry), marks the preserved query turn
-    as already persisted so ``persist_completion`` doesn't skip.  Otherwise
-    calls ``persist_query_start``.
+    For checkpoint replays (regenerate/retry), the preserved query row is
+    already in the database, so we skip the re-insert.  Otherwise calls
+    ``persist_query_start``.
     """
     if is_checkpoint_replay:
         turn_to_mark = (
@@ -496,7 +494,6 @@ async def persist_or_skip_replay(
             if request.fork_from_turn is not None
             else await persistence_service.get_or_calculate_turn_index()
         )
-        persistence_service.mark_query_persisted(turn_to_mark)
         logger.debug(
             f"[{log_prefix}] Skipped query persist (checkpoint replay): "
             f"thread_id={thread_id} turn_index={turn_to_mark}"

--- a/src/server/handlers/chat/flash_workflow.py
+++ b/src/server/handlers/chat/flash_workflow.py
@@ -455,8 +455,8 @@ async def astream_flash_workflow(
                     metadata={
                         "completed_at": datetime.now().isoformat(),
                         "execution_time": execution_time,
-                        "run_id": run_id,
                     },
+                    run_id=run_id,
                 )
 
                 # Backfill query records for steering messages that produced

--- a/src/server/handlers/chat/flash_workflow.py
+++ b/src/server/handlers/chat/flash_workflow.py
@@ -86,16 +86,18 @@ from .stream_from_log import stream_from_log
 async def astream_flash_workflow(
     request: ChatRequest,
     thread_id: str,
+    run_id: str,
     user_input: str,
     user_id: str,
     is_byok: bool = False,
     config=None,
+    dispatched: bool = False,
 ):
     """Async generator that streams Flash agent workflow events.
 
     Flash mode: no sandbox, no MCP, external tools only (web search, market
-    data, SEC filings). Follows the same background-task / reconnect pattern
-    as PTC but skips workspace and session setup.
+    data, SEC filings). State keyed by ``(thread_id, run_id)``; same
+    contract as PTC.
     """
     start_time = time.time()
     handler = None
@@ -110,12 +112,68 @@ async def astream_flash_workflow(
     logger.info(f"[FLASH_CHAT] Starting flash workflow: thread_id={thread_id}")
 
     slot_owned = True
+    admission_held = False
+    admission_lock = None
     try:
         if not setup.agent_config:
             raise HTTPException(
                 status_code=503,
                 detail="Flash Agent not initialized. Check server startup logs.",
             )
+
+        # =================================================================
+        # Admission gate
+        # =================================================================
+        # Per-thread asyncio.Lock that serializes the
+        # ``wait_or_steer → persist_query_start → start_workflow`` window.
+        # See the BTM docstring on ``get_admission_lock`` for the race
+        # this defends against.
+        manager = BackgroundTaskManager.get_instance()
+        admission_lock = await manager.get_admission_lock(thread_id)
+        await admission_lock.acquire()
+        admission_held = True
+
+        # =================================================================
+        # Early steering routing
+        # =================================================================
+        # If a workflow is already running (or soft-interrupted) for this
+        # thread, route this POST through the steering queue *before* any DB
+        # write. The persistence singleton's ``_turn_index_cache`` is shared
+        # across concurrent POSTs on the same thread, and
+        # ``qr_db.create_query`` uses ``ON CONFLICT (thread_id, turn_index)
+        # DO UPDATE``, so a second ``persist_query_start`` here would
+        # overwrite the running turn's query content with the steering text.
+        # Dispatched flow owns the BTM placeholder ``threads.py`` already
+        # reserved for it under the same ``(thread_id, run_id)`` key. We
+        # still must guarantee at most one in-flight LangGraph ``astream``
+        # per ``thread_id`` (the checkpointer is thread-keyed), so wait for
+        # any OTHER active run on the thread to settle. ``exclude_run_id``
+        # skips our own placeholder.
+        if dispatched:
+            settled = await manager.wait_for_soft_interrupted(
+                thread_id, exclude_run_id=run_id
+            )
+            if not settled:
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"Workflow {thread_id} is still running; dispatched "
+                        "follow-up could not be admitted."
+                    ),
+                )
+            ready, steering_event = True, None
+        else:
+            ready, steering_event = await wait_or_steer(
+                manager, thread_id, user_input, user_id
+            )
+        if not ready:
+            slot_owned = False
+            await release_burst_slot(user_id)
+            admission_lock.release()
+            admission_held = False
+            if steering_event:
+                yield steering_event
+            return
 
         # =================================================================
         # Database Persistence Setup
@@ -132,6 +190,7 @@ async def astream_flash_workflow(
         query_type, is_fork, persistence_service = await _setup_fork_and_persistence(
             request=request,
             thread_id=thread_id,
+            run_id=run_id,
             workspace_id=workspace_id,
             user_id=user_id,
             log_prefix="FLASH_FORK",
@@ -331,9 +390,11 @@ async def astream_flash_workflow(
             is_byok=is_byok,
             recursion_limit=get_flash_recursion_limit(),
         )
+        graph_config["run_id"] = run_id
 
         handler = WorkflowStreamHandler(
             thread_id=thread_id,
+            run_id=run_id,
             token_callback=token_callback,
             tool_tracker=tool_tracker,
             agent_config=config,
@@ -348,24 +409,14 @@ async def astream_flash_workflow(
         # =================================================================
 
         tracker = WorkflowTracker.get_instance()
-        manager = BackgroundTaskManager.get_instance()
-
-        # Wait for any running/soft-interrupted workflow to complete before
-        # starting new one
-        ready, steering_event = await wait_or_steer(
-            manager, thread_id, user_input, user_id
-        )
-        if not ready:
-            slot_owned = False
-            await release_burst_slot(user_id)
-            if steering_event:
-                yield steering_event
-            return
+        # ``manager`` was acquired at the top of this handler for the early
+        # steering-routing check; reuse it here.
 
         await tracker.mark_active(
             thread_id=thread_id,
             workspace_id=workspace_id,
             user_id=user_id,
+            run_id=run_id,
             metadata={
                 "started_at": datetime.now().isoformat(),
                 "msg_type": "flash",
@@ -374,8 +425,8 @@ async def astream_flash_workflow(
             },
         )
 
-        # Completion callback for background persistence
-        async def on_flash_workflow_complete():
+        async def on_flash_workflow_complete(task_info):
+            """Per-run state — no identity guards needed."""
             try:
                 execution_time = time.time() - start_time
                 _per_call_records = (
@@ -404,6 +455,7 @@ async def astream_flash_workflow(
                     metadata={
                         "completed_at": datetime.now().isoformat(),
                         "execution_time": execution_time,
+                        "run_id": run_id,
                     },
                 )
 
@@ -427,6 +479,7 @@ async def astream_flash_workflow(
         try:
             await manager.start_workflow(
                 thread_id=thread_id,
+                run_id=run_id,
                 workflow_generator=handler.stream_workflow(
                     graph=flash_graph,
                     input_state=input_state,
@@ -443,17 +496,21 @@ async def astream_flash_workflow(
                     "timezone": timezone_str,
                     "handler": handler,
                     "token_callback": token_callback,
+                    "persistence_service": persistence_service,
                 },
                 completion_callback=on_flash_workflow_complete,
                 graph=flash_graph,
             )
         except RuntimeError:
             # Race condition: another request registered first -- queue the
-            # message
+            # message. The admission lock should normally prevent reaching
+            # this branch, but it's kept as a belt-and-braces fallback.
             result = await steer_thread(thread_id, user_input, user_id)
             if result:
                 slot_owned = False
                 await release_burst_slot(user_id)
+                admission_lock.release()
+                admission_held = False
                 event_data = json.dumps(
                     {
                         "thread_id": thread_id,
@@ -474,8 +531,12 @@ async def astream_flash_workflow(
             )
         else:
             slot_owned = False  # Manager owns burst slot release from here
+            # Admission complete — release the lock so subsequent POSTs
+            # can see the new RUNNING TaskInfo via wait_or_steer.
+            admission_lock.release()
+            admission_held = False
 
-        async for event in stream_from_log(thread_id, last_event_id=None):
+        async for event in stream_from_log(thread_id, run_id, last_event_id=None):
             yield event
 
         # After the workflow ends, return any unconsumed steering messages so
@@ -524,4 +585,8 @@ async def astream_flash_workflow(
         raise
 
     finally:
+        # Release admission lock if any error path bypassed the normal
+        # release (e.g., exception before start_workflow).
+        if admission_held and admission_lock is not None:
+            admission_lock.release()
         ExecutionTracker.stop_tracking()

--- a/src/server/handlers/chat/ptc_workflow.py
+++ b/src/server/handlers/chat/ptc_workflow.py
@@ -519,6 +519,11 @@ async def astream_ptc_workflow(
             effective_plan_mode = False
             background_registry = await registry_store.get_or_create_registry(thread_id)
 
+        # Stamp the current turn's run_id on the registry so newly-registered
+        # subagents inherit it (spawned_run_id). The collector filters by this
+        # to avoid claiming subagents that belong to prior turns.
+        background_registry.current_run_id = run_id
+
         # Build graph with the workspace's session
         # Note: agent.md is injected dynamically by WorkspaceContextMiddleware
         # on every model call, ensuring it's always the latest content.

--- a/src/server/handlers/chat/ptc_workflow.py
+++ b/src/server/handlers/chat/ptc_workflow.py
@@ -882,8 +882,8 @@ async def astream_ptc_workflow(
                     metadata={
                         "completed_at": datetime.now().isoformat(),
                         "execution_time": execution_time,
-                        "run_id": run_id,
                     },
+                    run_id=run_id,
                 )
 
                 # Backfill query records for steering messages that produced orphan responses

--- a/src/server/handlers/chat/ptc_workflow.py
+++ b/src/server/handlers/chat/ptc_workflow.py
@@ -28,9 +28,6 @@ from src.server.models.chat import (
 )
 from src.server.services.background_registry_store import BackgroundRegistryStore
 from src.server.services.background_task_manager import BackgroundTaskManager
-from src.server.services.persistence.conversation import (
-    ConversationPersistenceService,
-)
 from src.server.services.workflow_tracker import WorkflowTracker
 from src.server.services.workspace_manager import WorkspaceManager
 from src.observability import (
@@ -200,17 +197,24 @@ async def _flash_report_back(ptc_thread_id: str, workspace_id: str | None) -> No
 async def astream_ptc_workflow(
     request: ChatRequest,
     thread_id: str,
+    run_id: str,
     user_input: str,
     user_id: str,
     workspace_id: str,
     is_byok: bool = False,
     config=None,
+    dispatched: bool = False,
 ):
     """Async generator that streams PTC agent workflow events.
 
-    Builds a per-workspace LangGraph graph and delegates streaming to
-    WorkflowStreamHandler. Workspace startup, background orchestration,
-    HITL resume, and completion persistence are all handled inline.
+    ``run_id`` is generated at the handler entry in ``threads.py`` and is
+    1:1 with ``conversation_response_id``. State (BTM, persistence, Redis
+    stream key) is keyed by ``(thread_id, run_id)`` so concurrent turns
+    on the same thread share no cross-turn state by construction.
+
+    ``dispatched`` marks the call as an X-Dispatch=background invocation
+    whose BTM placeholder was created upstream in ``threads.py``. The
+    handler skips ``wait_or_steer`` in that case.
     """
     start_time = time.time()
     handler = None
@@ -234,12 +238,85 @@ async def astream_ptc_workflow(
     ExecutionTracker.start_tracking()
 
     slot_owned = True
+    admission_held = False
+    admission_lock = None
     try:
         if not setup.agent_config:
             raise HTTPException(
                 status_code=503,
                 detail="PTC Agent not initialized. Check server startup logs.",
             )
+
+        # =====================================================================
+        # Admission gate
+        # =====================================================================
+        # Per-thread asyncio.Lock that serializes the
+        # ``wait_or_steer → persist_query_start → start_workflow`` window.
+        # Without this, two simultaneous cold POSTs on an idle thread both
+        # see "no in-flight task" in ``wait_or_steer``, both compute the
+        # same next ``turn_index``, and both ``persist_query_start`` calls
+        # race on the same row — the loser's content gets silently
+        # overwritten by ``ON CONFLICT DO UPDATE``.
+        manager = BackgroundTaskManager.get_instance()
+        admission_lock = await manager.get_admission_lock(thread_id)
+        await admission_lock.acquire()
+        admission_held = True
+
+        # =====================================================================
+        # Early steering routing
+        # =====================================================================
+        # If a workflow is already running (or soft-interrupted) for this
+        # thread, route this POST through the steering queue *before* any DB
+        # write. ``persist_query_start`` uses ``ON CONFLICT (thread_id,
+        # turn_index) DO UPDATE`` and the persistence singleton's cached
+        # ``_turn_index_cache`` is shared across concurrent POSTs on the same
+        # thread, so a second persist_query_start here would overwrite the
+        # currently-running turn's original query content with the steering
+        # text. Detecting steering here keeps ``conversation_queries`` clean
+        # and lets ``backfill_steering_queries`` write the canonical
+        # ``type='steering'`` row after the workflow completes.
+        workspace_manager = WorkspaceManager.get_instance()
+        needs_startup = not workspace_manager.has_ready_session(workspace_id)
+        # When the workspace was evicted/restarted, any in-BTM TaskInfo for
+        # this thread holds a stale sandbox reference. ``wait_or_steer``
+        # would block up to ~5s waiting on that zombie before timing out —
+        # cancel it first so steering routes against live state only.
+        if needs_startup:
+            await manager.cancel_stale_workflow(thread_id)
+        # Dispatched flow owns the BTM placeholder ``threads.py`` already
+        # reserved for it under the same ``(thread_id, run_id)`` key.
+        # We still must guarantee at most one in-flight LangGraph ``astream``
+        # per ``thread_id`` (the checkpointer is thread-keyed), so wait for
+        # any OTHER active run on the thread to settle. ``exclude_run_id``
+        # skips our own placeholder.
+        if dispatched:
+            settled = await manager.wait_for_soft_interrupted(
+                thread_id, exclude_run_id=run_id
+            )
+            if not settled:
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"Workflow {thread_id} is still running; dispatched "
+                        "follow-up could not be admitted."
+                    ),
+                )
+            ready, steering_event = True, None
+        else:
+            ready, steering_event = await wait_or_steer(
+                manager, thread_id, user_input, user_id
+            )
+        if not ready:
+            slot_owned = False
+            await release_burst_slot(user_id)
+            # Release admission immediately — no workflow will register
+            # under this lock, so holding it would needlessly block any
+            # follow-up POST.
+            admission_lock.release()
+            admission_held = False
+            if steering_event:
+                yield steering_event
+            return
 
         # =====================================================================
         # Database Persistence Setup
@@ -253,6 +330,7 @@ async def astream_ptc_workflow(
         query_type, is_fork, persistence_service = await _setup_fork_and_persistence(
             request=request,
             thread_id=thread_id,
+            run_id=run_id,
             workspace_id=workspace_id,
             user_id=user_id,
             log_prefix="PTC_FORK",
@@ -350,16 +428,15 @@ async def astream_ptc_workflow(
         subagents = request.subagents_enabled or config.subagents.enabled
         sandbox_id = None
 
-        workspace_manager = WorkspaceManager.get_instance()
-
-        # Check if workspace needs startup — emit early SSE so frontend
-        # can show "Starting workspace..." instead of a silent wait.
-        # NOTE: This is broader than the old `ws_status == "stopped"` check.
-        # It also fires on server-restart cold starts (workspace running in
-        # Daytona but no session in memory). The extra "starting/ready" SSE
-        # pair is harmless — frontend treats it as a brief spinner.
-        needs_startup = not workspace_manager.has_ready_session(workspace_id)
-
+        # ``workspace_manager`` and ``needs_startup`` were resolved above for
+        # the pre-steering stale-cancel hook. Reuse them — recomputing here
+        # would race with a concurrent reconnect that could flip the state.
+        #
+        # The branch below emits an early "Starting workspace..." SSE pair so
+        # the frontend can show a spinner instead of a silent wait. This is
+        # broader than the old `ws_status == "stopped"` check — it also fires
+        # on server-restart cold starts (workspace running in Daytona but no
+        # session in memory). The extra "starting/ready" SSE pair is harmless.
         if not needs_startup:
             session = await workspace_manager.get_session_for_workspace(
                 workspace_id, user_id=user_id
@@ -682,6 +759,10 @@ async def astream_ptc_workflow(
             recursion_limit=get_ptc_recursion_limit(),
             plan_mode=effective_plan_mode,
         )
+        # Propagate run_id to LangGraph via the top-level config key; it
+        # lands on ExecutionInfo.run_id and CheckpointMetadata.run_id so
+        # LangSmith / checkpoint inspection can correlate by this UUID.
+        graph_config["run_id"] = run_id
 
         # Extract background task registry from orchestrator (single source of truth for SSE events)
         # The orchestrator wraps the middleware which owns the registry
@@ -696,6 +777,7 @@ async def astream_ptc_workflow(
 
         handler = WorkflowStreamHandler(
             thread_id=thread_id,
+            run_id=run_id,
             token_callback=token_callback,
             tool_tracker=tool_tracker,
             background_registry=background_registry,
@@ -711,6 +793,7 @@ async def astream_ptc_workflow(
                 thread_id=thread_id,
                 workspace_id=workspace_id,
                 user_id=user_id,
+                run_id=run_id,
                 metadata={
                     "type": "ptc_agent",
                     "sandbox_id": sandbox_id,
@@ -725,53 +808,30 @@ async def astream_ptc_workflow(
         # Background Execution with Completion Callback
         # =====================================================================
 
-        manager = BackgroundTaskManager.get_instance()
-
-        # If the workspace was not ready (stopped or server restarted), any
-        # old workflow holds stale sandbox references.  Cancel it silently.
-        if needs_startup:
-            await manager.cancel_stale_workflow(thread_id)
-
-        # Wait for any soft-interrupted workflow to complete before starting new one
-        ready, steering_event = await wait_or_steer(
-            manager, thread_id, user_input, user_id
-        )
-        if not ready:
-            slot_owned = False
-            await release_burst_slot(user_id)
-            if steering_event:
-                yield steering_event
-            return
+        # ``manager`` was acquired at the top of this handler for the early
+        # steering-routing check; reuse it here. ``cancel_stale_workflow``
+        # already ran there (gated on ``needs_startup``) so steering routed
+        # against live state.
 
         # Define completion callback for background persistence
-        async def on_background_workflow_complete():
+        async def on_background_workflow_complete(task_info):
             """Persist workflow data after background execution completes.
 
-            Reads handler/token_callback from task_info metadata in case
-            reinvocation replaced them with new instances.
+            State is per-run, so this callback is naturally identity-safe:
+            ``task_info``, ``persistence_service``, and the Redis stream
+            key are all bound to this turn's ``run_id``. No cross-turn
+            checks needed.
             """
             try:
-                # Read fresh refs from task_info (may have been updated by reinvoke)
-                task_info = manager.tasks.get(thread_id)
-                _handler = task_info.metadata.get("handler") if task_info else handler
-                _token_cb = (
-                    task_info.metadata.get("token_callback")
-                    if task_info
-                    else token_callback
-                )
-                _start_time = (
-                    task_info.metadata.get("start_time", start_time)
-                    if task_info
-                    else start_time
-                )
+                _handler = task_info.metadata.get("handler", handler)
+                _token_cb = task_info.metadata.get("token_callback", token_callback)
+                _start_time = task_info.metadata.get("start_time", start_time)
 
                 execution_time = time.time() - _start_time
 
-                _persistence_service = ConversationPersistenceService.get_instance(
-                    thread_id
-                )
+                _persistence_service = persistence_service
                 _persistence_service._on_pair_persisted = (
-                    lambda: manager.clear_event_buffer(thread_id)
+                    lambda: manager.clear_event_buffer(thread_id, run_id)
                 )
 
                 _per_call_records = _token_cb.per_call_records if _token_cb else None
@@ -812,12 +872,12 @@ async def astream_ptc_workflow(
                     sse_events=_sse_events,
                 )
 
-                # Mark completed in Redis tracker
                 await tracker.mark_completed(
                     thread_id=thread_id,
                     metadata={
                         "completed_at": datetime.now().isoformat(),
                         "execution_time": execution_time,
+                        "run_id": run_id,
                     },
                 )
 
@@ -864,6 +924,7 @@ async def astream_ptc_workflow(
         # Start workflow in background with event buffering
         await manager.start_workflow(
             thread_id=thread_id,
+            run_id=run_id,
             workflow_generator=handler.stream_workflow(
                 graph=ptc_graph,
                 input_state=input_state,
@@ -882,11 +943,17 @@ async def astream_ptc_workflow(
                 "timezone": timezone_str,
                 "handler": handler,
                 "token_callback": token_callback,
+                "persistence_service": persistence_service,
             },
             completion_callback=on_background_workflow_complete,
-            graph=ptc_graph,  # Pass graph for state queries in completion/error handlers
+            graph=ptc_graph,
         )
         slot_owned = False  # Manager owns burst slot release from here
+        # Admission complete — release the lock so concurrent POSTs can
+        # see the new RUNNING TaskInfo via ``wait_or_steer`` and route
+        # to steering instead of contending here.
+        admission_lock.release()
+        admission_held = False
 
         _mark_phase("workflow_start")
         total_ms = (time.time() - start_time) * 1000
@@ -913,10 +980,10 @@ async def astream_ptc_workflow(
         for _k, _v in _phase_times.items():
             safe_record(chat_turn_phase_duration_ms, _v, {"phase": _k, "mode": "ptc"})
 
-        # Stream-backed first-connect: read from workflow:stream:{thread_id}
+        # Stream-backed first-connect: read from workflow:stream:{tid}:{rid}
         # via XREAD BLOCK. The workflow runs as a fully detached background
         # task — disconnect cannot reach it.
-        async for event in stream_from_log(thread_id, last_event_id=None):
+        async for event in stream_from_log(thread_id, run_id, last_event_id=None):
             yield event
 
         # After the workflow ends, return any unconsumed steering messages so
@@ -968,5 +1035,10 @@ async def astream_ptc_workflow(
         raise
 
     finally:
+        # Release admission lock if any error path bypassed the normal
+        # release (e.g., exception before start_workflow). Safe to call
+        # multiple times because ``admission_held`` gates the release.
+        if admission_held and admission_lock is not None:
+            admission_lock.release()
         # Always stop execution tracking to prevent memory leaks and context pollution
         ExecutionTracker.stop_tracking()

--- a/src/server/handlers/chat/stream_from_log.py
+++ b/src/server/handlers/chat/stream_from_log.py
@@ -258,6 +258,17 @@ async def stream_from_log(
             run_id = info.run_id
 
     if run_id is None:
+        # In-process TaskInfo gone (process restart). Before falling back to
+        # the legacy thread-only key, consult WorkflowTracker — the status
+        # blob is cross-process and now carries the active turn's run_id.
+        # Lets a post-restart reconnect still resolve to the per-run stream
+        # key without false-routing to the empty legacy key.
+        tracker = WorkflowTracker.get_instance()
+        status_obj = await tracker.get_status(thread_id)
+        if status_obj is not None:
+            run_id = status_obj.get("run_id")
+
+    if run_id is None:
         # Fall back to the legacy thread-only key. Compat shim for reconnects
         # to a pre-deploy in-flight workflow whose TaskInfo was lost on
         # restart. Drop in the next deploy once no in-flight workflows are

--- a/src/server/handlers/chat/stream_from_log.py
+++ b/src/server/handlers/chat/stream_from_log.py
@@ -26,6 +26,10 @@ from src.server.services.background_task_manager import (
     BackgroundTaskManager,
     TaskStatus,
 )
+from src.server.services.workflow_tracker import (
+    TERMINAL_STATUSES,
+    WorkflowTracker,
+)
 from src.utils.cache.redis_cache import get_cache_client
 
 from ._common import logger
@@ -198,7 +202,7 @@ async def _stream_from_redis_log(
                         continue
                     if isinstance(payload, bytes):
                         try:
-                            yield payload.decode("utf-8")
+                            decoded = payload.decode("utf-8")
                         except UnicodeDecodeError:
                             logger.warning(
                                 "[stream_from_log] Non-UTF8 payload in %s entry %s",
@@ -206,6 +210,7 @@ async def _stream_from_redis_log(
                                 entry_id,
                             )
                             continue
+                        yield decoded
                     else:
                         yield payload
 
@@ -231,44 +236,72 @@ async def _stream_from_redis_log(
 
 async def stream_from_log(
     thread_id: str,
+    run_id: Optional[str] = None,
     last_event_id: Optional[int] = None,
 ) -> AsyncGenerator[str, None]:
     """SSE consumer for the main workflow stream.
 
-    First-connect callers pass ``last_event_id=None`` (cursor at 0 — replay
-    everything in the stream then wait for new). Reconnect callers pass the
-    integer seq from ``Last-Event-ID`` / ``?last_event_id=`` so XREAD
-    resumes after that seq.
-
-    The ``increment_connection``/``decrement_connection`` calls bump the
-    workflow's ``active_connections`` counter (and refresh
-    ``last_access_at``). Without them, the abandoned-task cleanup at
-    ``BackgroundTaskManager._periodic_cleanup`` would force-cancel any
-    RUNNING task whose ``active_connections == 0`` after
-    ``abandoned_workflow_timeout`` (6 h default).
+    The stream is keyed by ``(thread_id, run_id)``. Callers without a
+    ``run_id`` fall back to the most recent run on the thread (status
+    endpoint convenience). A legacy ``workflow:stream:{thread_id}``
+    fallback covers reconnects to a workflow that started before the
+    run_id refactor was deployed; remove after one release window.
     """
     manager = BackgroundTaskManager.get_instance()
 
+    # Resolve run_id if caller didn't provide one. We may be reconnecting
+    # to a turn that is still in the cache (latest) — pick the most recent.
+    if run_id is None:
+        async with manager.task_lock:
+            info = manager._find_latest_for_thread(thread_id)
+        if info is not None:
+            run_id = info.run_id
+
+    if run_id is None:
+        # Fall back to the legacy thread-only key. Compat shim for reconnects
+        # to a pre-deploy in-flight workflow whose TaskInfo was lost on
+        # restart. Drop in the next deploy once no in-flight workflows are
+        # running on the old key.
+        legacy_key = f"workflow:stream:{thread_id}"
+        tracker = WorkflowTracker.get_instance()
+
+        async def _terminal_legacy() -> bool:
+            # WorkflowTracker.status is the cross-process source of truth
+            # when the in-process TaskInfo is gone. Eager-True here would
+            # exit immediately, dropping a reconnect during a rolling deploy.
+            status_obj = await tracker.get_status(thread_id)
+            if status_obj is None:
+                # No tracker record either — nothing to wait for; let the
+                # two-empty-round handshake drain whatever is in the stream
+                # and exit.
+                return True
+            status_val = status_obj.get("status")
+            return status_val in {s.value for s in TERMINAL_STATUSES}
+
+        async for event in _stream_from_redis_log(
+            stream_key=legacy_key,
+            terminal_check=_terminal_legacy,
+            last_event_id=last_event_id,
+        ):
+            yield event
+        return
+
     async def terminal_check() -> bool:
-        status = await manager.get_task_status(thread_id)
-        # ``status is None`` means the TaskInfo entry is gone (e.g. the
-        # placeholder cleanup in ``threads.py`` finally-block deleted a
-        # never-started workflow). Treat that as terminal so the consumer
-        # exits via the two-empty-round handshake instead of spinning
-        # XREAD/keepalive forever — the comment at threads.py:137-141
-        # explicitly relies on this behaviour.
-        return status is None or status in (
+        info = manager.tasks.get((thread_id, run_id))
+        if info is None:
+            return True
+        return info.status in (
             TaskStatus.COMPLETED, TaskStatus.FAILED, TaskStatus.CANCELLED
         )
 
     async def on_attach() -> None:
-        await manager.increment_connection(thread_id)
+        await manager.increment_connection(thread_id, run_id)
 
     async def on_detach() -> None:
-        await manager.decrement_connection(thread_id)
+        await manager.decrement_connection(thread_id, run_id)
 
     async for event in _stream_from_redis_log(
-        stream_key=f"workflow:stream:{thread_id}",
+        stream_key=f"workflow:stream:{thread_id}:{run_id}",
         terminal_check=terminal_check,
         last_event_id=last_event_id,
         on_attach=on_attach,

--- a/src/server/handlers/chat/stream_reconnect.py
+++ b/src/server/handlers/chat/stream_reconnect.py
@@ -25,18 +25,18 @@ from .stream_from_log import stream_from_log, stream_subagent_from_log
 
 async def reconnect_to_workflow_stream(
     thread_id: str,
+    run_id: str | None = None,
     last_event_id: int | None = None,
 ):
     """Reconnect to a running or completed workflow via Redis Streams.
 
-    ``stream_from_log`` maps both ``None`` and ``<= 0`` to cursor ``0``
-    (replay from the beginning), so we pass ``last_event_id`` through
-    untouched.
+    ``run_id`` targets a specific turn (canonical form). When omitted,
+    falls back to the latest run on the thread.
     """
     manager = BackgroundTaskManager.get_instance()
     tracker = WorkflowTracker.get_instance()
 
-    task_info = await manager.get_task_info(thread_id)
+    task_info = await manager.get_task_info(thread_id, run_id)
     workflow_status = await tracker.get_status(thread_id)
 
     if not task_info:
@@ -46,7 +46,11 @@ async def reconnect_to_workflow_stream(
             )
         raise HTTPException(status_code=404, detail=f"Workflow {thread_id} not found")
 
-    async for event in stream_from_log(thread_id, last_event_id):
+    # Resolve effective run_id from the task_info we just looked up so
+    # the downstream consumer uses the exact key.
+    effective_run_id = run_id or task_info.run_id
+
+    async for event in stream_from_log(thread_id, effective_run_id, last_event_id):
         yield event
 
     # After the workflow ends, return any unconsumed steering messages so the

--- a/src/server/handlers/streaming_handler.py
+++ b/src/server/handlers/streaming_handler.py
@@ -293,6 +293,7 @@ class WorkflowStreamHandler:
     def __init__(
         self,
         thread_id: str,
+        run_id: str,
         token_callback: Optional[Any] = None,
         tool_tracker: Optional[Any] = None,
         workflow_timeout: Optional[int] = None,
@@ -304,8 +305,16 @@ class WorkflowStreamHandler:
 
         Keepalives live in the SSE consumer (``stream_from_log``), not here —
         the producer side is just a thin LangGraph pass-through.
+
+        ``run_id`` is REQUIRED — it's emitted as the first SSE event
+        (``event: metadata``) of each stream so the frontend learns the
+        canonical per-turn identity immediately and can drive reconnect /
+        steering / demotion off it. Constructing a handler without a
+        ``run_id`` would silently strip that frame and leave the client
+        racing on reconnect.
         """
         self.thread_id = thread_id
+        self.run_id = run_id
         self.token_callback = token_callback
         self.tool_tracker = tool_tracker
         self.workflow_timeout = workflow_timeout or WORKFLOW_TIMEOUT
@@ -404,6 +413,16 @@ class WorkflowStreamHandler:
             attributes={"thread_id_hash": (self.thread_id or "")[:16]},
         )
         try:
+            # First event of every stream: ``metadata`` payload announcing
+            # the canonical run_id for this turn. Mirrors the
+            # langgraph_sdk SSE protocol so frontend reconnect/demotion
+            # logic can latch onto the authoritative identity immediately.
+            yield self._format_sse_event(
+                "metadata",
+                {"thread_id": self.thread_id, "run_id": self.run_id},
+                accumulate=False,
+            )
+
             # Snapshot old task IDs and emit initial batch of captured events.
             # Events are streamed with accumulate=False so they are NOT persisted
             # with this (new) response — the collector owns persistence to the

--- a/src/server/handlers/workflow_handler.py
+++ b/src/server/handlers/workflow_handler.py
@@ -225,6 +225,7 @@ async def get_workflow_status(thread_id: str) -> dict:
         # Get subagent info from background task manager
         active_tasks = []
         soft_interrupted = False
+        run_id = None
 
         try:
             from src.server.services.background_task_manager import (
@@ -236,6 +237,7 @@ async def get_workflow_status(thread_id: str) -> dict:
             if bg_status.get("status") != "not_found":
                 active_tasks = bg_status.get("active_tasks", [])
                 soft_interrupted = bg_status.get("soft_interrupted", False)
+                run_id = bg_status.get("run_id")
             elif can_reconnect:
                 # Redis says active/disconnected but BackgroundTaskManager has no
                 # record — likely a stale Redis key surviving a server restart.
@@ -283,6 +285,7 @@ async def get_workflow_status(thread_id: str) -> dict:
 
         response = {
             "thread_id": thread_id,
+            "run_id": run_id,
             "status": status,
             "can_reconnect": can_reconnect,
             "last_update": last_update,

--- a/src/server/services/automation_executor.py
+++ b/src/server/services/automation_executor.py
@@ -148,10 +148,16 @@ class AutomationExecutor:
                 astream_ptc_workflow,
             )
 
+            # Generate run_id locally — automations don't pass through the
+            # HTTP handler that normally creates it. Per-turn keying for
+            # BTM / persistence / Redis stream.
+            run_id = str(uuid4())
+
             if agent_mode == "flash":
                 generator = astream_flash_workflow(
                     request=request,
                     thread_id=thread_id,
+                    run_id=run_id,
                     user_input=instruction,
                     user_id=user_id,
                 )
@@ -159,6 +165,7 @@ class AutomationExecutor:
                 generator = astream_ptc_workflow(
                     request=request,
                     thread_id=thread_id,
+                    run_id=run_id,
                     user_input=instruction,
                     user_id=user_id,
                     workspace_id=workspace_id,
@@ -182,7 +189,7 @@ class AutomationExecutor:
             # may return empty text because the DB write hasn't landed yet.
             from src.server.services.background_task_manager import BackgroundTaskManager
             manager = BackgroundTaskManager.get_instance()
-            await manager.wait_for_persistence(thread_id)
+            await manager.wait_for_persistence(thread_id, run_id)
 
             # ─── Success ───────────────────────────────────────────
             await auto_db.update_execution_status(

--- a/src/server/services/background_task_manager.py
+++ b/src/server/services/background_task_manager.py
@@ -882,6 +882,13 @@ class BackgroundTaskManager:
                 f"for thread_id={thread_id}: {exc}"
             )
 
+        # Look up the per-thread registry once so we can evict each task's
+        # dict entry after its cleanup completes. Without this, _tasks grows
+        # unboundedly across turns on a long-lived thread (every subagent
+        # ever spawned stays referenced forever).
+        from src.server.services.background_registry_store import BackgroundRegistryStore
+        bg_registry = await BackgroundRegistryStore.get_instance().get_registry(thread_id)
+
         for task in tasks:
             task.per_call_records = []
             task.asyncio_task = None
@@ -916,6 +923,15 @@ class BackgroundTaskManager:
                     "redis_write_failed": getattr(task, "redis_write_failed", False),
                 },
             )
+
+            if bg_registry is not None:
+                try:
+                    await bg_registry.remove_task(task.tool_call_id)
+                except Exception as exc:
+                    logger.warning(
+                        f"[SubagentCleanup] remove_task failed for "
+                        f"thread_id={thread_id} task_id={task.task_id}: {exc}"
+                    )
 
     async def _collect_orphaned_subagent_results(
         self,
@@ -1212,12 +1228,22 @@ class BackgroundTaskManager:
         bg_registry = await bg_store.get_registry(thread_id)
         if bg_registry:
             tasks_to_collect = []
-            for t in bg_registry._tasks.values():
-                if t.collector_response_id:
-                    continue
-                if t.is_pending or t.captured_event_count > 0 or t.per_call_records:
-                    t.collector_response_id = response_id
-                    tasks_to_collect.append(t)
+            # Hold the registry lock during claim so two concurrent collectors
+            # (e.g., orphan from prior turn + current turn) can't both observe
+            # collector_response_id is None for the same task and double-claim.
+            async with bg_registry._lock:
+                for t in bg_registry._tasks.values():
+                    if t.collector_response_id:
+                        continue
+                    # Filter by spawned_run_id: only claim subagents spawned
+                    # by THIS turn. None matches as a compat shim for tasks
+                    # registered before run_id stamping shipped — remove the
+                    # None branch in the next deploy.
+                    if t.spawned_run_id is not None and t.spawned_run_id != run_id:
+                        continue
+                    if t.is_pending or t.captured_event_count > 0 or t.per_call_records:
+                        t.collector_response_id = response_id
+                        tasks_to_collect.append(t)
             if tasks_to_collect:
                 handler = metadata.get("handler")
                 sse_events = handler.get_sse_events() if handler else []
@@ -1477,12 +1503,18 @@ class BackgroundTaskManager:
             timeout = get_subagent_collector_timeout()
 
         try:
-            all_tasks = []
-            for t in bg_registry._tasks.values():
-                if t.collector_response_id:
-                    continue
-                t.collector_response_id = response_id
-                all_tasks.append(t)
+            # Same identity-safe claim as _mark_completed: hold the registry
+            # lock and filter by spawned_run_id so concurrent collectors can't
+            # double-claim and prior-turn subagents can't leak into this turn.
+            async with bg_registry._lock:
+                all_tasks = []
+                for t in bg_registry._tasks.values():
+                    if t.collector_response_id:
+                        continue
+                    if t.spawned_run_id is not None and t.spawned_run_id != response_id:
+                        continue
+                    t.collector_response_id = response_id
+                    all_tasks.append(t)
 
             for task in all_tasks:
                 if not task.completed and task.asyncio_task and task.asyncio_task.done():

--- a/src/server/services/background_task_manager.py
+++ b/src/server/services/background_task_manager.py
@@ -1374,7 +1374,7 @@ class BackgroundTaskManager:
 
         try:
             tracker = WorkflowTracker.get_instance()
-            await tracker.mark_failed(thread_id, error=error)
+            await tracker.mark_failed(thread_id, error=error, run_id=run_id)
         except Exception as tracker_err:
             logger.warning(
                 f"[BackgroundTaskManager] tracker.mark_failed failed for {key}: {tracker_err}"
@@ -1478,7 +1478,7 @@ class BackgroundTaskManager:
 
         try:
             tracker = WorkflowTracker.get_instance()
-            await tracker.mark_soft_interrupted(thread_id)
+            await tracker.mark_soft_interrupted(thread_id, run_id=run_id)
         except Exception as tracker_err:
             logger.warning(
                 f"[BackgroundTaskManager] tracker.mark_soft_interrupted failed for {key}: {tracker_err}"
@@ -1830,7 +1830,7 @@ class BackgroundTaskManager:
 
         try:
             tracker = WorkflowTracker.get_instance()
-            await tracker.mark_cancelled(thread_id)
+            await tracker.mark_cancelled(thread_id, run_id=run_id)
         except Exception as tracker_err:
             logger.warning(
                 f"[BackgroundTaskManager] tracker.mark_cancelled failed for {key}: {tracker_err}"

--- a/src/server/services/background_task_manager.py
+++ b/src/server/services/background_task_manager.py
@@ -1198,7 +1198,8 @@ class BackgroundTaskManager:
                     tracker = WorkflowTracker.get_instance()
                     await tracker.mark_interrupted(
                         thread_id=thread_id,
-                        metadata={"interrupt_reason": interrupt_reason, "run_id": run_id},
+                        run_id=run_id,
+                        metadata={"interrupt_reason": interrupt_reason},
                     )
                 except Exception as persist_error:
                     logger.error(

--- a/src/server/services/background_task_manager.py
+++ b/src/server/services/background_task_manager.py
@@ -2,10 +2,17 @@
 Background Task Manager
 
 Manages workflow execution as background asyncio tasks that continue running
-independently of SSE client connections. Workflows write events to a Redis
-Stream; consumers attach by stream key and read via XREAD BLOCK, sharing no
-in-process state with the workflow. Cleanup runs periodically to evict stale
-tasks.
+independently of SSE client connections. Workflows write events to per-run
+Redis Streams (``workflow:stream:{thread_id}:{run_id}``); consumers attach by
+stream key and read via XREAD BLOCK, sharing no in-process state with the
+workflow. Cleanup runs periodically to evict stale tasks.
+
+State is keyed by ``(thread_id, run_id)`` — each POST gets a fresh ``run_id``
+at the handler entry, so cross-turn state aliasing is impossible by
+construction. Per-thread admission locks still serialize the
+``wait_or_steer → persist_query_start → start_workflow`` window because
+Pregel doesn't serialize concurrent ``astream`` on the same thread, and the
+admission policy lives in our layer.
 """
 
 import asyncio
@@ -48,23 +55,26 @@ from src.server.utils.persistence_utils import (
 logger = logging.getLogger(__name__)
 
 
+# ========== Redis key helpers ==========
+
+
+def stream_key(thread_id: str, run_id: str) -> str:
+    """Per-run workflow event stream."""
+    return f"workflow:stream:{thread_id}:{run_id}"
+
+
+def stream_meta_key(thread_id: str, run_id: str) -> str:
+    """Per-run event-buffer metadata (HSET counter)."""
+    return f"workflow:events:meta:{thread_id}:{run_id}"
+
+
 # ========== Shared Helpers (DRY) ==========
 
 
 async def iter_subagent_events_full(
     thread_id: str, task
 ) -> AsyncIterator[dict]:
-    """Yield every captured record for a subagent in seq order.
-
-    Reads from the per-task Redis Stream's ``b"record"`` field via XRANGE.
-    Filters to ``seq <= captured_event_seq`` snapshot at entry so events
-    XADD'd after iteration starts don't leak into this pass.
-
-    Yields dicts with shape::
-
-        {"seq": int, "event": str, "data": dict, "agent_id": str | None,
-         "ts": float (optional)}
-    """
+    """Yield every captured record for a subagent in seq order."""
     if task is None or not thread_id:
         return
 
@@ -83,18 +93,17 @@ async def iter_subagent_events_full(
     if cache is None or not getattr(cache, "enabled", False) or cache.client is None:
         return
 
-    stream_key = f"subagent:stream:{thread_id}:{task.task_id}"
+    sa_stream_key = f"subagent:stream:{thread_id}:{task.task_id}"
     try:
-        entries = await cache.client.xrange(stream_key, min="-", max="+")
+        entries = await cache.client.xrange(sa_stream_key, min="-", max="+")
     except Exception as exc:
         logger.warning(
-            f"[SubagentCollector] XRANGE failed for {stream_key}: {exc}"
+            f"[SubagentCollector] XRANGE failed for {sa_stream_key}: {exc}"
         )
         return
 
     yielded = 0
     for entry_id, fields in entries or []:
-        # entry_id format: b"<seq>-0"
         try:
             seq_part = entry_id.decode("utf-8") if isinstance(entry_id, bytes) else entry_id
             seq = int(seq_part.split("-", 1)[0])
@@ -104,9 +113,6 @@ async def iter_subagent_events_full(
             continue
         raw = fields.get(b"record")
         if raw is None:
-            # Sentinel entries (subagent_stream_end) and any legacy
-            # single-field entries from before the dual-payload cutover
-            # have no record field — skip them in the collector path.
             continue
         try:
             payload = raw.decode("utf-8") if isinstance(raw, bytes) else raw
@@ -134,11 +140,7 @@ async def iter_subagent_events_full(
 
 
 def _record_to_persist_event(record: dict, thread_id: str) -> dict:
-    """Convert a captured-event record to persistence shape ``{event, data}``.
-
-    Injects ``thread_id`` into a copy of ``data`` so downstream consumers
-    can identify the originating thread without mutating the stored record.
-    """
+    """Convert a captured-event record to persistence shape ``{event, data}``."""
     data = dict(record.get("data") or {})
     data["thread_id"] = thread_id
     out: dict = {
@@ -166,40 +168,33 @@ class TaskStatus(str, Enum):
 class TaskInfo:
     """Information about a background workflow task."""
     thread_id: str
+    run_id: str
     status: TaskStatus
     created_at: datetime
     started_at: Optional[datetime] = None
     completed_at: Optional[datetime] = None
     last_access_at: datetime = field(default_factory=datetime.now)
 
-    # Task execution
     task: Optional[asyncio.Task] = None
-    inner_task: Optional[asyncio.Task] = None  # Reference to consume_workflow task
+    inner_task: Optional[asyncio.Task] = None
     error: Optional[str] = None
 
-    # Cancellation control
-    explicit_cancel: bool = False  # True if user explicitly cancelled
-    cancel_event: asyncio.Event = field(default_factory=asyncio.Event)  # Cooperative cancellation signal
+    explicit_cancel: bool = False
+    cancel_event: asyncio.Event = field(default_factory=asyncio.Event)
 
-    # Soft interrupt control (pause main agent, keep subagents running)
     soft_interrupt_event: asyncio.Event = field(default_factory=asyncio.Event)
     soft_interrupted: bool = False
 
     final_result: Optional[Any] = None
 
-    # Connection tracking
     active_connections: int = 0
 
-    # Metadata
     metadata: Dict[str, Any] = field(default_factory=dict)
 
-    # Completion callback
-    completion_callback: Optional[Callable[[], Coroutine[Any, Any, None]]] = None
+    completion_callback: Optional[Callable[["TaskInfo"], Coroutine[Any, Any, None]]] = None
 
-    # Signalled when _mark_completed finishes (persistence done)
     persistence_complete: asyncio.Event = field(default_factory=asyncio.Event)
 
-    # LangGraph compiled graph for state queries (stored per-task, not global)
     graph: Optional[Any] = None
 
 
@@ -207,24 +202,29 @@ class SoftInterruptError(Exception):
     """Internal control-flow exception for user ESC soft-interrupt."""
 
 
+# Type alias for the key used throughout the manager.
+TaskKey = tuple[str, str]
+
+
 class BackgroundTaskManager:
-    """
-    Manages background workflow task execution.
+    """Manages background workflow task execution.
 
-    Singleton service that handles:
-    - Task lifecycle (create, execute, complete, cleanup)
-    - Result buffering and streaming
-    - Connection management
-    - Automatic cleanup
+    Singleton. State keyed by ``(thread_id, run_id)`` — each POST gets a
+    fresh ``run_id`` so concurrent turns on the same thread are isolated
+    by construction.
     """
 
-    # Singleton instance
     _instance: Optional['BackgroundTaskManager'] = None
 
     def __init__(self):
-        """Initialize background task manager."""
-        self.tasks: Dict[str, TaskInfo] = {}
+        # Keyed by (thread_id, run_id). One slot per turn; no cross-turn
+        # aliasing because run_id is fresh per POST.
+        self.tasks: Dict[TaskKey, TaskInfo] = {}
         self.task_lock = asyncio.Lock()
+        # Per-thread admission locks remain thread-keyed: admission policy
+        # (wait_or_steer / one foreground turn at a time) is a thread-level
+        # invariant, independent of the per-turn key.
+        self._admission_locks: Dict[str, asyncio.Lock] = {}
 
         # Configuration
         self.max_concurrent = get_max_concurrent_workflows()
@@ -234,46 +234,57 @@ class BackgroundTaskManager:
         self.enable_storage = is_intermediate_storage_enabled()
         self.max_stored_messages = get_max_stored_messages_per_agent()
 
-        # Event storage configuration
         self.event_storage_backend = get_event_storage_backend()
         self.redis_event_ttl = get_redis_ttl_workflow_events()
 
-        # Cleanup task
         self.cleanup_task: Optional[asyncio.Task] = None
 
     @classmethod
     def get_instance(cls) -> 'BackgroundTaskManager':
-        """
-        Get singleton instance of BackgroundTaskManager.
-
-        Returns:
-            BackgroundTaskManager instance
-        """
         if cls._instance is None:
             cls._instance = cls()
         return cls._instance
 
-    async def _get_task_info_locked(self, thread_id: str) -> Optional[TaskInfo]:
+    # ---------- helpers ----------
+
+    def _find_latest_for_thread(self, thread_id: str) -> Optional[TaskInfo]:
+        """Return the most-recently-created TaskInfo for ``thread_id`` or None.
+
+        Used for thread-scoped lookups (e.g., /status?thread_id=...) where
+        the caller didn't provide a run_id.
         """
-        Acquire lock and get task info.
+        best: Optional[TaskInfo] = None
+        for (tid, _rid), info in self.tasks.items():
+            if tid != thread_id:
+                continue
+            if best is None or info.created_at > best.created_at:
+                best = info
+        return best
 
-        Helper method to reduce boilerplate of locking + dict lookup pattern.
+    def _find_active_for_thread(
+        self,
+        thread_id: str,
+        exclude_run_id: Optional[str] = None,
+    ) -> Optional[TaskInfo]:
+        """Return the most-recently-created active (non-terminal) TaskInfo.
 
-        Args:
-            thread_id: Workflow thread identifier
-
-        Returns:
-            TaskInfo or None if not found
+        ``exclude_run_id`` skips a specific run — used by dispatched flows
+        that want to check for OTHER active runs on the thread while
+        ignoring their own pre-registered placeholder.
         """
-        async with self.task_lock:
-            return self.tasks.get(thread_id)
+        best: Optional[TaskInfo] = None
+        live = (TaskStatus.QUEUED, TaskStatus.RUNNING, TaskStatus.SOFT_INTERRUPTED)
+        for (tid, rid), info in self.tasks.items():
+            if tid != thread_id or info.status not in live:
+                continue
+            if exclude_run_id is not None and rid == exclude_run_id:
+                continue
+            if best is None or info.created_at > best.created_at:
+                best = info
+        return best
 
     async def has_active_tasks_for_workspace(self, workspace_id: str) -> bool:
-        """Check if any active tasks exist for a workspace.
-
-        Includes SOFT_INTERRUPTED because the workflow may still be
-        winding down (flushing checkpoints, writing final state).
-        """
+        """Check if any active tasks exist for a workspace."""
         async with self.task_lock:
             active = (TaskStatus.RUNNING, TaskStatus.QUEUED, TaskStatus.SOFT_INTERRUPTED)
             for info in self.tasks.values():
@@ -306,27 +317,17 @@ class BackgroundTaskManager:
             logger.info("[BackgroundTaskManager] Stopped cleanup task")
 
     async def shutdown(self, timeout: float | None = None):
-        """
-        Gracefully shutdown background task manager.
-
-        Cancels all running workflows and waits for them to complete
-        before database pools are closed.
-
-        Args:
-            timeout: Maximum time to wait for tasks to complete (seconds)
-        """
+        """Gracefully shutdown background task manager."""
         if timeout is None:
             timeout = get_shutdown_timeout()
         logger.info("[BackgroundTaskManager] Starting graceful shutdown...")
 
-        # Stop cleanup task first
         await self.stop_cleanup_task()
 
-        # Get list of running workflows
         async with self.task_lock:
             running_tasks = [
-                (thread_id, info)
-                for thread_id, info in self.tasks.items()
+                (key, info)
+                for key, info in self.tasks.items()
                 if info.status in [TaskStatus.RUNNING, TaskStatus.QUEUED]
             ]
 
@@ -338,36 +339,30 @@ class BackgroundTaskManager:
             f"[BackgroundTaskManager] Cancelling {len(running_tasks)} running workflows"
         )
 
-        # Cancel all running workflows
-        for thread_id, info in running_tasks:
-            await self.cancel_workflow(thread_id)
+        for (thread_id, run_id), _info in running_tasks:
+            await self.cancel_workflow(thread_id, run_id)
 
-        # Wait for tasks to complete with timeout
         try:
             async with asyncio.timeout(timeout):
-                for thread_id, info in running_tasks:
+                for _key, info in running_tasks:
                     if info.task and not info.task.done():
                         try:
                             await info.task
                         except (asyncio.CancelledError, Exception):
-                            pass  # Expected during shutdown
+                            pass
         except asyncio.TimeoutError:
             logger.warning(
                 f"[BackgroundTaskManager] Shutdown timeout after {timeout}s, "
                 f"forcing cancellation of stuck tasks"
             )
-
-            # Aggressive cancellation: force cancel stuck tasks
             stuck_tasks = []
-            for thread_id, info in running_tasks:
+            for key, info in running_tasks:
                 if info.task and not info.task.done():
                     logger.warning(
-                        f"[BackgroundTaskManager] Force-cancelling stuck task: {thread_id}"
+                        f"[BackgroundTaskManager] Force-cancelling stuck task: {key}"
                     )
                     info.task.cancel()
                     stuck_tasks.append(info.task)
-
-            # Wait briefly for forced cancellations to complete
             if stuck_tasks:
                 try:
                     async with asyncio.timeout(5.0):
@@ -384,7 +379,6 @@ class BackgroundTaskManager:
         logger.info("[BackgroundTaskManager] Shutdown complete")
 
     async def _cleanup_loop(self):
-        """Periodic cleanup loop for stale tasks."""
         while True:
             try:
                 await asyncio.sleep(self.cleanup_interval)
@@ -401,11 +395,10 @@ class BackgroundTaskManager:
         abandoned_threshold = now - timedelta(seconds=self.abandoned_timeout)
         completed_threshold = now - timedelta(seconds=self.result_ttl)
 
-        to_remove = []
+        to_remove: list[TaskKey] = []
 
         async with self.task_lock:
-            for thread_id, info in self.tasks.items():
-                # Remove completed tasks after TTL
+            for key, info in self.tasks.items():
                 if info.status in [
                     TaskStatus.COMPLETED,
                     TaskStatus.FAILED,
@@ -413,98 +406,117 @@ class BackgroundTaskManager:
                     TaskStatus.SOFT_INTERRUPTED,
                 ]:
                     if info.completed_at and info.completed_at < completed_threshold:
-                        to_remove.append(thread_id)
+                        to_remove.append(key)
                         logger.info(
                             f"[BackgroundTaskManager] Cleanup: removing completed task "
-                            f"{thread_id} (age: {now - info.completed_at})"
+                            f"{key} (age: {now - info.completed_at})"
                         )
 
-                # Remove abandoned running tasks
                 elif info.status == TaskStatus.RUNNING:
                     if info.active_connections == 0 and info.last_access_at < abandoned_threshold:
-                        to_remove.append(thread_id)
+                        to_remove.append(key)
                         logger.warning(
                             f"[BackgroundTaskManager] Cleanup: removing abandoned task "
-                            f"{thread_id} (no connections for {now - info.last_access_at})"
+                            f"{key} (no connections for {now - info.last_access_at})"
                         )
-                        # Cancel the task
                         if info.task and not info.task.done():
                             info.task.cancel()
 
-            # Remove from registry
-            for thread_id in to_remove:
-                del self.tasks[thread_id]
+                elif info.status == TaskStatus.QUEUED and info.task is None:
+                    if info.created_at < abandoned_threshold:
+                        to_remove.append(key)
+                        logger.warning(
+                            f"[BackgroundTaskManager] Cleanup: removing orphaned QUEUED "
+                            f"placeholder {key} (age: {now - info.created_at})"
+                        )
+
+            for key in to_remove:
+                del self.tasks[key]
+
+            # Admission locks are NOT reclaimed here. ``get_admission_lock``
+            # returns the Lock object under ``task_lock`` but the caller
+            # then awaits ``acquire()`` outside the lock — if cleanup were
+            # to delete the entry in that gap, a concurrent ``get_admission_lock``
+            # would create a fresh Lock and both POSTs would acquire
+            # different lock objects, defeating admission. The dict is
+            # tiny (one entry per thread that has ever seen traffic);
+            # leave it.
 
         if to_remove:
             logger.info(
                 f"[BackgroundTaskManager] Cleaned up {len(to_remove)} tasks: {to_remove}"
             )
 
-    async def pre_register(self, thread_id: str) -> None:
-        """Pre-register a thread as QUEUED before the workflow generator starts.
+    async def get_admission_lock(self, thread_id: str) -> asyncio.Lock:
+        """Return the per-thread admission lock, creating it on first use.
 
-        Used by background dispatch (X-Dispatch: background) to close the timing
-        gap between the HTTP response and the generator reaching start_workflow().
-        Reconnecting clients see a QUEUED TaskInfo and attach to
-        ``workflow:stream:{thread_id}`` (initially empty) instead of a 404.
+        Serializes ``wait_or_steer → persist_query_start → start_workflow``
+        on a given thread so two simultaneous cold POSTs can't both pass
+        ``wait_or_steer`` and race on the same ``turn_index``.
         """
         async with self.task_lock:
-            if thread_id in self.tasks:
-                existing = self.tasks[thread_id]
-                if existing.status in [TaskStatus.QUEUED, TaskStatus.RUNNING]:
-                    return  # Already registered or running
-                # Remove old completed/failed task so the placeholder can be inserted
-                del self.tasks[thread_id]
+            lock = self._admission_locks.get(thread_id)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._admission_locks[thread_id] = lock
+        return lock
 
-            self.tasks[thread_id] = TaskInfo(
+    # ---------- workflow lifecycle ----------
+
+    async def pre_register(
+        self,
+        thread_id: str,
+        run_id: str,
+    ) -> bool:
+        """Pre-register a turn as QUEUED before the workflow generator starts.
+
+        Used by background dispatch (X-Dispatch: background) to close the
+        timing gap between dispatcher return and ``start_workflow``.
+        Reconnecting clients see a QUEUED TaskInfo and attach to the per-run
+        stream key (initially empty) instead of a 404.
+
+        Returns True if the placeholder was created, False if a record for
+        this exact ``(thread_id, run_id)`` already existed.
+        """
+        async with self.task_lock:
+            key = (thread_id, run_id)
+            if key in self.tasks:
+                return False
+
+            self.tasks[key] = TaskInfo(
                 thread_id=thread_id,
+                run_id=run_id,
                 status=TaskStatus.QUEUED,
                 created_at=datetime.now(),
             )
             logger.info(
                 f"[BackgroundTaskManager] Pre-registered dispatch placeholder "
-                f"for {thread_id}"
+                f"for thread_id={thread_id} run_id={run_id}"
             )
+            return True
 
     async def start_workflow(
         self,
         thread_id: str,
+        run_id: str,
         workflow_generator: Any,
         metadata: Optional[Dict[str, Any]] = None,
-        completion_callback: Optional[Callable[[], Coroutine[Any, Any, None]]] = None,
+        completion_callback: Optional[Callable[["TaskInfo"], Coroutine[Any, Any, None]]] = None,
         graph: Optional[Any] = None,
     ) -> TaskInfo:
-        """
-        Start a workflow as a background task.
-
-        Args:
-            thread_id: Workflow thread identifier
-            workflow_generator: Async generator from graph.astream()
-            metadata: Optional metadata about the workflow
-            completion_callback: Optional callback to invoke when workflow completes
-            graph: Optional LangGraph compiled graph for state queries during completion/error handling
-
-        Returns:
-            TaskInfo object tracking the background task
-
-        Raises:
-            ValueError: If max concurrent workflows exceeded
-            RuntimeError: If workflow already exists for thread_id
-        """
+        """Start a workflow as a background task."""
+        key = (thread_id, run_id)
         async with self.task_lock:
-            # Check if already exists
-            if thread_id in self.tasks:
-                existing = self.tasks[thread_id]
+            if key in self.tasks:
+                existing = self.tasks[key]
                 if existing.status == TaskStatus.QUEUED and existing.task is None:
-                    # Pre-registered dispatch placeholder — upgrade in-place so
-                    # the same TaskInfo identity stays valid for any
-                    # consumers already attached to workflow:stream:{thread_id}.
+                    # Upgrade pre-registered placeholder in-place.
                     existing.metadata = metadata or {}
                     existing.completion_callback = completion_callback
                     existing.graph = graph
                     existing.task = asyncio.create_task(
                         self._run_workflow_shielded(
-                            thread_id, workflow_generator,
+                            thread_id, run_id, workflow_generator,
                             cancel_event=existing.cancel_event,
                             soft_interrupt_event=existing.soft_interrupt_event,
                         )
@@ -513,28 +525,13 @@ class BackgroundTaskManager:
                     existing.started_at = datetime.now()
                     logger.info(
                         f"[BackgroundTaskManager] Upgraded pre-registered "
-                        f"workflow {thread_id} to RUNNING"
+                        f"workflow thread_id={thread_id} run_id={run_id} to RUNNING"
                     )
                     return existing
-                if existing.status in [TaskStatus.QUEUED, TaskStatus.RUNNING]:
-                    raise RuntimeError(
-                        f"Workflow {thread_id} already running with status {existing.status}"
-                    )
-                # Also block on SOFT_INTERRUPTED - the workflow just stopped and
-                # wait_for_soft_interrupted should be given time to see it
-                if existing.status == TaskStatus.SOFT_INTERRUPTED:
-                    raise RuntimeError(
-                        f"Workflow {thread_id} was just soft-interrupted. "
-                        f"Use wait_for_soft_interrupted() before starting a new workflow."
-                    )
-                # Remove completed task to allow re-run
-                logger.debug(
-                    f"[BackgroundTaskManager] Removing completed task {thread_id} "
-                    f"to start new execution"
+                raise RuntimeError(
+                    f"Workflow {key} already exists with status {existing.status}"
                 )
-                del self.tasks[thread_id]
 
-            # Check concurrent limit
             running_count = sum(
                 1 for t in self.tasks.values()
                 if t.status in [TaskStatus.QUEUED, TaskStatus.RUNNING]
@@ -545,9 +542,9 @@ class BackgroundTaskManager:
                     f"Currently running: {running_count}"
                 )
 
-            # Create task info
             task_info = TaskInfo(
                 thread_id=thread_id,
+                run_id=run_id,
                 status=TaskStatus.QUEUED,
                 created_at=datetime.now(),
                 metadata=metadata or {},
@@ -555,10 +552,9 @@ class BackgroundTaskManager:
                 graph=graph,
             )
 
-            # Start background task
             task_info.task = asyncio.create_task(
                 self._run_workflow_shielded(
-                    thread_id, workflow_generator,
+                    thread_id, run_id, workflow_generator,
                     cancel_event=task_info.cancel_event,
                     soft_interrupt_event=task_info.soft_interrupt_event,
                 )
@@ -566,12 +562,11 @@ class BackgroundTaskManager:
             task_info.status = TaskStatus.RUNNING
             task_info.started_at = datetime.now()
 
-            # Register task
-            self.tasks[thread_id] = task_info
+            self.tasks[key] = task_info
 
             logger.info(
-                f"[BackgroundTaskManager] Started workflow {thread_id} "
-                f"(running: {running_count + 1}/{self.max_concurrent})"
+                f"[BackgroundTaskManager] Started workflow thread_id={thread_id} "
+                f"run_id={run_id} (running: {running_count + 1}/{self.max_concurrent})"
             )
 
             return task_info
@@ -579,26 +574,15 @@ class BackgroundTaskManager:
     async def _run_workflow_shielded(
         self,
         thread_id: str,
+        run_id: str,
         workflow_generator: Any,
         cancel_event: asyncio.Event,
         soft_interrupt_event: asyncio.Event,
     ):
-        """
-        Run workflow with shield protection and cooperative cancellation.
-
-        Uses asyncio.shield() to protect from accidental disconnects, while
-        supporting explicit cancellation via cooperative event signaling.
-
-        Args:
-            thread_id: Workflow thread identifier
-            workflow_generator: Async generator from graph.astream()
-            cancel_event: Event signaling explicit cancellation
-            soft_interrupt_event: Event signaling soft interrupt (pause)
-        """
+        """Run workflow with shield protection and cooperative cancellation."""
+        key = (thread_id, run_id)
         try:
-            # Define the workflow consumer coroutine with cooperative cancellation
             async def consume_workflow(wf_gen):
-                """Consume workflow generator with cancellation/soft-interrupt checks."""
                 async for event in wf_gen:
                     if cancel_event.is_set():
                         with suppress(Exception):
@@ -611,56 +595,39 @@ class BackgroundTaskManager:
                         raise SoftInterruptError("Soft-interrupted by user")
 
                     if self.enable_storage:
-                        await self._buffer_event_redis(thread_id, event)
+                        await self._buffer_event_redis(thread_id, run_id, event)
 
-            # ----------------------------------------------------------
-            # First graph turn
-            # ----------------------------------------------------------
             inner_task = asyncio.create_task(consume_workflow(workflow_generator))
 
             async with self.task_lock:
-                task_info = self.tasks.get(thread_id)
+                task_info = self.tasks.get(key)
                 if task_info:
                     task_info.inner_task = inner_task
 
-            # ALWAYS use shield - cancellation handled cooperatively inside task
             await asyncio.shield(inner_task)
 
-            # Main graph finished — mark completed unconditionally.
-            # _mark_completed handles both cases:
-            # - No subagents: completion_callback persists, done.
-            # - Subagents pending: completion_callback persists main turn,
-            #   collector spawned to wait for subagents and persist their events.
-            await self._mark_completed(thread_id)
+            await self._mark_completed(thread_id, run_id)
 
         except SoftInterruptError:
-            # User pressed ESC: flush whatever state we have so follow-up queries
-            # can restore maximum progress.
-            await self._flush_checkpoint(thread_id)
-            await self._mark_soft_interrupted(thread_id)
+            await self._flush_checkpoint(thread_id, run_id)
+            await self._mark_soft_interrupted(thread_id, run_id)
             return
 
         except asyncio.CancelledError:
-            await self._mark_cancelled(thread_id)
+            await self._mark_cancelled(thread_id, run_id)
             raise
 
         except Exception as e:
-            # Workflow failed
             logger.error(
-                f"[BackgroundTaskManager] Workflow {thread_id} failed: {e}",
+                f"[BackgroundTaskManager] Workflow {key} failed: {e}",
                 exc_info=True
             )
-            await self._mark_failed(thread_id, str(e))
+            await self._mark_failed(thread_id, run_id, str(e))
 
-    async def _flush_checkpoint(self, thread_id: str) -> None:
-        """Force a checkpoint write for the current thread state.
-
-        The agent/checkpointer normally writes checkpoints at safe boundaries.
-        If the user presses ESC mid-run, this explicit flush makes sure the
-        latest available state is persisted so the next request can restore it.
-        """
+    async def _flush_checkpoint(self, thread_id: str, run_id: str) -> None:
+        """Force a checkpoint write for the current thread state on ESC."""
         async with self.task_lock:
-            task_info = self.tasks.get(thread_id)
+            task_info = self.tasks.get((thread_id, run_id))
             graph = task_info.graph if task_info else None
 
         if not graph:
@@ -691,36 +658,29 @@ class BackgroundTaskManager:
                 f"[BackgroundTaskManager] Failed to flush checkpoint for {thread_id}: {e}"
             )
 
-    async def _buffer_event_redis(self, thread_id: str, event: str):
-        """Append a workflow event to the per-thread Redis Stream.
-
-        Returns silently if the TaskInfo is gone (already cleaned up).
-        ``pipelined_event_buffer`` runs XADD + meta HSET in one MULTI/EXEC
-        outside the task_lock so Redis I/O can never block other appends.
-        """
+    async def _buffer_event_redis(self, thread_id: str, run_id: str, event: str):
+        """Append a workflow event to the per-run Redis Stream."""
+        key = (thread_id, run_id)
         async with self.task_lock:
-            if thread_id not in self.tasks:
+            if key not in self.tasks:
                 return
 
         try:
             cache = get_cache_client()
         except Exception as e:
             logger.warning(
-                f"[EventBuffer] get_cache_client() failed for {thread_id}: {e}; "
-                "dropping event"
+                f"[EventBuffer] get_cache_client() failed for {key}: {e}; dropping event"
             )
             return
         use_redis = self.event_storage_backend == "redis" and cache.enabled
 
         if not use_redis:
             logger.warning(
-                f"[EventBuffer] Redis unavailable for {thread_id}; "
+                f"[EventBuffer] Redis unavailable for {key}; "
                 "consumers attached to workflow:stream:* will see no events"
             )
             return
 
-        # Parse event ID from SSE format ("id: N\n..."). `partition` avoids
-        # allocating a full split list for events with multi-KB JSON bodies.
         event_id = None
         try:
             first_line, _, _ = event.partition("\n")
@@ -728,51 +688,43 @@ class BackgroundTaskManager:
         except (ValueError, IndexError):
             pass
 
-        # Without a parseable id the event can't land on the Stream
-        # (XADD needs an explicit ``<seq>-0`` id) and the meta hash counter
-        # would advance past an event that was never written, leaving a
-        # permanent gap in the stream. Bail and let the next event with
-        # a valid id keep the counter coherent.
         if event_id is None:
             logger.warning(
                 "[EventBuffer] Could not parse event ID from SSE string for "
-                f"{thread_id}; event dropped"
+                f"{key}; event dropped"
             )
             return
 
-        meta_key = f"workflow:events:meta:{thread_id}"
-        stream_key = f"workflow:stream:{thread_id}"
+        meta_k = stream_meta_key(thread_id, run_id)
+        stream_k = stream_key(thread_id, run_id)
 
         success, seq = await cache.pipelined_event_buffer(
-            meta_key=meta_key,
+            meta_key=meta_k,
             event=event,
             max_size=self.max_stored_messages,
             ttl=self.redis_event_ttl,
             last_event_id=event_id,
-            stream_key=stream_key,
+            stream_key=stream_k,
         )
 
         if not success:
             logger.error(
-                f"[EventBuffer] Redis pipeline failed for {thread_id}; "
+                f"[EventBuffer] Redis pipeline failed for {key}; "
                 "event dropped from workflow:stream:*"
             )
             return
 
-        logger.debug(f"[EventBuffer] Buffered event to Redis: {thread_id} (id={event_id}, seq={seq})")
+        logger.debug(f"[EventBuffer] Buffered event to Redis: {key} (id={event_id}, seq={seq})")
 
-        # Capacity warning — sample above 90% of max. Uses `seq` from HINCRBY so
-        # no extra round-trip. Strict `==` would silently skip the alert if seq
-        # jumped past threshold (pipeline retry, restart mid-burst). `>=` with
-        # a 1000-event modulo keeps the log quiet but guarantees every thread
-        # near-capacity produces at least one warning per 1000 events over.
         capacity_threshold = int(self.max_stored_messages * 0.9)
         if seq >= capacity_threshold and (seq - capacity_threshold) % 1000 == 0:
             logger.warning(
-                f"[EventBuffer] Buffer near capacity for {thread_id}: "
+                f"[EventBuffer] Buffer near capacity for {key}: "
                 f"{seq}/{self.max_stored_messages} events. "
                 "Oldest events will be dropped (FIFO)."
             )
+
+    # ========== Subagent collection ==========
 
     async def _collect_subagent_results_for_turn(
         self,
@@ -786,18 +738,10 @@ class BackgroundTaskManager:
         is_byok: bool = False,
         sandbox=None,
     ) -> None:
-        """Collect subagent results for a specific turn's tasks.
-
-        Similar to _collect_subagent_results_after_interrupt but operates on
-        a specific list of tasks (filtered by spawned_turn_index).
-        """
         if timeout is None:
             timeout = get_subagent_collector_timeout()
 
         try:
-            # Sync completion status: asyncio_task may be done but completed flag
-            # not yet set (e.g., after tail phase which checks asyncio_task.done()
-            # but doesn't set task.completed)
             for task in tasks:
                 if not task.completed and task.asyncio_task and task.asyncio_task.done():
                     task.completed = True
@@ -815,21 +759,17 @@ class BackgroundTaskManager:
 
             all_subagent_events: list[dict] = []
 
-            # Collect from already-completed tasks (Redis-fallback for any
-            # events that rotated past the in-memory tail during the run).
             for task in tasks:
                 if task.completed and task.captured_event_count > 0:
                     async for record in iter_subagent_events_full(thread_id, task):
                         enriched = _record_to_persist_event(record, thread_id)
                         all_subagent_events.append(enriched)
 
-            # Get pending tasks
             pending = {
                 t.asyncio_task: t for t in tasks
                 if t.is_pending and t.asyncio_task
             }
 
-            # Persist initial batch if any
             if all_subagent_events:
                 await self._persist_collected_events(
                     main_chunks, all_subagent_events, response_id,
@@ -837,17 +777,13 @@ class BackgroundTaskManager:
                 )
 
             if not pending:
-                # Persist subagent token usage as separate rows
                 await self._persist_subagent_usage(
                     response_id, tasks, thread_id, workspace_id, user_id,
                     is_byok=is_byok,
                 )
-                # Deferred cleanup: wait for per-task SSE streams to finish their
-                # final drain before clearing the captured-event tail and Redis buffers.
                 await self._await_drain_and_cleanup_tasks(tasks, thread_id)
                 return
 
-            # Wait for remaining tasks one-by-one
             deadline = time.time() + timeout
 
             while pending:
@@ -889,7 +825,6 @@ class BackgroundTaskManager:
                         thread_id, workspace_id, user_id, sandbox=sandbox,
                     )
 
-            # Spawn orphan collector for tasks that outlived the initial deadline
             if pending:
                 orphaned_tasks = list(pending.values())
                 logger.info(
@@ -911,15 +846,11 @@ class BackgroundTaskManager:
                     name=f"subagent-orphan-collector-{thread_id}",
                 )
 
-            # Persist subagent token usage as separate rows
-            # (only for tasks that were actually collected, not timed-out ones)
             collected_tasks = [t for t in tasks if t not in pending.values()]
             await self._persist_subagent_usage(
                 response_id, collected_tasks, thread_id, workspace_id, user_id,
                 is_byok=is_byok,
             )
-            # Deferred cleanup: wait for per-task SSE streams to finish their
-            # final drain before clearing captured_events and Redis buffers.
             await self._await_drain_and_cleanup_tasks(collected_tasks, thread_id)
 
         except Exception as e:
@@ -931,23 +862,14 @@ class BackgroundTaskManager:
     async def _await_drain_and_cleanup_tasks(
         self, tasks: list, thread_id: str, timeout: float | None = None
     ) -> None:
-        """Wait for per-task SSE streams to finish emitting, then clear buffers.
-
-        Each task carries an ``sse_drain_complete`` event that is set by
-        ``stream_subagent_task_events`` after its final drain.  We await all of
-        them concurrently so the collector only clears captured_events once every
-        live SSE consumer has delivered the full event sequence.
-
-        If no SSE consumer is connected (event never set), the timeout ensures
-        cleanup still happens — persistence has already succeeded at this point.
-        """
         if timeout is None:
             timeout = get_sse_drain_timeout()
+
         async def _wait_one(event: "asyncio.Event") -> None:
             try:
                 await asyncio.wait_for(event.wait(), timeout=timeout)
             except asyncio.TimeoutError:
-                pass  # No active SSE consumer, or too slow — safe to clear
+                pass
 
         await asyncio.gather(*[_wait_one(t.sse_drain_complete) for t in tasks])
 
@@ -959,11 +881,9 @@ class BackgroundTaskManager:
                 f"[SubagentCleanup] Cache client unavailable during cleanup "
                 f"for thread_id={thread_id}: {exc}"
             )
+
         for task in tasks:
             task.per_call_records = []
-            # Drop asyncio handles — the asyncio.Task object holds the
-            # coroutine frame, which can keep middleware/tool/LLM-callback
-            # closures alive long after the task itself is done.
             task.asyncio_task = None
             task.handler_task = None
             if cache is not None:
@@ -979,11 +899,6 @@ class BackgroundTaskManager:
                     )
                 except Exception:
                     pass
-                # One-release backward-compat sweep: pre-cutover workers
-                # RPUSH'd records to the legacy List under this key. The
-                # new code never reads or writes it, but stale entries
-                # from a worker that ran the same thread before deploy
-                # would otherwise sit in Redis until the 24h TTL.
                 try:
                     await cache.delete(
                         f"subagent:events:{thread_id}:{task.task_id}"
@@ -1014,26 +929,12 @@ class BackgroundTaskManager:
         is_byok: bool = False,
         sandbox=None,
     ) -> None:
-        """Continue collecting results for tasks that outlived the initial collector.
-
-        Spawned as a fire-and-forget task when the initial collector's deadline
-        expires with pending tasks.  Uses an **idle timeout** instead of a fixed
-        deadline: the timer resets whenever any pending task shows progress
-        (new captured events or tool call activity).  This means a subagent that
-        is actively working will never be abandoned, while a truly stuck one is
-        cleaned up after the idle period.
-
-        The tasks' collector_response_id is already set (retained from the initial
-        collector), preventing other collectors from double-claiming.
-        """
         idle_timeout = get_subagent_orphan_collector_timeout()
-        # How often to poll for progress when no task completes
         poll_interval = min(30.0, idle_timeout)
 
         try:
             all_subagent_events = list(prior_subagent_events)
 
-            # Sync completion: tasks may have finished between parent timeout and now
             for task in tasks:
                 if not task.completed and task.asyncio_task and task.asyncio_task.done():
                     task.completed = True
@@ -1048,7 +949,6 @@ class BackgroundTaskManager:
                 if t.is_pending and t.asyncio_task
             }
 
-            # Collect events from tasks that completed in the gap
             for task in tasks:
                 if (
                     task.completed
@@ -1060,7 +960,6 @@ class BackgroundTaskManager:
                         all_subagent_events.append(enriched)
 
             if not pending:
-                # All tasks completed between parent timeout and our start
                 if all_subagent_events:
                     await self._persist_collected_events(
                         main_chunks, all_subagent_events, response_id,
@@ -1082,10 +981,6 @@ class BackgroundTaskManager:
                 f"{idle_timeout}s idle timeout, thread_id={thread_id}"
             )
 
-            # Snapshot current activity state per pending task. ``count`` is
-            # the total events ever captured (includes those rotated out of
-            # the in-memory tail) so the liveness check stays correct even
-            # when subagents emit far past the tail size.
             last_activity: dict[asyncio.Task, tuple[float, int]] = {
                 at: (t.last_updated_at, t.captured_event_count)
                 for at, t in pending.items()
@@ -1093,7 +988,6 @@ class BackgroundTaskManager:
             last_progress_time = time.time()
 
             while pending:
-                # Check idle deadline
                 if time.time() - last_progress_time > idle_timeout:
                     logger.warning(
                         f"[OrphanCollector] Idle timeout ({idle_timeout}s) for "
@@ -1108,7 +1002,6 @@ class BackgroundTaskManager:
                 )
 
                 if done:
-                    # Task completion is progress
                     last_progress_time = time.time()
 
                     for asyncio_task in done:
@@ -1138,7 +1031,6 @@ class BackgroundTaskManager:
                             thread_id, workspace_id, user_id, sandbox=sandbox,
                         )
                 else:
-                    # No task completed this cycle — check for activity progress
                     for asyncio_task, task in pending.items():
                         prev_update, prev_events = last_activity.get(
                             asyncio_task, (0.0, 0)
@@ -1149,7 +1041,6 @@ class BackgroundTaskManager:
                             last_progress_time = time.time()
                             last_activity[asyncio_task] = (cur_update, cur_events)
 
-            # Release claims on tasks that are truly idle
             if pending:
                 for asyncio_task, task in pending.items():
                     task.collector_response_id = None
@@ -1172,21 +1063,19 @@ class BackgroundTaskManager:
                 f"[OrphanCollector] Failed for thread_id={thread_id}: {e}",
                 exc_info=True,
             )
-            # Release claims on failure so tasks aren't permanently locked
             for task in tasks:
                 if task.collector_response_id == response_id:
                     task.collector_response_id = None
 
-    # ========== Workflow Completion & Error Handlers ==========
+    # ========== Terminal handlers ==========
 
-    def _release_terminal_refs(self, thread_id: str) -> None:
-        """Drop heavy in-process refs once a TaskInfo is in terminal state.
-
-        Idempotent. Preserves small scalars used by /status, debug paths, and
-        downstream readers (workspace_id, user_id, is_byok, dispatch_kind,
-        response_id).
-        """
-        info = self.tasks.get(thread_id)
+    def _release_terminal_refs(
+        self,
+        thread_id: str,
+        run_id: str,
+    ) -> None:
+        """Drop heavy in-process refs once a TaskInfo is in terminal state."""
+        info = self.tasks.get((thread_id, run_id))
         if not info:
             return
         info.graph = None
@@ -1196,29 +1085,23 @@ class BackgroundTaskManager:
         info.metadata.pop("handler", None)
         info.metadata.pop("token_callback", None)
         info.metadata.pop("sandbox", None)
+        info.metadata.pop("persistence_service", None)
 
-    async def _mark_completed(self, thread_id: str):
-        """Mark workflow as completed and notify live subscribers.
-
-        Split into two phases to avoid holding the lock during heavy async I/O:
-        - Phase 1 (under lock): status update, sentinels, copy refs
-        - Phase 2 (outside lock): aget_state, persistence, callbacks, collector
-        """
-        # Phase 1: Quick state update under lock
+    async def _mark_completed(self, thread_id: str, run_id: str):
+        """Mark workflow as completed and notify live subscribers."""
+        key = (thread_id, run_id)
         async with self.task_lock:
-            task_info = self.tasks.get(thread_id)
+            task_info = self.tasks.get(key)
             if not task_info:
                 return
 
             task_info.status = TaskStatus.COMPLETED
             task_info.completed_at = datetime.now()
 
-            # Copy refs needed for persistence phase
             graph = task_info.graph
             metadata = task_info.metadata
             completion_callback = task_info.completion_callback
 
-        # Phase 2: Heavy I/O outside lock (with timeout protection)
         is_interrupted = False
         try:
             if graph:
@@ -1227,48 +1110,45 @@ class BackgroundTaskManager:
                     timeout=get_checkpoint_flush_timeout(),
                 )
                 if snapshot and snapshot.next:
-                    # Workflow has pending nodes = interrupted, not completed
                     is_interrupted = True
         except asyncio.TimeoutError:
             logger.error(
-                f"[BackgroundTaskManager] aget_state timed out for {thread_id} in _mark_completed"
+                f"[BackgroundTaskManager] aget_state timed out for {key} in _mark_completed"
             )
         except Exception as state_error:
             logger.warning(
-                f"[BackgroundTaskManager] Could not check workflow state for {thread_id}: {state_error}"
+                f"[BackgroundTaskManager] Could not check workflow state for {key}: {state_error}"
             )
 
-        # Database status will be updated by persistence service in transaction
         workspace_id = metadata.get("workspace_id")
         user_id = metadata.get("user_id")
 
-        # Persist workflow state based on completion vs interrupt
         if is_interrupted:
-            # Workflow interrupted - persist interrupt state with all required fields
             if workspace_id and user_id:
                 try:
                     from src.server.services.persistence.conversation import ConversationPersistenceService
 
-                    persistence_service = ConversationPersistenceService.get_instance(thread_id)
-                    persistence_service._on_pair_persisted = lambda: self.clear_event_buffer(thread_id)
+                    persistence_service = metadata.get("persistence_service")
+                    if persistence_service is None:
+                        persistence_service = ConversationPersistenceService.get_instance(
+                            thread_id, run_id,
+                            workspace_id=workspace_id, user_id=user_id,
+                        )
+                    persistence_service._on_pair_persisted = (
+                        lambda: self.clear_event_buffer(thread_id, run_id)
+                    )
 
-                    # Get token usage and per_call_records from token_callback
                     _, per_call_records = get_token_usage_from_callback(
                         metadata, "interrupt", thread_id
                     )
-
-                    # Get tool usage from handler (has cached result from SSE emission)
                     tool_usage = get_tool_usage_from_handler(
                         metadata, "interrupt", thread_id
                     )
-
-                    # Get SSE events for persistence (plan description, reasoning, etc.)
                     sse_events = get_sse_events_from_handler(
                         metadata, "interrupt", thread_id
                     )
 
-                    # Determine actual interrupt reason from SSE events
-                    interrupt_reason = "plan_review_required"  # default fallback
+                    interrupt_reason = "plan_review_required"
                     if sse_events:
                         for chunk in sse_events:
                             if chunk.get("event") == "interrupt":
@@ -1280,15 +1160,13 @@ class BackgroundTaskManager:
                                         interrupt_reason = "user_question"
                                 break
 
-                    # Calculate execution time from start_time
                     execution_time = calculate_execution_time(metadata)
 
-                    # Build metadata with all context
                     persist_metadata = {
                         "msg_type": metadata.get("msg_type"),
                         "stock_code": metadata.get("stock_code"),
                         "deepthinking": metadata.get("deepthinking", False),
-                        "is_byok": metadata.get("is_byok", False)
+                        "is_byok": metadata.get("is_byok", False),
                     }
 
                     await persistence_service.persist_interrupt(
@@ -1297,137 +1175,122 @@ class BackgroundTaskManager:
                         metadata=persist_metadata,
                         per_call_records=per_call_records,
                         tool_usage=tool_usage,
-                        sse_events=sse_events
+                        sse_events=sse_events,
                     )
-                    logger.info(f"[WorkflowPersistence] Workflow {thread_id} paused for human feedback")
+                    logger.info(f"[WorkflowPersistence] Workflow {key} paused for human feedback")
 
-                    # Update Redis workflow tracker to interrupted
-                    # (prevents frontend from reconnecting to a paused workflow)
                     tracker = WorkflowTracker.get_instance()
                     await tracker.mark_interrupted(
                         thread_id=thread_id,
-                        metadata={"interrupt_reason": interrupt_reason},
+                        metadata={"interrupt_reason": interrupt_reason, "run_id": run_id},
                     )
                 except Exception as persist_error:
                     logger.error(
-                        f"[WorkflowPersistence] Failed to persist interrupt for thread_id={thread_id}: {persist_error}",
-                        exc_info=True
+                        f"[WorkflowPersistence] Failed to persist interrupt for {key}: {persist_error}",
+                        exc_info=True,
                     )
         else:
-            # Workflow completed - invoke completion callback for full persistence
             if completion_callback:
                 try:
-                    await completion_callback()
+                    await completion_callback(task_info)
                 except Exception as e:
                     logger.error(
-                        f"[BackgroundTaskManager] Completion callback failed for {thread_id}: {e}",
-                        exc_info=True
+                        f"[BackgroundTaskManager] Completion callback failed for {key}: {e}",
+                        exc_info=True,
                     )
-                    # Update workflow status to error when callback fails.
-                    # Returning short-circuits the post-else collector spawn and
-                    # the second release_burst_slot — _mark_failed handles both.
-                    await self._mark_failed(thread_id, f"Completion callback failed: {str(e)}")
+                    await self._mark_failed(
+                        thread_id, run_id,
+                        f"Completion callback failed: {str(e)}",
+                    )
                     return
 
-        # Spawn collector for subagent events + usage merge
-        from src.server.services.persistence.conversation import ConversationPersistenceService
-        ps = ConversationPersistenceService.get_instance(thread_id)
-        response_id = ps._current_response_id
+        # Spawn collector for subagent events. response_id == run_id by 1:1 contract.
+        response_id = run_id
 
-        if response_id:
-            from src.server.services.background_registry_store import BackgroundRegistryStore
-            bg_store = BackgroundRegistryStore.get_instance()
-            bg_registry = await bg_store.get_registry(thread_id)
-            if bg_registry:
-                # Atomically claim uncollected tasks to prevent double-persist
-                # when two collectors run concurrently (e.g. subagent from turn 0
-                # still pending when turn 1 completes).
-                tasks_to_collect = []
-                for t in bg_registry._tasks.values():
-                    if t.collector_response_id:
-                        continue  # Already claimed by another turn's collector
-                    if t.is_pending or t.captured_event_count > 0 or t.per_call_records:
-                        t.collector_response_id = response_id
-                        tasks_to_collect.append(t)
-                if tasks_to_collect:
-                    workspace_id = metadata.get("workspace_id")
-                    user_id = metadata.get("user_id")
-                    handler = metadata.get("handler")
-                    sse_events = handler.get_sse_events() if handler else []
-                    if workspace_id and user_id:
-                        asyncio.create_task(
-                            self._collect_subagent_results_for_turn(
-                                thread_id=thread_id,
-                                response_id=response_id,
-                                original_chunks=sse_events or [],
-                                tasks=tasks_to_collect,
-                                workspace_id=workspace_id,
-                                user_id=user_id,
-                                is_byok=metadata.get("is_byok", False),
-                                sandbox=metadata.get("sandbox"),
-                            ),
-                            name=f"subagent-collector-{thread_id}-post-tail",
-                        )
+        from src.server.services.background_registry_store import BackgroundRegistryStore
+        bg_store = BackgroundRegistryStore.get_instance()
+        bg_registry = await bg_store.get_registry(thread_id)
+        if bg_registry:
+            tasks_to_collect = []
+            for t in bg_registry._tasks.values():
+                if t.collector_response_id:
+                    continue
+                if t.is_pending or t.captured_event_count > 0 or t.per_call_records:
+                    t.collector_response_id = response_id
+                    tasks_to_collect.append(t)
+            if tasks_to_collect:
+                handler = metadata.get("handler")
+                sse_events = handler.get_sse_events() if handler else []
+                if workspace_id and user_id:
+                    asyncio.create_task(
+                        self._collect_subagent_results_for_turn(
+                            thread_id=thread_id,
+                            response_id=response_id,
+                            original_chunks=sse_events or [],
+                            tasks=tasks_to_collect,
+                            workspace_id=workspace_id,
+                            user_id=user_id,
+                            is_byok=metadata.get("is_byok", False),
+                            sandbox=metadata.get("sandbox"),
+                        ),
+                        name=f"subagent-collector-{thread_id}-{run_id}-post-tail",
+                    )
 
-        # Release burst slot for all completion paths (normal + interrupt)
         if user_id:
             await release_burst_slot(user_id)
 
-        # Signal that persistence is done so callers (e.g. automation_executor)
-        # can safely read persisted data from the DB.
+        task_info.persistence_complete.set()
         async with self.task_lock:
-            task_info = self.tasks.get(thread_id)
-            if task_info:
-                task_info.persistence_complete.set()
-            self._release_terminal_refs(thread_id)
+            self._release_terminal_refs(thread_id, run_id)
 
-    async def wait_for_persistence(self, thread_id: str, timeout: float | None = None) -> bool:
-        """Wait until _mark_completed has finished persisting for *thread_id*.
+    async def wait_for_persistence(
+        self, thread_id: str, run_id: str, timeout: float | None = None
+    ) -> bool:
+        """Wait until _mark_completed has finished persisting for the given turn.
 
-        Returns True if persistence completed, False on timeout or missing task.
+        Captures the ``persistence_complete`` event reference under the lock
+        so a concurrent ``wait_for_soft_interrupted`` deletion of the entry
+        doesn't make us drop a still-pending wait on the floor.
         """
         if timeout is None:
             timeout = get_wait_for_persistence_timeout()
         async with self.task_lock:
-            task_info = self.tasks.get(thread_id)
-        if not task_info:
+            task_info = self.tasks.get((thread_id, run_id))
+            event = task_info.persistence_complete if task_info else None
+        if event is None:
             return False
         try:
-            await asyncio.wait_for(task_info.persistence_complete.wait(), timeout=timeout)
+            await asyncio.wait_for(event.wait(), timeout=timeout)
             return True
         except asyncio.TimeoutError:
             logger.warning(
-                f"[BackgroundTaskManager] wait_for_persistence timed out for {thread_id} "
-                f"after {timeout}s"
+                f"[BackgroundTaskManager] wait_for_persistence timed out for "
+                f"thread_id={thread_id} run_id={run_id} after {timeout}s"
             )
             return False
 
-    async def _mark_failed(self, thread_id: str, error: str):
-        """Mark workflow as failed and notify live subscribers.
-
-        Split into two phases to avoid holding the lock during heavy async I/O:
-        - Phase 1 (under lock): status update, sentinels, copy refs
-        - Phase 2 (outside lock): aget_state, persistence
-        """
-        # Phase 1: Quick state update under lock
+    async def _mark_failed(
+        self,
+        thread_id: str,
+        run_id: str,
+        error: str,
+    ):
+        """Mark workflow as failed and notify live subscribers."""
+        key = (thread_id, run_id)
         async with self.task_lock:
-            task_info = self.tasks.get(thread_id)
+            task_info = self.tasks.get(key)
             if not task_info:
                 return
 
             task_info.status = TaskStatus.FAILED
             task_info.completed_at = datetime.now()
             task_info.error = error
-
-            # Copy refs needed for persistence phase
             metadata = task_info.metadata
 
-        # Phase 2: Heavy I/O outside lock
         logger.error(
-            f"[BackgroundTaskManager] Workflow {thread_id} failed: {error}"
+            f"[BackgroundTaskManager] Workflow {key} failed: {error}"
         )
 
-        # Persist error with full details
         workspace_id = metadata.get("workspace_id")
         user_id = metadata.get("user_id")
 
@@ -1435,33 +1298,33 @@ class BackgroundTaskManager:
             try:
                 from src.server.services.persistence.conversation import ConversationPersistenceService
 
-                persistence_service = ConversationPersistenceService.get_instance(thread_id)
-                persistence_service._on_pair_persisted = lambda: self.clear_event_buffer(thread_id)
+                persistence_service = metadata.get("persistence_service")
+                if persistence_service is None:
+                    persistence_service = ConversationPersistenceService.get_instance(
+                        thread_id, run_id,
+                        workspace_id=workspace_id, user_id=user_id,
+                    )
+                persistence_service._on_pair_persisted = (
+                    lambda: self.clear_event_buffer(thread_id, run_id)
+                )
 
-                # Calculate execution time
                 execution_time = calculate_execution_time(metadata)
-
-                # Get token usage and per_call_records from token_callback
                 _, per_call_records = get_token_usage_from_callback(
                     metadata, "error", thread_id
                 )
-
-                # Get tool usage from handler (has cached result from SSE emission)
                 tool_usage = get_tool_usage_from_handler(
                     metadata, "error", thread_id
                 )
-
                 sse_events = get_sse_events_from_handler(
                     metadata, "error", thread_id
                 )
 
-                # Build metadata with all context
                 persist_metadata = {
                     "msg_type": metadata.get("msg_type"),
                     "stock_code": metadata.get("stock_code"),
                     "agent_llm_preset": metadata.get("agent_llm_preset", "default"),
                     "deepthinking": metadata.get("deepthinking", False),
-                    "is_byok": metadata.get("is_byok", False)
+                    "is_byok": metadata.get("is_byok", False),
                 }
 
                 await persistence_service.persist_error(
@@ -1471,63 +1334,44 @@ class BackgroundTaskManager:
                     per_call_records=per_call_records,
                     tool_usage=tool_usage,
                     sse_events=sse_events,
-                    metadata=persist_metadata
+                    metadata=persist_metadata,
                 )
-                logger.info(f"[WorkflowPersistence] Error persisted for thread_id={thread_id}")
+                logger.info(f"[WorkflowPersistence] Error persisted for {key}")
             except Exception as persist_error:
                 logger.error(
-                    f"[WorkflowPersistence] Failed to persist error for {thread_id}: {persist_error}",
-                    exc_info=True
+                    f"[WorkflowPersistence] Failed to persist error for {key}: {persist_error}",
+                    exc_info=True,
                 )
 
-        # Release burst slot for failure path
         if user_id:
             await release_burst_slot(user_id)
 
-        # Push terminal status to Redis so /status reports FAILED with bounded
-        # TTL instead of leaving the key as ACTIVE until natural expiry.
-        # Mirrors mark_completed/mark_cancelled.
         try:
             tracker = WorkflowTracker.get_instance()
             await tracker.mark_failed(thread_id, error=error)
         except Exception as tracker_err:
             logger.warning(
-                f"[BackgroundTaskManager] tracker.mark_failed failed for {thread_id}: {tracker_err}"
+                f"[BackgroundTaskManager] tracker.mark_failed failed for {key}: {tracker_err}"
             )
 
+        task_info.persistence_complete.set()
         async with self.task_lock:
-            task_info = self.tasks.get(thread_id)
-            if task_info:
-                task_info.persistence_complete.set()
-            self._release_terminal_refs(thread_id)
+            self._release_terminal_refs(thread_id, run_id)
 
-    async def _mark_soft_interrupted(self, thread_id: str) -> None:
-        """Mark workflow as soft-interrupted (ESC).
-
-        This ends the foreground workflow execution so the user can immediately
-        send a follow-up message on the same `thread_id`, while leaving any
-        independently running background subagent tasks alone.
-
-        Split into two phases to avoid holding the lock during heavy async I/O:
-        - Phase 1 (under lock): status update, sentinels, copy refs
-        - Phase 2 (outside lock): aget_state, persistence, subagent collector
-        """
-        # Phase 1: Quick state update under lock
+    async def _mark_soft_interrupted(self, thread_id: str, run_id: str) -> None:
+        """Mark workflow as soft-interrupted (ESC)."""
+        key = (thread_id, run_id)
         async with self.task_lock:
-            task_info = self.tasks.get(thread_id)
+            task_info = self.tasks.get(key)
             if not task_info:
                 return
 
             task_info.status = TaskStatus.SOFT_INTERRUPTED
             task_info.completed_at = datetime.now()
-
-            # Copy refs needed for persistence phase
             metadata = task_info.metadata
 
-        # Phase 2: Heavy I/O outside lock
-        logger.info(f"[BackgroundTaskManager] Marked as soft-interrupted: {thread_id}")
+        logger.info(f"[BackgroundTaskManager] Marked as soft-interrupted: {key}")
 
-        # Persist soft interrupt so query/response pair is saved
         workspace_id = metadata.get("workspace_id")
         user_id = metadata.get("user_id")
 
@@ -1535,25 +1379,25 @@ class BackgroundTaskManager:
             try:
                 from src.server.services.persistence.conversation import ConversationPersistenceService
 
-                persistence_service = ConversationPersistenceService.get_instance(
-                    thread_id,
-                    workspace_id=workspace_id,
-                    user_id=user_id
+                persistence_service = metadata.get("persistence_service")
+                if persistence_service is None:
+                    persistence_service = ConversationPersistenceService.get_instance(
+                        thread_id, run_id,
+                        workspace_id=workspace_id, user_id=user_id,
+                    )
+                persistence_service._on_pair_persisted = (
+                    lambda: self.clear_event_buffer(thread_id, run_id)
                 )
-                persistence_service._on_pair_persisted = lambda: self.clear_event_buffer(thread_id)
 
                 _, per_call_records = get_token_usage_from_callback(
                     metadata, "interrupt", thread_id
                 )
-
                 tool_usage = get_tool_usage_from_handler(
                     metadata, "interrupt", thread_id
                 )
-
                 sse_events = get_sse_events_from_handler(
                     metadata, "interrupt", thread_id
                 )
-
                 execution_time = calculate_execution_time(metadata)
 
                 persist_metadata = {
@@ -1562,7 +1406,7 @@ class BackgroundTaskManager:
                     "agent_llm_preset": metadata.get("agent_llm_preset", "default"),
                     "deepthinking": metadata.get("deepthinking", False),
                     "is_byok": metadata.get("is_byok", False),
-                    "soft_interrupted": True
+                    "soft_interrupted": True,
                 }
 
                 response_id = await persistence_service.persist_interrupt(
@@ -1571,11 +1415,10 @@ class BackgroundTaskManager:
                     metadata=persist_metadata,
                     per_call_records=per_call_records,
                     tool_usage=tool_usage,
-                    sse_events=sse_events
+                    sse_events=sse_events,
                 )
-                logger.info(f"[WorkflowPersistence] Soft interrupt persisted for thread_id={thread_id}")
+                logger.info(f"[WorkflowPersistence] Soft interrupt persisted for {key}")
 
-                # Spawn collector if subagents are still running
                 from src.server.services.background_registry_store import BackgroundRegistryStore
                 bg_store = BackgroundRegistryStore.get_instance()
                 bg_registry = await bg_store.get_registry(thread_id)
@@ -1583,7 +1426,7 @@ class BackgroundTaskManager:
                 if bg_registry and bg_registry.has_pending_tasks():
                     logger.info(
                         f"[WorkflowPersistence] {bg_registry.pending_count} subagents still running, "
-                        f"spawning result collector for thread_id={thread_id}"
+                        f"spawning result collector for {key}"
                     )
                     asyncio.create_task(
                         self._collect_subagent_results_after_interrupt(
@@ -1596,32 +1439,28 @@ class BackgroundTaskManager:
                             timeout=get_subagent_collector_timeout(),
                             is_byok=metadata.get("is_byok", False),
                         ),
-                        name=f"subagent-collector-{thread_id}",
+                        name=f"subagent-collector-{thread_id}-{run_id}",
                     )
             except Exception as persist_error:
                 logger.error(
-                    f"[WorkflowPersistence] Failed to persist soft interrupt for {thread_id}: {persist_error}",
-                    exc_info=True
+                    f"[WorkflowPersistence] Failed to persist soft interrupt for {key}: {persist_error}",
+                    exc_info=True,
                 )
 
-        # Release burst slot for soft interrupt path
         if user_id:
             await release_burst_slot(user_id)
 
-        # Push terminal status to Redis (bounded TTL).
         try:
             tracker = WorkflowTracker.get_instance()
             await tracker.mark_soft_interrupted(thread_id)
         except Exception as tracker_err:
             logger.warning(
-                f"[BackgroundTaskManager] tracker.mark_soft_interrupted failed for {thread_id}: {tracker_err}"
+                f"[BackgroundTaskManager] tracker.mark_soft_interrupted failed for {key}: {tracker_err}"
             )
 
+        task_info.persistence_complete.set()
         async with self.task_lock:
-            task_info = self.tasks.get(thread_id)
-            if task_info:
-                task_info.persistence_complete.set()
-            self._release_terminal_refs(thread_id)
+            self._release_terminal_refs(thread_id, run_id)
 
     async def _collect_subagent_results_after_interrupt(
         self,
@@ -1634,28 +1473,17 @@ class BackgroundTaskManager:
         timeout: float | None = None,
         is_byok: bool = False,
     ) -> None:
-        """Wait for subagents incrementally, persist as each completes.
-
-        Fire-and-forget task spawned by _mark_soft_interrupted() when background
-        subagents are still running after the user presses ESC.
-
-        Uses asyncio.FIRST_COMPLETED so each subagent's events are persisted
-        to DB as soon as that subagent finishes, rather than waiting for all.
-        """
         if timeout is None:
             timeout = get_subagent_collector_timeout()
 
         try:
-            # Claim uncollected tasks atomically to prevent double-persist
-            all_tasks = [
-                t for t in await bg_registry.get_all_tasks()
-                if not t.collector_response_id
-            ]
-            for t in all_tasks:
+            all_tasks = []
+            for t in bg_registry._tasks.values():
+                if t.collector_response_id:
+                    continue
                 t.collector_response_id = response_id
+                all_tasks.append(t)
 
-            # Sync completion status: asyncio_task may be done but completed flag
-            # not yet set (same gap as in _collect_subagent_results_for_turn)
             for task in all_tasks:
                 if not task.completed and task.asyncio_task and task.asyncio_task.done():
                     task.completed = True
@@ -1673,30 +1501,24 @@ class BackgroundTaskManager:
                 f"pending={bg_registry.pending_count}"
             )
 
-            # Main agent events (unchanged throughout)
             main_chunks = [
                 c for c in original_chunks
                 if c.get("data", {}).get("agent", "") not in subagent_agent_ids
             ]
 
-            # Accumulate subagent events across iterations
             all_subagent_events: list[dict] = []
 
-            # Collect from already-completed tasks (Redis-fallback covers
-            # events that rotated past the in-memory tail during the run)
             for task in all_tasks:
                 if task.completed and task.captured_event_count > 0:
                     async for record in iter_subagent_events_full(thread_id, task):
                         enriched = _record_to_persist_event(record, thread_id)
                         all_subagent_events.append(enriched)
 
-            # Get pending tasks
             pending = {
                 t.asyncio_task: t for t in all_tasks
                 if t.is_pending and t.asyncio_task
             }
 
-            # Persist initial batch if any already-completed tasks had events
             if all_subagent_events:
                 await self._persist_collected_events(
                     main_chunks, all_subagent_events, response_id,
@@ -1709,7 +1531,6 @@ class BackgroundTaskManager:
                         f"[SubagentCollector] No subagent events captured "
                         f"for thread_id={thread_id}"
                     )
-                # Persist subagent token usage as separate rows
                 await self._persist_subagent_usage(
                     response_id, all_tasks, thread_id, workspace_id, user_id,
                     is_byok=is_byok,
@@ -1717,7 +1538,6 @@ class BackgroundTaskManager:
                 await self._await_drain_and_cleanup_tasks(all_tasks, thread_id)
                 return
 
-            # Wait for remaining tasks one-by-one
             deadline = time.time() + timeout
 
             while pending:
@@ -1736,12 +1556,11 @@ class BackgroundTaskManager:
                 )
 
                 if not done:
-                    break  # timeout
+                    break
 
                 for asyncio_task in done:
                     task = pending.pop(asyncio_task)
 
-                    # Mark task completed
                     async with bg_registry._lock:
                         task.completed = True
                         try:
@@ -1750,7 +1569,6 @@ class BackgroundTaskManager:
                             task.error = str(e)
                             task.result = {"success": False, "error": str(e)}
 
-                    # Collect this task's captured events
                     if task.captured_event_count > 0:
                         async for record in iter_subagent_events_full(thread_id, task):
                             enriched = _record_to_persist_event(record, thread_id)
@@ -1761,14 +1579,12 @@ class BackgroundTaskManager:
                         f"persisting {len(all_subagent_events)} total events"
                     )
 
-                # Persist after each batch of completions
                 if all_subagent_events:
                     await self._persist_collected_events(
                         main_chunks, all_subagent_events, response_id,
                         thread_id, workspace_id, user_id,
                     )
 
-            # Spawn orphan collector for tasks that outlived the initial deadline
             if pending:
                 orphaned_tasks = list(pending.values())
                 logger.info(
@@ -1789,8 +1605,6 @@ class BackgroundTaskManager:
                     name=f"subagent-orphan-collector-{thread_id}",
                 )
 
-            # Persist subagent token usage as separate rows
-            # (only for tasks that were actually collected, not timed-out ones)
             collected_tasks = [t for t in all_tasks if t not in pending.values()]
             await self._persist_subagent_usage(
                 response_id, collected_tasks, thread_id, workspace_id, user_id,
@@ -1814,14 +1628,7 @@ class BackgroundTaskManager:
         user_id: str,
         sandbox=None,
     ) -> None:
-        """Clean and persist main + subagent events to DB.
-
-        Subagent events are already in correct sequential order from
-        event_capture.py's await-based capture (append_captured_event under lock).
-        We preserve this insertion order rather than sorting by timestamp,
-        which can reorder events captured in tight loops with identical
-        time.time() values.
-        """
+        """Clean and persist main + subagent events to DB."""
         import copy
 
         cleaned = []
@@ -1832,7 +1639,6 @@ class BackgroundTaskManager:
 
         updated_chunks = main_chunks + cleaned
 
-        # Capture sandbox images from subagent events → upload to cloud storage
         if sandbox:
             try:
                 from src.server.services.persistence.image_capture import (
@@ -1847,15 +1653,25 @@ class BackgroundTaskManager:
                     "[IMAGE_CAPTURE] Hook B failed", exc_info=True,
                 )
 
-        from src.server.services.persistence.conversation import (
-            ConversationPersistenceService,
-        )
-        persistence_service = ConversationPersistenceService.get_instance(
-            thread_id, workspace_id=workspace_id, user_id=user_id,
-        )
-        await persistence_service.update_sse_events(
-            response_id=response_id, sse_events=updated_chunks,
-        )
+        # Direct DB update — we know the response_id, no need to go through
+        # the persistence-service singleton (which would key by run_id and
+        # might not match a subagent collector running across turns).
+        from src.server.database import conversation as qr_db
+        try:
+            await qr_db.update_sse_events(
+                conversation_response_id=response_id,
+                sse_events=updated_chunks,
+            )
+            logger.info(
+                f"[SubagentCollector] Updated sse_events for "
+                f"response_id={response_id} ({len(updated_chunks)} events)"
+            )
+        except Exception as e:
+            logger.error(
+                f"[SubagentCollector] Failed to update sse_events "
+                f"response_id={response_id}: {e}",
+                exc_info=True,
+            )
 
     async def _persist_subagent_usage(
         self,
@@ -1866,20 +1682,7 @@ class BackgroundTaskManager:
         user_id: str,
         is_byok: bool = False,
     ) -> None:
-        """Persist each subagent's token usage as a separate row with msg_type='task'.
-
-        Instead of merging subagent costs into the parent turn's record, each
-        subagent gets its own conversation_usages row linked to the same
-        response_id. This avoids complex read-merge-write and keeps subagent
-        costs independently queryable.
-
-        Args:
-            response_id: The parent conversation_response_id (for association)
-            tasks: List of BackgroundTask objects with per_call_records
-            thread_id: Thread ID for logging
-            workspace_id: Workspace ID for the usage record
-            user_id: User ID for the usage record
-        """
+        """Persist each subagent's token usage as a separate row with msg_type='task'."""
         from src.server.services.persistence.usage import UsagePersistenceService
 
         tasks_with_records = [t for t in tasks if t.per_call_records]
@@ -1897,8 +1700,6 @@ class BackgroundTaskManager:
                 )
                 await usage_service.track_llm_usage(task.per_call_records)
 
-                # Enrich the computed token_usage with subagent identity
-                # (track_llm_usage already aggregated tokens + costs correctly)
                 if usage_service._token_usage is not None:
                     usage_service._token_usage["task_id"] = task.task_id
                     usage_service._token_usage["agent_id"] = task.agent_id
@@ -1927,29 +1728,20 @@ class BackgroundTaskManager:
                 f"thread_id={thread_id}"
             )
 
-    async def _mark_cancelled(self, thread_id: str):
-        """Mark workflow as cancelled and notify live subscribers.
-
-        Split into two phases to avoid holding the lock during heavy async I/O:
-        - Phase 1 (under lock): status update, sentinels, copy refs
-        - Phase 2 (outside lock): aget_state, persistence
-        """
-        # Phase 1: Quick state update under lock
+    async def _mark_cancelled(self, thread_id: str, run_id: str):
+        """Mark workflow as cancelled and notify live subscribers."""
+        key = (thread_id, run_id)
         async with self.task_lock:
-            task_info = self.tasks.get(thread_id)
+            task_info = self.tasks.get(key)
             if not task_info:
                 return
 
             task_info.status = TaskStatus.CANCELLED
             task_info.completed_at = datetime.now()
-
-            # Copy refs needed for persistence phase
             metadata = task_info.metadata
 
-        # Phase 2: Heavy I/O outside lock
-        logger.debug(f"[BackgroundTaskManager] Marked as cancelled: {thread_id}")
+        logger.debug(f"[BackgroundTaskManager] Marked as cancelled: {key}")
 
-        # Persist cancellation with full details
         workspace_id = metadata.get("workspace_id")
         user_id = metadata.get("user_id")
 
@@ -1957,34 +1749,34 @@ class BackgroundTaskManager:
             try:
                 from src.server.services.persistence.conversation import ConversationPersistenceService
 
-                persistence_service = ConversationPersistenceService.get_instance(thread_id)
-                persistence_service._on_pair_persisted = lambda: self.clear_event_buffer(thread_id)
+                persistence_service = metadata.get("persistence_service")
+                if persistence_service is None:
+                    persistence_service = ConversationPersistenceService.get_instance(
+                        thread_id, run_id,
+                        workspace_id=workspace_id, user_id=user_id,
+                    )
+                persistence_service._on_pair_persisted = (
+                    lambda: self.clear_event_buffer(thread_id, run_id)
+                )
 
-                # Calculate token usage AND keep per_call_records
                 _, per_call_records = get_token_usage_from_callback(
                     metadata, "cancellation", thread_id
                 )
-
-                # Get tool usage from handler (has cached result from SSE emission)
                 tool_usage = get_tool_usage_from_handler(
                     metadata, "cancellation", thread_id
                 )
-
                 sse_events = get_sse_events_from_handler(
                     metadata, "cancellation", thread_id
                 )
-
-                # Calculate execution time
                 execution_time = calculate_execution_time(metadata)
 
-                # Build persist metadata (include deepthinking for usage tracking)
                 persist_metadata = {
                     "msg_type": metadata.get("msg_type"),
                     "stock_code": metadata.get("stock_code"),
                     "agent_llm_preset": metadata.get("agent_llm_preset", "default"),
                     "deepthinking": metadata.get("deepthinking", False),
                     "is_byok": metadata.get("is_byok", False),
-                    "cancelled_by_user": True
+                    "cancelled_by_user": True,
                 }
 
                 await persistence_service.persist_cancelled(
@@ -1992,191 +1784,155 @@ class BackgroundTaskManager:
                     metadata=persist_metadata,
                     per_call_records=per_call_records,
                     tool_usage=tool_usage,
-                    sse_events=sse_events
+                    sse_events=sse_events,
                 )
-                logger.info(f"[WorkflowPersistence] Cancellation persisted for thread_id={thread_id}")
+                logger.info(f"[WorkflowPersistence] Cancellation persisted for {key}")
             except Exception as persist_error:
                 logger.error(
-                    f"[WorkflowPersistence] Failed to persist cancellation for {thread_id}: {persist_error}",
-                    exc_info=True
+                    f"[WorkflowPersistence] Failed to persist cancellation for {key}: {persist_error}",
+                    exc_info=True,
                 )
 
-        # Release burst slot for cancellation path
         if user_id:
             await release_burst_slot(user_id)
 
-        # Push terminal status to Redis from the single canonical site so
-        # every cancel path (cancel endpoint, stale-cancel reaper, soft-
-        # interrupt-abort) updates Redis. ``cancel_workflow`` in
-        # ``workflow_handler.py`` also marks the tracker before signalling
-        # us, so this call is a belt-and-braces in the cases where the
-        # workflow self-cancels without going through that endpoint.
         try:
             tracker = WorkflowTracker.get_instance()
             await tracker.mark_cancelled(thread_id)
         except Exception as tracker_err:
             logger.warning(
-                f"[BackgroundTaskManager] tracker.mark_cancelled failed for {thread_id}: {tracker_err}"
+                f"[BackgroundTaskManager] tracker.mark_cancelled failed for {key}: {tracker_err}"
             )
 
+        task_info.persistence_complete.set()
         async with self.task_lock:
-            task_info = self.tasks.get(thread_id)
-            if task_info:
-                task_info.persistence_complete.set()
-            self._release_terminal_refs(thread_id)
+            self._release_terminal_refs(thread_id, run_id)
 
-    async def get_task_status(self, thread_id: str) -> Optional[TaskStatus]:
-        """
-        Get status of a background task.
+    # ---------- status & introspection ----------
 
-        Args:
-            thread_id: Workflow thread identifier
-
-        Returns:
-            TaskStatus or None if not found
-        """
-        task_info = await self._get_task_info_locked(thread_id)
-        return task_info.status if task_info else None
-
-    async def get_task_info(self, thread_id: str) -> Optional[TaskInfo]:
-        """
-        Get full task information.
-
-        Args:
-            thread_id: Workflow thread identifier
-
-        Returns:
-            TaskInfo or None if not found
-        """
+    async def get_task_status(
+        self, thread_id: str, run_id: Optional[str] = None
+    ) -> Optional[TaskStatus]:
+        """Get status for a specific run, or latest run on thread if ``run_id`` omitted."""
         async with self.task_lock:
-            task_info = self.tasks.get(thread_id)
+            if run_id is not None:
+                task_info = self.tasks.get((thread_id, run_id))
+            else:
+                task_info = self._find_latest_for_thread(thread_id)
+            return task_info.status if task_info else None
+
+    async def get_task_info(
+        self, thread_id: str, run_id: Optional[str] = None
+    ) -> Optional[TaskInfo]:
+        """Get full task info for a specific run, or latest on thread."""
+        async with self.task_lock:
+            if run_id is not None:
+                task_info = self.tasks.get((thread_id, run_id))
+            else:
+                task_info = self._find_latest_for_thread(thread_id)
             if task_info:
-                # Update last access time
                 task_info.last_access_at = datetime.now()
             return task_info
 
-    async def increment_connection(self, thread_id: str) -> bool:
-        """
-        Increment active connection count for a workflow.
-
-        Args:
-            thread_id: Workflow thread identifier
-
-        Returns:
-            True if successful, False if task not found
-        """
+    async def increment_connection(
+        self, thread_id: str, run_id: Optional[str] = None
+    ) -> bool:
         async with self.task_lock:
-            task_info = self.tasks.get(thread_id)
+            if run_id is not None:
+                task_info = self.tasks.get((thread_id, run_id))
+            else:
+                task_info = self._find_latest_for_thread(thread_id)
             if task_info:
                 task_info.active_connections += 1
                 task_info.last_access_at = datetime.now()
-                logger.debug(
-                    f"[BackgroundTaskManager] Connection attached to {thread_id} "
-                    f"(active: {task_info.active_connections})"
-                )
                 return True
             return False
 
-    async def decrement_connection(self, thread_id: str) -> bool:
-        """
-        Decrement active connection count for a workflow.
-
-        Args:
-            thread_id: Workflow thread identifier
-
-        Returns:
-            True if successful, False if task not found
-        """
+    async def decrement_connection(
+        self, thread_id: str, run_id: Optional[str] = None
+    ) -> bool:
         async with self.task_lock:
-            task_info = self.tasks.get(thread_id)
+            if run_id is not None:
+                task_info = self.tasks.get((thread_id, run_id))
+            else:
+                task_info = self._find_latest_for_thread(thread_id)
             if task_info:
                 task_info.active_connections = max(0, task_info.active_connections - 1)
-                logger.debug(
-                    f"[BackgroundTaskManager] Connection detached from {thread_id} "
-                    f"(active: {task_info.active_connections})"
-                )
                 return True
             return False
 
-    async def clear_event_buffer(self, thread_id: str):
-        """Drop the workflow's Redis event keys after persistence.
+    async def clear_event_buffer(self, thread_id: str, run_id: str):
+        """Drop the per-run workflow event keys after persistence.
 
-        Called from `_on_pair_persisted` once the response row is saved. The
-        24h TTL on the keys is a safety net; this DEL is the explicit happy
-        path so a long-lived thread doesn't accumulate dozens of stream keys.
+        Per-run keying makes this trivially safe: a concurrent new POST gets
+        a different ``run_id`` and therefore different keys, so this DEL can
+        never wipe an in-flight workflow's live stream.
         """
         try:
             cache = get_cache_client()
 
             if self.event_storage_backend == "redis" and cache.enabled:
-                events_key = f"workflow:events:{thread_id}"
-                meta_key = f"workflow:events:meta:{thread_id}"
-                stream_key = f"workflow:stream:{thread_id}"
+                stream_k = stream_key(thread_id, run_id)
+                meta_k = stream_meta_key(thread_id, run_id)
 
-                await cache.delete(events_key)
-                await cache.delete(meta_key)
-                await cache.delete(stream_key)
+                await cache.delete(stream_k)
+                await cache.delete(meta_k)
 
-                logger.debug(f"[EventBuffer] Cleared Redis event buffer for {thread_id}")
-
+                logger.debug(
+                    f"[EventBuffer] Cleared Redis event buffer for "
+                    f"thread_id={thread_id} run_id={run_id}"
+                )
         except Exception as e:
             logger.error(
-                f"[EventBuffer] Error clearing event buffer for {thread_id}: {e}",
-                exc_info=True
+                f"[EventBuffer] Error clearing event buffer for "
+                f"thread_id={thread_id} run_id={run_id}: {e}",
+                exc_info=True,
             )
 
-    async def cancel_workflow(self, thread_id: str) -> bool:
-        """
-        Cancel a running workflow using cooperative event signaling.
+    async def cancel_workflow(
+        self, thread_id: str, run_id: Optional[str] = None
+    ) -> bool:
+        """Cancel a running workflow.
 
-        Sets the cancel_event flag which will be detected on the next event
-        iteration inside the shielded task, allowing graceful cancellation.
-
-        Args:
-            thread_id: Workflow thread identifier
-
-        Returns:
-            True if cancellation signaled, False if not found or already completed
+        ``run_id`` may be omitted — falls back to the most recent active
+        run on the thread.
         """
         async with self.task_lock:
-            task_info = self.tasks.get(thread_id)
+            if run_id is not None:
+                task_info = self.tasks.get((thread_id, run_id))
+            else:
+                task_info = self._find_active_for_thread(thread_id)
+
             if not task_info:
                 logger.warning(
-                    f"[BackgroundTaskManager] Cannot cancel {thread_id}: "
-                    f"workflow not found"
+                    f"[BackgroundTaskManager] Cannot cancel "
+                    f"thread_id={thread_id} run_id={run_id}: workflow not found"
                 )
                 return False
 
             if task_info.status not in [TaskStatus.QUEUED, TaskStatus.RUNNING]:
                 logger.info(
-                    f"[BackgroundTaskManager] Cannot cancel {thread_id}: "
+                    f"[BackgroundTaskManager] Cannot cancel "
+                    f"thread_id={thread_id} run_id={task_info.run_id}: "
                     f"status={task_info.status}"
                 )
                 return False
 
             task_info.cancel_event.set()
             task_info.explicit_cancel = True
-            logger.debug(f"[BackgroundTaskManager] Cancellation signaled: {thread_id}")
+            logger.debug(
+                f"[BackgroundTaskManager] Cancellation signaled: "
+                f"thread_id={thread_id} run_id={task_info.run_id}"
+            )
             return True
 
-    async def cancel_stale_workflow(self, thread_id: str, timeout: float = 10.0) -> bool:
-        """Cancel a stale workflow whose sandbox is dead.
-
-        Unlike cancel_workflow(), this also cancels the inner shielded task
-        and waits for the outer task to exit.  No-ops silently if no workflow
-        exists.  Only use for dead-sandbox cleanup, not user-initiated
-        cancellation.
-
-        Handles QUEUED, RUNNING, and SOFT_INTERRUPTED states (all stale when
-        the sandbox is gone).
-
-        Returns True if a workflow was found and cancelled.
-        """
+    async def cancel_stale_workflow(
+        self, thread_id: str, timeout: float = 10.0
+    ) -> bool:
+        """Cancel a stale workflow on the given thread."""
         async with self.task_lock:
-            task_info = self.tasks.get(thread_id)
-            if not task_info or task_info.status not in (
-                TaskStatus.QUEUED, TaskStatus.RUNNING, TaskStatus.SOFT_INTERRUPTED
-            ):
+            task_info = self._find_active_for_thread(thread_id)
+            if not task_info:
                 return False
 
             task_info.cancel_event.set()
@@ -2186,33 +1942,19 @@ class BackgroundTaskManager:
                 task_info.inner_task.cancel()
             stale_task = task_info.task
 
-        # Wait OUTSIDE the lock — _mark_completed/_mark_failed re-enter task_lock
         if stale_task and not stale_task.done():
             done, _ = await asyncio.wait({stale_task}, timeout=timeout)
             if not done:
                 logger.warning(
-                    f"[BackgroundTaskManager] Stale workflow {thread_id} "
+                    f"[BackgroundTaskManager] Stale workflow thread_id={thread_id} "
                     f"did not exit within {timeout}s"
                 )
         return True
 
     async def soft_interrupt_workflow(self, thread_id: str) -> Dict[str, Any]:
-        """
-        Soft interrupt a running workflow - pause main agent, keep subagents running.
-
-        Unlike cancel_workflow which stops everything, soft interrupt:
-        - Signals the main agent to pause at the next safe point
-        - Background subagents continue execution
-        - Workflow can be resumed with new input
-
-        Args:
-            thread_id: Workflow thread identifier
-
-        Returns:
-            Dict with status, can_resume, and active_subagents
-        """
+        """Soft interrupt the latest running workflow on the given thread."""
         async with self.task_lock:
-            task_info = self.tasks.get(thread_id)
+            task_info = self._find_active_for_thread(thread_id)
             if not task_info:
                 logger.warning(
                     f"[BackgroundTaskManager] Cannot soft interrupt {thread_id}: "
@@ -2227,7 +1969,6 @@ class BackgroundTaskManager:
                     "completed_subagents": [],
                 }
 
-            # Query registry for active/completed task IDs
             active_tasks: list[str] = []
             completed_tasks: list[str] = []
             try:
@@ -2250,52 +1991,41 @@ class BackgroundTaskManager:
                 return {
                     "status": task_info.status.value,
                     "thread_id": thread_id,
+                    "run_id": task_info.run_id,
                     "can_resume": False,
-                    # Backward-compatible key
                     "background_tasks": active_tasks,
-                    # Preferred keys (used by CLI)
                     "active_subagents": active_tasks,
                     "completed_subagents": completed_tasks,
                 }
 
-            # Set soft interrupt flag (different from cancel)
             task_info.soft_interrupt_event.set()
             task_info.soft_interrupted = True
             logger.info(
-                f"[BackgroundTaskManager] Soft interrupt signaled: {thread_id}, "
+                f"[BackgroundTaskManager] Soft interrupt signaled: "
+                f"thread_id={thread_id} run_id={task_info.run_id}, "
                 f"active_subagents={active_tasks}"
             )
 
             return {
                 "status": "soft_interrupted",
                 "thread_id": thread_id,
+                "run_id": task_info.run_id,
                 "can_resume": True,
-                # Backward-compatible key
                 "background_tasks": active_tasks,
-                # Preferred keys (used by CLI)
                 "active_subagents": active_tasks,
                 "completed_subagents": completed_tasks,
             }
 
     async def get_workflow_status(self, thread_id: str) -> Dict[str, Any]:
-        """
-        Get detailed workflow status including subagent information.
-
-        Args:
-            thread_id: Workflow thread identifier
-
-        Returns:
-            Dict with status, subagent info, timestamps
-        """
+        """Get detailed status for the latest run on a thread."""
         async with self.task_lock:
-            task_info = self.tasks.get(thread_id)
+            task_info = self._find_latest_for_thread(thread_id)
             if not task_info:
                 return {
                     "status": "not_found",
                     "thread_id": thread_id,
                 }
 
-            # Query registry for actual task IDs (not just agent names)
             active_tasks: list[str] = []
             try:
                 from src.server.services.background_registry_store import BackgroundRegistryStore
@@ -2310,6 +2040,7 @@ class BackgroundTaskManager:
             return {
                 "status": task_info.status.value,
                 "thread_id": thread_id,
+                "run_id": task_info.run_id,
                 "soft_interrupted": task_info.soft_interrupted,
                 "active_tasks": active_tasks,
                 "created_at": task_info.created_at.isoformat() if task_info.created_at else None,
@@ -2321,94 +2052,82 @@ class BackgroundTaskManager:
     async def wait_for_soft_interrupted(
         self,
         thread_id: str,
-        timeout: float | None = None
+        timeout: float | None = None,
+        exclude_run_id: Optional[str] = None,
     ) -> bool:
-        """
-        Wait for a soft-interrupted workflow to complete.
+        """Wait for the latest active workflow on the thread to settle.
 
-        Called before starting a new workflow on the same thread_id to ensure
-        seamless continuation after ESC interrupt.
+        Called before starting a new workflow on the same ``thread_id`` to
+        ensure clean continuation after an ESC interrupt. Per-thread (not
+        per-run) because callers are deciding whether a new run is admissible.
 
-        Args:
-            thread_id: Workflow thread identifier
-            timeout: Maximum time to wait in seconds
-
-        Returns:
-            True if workflow completed (or wasn't running), False if timed out
+        ``exclude_run_id`` lets dispatched callers ignore their own
+        pre-registered placeholder while checking for OTHER active runs.
         """
         if timeout is None:
             timeout = get_soft_interrupt_wait_timeout()
         async with self.task_lock:
-            task_info = self.tasks.get(thread_id)
+            task_info = self._find_active_for_thread(
+                thread_id, exclude_run_id=exclude_run_id
+            )
             if not task_info:
-                return True  # No workflow to wait for
+                return True
 
-            # Include SOFT_INTERRUPTED - the task may still be wrapping up
             if task_info.status not in [
                 TaskStatus.QUEUED, TaskStatus.RUNNING,
                 TaskStatus.SOFT_INTERRUPTED,
             ]:
-                return True  # Already fully completed
+                return True
 
             if not task_info.soft_interrupted and task_info.status != TaskStatus.SOFT_INTERRUPTED:
-                # Workflow is running but wasn't soft-interrupted
-                # This is an unexpected state - user might be trying to send
-                # concurrent messages. We'll wait briefly but not block too long.
                 timeout = min(timeout, 5.0)
 
             task = task_info.task
+            key = (task_info.thread_id, task_info.run_id)
 
         if not task:
             return True
 
         logger.info(
             f"[BackgroundTaskManager] Waiting for soft-interrupted workflow "
-            f"{thread_id} to complete (timeout={timeout}s)"
+            f"{key} to complete (timeout={timeout}s)"
         )
 
         try:
-            # Wait for the task to complete with timeout
             await asyncio.wait_for(asyncio.shield(task), timeout=timeout)
 
-            # Clean up the finished task so start_workflow can proceed
             async with self.task_lock:
-                task_info = self.tasks.get(thread_id)
+                task_info = self.tasks.get(key)
                 if task_info and task_info.status in (
                     TaskStatus.SOFT_INTERRUPTED, TaskStatus.COMPLETED,
                 ):
                     logger.info(
-                        f"[BackgroundTaskManager] Cleaning up {task_info.status.value} task {thread_id}"
+                        f"[BackgroundTaskManager] Cleaning up {task_info.status.value} "
+                        f"task {key}"
                     )
-                    del self.tasks[thread_id]
+                    del self.tasks[key]
 
             logger.info(
-                f"[BackgroundTaskManager] Previous workflow {thread_id} "
+                f"[BackgroundTaskManager] Previous workflow {key} "
                 f"completed, ready for new request"
             )
             return True
         except asyncio.TimeoutError:
             logger.warning(
                 f"[BackgroundTaskManager] Timeout waiting for soft-interrupted "
-                f"workflow {thread_id} after {timeout}s"
+                f"workflow {key} after {timeout}s"
             )
             return False
         except asyncio.CancelledError:
-            # Task was cancelled, which is fine - we can proceed
             return True
         except Exception as e:
             logger.warning(
                 f"[BackgroundTaskManager] Error waiting for soft-interrupted "
-                f"workflow {thread_id}: {e}"
+                f"workflow {key}: {e}"
             )
-            return True  # Proceed anyway
+            return True
 
     async def get_stats(self) -> Dict[str, Any]:
-        """
-        Get statistics about background tasks.
-
-        Returns:
-            Dictionary with task statistics
-        """
         async with self.task_lock:
             total = len(self.tasks)
             by_status = {}
@@ -2423,5 +2142,5 @@ class BackgroundTaskManager:
                 "max_concurrent": self.max_concurrent,
                 "active_connections": sum(
                     t.active_connections for t in self.tasks.values()
-                )
+                ),
             }

--- a/src/server/services/persistence/conversation.py
+++ b/src/server/services/persistence/conversation.py
@@ -7,8 +7,8 @@ DB operations follow LangGraph workflow stages, not HTTP request/response cycles
 Architecture:
 - Stage-level transactions (atomic operations per workflow stage)
 - Simple logging: [conversation] prefix for all operations
-- Thread-scoped service instances (one per workflow execution)
-- Works independently of SSE streaming
+- Per-run service instances, keyed by (thread_id, run_id) where
+  ``run_id == conversation_response_id`` 1:1.
 """
 
 import logging
@@ -21,84 +21,92 @@ from src.observability.tracing import safe_aspan
 
 logger = logging.getLogger(__name__)
 
-# Module-level instance cache: thread_id -> service instance
-_service_instances: Dict[str, "ConversationPersistenceService"] = {}
+# Module-level instance cache: (thread_id, run_id) -> service instance.
+# Keyed by run_id so a concurrent new POST gets its own slot — no cross-turn
+# state inheritance is possible by construction.
+_service_instances: Dict[tuple[str, str], "ConversationPersistenceService"] = {}
 
 
 class ConversationPersistenceService:
     """
-    Manages database persistence for a single workflow execution thread.
+    Manages database persistence for a single workflow execution turn.
 
     Lifecycle:
-    1. get_instance(thread_id) - Get or create service for thread
-    2. persist_query_start() - Create query at workflow start
-    3. persist_interrupt() - Update thread + create response (atomic)
-    4. persist_resume_feedback() - Create feedback query
-    5. persist_completion() - Update thread + create response (atomic)
-    6. cleanup() - Remove service instance from cache
+    1. get_instance(thread_id, run_id) — get or create service for this turn
+    2. persist_query_start() — create query at workflow start
+    3. persist_interrupt() / persist_completion() / persist_error() / persist_cancelled()
+       — accept response_id (= run_id) so the DB row's primary key matches
+       the on-the-wire identity
+    4. cleanup() — remove this turn's service instance from the cache
 
-    Usage:
-        service = ConversationPersistenceService.get_instance(thread_id)
-        await service.persist_query_start(content="Analyze Tesla", query_type="initial")
-        # ... workflow executes ...
-        await service.persist_completion(metadata={...})
-        await service.cleanup()
+    ``run_id == conversation_response_id`` is a 1:1 contract: each POST gets
+    a fresh ``run_id`` at the handler entry, and that value is the response
+    row's ``conversation_response_id``. HITL resumes, retries, and steering
+    all produce new ``run_id``s (and therefore new response rows).
     """
 
     def __init__(
         self,
         thread_id: str,
+        run_id: str,
         workspace_id: Optional[str] = None,
-        user_id: Optional[str] = None
+        user_id: Optional[str] = None,
     ):
-        """
-        Initialize persistence service for a workflow thread.
-
-        Args:
-            thread_id: LangGraph thread ID
-            workspace_id: Workspace ID
-            user_id: User ID
-        """
         self.thread_id = thread_id
+        self.run_id = run_id
         self.workspace_id = workspace_id
         self.user_id = user_id
 
-        # Post-persist callback (set by BackgroundTaskManager to clear event buffer, etc.)
+        # Post-persist callback (BackgroundTaskManager sets this to clear the
+        # Redis event buffer once persistence is durable).
         self._on_pair_persisted: Optional[callable] = None
 
         # Track persistence state per turn_index (Set-based for multi-iteration support)
-        self._persisted_queries: set[int] = set()        # Track which turn_index queries created
-        self._persisted_interrupts: set[int] = set()     # Track which turn_index interrupts saved
-        self._persisted_completions: set[int] = set()    # Track which turn_index completions saved
+        self._persisted_interrupts: set[int] = set()
+        self._persisted_completions: set[int] = set()
 
         # Cache turn_index to avoid repeated DB queries
         self._turn_index_cache: Optional[int] = None
         self._current_query_id: Optional[str] = None
-        self._current_response_id: Optional[str] = None
+        # ``_current_response_id`` is just ``run_id`` for the canonical
+        # path; kept as a field for legacy callers that read it.
+        self._current_response_id: Optional[str] = run_id
+
+        # Set once cleanup() runs so any post-cleanup terminal persist call
+        # short-circuits instead of re-INSERTing the response row at a stale
+        # turn_index (which would PK-collide on conversation_response_id).
+        self._finalized: bool = False
 
         logger.debug(
             f"[ConversationPersistence] Initialized service "
-            f"thread_id={thread_id} workspace_id={workspace_id} user_id={user_id}"
+            f"thread_id={thread_id} run_id={run_id} "
+            f"workspace_id={workspace_id} user_id={user_id}"
         )
 
     @classmethod
     def get_instance(
         cls,
         thread_id: str,
+        run_id: str,
         workspace_id: Optional[str] = None,
-        user_id: Optional[str] = None
+        user_id: Optional[str] = None,
     ) -> "ConversationPersistenceService":
-        """
-        Get or create service instance for a thread.
+        """Get or create the service instance for ``(thread_id, run_id)``.
 
-        Uses module-level cache to ensure single instance per thread.
+        Per-run keying eliminates the cross-turn singleton aliasing that
+        the old thread-keyed cache was prone to.
         """
-        if thread_id not in _service_instances:
-            _service_instances[thread_id] = cls(thread_id, workspace_id, user_id)
-            logger.debug(f"[ConversationPersistence] Created new service instance for thread_id={thread_id}")
+        key = (thread_id, run_id)
+        if key not in _service_instances:
+            _service_instances[key] = cls(
+                thread_id, run_id, workspace_id, user_id
+            )
+            logger.debug(
+                f"[ConversationPersistence] Created new service instance for "
+                f"thread_id={thread_id} run_id={run_id}"
+            )
 
-        # Update workspace_id and user_id if provided (may not be available at creation)
-        instance = _service_instances[thread_id]
+        instance = _service_instances[key]
         if workspace_id and not instance.workspace_id:
             instance.workspace_id = workspace_id
         if user_id and not instance.user_id:
@@ -108,52 +116,45 @@ class ConversationPersistenceService:
 
     def _clear_tracking_state(self):
         """Clear all per-turn tracking sets and cached IDs."""
-        self._persisted_queries.clear()
         self._persisted_interrupts.clear()
         self._persisted_completions.clear()
         self._current_query_id = None
-        self._current_response_id = None
 
     async def cleanup(self):
-        """Clean up service state and remove from instance cache."""
-        logger.info(f"[ConversationPersistence] Cleaning up service for thread_id={self.thread_id}")
+        """Drop this turn's service instance from the module cache.
+
+        Per-run keying makes this trivially identity-safe: no other turn can
+        share our cache slot, so removing it can never affect another turn.
+        """
+        logger.info(
+            f"[ConversationPersistence] Cleaning up service for "
+            f"thread_id={self.thread_id} run_id={self.run_id}"
+        )
 
         self._clear_tracking_state()
         self._turn_index_cache = None
+        self._finalized = True
 
-        # Remove from instance cache
-        if self.thread_id in _service_instances:
-            del _service_instances[self.thread_id]
-            logger.debug(f"[ConversationPersistence] Removed service from cache for thread_id={self.thread_id}")
-
-    def mark_query_persisted(self, turn_index: int):
-        """Mark a turn's query as already persisted (e.g., preserved during fork)."""
-        self._persisted_queries.add(turn_index)
+        _service_instances.pop((self.thread_id, self.run_id), None)
 
     def reset_for_fork(self, fork_turn_index: int):
-        """Reset persistence state for a fork/branch operation.
-
-        Sets turn_index to the fork point and clears tracking so the normal
-        flow persists fresh records for the new branch.
-        """
+        """Reset persistence state for a fork/branch operation."""
         self._clear_tracking_state()
         self._turn_index_cache = fork_turn_index
         logger.debug(
             f"[ConversationPersistence] Reset for fork at turn_index={fork_turn_index} "
-            f"thread_id={self.thread_id}"
+            f"thread_id={self.thread_id} run_id={self.run_id}"
         )
 
     async def get_or_calculate_turn_index(self, conn=None) -> int:
-        """
-        Get cached turn_index or calculate from database.
-
-        Caches result to avoid repeated COUNT queries within same workflow.
-        """
+        """Get cached turn_index or calculate from database."""
         if self._turn_index_cache is None:
-            self._turn_index_cache = await qr_db.get_next_turn_index(self.thread_id, conn=conn)
+            self._turn_index_cache = await qr_db.get_next_turn_index(
+                self.thread_id, conn=conn
+            )
             logger.debug(
                 f"[ConversationPersistence] Calculated turn_index={self._turn_index_cache} "
-                f"for thread_id={self.thread_id}"
+                f"for thread_id={self.thread_id} run_id={self.run_id}"
             )
         return self._turn_index_cache
 
@@ -163,11 +164,11 @@ class ConversationPersistenceService:
             self._turn_index_cache += 1
             logger.debug(
                 f"[ConversationPersistence] Incremented turn_index to {self._turn_index_cache} "
-                f"for thread_id={self.thread_id}"
+                f"for thread_id={self.thread_id} run_id={self.run_id}"
             )
 
     async def _finalize_pair(self):
-        """Increment turn index and run post-persist hook (clear event buffer, etc.)."""
+        """Increment turn index, run post-persist hook, release the per-run instance."""
         self.increment_turn_index()
         if self._on_pair_persisted:
             try:
@@ -175,16 +176,12 @@ class ConversationPersistenceService:
             except Exception as e:
                 logger.warning(
                     f"[ConversationPersistence] _on_pair_persisted callback failed "
-                    f"for thread_id={self.thread_id}: {e}"
+                    f"for thread_id={self.thread_id} run_id={self.run_id}: {e}"
                 )
+        await self.cleanup()
 
     async def _get_latest_checkpoint_id(self) -> str | None:
-        """Best-effort: get latest checkpoint_id from the checkpointer.
-
-        Called before terminal persist transactions so the ID can be passed
-        to update_thread_status in the same UPDATE.
-        Returns None silently if checkpointer is unavailable.
-        """
+        """Best-effort: get latest checkpoint_id from the checkpointer."""
         try:
             from src.server.app import setup
 
@@ -211,36 +208,15 @@ class ConversationPersistenceService:
         query_type: str,
         feedback_action: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
-        timestamp: Optional[datetime] = None
+        timestamp: Optional[datetime] = None,
     ) -> str:
-        """
-        Persist query at workflow start.
-
-        Should be called when workflow begins processing a user query.
-
-        Args:
-            content: User query content
-            query_type: Query type (initial, follow_up, resume_feedback)
-            feedback_action: Feedback action for HITL (ACCEPTED, EDIT_PLAN, etc.)
-            metadata: Additional metadata
-            timestamp: Query timestamp (defaults to now)
-
-        Returns:
-            query_id: Created query ID
-        """
+        """Persist query at workflow start. Returns ``query_id``."""
         turn_index = await self.get_or_calculate_turn_index()
-
-        if turn_index in self._persisted_queries:
-            logger.warning(
-                f"[ConversationPersistence] Query already created for thread_id={self.thread_id} "
-                f"turn_index={turn_index}, skipping"
-            )
-            return self._current_query_id
 
         try:
             query_id = str(uuid4())
 
-            await qr_db.create_query(
+            row = await qr_db.create_query(
                 conversation_query_id=query_id,
                 conversation_thread_id=self.thread_id,
                 turn_index=turn_index,
@@ -248,24 +224,38 @@ class ConversationPersistenceService:
                 query_type=query_type,
                 feedback_action=feedback_action,
                 metadata=metadata,
-                created_at=timestamp
+                created_at=timestamp,
             )
 
-            self._persisted_queries.add(turn_index)
-            self._current_query_id = query_id
+            # ON CONFLICT DO UPDATE keeps the existing primary key, so trust
+            # the RETURNING value over the freshly-generated UUID.
+            stored_query_id = (
+                row.get("conversation_query_id", query_id)
+                if isinstance(row, dict)
+                else query_id
+            )
+
+            self._current_query_id = stored_query_id
 
             logger.debug(
-                f"[ConversationPersistence] Created query for thread_id={self.thread_id} "
-                f"turn_index={turn_index} query_id={query_id}"
+                f"[ConversationPersistence] Persisted query for thread_id={self.thread_id} "
+                f"run_id={self.run_id} turn_index={turn_index} query_id={stored_query_id}"
             )
 
-            return query_id
+            return stored_query_id
 
+        except qr_db.QueryConflictError as e:
+            logger.warning(
+                f"[ConversationPersistence] Query conflict on persist_query_start "
+                f"thread_id={self.thread_id} run_id={self.run_id} "
+                f"turn_index={e.turn_index}: existing row content differs from new write"
+            )
+            raise
         except Exception as e:
             logger.error(
                 f"[ConversationPersistence] Failed to persist query start "
-                f"thread_id={self.thread_id}: {e}",
-                exc_info=True
+                f"thread_id={self.thread_id} run_id={self.run_id}: {e}",
+                exc_info=True,
             )
             raise
 
@@ -277,41 +267,30 @@ class ConversationPersistenceService:
         timestamp: Optional[datetime] = None,
         per_call_records: Optional[list] = None,
         tool_usage: Optional[Dict[str, int]] = None,
-        sse_events: Optional[List[Dict[str, Any]]] = None
+        sse_events: Optional[List[Dict[str, Any]]] = None,
     ) -> str:
-        """
-        Persist interrupt state (atomic transaction).
+        """Persist interrupt state (atomic). ``conversation_response_id`` = ``self.run_id``."""
+        if self._finalized:
+            logger.warning(
+                f"[ConversationPersistence] persist_interrupt called after finalization "
+                f"for thread_id={self.thread_id} run_id={self.run_id}; returning cached response_id"
+            )
+            return self._current_response_id
 
-        Groups operations:
-        1. Update thread status to "interrupted"
-        2. Create response with status="interrupted"
-        3. Create usage record (token + infrastructure credits)
-
-        Args:
-            interrupt_reason: Reason for interrupt (e.g., "plan_review_required")
-            execution_time: Execution time up to interrupt
-            metadata: Additional metadata (msg_type, stock_code, etc.)
-            timestamp: Response timestamp (defaults to now)
-            per_call_records: Per-call token records for accurate cost calculation
-            tool_usage: Tool usage counts for infrastructure cost tracking
-
-        Returns:
-            response_id: Created response ID
-        """
         turn_index = await self.get_or_calculate_turn_index()
 
         if turn_index in self._persisted_interrupts:
             logger.warning(
-                f"[ConversationPersistence] Interrupt already persisted for thread_id={self.thread_id} "
+                f"[ConversationPersistence] Interrupt already persisted for "
+                f"thread_id={self.thread_id} run_id={self.run_id} "
                 f"turn_index={turn_index}, skipping"
             )
             return self._current_response_id
 
         try:
-            response_id = str(uuid4())
+            response_id = self.run_id
             _checkpoint_id = await self._get_latest_checkpoint_id()
 
-            # Stage-level transaction: group update + create + usage tracking
             async with qr_db.get_db_connection() as conn:
                 async with conn.transaction():
                     await qr_db.update_thread_status(
@@ -329,51 +308,41 @@ class ConversationPersistenceService:
                         execution_time=execution_time,
                         created_at=timestamp,
                         sse_events=sse_events,
-                        conn=conn
+                        conn=conn,
                     )
 
-                    # NEW: Create usage record (token + infrastructure credits)
-                    # Track credits even for interrupted workflows to enable proper billing
                     if per_call_records or tool_usage:
                         from src.server.services.persistence.usage import UsagePersistenceService
 
                         usage_service = UsagePersistenceService(
                             thread_id=self.thread_id,
                             workspace_id=self.workspace_id,
-                            user_id=self.user_id
+                            user_id=self.user_id,
                         )
 
-                        # Track token usage if available
                         if per_call_records:
                             await usage_service.track_llm_usage(per_call_records)
 
-                        # Track tool usage if available
                         if tool_usage:
                             usage_service.record_tool_usage_batch(tool_usage)
 
-                        # Extract deepthinking from metadata
-                        # Note: msg_type is overridden to 'interrupted' for interrupted workflows
-                        # to enable clear separation in analytics/billing
                         deepthinking = metadata.get("deepthinking", False) if metadata else False
-
-                        # Extract BYOK flag from metadata
                         is_byok = metadata.get("is_byok", False) if metadata else False
 
-                        # Persist to conversation_usage table (status='interrupted')
-                        # Override msg_type to 'interrupted' for interrupted workflows
                         usage_persisted = await usage_service.persist_usage(
                             response_id=response_id,
                             timestamp=timestamp,
-                            msg_type="interrupted",  # Always use 'interrupted' for interrupted workflows
+                            msg_type="interrupted",
                             deepthinking=deepthinking,
                             status="interrupted",
                             conn=conn,
-                            is_byok=is_byok
+                            is_byok=is_byok,
                         )
 
                         if usage_persisted:
                             logger.info(
-                                f"Persisted interrupted workflow: thread_id={self.thread_id} response_id={response_id}"
+                                f"Persisted interrupted workflow: thread_id={self.thread_id} "
+                                f"response_id={response_id}"
                             )
                         else:
                             logger.warning(
@@ -394,7 +363,6 @@ class ConversationPersistenceService:
                 f"turn_index={turn_index} response_id={response_id}"
             )
 
-            # Increment turn_index and run post-persist hook (e.g. clear event buffer)
             await self._finalize_pair()
 
             return response_id
@@ -402,9 +370,10 @@ class ConversationPersistenceService:
         except Exception as e:
             logger.error(
                 f"[ConversationPersistence] Failed to persist interrupt "
-                f"thread_id={self.thread_id}: {e}",
-                exc_info=True
+                f"thread_id={self.thread_id} run_id={self.run_id}: {e}",
+                exc_info=True,
             )
+            _service_instances.pop((self.thread_id, self.run_id), None)
             raise
 
     async def persist_resume_feedback(
@@ -412,22 +381,9 @@ class ConversationPersistenceService:
         feedback_action: str,
         content: str = "",
         metadata: Optional[Dict[str, Any]] = None,
-        timestamp: Optional[datetime] = None
+        timestamp: Optional[datetime] = None,
     ) -> str:
-        """
-        Persist resume feedback query.
-
-        Called when user provides feedback after interrupt (e.g., accepts plan).
-
-        Args:
-            feedback_action: Feedback action (ACCEPTED, EDIT_PLAN, etc.)
-            content: User's additional input (if any)
-            metadata: Additional metadata
-            timestamp: Query timestamp (defaults to now)
-
-        Returns:
-            query_id: Created query ID
-        """
+        """Persist resume feedback query."""
         try:
             query_id = str(uuid4())
             turn_index = await self.get_or_calculate_turn_index()
@@ -440,10 +396,9 @@ class ConversationPersistenceService:
                 query_type="resume_feedback",
                 feedback_action=feedback_action,
                 metadata=metadata,
-                created_at=timestamp
+                created_at=timestamp,
             )
 
-            self.query_created = True
             self._current_query_id = query_id
 
             return query_id
@@ -452,7 +407,7 @@ class ConversationPersistenceService:
             logger.error(
                 f"[ConversationPersistence] Failed to persist resume feedback "
                 f"thread_id={self.thread_id}: {e}",
-                exc_info=True
+                exc_info=True,
             )
             raise
 
@@ -466,28 +421,16 @@ class ConversationPersistenceService:
         per_call_records: Optional[list] = None,
         tool_usage: Optional[Dict[str, int]] = None,
         sse_events: Optional[List[Dict[str, Any]]] = None,
-        skip_finalize: bool = False
+        skip_finalize: bool = False,
     ) -> str:
-        """
-        Persist workflow completion (atomic transaction).
+        """Persist workflow completion (atomic). ``conversation_response_id`` = ``self.run_id``."""
+        if self._finalized:
+            logger.warning(
+                f"[ConversationPersistence] persist_completion called after finalization "
+                f"for thread_id={self.thread_id} run_id={self.run_id}; returning cached response_id"
+            )
+            return self._current_response_id
 
-        Groups operations:
-        1. Update thread status to "completed"
-        2. Create response with status="completed"
-        3. Create usage record (token + infrastructure credits)
-
-        Args:
-            metadata: Additional metadata
-            warnings: Warning messages
-            errors: Error messages
-            execution_time: Total execution time
-            timestamp: Response timestamp (defaults to now)
-            per_call_records: Per-call token records for accurate cost calculation
-            tool_usage: Tool usage counts for infrastructure cost tracking
-
-        Returns:
-            response_id: Created response ID
-        """
         async with safe_aspan(
             "chat.turn.persist",
             {"status": "completed", "thread_id_hash": (self.thread_id or "")[:16]},
@@ -496,19 +439,18 @@ class ConversationPersistenceService:
 
             if turn_index in self._persisted_completions:
                 logger.warning(
-                    f"[ConversationPersistence] Completion already persisted for thread_id={self.thread_id} "
+                    f"[ConversationPersistence] Completion already persisted for "
+                    f"thread_id={self.thread_id} run_id={self.run_id} "
                     f"turn_index={turn_index}, skipping"
                 )
-                # Advance turn if caller expects it (e.g. reinvoke dedup after pre-tail persist)
                 if not skip_finalize:
                     await self._finalize_pair()
                 return self._current_response_id
 
             try:
-                response_id = str(uuid4())
+                response_id = self.run_id
                 _checkpoint_id = await self._get_latest_checkpoint_id()
 
-                # Stage-level transaction: group update + create + usage tracking
                 async with qr_db.get_db_connection() as conn:
                     async with conn.transaction():
                         await qr_db.update_thread_status(
@@ -527,35 +469,28 @@ class ConversationPersistenceService:
                             execution_time=execution_time,
                             created_at=timestamp,
                             sse_events=sse_events,
-                            conn=conn
+                            conn=conn,
                         )
 
-                        # Create usage record (token + infrastructure credits)
                         if per_call_records or tool_usage:
                             from src.server.services.persistence.usage import UsagePersistenceService
 
                             usage_service = UsagePersistenceService(
                                 thread_id=self.thread_id,
                                 workspace_id=self.workspace_id,
-                                user_id=self.user_id
+                                user_id=self.user_id,
                             )
 
-                            # Track token usage if available
                             if per_call_records:
                                 await usage_service.track_llm_usage(per_call_records)
 
-                            # Track tool usage if available
                             if tool_usage:
                                 usage_service.record_tool_usage_batch(tool_usage)
 
-                            # Extract msg_type and deepthinking from metadata
                             msg_type = metadata.get("msg_type") if metadata else None
                             deepthinking = metadata.get("deepthinking", False) if metadata else False
-
-                            # Extract BYOK flag from metadata
                             is_byok = metadata.get("is_byok", False) if metadata else False
 
-                            # Persist to conversation_usage table (status='completed')
                             await usage_service.persist_usage(
                                 response_id=response_id,
                                 timestamp=timestamp,
@@ -563,7 +498,7 @@ class ConversationPersistenceService:
                                 deepthinking=deepthinking,
                                 status="completed",
                                 conn=conn,
-                                is_byok=is_byok
+                                is_byok=is_byok,
                             )
 
                 self._persisted_completions.add(turn_index)
@@ -575,18 +510,17 @@ class ConversationPersistenceService:
                 )
 
                 if not skip_finalize:
-                    # Increment turn_index and run post-persist hook (e.g. clear event buffer)
                     await self._finalize_pair()
 
                 return response_id
 
-
             except Exception as e:
                 logger.error(
                     f"[ConversationPersistence] Failed to persist completion "
-                    f"thread_id={self.thread_id}: {e}",
-                    exc_info=True
+                    f"thread_id={self.thread_id} run_id={self.run_id}: {e}",
+                    exc_info=True,
                 )
+                _service_instances.pop((self.thread_id, self.run_id), None)
                 raise
 
     async def persist_error(
@@ -598,37 +532,24 @@ class ConversationPersistenceService:
         per_call_records: Optional[list] = None,
         tool_usage: Optional[Dict[str, int]] = None,
         sse_events: Optional[List[Dict[str, Any]]] = None,
-        metadata: Optional[Dict[str, Any]] = None
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> str:
-        """
-        Persist error state (atomic transaction).
+        """Persist error state (atomic). ``conversation_response_id`` = ``self.run_id``."""
+        if self._finalized:
+            logger.warning(
+                f"[ConversationPersistence] persist_error called after finalization "
+                f"for thread_id={self.thread_id} run_id={self.run_id}; returning cached response_id"
+            )
+            return self._current_response_id
 
-        Groups operations:
-        1. Update thread status to "error"
-        2. Create response with status="error"
-        3. Create usage record (token + infrastructure credits)
-
-        Args:
-            error_message: Error message
-            errors: Error list
-            execution_time: Execution time until error
-            timestamp: Response timestamp (defaults to now)
-            per_call_records: Per-call token records for accurate cost calculation
-            tool_usage: Tool usage counts for infrastructure cost tracking
-            metadata: Additional metadata (msg_type, deepthinking, etc.)
-
-        Returns:
-            response_id: Created response ID
-        """
         try:
-            response_id = str(uuid4())
+            response_id = self.run_id
             turn_index = await self.get_or_calculate_turn_index()
             _checkpoint_id = await self._get_latest_checkpoint_id()
 
             if errors is None:
                 errors = [error_message]
 
-            # Stage-level transaction: group update + create + usage tracking
             async with qr_db.get_db_connection() as conn:
                 async with conn.transaction():
                     await qr_db.update_thread_status(
@@ -648,37 +569,28 @@ class ConversationPersistenceService:
                         execution_time=execution_time,
                         created_at=timestamp,
                         sse_events=sse_events,
-                        conn=conn
+                        conn=conn,
                     )
 
-
-                    # NEW: Create usage record (token + infrastructure credits)
-                    # Track credits even for failed workflows for accurate billing
                     if per_call_records or tool_usage:
                         from src.server.services.persistence.usage import UsagePersistenceService
 
                         usage_service = UsagePersistenceService(
                             thread_id=self.thread_id,
                             workspace_id=self.workspace_id,
-                            user_id=self.user_id
+                            user_id=self.user_id,
                         )
 
-                        # Track token usage if available
                         if per_call_records:
                             await usage_service.track_llm_usage(per_call_records)
 
-                        # Track tool usage if available
                         if tool_usage:
                             usage_service.record_tool_usage_batch(tool_usage)
 
-                        # Extract msg_type and deepthinking from metadata
                         msg_type = metadata.get("msg_type") if metadata else None
                         deepthinking = metadata.get("deepthinking", False) if metadata else False
-
-                        # Extract BYOK flag from metadata
                         is_byok = metadata.get("is_byok", False) if metadata else False
 
-                        # Persist to conversation_usage table (status='error')
                         usage_persisted = await usage_service.persist_usage(
                             response_id=response_id,
                             timestamp=timestamp,
@@ -686,12 +598,13 @@ class ConversationPersistenceService:
                             deepthinking=deepthinking,
                             status="error",
                             conn=conn,
-                            is_byok=is_byok
+                            is_byok=is_byok,
                         )
 
                         if usage_persisted:
                             logger.info(
-                                f"Persisted failed workflow: thread_id={self.thread_id} response_id={response_id}"
+                                f"Persisted failed workflow: thread_id={self.thread_id} "
+                                f"response_id={response_id}"
                             )
                         else:
                             logger.warning(
@@ -711,7 +624,6 @@ class ConversationPersistenceService:
                 f"turn_index={turn_index} response_id={response_id}"
             )
 
-            # Increment turn_index and run post-persist hook (e.g. clear event buffer)
             await self._finalize_pair()
 
             return response_id
@@ -719,9 +631,10 @@ class ConversationPersistenceService:
         except Exception as e:
             logger.error(
                 f"[ConversationPersistence] Failed to persist error "
-                f"thread_id={self.thread_id}: {e}",
-                exc_info=True
+                f"thread_id={self.thread_id} run_id={self.run_id}: {e}",
+                exc_info=True,
             )
+            _service_instances.pop((self.thread_id, self.run_id), None)
             raise
 
     async def persist_cancelled(
@@ -731,32 +644,21 @@ class ConversationPersistenceService:
         timestamp: Optional[datetime] = None,
         per_call_records: Optional[list] = None,
         tool_usage: Optional[Dict[str, int]] = None,
-        sse_events: Optional[List[Dict[str, Any]]] = None
+        sse_events: Optional[List[Dict[str, Any]]] = None,
     ) -> str:
-        """
-        Persist cancelled state (atomic transaction).
+        """Persist cancelled state (atomic). ``conversation_response_id`` = ``self.run_id``."""
+        if self._finalized:
+            logger.warning(
+                f"[ConversationPersistence] persist_cancelled called after finalization "
+                f"for thread_id={self.thread_id} run_id={self.run_id}; returning cached response_id"
+            )
+            return self._current_response_id
 
-        Groups operations:
-        1. Update thread status to "cancelled"
-        2. Create response with status="cancelled"
-        3. Create usage record (token + infrastructure credits)
-
-        Args:
-            execution_time: Execution time until cancellation
-            metadata: Additional metadata
-            timestamp: Response timestamp (defaults to now)
-            per_call_records: Per-call token records for accurate cost calculation
-            tool_usage: Tool usage counts for infrastructure cost tracking
-
-        Returns:
-            response_id: Created response ID
-        """
         try:
-            response_id = str(uuid4())
+            response_id = self.run_id
             turn_index = await self.get_or_calculate_turn_index()
             _checkpoint_id = await self._get_latest_checkpoint_id()
 
-            # Stage-level transaction: group update + create + usage tracking
             async with qr_db.get_db_connection() as conn:
                 async with conn.transaction():
                     await qr_db.update_thread_status(
@@ -776,37 +678,28 @@ class ConversationPersistenceService:
                         execution_time=execution_time,
                         created_at=timestamp,
                         sse_events=sse_events,
-                        conn=conn
+                        conn=conn,
                     )
 
-
-                    # NEW: Create usage record (token + infrastructure credits)
-                    # Track credits even for cancelled workflows for accurate billing
                     if per_call_records or tool_usage:
                         from src.server.services.persistence.usage import UsagePersistenceService
 
                         usage_service = UsagePersistenceService(
                             thread_id=self.thread_id,
                             workspace_id=self.workspace_id,
-                            user_id=self.user_id
+                            user_id=self.user_id,
                         )
 
-                        # Track token usage if available
                         if per_call_records:
                             await usage_service.track_llm_usage(per_call_records)
 
-                        # Track tool usage if available
                         if tool_usage:
                             usage_service.record_tool_usage_batch(tool_usage)
 
-                        # Extract msg_type and deepthinking from metadata
                         msg_type = metadata.get("msg_type") if metadata else None
                         deepthinking = metadata.get("deepthinking", False) if metadata else False
-
-                        # Extract BYOK flag from metadata
                         is_byok = metadata.get("is_byok", False) if metadata else False
 
-                        # Persist to conversation_usage table (status='cancelled')
                         usage_persisted = await usage_service.persist_usage(
                             response_id=response_id,
                             timestamp=timestamp,
@@ -814,12 +707,13 @@ class ConversationPersistenceService:
                             deepthinking=deepthinking,
                             status="cancelled",
                             conn=conn,
-                            is_byok=is_byok
+                            is_byok=is_byok,
                         )
 
                         if usage_persisted:
                             logger.info(
-                                f"Persisted cancelled workflow: thread_id={self.thread_id} response_id={response_id}"
+                                f"Persisted cancelled workflow: thread_id={self.thread_id} "
+                                f"response_id={response_id}"
                             )
                         else:
                             logger.warning(
@@ -839,7 +733,6 @@ class ConversationPersistenceService:
                 f"turn_index={turn_index} response_id={response_id}"
             )
 
-            # Increment turn_index and run post-persist hook (e.g. clear event buffer)
             await self._finalize_pair()
 
             return response_id
@@ -847,9 +740,10 @@ class ConversationPersistenceService:
         except Exception as e:
             logger.error(
                 f"[ConversationPersistence] Failed to persist cancellation "
-                f"thread_id={self.thread_id}: {e}",
-                exc_info=True
+                f"thread_id={self.thread_id} run_id={self.run_id}: {e}",
+                exc_info=True,
             )
+            _service_instances.pop((self.thread_id, self.run_id), None)
             raise
 
     async def update_sse_events(
@@ -857,18 +751,7 @@ class ConversationPersistenceService:
         response_id: str,
         sse_events: List[Dict[str, Any]],
     ) -> bool:
-        """Update sse_events for an already-persisted response.
-
-        Used by the post-interrupt subagent result collector to replace
-        incomplete subagent events with the full set captured by middleware.
-
-        Args:
-            response_id: The response ID to update
-            sse_events: Updated SSE events list
-
-        Returns:
-            True if the row was updated, False if not found
-        """
+        """Update sse_events for an already-persisted response."""
         try:
             result = await qr_db.update_sse_events(
                 conversation_response_id=response_id,

--- a/src/server/services/workflow_tracker.py
+++ b/src/server/services/workflow_tracker.py
@@ -109,26 +109,14 @@ class WorkflowTracker:
         timestamp_field: str,
         metadata: Optional[Dict[str, Any]] = None,
         ttl: Optional[int] = None,
+        run_id: Optional[str] = None,
     ) -> bool:
         """
         Helper to update workflow status with metadata preservation.
 
-        Consolidates the common pattern of:
-        1. Get existing status from Redis
-        2. Create default if not exists
-        3. Update status and timestamp fields
-        4. Merge metadata
-        5. Save with optional TTL
-
-        Args:
-            thread_id: Thread/workflow identifier
-            new_status: New status to set
-            timestamp_field: Field name for timestamp (e.g., "completed_at")
-            metadata: Optional metadata to merge
-            ttl: Optional TTL in seconds
-
-        Returns:
-            True if successful, False otherwise
+        When ``run_id`` is provided, the update is skipped if the
+        stored blob's ``run_id`` doesn't match — prevents a late terminal
+        from run A overwriting active status set by run B.
         """
         try:
             key = f"{self.STATUS_PREFIX}{thread_id}"
@@ -140,6 +128,16 @@ class WorkflowTracker:
                     "thread_id": thread_id,
                     "started_at": datetime.now().isoformat()
                 }
+
+            if run_id is not None:
+                stored_run_id = existing.get("run_id")
+                if stored_run_id is not None and stored_run_id != run_id:
+                    logger.debug(
+                        f"[WorkflowTracker] Skipping {new_status} update for "
+                        f"thread_id={thread_id}: stored run_id={stored_run_id} "
+                        f"!= expected={run_id}"
+                    )
+                    return False
 
             # Update status and timestamp
             existing["status"] = new_status
@@ -214,19 +212,15 @@ class WorkflowTracker:
     async def mark_completed(
         self,
         thread_id: str,
-        metadata: Optional[Dict[str, Any]] = None
+        metadata: Optional[Dict[str, Any]] = None,
+        run_id: Optional[str] = None,
     ) -> bool:
         """
         Mark workflow as completed (finished executing).
 
         Sets TTL per redis.ttl.workflow_status config (keeps brief history).
-
-        Args:
-            thread_id: Thread/workflow identifier
-            metadata: Optional completion metadata
-
-        Returns:
-            True if successfully marked, False otherwise
+        Pass ``run_id`` to no-op the write when the active run has
+        already advanced to a different turn.
         """
         if not self.enabled:
             return False
@@ -237,7 +231,8 @@ class WorkflowTracker:
             new_status=WorkflowStatus.COMPLETED,
             timestamp_field="completed_at",
             metadata=metadata,
-            ttl=ttl
+            ttl=ttl,
+            run_id=run_id,
         )
 
         if success:
@@ -284,16 +279,12 @@ class WorkflowTracker:
 
         return success
 
-    async def mark_cancelled(self, thread_id: str) -> bool:
-        """
-        Mark workflow as cancelled (explicitly stopped by user).
-
-        Args:
-            thread_id: Thread/workflow identifier
-
-        Returns:
-            True if successfully marked, False otherwise
-        """
+    async def mark_cancelled(
+        self,
+        thread_id: str,
+        run_id: Optional[str] = None,
+    ) -> bool:
+        """Mark workflow as cancelled (explicitly stopped by user)."""
         if not self.enabled:
             return False
 
@@ -302,7 +293,8 @@ class WorkflowTracker:
             new_status=WorkflowStatus.CANCELLED,
             timestamp_field="cancelled_at",
             metadata=None,
-            ttl=get_redis_ttl_workflow_status()
+            ttl=get_redis_ttl_workflow_status(),
+            run_id=run_id,
         )
 
         if success:
@@ -316,13 +308,9 @@ class WorkflowTracker:
         self,
         thread_id: str,
         error: Optional[str] = None,
+        run_id: Optional[str] = None,
     ) -> bool:
-        """Mark workflow as failed (uncaught exception or unrecoverable error).
-
-        Mirrors mark_completed/mark_cancelled — bounded TTL so /status correctly
-        reports a terminal state instead of leaving the key as ACTIVE until
-        natural Redis expiry.
-        """
+        """Mark workflow as failed (uncaught exception or unrecoverable error)."""
         if not self.enabled:
             return False
 
@@ -332,6 +320,7 @@ class WorkflowTracker:
             timestamp_field="failed_at",
             metadata={"error": error} if error else None,
             ttl=get_redis_ttl_workflow_status(),
+            run_id=run_id,
         )
 
         if success:
@@ -341,7 +330,11 @@ class WorkflowTracker:
 
         return success
 
-    async def mark_soft_interrupted(self, thread_id: str) -> bool:
+    async def mark_soft_interrupted(
+        self,
+        thread_id: str,
+        run_id: Optional[str] = None,
+    ) -> bool:
         """Mark workflow as soft-interrupted (main agent paused, subagents can still complete).
 
         Distinct from INTERRUPTED (HITL pause, indefinite TTL): SOFT_INTERRUPTED
@@ -356,6 +349,7 @@ class WorkflowTracker:
             timestamp_field="soft_interrupted_at",
             metadata=None,
             ttl=get_redis_ttl_workflow_status(),
+            run_id=run_id,
         )
 
         if success:

--- a/src/server/services/workflow_tracker.py
+++ b/src/server/services/workflow_tracker.py
@@ -246,7 +246,8 @@ class WorkflowTracker:
     async def mark_interrupted(
         self,
         thread_id: str,
-        metadata: Optional[Dict[str, Any]] = None
+        metadata: Optional[Dict[str, Any]] = None,
+        run_id: Optional[str] = None,
     ) -> bool:
         """
         Mark workflow as interrupted (paused for human-in-the-loop review).
@@ -254,12 +255,9 @@ class WorkflowTracker:
         The workflow is waiting for user input (e.g., plan approval) and is
         NOT actively streaming. Uses the same TTL as completed workflows.
 
-        Args:
-            thread_id: Thread/workflow identifier
-            metadata: Optional metadata about the interrupt
-
-        Returns:
-            True if successfully marked, False otherwise
+        When `run_id` is supplied, the write is skipped if the stored status
+        belongs to a different run — prevents a stale HITL interrupt from
+        clobbering a newer turn's ACTIVE status.
         """
         if not self.enabled:
             return False
@@ -269,7 +267,8 @@ class WorkflowTracker:
             new_status=WorkflowStatus.INTERRUPTED,
             timestamp_field="interrupted_at",
             metadata=metadata,
-            ttl=None  # No TTL - workflow can be resumed at any time
+            ttl=None,  # No TTL - workflow can be resumed at any time
+            run_id=run_id,
         )
 
         if success:

--- a/src/server/services/workflow_tracker.py
+++ b/src/server/services/workflow_tracker.py
@@ -167,7 +167,8 @@ class WorkflowTracker:
         thread_id: str,
         workspace_id: str,
         user_id: str,
-        metadata: Optional[Dict[str, Any]] = None
+        metadata: Optional[Dict[str, Any]] = None,
+        run_id: Optional[str] = None,
     ) -> bool:
         """
         Mark workflow as active (currently executing with connection).
@@ -177,6 +178,7 @@ class WorkflowTracker:
             workspace_id: Workspace identifier
             user_id: User identifier
             metadata: Optional additional metadata
+            run_id: Current turn's LangGraph run_id (== conversation_response_id)
 
         Returns:
             True if successfully marked, False otherwise
@@ -191,6 +193,7 @@ class WorkflowTracker:
                 "thread_id": thread_id,
                 "workspace_id": workspace_id,
                 "user_id": user_id,
+                "run_id": run_id,
                 "started_at": datetime.now().isoformat(),
                 "last_update": datetime.now().isoformat(),
                 "metadata": metadata or {}

--- a/src/tools/secretary/utils.py
+++ b/src/tools/secretary/utils.py
@@ -187,20 +187,38 @@ async def _extract_from_redis(thread_id: str) -> str:
     )
     from src.utils.cache.redis_cache import get_cache_client
 
-    # Resolve the per-run stream key from the in-process task table;
-    # fall back to the legacy thread-only key when no TaskInfo survives.
+    # Resolve the per-run stream key: prefer in-process BTM, then the
+    # cross-process WorkflowTracker blob, then fall back to the legacy
+    # thread-only key. The tracker path covers post-restart reconnects
+    # where BTM is empty but the active run's run_id is still in Redis.
     key = f"workflow:stream:{thread_id}"
+    resolved_run_id: str | None = None
     try:
         manager = BackgroundTaskManager.get_instance()
         async with manager.task_lock:
             info = manager._find_latest_for_thread(thread_id)
         if info is not None and getattr(info, "run_id", None):
-            key = stream_key(thread_id, info.run_id)
+            resolved_run_id = info.run_id
     except Exception as e:
         logger.warning(
-            f"Failed to resolve run_id for thread {thread_id}, "
-            f"falling back to legacy key: {e}"
+            f"Failed to resolve run_id from BTM for thread {thread_id}: {e}"
         )
+
+    if resolved_run_id is None:
+        try:
+            from src.server.services.workflow_tracker import WorkflowTracker
+
+            tracker = WorkflowTracker.get_instance()
+            status_obj = await tracker.get_status(thread_id)
+            if status_obj is not None:
+                resolved_run_id = status_obj.get("run_id")
+        except Exception as e:
+            logger.warning(
+                f"Failed to resolve run_id from tracker for thread {thread_id}: {e}"
+            )
+
+    if resolved_run_id is not None:
+        key = stream_key(thread_id, resolved_run_id)
 
     try:
         cache = get_cache_client()

--- a/src/tools/secretary/utils.py
+++ b/src/tools/secretary/utils.py
@@ -168,21 +168,45 @@ async def extract_text_from_thread(thread_id: str) -> dict[str, Any]:
 async def _extract_from_redis(thread_id: str) -> str:
     """Extract text content from Redis SSE event buffer.
 
-    Reads the tail of the per-thread Redis Stream (``workflow:stream:{tid}``)
-    and decodes the pre-rendered SSE wire string from each entry's
-    ``b"event"`` field. The Stream replaced the legacy Redis List spill;
-    XREVRANGE with COUNT yields the most-recent 500 entries cheaply, then
-    we reverse to chronological order to mirror the old RPUSH semantics.
+    Reads the tail of the per-run Redis Stream
+    (``workflow:stream:{tid}:{run_id}``) and decodes the pre-rendered SSE
+    wire string from each entry's ``b"event"`` field. The run_id is
+    resolved from the in-process ``BackgroundTaskManager`` for the most
+    recent turn on the thread. When no in-process TaskInfo exists (process
+    restart, all entries TTL'd out), falls back to the legacy
+    ``workflow:stream:{tid}`` key for backward compat during the deploy
+    window. XREVRANGE with COUNT yields the most-recent 500 entries
+    cheaply, then we reverse to chronological order to mirror the old
+    RPUSH semantics.
     """
+    # Local imports to avoid load-order coupling with the server package
+    # at agent import time.
+    from src.server.services.background_task_manager import (
+        BackgroundTaskManager,
+        stream_key,
+    )
     from src.utils.cache.redis_cache import get_cache_client
+
+    # Resolve the per-run stream key from the in-process task table;
+    # fall back to the legacy thread-only key when no TaskInfo survives.
+    key = f"workflow:stream:{thread_id}"
+    try:
+        manager = BackgroundTaskManager.get_instance()
+        async with manager.task_lock:
+            info = manager._find_latest_for_thread(thread_id)
+        if info is not None and getattr(info, "run_id", None):
+            key = stream_key(thread_id, info.run_id)
+    except Exception as e:
+        logger.warning(
+            f"Failed to resolve run_id for thread {thread_id}, "
+            f"falling back to legacy key: {e}"
+        )
 
     try:
         cache = get_cache_client()
         if not getattr(cache, "enabled", False) or cache.client is None:
             return ""
-        entries = await cache.client.xrevrange(
-            f"workflow:stream:{thread_id}", count=500
-        )
+        entries = await cache.client.xrevrange(key, count=500)
     except Exception as e:
         logger.error(f"Failed to read Redis events for thread {thread_id}: {e}")
         return ""

--- a/tests/integration/test_conversation_persistence.py
+++ b/tests/integration/test_conversation_persistence.py
@@ -186,7 +186,10 @@ class TestQueryCRUD:
     async def test_idempotent_query_insert(
         self, seed_workspace, patched_get_db_connection
     ):
+        import pytest
+
         from src.server.database.conversation import (
+            QueryConflictError,
             create_query,
             create_thread,
             get_queries_for_thread,
@@ -210,19 +213,33 @@ class TestQueryCRUD:
             query_type="initial",
             idempotent=True,
         )
-        # Re-insert with same thread+turn_index but different content
+
+        # Same (thread, turn_index, content) is a true no-op.
         await create_query(
-            conversation_query_id=query_id,
+            conversation_query_id=str(uuid.uuid4()),
             conversation_thread_id=thread_id,
             turn_index=0,
-            content="Updated",
+            content="Original",
             query_type="initial",
             idempotent=True,
         )
 
+        # Same (thread, turn_index) with different content raises — the
+        # content-gated upsert refuses to silently overwrite a concurrent
+        # write's row.
+        with pytest.raises(QueryConflictError):
+            await create_query(
+                conversation_query_id=str(uuid.uuid4()),
+                conversation_thread_id=thread_id,
+                turn_index=0,
+                content="Updated",
+                query_type="initial",
+                idempotent=True,
+            )
+
         queries, total = await get_queries_for_thread(thread_id)
         assert total == 1
-        assert queries[0]["content"] == "Updated"
+        assert queries[0]["content"] == "Original"
 
 
 class TestResponseCRUD:

--- a/tests/unit/core/sandbox/test_sandbox_shutdown_race.py
+++ b/tests/unit/core/sandbox/test_sandbox_shutdown_race.py
@@ -89,7 +89,8 @@ class TestHasActiveTasksForWorkspace:
     @pytest.mark.asyncio
     async def test_running_task_matches(self):
         mgr = BackgroundTaskManager()
-        mgr.tasks["thread-1"] = TaskInfo(
+        mgr.tasks[("thread-1", "run-1")] = TaskInfo(
+            run_id="run-1",
             thread_id="thread-1",
             status=TaskStatus.RUNNING,
             created_at=datetime.now(),
@@ -100,7 +101,8 @@ class TestHasActiveTasksForWorkspace:
     @pytest.mark.asyncio
     async def test_queued_task_matches(self):
         mgr = BackgroundTaskManager()
-        mgr.tasks["thread-1"] = TaskInfo(
+        mgr.tasks[("thread-1", "run-1")] = TaskInfo(
+            run_id="run-1",
             thread_id="thread-1",
             status=TaskStatus.QUEUED,
             created_at=datetime.now(),
@@ -111,7 +113,8 @@ class TestHasActiveTasksForWorkspace:
     @pytest.mark.asyncio
     async def test_completed_task_does_not_match(self):
         mgr = BackgroundTaskManager()
-        mgr.tasks["thread-1"] = TaskInfo(
+        mgr.tasks[("thread-1", "run-1")] = TaskInfo(
+            run_id="run-1",
             thread_id="thread-1",
             status=TaskStatus.COMPLETED,
             created_at=datetime.now(),
@@ -122,7 +125,8 @@ class TestHasActiveTasksForWorkspace:
     @pytest.mark.asyncio
     async def test_soft_interrupted_task_matches(self):
         mgr = BackgroundTaskManager()
-        mgr.tasks["thread-1"] = TaskInfo(
+        mgr.tasks[("thread-1", "run-1")] = TaskInfo(
+            run_id="run-1",
             thread_id="thread-1",
             status=TaskStatus.SOFT_INTERRUPTED,
             created_at=datetime.now(),
@@ -133,7 +137,8 @@ class TestHasActiveTasksForWorkspace:
     @pytest.mark.asyncio
     async def test_different_workspace_does_not_match(self):
         mgr = BackgroundTaskManager()
-        mgr.tasks["thread-1"] = TaskInfo(
+        mgr.tasks[("thread-1", "run-1")] = TaskInfo(
+            run_id="run-1",
             thread_id="thread-1",
             status=TaskStatus.RUNNING,
             created_at=datetime.now(),

--- a/tests/unit/server/app/test_threads_content_location.py
+++ b/tests/unit/server/app/test_threads_content_location.py
@@ -1,0 +1,191 @@
+"""Tests for the ``Content-Location`` header and ``run_id`` plumbing on the
+chat-message endpoints.
+
+The backend mints a fresh UUID per POST (the canonical per-turn ``run_id``)
+and advertises the matching reconnect URL via ``Content-Location`` so the
+frontend can resume the exact run after a disconnect. The reconnect endpoint
+must propagate ``run_id`` straight through to the underlying replay logic.
+"""
+
+import re
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from tests.conftest import create_test_app
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+)
+
+
+@pytest_asyncio.fixture
+async def threads_client():
+    """Threads router only, with auth + rate-limit dependencies neutralised.
+
+    Override the default ``ChatAuthResult`` so the BYOK/tier guard treats
+    the request as a platform tier-0 user (skip the 403). The fixture in
+    ``conftest`` defaults to ``access_tier=-1`` which trips the no-provider
+    gate in ``_handle_send_message``.
+    """
+    from src.server.app.threads import router
+    from src.server.dependencies.usage_limits import (
+        ChatAuthResult,
+        enforce_chat_limit,
+    )
+
+    app = create_test_app(router)
+    app.dependency_overrides[enforce_chat_limit] = lambda: ChatAuthResult(
+        user_id="test-user-123", access_tier=0
+    )
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c
+
+
+def _empty_async_gen():
+    async def _gen():
+        if False:
+            yield ""  # pragma: no cover — empty stream
+        return
+
+    return _gen()
+
+
+def _resolved_config():
+    """Minimal stub for ``resolve_llm_config`` return value."""
+    cfg = MagicMock()
+    cfg.llm_client = None  # mark request as platform-served, keeps is_byok=False
+    cfg.llm = MagicMock(name="claude-sonnet-4-5", flash="claude-haiku")
+    cfg.llm.name = "claude-sonnet-4-5"
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/threads/{tid}/messages → Content-Location header
+# ---------------------------------------------------------------------------
+
+
+class TestContentLocationHeader:
+
+    @pytest.mark.asyncio
+    async def test_post_includes_content_location_with_uuid_run_id(
+        self, threads_client
+    ):
+        """Header announces the reconnect URL for THIS run.
+
+        Format: ``/api/v1/threads/{tid}/messages/stream?run_id={uuid}``
+        """
+        from src.server.app import setup as setup_module
+        from src.server.handlers.chat import resolve_llm_config
+
+        tid = "tid-fixed-1"
+
+        # WorkspaceManager.get_instance requires config on first call; fake
+        # a singleton that reports the workspace as ready (skips DB lookup).
+        wm_singleton = MagicMock()
+        wm_singleton.has_ready_session.return_value = True
+
+        # All of these are deferred imports inside the handler — patch at
+        # the source module, not the threads namespace.
+        with patch.object(setup_module, "agent_config", MagicMock()), \
+             patch("src.server.handlers.chat.resolve_llm_config", new=AsyncMock(return_value=_resolved_config())), \
+             patch("src.server.dependencies.usage_limits.enforce_credit_limit", new=AsyncMock()), \
+             patch("src.server.database.conversation.get_thread_by_id", new=AsyncMock(return_value={"workspace_id": "ws-1"})), \
+             patch("src.server.services.workspace_manager.WorkspaceManager.get_instance", return_value=wm_singleton), \
+             patch("src.server.handlers.chat.astream_ptc_workflow", return_value=_empty_async_gen()), \
+             patch("src.server.app.threads.observe_chat_stream", side_effect=lambda gen, **_: gen):
+            # Use a context manager so we DON'T consume the body — just read headers.
+            async with threads_client.stream(
+                "POST",
+                f"/api/v1/threads/{tid}/messages",
+                json={
+                    "workspace_id": "ws-1",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "agent_mode": "ptc",
+                },
+            ) as resp:
+                assert resp.status_code == 200
+                loc = resp.headers.get("content-location")
+                assert loc is not None, (
+                    f"Content-Location missing from response headers: {dict(resp.headers)!r}"
+                )
+                # Path prefix + thread_id are echoed verbatim.
+                prefix = f"/api/v1/threads/{tid}/messages/stream?run_id="
+                assert loc.startswith(prefix), (
+                    f"unexpected Content-Location: {loc!r}"
+                )
+                run_id = loc[len(prefix):]
+                assert UUID_RE.match(run_id), (
+                    f"run_id is not a UUID: {run_id!r}"
+                )
+
+        # Sanity: the canonical resolver was actually invoked (proves the
+        # mocked path was hit, not some short-circuit error response).
+        assert resolve_llm_config is not None
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/threads/{tid}/messages/stream — reconnect wiring
+# ---------------------------------------------------------------------------
+
+
+class TestReconnectWiring:
+    """``run_id`` from the querystring must reach
+    ``reconnect_to_workflow_stream`` unchanged. When omitted, the parameter
+    is forwarded as ``None`` so downstream code falls back to "latest run on
+    the thread."
+    """
+
+    @pytest.mark.asyncio
+    async def test_reconnect_forwards_run_id_and_last_event_id(self, threads_client):
+        captured: dict[str, Any] = {}
+
+        async def _fake_reconnect(thread_id, run_id, last_event_id):
+            captured["args"] = (thread_id, run_id, last_event_id)
+            if False:
+                yield ""
+
+        with patch("src.server.app.threads.require_thread_owner", new=AsyncMock()), \
+             patch("src.server.handlers.chat.reconnect_to_workflow_stream", new=_fake_reconnect):
+            resp = await threads_client.get(
+                "/api/v1/threads/tid-X/messages/stream",
+                params={"run_id": "r-X", "last_event_id": 5},
+            )
+
+        assert resp.status_code == 200
+        assert captured["args"] == ("tid-X", "r-X", 5), (
+            f"reconnect wiring mismatch: got {captured.get('args')!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_reconnect_without_run_id_passes_none(self, threads_client):
+        captured: dict[str, Any] = {}
+
+        async def _fake_reconnect(thread_id, run_id, last_event_id):
+            captured["args"] = (thread_id, run_id, last_event_id)
+            if False:
+                yield ""
+
+        with patch("src.server.app.threads.require_thread_owner", new=AsyncMock()), \
+             patch("src.server.handlers.chat.reconnect_to_workflow_stream", new=_fake_reconnect):
+            resp = await threads_client.get(
+                "/api/v1/threads/tid-Y/messages/stream",
+            )
+
+        assert resp.status_code == 200
+        thread_id, run_id, _last = captured["args"]
+        assert thread_id == "tid-Y"
+        assert run_id is None, (
+            f"run_id must default to None when missing; got {run_id!r}"
+        )

--- a/tests/unit/server/database/test_conversation_query_conflict.py
+++ b/tests/unit/server/database/test_conversation_query_conflict.py
@@ -1,0 +1,87 @@
+"""Regression tests for the idempotent ``create_query`` collision path.
+
+The idempotent ``INSERT ... ON CONFLICT DO UPDATE`` gates the UPDATE on
+``content IS NOT DISTINCT FROM EXCLUDED.content`` so that:
+
+* same-content retries (HITL resume, network retry) silently no-op, AND
+* different-content collisions (a concurrent POST that bypassed the
+  in-process admission lock) surface as ``QueryConflictError`` — never
+  silently overwrite the loser's row.
+
+The "no RETURNING row + WHERE-gate fired" path is the only one that
+distinguishes these two cases. These tests pin that branch by driving the
+mock cursor through the two sequential fetchone() calls the function makes:
+the original ``RETURNING`` from the gated UPDATE, and the follow-up SELECT
+that fetches the colliding row's content.
+"""
+
+import pytest
+
+from src.server.database.conversation import QueryConflictError, create_query
+
+
+# ---------------------------------------------------------------------------
+# QueryConflictError surface
+# ---------------------------------------------------------------------------
+
+
+class TestCreateQueryIdempotentConflict:
+    """When the WHERE-gate blocks the UPDATE and a colliding row already
+    exists with different content, ``create_query`` must raise
+    ``QueryConflictError`` carrying the turn_index and the existing content.
+    """
+
+    @pytest.mark.asyncio
+    async def test_raises_query_conflict_when_existing_content_differs(
+        self, mock_db_connection, mock_cursor
+    ):
+        # First fetchone(): the INSERT...RETURNING returned no row (the
+        # WHERE-gate blocked the UPDATE because EXCLUDED.content differs).
+        # Second fetchone(): the follow-up SELECT finds the row that won
+        # the race, with its (different) content.
+        mock_cursor.fetchone.side_effect = [
+            None,  # gated UPDATE returned nothing
+            {"content": "other text"},  # the colliding row's content
+        ]
+
+        with pytest.raises(QueryConflictError) as excinfo:
+            await create_query(
+                conversation_query_id="q-1",
+                conversation_thread_id="t-1",
+                turn_index=3,
+                content="new content",
+                query_type="ptc",
+            )
+
+        err = excinfo.value
+        assert err.thread_id == "t-1"
+        assert err.turn_index == 3
+        assert err.existing_content == "other text", (
+            f"existing_content should be the row that won the race; "
+            f"got {err.existing_content!r}"
+        )
+        # Message text includes the thread and turn (used by ops dashboards
+        # and log alerts).
+        assert "t-1" in str(err)
+        assert "turn_index=3" in str(err)
+
+    @pytest.mark.asyncio
+    async def test_existing_content_none_when_followup_select_finds_nothing(
+        self, mock_db_connection, mock_cursor
+    ):
+        """Edge case: the gated UPDATE returned nothing AND the follow-up
+        SELECT also finds no row (rare — the conflict row was deleted
+        between the two queries). Surface the conflict anyway so the caller
+        sees the collision instead of returning None silently."""
+        mock_cursor.fetchone.side_effect = [None, None]
+
+        with pytest.raises(QueryConflictError) as excinfo:
+            await create_query(
+                conversation_query_id="q-1",
+                conversation_thread_id="t-1",
+                turn_index=0,
+                content="anything",
+                query_type="ptc",
+            )
+
+        assert excinfo.value.existing_content is None

--- a/tests/unit/server/handlers/chat/test_stream_from_log.py
+++ b/tests/unit/server/handlers/chat/test_stream_from_log.py
@@ -582,8 +582,14 @@ async def test_stream_from_log_bumps_workflow_connection_counter(monkeypatch):
     cache = _make_cache([[], []])  # two empty rounds → terminal handshake
     monkeypatch.setattr(sfl_mod, "get_cache_client", lambda: cache)
 
+    # Build a fake manager with the new (thread_id, run_id)-keyed surface.
+    fake_task = MagicMock()
+    fake_task.run_id = "r-1"
+    fake_task.status = TaskStatus.COMPLETED
+
     fake_manager = MagicMock()
-    fake_manager.get_task_status = AsyncMock(return_value=TaskStatus.COMPLETED)
+    fake_manager.tasks = {("t-housekeeping", "r-1"): fake_task}
+    fake_manager._find_latest_for_thread = MagicMock(return_value=fake_task)
     fake_manager.increment_connection = AsyncMock(return_value=True)
     fake_manager.decrement_connection = AsyncMock(return_value=True)
     monkeypatch.setattr(
@@ -593,8 +599,8 @@ async def test_stream_from_log_bumps_workflow_connection_counter(monkeypatch):
     async for _ in stream_from_log("t-housekeeping", last_event_id=None):
         pass
 
-    fake_manager.increment_connection.assert_awaited_once_with("t-housekeeping")
-    fake_manager.decrement_connection.assert_awaited_once_with("t-housekeeping")
+    fake_manager.increment_connection.assert_awaited_once_with("t-housekeeping", "r-1")
+    fake_manager.decrement_connection.assert_awaited_once_with("t-housekeeping", "r-1")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/server/handlers/test_chat_common.py
+++ b/tests/unit/server/handlers/test_chat_common.py
@@ -512,11 +512,11 @@ class TestEnsureThread:
 
 class TestPersistOrSkipReplay:
     @pytest.mark.asyncio
-    async def test_checkpoint_replay_marks_persisted(self):
+    async def test_checkpoint_replay_skips_persist(self):
         from src.server.handlers.chat._common import persist_or_skip_replay
 
         persistence = MagicMock()
-        persistence.mark_query_persisted = MagicMock()
+        persistence.persist_query_start = AsyncMock()
         request = MagicMock()
         request.fork_from_turn = 3
 
@@ -532,7 +532,7 @@ class TestPersistOrSkipReplay:
             log_prefix="TEST",
         )
 
-        persistence.mark_query_persisted.assert_called_once_with(3)
+        persistence.persist_query_start.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_checkpoint_replay_no_fork_calculates_turn(self):
@@ -540,7 +540,7 @@ class TestPersistOrSkipReplay:
 
         persistence = MagicMock()
         persistence.get_or_calculate_turn_index = AsyncMock(return_value=5)
-        persistence.mark_query_persisted = MagicMock()
+        persistence.persist_query_start = AsyncMock()
         request = MagicMock()
         request.fork_from_turn = None
 
@@ -556,7 +556,8 @@ class TestPersistOrSkipReplay:
             log_prefix="TEST",
         )
 
-        persistence.mark_query_persisted.assert_called_once_with(5)
+        persistence.get_or_calculate_turn_index.assert_awaited_once()
+        persistence.persist_query_start.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_normal_query_persists(self):

--- a/tests/unit/server/handlers/test_ptc_workflow_workspace_status.py
+++ b/tests/unit/server/handlers/test_ptc_workflow_workspace_status.py
@@ -131,6 +131,7 @@ async def _run_to_sentinel(request, workspace_manager):
         gen = astream_ptc_workflow(
             request=request,
             thread_id="t-1",
+            run_id="r-1",
             user_input="hi",
             user_id="u-1",
             workspace_id="ws-1",

--- a/tests/unit/server/handlers/test_streaming_handler.py
+++ b/tests/unit/server/handlers/test_streaming_handler.py
@@ -199,7 +199,7 @@ class TestWorkflowStreamHandlerFormatting:
     def _make_handler(self, thread_id="test-thread"):
         from src.server.handlers.streaming_handler import WorkflowStreamHandler
 
-        return WorkflowStreamHandler(thread_id=thread_id)
+        return WorkflowStreamHandler(thread_id=thread_id, run_id="r-test")
 
     def test_format_sse_event_basic(self):
         handler = self._make_handler()
@@ -395,7 +395,7 @@ class TestToolCallFiltering:
     def _make_handler(self):
         from src.server.handlers.streaming_handler import WorkflowStreamHandler
 
-        return WorkflowStreamHandler(thread_id="test-thread")
+        return WorkflowStreamHandler(thread_id="test-thread", run_id="r-test")
 
     def test_filters_empty_name(self):
         handler = self._make_handler()
@@ -465,7 +465,7 @@ class TestInterruptHandling:
     def _make_handler(self):
         from src.server.handlers.streaming_handler import WorkflowStreamHandler
 
-        return WorkflowStreamHandler(thread_id="int-thread")
+        return WorkflowStreamHandler(thread_id="int-thread", run_id="r-test")
 
     def test_handles_dict_interrupt_value(self):
         handler = self._make_handler()
@@ -517,7 +517,7 @@ class TestTaskArtifactEvent:
     def _make_handler(self):
         from src.server.handlers.streaming_handler import WorkflowStreamHandler
 
-        return WorkflowStreamHandler(thread_id="t-task-artifact")
+        return WorkflowStreamHandler(thread_id="t-task-artifact", run_id="r-test")
 
     def test_task_artifact_event_includes_tool_call_id(self):
         """Artifact event for a spawned task must carry tool_call_id."""
@@ -574,7 +574,7 @@ class TestEventCounter:
     def test_uses_event_counter_when_set(self):
         from src.server.handlers.streaming_handler import WorkflowStreamHandler
 
-        handler = WorkflowStreamHandler(thread_id="t1")
+        handler = WorkflowStreamHandler(thread_id="t1", run_id="r-test")
         counter = MagicMock()
         counter.next.side_effect = [42, 43]
         handler.event_counter = counter
@@ -595,7 +595,7 @@ class TestToolNodeInnerLLMSuppression:
 
     def _handler(self):
         from src.server.handlers.streaming_handler import WorkflowStreamHandler
-        return WorkflowStreamHandler(thread_id="t-tool-gate")
+        return WorkflowStreamHandler(thread_id="t-tool-gate", run_id="r-test")
 
     def _chunk(self, content, kwargs=None):
         from langchain_core.messages import AIMessageChunk
@@ -758,7 +758,7 @@ class TestResolveTokenThreshold:
     def _handler(self, agent_config=None):
         from src.server.handlers.streaming_handler import WorkflowStreamHandler
 
-        return WorkflowStreamHandler(thread_id="t1", agent_config=agent_config)
+        return WorkflowStreamHandler(thread_id="t1", run_id="r-test", agent_config=agent_config)
 
     def _cfg(self, threshold: int):
         cfg = MagicMock()
@@ -803,7 +803,7 @@ class TestCompactionChunkRouting:
     def _handler(self):
         from src.server.handlers.streaming_handler import WorkflowStreamHandler
 
-        return WorkflowStreamHandler(thread_id="t1")
+        return WorkflowStreamHandler(thread_id="t1", run_id="r-test")
 
     def test_reasoning_signal_routes_to_compaction_when_flagged(self):
         handler = self._handler()

--- a/tests/unit/server/handlers/test_streaming_handler_metadata.py
+++ b/tests/unit/server/handlers/test_streaming_handler_metadata.py
@@ -1,0 +1,109 @@
+"""Tests for the per-stream ``metadata`` SSE frame produced by
+``WorkflowStreamHandler.stream_workflow``.
+
+Contract: ``run_id`` is REQUIRED at construction time. Every stream
+announces that ``run_id`` as the FIRST yielded SSE chunk (``event:
+metadata``). Frontend reconnect / demotion / steering boundary logic
+latches onto this frame, so it must appear before any model output, and
+the handler must not be constructible without a real ``run_id`` (a
+``None`` would leak through the persisted SSE log and poison the
+frontend reconnect URL).
+
+The metadata frame is also written with ``accumulate=False`` so it does
+NOT end up in the response's persisted SSE event log. (Replay paths
+synthesise it on demand from the response row's ``conversation_response_id``.)
+"""
+
+import json
+
+import pytest
+
+from src.server.handlers.streaming_handler import WorkflowStreamHandler
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _EmptyGraph:
+    """LangGraph stand-in: ``astream`` yields nothing.
+
+    The handler still drains the post-loop blocks (credit_usage etc.) but
+    those run only when token_callback / tool_tracker contributed records.
+    With both None the handler emits the metadata frame and exits cleanly.
+    """
+
+    def astream(self, _input_state, config=None, stream_mode=None, subgraphs=None):
+        async def _gen():
+            if False:
+                yield  # pragma: no cover — empty async generator
+            return
+
+        return _gen()
+
+
+def _parse_sse(chunk: str):
+    """Return (event_name, parsed_data_dict) for a well-formed SSE chunk."""
+    event_line = next(
+        line for line in chunk.split("\n") if line.startswith("event: ")
+    )
+    data_line = next(
+        line for line in chunk.split("\n") if line.startswith("data: ")
+    )
+    return event_line[len("event: "):], json.loads(data_line[len("data: "):])
+
+
+async def _collect_stream(handler: WorkflowStreamHandler):
+    return [
+        chunk
+        async for chunk in handler.stream_workflow(
+            _EmptyGraph(), input_state={}, config={}
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Metadata frame contract
+# ---------------------------------------------------------------------------
+
+
+class TestMetadataFrameFirst:
+    """Per-stream metadata announces the canonical run_id as event #1."""
+
+    @pytest.mark.asyncio
+    async def test_metadata_is_first_event_when_run_id_set(self):
+        handler = WorkflowStreamHandler(thread_id="t-1", run_id="r-abc")
+        chunks = await _collect_stream(handler)
+        assert chunks, "expected at least the metadata frame"
+        event_name, data = _parse_sse(chunks[0])
+        assert event_name == "metadata"
+        assert data == {"thread_id": "t-1", "run_id": "r-abc"}
+
+    @pytest.mark.asyncio
+    async def test_metadata_frame_is_not_persisted(self):
+        """Persisted SSE log must NOT include the metadata frame — it's a
+        per-connection identity hand-shake. The accumulator owns persistence,
+        so a missing accumulated entry proves ``accumulate=False`` flowed
+        through ``_format_sse_event``."""
+        handler = WorkflowStreamHandler(thread_id="t-1", run_id="r-abc")
+        chunks = await _collect_stream(handler)
+        assert chunks  # sanity — metadata was emitted to the wire
+        persisted = handler.get_sse_events()
+        # Either no events were accumulated at all (None), or — if some
+        # later credit event slipped through — metadata is not among them.
+        if persisted is None:
+            return
+        kinds = [e["event"] for e in persisted]
+        assert "metadata" not in kinds, (
+            f"metadata frame must not be persisted; got accumulated events={kinds!r}"
+        )
+
+    def test_run_id_is_required_at_construction(self):
+        """``run_id`` has no default — forgetting it is a TypeError, not a
+        silently-malformed stream. This is the structural guarantee that
+        replaces the old ``run_id=None`` suppression branch: there's no
+        way for a caller to construct the handler without committing to a
+        canonical per-turn identity."""
+        with pytest.raises(TypeError):
+            WorkflowStreamHandler(thread_id="t-1")  # type: ignore[call-arg]

--- a/tests/unit/server/services/test_background_task_manager.py
+++ b/tests/unit/server/services/test_background_task_manager.py
@@ -45,10 +45,12 @@ def _make_task_info(
     status: TaskStatus = TaskStatus.RUNNING,
     task: asyncio.Task | None = None,
     inner_task: asyncio.Task | None = None,
+    run_id: str = "run-1",
 ) -> TaskInfo:
     """Create a TaskInfo with sensible defaults for testing."""
     return TaskInfo(
         thread_id=thread_id,
+        run_id=run_id,
         status=status,
         created_at=datetime.now(),
         started_at=datetime.now(),
@@ -100,7 +102,7 @@ class TestCancelStaleWorkflowRunning:
             task=outer_future,
             inner_task=mock_inner,
         )
-        btm.tasks["thread-1"] = task_info
+        btm.tasks[("thread-1", "run-1")] = task_info
 
         result = await btm.cancel_stale_workflow("thread-1")
 
@@ -133,7 +135,7 @@ class TestCancelStaleWorkflowSoftInterrupted:
             task=outer_future,
             inner_task=mock_inner,
         )
-        btm.tasks["thread-1"] = task_info
+        btm.tasks[("thread-1", "run-1")] = task_info
 
         result = await btm.cancel_stale_workflow("thread-1")
 
@@ -154,7 +156,7 @@ class TestCancelStaleWorkflowCompleted:
         btm = _make_btm()
 
         task_info = _make_task_info(status=TaskStatus.COMPLETED)
-        btm.tasks["thread-1"] = task_info
+        btm.tasks[("thread-1", "run-1")] = task_info
 
         result = await btm.cancel_stale_workflow("thread-1")
 
@@ -186,7 +188,7 @@ class TestCancelStaleWorkflowTimeout:
             task=never_done,
             inner_task=mock_inner,
         )
-        btm.tasks["thread-1"] = task_info
+        btm.tasks[("thread-1", "run-1")] = task_info
 
         with caplog.at_level(logging.WARNING):
             result = await btm.cancel_stale_workflow("thread-1", timeout=0.05)
@@ -198,6 +200,87 @@ class TestCancelStaleWorkflowTimeout:
 # ---------------------------------------------------------------------------
 # consume_workflow uses closure-captured events
 # ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# cancel_workflow — run_id targeting (active vs latest, explicit vs implicit)
+# ---------------------------------------------------------------------------
+
+class TestCancelWorkflowRunIdTargeting:
+    """``cancel_workflow(thread_id)`` without an explicit run_id must target
+    the still-active run on the thread — not the most recently *created* row
+    (which may already be terminal). With an explicit run_id, the cancel
+    must hit exactly that key even if another run is more recent."""
+
+    @pytest.mark.asyncio
+    async def test_implicit_targets_active_not_latest_completed(self):
+        """Older RUNNING + newer COMPLETED on the same thread ⇒ cancel hits
+        the RUNNING one. The COMPLETED row stays untouched (no cancel_event)."""
+        btm = _make_btm()
+
+        # Older RUNNING task (created earlier)
+        older_running = _make_task_info(
+            status=TaskStatus.RUNNING, run_id="run-older"
+        )
+        older_running.created_at = datetime(2024, 1, 1, 12, 0, 0)
+
+        # Newer COMPLETED task (created later)
+        newer_completed = _make_task_info(
+            status=TaskStatus.COMPLETED, run_id="run-newer"
+        )
+        newer_completed.created_at = datetime(2024, 1, 1, 12, 5, 0)
+
+        btm.tasks[("thread-1", "run-older")] = older_running
+        btm.tasks[("thread-1", "run-newer")] = newer_completed
+
+        result = await btm.cancel_workflow("thread-1")
+
+        assert result is True
+        assert older_running.cancel_event.is_set()
+        assert older_running.explicit_cancel is True
+        # Newer terminal row must NOT have been disturbed.
+        assert not newer_completed.cancel_event.is_set()
+        assert newer_completed.explicit_cancel is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_only_terminal_runs_exist(self):
+        """No live runs on the thread ⇒ cancel is a no-op + returns False."""
+        btm = _make_btm()
+
+        for status in (TaskStatus.COMPLETED, TaskStatus.FAILED, TaskStatus.CANCELLED):
+            ti = _make_task_info(status=status, run_id=f"run-{status.value}")
+            btm.tasks[("thread-1", ti.run_id)] = ti
+
+        result = await btm.cancel_workflow("thread-1")
+
+        assert result is False
+        for ti in btm.tasks.values():
+            assert not ti.cancel_event.is_set()
+            assert ti.explicit_cancel is False
+
+    @pytest.mark.asyncio
+    async def test_explicit_run_id_targets_that_run_even_when_older(self):
+        """A caller that passes a specific run_id wants THAT run cancelled,
+        not "the most recent thing on the thread"."""
+        btm = _make_btm()
+
+        target = _make_task_info(status=TaskStatus.RUNNING, run_id="run-target")
+        target.created_at = datetime(2024, 1, 1, 12, 0, 0)
+
+        more_recent = _make_task_info(status=TaskStatus.RUNNING, run_id="run-newer")
+        more_recent.created_at = datetime(2024, 1, 1, 12, 10, 0)
+
+        btm.tasks[("thread-1", "run-target")] = target
+        btm.tasks[("thread-1", "run-newer")] = more_recent
+
+        result = await btm.cancel_workflow("thread-1", run_id="run-target")
+
+        assert result is True
+        assert target.cancel_event.is_set()
+        assert target.explicit_cancel is True
+        # The more-recent unrelated run must NOT be affected.
+        assert not more_recent.cancel_event.is_set()
+        assert more_recent.explicit_cancel is False
+
 
 class TestConsumeWorkflowUsesClosureEvents:
 
@@ -223,7 +306,7 @@ class TestConsumeWorkflowUsesClosureEvents:
 
         # Pre-register a RUNNING task so _run_workflow_shielded can find it
         task_info = _make_task_info(thread_id="thread-closure", status=TaskStatus.RUNNING)
-        btm.tasks["thread-closure"] = task_info
+        btm.tasks[("thread-closure", "run-1")] = task_info
 
         # Patch _mark_completed, _mark_cancelled, _mark_failed, _mark_soft_interrupted
         # so they don't try to do real persistence work
@@ -245,6 +328,7 @@ class TestConsumeWorkflowUsesClosureEvents:
             try:
                 await btm._run_workflow_shielded(
                     thread_id="thread-closure",
+                    run_id="run-1",
                     workflow_generator=fake_workflow(),
                     cancel_event=cancel_event,
                     soft_interrupt_event=soft_interrupt_event,

--- a/tests/unit/server/services/test_background_task_terminal_cleanup.py
+++ b/tests/unit/server/services/test_background_task_terminal_cleanup.py
@@ -177,7 +177,9 @@ class TestMarkFailedReleases:
         assert info.metadata["user_id"] == "u-1"
         # Wiring: tracker.mark_failed called so /status reports FAILED with
         # bounded TTL instead of leaving the key as ACTIVE.
-        mock_tracker.mark_failed.assert_awaited_once_with("t-1", error="boom")
+        mock_tracker.mark_failed.assert_awaited_once_with(
+            "t-1", error="boom", run_id="r-1"
+        )
 
 
 class TestMarkCancelledReleases:
@@ -198,7 +200,7 @@ class TestMarkCancelledReleases:
         assert info.graph is None
         # Wiring: tracker.mark_cancelled called from the canonical site so
         # stale-cancel reaper / soft-interrupt-abort paths also update Redis.
-        mock_tracker.mark_cancelled.assert_awaited_once_with("t-1")
+        mock_tracker.mark_cancelled.assert_awaited_once_with("t-1", run_id="r-1")
 
 
 class TestMarkSoftInterruptedReleases:
@@ -217,7 +219,7 @@ class TestMarkSoftInterruptedReleases:
 
         assert info.persistence_complete.is_set()
         assert info.graph is None
-        mock_tracker.mark_soft_interrupted.assert_awaited_once_with("t-1")
+        mock_tracker.mark_soft_interrupted.assert_awaited_once_with("t-1", run_id="r-1")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/server/services/test_background_task_terminal_cleanup.py
+++ b/tests/unit/server/services/test_background_task_terminal_cleanup.py
@@ -32,12 +32,11 @@ def _make_btm() -> BackgroundTaskManager:
         return BackgroundTaskManager()
 
 
-def _make_info(thread_id: str = "t-1", **metadata) -> TaskInfo:
+def _make_info(thread_id: str = "t-1", run_id: str = "r-1", **metadata) -> TaskInfo:
     md = {
         "workspace_id": "ws-1",
         "user_id": "u-1",
         "is_byok": False,
-        "dispatch_kind": "foreground",
         "response_id": "r-1",
         "handler": object(),
         "token_callback": object(),
@@ -46,6 +45,7 @@ def _make_info(thread_id: str = "t-1", **metadata) -> TaskInfo:
     md.update(metadata)
     info = TaskInfo(
         thread_id=thread_id,
+        run_id=run_id,
         status=TaskStatus.RUNNING,
         created_at=datetime.now(),
         metadata=md,
@@ -66,9 +66,9 @@ class TestReleaseTerminalRefs:
     async def test_releases_heavy_refs_keeps_scalars(self):
         btm = _make_btm()
         info = _make_info()
-        btm.tasks["t-1"] = info
+        btm.tasks[("t-1", "r-1")] = info
 
-        btm._release_terminal_refs("t-1")
+        btm._release_terminal_refs("t-1", "r-1")
 
         assert info.graph is None
         assert info.completion_callback is None
@@ -79,17 +79,16 @@ class TestReleaseTerminalRefs:
         assert info.metadata["workspace_id"] == "ws-1"
         assert info.metadata["user_id"] == "u-1"
         assert info.metadata["is_byok"] is False
-        assert info.metadata["dispatch_kind"] == "foreground"
         assert info.metadata["response_id"] == "r-1"
 
     @pytest.mark.asyncio
     async def test_idempotent(self):
         btm = _make_btm()
         info = _make_info()
-        btm.tasks["t-1"] = info
+        btm.tasks[("t-1", "r-1")] = info
 
-        btm._release_terminal_refs("t-1")
-        btm._release_terminal_refs("t-1")  # No exception
+        btm._release_terminal_refs("t-1", "r-1")
+        btm._release_terminal_refs("t-1", "r-1")  # No exception
 
         assert info.graph is None
         assert info.metadata["workspace_id"] == "ws-1"
@@ -97,7 +96,7 @@ class TestReleaseTerminalRefs:
     @pytest.mark.asyncio
     async def test_missing_thread_is_safe(self):
         btm = _make_btm()
-        btm._release_terminal_refs("missing")  # Must not raise
+        btm._release_terminal_refs("missing", "r-x")  # Must not raise
 
     @pytest.mark.asyncio
     async def test_inner_task_only_dropped_when_done(self):
@@ -106,9 +105,9 @@ class TestReleaseTerminalRefs:
         running = MagicMock(spec=asyncio.Task)
         running.done.return_value = False
         info.inner_task = running
-        btm.tasks["t-1"] = info
+        btm.tasks[("t-1", "r-1")] = info
 
-        btm._release_terminal_refs("t-1")
+        btm._release_terminal_refs("t-1", "r-1")
 
         assert info.inner_task is running
 
@@ -127,19 +126,18 @@ class TestMarkCompletedReleases:
         info.completion_callback = AsyncMock()
         info.metadata["workspace_id"] = "ws-1"
         info.metadata["user_id"] = "u-1"
-        btm.tasks["t-1"] = info
+        btm.tasks[("t-1", "r-1")] = info
 
-        bg_store = MagicMock()
-        bg_store.get_instance.return_value.get_registry = AsyncMock(return_value=None)
-        ps_module = MagicMock()
-        ps_module.ConversationPersistenceService.get_instance.return_value._current_response_id = None
+        bg_store_module = MagicMock()
+        bg_store_instance = MagicMock()
+        bg_store_instance.get_registry = AsyncMock(return_value=None)
+        bg_store_module.BackgroundRegistryStore.get_instance.return_value = bg_store_instance
 
         with patch("src.server.services.background_task_manager.release_burst_slot", new=AsyncMock()), \
              patch.dict("sys.modules", {
-                 "src.server.services.background_registry_store": bg_store,
-                 "src.server.services.persistence.conversation": ps_module,
+                 "src.server.services.background_registry_store": bg_store_module,
              }):
-            await btm._mark_completed("t-1")
+            await btm._mark_completed("t-1", "r-1")
 
         assert info.persistence_complete.is_set()
         assert info.graph is None
@@ -167,12 +165,12 @@ class TestMarkFailedReleases:
         btm = _make_btm()
         info = _make_info()
         info.metadata["workspace_id"] = None  # Skip persistence body
-        btm.tasks["t-1"] = info
+        btm.tasks[("t-1", "r-1")] = info
 
         tracker_patch, mock_tracker = _patch_tracker()
         with patch("src.server.services.background_task_manager.release_burst_slot", new=AsyncMock()), \
              tracker_patch:
-            await btm._mark_failed("t-1", "boom")
+            await btm._mark_failed("t-1", "r-1", "boom")
 
         assert info.persistence_complete.is_set()
         assert info.graph is None
@@ -189,16 +187,15 @@ class TestMarkCancelledReleases:
         btm = _make_btm()
         info = _make_info()
         info.metadata["workspace_id"] = None  # Skip persistence body
-        btm.tasks["t-1"] = info
+        btm.tasks[("t-1", "r-1")] = info
 
         tracker_patch, mock_tracker = _patch_tracker()
         with patch("src.server.services.background_task_manager.release_burst_slot", new=AsyncMock()), \
              tracker_patch:
-            await btm._mark_cancelled("t-1")
+            await btm._mark_cancelled("t-1", "r-1")
 
         assert info.persistence_complete.is_set()
         assert info.graph is None
-        assert info.metadata["dispatch_kind"] == "foreground"
         # Wiring: tracker.mark_cancelled called from the canonical site so
         # stale-cancel reaper / soft-interrupt-abort paths also update Redis.
         mock_tracker.mark_cancelled.assert_awaited_once_with("t-1")
@@ -211,12 +208,12 @@ class TestMarkSoftInterruptedReleases:
         btm = _make_btm()
         info = _make_info()
         info.metadata["workspace_id"] = None  # Skip persistence body
-        btm.tasks["t-1"] = info
+        btm.tasks[("t-1", "r-1")] = info
 
         tracker_patch, mock_tracker = _patch_tracker()
         with patch("src.server.services.background_task_manager.release_burst_slot", new=AsyncMock()), \
              tracker_patch:
-            await btm._mark_soft_interrupted("t-1")
+            await btm._mark_soft_interrupted("t-1", "r-1")
 
         assert info.persistence_complete.is_set()
         assert info.graph is None
@@ -235,7 +232,7 @@ class TestMarkCompletedCallbackFailure:
         btm = _make_btm()
         info = _make_info()
         info.completion_callback = AsyncMock(side_effect=RuntimeError("boom"))
-        btm.tasks["t-1"] = info
+        btm.tasks[("t-1", "r-1")] = info
 
         burst_release = AsyncMock()
         bg_store_module = MagicMock()
@@ -261,7 +258,7 @@ class TestMarkCompletedCallbackFailure:
                  "src.server.services.background_registry_store": bg_store_module,
                  "src.server.services.persistence.conversation": ps_module,
              }):
-            await btm._mark_completed("t-1")
+            await btm._mark_completed("t-1", "r-1")
 
         # Burst slot released exactly once (via _mark_failed only)
         assert burst_release.call_count == 1

--- a/tests/unit/server/services/test_event_buffer.py
+++ b/tests/unit/server/services/test_event_buffer.py
@@ -32,14 +32,17 @@ def _make_btm(backend: str = "redis") -> BackgroundTaskManager:
     return btm
 
 
-def _register_task(btm: BackgroundTaskManager, thread_id: str = "thread-1") -> TaskInfo:
+def _register_task(
+    btm: BackgroundTaskManager, thread_id: str = "thread-1", run_id: str = "run-1"
+) -> TaskInfo:
     task_info = TaskInfo(
         thread_id=thread_id,
+        run_id=run_id,
         status=TaskStatus.RUNNING,
         created_at=datetime.now(),
         started_at=datetime.now(),
     )
-    btm.tasks[thread_id] = task_info
+    btm.tasks[(thread_id, run_id)] = task_info
     return task_info
 
 
@@ -59,15 +62,15 @@ class TestBufferEventRedisHappyPath:
             "src.server.services.background_task_manager.get_cache_client",
             return_value=mock_cache,
         ):
-            await btm._buffer_event_redis("thread-1", "id: 42\nevent: x\ndata: hi\n\n")
+            await btm._buffer_event_redis("thread-1", "run-1", "id: 42\nevent: x\ndata: hi\n\n")
 
         assert mock_cache.pipelined_event_buffer.await_count == 1
         call = mock_cache.pipelined_event_buffer.await_args
         # Main workflow path is stream-only; persistence comes from
         # StreamEventAccumulator, not from a separate List.
         assert "events_key" not in call.kwargs
-        assert call.kwargs["meta_key"] == "workflow:events:meta:thread-1"
-        assert call.kwargs["stream_key"] == "workflow:stream:thread-1"
+        assert call.kwargs["meta_key"] == "workflow:events:meta:thread-1:run-1"
+        assert call.kwargs["stream_key"] == "workflow:stream:thread-1:run-1"
         assert call.kwargs["last_event_id"] == 42
         assert call.kwargs["max_size"] == 1000
         assert call.kwargs["ttl"] == 86400
@@ -92,7 +95,7 @@ class TestBufferEventRedisHappyPath:
             "src.server.services.background_task_manager.get_cache_client",
             return_value=mock_cache,
         ):
-            await btm._buffer_event_redis("thread-1", "event: x\ndata: hi\n\n")
+            await btm._buffer_event_redis("thread-1", "run-1", "event: x\ndata: hi\n\n")
 
         assert mock_cache.pipelined_event_buffer.await_count == 0
 
@@ -121,7 +124,7 @@ class TestBufferEventRedisFailureModes:
             return_value=mock_cache,
         ):
             # Must not raise.
-            await btm._buffer_event_redis("thread-1", "id: 1\ndata: lost-if-broken\n\n")
+            await btm._buffer_event_redis("thread-1", "run-1", "id: 1\ndata: lost-if-broken\n\n")
 
         assert mock_cache.pipelined_event_buffer.await_count == 1
 
@@ -135,7 +138,7 @@ class TestBufferEventRedisFailureModes:
             "src.server.services.background_task_manager.get_cache_client",
             side_effect=RuntimeError("cache singleton init failed"),
         ):
-            await btm._buffer_event_redis("thread-1", "id: 42\ndata: must-survive\n\n")
+            await btm._buffer_event_redis("thread-1", "run-1", "id: 42\ndata: must-survive\n\n")
 
     @pytest.mark.asyncio
     async def test_redis_disabled_skips_pipeline(self):
@@ -151,6 +154,6 @@ class TestBufferEventRedisFailureModes:
             "src.server.services.background_task_manager.get_cache_client",
             return_value=mock_cache,
         ):
-            await btm._buffer_event_redis("thread-1", "id: 1\ndata: x\n\n")
+            await btm._buffer_event_redis("thread-1", "run-1", "id: 1\ndata: x\n\n")
 
         assert mock_cache.pipelined_event_buffer.await_count == 0

--- a/tests/unit/server/services/test_per_turn_state_reset.py
+++ b/tests/unit/server/services/test_per_turn_state_reset.py
@@ -1,0 +1,450 @@
+"""Tests for per-turn state isolation under ``run_id`` keying.
+
+The previous design relied on identity-guard scaffolding (TaskInfo identity
+checks, ``_tracker_write_is_safe``, ``acquire_for_new_execution``, etc.)
+because state was keyed by ``thread_id`` alone. After the run_id refactor,
+state is keyed by ``(thread_id, run_id)`` so cross-turn aliasing is
+impossible by construction — these tests pin that invariant.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from datetime import datetime
+
+from src.server.services.background_task_manager import (
+    BackgroundTaskManager,
+    TaskInfo,
+    TaskStatus,
+)
+from src.server.services.persistence import conversation as persistence_module
+from src.server.services.persistence.conversation import (
+    ConversationPersistenceService,
+)
+
+
+def _new_task_info(
+    thread_id: str, run_id: str, status: "TaskStatus"
+) -> "TaskInfo":
+    return TaskInfo(
+        thread_id=thread_id,
+        run_id=run_id,
+        status=status,
+        created_at=datetime.now(),
+    )
+
+
+def _make_btm() -> BackgroundTaskManager:
+    with patch("src.server.services.background_task_manager.get_max_concurrent_workflows", return_value=10), \
+         patch("src.server.services.background_task_manager.get_workflow_result_ttl", return_value=3600), \
+         patch("src.server.services.background_task_manager.get_abandoned_workflow_timeout", return_value=3600), \
+         patch("src.server.services.background_task_manager.get_cleanup_interval", return_value=60), \
+         patch("src.server.services.background_task_manager.is_intermediate_storage_enabled", return_value=False), \
+         patch("src.server.services.background_task_manager.get_max_stored_messages_per_agent", return_value=1000), \
+         patch("src.server.services.background_task_manager.get_event_storage_backend", return_value="redis"), \
+         patch("src.server.services.background_task_manager.get_redis_ttl_workflow_events", return_value=86400):
+        return BackgroundTaskManager()
+
+
+@pytest.fixture(autouse=True)
+def _clear_persistence_singleton_cache():
+    persistence_module._service_instances.clear()
+    yield
+    persistence_module._service_instances.clear()
+
+
+# ---------------------------------------------------------------------------
+# BTM: per-run keying invariants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pre_register_uses_per_run_key():
+    """Each ``(thread_id, run_id)`` gets its own slot — same thread, two
+    runs coexist in the cache."""
+    btm = _make_btm()
+    assert await btm.pre_register("thread-X", "run-A") is True
+    assert await btm.pre_register("thread-X", "run-B") is True
+    assert ("thread-X", "run-A") in btm.tasks
+    assert ("thread-X", "run-B") in btm.tasks
+
+
+@pytest.mark.asyncio
+async def test_pre_register_rejects_duplicate_run():
+    """Re-registering the exact same ``(thread_id, run_id)`` is a no-op
+    that returns False."""
+    btm = _make_btm()
+    assert await btm.pre_register("thread-X", "run-A") is True
+    assert await btm.pre_register("thread-X", "run-A") is False
+
+
+@pytest.mark.asyncio
+async def test_clear_event_buffer_is_run_scoped():
+    """clear_event_buffer DELs only the per-run keys — never bleeds across
+    runs on the same thread."""
+    btm = _make_btm()
+
+    cache = MagicMock()
+    cache.enabled = True
+    cache.delete = AsyncMock()
+    with patch(
+        "src.server.services.background_task_manager.get_cache_client",
+        return_value=cache,
+    ):
+        await btm.clear_event_buffer("thread-Z", "run-A")
+
+    deleted = [call.args[0] for call in cache.delete.await_args_list]
+    assert "workflow:stream:thread-Z:run-A" in deleted
+    assert "workflow:events:meta:thread-Z:run-A" in deleted
+    # No legacy thread-only key DEL: the new scheme never writes it.
+    assert "workflow:stream:thread-Z" not in deleted
+
+
+@pytest.mark.asyncio
+async def test_admission_lock_is_per_thread_and_idempotent():
+    """Admission lock is thread-scoped because admission is a per-thread
+    invariant (one foreground turn at a time on a thread)."""
+    import asyncio
+    btm = _make_btm()
+
+    a1 = await btm.get_admission_lock("thread-A")
+    a2 = await btm.get_admission_lock("thread-A")
+    b = await btm.get_admission_lock("thread-B")
+
+    assert a1 is a2
+    assert a1 is not b
+    assert isinstance(a1, asyncio.Lock)
+
+
+@pytest.mark.asyncio
+async def test_get_task_info_with_run_id_targets_specific_run():
+    """``get_task_info(tid, rid)`` targets exactly that run."""
+    btm = _make_btm()
+    ti_a = _new_task_info("thread-X", "run-A", TaskStatus.RUNNING)
+    ti_b = _new_task_info("thread-X", "run-B", TaskStatus.QUEUED)
+    btm.tasks[("thread-X", "run-A")] = ti_a
+    btm.tasks[("thread-X", "run-B")] = ti_b
+
+    fetched_a = await btm.get_task_info("thread-X", "run-A")
+    fetched_b = await btm.get_task_info("thread-X", "run-B")
+
+    assert fetched_a is ti_a
+    assert fetched_b is ti_b
+
+
+@pytest.mark.asyncio
+async def test_get_task_info_without_run_id_returns_latest():
+    """``get_task_info(tid)`` (no run_id) returns the latest-created run."""
+    import asyncio as _a
+
+    btm = _make_btm()
+    older = _new_task_info("thread-X", "run-A", TaskStatus.COMPLETED)
+    # Tiny sleep so created_at strictly differs.
+    await _a.sleep(0.001)
+    newer = _new_task_info("thread-X", "run-B", TaskStatus.RUNNING)
+    btm.tasks[("thread-X", "run-A")] = older
+    btm.tasks[("thread-X", "run-B")] = newer
+
+    fetched = await btm.get_task_info("thread-X")
+    assert fetched is newer
+
+
+@pytest.mark.asyncio
+async def test_mark_failed_marks_only_targeted_run():
+    """``_mark_failed(tid, rid)`` mutates only that run — a concurrent
+    different-run TaskInfo on the same thread is untouched."""
+    btm = _make_btm()
+    old = _new_task_info("thread-F", "run-old", TaskStatus.RUNNING)
+    new = _new_task_info("thread-F", "run-new", TaskStatus.RUNNING)
+    old.metadata = {"workspace_id": None, "user_id": None}
+    new.metadata = {"workspace_id": None, "user_id": None}
+    btm.tasks[("thread-F", "run-old")] = old
+    btm.tasks[("thread-F", "run-new")] = new
+
+    await btm._mark_failed("thread-F", "run-old", "boom")
+
+    assert old.status == TaskStatus.FAILED
+    assert old.error == "boom"
+    assert new.status == TaskStatus.RUNNING
+    assert new.error is None
+
+
+@pytest.mark.asyncio
+async def test_cleanup_preserves_admission_locks():
+    """Admission locks are NOT reclaimed by cleanup.
+
+    Reclaiming them creates a race: ``get_admission_lock`` returns the
+    Lock object under ``task_lock`` and the caller then awaits
+    ``acquire()`` outside the lock. A cleanup-time deletion in that gap
+    would let a concurrent caller create a fresh Lock for the same
+    thread, and both POSTs would acquire DIFFERENT lock objects — silently
+    defeating admission. The dict is tiny; we keep it.
+    """
+    from datetime import timedelta
+
+    btm = _make_btm()
+    btm.result_ttl = 0
+
+    lock = await btm.get_admission_lock("thread-L")
+    assert "thread-L" in btm._admission_locks
+
+    ti = _new_task_info("thread-L", "run-1", TaskStatus.COMPLETED)
+    ti.completed_at = datetime.now() - timedelta(hours=1)
+    btm.tasks[("thread-L", "run-1")] = ti
+
+    await btm._cleanup_abandoned_tasks()
+
+    # Task entry is evicted, but the admission lock survives.
+    assert ("thread-L", "run-1") not in btm.tasks
+    assert "thread-L" in btm._admission_locks
+    assert btm._admission_locks["thread-L"] is lock
+    assert not lock.locked()
+
+
+# ---------------------------------------------------------------------------
+# Persistence service: per-run keying invariants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_instance_keyed_by_thread_and_run():
+    """Two runs on the same thread get distinct persistence instances."""
+    a = ConversationPersistenceService.get_instance("thread-X", "run-A")
+    b = ConversationPersistenceService.get_instance("thread-X", "run-B")
+    assert a is not b
+    # Same key returns the same instance.
+    a2 = ConversationPersistenceService.get_instance("thread-X", "run-A")
+    assert a is a2
+
+
+@pytest.mark.asyncio
+async def test_cleanup_is_run_scoped():
+    """Cleaning up one run's service must not touch another run's cache entry."""
+    a = ConversationPersistenceService.get_instance("thread-X", "run-A")
+    b = ConversationPersistenceService.get_instance("thread-X", "run-B")
+
+    await a.cleanup()
+
+    assert ("thread-X", "run-A") not in persistence_module._service_instances
+    assert persistence_module._service_instances[("thread-X", "run-B")] is b
+
+
+@pytest.mark.asyncio
+async def test_persist_query_start_does_not_gate_on_in_memory_set():
+    """``persist_query_start`` always calls ``create_query`` — the DB's
+    ON CONFLICT is the canonical idempotency check."""
+    svc = ConversationPersistenceService.get_instance(
+        "thread-Q", "run-Q",
+        workspace_id="ws-1", user_id="u-1",
+    )
+    # The in-memory dedup set was removed; ON CONFLICT in the DB is the
+    # only idempotency check. persist_query_start must always call create_query.
+    svc._turn_index_cache = 1
+
+    db_returned_uuid = "11111111-1111-1111-1111-111111111111"
+    create_query_mock = AsyncMock(
+        return_value={"conversation_query_id": db_returned_uuid, "turn_index": 1}
+    )
+
+    with patch(
+        "src.server.services.persistence.conversation.qr_db.create_query",
+        create_query_mock,
+    ):
+        returned = await svc.persist_query_start(
+            content="hello", query_type="initial",
+        )
+
+    create_query_mock.assert_awaited_once()
+    kwargs = create_query_mock.call_args.kwargs
+    assert kwargs["conversation_thread_id"] == "thread-Q"
+    assert kwargs["turn_index"] == 1
+    assert returned == db_returned_uuid
+
+
+@pytest.mark.asyncio
+async def test_persist_query_start_raises_on_content_conflict():
+    """QueryConflictError surfaces (not silently overwritten) when an
+    existing row's content differs."""
+    from src.server.database.conversation import QueryConflictError
+
+    svc = ConversationPersistenceService.get_instance(
+        "thread-Q", "run-Q",
+        workspace_id="ws-1", user_id="u-1",
+    )
+
+    async def _raise(*args, **kwargs):
+        raise QueryConflictError(
+            thread_id="thread-Q", turn_index=0,
+            existing_content="earlier content",
+        )
+
+    with patch.object(persistence_module.qr_db, "create_query", side_effect=_raise), \
+         patch.object(persistence_module.qr_db, "get_next_turn_index", AsyncMock(return_value=0)):
+        with pytest.raises(QueryConflictError) as excinfo:
+            await svc.persist_query_start(
+                content="new content", query_type="initial",
+            )
+
+    assert excinfo.value.turn_index == 0
+
+
+# ---------------------------------------------------------------------------
+# _setup_fork_and_persistence wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_setup_fork_and_persistence_uses_run_id_keyed_get_instance():
+    """``_setup_fork_and_persistence`` must call ``get_instance(tid, rid, ...)``
+    so the per-run keying is the canonical source of truth — no
+    ``acquire_for_new_execution`` workaround anymore."""
+    from src.server.handlers.chat import _common
+    from src.server.models.chat import ChatRequest
+
+    request = MagicMock(spec=ChatRequest)
+    request.query_type = None
+    request.hitl_response = None
+    request.checkpoint_id = None
+    request.messages = []
+    request.fork_from_turn = None
+
+    sentinel = MagicMock(spec=ConversationPersistenceService)
+    sentinel.reset_for_fork = MagicMock()
+    sentinel.get_or_calculate_turn_index = AsyncMock(return_value=0)
+
+    with patch.object(
+        _common.ConversationPersistenceService,
+        "get_instance",
+        return_value=sentinel,
+    ) as get_instance_mock:
+        query_type, is_fork, persistence_service = await _common._setup_fork_and_persistence(
+            request=request,
+            thread_id="thread-W",
+            run_id="run-W",
+            workspace_id="ws-W",
+            user_id="user-W",
+        )
+
+    get_instance_mock.assert_called_once_with(
+        thread_id="thread-W", run_id="run-W",
+        workspace_id="ws-W", user_id="user-W",
+    )
+    assert persistence_service is sentinel
+    assert query_type == "initial"
+    assert is_fork is False
+    sentinel.get_or_calculate_turn_index.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_persist_completion_uses_run_id_as_response_id():
+    """``persist_completion`` writes the response row with
+    ``conversation_response_id == self.run_id`` (1:1 contract)."""
+    svc = ConversationPersistenceService.get_instance(
+        "thread-C", "11111111-2222-3333-4444-555555555555",
+        workspace_id="ws-1", user_id="u-1",
+    )
+
+    captured = {}
+
+    async def _create_response(**kwargs):
+        captured.update(kwargs)
+        return None
+
+    mock_conn = MagicMock()
+    mock_conn.transaction = MagicMock(
+        return_value=MagicMock(
+            __aenter__=AsyncMock(return_value=None),
+            __aexit__=AsyncMock(return_value=None),
+        )
+    )
+
+    @AsyncMock
+    async def _update_thread_status(*args, **kwargs):
+        return None
+
+    class _ConnCtx:
+        async def __aenter__(self):
+            return mock_conn
+
+        async def __aexit__(self, *args):
+            return None
+
+    with patch.object(persistence_module.qr_db, "get_next_turn_index",
+                      AsyncMock(return_value=0)), \
+         patch.object(persistence_module.qr_db, "create_response",
+                      side_effect=_create_response), \
+         patch.object(persistence_module.qr_db, "update_thread_status",
+                      AsyncMock(return_value=None)), \
+         patch.object(persistence_module.qr_db, "get_db_connection",
+                      return_value=_ConnCtx()), \
+         patch.object(svc, "_get_latest_checkpoint_id",
+                      AsyncMock(return_value=None)):
+        response_id = await svc.persist_completion(
+            metadata={"msg_type": "ptc"},
+            execution_time=0.1,
+        )
+
+    assert response_id == "11111111-2222-3333-4444-555555555555"
+    assert captured["conversation_response_id"] == "11111111-2222-3333-4444-555555555555"
+
+
+@pytest.mark.asyncio
+async def test_persist_completion_after_cleanup_short_circuits():
+    """A second ``persist_completion`` after the first one has finalized
+    (cleanup ran inside ``_finalize_pair``) must short-circuit: return the
+    cached ``run_id`` without hitting the DB layer again. Prevents the
+    stale-instance PK-collision scenario where a lingering ref re-INSERTs
+    at a recalculated turn_index.
+    """
+    run_id = "11111111-2222-3333-4444-555555555555"
+    svc = ConversationPersistenceService.get_instance(
+        "thread-C2", run_id,
+        workspace_id="ws-1", user_id="u-1",
+    )
+
+    create_response_mock = AsyncMock(return_value=None)
+
+    class _ConnCtx:
+        async def __aenter__(self):
+            conn = MagicMock()
+            conn.transaction = MagicMock(
+                return_value=MagicMock(
+                    __aenter__=AsyncMock(return_value=None),
+                    __aexit__=AsyncMock(return_value=None),
+                )
+            )
+            return conn
+
+        async def __aexit__(self, *args):
+            return None
+
+    with patch.object(persistence_module.qr_db, "get_next_turn_index",
+                      AsyncMock(return_value=0)), \
+         patch.object(persistence_module.qr_db, "create_response",
+                      create_response_mock), \
+         patch.object(persistence_module.qr_db, "update_thread_status",
+                      AsyncMock(return_value=None)), \
+         patch.object(persistence_module.qr_db, "get_db_connection",
+                      return_value=_ConnCtx()), \
+         patch.object(svc, "_get_latest_checkpoint_id",
+                      AsyncMock(return_value=None)):
+        first = await svc.persist_completion(
+            metadata={"msg_type": "ptc"},
+            execution_time=0.1,
+        )
+        # cleanup() inside _finalize_pair should now have flipped _finalized.
+        assert svc._finalized is True
+
+        # A second call on the same (now post-cleanup) instance must NOT
+        # re-INSERT — it must return the cached response_id.
+        second = await svc.persist_completion(
+            metadata={"msg_type": "ptc"},
+            execution_time=0.1,
+        )
+
+    assert first == run_id
+    assert second == run_id
+    create_response_mock.assert_awaited_once()

--- a/tests/unit/server/services/test_subagent_cross_turn_isolation.py
+++ b/tests/unit/server/services/test_subagent_cross_turn_isolation.py
@@ -1,0 +1,438 @@
+"""Regression tests for adversarial findings A2, A7, A8, A4.
+
+Covers:
+- A2: Subagent collector filters by ``spawned_run_id`` so prior-turn
+  subagents can't get claimed by a later turn's collector.
+- A7: ``_await_drain_and_cleanup_tasks`` evicts collected tasks from the
+  per-thread registry so the dict doesn't grow unboundedly across turns.
+- A8: The claim loop in ``_mark_completed`` holds ``bg_registry._lock``
+  so two concurrent collectors can't both observe ``collector_response_id``
+  is ``None`` for the same task and double-claim.
+- A4: The legacy-fallback ``stream_from_log`` path polls WorkflowTracker
+  instead of exiting eagerly, so a rolling-deploy reconnect can still
+  drain in-flight events.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ptc_agent.agent.middleware.background_subagent.registry import (
+    BackgroundTask,
+    BackgroundTaskRegistry,
+)
+from src.server.services.background_task_manager import (
+    BackgroundTaskManager,
+    TaskInfo,
+    TaskStatus,
+)
+
+
+def _make_btm() -> BackgroundTaskManager:
+    with patch("src.server.services.background_task_manager.get_max_concurrent_workflows", return_value=10), \
+         patch("src.server.services.background_task_manager.get_workflow_result_ttl", return_value=3600), \
+         patch("src.server.services.background_task_manager.get_abandoned_workflow_timeout", return_value=3600), \
+         patch("src.server.services.background_task_manager.get_cleanup_interval", return_value=60), \
+         patch("src.server.services.background_task_manager.is_intermediate_storage_enabled", return_value=False), \
+         patch("src.server.services.background_task_manager.get_max_stored_messages_per_agent", return_value=1000), \
+         patch("src.server.services.background_task_manager.get_event_storage_backend", return_value="memory"), \
+         patch("src.server.services.background_task_manager.get_redis_ttl_workflow_events", return_value=86400):
+        return BackgroundTaskManager()
+
+
+def _make_subagent_task(
+    *, tool_call_id: str, task_id: str, spawned_run_id: str | None
+) -> BackgroundTask:
+    """A BackgroundTask shaped enough for the collector claim loop to consider it."""
+    t = BackgroundTask(
+        tool_call_id=tool_call_id,
+        task_id=task_id,
+        description="d",
+        prompt="p",
+        subagent_type="general-purpose",
+        spawned_run_id=spawned_run_id,
+    )
+    # Make it claimable: completed with captured events, no asyncio_task pending.
+    t.completed = True
+    t.captured_event_count = 1
+    return t
+
+
+# ---------------------------------------------------------------------------
+# A2 — collector filters by spawned_run_id
+# ---------------------------------------------------------------------------
+
+
+class TestCollectorFiltersBySpawnedRunId:
+
+    @pytest.mark.asyncio
+    async def test_prior_turn_subagents_not_claimed_by_later_turn(self):
+        """Subagent registered under run-1 stays unclaimed when run-2's
+        collector runs. Prevents the cross-turn event leak."""
+        btm = _make_btm()
+
+        # run-2 is the turn whose _mark_completed we are simulating.
+        run_id_current = "run-2"
+        thread_id = "thread-A"
+
+        # The current turn is in-flight in BTM
+        btm.tasks[(thread_id, run_id_current)] = TaskInfo(
+            thread_id=thread_id,
+            run_id=run_id_current,
+            status=TaskStatus.RUNNING,
+            created_at=datetime.now(),
+            metadata={"workspace_id": "ws-1", "user_id": "u-1"},
+        )
+
+        # Registry holds one prior-turn subagent and one current-turn subagent.
+        registry = BackgroundTaskRegistry(thread_id=thread_id)
+        prior = _make_subagent_task(
+            tool_call_id="tc-prior", task_id="prior1",
+            spawned_run_id="run-1",
+        )
+        current = _make_subagent_task(
+            tool_call_id="tc-current", task_id="curr1",
+            spawned_run_id=run_id_current,
+        )
+        registry._tasks["tc-prior"] = prior
+        registry._tasks["tc-current"] = current
+
+        bg_store = MagicMock()
+        bg_store.get_registry = AsyncMock(return_value=registry)
+
+        # Patch out everything _mark_completed does AFTER the claim loop so
+        # the test only exercises the claim logic.
+        with patch(
+            "src.server.services.background_registry_store.BackgroundRegistryStore.get_instance",
+            return_value=bg_store,
+        ), patch.object(btm, "_release_terminal_refs"), \
+             patch.object(btm, "_collect_subagent_results_for_turn",
+                          new_callable=AsyncMock) as collect_mock, \
+             patch("src.server.services.background_task_manager.release_burst_slot",
+                   new_callable=AsyncMock):
+            await btm._mark_completed(thread_id, run_id_current)
+            # The collector is spawned via asyncio.create_task; yield once
+            # to let it run.
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+        # _collect_subagent_results_for_turn was called with ONLY the current task.
+        assert collect_mock.await_count == 1
+        kwargs = collect_mock.await_args.kwargs
+        collected_ids = {t.tool_call_id for t in kwargs["tasks"]}
+        assert collected_ids == {"tc-current"}
+        # The prior task remains unclaimed and available for its own turn's
+        # collector (or the orphan path) to handle.
+        assert prior.collector_response_id is None
+        assert current.collector_response_id == run_id_current
+
+    @pytest.mark.asyncio
+    async def test_unstamped_task_treated_as_compat(self):
+        """A task with spawned_run_id=None (registered before the fix
+        shipped) is still claimable so in-flight subagents during the
+        deploy window don't get orphaned."""
+        btm = _make_btm()
+        run_id_current = "run-2"
+        thread_id = "thread-B"
+        btm.tasks[(thread_id, run_id_current)] = TaskInfo(
+            thread_id=thread_id,
+            run_id=run_id_current,
+            status=TaskStatus.RUNNING,
+            created_at=datetime.now(),
+            metadata={"workspace_id": "ws-1", "user_id": "u-1"},
+        )
+
+        registry = BackgroundTaskRegistry(thread_id=thread_id)
+        legacy = _make_subagent_task(
+            tool_call_id="tc-legacy", task_id="leg1",
+            spawned_run_id=None,
+        )
+        registry._tasks["tc-legacy"] = legacy
+
+        bg_store = MagicMock()
+        bg_store.get_registry = AsyncMock(return_value=registry)
+
+        with patch(
+            "src.server.services.background_registry_store.BackgroundRegistryStore.get_instance",
+            return_value=bg_store,
+        ), patch.object(btm, "_release_terminal_refs"), \
+             patch.object(btm, "_collect_subagent_results_for_turn",
+                          new_callable=AsyncMock) as collect_mock, \
+             patch("src.server.services.background_task_manager.release_burst_slot",
+                   new_callable=AsyncMock):
+            await btm._mark_completed(thread_id, run_id_current)
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+        assert collect_mock.await_count == 1
+        collected_ids = {t.tool_call_id for t in collect_mock.await_args.kwargs["tasks"]}
+        assert collected_ids == {"tc-legacy"}
+        assert legacy.collector_response_id == run_id_current
+
+
+# ---------------------------------------------------------------------------
+# A8 — claim loop holds bg_registry._lock
+# ---------------------------------------------------------------------------
+
+
+class TestClaimLoopHoldsRegistryLock:
+
+    @pytest.mark.asyncio
+    async def test_claim_blocks_when_lock_held_elsewhere(self):
+        """If a competing coroutine holds bg_registry._lock, _mark_completed's
+        claim loop can't observe collector_response_id mid-mutation. We
+        prove this by holding the lock and timing-out _mark_completed."""
+        btm = _make_btm()
+        thread_id = "thread-C"
+        run_id = "run-C"
+        btm.tasks[(thread_id, run_id)] = TaskInfo(
+            thread_id=thread_id, run_id=run_id,
+            status=TaskStatus.RUNNING, created_at=datetime.now(),
+            metadata={"workspace_id": "ws-1", "user_id": "u-1"},
+        )
+
+        registry = BackgroundTaskRegistry(thread_id=thread_id)
+        registry._tasks["tc-X"] = _make_subagent_task(
+            tool_call_id="tc-X", task_id="X", spawned_run_id=run_id,
+        )
+
+        bg_store = MagicMock()
+        bg_store.get_registry = AsyncMock(return_value=registry)
+
+        async def hold_lock_then_release(release_after: float) -> None:
+            async with registry._lock:
+                await asyncio.sleep(release_after)
+
+        with patch(
+            "src.server.services.background_registry_store.BackgroundRegistryStore.get_instance",
+            return_value=bg_store,
+        ), patch.object(btm, "_release_terminal_refs"), \
+             patch.object(btm, "_collect_subagent_results_for_turn",
+                          new_callable=AsyncMock) as collect_mock, \
+             patch("src.server.services.background_task_manager.release_burst_slot",
+                   new_callable=AsyncMock):
+            # Start a hog that holds the lock for ~150ms.
+            hog = asyncio.create_task(hold_lock_then_release(0.15))
+            await asyncio.sleep(0.01)  # let hog acquire
+
+            # _mark_completed must block on the lock and not proceed past
+            # the claim until the hog releases. We verify by checking that
+            # the task has not been claimed before hog releases.
+            mc_task = asyncio.create_task(btm._mark_completed(thread_id, run_id))
+            await asyncio.sleep(0.05)
+            task = registry._tasks["tc-X"]
+            assert task.collector_response_id is None, (
+                "claim happened while lock was held — A8 not enforced"
+            )
+
+            await hog
+            await mc_task
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+        assert task.collector_response_id == run_id
+        assert collect_mock.await_count == 1
+
+
+# ---------------------------------------------------------------------------
+# A7 — _await_drain_and_cleanup_tasks evicts from registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryEvictionAfterDrain:
+
+    @pytest.mark.asyncio
+    async def test_drain_removes_task_from_registry_dict(self):
+        """After cleanup, the registry's _tasks dict is empty so long-lived
+        threads don't accumulate completed-subagent entries forever."""
+        btm = _make_btm()
+        thread_id = "thread-D"
+
+        registry = BackgroundTaskRegistry(thread_id=thread_id)
+        task_a = _make_subagent_task(
+            tool_call_id="tc-a", task_id="a", spawned_run_id="run-1",
+        )
+        task_a.sse_drain_complete.set()
+        task_b = _make_subagent_task(
+            tool_call_id="tc-b", task_id="b", spawned_run_id="run-1",
+        )
+        task_b.sse_drain_complete.set()
+        registry._tasks["tc-a"] = task_a
+        registry._tasks["tc-b"] = task_b
+        registry._task_id_to_tool_call_id["a"] = "tc-a"
+        registry._task_id_to_tool_call_id["b"] = "tc-b"
+
+        bg_store = MagicMock()
+        bg_store.get_registry = AsyncMock(return_value=registry)
+
+        # Stub the cache to a disabled-style object so deletes no-op.
+        with patch(
+            "src.server.services.background_registry_store.BackgroundRegistryStore.get_instance",
+            return_value=bg_store,
+        ), patch(
+            "src.server.services.background_task_manager.get_cache_client",
+            side_effect=Exception("no cache"),
+        ), patch(
+            "src.server.services.background_task_manager.get_sse_drain_timeout",
+            return_value=0.1,
+        ):
+            await btm._await_drain_and_cleanup_tasks([task_a, task_b], thread_id)
+
+        assert registry._tasks == {}
+        assert registry._task_id_to_tool_call_id == {}
+
+
+class TestRegistryRemoveTask:
+
+    @pytest.mark.asyncio
+    async def test_remove_task_drops_all_mappings(self):
+        """remove_task evicts the task, its task_id lookup, results, and
+        any namespace mappings keyed to it."""
+        registry = BackgroundTaskRegistry(thread_id="t")
+        task = _make_subagent_task(
+            tool_call_id="tc1", task_id="id1", spawned_run_id="r1",
+        )
+        registry._tasks["tc1"] = task
+        registry._task_id_to_tool_call_id["id1"] = "tc1"
+        registry._ns_uuid_to_tool_call_id["uuid-alpha"] = "tc1"
+        registry._ns_uuid_to_tool_call_id["uuid-other"] = "tc-other"
+        registry._results["tc1"] = {"success": True}
+
+        await registry.remove_task("tc1")
+
+        assert "tc1" not in registry._tasks
+        assert "id1" not in registry._task_id_to_tool_call_id
+        assert "uuid-alpha" not in registry._ns_uuid_to_tool_call_id
+        # Unrelated mapping survives.
+        assert registry._ns_uuid_to_tool_call_id["uuid-other"] == "tc-other"
+        assert "tc1" not in registry._results
+
+    @pytest.mark.asyncio
+    async def test_remove_missing_task_is_noop(self):
+        registry = BackgroundTaskRegistry(thread_id="t")
+        await registry.remove_task("does-not-exist")  # must not raise
+        assert registry._tasks == {}
+
+
+# ---------------------------------------------------------------------------
+# A4 — legacy stream_from_log fallback polls WorkflowTracker
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyFallbackTerminalCheck:
+    """The pre-deploy reconnect path (run_id absent from request, no
+    TaskInfo in process) must NOT eager-exit on the first terminal-check
+    — it should wait until WorkflowTracker reports a terminal status."""
+
+    @pytest.mark.asyncio
+    async def test_terminal_when_tracker_reports_completed(self):
+        from src.server.handlers.chat import stream_from_log as sfl
+
+        cache = MagicMock()
+        cache.enabled = True
+        cache.client = MagicMock()
+        # First xread yields events; second is empty; tracker says
+        # completed so the loop exits cleanly.
+        cache.client.xread = AsyncMock(side_effect=[
+            [(b"workflow:stream:t-leg", [
+                (b"1-0", {b"event": b"id: 1\nevent: x\ndata: a\n\n"}),
+            ])],
+            [],
+            [],
+        ])
+
+        tracker = MagicMock()
+        tracker.get_status = AsyncMock(return_value={"status": "completed"})
+
+        manager = MagicMock()
+        manager._find_latest_for_thread = MagicMock(return_value=None)
+        manager.task_lock = asyncio.Lock()
+
+        with patch.object(sfl, "get_cache_client", return_value=cache), \
+             patch.object(sfl.WorkflowTracker, "get_instance", return_value=tracker), \
+             patch.object(sfl.BackgroundTaskManager, "get_instance", return_value=manager):
+            collected: list[str] = []
+            async for event in sfl.stream_from_log("t-leg", run_id=None, last_event_id=None):
+                collected.append(event)
+
+        # The actual event was yielded — proves we didn't exit before draining.
+        assert any("event: x" in e for e in collected)
+        # And we DID consult the tracker.
+        assert tracker.get_status.await_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_not_terminal_when_tracker_reports_active(self):
+        """Active per the tracker ⇒ terminal_check returns False, so the
+        consumer keeps polling. We bound the test by limiting the xread
+        sequence and switching the tracker to terminal mid-flight."""
+        from src.server.handlers.chat import stream_from_log as sfl
+
+        cache = MagicMock()
+        cache.enabled = True
+        cache.client = MagicMock()
+        # Two empty rounds while the tracker says active, then tracker
+        # flips to completed and we exit.
+        cache.client.xread = AsyncMock(side_effect=[
+            [],  # empty round 1
+            [],  # empty round 2
+            [],  # empty round 3 — exits after tracker now says completed
+        ])
+
+        states = iter([
+            {"status": "active"},
+            {"status": "active"},
+            {"status": "completed"},
+            {"status": "completed"},
+        ])
+        tracker = MagicMock()
+        tracker.get_status = AsyncMock(side_effect=lambda _tid: next(states))
+
+        manager = MagicMock()
+        manager._find_latest_for_thread = MagicMock(return_value=None)
+        manager.task_lock = asyncio.Lock()
+
+        with patch.object(sfl, "get_cache_client", return_value=cache), \
+             patch.object(sfl.WorkflowTracker, "get_instance", return_value=tracker), \
+             patch.object(sfl.BackgroundTaskManager, "get_instance", return_value=manager):
+            collected: list[str] = []
+            async for event in sfl.stream_from_log("t-leg", run_id=None, last_event_id=None):
+                collected.append(event)
+                if len(collected) > 10:
+                    break  # safety
+
+        # Multiple polls — at least the two while active and the terminal ones.
+        assert tracker.get_status.await_count >= 2
+
+    @pytest.mark.asyncio
+    async def test_terminal_when_tracker_returns_none(self):
+        """No status record at all ⇒ nothing to wait for; the consumer
+        falls through after draining whatever is in the stream."""
+        from src.server.handlers.chat import stream_from_log as sfl
+
+        cache = MagicMock()
+        cache.enabled = True
+        cache.client = MagicMock()
+        cache.client.xread = AsyncMock(side_effect=[[], []])
+
+        tracker = MagicMock()
+        tracker.get_status = AsyncMock(return_value=None)
+
+        manager = MagicMock()
+        manager._find_latest_for_thread = MagicMock(return_value=None)
+        manager.task_lock = asyncio.Lock()
+
+        with patch.object(sfl, "get_cache_client", return_value=cache), \
+             patch.object(sfl.WorkflowTracker, "get_instance", return_value=tracker), \
+             patch.object(sfl.BackgroundTaskManager, "get_instance", return_value=manager):
+            collected: list[str] = []
+            async for event in sfl.stream_from_log("t-leg", run_id=None, last_event_id=None):
+                collected.append(event)
+                if len(collected) > 5:
+                    break
+
+        # We polled the tracker, and exit happens after empty rounds.
+        assert tracker.get_status.await_count >= 1

--- a/tests/unit/tools/secretary/test_extract_from_redis.py
+++ b/tests/unit/tools/secretary/test_extract_from_redis.py
@@ -110,6 +110,53 @@ async def test_cache_disabled_returns_empty():
 
 
 @pytest.mark.asyncio
+async def test_extract_from_redis_uses_per_run_key_when_taskinfo_present():
+    """When BTM has a TaskInfo for the thread, read the per-run stream
+    (``workflow:stream:{tid}:{run_id}``) — not the legacy thread-only key."""
+    import asyncio
+    from datetime import datetime
+
+    from src.server.services.background_task_manager import (
+        BackgroundTaskManager,
+        TaskInfo,
+        TaskStatus,
+    )
+
+    info = TaskInfo(
+        thread_id="t-test",
+        run_id="r-test-123",
+        status=TaskStatus.RUNNING,
+        created_at=datetime.now(),
+    )
+    stub_btm = MagicMock()
+    stub_btm.task_lock = asyncio.Lock()
+    stub_btm._find_latest_for_thread = MagicMock(return_value=info)
+
+    cache = MagicMock()
+    cache.enabled = True
+    cache.client = MagicMock()
+    cache.client.xrevrange = AsyncMock(
+        return_value=[(b"1-0", {b"event": _sse(1, "per-run hit")})]
+    )
+
+    BackgroundTaskManager._instance = None
+    try:
+        with patch.object(
+            BackgroundTaskManager, "get_instance", return_value=stub_btm
+        ), patch(
+            "src.utils.cache.redis_cache.get_cache_client", return_value=cache
+        ):
+            text = await _extract_from_redis("t-test")
+    finally:
+        BackgroundTaskManager._instance = None
+
+    assert text == "per-run hit"
+    cache.client.xrevrange.assert_awaited_once_with(
+        "workflow:stream:t-test:r-test-123", count=500
+    )
+
+
+@pytest.mark.asyncio
 async def test_xrevrange_failure_returns_empty():
     cache = MagicMock()
     cache.enabled = True

--- a/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.demotion.test.ts
+++ b/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.demotion.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Tests the steering "demotion" path in handleSendSteering.
+ *
+ * When the user sends a follow-up while the agent is mid-stream, the UI
+ * POSTs to the same endpoint and tags the user message as `steering: true`.
+ * The backend usually replies with a ``steering_accepted`` SSE event and
+ * the message is delivered mid-turn.
+ *
+ * RACE: if the agent's previous turn flipped to a terminal state between
+ * the UI's ``isLoading`` snapshot and the POST landing, the backend opens
+ * a *new* turn instead. The very first event the UI sees is then the
+ * authoritative ``metadata`` frame for that fresh run (not
+ * ``steering_accepted``). The hook must DEMOTE the steering bubble back to
+ * a normal user message, append a fresh assistant placeholder, and route
+ * all subsequent chunks into that new assistant — otherwise the new turn
+ * would render on top of the previous turn's assistant bubble.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+import { act, waitFor } from '@testing-library/react';
+import { renderHookWithProviders } from '@/test/utils';
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before any imports that depend on them
+// ---------------------------------------------------------------------------
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+vi.mock('@/lib/supabase', () => ({ supabase: null }));
+
+vi.mock('../utils/threadStorage', () => ({
+  getStoredThreadId: vi.fn().mockReturnValue(null),
+  setStoredThreadId: vi.fn(),
+  removeStoredThreadId: vi.fn(),
+}));
+
+// The real handleTextContent mutates the assistant message via the setter
+// it receives. We capture the calls so we can assert chunks were routed
+// to the *new* (demoted) assistant message id, not the old one.
+const textContentCalls: Array<{ assistantMessageId: string; text: string }> = [];
+
+vi.mock('../utils/streamEventHandlers', () => ({
+  handleReasoningSignal: vi.fn(),
+  handleReasoningContent: vi.fn(),
+  handleTextContent: vi.fn(({ event, assistantMessageId }) => {
+    textContentCalls.push({
+      assistantMessageId,
+      text: (event?.content as string) || '',
+    });
+    return true;
+  }),
+  handleToolCalls: vi.fn(),
+  handleToolCallResult: vi.fn(),
+  handleToolCallChunks: vi.fn(),
+  handleTodoUpdate: vi.fn(),
+  isSubagentEvent: vi.fn().mockReturnValue(false),
+  handleSubagentMessageChunk: vi.fn(),
+  handleSubagentToolCallChunks: vi.fn(),
+  handleSubagentToolCalls: vi.fn(),
+  handleSubagentToolCallResult: vi.fn(),
+  handleTaskSteeringAccepted: vi.fn(),
+  getOrCreateTaskRefs: vi.fn().mockReturnValue({
+    contentOrderCounterRef: { current: 0 },
+    currentReasoningIdRef: { current: null },
+    currentToolCallIdRef: { current: null },
+  }),
+}));
+
+vi.mock('../utils/historyEventHandlers', () => ({
+  handleHistoryUserMessage: vi.fn(),
+  handleHistoryReasoningSignal: vi.fn(),
+  handleHistoryReasoningContent: vi.fn(),
+  handleHistoryTextContent: vi.fn(),
+  handleHistoryToolCalls: vi.fn(),
+  handleHistoryToolCallResult: vi.fn(),
+  handleHistoryTodoUpdate: vi.fn(),
+  handleHistorySteeringDelivered: vi.fn(),
+  handleHistoryInterrupt: vi.fn(),
+  handleHistoryArtifact: vi.fn(),
+}));
+
+vi.mock('../../utils/api', () => ({
+  sendChatMessageStream: vi.fn(),
+  sendHitlResponse: vi.fn(),
+  replayThreadHistory: vi.fn().mockResolvedValue(undefined),
+  getWorkflowStatus: vi.fn().mockResolvedValue({ can_reconnect: false, status: 'completed' }),
+  reconnectToWorkflowStream: vi.fn(),
+  streamSubagentTaskEvents: vi.fn(),
+  fetchThreadTurns: vi.fn().mockResolvedValue({ turns: [], retry_checkpoint_id: null }),
+  submitFeedback: vi.fn(),
+  removeFeedback: vi.fn(),
+  getThreadFeedback: vi.fn().mockResolvedValue([]),
+  watchThread: vi.fn(),
+}));
+
+import { sendChatMessageStream } from '../../utils/api';
+import { useChatMessages } from '../useChatMessages';
+import type { UserMessage, AssistantMessage } from '@/types/chat';
+
+const mockSendStream = sendChatMessageStream as Mock;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type OnEvent = (e: Record<string, unknown>) => void;
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (v: T) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+describe('useChatMessages — handleSendSteering demotion path', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    textContentCalls.length = 0;
+  });
+
+  it('first non-steering event demotes the steering bubble to a new turn', async () => {
+    // First call: hang forever so isLoading stays true while we trigger
+    // the second (steering) POST. We capture the onEvent callback in case
+    // we need to release it, but the test only needs the side effects of
+    // the SECOND call's events.
+    const firstHang = deferred<{ disconnected: boolean }>();
+    let secondOnEvent: OnEvent | null = null;
+
+    mockSendStream.mockImplementation(
+      async (
+        _msg: string,
+        _ws: string,
+        _tid: string | null,
+        _hist: unknown[],
+        _plan: boolean,
+        onEvent: OnEvent,
+      ) => {
+        if (mockSendStream.mock.calls.length === 1) {
+          // Emit thread_id so subsequent history-load short-circuits.
+          onEvent({ event: 'thread_id', thread_id: 'thread-demote-1' });
+          return firstHang.promise;
+        }
+        // Second call = the steering POST. Capture the callback for the
+        // test to drive directly.
+        secondOnEvent = onEvent;
+        return { disconnected: false };
+      },
+    );
+
+    const { result } = renderHookWithProviders(() =>
+      useChatMessages('ws-demote'),
+    );
+
+    // Fire the first message and let `isLoading` flip to true.
+    let firstSend: Promise<unknown> = Promise.resolve();
+    await act(async () => {
+      firstSend = result.current.handleSendMessage('first turn', false);
+      // Yield once so the synchronous setIsLoading flush propagates.
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    // Second send while still streaming → routes to handleSendSteering.
+    let steeringSend: Promise<unknown> = Promise.resolve();
+    await act(async () => {
+      steeringSend = result.current.handleSendMessage('follow-up steering', false);
+      // Let the handler kick off and the mock implementation run.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Two POSTs total now (original + steering).
+    expect(mockSendStream).toHaveBeenCalledTimes(2);
+    expect(secondOnEvent).not.toBeNull();
+
+    // The user message added by handleSendSteering should be tagged
+    // ``steering: true`` initially.
+    await waitFor(() => {
+      const userMsgs = result.current.messages.filter(
+        (m): m is UserMessage => m.role === 'user',
+      );
+      // Two user messages: the original send and the steering send.
+      expect(userMsgs.length).toBeGreaterThanOrEqual(2);
+      const steeringUser = userMsgs[userMsgs.length - 1];
+      expect((steeringUser as UserMessage & { steering?: boolean }).steering).toBe(true);
+    });
+
+    // Snapshot the assistants BEFORE demotion fires, so we can detect the
+    // newly-appended one.
+    const assistantsBefore = result.current.messages.filter(
+      (m) => m.role === 'assistant',
+    );
+
+    // First non-steering event from the steering stream = backend opened a
+    // new turn instead of accepting steering mid-flight. Per the SSE
+    // protocol, the very first frame is ``metadata`` carrying the new run_id.
+    await act(async () => {
+      secondOnEvent!({
+        event: 'metadata',
+        thread_id: 'thread-demote-1',
+        run_id: 'run-demoted-1',
+      });
+      // A subsequent message_chunk should render into the *new* assistant.
+      secondOnEvent!({
+        event: 'message_chunk',
+        role: 'assistant',
+        content: 'demoted reply',
+        content_type: 'text',
+        agent: 'main',
+        id: 'msg-demoted-1',
+      });
+      await Promise.resolve();
+    });
+
+    // ---- (a) the user message is no longer flagged as steering ---------
+    await waitFor(() => {
+      const userMsgs = result.current.messages.filter(
+        (m): m is UserMessage => m.role === 'user',
+      );
+      const steeringUser = userMsgs[userMsgs.length - 1] as UserMessage & {
+        steering?: boolean;
+      };
+      expect(steeringUser.steering).toBeFalsy();
+    });
+
+    // ---- (b) a new assistant placeholder was appended ------------------
+    const assistantsAfter = result.current.messages.filter(
+      (m): m is AssistantMessage => m.role === 'assistant',
+    );
+    expect(assistantsAfter.length).toBe(assistantsBefore.length + 1);
+    const demotedAssistant = assistantsAfter[assistantsAfter.length - 1];
+    // The demoted assistant must be a fresh id, not the original one.
+    if (assistantsBefore.length > 0) {
+      expect(demotedAssistant.id).not.toBe(assistantsBefore[0].id);
+    }
+
+    // ---- (c) message_chunk content was routed into the NEW assistant ---
+    // We mocked handleTextContent so it records the target assistantMessageId.
+    expect(textContentCalls.length).toBeGreaterThan(0);
+    const routedTo = textContentCalls[textContentCalls.length - 1].assistantMessageId;
+    expect(routedTo).toBe(demotedAssistant.id);
+
+    // Cleanup: release the first hang so the original POST resolves and
+    // the awaiting handlers finish without leaking timers.
+    firstHang.resolve({ disconnected: false });
+    await act(async () => {
+      await firstSend.catch(() => undefined);
+      await steeringSend.catch(() => undefined);
+    });
+  });
+});

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -18,7 +18,7 @@ import { type SubagentTokenUsage, ZERO_USAGE, extractTokenUsageDelta, accumulate
 import { computeSteeringBoundary, shouldSkipSteeringRollback } from '../utils/steeringRollback';
 export { removeStoredThreadId } from './utils/threadStorage';
 import { createUserMessage, createAssistantMessage, createNotificationMessage, appendMessage, updateMessage, type AttachmentMeta } from './utils/messageHelpers';
-import type { ChatMessage, AssistantMessage } from '@/types/chat';
+import type { ChatMessage, AssistantMessage, UserMessage } from '@/types/chat';
 import type { ActionRequest, ToolCallData, TodoItem } from '@/types/sse';
 import type { HtmlWidgetData, PreviewData } from './utils/types';
 import { createRecentlySentTracker } from './utils/recentlySentTracker';
@@ -149,6 +149,7 @@ interface SSEEvent {
   active_tasks?: string[];
   can_reconnect?: boolean;
   is_shared?: boolean;
+  run_id?: string;
   [key: string]: unknown;
 }
 
@@ -602,6 +603,12 @@ export function useChatMessages(
 
   // Track the last received SSE event ID for reconnection
   const lastEventIdRef = useRef<number | string | null>(null);
+  // Track the active run_id for this thread. Populated from the SSE
+  // ``metadata`` event (first event of every workflow stream) so reconnect
+  // can target the exact ``workflow:stream:{tid}:{rid}`` key and so the
+  // steering handler can detect when a POST was routed as a new turn
+  // (race: status flipped terminal between isLoading check and POST land).
+  const currentRunIdRef = useRef<string | null>(null);
   // Ref-based thread ID for use inside closures (avoids stale React state in callbacks)
   const threadIdRef = useRef(threadId);
   // Batch back-to-back offload events into a single notification
@@ -2103,7 +2110,12 @@ export function useChatMessages(
       // Replay buffered events first — this processes artifact{task,spawned} events
       // which create subagent cards with the correct description/type. Per-task streams
       // are opened AFTER so they merge into existing cards instead of creating empty ones.
-      const result = await reconnectToWorkflowStream(threadId, lastEventIdRef.current as number | null, processEvent);
+      const result = await reconnectToWorkflowStream(
+        threadId,
+        currentRunIdRef.current,
+        lastEventIdRef.current as number | null,
+        processEvent,
+      );
       if (result?.disconnected) {
         throw new Error('Reconnection stream disconnected');
       }
@@ -2649,6 +2661,16 @@ export function useChatMessages(
       // Track last event ID for reconnection
       if (event._eventId != null) {
         lastEventIdRef.current = event._eventId;
+      }
+
+      // The ``metadata`` event is the first event of every workflow stream
+      // and carries the authoritative run_id for this turn. Latch it so
+      // reconnect targets ``workflow:stream:{tid}:{rid}`` precisely.
+      if (eventType === 'metadata') {
+        if (event.run_id) {
+          currentRunIdRef.current = event.run_id;
+        }
+        return;
       }
 
       // compaction_chunk is the side channel for LLM output from the
@@ -3654,6 +3676,16 @@ export function useChatMessages(
   /**
    * Handles sending a message while the agent is already streaming (steering).
    * The backend will accept it for injection before the next LLM call.
+   *
+   * Demotion path: the frontend's ``isLoading`` lags the backend's task status by
+   * the SSE-drain window. If the user sends after the workflow has flipped to a
+   * terminal status but before the terminal SSE event reaches us, ``wait_or_steer``
+   * routes this POST as a new turn instead of steering. The backend emits an
+   * authoritative ``metadata`` event (with a fresh ``run_id``) as the first event
+   * of the new turn's stream — receipt of any ``metadata`` event on the steering
+   * POST means we got routed as a new turn. We demote the user bubble (strip the
+   * badge) and switch subsequent events to the standard stream processor so the
+   * new turn renders normally.
    */
   const handleSendSteering = async (message: string, planMode: boolean = false, additionalContext: Record<string, unknown>[] | null = null, attachmentMeta: Record<string, unknown>[] | null = null) => {
     // Show user message in chat with steering indicator
@@ -3661,6 +3693,46 @@ export function useChatMessages(
     const userMessage: MessageRecord = { ...userMsg, steering: true };
     recentlySentTrackerRef.current.track(message.trim(), userMessage.timestamp, userMessage.id);
     setMessages((prev) => appendMessage(prev,userMessage));
+
+    let demotedToNewTurn = false;
+    let demotedProcessor: ((event: SSEEvent) => void) | null = null;
+    let demotedAssistantId: string | null = null;
+    const demotedInterruptedRef = { current: false };
+
+    const demoteToNewTurn = (): void => {
+      demotedToNewTurn = true;
+      setMessages((prev) =>
+        updateMessage(prev, userMessage.id as string, (msg) => {
+          if (msg.role !== 'user') return msg;
+          const next: UserMessage & { queuePosition?: unknown; queueError?: unknown } = { ...msg };
+          delete next.steering;
+          delete next.queuePosition;
+          delete next.queueError;
+          return next;
+        })
+      );
+      const newAssistantId = `assistant-${Date.now()}`;
+      demotedAssistantId = newAssistantId;
+      contentOrderCounterRef.current = 0;
+      currentReasoningIdRef.current = null;
+      currentToolCallIdRef.current = null;
+      const assistantMessage = createAssistantMessage(newAssistantId);
+      setMessages((prev) => appendMessage(prev, assistantMessage));
+      currentMessageRef.current = newAssistantId;
+      isStreamingRef.current = true;
+      setIsLoading(true);
+      const refs = {
+        contentOrderCounterRef,
+        currentReasoningIdRef,
+        currentToolCallIdRef,
+        steeringAtOrderRef,
+        updateTodoListCard: updateTodoListCard || undefined,
+        isNewConversation: false,
+        subagentStateRefs: subagentStateRefsRef.current,
+        updateSubagentCard: updateSubagentCard || (() => {}),
+      };
+      demotedProcessor = createStreamEventProcessor(newAssistantId, refs, getTaskIdFromEvent, demotedInterruptedRef);
+    };
 
     try {
       // Send to same endpoint — backend will auto-accept steering and return steering_accepted SSE
@@ -3686,6 +3758,20 @@ export function useChatMessages(
                 queuePosition: event.position,
               }))
             );
+            return;
+          }
+          // First non-steering event = backend routed as a new turn (race: status
+          // flipped to terminal before our POST landed). The first frame in that
+          // case is the authoritative ``metadata`` event (carrying a fresh
+          // run_id) per the backend SSE protocol; we also accept any other
+          // non-steering event here as defense-in-depth (e.g. an early error
+          // before workflow start). The demoted processor handles ``metadata``
+          // itself — it stores ``run_id`` into ``currentRunIdRef``.
+          if (!demotedToNewTurn) {
+            demoteToNewTurn();
+          }
+          if (demotedProcessor) {
+            demotedProcessor(event);
           }
         },
         additionalContext,
@@ -3698,9 +3784,45 @@ export function useChatMessages(
         null,
         null,
         platform,
+        // If the backend demotes this steering POST to a new turn, latch the
+        // fresh run_id from response headers immediately so a mid-stream
+        // disconnect can reconnect to the right workflow:stream key.
+        (runId) => {
+          currentRunIdRef.current = runId;
+        },
       );
+      if (demotedToNewTurn) {
+        const finalId = currentMessageRef.current || demotedAssistantId;
+        if (finalId) {
+          setMessages((prev) =>
+            updateMessage(prev, finalId, (msg) => ({
+              ...msg,
+              isStreaming: false,
+            }))
+          );
+          if (!demotedInterruptedRef.current) {
+            cleanupAfterStreamEnd(finalId);
+          }
+        }
+      }
     } catch (err: unknown) {
       console.error('Error sending steering:', err);
+      if (demotedToNewTurn && demotedAssistantId) {
+        // Demoted path: the failure belongs to the new turn's assistant, not the steering badge.
+        const finalAssistantId = demotedAssistantId;
+        setMessages((prev) =>
+          updateMessage(prev, finalAssistantId, (msg) => ({
+            ...msg,
+            content: msg.content || 'Failed to send message. Please try again.',
+            isStreaming: false,
+            error: true,
+          }))
+        );
+        setMessageError((err as Error).message || 'Failed to send message');
+        isStreamingRef.current = false;
+        setIsLoading(false);
+        return;
+      }
       // Update user message to show steering failure
       setMessages((prev) =>
         updateMessage(prev,userMessage.id as string, (msg) => ({
@@ -3794,6 +3916,10 @@ export function useChatMessages(
     contentOrderCounterRef.current = 0;
     currentReasoningIdRef.current = null;
     currentToolCallIdRef.current = null;
+    // Clear the active run_id; the new turn's metadata frame will repopulate
+    // it. Prevents a stale run_id from biasing a reconnect into an older
+    // ``workflow:stream:{tid}:{rid}`` key.
+    currentRunIdRef.current = null;
 
     const assistantMessage = createAssistantMessage(assistantMessageId);
 
@@ -3838,6 +3964,12 @@ export function useChatMessages(
         reasoningEffort || null,
         fastMode || null,
         platform,
+        // Latch run_id from Content-Location BEFORE the first SSE body byte —
+        // closes the reconnect race window if the stream drops between our
+        // pre-POST clear (line ~3916) and the new turn's first metadata event.
+        (runId) => {
+          currentRunIdRef.current = runId;
+        },
       );
 
       if (result?.disconnected) {
@@ -3937,6 +4069,10 @@ export function useChatMessages(
     contentOrderCounterRef.current = 0;
     currentReasoningIdRef.current = null;
     currentToolCallIdRef.current = null;
+    // HITL resume always opens a fresh run on the backend (1:1 with
+    // ``conversation_response_id``); clear the stale ref so the new turn's
+    // metadata frame is the source of truth.
+    currentRunIdRef.current = null;
 
     const assistantMessage = createAssistantMessage(assistantMessageId);
     setMessages((prev) => appendMessage(prev, assistantMessage));
@@ -3970,7 +4106,15 @@ export function useChatMessages(
         processEvent,
         planMode,
         lastModelOptionsRef.current as { model?: string; reasoningEffort?: string; fastMode?: boolean },
-        agentMode
+        agentMode,
+        // Latch the fresh run_id from response headers before the first SSE
+        // body byte. Without this, an early disconnect (between the pre-POST
+        // clear at line ~4063 and the metadata frame) would let
+        // attemptReconnectAfterDisconnect fall back to the prior
+        // SOFT_INTERRUPTED TaskInfo and silently hang.
+        (runId) => {
+          currentRunIdRef.current = runId;
+        },
       );
 
       if (result?.disconnected) {
@@ -4260,6 +4404,9 @@ export function useChatMessages(
     contentOrderCounterRef.current = 0;
     currentReasoningIdRef.current = null;
     currentToolCallIdRef.current = null;
+    // Edit/regenerate opens a fresh backend run; clear the prior run_id so
+    // the new metadata frame becomes the source of truth.
+    currentRunIdRef.current = null;
 
     const assistantMessage = createAssistantMessage(assistantMessageId);
     const userMessage = message ? createUserMessage(message) : null;
@@ -4313,6 +4460,11 @@ export function useChatMessages(
         modelOptions.reasoningEffort || null,
         modelOptions.fastMode || null,
         platform,
+        // Latch run_id from response headers — see handleSendMessage for the
+        // same closing-the-race rationale.
+        (runId) => {
+          currentRunIdRef.current = runId;
+        },
       );
 
       if (result?.disconnected) {

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -3698,9 +3698,18 @@ export function useChatMessages(
     let demotedProcessor: ((event: SSEEvent) => void) | null = null;
     let demotedAssistantId: string | null = null;
     const demotedInterruptedRef = { current: false };
+    // Stash the Content-Location run_id but DO NOT commit it to
+    // currentRunIdRef until we've seen evidence that this POST actually
+    // started a new workflow (i.e., demoteToNewTurn fires). Committing
+    // eagerly on Content-Location alone would overwrite the active
+    // workflow's run_id when the backend routes this as steering-only.
+    let pendingRunIdFromHeader: string | null = null;
 
     const demoteToNewTurn = (): void => {
       demotedToNewTurn = true;
+      if (pendingRunIdFromHeader) {
+        currentRunIdRef.current = pendingRunIdFromHeader;
+      }
       setMessages((prev) =>
         updateMessage(prev, userMessage.id as string, (msg) => {
           if (msg.role !== 'user') return msg;
@@ -3784,11 +3793,13 @@ export function useChatMessages(
         null,
         null,
         platform,
-        // If the backend demotes this steering POST to a new turn, latch the
-        // fresh run_id from response headers immediately so a mid-stream
-        // disconnect can reconnect to the right workflow:stream key.
+        // Stash the Content-Location run_id but defer the commit until
+        // demoteToNewTurn fires. Backend emits Content-Location on every
+        // POST including pure-steering responses; committing eagerly would
+        // overwrite the active workflow's run_id with a stream key that
+        // never gets written to.
         (runId) => {
-          currentRunIdRef.current = runId;
+          pendingRunIdFromHeader = runId;
         },
       );
       if (demotedToNewTurn) {

--- a/web/src/pages/ChatAgent/utils/__tests__/api.test.ts
+++ b/web/src/pages/ChatAgent/utils/__tests__/api.test.ts
@@ -147,6 +147,7 @@ describe('ChatAgent API utilities', () => {
       global.fetch = vi.fn().mockResolvedValue({
         ok: true,
         status: 200,
+        headers: new Headers(),
         body: {
           getReader: () => ({
             read: vi.fn().mockResolvedValue({ done: true, value: undefined }),
@@ -200,6 +201,67 @@ describe('ChatAgent API utilities', () => {
       expect(body.llm_model).toBe('gpt-4o');
       expect(body.reasoning_effort).toBe('high');
       expect(body.fast_mode).toBe(true);
+    });
+
+    it('invokes onRunIdResolved with the run_id from Content-Location BEFORE reading the body', async () => {
+      // Track ordering: did onRunIdResolved fire before any reader.read() call?
+      const callOrder: string[] = [];
+      const readMock = vi.fn().mockImplementation(() => {
+        callOrder.push('body-read');
+        return Promise.resolve({ done: true, value: undefined });
+      });
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers({
+          'Content-Location': '/api/v1/threads/t-1/messages/stream?run_id=abc-123',
+        }),
+        body: {
+          getReader: () => ({ read: readMock }),
+        },
+      });
+
+      const onRunIdResolved = vi.fn().mockImplementation((rid: string) => {
+        callOrder.push(`run-id:${rid}`);
+      });
+
+      await sendHitlResponse(
+        'ws-1', 't-1',
+        { int1: { decisions: [{ type: 'approve' }] } },
+        () => {},
+        false,
+        {},
+        'ptc',
+        onRunIdResolved,
+      );
+
+      expect(onRunIdResolved).toHaveBeenCalledTimes(1);
+      expect(onRunIdResolved).toHaveBeenCalledWith('abc-123');
+      // The run_id MUST be latched before any body byte is read.
+      expect(callOrder[0]).toBe('run-id:abc-123');
+    });
+
+    it('does NOT invoke onRunIdResolved when Content-Location lacks run_id', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'Content-Location': '/api/v1/threads/t-1/messages/stream' }),
+        body: {
+          getReader: () => ({ read: vi.fn().mockResolvedValue({ done: true, value: undefined }) }),
+        },
+      });
+
+      const onRunIdResolved = vi.fn();
+      await sendHitlResponse(
+        'ws-1', 't-1',
+        { int1: { decisions: [{ type: 'approve' }] } },
+        () => {},
+        false,
+        {},
+        'ptc',
+        onRunIdResolved,
+      );
+      expect(onRunIdResolved).not.toHaveBeenCalled();
     });
   });
 });

--- a/web/src/pages/ChatAgent/utils/api.ts
+++ b/web/src/pages/ChatAgent/utils/api.ts
@@ -133,12 +133,47 @@ export async function updateThreadTitle(threadId: string, title: string | null) 
 
 // --- Streaming (fetch + ReadableStream; axios not used) ---
 
+/**
+ * Parse a `run_id` query parameter out of a backend `Content-Location` header
+ * value such as `/api/v1/threads/{tid}/messages/stream?run_id={uuid}`.
+ * Returns `null` when the value is missing or has no `run_id` param.
+ */
+export function parseRunIdFromContentLocation(
+  contentLocation: string | null | undefined,
+): string | null {
+  if (!contentLocation) return null;
+  const qIdx = contentLocation.indexOf('?');
+  if (qIdx === -1) return null;
+  try {
+    const params = new URLSearchParams(contentLocation.slice(qIdx + 1));
+    const runId = params.get('run_id');
+    return runId && runId.length > 0 ? runId : null;
+  } catch {
+    return null;
+  }
+}
+
 async function streamFetch(
   url: string,
   opts: RequestInit,
-  onEvent: (event: Record<string, unknown>) => void
-) {
+  onEvent: (event: Record<string, unknown>) => void,
+  onHeaders?: (contentLocation: string | null) => void,
+): Promise<{ disconnected: boolean; contentLocation: string | null }> {
   const res = await fetch(`${baseURL}${url}`, opts);
+  // Snapshot Content-Location before body errors so callers can recover the
+  // canonical reconnect URL (carries ?run_id=…) even when a 4xx aborts later.
+  const contentLocation = res.headers.get('Content-Location');
+  // Notify the caller of headers IMMEDIATELY — well before any SSE body byte —
+  // so the run_id can be latched before the first `metadata` event arrives.
+  // Closes the reconnect race window between "clear stale run_id" and "new
+  // turn's first metadata frame" (see useChatMessages.resumeWithHitlResponse).
+  if (onHeaders) {
+    try {
+      onHeaders(contentLocation);
+    } catch (e) {
+      console.warn('[api] onHeaders callback threw', e);
+    }
+  }
   if (!res.ok) {
     // Handle 429 (rate limit) with structured detail
     if (res.status === 429) {
@@ -224,7 +259,7 @@ async function streamFetch(
       throw error;
     }
   }
-  return { disconnected };
+  return { disconnected, contentLocation };
 }
 
 export async function replayThreadHistory(threadId: string, onEvent: (event: Record<string, unknown>) => void = () => {}) {
@@ -250,6 +285,7 @@ export async function sendChatMessageStream(
   reasoningEffort: string | null = null,
   fastMode: boolean | null = null,
   platform: string | null = null,
+  onRunIdResolved: ((runId: string) => void) | null = null,
 ) {
   // For checkpoint replay (regenerate/retry), send empty messages
   const messages = checkpointId && !message
@@ -293,7 +329,13 @@ export async function sendChatMessageStream(
       },
       body: JSON.stringify(body),
     },
-    onEvent
+    onEvent,
+    onRunIdResolved
+      ? (contentLocation) => {
+          const runId = parseRunIdFromContentLocation(contentLocation);
+          if (runId) onRunIdResolved(runId);
+        }
+      : undefined,
   );
 }
 
@@ -370,18 +412,29 @@ export function watchThread(
 }
 
 /**
- * Reconnect to an in-progress workflow stream (replays buffered events, then live stream)
+ * Reconnect to an in-progress workflow stream (replays buffered events, then live stream).
+ *
+ * When ``runId`` is provided, the backend targets the exact per-run Redis
+ * stream key (``workflow:stream:{tid}:{rid}``). When omitted, the backend
+ * falls back to the latest run on the thread.
+ *
  * @param {string} threadId - The thread ID to reconnect to
+ * @param {string|null} runId - The specific run to target; null = latest
  * @param {number|null} lastEventId - Last received event ID for deduplication
  * @param {Function} onEvent - Callback for each SSE event
  */
 export async function reconnectToWorkflowStream(
   threadId: string,
+  runId: string | null = null,
   lastEventId: number | null = null,
   onEvent: (event: Record<string, unknown>) => void = () => {}
 ) {
   if (!threadId) throw new Error('Thread ID is required');
-  const queryParam = lastEventId != null ? `?last_event_id=${lastEventId}` : '';
+  const params = new URLSearchParams();
+  if (runId) params.set('run_id', runId);
+  if (lastEventId != null) params.set('last_event_id', String(lastEventId));
+  const query = params.toString();
+  const queryParam = query ? `?${query}` : '';
   const authHeaders = await getAuthHeaders();
   return await streamFetch(
     `/api/v1/threads/${threadId}/messages/stream${queryParam}`,
@@ -544,7 +597,8 @@ export async function sendHitlResponse(
   onEvent: (event: Record<string, unknown>) => void = () => {},
   planMode: boolean = false,
   modelOptions: { model?: string; reasoningEffort?: string; fastMode?: boolean } = {},
-  agentMode: string = 'ptc'
+  agentMode: string = 'ptc',
+  onRunIdResolved: ((runId: string) => void) | null = null,
 ) {
   const body: Record<string, unknown> = {
     workspace_id: workspaceId,
@@ -568,7 +622,13 @@ export async function sendHitlResponse(
       },
       body: JSON.stringify(body),
     },
-    onEvent
+    onEvent,
+    onRunIdResolved
+      ? (contentLocation) => {
+          const runId = parseRunIdFromContentLocation(contentLocation);
+          if (runId) onRunIdResolved(runId);
+        }
+      : undefined,
   );
 }
 

--- a/web/src/pages/MarketView/hooks/useMarketChat.ts
+++ b/web/src/pages/MarketView/hooks/useMarketChat.ts
@@ -130,6 +130,14 @@ export function useMarketChat(): UseMarketChatReturn {
   const threadIdRef = useRef('__default__');
   const contentOrderCounterRef = useRef(0);
   const currentReasoningIdRef = useRef<string | null>(null);
+  // Track the active run_id for this thread. Populated from the SSE
+  // ``metadata`` event (first event of every workflow stream) so any
+  // future reconnect path can target ``workflow:stream:{tid}:{rid}``
+  // precisely. MarketView's flash chat currently has no SSE reconnect
+  // surface (only the market-data WebSocket reconnects); captured here
+  // for parity with ChatAgent's useChatMessages so the ref is ready if
+  // a reconnect helper is added later.
+  const currentRunIdRef = useRef<string | null>(null);
 
   // --- Batching infrastructure ---
   // Pending updates accumulate here; flushed on a timer
@@ -394,6 +402,10 @@ export function useMarketChat(): UseMarketChatReturn {
     const assistantMessageId = `assistant-${Date.now()}`;
     contentOrderCounterRef.current = 0;
     currentReasoningIdRef.current = null;
+    // Clear the active run_id so the new turn's ``metadata`` frame becomes
+    // the source of truth. Prevents a stale run_id from biasing any future
+    // reconnect into a prior run's buffered stream.
+    currentRunIdRef.current = null;
 
     const assistantMessage = createAssistantMessage(assistantMessageId);
     setMessages((prev) => appendMessage(prev, assistantMessage));
@@ -416,6 +428,18 @@ export function useMarketChat(): UseMarketChatReturn {
           // Update thread_id if provided in the event
           if (event.thread_id && event.thread_id !== threadIdRef.current && event.thread_id !== '__default__') {
             threadIdRef.current = event.thread_id as string;
+          }
+
+          // The ``metadata`` event is the first event of every workflow
+          // stream and carries the authoritative run_id for this turn.
+          // Latch it so any future reconnect path can target
+          // ``workflow:stream:{tid}:{rid}`` precisely. Return early so it
+          // doesn't fall through to the message handlers.
+          if (eventType === 'metadata') {
+            if (event.run_id) {
+              currentRunIdRef.current = event.run_id as string;
+            }
+            return;
           }
 
           // Handle different event types

--- a/web/src/types/sse.ts
+++ b/web/src/types/sse.ts
@@ -1,6 +1,7 @@
 /** SSE event type union and per-event interfaces */
 
 export type SSEEventType =
+  | 'metadata'
   | 'reasoning_signal'
   | 'reasoning_content'
   | 'message_chunk'
@@ -23,6 +24,17 @@ export interface BaseSSEEvent {
   agent?: string;
   _eventId?: number | string;
   timestamp?: string | number;
+}
+
+/**
+ * First event of every workflow stream. Announces the authoritative
+ * ``run_id`` for this turn so the client can latch reconnect/demotion
+ * logic onto it. Mirrors the langgraph_sdk SSE ``metadata`` payload.
+ */
+export interface MetadataEvent extends BaseSSEEvent {
+  event: 'metadata';
+  run_id: string;
+  thread_id: string;
 }
 
 export interface ReasoningSignalEvent extends BaseSSEEvent {
@@ -181,6 +193,7 @@ export interface FinishEvent extends BaseSSEEvent {
 
 /** Discriminated union of all SSE events */
 export type SSEEvent =
+  | MetadataEvent
   | ReasoningSignalEvent
   | ReasoningContentEvent
   | MessageChunkEvent


### PR DESCRIPTION
## Summary

Adopts LangGraph `run_id` as the first-class per-turn identity across the langalpha chat service. Replaces identity-guard scaffolding (`expected=task_info` plumbing, `acquire_for_new_execution` evict-before-construct, captured-TaskInfo identity capture) with `(thread_id, run_id)` keying that makes cross-turn state leakage categorically impossible. `run_id == conversation_response_id` 1:1 — generated once at handler entry, threaded through workflow → BTM → Redis stream keys → SSE `metadata` event → DB.

**Backend — per-turn identity refactor (`652ebcd2`)**
- New `run_id = uuid4()` at `threads.py` handler entry, single generation site.
- Persistence: `persist_completion/interrupt/failed/cancelled` accept `response_id`; `_service_instances` re-keyed to `(thread_id, run_id)`.
- BTM `tasks` re-keyed to `(tid, rid)`; Redis stream → `workflow:stream:{tid}:{rid}`; `WorkflowTracker.status` blob carries `run_id`.
- Compat shim: `_stream_from_redis_log` falls back to legacy `workflow:stream:{tid}` when run_id missing (5 lines, removable next deploy).
- Removed `_reset_event_buffer_state`, `expected=` guards, `acquire_for_new_execution`, `dispatch_kind` slot uniqueness.

**Subagent isolation (`96e5bc60`)**
- `BackgroundTaskRegistry.register()` accepts explicit `run_id`; middleware reads from `request.runtime.config["run_id"]` instead of shared `current_run_id` cell. Concurrent turns can no longer overwrite each other's spawned-task `run_id`.

**Frontend — SSE metadata + authoritative demotion (`a316df59`)**
- `useChatMessages` consumes `event: metadata` to populate `currentRunIdRef`; reconnect URL includes `run_id`.
- Steering demotion is now authoritative (driven by `metadata` event with new `run_id`) instead of the heuristic "first non-steering event" check. Bookkeeping in `handleSendSteering` simplified.

**Cross-turn race fixes (`04ef2499`)**
- WorkflowTracker `mark_completed/failed/cancelled/soft_interrupted` accept `run_id` and CAS-check stored vs provided before writing — prevents a stale terminal from clobbering a fresh turn.
- `threads.py:181` dispatched-failure cleanup now reads `status.get("run_id")` (was `meta.get("run_id")`, always None after the refactor).
- `stream_from_log` falls back to `WorkflowTracker` then legacy key when `?run_id=` is absent.
- Steering Content-Location latch is stashed instead of committed — demotion only fires when first non-steering event lands.

**Docs (`7983c7d4`)**
- `docs/api/README.md` documents `metadata` event, `?run_id=` reconnect, `Content-Location` header, and the missing event-type entries (`reasoning_content`, `tool_call_chunks`, etc.).

## Diff Size

- Total: 37 files changed, 3517 insertions(+), 1399 deletions(-)
- Net (excl. tests): 21 files changed, 1705 insertions(+), 1333 deletions(-)

## Test Coverage

```
CODE PATHS                                                  USER FLOWS
[+] src/server/app/threads.py                               [+] POST /messages (foreground)
  ├── _handle_send_message (run_id generation)                ├── [★★★ TESTED] Content-Location + metadata first  — e2e T1
  │   ├── [★★★ TESTED] foreground POST → run_id in header   └── [★★★ TESTED] Reconnect by run_id resumes        — e2e T2
  │   ├── [★★★ TESTED] dispatched POST → run_id in JSON
  │   └── [★★★ TESTED] dispatched failure cleanup (status guard)  [+] POST /messages (dispatched)
  └── _stream_from_log                                         ├── [★★★ TESTED] returns run_id JSON              — e2e T3
      ├── [★★★ TESTED] per-run key reconnect                  └── [★★★ TESTED] concurrent dispatched → 409      — e2e T4
      ├── [★★★ TESTED] WorkflowTracker fallback (run_id None)
      └── [★★★ TESTED] legacy stream fallback (compat shim)  [+] Concurrent POST race
                                                                ├── [★★★ TESTED] foreground → steering           — e2e T5
[+] src/server/services/background_task_manager.py            └── [★★★ TESTED] dispatched → 409
  ├── (tid, rid) keying — all CRUD paths                    [+] DB persistence
  ├── [★★★ TESTED] terminal status passes run_id to tracker   └── [★★★ TESTED] run_id == conversation_response_id — e2e T6
  └── [★★★ TESTED] subagent registry race fix                [+] PTC workspace bringup
                                                                └── [★★★ TESTED] workspace_status → metadata → chunks — e2e T7
[+] src/server/services/workflow_tracker.py
  └── [★★★ TESTED] CAS-guard mark_completed/failed/cancelled  [+] Frontend
                                                                ├── [★★★ TESTED] metadata event populates currentRunIdRef
[+] src/ptc_agent/.../background_subagent/registry.py         ├── [★★★ TESTED] reconnect URL includes run_id
  └── [★★★ TESTED] explicit run_id per task (no shared cell)  └── [★★★ TESTED] steering demotion driven by metadata

[+] web/src/pages/ChatAgent/hooks/useChatMessages.ts
  ├── [★★★ TESTED] currentRunIdRef populated from metadata
  └── [★★★ TESTED] pendingRunIdFromHeader stash + demote-commit
```

Backend: 3464 tests pass. Frontend: 1116 tests pass. Live e2e wire-contract sweep against wt1 backend (real Postgres + Redis + LLM) — all 7 tests pass.

## Pre-Landing Review

4 high-confidence races surfaced and fixed in `04ef2499`:
- **C1** Registry race when shared `current_run_id` overwritten by concurrent turn (Claude 9/10)
- **C2** Steering Content-Location latch pollutes frontend run_id ref (Codex P0)
- **C3** Legacy stream fallback wrong post-restart (Claude+Codex 9/10)
- **C4** WorkflowTracker terminal updates not run-guarded (Codex P0)

No remaining critical findings. Quality score: 6.5.

## Adversarial Review

Both Claude adversarial subagent and Codex run; Codex structured review with P1 gate ran (diff >200 lines). All P1 findings resolved by `04ef2499`. Cross-model synthesis confirmed: zero remaining open issues.

## Plan Completion

Plan: `lets-do-1-make-polymorphic-nygaard.md`

| Item | Status |
|---|---|
| Step 1.1 — `run_id` at handler entry | DONE |
| Step 1.2 — persist_* accept response_id | DONE |
| Step 1.3 — re-key Redis streams | DONE |
| Step 1.4 — re-key in-process registries | DONE |
| Step 1.5 — WorkflowTracker + cancel/steering | DONE |
| Step 1.6 — `metadata` SSE event | DONE |
| Step 1.7 — Background dispatch returns run_id | DONE |
| Step 1.8 — Remove identity-guard scaffolding | DONE |

All 8 plan items: DONE. Backstops kept by design: `QueryConflictError`, per-thread admission lock (Pregel doesn't serialize concurrent `astream`).

## Verification Results

Live e2e smoke test (`/e2e-chat` wire-contract sweep T1–T7) against wt1 backend on port 8040, real Postgres + Redis + LLM:

```
T1 — Content-Location + metadata first        PASS  run_id=89dfc7c6... in header, metadata at id:1
T2 — Reconnect by run_id resumes              PASS  from LAST_ID=151 → id:152 (611 message_chunks after)
T3 — Dispatched returns run_id JSON           PASS  {"status":"dispatched","run_id":"29f7be0a..."}
T4 — Concurrent dispatched returns 409        PASS  "still running; dispatched follow-up could not be admitted"
T5 — Concurrent foreground routes to steering PASS  event: steering_accepted, HTTP 200
T6 — conversation_response_id == run_id       PASS  a4025636... exact UUID match in DB
T7 — PTC workspace bringup + run_id           PASS  workspace_status (2) → metadata → 290 message_chunks
```

## Documentation

- `docs/api/README.md` — documented the run_id refactor's user-visible surface:
  - Quick Start step 2 now notes the first SSE frame is `event: metadata` carrying `{thread_id, run_id}` and that POST responses set `Content-Location: /api/v1/threads/{tid}/messages/stream?run_id={rid}` for exact reconnect targeting.
  - Quick Start step 4 documents the new `?run_id=` query param on `GET /messages/stream` (falls back to the latest run when omitted) and updates the curl example.
  - SSE Event Types: added `metadata`, `reasoning_content`, `reasoning_signal`, `tool_call_chunks`, `user_message`, `workflow_status`, `thread_created`, `steering_delivered`, `task_steering_accepted`; renamed `done` to `finish` to match `web/src/types/sse.ts`.

No CHANGELOG / VERSION / TODOS / ARCHITECTURE files in this repo, so nothing to bump.

## Test plan

- [x] Backend unit tests: 3464 passed
- [x] Frontend unit tests: 1116 passed
- [x] Live e2e wire-contract sweep (T1–T7): all PASS against wt1 backend with real Postgres + Redis + LLM
- [x] Adversarial review (Claude + Codex): all P1 resolved
- [x] DB persistence verified: `conversation_response_id == run_id` (1:1 contract)