### PR TITLE
fix(ci): pass PR review body via env to stop shell injection

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,21 +46,20 @@ jobs:
             repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews/${{ github.event.review.id }}/comments \
             --jq '.[].body' 2>/dev/null || echo "")
 
-          # Also check the review body itself
-          REVIEW_BODY="${{ github.event.review.body }}"
-
-          # Combine both and check for @claude
+          # Combine the review body (passed via env so it is never interpolated
+          # into this script) with the inline comments, then check for @claude.
           ALL_TEXT="$REVIEW_COMMENTS $REVIEW_BODY"
 
           if echo "$ALL_TEXT" | grep -q "@claude"; then
-            echo "has_claude=true" >> $GITHUB_OUTPUT
+            echo "has_claude=true" >> "$GITHUB_OUTPUT"
             echo "Found @claude in review"
           else
-            echo "has_claude=false" >> $GITHUB_OUTPUT
+            echo "has_claude=false" >> "$GITHUB_OUTPUT"
             echo "No @claude found in review"
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REVIEW_BODY: ${{ github.event.review.body }}
 
       - name: Run Claude Code
         id: claude


### PR DESCRIPTION
## Summary
The Claude Code workflow's "Check review comments for @claude" step interpolated `${{ github.event.review.body }}` directly into a bash `run:` block. Any review body containing backticks, quotes, `$(...)`, or command-like words was parsed as shell rather than data — a command-injection sink. In practice CodeRabbit's first-review summaries (full of backticks and fenced code) broke the step with exit code 126, failing the workflow once per PR (only the first CodeRabbit review carries a body; later incremental reviews have empty bodies and passed).

## Changes
- Pass the review body through the step `env:` as `REVIEW_BODY` instead of interpolating it into the script, so bash treats it as a plain string.
- Quote the `$GITHUB_OUTPUT` redirects.

## Test Plan
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/claude.yml'))"` parses cleanly.
- On the next PR review (including a CodeRabbit summary with backticks/quotes), the "Check review comments for @claude" step should complete successfully instead of failing with exit 126.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved GitHub Actions workflow configuration for better environment variable handling in PR review checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ginlix-ai/LangAlpha/pull/239?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->