### PR TITLE
fix: enforce LF line endings for shell scripts and Dockerfiles

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,9 @@
 # .gitattributes
 
 *.ipynb linguist-vendored
+
+# Shell scripts and Dockerfiles must use LF so they run inside Linux containers
+# even when checked out on Windows with core.autocrlf=true.
+*.sh        text eol=lf
+Dockerfile  text eol=lf
+Dockerfile.* text eol=lf


### PR DESCRIPTION
## Summary

Fixes #212 — `docker compose up --build` fails on Windows because `scripts/docker_entrypoint.sh` gets checked out with CRLF line endings (default `core.autocrlf=true`), which the Linux container can't execute.

Adds explicit `text eol=lf` rules in `.gitattributes` for `*.sh` and `Dockerfile*` so the working tree stays LF on every platform.

## Diff Size
- Total: 1 file changed, 7 insertions(+), 1 deletion(-)
- Net (excl. tests): same — config-only change

## Regression risk

None for Linux/macOS users:
- Verified every committed `*.sh` and `Dockerfile*` is already stored as LF in git, so renormalization is a no-op.
- `core.autocrlf` on Linux/macOS defaults to `false`/`input` — behavior is unchanged.
- No spurious `git status` modifications after pulling this change.

Windows users with `core.autocrlf=true` are the only ones affected, and the effect is the intended fix: shell scripts now check out as LF instead of CRLF. If they have an existing CRLF working copy from a prior checkout, a one-time `git add --renormalize .` cleans it up.

## Test plan
- [x] Verified all committed `*.sh` and `Dockerfile*` files already store as LF (no in-repo content change)
- [ ] Validate on Windows: clone fresh, run `docker compose up --build`, confirm entrypoint runs