### PR TITLE
fix(chat): default model selector to last-used model

### DIFF
--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -631,6 +631,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     tokenUsage,
     threadId: currentThreadId,
     threadModels,
+    lastThreadModel,
     isShared: threadIsShared,
     insertNotification,
     handleEditMessage,
@@ -2270,7 +2271,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
                       files={workspaceFiles}
                       tokenUsage={tokenUsage}
                       onAction={handleAction}
-                      initialModel={threadModels[0] || null}
+                      initialModel={lastThreadModel || null}
                       threadModels={threadModels}
                       mode={isFlashMode ? 'fast' : 'ptc'}
                     />

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -2271,7 +2271,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
                       files={workspaceFiles}
                       tokenUsage={tokenUsage}
                       onAction={handleAction}
-                      initialModel={lastThreadModel || null}
+                      initialModel={lastThreadModel}
                       threadModels={threadModels}
                       mode={isFlashMode ? 'fast' : 'ptc'}
                     />

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -575,6 +575,12 @@ export function useChatMessages(
   // Track all LLM models used in this thread (ordered, deduplicated)
   const [threadModels, setThreadModels] = useState<string[]>([]);
 
+  // Track the model used by the most recent query in this thread (overwritten,
+  // not deduplicated) so re-opening a history thread defaults to the last-used
+  // model rather than the first. Distinct from threadModels because dedup there
+  // makes its tail unreliable when a thread switches models back and forth.
+  const [lastThreadModel, setLastThreadModel] = useState<string | null>(null);
+
   // Track if streaming is in progress to prevent history loading during streaming
   const isStreamingRef = useRef(false);
 
@@ -683,6 +689,7 @@ export function useChatMessages(
       if (isThreadSwitch) {
         setMessages([]);
         setThreadModels([]);
+        setLastThreadModel(null);
         // Reset refs
         contentOrderCounterRef.current = 0;
         currentReasoningIdRef.current = null;
@@ -881,6 +888,8 @@ export function useChatMessages(
           if (event.metadata?.llm_model) {
             const llmModel = event.metadata.llm_model as string;
             setThreadModels(prev => prev.includes(llmModel) ? prev : [...prev, llmModel]);
+            // History replays chronologically, so the last write wins = most recent query's model.
+            setLastThreadModel(llmModel);
           }
           // Resolve pending plan_approval interrupt from content (empty = approved, non-empty = rejected).
           {
@@ -3915,6 +3924,7 @@ export function useChatMessages(
     // Track model used in this send
     if (model) {
       setThreadModels(prev => prev.includes(model) ? prev : [...prev, model]);
+      setLastThreadModel(model);
     }
 
     // Add user message after history messages
@@ -4688,6 +4698,7 @@ export function useChatMessages(
     messages,
     threadId,
     threadModels,
+    lastThreadModel,
     isLoading,
     hasActiveSubagents,
     workspaceStarting,

--- a/web/src/pages/MarketView/components/MarketChatPanel.tsx
+++ b/web/src/pages/MarketView/components/MarketChatPanel.tsx
@@ -259,6 +259,7 @@ function ChatBody(props: ChatBodyProps): React.ReactElement {
     messageError,
     threadId,
     threadModels,
+    lastThreadModel,
     handleSendMessage,
     getSubagentHistory,
   } = chat;
@@ -367,7 +368,7 @@ function ChatBody(props: ChatBodyProps): React.ReactElement {
     setDialogPayload({ type: 'toolcall', toolCallProcess: proc as ToolCallProcessRecord });
   }, []);
 
-  const initialModel = useMemo(() => threadModels[threadModels.length - 1] ?? null, [threadModels]);
+  const initialModel = lastThreadModel ?? null;
 
   const showQuickQueries = messages.length === 0 && !isLoading && !isLoadingHistory;
 


### PR DESCRIPTION
## Summary
Re-opening a chat thread now defaults the model selector to the **last** model used in that thread, not the first.

`threadModels` is deduplicated, so its tail is unreliable: a thread that toggles models (A → B → A) dedupes to `[A, B]`, whose tail is `B` even though the real last-used model is `A`. This adds a dedicated `lastThreadModel` state that is overwritten per query (not deduped), so it always holds the true most-recent model. It is set during history replay (chronological, last write wins) and on send, and reset on thread switch.

Also unifies behavior across surfaces: `ChatView` previously seeded the *first* model; `MarketChatPanel` used the unreliable deduped tail. Both now read `lastThreadModel`.

## Diff Size
- Total: 3 files, +15/-2
- Net (excl. tests): 3 files, +15/-2

## Pre-Landing Review
Ran `/review` — clean. Verified: `useMemo` still used (not an unused import), `threadModels` still used (passed as a prop), 0 ESLint errors on changed files, and `initialModel` reactively syncs the selector via the effect at `chat-input.tsx:390-393` (so the value populated async during history replay still applies).

## Test plan
- [x] Frontend tests pass — 548 tests / 50 files (ChatAgent + MarketView areas)
- [x] ESLint clean on changed files
- [ ] No automated regression test added (declined during review for a 15-line state change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat threads now remember the last-used language model and automatically apply it when reopening conversations, making model selection more consistent across history replay and new messages.
  * The remembered model is exposed to chat inputs so reopened threads default to the most recently used model for that thread.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ginlix-ai/LangAlpha/pull/238?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->