### PR TITLE
fix(llms): guard codex-oauth null Responses output

### DIFF
--- a/src/llms/extension/codex.py
+++ b/src/llms/extension/codex.py
@@ -128,6 +128,9 @@ def _install_responses_output_guard() -> None:
     patch the single chokepoint all read paths (sync, async, streaming) funnel
     through. Streamed text is already captured from ``output_text.delta`` events,
     so an empty terminal output loses no content.
+
+    Remove once langchain_openai guards ``response.output`` upstream — the guard
+    then becomes a no-op (it only mutates when ``output`` is None).
     """
     try:
         import langchain_openai.chat_models.base as _base
@@ -152,6 +155,9 @@ def _install_responses_output_guard() -> None:
             try:
                 response.output = []
             except Exception:
+                # Response isn't frozen today, so the line above succeeds. Kept as
+                # insurance: a frozen SDK model would raise pydantic ValidationError
+                # (not TypeError), and object.__setattr__ bypasses the frozen check.
                 object.__setattr__(response, "output", [])
         return orig(response, *args, **kwargs)
 

--- a/src/llms/extension/codex.py
+++ b/src/llms/extension/codex.py
@@ -115,3 +115,48 @@ class ChatCodexOpenAI(ChatOpenAI):
         # Codex API rejects role:"system" — promote to instructions field
         _extract_system_to_instructions(payload)
         return payload
+
+
+def _install_responses_output_guard() -> None:
+    """Coerce a null Responses-API ``output`` to ``[]`` before langchain iterates it.
+
+    The chatgpt.com Codex backend ships ``response.output = null`` on terminal
+    stream frames. langchain_openai (through 1.2.2, latest) iterates it unguarded
+    in ``_construct_lc_result_from_responses_api`` and raises
+    ``TypeError('NoneType' object is not iterable)``, killing the turn. The
+    backend rejects the request-side ``exclude`` workaround with HTTP 400, so we
+    patch the single chokepoint all read paths (sync, async, streaming) funnel
+    through. Streamed text is already captured from ``output_text.delta`` events,
+    so an empty terminal output loses no content.
+    """
+    try:
+        import langchain_openai.chat_models.base as _base
+
+        orig = _base._construct_lc_result_from_responses_api
+    except (ImportError, AttributeError):
+        # langchain_openai internals moved. Degrade to no guard rather than
+        # breaking module import (which would take down all codex-oauth).
+        logger.warning(
+            "[codex] Responses output guard not installed — "
+            "langchain_openai._construct_lc_result_from_responses_api is gone; "
+            "codex-oauth may crash on a null terminal output frame"
+        )
+        return
+
+    if getattr(orig, "_codex_output_guarded", False):
+        return
+
+    def _guarded(response, *args, **kwargs):
+        if getattr(response, "output", None) is None:
+            logger.debug("[codex] coerced null Responses output to [] (backend sent output=null)")
+            try:
+                response.output = []
+            except Exception:
+                object.__setattr__(response, "output", [])
+        return orig(response, *args, **kwargs)
+
+    _guarded._codex_output_guarded = True
+    _base._construct_lc_result_from_responses_api = _guarded
+
+
+_install_responses_output_guard()

--- a/tests/unit/llms/test_codex_extension.py
+++ b/tests/unit/llms/test_codex_extension.py
@@ -1,6 +1,5 @@
 """Tests for ChatCodexOpenAI system message → instructions promotion."""
 
-import pytest
 from langchain_core.messages import HumanMessage, SystemMessage
 
 from src.llms.extension.codex import ChatCodexOpenAI
@@ -73,6 +72,44 @@ class TestSystemToInstructions:
         payload = llm._get_request_payload(messages)
 
         assert payload["instructions"] == "Dynamic prompt\n\nstatic placeholder"
+
+
+class TestNullOutputGuard:
+    """chatgpt.com Codex backend ships response.output=null on terminal stream
+    frames. langchain_openai iterates it unguarded and raises
+    TypeError('NoneType' object is not iterable). Importing the codex extension
+    installs a guard that coerces null output to [] before iteration.
+    """
+
+    def _null_output_response(self):
+        from openai.types.responses import Response
+
+        # Exactly what langchain's _coerce_chunk_response yields for a terminal
+        # frame whose output is null (non-validating model_construct).
+        return Response.model_construct(
+            id="resp_test", created_at=0.0, model="gpt-5.3-codex",
+            object="response", status="completed", error=None, usage=None,
+            incomplete_details=None, output=None, parallel_tool_calls=False,
+            tool_choice="auto", tools=[], metadata={},
+        )
+
+    def test_null_output_does_not_crash(self):
+        import langchain_openai.chat_models.base as base
+
+        # Without the guard this raises TypeError('NoneType' object is not iterable).
+        result = base._construct_lc_result_from_responses_api(
+            self._null_output_response()
+        )
+        assert result.generations[0].message.content in ("", [])
+
+    def test_guard_installed_and_idempotent(self):
+        import langchain_openai.chat_models.base as base
+        from src.llms.extension.codex import _install_responses_output_guard
+
+        fn = base._construct_lc_result_from_responses_api
+        assert getattr(fn, "_codex_output_guarded", False) is True
+        _install_responses_output_guard()  # re-running must be a no-op
+        assert base._construct_lc_result_from_responses_api is fn
 
 
 class TestStatelessIdSanitization:


### PR DESCRIPTION
## Summary

Fixes `TypeError: 'NoneType' object is not iterable` that kills codex-oauth turns.

The chatgpt.com Codex backend (`codex-oauth` provider, `use_response_api=true`) ships `response.output = null` on terminal `response.completed` stream frames. `langchain_openai` (1.2.2, latest) iterates that field unguarded in `_construct_lc_result_from_responses_api` (`chat_models/base.py`), so the whole turn dies.

- **fix(llms):** import-time guard in `ChatCodexOpenAI` that coerces `response.output` to `[]` before iteration, at the single chokepoint all read paths (sync/async/streaming) funnel through. Streamed text is already captured from `output_text.delta` events, so an empty terminal output loses no content. The guard is wrapped in `try/except (ImportError, AttributeError)` so a future langchain rename degrades to no-guard + a warning instead of breaking module import, and logs at debug when it fires.
- **test(llms):** regression test that runs a `output=None` Response through the real crash path (fails without the guard) + idempotency check.

Why not the request-side `exclude=["output"]` approach (openai codex-rs `d8044aede8`): the live backend rejects it with `HTTP 400 {'detail': 'Unsupported parameter: exclude'}` — it's only on OpenAI's dev branch, not prod.

## Diff Size
- Total: 2 files changed, 83 insertions, 1 deletion
- Net (excl. tests): 1 file changed, 45 insertions

## Test Coverage
`TestNullOutputGuard`: 2 tests — null output no longer crashes `_construct_lc_result_from_responses_api`; guard installs idempotently. Existing `ChatCodexOpenAI` tests preserved.

## Pre-Landing Review
2 robustness findings, both auto-fixed: (1) import-time hard dependency on a langchain internal could brick codex-oauth → wrapped in try/except; (2) silent coercion → added debug log. No SQL/shell/race/trust-boundary issues.

## Test plan
- [x] `tests/unit/llms/test_codex_extension.py` — 8/8 pass
- [x] Broader llms + codex-touching suite — 434 pass
- [x] ruff clean
- [x] Confirm against a live codex-oauth chat that previously crashed (client-side fix, cannot 400)