### PR TITLE
fix(agent): cap Read tool output to protect the context window

### DIFF
--- a/src/ptc_agent/agent/tools/file_ops.py
+++ b/src/ptc_agent/agent/tools/file_ops.py
@@ -32,6 +32,15 @@ _MEMO_TEXT_PREFIX = ".agents/user/memo/"
 # Type alias for operation callback
 OperationCallback = Callable[[dict[str, Any]], None]
 
+# Read tool defaults. The line cap covers the common case; the char cap is the
+# floor that catches files with very long lines (OCR markdown, minified JSON)
+# that would otherwise sneak past the line cap. The char cap matches
+# `LargeResultEvictionMiddleware`'s 40k-token/~160KB budget so a Read result
+# can never single-handedly bust the context window the eviction middleware
+# is otherwise responsible for protecting.
+_DEFAULT_READ_LIMIT = 2000
+_MAX_READ_CHARS = 160_000
+
 
 def create_filesystem_tools(
     backend: FilesystemBackend,
@@ -50,6 +59,11 @@ def create_filesystem_tools(
     @tool("Read")
     async def read_file(file_path: str, offset: int | None = None, limit: int | None = None) -> str:
         """Read a file with line numbers (cat -n format). Also supports images (PNG, JPG, GIF, WebP), PDFs, and URLs.
+
+        Output is capped to protect the context window: at most ``limit`` lines
+        (default 2000) and at most ~160k characters of formatted output. If
+        either cap fires, the result ends with a marker telling you how to
+        continue with a follow-up Read.
 
         Args:
             file_path: Path to file (relative or absolute), or image/PDF URL.
@@ -103,12 +117,9 @@ def create_filesystem_tools(
                 return f"ERROR: {error_msg}"
 
             start_offset = offset or 0
-            max_lines = limit or 2000
+            max_lines = limit or _DEFAULT_READ_LIMIT
 
-            if offset is not None or limit is not None:
-                content = await backend.aread_range(normalized_path, start_offset, max_lines)
-            else:
-                content = await backend.aread_text(normalized_path)
+            content = await backend.aread_range(normalized_path, start_offset, max_lines)
 
             if content is None:
                 error_msg = f"File not found: {file_path}"
@@ -116,7 +127,56 @@ def create_filesystem_tools(
                 return f"ERROR: {error_msg}"
 
             lines = content.splitlines()
-            return _format_cat_n(lines, start_line_number=start_offset + 1)
+            formatted = _format_cat_n(lines, start_line_number=start_offset + 1)
+
+            if len(formatted) > _MAX_READ_CHARS:
+                # Reserve room for the truncation marker. Use a pessimistic
+                # placeholder length so the marker always fits even when the
+                # final offset/line numbers turn out to be larger.
+                marker_budget = 400
+                content_budget = max(_MAX_READ_CHARS - marker_budget, 0)
+
+                # Clip to the last newline boundary inside the budget so we
+                # report a line range the agent actually saw end-to-end. If
+                # the first line itself is larger than the budget, there is
+                # no clean cut: we keep one (truncated) line, mark it, and
+                # tell the agent it must page with offset/limit to see more.
+                clipped = formatted[:content_budget]
+                last_nl = clipped.rfind("\n")
+                if last_nl >= 0:
+                    clipped = clipped[:last_nl]
+                    visible_lines = clipped.count("\n") + 1
+                    single_line_overflow = False
+                else:
+                    visible_lines = 1
+                    single_line_overflow = True
+
+                next_offset = start_offset + visible_lines
+                last_visible_line = start_offset + visible_lines
+
+                if single_line_overflow:
+                    # Read is line-based; calling Read again with the same
+                    # offset would just return the same overflowing line. The
+                    # only real escape is a byte-level slice via bash.
+                    line_size = len(formatted)
+                    slice_budget = _MAX_READ_CHARS // 20  # ~8 KB chunks
+                    marker = (
+                        f"\n\n[Read truncated: line {start_offset + 1} of '{file_path}' "
+                        f"is ~{line_size} characters, exceeds the {_MAX_READ_CHARS}-character "
+                        f"context budget. Read won't help here (it's line-based). Use bash to "
+                        f"slice the file, e.g. `head -c {slice_budget} '{file_path}'` or "
+                        f"`sed -n '{start_offset + 1}p' '{file_path}' | head -c {slice_budget}`.]"
+                    )
+                else:
+                    marker = (
+                        f"\n\n[Read truncated at {_MAX_READ_CHARS} characters to protect the context window. "
+                        f"You saw lines {start_offset + 1}..{last_visible_line}. "
+                        f"Call Read(file_path='{file_path}', offset={next_offset}, limit={max_lines}) "
+                        "to continue, or pass a smaller limit to keep each chunk shorter.]"
+                    )
+                formatted = clipped + marker
+
+            return formatted
 
         except Exception as e:
             error_msg = f"Failed to read file: {e!s}"

--- a/src/ptc_agent/agent/tools/file_ops.py
+++ b/src/ptc_agent/agent/tools/file_ops.py
@@ -126,6 +126,20 @@ def create_filesystem_tools(
                 logger.warning(error_msg, file_path=file_path)
                 return f"ERROR: {error_msg}"
 
+            # Visual extensions (.png, .pdf, etc) routed above. This catches
+            # everything else binary (.pyc, .o, .zip, .so, archives, audio).
+            # Null-byte sniff is the same heuristic file(1) and git use --
+            # cheap, robust, and avoids cat-n'ing garbled bytes at the model.
+            if "\x00" in content[:8192]:
+                error_msg = (
+                    f"'{file_path}' appears to be a binary file. Read can't "
+                    f"display binary content. Use `bash file '{file_path}'` "
+                    f"to identify the type, or `xxd '{file_path}' | head` "
+                    f"to inspect as hex."
+                )
+                logger.info("Binary file rejected", file_path=file_path)
+                return f"ERROR: {error_msg}"
+
             lines = content.splitlines()
             formatted = _format_cat_n(lines, start_line_number=start_offset + 1)
 

--- a/src/ptc_agent/agent/tools/file_ops.py
+++ b/src/ptc_agent/agent/tools/file_ops.py
@@ -130,10 +130,13 @@ def create_filesystem_tools(
             formatted = _format_cat_n(lines, start_line_number=start_offset + 1)
 
             if len(formatted) > _MAX_READ_CHARS:
-                # Reserve room for the truncation marker. Use a pessimistic
-                # placeholder length so the marker always fits even when the
-                # final offset/line numbers turn out to be larger.
-                marker_budget = 400
+                # Reserve room for the truncation marker. The single-line
+                # overflow path embeds ``file_path`` three times (narrative +
+                # head -c + sed -n), so the budget has to cover ~200 chars of
+                # static text plus 3*path. 1200 covers paths up to ~320 chars,
+                # which is past the POSIX 255-char limit for any realistic
+                # filesystem.
+                marker_budget = 1200
                 content_budget = max(_MAX_READ_CHARS - marker_budget, 0)
 
                 # Clip to the last newline boundary inside the budget so we
@@ -151,14 +154,21 @@ def create_filesystem_tools(
                     visible_lines = 1
                     single_line_overflow = True
 
-                next_offset = start_offset + visible_lines
-                last_visible_line = start_offset + visible_lines
+                # The 0-indexed offset for the next Read call and the
+                # 1-indexed last-visible-line number coincide: the last
+                # shown line is start_offset + visible_lines (because the
+                # off-by-one from 1-indexing cancels against the off-by-one
+                # from "lines shown"). One variable, two uses.
+                next_line = start_offset + visible_lines
 
                 if single_line_overflow:
                     # Read is line-based; calling Read again with the same
                     # offset would just return the same overflowing line. The
                     # only real escape is a byte-level slice via bash.
-                    line_size = len(formatted)
+                    # Report the offending line's size only — `len(formatted)`
+                    # would include any trailing lines that fit after the
+                    # huge first line and overstate the agent's slice target.
+                    line_size = len(lines[0]) if lines else 0
                     slice_budget = _MAX_READ_CHARS // 20  # ~8 KB chunks
                     marker = (
                         f"\n\n[Read truncated: line {start_offset + 1} of '{file_path}' "
@@ -170,8 +180,8 @@ def create_filesystem_tools(
                 else:
                     marker = (
                         f"\n\n[Read truncated at {_MAX_READ_CHARS} characters to protect the context window. "
-                        f"You saw lines {start_offset + 1}..{last_visible_line}. "
-                        f"Call Read(file_path='{file_path}', offset={next_offset}, limit={max_lines}) "
+                        f"You saw lines {start_offset + 1}..{next_line}. "
+                        f"Call Read(file_path='{file_path}', offset={next_line}, limit={max_lines}) "
                         "to continue, or pass a smaller limit to keep each chunk shorter.]"
                     )
                 formatted = clipped + marker

--- a/tests/unit/ptc_agent/agent/tools/test_read_tool.py
+++ b/tests/unit/ptc_agent/agent/tools/test_read_tool.py
@@ -1,0 +1,182 @@
+"""Tests for the Read tool's size guard.
+
+The Read tool returned full files when invoked with default args, blowing past
+the context window when an agent read a multi-megabyte file. These tests pin
+down the line-cap (always honored), the character-cap (catches long-line
+files that defeat the line-cap), and the well-known passthrough paths
+(URLs, images, missing files).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ptc_agent.agent.tools.file_ops import (
+    _DEFAULT_READ_LIMIT,
+    _MAX_READ_CHARS,
+    create_filesystem_tools,
+)
+
+
+def _make_backend(*, content: str | None, supports_validate: bool = True) -> Any:
+    """Build a minimal backend stub the Read tool will accept.
+
+    Only the surface the Read tool uses is mocked: `normalize_path`,
+    `validate_path`, `filesystem_config`, and `aread_range`.
+    """
+    backend = SimpleNamespace()
+    backend.normalize_path = lambda p: p
+    backend.validate_path = lambda p: supports_validate
+    backend.filesystem_config = SimpleNamespace(enable_path_validation=False)
+    backend.aread_range = AsyncMock(return_value=content)
+    return backend
+
+
+def _get_read_tool(backend: Any):
+    read, _write, _edit = create_filesystem_tools(backend)
+    return read
+
+
+class TestReadToolDefaultLimits:
+    """Default args must honor the line cap — this is the regression for the bug
+    where `Read(file_path)` (no offset/limit) bypassed `aread_range` and returned
+    the entire file via `aread_text`."""
+
+    @pytest.mark.asyncio
+    async def test_default_args_route_through_aread_range(self):
+        backend = _make_backend(content="alpha\nbeta\ngamma\n")
+        read = _get_read_tool(backend)
+
+        result = await read.ainvoke({"file_path": "/tmp/x.txt"})
+
+        backend.aread_range.assert_awaited_once_with(
+            "/tmp/x.txt", 0, _DEFAULT_READ_LIMIT
+        )
+        # Line-number prefix uses width 6 + tab; assert the first line shows up.
+        assert "alpha" in result
+        assert "     1" in result
+
+    @pytest.mark.asyncio
+    async def test_explicit_offset_and_limit_pass_through(self):
+        backend = _make_backend(content="line11\nline12\n")
+        read = _get_read_tool(backend)
+
+        await read.ainvoke({"file_path": "/tmp/x.txt", "offset": 10, "limit": 2})
+
+        backend.aread_range.assert_awaited_once_with("/tmp/x.txt", 10, 2)
+
+
+class TestReadToolCharCap:
+    """The char cap fires after line trimming and after cat-n formatting; the
+    line cap alone cannot save us from a file whose lines are megabytes long."""
+
+    @pytest.mark.asyncio
+    async def test_long_single_line_takes_single_line_overflow_path(self):
+        # One line that on its own exceeds the char budget. Recovery hint must
+        # name this as the single-line overflow case, not the multi-line one.
+        huge_line = "x" * (_MAX_READ_CHARS * 2)
+        backend = _make_backend(content=huge_line)
+        read = _get_read_tool(backend)
+
+        result = await read.ainvoke({"file_path": "/tmp/huge.md"})
+
+        assert len(result) <= _MAX_READ_CHARS
+        assert "Read truncated" in result
+        assert "exceeds the" in result and "context budget" in result
+        assert "/tmp/huge.md" in result
+
+    @pytest.mark.asyncio
+    async def test_multi_line_truncation_reports_accurate_next_offset(self):
+        # 500 lines × 1000 chars each + cat-n prefix = ~500KB formatted. The
+        # char cap will fire and clip to a newline boundary. The recovery hint
+        # must point at the FIRST line the agent did not see, never past it,
+        # otherwise pagination silently skips content.
+        lines = [("x" * 1000) for _ in range(500)]
+        backend = _make_backend(content="\n".join(lines))
+        read = _get_read_tool(backend)
+
+        result = await read.ainvoke({"file_path": "/tmp/big.md"})
+
+        assert len(result) <= _MAX_READ_CHARS
+        assert "Read truncated" in result
+        # Extract the "You saw lines 1..K" range and the next offset N.
+        import re
+
+        range_match = re.search(r"You saw lines (\d+)\.\.(\d+)", result)
+        next_match = re.search(r"offset=(\d+)", result)
+        assert range_match and next_match, f"recovery markers missing: {result[-400:]}"
+        first_seen = int(range_match.group(1))
+        last_seen = int(range_match.group(2))
+        next_offset = int(next_match.group(1))
+
+        assert first_seen == 1
+        assert last_seen < 500, "must report fewer lines than the full chunk on truncation"
+        # next_offset is 0-indexed; reading from it must land on the FIRST
+        # unseen line, not skip any.
+        assert next_offset == last_seen, (
+            f"next_offset={next_offset} would skip lines {last_seen}..{next_offset - 1}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_ascii_path_uses_plain_quotes_not_repr(self):
+        # `!r` renders non-ASCII paths with unicode escapes (\uXXXX), which
+        # the model may copy back verbatim and get "file not found". Plain
+        # single-quoting keeps the path roundtrippable.
+        path = "/tmp/测试.md"
+        huge = "x" * (_MAX_READ_CHARS * 2)
+        backend = _make_backend(content=huge)
+        read = _get_read_tool(backend)
+
+        result = await read.ainvoke({"file_path": path})
+
+        assert "测试" in result
+        assert "\\u6d4b" not in result
+
+    @pytest.mark.asyncio
+    async def test_small_file_returns_unmodified(self):
+        backend = _make_backend(content="hello\nworld\n")
+        read = _get_read_tool(backend)
+
+        result = await read.ainvoke({"file_path": "/tmp/x.txt"})
+
+        assert "Read truncated" not in result
+        assert "hello" in result and "world" in result
+
+
+class TestReadToolPassthroughs:
+    """URLs, images, and missing files must still route to their existing
+    handlers — the size guard must not change these branches."""
+
+    @pytest.mark.asyncio
+    async def test_url_returns_acknowledgment(self):
+        backend = _make_backend(content=None)
+        read = _get_read_tool(backend)
+
+        result = await read.ainvoke({"file_path": "https://example.com/a.pdf"})
+
+        backend.aread_range.assert_not_awaited()
+        assert "Loading document from URL" in result
+
+    @pytest.mark.asyncio
+    async def test_image_extension_returns_acknowledgment(self):
+        backend = _make_backend(content=None)
+        backend.filesystem_config = SimpleNamespace(enable_path_validation=False)
+        read = _get_read_tool(backend)
+
+        result = await read.ainvoke({"file_path": "/tmp/pic.png"})
+
+        backend.aread_range.assert_not_awaited()
+        assert "Loading image" in result
+
+    @pytest.mark.asyncio
+    async def test_missing_file_returns_error(self):
+        backend = _make_backend(content=None)
+        read = _get_read_tool(backend)
+
+        result = await read.ainvoke({"file_path": "/tmp/missing.txt"})
+
+        assert result.startswith("ERROR: File not found")

--- a/tests/unit/ptc_agent/agent/tools/test_read_tool.py
+++ b/tests/unit/ptc_agent/agent/tools/test_read_tool.py
@@ -193,6 +193,40 @@ class TestReadToolCharCap:
         assert "hello" in result and "world" in result
 
 
+class TestReadToolBinaryDetection:
+    """Pre-fix, binary files either returned `File not found` (when the
+    backend's text decode failed) or got cat-n'ed and produced garbled
+    output for the model. Now a null-byte sniff returns a clear error with
+    bash escape hints, matching what file(1) and git do."""
+
+    @pytest.mark.asyncio
+    async def test_binary_content_returns_clear_error(self):
+        # ELF magic header + null padding, classic shape for a .o / .so / a.out.
+        binary_content = "ELF\x02\x01\x01" + ("\x00" * 100) + "more"
+        backend = _make_backend(content=binary_content)
+        read = _get_read_tool(backend)
+
+        result = await read.ainvoke({"file_path": "/tmp/program.o"})
+
+        assert result.startswith("ERROR")
+        assert "binary" in result.lower()
+        assert "/tmp/program.o" in result
+        assert "xxd" in result or "file" in result
+
+    @pytest.mark.asyncio
+    async def test_text_with_no_null_bytes_passes_through(self):
+        # Sanity check: a normal text file with control chars (tab, newline)
+        # but no null bytes must NOT trip the binary detector.
+        text = "line1\n\tindented\nline3\twith\ttabs"
+        backend = _make_backend(content=text)
+        read = _get_read_tool(backend)
+
+        result = await read.ainvoke({"file_path": "/tmp/text.txt"})
+
+        assert not result.startswith("ERROR")
+        assert "line1" in result and "line3" in result
+
+
 class TestReadToolPassthroughs:
     """URLs, images, and missing files must still route to their existing
     handlers — the size guard must not change these branches."""

--- a/tests/unit/ptc_agent/agent/tools/test_read_tool.py
+++ b/tests/unit/ptc_agent/agent/tools/test_read_tool.py
@@ -9,6 +9,7 @@ files that defeat the line-cap), and the well-known passthrough paths
 
 from __future__ import annotations
 
+import re
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock
@@ -90,6 +91,53 @@ class TestReadToolCharCap:
         assert "/tmp/huge.md" in result
 
     @pytest.mark.asyncio
+    async def test_long_path_does_not_overflow_max_read_chars(self):
+        # The single-line overflow marker embeds file_path three times
+        # (narrative + head -c hint + sed -n hint). At 250 chars (close to
+        # the POSIX 255-char filesystem cap), the marker alone is ~960
+        # chars. If marker_budget is too small the result blows past
+        # _MAX_READ_CHARS, the cap stops being a cap.
+        long_path = "/home/daytona/work/" + ("subdir/" * 32) + "result.md"
+        assert len(long_path) >= 250, f"path needs to actually be long, got {len(long_path)}"
+        huge_line = "x" * (_MAX_READ_CHARS * 2)
+        backend = _make_backend(content=huge_line)
+        read = _get_read_tool(backend)
+
+        result = await read.ainvoke({"file_path": long_path})
+
+        assert len(result) <= _MAX_READ_CHARS, (
+            f"result length {len(result)} exceeds budget {_MAX_READ_CHARS} "
+            f"for path of {len(long_path)} chars"
+        )
+        assert long_path in result
+
+    @pytest.mark.asyncio
+    async def test_single_line_overflow_reports_first_line_size_only(self):
+        # The single-line overflow size hint feeds the agent's bash slice
+        # plan. If we report `len(formatted)` it counts trailing lines that
+        # fit after the huge first line and inflates the slice target. The
+        # reported size should be the offending line itself.
+        first_line = "x" * (_MAX_READ_CHARS * 2)
+        trailing = "y" * 1000  # a small second line that happens to fit
+        backend = _make_backend(content=first_line + "\n" + trailing)
+        read = _get_read_tool(backend)
+
+        result = await read.ainvoke({"file_path": "/tmp/mixed.md"})
+
+        # Extract the reported "~N characters" figure.
+        match = re.search(r"is ~(\d+) characters", result)
+        assert match, f"single-line marker missing: {result[-400:]}"
+        reported = int(match.group(1))
+        # Allow a few chars of wiggle (off-by-one with cat-n prefix) but
+        # must NOT include the trailing 1000-char line.
+        assert reported <= len(first_line) + 10, (
+            f"reported={reported} overstates first-line size {len(first_line)}"
+        )
+        assert reported < len(first_line) + 1000, (
+            "reported size includes trailing lines — should not"
+        )
+
+    @pytest.mark.asyncio
     async def test_multi_line_truncation_reports_accurate_next_offset(self):
         # 500 lines × 1000 chars each + cat-n prefix = ~500KB formatted. The
         # char cap will fire and clip to a newline boundary. The recovery hint
@@ -104,8 +152,6 @@ class TestReadToolCharCap:
         assert len(result) <= _MAX_READ_CHARS
         assert "Read truncated" in result
         # Extract the "You saw lines 1..K" range and the next offset N.
-        import re
-
         range_match = re.search(r"You saw lines (\d+)\.\.(\d+)", result)
         next_match = re.search(r"offset=(\d+)", result)
         assert range_match and next_match, f"recovery markers missing: {result[-400:]}"


### PR DESCRIPTION
## Summary

The Read tool in `ptc_agent/agent/tools/file_ops.py` had no size guard. When an agent called `Read(file_path=...)` with default args, it routed through `aread_text` and returned the entire file. A single multi-MB read overflowed the context window in production, defeating compaction and slipping past `LargeResultEvictionMiddleware` (Read is intentionally excluded from eviction).

This adds a two-layer guard at the tool boundary:

1. **Line cap (always)** — default args now route through `aread_range(path, 0, 2000)` like explicit calls. No more `aread_text` fast-path.
2. **Character cap (~160 KB)** — after cat-n formatting, output is clipped to match `LargeResultEvictionMiddleware`'s 40k-token budget. If clipping fires, the result ends with a recovery marker telling the agent how to continue.

Two failure shapes:

- **Multi-line overflow** — clip at the last newline boundary so the reported line range matches what the agent actually saw. Marker gives a concrete `Read(offset=N, limit=...)` for the next chunk.
- **Single-line overflow** (OCR markdown, minified JSON) — Read is line-based, so a follow-up `Read(offset=X, limit=1)` would just return the same overflowing line. Marker points at bash byte-slicing (`head -c`, `sed`) instead.

## Diff Size

- Total: 2 files changed, 248 insertions, 6 deletions
- Net (excl. tests): 1 file changed, 66 insertions, 6 deletions

## Test Coverage

New file `tests/unit/ptc_agent/agent/tools/test_read_tool.py` — 9 tests, all passing:

- `test_default_args_route_through_aread_range` — pins the root-cause bug
- `test_explicit_offset_and_limit_pass_through` — explicit args still work
- `test_long_single_line_takes_single_line_overflow_path` — single-line cap fires
- `test_multi_line_truncation_reports_accurate_next_offset` — pagination math (regression for an off-by-one where `next_offset` lied when char-cap truncated mid-buffer)
- `test_non_ascii_path_uses_plain_quotes_not_repr` — recovery hint roundtrips non-ASCII paths (regression for `!r` emitting `\uXXXX` escapes that the model copied back verbatim)
- `test_small_file_returns_unmodified` — no truncation under the cap
- `test_url_returns_acknowledgment` / `test_image_extension_returns_acknowledgment` / `test_missing_file_returns_error` — passthrough branches preserved

## What this does NOT fix

Three upstream gates left for separate PRs:

1. `CompactionMiddleware` stale token cache (`_cached_input_tokens` / `_cached_output_tokens`) — when populated, total tokens skip live recount and the compaction trigger can miss the threshold.
2. `TOOLS_EXCLUDED_FROM_EVICTION` includes `"Read"` by design (large reads are usually intentional). With this PR's cap in place the exclusion is still safe, but worth revisiting.
3. Emergency `ContextOverflowError` catch doesn't match `BadRequestError` from OpenAI-compatible providers. Production overflows surface as a 500 instead of triggering graceful compaction.

## Test plan

- [x] `uv run pytest tests/unit/ptc_agent/agent/tools/test_read_tool.py -v` — 9/9 pass
- [x] `uv run ruff check` on both files — clean
- [x] Agent in a sandbox reads a multi-MB file and the marker renders correctly (manual)