### PR TITLE
feat(llms): add Opus 4.8 + Qwen3.7-Max, retire Opus 4.7 + Qwen3.6-Max

### DIFF
--- a/src/llms/llm.py
+++ b/src/llms/llm.py
@@ -97,25 +97,6 @@ class ModelConfig:
         """Get provider configuration from the flattened provider dict."""
         return self._flat_providers.get(provider, {})
 
-    def get_model_pricing(self, custom_model_name: str) -> Optional[Dict[str, Any]]:
-        """Get pricing information for a specific model from manifest."""
-        # Get model info from llm_config first
-        model_info = self.llm_config.get(custom_model_name)
-        if not model_info:
-            return None
-
-        provider = model_info["provider"]
-        model_id = model_info["model_id"]
-
-        # Then look up pricing in manifest. Variant providers (e.g. OAuth) carry
-        # no pricing of their own; fall back to the parent provider's entry so
-        # they inherit the identical price for the same model_id.
-        for prov in (provider, self.get_parent_provider(provider)):
-            for model in self.manifest["models"].get(prov, []):
-                if model["id"] == model_id:
-                    return model.get('pricing')
-        return None
-
     def get_model_info(self, provider: str, model_id: str) -> Optional[Dict[str, Any]]:
         """Get full model information from manifest by provider and model_id.
 

--- a/src/llms/llm.py
+++ b/src/llms/llm.py
@@ -107,11 +107,13 @@ class ModelConfig:
         provider = model_info["provider"]
         model_id = model_info["model_id"]
 
-        # Then look up pricing in manifest
-        models = self.manifest["models"].get(provider, [])
-        for model in models:
-            if model["id"] == model_id:
-                return model.get('pricing')
+        # Then look up pricing in manifest. Variant providers (e.g. OAuth) carry
+        # no pricing of their own; fall back to the parent provider's entry so
+        # they inherit the identical price for the same model_id.
+        for prov in (provider, self.get_parent_provider(provider)):
+            for model in self.manifest["models"].get(prov, []):
+                if model["id"] == model_id:
+                    return model.get('pricing')
         return None
 
     def get_model_info(self, provider: str, model_id: str) -> Optional[Dict[str, Any]]:

--- a/src/llms/manifest/models.json
+++ b/src/llms/manifest/models.json
@@ -67,8 +67,8 @@
       }
     }
   },
-  "claude-opus-4-7": {
-    "model_id": "claude-opus-4-7",
+  "claude-opus-4-8": {
+    "model_id": "claude-opus-4-8",
     "provider": "anthropic",
     "visible": true,
     "input_modalities": [
@@ -545,8 +545,8 @@
       "text"
     ]
   },
-  "qwen3.6-max-preview": {
-    "model_id": "qwen3.6-max-preview",
+  "qwen3.7-max": {
+    "model_id": "qwen3.7-max",
     "provider": "dashscope",
     "visible": true,
     "input_modalities": [
@@ -606,8 +606,8 @@
       "enable_thinking": true
     }
   },
-  "qwen3.6-max-preview-intl": {
-    "model_id": "qwen3.6-max-preview",
+  "qwen3.7-max-intl": {
+    "model_id": "qwen3.7-max",
     "provider": "dashscope-intl",
     "visible": true,
     "input_modalities": [
@@ -877,8 +877,8 @@
       }
     }
   },
-  "claude-opus-4-7-oauth": {
-    "model_id": "claude-opus-4-7",
+  "claude-opus-4-8-oauth": {
+    "model_id": "claude-opus-4-8",
     "provider": "claude-oauth",
     "visible": true,
     "input_modalities": [
@@ -935,8 +935,8 @@
       "dimensions": 1536
     }
   },
-  "claude-opus-4-7-oauth-1m": {
-    "model_id": "claude-opus-4-7",
+  "claude-opus-4-8-oauth-1m": {
+    "model_id": "claude-opus-4-8",
     "provider": "claude-oauth",
     "visible": true,
     "input_modalities": [

--- a/src/llms/manifest/providers.json
+++ b/src/llms/manifest/providers.json
@@ -691,6 +691,8 @@
         "name": "Qwen3.7 Max",
         "is_reasoning": true,
         "description": "Alibaba's largest and most capable Qwen3.7 Max — flagship agentic model excelling at coding, office/productivity, and long-horizon autonomous execution",
+        "context_window": 1000000,
+        "max_output": 65536,
         "pricing": {
           "input": 1.714,
           "cached_input": 0.343,
@@ -945,6 +947,8 @@
         "name": "Qwen3.7 Max (SG)",
         "is_reasoning": true,
         "description": "Alibaba's Qwen3.7 Max — Singapore international region",
+        "context_window": 1000000,
+        "max_output": 65536,
         "pricing": {
           "input": 2.677,
           "cached_input": 0.535,

--- a/src/llms/manifest/providers.json
+++ b/src/llms/manifest/providers.json
@@ -124,12 +124,12 @@
     ],
     "anthropic": [
       {
-        "id": "claude-opus-4-7",
-        "name": "Claude 4.7 Opus",
+        "id": "claude-opus-4-8",
+        "name": "Claude 4.8 Opus",
         "is_reasoning": true,
-        "description": "Claude 4.7 Opus model",
+        "description": "Claude 4.8 Opus model",
         "alias": [
-          "claude-opus-4.7"
+          "claude-opus-4.8"
         ],
         "pricing": {
           "input": 5.0,
@@ -276,9 +276,9 @@
         "context_window": 1000000,
         "max_output": 384000,
         "pricing": {
-          "input": 1.74,
-          "cached_input": 0.145,
-          "output": 3.48,
+          "input": 0.435,
+          "cached_input": 0.003625,
+          "output": 0.87,
           "unit": "per_1m_tokens"
         }
       },
@@ -291,7 +291,7 @@
         "max_output": 384000,
         "pricing": {
           "input": 0.14,
-          "cached_input": 0.028,
+          "cached_input": 0.0028,
           "output": 0.28,
           "unit": "per_1m_tokens"
         }
@@ -687,36 +687,15 @@
     ],
     "dashscope": [
       {
-        "id": "qwen3.6-max-preview",
-        "name": "Qwen3.6 Max Preview",
+        "id": "qwen3.7-max",
+        "name": "Qwen3.7 Max",
         "is_reasoning": true,
-        "description": "Alibaba's largest and most capable Qwen3.6 Max Preview — improved vibe coding, coding agent execution, and frontend development",
-        "context_window": 262144,
-        "max_output": 65536,
+        "description": "Alibaba's largest and most capable Qwen3.7 Max — flagship agentic model excelling at coding, office/productivity, and long-horizon autonomous execution",
         "pricing": {
-          "input_tiers": [
-            {
-              "max_tokens": 128000,
-              "rate": 1.291,
-              "cached_input": 0.129
-            },
-            {
-              "max_tokens": 256000,
-              "rate": 2.152,
-              "cached_input": 0.215
-            }
-          ],
-          "output_tiers": [
-            {
-              "max_tokens": 128000,
-              "rate": 7.747
-            },
-            {
-              "max_tokens": 256000,
-              "rate": 12.912
-            }
-          ],
-          "output_pricing_mode": "input_dependent",
+          "input": 1.714,
+          "cached_input": 0.343,
+          "cache_5m": 2.143,
+          "output": 5.143,
           "unit": "per_1m_tokens"
         }
       },
@@ -962,36 +941,15 @@
     ],
     "dashscope-intl": [
       {
-        "id": "qwen3.6-max-preview",
-        "name": "Qwen3.6 Max Preview (SG)",
+        "id": "qwen3.7-max",
+        "name": "Qwen3.7 Max (SG)",
         "is_reasoning": true,
-        "description": "Alibaba's Qwen3.6 Max Preview — Singapore international region",
-        "context_window": 262144,
-        "max_output": 65536,
+        "description": "Alibaba's Qwen3.7 Max — Singapore international region",
         "pricing": {
-          "input_tiers": [
-            {
-              "max_tokens": 128000,
-              "rate": 1.398,
-              "cached_input": 0.140
-            },
-            {
-              "max_tokens": 256000,
-              "rate": 2.150,
-              "cached_input": 0.215
-            }
-          ],
-          "output_tiers": [
-            {
-              "max_tokens": 128000,
-              "rate": 8.387
-            },
-            {
-              "max_tokens": 256000,
-              "rate": 12.902
-            }
-          ],
-          "output_pricing_mode": "input_dependent",
+          "input": 2.677,
+          "cached_input": 0.535,
+          "cache_5m": 3.346,
+          "output": 8.030,
           "unit": "per_1m_tokens"
         }
       },

--- a/tests/unit/llms/test_input_modalities.py
+++ b/tests/unit/llms/test_input_modalities.py
@@ -48,7 +48,7 @@ class TestGetInputModalities:
 
     def test_oauth_variant_inherits_modalities(self, model_config):
         """OAuth models should have explicit modalities, not fall back to default."""
-        result = model_config.get_input_modalities("claude-opus-4-7-oauth")
+        result = model_config.get_input_modalities("claude-opus-4-8-oauth")
         assert "image" in result
         assert "pdf" in result
 

--- a/tests/unit/llms/test_model_pricing_inheritance.py
+++ b/tests/unit/llms/test_model_pricing_inheritance.py
@@ -1,0 +1,44 @@
+"""Tests for ModelConfig.get_model_pricing() parent-provider inheritance."""
+
+import pytest
+
+from src.llms.llm import ModelConfig
+
+
+class TestGetModelPricing:
+    """OAuth/variant models carry no pricing of their own and inherit the
+    parent provider's entry for the same model_id."""
+
+    @pytest.fixture
+    def model_config(self):
+        return ModelConfig()
+
+    def test_direct_provider_pricing(self, model_config):
+        pricing = model_config.get_model_pricing("claude-opus-4-8")
+        assert pricing is not None
+        assert pricing["input"] == 5.0
+        assert pricing["output"] == 25.0
+
+    def test_oauth_variant_inherits_parent_pricing(self, model_config):
+        """claude-oauth has no pricing list; falls back to anthropic."""
+        pricing = model_config.get_model_pricing("claude-opus-4-8-oauth")
+        assert pricing is not None
+        assert pricing["input"] == 5.0
+        assert pricing["output"] == 25.0
+
+    def test_oauth_1m_variant_inherits_parent_pricing(self, model_config):
+        pricing = model_config.get_model_pricing("claude-opus-4-8-oauth-1m")
+        assert pricing is not None
+        assert pricing["input"] == 5.0
+
+    def test_intl_variant_uses_own_pricing_not_parent(self, model_config):
+        """dashscope-intl has its own pricing list, so it must NOT inherit the
+        cheaper CN rates from the parent dashscope provider."""
+        cn = model_config.get_model_pricing("qwen3.7-max")
+        intl = model_config.get_model_pricing("qwen3.7-max-intl")
+        assert cn["input"] == 1.714
+        assert intl["input"] == 2.677
+        assert cn["input"] != intl["input"]
+
+    def test_unknown_model_returns_none(self, model_config):
+        assert model_config.get_model_pricing("does-not-exist") is None

--- a/tests/unit/llms/test_model_pricing_inheritance.py
+++ b/tests/unit/llms/test_model_pricing_inheritance.py
@@ -1,44 +1,40 @@
-"""Tests for ModelConfig.get_model_pricing() parent-provider inheritance."""
+"""Pricing resolution for the new model entries via the canonical
+find_model_pricing() path used by cost tracking.
 
-import pytest
+Variant providers (OAuth) carry no pricing of their own and inherit the
+parent provider's entry; region variants keep their own rates.
+"""
 
-from src.llms.llm import ModelConfig
+from src.llms.pricing_utils import find_model_pricing
 
 
-class TestGetModelPricing:
-    """OAuth/variant models carry no pricing of their own and inherit the
-    parent provider's entry for the same model_id."""
-
-    @pytest.fixture
-    def model_config(self):
-        return ModelConfig()
-
-    def test_direct_provider_pricing(self, model_config):
-        pricing = model_config.get_model_pricing("claude-opus-4-8")
+class TestModelPricingResolution:
+    def test_anthropic_direct_pricing(self):
+        pricing = find_model_pricing("claude-opus-4-8", provider="anthropic")
         assert pricing is not None
         assert pricing["input"] == 5.0
         assert pricing["output"] == 25.0
 
-    def test_oauth_variant_inherits_parent_pricing(self, model_config):
-        """claude-oauth has no pricing list; falls back to anthropic."""
-        pricing = model_config.get_model_pricing("claude-opus-4-8-oauth")
+    def test_oauth_variant_inherits_parent_pricing(self):
+        """claude-oauth has no pricing list; inherits anthropic for the same id."""
+        pricing = find_model_pricing("claude-opus-4-8", provider="claude-oauth")
         assert pricing is not None
         assert pricing["input"] == 5.0
         assert pricing["output"] == 25.0
 
-    def test_oauth_1m_variant_inherits_parent_pricing(self, model_config):
-        pricing = model_config.get_model_pricing("claude-opus-4-8-oauth-1m")
+    def test_qwen_cn_pricing(self):
+        pricing = find_model_pricing("qwen3.7-max", provider="dashscope")
         assert pricing is not None
-        assert pricing["input"] == 5.0
+        assert pricing["input"] == 1.714
 
-    def test_intl_variant_uses_own_pricing_not_parent(self, model_config):
+    def test_intl_variant_keeps_own_pricing_not_parent(self):
         """dashscope-intl has its own pricing list, so it must NOT inherit the
         cheaper CN rates from the parent dashscope provider."""
-        cn = model_config.get_model_pricing("qwen3.7-max")
-        intl = model_config.get_model_pricing("qwen3.7-max-intl")
+        cn = find_model_pricing("qwen3.7-max", provider="dashscope")
+        intl = find_model_pricing("qwen3.7-max", provider="dashscope-intl")
         assert cn["input"] == 1.714
         assert intl["input"] == 2.677
         assert cn["input"] != intl["input"]
 
-    def test_unknown_model_returns_none(self, model_config):
-        assert model_config.get_model_pricing("does-not-exist") is None
+    def test_unknown_model_returns_none(self):
+        assert find_model_pricing("does-not-exist", provider="anthropic") is None


### PR DESCRIPTION
## Summary

Model manifest refresh plus a small pricing-path cleanup.

**Model roster**
- Add **Claude Opus 4.8** — `claude-opus-4-8` (api), `claude-opus-4-8-oauth`, `claude-opus-4-8-oauth-1m` (1M context, `context-1m-2025-08-07` beta). Mirrors the retired 4.7 config; pricing $5 in / $25 out per 1M.
- Add **Qwen3.7-Max** — `qwen3.7-max` (CN `dashscope`) and `qwen3.7-max-intl` (`dashscope-intl`). Prices converted from the published RMB list rates at 7 RMB/USD.
- Retire **Opus 4.7** (all 3 variants) and **Qwen3.6-Max** (CN + intl), including their pricing entries.

**Pricing**
- Fold the now-permanent **DeepSeek V4** discount into list pricing: pro input 1.74→0.435, cached 0.145→0.003625, output 3.48→0.87. Also correct a 10×-high `cached_input` on both DeepSeek tiers (flash 0.028→0.0028).

**Cleanup**
- Remove `ModelConfig.get_model_pricing` — dead since the initial release (zero callers, ever). Cost tracking uses `pricing_utils.find_model_pricing`, which already resolves provider → parent → global and is the superset. The deleted method returned `None` for OAuth/variant providers, so removing it also drops a latently-wrong path.

## Diff Size
- Total: 5 files changed, 73 insertions(+), 92 deletions(-)
- Net (excl. tests): 3 files changed, ~30 insertions, ~88 deletions

## Test Coverage
New code paths: the only behavioral change is a deletion. Pricing resolution for the new entries is covered via the real billing path (`find_model_pricing`): Opus 4.8 direct, OAuth inheriting parent rates, Qwen3.7-Max CN, intl keeping its own rate, and unknown→None.

## Pre-Landing Review
Clean. JSON valid; manifest integrity + system_provider/tier suites pass (204); no dangling references to removed models in runtime config/defaults; the one manifest-backed test repointed off 4.7 onto 4.8.

## Eval Results
No prompt-related files changed — evals skipped.

## Design Review
No frontend files changed — design review skipped.

## Test plan
- [x] Full backend unit suite: 3480 passed
- [x] llms suite post-cleanup: 425 passed

## Notes / risk
- Pricing values cross-checked: DeepSeek 75%-off math, Qwen RMB÷7, Opus 4.8 mirrors 4.7. Confirm the 7 RMB/USD rate and the DeepSeek `cached_input` 10× correction match intended billing.
- `get_model_pricing` removal is a public-method deletion (langalpha is OSS), but it was never called.