### PR TITLE
feat(workspace): proactively warm sandboxes on workspace entry

### DIFF
--- a/src/server/app/setup.py
+++ b/src/server/app/setup.py
@@ -426,6 +426,23 @@ async def lifespan(app: FastAPI):
     # 3. Shutdown Workspace Manager (stop cleanup task, clear cache)
     if workspace_manager is not None:
         try:
+            # Drain in-flight warm tasks first so a task cancelled mid-Phase-2
+            # reverts its 'starting' row to 'stopped' (CancelledError revert)
+            # instead of being torn down abruptly and left wedged.
+            from src.server.app.workspaces import drain_warm_tasks
+
+            await drain_warm_tasks()
+        except Exception as e:
+            logger.warning(f"Error draining warm tasks: {e}")
+        try:
+            from src.server.services.workspace_status_pubsub import (
+                close_status_pubsub_pool,
+            )
+
+            await close_status_pubsub_pool()
+        except Exception as e:
+            logger.warning(f"Error closing status pubsub pool: {e}")
+        try:
             logger.info("Shutting down Workspace Manager...")
             await workspace_manager.shutdown()
             logger.info("Workspace Manager shutdown complete")

--- a/src/server/app/workspaces.py
+++ b/src/server/app/workspaces.py
@@ -290,20 +290,29 @@ async def workspace_status_events(workspace_id: str, x_user_id: CurrentUserId):
                     # spinner even when a background warm (not this client's
                     # chat) owns the start.
                     sandbox_state = payload.get("sandbox_state")
+                    hinted = payload.get("status")
                     if (
                         sandbox_state
                         and sandbox_state != last_sandbox_state
                         and last_status not in _EVENTS_TERMINAL
                     ):
                         last_sandbox_state = sandbox_state
+                        # Pair the refinement with the payload's own status, not
+                        # the cached last_status. A publish can carry
+                        # {status:'starting', sandbox_state:'archived'} while
+                        # reconcile() still has last_status on 'stopped' (the
+                        # 'starting' publish raced ahead of its commit). Emitting
+                        # 'stopped' here makes the FE drop the archived hint, and
+                        # the follow-up plain 'starting' (from reconcile) carries
+                        # no refinement — so the slow-restore spinner is lost.
+                        event_status = hinted if isinstance(hinted, str) else last_status
                         yield _sse_status_event(
-                            workspace_id, last_status, sandbox_state=sandbox_state
+                            workspace_id, event_status, sandbox_state=sandbox_state
                         )
                     # Treat the status hint as advisory only. A publish can race
                     # ahead of its transaction commit (or be spurious), and a
                     # terminal status closes the stream — so confirm against the
                     # authoritative DB row (via reconcile) before trusting it.
-                    hinted = payload.get("status")
                     if not hinted or hinted == last_status:
                         continue
                     event, close = await reconcile()

--- a/src/server/app/workspaces.py
+++ b/src/server/app/workspaces.py
@@ -14,10 +14,14 @@ Endpoints:
 - DELETE /api/v1/workspaces/{workspace_id} - Delete workspace
 """
 
+import asyncio
+import json
 import logging
+import time
 from typing import Literal
 
 from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import Response, StreamingResponse
 
 from src.server.utils.api import CurrentUserId, require_workspace_owner
 from src.server.dependencies.usage_limits import WorkspaceLimitCheck
@@ -38,6 +42,7 @@ from src.server.models.workspace import (
 )
 from src.server.models.workspace_refresh import WorkspaceRefreshResponse
 from src.server.services.workspace_manager import WorkspaceManager
+from src.server.services.workspace_status_pubsub import subscribe_to_status
 
 logger = logging.getLogger(__name__)
 
@@ -187,6 +192,144 @@ async def list_workspaces(
         raise HTTPException(status_code=500, detail="Failed to list workspaces")
 
 
+_SSE_HEADERS = {
+    "Cache-Control": "no-cache",
+    "X-Accel-Buffering": "no",
+    "Connection": "keep-alive",
+}
+_EVENTS_KEEPALIVE_S = 30.0
+_EVENTS_MAX_DURATION_S = 600.0
+_EVENTS_TERMINAL = {"running", "error", "deleted"}
+
+
+def _sse_status_event(
+    workspace_id: str, status: str, sandbox_state: str | None = None
+) -> str:
+    data = {"workspace_id": workspace_id, "status": status}
+    if sandbox_state:
+        data["sandbox_state"] = sandbox_state
+    return f"event: status\ndata: {json.dumps(data)}\n\n"
+
+
+@router.get("/{workspace_id}/events")
+async def workspace_status_events(workspace_id: str, x_user_id: CurrentUserId):
+    """Push workspace lifecycle status changes to the client via SSE.
+
+    Replaces the previous 4-second interval polling on the frontend. The
+    handler emits the current status immediately, then one ``status``
+    event per transition (stopped → starting → running). Closes once the
+    status is terminal (``running``, ``error``, ``deleted``), or after a
+    600 s hard cap. A ``: ping\\n\\n`` keepalive is sent every 30 s.
+
+    Falls back to DB polling at the keepalive interval when Redis pub/sub
+    is unavailable so the FE never needs an interval-polling sidecar.
+    """
+    workspace = await db_get_workspace(workspace_id)
+    require_workspace_owner(workspace, user_id=x_user_id)
+
+    initial_status = workspace["status"]
+
+    async def event_generator():
+        started = time.monotonic()
+        last_status = initial_status
+        last_sandbox_state: str | None = None
+
+        async def reconcile() -> tuple[str | None, bool]:
+            """Re-read the authoritative DB row and diff against last_status.
+
+            Returns ``(event_to_yield_or_None, should_close)``. Closes the
+            stream when the workspace is gone or has reached a terminal status.
+            Single source of the read → diff → emit logic shared by the
+            post-subscribe read, the keepalive tick, the pub/sub hint confirm,
+            and the Redis-disabled poll.
+            """
+            nonlocal last_status
+            ws = await db_get_workspace(workspace_id)
+            if ws is None:
+                return None, True
+            if ws["status"] == last_status:
+                return None, False
+            last_status = ws["status"]
+            return (
+                _sse_status_event(workspace_id, last_status),
+                last_status in _EVENTS_TERMINAL,
+            )
+
+        yield _sse_status_event(workspace_id, last_status)
+        if last_status in _EVENTS_TERMINAL:
+            return
+
+        async with subscribe_to_status(workspace_id) as wait_for_notify:
+            # Always re-read after subscribing — the publish for the current
+            # status could have fired between the initial DB read above and
+            # the SUBSCRIBE below.
+            event, close = await reconcile()
+            if event:
+                yield event
+            if close:
+                return
+
+            while time.monotonic() - started < _EVENTS_MAX_DURATION_S:
+                if wait_for_notify is not None:
+                    payload = await wait_for_notify(_EVENTS_KEEPALIVE_S)
+                    if payload is None:
+                        # Keepalive tick or a missed message — re-read to be
+                        # safe, then send keepalive.
+                        event, close = await reconcile()
+                        if event:
+                            yield event
+                        if close:
+                            return
+                        yield ": ping\n\n"
+                        continue
+                    # Forward a sandbox sub-state refinement (e.g. 'archived')
+                    # immediately. It's a non-terminal hint during the
+                    # 'starting' phase — it can't close the stream and isn't
+                    # persisted in the DB, so it's emitted directly without a
+                    # DB re-read. Lets the FE escalate to the slow-restore
+                    # spinner even when a background warm (not this client's
+                    # chat) owns the start.
+                    sandbox_state = payload.get("sandbox_state")
+                    if (
+                        sandbox_state
+                        and sandbox_state != last_sandbox_state
+                        and last_status not in _EVENTS_TERMINAL
+                    ):
+                        last_sandbox_state = sandbox_state
+                        yield _sse_status_event(
+                            workspace_id, last_status, sandbox_state=sandbox_state
+                        )
+                    # Treat the status hint as advisory only. A publish can race
+                    # ahead of its transaction commit (or be spurious), and a
+                    # terminal status closes the stream — so confirm against the
+                    # authoritative DB row (via reconcile) before trusting it.
+                    hinted = payload.get("status")
+                    if not hinted or hinted == last_status:
+                        continue
+                    event, close = await reconcile()
+                    if event:
+                        yield event
+                    if close:
+                        return
+                else:
+                    # Redis-disabled fallback: server-side keepalive-paced poll.
+                    await asyncio.sleep(_EVENTS_KEEPALIVE_S)
+                    event, close = await reconcile()
+                    if event:
+                        yield event
+                    if close:
+                        return
+                    yield ": ping\n\n"
+
+        yield "event: timeout\ndata: {}\n\n"
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers=_SSE_HEADERS,
+    )
+
+
 @router.get("/{workspace_id}", response_model=WorkspaceResponse)
 async def get_workspace(workspace_id: str, x_user_id: CurrentUserId):
     """
@@ -255,10 +398,59 @@ async def update_workspace(
         raise HTTPException(status_code=500, detail="Failed to update workspace")
 
 
+# Strong references to in-flight warm tasks. asyncio holds only *weak*
+# references to tasks, so a fire-and-forget create_task whose handle goes out
+# of scope can be garbage-collected mid-flight — which, after the row was
+# claimed to 'starting', would wedge the workspace. Hold a strong ref until
+# the task finishes (discarded in the done callback below).
+_warm_tasks: set[asyncio.Task] = set()
+
+
+def _log_warm_task_exception(workspace_id: str, task: asyncio.Task) -> None:
+    """Surface background warm-task failures (silent create_task is dangerous)."""
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.exception(
+            "Background warm task for workspace %s failed: %s",
+            workspace_id,
+            exc,
+            exc_info=exc,
+        )
+
+
+async def drain_warm_tasks() -> None:
+    """Cancel and await in-flight warm tasks on shutdown.
+
+    A warm task cancelled mid-Phase-2 triggers the CancelledError revert in
+    WorkspaceManager.get_session_for_workspace, which resets the row from
+    'starting' back to 'stopped'. Without this drain the event loop tears the
+    tasks down abruptly during shutdown and the revert may not land, leaving
+    rows wedged in 'starting' until the next process reaps them. Call from the
+    app lifespan shutdown BEFORE WorkspaceManager.shutdown().
+    """
+    if not _warm_tasks:
+        return
+    tasks = list(_warm_tasks)
+    logger.info("Draining %d in-flight warm task(s) on shutdown", len(tasks))
+    for task in tasks:
+        task.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)
+
+
 @router.post("/{workspace_id}/start", response_model=WorkspaceActionResponse)
 async def start_workspace(
     workspace_id: str,
     x_user_id: CurrentUserId,
+    lazy: bool = Query(
+        False,
+        description=(
+            "If true, schedule the restart in the background and return 202 "
+            "immediately with status='starting'. If false (default), block "
+            "until the session is ready and return status='running'."
+        ),
+    ),
 ):
     """
     Start a stopped workspace.
@@ -266,8 +458,15 @@ async def start_workspace(
     This restarts the Daytona sandbox, which is much faster than creating
     a new one (~5 seconds vs ~60 seconds).
 
+    With ``lazy=true``, the endpoint returns 202 immediately and continues
+    the restart in a background task — used by the proactive warm-on-entry
+    UI flow to avoid blocking the request for stopped-hot (~5s) or
+    archived (~60-300s) restores.
+
     Args:
         workspace_id: Workspace UUID
+        lazy: When true, return 202 + 'starting' immediately and continue
+            the restart in the background. Default false (blocking).
 
     Returns:
         Action result
@@ -302,7 +501,32 @@ async def start_workspace(
                 detail=f"Cannot start workspace in '{workspace['status']}' state",
             )
 
-        # Start by getting session (triggers restart)
+        if lazy:
+            # Schedule the restart and return 202 immediately. The chat path's
+            # own get_session_for_workspace call will dedupe against this via
+            # the existing _observed_lock and _pending_lazy_sync primitives.
+            task = asyncio.create_task(
+                manager.get_session_for_workspace(workspace_id, user_id=x_user_id),
+                name=f"warm-workspace-{workspace_id}",
+            )
+            _warm_tasks.add(task)
+            task.add_done_callback(_warm_tasks.discard)
+            task.add_done_callback(
+                lambda t, wid=workspace_id: _log_warm_task_exception(wid, t)
+            )
+            logger.info(f"Scheduled warm restart for workspace {workspace_id}")
+            payload = WorkspaceActionResponse(
+                workspace_id=workspace_id,
+                status="starting",
+                message="Workspace warm initiated",
+            )
+            return Response(
+                status_code=202,
+                content=payload.model_dump_json(),
+                media_type="application/json",
+            )
+
+        # Existing blocking path
         await manager.get_session_for_workspace(workspace_id, user_id=x_user_id)
 
         logger.info(f"Started workspace {workspace_id}")

--- a/src/server/app/workspaces.py
+++ b/src/server/app/workspaces.py
@@ -291,21 +291,23 @@ async def workspace_status_events(workspace_id: str, x_user_id: CurrentUserId):
                     # chat) owns the start.
                     sandbox_state = payload.get("sandbox_state")
                     hinted = payload.get("status")
+                    # Pair the refinement with the payload's own status, not the
+                    # cached last_status. A publish can carry {status:'starting',
+                    # sandbox_state:'archived'} while reconcile() still has
+                    # last_status on 'stopped' (the 'starting' publish raced ahead
+                    # of its commit). Emitting 'stopped' here makes the FE drop
+                    # the archived hint, and the follow-up plain 'starting' (from
+                    # reconcile) carries no refinement — the spinner is lost.
+                    event_status = hinted if isinstance(hinted, str) else last_status
                     if (
                         sandbox_state
                         and sandbox_state != last_sandbox_state
-                        and last_status not in _EVENTS_TERMINAL
+                        and event_status not in _EVENTS_TERMINAL
                     ):
+                        # Guard on event_status (what we emit), not last_status —
+                        # this is a non-terminal hint, so it must never carry a
+                        # terminal status. reconcile() owns terminal transitions.
                         last_sandbox_state = sandbox_state
-                        # Pair the refinement with the payload's own status, not
-                        # the cached last_status. A publish can carry
-                        # {status:'starting', sandbox_state:'archived'} while
-                        # reconcile() still has last_status on 'stopped' (the
-                        # 'starting' publish raced ahead of its commit). Emitting
-                        # 'stopped' here makes the FE drop the archived hint, and
-                        # the follow-up plain 'starting' (from reconcile) carries
-                        # no refinement — so the slow-restore spinner is lost.
-                        event_status = hinted if isinstance(hinted, str) else last_status
                         yield _sse_status_event(
                             workspace_id, event_status, sandbox_state=sandbox_state
                         )

--- a/src/server/database/workspace.py
+++ b/src/server/database/workspace.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from psycopg.rows import dict_row
 
 from src.server.database.conversation import get_db_connection
+from src.server.services.workspace_status_pubsub import publish_status_change
 
 logger = logging.getLogger(__name__)
 
@@ -437,11 +438,69 @@ async def update_workspace_status(
 
         if result:
             logger.debug(f"Updated workspace {workspace_id} status to: {status}")
+            # Best-effort cross-worker notification — wakes any
+            # _wait_for_start_completion loop and any /events SSE
+            # subscribers in milliseconds. Swallows on failure.
+            await publish_status_change(workspace_id, status)
             return dict(result)
         return None
 
     except Exception as e:
         logger.error(f"Error updating workspace {workspace_id} status: {e}")
+        raise
+
+
+async def try_claim_workspace_for_start(
+    workspace_id: str,
+    conn=None,
+) -> Optional[Dict[str, Any]]:
+    """Atomically claim a stopped workspace for a start transition.
+
+    Cross-worker mutex for the stopped → starting transition. Only the worker
+    whose UPDATE returns a row should proceed to restart the sandbox; losers
+    must wait for the winner to flip status to 'running' (or 'error').
+
+    Returns:
+        The updated workspace row (status='starting') if claimed; None if
+        the workspace was not in 'stopped' state (already starting, running,
+        creating, error, deleted, or stopping).
+    """
+    try:
+        now = datetime.now(timezone.utc)
+        query = """
+            UPDATE workspaces
+            SET status = 'starting', updated_at = %s
+            WHERE workspace_id = %s AND status = 'stopped'
+            RETURNING workspace_id, user_id, name, description, sandbox_id,
+                      status, created_at, updated_at, last_activity_at, stopped_at, config, artifacts,
+                      is_pinned, sort_order
+        """
+        params = (now, workspace_id)
+
+        async def _execute(cur):
+            await cur.execute(query, params)
+            return await cur.fetchone()
+
+        if conn:
+            async with conn.cursor(row_factory=dict_row) as cur:
+                result = await _execute(cur)
+        else:
+            async with get_db_connection() as conn:
+                async with conn.cursor(row_factory=dict_row) as cur:
+                    result = await _execute(cur)
+
+        if result:
+            logger.debug(f"Claimed workspace {workspace_id} for start (was stopped)")
+            # Notify so cross-worker /events subscribers learn about the
+            # stopped → starting flip without polling. The wait loop in
+            # WorkspaceManager doesn't need this (the loser path triggers
+            # only after the claim returns None), but the FE does.
+            await publish_status_change(workspace_id, "starting")
+            return dict(result)
+        return None
+
+    except Exception as e:
+        logger.error(f"Error claiming workspace {workspace_id} for start: {e}")
         raise
 
 

--- a/src/server/database/workspace.py
+++ b/src/server/database/workspace.py
@@ -452,13 +452,16 @@ async def update_workspace_status(
 
 async def try_claim_workspace_for_start(
     workspace_id: str,
-    conn=None,
 ) -> Optional[Dict[str, Any]]:
     """Atomically claim a stopped workspace for a start transition.
 
     Cross-worker mutex for the stopped → starting transition. Only the worker
     whose UPDATE returns a row should proceed to restart the sandbox; losers
     must wait for the winner to flip status to 'running' (or 'error').
+
+    Owns its own connection so the UPDATE is committed before the publish
+    fires — a caller-supplied transaction would let publish_status_change
+    wake SSE subscribers that then read the still-'stopped' row.
 
     Returns:
         The updated workspace row (status='starting') if claimed; None if
@@ -477,17 +480,10 @@ async def try_claim_workspace_for_start(
         """
         params = (now, workspace_id)
 
-        async def _execute(cur):
-            await cur.execute(query, params)
-            return await cur.fetchone()
-
-        if conn:
+        async with get_db_connection() as conn:
             async with conn.cursor(row_factory=dict_row) as cur:
-                result = await _execute(cur)
-        else:
-            async with get_db_connection() as conn:
-                async with conn.cursor(row_factory=dict_row) as cur:
-                    result = await _execute(cur)
+                await cur.execute(query, params)
+                result = await cur.fetchone()
 
         if result:
             logger.debug(f"Claimed workspace {workspace_id} for start (was stopped)")

--- a/src/server/services/workspace_manager.py
+++ b/src/server/services/workspace_manager.py
@@ -1287,7 +1287,20 @@ class WorkspaceManager:
                     f"Phase 2 sync transient for workspace {workspace_id} "
                     f"(will retry next request): {e}"
                 )
+                # Capture before reverting — the revert clears _pending_lazy_sync.
+                was_unpromoted_lazy = workspace_id in self._pending_lazy_sync
                 await self._revert_unpromoted_lazy_start(workspace_id)
+                if was_unpromoted_lazy:
+                    # We just reverted this lazy start's row to 'stopped'. The
+                    # sandbox is healthy (has_failed() was False), but returning
+                    # the session now hands the caller a sandbox the DB says is
+                    # 'stopped' — other workers would claim and spawn a second
+                    # one (split-brain). Surface the transient so the caller
+                    # re-claims cleanly, mirroring the generic Exception branch.
+                    raise
+                # Already-'running' re-sync hit a transient; the sandbox was
+                # usable before this periodic sync, so keep the cached session
+                # and let the next request retry.
             except asyncio.CancelledError:
                 # A client disconnect or server shutdown mid-Phase-2 cancels
                 # this coroutine. CancelledError is a BaseException, so without

--- a/src/server/services/workspace_manager.py
+++ b/src/server/services/workspace_manager.py
@@ -36,10 +36,15 @@ from src.server.database.workspace import (
     delete_workspace as db_delete_workspace,
     get_workspace as db_get_workspace,
     get_workspaces_by_status,
+    try_claim_workspace_for_start,
     update_workspace_activity,
     update_workspace_status,
 )
 from src.server.services.persistence.file import FilePersistenceService
+from src.server.services.workspace_status_pubsub import (
+    publish_status_change,
+    subscribe_to_status,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -57,10 +62,30 @@ class WorkspaceManager:
         config: AgentConfig,
         idle_timeout: int = 1800,  # 30 minutes default
         cleanup_interval: int = 300,  # 5 minutes
+        start_wait_timeout: float = 300.0,
+        start_wait_poll_interval: float = 0.5,
+        reap_stuck_after: float | None = None,
     ):
         self.config = config
         self.idle_timeout = idle_timeout
         self.cleanup_interval = cleanup_interval
+        # Cross-worker start-mutex polling — see _wait_for_start_completion.
+        # 300s covers the worst-case archived-sandbox cold restore and the
+        # ceiling for how long a loser waits on the claim winner.
+        self.start_wait_timeout = start_wait_timeout
+        self.start_wait_poll_interval = start_wait_poll_interval
+        # Reaper age threshold — MUST be strictly greater than the worst-case
+        # legit start (start_wait_timeout), or the reaper races an in-flight
+        # archived restore: it would flip the row to 'stopped' AND discard its
+        # _pending_lazy_sync membership, silently no-op'ing the owner's later
+        # promotion (ready session, 'stopped' DB row) and triggering a
+        # duplicate restart. 2x gives headroom past the 60-300s worst case;
+        # only a genuinely-wedged start exceeds it.
+        self.reap_stuck_after = (
+            reap_stuck_after
+            if reap_stuck_after is not None
+            else start_wait_timeout * 2
+        )
 
         # In-memory session cache (workspace_id -> Session)
         self._sessions: Dict[str, Session] = {}
@@ -72,6 +97,22 @@ class WorkspaceManager:
         # Per-workspace locks (replaces global _lock to avoid cross-workspace blocking)
         self._lock_registry_mu = asyncio.Lock()  # protects _workspace_locks dict only
         self._workspace_locks: Dict[str, asyncio.Lock] = {}
+
+        # In-worker Phase 2 dedupe — when the warm endpoint + a chat
+        # message race, both arrive in ``get_session_for_workspace`` for
+        # the same workspace within the warm window. The per-workspace
+        # lock serializes the cache check but Phase 2 (ensure_sandbox_ready
+        # + sync_sandbox_assets) runs OUTSIDE the lock, so the second
+        # caller would otherwise duplicate the work. The first caller
+        # installs an event here; the second awaits it and returns the
+        # cached session the first caller hydrated.
+        self._phase2_events: Dict[str, asyncio.Event] = {}
+
+        # Strong refs to fire-and-forget sandbox-state broadcast publishes
+        # spawned from the (sync) on_state_observed callback. asyncio holds
+        # only weak refs to tasks, so without this they could be GC'd before
+        # the PUBLISH lands. Discarded in each task's done callback.
+        self._status_publish_tasks: set[asyncio.Task] = set()
 
         # Track last sync time per workspace for cooldown
         self._last_sync_at: Dict[str, float] = {}
@@ -701,6 +742,7 @@ class WorkspaceManager:
         workspace_id: str,
         user_id: str | None = None,
         on_state_observed: Callable[[str], None] | None = None,
+        _attempt: int = 0,
     ) -> Session:
         """
         Get or restart session for workspace.
@@ -738,6 +780,7 @@ class WorkspaceManager:
         session: Session | None = None
         needs_sync = False
         needs_deferred_sync = False
+        pending_start_wait = False
         workspace_user_id = user_id
 
         async with self._observed_lock(
@@ -813,64 +856,38 @@ class WorkspaceManager:
             # No usable cached session — handle based on status
             if session is None:
                 if status in ("stopped", "starting"):
-                    # "starting" means a prior lazy init is either in flight or
-                    # failed after clearing the cached session; re-entering the
-                    # restart flow is idempotent — it resets status to
-                    # "starting" (no-op) and kicks off a fresh lazy init.
-                    logger.info(
-                        f"Restarting workspace {workspace_id} from status={status}"
-                    )
-                    session = await self._restart_workspace(
-                        workspace,
-                        user_id=workspace_user_id,
-                        lazy_init=True,
-                        on_state_observed=on_state_observed,
-                    )
-                    # Don't return immediately for lazy init — fall through
-                    # to Phase 2 which waits for init and handles SandboxGoneError.
-                    needs_sync = True
-                    needs_deferred_sync = True
-
-                elif status == "running":
-                    core_config = self.config.to_core_config()
-                    session = SessionManager.get_session(workspace_id, core_config)
-
-                    if not session._initialized:
-                        sandbox_id = workspace.get("sandbox_id")
-                        try:
-                            await session.initialize(
-                                sandbox_id=sandbox_id,
-                                on_state_observed=on_state_observed,
-                            )
-                        except SandboxGoneError as e:
-                            await self._clear_session(workspace_id)
-                            logger.warning(
-                                f"Sandbox {sandbox_id} unavailable for workspace "
-                                f"{workspace_id} ({e}). Creating fresh sandbox."
-                            )
-                            return await self._recover_sandbox(
-                                workspace_id, workspace_user_id, core_config
-                            )
-                        _mark("session_initialize")
-
-                        await self._sync_sandbox_assets(
+                    # Cross-worker mutex: only one worker may transition
+                    # stopped → starting at a time. Try the claim HERE (a fast
+                    # atomic UPDATE) but NEVER wait under the lock — a 60-300s
+                    # archived cold-start would head-of-line block every other
+                    # op on this workspace (stop/delete/concurrent get) until
+                    # the 60s lock-acquire ceiling. The winner restarts and
+                    # owes Phase 2; losers (and arrivals already at 'starting')
+                    # set pending_start_wait and wait OUTSIDE the lock below.
+                    if status == "stopped":
+                        session = await self._claim_and_restart(
                             workspace_id,
                             workspace_user_id,
-                            session.sandbox,
-                            reusing_sandbox=sandbox_id is not None,
+                            on_state_observed,
                         )
-                        _mark("cold_asset_sync")
-
-                        # Check if sandbox needs config migration
-                        migrated = await self._maybe_migrate_sandbox(
-                            workspace_id, workspace_user_id, session, workspace
-                        )
-                        if migrated is not None:
-                            session = migrated
-                    else:
+                    if session is not None:
+                        # Winner: lazy-init Phase 2 needs to sync + promote.
                         needs_sync = True
+                        needs_deferred_sync = True
+                    else:
+                        # Lost the claim, or status was already 'starting'.
+                        pending_start_wait = True
 
-                    self._sessions[workspace_id] = session
+                elif status == "running":
+                    session, did_init = await self._attach_running_session(
+                        workspace,
+                        workspace_user_id,
+                        on_state_observed,
+                        _mark,
+                    )
+                    if not did_init:
+                        # Session was already initialized — refresh via Phase 2 sync.
+                        needs_sync = True
 
                 elif status == "creating":
                     raise RuntimeError(
@@ -1013,28 +1030,184 @@ class WorkspaceManager:
                 else:
                     raise RuntimeError(f"Unknown workspace status: {status}")
 
-        # ── Phase 2: Expensive sync operations OUTSIDE the lock ──
-        # These are safe to call concurrently (idempotent or have their own internal guards).
-        # Wrapped in try/except because a concurrent stop_workspace could invalidate
-        # the session while we're syncing. The session is already cached and usable;
-        # sync is best-effort — next request will retry if it failed.
+            # In-worker Phase 2 dedupe gate. Set up while still inside the
+            # per-workspace lock so two same-worker callers can't both
+            # install events for the same workspace.
+            phase2_owner = False
+            phase2_event: Optional[asyncio.Event] = None
+            if needs_sync and session is not None and session.sandbox is not None:
+                existing_event = self._phase2_events.get(workspace_id)
+                if existing_event is not None and not existing_event.is_set():
+                    phase2_event = existing_event
+                else:
+                    phase2_event = asyncio.Event()
+                    self._phase2_events[workspace_id] = phase2_event
+                    phase2_owner = True
+
+        # ── Phase 1.5: cross-worker start wait, OUTSIDE the per-workspace lock ──
+        # A caller that lost the claim (or arrived at status 'starting') waits
+        # for the owning worker to finish, then attaches the now-running session
+        # (or retries the claim once if the owner failed). Outside the lock so a
+        # slow archived cold-start (60-300s) doesn't head-of-line block other
+        # ops on this workspace behind the 60s lock-acquire ceiling.
+        if pending_start_wait:
+            return await self._await_in_flight_start(
+                workspace_id,
+                user_id=user_id,
+                workspace_user_id=workspace_user_id,
+                on_state_observed=on_state_observed,
+                mark=_mark,
+                attempt=_attempt,
+            )
+
+        # ── Phase 2: expensive sync OUTSIDE the lock (idempotent / self-guarded).
+        # Coalesces same-worker callers on the dedupe gate, promotes a lazy start
+        # to 'running' only once the sandbox is fully ready, and reverts to
+        # 'stopped' on any failure. See _complete_phase2_sync.
         _mark("lock_and_init")
+        session = await self._complete_phase2_sync(
+            workspace_id,
+            session,
+            workspace_user_id=workspace_user_id,
+            needs_sync=needs_sync,
+            needs_deferred_sync=needs_deferred_sync,
+            phase2_owner=phase2_owner,
+            phase2_event=phase2_event,
+            mark=_mark,
+        )
+
+        if _session_phases:
+            total = sum(_session_phases.values())
+            phases = " ".join(f"{k}={v:.0f}ms" for k, v in _session_phases.items())
+            logger.info(
+                f"[SESSION_TIMING] workspace_id={workspace_id} total={total:.0f}ms ({phases})"
+            )
+            # Classify path: cold_resume = lazy-restart path (needs_deferred_sync),
+            # warm_sync = cached session that needed a sync refresh, cold_create =
+            # first session for this workspace (not previously cached).
+            if needs_deferred_sync:
+                session_path = "cold_resume"
+            elif _was_cached:
+                session_path = "warm_sync"
+            else:
+                session_path = "cold_create"
+            safe_add(session_path_counter, 1, {"path": session_path})
+            safe_record(session_acquire_total_ms, total, {"session_path": session_path})
+            for _phase, _ms in _session_phases.items():
+                safe_record(
+                    session_acquire_phase_duration_ms,
+                    _ms,
+                    {"phase": _phase, "session_path": session_path},
+                )
+
+        return session
+
+    async def _await_in_flight_start(
+        self,
+        workspace_id: str,
+        *,
+        user_id: str | None,
+        workspace_user_id: str | None,
+        on_state_observed: Callable[[str], None] | None,
+        mark: Callable[[str], None],
+        attempt: int,
+    ) -> Session:
+        """Wait for another worker's in-flight start, then attach (or retry once).
+
+        Entered when this caller lost the stopped→starting claim or arrived
+        while status was already 'starting'. Runs OUTSIDE the per-workspace
+        lock; re-acquires it only briefly to attach the now-running session.
+
+        Raises:
+            RuntimeError: the start ended in an unexpected status.
+        """
+        ws_done = await self._wait_for_start_completion(workspace_id)
+        wait_status = ws_done["status"]
+        if wait_status == "running":
+            async with self._observed_lock(workspace_id, "workspace.session.attach"):
+                session, _ = await self._attach_running_session(
+                    ws_done, workspace_user_id, on_state_observed, mark
+                )
+            return session
+        if wait_status == "stopped" and attempt == 0:
+            # Owner failed and reverted to 'stopped'. Retry the whole start
+            # once: the recursive call re-enters Phase 1 and re-claims,
+            # becoming the owner with a full Phase 2 — so we don't have to
+            # duplicate the claim+sync+promote logic here. Bounded to one
+            # retry by the attempt guard.
+            logger.info(
+                f"Workspace {workspace_id} reverted to 'stopped' "
+                "(prior owner failed); retrying start"
+            )
+            return await self.get_session_for_workspace(
+                workspace_id,
+                user_id=user_id,
+                on_state_observed=on_state_observed,
+                _attempt=attempt + 1,
+            )
+        raise RuntimeError(
+            f"Workspace {workspace_id} ended start in unexpected "
+            f"status '{wait_status}' after waiting"
+        )
+
+    async def _complete_phase2_sync(
+        self,
+        workspace_id: str,
+        session: Session | None,
+        *,
+        workspace_user_id: str | None,
+        needs_sync: bool,
+        needs_deferred_sync: bool,
+        phase2_owner: bool,
+        phase2_event: Optional[asyncio.Event],
+        mark: Callable[[str], None],
+    ) -> Session | None:
+        """Run the post-lock sync/promote step and return the usable session.
+
+        Expensive operations (ensure_sandbox_ready, asset sync, file restore)
+        run OUTSIDE the per-workspace lock — they're idempotent or self-guarded.
+        Same-worker callers coalesce on ``phase2_event``: the owner runs the
+        work, waiters await the gate then trust the authoritative DB row. A lazy
+        start is promoted to 'running' only after the sandbox is fully ready;
+        any failure reverts the row to 'stopped' so it never lingers half-ready.
+        Returns the session to hand back (possibly one freshly recovered from a
+        SandboxGoneError).
+        """
         if needs_sync and session and session.sandbox:
+            if not phase2_owner:
+                # Another caller on this worker is already running Phase 2.
+                # Wait for them and return the session they hydrated.
+                assert phase2_event is not None
+                try:
+                    await asyncio.wait_for(
+                        phase2_event.wait(),
+                        timeout=self.start_wait_timeout,
+                    )
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "Phase 2 wait timed out for workspace %s after %.0fs",
+                        workspace_id,
+                        self.start_wait_timeout,
+                    )
+                mark("phase2_wait")
+                # The Phase 2 owner is the authoritative status writer:
+                # 'running' on success, 'stopped'/'error' on failure. Trust the
+                # DB, not the cached session — on owner failure the cache may
+                # hold a stale or half-initialized session, and returning it
+                # would silently hand back a broken sandbox.
+                ws_after = await db_get_workspace(workspace_id)
+                if ws_after is not None and ws_after["status"] == "running":
+                    return self._sessions.get(workspace_id, session)
+                raise RuntimeError(
+                    f"Workspace {workspace_id} did not reach 'running' after "
+                    f"Phase 2 (status={ws_after['status'] if ws_after else 'deleted'})"
+                )
+
             try:
                 await session.sandbox.ensure_sandbox_ready()
-                _mark("sandbox_ready")
+                mark("sandbox_ready")
 
                 if needs_deferred_sync:
-                    # Only promote when a lazy init actually happened (row is
-                    # still in _pending_lazy_sync). A forced non-lazy restart
-                    # already flipped status to running + stamped activity
-                    # inside _restart_workspace — no-op here.
-                    if workspace_id in self._pending_lazy_sync:
-                        await update_workspace_status(
-                            workspace_id=workspace_id,
-                            status="running",
-                        )
-                        await update_workspace_activity(workspace_id)
                     logger.debug(
                         f"Completing deferred sync for lazy-init workspace {workspace_id}"
                     )
@@ -1044,10 +1217,23 @@ class WorkspaceManager:
                         session.sandbox,
                         reusing_sandbox=True,
                     )
-                    _mark("asset_sync")
+                    mark("asset_sync")
                     await self._maybe_restore_files(workspace_id, session.sandbox)
-                    _mark("file_restore")
-                    self._pending_lazy_sync.discard(workspace_id)
+                    mark("file_restore")
+                    # Promote to 'running' ONLY after the sandbox is ready AND
+                    # assets + files are synced — so 'running' (and its pub/sub
+                    # notification + SSE close) truthfully means "usable". Any
+                    # failure above is caught below and reverts the row to
+                    # 'stopped', never leaving a half-ready 'running'. A forced
+                    # non-lazy restart already promoted inside _restart_workspace
+                    # (not in _pending_lazy_sync) — no-op here.
+                    if workspace_id in self._pending_lazy_sync:
+                        await update_workspace_status(
+                            workspace_id=workspace_id,
+                            status="running",
+                        )
+                        await update_workspace_activity(workspace_id)
+                        self._pending_lazy_sync.discard(workspace_id)
 
                 self._record_sync(workspace_id)
             except SandboxGoneError as e:
@@ -1090,6 +1276,10 @@ class WorkspaceManager:
                     # would tear down the healthy replacement's MCP+provider.
                     # Pass evict_session so the pop inside _clear_session is
                     # also identity-guarded across its own await boundary.
+                    # Revert BEFORE clearing the session — _clear_session
+                    # discards _pending_lazy_sync, which would make the revert
+                    # a no-op (it keys off pending membership).
+                    await self._revert_unpromoted_lazy_start(workspace_id)
                     if self._sessions.get(workspace_id) is session:
                         await self._clear_session(workspace_id, evict_session=session)
                     raise
@@ -1097,37 +1287,293 @@ class WorkspaceManager:
                     f"Phase 2 sync transient for workspace {workspace_id} "
                     f"(will retry next request): {e}"
                 )
+                await self._revert_unpromoted_lazy_start(workspace_id)
+            except asyncio.CancelledError:
+                # A client disconnect or server shutdown mid-Phase-2 cancels
+                # this coroutine. CancelledError is a BaseException, so without
+                # this clause it bypasses every revert handler and leaves the
+                # row wedged in 'starting' forever (no reaper would promote it,
+                # and /start rejects non-'stopped'). Revert on a shielded task
+                # so the DB write survives the cancellation; if the event loop
+                # itself is tearing down, reap_stuck_starting_workspaces() is
+                # the backstop on the next process. Re-raise to preserve
+                # cancellation semantics.
+                revert = asyncio.ensure_future(
+                    self._revert_unpromoted_lazy_start(workspace_id)
+                )
+                try:
+                    await asyncio.shield(revert)
+                except asyncio.CancelledError:
+                    pass
+                raise
             except Exception as e:
                 logger.warning(
-                    f"Phase 2 sync failed for workspace {workspace_id} "
-                    f"(will retry next request): {e}"
+                    f"Phase 2 sync failed for workspace {workspace_id}: {e}"
                 )
-
-        if _session_phases:
-            total = sum(_session_phases.values())
-            phases = " ".join(f"{k}={v:.0f}ms" for k, v in _session_phases.items())
-            logger.info(
-                f"[SESSION_TIMING] workspace_id={workspace_id} total={total:.0f}ms ({phases})"
-            )
-            # Classify path: cold_resume = lazy-restart path (needs_deferred_sync),
-            # warm_sync = cached session that needed a sync refresh, cold_create =
-            # first session for this workspace (not previously cached).
-            if needs_deferred_sync:
-                session_path = "cold_resume"
-            elif _was_cached:
-                session_path = "warm_sync"
-            else:
-                session_path = "cold_create"
-            safe_add(session_path_counter, 1, {"path": session_path})
-            safe_record(session_acquire_total_ms, total, {"session_path": session_path})
-            for _phase, _ms in _session_phases.items():
-                safe_record(
-                    session_acquire_phase_duration_ms,
-                    _ms,
-                    {"phase": _phase, "session_path": session_path},
-                )
+                # Capture before reverting — the revert clears _pending_lazy_sync.
+                was_unpromoted_lazy = workspace_id in self._pending_lazy_sync
+                await self._revert_unpromoted_lazy_start(workspace_id)
+                if was_unpromoted_lazy:
+                    # Lazy start failed before promotion: we just reverted the
+                    # row to 'stopped' and the sandbox never finished asset/file
+                    # sync. Returning the session would hand the agent a
+                    # half-initialized sandbox while the DB says 'stopped'.
+                    # Surface the failure so the caller re-claims cleanly.
+                    raise
+                # Already-'running' re-sync hit a transient error; the sandbox
+                # was usable before this periodic sync, so keep the cached
+                # session and let the next request retry the sync.
+            finally:
+                # Release the dedupe gate so any waiter on this worker can
+                # proceed. Identity-check the registry slot so a fresh event
+                # installed by the NEXT caller (already past our finally)
+                # isn't accidentally evicted.
+                if phase2_event is not None:
+                    phase2_event.set()
+                    if self._phase2_events.get(workspace_id) is phase2_event:
+                        self._phase2_events.pop(workspace_id, None)
+        elif phase2_owner and phase2_event is not None:
+            # We installed a dedupe event under the lock, but the Phase 2
+            # precondition (session.sandbox) no longer holds — e.g. a
+            # concurrent stop_workspace nulled the sandbox between lock
+            # release and here. Release the gate so waiters (and any future
+            # caller that would attach to this event) don't hang out the
+            # full start timeout on an event nobody will ever set.
+            phase2_event.set()
+            if self._phase2_events.get(workspace_id) is phase2_event:
+                self._phase2_events.pop(workspace_id, None)
 
         return session
+
+    async def _revert_unpromoted_lazy_start(self, workspace_id: str) -> None:
+        """Revert a lazy-start owner's row to 'stopped' when Phase 2 fails
+        before promotion.
+
+        The cross-worker mutex parks losers in ``_wait_for_start_completion``
+        until the row leaves 'starting'. If the claim winner fails in Phase 2
+        (ensure_sandbox_ready / asset sync / file restore) the row would
+        otherwise stay 'starting' with no reaper, so every loser waits out the
+        full ``start_wait_timeout``. Reverting to 'stopped' (and publishing via
+        ``update_workspace_status``) lets losers retry the claim immediately.
+
+        No-op once the row has been promoted to 'running' (the owner discards
+        it from ``_pending_lazy_sync`` on promotion), and for non-lazy restarts
+        (never added to ``_pending_lazy_sync``).
+        """
+        if workspace_id not in self._pending_lazy_sync:
+            return
+        self._pending_lazy_sync.discard(workspace_id)
+        try:
+            await update_workspace_status(workspace_id=workspace_id, status="stopped")
+        except Exception:
+            # Best-effort — if the revert itself fails, the start_wait_timeout
+            # still recovers losers, just with worse latency.
+            logger.exception(
+                "Failed to revert workspace %s to 'stopped' after Phase 2 failure",
+                workspace_id,
+            )
+
+    async def _attach_running_session(
+        self,
+        workspace: Dict[str, Any],
+        workspace_user_id: str | None,
+        on_state_observed: Callable[[str], None] | None,
+        mark: Callable[[str], None],
+    ) -> tuple[Session, bool]:
+        """Acquire/initialize a session for a workspace whose DB status is 'running'.
+
+        Shared between the running-status branch and the cross-worker wait
+        paths (where another worker just promoted status to 'running').
+        Caller must hold the per-workspace `_observed_lock`.
+
+        Returns:
+            (session, did_init) — ``did_init`` is True when this call performed
+            the cold initialization, False when the cached session was already
+            initialized (caller should run Phase 2 sync).
+        """
+        workspace_id = str(workspace["workspace_id"])
+        core_config = self.config.to_core_config()
+        session = SessionManager.get_session(workspace_id, core_config)
+        did_init = False
+
+        if not session._initialized:
+            sandbox_id = workspace.get("sandbox_id")
+            try:
+                await session.initialize(
+                    sandbox_id=sandbox_id,
+                    on_state_observed=on_state_observed,
+                )
+            except SandboxGoneError as e:
+                await self._clear_session(workspace_id)
+                logger.warning(
+                    f"Sandbox {sandbox_id} unavailable for workspace "
+                    f"{workspace_id} ({e}). Creating fresh sandbox."
+                )
+                recovered = await self._recover_sandbox(
+                    workspace_id, workspace_user_id, core_config
+                )
+                return recovered, True
+            mark("session_initialize")
+
+            await self._sync_sandbox_assets(
+                workspace_id,
+                workspace_user_id,
+                session.sandbox,
+                reusing_sandbox=sandbox_id is not None,
+            )
+            mark("cold_asset_sync")
+
+            migrated = await self._maybe_migrate_sandbox(
+                workspace_id, workspace_user_id, session, workspace
+            )
+            if migrated is not None:
+                session = migrated
+            did_init = True
+
+        self._sessions[workspace_id] = session
+        return session, did_init
+
+    async def _claim_and_restart(
+        self,
+        workspace_id: str,
+        workspace_user_id: str | None,
+        on_state_observed: Callable[[str], None] | None,
+    ) -> Optional[Session]:
+        """Try to win the stopped→starting claim and restart the workspace.
+
+        On exception during restart, revert the row back to 'stopped' so other
+        callers can retry immediately instead of waiting out the 300s timeout.
+
+        Returns:
+            Session if we won the claim and restarted, None if another worker
+            had already moved the row out of 'stopped'.
+        """
+        claimed = await try_claim_workspace_for_start(workspace_id)
+        if claimed is None:
+            return None
+
+        def _observe_and_broadcast(state: str) -> None:
+            # Forward to the caller's own observer (the chat path uses it to
+            # drive its in-conversation spinner).
+            if on_state_observed is not None:
+                on_state_observed(state)
+            # Broadcast a slow-restore hint cross-worker. The pre-start sandbox
+            # state is observed only by whoever wins the claim; without this,
+            # a worker that lost the claim (or the /events SSE the frontend
+            # opened on entry) never learns the restore is the slow 'archived'
+            # kind. Publishing it on the status channel lets every consumer
+            # show the right spinner regardless of who owns the start.
+            if state == "archived":
+                task = asyncio.ensure_future(
+                    publish_status_change(
+                        workspace_id, "starting", extra={"sandbox_state": state}
+                    )
+                )
+                self._status_publish_tasks.add(task)
+                task.add_done_callback(self._status_publish_tasks.discard)
+
+        try:
+            logger.info(
+                f"Restarting workspace {workspace_id} (claimed for start)"
+            )
+            return await self._restart_workspace(
+                claimed,
+                user_id=workspace_user_id,
+                lazy_init=True,
+                on_state_observed=_observe_and_broadcast,
+            )
+        except Exception:
+            # Best-effort revert — if it fails, the 300s timeout still recovers,
+            # just with worse UX. Don't shadow the original exception.
+            try:
+                await update_workspace_status(
+                    workspace_id=workspace_id,
+                    status="stopped",
+                )
+            except Exception:
+                logger.exception(
+                    f"Failed to revert workspace {workspace_id} status after start error"
+                )
+            raise
+
+    async def _wait_for_start_completion(
+        self,
+        workspace_id: str,
+        max_wait_s: float | None = None,
+        poll_interval_s: float | None = None,
+    ) -> Dict[str, Any]:
+        """Wait for an in-flight start to resolve, using pub/sub + DB safety net.
+
+        Used by the cross-worker mutex path: when ``try_claim_workspace_for_start``
+        returns None, another worker (or process) is mid-start. We subscribe
+        to the Redis status channel BEFORE re-reading the DB to close the
+        race where the publish landed during the lock window, then await
+        notifications with a 30 s ceiling so a missed message still re-reads
+        the DB instead of waiting out the full timeout.
+
+        When Redis is unavailable, falls back to the original exponential-
+        backoff DB poll (0.5 s → 2 s cap).
+
+        Returns the updated workspace dict.
+
+        Raises:
+            ValueError: Workspace deleted while waiting.
+            RuntimeError: Status went to 'error', or timeout exceeded.
+        """
+        timeout = self.start_wait_timeout if max_wait_s is None else max_wait_s
+        base_interval = (
+            self.start_wait_poll_interval if poll_interval_s is None else poll_interval_s
+        )
+        max_interval = max(base_interval, 2.0)
+        deadline = time.monotonic() + timeout
+
+        async with subscribe_to_status(workspace_id) as wait_for_notify:
+            # Read DB AFTER subscribing — closes the race where the
+            # publish landed before our SUBSCRIBE completed.
+            workspace = await db_get_workspace(workspace_id)
+            if not workspace:
+                raise ValueError(
+                    f"Workspace {workspace_id} not found while waiting for start"
+                )
+            status = workspace["status"]
+            if status == "running":
+                return workspace
+            if status == "error":
+                raise RuntimeError(f"Workspace {workspace_id} failed to start")
+            if status != "starting":
+                return workspace
+
+            interval = base_interval
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+
+                if wait_for_notify is not None:
+                    # Pub/sub fast path. Cap at 30 s so a dropped publish
+                    # still triggers a periodic DB re-read.
+                    await wait_for_notify(min(remaining, 30.0))
+                else:
+                    await asyncio.sleep(min(interval, remaining))
+                    interval = min(interval * 2, max_interval)
+
+                workspace = await db_get_workspace(workspace_id)
+                if not workspace:
+                    raise ValueError(
+                        f"Workspace {workspace_id} not found while waiting for start"
+                    )
+                status = workspace["status"]
+                if status == "running":
+                    return workspace
+                if status == "error":
+                    raise RuntimeError(f"Workspace {workspace_id} failed to start")
+                if status != "starting":
+                    return workspace
+
+        raise RuntimeError(
+            f"Workspace {workspace_id} stuck in 'starting' after {timeout:.0f}s; "
+            "another worker may have died mid-start"
+        )
 
     async def _restart_workspace(
         self,
@@ -1476,6 +1922,76 @@ class WorkspaceManager:
 
         return stopped_count
 
+    async def reap_stuck_starting_workspaces(self) -> int:
+        """Revert workspaces wedged in 'starting' back to 'stopped'.
+
+        Backstop for the cross-worker start mutex: if a claim winner's Phase 2
+        dies without reverting (worker crash, event-loop teardown that beats the
+        CancelledError revert, or a publish that never lands), the row stays
+        'starting' with no other recovery path — every later caller waits out
+        start_wait_timeout then raises, and /start rejects non-'stopped'.
+
+        Never reaps a start THIS process is still running: an in-flight lazy
+        owner holds ``_pending_lazy_sync`` membership and will promote (on
+        success) or revert (on failure) the row itself. Reaping it would discard
+        that membership and silently no-op the owner's promotion, stranding a
+        ready session behind a 'stopped' row and triggering a duplicate restart.
+        That guard makes the in-process case correct regardless of how slow the
+        restore is. The ``reap_stuck_after`` threshold (2x start_wait_timeout by
+        default) then only governs the cross-process backstop — rows wedged by a
+        crashed/recycled worker, which carry no local membership.
+
+        Returns:
+            Number of workspaces reverted.
+        """
+        now = datetime.now(timezone.utc)
+        reverted = 0
+
+        starting_workspaces = await get_workspaces_by_status("starting", limit=1000)
+        if len(starting_workspaces) == 1000:
+            logger.warning(
+                "reap_stuck_starting hit the 1000-row scan cap; more stuck "
+                "rows may remain and will be reaped on the next cycle"
+            )
+        for workspace in starting_workspaces:
+            updated_at = workspace.get("updated_at")
+            if not updated_at:
+                continue
+            if updated_at.tzinfo is None:
+                updated_at = updated_at.replace(tzinfo=timezone.utc)
+            if (now - updated_at).total_seconds() <= self.reap_stuck_after:
+                continue
+
+            workspace_id = str(workspace["workspace_id"])
+            if workspace_id in self._pending_lazy_sync:
+                # A lazy-start owner on THIS worker is still mid-flight. It
+                # owns the row's transition (promote on success, revert on
+                # failure); reaping here would discard its membership and
+                # no-op that promotion, leaving a ready session behind a
+                # 'stopped' row. Cross-process stuck rows have no local
+                # membership and fall through to the reap below.
+                continue
+            logger.warning(
+                f"Reaping workspace {workspace_id} stuck in 'starting' for "
+                f"{(now - updated_at).total_seconds():.0f}s "
+                f"(threshold {self.reap_stuck_after:.0f}s); reverting to 'stopped'"
+            )
+            try:
+                await update_workspace_status(
+                    workspace_id=workspace_id, status="stopped"
+                )
+                self._pending_lazy_sync.discard(workspace_id)
+                reverted += 1
+            except Exception as e:
+                logger.error(
+                    f"Error reaping stuck-starting workspace {workspace_id}: {e}"
+                )
+
+        if reverted > 0:
+            logger.info(f"Reaped {reverted} workspaces stuck in 'starting'")
+
+        return reverted
+
     async def start_cleanup_task(self) -> None:
         """Start background cleanup task."""
         if self._cleanup_task is not None:
@@ -1489,6 +2005,7 @@ class WorkspaceManager:
                     await asyncio.sleep(self.cleanup_interval)
                     if not self._shutdown:
                         await self.cleanup_idle_workspaces()
+                        await self.reap_stuck_starting_workspaces()
                 except asyncio.CancelledError:
                     break
                 except Exception as e:

--- a/src/server/services/workspace_manager.py
+++ b/src/server/services/workspace_manager.py
@@ -1311,7 +1311,7 @@ class WorkspaceManager:
                 # itself is tearing down, reap_stuck_starting_workspaces() is
                 # the backstop on the next process. Re-raise to preserve
                 # cancellation semantics.
-                revert = asyncio.ensure_future(
+                revert = asyncio.create_task(
                     self._revert_unpromoted_lazy_start(workspace_id)
                 )
                 try:
@@ -1477,7 +1477,7 @@ class WorkspaceManager:
             # kind. Publishing it on the status channel lets every consumer
             # show the right spinner regardless of who owns the start.
             if state == "archived":
-                task = asyncio.ensure_future(
+                task = asyncio.create_task(
                     publish_status_change(
                         workspace_id, "starting", extra={"sandbox_state": state}
                     )

--- a/src/server/services/workspace_status_pubsub.py
+++ b/src/server/services/workspace_status_pubsub.py
@@ -1,0 +1,218 @@
+"""Cross-worker pub/sub for workspace lifecycle status changes.
+
+Replaces the loser-side DB poll loop with a push notification so a
+stopped→running transition wakes waiting workers in milliseconds rather
+than 0.5–2 s polling cycles. Also feeds the ``/workspaces/{id}/events``
+SSE channel so the frontend can drop interval-polling.
+
+Degrades silently when Redis is unavailable: ``subscribe_to_status``
+yields ``None`` and ``publish_status_change`` is a no-op, so callers
+must keep their DB-poll path as a safety net.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from contextlib import asynccontextmanager
+from typing import AsyncIterator, Awaitable, Callable, Optional
+
+import redis.asyncio as redis
+from redis.asyncio.connection import ConnectionPool
+
+from src.config.settings import get_redis_max_connections
+from src.utils.cache.redis_cache import RedisCacheClient, get_cache_client
+
+logger = logging.getLogger(__name__)
+
+# Dedicated connection pool for long-lived status subscriptions. Each /events
+# SSE stream (up to 600s) and each cross-worker start wait (up to 300s) holds a
+# connection for the subscription's lifetime. Isolating them in their own pool
+# keeps a burst of warming workspaces from exhausting the shared cache pool and
+# degrading unrelated cache/SSE-buffer ops. Publishes stay on the shared cache
+# client (they're sub-millisecond and don't hold a connection).
+_pubsub_client: Optional[redis.Redis] = None
+_pubsub_pool: Optional[ConnectionPool] = None
+_pubsub_init_lock = asyncio.Lock()
+
+# Backoff after a broken-connection get_message so error paths don't busy-spin.
+_BROKEN_CONN_BACKOFF_S = 1.0
+
+
+async def _get_pubsub_client(cache: RedisCacheClient) -> redis.Redis:
+    """Return the dedicated pubsub client, lazily built from the cache's URL.
+
+    Falls back to the shared cache client if the dedicated pool can't be
+    created — correctness is unaffected, only the pool isolation is lost.
+    """
+    global _pubsub_client, _pubsub_pool
+    if _pubsub_client is not None:
+        return _pubsub_client
+    async with _pubsub_init_lock:
+        if _pubsub_client is not None:
+            return _pubsub_client
+        try:
+            _pubsub_pool = ConnectionPool.from_url(
+                cache.url,
+                max_connections=get_redis_max_connections(),
+                decode_responses=False,
+                health_check_interval=30,
+            )
+            _pubsub_client = redis.Redis(connection_pool=_pubsub_pool)
+        except Exception as exc:
+            logger.warning(
+                "Failed to init dedicated pubsub pool, using shared cache pool: %s",
+                exc,
+            )
+            return cache.client
+    return _pubsub_client
+
+
+async def close_status_pubsub_pool() -> None:
+    """Tear down the dedicated pubsub pool on shutdown. Best-effort."""
+    global _pubsub_client, _pubsub_pool
+    client, _pubsub_client = _pubsub_client, None
+    pool, _pubsub_pool = _pubsub_pool, None
+    if client is not None:
+        try:
+            await client.aclose()
+        except Exception:
+            pass
+    if pool is not None:
+        try:
+            await pool.disconnect()
+        except Exception:
+            pass
+
+
+# Single source of truth for the channel name format.
+def status_channel(workspace_id: str) -> str:
+    return f"ws:status:{workspace_id}"
+
+
+# Type of the `wait()` coroutine yielded by subscribe_to_status.
+WaitFn = Callable[[Optional[float]], Awaitable[Optional[dict]]]
+
+
+async def publish_status_change(
+    workspace_id: str,
+    status: str,
+    *,
+    extra: Optional[dict] = None,
+) -> None:
+    """Best-effort cross-worker notification of a status transition.
+
+    Never raises — failures are debug-logged and swallowed so callers
+    can wire this into critical paths (DB writes) without risking the
+    main mutation.
+    """
+    cache = get_cache_client()
+    if not cache.enabled or not cache.client:
+        return
+    payload: dict = {"workspace_id": workspace_id, "status": status}
+    if extra:
+        payload.update(extra)
+    try:
+        await cache.client.publish(status_channel(workspace_id), json.dumps(payload))
+    except Exception as exc:
+        logger.debug(
+            "Failed to publish status change for %s: %s", workspace_id, exc
+        )
+
+
+@asynccontextmanager
+async def subscribe_to_status(
+    workspace_id: str,
+) -> AsyncIterator[Optional[WaitFn]]:
+    """Subscribe to a workspace's status channel and yield a ``wait()`` coroutine.
+
+    Yields ``None`` when Redis is disabled so callers fall back to DB
+    polling. When the channel is live, yields an async ``wait(timeout)``
+    that returns the next decoded payload dict (or ``None`` on timeout /
+    decode error). Subscribers MUST re-read the authoritative DB state
+    after subscribing — the channel may have published before our
+    SUBSCRIBE completed.
+    """
+    cache = get_cache_client()
+    if not cache.enabled or not cache.client:
+        yield None
+        return
+
+    client = await _get_pubsub_client(cache)
+    pubsub = client.pubsub()
+    try:
+        await pubsub.subscribe(status_channel(workspace_id))
+    except Exception as exc:
+        logger.debug(
+            "Failed to subscribe to status channel for %s: %s",
+            workspace_id,
+            exc,
+        )
+        try:
+            await pubsub.aclose()
+        except Exception:
+            pass
+        yield None
+        return
+
+    async def _wait(timeout: Optional[float] = None) -> Optional[dict]:
+        try:
+            msg = await pubsub.get_message(
+                ignore_subscribe_messages=True,
+                timeout=timeout,
+            )
+        except Exception as exc:
+            logger.debug("Pubsub get_message error for %s: %s", workspace_id, exc)
+            # On a broken connection get_message raises immediately instead of
+            # blocking for `timeout`; pace the error path so looping callers
+            # (the start-wait loop, the /events SSE handler) don't busy-spin
+            # DB reads until their deadline. Cap at the requested timeout so we
+            # never sleep longer than the caller asked to wait.
+            backoff = _BROKEN_CONN_BACKOFF_S if timeout is None else min(timeout, _BROKEN_CONN_BACKOFF_S)
+            await asyncio.sleep(backoff)
+            return None
+        if not msg or msg.get("type") != "message":
+            return None
+        data = msg.get("data")
+        if isinstance(data, bytes):
+            try:
+                data = data.decode("utf-8")
+            except UnicodeDecodeError:
+                return None
+        try:
+            payload = json.loads(data)
+        except (json.JSONDecodeError, TypeError):
+            return None
+        return payload if isinstance(payload, dict) else None
+
+    try:
+        yield _wait
+    finally:
+        # Cancellation-safe teardown — unsubscribe then close, swallowing
+        # everything so a cancelled SSE generator doesn't leak warnings.
+        try:
+            await pubsub.unsubscribe(status_channel(workspace_id))
+        except Exception:
+            pass
+        try:
+            await pubsub.aclose()
+        except Exception:
+            pass
+
+
+async def wait_for_status_change(
+    workspace_id: str,
+    *,
+    timeout: float,
+) -> Optional[dict]:
+    """Subscribe once and wait for a single status-change payload.
+
+    Returns the payload, or ``None`` if Redis is disabled or the
+    timeout elapses without a message. Convenience wrapper used by
+    callers that don't need a long-lived subscription.
+    """
+    async with subscribe_to_status(workspace_id) as wait:
+        if wait is None:
+            return None
+        return await wait(timeout)

--- a/src/server/services/workspace_status_pubsub.py
+++ b/src/server/services/workspace_status_pubsub.py
@@ -35,6 +35,12 @@ logger = logging.getLogger(__name__)
 _pubsub_client: Optional[redis.Redis] = None
 _pubsub_pool: Optional[ConnectionPool] = None
 _pubsub_init_lock = asyncio.Lock()
+# Sticky flag set when dedicated-pool construction fails (deterministic — a bad
+# URL fails every time). Lets later calls return the shared client via the
+# lock-free fast path instead of re-acquiring the lock and retrying a build that
+# can't succeed. NOT stored in _pubsub_client: that would make
+# close_status_pubsub_pool aclose() the shared cache client. Reset on shutdown.
+_pubsub_fallback = False
 
 # Backoff after a broken-connection get_message so error paths don't busy-spin.
 _BROKEN_CONN_BACKOFF_S = 1.0
@@ -46,12 +52,16 @@ async def _get_pubsub_client(cache: RedisCacheClient) -> redis.Redis:
     Falls back to the shared cache client if the dedicated pool can't be
     created — correctness is unaffected, only the pool isolation is lost.
     """
-    global _pubsub_client, _pubsub_pool
+    global _pubsub_client, _pubsub_pool, _pubsub_fallback
     if _pubsub_client is not None:
         return _pubsub_client
+    if _pubsub_fallback:
+        return cache.client
     async with _pubsub_init_lock:
         if _pubsub_client is not None:
             return _pubsub_client
+        if _pubsub_fallback:
+            return cache.client
         try:
             _pubsub_pool = ConnectionPool.from_url(
                 cache.url,
@@ -65,15 +75,18 @@ async def _get_pubsub_client(cache: RedisCacheClient) -> redis.Redis:
                 "Failed to init dedicated pubsub pool, using shared cache pool: %s",
                 exc,
             )
+            _pubsub_fallback = True
             return cache.client
     return _pubsub_client
 
 
 async def close_status_pubsub_pool() -> None:
     """Tear down the dedicated pubsub pool on shutdown. Best-effort."""
-    global _pubsub_client, _pubsub_pool
+    global _pubsub_client, _pubsub_pool, _pubsub_fallback
     client, _pubsub_client = _pubsub_client, None
     pool, _pubsub_pool = _pubsub_pool, None
+    # Clear the sticky fallback so a restart can re-attempt the dedicated pool.
+    _pubsub_fallback = False
     if client is not None:
         try:
             await client.aclose()

--- a/tests/unit/server/app/test_workspaces.py
+++ b/tests/unit/server/app/test_workspaces.py
@@ -5,9 +5,10 @@ Covers CRUD operations, start/stop/archive/delete lifecycle actions,
 flash workspace, reorder, and ownership guards.
 """
 
+import asyncio
 import uuid
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 import pytest_asyncio
@@ -478,6 +479,359 @@ async def test_start_workspace_forbidden(client):
             f"/api/v1/workspaces/{ws['workspace_id']}/start"
         )
 
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_start_workspace_lazy_returns_202_and_schedules(client):
+    """lazy=true returns 202 with status='starting' and schedules a background task."""
+    ws = _ws(status="stopped")
+
+    # Use a long-running coroutine so we can verify the endpoint did NOT await it.
+    started_event = asyncio.Event()
+    finish_event = asyncio.Event()
+
+    async def slow_get_session(*args, **kwargs):
+        started_event.set()
+        await finish_event.wait()
+
+    with (
+        patch(
+            "src.server.app.workspaces.db_get_workspace",
+            new_callable=AsyncMock,
+            return_value=ws,
+        ),
+        patch("src.server.app.workspaces.WorkspaceManager") as MockWM,
+    ):
+        mock_manager = AsyncMock()
+        mock_manager.get_session_for_workspace = AsyncMock(side_effect=slow_get_session)
+        MockWM.get_instance.return_value = mock_manager
+
+        resp = await client.post(
+            f"/api/v1/workspaces/{ws['workspace_id']}/start?lazy=true"
+        )
+
+        assert resp.status_code == 202
+        body = resp.json()
+        assert body["status"] == "starting"
+        assert body["workspace_id"] == ws["workspace_id"]
+
+        # The background task should have started but not finished — yield once.
+        await asyncio.sleep(0)
+        assert started_event.is_set(), "background task was not scheduled"
+
+        # Let the task complete so it doesn't leak into other tests.
+        finish_event.set()
+        await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_start_workspace_lazy_already_running_short_circuits(client):
+    """lazy=true on a running workspace returns 200 without scheduling."""
+    ws = _ws(status="running")
+    with (
+        patch(
+            "src.server.app.workspaces.db_get_workspace",
+            new_callable=AsyncMock,
+            return_value=ws,
+        ),
+        patch("src.server.app.workspaces.WorkspaceManager") as MockWM,
+    ):
+        mock_manager = AsyncMock()
+        mock_manager.get_session_for_workspace = AsyncMock()
+        MockWM.get_instance.return_value = mock_manager
+
+        resp = await client.post(
+            f"/api/v1/workspaces/{ws['workspace_id']}/start?lazy=true"
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "running"
+    mock_manager.get_session_for_workspace.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_start_workspace_lazy_already_starting_short_circuits(client):
+    """lazy=true on a starting workspace returns 200 without scheduling."""
+    ws = _ws(status="starting")
+    with (
+        patch(
+            "src.server.app.workspaces.db_get_workspace",
+            new_callable=AsyncMock,
+            return_value=ws,
+        ),
+        patch("src.server.app.workspaces.WorkspaceManager") as MockWM,
+    ):
+        mock_manager = AsyncMock()
+        mock_manager.get_session_for_workspace = AsyncMock()
+        MockWM.get_instance.return_value = mock_manager
+
+        resp = await client.post(
+            f"/api/v1/workspaces/{ws['workspace_id']}/start?lazy=true"
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "starting"
+    mock_manager.get_session_for_workspace.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_start_workspace_lazy_invalid_state_rejects(client):
+    """lazy=true on a non-startable status returns 400."""
+    ws = _ws(status="creating")
+    with (
+        patch(
+            "src.server.app.workspaces.db_get_workspace",
+            new_callable=AsyncMock,
+            return_value=ws,
+        ),
+        patch("src.server.app.workspaces.WorkspaceManager") as MockWM,
+    ):
+        MockWM.get_instance.return_value = AsyncMock()
+
+        resp = await client.post(
+            f"/api/v1/workspaces/{ws['workspace_id']}/start?lazy=true"
+        )
+
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_drain_warm_tasks_cancels_in_flight():
+    """drain_warm_tasks cancels and awaits every tracked warm task so a task
+    cancelled mid-Phase-2 can revert its row instead of being torn down."""
+    from src.server.app import workspaces as ws_mod
+
+    started = asyncio.Event()
+
+    async def never_finishes():
+        started.set()
+        await asyncio.Event().wait()  # blocks forever until cancelled
+
+    task = asyncio.create_task(never_finishes())
+    ws_mod._warm_tasks.add(task)
+    task.add_done_callback(ws_mod._warm_tasks.discard)
+    await started.wait()
+
+    await ws_mod.drain_warm_tasks()
+
+    assert task.cancelled()
+    assert not ws_mod._warm_tasks
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/workspaces/{workspace_id}/events — SSE status stream
+# ---------------------------------------------------------------------------
+
+
+def _parse_sse(buffer: str):
+    """Yield (event_name, data) tuples from an SSE wire buffer."""
+    for chunk in buffer.split("\n\n"):
+        if not chunk.strip():
+            continue
+        event_name = ""
+        data = ""
+        for line in chunk.split("\n"):
+            if line.startswith("event:"):
+                event_name = line[6:].strip()
+            elif line.startswith("data:"):
+                data += line[5:].strip()
+        yield event_name, data
+
+
+async def _collect_sse_events(client, url, *, want_events: int, timeout: float = 2.0):
+    """Open an SSE stream and collect up to `want_events` events, then close."""
+    import json as _json
+
+    events: list[tuple[str, dict]] = []
+    async with client.stream("GET", url) as resp:
+        assert resp.status_code == 200
+        buffer = ""
+
+        async def _read_loop():
+            nonlocal buffer
+            async for chunk in resp.aiter_text():
+                buffer += chunk
+                while "\n\n" in buffer:
+                    raw, _, buffer = buffer.partition("\n\n")
+                    for name, data in _parse_sse(raw + "\n\n"):
+                        if name == "status" and data:
+                            try:
+                                events.append((name, _json.loads(data)))
+                            except Exception:
+                                events.append((name, {}))
+                        elif name == "timeout":
+                            events.append((name, {}))
+                    if len(events) >= want_events:
+                        return
+
+        try:
+            await asyncio.wait_for(_read_loop(), timeout=timeout)
+        except asyncio.TimeoutError:
+            pass
+    return events
+
+
+@pytest.mark.asyncio
+async def test_workspace_events_emits_initial_status_then_pubsub_transition(client):
+    """SSE endpoint sends current status immediately, then each pub/sub transition."""
+    from contextlib import asynccontextmanager
+
+    ws = _ws(status="starting")
+    ws_running = {**ws, "status": "running"}
+    # 1st DB read (initial event), 2nd DB read (post-subscribe), 3rd DB read after notify
+    db_seq = iter([ws, ws, ws_running])
+
+    async def fake_db(workspace_id, conn=None):
+        try:
+            return next(db_seq)
+        except StopIteration:
+            return ws_running
+
+    @asynccontextmanager
+    async def fake_subscribe(workspace_id):
+        sent = False
+
+        async def wait(timeout):
+            nonlocal sent
+            if not sent:
+                sent = True
+                return {"workspace_id": workspace_id, "status": "running"}
+            return None
+
+        yield wait
+
+    with (
+        patch(
+            "src.server.app.workspaces.db_get_workspace",
+            new=AsyncMock(side_effect=fake_db),
+        ),
+        patch(
+            "src.server.app.workspaces.subscribe_to_status",
+            new=fake_subscribe,
+        ),
+    ):
+        events = await _collect_sse_events(
+            client,
+            f"/api/v1/workspaces/{ws['workspace_id']}/events",
+            want_events=2,
+            timeout=2.0,
+        )
+
+    statuses = [e[1].get("status") for e in events if e[0] == "status"]
+    assert "starting" in statuses
+    assert "running" in statuses
+    # Running is terminal — stream closes immediately after, no further events.
+
+
+@pytest.mark.asyncio
+async def test_workspace_events_forwards_archived_sandbox_state(client):
+    """A pub/sub hint carrying sandbox_state='archived' during the 'starting'
+    phase is forwarded as a refinement event (no DB re-read, stream stays open)
+    so the FE can escalate to the slow-restore spinner even when a background
+    warm — not this client — owns the start."""
+    from contextlib import asynccontextmanager
+
+    ws = _ws(status="starting")
+    ws_running = {**ws, "status": "running"}
+    # initial read, post-subscribe read; the archived refinement does NOT
+    # re-read; the running transition re-reads.
+    db_seq = iter([ws, ws, ws_running])
+
+    async def fake_db(workspace_id, conn=None):
+        try:
+            return next(db_seq)
+        except StopIteration:
+            return ws_running
+
+    @asynccontextmanager
+    async def fake_subscribe(workspace_id):
+        msgs = iter(
+            [
+                {"workspace_id": workspace_id, "status": "starting",
+                 "sandbox_state": "archived"},
+                {"workspace_id": workspace_id, "status": "running"},
+            ]
+        )
+
+        async def wait(timeout):
+            return next(msgs, None)
+
+        yield wait
+
+    with (
+        patch(
+            "src.server.app.workspaces.db_get_workspace",
+            new=AsyncMock(side_effect=fake_db),
+        ),
+        patch(
+            "src.server.app.workspaces.subscribe_to_status",
+            new=fake_subscribe,
+        ),
+    ):
+        events = await _collect_sse_events(
+            client,
+            f"/api/v1/workspaces/{ws['workspace_id']}/events",
+            want_events=3,
+            timeout=2.0,
+        )
+
+    status_events = [e[1] for e in events if e[0] == "status"]
+    # The archived refinement carries status 'starting' + sandbox_state.
+    assert any(
+        e.get("status") == "starting" and e.get("sandbox_state") == "archived"
+        for e in status_events
+    )
+    assert any(e.get("status") == "running" for e in status_events)
+
+
+@pytest.mark.asyncio
+async def test_workspace_events_terminates_on_initial_running(client):
+    """If the workspace is already running, the stream emits one event then closes."""
+    from contextlib import asynccontextmanager
+
+    ws = _ws(status="running")
+
+    @asynccontextmanager
+    async def fake_subscribe(workspace_id):
+        async def wait(timeout):
+            return None
+
+        yield wait
+
+    with (
+        patch(
+            "src.server.app.workspaces.db_get_workspace",
+            new=AsyncMock(return_value=ws),
+        ),
+        patch(
+            "src.server.app.workspaces.subscribe_to_status",
+            new=fake_subscribe,
+        ),
+    ):
+        events = await _collect_sse_events(
+            client,
+            f"/api/v1/workspaces/{ws['workspace_id']}/events",
+            want_events=1,
+            timeout=1.0,
+        )
+
+    assert events[0][0] == "status"
+    assert events[0][1].get("status") == "running"
+
+
+@pytest.mark.asyncio
+async def test_workspace_events_forbidden(client):
+    """SSE endpoint enforces ownership."""
+    ws = _ws(user_id="other-user", status="stopped")
+    with patch(
+        "src.server.app.workspaces.db_get_workspace",
+        new_callable=AsyncMock,
+        return_value=ws,
+    ):
+        resp = await client.get(
+            f"/api/v1/workspaces/{ws['workspace_id']}/events"
+        )
     assert resp.status_code == 403
 
 

--- a/tests/unit/server/app/test_workspaces.py
+++ b/tests/unit/server/app/test_workspaces.py
@@ -516,9 +516,11 @@ async def test_start_workspace_lazy_returns_202_and_schedules(client):
         assert body["status"] == "starting"
         assert body["workspace_id"] == ws["workspace_id"]
 
-        # The background task should have started but not finished — yield once.
-        await asyncio.sleep(0)
-        assert started_event.is_set(), "background task was not scheduled"
+        # The background task should have started but not finished. Wait on the
+        # event directly rather than a single scheduler tick (asyncio.sleep(0)),
+        # which can flake under load if the task needs more than one tick to
+        # reach started_event.set().
+        await asyncio.wait_for(started_event.wait(), timeout=0.5)
 
         # Let the task complete so it doesn't leak into other tests.
         finish_event.set()
@@ -658,8 +660,12 @@ async def _collect_sse_events(client, url, *, want_events: int, timeout: float =
                         if name == "status" and data:
                             try:
                                 events.append((name, _json.loads(data)))
-                            except Exception:
-                                events.append((name, {}))
+                            except Exception as exc:
+                                # Fail fast — a malformed payload is a real
+                                # serialization regression, not something to mask.
+                                raise AssertionError(
+                                    f"Invalid SSE JSON payload for 'status': {data!r}"
+                                ) from exc
                         elif name == "timeout":
                             events.append((name, {}))
                     if len(events) >= want_events:

--- a/tests/unit/server/services/test_workspace_manager.py
+++ b/tests/unit/server/services/test_workspace_manager.py
@@ -1280,9 +1280,11 @@ from ptc_agent.core.sandbox.runtime import SandboxTransientError  # noqa: E402
 
 
 class TestPhase2ErrorNarrowing:
-    """Phase 2 now distinguishes a failed lazy init (has_failed() == True,
-    clear + re-raise) from a post-init transient (has_failed() == False,
-    swallow + retry next request). Generic Exception keeps the legacy
+    """Phase 2 distinguishes a failed lazy init (has_failed() == True,
+    clear + re-raise) from a post-init transient (has_failed() == False).
+    For an UNPROMOTED lazy start, a post-init transient reverts the row to
+    'stopped' and re-raises so the caller can't return a sandbox behind a
+    'stopped' row (split-brain). Generic Exception keeps the legacy
     best-effort-retry behavior — regression-guarded here."""
 
     def setup_method(self):
@@ -1330,12 +1332,15 @@ class TestPhase2ErrorNarrowing:
     @patch("src.server.services.workspace_manager.SessionManager")
     @patch("src.server.services.workspace_manager.update_workspace_status")
     @patch("src.server.services.workspace_manager.update_workspace_activity")
-    async def test_phase2_transient_post_init_swallowed(
+    async def test_phase2_transient_post_init_lazy_reverts_and_raises(
         self, mock_activity, mock_status, mock_session_mgr, mock_get_ws
     ):
-        """SandboxTransientError after sandbox is ready (e.g., asset sync)
-        leaves the healthy session in cache and is best-effort retried next
-        request. has_failed() == False is the discriminator."""
+        """A post-init transient (e.g. asset sync) on an UNPROMOTED lazy start
+        reverts the row to 'stopped' and re-raises. has_failed() == False, so
+        the sandbox is healthy — but returning the session here would hand back
+        a sandbox the DB says is 'stopped', letting another worker spawn a
+        second one (split-brain). The discriminator is _pending_lazy_sync
+        membership; the deferred-sync asset step is reached only on that path."""
         manager = self._make_manager()
         ws_id = str(uuid.uuid4())
         mock_get_ws.return_value = _make_workspace(
@@ -1351,16 +1356,21 @@ class TestPhase2ErrorNarrowing:
             side_effect=SandboxTransientError("sync blip")
         )
         manager._maybe_restore_files = AsyncMock()
-        manager._pending_lazy_sync.add(ws_id)  # force deferred-sync branch
+        manager._pending_lazy_sync.add(ws_id)  # unpromoted lazy start
         manager._sessions[ws_id] = session
         manager._last_sync_at = {}
         mock_session_mgr.cleanup_session = AsyncMock()
 
-        result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
+        with pytest.raises(SandboxTransientError):
+            await manager.get_session_for_workspace(ws_id, user_id="user-1")
 
-        assert result is session  # still cached, no clear
+        # Row reverted so cross-worker losers re-claim immediately instead of
+        # the caller returning a sandbox behind a 'stopped' row.
+        mock_status.assert_any_await(workspace_id=ws_id, status="stopped")
+        assert ws_id not in manager._pending_lazy_sync
+        # has_failed() was False — the healthy session is left cached (not
+        # cleared); the next request re-claims against the reverted row.
         mock_session_mgr.cleanup_session.assert_not_awaited()
-        assert ws_id in manager._sessions
 
     @pytest.mark.asyncio
     @patch("src.server.services.workspace_manager.db_get_workspace")

--- a/tests/unit/server/services/test_workspace_manager.py
+++ b/tests/unit/server/services/test_workspace_manager.py
@@ -398,6 +398,136 @@ class TestCleanupIdle:
         mock_stop.assert_not_awaited()
 
 
+class TestReapStuckStarting:
+    """reap_stuck_starting_workspaces reverts rows wedged in 'starting' past the
+    reap_stuck_after window, but never reaps a start THIS worker is still running
+    (it holds _pending_lazy_sync membership) and leaves fresh rows alone."""
+
+    def setup_method(self):
+        WorkspaceManager.reset_instance()
+
+    def teardown_method(self):
+        WorkspaceManager.reset_instance()
+
+    @pytest.mark.asyncio
+    @patch(
+        "src.server.services.workspace_manager.update_workspace_status",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "src.server.services.workspace_manager.get_workspaces_by_status",
+        new_callable=AsyncMock,
+    )
+    async def test_reaps_stale_starting_row(self, mock_get_by_status, mock_status):
+        """A row wedged past the threshold with NO local membership is the
+        cross-process case (a crashed/recycled worker left it 'starting'): no
+        in-process owner will ever recover it, so the reaper reverts it."""
+        manager = WorkspaceManager.get_instance(config=_make_config())
+        ws_id = str(uuid.uuid4())
+        stale = _make_workspace(
+            workspace_id=ws_id,
+            status="starting",
+            updated_at=datetime.now(timezone.utc)
+            - timedelta(seconds=manager.reap_stuck_after + 1),
+        )
+        mock_get_by_status.return_value = [stale]
+        # No _pending_lazy_sync membership — no owner on this worker.
+
+        reverted = await manager.reap_stuck_starting_workspaces()
+
+        assert reverted == 1
+        mock_status.assert_awaited_once_with(workspace_id=ws_id, status="stopped")
+
+    @pytest.mark.asyncio
+    @patch(
+        "src.server.services.workspace_manager.update_workspace_status",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "src.server.services.workspace_manager.get_workspaces_by_status",
+        new_callable=AsyncMock,
+    )
+    async def test_leaves_in_flight_lazy_owner_past_threshold(
+        self, mock_get_by_status, mock_status
+    ):
+        """Even PAST the threshold, a row this worker is still starting (it holds
+        _pending_lazy_sync) must NOT be reaped — the owner will promote on success
+        or revert on failure. Reaping would discard the membership and no-op the
+        owner's promotion, stranding a ready session behind a 'stopped' row. This
+        guards the slow-archived-restore race independently of the threshold."""
+        manager = WorkspaceManager.get_instance(config=_make_config())
+        ws_id = str(uuid.uuid4())
+        owned = _make_workspace(
+            workspace_id=ws_id,
+            status="starting",
+            updated_at=datetime.now(timezone.utc)
+            - timedelta(seconds=manager.reap_stuck_after + 1),
+        )
+        mock_get_by_status.return_value = [owned]
+        manager._pending_lazy_sync.add(ws_id)
+
+        reverted = await manager.reap_stuck_starting_workspaces()
+
+        assert reverted == 0
+        mock_status.assert_not_awaited()
+        # Membership preserved so the owner's later promotion still fires.
+        assert ws_id in manager._pending_lazy_sync
+
+    @pytest.mark.asyncio
+    @patch(
+        "src.server.services.workspace_manager.update_workspace_status",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "src.server.services.workspace_manager.get_workspaces_by_status",
+        new_callable=AsyncMock,
+    )
+    async def test_leaves_fresh_starting_row(self, mock_get_by_status, mock_status):
+        """A start still within the wait window must NOT be reaped — that would
+        yank a legitimately in-flight cold restore out from under its owner."""
+        manager = WorkspaceManager.get_instance(config=_make_config())
+        fresh = _make_workspace(
+            status="starting",
+            updated_at=datetime.now(timezone.utc) - timedelta(seconds=10),
+        )
+        mock_get_by_status.return_value = [fresh]
+
+        reverted = await manager.reap_stuck_starting_workspaces()
+
+        assert reverted == 0
+        mock_status.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch(
+        "src.server.services.workspace_manager.update_workspace_status",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "src.server.services.workspace_manager.get_workspaces_by_status",
+        new_callable=AsyncMock,
+    )
+    async def test_leaves_slow_but_legit_restore(self, mock_get_by_status, mock_status):
+        """A row older than start_wait_timeout but younger than reap_stuck_after
+        is below the reap threshold and must NOT be reaped — even with no local
+        membership (e.g. a cross-process start that is slow but not yet wedged).
+        This isolates the threshold boundary from the in-process owner guard."""
+        manager = WorkspaceManager.get_instance(config=_make_config())
+        ws_id = str(uuid.uuid4())
+        # Halfway between the two thresholds (e.g. ~450s with defaults).
+        age = (manager.start_wait_timeout + manager.reap_stuck_after) / 2
+        slow = _make_workspace(
+            workspace_id=ws_id,
+            status="starting",
+            updated_at=datetime.now(timezone.utc) - timedelta(seconds=age),
+        )
+        mock_get_by_status.return_value = [slow]
+
+        reverted = await manager.reap_stuck_starting_workspaces()
+
+        assert reverted == 0
+        mock_status.assert_not_awaited()
+
+
 # ---------------------------------------------------------------------------
 # shutdown
 # ---------------------------------------------------------------------------
@@ -867,8 +997,9 @@ class TestSandboxRecovery:
     @patch("src.server.services.workspace_manager.SessionManager")
     @patch("src.server.services.workspace_manager.update_workspace_status")
     @patch("src.server.services.workspace_manager.update_workspace_activity")
+    @patch("src.server.services.workspace_manager.try_claim_workspace_for_start", new_callable=AsyncMock)
     async def test_stopped_workspace_lazy_init_sandbox_gone_recovers(
-        self, mock_activity, mock_status, mock_session_mgr, mock_get_ws
+        self, mock_claim, mock_activity, mock_status, mock_session_mgr, mock_get_ws
     ):
         """REGRESSION: First request to a stopped workspace whose sandbox is deleted.
 
@@ -882,6 +1013,8 @@ class TestSandboxRecovery:
         ws_id = str(uuid.uuid4())
         workspace = _make_workspace(workspace_id=ws_id, status="stopped")
         mock_get_ws.return_value = workspace
+        # Cross-worker claim succeeds — this worker wins the start mutex.
+        mock_claim.return_value = workspace
 
         # _restart_workspace returns a session whose sandbox will fail in Phase 2
         lazy_session = _make_mock_session()
@@ -1023,8 +1156,9 @@ class TestOnStateObservedForwarding:
     @patch("src.server.services.workspace_manager.SessionManager")
     @patch("src.server.services.workspace_manager.update_workspace_activity")
     @patch("src.server.services.workspace_manager.update_workspace_status")
+    @patch("src.server.services.workspace_manager.try_claim_workspace_for_start", new_callable=AsyncMock)
     async def test_stopped_path_forwards_callback_to_initialize_lazy(
-        self, mock_status, mock_activity, mock_session_mgr, mock_get_ws
+        self, mock_claim, mock_status, mock_activity, mock_session_mgr, mock_get_ws
     ):
         """status=stopped + matching config hash → _restart_workspace keeps
         lazy_init=True → session.initialize_lazy(..., on_state_observed=sentinel)."""
@@ -1038,24 +1172,30 @@ class TestOnStateObservedForwarding:
             config={"sandbox_config_hash": "matching-hash"},
         )
         mock_get_ws.return_value = workspace
+        mock_claim.return_value = workspace
         session = _make_mock_session(initialized=False)
         # Simulate lazy init leaving sandbox ready so Phase 2 doesn't retry.
         session.sandbox.is_ready = MagicMock(return_value=True)
         session.sandbox.has_failed = MagicMock(return_value=False)
         mock_session_mgr.get_session.return_value = session
 
-        def sentinel(_s: str) -> None:
-            return None
+        observed: list[str] = []
+
+        def sentinel(s: str) -> None:
+            observed.append(s)
 
         await manager.get_session_for_workspace(
             ws_id, user_id="user-1", on_state_observed=sentinel
         )
 
         session.initialize_lazy.assert_awaited_once()
-        assert (
-            session.initialize_lazy.await_args.kwargs.get("on_state_observed")
-            is sentinel
-        )
+        forwarded = session.initialize_lazy.await_args.kwargs.get("on_state_observed")
+        # The stopped (claim-owner) path wraps the caller's callback so it can
+        # also broadcast the archived hint cross-worker — the wrapper must still
+        # invoke the original observer.
+        assert forwarded is not None
+        forwarded("stopped")
+        assert observed == ["stopped"]
         # Lazy path must not have touched the eager initialize.
         session.initialize.assert_not_awaited()
 
@@ -1064,8 +1204,9 @@ class TestOnStateObservedForwarding:
     @patch("src.server.services.workspace_manager.SessionManager")
     @patch("src.server.services.workspace_manager.update_workspace_activity")
     @patch("src.server.services.workspace_manager.update_workspace_status")
+    @patch("src.server.services.workspace_manager.try_claim_workspace_for_start", new_callable=AsyncMock)
     async def test_restart_forced_non_lazy_forwards_callback_to_initialize(
-        self, mock_status, mock_activity, mock_session_mgr, mock_get_ws
+        self, mock_claim, mock_status, mock_activity, mock_session_mgr, mock_get_ws
     ):
         """Config hash mismatch inside _restart_workspace forces lazy_init=False
         → session.initialize(..., on_state_observed=sentinel) instead of initialize_lazy."""
@@ -1078,20 +1219,28 @@ class TestOnStateObservedForwarding:
             config={"sandbox_config_hash": "old-hash"},
         )
         mock_get_ws.return_value = workspace
+        mock_claim.return_value = workspace
         session = _make_mock_session(initialized=False)
         session.sandbox.is_ready = MagicMock(return_value=True)
         session.sandbox.has_failed = MagicMock(return_value=False)
         mock_session_mgr.get_session.return_value = session
 
-        def sentinel(_s: str) -> None:
-            return None
+        observed: list[str] = []
+
+        def sentinel(s: str) -> None:
+            observed.append(s)
 
         await manager.get_session_for_workspace(
             ws_id, user_id="user-1", on_state_observed=sentinel
         )
 
         session.initialize.assert_awaited_once()
-        assert session.initialize.await_args.kwargs.get("on_state_observed") is sentinel
+        forwarded = session.initialize.await_args.kwargs.get("on_state_observed")
+        # Claim-owner path wraps the caller's callback; the wrapper must still
+        # invoke the original observer even on the forced non-lazy branch.
+        assert forwarded is not None
+        forwarded("stopped")
+        assert observed == ["stopped"]
         session.initialize_lazy.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -1369,15 +1518,18 @@ class TestIntermediateStartingStatus:
     @patch("src.server.services.workspace_manager.SessionManager")
     @patch("src.server.services.workspace_manager.update_workspace_status")
     @patch("src.server.services.workspace_manager.update_workspace_activity")
+    @patch("src.server.services.workspace_manager.try_claim_workspace_for_start", new_callable=AsyncMock)
     async def test_phase2_success_promotes_starting_to_running_and_stamps(
-        self, mock_activity, mock_status, mock_session_mgr, mock_get_ws
+        self, mock_claim, mock_activity, mock_status, mock_session_mgr, mock_get_ws
     ):
         """When Phase 2 finishes the deferred sync, DB is promoted to
         running AND activity is stamped in that order (mirrors PR #152's
         invariant for the lazy path)."""
         manager = self._make_manager()
         ws_id = str(uuid.uuid4())
-        mock_get_ws.return_value = self._lazy_workspace(ws_id, status="stopped")
+        workspace = self._lazy_workspace(ws_id, status="stopped")
+        mock_get_ws.return_value = workspace
+        mock_claim.return_value = workspace
 
         lazy_session = _make_mock_session()
         lazy_session.sandbox.ensure_sandbox_ready = AsyncMock()
@@ -1410,14 +1562,19 @@ class TestIntermediateStartingStatus:
     @patch("src.server.services.workspace_manager.SessionManager")
     @patch("src.server.services.workspace_manager.update_workspace_status")
     @patch("src.server.services.workspace_manager.update_workspace_activity")
-    async def test_phase2_failure_leaves_status_at_starting(
-        self, mock_activity, mock_status, mock_session_mgr, mock_get_ws
+    @patch("src.server.services.workspace_manager.try_claim_workspace_for_start", new_callable=AsyncMock)
+    async def test_phase2_failure_reverts_status_to_stopped(
+        self, mock_claim, mock_activity, mock_status, mock_session_mgr, mock_get_ws
     ):
-        """Phase 2 exhausts retries → status stays "starting" (never flipped
-        to running), next request re-enters the stopped/starting branch."""
+        """Claim winner fails in Phase 2 → row is reverted "starting" → "stopped"
+        (never promoted to running), so cross-worker losers can re-claim
+        immediately instead of waiting out the full start_wait_timeout. The
+        original exception still propagates."""
         manager = self._make_manager()
         ws_id = str(uuid.uuid4())
-        mock_get_ws.return_value = self._lazy_workspace(ws_id, status="stopped")
+        workspace = self._lazy_workspace(ws_id, status="stopped")
+        mock_get_ws.return_value = workspace
+        mock_claim.return_value = workspace
 
         lazy_session = _make_mock_session()
         lazy_session.sandbox.ensure_sandbox_ready = AsyncMock(
@@ -1430,33 +1587,176 @@ class TestIntermediateStartingStatus:
         with pytest.raises(SandboxTransientError):
             await manager.get_session_for_workspace(ws_id, user_id="user-1")
 
-        status_calls = [
-            c.kwargs for c in mock_status.await_args_list
-        ]
-        assert {c["status"] for c in status_calls} == {"starting"}
+        status_calls = [c.kwargs for c in mock_status.await_args_list]
+        # 'starting' from the claim/restart, then 'stopped' from the Phase 2
+        # failure revert — and crucially never 'running'.
+        assert {c["status"] for c in status_calls} == {"starting", "stopped"}
+        assert status_calls[-1]["status"] == "stopped"
+        # Pending-sync marker cleared so the workspace isn't wedged.
+        assert ws_id not in manager._pending_lazy_sync
 
     @pytest.mark.asyncio
     @patch("src.server.services.workspace_manager.db_get_workspace")
     @patch("src.server.services.workspace_manager.SessionManager")
     @patch("src.server.services.workspace_manager.update_workspace_status")
     @patch("src.server.services.workspace_manager.update_workspace_activity")
-    async def test_status_starting_reenters_restart_flow(
-        self, mock_activity, mock_status, mock_session_mgr, mock_get_ws
+    @patch("src.server.services.workspace_manager.try_claim_workspace_for_start", new_callable=AsyncMock)
+    async def test_phase2_generic_failure_reverts_status_to_stopped(
+        self, mock_claim, mock_activity, mock_status, mock_session_mgr, mock_get_ws
     ):
-        """If a prior lazy init left the row in "starting" (e.g. failed and
-        cleared), the next request with no cached session re-enters the
-        restart flow just like "stopped" would."""
+        """A generic Phase 2 failure on an unpromoted lazy start is the most
+        dangerous path: it must revert the row to 'stopped' so losers re-claim
+        immediately, AND re-raise rather than return the session — returning it
+        would hand the agent a sandbox that never finished asset/file sync while
+        the DB says 'stopped'."""
         manager = self._make_manager()
         ws_id = str(uuid.uuid4())
-        mock_get_ws.return_value = self._lazy_workspace(ws_id, status="starting")
+        workspace = self._lazy_workspace(ws_id, status="stopped")
+        mock_get_ws.return_value = workspace
+        mock_claim.return_value = workspace
 
         lazy_session = _make_mock_session()
-        lazy_session.sandbox.ensure_sandbox_ready = AsyncMock()
+        lazy_session.sandbox.ensure_sandbox_ready = AsyncMock(
+            side_effect=RuntimeError("daytona hiccup")
+        )
         mock_session_mgr.get_session.return_value = lazy_session
+
+        # Unpromoted lazy start: the failure is surfaced, not swallowed.
+        with pytest.raises(RuntimeError, match="daytona hiccup"):
+            await manager.get_session_for_workspace(ws_id, user_id="user-1")
+
+        status_calls = [c.kwargs for c in mock_status.await_args_list]
+        assert {c["status"] for c in status_calls} == {"starting", "stopped"}
+        assert status_calls[-1]["status"] == "stopped"
+        assert ws_id not in manager._pending_lazy_sync
+
+    @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.db_get_workspace")
+    @patch("src.server.services.workspace_manager.SessionManager")
+    @patch("src.server.services.workspace_manager.update_workspace_status")
+    @patch("src.server.services.workspace_manager.update_workspace_activity")
+    @patch(
+        "src.server.services.workspace_manager.try_claim_workspace_for_start",
+        new_callable=AsyncMock,
+    )
+    async def test_phase2_cancelled_reverts_status_to_stopped(
+        self, mock_claim, mock_activity, mock_status, mock_session_mgr, mock_get_ws
+    ):
+        """A client disconnect / shutdown cancels Phase 2. CancelledError is a
+        BaseException, so without an explicit handler it would bypass every
+        revert and wedge the row in 'starting' forever. It must revert to
+        'stopped' AND re-raise to preserve cancellation semantics."""
+        manager = self._make_manager()
+        ws_id = str(uuid.uuid4())
+        workspace = self._lazy_workspace(ws_id, status="stopped")
+        mock_get_ws.return_value = workspace
+        mock_claim.return_value = workspace
+
+        lazy_session = _make_mock_session()
+        lazy_session.sandbox.ensure_sandbox_ready = AsyncMock(
+            side_effect=asyncio.CancelledError()
+        )
+        mock_session_mgr.get_session.return_value = lazy_session
+
+        with pytest.raises(asyncio.CancelledError):
+            await manager.get_session_for_workspace(ws_id, user_id="user-1")
+
+        status_calls = [c.kwargs for c in mock_status.await_args_list]
+        assert status_calls[-1]["status"] == "stopped"
+        assert ws_id not in manager._pending_lazy_sync
+
+    @pytest.mark.asyncio
+    @patch(
+        "src.server.services.workspace_manager.publish_status_change",
+        new_callable=AsyncMock,
+    )
+    @patch("src.server.services.workspace_manager.db_get_workspace")
+    @patch("src.server.services.workspace_manager.SessionManager")
+    @patch("src.server.services.workspace_manager.update_workspace_status")
+    @patch("src.server.services.workspace_manager.update_workspace_activity")
+    @patch(
+        "src.server.services.workspace_manager.try_claim_workspace_for_start",
+        new_callable=AsyncMock,
+    )
+    async def test_claim_owner_broadcasts_archived_state(
+        self,
+        mock_claim,
+        mock_activity,
+        mock_status,
+        mock_session_mgr,
+        mock_get_ws,
+        mock_publish,
+    ):
+        """When the pre-start sandbox state is 'archived', the claim owner
+        publishes it on the status channel so cross-worker consumers (the
+        /events SSE, a losing worker's chat spinner) can show the slow-restore
+        copy regardless of who owns the start."""
+        manager = self._make_manager()
+        ws_id = str(uuid.uuid4())
+        workspace = self._lazy_workspace(ws_id, status="stopped")
+        mock_get_ws.return_value = workspace
+        mock_claim.return_value = workspace
+
+        session = _make_mock_session(initialized=False)
+        session.sandbox.is_ready = MagicMock(return_value=True)
+        session.sandbox.has_failed = MagicMock(return_value=False)
+
+        async def fake_init_lazy(*args, on_state_observed=None, **kwargs):
+            if on_state_observed is not None:
+                on_state_observed("archived")
+
+        session.initialize_lazy = AsyncMock(side_effect=fake_init_lazy)
+        mock_session_mgr.get_session.return_value = session
 
         await manager.get_session_for_workspace(ws_id, user_id="user-1")
 
-        lazy_session.initialize_lazy.assert_awaited_once()
+        archived = [
+            c
+            for c in mock_publish.call_args_list
+            if (c.kwargs.get("extra") or {}).get("sandbox_state") == "archived"
+        ]
+        assert archived, "claim owner did not broadcast archived sandbox_state"
+        assert archived[0].args[1] == "starting"
+
+    @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.db_get_workspace")
+    @patch("src.server.services.workspace_manager.SessionManager")
+    @patch("src.server.services.workspace_manager.update_workspace_status")
+    @patch("src.server.services.workspace_manager.update_workspace_activity")
+    async def test_status_starting_waits_for_other_worker_to_finish(
+        self, mock_activity, mock_status, mock_session_mgr, mock_get_ws
+    ):
+        """Cross-worker safety: a request landing on a workspace already in
+        'starting' MUST NOT restart (would double-start the sandbox in another
+        worker). It waits for the in-flight start to flip status to 'running',
+        then attaches to that session via the running path.
+
+        Replaces the prior "re-enter restart flow" behavior, which was unsafe
+        under multi-worker deployments — see ``try_claim_workspace_for_start``
+        and ``_wait_for_start_completion``.
+        """
+        manager = self._make_manager()
+        # Tighten polling so the test does not depend on default 300s/0.5s.
+        manager.start_wait_timeout = 5.0
+        manager.start_wait_poll_interval = 0.01
+        ws_id = str(uuid.uuid4())
+        starting_ws = self._lazy_workspace(ws_id, status="starting")
+        running_ws = self._lazy_workspace(ws_id, status="running")
+        # First read sees 'starting'; first poll-iteration read inside
+        # _wait_for_start_completion sees 'running' (other worker finished).
+        mock_get_ws.side_effect = [starting_ws, running_ws]
+
+        session = _make_mock_session(initialized=True)
+        session.sandbox.is_ready = MagicMock(return_value=True)
+        session.sandbox.has_failed = MagicMock(return_value=False)
+        mock_session_mgr.get_session.return_value = session
+
+        result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
+
+        # Did NOT call initialize_lazy — we did not restart.
+        session.initialize_lazy.assert_not_awaited()
+        # Returned a usable session attached via the running path.
+        assert result is session
 
 
 # ---------------------------------------------------------------------------
@@ -1489,3 +1789,236 @@ class TestStatusRoutesToDbFallback:
         source = inspect.getsource(public)
         assert f'"{status}"' in source
         assert '"stopped", "stopping", "starting"' in source
+
+
+# ---------------------------------------------------------------------------
+# Multi-worker start mutex — cross-process race protection
+# ---------------------------------------------------------------------------
+
+
+class TestMultiWorkerStartMutex:
+    """``try_claim_workspace_for_start`` atomically flips status='stopped' →
+    'starting'; only the winner restarts. Losers wait via
+    ``_wait_for_start_completion`` and attach via the running path. These
+    tests cover that contract."""
+
+    def setup_method(self):
+        WorkspaceManager.reset_instance()
+
+    def teardown_method(self):
+        WorkspaceManager.reset_instance()
+
+    def _make_manager(self):
+        manager = WorkspaceManager.get_instance(config=_make_config())
+        manager.start_wait_timeout = 5.0
+        manager.start_wait_poll_interval = 0.01
+        manager._sync_sandbox_assets = AsyncMock()
+        manager._maybe_restore_files = AsyncMock()
+        manager._maybe_migrate_sandbox = AsyncMock(return_value=None)
+        return manager
+
+    @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.db_get_workspace")
+    @patch("src.server.services.workspace_manager.SessionManager")
+    @patch("src.server.services.workspace_manager.update_workspace_status")
+    @patch("src.server.services.workspace_manager.update_workspace_activity")
+    @patch("src.server.services.workspace_manager.try_claim_workspace_for_start", new_callable=AsyncMock)
+    async def test_winner_proceeds_with_restart(
+        self, mock_claim, mock_activity, mock_status, mock_session_mgr, mock_get_ws
+    ):
+        """Worker that wins the claim restarts the sandbox normally."""
+        manager = self._make_manager()
+        ws_id = str(uuid.uuid4())
+        # Provide a matching config hash so _restart_workspace keeps lazy_init=True.
+        manager._compute_sandbox_config_hash = MagicMock(return_value="match")
+        workspace = _make_workspace(
+            workspace_id=ws_id,
+            status="stopped",
+            config={"sandbox_config_hash": "match"},
+        )
+        mock_get_ws.return_value = workspace
+        # Claim succeeds — we own the start.
+        mock_claim.return_value = workspace
+
+        session = _make_mock_session()
+        session.sandbox.ensure_sandbox_ready = AsyncMock()
+        mock_session_mgr.get_session.return_value = session
+
+        await manager.get_session_for_workspace(ws_id, user_id="user-1")
+
+        mock_claim.assert_awaited_once_with(ws_id)
+        session.initialize_lazy.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.db_get_workspace")
+    @patch("src.server.services.workspace_manager.SessionManager")
+    @patch("src.server.services.workspace_manager.update_workspace_status")
+    @patch("src.server.services.workspace_manager.update_workspace_activity")
+    @patch("src.server.services.workspace_manager.try_claim_workspace_for_start", new_callable=AsyncMock)
+    async def test_loser_waits_then_attaches_via_running_path(
+        self, mock_claim, mock_activity, mock_status, mock_session_mgr, mock_get_ws
+    ):
+        """Worker that loses the claim does NOT restart — it waits for the
+        winner to finish, then attaches to the now-running session."""
+        manager = self._make_manager()
+        ws_id = str(uuid.uuid4())
+        stopped_ws = _make_workspace(workspace_id=ws_id, status="stopped")
+        running_ws = _make_workspace(workspace_id=ws_id, status="running")
+        # Phase 1 DB read sees 'stopped'; subsequent poll inside the wait
+        # sees 'running' (winner finished).
+        mock_get_ws.side_effect = [stopped_ws, running_ws]
+        # Claim returns None — another worker already claimed.
+        mock_claim.return_value = None
+
+        session = _make_mock_session(initialized=True)
+        session.sandbox.is_ready = MagicMock(return_value=True)
+        session.sandbox.has_failed = MagicMock(return_value=False)
+        mock_session_mgr.get_session.return_value = session
+
+        result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
+
+        mock_claim.assert_awaited_once_with(ws_id)
+        # Critical: did not restart — no double-start across workers.
+        session.initialize_lazy.assert_not_awaited()
+        assert result is session
+
+    @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.db_get_workspace")
+    @patch("src.server.services.workspace_manager.SessionManager")
+    @patch("src.server.services.workspace_manager.update_workspace_status")
+    @patch("src.server.services.workspace_manager.update_workspace_activity")
+    @patch("src.server.services.workspace_manager.try_claim_workspace_for_start", new_callable=AsyncMock)
+    async def test_loser_raises_when_winner_errors(
+        self, mock_claim, mock_activity, mock_status, mock_session_mgr, mock_get_ws
+    ):
+        """If the winning worker's start fails (status → 'error'), waiting
+        losers surface a RuntimeError rather than hanging or silent success."""
+        manager = self._make_manager()
+        ws_id = str(uuid.uuid4())
+        stopped_ws = _make_workspace(workspace_id=ws_id, status="stopped")
+        error_ws = _make_workspace(workspace_id=ws_id, status="error")
+        mock_get_ws.side_effect = [stopped_ws, error_ws]
+        mock_claim.return_value = None
+
+        with pytest.raises(RuntimeError, match="failed to start"):
+            await manager.get_session_for_workspace(ws_id, user_id="user-1")
+
+    @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.db_get_workspace")
+    async def test_wait_helper_times_out_when_stuck(self, mock_get_ws):
+        """If status sits in 'starting' past the timeout (winner died mid-
+        start), the wait helper raises rather than waiting forever."""
+        manager = self._make_manager()
+        manager.start_wait_timeout = 0.1
+        manager.start_wait_poll_interval = 0.02
+        ws_id = str(uuid.uuid4())
+        starting_ws = _make_workspace(workspace_id=ws_id, status="starting")
+        mock_get_ws.return_value = starting_ws
+
+        with pytest.raises(RuntimeError, match="stuck in 'starting'"):
+            await manager._wait_for_start_completion(ws_id)
+
+    @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.db_get_workspace")
+    async def test_wait_helper_raises_on_deletion(self, mock_get_ws):
+        """Workspace deleted while waiting → ValueError (caller must not
+        keep polling a row that no longer exists)."""
+        manager = self._make_manager()
+        ws_id = str(uuid.uuid4())
+        mock_get_ws.return_value = None
+
+        with pytest.raises(ValueError, match="not found"):
+            await manager._wait_for_start_completion(ws_id)
+
+    @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.db_get_workspace")
+    @patch("src.server.services.workspace_manager.SessionManager")
+    @patch("src.server.services.workspace_manager.update_workspace_status")
+    @patch("src.server.services.workspace_manager.update_workspace_activity")
+    @patch(
+        "src.server.services.workspace_manager.try_claim_workspace_for_start",
+        new_callable=AsyncMock,
+    )
+    async def test_start_wait_does_not_hold_workspace_lock(
+        self, mock_claim, mock_activity, mock_status, mock_session_mgr, mock_get_ws
+    ):
+        """Regression: the cross-worker start wait must run OUTSIDE the per-
+        workspace lock. Otherwise a 60-300s archived cold-start head-of-line
+        blocks every other op on that workspace (stop/delete/another get)
+        behind the 60s lock-acquire ceiling."""
+        manager = self._make_manager()
+        ws_id = str(uuid.uuid4())
+        starting_ws = _make_workspace(workspace_id=ws_id, status="starting")
+        running_ws = _make_workspace(workspace_id=ws_id, status="running")
+        mock_get_ws.side_effect = [starting_ws, running_ws]
+        mock_claim.return_value = None  # 'starting' arrival skips the claim
+
+        session = _make_mock_session(initialized=True)
+        session.sandbox.is_ready = MagicMock(return_value=True)
+        session.sandbox.has_failed = MagicMock(return_value=False)
+        mock_session_mgr.get_session.return_value = session
+
+        # Gate the wait so we can probe the lock while the caller is parked in it.
+        release = asyncio.Event()
+
+        async def _blocking_wait(workspace_id, *a, **k):
+            await release.wait()
+            return running_ws
+
+        manager._wait_for_start_completion = AsyncMock(side_effect=_blocking_wait)
+
+        waiter = asyncio.create_task(
+            manager.get_session_for_workspace(ws_id, user_id="user-1")
+        )
+        await asyncio.sleep(0.05)  # let the waiter reach the gated wait
+        assert not waiter.done()
+
+        # The per-workspace lock MUST be free while the waiter waits. Short
+        # timeout so a regression (wait-inside-lock) fails fast instead of
+        # hanging the full 60s lock-acquire ceiling.
+        async def _probe():
+            async with manager._observed_lock(ws_id, "probe"):
+                return True
+
+        assert await asyncio.wait_for(_probe(), timeout=2.0) is True
+
+        release.set()
+        result = await waiter
+        assert result is session
+
+    @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.db_get_workspace")
+    @patch("src.server.services.workspace_manager.SessionManager")
+    @patch("src.server.services.workspace_manager.update_workspace_status")
+    @patch("src.server.services.workspace_manager.update_workspace_activity")
+    @patch(
+        "src.server.services.workspace_manager.try_claim_workspace_for_start",
+        new_callable=AsyncMock,
+    )
+    async def test_loser_retries_once_when_owner_reverts_to_stopped(
+        self, mock_claim, mock_activity, mock_status, mock_session_mgr, mock_get_ws
+    ):
+        """If the winner fails and reverts 'starting'→'stopped', the waiting
+        loser retries the start once and becomes the owner (restart runs)."""
+        manager = self._make_manager()
+        manager._compute_sandbox_config_hash = MagicMock(return_value="match")
+        ws_id = str(uuid.uuid4())
+        stopped_ws = _make_workspace(
+            workspace_id=ws_id,
+            status="stopped",
+            config={"sandbox_config_hash": "match"},
+        )
+        mock_get_ws.return_value = stopped_ws  # both Phase 1 reads see 'stopped'
+        # First claim loses; the post-revert retry wins.
+        mock_claim.side_effect = [None, stopped_ws]
+        # Owner failed and reverted the row back to 'stopped'.
+        manager._wait_for_start_completion = AsyncMock(return_value=stopped_ws)
+
+        session = _make_mock_session()
+        session.sandbox.ensure_sandbox_ready = AsyncMock()
+        mock_session_mgr.get_session.return_value = session
+
+        await manager.get_session_for_workspace(ws_id, user_id="user-1")
+
+        assert mock_claim.await_count == 2
+        session.initialize_lazy.assert_awaited_once()

--- a/tests/unit/server/services/test_workspace_status_pubsub.py
+++ b/tests/unit/server/services/test_workspace_status_pubsub.py
@@ -1,0 +1,238 @@
+"""Unit tests for the workspace status pub/sub primitive.
+
+Focus on the contract callers depend on:
+- publish_status_change writes a JSON payload to the per-workspace channel
+- subscribe_to_status yields a wait() that returns decoded payloads
+- Redis-disabled paths are no-ops / return None so callers fall back cleanly
+"""
+
+import json
+
+import pytest
+
+from src.server.services import workspace_status_pubsub
+from src.server.services.workspace_status_pubsub import (
+    publish_status_change,
+    status_channel,
+    subscribe_to_status,
+    wait_for_status_change,
+)
+
+
+class _FakePubsub:
+    def __init__(self, messages=None):
+        self._messages = list(messages or [])
+        self.subscribed: list[str] = []
+        self.unsubscribed: list[str] = []
+        self.closed = False
+
+    async def subscribe(self, channel):
+        self.subscribed.append(channel)
+
+    async def unsubscribe(self, channel):
+        self.unsubscribed.append(channel)
+
+    async def aclose(self):
+        self.closed = True
+
+    async def get_message(self, ignore_subscribe_messages=True, timeout=None):
+        if self._messages:
+            return self._messages.pop(0)
+        return None
+
+
+class _FakeRedisClient:
+    def __init__(self, pubsub_obj=None):
+        self.published: list[tuple[str, str]] = []
+        self._pubsub_obj = pubsub_obj
+
+    async def publish(self, channel, payload):
+        self.published.append((channel, payload))
+
+    def pubsub(self):
+        return self._pubsub_obj if self._pubsub_obj is not None else _FakePubsub()
+
+
+class _FakeCache:
+    def __init__(self, *, enabled, client):
+        self.enabled = enabled
+        self.client = client
+
+
+def _install_cache(monkeypatch, cache):
+    monkeypatch.setattr(
+        workspace_status_pubsub, "get_cache_client", lambda: cache
+    )
+
+
+@pytest.mark.asyncio
+async def test_publish_is_noop_when_redis_disabled(monkeypatch):
+    _install_cache(monkeypatch, _FakeCache(enabled=False, client=None))
+    # Must not raise even though there's no client.
+    await publish_status_change("ws-1", "running")
+
+
+@pytest.mark.asyncio
+async def test_publish_writes_payload_to_channel(monkeypatch):
+    client = _FakeRedisClient()
+    _install_cache(monkeypatch, _FakeCache(enabled=True, client=client))
+
+    await publish_status_change("ws-abc", "starting")
+
+    assert len(client.published) == 1
+    channel, payload = client.published[0]
+    assert channel == status_channel("ws-abc")
+    assert json.loads(payload) == {"workspace_id": "ws-abc", "status": "starting"}
+
+
+@pytest.mark.asyncio
+async def test_publish_merges_extra_fields(monkeypatch):
+    client = _FakeRedisClient()
+    _install_cache(monkeypatch, _FakeCache(enabled=True, client=client))
+
+    await publish_status_change("ws-1", "running", extra={"src": "winner"})
+
+    _, payload = client.published[0]
+    decoded = json.loads(payload)
+    assert decoded == {"workspace_id": "ws-1", "status": "running", "src": "winner"}
+
+
+@pytest.mark.asyncio
+async def test_publish_swallows_client_error(monkeypatch):
+    class _ExplodingClient(_FakeRedisClient):
+        async def publish(self, channel, payload):
+            raise RuntimeError("redis down")
+
+    _install_cache(
+        monkeypatch, _FakeCache(enabled=True, client=_ExplodingClient())
+    )
+    # Must not raise — pub/sub is best-effort.
+    await publish_status_change("ws-1", "running")
+
+
+@pytest.mark.asyncio
+async def test_subscribe_yields_none_when_redis_disabled(monkeypatch):
+    _install_cache(monkeypatch, _FakeCache(enabled=False, client=None))
+
+    async with subscribe_to_status("ws-1") as wait:
+        assert wait is None
+
+
+@pytest.mark.asyncio
+async def test_subscribe_yields_wait_and_decodes_payload(monkeypatch):
+    payload = json.dumps({"workspace_id": "ws-1", "status": "running"})
+    pubsub = _FakePubsub([{"type": "message", "data": payload.encode()}])
+    client = _FakeRedisClient(pubsub_obj=pubsub)
+    _install_cache(monkeypatch, _FakeCache(enabled=True, client=client))
+
+    async with subscribe_to_status("ws-1") as wait:
+        assert wait is not None
+        msg = await wait(0.1)
+        assert msg == {"workspace_id": "ws-1", "status": "running"}
+
+    # Cleanup happens in the contextmanager __aexit__.
+    assert pubsub.subscribed == [status_channel("ws-1")]
+    assert pubsub.unsubscribed == [status_channel("ws-1")]
+    assert pubsub.closed is True
+
+
+@pytest.mark.asyncio
+async def test_subscribe_decodes_string_payload(monkeypatch):
+    payload = json.dumps({"workspace_id": "ws-1", "status": "error"})
+    pubsub = _FakePubsub([{"type": "message", "data": payload}])
+    _install_cache(
+        monkeypatch,
+        _FakeCache(enabled=True, client=_FakeRedisClient(pubsub_obj=pubsub)),
+    )
+
+    async with subscribe_to_status("ws-1") as wait:
+        assert await wait(0.1) == {"workspace_id": "ws-1", "status": "error"}
+
+
+@pytest.mark.asyncio
+async def test_subscribe_returns_none_for_non_message(monkeypatch):
+    pubsub = _FakePubsub([{"type": "subscribe", "data": 1}])
+    _install_cache(
+        monkeypatch,
+        _FakeCache(enabled=True, client=_FakeRedisClient(pubsub_obj=pubsub)),
+    )
+
+    async with subscribe_to_status("ws-1") as wait:
+        assert await wait(0.1) is None
+
+
+@pytest.mark.asyncio
+async def test_subscribe_returns_none_on_invalid_json(monkeypatch):
+    pubsub = _FakePubsub([{"type": "message", "data": "not-json"}])
+    _install_cache(
+        monkeypatch,
+        _FakeCache(enabled=True, client=_FakeRedisClient(pubsub_obj=pubsub)),
+    )
+
+    async with subscribe_to_status("ws-1") as wait:
+        assert await wait(0.1) is None
+
+
+@pytest.mark.asyncio
+async def test_subscribe_yields_none_when_subscribe_raises(monkeypatch):
+    class _FailingPubsub(_FakePubsub):
+        async def subscribe(self, channel):
+            raise RuntimeError("subscribe failed")
+
+    pubsub = _FailingPubsub()
+    _install_cache(
+        monkeypatch,
+        _FakeCache(enabled=True, client=_FakeRedisClient(pubsub_obj=pubsub)),
+    )
+
+    async with subscribe_to_status("ws-1") as wait:
+        # Subscribe failure must downgrade to "no pub/sub" so callers fall
+        # back to DB polling instead of raising mid-request.
+        assert wait is None
+
+
+@pytest.mark.asyncio
+async def test_wait_paces_on_get_message_error(monkeypatch):
+    """A broken pubsub connection (get_message raises) must return None AND
+    sleep, so looping callers don't busy-spin DB reads until their deadline."""
+
+    class _ErroringPubsub(_FakePubsub):
+        async def get_message(self, ignore_subscribe_messages=True, timeout=None):
+            raise RuntimeError("connection reset")
+
+    _install_cache(
+        monkeypatch,
+        _FakeCache(enabled=True, client=_FakeRedisClient(pubsub_obj=_ErroringPubsub())),
+    )
+
+    slept: list[float] = []
+
+    async def _fake_sleep(delay):
+        slept.append(delay)
+
+    monkeypatch.setattr(workspace_status_pubsub.asyncio, "sleep", _fake_sleep)
+
+    async with subscribe_to_status("ws-1") as wait:
+        assert await wait(0.1) is None
+
+    # Floored at the caller's timeout (capped at 1.0s).
+    assert slept == [0.1]
+
+
+@pytest.mark.asyncio
+async def test_wait_for_status_change_returns_payload(monkeypatch):
+    payload = json.dumps({"workspace_id": "ws-1", "status": "running"})
+    pubsub = _FakePubsub([{"type": "message", "data": payload.encode()}])
+    _install_cache(
+        monkeypatch,
+        _FakeCache(enabled=True, client=_FakeRedisClient(pubsub_obj=pubsub)),
+    )
+
+    result = await wait_for_status_change("ws-1", timeout=0.1)
+    assert result == {"workspace_id": "ws-1", "status": "running"}
+
+
+@pytest.mark.asyncio
+async def test_wait_for_status_change_returns_none_when_disabled(monkeypatch):
+    _install_cache(monkeypatch, _FakeCache(enabled=False, client=None))
+    assert await wait_for_status_change("ws-1", timeout=0.05) is None

--- a/web/src/pages/ChatAgent/ChatAgent.tsx
+++ b/web/src/pages/ChatAgent/ChatAgent.tsx
@@ -8,6 +8,8 @@ import { queryKeys } from '../../lib/queryKeys';
 import { getWorkspaceThreads, getThread } from './utils/api';
 import { getChatSession } from './hooks/utils/chatSessionRestore';
 import { useChatViewCache } from './hooks/useChatViewCache';
+import { useWarmWorkspaceSandbox } from './hooks/useWarmWorkspaceSandbox';
+import { warmWorkspace } from './utils/warmWorkspace';
 import ChatView from './components/ChatView';
 import './ChatAgent.css';
 
@@ -162,6 +164,12 @@ function ChatAgent(): React.ReactElement | null {
 
   const queryClient = useQueryClient();
 
+  // Proactively warm the sandbox the moment a user enters a workspace.
+  // Covers direct URL nav, refresh, and back-button — the gallery-click
+  // path also calls warmWorkspace via handleWorkspaceSelect; both share
+  // the same in-flight dedupe Map.
+  const warmingState = useWarmWorkspaceSandbox(workspaceId);
+
   // Track in-progress __default__ → real threadId resolutions. Keyed by workspaceId:
   // at most one such resolution can be in flight per workspace (a fresh __default__
   // can't be created while the previous one is still bridging, because the source-side
@@ -225,13 +233,16 @@ function ChatAgent(): React.ReactElement | null {
    * Passes workspace name via route state to avoid refetching all workspaces
    */
   const handleWorkspaceSelect = useCallback((selectedWorkspaceId: string, workspaceName?: string, workspaceStatus?: string) => {
+    if (workspaceStatus === 'stopped') {
+      void warmWorkspace(selectedWorkspaceId, queryClient);
+    }
     navigate(`/chat/${selectedWorkspaceId}`, {
       state: {
         workspaceName: workspaceName || 'Workspace',
         workspaceStatus: workspaceStatus || null,
       },
     });
-  }, [navigate]);
+  }, [navigate, queryClient]);
 
   const handleBackToWorkspaceGallery = useCallback(() => {
     navigate('/chat');
@@ -352,6 +363,7 @@ function ChatAgent(): React.ReactElement | null {
           onBack={handleBackToThreadGallery}
           workspaceName={entry.workspaceName}
           isActive={isEntryActive}
+          warmingState={entry.workspaceId === workspaceId ? warmingState : false}
           onThreadResolved={(oldTid, newTid) => {
             if (import.meta.env.DEV && resolvingRef.current.has(entry.workspaceId)) {
               console.warn('[ChatAgent] overlapping thread resolution for workspace', entry.workspaceId);

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -11,6 +11,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { queryKeys } from '@/lib/queryKeys';
 import { updateCurrentUser } from '../../Dashboard/utils/api';
 import { softInterruptWorkflow, getWorkspace, summarizeThread, offloadThread, getPreviewUrl } from '../utils/api';
+import { mergeWarmingDisplay } from '../utils/warmWorkspace';
 import { useChatMessages } from '../hooks/useChatMessages';
 import { saveChatSession, getChatSession, clearChatSession } from '../hooks/utils/chatSessionRestore';
 import type { PreviewData } from '../hooks/utils/types';
@@ -197,6 +198,10 @@ interface ChatViewProps {
   workspaceName?: string;
   isActive?: boolean;
   onThreadResolved?: (oldThreadId: string, newThreadId: string) => void;
+  // Warming state from the entry-time /events stream (useWarmWorkspaceSandbox).
+  // Lets the spinner show the slow-restore copy when a background warm — not a
+  // chat message — owns the sandbox start.
+  warmingState?: false | 'starting' | 'archived';
 }
 
 interface SubagentStatusIndicatorProps {
@@ -286,7 +291,7 @@ function SubagentStatusIndicator({ status, currentTool, toolCalls = 0, messages 
   );
 }
 
-function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName: initialWorkspaceName, isActive = true, onThreadResolved }: ChatViewProps): React.ReactElement | null {
+function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName: initialWorkspaceName, isActive = true, onThreadResolved, warmingState = false }: ChatViewProps): React.ReactElement | null {
   const { t } = useTranslation();
   const isMobile = useIsMobile();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -637,6 +642,16 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     getSubagentHistory,
     resolveSubagentIdToAgentId,
   } = useChatMessages(workspaceId, threadId, updateTodoListCard as (todoData: Record<string, unknown>) => void, updateSubagentCard, inactivateAllSubagents, finalizePendingTodos, handleOnboardingRelatedToolComplete, handleFileArtifact, handleOpenPreviewFromStream, agentMode, clearSubagentCards, handleWorkspaceCreated, 'web');
+
+  // Spinner state merges the in-conversation signal (chat SSE `workspace_status`
+  // events, set when this client's message owns the start) with the entry-time
+  // warming signal (the /events stream, which sees the start even when a
+  // background warm owns it). 'archived' from either source wins so the slow-
+  // restore copy survives a plain 'starting' from the other.
+  const displayWorkspaceStarting = mergeWarmingDisplay(
+    workspaceStarting,
+    warmingState,
+  );
 
   const chatPlaceholder = useMemo(() => {
     if (pendingRejection) return t('chat.placeholderPendingRejection');
@@ -2206,11 +2221,11 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
                         {t('chat.backgroundTasksRunning')}
                       </div>
                     )}
-                    {workspaceStarting && (
+                    {displayWorkspaceStarting && (
                       <div className="flex items-center gap-2 px-3 py-1.5 text-xs"
                         style={{ color: 'var(--color-text-tertiary)' }}>
                         <Loader2 className="h-3.5 w-3.5 animate-spin" style={{ color: 'var(--color-accent-primary)' }} />
-                        <span>{t(workspaceStarting === 'archived' ? 'chat.workspaceRestoring' : 'chat.workspaceStarting')}</span>
+                        <span>{t(displayWorkspaceStarting === 'archived' ? 'chat.workspaceRestoring' : 'chat.workspaceStarting')}</span>
                         <HoverCard openDelay={150} closeDelay={100}>
                           <HoverCardTrigger asChild>
                             <button
@@ -2224,12 +2239,12 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
                           </HoverCardTrigger>
                           <HoverCardContent side="top" align="start" className="w-80 text-xs leading-relaxed">
                             <div className="font-medium mb-1" style={{ color: 'var(--color-text-primary)' }}>
-                              {t(workspaceStarting === 'archived' ? 'chat.workspaceStateArchivedTitle' : 'chat.workspaceStateStartingTitle')}
+                              {t(displayWorkspaceStarting === 'archived' ? 'chat.workspaceStateArchivedTitle' : 'chat.workspaceStateStartingTitle')}
                             </div>
                             <p style={{ color: 'var(--color-text-secondary)' }}>
-                              {t(workspaceStarting === 'archived' ? 'chat.workspaceStateArchivedBody' : 'chat.workspaceStateStartingBody')}
+                              {t(displayWorkspaceStarting === 'archived' ? 'chat.workspaceStateArchivedBody' : 'chat.workspaceStateStartingBody')}
                             </p>
-                            {workspaceStarting === 'archived' && (
+                            {displayWorkspaceStarting === 'archived' && (
                               <p className="mt-2" style={{ color: 'var(--color-text-tertiary)' }}>
                                 {t('chat.workspaceStateArchivedFootnote')}
                               </p>

--- a/web/src/pages/ChatAgent/hooks/__tests__/useWarmWorkspaceSandbox.test.tsx
+++ b/web/src/pages/ChatAgent/hooks/__tests__/useWarmWorkspaceSandbox.test.tsx
@@ -1,0 +1,380 @@
+import React from 'react';
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Mock } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+
+vi.mock('@/api/client', () => {
+  const mockGet = vi.fn().mockResolvedValue({ data: {} });
+  const mockPost = vi.fn().mockResolvedValue({ data: {} });
+  return {
+    api: {
+      get: mockGet,
+      post: mockPost,
+      put: vi.fn(),
+      delete: vi.fn(),
+      patch: vi.fn(),
+      defaults: { baseURL: 'http://localhost:8000' },
+    },
+  };
+});
+
+vi.mock('@/lib/supabase', () => ({ supabase: null }));
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { api } from '@/api/client';
+import { queryKeys } from '@/lib/queryKeys';
+
+import { useWarmWorkspaceSandbox } from '../useWarmWorkspaceSandbox';
+import { __resetWarmStateForTests } from '../../utils/warmWorkspace';
+
+const mockGet = api.get as Mock;
+const mockPost = api.post as Mock;
+
+function wrapper(qc: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+function makeClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0, refetchOnMount: false },
+    },
+  });
+}
+
+interface SSEStreamHandle {
+  /** Push an SSE chunk to the consumer. */
+  push: (chunk: string) => Promise<void>;
+  /** Signal EOF — resolves the consumer's read loop. */
+  close: () => Promise<void>;
+  /** Capture aborts triggered by useEffect cleanup. */
+  aborted: () => boolean;
+}
+
+function makeMockSSEStream(): {
+  fetchMock: Mock;
+  next: () => Promise<SSEStreamHandle>;
+} {
+  const pending: Array<(h: SSEStreamHandle) => void> = [];
+  const handles: SSEStreamHandle[] = [];
+
+  function makeHandle(signal?: AbortSignal): SSEStreamHandle {
+    const encoder = new TextEncoder();
+    let pushChunk: ((c: Uint8Array | null) => void) | null = null;
+    let waiting: Promise<Uint8Array | null> = new Promise((resolve) => {
+      pushChunk = resolve;
+    });
+
+    let aborted = false;
+    if (signal) {
+      const onAbort = () => {
+        aborted = true;
+        // Resolve any pending read so the consumer's loop exits.
+        if (pushChunk) {
+          pushChunk(null);
+          waiting = new Promise((resolve) => {
+            pushChunk = resolve;
+          });
+        }
+      };
+      if (signal.aborted) onAbort();
+      else signal.addEventListener('abort', onAbort);
+    }
+
+    const stream = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        const chunk = await waiting;
+        waiting = new Promise((resolve) => {
+          pushChunk = resolve;
+        });
+        if (chunk === null) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(chunk);
+      },
+    });
+
+    void stream; // attached below via Response
+
+    return {
+      push: async (chunk: string) => {
+        if (pushChunk) {
+          const fn = pushChunk;
+          pushChunk = null;
+          fn(encoder.encode(chunk));
+          // Yield so the consumer can drain.
+          await Promise.resolve();
+        }
+      },
+      close: async () => {
+        if (pushChunk) {
+          const fn = pushChunk;
+          pushChunk = null;
+          fn(null);
+          await Promise.resolve();
+        }
+      },
+      aborted: () => aborted,
+    };
+  }
+
+  const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+    // Re-create per call so consecutive fetches don't share state.
+    const encoder = new TextEncoder();
+    let pushChunk: ((c: Uint8Array | null) => void) | null = null;
+    let waiting: Promise<Uint8Array | null> = new Promise((resolve) => {
+      pushChunk = resolve;
+    });
+    let aborted = false;
+
+    const signal = init?.signal;
+    if (signal) {
+      const onAbort = () => {
+        aborted = true;
+        if (pushChunk) {
+          const fn = pushChunk;
+          pushChunk = null;
+          fn(null);
+        }
+      };
+      if (signal.aborted) onAbort();
+      else signal.addEventListener('abort', onAbort);
+    }
+
+    const stream = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        const chunk = await waiting;
+        waiting = new Promise((resolve) => {
+          pushChunk = resolve;
+        });
+        if (chunk === null) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(chunk);
+      },
+    });
+
+    const handle: SSEStreamHandle = {
+      push: async (chunk: string) => {
+        if (pushChunk) {
+          const fn = pushChunk;
+          pushChunk = null;
+          fn(encoder.encode(chunk));
+          await Promise.resolve();
+        }
+      },
+      close: async () => {
+        if (pushChunk) {
+          const fn = pushChunk;
+          pushChunk = null;
+          fn(null);
+          await Promise.resolve();
+        }
+      },
+      aborted: () => aborted,
+    };
+    handles.push(handle);
+    const waiter = pending.shift();
+    if (waiter) waiter(handle);
+
+    return new Response(stream, {
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream' },
+    });
+  });
+
+  return {
+    fetchMock,
+    next: () =>
+      new Promise((resolve) => {
+        const existing = handles.find((_h, i) => i === fetchMock.mock.calls.length - 1);
+        if (existing) resolve(existing);
+        else pending.push(resolve);
+      }),
+  };
+}
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  mockGet.mockReset().mockResolvedValue({
+    data: { workspace_id: 'ws-1', status: 'stopped' },
+  });
+  mockPost.mockReset().mockResolvedValue({
+    data: { workspace_id: 'ws-1', status: 'starting', message: 'ok' },
+  });
+  __resetWarmStateForTests();
+});
+
+afterEach(() => {
+  __resetWarmStateForTests();
+  global.fetch = originalFetch;
+});
+
+describe('useWarmWorkspaceSandbox', () => {
+  it('fires warmWorkspace on mount when workspaceId is set', async () => {
+    const qc = makeClient();
+    const { fetchMock } = makeMockSSEStream();
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    renderHook(() => useWarmWorkspaceSandbox('ws-1'), {
+      wrapper: wrapper(qc),
+    });
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith('/api/v1/workspaces/ws-1/start?lazy=true');
+    });
+  });
+
+  it('no-ops when workspaceId is null', async () => {
+    const qc = makeClient();
+    const { fetchMock } = makeMockSSEStream();
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    renderHook(() => useWarmWorkspaceSandbox(null), {
+      wrapper: wrapper(qc),
+    });
+
+    await new Promise((res) => setTimeout(res, 20));
+    expect(mockPost).not.toHaveBeenCalled();
+    expect(mockGet).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('opens the events SSE stream after mount', async () => {
+    const qc = makeClient();
+    const { fetchMock } = makeMockSSEStream();
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    renderHook(() => useWarmWorkspaceSandbox('ws-1'), {
+      wrapper: wrapper(qc),
+    });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain('/api/v1/workspaces/ws-1/events');
+  });
+
+  it('patches detail + list caches when the stream emits a status event', async () => {
+    // gcTime: Infinity so the seeded entries aren't garbage-collected between
+    // setQueryData and the assertion (the hook reads via getQueryData, not an
+    // observer, so a gcTime:0 client would evict them before we can check).
+    const qc = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: Infinity, staleTime: 0, refetchOnMount: false },
+      },
+    });
+    qc.setQueryData(queryKeys.workspaces.detail('ws-1'), {
+      workspace_id: 'ws-1',
+      status: 'stopped',
+    });
+    qc.setQueryData(queryKeys.workspaces.lists(), [
+      { workspace_id: 'ws-1', status: 'stopped', name: 'A' },
+    ]);
+    const { fetchMock, next } = makeMockSSEStream();
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    renderHook(() => useWarmWorkspaceSandbox('ws-1'), {
+      wrapper: wrapper(qc),
+    });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+    const handle = await next();
+
+    await act(async () => {
+      await handle.push(
+        'event: status\ndata: {"workspace_id":"ws-1","status":"starting"}\n\n',
+      );
+    });
+
+    // The hook's onStatus pushes each transition into both caches so the
+    // gallery and the detail view reflect the warm without a refetch.
+    await waitFor(() => {
+      const detail = qc.getQueryData<{ status?: string }>(
+        queryKeys.workspaces.detail('ws-1'),
+      );
+      expect(detail?.status).toBe('starting');
+    });
+    const list = qc.getQueryData<Array<{ workspace_id: string; status: string }>>(
+      queryKeys.workspaces.lists(),
+    );
+    expect(list?.find((w) => w.workspace_id === 'ws-1')?.status).toBe('starting');
+  });
+
+  it('returns "archived" when the stream emits a sandbox_state refinement', async () => {
+    const qc = makeClient();
+    const { fetchMock, next } = makeMockSSEStream();
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useWarmWorkspaceSandbox('ws-1'), {
+      wrapper: wrapper(qc),
+    });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+    const handle = await next();
+
+    // Generic starting first, then the archived refinement.
+    await act(async () => {
+      await handle.push(
+        'event: status\ndata: {"workspace_id":"ws-1","status":"starting"}\n\n',
+      );
+    });
+    await waitFor(() => expect(result.current).toBe('starting'));
+
+    await act(async () => {
+      await handle.push(
+        'event: status\ndata: {"workspace_id":"ws-1","status":"starting","sandbox_state":"archived"}\n\n',
+      );
+    });
+    await waitFor(() => expect(result.current).toBe('archived'));
+
+    // Reaching a terminal status clears the warming spinner.
+    await act(async () => {
+      await handle.push(
+        'event: status\ndata: {"workspace_id":"ws-1","status":"running"}\n\n',
+      );
+    });
+    await waitFor(() => expect(result.current).toBe(false));
+  });
+
+  it('aborts the stream on unmount', async () => {
+    const qc = makeClient();
+    let capturedSignal: AbortSignal | null = null;
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      capturedSignal = init?.signal ?? null;
+      // Return a never-completing stream so we can verify the abort.
+      const stream = new ReadableStream<Uint8Array>({});
+      return new Response(stream, {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      });
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { unmount } = renderHook(() => useWarmWorkspaceSandbox('ws-1'), {
+      wrapper: wrapper(qc),
+    });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+
+    // Cast on read: TS control-flow-narrows a closure-assigned `let` to
+    // `never` here, so the union annotation is reasserted at the use site.
+    expect((capturedSignal as AbortSignal | null)?.aborted).toBe(false);
+    act(() => unmount());
+    expect((capturedSignal as AbortSignal | null)?.aborted).toBe(true);
+  });
+});

--- a/web/src/pages/ChatAgent/hooks/useWarmWorkspaceSandbox.ts
+++ b/web/src/pages/ChatAgent/hooks/useWarmWorkspaceSandbox.ts
@@ -25,7 +25,7 @@ import { useQueryClient } from '@tanstack/react-query';
 
 import { queryKeys } from '@/lib/queryKeys';
 
-import { streamWorkspaceEvents } from '../utils/api';
+import { getWorkspace, streamWorkspaceEvents } from '../utils/api';
 import { patchWorkspaceStatusInCaches, warmWorkspace } from '../utils/warmWorkspace';
 
 const TERMINAL_STATUSES = new Set(['running', 'error', 'deleted']);
@@ -87,16 +87,30 @@ export function useWarmWorkspaceSandbox(
       // The stream closed (terminal status, server timeout, or a dropped
       // connection). If we never observed a terminal status, the optimistic
       // 'starting' written by warmWorkspace could be stale — the backend may
-      // have reached 'running' after the stream died. Refetch to reconcile so
-      // a dropped stream can't pin the UI on 'starting' indefinitely.
+      // have reached 'running' after the stream died.
       if (controller.signal.aborted) return;
       const current = queryClient.getQueryData<{ status?: string }>(
         queryKeys.workspaces.detail(workspaceId),
       );
       if (!current?.status || !TERMINAL_STATUSES.has(current.status)) {
-        void queryClient.invalidateQueries({
-          queryKey: queryKeys.workspaces.detail(workspaceId),
-        });
+        // Fetch the authoritative status and reconcile local state. A bare
+        // invalidateQueries can't clear the spinner: in TanStack v5 it only
+        // refetches *active* queries, and even on refetch it never updates this
+        // hook's local `warming` — so a stream that ends mid-'starting' (600s
+        // server timeout or a dropped connection) would pin the spinner on
+        // 'starting' indefinitely.
+        try {
+          const fresh = await queryClient.fetchQuery({
+            queryKey: queryKeys.workspaces.detail(workspaceId),
+            queryFn: () => getWorkspace(workspaceId),
+          });
+          const status = (fresh as { status?: string })?.status;
+          if (status) patchWorkspaceStatusInCaches(queryClient, workspaceId, status);
+          if (status !== 'starting') setWarming(false);
+        } catch {
+          // Best-effort reconcile; chat-time start surfaces real errors.
+          setWarming(false);
+        }
       } else {
         // Reached a terminal status — clear the warming spinner.
         setWarming(false);

--- a/web/src/pages/ChatAgent/hooks/useWarmWorkspaceSandbox.ts
+++ b/web/src/pages/ChatAgent/hooks/useWarmWorkspaceSandbox.ts
@@ -1,0 +1,109 @@
+/**
+ * useWarmWorkspaceSandbox
+ *
+ * Fires `warmWorkspace` on mount when a workspace id is resolved (covers
+ * direct URL nav, refresh, and back-button — the click handler in
+ * ChatAgent.tsx covers the gallery-click path; both go through the same
+ * dedupe primitive).
+ *
+ * Subscribes to `/api/v1/workspaces/{id}/events` via SSE so each backend
+ * status transition (stopped → starting → running) is pushed directly
+ * into the React Query cache. Replaces the previous 4-second invalidate-
+ * polling loop. The SSE handler closes itself on terminal status or the
+ * 600 s server-side cap; backend falls back to server-side polling when
+ * Redis is unavailable, so the client never needs an interval sidecar.
+ *
+ * Returns the current warming state derived from the stream:
+ * `false` (not warming / ready) | `'starting'` | `'archived'` (slow restore
+ * from cold storage). This lets the entry-time UI show the same two-level
+ * spinner the chat path shows, even when a background warm — not a chat
+ * message — owns the start.
+ */
+import { useEffect, useState } from 'react';
+
+import { useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/lib/queryKeys';
+
+import { streamWorkspaceEvents } from '../utils/api';
+import { patchWorkspaceStatusInCaches, warmWorkspace } from '../utils/warmWorkspace';
+
+const TERMINAL_STATUSES = new Set(['running', 'error', 'deleted']);
+
+export type WarmingState = false | 'starting' | 'archived';
+
+export function useWarmWorkspaceSandbox(
+  workspaceId: string | null,
+): WarmingState {
+  const queryClient = useQueryClient();
+  const [warming, setWarming] = useState<WarmingState>(false);
+
+  useEffect(() => {
+    if (!workspaceId) return;
+    void warmWorkspace(workspaceId, queryClient);
+  }, [workspaceId, queryClient]);
+
+  useEffect(() => {
+    if (!workspaceId) return;
+    setWarming(false);
+    // Don't open a stream for a workspace we already know is terminal
+    // (running/error/deleted) — it has nothing left to transition to, and the
+    // server would only emit the current status and close. Saves a request +
+    // a server-side DB read on every navigation to an already-running
+    // workspace (the common case). When status is unknown (cold nav), open the
+    // stream — warmWorkspace resolves the real status concurrently.
+    const known = queryClient.getQueryData<{ status?: string }>(
+      queryKeys.workspaces.detail(workspaceId),
+    );
+    if (known?.status && TERMINAL_STATUSES.has(known.status)) return;
+
+    const controller = new AbortController();
+    void (async () => {
+      try {
+        await streamWorkspaceEvents(
+          workspaceId,
+          (status, sandboxState) => {
+            patchWorkspaceStatusInCaches(queryClient, workspaceId, status);
+            setWarming((prev) => {
+              if (status !== 'starting') return false;
+              if (sandboxState === 'archived') return 'archived';
+              // A plain 'starting' must not downgrade an 'archived' we already
+              // saw — the refinement event arrives after the generic one.
+              return prev === 'archived' ? 'archived' : 'starting';
+            });
+          },
+          controller.signal,
+        );
+      } catch (err) {
+        if (import.meta.env?.DEV) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            '[useWarmWorkspaceSandbox] events stream ended',
+            workspaceId,
+            err,
+          );
+        }
+      }
+      // The stream closed (terminal status, server timeout, or a dropped
+      // connection). If we never observed a terminal status, the optimistic
+      // 'starting' written by warmWorkspace could be stale — the backend may
+      // have reached 'running' after the stream died. Refetch to reconcile so
+      // a dropped stream can't pin the UI on 'starting' indefinitely.
+      if (controller.signal.aborted) return;
+      const current = queryClient.getQueryData<{ status?: string }>(
+        queryKeys.workspaces.detail(workspaceId),
+      );
+      if (!current?.status || !TERMINAL_STATUSES.has(current.status)) {
+        void queryClient.invalidateQueries({
+          queryKey: queryKeys.workspaces.detail(workspaceId),
+        });
+      } else {
+        // Reached a terminal status — clear the warming spinner.
+        setWarming(false);
+      }
+    })();
+    return () => controller.abort();
+  }, [workspaceId, queryClient]);
+
+  return warming;
+}

--- a/web/src/pages/ChatAgent/utils/__tests__/api.test.ts
+++ b/web/src/pages/ChatAgent/utils/__tests__/api.test.ts
@@ -32,6 +32,7 @@ import {
   getThread,
   deleteThread,
   sendHitlResponse,
+  streamWorkspaceEvents,
 } from '../api';
 
 const mockGet = api.get as Mock;
@@ -262,6 +263,125 @@ describe('ChatAgent API utilities', () => {
         onRunIdResolved,
       );
       expect(onRunIdResolved).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('streamWorkspaceEvents', () => {
+    let originalFetch: typeof global.fetch;
+
+    beforeEach(() => {
+      originalFetch = global.fetch;
+    });
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    /** Build a fetch mock whose body streams the given SSE text chunks. */
+    function mockSSEResponse(chunks: string[], { ok = true } = {}) {
+      const encoder = new TextEncoder();
+      const queue = [...chunks];
+      const reader = {
+        read: vi.fn(async () => {
+          if (queue.length === 0) return { done: true, value: undefined };
+          return { done: false, value: encoder.encode(queue.shift()!) };
+        }),
+        cancel: vi.fn(async () => {}),
+      };
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok,
+        status: ok ? 200 : 503,
+        body: ok ? { getReader: () => reader } : null,
+      });
+      global.fetch = fetchMock as unknown as typeof fetch;
+      return { fetchMock, reader };
+    }
+
+    const ctrl = () => new AbortController().signal;
+
+    it('parses a status event and passes status + sandbox_state', async () => {
+      mockSSEResponse([
+        'event: status\ndata: {"workspace_id":"ws-1","status":"starting","sandbox_state":"archived"}\n\n',
+      ]);
+      const onStatus = vi.fn();
+      await streamWorkspaceEvents('ws-1', onStatus, ctrl());
+      expect(onStatus).toHaveBeenCalledWith('starting', 'archived');
+    });
+
+    it('omits sandbox_state when the payload has none', async () => {
+      mockSSEResponse([
+        'event: status\ndata: {"workspace_id":"ws-1","status":"running"}\n\n',
+      ]);
+      const onStatus = vi.fn();
+      await streamWorkspaceEvents('ws-1', onStatus, ctrl());
+      expect(onStatus).toHaveBeenCalledWith('running', undefined);
+    });
+
+    it('handles an event split across read() chunks', async () => {
+      // The "data:" line arrives in a separate read than "event:".
+      mockSSEResponse([
+        'event: status\n',
+        'data: {"status":"starting"}\n\n',
+      ]);
+      const onStatus = vi.fn();
+      await streamWorkspaceEvents('ws-1', onStatus, ctrl());
+      expect(onStatus).toHaveBeenCalledWith('starting', undefined);
+    });
+
+    it('stops on a timeout event without emitting further statuses', async () => {
+      mockSSEResponse([
+        'event: status\ndata: {"status":"starting"}\n\n',
+        'event: timeout\ndata: {}\n\n',
+        'event: status\ndata: {"status":"running"}\n\n',
+      ]);
+      const onStatus = vi.fn();
+      await streamWorkspaceEvents('ws-1', onStatus, ctrl());
+      expect(onStatus).toHaveBeenCalledTimes(1);
+      expect(onStatus).toHaveBeenCalledWith('starting', undefined);
+    });
+
+    it('skips a malformed payload but keeps consuming the stream', async () => {
+      mockSSEResponse([
+        'event: status\ndata: {not json}\n\n',
+        'event: status\ndata: {"status":"running"}\n\n',
+      ]);
+      const onStatus = vi.fn();
+      await streamWorkspaceEvents('ws-1', onStatus, ctrl());
+      expect(onStatus).toHaveBeenCalledTimes(1);
+      expect(onStatus).toHaveBeenCalledWith('running', undefined);
+    });
+
+    it('returns without emitting when the response is not ok', async () => {
+      mockSSEResponse(['event: status\ndata: {"status":"running"}\n\n'], { ok: false });
+      const onStatus = vi.fn();
+      await streamWorkspaceEvents('ws-1', onStatus, ctrl());
+      expect(onStatus).not.toHaveBeenCalled();
+    });
+
+    it('no-ops with an empty workspace id and never fetches', async () => {
+      const fetchMock = vi.fn();
+      global.fetch = fetchMock as unknown as typeof fetch;
+      const onStatus = vi.fn();
+      await streamWorkspaceEvents('', onStatus, ctrl());
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(onStatus).not.toHaveBeenCalled();
+    });
+
+    it('swallows a network error and resolves (best-effort)', async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error('network down')) as unknown as typeof fetch;
+      const onStatus = vi.fn();
+      await expect(
+        streamWorkspaceEvents('ws-1', onStatus, ctrl()),
+      ).resolves.toBeUndefined();
+      expect(onStatus).not.toHaveBeenCalled();
+    });
+
+    it('cancels the reader on close to release the stream', async () => {
+      const { reader } = mockSSEResponse([
+        'event: status\ndata: {"status":"running"}\n\n',
+      ]);
+      await streamWorkspaceEvents('ws-1', vi.fn(), ctrl());
+      expect(reader.cancel).toHaveBeenCalled();
     });
   });
 });

--- a/web/src/pages/ChatAgent/utils/__tests__/warmWorkspace.test.ts
+++ b/web/src/pages/ChatAgent/utils/__tests__/warmWorkspace.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Mock } from 'vitest';
+
+vi.mock('@/api/client', () => {
+  const mockGet = vi.fn().mockResolvedValue({ data: {} });
+  const mockPost = vi.fn().mockResolvedValue({ data: {} });
+  return {
+    api: {
+      get: mockGet,
+      post: mockPost,
+      put: vi.fn(),
+      delete: vi.fn(),
+      patch: vi.fn(),
+      defaults: { baseURL: 'http://localhost:8000' },
+    },
+  };
+});
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: null,
+}));
+
+import { QueryClient } from '@tanstack/react-query';
+
+import { api } from '@/api/client';
+import { queryKeys } from '@/lib/queryKeys';
+
+import {
+  warmWorkspace,
+  mergeWarmingDisplay,
+  __resetWarmStateForTests,
+} from '../warmWorkspace';
+
+const mockGet = api.get as Mock;
+const mockPost = api.post as Mock;
+
+function makeClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+    },
+  });
+}
+
+beforeEach(() => {
+  mockGet.mockReset().mockResolvedValue({ data: {} });
+  mockPost.mockReset().mockResolvedValue({
+    data: { workspace_id: 'ws-1', status: 'starting', message: 'ok' },
+  });
+  __resetWarmStateForTests();
+});
+
+afterEach(() => {
+  __resetWarmStateForTests();
+});
+
+describe('warmWorkspace', () => {
+  it('skips when cached status is not stopped', async () => {
+    const qc = makeClient();
+    qc.setQueryData(queryKeys.workspaces.detail('ws-1'), {
+      workspace_id: 'ws-1',
+      status: 'running',
+    });
+
+    await warmWorkspace('ws-1', qc);
+
+    expect(mockPost).not.toHaveBeenCalled();
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('fires /start?lazy=true when cached status is stopped', async () => {
+    const qc = makeClient();
+    qc.setQueryData(queryKeys.workspaces.detail('ws-1'), {
+      workspace_id: 'ws-1',
+      status: 'stopped',
+    });
+
+    await warmWorkspace('ws-1', qc);
+
+    expect(mockPost).toHaveBeenCalledTimes(1);
+    expect(mockPost).toHaveBeenCalledWith('/api/v1/workspaces/ws-1/start?lazy=true');
+  });
+
+  it('writes response status into detail cache', async () => {
+    const qc = makeClient();
+    qc.setQueryData(queryKeys.workspaces.detail('ws-1'), {
+      workspace_id: 'ws-1',
+      status: 'stopped',
+      name: 'foo',
+    });
+
+    await warmWorkspace('ws-1', qc);
+
+    const cached = qc.getQueryData(queryKeys.workspaces.detail('ws-1')) as {
+      status: string;
+      name: string;
+    };
+    expect(cached.status).toBe('starting');
+    expect(cached.name).toBe('foo');
+  });
+
+  it('patches matching workspace in cached list query', async () => {
+    const qc = makeClient();
+    qc.setQueryData(queryKeys.workspaces.detail('ws-1'), {
+      workspace_id: 'ws-1',
+      status: 'stopped',
+    });
+    const listKey = queryKeys.workspaces.list({ limit: 20 });
+    qc.setQueryData(listKey, [
+      { workspace_id: 'ws-1', status: 'stopped' },
+      { workspace_id: 'ws-2', status: 'running' },
+    ]);
+
+    await warmWorkspace('ws-1', qc);
+
+    const list = qc.getQueryData(listKey) as Array<{ workspace_id: string; status: string }>;
+    expect(list[0].status).toBe('starting');
+    expect(list[1].status).toBe('running');
+  });
+
+  it('dedupes concurrent calls via in-flight Map', async () => {
+    const qc = makeClient();
+    qc.setQueryData(queryKeys.workspaces.detail('ws-1'), {
+      workspace_id: 'ws-1',
+      status: 'stopped',
+    });
+
+    let resolveStart: (value: { data: unknown }) => void = () => {};
+    mockPost.mockReturnValueOnce(
+      new Promise((res) => {
+        resolveStart = res;
+      }),
+    );
+
+    const p1 = warmWorkspace('ws-1', qc);
+    const p2 = warmWorkspace('ws-1', qc);
+    const p3 = warmWorkspace('ws-1', qc);
+
+    expect(mockPost).toHaveBeenCalledTimes(1);
+
+    resolveStart({
+      data: { workspace_id: 'ws-1', status: 'starting', message: 'ok' },
+    });
+    await Promise.all([p1, p2, p3]);
+
+    expect(mockPost).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetches workspace detail when cache is empty (direct URL path)', async () => {
+    const qc = makeClient();
+    mockGet.mockResolvedValueOnce({
+      data: { workspace_id: 'ws-1', status: 'stopped' },
+    });
+
+    await warmWorkspace('ws-1', qc);
+
+    expect(mockGet).toHaveBeenCalledWith('/api/v1/workspaces/ws-1');
+    expect(mockPost).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire if fetched detail is not stopped', async () => {
+    const qc = makeClient();
+    mockGet.mockResolvedValueOnce({
+      data: { workspace_id: 'ws-1', status: 'running' },
+    });
+
+    await warmWorkspace('ws-1', qc);
+
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('swallows /start errors silently (best-effort)', async () => {
+    const qc = makeClient();
+    qc.setQueryData(queryKeys.workspaces.detail('ws-1'), {
+      workspace_id: 'ws-1',
+      status: 'stopped',
+    });
+    mockPost.mockRejectedValueOnce(new Error('boom'));
+
+    await expect(warmWorkspace('ws-1', qc)).resolves.toBeUndefined();
+  });
+
+  it('clears in-flight entry after settle so re-stop allows re-fire', async () => {
+    const qc = makeClient();
+    qc.setQueryData(queryKeys.workspaces.detail('ws-1'), {
+      workspace_id: 'ws-1',
+      status: 'stopped',
+    });
+
+    await warmWorkspace('ws-1', qc);
+    expect(mockPost).toHaveBeenCalledTimes(1);
+
+    // Simulate user stopping the workspace again.
+    qc.setQueryData(queryKeys.workspaces.detail('ws-1'), {
+      workspace_id: 'ws-1',
+      status: 'stopped',
+    });
+
+    await warmWorkspace('ws-1', qc);
+    expect(mockPost).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not clobber a faster SSE running with the 202 starting patch', async () => {
+    const qc = makeClient();
+    qc.setQueryData(queryKeys.workspaces.detail('ws-1'), {
+      workspace_id: 'ws-1',
+      status: 'stopped',
+    });
+
+    let resolveStart: (value: { data: unknown }) => void = () => {};
+    mockPost.mockReturnValueOnce(
+      new Promise((res) => {
+        resolveStart = res;
+      }),
+    );
+
+    const p = warmWorkspace('ws-1', qc);
+
+    // SSE pushes a fast 'running' transition before the 202 resolves.
+    qc.setQueryData(queryKeys.workspaces.detail('ws-1'), {
+      workspace_id: 'ws-1',
+      status: 'running',
+    });
+
+    resolveStart({
+      data: { workspace_id: 'ws-1', status: 'starting', message: 'ok' },
+    });
+    await p;
+
+    const cached = qc.getQueryData(queryKeys.workspaces.detail('ws-1')) as {
+      status: string;
+    };
+    // The slower 'starting' patch must NOT overwrite the SSE 'running'.
+    expect(cached.status).toBe('running');
+  });
+
+  it('no-ops for empty workspaceId', async () => {
+    const qc = makeClient();
+    await warmWorkspace('', qc);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+});
+
+describe('mergeWarmingDisplay', () => {
+  it('returns false when neither source is warming', () => {
+    expect(mergeWarmingDisplay(false, false)).toBe(false);
+  });
+
+  it('shows the chat-path signal when only it is warming', () => {
+    expect(mergeWarmingDisplay('starting', false)).toBe('starting');
+  });
+
+  it('shows the entry-time warm signal when only it is warming', () => {
+    expect(mergeWarmingDisplay(false, 'starting')).toBe('starting');
+  });
+
+  it("lets 'archived' from the chat path win over a plain 'starting' warm", () => {
+    expect(mergeWarmingDisplay('archived', 'starting')).toBe('archived');
+  });
+
+  it("lets 'archived' from the warm signal win over a plain 'starting' chat", () => {
+    expect(mergeWarmingDisplay('starting', 'archived')).toBe('archived');
+  });
+
+  it("returns 'archived' when only the warm signal observed the refinement", () => {
+    expect(mergeWarmingDisplay(false, 'archived')).toBe('archived');
+  });
+});

--- a/web/src/pages/ChatAgent/utils/api.ts
+++ b/web/src/pages/ChatAgent/utils/api.ts
@@ -123,12 +123,17 @@ export async function streamWorkspaceEvents(
       buffer = chunks.pop() ?? '';
       for (const chunk of chunks) {
         let eventType = '';
-        let data = '';
+        const dataLines: string[] = [];
         for (const raw of chunk.split('\n')) {
           if (raw.startsWith('event:')) eventType = raw.slice(6).trim();
-          else if (raw.startsWith('data:')) data += raw.slice(5).trim();
+          else if (raw.startsWith('data:')) dataLines.push(raw.slice(5).trim());
           // Comments (lines starting with ':') and unknown fields ignored.
         }
+        // Per the SSE spec, multiple data: lines join with a newline. The
+        // backend emits single-line json.dumps payloads, so this is one line in
+        // practice — but joining correctly keeps a multi-line payload parseable
+        // instead of silently corrupting the JSON.
+        const data = dataLines.join('\n');
         if (eventType === 'status' && data) {
           try {
             const parsed = JSON.parse(data) as {

--- a/web/src/pages/ChatAgent/utils/api.ts
+++ b/web/src/pages/ChatAgent/utils/api.ts
@@ -63,6 +63,107 @@ export async function reorderWorkspaces(items: Array<{ workspace_id: string; pos
   await api.post('/api/v1/workspaces/reorder', { items });
 }
 
+export interface WorkspaceActionResponse {
+  workspace_id: string;
+  status: string;
+  message?: string;
+}
+
+/**
+ * Start (or warm) a stopped workspace. When { lazy: true }, the backend
+ * returns 202 immediately and continues the restart in a background task.
+ */
+export async function startWorkspace(
+  workspaceId: string,
+  opts: { lazy?: boolean } = {},
+): Promise<WorkspaceActionResponse> {
+  if (!workspaceId) throw new Error('Workspace ID is required');
+  const params = opts.lazy ? '?lazy=true' : '';
+  const { data } = await api.post(`/api/v1/workspaces/${workspaceId}/start${params}`);
+  return data;
+}
+
+/**
+ * Subscribe to workspace lifecycle status via SSE. Invokes `onStatus`
+ * for each status transition reported by the backend, passing an optional
+ * `sandboxState` refinement (e.g. 'archived') when present so callers can
+ * show a slow-restore spinner. Resolves when the stream closes (terminal
+ * status, server timeout, or aborted via the AbortController signal).
+ * Best-effort: network errors resolve without throwing so callers don't
+ * need defensive wrappers.
+ */
+export async function streamWorkspaceEvents(
+  workspaceId: string,
+  onStatus: (status: string, sandboxState?: string) => void,
+  signal: AbortSignal,
+): Promise<void> {
+  if (!workspaceId) return;
+  const authHeaders = await getAuthHeaders();
+  let res: Response;
+  try {
+    res = await fetch(`${baseURL}/api/v1/workspaces/${workspaceId}/events`, {
+      method: 'GET',
+      headers: { ...authHeaders, Accept: 'text/event-stream' },
+      signal,
+    });
+  } catch {
+    return; // network error or aborted — caller wants best-effort
+  }
+  if (!res.ok || !res.body) return;
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) return;
+      buffer += decoder.decode(value, { stream: true });
+      const chunks = buffer.split('\n\n');
+      buffer = chunks.pop() ?? '';
+      for (const chunk of chunks) {
+        let eventType = '';
+        let data = '';
+        for (const raw of chunk.split('\n')) {
+          if (raw.startsWith('event:')) eventType = raw.slice(6).trim();
+          else if (raw.startsWith('data:')) data += raw.slice(5).trim();
+          // Comments (lines starting with ':') and unknown fields ignored.
+        }
+        if (eventType === 'status' && data) {
+          try {
+            const parsed = JSON.parse(data) as {
+              status?: string;
+              sandbox_state?: string;
+            };
+            if (typeof parsed.status === 'string') {
+              onStatus(
+                parsed.status,
+                typeof parsed.sandbox_state === 'string'
+                  ? parsed.sandbox_state
+                  : undefined,
+              );
+            }
+          } catch { /* ignore malformed payload */ }
+        } else if (eventType === 'timeout') {
+          return;
+        }
+      }
+    }
+  } catch (err) {
+    if ((err as { name?: string })?.name === 'AbortError') return;
+    // Best-effort — drop everything else.
+  } finally {
+    // Deterministically release the stream so repeated workspace navigation
+    // doesn't retain fetch/body resources until browser GC. cancel() also
+    // releases the lock; both are no-ops if the stream already closed.
+    try {
+      await reader.cancel();
+    } catch {
+      /* already closed / aborted */
+    }
+  }
+}
+
 // --- Threads ---
 
 /**

--- a/web/src/pages/ChatAgent/utils/warmWorkspace.ts
+++ b/web/src/pages/ChatAgent/utils/warmWorkspace.ts
@@ -1,0 +1,141 @@
+/**
+ * warmWorkspace — proactive sandbox warming primitive.
+ *
+ * Shared between gallery click handlers and mount-time hooks so both call
+ * sites go through the same dedupe Map. The backend's /start?lazy=true
+ * returns 202 immediately and continues the restart in a background task.
+ *
+ * Best-effort: 4xx, 404, and network errors are swallowed silently. The
+ * chat-time get_session_for_workspace path will surface real errors with
+ * proper UX when the user actually sends a message.
+ */
+import { QueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/lib/queryKeys';
+
+import { getWorkspace, startWorkspace } from './api';
+
+interface WorkspaceLike {
+  workspace_id?: string;
+  id?: string;
+  status?: string;
+  [key: string]: unknown;
+}
+
+const inFlight = new Map<string, Promise<void>>();
+
+/**
+ * Write `status` into both the workspace detail cache and any active
+ * workspace-list caches. Shared between `warmWorkspace` (writes the
+ * 202 /start response) and `useWarmWorkspaceSandbox` (writes each
+ * SSE-pushed transition) so a single status change visibly updates
+ * every gallery + detail consumer without a network round-trip.
+ */
+export function patchWorkspaceStatusInCaches(
+  queryClient: QueryClient,
+  workspaceId: string,
+  status: string,
+): void {
+  queryClient.setQueryData<WorkspaceLike | undefined>(
+    queryKeys.workspaces.detail(workspaceId),
+    (prev) => (prev ? { ...prev, status } : prev),
+  );
+  const patchOne = (w: WorkspaceLike): WorkspaceLike =>
+    (w.workspace_id ?? w.id) === workspaceId ? { ...w, status } : w;
+  queryClient.setQueriesData<unknown>(
+    { queryKey: queryKeys.workspaces.lists() },
+    (prev: unknown) => {
+      if (!prev) return prev;
+      if (Array.isArray(prev)) {
+        return (prev as WorkspaceLike[]).map(patchOne);
+      }
+      if (typeof prev === 'object' && prev !== null) {
+        const obj = prev as { workspaces?: WorkspaceLike[] };
+        if (Array.isArray(obj.workspaces)) {
+          return { ...obj, workspaces: obj.workspaces.map(patchOne) };
+        }
+      }
+      return prev;
+    },
+  );
+}
+
+/** Two-level warming state the chat spinner renders: not warming, a generic
+ * start, or a slow restore from cold storage. */
+export type WarmingDisplay = false | 'starting' | 'archived';
+
+/**
+ * Merge the chat-path start signal (`workspaceStarting`) with the entry-time
+ * warm signal (`warmingState`) into the single state the spinner shows.
+ * 'archived' from EITHER source wins so a slow cold-storage restore always
+ * gets the longer-wait copy even when only one source observed the refinement;
+ * otherwise the first truthy signal shows.
+ */
+export function mergeWarmingDisplay(
+  workspaceStarting: WarmingDisplay,
+  warmingState: WarmingDisplay,
+): WarmingDisplay {
+  if (workspaceStarting === 'archived' || warmingState === 'archived') {
+    return 'archived';
+  }
+  return workspaceStarting || warmingState || false;
+}
+
+export function warmWorkspace(
+  workspaceId: string,
+  queryClient: QueryClient,
+): Promise<void> {
+  if (!workspaceId) return Promise.resolve();
+
+  const existing = inFlight.get(workspaceId);
+  if (existing) return existing;
+
+  const cached = queryClient.getQueryData<WorkspaceLike>(
+    queryKeys.workspaces.detail(workspaceId),
+  );
+  if (cached && cached.status && cached.status !== 'stopped') {
+    return Promise.resolve();
+  }
+
+  const p = (async () => {
+    try {
+      const detail =
+        cached ??
+        (await queryClient.fetchQuery({
+          queryKey: queryKeys.workspaces.detail(workspaceId),
+          queryFn: () => getWorkspace(workspaceId),
+        }));
+      if (!detail || detail.status !== 'stopped') return;
+
+      const resp = await startWorkspace(workspaceId, { lazy: true });
+      // Only reflect the 202 'starting' if nothing has advanced the cache past
+      // 'stopped' meanwhile. The SSE stream (useWarmWorkspaceSandbox) can push
+      // a fast 'running' (or 'error') before this slower patch lands; without
+      // the guard, 'starting' would clobber it and wedge the UI on 'starting'
+      // until the next refetch.
+      const current = queryClient.getQueryData<WorkspaceLike>(
+        queryKeys.workspaces.detail(workspaceId),
+      );
+      if (!current?.status || current.status === 'stopped') {
+        patchWorkspaceStatusInCaches(queryClient, workspaceId, resp.status);
+      }
+    } catch (err) {
+      // Best-effort warming — chat-time start path surfaces real errors with
+      // proper UX. Log in dev so programmer mistakes (URL typos, response
+      // shape changes) don't disappear silently.
+      if (import.meta.env?.DEV) {
+        // eslint-disable-next-line no-console
+        console.warn('[warmWorkspace] failed', workspaceId, err);
+      }
+    } finally {
+      inFlight.delete(workspaceId);
+    }
+  })();
+
+  inFlight.set(workspaceId, p);
+  return p;
+}
+
+export function __resetWarmStateForTests(): void {
+  inFlight.clear();
+}


### PR DESCRIPTION
## Summary

Starts a workspace's Daytona sandbox the moment a user *enters* the workspace (gallery click, direct URL, refresh, back-button) instead of waiting for the first chat message, cutting first-message latency from seconds (or 60–300s on an archived cold restore) to near-zero.

**Backend** — `POST /workspaces/{id}/start?lazy=true` returns `202 Accepted` with `status='starting'` and finishes the restart in a background task (strong-ref tracked, drained on shutdown). A new `GET /workspaces/{id}/events` SSE channel, backed by a dedicated Redis status pub/sub, pushes each lifecycle transition to the client. A cross-worker DB claim mutex (`try_claim_workspace_for_start`) plus a stuck-row reaper coordinate concurrent starts across workers.

**Frontend** — a shared `warmWorkspace()` primitive (dedupe map + optimistic cache patch) fires from both the gallery click and a `useWarmWorkspaceSandbox` mount hook; `streamWorkspaceEvents()` consumes the SSE channel and patches the React Query cache (replacing the old 4s interval poll). `ChatView` merges the chat-path and entry-time start signals via `mergeWarmingDisplay`, so an `archived` slow-restore from either source shows the longer-wait spinner copy.

## Diff Size
- Total: **15 files, +3409 / −139**
- Net (excl. tests): **11 files, +1530 / −105**

## Test Coverage
AI-assessed **~87%** of changed code paths (was 74% pre-gap-closing). Closed in this PR: `streamWorkspaceEvents` SSE parser (9 direct tests), a no-op stub test that asserted nothing, and the `ChatView` spinner-merge (extracted to a pure `mergeWarmingDisplay` + 6 tests).
- Backend: 1402 server unit tests pass.
- Frontend: 1148 tests pass (103 files).

Remaining lower-value gaps (best-effort / transitively-exercised): pub/sub pool lazy-build + teardown, `/events` Redis-disabled poll fallback + 600s timeout tick, `try_claim_workspace_for_start` own SQL branches (currently mocked at the manager layer), same-worker Phase-2 dedupe-gate waiter.

## Pre-Landing Review
Clean. Adversarial review surfaced one P1 (fixed) and four P2s (deferred — see below). Earlier `/review` on this branch: clean, quality 9.0.

**Fixed (P1):** the reaper could revert a legit slow archived restore to `stopped` and discard its `_pending_lazy_sync` membership, no-op'ing the owner's promotion (ready session stranded behind a `stopped` row + duplicate restart). The reaper now skips any start this worker still owns; the threshold governs only the cross-process backstop. +1 test.

## Deferred follow-ups (P2 — not blocking)
- **Pub/sub pool sizing** — dedicated pool at full 150 doubles the per-process Redis budget; fails safe (ConnectionError → DB-poll). Deploy tuning, not a code bug.
- **`/events` per-user stream cap** — endpoint has no concurrency cap; the FE path is bounded. Needs design; multi-worker hardening was out of the plan's scope.
- **Same-worker Phase-2 waiter** raises after one `start_wait_timeout` (the cross-worker waiter loops) — only on >300s restores.
- **`api.ts` frozen spinner** on the 600s `timeout` event if still `starting` — only on >600s restores.
- **Pre-existing:** `PTCSandbox` F821 ruff warning in `push_vault_secrets` (already on `origin/main`, not introduced here).

## Plan Completion
Plan: "Proactive Sandbox Warming on Workspace Entry" — 11/16 DONE + 4 CHANGED (goals met via SSE instead of polling; `asyncio.create_task` instead of `BackgroundTaskManager`, both plan-permitted). The plan-deferred multi-worker locking and SSE channel were built here. 1 PARTIAL: no dedicated "blocking `/start` unchanged" regression test.

## Test plan
- [x] Backend unit suite (1402 passed)
- [x] Frontend suite (1148 passed, 103 files)
- [x] `tsc --noEmit` clean, `eslint` 0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SSE endpoint for real-time workspace status; client-side stream parser and start API helpers.
  * Lazy/background workspace start (HTTP 202) and a React hook + warmWorkspace helper; UI shows warmingState.

* **Improvements**
  * Cross-worker start coordination, stuck-start reaping, and cleaner shutdown draining of in-flight warm tasks.
  * Redis-backed pub/sub for status notifications with resilient fallbacks and best-effort publishing.

* **Tests**
  * Broad unit tests covering SSE, warming, start flows, pub/sub, and recovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ginlix-ai/LangAlpha/pull/235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->