### PR TITLE
Add optional Adanos market sentiment tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,11 @@ SANDBOX_PROVIDER=
 # Without this key, enable Yahoo Finance MCP servers in agent_config.yaml for free data.
 FMP_API_KEY=
 
+# Adanos Market Sentiment — optional US-equity sentiment from Reddit, X / FinTwit,
+# news, and Polymarket for the native get_adanos_market_sentiment tool.
+ADANOS_API_KEY=
+ADANOS_API_BASE_URL=https://api.adanos.org
+
 # =============================================================================
 # LLM API Keys — set one, or use BYOK via OAuth (Codex, Claude)
 # =============================================================================

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ LangAlpha supports a three-tier data provider hierarchy. Each tier is optional â
 | 1    | **ginlix-data** (hosted proxy)    | `GINLIX_DATA_URL` | Real-time WebSocket price feed, intraday data, extented trading hour data, options data    |
 | 2    | **FMP** (Financial Modeling Prep) | `FMP_API_KEY`     | High-quality fundamentals, financial statements, macro data, analyst data                  |
 | 3    | **Yahoo Finance** (yfinance)      | *None â€” free*     | Price history, basic fundamentals, earnings, holdings, insider transactions, ESG, screener |
+| Optional | **Adanos Market Sentiment** | `ADANOS_API_KEY` | US-equity sentiment from Reddit, X / FinTwit, news, and Polymarket via the native `get_adanos_market_sentiment` tool |
 
 
 All tiers are enabled by default. To run with **free data only** (Yahoo Finance), run `make config` with prompted selection. You can also edit `agent_config.yaml` manually.

--- a/src/ptc_agent/agent/agent.py
+++ b/src/ptc_agent/agent/agent.py
@@ -93,11 +93,12 @@ from src.tools.search import get_web_search_tool
 from src.tools.fetch import web_fetch_tool
 from src.tools.sec.tool import get_sec_filing
 from src.tools.market_data.tool import (
-    get_stock_daily_prices,
+    get_adanos_market_sentiment,
     get_company_overview,
     get_market_indices,
     get_options_chain,
     get_sector_performance,
+    get_stock_daily_prices,
     screen_stocks,
 )
 from ptc_agent.config import AgentConfig
@@ -468,6 +469,7 @@ class PTCAgent:
             get_sec_filing,  # SEC filing extraction (10-K, 10-Q, 8-K)
             get_stock_daily_prices,  # Stock OHLCV price data
             get_company_overview,  # Company investment analysis (includes real-time quote)
+            get_adanos_market_sentiment,  # Optional Adanos sentiment for US equities
             get_market_indices,  # Market indices data
             get_options_chain,  # Options contracts chain with snapshot pricing
             get_sector_performance,  # Sector performance metrics

--- a/src/ptc_agent/agent/flash/agent.py
+++ b/src/ptc_agent/agent/flash/agent.py
@@ -40,11 +40,12 @@ from src.tools.search import get_web_search_tool
 from src.tools.fetch import web_fetch_tool
 from src.tools.sec.tool import get_sec_filing
 from src.tools.market_data.tool import (
-    get_stock_daily_prices,
+    get_adanos_market_sentiment,
     get_company_overview,
     get_market_indices,
     get_options_chain,
     get_sector_performance,
+    get_stock_daily_prices,
     screen_stocks,
 )
 
@@ -134,6 +135,7 @@ class FlashAgent:
                 get_sec_filing,
                 get_stock_daily_prices,
                 get_company_overview,
+                get_adanos_market_sentiment,
                 get_market_indices,
                 get_options_chain,
                 get_sector_performance,

--- a/src/tools/market_data/__init__.py
+++ b/src/tools/market_data/__init__.py
@@ -11,19 +11,22 @@ Available tools:
 - get_market_indices: Market indices data (S&P 500, NASDAQ, Dow Jones)
 - get_sector_performance: Sector performance metrics
 - screen_stocks: Stock screener with filters for market cap, price, sector, etc.
+- get_adanos_market_sentiment: Optional Adanos sentiment from Reddit, X / FinTwit, news, and Polymarket
 """
 
 from .tool import (
-    get_stock_daily_prices,
+    get_adanos_market_sentiment,
     get_company_overview,
     get_market_indices,
     get_market_movers,
     get_options_chain,
     get_sector_performance,
+    get_stock_daily_prices,
     screen_stocks,
 )
 
 __all__ = [
+    "get_adanos_market_sentiment",
     "get_stock_daily_prices",
     "get_company_overview",
     "get_market_indices",

--- a/src/tools/market_data/adanos_sentiment.py
+++ b/src/tools/market_data/adanos_sentiment.py
@@ -1,0 +1,188 @@
+"""Adanos Market Sentiment API helpers for native finance tools."""
+
+from __future__ import annotations
+
+import os
+from datetime import date, datetime, timezone
+from typing import Any
+
+import httpx
+
+ADANOS_API_BASE_URL = "https://api.adanos.org"
+ADANOS_SOURCES = ("reddit", "x", "news", "polymarket")
+
+
+def _parse_date(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.date().isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).date().isoformat()
+    except ValueError:
+        return datetime.strptime(text[:10], "%Y-%m-%d").date().isoformat()
+
+
+def _normalize_sources(sources: list[str] | str | None) -> list[str]:
+    if sources is None:
+        requested = list(ADANOS_SOURCES)
+    elif isinstance(sources, str):
+        requested = [source.strip().lower() for source in sources.split(",") if source.strip()]
+    else:
+        requested = [str(source).strip().lower() for source in sources if str(source).strip()]
+
+    invalid = [source for source in requested if source not in ADANOS_SOURCES]
+    if invalid:
+        raise ValueError(f"Unsupported Adanos source(s): {', '.join(invalid)}")
+    return requested
+
+
+def _sentiment_value(payload: dict[str, Any]) -> Any:
+    for key in ("sentiment_score", "sentiment", "overall_sentiment", "average_sentiment"):
+        if key in payload:
+            return payload[key]
+    return None
+
+
+def _mentions_value(payload: dict[str, Any]) -> Any:
+    for key in ("mentions", "mention_count", "total_mentions", "count"):
+        if key in payload:
+            return payload[key]
+    return None
+
+
+async def _fetch_adanos_json(
+    *,
+    path: str,
+    params: dict[str, Any],
+    api_key: str,
+    base_url: str,
+    timeout: float,
+) -> dict[str, Any]:
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        response = await client.get(
+            f"{base_url.rstrip('/')}{path}",
+            headers={"X-API-Key": api_key},
+            params={key: value for key, value in params.items() if value not in (None, "")},
+        )
+        response.raise_for_status()
+        payload = response.json()
+    if isinstance(payload, dict):
+        return payload
+    return {"data": payload}
+
+
+def _format_adanos_sentiment_report(
+    *,
+    symbol: str | None,
+    mode: str,
+    days: int,
+    end_date: str | None,
+    results: dict[str, dict[str, Any]],
+    errors: dict[str, str],
+) -> str:
+    title = f"Adanos Market Sentiment: {symbol}" if symbol else "Adanos Market Sentiment: Market"
+    lines = [f"## {title}", f"**Window:** {days} days"]
+    if end_date:
+        lines.append(f"**End date:** {end_date}")
+    lines.append("")
+
+    if results:
+        lines.extend(["| Source | Sentiment | Mentions / Count | Status |", "|--------|-----------|------------------|--------|"])
+        for source, payload in results.items():
+            sentiment = _sentiment_value(payload)
+            mentions = _mentions_value(payload)
+            lines.append(
+                f"| {source} | {sentiment if sentiment is not None else 'N/A'} | "
+                f"{mentions if mentions is not None else 'N/A'} | ok |"
+            )
+
+    if errors:
+        if results:
+            lines.append("")
+        lines.extend(["| Source | Error |", "|--------|-------|"])
+        for source, message in errors.items():
+            lines.append(f"| {source} | {message} |")
+
+    if not results and not errors:
+        lines.append("No Adanos sentiment data returned.")
+
+    if mode == "market":
+        lines.append("\nUse this as broad market mood context, not as a standalone trading signal.")
+    else:
+        lines.append("\nUse this as one external sentiment input alongside price, fundamentals, and news.")
+    return "\n".join(lines)
+
+
+async def fetch_adanos_market_sentiment(
+    symbol: str | None = None,
+    *,
+    sources: list[str] | str | None = None,
+    days: int = 7,
+    end_date: str | None = None,
+    mode: str = "stock",
+    api_key: str | None = None,
+    base_url: str | None = None,
+    timeout: float = 20.0,
+) -> tuple[str, dict[str, Any]]:
+    """Fetch optional Adanos sentiment for a US equity or broad market."""
+    resolved_api_key = (api_key or os.getenv("ADANOS_API_KEY") or "").strip()
+    if not resolved_api_key:
+        raise ValueError("ADANOS_API_KEY is required to fetch Adanos market sentiment data.")
+
+    mode_text = str(mode or "stock").strip().lower()
+    if mode_text not in {"stock", "market"}:
+        raise ValueError("mode must be 'stock' or 'market'.")
+
+    ticker = str(symbol or "").strip().upper()
+    if mode_text == "stock" and not ticker:
+        raise ValueError("symbol is required when mode='stock'.")
+
+    day_count = max(int(days), 1)
+    end_text = _parse_date(end_date) or datetime.now(timezone.utc).date().isoformat()
+    requested_sources = _normalize_sources(sources)
+    resolved_base_url = base_url or os.getenv("ADANOS_API_BASE_URL") or ADANOS_API_BASE_URL
+
+    results: dict[str, dict[str, Any]] = {}
+    errors: dict[str, str] = {}
+    for source in requested_sources:
+        path = (
+            f"/{source}/stocks/v1/market-sentiment"
+            if mode_text == "market"
+            else f"/{source}/stocks/v1/stock/{ticker}"
+        )
+        try:
+            results[source] = await _fetch_adanos_json(
+                path=path,
+                params={"days": day_count, "to": end_text},
+                api_key=resolved_api_key,
+                base_url=resolved_base_url,
+                timeout=timeout,
+            )
+        except Exception as exc:
+            errors[source] = str(exc)
+
+    content = _format_adanos_sentiment_report(
+        symbol=ticker if mode_text == "stock" else None,
+        mode=mode_text,
+        days=day_count,
+        end_date=end_text,
+        results=results,
+        errors=errors,
+    )
+    artifact = {
+        "type": "adanos_market_sentiment",
+        "mode": mode_text,
+        "symbol": ticker if mode_text == "stock" else None,
+        "sources": requested_sources,
+        "days": day_count,
+        "end_date": end_text,
+        "results": results,
+        "errors": errors,
+    }
+    return content, artifact

--- a/src/tools/market_data/tool.py
+++ b/src/tools/market_data/tool.py
@@ -19,6 +19,7 @@ from .implementations import (
     fetch_stock_daily_prices,
     fetch_stock_screener,
 )
+from .adanos_sentiment import fetch_adanos_market_sentiment
 
 
 @tool(response_format="content_and_artifact")
@@ -386,4 +387,43 @@ async def get_market_movers(
         get_market_movers("losers")
     """
     content, artifact = await fetch_market_movers(direction, config=config)
+    return content, artifact
+
+
+@tool(response_format="content_and_artifact")
+async def get_adanos_market_sentiment(
+    symbol: Optional[str] = None,
+    sources: Optional[List[str]] = None,
+    days: int = 7,
+    end_date: Optional[str] = None,
+    mode: str = "stock",
+) -> Tuple[str, Dict[str, Any]]:
+    """
+    Get optional Adanos Market Sentiment API data for US equities.
+
+    Adanos combines Reddit, X / FinTwit, financial news, and Polymarket signals.
+    Use this as external sentiment context alongside prices, fundamentals, SEC
+    filings, and news — not as a standalone trading recommendation.
+
+    Args:
+        symbol: US stock ticker such as "AAPL" or "TSLA". Required for stock mode.
+        sources: Optional subset of ["reddit", "x", "news", "polymarket"].
+        days: Lookback window in days. Defaults to 7.
+        end_date: Optional YYYY-MM-DD end date. Defaults to today.
+        mode: "stock" for per-ticker sentiment, or "market" for broad market sentiment.
+
+    Returns:
+        Markdown summary plus an artifact containing raw per-source API payloads.
+
+    Requirements:
+        Set ADANOS_API_KEY in the environment. ADANOS_API_BASE_URL can override
+        the default https://api.adanos.org endpoint for self-hosted testing.
+    """
+    content, artifact = await fetch_adanos_market_sentiment(
+        symbol=symbol,
+        sources=sources,
+        days=days,
+        end_date=end_date,
+        mode=mode,
+    )
     return content, artifact

--- a/tests/unit/tools/test_adanos_market_sentiment.py
+++ b/tests/unit/tools/test_adanos_market_sentiment.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import pytest
+
+from src.tools.market_data.adanos_sentiment import fetch_adanos_market_sentiment
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class _FakeAsyncClient:
+    calls: list[dict] = []
+
+    def __init__(self, *, timeout: float):
+        self.timeout = timeout
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get(self, url: str, *, headers: dict, params: dict):
+        self.calls.append(
+            {
+                "url": url,
+                "headers": headers,
+                "params": params,
+                "timeout": self.timeout,
+            }
+        )
+        return _FakeResponse({"sentiment_score": 0.42, "mentions": 12})
+
+
+@pytest.fixture(autouse=True)
+def reset_fake_client():
+    _FakeAsyncClient.calls = []
+
+
+@pytest.mark.asyncio
+async def test_fetch_adanos_stock_sentiment_calls_requested_sources(monkeypatch):
+    monkeypatch.setenv("ADANOS_API_KEY", "test-key")
+    monkeypatch.setattr(
+        "src.tools.market_data.adanos_sentiment.httpx.AsyncClient",
+        _FakeAsyncClient,
+    )
+
+    content, artifact = await fetch_adanos_market_sentiment(
+        "aapl",
+        sources=["reddit", "news"],
+        days=5,
+        end_date="2026-05-20",
+        base_url="https://adanos.test",
+    )
+
+    assert "Adanos Market Sentiment: AAPL" in content
+    assert "| reddit | 0.42 | 12 | ok |" in content
+    assert artifact["type"] == "adanos_market_sentiment"
+    assert artifact["symbol"] == "AAPL"
+    assert artifact["sources"] == ["reddit", "news"]
+    assert _FakeAsyncClient.calls[0]["url"] == "https://adanos.test/reddit/stocks/v1/stock/AAPL"
+    assert _FakeAsyncClient.calls[0]["headers"] == {"X-API-Key": "test-key"}
+    assert _FakeAsyncClient.calls[0]["params"] == {"days": 5, "to": "2026-05-20"}
+
+
+@pytest.mark.asyncio
+async def test_fetch_adanos_market_sentiment_uses_market_endpoint(monkeypatch):
+    monkeypatch.setenv("ADANOS_API_KEY", "test-key")
+    monkeypatch.setattr(
+        "src.tools.market_data.adanos_sentiment.httpx.AsyncClient",
+        _FakeAsyncClient,
+    )
+
+    content, artifact = await fetch_adanos_market_sentiment(
+        mode="market",
+        sources="polymarket",
+        days=3,
+        end_date="2026-05-20",
+        base_url="https://adanos.test",
+    )
+
+    assert "Adanos Market Sentiment: Market" in content
+    assert artifact["mode"] == "market"
+    assert artifact["symbol"] is None
+    assert _FakeAsyncClient.calls[0]["url"] == "https://adanos.test/polymarket/stocks/v1/market-sentiment"
+    assert _FakeAsyncClient.calls[0]["params"] == {"days": 3, "to": "2026-05-20"}
+
+
+@pytest.mark.asyncio
+async def test_fetch_adanos_sentiment_requires_api_key(monkeypatch):
+    monkeypatch.delenv("ADANOS_API_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="ADANOS_API_KEY is required"):
+        await fetch_adanos_market_sentiment("MSFT", sources="x")
+
+
+@pytest.mark.asyncio
+async def test_fetch_adanos_sentiment_rejects_unknown_sources(monkeypatch):
+    monkeypatch.setenv("ADANOS_API_KEY", "test-key")
+
+    with pytest.raises(ValueError, match="Unsupported Adanos source"):
+        await fetch_adanos_market_sentiment("MSFT", sources="crypto")


### PR DESCRIPTION
## Summary
- Add a native `get_adanos_market_sentiment` finance tool for optional US-equity sentiment context
- Fetch per-stock or broad market sentiment from Adanos sources: Reddit, X / FinTwit, news, and Polymarket
- Wire the tool into the main and flash agent finance toolsets
- Document `ADANOS_API_KEY` / `ADANOS_API_BASE_URL` and add focused unit coverage

## Design notes
- No new required service: the tool only calls Adanos when explicitly used and `ADANOS_API_KEY` is configured
- Keeps the existing provider registry untouched; sentiment is research context, not OHLCV/fundamentals replacement
- Sends `days` plus `to` to keep the Adanos request window explicit

## Checks
- `uv run python -m pytest tests/unit/tools/test_adanos_market_sentiment.py -q`
- `uv run python -m pytest tests/unit/tools/test_market_data_tools.py tests/unit/tools/test_adanos_market_sentiment.py -q`
- `uv run --extra dev ruff check src/tools/market_data/adanos_sentiment.py tests/unit/tools/test_adanos_market_sentiment.py src/tools/market_data/tool.py src/tools/market_data/__init__.py src/ptc_agent/agent/agent.py src/ptc_agent/agent/flash/agent.py`
- `uv run python -m py_compile src/tools/market_data/adanos_sentiment.py src/tools/market_data/tool.py tests/unit/tools/test_adanos_market_sentiment.py src/ptc_agent/agent/agent.py src/ptc_agent/agent/flash/agent.py`
- `git diff --check`