### PR TITLE
feat(chat): unify LLM credential resolution into one chokepoint

### DIFF
--- a/src/ptc_agent/agent/agent.py
+++ b/src/ptc_agent/agent/agent.py
@@ -43,6 +43,7 @@ from ptc_agent.agent.middleware import (
     TodoWriteMiddleware,
     SkillsMiddleware,
     CompactionMiddleware,
+    resolve_compaction_client,
     LargeResultEvictionMiddleware,
     SteeringMiddleware,
     SubagentSteeringMiddleware,
@@ -648,16 +649,9 @@ class PTCAgent:
         compaction_config = self.config.compaction.model_dump()
         if self.config.llm and self.config.llm.compaction:
             compaction_config["llm"] = self.config.llm.compaction
-            compaction_client = self.config.subsidiary_llm_clients.get("compaction")
-            if compaction_client:
-                compaction_config["_llm_client"] = compaction_client
-            elif self.config.llm_client:
-                # Copy so CompactionMiddleware.from_config() can set
-                # streaming=False without mutating the main agent's model.
-                compaction_config["_llm_client"] = self.config.llm_client.model_copy()
-        elif self.config.llm_client:
-            # No dedicated compaction model; fall back to main agent LLM
-            compaction_config["_llm_client"] = self.config.llm_client.model_copy()
+        client = resolve_compaction_client(self.config)
+        if client is not None:
+            compaction_config["_llm_client"] = client
         compaction = CompactionMiddleware.from_config(config=compaction_config, backend=backend)
 
         model_resilience = self._build_model_resilience_middleware()

--- a/src/ptc_agent/agent/agent.py
+++ b/src/ptc_agent/agent/agent.py
@@ -596,6 +596,7 @@ class PTCAgent:
             user_profile=user_profile,
             current_time=current_time,
             thread_id=short_thread_id,
+            config=self.config,
         )
         subagents = create_subagents(
             registry=subagent_registry,

--- a/src/ptc_agent/agent/flash/agent.py
+++ b/src/ptc_agent/agent/flash/agent.py
@@ -18,6 +18,7 @@ from ptc_agent.agent.middleware import (
     ToolErrorHandlingMiddleware,
     ToolResultNormalizationMiddleware,
     CompactionMiddleware,
+    resolve_compaction_client,
     SkillsMiddleware,
     AskUserMiddleware,
 )
@@ -242,13 +243,9 @@ class FlashAgent:
         if self.config.llm.compaction:
             compaction_config = self.config.compaction.model_dump()
             compaction_config["llm"] = self.config.llm.compaction
-            compaction_client = self.config.subsidiary_llm_clients.get("compaction")
-            if compaction_client:
-                compaction_config["_llm_client"] = compaction_client
-            elif self.config.llm_client:
-                # Copy so CompactionMiddleware.from_config() can set
-                # streaming=False without mutating the main agent's model.
-                compaction_config["_llm_client"] = self.config.llm_client.model_copy()
+            client = resolve_compaction_client(self.config)
+            if client is not None:
+                compaction_config["_llm_client"] = client
         compaction = CompactionMiddleware.from_config(config=compaction_config, backend=None)
         if compaction is not None:
             main_middleware.append(compaction)

--- a/src/ptc_agent/agent/middleware/__init__.py
+++ b/src/ptc_agent/agent/middleware/__init__.py
@@ -61,6 +61,7 @@ from .compaction import (
     CompactionMiddleware,
     DEFAULT_SUMMARY_PROMPT,
     count_tokens_tiktoken,
+    resolve_compaction_client,
 )
 
 # Skills middleware (registry + dynamic loader)
@@ -148,6 +149,7 @@ __all__ = [
     "CompactionMiddleware",
     "DEFAULT_SUMMARY_PROMPT",
     "count_tokens_tiktoken",
+    "resolve_compaction_client",
     # Skills
     "SkillsMiddleware",
     # Large result eviction

--- a/src/ptc_agent/agent/middleware/compaction/__init__.py
+++ b/src/ptc_agent/agent/middleware/compaction/__init__.py
@@ -19,6 +19,7 @@ from ptc_agent.agent.middleware.compaction.utils import (
     compute_absolute_cutoff,
     count_tokens_tiktoken,
     get_effective_messages,
+    resolve_compaction_client,
     strip_base64_from_content,
     strip_base64_from_messages,
 )
@@ -42,6 +43,7 @@ __all__ = [
     "count_tokens_tiktoken",
     "get_effective_messages",
     "offload_tool_args",
+    "resolve_compaction_client",
     "strip_base64_from_content",
     "strip_base64_from_messages",
 ]

--- a/src/ptc_agent/agent/middleware/compaction/utils.py
+++ b/src/ptc_agent/agent/middleware/compaction/utils.py
@@ -1,10 +1,12 @@
 """Token counting, prompt template, and truncation utilities for compaction."""
 
+from __future__ import annotations
+
 import logging
 import re
 import uuid
 from collections.abc import Iterable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import tiktoken
 
@@ -24,7 +26,26 @@ from ptc_agent.agent.middleware.compaction.types import (
     TRUNCATABLE_TOOLS,
 )
 
+if TYPE_CHECKING:
+    from ptc_agent.config.agent import AgentConfig
+
 logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Compaction client resolution
+# =============================================================================
+
+
+def resolve_compaction_client(config: AgentConfig) -> Any | None:
+    """Return the compaction LLM client (role-resolved or main-copy), or None.
+
+    With a dedicated compaction model, use the pre-resolved role client
+    (credentialed users) or None (platform users keep the cheap name-based
+    model). Without one, fall back to a copy of the main client.
+    """
+    has_compaction_model = bool(config.llm and config.llm.compaction)
+    return config.client_for_role("compaction", fallback_to_main=not has_compaction_model)
 
 
 # =============================================================================

--- a/src/ptc_agent/agent/subagents/compiler.py
+++ b/src/ptc_agent/agent/subagents/compiler.py
@@ -9,7 +9,7 @@ The compiler handles:
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import structlog
 
@@ -17,6 +17,9 @@ from ptc_agent.agent.middleware.skills.content import load_skill_content
 from ptc_agent.agent.middleware.skills.registry import SKILL_REGISTRY
 from ptc_agent.agent.prompts import build_tool_summary_from_registry, get_loader
 from ptc_agent.agent.subagents.definition import SubagentDefinition
+
+if TYPE_CHECKING:
+    from ptc_agent.config.agent import AgentConfig
 
 logger = structlog.get_logger(__name__)
 
@@ -67,7 +70,7 @@ class SubagentCompiler:
         user_profile: dict[str, Any] | None = None,
         current_time: str | None = None,
         thread_id: str = "",
-        config: Any | None = None,
+        config: AgentConfig | None = None,
     ) -> None:
         self._sandbox = sandbox
         self._mcp_registry = mcp_registry

--- a/src/ptc_agent/agent/subagents/compiler.py
+++ b/src/ptc_agent/agent/subagents/compiler.py
@@ -67,6 +67,7 @@ class SubagentCompiler:
         user_profile: dict[str, Any] | None = None,
         current_time: str | None = None,
         thread_id: str = "",
+        config: Any | None = None,
     ) -> None:
         self._sandbox = sandbox
         self._mcp_registry = mcp_registry
@@ -74,6 +75,7 @@ class SubagentCompiler:
         self._user_profile = user_profile
         self._current_time = current_time
         self._thread_id = thread_id
+        self._config = config
 
     # ── Public API ────────────────────────────────────────────────────
 
@@ -89,8 +91,15 @@ class SubagentCompiler:
             "tools": tools,
         }
 
-        if definition.model is not None:
-            result["model"] = definition.model
+        # Resolved client (credentialed user) overrides the string model name.
+        resolved = None
+        if self._config is not None:
+            resolved = self._config.client_for_role(
+                f"subagent:{definition.name}", fallback_to_main=False
+            )
+        model = resolved if resolved is not None else definition.model
+        if model is not None:
+            result["model"] = model
 
         return result
 

--- a/src/ptc_agent/config/agent.py
+++ b/src/ptc_agent/config/agent.py
@@ -7,6 +7,7 @@ Use src.config.loaders for file-based loading.
 """
 
 import os
+from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -27,6 +28,20 @@ from ptc_agent.config.core import (
 
 if TYPE_CHECKING:
     from langchain_core.language_models import BaseChatModel
+
+
+class CredentialSource(StrEnum):
+    """Which credential actually produced an LLM client.
+
+    Distinct from ``ModelSource`` (server-side, classifies the model as
+    SYSTEM/CUSTOM/UNKNOWN). Set by ``resolve_llm_config`` to record the
+    credential that built ``AgentConfig.llm_client``.
+    """
+
+    OAUTH = "oauth"
+    BYOK = "byok"
+    PLATFORM = "platform"
+    NONE = "none"
 
 
 class CompactionConfig(BaseModel):
@@ -236,6 +251,10 @@ class AgentConfig(BaseModel):
     # Runtime data (not from config files)
     llm_definition: LLMDefinition | None = Field(default=None, exclude=True)
     llm_client: Any | None = Field(default=None, exclude=True)  # BaseChatModel instance
+    # Which credential produced ``llm_client``; set by ``resolve_llm_config``.
+    credential_source: CredentialSource = Field(
+        default=CredentialSource.NONE, exclude=True
+    )
     subsidiary_llm_clients: dict[str, Any] = Field(default_factory=dict, exclude=True)
     fallback_llm_clients: list[Any] | None = Field(default=None, exclude=True)  # Pre-resolved fallback instances
     # Forwarded by ``get_llm_client()`` to ``create_llm(cache_key=...)`` for
@@ -490,6 +509,23 @@ class AgentConfig(BaseModel):
 
         ensure_model_in_manifest(self.llm.name)
         return create_llm(self.llm.name, cache_key=self.cache_key)
+
+    def client_for_role(self, role: str, *, fallback_to_main: bool = False):
+        """Return the pre-resolved client for a role, or None.
+
+        Roles: "compaction", "fetch", "subagent:<name>". Returns a
+        ``.model_copy()`` so role-local mutation (e.g. compaction setting
+        ``streaming=False``) never touches the shared main client. With
+        ``fallback_to_main=True`` and no role client, returns a copy of the
+        main client when one exists.
+        """
+        c = self.subsidiary_llm_clients.get(role)
+        if c is not None:
+            return c.model_copy()
+        if not fallback_to_main:
+            return None
+        main = self.llm_client
+        return main.model_copy() if main is not None else None
 
     def to_core_config(self) -> CoreConfig:
         """Convert to CoreConfig for use with SessionManager.

--- a/src/server/app/threads.py
+++ b/src/server/app/threads.py
@@ -535,6 +535,7 @@ async def _handle_send_message(
             reasoning_effort=getattr(request, "reasoning_effort", None),
             fast_mode=getattr(request, "fast_mode", None),
             thread_id=thread_id,
+            enabled_subagents=request.subagents_enabled,
         )
 
         # is_byok reflects whether THIS request actually uses a user-provided key

--- a/src/server/app/threads.py
+++ b/src/server/app/threads.py
@@ -525,6 +525,7 @@ async def _handle_send_message(
         # Resolve LLM config eagerly — credit check must happen before SSE stream starts
         from src.server.handlers.chat import resolve_llm_config
         from src.server.dependencies.usage_limits import enforce_credit_limit
+        from ptc_agent.config.agent import CredentialSource
 
         config = await resolve_llm_config(
             setup.agent_config,
@@ -538,9 +539,9 @@ async def _handle_send_message(
             enabled_subagents=request.subagents_enabled,
         )
 
-        # is_byok reflects whether THIS request actually uses a user-provided key
-        # (BYOK, custom model via BYOK, or OAuth), not just whether the toggle is on
-        is_byok = config.llm_client is not None
+        # is_byok is True only when the stamped credential_source confirms the user
+        # supplied their own key (OAUTH or BYOK), not merely that a client object exists.
+        is_byok = config.credential_source in (CredentialSource.OAUTH, CredentialSource.BYOK)
 
         # Credit check: always enforce.
         # - Platform-served (is_byok=False): block when daily limit reached.

--- a/src/server/handlers/chat/llm_config.py
+++ b/src/server/handlers/chat/llm_config.py
@@ -43,6 +43,23 @@ class ResolvedClient:
 # ---------------------------------------------------------------------------
 
 
+def _candidate_slugs(provider: str, mc) -> list[str]:
+    """Return [provider → parent → sibling variants] in BYOK priority order.
+
+    Shared by ``_walk_byok_candidates`` (key lookup) and STEP-0 prefetch so the
+    two can't drift. Excludes platform-only siblings (BYOK keys never live there).
+    """
+    parent = mc.get_parent_provider(provider)
+    candidates: list[str] = [provider]
+    if parent and parent != provider:
+        candidates.append(parent)
+    root = parent if parent else provider
+    for sibling in mc.get_child_variants(root):
+        if sibling not in candidates:
+            candidates.append(sibling)
+    return candidates
+
+
 async def _walk_byok_candidates(
     user_id,
     provider,
@@ -62,14 +79,7 @@ async def _walk_byok_candidates(
     """
     from src.server.database.api_keys import get_byok_configs_for_providers
 
-    parent = mc.get_parent_provider(provider)
-    candidates: list[str] = [provider]
-    if parent and parent != provider:
-        candidates.append(parent)
-    root = parent if parent else provider
-    for sibling in mc.get_child_variants(root):
-        if sibling not in candidates:
-            candidates.append(sibling)
+    candidates = _candidate_slugs(provider, mc)
 
     if _byok_cache is None:
         # Back-compat path: no request-scoped cache, batch-fetch all candidates.
@@ -601,15 +611,52 @@ async def classify_model(
     return ModelSource.UNKNOWN, {}
 
 
+# ---------------------------------------------------------------------------
+# LLM roles — compaction / fetch / per-subagent. A dumb record + builder so the
+# resolution loop is a flat iteration instead of bespoke per-role branches.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LLMRole:
+    """A subsidiary model slot to resolve a client for.
+
+    ``key`` is the ``subsidiary_llm_clients`` key ("compaction" | "fetch" |
+    "subagent:<name>"). ``fallback_to_main`` controls whether a keyless role
+    inherits a copy of the main client at materialization time. Priority
+    service tier is main-only, so ``service_tier`` stays None for roles.
+    """
+
+    key: str
+    model: str | None
+    fallback_to_main: bool = True
+    service_tier: str | None = None
+
+
+def role_registry(config, enabled_subagents, subagent_defs) -> list[LLMRole]:
+    """Build the ordered list of model roles to resolve for this request."""
+    roles = [
+        LLMRole("compaction", config.llm.compaction),
+        LLMRole("fetch", config.llm.fetch),
+    ]
+    for name in enabled_subagents:
+        defn = subagent_defs.get(name)
+        if defn is not None and getattr(defn, "model", None):
+            roles.append(LLMRole(f"subagent:{name}", defn.model))
+    return [r for r in roles if r.model]
+
+
 async def resolve_llm_config(
     base_config,
     user_id: str,
     request_model: str | None,
-    is_byok: bool,
+    is_byok: bool | None = None,
     mode: str = "ptc",
     reasoning_effort: str | None = None,
     fast_mode: bool | None = None,
     thread_id: str | None = None,
+    *,
+    enabled_subagents: list[str] | None = None,
 ):
     """
     Resolve final LLM config with priority:
@@ -618,12 +665,27 @@ async def resolve_llm_config(
 
     Mode determines which config field and preference key to use
     (see _MODE_MODEL_MAP). Easy to extend for new modes.
+
+    ``is_byok=None`` self-resolves via ``is_byok_active`` (guards future entry
+    points; all current callers pass it explicitly). ``enabled_subagents``
+    threads the request's active subagent list so per-subagent model roles get
+    their own credential resolution; ``None`` falls back to the config default.
     """
     from ptc_agent.config import LLMConfig
+
+    if is_byok is None:
+        from src.server.database.api_keys import is_byok_active
+
+        is_byok = await is_byok_active(user_id)
 
     model_field, pref_key = _MODE_MODEL_MAP[mode]
     config = base_config
     model_pref = await get_model_preference(user_id)
+    _enabled_subagents = (
+        enabled_subagents
+        if enabled_subagents is not None
+        else list(config.subagents.enabled)
+    )
 
     # Bootstrap LLMConfig when agent_config.yaml has llm: null.
     # The user must have configured a model via the UI or per-request param.
@@ -768,150 +830,173 @@ async def resolve_llm_config(
         effective_fast = model_pref.get("fast_mode")
     effective_service_tier = "priority" if effective_fast else None
 
-    # Try OAuth-connected providers first (independent of BYOK toggle)
-    oauth_client = await resolve_oauth_llm_client(
-        user_id, effective_model, effective_reasoning,
-        service_tier=effective_service_tier,
-        cache_key=thread_id,
-    )
-    if oauth_client:
-        if config is base_config:
-            config = config.model_copy(deep=True)
-        config.llm_client = oauth_client
-    # Then try BYOK
-    elif is_byok:
-        byok_client = await resolve_byok_llm_client(
-            user_id, effective_model, is_byok, effective_reasoning,
-            _pref_cache=model_pref,
-            cache_key=thread_id,
-        )
-        if byok_client:
-            if config is base_config:
-                config = config.model_copy(deep=True)
-            config.llm_client = byok_client
-        elif is_custom or is_custom_provider:
-            # Custom model selected but no key resolvable — fail loud with a CTA
-            # instead of letting downstream create_llm() crash with a generic
-            # "Model X not found in models.json" error.
-            _raise_byok_key_required(effective_model)
-    # Default path (system key) — apply reasoning_effort if set
-    elif effective_reasoning:
-        from src.llms.llm import create_llm
+    # STEP 0 — best-effort batch BYOK prefetch. Pure perf: ``_walk_byok_candidates``
+    # is cache-miss-safe (a slug absent from the cache falls back to a direct
+    # lookup), so this query never needs to be exhaustive and must never become a
+    # correctness dependency. Gather candidate provider slugs for the main model +
+    # every role model + every fallback model, issue ONE query, and seed the
+    # tri-state cache. On any error fall back to an empty cache (every walk then
+    # does its own direct lookup — correct, just unoptimized).
+    byok_cache: dict[str, dict | None] = {}
+    if is_byok:
+        try:
+            from src.llms.llm import LLM as LLMFactory
 
-        if config is base_config:
-            config = config.model_copy(deep=True)
-        config.llm_client = create_llm(
-            effective_model,
-            reasoning_effort=effective_reasoning,
-            cache_key=thread_id,
-        )
-        logger.debug(
-            f"[CHAT] Applied reasoning_effort={effective_reasoning} to {effective_model}"
-        )
+            mc = LLMFactory.get_model_config()
+            _candidate_models = [effective_model]
+            _candidate_models += [
+                m for m in (config.llm.compaction, config.llm.fetch) if m
+            ]
+            _candidate_models += list(config.llm.fallback or [])
+            all_slugs: set[str] = set()
+            for _m in _candidate_models:
+                _src, _cfg = await classify_model(user_id, _m, _pref_cache=model_pref)
+                # SYSTEM entries (models.json) and CUSTOM entries (user config)
+                # both carry a "provider" slug; UNKNOWN carries nothing.
+                _prov = _cfg.get("provider") if _src != ModelSource.UNKNOWN else None
+                if _prov:
+                    all_slugs.update(_candidate_slugs(_prov, mc))
+            if all_slugs:
+                from src.server.database.api_keys import get_byok_configs_for_providers
+
+                _slugs = list(all_slugs)
+                _configs = await get_byok_configs_for_providers(user_id, _slugs)
+                byok_cache = {slug: _configs.get(slug) for slug in _slugs}
+        except Exception:
+            logger.warning(
+                "[CHAT] BYOK batch prefetch failed; falling back to per-walk lookups",
+                exc_info=True,
+            )
+            byok_cache = {}
+
+    # Main model — single primitive call. OAuth-first → BYOK → platform fallback
+    # (only when allow_platform_fallback and the model is SYSTEM). The
+    # ``bool(effective_reasoning)`` gate preserves the old behavior exactly: a
+    # non-credentialed reasoning request gets an eager platform client (tagged
+    # PLATFORM); a non-reasoning non-credentialed request leaves llm_client=None
+    # (NONE) for the lazy OSS path. An OAuth-required HTTPException propagates.
+    main = await resolve_model_client(
+        user_id, effective_model, is_byok=is_byok, cache_key=thread_id,
+        reasoning_effort=effective_reasoning, service_tier=effective_service_tier,
+        allow_platform_fallback=bool(effective_reasoning),
+        _pref_cache=model_pref, _byok_cache=byok_cache,
+    )
+    if config is base_config:
+        config = config.model_copy(deep=True)
+    # Always store credential_source (even NONE) — single source of truth
+    # downstream (credit gate, materialization gate, billing signal).
+    config.credential_source = main.credential_source
+    if main.client is not None:
+        config.llm_client = main.client
+    elif is_custom or is_custom_provider:
+        # Custom model selected but no usable key — fail loud with a CTA.
+        _raise_byok_key_required(effective_model)
 
     # Stash on config so the lazy ``AgentConfig.get_llm_client()`` path forwards
-    # it to ``create_llm`` when no OAuth/BYOK/reasoning branch pre-built the client.
+    # it to ``create_llm`` when no client was pre-built.
     if thread_id and config.cache_key != thread_id:
-        if config is base_config:
-            config = config.model_copy(deep=True)
         config.cache_key = thread_id
 
-    # Resolve OAuth/BYOK for subsidiary + fallback models in parallel.
-    # Each model tries OAuth first, then BYOK if OAuth fails.
-    import asyncio
+    # Build the subagent definition map via the registry so built-ins are
+    # included (raw ``config.subagents.definitions`` only holds user overrides).
+    # ``get`` returns None for unknown names (skip); ``get_enabled`` would raise.
+    try:
+        from ptc_agent.agent.subagents.registry import SubagentRegistry
 
-    async def _resolve_one(model_name: str):
-        """Resolve one subsidiary/fallback model. Returns (client, source).
+        _registry = SubagentRegistry(user_definitions=config.subagents.definitions)
+        subagent_defs = {name: _registry.get(name) for name in _enabled_subagents}
+    except Exception:
+        logger.error("[CHAT] Failed to build subagent registry; skipping subagent roles", exc_info=True)
+        subagent_defs = {}
 
-        ``source`` tells the fallback merge loop whether a missed OAuth/BYOK
-        resolve can fall back to a platform-keyed client (only valid for
-        system models). On exception the source is ``None`` — callers should
-        treat that as "already logged, skip".
-        """
+    roles = role_registry(config, _enabled_subagents, subagent_defs)
+
+    # Resolve each role through the primitive. Roles never get an eager platform
+    # client (allow_platform_fallback=False): a role's own system model with no
+    # user key resolves to None here — the cheap name-based platform path
+    # (compaction/fetch) or the string-name OSS path (subagents) handles it.
+    # service_tier (priority) is main-only.
+    for role in roles:
         try:
-            source, _ = await classify_model(
-                user_id, model_name, _pref_cache=model_pref,
+            rc = await resolve_model_client(
+                user_id, role.model, is_byok=is_byok, cache_key=thread_id,
+                allow_platform_fallback=False, service_tier=None,
+                _pref_cache=model_pref, _byok_cache=byok_cache,
             )
-            client = await resolve_oauth_llm_client(
-                user_id, model_name, cache_key=thread_id,
-            )
-            if not client and is_byok:
-                client = await resolve_byok_llm_client(
-                    user_id, model_name, is_byok,
-                    _pref_cache=model_pref,
-                    cache_key=thread_id,
-                )
-            return client, source
         except Exception:
-            logger.error("[CHAT] Failed to resolve model %s, skipping", model_name, exc_info=True)
-            return None, None
+            logger.error(
+                "[CHAT] Failed to resolve role %s model %s, skipping",
+                role.key, role.model, exc_info=True,
+            )
+            continue
+        if rc.client is not None:
+            # ``compaction``/``fetch`` are consumed today (agent.py / _common.py);
+            # ``subagent:<name>`` clients are read by the subagent compiler
+            # injection landing later in this refactor (via ``client_for_role``).
+            config.subsidiary_llm_clients[role.key] = rc.client
+        elif rc.model_source is not None and rc.model_source != ModelSource.SYSTEM:
+            logger.warning(
+                "[CHAT] Role '%s' model '%s' is a custom model without a usable "
+                "BYOK key — falling back to default.",
+                role.key, role.model,
+            )
 
-    subsidiary_pairs = [(role, m) for role, m in [("compaction", config.llm.compaction), ("fetch", config.llm.fetch)] if m]
-    fallback_models = config.llm.fallback or []
-
-    all_models = [m for _, m in subsidiary_pairs] + list(fallback_models)
-    if all_models:
-        results = await asyncio.gather(*[_resolve_one(m) for m in all_models])
-
-        sub_count = len(subsidiary_pairs)
-        for i, (role, sub_name) in enumerate(subsidiary_pairs):
-            client, source = results[i]
-            if client:
-                if config is base_config:
-                    config = config.model_copy(deep=True)
-                config.subsidiary_llm_clients[role] = client
-                continue
-            # Mirror the fallback-loop warning so silently-dropped subsidiaries
-            # (e.g. user picked a custom compaction model without a BYOK key)
-            # surface in the logs. Main model stays hard-raised at the preflight;
-            # subsidiaries degrade: compaction falls back to the main llm_client,
-            # fetch re-constructs from the name via the factory.
-            if source is not None and source != ModelSource.SYSTEM:
-                logger.warning(
-                    "[CHAT] Subsidiary role '%s' model '%s' is a custom model "
-                    "without a usable BYOK key — falling back to default. "
-                    "Add a key in Settings to enable.",
-                    role,
-                    sub_name,
+    # BYOK-pure write-time materialization. Gate on the credential SIGNAL, not on
+    # llm_client presence (Codex #2): a non-BYOK reasoning user has
+    # credential_source=PLATFORM with a platform llm_client that must NOT be
+    # copied into roles. Only OAUTH/BYOK users seed keyless roles with a main
+    # copy. PLATFORM/NONE users store nothing → cheap name path stays.
+    has_user_cred = config.credential_source in (
+        CredentialSource.OAUTH, CredentialSource.BYOK,
+    )
+    if has_user_cred and config.llm_client is not None:
+        for role in roles:
+            if role.fallback_to_main and role.key not in config.subsidiary_llm_clients:
+                # ``subagent:<name>`` main-client copies are read by the subagent
+                # compiler injection landing later in this refactor (via
+                # ``client_for_role``); compaction/fetch are read today.
+                config.subsidiary_llm_clients[role.key] = config.llm_client.model_copy()
+                logger.info(
+                    "[CHAT] Role '%s' has no own key; falling back to the user's "
+                    "main client (cost shifts to main-model rate).",
+                    role.key,
                 )
 
-        # Merge resolved OAuth/BYOK clients with platform fallbacks.
-        # For each fallback model: use the pre-resolved client if available,
-        # otherwise create a platform-keyed client so no model is silently dropped.
-        # Custom fallback models without a usable key are skipped with a
-        # visible warning — we reuse the source already computed by
-        # ``_resolve_one`` instead of re-classifying.
-        from src.llms.llm import create_llm as _create_llm
-
-        fallback_results = results[sub_count:]
+    # Fallback models — route each through the primitive with platform fallback
+    # ON (SYSTEM names without a user key still get a platform client so no model
+    # is silently dropped). Custom/unknown fallbacks without a usable key warn +
+    # skip. Preserve the byok_count debug log.
+    fallback_models = config.llm.fallback or []
+    if fallback_models:
         merged_fallbacks = []
         byok_count = 0
-        for i, model_name in enumerate(fallback_models):
-            client, source = fallback_results[i]
-            if client:
-                merged_fallbacks.append(client)
-                byok_count += 1
+        for model_name in fallback_models:
+            try:
+                fc = await resolve_model_client(
+                    user_id, model_name, is_byok=is_byok, cache_key=thread_id,
+                    allow_platform_fallback=True,
+                    _pref_cache=model_pref, _byok_cache=byok_cache,
+                )
+            except Exception:
+                logger.error(
+                    "[CHAT] Failed to resolve fallback model %s, skipping",
+                    model_name, exc_info=True,
+                )
                 continue
-            if source is None:
-                # ``_resolve_one`` caught an exception and already logged it.
-                continue
-            if source != ModelSource.SYSTEM:
-                # Custom (or unknown) fallback without a usable key — can't
-                # build a platform client for a non-system name.
+            if fc.client is not None:
+                merged_fallbacks.append(fc.client)
+                if fc.credential_source in (CredentialSource.OAUTH, CredentialSource.BYOK):
+                    byok_count += 1
+            elif fc.model_source is not None and fc.model_source != ModelSource.SYSTEM:
                 logger.warning(
                     "[CHAT] Fallback model '%s' is a custom model without a "
                     "usable BYOK key — skipping. Add a key in Settings to enable.",
                     model_name,
                 )
-                continue
-            try:
-                merged_fallbacks.append(_create_llm(model_name, cache_key=thread_id))
-            except Exception:
-                logger.warning("[CHAT] Failed to create platform fallback for %s, skipping", model_name)
+            # else: SYSTEM with no client (shouldn't happen with platform
+            # fallback on) — guard by skipping.
 
         if merged_fallbacks:
-            if config is base_config:
-                config = config.model_copy(deep=True)
             config.fallback_llm_clients = merged_fallbacks
             if byok_count:
                 logger.debug(

--- a/src/server/handlers/chat/llm_config.py
+++ b/src/server/handlers/chat/llm_config.py
@@ -7,6 +7,7 @@ lookups.
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any
@@ -550,24 +551,46 @@ def role_registry(config, enabled_subagents, subagent_defs) -> list[LLMRole]:
     return [r for r in roles if r.model]
 
 
+def _build_roles(config, enabled_subagents: list[str]) -> list[LLMRole]:
+    """Build the role list once, resolving subagent defs through the registry.
+
+    Shared by the BYOK prefetch (so subagent model slugs land in the batch) and
+    the role-client resolver (so the registry is built once, not twice).
+    """
+    try:
+        from ptc_agent.agent.subagents.registry import SubagentRegistry
+
+        registry = SubagentRegistry(user_definitions=config.subagents.definitions)
+        subagent_defs = {name: registry.get(name) for name in enabled_subagents}
+    except Exception:
+        logger.error(
+            "[CHAT] Failed to build subagent registry; skipping subagent roles",
+            exc_info=True,
+        )
+        subagent_defs = {}
+    return role_registry(config, enabled_subagents, subagent_defs)
+
+
 async def _prefetch_byok_cache(
     user_id: str, config, effective_model: str, model_pref: dict,
+    roles: list[LLMRole],
 ) -> dict[str, dict | None]:
     """Best-effort batch BYOK prefetch → tri-state cache for ``_walk_byok_candidates``.
 
-    Gathers candidate provider slugs across the main model, every role model,
-    and every fallback model, issues ONE ``get_byok_configs_for_providers``
-    query, and seeds the cache. Pure perf: every walk is cache-miss-safe (a slug
-    absent from the cache falls back to a direct lookup), so this must never
-    become a correctness dependency. On any error returns ``{}`` — each walk
-    then does its own direct lookup (correct, just unoptimized).
+    Gathers candidate provider slugs across the main model, every role model
+    (compaction / fetch / subagent), and every fallback model, issues ONE
+    ``get_byok_configs_for_providers`` query, and seeds the cache. Pure perf:
+    every walk is cache-miss-safe (a slug absent from the cache falls back to a
+    direct lookup), so this must never become a correctness dependency. On any
+    error returns ``{}`` — each walk then does its own direct lookup (correct,
+    just unoptimized).
     """
     from src.llms.llm import LLM as LLMFactory
 
     try:
         mc = LLMFactory.get_model_config()
         candidate_models = [effective_model]
-        candidate_models += [m for m in (config.llm.compaction, config.llm.fetch) if m]
+        candidate_models += [r.model for r in roles if r.model]
         candidate_models += list(config.llm.fallback or [])
         all_slugs: set[str] = set()
         for m in candidate_models:
@@ -593,7 +616,7 @@ async def _prefetch_byok_cache(
 
 
 async def _resolve_role_clients(
-    config, user_id: str, enabled_subagents: list[str], model_pref: dict,
+    config, user_id: str, roles: list[LLMRole], model_pref: dict,
     byok_cache: dict, *, is_byok: bool, cache_key: str | None,
 ) -> None:
     """Resolve compaction/fetch/subagent role clients onto ``config`` in place.
@@ -602,25 +625,14 @@ async def _resolve_role_clients(
     ``config.llm_client`` are set. Roles never get an eager platform client
     (``allow_platform_fallback=False``); a keyless role for an OAUTH/BYOK user
     is seeded with a copy of the main client (BYOK-pure), while PLATFORM/NONE
-    users store nothing so the cheap name-based path stays.
+    users store nothing so the cheap name-based path stays. Each role's I/O
+    (OAuth check + BYOK walk) runs concurrently; writes happen after the gather
+    so the SSE hot path waits one round-trip, not N.
     """
-    try:
-        from ptc_agent.agent.subagents.registry import SubagentRegistry
 
-        registry = SubagentRegistry(user_definitions=config.subagents.definitions)
-        subagent_defs = {name: registry.get(name) for name in enabled_subagents}
-    except Exception:
-        logger.error(
-            "[CHAT] Failed to build subagent registry; skipping subagent roles",
-            exc_info=True,
-        )
-        subagent_defs = {}
-
-    roles = role_registry(config, enabled_subagents, subagent_defs)
-
-    for role in roles:
+    async def _resolve_one(role: LLMRole):
         try:
-            rc = await resolve_model_client(
+            return role, await resolve_model_client(
                 user_id, role.model, is_byok=is_byok, cache_key=cache_key,
                 allow_platform_fallback=False, service_tier=None,
                 _pref_cache=model_pref, _byok_cache=byok_cache,
@@ -630,6 +642,10 @@ async def _resolve_role_clients(
                 "[CHAT] Failed to resolve role %s model %s, skipping",
                 role.key, role.model, exc_info=True,
             )
+            return role, None
+
+    for role, rc in await asyncio.gather(*(_resolve_one(r) for r in roles)):
+        if rc is None:
             continue
         if rc.client is not None:
             config.subsidiary_llm_clients[role.key] = rc.client
@@ -669,11 +685,9 @@ async def _resolve_fallback_clients(
     if not fallback_models:
         return
 
-    merged_fallbacks = []
-    byok_count = 0
-    for model_name in fallback_models:
+    async def _resolve_one(model_name: str):
         try:
-            fc = await resolve_model_client(
+            return model_name, await resolve_model_client(
                 user_id, model_name, is_byok=is_byok, cache_key=cache_key,
                 allow_platform_fallback=True,
                 _pref_cache=model_pref, _byok_cache=byok_cache,
@@ -683,6 +697,15 @@ async def _resolve_fallback_clients(
                 "[CHAT] Failed to resolve fallback model %s, skipping",
                 model_name, exc_info=True,
             )
+            return model_name, None
+
+    merged_fallbacks = []
+    byok_count = 0
+    # Resolve concurrently; append in declared order to preserve fallback priority.
+    for model_name, fc in await asyncio.gather(
+        *(_resolve_one(m) for m in fallback_models)
+    ):
+        if fc is None:
             continue
         if fc.client is not None:
             merged_fallbacks.append(fc.client)
@@ -892,9 +915,12 @@ async def resolve_llm_config(
         effective_fast = model_pref.get("fast_mode")
     effective_service_tier = "priority" if effective_fast else None
 
+    # Build the role list once (shared by the prefetch and the resolver below).
+    roles = _build_roles(config, _enabled_subagents)
+
     # STEP 0 — best-effort batch BYOK prefetch (pure perf; see helper docstring).
     byok_cache: dict[str, dict | None] = (
-        await _prefetch_byok_cache(user_id, config, effective_model, model_pref)
+        await _prefetch_byok_cache(user_id, config, effective_model, model_pref, roles)
         if is_byok
         else {}
     )
@@ -927,14 +953,18 @@ async def resolve_llm_config(
         config.cache_key = thread_id
 
     # Subsidiary role clients (compaction / fetch / subagent:*) + BYOK-pure
-    # materialization, then fallback models. Both resolve through the primitive.
-    await _resolve_role_clients(
-        config, user_id, _enabled_subagents, model_pref, byok_cache,
-        is_byok=is_byok, cache_key=thread_id,
-    )
-    await _resolve_fallback_clients(
-        config, user_id, model_pref, byok_cache,
-        is_byok=is_byok, cache_key=thread_id,
+    # materialization, and fallback models. Both resolve through the primitive
+    # and write disjoint config fields (subsidiary_llm_clients vs
+    # fallback_llm_clients), so they run concurrently.
+    await asyncio.gather(
+        _resolve_role_clients(
+            config, user_id, roles, model_pref, byok_cache,
+            is_byok=is_byok, cache_key=thread_id,
+        ),
+        _resolve_fallback_clients(
+            config, user_id, model_pref, byok_cache,
+            is_byok=is_byok, cache_key=thread_id,
+        ),
     )
 
     return config

--- a/src/server/handlers/chat/llm_config.py
+++ b/src/server/handlers/chat/llm_config.py
@@ -660,7 +660,11 @@ async def _resolve_role_clients(
     # SIGNAL: by the primitive's invariant OAUTH/BYOK ⟹ llm_client is set, so a
     # main-client copy is safe. PLATFORM/NONE users store nothing → cheap name
     # path stays (a non-BYOK reasoning user's PLATFORM client is NOT copied).
-    if config.credential_source in (CredentialSource.OAUTH, CredentialSource.BYOK):
+    # The explicit None check makes the invariant a guard, not an assumption.
+    if (
+        config.credential_source in (CredentialSource.OAUTH, CredentialSource.BYOK)
+        and config.llm_client is not None
+    ):
         for role in roles:
             if role.fallback_to_main and role.key not in config.subsidiary_llm_clients:
                 config.subsidiary_llm_clients[role.key] = config.llm_client.model_copy()

--- a/src/server/handlers/chat/llm_config.py
+++ b/src/server/handlers/chat/llm_config.py
@@ -646,6 +646,161 @@ def role_registry(config, enabled_subagents, subagent_defs) -> list[LLMRole]:
     return [r for r in roles if r.model]
 
 
+async def _prefetch_byok_cache(
+    user_id: str, config, effective_model: str, model_pref: dict,
+) -> dict[str, dict | None]:
+    """Best-effort batch BYOK prefetch → tri-state cache for ``_walk_byok_candidates``.
+
+    Gathers candidate provider slugs across the main model, every role model,
+    and every fallback model, issues ONE ``get_byok_configs_for_providers``
+    query, and seeds the cache. Pure perf: every walk is cache-miss-safe (a slug
+    absent from the cache falls back to a direct lookup), so this must never
+    become a correctness dependency. On any error returns ``{}`` — each walk
+    then does its own direct lookup (correct, just unoptimized).
+    """
+    from src.llms.llm import LLM as LLMFactory
+
+    try:
+        mc = LLMFactory.get_model_config()
+        candidate_models = [effective_model]
+        candidate_models += [m for m in (config.llm.compaction, config.llm.fetch) if m]
+        candidate_models += list(config.llm.fallback or [])
+        all_slugs: set[str] = set()
+        for m in candidate_models:
+            src_, cfg = await classify_model(user_id, m, _pref_cache=model_pref)
+            # SYSTEM (models.json) and CUSTOM (user config) both carry a
+            # "provider" slug; UNKNOWN carries nothing.
+            prov = cfg.get("provider") if src_ != ModelSource.UNKNOWN else None
+            if prov:
+                all_slugs.update(_candidate_slugs(prov, mc))
+        if not all_slugs:
+            return {}
+        from src.server.database.api_keys import get_byok_configs_for_providers
+
+        slugs = list(all_slugs)
+        configs = await get_byok_configs_for_providers(user_id, slugs)
+        return {slug: configs.get(slug) for slug in slugs}
+    except Exception:
+        logger.warning(
+            "[CHAT] BYOK batch prefetch failed; falling back to per-walk lookups",
+            exc_info=True,
+        )
+        return {}
+
+
+async def _resolve_role_clients(
+    config, user_id: str, enabled_subagents: list[str], model_pref: dict,
+    byok_cache: dict, *, is_byok: bool, cache_key: str | None,
+) -> None:
+    """Resolve compaction/fetch/subagent role clients onto ``config`` in place.
+
+    Assumes ``config`` is already a copy and ``config.credential_source`` /
+    ``config.llm_client`` are set. Roles never get an eager platform client
+    (``allow_platform_fallback=False``); a keyless role for an OAUTH/BYOK user
+    is seeded with a copy of the main client (BYOK-pure), while PLATFORM/NONE
+    users store nothing so the cheap name-based path stays.
+    """
+    try:
+        from ptc_agent.agent.subagents.registry import SubagentRegistry
+
+        registry = SubagentRegistry(user_definitions=config.subagents.definitions)
+        subagent_defs = {name: registry.get(name) for name in enabled_subagents}
+    except Exception:
+        logger.error(
+            "[CHAT] Failed to build subagent registry; skipping subagent roles",
+            exc_info=True,
+        )
+        subagent_defs = {}
+
+    roles = role_registry(config, enabled_subagents, subagent_defs)
+
+    for role in roles:
+        try:
+            rc = await resolve_model_client(
+                user_id, role.model, is_byok=is_byok, cache_key=cache_key,
+                allow_platform_fallback=False, service_tier=None,
+                _pref_cache=model_pref, _byok_cache=byok_cache,
+            )
+        except Exception:
+            logger.error(
+                "[CHAT] Failed to resolve role %s model %s, skipping",
+                role.key, role.model, exc_info=True,
+            )
+            continue
+        if rc.client is not None:
+            config.subsidiary_llm_clients[role.key] = rc.client
+        elif rc.model_source is not None and rc.model_source != ModelSource.SYSTEM:
+            logger.warning(
+                "[CHAT] Role '%s' model '%s' is a custom model without a usable "
+                "BYOK key — falling back to default.",
+                role.key, role.model,
+            )
+
+    # BYOK-pure write-time materialization. Gate purely on the credential
+    # SIGNAL: by the primitive's invariant OAUTH/BYOK ⟹ llm_client is set, so a
+    # main-client copy is safe. PLATFORM/NONE users store nothing → cheap name
+    # path stays (a non-BYOK reasoning user's PLATFORM client is NOT copied).
+    if config.credential_source in (CredentialSource.OAUTH, CredentialSource.BYOK):
+        for role in roles:
+            if role.fallback_to_main and role.key not in config.subsidiary_llm_clients:
+                config.subsidiary_llm_clients[role.key] = config.llm_client.model_copy()
+                logger.info(
+                    "[CHAT] Role '%s' has no own key; falling back to the user's "
+                    "main client (cost shifts to main-model rate).",
+                    role.key,
+                )
+
+
+async def _resolve_fallback_clients(
+    config, user_id: str, model_pref: dict, byok_cache: dict,
+    *, is_byok: bool, cache_key: str | None,
+) -> None:
+    """Resolve ``config.llm.fallback`` names into client instances in place.
+
+    Platform fallback is ON so a SYSTEM fallback name without a user key still
+    yields a platform client (no model silently dropped). Custom/unknown
+    fallbacks without a usable key warn + skip.
+    """
+    fallback_models = config.llm.fallback or []
+    if not fallback_models:
+        return
+
+    merged_fallbacks = []
+    byok_count = 0
+    for model_name in fallback_models:
+        try:
+            fc = await resolve_model_client(
+                user_id, model_name, is_byok=is_byok, cache_key=cache_key,
+                allow_platform_fallback=True,
+                _pref_cache=model_pref, _byok_cache=byok_cache,
+            )
+        except Exception:
+            logger.error(
+                "[CHAT] Failed to resolve fallback model %s, skipping",
+                model_name, exc_info=True,
+            )
+            continue
+        if fc.client is not None:
+            merged_fallbacks.append(fc.client)
+            if fc.credential_source in (CredentialSource.OAUTH, CredentialSource.BYOK):
+                byok_count += 1
+        elif fc.model_source is not None and fc.model_source != ModelSource.SYSTEM:
+            logger.warning(
+                "[CHAT] Fallback model '%s' is a custom model without a "
+                "usable BYOK key — skipping. Add a key in Settings to enable.",
+                model_name,
+            )
+        # else: SYSTEM with no client (shouldn't happen with platform fallback
+        # on) — guard by skipping.
+
+    if merged_fallbacks:
+        config.fallback_llm_clients = merged_fallbacks
+        if byok_count:
+            logger.debug(
+                f"[CHAT] Resolved {byok_count}/{len(fallback_models)} fallback models via OAuth/BYOK"
+            )
+
+
 async def resolve_llm_config(
     base_config,
     user_id: str,
@@ -680,6 +835,13 @@ async def resolve_llm_config(
 
     model_field, pref_key = _MODE_MODEL_MAP[mode]
     config = base_config
+
+    def _cow():
+        """Copy-on-write: deep-copy base_config the first time we mutate it."""
+        nonlocal config
+        if config is base_config:
+            config = config.model_copy(deep=True)
+
     model_pref = await get_model_preference(user_id)
     _enabled_subagents = (
         enabled_subagents
@@ -695,7 +857,7 @@ async def resolve_llm_config(
             raise ValueError(
                 "No model configured. Set llm in agent_config.yaml or select a model in Settings."
             )
-        config = config.model_copy(deep=True)
+        _cow()
         config.llm = LLMConfig(
             name=resolved_name if mode == "ptc" else "placeholder",
             flash=resolved_name if mode == "flash" else model_pref.get("preferred_flash_model"),
@@ -710,14 +872,14 @@ async def resolve_llm_config(
         config.llm_client = None
         logger.debug(f"[CHAT] No system default LLM; bootstrapped from user preferences: {resolved_name}")
     elif request_model:
-        config = config.model_copy(deep=True)
+        _cow()
         setattr(config.llm, model_field, request_model)
         config.llm_client = None
         logger.debug(f"[CHAT] Using per-request LLM model: {request_model}")
     else:
         preferred = model_pref.get(pref_key)
         if preferred:
-            config = config.model_copy(deep=True)
+            _cow()
             setattr(config.llm, model_field, preferred)
             config.llm_client = None
             logger.debug(f"[CHAT] Using {pref_key}: {preferred}")
@@ -739,14 +901,12 @@ async def resolve_llm_config(
     for pref_key_other, config_field in _other_model_keys:
         user_val = model_pref.get(pref_key_other)
         if user_val:
-            if config is base_config:
-                config = config.model_copy(deep=True)
+            _cow()
             setattr(config.llm, config_field, user_val)
 
     user_fallback = model_pref.get("fallback_models")
     if user_fallback is not None:
-        if config is base_config:
-            config = config.model_copy(deep=True)
+        _cow()
         config.llm.fallback = user_fallback
 
     # Compaction profile: a named preset (aggressive/moderate/extended/relaxed)
@@ -762,8 +922,7 @@ async def resolve_llm_config(
         else None
     )
     if preset:
-        if config is base_config:
-            config = config.model_copy(deep=True)
+        _cow()
         for field, value in preset.items():
             setattr(config.compaction, field, value)
 
@@ -798,8 +957,8 @@ async def resolve_llm_config(
     # falls through so the downstream error surfaces the config bug.
     if source == ModelSource.UNKNOWN and not is_custom_provider:
         # Only the five scalar keys feed ``effective_model`` — fallback_models
-        # is tried by ``_resolve_one_with_fallbacks`` on a separate path and
-        # never flows through here, so it's intentionally excluded from this
+        # is resolved separately in ``_resolve_fallback_clients`` and never
+        # flows through here, so it's intentionally excluded from this
         # attribution check (the scrub in ``_cleanup_stale_model_preferences``
         # still filters fallback_models once it fires).
         from_pref = any(
@@ -815,8 +974,7 @@ async def resolve_llm_config(
 
     # Thread custom model input_modalities onto config
     if custom_cm and custom_cm.get("input_modalities"):
-        if config is base_config:
-            config = config.model_copy(deep=True)
+        _cow()
         config.input_modalities = custom_cm["input_modalities"]
 
     # Resolve reasoning effort: per-request > user pref > None (use model default)
@@ -830,44 +988,12 @@ async def resolve_llm_config(
         effective_fast = model_pref.get("fast_mode")
     effective_service_tier = "priority" if effective_fast else None
 
-    # STEP 0 — best-effort batch BYOK prefetch. Pure perf: ``_walk_byok_candidates``
-    # is cache-miss-safe (a slug absent from the cache falls back to a direct
-    # lookup), so this query never needs to be exhaustive and must never become a
-    # correctness dependency. Gather candidate provider slugs for the main model +
-    # every role model + every fallback model, issue ONE query, and seed the
-    # tri-state cache. On any error fall back to an empty cache (every walk then
-    # does its own direct lookup — correct, just unoptimized).
-    byok_cache: dict[str, dict | None] = {}
-    if is_byok:
-        try:
-            from src.llms.llm import LLM as LLMFactory
-
-            mc = LLMFactory.get_model_config()
-            _candidate_models = [effective_model]
-            _candidate_models += [
-                m for m in (config.llm.compaction, config.llm.fetch) if m
-            ]
-            _candidate_models += list(config.llm.fallback or [])
-            all_slugs: set[str] = set()
-            for _m in _candidate_models:
-                _src, _cfg = await classify_model(user_id, _m, _pref_cache=model_pref)
-                # SYSTEM entries (models.json) and CUSTOM entries (user config)
-                # both carry a "provider" slug; UNKNOWN carries nothing.
-                _prov = _cfg.get("provider") if _src != ModelSource.UNKNOWN else None
-                if _prov:
-                    all_slugs.update(_candidate_slugs(_prov, mc))
-            if all_slugs:
-                from src.server.database.api_keys import get_byok_configs_for_providers
-
-                _slugs = list(all_slugs)
-                _configs = await get_byok_configs_for_providers(user_id, _slugs)
-                byok_cache = {slug: _configs.get(slug) for slug in _slugs}
-        except Exception:
-            logger.warning(
-                "[CHAT] BYOK batch prefetch failed; falling back to per-walk lookups",
-                exc_info=True,
-            )
-            byok_cache = {}
+    # STEP 0 — best-effort batch BYOK prefetch (pure perf; see helper docstring).
+    byok_cache: dict[str, dict | None] = (
+        await _prefetch_byok_cache(user_id, config, effective_model, model_pref)
+        if is_byok
+        else {}
+    )
 
     # Main model — single primitive call. OAuth-first → BYOK → platform fallback
     # (only when allow_platform_fallback and the model is SYSTEM). The
@@ -881,8 +1007,7 @@ async def resolve_llm_config(
         allow_platform_fallback=bool(effective_reasoning),
         _pref_cache=model_pref, _byok_cache=byok_cache,
     )
-    if config is base_config:
-        config = config.model_copy(deep=True)
+    _cow()
     # Always store credential_source (even NONE) — single source of truth
     # downstream (credit gate, materialization gate, billing signal).
     config.credential_source = main.credential_source
@@ -897,110 +1022,15 @@ async def resolve_llm_config(
     if thread_id and config.cache_key != thread_id:
         config.cache_key = thread_id
 
-    # Build the subagent definition map via the registry so built-ins are
-    # included (raw ``config.subagents.definitions`` only holds user overrides).
-    # ``get`` returns None for unknown names (skip); ``get_enabled`` would raise.
-    try:
-        from ptc_agent.agent.subagents.registry import SubagentRegistry
-
-        _registry = SubagentRegistry(user_definitions=config.subagents.definitions)
-        subagent_defs = {name: _registry.get(name) for name in _enabled_subagents}
-    except Exception:
-        logger.error("[CHAT] Failed to build subagent registry; skipping subagent roles", exc_info=True)
-        subagent_defs = {}
-
-    roles = role_registry(config, _enabled_subagents, subagent_defs)
-
-    # Resolve each role through the primitive. Roles never get an eager platform
-    # client (allow_platform_fallback=False): a role's own system model with no
-    # user key resolves to None here — the cheap name-based platform path
-    # (compaction/fetch) or the string-name OSS path (subagents) handles it.
-    # service_tier (priority) is main-only.
-    for role in roles:
-        try:
-            rc = await resolve_model_client(
-                user_id, role.model, is_byok=is_byok, cache_key=thread_id,
-                allow_platform_fallback=False, service_tier=None,
-                _pref_cache=model_pref, _byok_cache=byok_cache,
-            )
-        except Exception:
-            logger.error(
-                "[CHAT] Failed to resolve role %s model %s, skipping",
-                role.key, role.model, exc_info=True,
-            )
-            continue
-        if rc.client is not None:
-            # ``compaction``/``fetch`` are consumed today (agent.py / _common.py);
-            # ``subagent:<name>`` clients are read by the subagent compiler
-            # injection landing later in this refactor (via ``client_for_role``).
-            config.subsidiary_llm_clients[role.key] = rc.client
-        elif rc.model_source is not None and rc.model_source != ModelSource.SYSTEM:
-            logger.warning(
-                "[CHAT] Role '%s' model '%s' is a custom model without a usable "
-                "BYOK key — falling back to default.",
-                role.key, role.model,
-            )
-
-    # BYOK-pure write-time materialization. Gate on the credential SIGNAL, not on
-    # llm_client presence (Codex #2): a non-BYOK reasoning user has
-    # credential_source=PLATFORM with a platform llm_client that must NOT be
-    # copied into roles. Only OAUTH/BYOK users seed keyless roles with a main
-    # copy. PLATFORM/NONE users store nothing → cheap name path stays.
-    has_user_cred = config.credential_source in (
-        CredentialSource.OAUTH, CredentialSource.BYOK,
+    # Subsidiary role clients (compaction / fetch / subagent:*) + BYOK-pure
+    # materialization, then fallback models. Both resolve through the primitive.
+    await _resolve_role_clients(
+        config, user_id, _enabled_subagents, model_pref, byok_cache,
+        is_byok=is_byok, cache_key=thread_id,
     )
-    if has_user_cred and config.llm_client is not None:
-        for role in roles:
-            if role.fallback_to_main and role.key not in config.subsidiary_llm_clients:
-                # ``subagent:<name>`` main-client copies are read by the subagent
-                # compiler injection landing later in this refactor (via
-                # ``client_for_role``); compaction/fetch are read today.
-                config.subsidiary_llm_clients[role.key] = config.llm_client.model_copy()
-                logger.info(
-                    "[CHAT] Role '%s' has no own key; falling back to the user's "
-                    "main client (cost shifts to main-model rate).",
-                    role.key,
-                )
-
-    # Fallback models — route each through the primitive with platform fallback
-    # ON (SYSTEM names without a user key still get a platform client so no model
-    # is silently dropped). Custom/unknown fallbacks without a usable key warn +
-    # skip. Preserve the byok_count debug log.
-    fallback_models = config.llm.fallback or []
-    if fallback_models:
-        merged_fallbacks = []
-        byok_count = 0
-        for model_name in fallback_models:
-            try:
-                fc = await resolve_model_client(
-                    user_id, model_name, is_byok=is_byok, cache_key=thread_id,
-                    allow_platform_fallback=True,
-                    _pref_cache=model_pref, _byok_cache=byok_cache,
-                )
-            except Exception:
-                logger.error(
-                    "[CHAT] Failed to resolve fallback model %s, skipping",
-                    model_name, exc_info=True,
-                )
-                continue
-            if fc.client is not None:
-                merged_fallbacks.append(fc.client)
-                if fc.credential_source in (CredentialSource.OAUTH, CredentialSource.BYOK):
-                    byok_count += 1
-            elif fc.model_source is not None and fc.model_source != ModelSource.SYSTEM:
-                logger.warning(
-                    "[CHAT] Fallback model '%s' is a custom model without a "
-                    "usable BYOK key — skipping. Add a key in Settings to enable.",
-                    model_name,
-                )
-            # else: SYSTEM with no client (shouldn't happen with platform
-            # fallback on) — guard by skipping.
-
-        if merged_fallbacks:
-            config.fallback_llm_clients = merged_fallbacks
-            if byok_count:
-                logger.debug(
-                    f"[CHAT] Resolved {byok_count}/{len(fallback_models)} fallback models via OAuth/BYOK"
-                )
+    await _resolve_fallback_clients(
+        config, user_id, model_pref, byok_cache,
+        is_byok=is_byok, cache_key=thread_id,
+    )
 
     return config

--- a/src/server/handlers/chat/llm_config.py
+++ b/src/server/handlers/chat/llm_config.py
@@ -109,6 +109,29 @@ async def _walk_byok_candidates(
     return None, None
 
 
+def _inherit_custom_provider_sdk(custom_config, parent_provider, provider_def, mc):
+    """Make a custom provider inherit its manifest parent's SDK/headers (#221).
+
+    A user-defined custom provider slug isn't in the manifest, so
+    ``from_custom_config`` derives ``sdk`` from an empty ``provider_info`` and
+    defaults to ``"openai"`` — which 404s an Anthropic-shaped endpoint
+    (``/chat/completions`` vs ``/v1/messages``). Rewriting ``provider`` to the
+    manifest parent fixes the SDK and ``default_headers``.
+
+    Skip the rewrite for openai parents: the default already yields
+    ``sdk="openai"``, and inheriting the manifest openai entry would force
+    ``use_response_api`` / ``prompt_cache_key`` onto OpenAI-compatible gateways
+    (vLLM/LiteLLM/OpenRouter) that only speak ``/chat/completions``. The custom
+    provider's own ``use_response_api`` opt-in is honoured either way.
+    """
+    updates: dict = {}
+    if mc.get_provider_info(parent_provider).get("sdk") not in (None, "openai"):
+        updates["provider"] = parent_provider
+    if provider_def.get("use_response_api"):
+        updates["_use_response_api"] = True
+    return {**custom_config, **updates} if updates else custom_config
+
+
 async def _resolve_custom_model_byok(
     user_id: str,
     model_name: str,
@@ -139,9 +162,9 @@ async def _resolve_custom_model_byok(
     if cp_by_name:
         byok_config = await get_byok_config_for_provider(user_id, model_name)
         if byok_config:
-            base_url = byok_config.get("base_url") or mc.get_provider_info(cp_by_name["parent_provider"]).get("base_url")
-            if cp_by_name.get("use_response_api"):
-                custom_config = {**custom_config, "_use_response_api": True}
+            parent = cp_by_name["parent_provider"]
+            base_url = byok_config.get("base_url") or mc.get_provider_info(parent).get("base_url")
+            custom_config = _inherit_custom_provider_sdk(custom_config, parent, cp_by_name, mc)
             return byok_config, base_url, custom_config
 
     # 2. Provider field is a custom sub-provider
@@ -149,9 +172,9 @@ async def _resolve_custom_model_byok(
     if cp_by_provider:
         byok_config = await get_byok_config_for_provider(user_id, provider)
         if byok_config:
-            base_url = byok_config.get("base_url") or mc.get_provider_info(cp_by_provider["parent_provider"]).get("base_url")
-            if cp_by_provider.get("use_response_api"):
-                custom_config = {**custom_config, "_use_response_api": True}
+            parent = cp_by_provider["parent_provider"]
+            base_url = byok_config.get("base_url") or mc.get_provider_info(parent).get("base_url")
+            custom_config = _inherit_custom_provider_sdk(custom_config, parent, cp_by_provider, mc)
             return byok_config, base_url, custom_config
 
     # 3. System provider — walk [provider → parent → sibling variants] for a

--- a/src/server/handlers/chat/llm_config.py
+++ b/src/server/handlers/chat/llm_config.py
@@ -7,8 +7,11 @@ lookups.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from enum import StrEnum
-from typing import NoReturn
+from typing import Any, NoReturn
+
+from ptc_agent.config.agent import CredentialSource
 
 from ._common import logger
 
@@ -22,9 +25,72 @@ _MODE_MODEL_MAP = {
 }
 
 
+@dataclass(frozen=True)
+class ResolvedClient:
+    """A resolved LLM client plus its model and credential provenance.
+
+    ``model_source`` (a ``ModelSource``) and ``credential_source`` are
+    orthogonal — a BYOK user on a system-catalog model yields SYSTEM + BYOK.
+    """
+
+    client: Any | None
+    model_source: Any | None  # ModelSource
+    credential_source: CredentialSource
+
+
 # ---------------------------------------------------------------------------
 # Private helpers
 # ---------------------------------------------------------------------------
+
+
+async def _walk_byok_candidates(
+    user_id,
+    provider,
+    mc,
+    *,
+    _byok_cache=None,
+):
+    """Walk [provider → parent → sibling variants] for a stored BYOK key.
+
+    Returns ``(byok_config, holding_slug)`` — the first candidate (in priority
+    order) that has a key, or ``(None, None)``. Honors a request-scoped
+    ``_byok_cache`` (``dict[str, dict | None] | None``): a slug mapping to a
+    dict is a confirmed key, a slug mapping to ``None`` is confirmed-absent, and
+    a slug absent from the cache is NOT prefetched — it MUST fall back to a
+    direct ``get_byok_configs_for_providers`` lookup so a cache miss is never a
+    silent false "no key". Direct-fetch results are written back into the cache.
+    """
+    from src.server.database.api_keys import get_byok_configs_for_providers
+
+    parent = mc.get_parent_provider(provider)
+    candidates: list[str] = [provider]
+    if parent and parent != provider:
+        candidates.append(parent)
+    root = parent if parent else provider
+    for sibling in mc.get_child_variants(root):
+        if sibling not in candidates:
+            candidates.append(sibling)
+
+    if _byok_cache is None:
+        # Back-compat path: no request-scoped cache, batch-fetch all candidates.
+        configs = await get_byok_configs_for_providers(user_id, candidates)
+    else:
+        # Tri-state cache: a slug absent from the cache was never prefetched, so
+        # it must be fetched directly — only a recorded ``None`` counts as a
+        # confirmed absence.
+        missing = [c for c in candidates if c not in _byok_cache]
+        if missing:
+            fetched = await get_byok_configs_for_providers(user_id, missing)
+            for slug in missing:
+                _byok_cache[slug] = fetched.get(slug)
+        configs = {c: _byok_cache.get(c) for c in candidates}
+
+    for candidate in candidates:  # keep the provider → parent → sibling priority
+        byok_config = configs.get(candidate)
+        if byok_config:
+            return byok_config, candidate
+
+    return None, None
 
 
 async def _resolve_custom_model_byok(
@@ -33,6 +99,7 @@ async def _resolve_custom_model_byok(
     custom_config: dict,
     mc,
     _pref_cache: dict | None = None,
+    _byok_cache: dict | None = None,
 ):
     """
     Resolve BYOK key + base_url for a user-defined custom model.
@@ -71,42 +138,25 @@ async def _resolve_custom_model_byok(
                 custom_config = {**custom_config, "_use_response_api": True}
             return byok_config, base_url, custom_config
 
-    # 3. System provider — try the provider's own slug first (variants like
-    #    ``moonshot-coding`` store their key under their own slug), then the
-    #    parent, then any sibling variants of the parent. The last step covers
-    #    the mirror case where a custom model is tagged with the parent slug
-    #    but the user only configured a variant (e.g. coding-plan) so the key
-    #    lives under the variant.
-    #
-    #    Single batch query instead of a per-candidate round-trip: typical
-    #    candidate list is 2-4 entries, and the chat hot path can't afford
-    #    N round-trips per request.
-    from src.server.database.api_keys import get_byok_configs_for_providers
-
-    parent = mc.get_parent_provider(provider)
-    candidates: list[str] = [provider]
-    if parent and parent != provider:
-        candidates.append(parent)
-    root = parent if parent else provider
-    for sibling in mc.get_child_variants(root):
-        if sibling not in candidates:
-            candidates.append(sibling)
-
-    configs = await get_byok_configs_for_providers(user_id, candidates)
-    for candidate in candidates:  # keep the provider → parent → sibling priority
-        byok_config = configs.get(candidate)
-        if byok_config:
-            base_url = byok_config.get("base_url") or mc.get_provider_info(candidate).get("base_url")
-            # Rewrite ``provider`` to the candidate that actually held the key.
-            # ``create_llm_from_custom`` reads SDK / default_headers /
-            # use_response_api from the provider field, so if a custom model
-            # tagged ``dashscope`` resolves via its ``dashscope-coding``
-            # sibling, we need the SDK to match the coding-plan endpoint —
-            # otherwise we'd build a Qwen client pointed at an
-            # Anthropic-shaped URL and fail every request.
-            if candidate != provider:
-                custom_config = {**custom_config, "provider": candidate}
-            return byok_config, base_url, custom_config
+    # 3. System provider — walk [provider → parent → sibling variants] for a
+    #    stored key. The sibling step covers the mirror case where a custom
+    #    model is tagged with the parent slug but the user only configured a
+    #    variant (e.g. coding-plan) so the key lives under the variant.
+    byok_config, holding = await _walk_byok_candidates(
+        user_id, provider, mc, _byok_cache=_byok_cache,
+    )
+    if byok_config:
+        base_url = byok_config.get("base_url") or mc.get_provider_info(holding).get("base_url")
+        # Rewrite ``provider`` to the candidate that actually held the key.
+        # ``create_llm_from_custom`` reads SDK / default_headers /
+        # use_response_api from the provider field, so if a custom model
+        # tagged ``dashscope`` resolves via its ``dashscope-coding``
+        # sibling, we need the SDK to match the coding-plan endpoint —
+        # otherwise we'd build a Qwen client pointed at an
+        # Anthropic-shaped URL and fail every request.
+        if holding != provider:
+            custom_config = {**custom_config, "provider": holding}
+        return byok_config, base_url, custom_config
 
     return None, None, custom_config
 
@@ -243,6 +293,7 @@ async def resolve_byok_llm_client(
     reasoning_effort: str | None = None,
     _pref_cache: dict | None = None,
     cache_key: str | None = None,
+    _byok_cache: dict | None = None,
 ):
     """
     If BYOK is active, build an LLM client for ``model_name``. Returns None
@@ -251,8 +302,10 @@ async def resolve_byok_llm_client(
     HTTPException for custom models on the main-model path — this function
     stays at debug log level so the user sees one error, not two.
 
-    - System model: look up BYOK key under the model's parent provider,
-      resolving variants to the parent's endpoint.
+    - System model: walk [provider → parent → sibling variants] for the BYOK
+      key (coding-plan variants store it under their own slug), but build
+      against the MODEL'S OWN provider endpoint, never the candidate that
+      merely held the key.
     - Custom model (custom shadows built-in when names collide): walk the
       custom/provider/variant key chain via ``_resolve_custom_model_byok``.
     - Unknown name but matches a user's ``custom_providers`` slug:
@@ -260,12 +313,12 @@ async def resolve_byok_llm_client(
 
     ``classify_model`` is O(1) with ``_pref_cache`` populated, so callers
     don't need to pre-classify — pass the cache and this function does its
-    own lookup.
+    own lookup. ``_byok_cache`` is a request-scoped tri-state cache threaded
+    into ``_walk_byok_candidates`` (see its contract).
     """
     if not is_byok:
         return None
 
-    from src.server.database.api_keys import get_byok_config_for_provider
     from src.llms.llm import LLM as LLMFactory, create_llm, create_llm_from_custom
 
     mc = LLMFactory.get_model_config()
@@ -278,7 +331,8 @@ async def resolve_byok_llm_client(
     # variant's key to handle this name.
     if source == ModelSource.CUSTOM:
         byok_config, base_url, custom_config = await _resolve_custom_model_byok(
-            user_id, model_name, config_entry, mc, _pref_cache=_pref_cache,
+            user_id, model_name, config_entry, mc,
+            _pref_cache=_pref_cache, _byok_cache=_byok_cache,
         )
         if not byok_config:
             # ``resolve_llm_config`` converts this None into an HTTPException
@@ -315,7 +369,8 @@ async def resolve_byok_llm_client(
             "provider": cp_config["parent_provider"],
         }
         byok_config, base_url, custom_config = await _resolve_custom_model_byok(
-            user_id, model_name, synthetic_cm, mc, _pref_cache=_pref_cache,
+            user_id, model_name, synthetic_cm, mc,
+            _pref_cache=_pref_cache, _byok_cache=_byok_cache,
         )
         if not byok_config:
             return None
@@ -326,19 +381,25 @@ async def resolve_byok_llm_client(
             cache_key=cache_key,
         )
 
-    # System model — BYOK key lives under the parent provider.
+    # System model — the BYOK key may live under the model's own provider
+    # slug (coding-plan variants store it there), its parent, or a sibling
+    # variant. Walk all three; but pin SDK + base_url to the MODEL'S OWN
+    # provider, never the candidate that merely held the key.
     provider = config_entry["provider"]
-    parent = mc.get_parent_provider(provider)
-    byok_config = await get_byok_config_for_provider(user_id, parent)
+    byok_config, holding = await _walk_byok_candidates(
+        user_id, provider, mc, _byok_cache=_byok_cache,
+    )
     if not byok_config:
         return None
-
-    base_url = byok_config.get("base_url")
-    if not base_url:
-        base_url = mc.get_provider_info(parent).get("base_url")
-
+    # base_url precedence: a user custom base_url on the holding slug wins;
+    # otherwise the MODEL'S OWN provider endpoint (NOT the parent's, NOT the
+    # candidate's). This is the coding-variant fix: a dashscope-coding model
+    # (anthropic SDK) whose key lives under parent `dashscope` (openai SDK)
+    # must still build against the anthropic coding endpoint.
+    base_url = byok_config.get("base_url") or mc.get_provider_info(provider).get("base_url")
     logger.debug(
-        f"[CHAT] Resolved BYOK client for model={model_name} parent={parent} base_url={base_url or 'SDK default'}"
+        f"[CHAT] Resolved BYOK client for system model={model_name} "
+        f"provider={provider} key_held_by={holding} base_url={base_url or 'SDK default'}"
     )
     return create_llm(
         model_name,
@@ -414,6 +475,57 @@ async def resolve_oauth_llm_client(
         cache_key=cache_key,
         **({"service_tier": service_tier} if service_tier and provider != "claude-oauth" else {}),
     )
+
+
+async def resolve_model_client(
+    user_id,
+    model_name,
+    *,
+    is_byok,
+    cache_key=None,
+    reasoning_effort=None,
+    service_tier=None,
+    allow_platform_fallback=False,
+    _pref_cache=None,
+    _byok_cache=None,
+) -> ResolvedClient:
+    """Resolve a client for ``model_name`` and report which credential built it.
+
+    Tries OAuth first (always, independent of ``is_byok``), then BYOK (if
+    enabled), then a platform-keyed client (only for SYSTEM models when
+    ``allow_platform_fallback`` is set). ``model_source`` classifies the model;
+    ``credential_source`` records which credential produced the client — the two
+    are orthogonal. An OAuth-required HTTPException is allowed to propagate.
+    """
+    source, _ = await classify_model(user_id, model_name, _pref_cache=_pref_cache)
+
+    client = await resolve_oauth_llm_client(
+        user_id, model_name, reasoning_effort,
+        service_tier=service_tier, cache_key=cache_key,
+    )
+    if client:
+        return ResolvedClient(client, source, CredentialSource.OAUTH)
+
+    if is_byok:
+        client = await resolve_byok_llm_client(
+            user_id, model_name, is_byok, reasoning_effort,
+            _pref_cache=_pref_cache, cache_key=cache_key, _byok_cache=_byok_cache,
+        )
+        if client:
+            return ResolvedClient(client, source, CredentialSource.BYOK)
+
+    # Platform fallback — only for SYSTEM-catalog models. Reached when OAuth and
+    # BYOK both miss. service_tier is OAuth-only (matches the main-branch
+    # reasoning path), so it is intentionally NOT passed here.
+    if allow_platform_fallback and source == ModelSource.SYSTEM:
+        from src.llms.llm import create_llm
+
+        client = create_llm(
+            model_name, reasoning_effort=reasoning_effort, cache_key=cache_key,
+        )
+        return ResolvedClient(client, source, CredentialSource.PLATFORM)
+
+    return ResolvedClient(None, source, CredentialSource.NONE)
 
 
 async def get_model_preference(user_id: str) -> dict:

--- a/src/server/handlers/chat/llm_config.py
+++ b/src/server/handlers/chat/llm_config.py
@@ -9,11 +9,17 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any, NoReturn
+from typing import Any
 
 from ptc_agent.config.agent import CredentialSource
 
 from ._common import logger
+from .model_availability import (
+    _MODEL_PREF_KEYS,
+    _cleanup_stale_model_preferences,
+    _raise_byok_key_required,
+    _raise_model_removed,
+)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -169,131 +175,6 @@ async def _resolve_custom_model_byok(
         return byok_config, base_url, custom_config
 
     return None, None, custom_config
-
-
-# ---------------------------------------------------------------------------
-# Public API
-# ---------------------------------------------------------------------------
-
-
-def _raise_byok_key_required(model_name: str) -> None:
-    """Raise a user-facing HTTPException pointing the user to Settings.
-
-    Used when a custom model is selected but no usable API key can be found
-    (BYOK disabled, or BYOK enabled but no key stored). Mirrors the
-    ``oauth_required`` error shape so the chat UI renders a single banner with
-    a clickable CTA.
-    """
-    from fastapi import HTTPException
-
-    raise HTTPException(
-        status_code=400,
-        detail={
-            "message": (
-                f"API key required for custom model '{model_name}'. "
-                "Enable BYOK and add the key in Settings."
-            ),
-            "type": "byok_key_required",
-            "link": {"url": "/settings?tab=model", "label": "Open Settings"},
-        },
-    )
-
-
-# Preference keys that hold a single model name. Used by the stale-pref
-# scrubber when a saved model vanishes from the manifest.
-_MODEL_PREF_KEYS = (
-    "preferred_model",
-    "preferred_flash_model",
-    "fetch_model",
-    "compaction_model",
-    "summarization_model",
-)
-
-
-async def _cleanup_stale_model_preferences(user_id: str) -> list[tuple[str, str]]:
-    """Drop stale model names from the user's prefs. Returns ``[(key, name), ...]``."""
-    from src.llms.llm import LLM as LLMFactory
-    from src.server.database.user import (
-        invalidate_user_prefs_cache,
-        upsert_user_preferences,
-    )
-
-    # Bust cache + re-read so a concurrent Settings save isn't clobbered.
-    await invalidate_user_prefs_cache(user_id)
-    pref = await get_model_preference(user_id)
-
-    mc = LLMFactory.get_model_config()
-    custom_models = {cm.get("name") for cm in (pref.get("custom_models") or [])}
-    custom_providers = {cp.get("name") for cp in (pref.get("custom_providers") or [])}
-
-    def resolvable(name: str | None) -> bool:
-        if not name:
-            return True  # empty = not set; nothing to scrub
-        return (
-            name in custom_models
-            or name in custom_providers
-            or mc.get_model_config(name) is not None
-        )
-
-    # Values: ``None`` for scalar deletes, ``list[str]`` (or ``None``) for
-    # fallback_models. Merge-upsert interprets ``None`` as key deletion.
-    updates: dict[str, list[str] | None] = {}
-    removed: list[tuple[str, str]] = []
-
-    for key in _MODEL_PREF_KEYS:
-        val = pref.get(key)
-        if val and not resolvable(val):
-            updates[key] = None
-            removed.append((key, val))
-
-    fallback = pref.get("fallback_models")
-    if isinstance(fallback, list):
-        kept: list[str] = []
-        for m in fallback:
-            if resolvable(m):
-                kept.append(m)
-            else:
-                removed.append(("fallback_models", m))
-        if len(kept) != len(fallback):
-            # Empty list → delete the key entirely so it doesn't linger as ``[]``
-            updates["fallback_models"] = kept or None
-
-    if updates:
-        # Residual race window: between the re-read above and this upsert, a
-        # Settings save could still land and get overwritten by our ``None``
-        # delete. Narrow (single DB read → single DB write) and self-healing
-        # (the user saves again and it sticks). Not worth a CTE or advisory
-        # lock for the size of the hole.
-        await upsert_user_preferences(user_id=user_id, other_preference=updates)
-        await invalidate_user_prefs_cache(user_id)
-        logger.info(
-            f"[CHAT] Scrubbed stale model prefs for user={user_id}: {removed}"
-        )
-
-    return removed
-
-
-def _raise_model_removed(
-    model_name: str, removed: list[tuple[str, str]]
-) -> NoReturn:
-    """Raise a 400 with a CTA banner payload when a saved model no longer resolves."""
-    from fastapi import HTTPException
-
-    other = sorted({name for _, name in removed if name != model_name})
-    extra = f" Also cleared: {', '.join(other)}." if other else ""
-
-    raise HTTPException(
-        status_code=400,
-        detail={
-            "message": (
-                f"Model '{model_name}' is no longer available. "
-                "Your saved preference has been cleared — open Settings to pick a current model."
-                + extra
-            ),
-            "type": "model_removed",
-            "link": {"url": "/settings?tab=model", "label": "Open Settings"},
-        },
-    )
 
 
 async def resolve_byok_llm_client(

--- a/src/server/handlers/chat/model_availability.py
+++ b/src/server/handlers/chat/model_availability.py
@@ -1,0 +1,137 @@
+"""Model-availability error responses + stale-preference scrubbing.
+
+When a selected model can't be served — a custom model with no usable key, or a
+saved preference whose model has vanished from the manifest — the chat handler
+needs to fail loudly with a CTA banner rather than silently downgrade. This
+module owns those user-facing 400s and the pref-scrub that backs the
+``model_removed`` case. ``resolve_llm_config`` invokes them; they are not part
+of the resolution engine itself.
+"""
+
+from __future__ import annotations
+
+from typing import NoReturn
+
+from ._common import logger
+
+
+def _raise_byok_key_required(model_name: str) -> None:
+    """Raise a user-facing HTTPException pointing the user to Settings.
+
+    Used when a custom model is selected but no usable API key can be found
+    (BYOK disabled, or BYOK enabled but no key stored). Mirrors the
+    ``oauth_required`` error shape so the chat UI renders a single banner with
+    a clickable CTA.
+    """
+    from fastapi import HTTPException
+
+    raise HTTPException(
+        status_code=400,
+        detail={
+            "message": (
+                f"API key required for custom model '{model_name}'. "
+                "Enable BYOK and add the key in Settings."
+            ),
+            "type": "byok_key_required",
+            "link": {"url": "/settings?tab=model", "label": "Open Settings"},
+        },
+    )
+
+
+# Preference keys that hold a single model name. Used by the stale-pref
+# scrubber when a saved model vanishes from the manifest.
+_MODEL_PREF_KEYS = (
+    "preferred_model",
+    "preferred_flash_model",
+    "fetch_model",
+    "compaction_model",
+    "summarization_model",
+)
+
+
+async def _cleanup_stale_model_preferences(user_id: str) -> list[tuple[str, str]]:
+    """Drop stale model names from the user's prefs. Returns ``[(key, name), ...]``."""
+    from src.llms.llm import LLM as LLMFactory
+    from src.server.database.user import (
+        invalidate_user_prefs_cache,
+        upsert_user_preferences,
+    )
+
+    from .llm_config import get_model_preference
+
+    # Bust cache + re-read so a concurrent Settings save isn't clobbered.
+    await invalidate_user_prefs_cache(user_id)
+    pref = await get_model_preference(user_id)
+
+    mc = LLMFactory.get_model_config()
+    custom_models = {cm.get("name") for cm in (pref.get("custom_models") or [])}
+    custom_providers = {cp.get("name") for cp in (pref.get("custom_providers") or [])}
+
+    def resolvable(name: str | None) -> bool:
+        if not name:
+            return True  # empty = not set; nothing to scrub
+        return (
+            name in custom_models
+            or name in custom_providers
+            or mc.get_model_config(name) is not None
+        )
+
+    # Values: ``None`` for scalar deletes, ``list[str]`` (or ``None``) for
+    # fallback_models. Merge-upsert interprets ``None`` as key deletion.
+    updates: dict[str, list[str] | None] = {}
+    removed: list[tuple[str, str]] = []
+
+    for key in _MODEL_PREF_KEYS:
+        val = pref.get(key)
+        if val and not resolvable(val):
+            updates[key] = None
+            removed.append((key, val))
+
+    fallback = pref.get("fallback_models")
+    if isinstance(fallback, list):
+        kept: list[str] = []
+        for m in fallback:
+            if resolvable(m):
+                kept.append(m)
+            else:
+                removed.append(("fallback_models", m))
+        if len(kept) != len(fallback):
+            # Empty list → delete the key entirely so it doesn't linger as ``[]``
+            updates["fallback_models"] = kept or None
+
+    if updates:
+        # Residual race window: between the re-read above and this upsert, a
+        # Settings save could still land and get overwritten by our ``None``
+        # delete. Narrow (single DB read → single DB write) and self-healing
+        # (the user saves again and it sticks). Not worth a CTE or advisory
+        # lock for the size of the hole.
+        await upsert_user_preferences(user_id=user_id, other_preference=updates)
+        await invalidate_user_prefs_cache(user_id)
+        logger.info(
+            f"[CHAT] Scrubbed stale model prefs for user={user_id}: {removed}"
+        )
+
+    return removed
+
+
+def _raise_model_removed(
+    model_name: str, removed: list[tuple[str, str]]
+) -> NoReturn:
+    """Raise a 400 with a CTA banner payload when a saved model no longer resolves."""
+    from fastapi import HTTPException
+
+    other = sorted({name for _, name in removed if name != model_name})
+    extra = f" Also cleared: {', '.join(other)}." if other else ""
+
+    raise HTTPException(
+        status_code=400,
+        detail={
+            "message": (
+                f"Model '{model_name}' is no longer available. "
+                "Your saved preference has been cleared — open Settings to pick a current model."
+                + extra
+            ),
+            "type": "model_removed",
+            "link": {"url": "/settings?tab=model", "label": "Open Settings"},
+        },
+    )

--- a/src/server/handlers/chat/ptc_workflow.py
+++ b/src/server/handlers/chat/ptc_workflow.py
@@ -418,6 +418,7 @@ async def astream_ptc_workflow(
                 reasoning_effort=getattr(request, "reasoning_effort", None),
                 fast_mode=getattr(request, "fast_mode", None),
                 thread_id=thread_id,
+                enabled_subagents=request.subagents_enabled,
             )
 
         # Propagate fetch model override to tool context

--- a/src/server/services/automation_executor.py
+++ b/src/server/services/automation_executor.py
@@ -111,6 +111,10 @@ class AutomationExecutor:
             has_byok, has_oauth = await asyncio.gather(
                 is_byok_active(user_id), has_any_oauth_token(user_id)
             )
+            # has_cred drives the credit gate (BYOK negative-balance vs platform
+            # daily-credit). The workflow's is_byok only controls whether the
+            # BYOK ladder is attempted, so it keys off has_byok alone — passing
+            # has_cred would fire a futile BYOK prefetch for OAuth-only users.
             has_cred = has_byok or has_oauth
             await enforce_credit_limit(user_id, byok=has_cred)
 
@@ -172,7 +176,7 @@ class AutomationExecutor:
                     run_id=run_id,
                     user_input=instruction,
                     user_id=user_id,
-                    is_byok=has_cred,
+                    is_byok=has_byok,
                 )
             else:
                 generator = astream_ptc_workflow(
@@ -182,7 +186,7 @@ class AutomationExecutor:
                     user_input=instruction,
                     user_id=user_id,
                     workspace_id=workspace_id,
-                    is_byok=has_cred,
+                    is_byok=has_byok,
                 )
 
             # Notify webhooks: started

--- a/src/server/services/automation_executor.py
+++ b/src/server/services/automation_executor.py
@@ -13,7 +13,10 @@ from uuid import uuid4
 
 from src.server.database import automation as auto_db
 from src.server.models.automation import PriceTriggerConfig, RetriggerMode
+from src.server.database.api_keys import is_byok_active
+from src.server.database.oauth_tokens import has_any_oauth_token
 from src.server.database.workspace import get_or_create_flash_workspace
+from src.server.dependencies.usage_limits import enforce_credit_limit
 from src.server.models.chat import ChatMessage, ChatRequest
 from src.server.services.webhook_client import WebhookClient
 from src.observability import automation_executions, safe_add
@@ -100,9 +103,13 @@ class AutomationExecutor:
         )
 
         thread_id = None
+        workspace_id = None
         try:
+            # ─── Credential check + credit gate ───────────────────
+            has_cred = await is_byok_active(user_id) or await has_any_oauth_token(user_id)
+            await enforce_credit_limit(user_id, byok=has_cred)
+
             # ─── Resolve workspace ─────────────────────────────────
-            workspace_id = None
             if agent_mode == "flash":
                 flash_ws = await get_or_create_flash_workspace(user_id)
                 workspace_id = str(flash_ws["workspace_id"])
@@ -160,6 +167,7 @@ class AutomationExecutor:
                     run_id=run_id,
                     user_input=instruction,
                     user_id=user_id,
+                    is_byok=has_cred,
                 )
             else:
                 generator = astream_ptc_workflow(
@@ -169,6 +177,7 @@ class AutomationExecutor:
                     user_input=instruction,
                     user_id=user_id,
                     workspace_id=workspace_id,
+                    is_byok=has_cred,
                 )
 
             # Notify webhooks: started
@@ -245,7 +254,9 @@ class AutomationExecutor:
                 completed_at=datetime.now(timezone.utc),
             )
 
-            # Increment failure count (may auto-disable)
+            # Increment failure count (may auto-disable). A credit-gate 429 from
+            # enforce_credit_limit lands here too — intentionally counted as a
+            # failure so a persistently zero-credit automation auto-disables.
             await auto_db.increment_failure_count(automation_id)
 
             # Restore price automations from 'executing' to 'active' on failure

--- a/src/server/services/automation_executor.py
+++ b/src/server/services/automation_executor.py
@@ -6,6 +6,7 @@ Builds a ChatRequest, invokes the appropriate agent workflow,
 and drains the async generator (no HTTP client to consume SSE).
 """
 
+import asyncio
 import logging
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
@@ -106,7 +107,11 @@ class AutomationExecutor:
         workspace_id = None
         try:
             # ─── Credential check + credit gate ───────────────────
-            has_cred = await is_byok_active(user_id) or await has_any_oauth_token(user_id)
+            # BYOK and OAuth checks are independent — run concurrently.
+            has_byok, has_oauth = await asyncio.gather(
+                is_byok_active(user_id), has_any_oauth_token(user_id)
+            )
+            has_cred = has_byok or has_oauth
             await enforce_credit_limit(user_id, byok=has_cred)
 
             # ─── Resolve workspace ─────────────────────────────────

--- a/src/server/services/insight_service.py
+++ b/src/server/services/insight_service.py
@@ -173,24 +173,20 @@ def _extract_structured_output(raw_text: str) -> dict:
     )
 
 
-async def _llm_extract_fallback(raw_text: str) -> dict:
-    """Extract structured insight data via a separate LLM call with response_schema.
+async def _llm_extract_fallback(raw_text: str, user_id: str | None) -> dict:
+    """Extract structured insight data via the canonical one-shot LLM wrapper.
 
-    Uses make_api_call with response_schema for native structured output,
-    which includes its own retry + manual JSON parse fallback chain.
+    Routes through ``LLMService.complete`` so BYOK / OAuth credentials are
+    respected (or the platform default is used when ``user_id`` is None).
+    ``user_id`` is required so callers must be explicit about the platform path.
     """
-    from src.llms import create_llm
-    from src.llms.api_call import make_api_call
     from src.server.models.market_insight import InsightOutputSchema
-
+    from src.server.services.llm_service import LLMService
     from src.server.app import setup
 
-    config = setup.agent_config
-    flash_model_name = config.llm.flash if config and config.llm else "claude-haiku-4-5-20251001"
-
-    llm = create_llm(flash_model_name)
-    result = await make_api_call(
-        llm,
+    svc = LLMService(agent_config=setup.agent_config, logger=logger)
+    result = await svc.complete(
+        user_id=user_id,
         system_prompt=(
             "You are a structured data extractor. Extract the market insight data "
             "from the provided text into the required JSON schema. "
@@ -198,6 +194,7 @@ async def _llm_extract_fallback(raw_text: str) -> dict:
         ),
         user_prompt=raw_text,
         response_schema=InsightOutputSchema,
+        mode="flash",
     )
     return result.model_dump() if hasattr(result, "model_dump") else dict(result)
 
@@ -437,7 +434,7 @@ class InsightService:
                 _run_flash_agent(prompt + "\n\n" + _JSON_GUIDELINES, user_id=user_id),
                 timeout=self._generation_timeout,
             )
-            parsed = await self._extract_with_fallback(raw_text)
+            parsed = await self._extract_with_fallback(raw_text, user_id=user_id)
             elapsed_ms = int((time.monotonic() - start_time) * 1000)
 
             await insight_db.complete_market_insight(
@@ -729,7 +726,7 @@ class InsightService:
                 _run_flash_agent(instruction + "\n\n" + _JSON_GUIDELINES, user_id=system_user_id),
                 timeout=self._generation_timeout,
             )
-            parsed = await self._extract_with_fallback(raw_text)
+            parsed = await self._extract_with_fallback(raw_text, user_id=system_user_id)
             elapsed_ms = int((time.monotonic() - start_time) * 1000)
 
             await insight_db.complete_market_insight(
@@ -774,13 +771,13 @@ class InsightService:
             except Exception:
                 logger.warning(f"[MARKET_INSIGHT] Failed to mark {insight_id} as failed")
 
-    async def _extract_with_fallback(self, raw_text: str) -> dict:
+    async def _extract_with_fallback(self, raw_text: str, user_id: str | None) -> dict:
         """Extract structured output from raw text, falling back to LLM if direct parse fails."""
         try:
             return _extract_structured_output(raw_text)
         except ValueError:
             logger.info("[MARKET_INSIGHT] Direct JSON parse failed, trying LLM fallback")
-            return await _llm_extract_fallback(raw_text)
+            return await _llm_extract_fallback(raw_text, user_id=user_id)
 
 
 class InsightAlreadyGeneratingError(Exception):

--- a/src/server/services/llm_service.py
+++ b/src/server/services/llm_service.py
@@ -15,10 +15,12 @@ Two code paths:
   ``agent_config.llm.flash`` (or ``request_model``) with platform
   credentials. No DB hit.
 - ``user_id="..."`` — full user-aware resolution through
-  ``resolve_llm_config``. If that function returns a config whose
-  ``llm_client`` is ``None`` (no BYOK / OAuth configured), we fall back to
-  ``create_llm(effective_model)`` on the resolved model name so the call
-  still goes through.
+  ``resolve_llm_config``. A ``platform_key_fallback`` log is emitted
+  whenever ``credential_source`` is not OAUTH or BYOK (i.e. the user's own
+  credential did NOT pay for the call). This fires for both the eager-PLATFORM
+  case (``llm_client`` already set by resolver) and the lazy-NONE case
+  (``llm_client`` is None → ``create_llm`` fallback). It is the seam a future
+  deduction hook will read.
 
 Memo metadata generation is the first caller; thread titles, follow-up
 suggestions, hint messages, and the insight-service fallback are the
@@ -35,6 +37,7 @@ from typing import Any, Literal, Type, TypeVar
 
 from pydantic import BaseModel
 
+from ptc_agent.config.agent import CredentialSource
 from src.llms.api_call import make_api_call
 from src.llms.llm import create_llm
 from src.server.handlers.chat.llm_config import _MODE_MODEL_MAP, resolve_llm_config
@@ -88,19 +91,28 @@ class LLMService:
                 fast_mode=None,
             )
             llm = resolved_config.llm_client
+            model_field, _ = _MODE_MODEL_MAP[mode]
+            effective_model = (
+                getattr(resolved_config.llm, model_field, None)
+                or resolved_config.llm.name
+            )
             if llm is None:
                 # No BYOK / OAuth configured and no reasoning override — fall
                 # back to a platform-keyed client on the resolved model name.
-                model_field, _ = _MODE_MODEL_MAP[mode]
-                effective_model = (
-                    getattr(resolved_config.llm, model_field, None)
-                    or resolved_config.llm.name
-                )
+                llm = create_llm(effective_model, reasoning_effort=reasoning_effort)
+            if resolved_config.credential_source not in (
+                CredentialSource.OAUTH,
+                CredentialSource.BYOK,
+            ):
                 self._logger.info(
                     "llm_service.platform_key_fallback",
-                    extra={"user_id": user_id, "model": effective_model, "mode": mode},
+                    extra={
+                        "user_id": user_id,
+                        "model": effective_model,
+                        "mode": mode,
+                        "credential_source": str(resolved_config.credential_source),
+                    },
                 )
-                llm = create_llm(effective_model, reasoning_effort=reasoning_effort)
 
         return await make_api_call(
             llm,

--- a/tests/unit/ptc_agent/agent/middleware/compaction/test_resolve_compaction_client.py
+++ b/tests/unit/ptc_agent/agent/middleware/compaction/test_resolve_compaction_client.py
@@ -1,0 +1,100 @@
+"""Unit tests for ``resolve_compaction_client``.
+
+Covers the four cases documented on the helper:
+1. Compaction model set + role client stored → returns a distinct copy of it.
+2. Compaction model set + no role client → None (platform users keep name-based model).
+3. No compaction model + main llm_client set → copy of main client.
+4. No compaction model + llm_client None → None.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+
+from ptc_agent.config import AgentConfig, LLMConfig
+from ptc_agent.config.core import (
+    DaytonaConfig,
+    FilesystemConfig,
+    LoggingConfig,
+    MCPConfig,
+    SandboxConfig,
+    SecurityConfig,
+)
+from ptc_agent.agent.middleware.compaction.utils import resolve_compaction_client
+
+
+@dataclass
+class _FakeClient:
+    """Minimal stand-in for a BaseChatModel with ``.model_copy()``."""
+
+    name: str
+    _tag: object = field(default_factory=object)
+
+    def model_copy(self) -> "_FakeClient":
+        return replace(self, _tag=object())
+
+
+def _config(**overrides) -> AgentConfig:
+    base = dict(
+        llm=LLMConfig(name="main-model"),
+        security=SecurityConfig(),
+        logging=LoggingConfig(),
+        sandbox=SandboxConfig(daytona=DaytonaConfig(api_key="test-key")),
+        mcp=MCPConfig(),
+        filesystem=FilesystemConfig(),
+    )
+    base.update(overrides)
+    return AgentConfig(**base)
+
+
+class TestResolveCompactionClient:
+    def test_compaction_model_with_role_client_returns_distinct_copy(self):
+        stored = _FakeClient(name="compaction-model")
+        cfg = _config(
+            llm=LLMConfig(name="main-model", compaction="some-compaction-model"),
+            subsidiary_llm_clients={"compaction": stored},
+        )
+
+        result = resolve_compaction_client(cfg)
+
+        assert result is not None
+        assert result is not stored  # model_copy -> distinct identity
+        assert result.name == stored.name
+
+    def test_compaction_model_without_role_client_returns_none(self):
+        # Platform users: compaction model name set but no pre-resolved client;
+        # they should use the name-based path, not the main model.
+        cfg = _config(
+            llm=LLMConfig(name="main-model", compaction="some-compaction-model"),
+            subsidiary_llm_clients={},
+            llm_client=_FakeClient(name="main-client"),
+        )
+
+        result = resolve_compaction_client(cfg)
+
+        assert result is None
+
+    def test_no_compaction_model_with_main_client_returns_copy_of_main(self):
+        main = _FakeClient(name="main-client")
+        cfg = _config(
+            llm=LLMConfig(name="main-model", compaction=None),
+            subsidiary_llm_clients={},
+            llm_client=main,
+        )
+
+        result = resolve_compaction_client(cfg)
+
+        assert result is not None
+        assert result is not main  # model_copy -> distinct identity
+        assert result.name == main.name
+
+    def test_no_compaction_model_no_main_client_returns_none(self):
+        cfg = _config(
+            llm=LLMConfig(name="main-model", compaction=None),
+            subsidiary_llm_clients={},
+            llm_client=None,
+        )
+
+        result = resolve_compaction_client(cfg)
+
+        assert result is None

--- a/tests/unit/ptc_agent/agent/test_subagent_compiler.py
+++ b/tests/unit/ptc_agent/agent/test_subagent_compiler.py
@@ -1,0 +1,122 @@
+"""Tests for SubagentCompiler credential injection (Task 7).
+
+Verifies that a resolved BaseChatModel client from AgentConfig.subsidiary_llm_clients
+reaches the compiled SubAgent dict that subagent.py:432 consumes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+
+import pytest
+
+from ptc_agent.agent.subagents.compiler import SubagentCompiler
+from ptc_agent.agent.subagents.definition import SubagentDefinition
+from ptc_agent.config import AgentConfig, LLMConfig
+from ptc_agent.config.core import (
+    DaytonaConfig,
+    FilesystemConfig,
+    LoggingConfig,
+    MCPConfig,
+    SandboxConfig,
+    SecurityConfig,
+)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _FakeClient:
+    """Minimal BaseChatModel stand-in with ``.model_copy()``."""
+
+    name: str
+    _tag: object = field(default_factory=object)
+
+    def model_copy(self) -> "_FakeClient":
+        return replace(self, _tag=object())
+
+
+def _config(**overrides) -> AgentConfig:
+    base = dict(
+        llm=LLMConfig(name="main-placeholder"),
+        security=SecurityConfig(),
+        logging=LoggingConfig(),
+        sandbox=SandboxConfig(daytona=DaytonaConfig(api_key="test-key")),
+        mcp=MCPConfig(),
+        filesystem=FilesystemConfig(),
+    )
+    base.update(overrides)
+    return AgentConfig(**base)
+
+
+def _defn(name: str = "research", model: str | None = "cheap-placeholder") -> SubagentDefinition:
+    return SubagentDefinition(
+        name=name,
+        description="test subagent",
+        custom_prompt="stub prompt",
+        model=model,
+    )
+
+
+def _compiler(**kwargs) -> SubagentCompiler:
+    """Build a compiler with no sandbox/mcp so compile() never touches FS."""
+    return SubagentCompiler(**kwargs)
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+class TestSubagentCompilerClientInjection:
+    def test_instance_injection(self):
+        """Resolved client instance replaces the string model name."""
+        stored = _FakeClient(name="byok-subagent-model")
+        cfg = _config(subsidiary_llm_clients={"subagent:research": stored})
+        compiler = _compiler(config=cfg)
+
+        result = compiler.compile(_defn(name="research", model="cheap-placeholder"))
+
+        # model key must be a client instance, not the string
+        assert isinstance(result["model"], _FakeClient)
+        assert result["model"] is not stored  # model_copy -> distinct object
+        assert result["model"].name == stored.name
+
+    def test_string_fallback_when_no_subagent_client(self):
+        """Falls back to definition.model string when subsidiary_llm_clients has no entry."""
+        cfg = _config(subsidiary_llm_clients={})
+        compiler = _compiler(config=cfg)
+
+        result = compiler.compile(_defn(name="research", model="cheap-placeholder"))
+
+        assert result["model"] == "cheap-placeholder"
+
+    def test_back_compat_no_config(self):
+        """SubagentCompiler(config=None) behaves exactly as before — string passthrough."""
+        compiler = _compiler()  # no config kwarg
+
+        result = compiler.compile(_defn(name="research", model="cheap-placeholder"))
+
+        assert result["model"] == "cheap-placeholder"
+
+    def test_back_compat_no_model_no_config(self):
+        """definition.model=None and no config → no 'model' key."""
+        compiler = _compiler()
+
+        result = compiler.compile(_defn(name="research", model=None))
+
+        assert "model" not in result
+
+    def test_consumption_shape(self):
+        """agent_.get('model', default_model) returns the injected instance (exact consumer expression)."""
+        stored = _FakeClient(name="byok-subagent-model")
+        cfg = _config(subsidiary_llm_clients={"subagent:worker": stored})
+        compiler = _compiler(config=cfg)
+
+        agent_ = compiler.compile(_defn(name="worker", model="cheap-placeholder"))
+        default_model = "default-placeholder"
+
+        # This is the exact expression from subagent.py:432
+        subagent_model = agent_.get("model", default_model)
+
+        assert isinstance(subagent_model, _FakeClient)
+        assert subagent_model.name == stored.name

--- a/tests/unit/ptc_agent/config/test_client_for_role.py
+++ b/tests/unit/ptc_agent/config/test_client_for_role.py
@@ -1,0 +1,85 @@
+"""Unit tests for ``AgentConfig.client_for_role`` and ``CredentialSource``.
+
+``client_for_role`` must return a distinct ``.model_copy()`` so role-local
+mutation never touches the shared main client, honor ``fallback_to_main``,
+and read the raw ``llm_client`` field (not ``get_llm_client()``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+
+from ptc_agent.config import AgentConfig, LLMConfig
+from ptc_agent.config.agent import CredentialSource
+from ptc_agent.config.core import (
+    DaytonaConfig,
+    FilesystemConfig,
+    LoggingConfig,
+    MCPConfig,
+    SandboxConfig,
+    SecurityConfig,
+)
+
+
+@dataclass
+class _FakeClient:
+    """Minimal stand-in for a BaseChatModel with ``.model_copy()``."""
+
+    name: str
+    streaming: bool = True
+    _tag: object = field(default_factory=object)
+
+    def model_copy(self) -> "_FakeClient":
+        # New instance, equal config, fresh identity tag so identity differs.
+        return replace(self, _tag=object())
+
+
+def _config(**overrides) -> AgentConfig:
+    """Minimal AgentConfig matching the construction pattern used elsewhere."""
+    base = dict(
+        llm=LLMConfig(name="main-model"),
+        security=SecurityConfig(),
+        logging=LoggingConfig(),
+        sandbox=SandboxConfig(daytona=DaytonaConfig(api_key="test-key")),
+        mcp=MCPConfig(),
+        filesystem=FilesystemConfig(),
+    )
+    base.update(overrides)
+    return AgentConfig(**base)
+
+
+class TestClientForRole:
+    def test_role_present_returns_distinct_copy_with_equal_config(self):
+        stored = _FakeClient(name="compaction-model")
+        cfg = _config(subsidiary_llm_clients={"compaction": stored})
+
+        result = cfg.client_for_role("compaction")
+
+        assert result is not None
+        assert result is not stored  # model_copy -> distinct object
+        assert result.name == stored.name
+        assert result.streaming == stored.streaming
+
+    def test_role_absent_no_fallback_returns_none(self):
+        cfg = _config(subsidiary_llm_clients={})
+        assert cfg.client_for_role("compaction") is None
+
+    def test_role_absent_fallback_to_main_returns_copy_of_main(self):
+        main = _FakeClient(name="main-client")
+        cfg = _config(subsidiary_llm_clients={}, llm_client=main)
+
+        result = cfg.client_for_role("compaction", fallback_to_main=True)
+
+        assert result is not None
+        assert result is not main
+        assert result.name == main.name
+
+    def test_role_absent_fallback_to_main_but_no_main_returns_none(self):
+        cfg = _config(subsidiary_llm_clients={}, llm_client=None)
+        assert cfg.client_for_role("compaction", fallback_to_main=True) is None
+
+
+class TestCredentialSource:
+    def test_default_on_fresh_config_is_none(self):
+        cfg = _config()
+        assert cfg.credential_source is CredentialSource.NONE

--- a/tests/unit/server/app/test_threads_credit_gate.py
+++ b/tests/unit/server/app/test_threads_credit_gate.py
@@ -1,0 +1,160 @@
+"""Tests for the credit-gate ``is_byok`` logic in ``_handle_send_message``.
+
+The gate reads ``config.credential_source`` (set by ``resolve_llm_config``) to
+decide which enforcement path to take:
+  - OAUTH or BYOK  → ``enforce_credit_limit(byok=True)``  (negative-balance only)
+  - PLATFORM or NONE → ``enforce_credit_limit(byok=False)`` (daily quota check)
+
+The regression guard: even when ``config.llm_client`` is set (non-None), a
+PLATFORM credential_source must still produce ``byok=False``.  The old check
+``is_byok = config.llm_client is not None`` would have produced ``byok=True``
+for a platform-reasoning user whose eager client build set ``llm_client``.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from ptc_agent.config.agent import CredentialSource
+from tests.conftest import create_test_app
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(credential_source: CredentialSource, *, llm_client_set: bool = False):
+    """Stub ``AgentConfig``-like object returned by ``resolve_llm_config``."""
+    cfg = MagicMock()
+    cfg.credential_source = credential_source
+    # Set llm_client to a non-None object to exercise the regression guard.
+    cfg.llm_client = MagicMock(name="platform-client") if llm_client_set else None
+    cfg.llm = MagicMock()
+    cfg.llm.name = "claude-sonnet-placeholder"
+    return cfg
+
+
+def _empty_async_gen():
+    async def _gen():
+        if False:
+            yield ""
+
+    return _gen()
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def threads_client():
+    """Threads router with auth + rate-limit dependencies neutralised."""
+    from src.server.app.threads import router
+    from src.server.dependencies.usage_limits import ChatAuthResult, enforce_chat_limit
+
+    app = create_test_app(router)
+    app.dependency_overrides[enforce_chat_limit] = lambda: ChatAuthResult(
+        user_id="usr-placeholder-001", access_tier=0
+    )
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Parametrised gate test
+# ---------------------------------------------------------------------------
+
+
+_GATE_CASES: list[tuple[CredentialSource, bool, bool]] = [
+    # (credential_source, llm_client_set, expected_byok)
+    # PLATFORM with llm_client set — the core regression case:
+    # old code would give byok=True; new code must give byok=False.
+    (CredentialSource.PLATFORM, True, False),
+    # NONE — no credential at all, platform path.
+    (CredentialSource.NONE, False, False),
+    # BYOK — user provided own key.
+    (CredentialSource.BYOK, True, True),
+    # OAUTH — user connected via OAuth.
+    (CredentialSource.OAUTH, True, True),
+]
+
+
+@pytest.mark.parametrize(
+    "credential_source, llm_client_set, expected_byok",
+    _GATE_CASES,
+    ids=[c[0].value for c in _GATE_CASES],
+)
+@pytest.mark.asyncio
+async def test_credit_gate_byok_arg(
+    threads_client,
+    credential_source: CredentialSource,
+    llm_client_set: bool,
+    expected_byok: bool,
+):
+    """``enforce_credit_limit`` receives the correct ``byok`` kwarg.
+
+    The config stub always carries the given ``credential_source``; when
+    ``llm_client_set=True`` the stub also carries a non-None ``llm_client``
+    to prove the old ``llm_client is not None`` heuristic would have misfired.
+    """
+    from src.server.app import setup as setup_module
+
+    stub_config = _make_config(credential_source, llm_client_set=llm_client_set)
+
+    enforce_mock = AsyncMock()
+    wm_singleton = MagicMock()
+    wm_singleton.has_ready_session.return_value = True
+
+    with (
+        patch.object(setup_module, "agent_config", MagicMock()),
+        patch(
+            "src.server.handlers.chat.resolve_llm_config",
+            new=AsyncMock(return_value=stub_config),
+        ),
+        patch(
+            "src.server.dependencies.usage_limits.enforce_credit_limit",
+            new=enforce_mock,
+        ),
+        patch(
+            "src.server.database.conversation.get_thread_by_id",
+            new=AsyncMock(return_value={"workspace_id": "ws-placeholder"}),
+        ),
+        patch(
+            "src.server.services.workspace_manager.WorkspaceManager.get_instance",
+            return_value=wm_singleton,
+        ),
+        patch(
+            "src.server.handlers.chat.astream_ptc_workflow",
+            return_value=_empty_async_gen(),
+        ),
+        patch(
+            "src.server.app.threads.observe_chat_stream",
+            side_effect=lambda gen, **_: gen,
+        ),
+    ):
+        async with threads_client.stream(
+            "POST",
+            "/api/v1/threads/tid-placeholder/messages",
+            json={
+                "workspace_id": "ws-placeholder",
+                "messages": [{"role": "user", "content": "test query"}],
+                "agent_mode": "ptc",
+            },
+        ) as resp:
+            assert resp.status_code == 200
+
+    # Verify enforce_credit_limit was called with the expected byok value.
+    enforce_mock.assert_awaited_once()
+    _, kwargs = enforce_mock.await_args
+    actual_byok = kwargs.get("byok")
+    assert actual_byok is expected_byok, (
+        f"credential_source={credential_source!r} llm_client_set={llm_client_set}: "
+        f"expected enforce_credit_limit(byok={expected_byok}), got byok={actual_byok!r}"
+    )

--- a/tests/unit/server/handlers/chat/test_byok_candidate_walk.py
+++ b/tests/unit/server/handlers/chat/test_byok_candidate_walk.py
@@ -1,0 +1,199 @@
+"""Tests for _walk_byok_candidates() and the system-branch coding-variant fix.
+
+A neutral placeholder model ``vendor-x-coding`` (anthropic-style coding
+endpoint) whose parent ``vendor-x`` is openai-style reproduces the SDK-trap:
+the key may live under the variant slug OR the parent, but the client must
+always build against the MODEL'S OWN endpoint. Also covers the _byok_cache
+tri-state miss-safety contract.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+HANDLER = "src.server.handlers.chat.llm_config"
+DB_KEYS = "src.server.database.api_keys"
+
+CODING_URL = "https://coding.example/anthropic"
+PARENT_URL = "https://api.example/v1"
+
+
+def _mock_mc():
+    """vendor-x-coding (own endpoint CODING_URL) is a child variant of
+    vendor-x (parent endpoint PARENT_URL)."""
+    providers = {
+        "vendor-x-coding": {"parent": "vendor-x", "base_url": CODING_URL},
+        "vendor-x": {"base_url": PARENT_URL},
+    }
+    system_models = {
+        "vendor-x-coding": {"provider": "vendor-x-coding"},
+        # A system model tagged with the PARENT slug — used by the
+        # sibling-held-key mirror case.
+        "vendor-x": {"provider": "vendor-x"},
+    }
+
+    mc = MagicMock()
+    mc.get_model_config.side_effect = lambda n: system_models.get(n)
+    mc.get_provider_info.side_effect = lambda n: providers.get(n, {})
+    mc.get_parent_provider.side_effect = lambda n: providers.get(n, {}).get("parent", n)
+    mc.get_child_variants.side_effect = lambda n: [
+        k for k, info in providers.items() if info.get("parent") == n and k != n
+    ]
+    return mc
+
+
+def _no_custom_model():
+    """Force SYSTEM classification by stubbing out the custom lookup."""
+    return patch(
+        f"{HANDLER}.get_custom_model_config",
+        new_callable=AsyncMock,
+        return_value=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# System-branch coding-variant fix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_key_under_variant_slug_uses_own_coding_endpoint():
+    """Key stored only under the variant slug → resolves, builds against the
+    model's own coding endpoint."""
+    from src.server.handlers.chat.llm_config import resolve_byok_llm_client
+
+    mc = _mock_mc()
+    mock_llm = MagicMock(name="llm")
+    with (
+        _no_custom_model(),
+        patch("src.llms.llm.LLM.get_model_config", return_value=mc),
+        patch(
+            f"{DB_KEYS}.get_byok_configs_for_providers",
+            new_callable=AsyncMock,
+            return_value={"vendor-x-coding": {"api_key": "k", "base_url": None}},
+        ),
+        patch("src.llms.llm.create_llm", return_value=mock_llm) as mock_create,
+    ):
+        result = await resolve_byok_llm_client("u", "vendor-x-coding", True)
+
+    assert result is mock_llm
+    assert mock_create.call_args.kwargs["base_url"] == CODING_URL
+
+
+@pytest.mark.asyncio
+async def test_key_under_parent_still_uses_own_coding_endpoint():
+    """Key stored only under the PARENT slug → walk finds it, but base_url is
+    the model's OWN coding endpoint, NOT the parent's openai endpoint."""
+    from src.server.handlers.chat.llm_config import resolve_byok_llm_client
+
+    mc = _mock_mc()
+    mock_llm = MagicMock(name="llm")
+    with (
+        _no_custom_model(),
+        patch("src.llms.llm.LLM.get_model_config", return_value=mc),
+        patch(
+            f"{DB_KEYS}.get_byok_configs_for_providers",
+            new_callable=AsyncMock,
+            return_value={"vendor-x": {"api_key": "k", "base_url": None}},
+        ),
+        patch("src.llms.llm.create_llm", return_value=mock_llm) as mock_create,
+    ):
+        result = await resolve_byok_llm_client("u", "vendor-x-coding", True)
+
+    assert result is mock_llm
+    # SDK-trap guard: own coding endpoint, never the parent's openai one.
+    assert mock_create.call_args.kwargs["base_url"] == CODING_URL
+    assert mock_create.call_args.kwargs["base_url"] != PARENT_URL
+
+
+@pytest.mark.asyncio
+async def test_key_under_sibling_resolves_with_own_parent_endpoint():
+    """Mirror case (the walk's reason for existing): a system model tagged with
+    the PARENT slug ``vendor-x`` whose key is stored ONLY under a sibling
+    variant ``vendor-x-coding``. Resolves via the sibling, but base_url is
+    pinned to the model's OWN provider (vendor-x), not the sibling's."""
+    from src.server.handlers.chat.llm_config import (
+        _walk_byok_candidates,
+        resolve_byok_llm_client,
+    )
+
+    mc = _mock_mc()
+    # Sibling reachable from the parent.
+    assert mc.get_child_variants("vendor-x") == ["vendor-x-coding"]
+
+    sibling_cfg = {"api_key": "k", "base_url": None}
+    mock_llm = MagicMock(name="llm")
+    with (
+        _no_custom_model(),
+        patch("src.llms.llm.LLM.get_model_config", return_value=mc),
+        patch(
+            f"{DB_KEYS}.get_byok_configs_for_providers",
+            new_callable=AsyncMock,
+            return_value={"vendor-x-coding": sibling_cfg},
+        ),
+        patch("src.llms.llm.create_llm", return_value=mock_llm) as mock_create,
+    ):
+        # Direct helper: confirms provider → parent → sibling priority lands on
+        # the sibling and reports it as the holder.
+        byok_config, holding = await _walk_byok_candidates("u", "vendor-x", mc)
+        assert byok_config == sibling_cfg
+        assert holding == "vendor-x-coding"
+
+        result = await resolve_byok_llm_client("u", "vendor-x", True)
+
+    assert result is mock_llm
+    # Own-endpoint pin: the model's own provider (vendor-x), NOT the sibling's.
+    assert mock_create.call_args.kwargs["base_url"] == PARENT_URL
+    assert mock_create.call_args.kwargs["base_url"] != CODING_URL
+
+
+# ---------------------------------------------------------------------------
+# _walk_byok_candidates — cache tri-state contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cache_miss_falls_back_to_direct_lookup():
+    """A candidate slug absent from a provided _byok_cache still resolves via
+    the direct-lookup fallback (a cache miss is never a false 'no key')."""
+    from src.server.handlers.chat.llm_config import _walk_byok_candidates
+
+    mc = _mock_mc()
+    # Cache has the parent recorded-absent but NOT the variant slug.
+    cache = {"vendor-x": None}
+    direct = AsyncMock(
+        return_value={"vendor-x-coding": {"api_key": "k", "base_url": None}},
+    )
+    with patch(f"{DB_KEYS}.get_byok_configs_for_providers", direct):
+        byok_config, holding = await _walk_byok_candidates(
+            "u", "vendor-x-coding", mc, _byok_cache=cache,
+        )
+
+    assert byok_config == {"api_key": "k", "base_url": None}
+    assert holding == "vendor-x-coding"
+    # The missing slug must have been the one fetched directly.
+    direct.assert_awaited_once()
+    assert direct.await_args.args[1] == ["vendor-x-coding"]
+    # Cache is updated with the fetched result.
+    assert cache["vendor-x-coding"] == {"api_key": "k", "base_url": None}
+
+
+@pytest.mark.asyncio
+async def test_cache_none_value_treated_as_absent_without_requery():
+    """A slug present with value None is a confirmed absence — no direct
+    re-query for that slug."""
+    from src.server.handlers.chat.llm_config import _walk_byok_candidates
+
+    mc = _mock_mc()
+    # Both candidates recorded-absent; parent holds nothing either.
+    cache = {"vendor-x-coding": None, "vendor-x": None}
+    direct = AsyncMock(return_value={})
+    with patch(f"{DB_KEYS}.get_byok_configs_for_providers", direct):
+        byok_config, holding = await _walk_byok_candidates(
+            "u", "vendor-x-coding", mc, _byok_cache=cache,
+        )
+
+    assert byok_config is None
+    assert holding is None
+    # Everything was cached (as None) → no direct lookup at all.
+    direct.assert_not_awaited()

--- a/tests/unit/server/handlers/chat/test_custom_provider_sdk_inheritance.py
+++ b/tests/unit/server/handlers/chat/test_custom_provider_sdk_inheritance.py
@@ -1,0 +1,111 @@
+"""Tests for #221: custom providers must inherit their parent's SDK.
+
+A user-defined ``custom_providers`` slug is absent from the manifest, so
+``from_custom_config`` derives ``sdk`` from an empty ``provider_info`` and
+defaults to ``"openai"``. For an Anthropic-parented custom provider that
+produces an OpenAI client pointed at an Anthropic endpoint → 404 on
+``/chat/completions``. ``_resolve_custom_model_byok`` must rewrite the
+provider to the manifest parent so the SDK resolves correctly — while leaving
+OpenAI-compatible gateways untouched (no forced Responses API).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.server.handlers.chat.llm_config import _resolve_custom_model_byok
+
+H = "src.server.handlers.chat.llm_config"
+DBK = "src.server.database.api_keys"
+
+
+def _mock_mc(parent_sdk, *, parent_extra=None):
+    """ModelConfig whose only manifest provider is the parent."""
+    parents = {"vendor-parent": {"sdk": parent_sdk, **(parent_extra or {})}}
+    mc = MagicMock()
+    mc.get_provider_info.side_effect = lambda p: parents.get(p, {})
+    return mc
+
+
+def _patches(provider_def, key=None):
+    """Stub custom-provider lookup + BYOK key store for one custom provider."""
+    key = key or {"api_key": "user-key", "base_url": "https://gw.example/anthropic"}
+
+    async def get_cp(user_id, name, _pref_cache=None):
+        return provider_def if name == provider_def["name"] else None
+
+    return (
+        patch(f"{H}.get_custom_provider_config", new_callable=AsyncMock, side_effect=get_cp),
+        patch(f"{DBK}.get_byok_config_for_provider", new_callable=AsyncMock, return_value=key),
+        patch(f"{DBK}.get_byok_configs_for_providers", new_callable=AsyncMock, return_value={}),
+    )
+
+
+@pytest.mark.asyncio
+async def test_path2_anthropic_parent_rewrites_provider_to_parent():
+    """Model's ``provider`` is a custom slug with an anthropic parent → the
+    returned config provider is rewritten to the parent so SDK = anthropic."""
+    provider_def = {"name": "my-anthropic-gw", "parent_provider": "vendor-parent"}
+    custom_model = {"name": "eval-model", "model_id": "some-model", "provider": "my-anthropic-gw"}
+    mc = _mock_mc("anthropic")
+
+    p1, p2, p3 = _patches(provider_def)
+    with p1, p2, p3:
+        byok, base_url, out = await _resolve_custom_model_byok("u", "eval-model", dict(custom_model), mc)
+
+    # SDK now resolves via the parent's manifest entry, not the (absent) slug.
+    assert out["provider"] == "vendor-parent"
+    sdk = mc.get_provider_info(out["provider"]).get("sdk") or "openai"
+    assert sdk == "anthropic"
+    assert base_url == "https://gw.example/anthropic"
+
+
+@pytest.mark.asyncio
+async def test_path1_anthropic_parent_rewrites_provider_to_parent():
+    """Model name itself is the custom provider slug (Path 1) → same rewrite."""
+    provider_def = {"name": "my-anthropic-gw", "parent_provider": "vendor-parent"}
+    custom_model = {"name": "my-anthropic-gw", "model_id": "some-model", "provider": "my-anthropic-gw"}
+    mc = _mock_mc("anthropic")
+
+    p1, p2, p3 = _patches(provider_def)
+    with p1, p2, p3:
+        byok, base_url, out = await _resolve_custom_model_byok("u", "my-anthropic-gw", dict(custom_model), mc)
+
+    assert out["provider"] == "vendor-parent"
+
+
+@pytest.mark.asyncio
+async def test_openai_parent_does_not_rewrite_or_force_response_api():
+    """OpenAI-compatible gateway: provider must stay the custom slug so the
+    default sdk="openai" applies WITHOUT inheriting the manifest openai entry's
+    use_response_api (which would break /chat/completions-only gateways)."""
+    provider_def = {"name": "my-openai-gw", "parent_provider": "vendor-parent"}
+    custom_model = {"name": "eval-model", "model_id": "some-model", "provider": "my-openai-gw"}
+    # Parent openai entry carries use_response_api=True — must NOT leak through.
+    mc = _mock_mc("openai", parent_extra={"use_response_api": True})
+
+    p1, p2, p3 = _patches(provider_def)
+    with p1, p2, p3:
+        byok, base_url, out = await _resolve_custom_model_byok("u", "eval-model", dict(custom_model), mc)
+
+    # Provider unchanged → from_custom_config sees {} → sdk defaults to openai,
+    # use_response_api stays False (the safe gateway default).
+    assert out["provider"] == "my-openai-gw"
+    assert "_use_response_api" not in out
+
+
+@pytest.mark.asyncio
+async def test_custom_provider_explicit_use_response_api_opt_in_preserved():
+    """A custom provider that explicitly opts into the Responses API still gets
+    the ``_use_response_api`` flag, regardless of parent SDK."""
+    provider_def = {
+        "name": "my-openai-gw", "parent_provider": "vendor-parent", "use_response_api": True,
+    }
+    custom_model = {"name": "eval-model", "model_id": "some-model", "provider": "my-openai-gw"}
+    mc = _mock_mc("openai")
+
+    p1, p2, p3 = _patches(provider_def)
+    with p1, p2, p3:
+        byok, base_url, out = await _resolve_custom_model_byok("u", "eval-model", dict(custom_model), mc)
+
+    assert out.get("_use_response_api") is True

--- a/tests/unit/server/handlers/chat/test_resolve_llm_config_credential.py
+++ b/tests/unit/server/handlers/chat/test_resolve_llm_config_credential.py
@@ -1,0 +1,335 @@
+"""Tests for resolve_llm_config() credential-source wiring + role registry.
+
+Covers the credential_source matrix written onto AgentConfig (OAUTH / BYOK /
+PLATFORM / NONE), the BYOK-pure write-time materialization gate (Codex #2:
+a PLATFORM client must NOT be copied into subsidiary roles), the role_registry
+builder, and the is_byok self-resolving net.
+
+The network/DB surface is fully mocked: resolve_oauth_llm_client,
+resolve_byok_llm_client, classify_model, get_byok_configs_for_providers,
+is_byok_active, create_llm, and SubagentRegistry.
+"""
+
+import contextlib
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ptc_agent.config.agent import (
+    AgentConfig,
+    CredentialSource,
+    LLMConfig,
+)
+
+HANDLER = "src.server.handlers.chat.llm_config"
+
+
+def _make_config(*, compaction=None, fetch=None, fallback=None, subagents_enabled=None):
+    """Build a minimal real AgentConfig via the create() factory."""
+    cfg = AgentConfig.create(llm=MagicMock(name="placeholder-llm"))
+    cfg.llm = LLMConfig(name="main-model", compaction=compaction, fetch=fetch, fallback=fallback)
+    cfg.llm_client = None
+    cfg.subsidiary_llm_clients = {}
+    cfg.fallback_llm_clients = None
+    if subagents_enabled is not None:
+        cfg.subagents.enabled = subagents_enabled
+    return cfg
+
+
+class _FakeClient:
+    """A stand-in LLM client with a model_copy() that returns a distinct copy."""
+
+    def __init__(self, label):
+        self.label = label
+
+    def model_copy(self):
+        c = _FakeClient(self.label)
+        c._copied_from = self
+        return c
+
+
+def _common_patches(
+    *,
+    oauth=None,
+    byok=None,
+    classify_source=None,
+    platform_client=None,
+    is_byok_active_val=False,
+):
+    """Bundle the standard patch set. ``classify_source`` is a ModelSource."""
+    from src.server.handlers.chat.llm_config import ModelSource
+
+    src = classify_source if classify_source is not None else ModelSource.SYSTEM
+
+    patches = [
+        patch(
+            f"{HANDLER}.classify_model",
+            new_callable=AsyncMock,
+            return_value=(src, {}),
+        ),
+        patch(
+            f"{HANDLER}.get_custom_provider_config",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            f"{HANDLER}.get_model_preference",
+            new_callable=AsyncMock,
+            return_value={},
+        ),
+        patch(
+            f"{HANDLER}.resolve_oauth_llm_client",
+            new_callable=AsyncMock,
+            return_value=oauth,
+        ),
+        patch(
+            f"{HANDLER}.resolve_byok_llm_client",
+            new_callable=AsyncMock,
+            return_value=byok,
+        ),
+        patch(
+            "src.server.database.api_keys.is_byok_active",
+            new_callable=AsyncMock,
+            return_value=is_byok_active_val,
+        ),
+        patch(
+            "src.server.database.api_keys.get_byok_configs_for_providers",
+            new_callable=AsyncMock,
+            return_value={},
+        ),
+        patch("src.llms.llm.create_llm", return_value=platform_client),
+    ]
+    return patches
+
+
+@contextlib.contextmanager
+def _entered(patches):
+    """Enter every patch in ``patches`` (a list of patch objects)."""
+    with contextlib.ExitStack() as stack:
+        for p in patches:
+            stack.enter_context(p)
+        yield
+
+
+# ---------------------------------------------------------------------------
+# credential_source matrix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_oauth_user_sets_oauth_source():
+    from src.server.handlers.chat.llm_config import resolve_llm_config
+
+    oauth_client = _FakeClient("oauth")
+    with _entered(_common_patches(oauth=oauth_client)):
+        cfg = await resolve_llm_config(_make_config(), "u", "main-model", True)
+
+    assert cfg.credential_source == CredentialSource.OAUTH
+    assert cfg.llm_client is oauth_client
+
+
+@pytest.mark.asyncio
+async def test_byok_user_sets_byok_source():
+    from src.server.handlers.chat.llm_config import resolve_llm_config
+
+    byok_client = _FakeClient("byok")
+    with _entered(_common_patches(byok=byok_client)):
+        cfg = await resolve_llm_config(_make_config(), "u", "main-model", True)
+
+    assert cfg.credential_source == CredentialSource.BYOK
+    assert cfg.llm_client is byok_client
+
+
+@pytest.mark.asyncio
+async def test_non_byok_reasoning_uses_platform():
+    from src.server.handlers.chat.llm_config import resolve_llm_config
+
+    platform_client = _FakeClient("platform")
+    with _entered(_common_patches(platform_client=platform_client)):
+        cfg = await resolve_llm_config(
+            _make_config(), "u", "main-model", False, reasoning_effort="high"
+        )
+
+    assert cfg.credential_source == CredentialSource.PLATFORM
+    assert cfg.llm_client is platform_client
+
+
+@pytest.mark.asyncio
+async def test_non_byok_no_reasoning_is_none():
+    from src.server.handlers.chat.llm_config import resolve_llm_config
+
+    with _entered(_common_patches()):
+        cfg = await resolve_llm_config(_make_config(), "u", "main-model", False)
+
+    assert cfg.credential_source == CredentialSource.NONE
+    assert cfg.llm_client is None
+
+
+@pytest.mark.asyncio
+async def test_byok_on_system_model_is_byok_source():
+    """Orthogonality: BYOK key on a SYSTEM-catalog model → cred=BYOK."""
+    from src.server.handlers.chat.llm_config import ModelSource, resolve_llm_config
+
+    byok_client = _FakeClient("byok")
+    with _entered(_common_patches(byok=byok_client, classify_source=ModelSource.SYSTEM)):
+        cfg = await resolve_llm_config(_make_config(), "u", "main-model", True)
+
+    assert cfg.credential_source == CredentialSource.BYOK
+
+
+# ---------------------------------------------------------------------------
+# materialization gate (Codex #2 regression)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_platform_client_not_copied_into_roles():
+    """Non-BYOK+reasoning (PLATFORM) main client must NOT seed subsidiary roles."""
+    from src.server.handlers.chat.llm_config import resolve_llm_config
+
+    platform_client = _FakeClient("platform")
+    # compaction model resolves to no client (no key, no platform fallback for roles)
+    with _entered(_common_patches(platform_client=platform_client)):
+        cfg = await resolve_llm_config(
+            _make_config(compaction="compaction-model"),
+            "u",
+            "main-model",
+            False,
+            reasoning_effort="high",
+        )
+
+    assert cfg.credential_source == CredentialSource.PLATFORM
+    assert "compaction" not in cfg.subsidiary_llm_clients
+
+
+@pytest.mark.asyncio
+async def test_byok_main_copied_into_keyless_role():
+    """BYOK user with a compaction model they have no key for → role gets a main copy."""
+    from src.server.handlers.chat.llm_config import resolve_llm_config
+
+    byok_client = _FakeClient("byok-main")
+
+    # OAuth None always; BYOK returns the main client for the main model, but
+    # None for the compaction role model.
+    async def _byok(user_id, model_name, is_byok, *a, **k):
+        return byok_client if model_name == "main-model" else None
+
+    with (
+        patch(
+            f"{HANDLER}.classify_model",
+            new_callable=AsyncMock,
+            return_value=(__import__(HANDLER, fromlist=["ModelSource"]).ModelSource.SYSTEM, {}),
+        ),
+        patch(f"{HANDLER}.get_custom_provider_config", new_callable=AsyncMock, return_value=None),
+        patch(f"{HANDLER}.get_model_preference", new_callable=AsyncMock, return_value={}),
+        patch(f"{HANDLER}.resolve_oauth_llm_client", new_callable=AsyncMock, return_value=None),
+        patch(f"{HANDLER}.resolve_byok_llm_client", side_effect=_byok),
+        patch("src.server.database.api_keys.is_byok_active", new_callable=AsyncMock, return_value=True),
+        patch("src.server.database.api_keys.get_byok_configs_for_providers", new_callable=AsyncMock, return_value={}),
+        patch("src.llms.llm.create_llm", return_value=None),
+    ):
+        cfg = await resolve_llm_config(
+            _make_config(compaction="compaction-model"), "u", "main-model", True
+        )
+
+    assert cfg.credential_source == CredentialSource.BYOK
+    assert "compaction" in cfg.subsidiary_llm_clients
+    # It is a COPY of the main client, not the same instance.
+    copy = cfg.subsidiary_llm_clients["compaction"]
+    assert copy is not byok_client
+    assert getattr(copy, "_copied_from", None) is byok_client
+
+
+@pytest.mark.asyncio
+async def test_system_user_leaves_role_keys_absent():
+    """A NONE-cred (system/platform) user stores no subsidiary clients (cheap name path)."""
+    from src.server.handlers.chat.llm_config import resolve_llm_config
+
+    with _entered(_common_patches()):
+        cfg = await resolve_llm_config(
+            _make_config(compaction="compaction-model", fetch="fetch-model"),
+            "u",
+            "main-model",
+            False,
+        )
+
+    assert cfg.credential_source == CredentialSource.NONE
+    assert "compaction" not in cfg.subsidiary_llm_clients
+    assert "fetch" not in cfg.subsidiary_llm_clients
+
+
+# ---------------------------------------------------------------------------
+# is_byok self-resolving net
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_is_byok_none_self_resolves():
+    from src.server.handlers.chat.llm_config import resolve_llm_config
+
+    is_byok_active = AsyncMock(return_value=False)
+    byok = AsyncMock(return_value=None)
+    with (
+        patch(
+            f"{HANDLER}.classify_model",
+            new_callable=AsyncMock,
+            return_value=(__import__(HANDLER, fromlist=["ModelSource"]).ModelSource.SYSTEM, {}),
+        ),
+        patch(f"{HANDLER}.get_custom_provider_config", new_callable=AsyncMock, return_value=None),
+        patch(f"{HANDLER}.get_model_preference", new_callable=AsyncMock, return_value={}),
+        patch(f"{HANDLER}.resolve_oauth_llm_client", new_callable=AsyncMock, return_value=None),
+        patch(f"{HANDLER}.resolve_byok_llm_client", byok),
+        patch("src.server.database.api_keys.is_byok_active", is_byok_active),
+        patch("src.server.database.api_keys.get_byok_configs_for_providers", new_callable=AsyncMock, return_value={}),
+        patch("src.llms.llm.create_llm", return_value=None),
+    ):
+        cfg = await resolve_llm_config(_make_config(), "u", "main-model", None)
+
+    is_byok_active.assert_awaited_once_with("u")
+    assert cfg.credential_source == CredentialSource.NONE
+
+
+# ---------------------------------------------------------------------------
+# role_registry
+# ---------------------------------------------------------------------------
+
+
+def test_role_registry_compaction_fetch_and_subagents():
+    from src.server.handlers.chat.llm_config import LLMRole, role_registry
+
+    cfg = _make_config(compaction="cm", fetch="fm")
+    sub_with_model = MagicMock()
+    sub_with_model.model = "sub-model"
+    sub_no_model = MagicMock()
+    sub_no_model.model = None
+    subagent_defs = {"research": sub_with_model, "writer": sub_no_model}
+
+    roles = role_registry(cfg, ["research", "writer"], subagent_defs)
+    keys = [r.key for r in roles]
+
+    assert "compaction" in keys
+    assert "fetch" in keys
+    assert "subagent:research" in keys
+    # subagent without a model: no role
+    assert "subagent:writer" not in keys
+    assert all(isinstance(r, LLMRole) for r in roles)
+
+
+def test_role_registry_skips_missing_compaction_fetch():
+    from src.server.handlers.chat.llm_config import role_registry
+
+    cfg = _make_config()  # no compaction, no fetch
+    roles = role_registry(cfg, [], {})
+    assert roles == []
+
+
+def test_role_registry_unknown_enabled_name_skipped():
+    """An enabled subagent absent from subagent_defs is skipped (no raise)."""
+    from src.server.handlers.chat.llm_config import role_registry
+
+    cfg = _make_config(compaction="cm")
+    # 'ghost' is enabled but not in defs (registry.get() returned None → absent)
+    roles = role_registry(cfg, ["ghost"], {})
+    keys = [r.key for r in roles]
+    assert keys == ["compaction"]
+    assert "subagent:ghost" not in keys

--- a/tests/unit/server/handlers/chat/test_resolve_model_client.py
+++ b/tests/unit/server/handlers/chat/test_resolve_model_client.py
@@ -1,0 +1,203 @@
+"""Tests for resolve_model_client() — the unified resolution primitive.
+
+Covers credential-source attribution (OAUTH / BYOK / PLATFORM / NONE), the
+platform-fallback gate (SYSTEM only), the orthogonality of model_source vs
+credential_source, and HTTPException propagation from the OAuth path.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ptc_agent.config.agent import CredentialSource
+
+HANDLER = "src.server.handlers.chat.llm_config"
+
+
+def _patch_classify(source):
+    """Patch classify_model to return (source, {})."""
+    from src.server.handlers.chat.llm_config import ModelSource  # noqa: F401
+
+    return patch(
+        f"{HANDLER}.classify_model",
+        new_callable=AsyncMock,
+        return_value=(source, {}),
+    )
+
+
+@pytest.mark.asyncio
+async def test_oauth_present_returns_oauth_and_skips_byok():
+    from src.server.handlers.chat.llm_config import ModelSource, resolve_model_client
+
+    oauth_client = MagicMock(name="oauth-client")
+    byok = AsyncMock(name="byok")
+    with (
+        _patch_classify(ModelSource.SYSTEM),
+        patch(
+            f"{HANDLER}.resolve_oauth_llm_client",
+            new_callable=AsyncMock,
+            return_value=oauth_client,
+        ),
+        patch(f"{HANDLER}.resolve_byok_llm_client", byok),
+    ):
+        result = await resolve_model_client("u", "m", is_byok=True)
+
+    assert result.client is oauth_client
+    assert result.credential_source == CredentialSource.OAUTH
+    byok.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_byok_present_returns_byok():
+    from src.server.handlers.chat.llm_config import ModelSource, resolve_model_client
+
+    byok_client = MagicMock(name="byok-client")
+    with (
+        _patch_classify(ModelSource.SYSTEM),
+        patch(
+            f"{HANDLER}.resolve_oauth_llm_client",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            f"{HANDLER}.resolve_byok_llm_client",
+            new_callable=AsyncMock,
+            return_value=byok_client,
+        ),
+    ):
+        result = await resolve_model_client("u", "m", is_byok=True)
+
+    assert result.client is byok_client
+    assert result.credential_source == CredentialSource.BYOK
+
+
+@pytest.mark.asyncio
+async def test_platform_fallback_when_byok_none_and_system():
+    from src.server.handlers.chat.llm_config import ModelSource, resolve_model_client
+
+    platform_client = MagicMock(name="platform-client")
+    with (
+        _patch_classify(ModelSource.SYSTEM),
+        patch(
+            f"{HANDLER}.resolve_oauth_llm_client",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            f"{HANDLER}.resolve_byok_llm_client",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch("src.llms.llm.create_llm", return_value=platform_client) as mock_create,
+    ):
+        result = await resolve_model_client(
+            "u", "m", is_byok=True, allow_platform_fallback=True,
+        )
+
+    assert result.client is platform_client
+    assert result.credential_source == CredentialSource.PLATFORM
+    mock_create.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_no_fallback_when_disabled():
+    from src.server.handlers.chat.llm_config import ModelSource, resolve_model_client
+
+    with (
+        _patch_classify(ModelSource.SYSTEM),
+        patch(
+            f"{HANDLER}.resolve_oauth_llm_client",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            f"{HANDLER}.resolve_byok_llm_client",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch("src.llms.llm.create_llm") as mock_create,
+    ):
+        result = await resolve_model_client(
+            "u", "m", is_byok=True, allow_platform_fallback=False,
+        )
+
+    assert result.client is None
+    assert result.credential_source == CredentialSource.NONE
+    mock_create.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_platform_fallback_not_built_for_custom():
+    """Platform fallback only applies to SYSTEM models, never CUSTOM."""
+    from src.server.handlers.chat.llm_config import ModelSource, resolve_model_client
+
+    with (
+        _patch_classify(ModelSource.CUSTOM),
+        patch(
+            f"{HANDLER}.resolve_oauth_llm_client",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            f"{HANDLER}.resolve_byok_llm_client",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch("src.llms.llm.create_llm") as mock_create,
+    ):
+        result = await resolve_model_client(
+            "u", "m", is_byok=True, allow_platform_fallback=True,
+        )
+
+    assert result.client is None
+    assert result.credential_source == CredentialSource.NONE
+    mock_create.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_byok_on_system_model_is_orthogonal():
+    """A BYOK user on a SYSTEM-catalog model: model_source=SYSTEM, cred=BYOK."""
+    from src.server.handlers.chat.llm_config import ModelSource, resolve_model_client
+
+    byok_client = MagicMock(name="byok-client")
+    with (
+        _patch_classify(ModelSource.SYSTEM),
+        patch(
+            f"{HANDLER}.resolve_oauth_llm_client",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            f"{HANDLER}.resolve_byok_llm_client",
+            new_callable=AsyncMock,
+            return_value=byok_client,
+        ),
+    ):
+        result = await resolve_model_client("u", "m", is_byok=True)
+
+    assert result.model_source == ModelSource.SYSTEM
+    assert result.credential_source == CredentialSource.BYOK
+
+
+@pytest.mark.asyncio
+async def test_oauth_required_exception_propagates():
+    """An OAuth-required HTTPException must NOT be swallowed."""
+    from fastapi import HTTPException
+
+    from src.server.handlers.chat.llm_config import ModelSource, resolve_model_client
+
+    exc = HTTPException(status_code=400, detail={"type": "oauth_required"})
+    with (
+        _patch_classify(ModelSource.SYSTEM),
+        patch(
+            f"{HANDLER}.resolve_oauth_llm_client",
+            new_callable=AsyncMock,
+            side_effect=exc,
+        ),
+        patch(f"{HANDLER}.resolve_byok_llm_client", new_callable=AsyncMock) as byok,
+    ):
+        with pytest.raises(HTTPException) as raised:
+            await resolve_model_client("u", "m", is_byok=True)
+
+    assert raised.value.detail["type"] == "oauth_required"
+    byok.assert_not_called()

--- a/tests/unit/server/handlers/test_byok_resolution.py
+++ b/tests/unit/server/handlers/test_byok_resolution.py
@@ -84,9 +84,9 @@ class TestResolveBYOKSystemModel:
         with (
             patch("src.llms.llm.LLM.get_model_config", return_value=mc),
             patch(
-                f"{DB_KEYS}.get_byok_config_for_provider",
+                f"{DB_KEYS}.get_byok_configs_for_providers",
                 new_callable=AsyncMock,
-                return_value={"api_key": "user-key-123", "base_url": None},
+                return_value={"openai": {"api_key": "user-key-123", "base_url": None}},
             ),
             patch("src.llms.llm.create_llm", return_value=mock_llm) as mock_create,
         ):
@@ -109,9 +109,9 @@ class TestResolveBYOKSystemModel:
         with (
             patch("src.llms.llm.LLM.get_model_config", return_value=mc),
             patch(
-                f"{DB_KEYS}.get_byok_config_for_provider",
+                f"{DB_KEYS}.get_byok_configs_for_providers",
                 new_callable=AsyncMock,
-                return_value=None,
+                return_value={},
             ),
         ):
             result = await resolve_byok_llm_client("user-1", "gpt-4o", True)
@@ -131,9 +131,9 @@ class TestResolveBYOKSystemModel:
         with (
             patch("src.llms.llm.LLM.get_model_config", return_value=mc),
             patch(
-                f"{DB_KEYS}.get_byok_config_for_provider",
+                f"{DB_KEYS}.get_byok_configs_for_providers",
                 new_callable=AsyncMock,
-                return_value={"api_key": "key", "base_url": "https://custom.openai.com"},
+                return_value={"openai": {"api_key": "key", "base_url": "https://custom.openai.com"}},
             ),
             patch("src.llms.llm.create_llm", return_value=mock_llm) as mock_create,
         ):
@@ -144,7 +144,8 @@ class TestResolveBYOKSystemModel:
 
     @pytest.mark.asyncio
     async def test_sub_provider_resolves_parent(self):
-        """Platform sub-provider should resolve to parent's BYOK key."""
+        """A sub-provider model resolves the key stored under its parent slug,
+        but builds against the model's OWN provider endpoint."""
         from src.server.handlers.chat.llm_config import resolve_byok_llm_client
 
         mc = _mock_model_config(
@@ -158,16 +159,19 @@ class TestResolveBYOKSystemModel:
         with (
             patch("src.llms.llm.LLM.get_model_config", return_value=mc),
             patch(
-                f"{DB_KEYS}.get_byok_config_for_provider",
+                f"{DB_KEYS}.get_byok_configs_for_providers",
                 new_callable=AsyncMock,
-                return_value={"api_key": "acme-key", "base_url": None},
+                # Key stored only under the parent slug.
+                return_value={"acme": {"api_key": "acme-key", "base_url": None}},
             ),
             patch("src.llms.llm.create_llm", return_value=mock_llm) as mock_create,
         ):
             result = await resolve_byok_llm_client("user-1", "test-model", True)
 
-        # Should look up parent provider, not platform variant
+        # Resolves via the parent key, but builds against the model's OWN
+        # provider endpoint (acme-platform), never the parent's.
         assert result is mock_llm
+        assert mock_create.call_args.kwargs["base_url"] == "https://proxy.example.com"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/server/handlers/test_chat_common.py
+++ b/tests/unit/server/handlers/test_chat_common.py
@@ -446,6 +446,116 @@ class TestApplyFetchOverride:
 
 
 # ---------------------------------------------------------------------------
+# apply_fetch_override — real context-var contract (regression lock)
+#
+# These tests assert the actual ContextVar state transitions rather than mock
+# call counts. Each case is isolated in its own copy_context().run() so no
+# override leaks into other tests or the module-global vars.
+# ---------------------------------------------------------------------------
+
+
+class TestApplyFetchOverrideContextVars:
+    """Contract tests using real ContextVars (no mocking of the vars themselves).
+
+    Isolation: every case runs inside ``contextvars.copy_context().run(...)``
+    so the process-global vars are untouched outside each sub-run.
+    """
+
+    def _run_and_capture(self, config):
+        """Run apply_fetch_override in an isolated context; return snapshot."""
+        import contextvars
+        from src.server.handlers.chat._common import apply_fetch_override
+        from src.tools.fetch import fetch_model_override, fetch_llm_client_override
+
+        results = {}
+
+        def _inner():
+            apply_fetch_override(config)
+            results["model"] = fetch_model_override.get()
+            results["client"] = fetch_llm_client_override.get()
+
+        contextvars.copy_context().run(_inner)
+        return results
+
+    def test_credentialed_user_sets_both_vars(self):
+        """Credentialed (BYOK/OAuth) path: subsidiary_llm_clients['fetch'] is
+        pre-populated by resolve_llm_config — apply_fetch_override must forward
+        it verbatim into fetch_llm_client_override (fetch.py copies at use time).
+        """
+        fake_client = MagicMock(name="byok-fetch-client")
+        config = MagicMock()
+        config.llm.fetch = "claude-haiku-4-5"
+        config.subsidiary_llm_clients = {"fetch": fake_client}
+
+        snap = self._run_and_capture(config)
+
+        assert snap["model"] == "claude-haiku-4-5"
+        assert snap["client"] is fake_client
+
+    def test_platform_user_leaves_client_var_unset(self):
+        """Platform/system path: no entry in subsidiary_llm_clients → the
+        client context var must remain None so fetch.py uses LLM(model).get_llm().
+        """
+        config = MagicMock()
+        config.llm.fetch = "claude-haiku-4-5"
+        config.subsidiary_llm_clients = {}  # platform user — nothing materialized
+
+        snap = self._run_and_capture(config)
+
+        assert snap["model"] == "claude-haiku-4-5"
+        assert snap["client"] is None  # default — fetch.py takes the platform path
+
+    def test_no_fetch_model_leaves_both_vars_unset(self):
+        """When config.llm.fetch is falsy neither context var should be set."""
+        config = MagicMock()
+        config.llm.fetch = None
+        config.subsidiary_llm_clients = {"fetch": MagicMock()}  # should be ignored
+
+        snap = self._run_and_capture(config)
+
+        assert snap["model"] is None   # ContextVar default
+        assert snap["client"] is None  # ContextVar default
+
+    def test_stored_client_is_not_copied_by_apply_fetch_override(self):
+        """apply_fetch_override must store the raw shared instance (not a copy).
+        fetch.py performs the .model_copy() at consumption time — this test
+        guards against a double-copy regression.
+        """
+        fake_client = MagicMock(name="shared-client")
+        config = MagicMock()
+        config.llm.fetch = "claude-haiku-4-5"
+        config.subsidiary_llm_clients = {"fetch": fake_client}
+
+        snap = self._run_and_capture(config)
+
+        # Must be the exact same object — no copy performed here.
+        assert snap["client"] is fake_client
+        fake_client.model_copy.assert_not_called()
+
+    def test_context_isolation_across_cases(self):
+        """Override set in one isolated run must not bleed into the next run."""
+        import contextvars
+        from src.server.handlers.chat._common import apply_fetch_override
+        from src.tools.fetch import fetch_llm_client_override
+
+        leak_sentinel = MagicMock(name="leaked-client")
+
+        config_with = MagicMock()
+        config_with.llm.fetch = "some-model"
+        config_with.subsidiary_llm_clients = {"fetch": leak_sentinel}
+
+        # First run sets the client in its own context copy.
+        def _first():
+            apply_fetch_override(config_with)
+            assert fetch_llm_client_override.get() is leak_sentinel
+
+        contextvars.copy_context().run(_first)
+
+        # Process-global var must still be None.
+        assert fetch_llm_client_override.get() is None
+
+
+# ---------------------------------------------------------------------------
 # ensure_thread
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/server/handlers/test_resolve_llm_config.py
+++ b/tests/unit/server/handlers/test_resolve_llm_config.py
@@ -1068,11 +1068,12 @@ class TestClassifyModelDirect:
 
 class TestClassifyModelDedup:
     @pytest.mark.asyncio
-    async def test_classify_called_once_per_distinct_model(self, base_config):
-        """resolve_llm_config should classify each distinct model exactly once
-        at the orchestration layer: one call for the main model and one per
-        fallback (via _resolve_one). Inner helpers are mocked, so any
-        re-classification they do internally is excluded from this count.
+    async def test_classify_only_distinct_models(self, base_config):
+        """resolve_llm_config only classifies the distinct models in play: the
+        main model and each fallback. The pref cache keeps every classify O(1)
+        and free of extra DB reads, so the set of names is the invariant we care
+        about (the per-name count is an implementation detail of the STEP-0
+        prefetch + per-model primitive resolution).
         """
         from src.server.handlers.chat.llm_config import (
             resolve_llm_config,
@@ -1097,14 +1098,18 @@ class TestClassifyModelDedup:
             patch(f"{HANDLER}.classify_model", classify_mock),
             patch(f"{HANDLER}.resolve_oauth_llm_client", new_callable=AsyncMock, return_value=None),
             patch(f"{HANDLER}.resolve_byok_llm_client", new_callable=AsyncMock, return_value=None),
+            patch(
+                "src.server.database.api_keys.get_byok_configs_for_providers",
+                new_callable=AsyncMock,
+                return_value={},
+            ),
             patch("src.llms.llm.LLM.get_model_config", return_value=mock_mc),
         ):
             await resolve_llm_config(base_config, "user-1", None, True)
 
-        # 1 main + 2 fallbacks = 3 classification calls. No more, no less.
-        assert classify_mock.await_count == 3
-        called_names = [call.args[1] for call in classify_mock.await_args_list]
-        assert set(called_names) == {"system-default-model", "fb-a", "fb-b"}
+        # No model outside {main, fallbacks} is ever classified.
+        called_names = {call.args[1] for call in classify_mock.await_args_list}
+        assert called_names == {"system-default-model", "fb-a", "fb-b"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/server/services/test_automation_executor_credit.py
+++ b/tests/unit/server/services/test_automation_executor_credit.py
@@ -1,0 +1,297 @@
+"""
+Tests for AutomationExecutor credential resolution and credit gating.
+
+Covers:
+- BYOK-only user: is_byok=True passed to astream_*, byok=True to gate
+- OAuth-only user: treated as has_cred=True (not mis-gated as platform)
+- Neither BYOK nor OAuth: byok=False to gate (platform daily-credit path)
+- Zero-credit platform user: 429 from enforce_credit_limit gates before
+  any workflow invocation and records the execution as failed
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from src.server.services.automation_executor import AutomationExecutor
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_USER_ID = "user-test-placeholder"
+_AUTO_ID = "auto-test-placeholder"
+_EXEC_ID = "exec-test-placeholder"
+_WS_ID = "ws-test-placeholder"
+
+
+def _make_automation(agent_mode="flash", **overrides):
+    data = {
+        "automation_id": _AUTO_ID,
+        "user_id": _USER_ID,
+        "agent_mode": agent_mode,
+        "instruction": "Summarize today's market",
+        "trigger_type": "cron",
+        "workspace_id": _WS_ID if agent_mode == "ptc" else None,
+        "thread_strategy": "new",
+        "conversation_thread_id": None,
+        "llm_model": None,
+        "additional_context": None,
+        "trigger_config": None,
+    }
+    data.update(overrides)
+    return data
+
+
+async def _empty_async_gen(*args, **kwargs):
+    """Empty async generator — stands in for astream_*_workflow."""
+    return
+    yield  # make it an async generator
+
+
+# ---------------------------------------------------------------------------
+# Base patch targets
+# ---------------------------------------------------------------------------
+
+_PATCHES = {
+    "is_byok_active": "src.server.services.automation_executor.is_byok_active",
+    "has_any_oauth": "src.server.services.automation_executor.has_any_oauth_token",
+    "enforce_credit": "src.server.services.automation_executor.enforce_credit_limit",
+    "auto_db": "src.server.services.automation_executor.auto_db",
+    "flash_ws": "src.server.services.automation_executor.get_or_create_flash_workspace",
+    "btm": "src.server.services.background_task_manager.BackgroundTaskManager",
+    "fire_webhook": "src.server.services.automation_executor.AutomationExecutor._fire_webhook",
+}
+
+
+def _patch_all(
+    is_byok=False,
+    has_oauth=False,
+    credit_raises=None,
+):
+    """Return a dict of patches to apply with context managers."""
+    return {
+        "is_byok_active": patch(
+            _PATCHES["is_byok_active"], new=AsyncMock(return_value=is_byok)
+        ),
+        "has_any_oauth": patch(
+            _PATCHES["has_any_oauth"], new=AsyncMock(return_value=has_oauth)
+        ),
+        "enforce_credit": patch(
+            _PATCHES["enforce_credit"],
+            new=AsyncMock(side_effect=credit_raises),
+        ),
+        "auto_db": patch(_PATCHES["auto_db"]),
+        "flash_ws": patch(
+            _PATCHES["flash_ws"],
+            new=AsyncMock(return_value={"workspace_id": _WS_ID}),
+        ),
+        "fire_webhook": patch(
+            _PATCHES["fire_webhook"], new=AsyncMock(return_value=None)
+        ),
+        "btm": patch(_PATCHES["btm"]),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCredentialGate:
+    """AutomationExecutor passes correct is_byok and credit gate to workflows."""
+
+    @pytest.mark.asyncio
+    async def test_byok_only_user_flash(self):
+        """BYOK-only user: enforce_credit called with byok=True, workflow gets is_byok=True."""
+        patches = _patch_all(is_byok=True, has_oauth=False)
+
+        with (
+            patches["is_byok_active"] as mock_byok,
+            patches["has_any_oauth"],
+            patches["enforce_credit"] as mock_credit,
+            patches["auto_db"] as mock_adb,
+            patches["flash_ws"],
+            patches["fire_webhook"],
+            patches["btm"] as mock_btm_cls,
+            patch(
+                "src.server.handlers.chat.astream_flash_workflow",
+                side_effect=_empty_async_gen,
+            ) as mock_astream,
+        ):
+            _setup_auto_db(mock_adb)
+            _setup_btm(mock_btm_cls)
+
+            executor = AutomationExecutor()
+            automation = _make_automation(agent_mode="flash")
+            await executor.execute(automation, _EXEC_ID)
+
+        mock_byok.assert_awaited_once_with(_USER_ID)
+        mock_credit.assert_awaited_once_with(_USER_ID, byok=True)
+
+        _assert_astream_called_with_byok(mock_astream, expected_byok=True)
+
+    @pytest.mark.asyncio
+    async def test_oauth_only_user_flash(self):
+        """OAuth-only user: treated as has_cred=True, not mis-gated as platform user."""
+        patches = _patch_all(is_byok=False, has_oauth=True)
+
+        with (
+            patches["is_byok_active"],
+            patches["has_any_oauth"] as mock_oauth,
+            patches["enforce_credit"] as mock_credit,
+            patches["auto_db"] as mock_adb,
+            patches["flash_ws"],
+            patches["fire_webhook"],
+            patches["btm"] as mock_btm_cls,
+            patch(
+                "src.server.handlers.chat.astream_flash_workflow",
+                side_effect=_empty_async_gen,
+            ) as mock_astream,
+        ):
+            _setup_auto_db(mock_adb)
+            _setup_btm(mock_btm_cls)
+
+            executor = AutomationExecutor()
+            automation = _make_automation(agent_mode="flash")
+            await executor.execute(automation, _EXEC_ID)
+
+        mock_oauth.assert_awaited_once_with(_USER_ID)
+        mock_credit.assert_awaited_once_with(_USER_ID, byok=True)
+
+        _assert_astream_called_with_byok(mock_astream, expected_byok=True)
+
+    @pytest.mark.asyncio
+    async def test_no_cred_user_flash(self):
+        """Neither BYOK nor OAuth: enforce_credit called with byok=False (platform path)."""
+        patches = _patch_all(is_byok=False, has_oauth=False)
+
+        with (
+            patches["is_byok_active"],
+            patches["has_any_oauth"],
+            patches["enforce_credit"] as mock_credit,
+            patches["auto_db"] as mock_adb,
+            patches["flash_ws"],
+            patches["fire_webhook"],
+            patches["btm"] as mock_btm_cls,
+            patch(
+                "src.server.handlers.chat.astream_flash_workflow",
+                side_effect=_empty_async_gen,
+            ) as mock_astream,
+        ):
+            _setup_auto_db(mock_adb)
+            _setup_btm(mock_btm_cls)
+
+            executor = AutomationExecutor()
+            automation = _make_automation(agent_mode="flash")
+            await executor.execute(automation, _EXEC_ID)
+
+        mock_credit.assert_awaited_once_with(_USER_ID, byok=False)
+
+        _assert_astream_called_with_byok(mock_astream, expected_byok=False)
+
+    @pytest.mark.asyncio
+    async def test_byok_only_user_ptc(self):
+        """BYOK-only user running PTC automation: workflow gets is_byok=True."""
+        patches = _patch_all(is_byok=True, has_oauth=False)
+
+        with (
+            patches["is_byok_active"],
+            patches["has_any_oauth"],
+            patches["enforce_credit"] as mock_credit,
+            patches["auto_db"] as mock_adb,
+            patches["flash_ws"],
+            patches["fire_webhook"],
+            patches["btm"] as mock_btm_cls,
+            patch(
+                "src.server.handlers.chat.astream_ptc_workflow",
+                side_effect=_empty_async_gen,
+            ) as mock_astream,
+        ):
+            _setup_auto_db(mock_adb)
+            _setup_btm(mock_btm_cls)
+
+            executor = AutomationExecutor()
+            automation = _make_automation(agent_mode="ptc")
+            await executor.execute(automation, _EXEC_ID)
+
+        mock_credit.assert_awaited_once_with(_USER_ID, byok=True)
+        _assert_astream_called_with_byok(mock_astream, expected_byok=True)
+
+    @pytest.mark.asyncio
+    async def test_zero_credit_platform_user_is_gated(self):
+        """429 from enforce_credit_limit blocks the workflow and records failure."""
+        exc = HTTPException(status_code=429, detail={"message": "daily credit limit", "type": "credit_limit"})
+        patches = _patch_all(is_byok=False, has_oauth=False, credit_raises=exc)
+
+        with (
+            patches["is_byok_active"],
+            patches["has_any_oauth"],
+            patches["enforce_credit"],
+            patches["auto_db"] as mock_adb,
+            patches["flash_ws"],
+            patches["fire_webhook"],
+            patches["btm"] as mock_btm_cls,
+            patch(
+                "src.server.handlers.chat.astream_flash_workflow",
+                side_effect=_empty_async_gen,
+            ) as mock_astream,
+        ):
+            _setup_auto_db(mock_adb)
+            _setup_btm(mock_btm_cls)
+
+            executor = AutomationExecutor()
+            automation = _make_automation(agent_mode="flash")
+            await executor.execute(automation, _EXEC_ID)
+
+        # Workflow must NOT have been invoked
+        mock_astream.assert_not_called()
+
+        # Execution must be recorded as failed
+        _assert_execution_marked_failed(mock_adb)
+
+        # A credit-gate 429 is intentionally counted toward the failure count,
+        # so a persistently zero-credit automation eventually auto-disables.
+        mock_adb.increment_failure_count.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Assertion helpers
+# ---------------------------------------------------------------------------
+
+
+def _assert_astream_called_with_byok(mock_astream, *, expected_byok: bool):
+    """Assert the astream mock was called exactly once with is_byok=expected_byok."""
+    mock_astream.assert_called_once()
+    _, kwargs = mock_astream.call_args
+    assert "is_byok" in kwargs, "astream call missing is_byok kwarg"
+    assert kwargs["is_byok"] is expected_byok, (
+        f"expected is_byok={expected_byok}, got {kwargs['is_byok']}"
+    )
+
+
+def _assert_execution_marked_failed(mock_adb):
+    """Assert update_execution_status was called with 'failed'."""
+    calls = mock_adb.update_execution_status.call_args_list
+    statuses = [c.args[1] if c.args else c.kwargs.get("status") for c in calls]
+    assert "failed" in statuses, (
+        f"Expected execution to be marked 'failed', got statuses: {statuses}"
+    )
+
+
+def _setup_auto_db(mock_adb):
+    """Wire up common auto_db mock return values."""
+    mock_adb.update_execution_status = AsyncMock()
+    mock_adb.reset_failure_count = AsyncMock()
+    mock_adb.increment_failure_count = AsyncMock()
+    mock_adb.update_automation_next_run = AsyncMock()
+    mock_adb.update_automation = AsyncMock()
+    mock_adb.restore_executing_to_active = AsyncMock()
+
+
+def _setup_btm(mock_btm_cls):
+    """Wire up BackgroundTaskManager mock."""
+    mock_btm = MagicMock()
+    mock_btm.wait_for_persistence = AsyncMock()
+    mock_btm_cls.get_instance = MagicMock(return_value=mock_btm)

--- a/tests/unit/server/services/test_automation_executor_credit.py
+++ b/tests/unit/server/services/test_automation_executor_credit.py
@@ -134,7 +134,9 @@ class TestCredentialGate:
 
     @pytest.mark.asyncio
     async def test_oauth_only_user_flash(self):
-        """OAuth-only user: treated as has_cred=True, not mis-gated as platform user."""
+        """OAuth-only user: credit gate sees has_cred=True (not mis-gated as a
+        platform user), but the workflow gets is_byok=False — the BYOK ladder is
+        not attempted for a user with no BYOK keys."""
         patches = _patch_all(is_byok=False, has_oauth=True)
 
         with (
@@ -158,9 +160,11 @@ class TestCredentialGate:
             await executor.execute(automation, _EXEC_ID)
 
         mock_oauth.assert_awaited_once_with(_USER_ID)
+        # Credit gate keys off has_cred (BYOK or OAuth); workflow is_byok keys
+        # off has_byok alone — OAuth-only ⟹ gate byok=True, workflow is_byok=False.
         mock_credit.assert_awaited_once_with(_USER_ID, byok=True)
 
-        _assert_astream_called_with_byok(mock_astream, expected_byok=True)
+        _assert_astream_called_with_byok(mock_astream, expected_byok=False)
 
     @pytest.mark.asyncio
     async def test_no_cred_user_flash(self):

--- a/tests/unit/server/services/test_insight_service.py
+++ b/tests/unit/server/services/test_insight_service.py
@@ -8,7 +8,7 @@ user context building, and schedule computation.
 import asyncio
 import json
 from datetime import datetime, timedelta, timezone
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -19,6 +19,7 @@ from src.server.services.insight_service import (
     InsightService,
     _extract_json_string,
     _extract_structured_output,
+    _llm_extract_fallback,
 )
 
 
@@ -135,7 +136,7 @@ class TestExtractWithFallback:
     )
     async def test_direct_parse_succeeds(self, mock_extract):
         svc = InsightService()
-        result = await svc._extract_with_fallback("some raw text")
+        result = await svc._extract_with_fallback("some raw text", user_id=None)
 
         assert result["headline"] == "Markets rally on strong earnings"
         mock_extract.assert_called_once_with("some raw text")
@@ -152,11 +153,135 @@ class TestExtractWithFallback:
     )
     async def test_direct_fails_llm_fallback_succeeds(self, mock_extract, mock_fallback):
         svc = InsightService()
-        result = await svc._extract_with_fallback("bad raw text")
+        result = await svc._extract_with_fallback("bad raw text", user_id=None)
 
         assert result["headline"] == "Fallback headline"
         mock_extract.assert_called_once_with("bad raw text")
-        mock_fallback.assert_awaited_once_with("bad raw text")
+        mock_fallback.assert_awaited_once_with("bad raw text", user_id=None)
+
+    @pytest.mark.asyncio
+    @patch(
+        "src.server.services.insight_service._llm_extract_fallback",
+        new_callable=AsyncMock,
+        return_value=_valid_output(headline="Fallback user headline"),
+    )
+    @patch(
+        "src.server.services.insight_service._extract_structured_output",
+        side_effect=ValueError("Direct JSON parsing failed"),
+    )
+    async def test_extract_with_fallback_threads_user_id(self, mock_extract, mock_fallback):
+        """user_id passed to _extract_with_fallback is forwarded to _llm_extract_fallback."""
+        svc = InsightService()
+        result = await svc._extract_with_fallback("bad raw text", user_id="usr-abc")
+
+        assert result["headline"] == "Fallback user headline"
+        mock_fallback.assert_awaited_once_with("bad raw text", user_id="usr-abc")
+
+    @pytest.mark.asyncio
+    @patch(
+        "src.server.services.insight_service._llm_extract_fallback",
+        new_callable=AsyncMock,
+        return_value=_valid_output(headline="Fallback none headline"),
+    )
+    @patch(
+        "src.server.services.insight_service._extract_structured_output",
+        side_effect=ValueError("Direct JSON parsing failed"),
+    )
+    async def test_extract_with_fallback_none_user_id(self, mock_extract, mock_fallback):
+        """user_id=None is forwarded unchanged (system/scheduled path)."""
+        svc = InsightService()
+        result = await svc._extract_with_fallback("bad raw text", user_id=None)
+
+        assert result["headline"] == "Fallback none headline"
+        mock_fallback.assert_awaited_once_with("bad raw text", user_id=None)
+
+
+# ---------------------------------------------------------------------------
+# _llm_extract_fallback
+# ---------------------------------------------------------------------------
+
+class TestLLMExtractFallback:
+    """Test _llm_extract_fallback routes through LLMService.complete."""
+
+    @pytest.mark.asyncio
+    async def test_calls_llm_service_complete_with_user_id(self):
+        """_llm_extract_fallback delegates to LLMService.complete with the supplied user_id."""
+        from src.server.models.market_insight import InsightOutputSchema
+
+        stub_result = MagicMock(spec=InsightOutputSchema)
+        stub_result.model_dump.return_value = _valid_output()
+
+        mock_agent_config = MagicMock()
+
+        with (
+            patch("src.server.app.setup") as mock_setup,
+            patch("src.server.services.llm_service.LLMService") as MockLLMService,
+        ):
+            mock_setup.agent_config = mock_agent_config
+            mock_instance = MagicMock()
+            mock_instance.complete = AsyncMock(return_value=stub_result)
+            MockLLMService.return_value = mock_instance
+
+            result = await _llm_extract_fallback("some raw text", user_id="usr-x")
+
+        # Constructor must receive agent_config from setup
+        ctor_kwargs = MockLLMService.call_args.kwargs
+        assert ctor_kwargs["agent_config"] is mock_agent_config
+        # complete() must be called with user_id, response_schema, mode
+        mock_instance.complete.assert_awaited_once()
+        call_kwargs = mock_instance.complete.call_args.kwargs
+        assert call_kwargs["user_id"] == "usr-x"
+        assert call_kwargs["response_schema"] is InsightOutputSchema
+        assert call_kwargs["mode"] == "flash"
+        assert result == _valid_output()
+
+    @pytest.mark.asyncio
+    async def test_calls_llm_service_complete_with_none_user_id(self):
+        """user_id=None is passed through to LLMService.complete (system/scheduled path)."""
+        from src.server.models.market_insight import InsightOutputSchema
+
+        stub_result = MagicMock(spec=InsightOutputSchema)
+        stub_result.model_dump.return_value = _valid_output()
+
+        mock_agent_config = MagicMock()
+
+        with (
+            patch("src.server.app.setup") as mock_setup,
+            patch("src.server.services.llm_service.LLMService") as MockLLMService,
+        ):
+            mock_setup.agent_config = mock_agent_config
+            mock_instance = MagicMock()
+            mock_instance.complete = AsyncMock(return_value=stub_result)
+            MockLLMService.return_value = mock_instance
+
+            result = await _llm_extract_fallback("some raw text", user_id=None)
+
+        call_kwargs = mock_instance.complete.call_args.kwargs
+        assert call_kwargs["user_id"] is None
+        assert call_kwargs["mode"] == "flash"
+        assert result == _valid_output()
+
+    @pytest.mark.asyncio
+    async def test_no_create_llm_imported(self):
+        """_llm_extract_fallback must not import or call create_llm."""
+        stub_result = MagicMock()
+        stub_result.model_dump.return_value = _valid_output()
+
+        mock_agent_config = MagicMock()
+
+        with (
+            patch("src.server.app.setup") as mock_setup,
+            patch("src.server.services.llm_service.LLMService") as MockLLMService,
+            patch("src.llms.llm.create_llm") as mock_create_llm,
+        ):
+            mock_setup.agent_config = mock_agent_config
+            mock_instance = MagicMock()
+            mock_instance.complete = AsyncMock(return_value=stub_result)
+            MockLLMService.return_value = mock_instance
+
+            await _llm_extract_fallback("some text", user_id="usr-y")
+
+        mock_create_llm.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/server/services/test_llm_service.py
+++ b/tests/unit/server/services/test_llm_service.py
@@ -9,6 +9,8 @@ Covers:
 - ``response_schema=SomeModel`` returns a pydantic instance.
 - ``return_token_usage=True`` returns a tuple.
 - ``request_model`` override reaches both code paths (None + user_id).
+- ``platform_key_fallback`` log fires for PLATFORM/NONE credential sources
+  and is suppressed for OAUTH/BYOK and the ``user_id=None`` system path.
 """
 
 from __future__ import annotations
@@ -19,6 +21,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from pydantic import BaseModel
 
+from ptc_agent.config.agent import CredentialSource
 from src.server.services.llm_service import LLMService
 
 
@@ -129,6 +132,7 @@ class TestUserIdProvided:
         resolved_config = SimpleNamespace(
             llm=SimpleNamespace(flash="flash-resolved", name="name-resolved"),
             llm_client=resolved_llm,
+            credential_source=CredentialSource.BYOK,
         )
 
         with (
@@ -187,6 +191,7 @@ class TestUserIdProvided:
         resolved_config = SimpleNamespace(
             llm=SimpleNamespace(flash="flash-resolved", name="name-resolved"),
             llm_client=None,
+            credential_source=CredentialSource.NONE,
         )
         fake_llm = MagicMock(name="fallback_llm")
 
@@ -320,6 +325,7 @@ class TestRequestModelOverride:
         resolved_config = SimpleNamespace(
             llm=SimpleNamespace(flash="flash-resolved", name="name-resolved"),
             llm_client=MagicMock(),
+            credential_source=CredentialSource.BYOK,
         )
 
         with (
@@ -341,3 +347,142 @@ class TestRequestModelOverride:
             )
 
         assert mock_resolve.await_args.kwargs["request_model"] == "custom-model-slug"
+
+
+# ---------------------------------------------------------------------------
+# platform_key_fallback signal — driven by credential_source, not llm is None
+# ---------------------------------------------------------------------------
+
+
+def _make_resolved_config(
+    *,
+    credential_source: CredentialSource,
+    llm_client=None,
+    flash: str = "flash-model",
+    name: str = "name-model",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        llm=SimpleNamespace(flash=flash, name=name),
+        llm_client=llm_client,
+        credential_source=credential_source,
+    )
+
+
+class TestPlatformKeyFallbackSignal:
+    """``platform_key_fallback`` must fire for PLATFORM and NONE, not for OAUTH/BYOK."""
+
+    async def _run(self, service, *, credential_source, llm_client):
+        """Helper: patch resolve_llm_config with given source/client, run complete()."""
+        resolved_config = _make_resolved_config(
+            credential_source=credential_source, llm_client=llm_client
+        )
+        fake_llm = MagicMock(name="fake_llm")
+        with (
+            patch(
+                "src.server.services.llm_service.resolve_llm_config",
+                new_callable=AsyncMock,
+                return_value=resolved_config,
+            ),
+            patch(
+                "src.server.services.llm_service.create_llm",
+                return_value=fake_llm,
+            ),
+            patch(
+                "src.server.services.llm_service.make_api_call",
+                new_callable=AsyncMock,
+                return_value="ok",
+            ),
+        ):
+            await service.complete(user_id="user-a", user_prompt="test", mode="flash")
+
+    @pytest.mark.asyncio
+    async def test_platform_eager_emits_signal(self):
+        """PLATFORM + llm_client SET (eager case missed by the old code) → signal fires."""
+        agent_config = _make_agent_config()
+        mock_logger = MagicMock()
+        service = LLMService(agent_config=agent_config, logger=mock_logger)
+
+        eager_client = MagicMock(name="eager_platform_client")
+        await self._run(
+            service,
+            credential_source=CredentialSource.PLATFORM,
+            llm_client=eager_client,
+        )
+
+        mock_logger.info.assert_called_once()
+        call_args = mock_logger.info.call_args
+        assert call_args.args[0] == "llm_service.platform_key_fallback"
+        extra = call_args.kwargs["extra"]
+        assert extra["user_id"] == "user-a"
+        assert extra["credential_source"] == str(CredentialSource.PLATFORM)
+
+    @pytest.mark.asyncio
+    async def test_none_lazy_emits_signal(self):
+        """NONE + llm_client None (lazy create_llm path) → signal fires."""
+        agent_config = _make_agent_config()
+        mock_logger = MagicMock()
+        service = LLMService(agent_config=agent_config, logger=mock_logger)
+
+        await self._run(
+            service,
+            credential_source=CredentialSource.NONE,
+            llm_client=None,
+        )
+
+        mock_logger.info.assert_called_once()
+        call_args = mock_logger.info.call_args
+        assert call_args.args[0] == "llm_service.platform_key_fallback"
+        extra = call_args.kwargs["extra"]
+        assert extra["credential_source"] == str(CredentialSource.NONE)
+
+    @pytest.mark.asyncio
+    async def test_byok_suppresses_signal(self):
+        """BYOK → no platform log."""
+        agent_config = _make_agent_config()
+        mock_logger = MagicMock()
+        service = LLMService(agent_config=agent_config, logger=mock_logger)
+
+        await self._run(
+            service,
+            credential_source=CredentialSource.BYOK,
+            llm_client=MagicMock(name="byok_client"),
+        )
+
+        mock_logger.info.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_oauth_suppresses_signal(self):
+        """OAUTH → no platform log."""
+        agent_config = _make_agent_config()
+        mock_logger = MagicMock()
+        service = LLMService(agent_config=agent_config, logger=mock_logger)
+
+        await self._run(
+            service,
+            credential_source=CredentialSource.OAUTH,
+            llm_client=MagicMock(name="oauth_client"),
+        )
+
+        mock_logger.info.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_user_id_none_system_path_suppresses_signal(self):
+        """user_id=None (system task) → no resolution → no platform log."""
+        agent_config = _make_agent_config(flash="sys-flash-model")
+        mock_logger = MagicMock()
+        service = LLMService(agent_config=agent_config, logger=mock_logger)
+
+        with (
+            patch(
+                "src.server.services.llm_service.create_llm",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "src.server.services.llm_service.make_api_call",
+                new_callable=AsyncMock,
+                return_value="ok",
+            ),
+        ):
+            await service.complete(user_id=None, user_prompt="system task")
+
+        mock_logger.info.assert_not_called()

--- a/tests/unit/test_llm_constructor_boundary.py
+++ b/tests/unit/test_llm_constructor_boundary.py
@@ -138,6 +138,11 @@ def scan_tree(roots: tuple[str, ...]) -> tuple[list[Violation], list[tuple[str, 
     parse_errors: list[tuple[str, str]] = []
     for root in roots:
         abs_root = os.path.join(REPO_ROOT, root)
+        if not os.path.isdir(abs_root):
+            # A renamed/moved scan root must fail loudly, not silently drop
+            # coverage for that directory.
+            parse_errors.append((root, "scan root does not exist"))
+            continue
         for dirpath, _dirnames, filenames in os.walk(abs_root):
             if "__pycache__" in dirpath.split(os.sep):
                 continue

--- a/tests/unit/test_llm_constructor_boundary.py
+++ b/tests/unit/test_llm_constructor_boundary.py
@@ -1,0 +1,265 @@
+"""CI guard: forbid request-time LLM constructors outside the credential-resolution chain.
+
+AST-scans agent/tool/server-service source for calls to request-time LLM
+constructors and fails on any call not on the allowlist. New code must route
+through ``resolve_llm_config`` / ``LLMService.complete`` so BYOK, OAuth, and
+per-user model preferences are respected.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+from dataclasses import dataclass
+
+# Repo root = two levels up from this file (tests/unit/).
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Dirs scanned for request-time constructor calls (relative to repo root).
+SCAN_ROOTS = (
+    "src/ptc_agent",
+    "src/tools",
+    "src/server/services",
+)
+
+# Bare-name constructors: create_llm("...") etc.
+BARE_CONSTRUCTORS = frozenset(
+    {
+        "create_llm",
+        "create_llm_from_custom",
+        "init_chat_model",
+        "get_llm_by_type",
+    }
+)
+
+# Method-call constructors: the `LLM(model).get_llm()` pattern. Matched on the
+# attribute name only (node.func.attr).
+ATTR_CONSTRUCTORS = frozenset({"get_llm"})
+
+# LangChain chat-model class constructors (explicit set so app data models like
+# ChatRequest / ChatMessage are NOT mistaken for LLM constructors).
+#
+# Known scanner limitations (deliberate trade-offs — silence does NOT prove safety):
+#   1. Aliased imports are NOT caught: `from x import create_llm as foo; foo(...)`
+#      matches on the callee name only, so a renamed callee slips through. Keep using
+#      the canonical constructor names (BARE_CONSTRUCTORS / ATTR_CONSTRUCTORS above).
+#   2. New LangChain chat-model provider classes not listed below are missed. This is
+#      an explicit allowlist on purpose — a Chat*-prefix heuristic false-positives on
+#      app models like ChatRequest / ChatMessage. When adopting a new provider (e.g.
+#      ChatXAI), add its class name here so direct construction is detected.
+CHAT_MODEL_CLASSES = frozenset(
+    {
+        "ChatOpenAI",
+        "AzureChatOpenAI",
+        "ChatAnthropic",
+        "ChatGoogleGenerativeAI",
+        "ChatVertexAI",
+        "ChatBedrock",
+        "ChatBedrockConverse",
+        "ChatLiteLLM",
+        "ChatDeepSeek",
+        "ChatGroq",
+        "ChatMistralAI",
+        "ChatCohere",
+        "ChatFireworks",
+        "ChatTogether",
+        "ChatOllama",
+    }
+)
+
+CONSTRUCTOR_NAMES = BARE_CONSTRUCTORS | ATTR_CONSTRUCTORS | CHAT_MODEL_CLASSES
+
+
+# Allowlist of legitimate request-time constructor call sites.
+# Keyed by (relative_path, callee_name) -> expected call count. The count makes
+# the guard bite: a NEW call of an already-listed (file, callee) trips a count
+# mismatch and forces a deliberate, justified bump here.
+ALLOWLIST: dict[tuple[str, str], int] = {
+    # get_llm_client lazy factory — OSS standalone path, no server resolution ran.
+    ("src/ptc_agent/config/agent.py", "create_llm"): 1,
+    # flash standalone build.
+    ("src/ptc_agent/agent/flash/agent.py", "create_llm"): 1,
+    # flash fallback-model name path.
+    ("src/ptc_agent/agent/flash/agent.py", "get_llm_by_type"): 1,
+    # main-agent fallback-model name path.
+    ("src/ptc_agent/agent/agent.py", "get_llm_by_type"): 1,
+    # compaction summarizer name path (compact.py helper).
+    ("src/ptc_agent/agent/middleware/compaction/compact.py", "get_llm_by_type"): 1,
+    # compaction middleware fallback name path.
+    ("src/ptc_agent/agent/middleware/compaction/middleware.py", "get_llm_by_type"): 1,
+    # compaction middleware model coercion (string model -> chat model).
+    ("src/ptc_agent/agent/middleware/compaction/middleware.py", "init_chat_model"): 1,
+    # non-BYOK fetch name path (reached only for non-credentialed users).
+    ("src/tools/fetch.py", "get_llm"): 1,
+    # user_id=None system path AND resolved-None platform fallback (two calls).
+    ("src/server/services/llm_service.py", "create_llm"): 2,
+}
+
+
+@dataclass(frozen=True)
+class Violation:
+    path: str  # repo-relative
+    line: int
+    callee: str
+
+
+def _callee_name(func: ast.expr) -> str | None:
+    """Return the callee name for a Call node's func, or None if not a name/attr."""
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def find_constructor_calls(source: str, rel_path: str) -> list[Violation]:
+    """Parse source and return every request-time LLM constructor Call as a Violation.
+
+    Because matches are AST Call nodes, docstring examples and comments are
+    naturally excluded (they are str constants, not parsed calls).
+    """
+    tree = ast.parse(source, filename=rel_path)
+    found: list[Violation] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = _callee_name(node.func)
+        if name is not None and name in CONSTRUCTOR_NAMES:
+            found.append(Violation(path=rel_path, line=node.lineno, callee=name))
+    return found
+
+
+def scan_tree(roots: tuple[str, ...]) -> tuple[list[Violation], list[tuple[str, str]]]:
+    """Scan roots for constructor calls. Returns (calls, parse_errors).
+
+    Skips __pycache__ and test files; reports unparseable files instead of crashing.
+    """
+    calls: list[Violation] = []
+    parse_errors: list[tuple[str, str]] = []
+    for root in roots:
+        abs_root = os.path.join(REPO_ROOT, root)
+        for dirpath, _dirnames, filenames in os.walk(abs_root):
+            if "__pycache__" in dirpath.split(os.sep):
+                continue
+            for fn in filenames:
+                if not fn.endswith(".py"):
+                    continue
+                if fn.startswith("test_") or fn.endswith("_test.py"):
+                    continue
+                abs_path = os.path.join(dirpath, fn)
+                rel_path = os.path.relpath(abs_path, REPO_ROOT)
+                try:
+                    with open(abs_path, encoding="utf-8") as fh:
+                        source = fh.read()
+                except (OSError, UnicodeDecodeError) as exc:
+                    parse_errors.append((rel_path, str(exc)))
+                    continue
+                try:
+                    calls.extend(find_constructor_calls(source, rel_path))
+                except SyntaxError as exc:
+                    parse_errors.append((rel_path, str(exc)))
+    return calls, parse_errors
+
+
+def violations_against_allowlist(
+    calls: list[Violation], allowlist: dict[tuple[str, str], int]
+) -> list[str]:
+    """Return human-readable violation messages for calls not matching the allowlist.
+
+    Three ways to violate: (1) a (file, callee) not in the allowlist at all,
+    (2) more or fewer calls of a listed (file, callee) than the expected count,
+    (3) a stale allowlist entry whose (file, callee) is no longer present.
+    """
+    messages: list[str] = []
+
+    # Group calls by (file, callee).
+    grouped: dict[tuple[str, str], list[Violation]] = {}
+    for call in calls:
+        grouped.setdefault((call.path, call.callee), []).append(call)
+
+    for key, group in sorted(grouped.items()):
+        rel_path, callee = key
+        expected = allowlist.get(key)
+        if expected is None:
+            for v in group:
+                messages.append(
+                    f"{v.path}:{v.line}: unexpected request-time LLM constructor "
+                    f"'{v.callee}' (this (file, callee) is not on the allowlist)"
+                )
+        elif len(group) != expected:
+            lines = ", ".join(str(v.line) for v in sorted(group, key=lambda x: x.line))
+            messages.append(
+                f"{rel_path}: '{callee}' called {len(group)} time(s) at line(s) "
+                f"{lines}, but allowlist expects {expected}"
+            )
+
+    # Stale-entry check: an allowlisted (file, callee) with no matching found call
+    # is dead weight after a refactor/rename/delete — flag it so it gets removed.
+    for key, expected in sorted(allowlist.items()):
+        if key not in grouped:
+            rel_path, callee = key
+            messages.append(
+                f"{rel_path}: '{callee}' is allowlisted (expected {expected}) but was "
+                f"not found — remove this stale entry"
+            )
+
+    return messages
+
+
+_REMEDIATION = (
+    "\n\nYou added (or moved) a request-time LLM constructor in a scanned dir. "
+    "Route the call through resolve_llm_config / LLMService.complete instead so "
+    "BYOK, OAuth, and per-user model preferences are respected. If it is a "
+    "legitimate platform or lazy-fallback path, add it to the ALLOWLIST in "
+    "tests/unit/test_llm_constructor_boundary.py with a one-line justification "
+    "(and bump the expected count if extending an existing entry)."
+)
+
+
+def test_no_unallowlisted_llm_constructors() -> None:
+    """The scanned tree must contain only allowlisted request-time constructors."""
+    calls, parse_errors = scan_tree(SCAN_ROOTS)
+    assert not parse_errors, f"files failed to parse: {parse_errors}"
+
+    messages = violations_against_allowlist(calls, ALLOWLIST)
+    assert not messages, "request-time LLM constructor boundary violations:\n" + "\n".join(
+        messages
+    ) + _REMEDIATION
+
+
+def test_insight_service_has_no_constructors() -> None:
+    """insight_service.py must route through LLMService — no direct constructors.
+
+    Intentionally rescans the tree (rather than sharing the main test's scan) to
+    stand as standalone intent-documentation: insight_service must never regain a
+    request-time LLM constructor, even via `-k insight`.
+    """
+    calls, _ = scan_tree(SCAN_ROOTS)
+    offenders = [c for c in calls if c.path.endswith("services/insight_service.py")]
+    assert not offenders, (
+        "insight_service.py must not call LLM constructors directly; found "
+        + ", ".join(f"{c.callee}@{c.line}" for c in offenders)
+        + _REMEDIATION
+    )
+
+
+def test_scanner_detects_stray_constructor() -> None:
+    """Self-test: a synthetic off-allowlist call is flagged as a violation.
+
+    Proves the guard is not vacuous — a real stray constructor would be caught.
+    """
+    snippet = "from x import create_llm\nllm = create_llm('some-model')\n"
+    calls = find_constructor_calls(snippet, "src/tools/stray_example.py")
+    assert any(c.callee == "create_llm" for c in calls), "scanner missed a stray call"
+
+    # With an empty allowlist the synthetic call must register as a violation.
+    messages = violations_against_allowlist(calls, allowlist={})
+    assert messages, "scanner produced no violation for an off-allowlist call"
+    assert any("create_llm" in m for m in messages)
+
+
+def test_scanner_ignores_docstring_example() -> None:
+    """AST scan must NOT flag a constructor name that appears only in a docstring."""
+    snippet = '"""Example:\n\n    llm = ChatAnthropic(model="x")\n"""\n\nx = 1\n'
+    calls = find_constructor_calls(snippet, "src/ptc_agent/config/example.py")
+    assert not calls, f"docstring example was wrongly flagged: {calls}"


### PR DESCRIPTION
## Summary

A BYOK/OAuth user's own key was silently replaced by the platform key on several
LLM paths. These weren't independent bugs — they were divergences from an
architecture that already half-existed. This finishes it: one resolution
primitive, one role accessor, roles-as-data, and a CI guard so new code can't
reintroduce a divergent path.

**Core abstraction**
- `CredentialSource` (OAUTH / BYOK / PLATFORM / NONE) — first-class answer to
  "did the user's credential pay?", distinct from `ModelSource` (which classifies
  the model). Stamped on `AgentConfig.credential_source` by the resolver.
- `resolve_model_client()` — single primitive returning `ResolvedClient(client,
  model_source, credential_source)`. One OAuth → BYOK → platform ladder replaces
  three duplicated platform-fallback spots.
- `role_registry()` + `LLMRole` — compaction, fetch, and `subagent:<name>` resolve
  through one loop with one BYOK-pure fallback policy. Subagents stop being a
  special case.
- `client_for_role()` accessor on `AgentConfig` — consumers read role clients
  through one method; the BYOK-pure fallback is materialized once at write time.

**Bug fixes that fall out of it**
- **Credit-gate bypass (`threads.py`):** gate now keys off `credential_source`,
  not `llm_client is not None`. A non-BYOK reasoning user built a platform client,
  which made `llm_client != None` → wrongly treated as BYOK → hit the BYOK
  negative-balance gate instead of the platform daily-credit gate. Closed.
- **Automation (`automation_executor.py`):** previously skipped the credit gate
  entirely and never attempted BYOK. Now computes `has_cred = is_byok_active OR
  has_any_oauth_token`, gates with `enforce_credit_limit` before the workflow, and
  passes `is_byok=has_cred` to both workflow calls. OAuth-only users no longer
  mis-gated as platform.
- **Coding-variant BYOK (`resolve_byok_llm_client`):** system branch now walks
  [provider → parent → sibling] to find the key, but pins SDK/base_url to the
  model's own provider. Fixes silent platform fallback for `*-coding` models whose
  key lives under the variant slug.
- **Custom-provider SDK (#221):** custom providers inherit their manifest parent's
  SDK so an Anthropic-parented gateway no longer builds an OpenAI client pointed at
  an Anthropic endpoint (404). OpenAI-compatible gateways are left untouched (no
  forced Responses API).
- **Fetch / compaction:** both now use the materialized role client for BYOK users
  (their key pays) and the cheap name-based platform model for system users.
- **Insight fallback:** routed through `LLMService.complete` with a threaded
  `user_id` — deletes the last raw `create_llm` in the insight path.

**Forever guard**
- `test_llm_constructor_boundary.py` — AST scan of `ptc_agent/**`, `tools/**`,
  `server/services/**` for request-time LLM constructors off an allowlist. New
  divergent paths fail CI.

## Diff Size
- Total: 31 files changed, 3038 insertions(+), 416 deletions(-)
- Net (excl. tests): 14 files changed, 749 insertions(+), 393 deletions(-)

## Test Coverage
3555 backend unit tests pass. 15 test files added/changed covering:
- `resolve_model_client` (OAuth-first / BYOK-second / platform-only-when-allowed)
- `credential_source` matrix (OAuth, BYOK, BYOK-on-system-model, non-BYOK+reasoning
  → PLATFORM, non-BYOK no-reasoning → NONE)
- BYOK-pure materialization gated on `credential_source` (PLATFORM client NOT
  copied into roles — regression guard)
- coding-variant walk + SDK-trap guard (neutral placeholder providers)
- `threads.py` credit-gate regression (platform daily vs BYOK negative-balance)
- automation gate (BYOK-only / OAuth-only / neither + gate-before-workflow)
- subagent instance injection reaches `create_agent` (not the string)
- fetch context-var contract + copy-before-mutate
- `_byok_cache` miss safety (custom provider resolves via direct lookup)
- the constructor-boundary AST guard + self-test

## Live verification (against a running backend, BYOK user)
- Web fetch: extraction sub-call billed `billing_type: byok`, 0 platform cost
- Subagent: research subagent's calls billed byok, 0 platform cost
- Automation (happy path): gate passed, run billed byok, `total_credits=0`
- Automation (gate block): forced negative balance → execution `failed` with
  `429 negative_balance`, no usage row created, workflow never ran
- Platform billing (prod manifest): `is_byok=false`, credits charged

## Out of scope (tracked, deferred)
- Platform-credit deduction (cross-service ginlix-platform integration) — this
  change only gates and emits the `metered_to_user` signal; no code deducts yet.
- Thread-less one-shot / insight usage recording — needs a thread-less usage path
  AND the absent deduction consumer; designed together later.
- OpenAI O1/O3 Responses-API edge cases, DELETE-key cache invalidation, HITL resume
  BYOK threading — documented in the plan, not triggered by current models.

## Test plan
- [x] 3555 backend unit tests pass (`PYTHONPATH=src pytest tests/unit/ -q`)
- [x] Live e2e: BYOK billing on main model, fetch, subagent, automation
- [x] Live e2e: automation credit gate blocks (no free run)
- [x] Live e2e: platform billing charges credits (prod manifest)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per‑subagent model selection so agents can use role-specific models.

* **Bug Fixes**
  * Fixed credential-source handling and BYOK key discovery across provider variants.
  * Clearer user-facing errors when a selected model is unavailable, with a Settings CTA.

* **Infrastructure**
  * Improved LLM credential resolution, compaction client selection, and credit‑gating for automation workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->