### PR TITLE
ci(e2e): run frontend-e2e in Playwright container to fix install hang

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,10 @@ jobs:
     # pulled from MCR. This removes the `playwright install` download step,
     # whose post-download hang (Chromium fetch reaches 100% then stalls during
     # extraction / next-artifact fetch from cdn.playwright.dev) was hanging CI.
-    # KEEP THIS TAG IN SYNC with "@playwright/test" in web/package.json.
+    # KEEP THIS TAG IN SYNC with the @playwright/test version resolved in
+    # web/pnpm-lock.yaml (package.json uses a ^ range, so the lockfile is the
+    # source of truth). A mismatch makes playwright test fail on a browser/
+    # library version error.
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     defaults:
@@ -131,12 +134,12 @@ jobs:
         working-directory: web
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: latest
       - uses: actions/setup-node@v4
         with:
           node-version: 24
+      - uses: pnpm/action-setup@v4
+        with:
+          version: latest
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec playwright test
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,19 +117,27 @@ jobs:
   frontend-e2e:
     runs-on: ubuntu-latest
     needs: frontend-unit
+    # Bound a hung run instead of riding GitHub's 6h default timeout.
+    timeout-minutes: 20
+    # Official Playwright image ships the browser + system deps pre-installed,
+    # pulled from MCR. This removes the `playwright install` download step,
+    # whose post-download hang (Chromium fetch reaches 100% then stalls during
+    # extraction / next-artifact fetch from cdn.playwright.dev) was hanging CI.
+    # KEEP THIS TAG IN SYNC with "@playwright/test" in web/package.json.
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
     defaults:
       run:
         working-directory: web
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
       - uses: pnpm/action-setup@v4
         with:
           version: latest
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
       - run: pnpm install --frozen-lockfile
-      - run: pnpm exec playwright install chromium --with-deps
       - run: pnpm exec playwright test
       - uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
## Problem

The `frontend-e2e` job hangs intermittently — often enough to block PRs. The Chromium download in `pnpm exec playwright install chromium --with-deps` reaches **100% of 167.3 MiB** from `cdn.playwright.dev`, then the install step stops making progress (hang is post-download: archive extraction or the next-artifact fetch for the headless shell / ffmpeg). No job in `test.yml` sets `timeout-minutes`, so the stall rides GitHub's default 6-hour job timeout instead of failing fast. A healthy run is ~2 min.

## Fix

Run `frontend-e2e` inside the official Playwright container (`mcr.microsoft.com/playwright:v1.58.2-noble`), which ships the browser + system deps pre-baked and is pulled from Microsoft Container Registry. This removes the `playwright install` download step entirely, so the post-download hang can't occur. Also adds `timeout-minutes: 20` so any future stall fails fast.

- Drop `pnpm exec playwright install chromium --with-deps` (container provides the browser).
- Add `container.image: mcr.microsoft.com/playwright:v1.58.2-noble` + `timeout-minutes: 20`.
- Reorder `setup-node` after `pnpm/action-setup`.

Image tag is coupled to `@playwright/test` (`^1.58.2`) in `web/package.json` — a `KEEP THIS TAG IN SYNC` comment marks the coupling. The config only uses the `chromium` project, which the image has.

## Diff Size
- Total: 1 file changed, 12 insertions(+), 4 deletions(-)

## Test plan
- [ ] frontend-e2e goes green on this PR (the real signal — confirms pnpm install + playwright test run cleanly inside the container)
- [x] YAML validates; all 5 jobs intact; only frontend-e2e changed