### PR TITLE
fix(chat): reconnect from live-stream cursor after refresh

### DIFF
--- a/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.reconnectCursor.test.ts
+++ b/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.reconnectCursor.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Regression: reconnect after refresh must NOT carry the history-replay cursor
+ * into the live workflow stream.
+ *
+ * `/messages/replay` numbers events with a cumulative per-thread counter (a
+ * thread with lots of history reaches id 900+). The live workflow stream
+ * (`workflow:stream:{tid}:{rid}`) resets its ids to 1 per run. If the client
+ * reconnects with the replay-derived `last_event_id`, the backend's XREAD
+ * cursor overshoots the fresh run's id space, blocks forever, and the stream
+ * delivers zero events — the response sits frozen.
+ *
+ * Contract pinned here: after replaying history, the reconnect is issued with
+ * `last_event_id == null` (replay the live stream from the start), regardless of
+ * how large the replayed event ids were. `lastEventIdRef` is reserved for ids
+ * received on the LIVE stream only.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+import { waitFor } from '@testing-library/react';
+import { renderHookWithProviders } from '@/test/utils';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+vi.mock('@/lib/supabase', () => ({ supabase: null }));
+
+vi.mock('../utils/threadStorage', () => ({
+  getStoredThreadId: vi.fn().mockReturnValue('thread-A'),
+  setStoredThreadId: vi.fn(),
+  removeStoredThreadId: vi.fn(),
+}));
+
+vi.mock('../utils/streamEventHandlers', () => ({
+  handleReasoningSignal: vi.fn(),
+  handleReasoningContent: vi.fn(),
+  handleTextContent: vi.fn(),
+  handleToolCalls: vi.fn(),
+  handleToolCallResult: vi.fn(),
+  handleToolCallChunks: vi.fn(),
+  handleTodoUpdate: vi.fn(),
+  isSubagentEvent: vi.fn().mockReturnValue(false),
+  handleSubagentMessageChunk: vi.fn(),
+  handleSubagentToolCallChunks: vi.fn(),
+  handleSubagentToolCalls: vi.fn(),
+  handleSubagentToolCallResult: vi.fn(),
+  handleTaskSteeringAccepted: vi.fn(),
+  getOrCreateTaskRefs: vi.fn().mockReturnValue({
+    contentOrderCounterRef: { current: 0 },
+    currentReasoningIdRef: { current: null },
+    currentToolCallIdRef: { current: null },
+  }),
+}));
+
+vi.mock('../utils/historyEventHandlers', () => ({
+  handleHistoryUserMessage: vi.fn(),
+  handleHistoryReasoningSignal: vi.fn(),
+  handleHistoryReasoningContent: vi.fn(),
+  handleHistoryTextContent: vi.fn(),
+  handleHistoryToolCalls: vi.fn(),
+  handleHistoryToolCallResult: vi.fn(),
+  handleHistoryTodoUpdate: vi.fn(),
+  handleHistorySteeringDelivered: vi.fn(),
+  handleHistoryInterrupt: vi.fn(),
+  handleHistoryArtifact: vi.fn(),
+}));
+
+vi.mock('../../utils/api', () => ({
+  sendChatMessageStream: vi.fn(),
+  sendHitlResponse: vi.fn(),
+  // Replay a thread with substantial history: events carry a large cumulative
+  // id-space (last id 930), mirroring the real `/messages/replay` counter.
+  replayThreadHistory: vi.fn().mockImplementation(async (tid: string, onEvent: (e: Record<string, unknown>) => void) => {
+    onEvent({ event: 'user_message', _eventId: 929, turn_index: 0, content: 'earlier turn' });
+    onEvent({ event: 'replay_done', _eventId: 930, thread_id: tid });
+  }),
+  getWorkflowStatus: vi.fn().mockResolvedValue({
+    can_reconnect: true,
+    status: 'active',
+    active_tasks: [],
+    is_shared: false,
+  }),
+  reconnectToWorkflowStream: vi.fn().mockResolvedValue({ disconnected: false }),
+  streamSubagentTaskEvents: vi.fn(),
+  fetchThreadTurns: vi.fn().mockResolvedValue({ turns: [], retry_checkpoint_id: null }),
+  submitFeedback: vi.fn(),
+  removeFeedback: vi.fn(),
+  getThreadFeedback: vi.fn().mockResolvedValue([]),
+}));
+
+import { reconnectToWorkflowStream } from '../../utils/api';
+import { useChatMessages } from '../useChatMessages';
+
+const mockReconnect = reconnectToWorkflowStream as Mock;
+
+describe('useChatMessages – reconnect cursor after refresh', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reconnects with a null last_event_id even when history replay had large event ids', async () => {
+    renderHookWithProviders(() => useChatMessages('ws-A', 'thread-A'));
+
+    await waitFor(() => {
+      expect(mockReconnect).toHaveBeenCalledTimes(1);
+    });
+
+    // Signature: reconnectToWorkflowStream(threadId, runId, lastEventId, onEvent)
+    const [threadIdArg, runIdArg, lastEventIdArg] = mockReconnect.mock.calls[0];
+    expect(threadIdArg).toBe('thread-A');
+    expect(runIdArg).toBeNull(); // fresh attach — no run_id known yet
+    // The bug: this was 930 (the replay cursor), which overshoots the live
+    // per-run stream and freezes the reconnect. Must be null/0.
+    expect(lastEventIdArg ?? null).toBeNull();
+  });
+});

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -725,6 +725,14 @@ export function useChatMessages(
       newMessagesStartIndexRef.current = 0;
       setMessages((prev) => prev.filter((m) => !m.isHistory));
 
+      // Fresh attach (refresh or thread switch): clear the live-stream cursor so
+      // the subsequent reconnect replays the run's stream from the start. We
+      // hold no live events yet, and the replay id-space must not leak into the
+      // live reconnect (see the note in the replay handler below). The
+      // mid-stream disconnect-retry path does NOT call this loader, so its
+      // resume cursor is preserved.
+      lastEventIdRef.current = null;
+
       const threadIdToUse = threadId;
       console.log('[History] Loading history for thread:', threadIdToUse);
 
@@ -754,10 +762,15 @@ export function useChatMessages(
         const hasRole = event.role !== undefined;
         const hasPairIndex = event.turn_index !== undefined;
 
-        // Track last event ID so reconnectToStream can deduplicate
-        if (event._eventId != null) {
-          lastEventIdRef.current = event._eventId;
-        }
+        // NOTE: do NOT write `event._eventId` into `lastEventIdRef` here.
+        // Replay (`/messages/replay`) numbers events with a cumulative
+        // per-thread counter, while the live workflow stream
+        // (`workflow:stream:{tid}:{rid}`) resets its ids to 1 per run. After a
+        // refresh, carrying the replay cursor into the live reconnect overshoots
+        // the run's id space — the backend's XREAD blocks forever and the stream
+        // delivers zero events (frozen response). `lastEventIdRef` must only ever
+        // track ids received on the LIVE stream (set in the streaming
+        // `processEvent` handler); history dedup uses deterministic bubble ids.
 
         // compaction_chunk is the side channel for LLM output from the
         // compaction middleware (bracketed by context_window summarize


### PR DESCRIPTION
## Summary

Fixes a recent regression where refreshing the page mid-stream left the agent response **frozen** — the reconnect connected but no tokens ever resumed.

**Root cause.** After a refresh the client reconnected to the live workflow stream using the last event id from history replay (`/messages/replay`). Replay numbers events with a *cumulative per-thread* counter, but the live per-run stream (`workflow:stream:{tid}:{rid}`) **resets its ids to 1 each run** (since the per-turn `run_id` refactor, #233/#223 lineage). On a thread with history, the replay cursor far exceeds the fresh run's live ids, so the backend `XREAD` blocks forever on ids that never arrive → zero events delivered → frozen UI. New threads worked; old ones froze.

**Fix.** `lastEventIdRef` now tracks **only** live-stream event ids and is cleared on every fresh attach, so a post-refresh reconnect replays the run's stream from the start. The mid-stream network-disconnect retry path is untouched (it keeps its live cursor). No backend change.

## Diff Size
- Total: 2 files, +133/-4
- Net (excl. tests): 1 file, +17/-4

## Empirical verification (real backend)
- `/status` after refresh → `can_reconnect: true` (backend healthy, workflow detached and running)
- reconnect `?last_event_id=0` → 23 message_chunks ✅
- reconnect `?last_event_id=2000` (overshoot = long-history replay id) → 0 events, hangs ❌ (the freeze)
- user's real 83-message thread: replay last id = **930** vs a fresh run's live ids ~1–50

## Test Coverage
New regression test `useChatMessages.reconnectCursor.test.ts`: mounts the hook on a thread whose replay carried large cumulative ids and asserts the reconnect issues `last_event_id == null`. Verified to **fail on the pre-fix code** (`expected 929 to be null`) and pass after.

## Pre-Landing Review
Ran `/review` — verdict: clean. Traced every `loadConversationHistory` caller, every `lastEventIdRef` read/write, the `isStreamingRef` guard race, the thread-switch edge, and the subagent reconnect path (separate id-space, unaffected). No findings.

## Test plan
- [x] Full frontend suite: 1149 tests / 104 files pass (`pnpm vitest run`)
- [x] Regression test fails on buggy code, passes on fix
- [x] ESLint clean on changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed message history loading when reconnecting after a refresh or switching threads. The chat stream now correctly resets its position to ensure messages load from the proper starting point without carrying over incorrect cursor state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ginlix-ai/LangAlpha/pull/237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->