### PR TITLE
fix(price-monitor): send service-account user id on snapshot polls

### DIFF
--- a/src/server/services/price_monitor.py
+++ b/src/server/services/price_monitor.py
@@ -31,6 +31,11 @@ _REFERENCE_REFRESH_INTERVAL = 300  # seconds — refresh reference prices
 _ONE_SHOT_DEDUP_TTL = 300  # seconds — must exceed _REFRESH_INTERVAL to avoid re-trigger races
 _MIN_TRADING_DAY_TTL = 300  # 5 min floor for trading-day TTL
 
+# Service-account identity for background service-to-service data calls.
+# Matches the principal the live-data WS stream already sends so both
+# transports authenticate the same way.
+_SERVICE_USER_ID = "langalpha-service"
+
 _ET = ZoneInfo("America/New_York")
 _MARKET_OPEN_HOUR = 9
 _MARKET_OPEN_MINUTE = 30
@@ -165,7 +170,9 @@ class ConditionEvaluator:
 
             # Fetch stock snapshots
             if stock_syms:
-                snaps = await provider.get_snapshots(stock_syms, asset_type="stocks")
+                snaps = await provider.get_snapshots(
+                    stock_syms, asset_type="stocks", user_id=_SERVICE_USER_ID
+                )
                 for snap in snaps:
                     sym = snap.get("symbol", "").upper()
                     if sym:
@@ -177,7 +184,9 @@ class ConditionEvaluator:
 
             # Fetch index snapshots (response uses display symbols)
             if index_syms:
-                snaps = await provider.get_snapshots(index_syms, asset_type="indices")
+                snaps = await provider.get_snapshots(
+                    index_syms, asset_type="indices", user_id=_SERVICE_USER_ID
+                )
                 for snap in snaps:
                     raw_sym = snap.get("symbol", "").upper()
                     bare = _from_display_symbol(raw_sym)
@@ -594,7 +603,9 @@ class PriceMonitorService:
         # Fetch stock snapshots
         if stock_syms:
             try:
-                snaps = await provider.get_snapshots(stock_syms, asset_type="stocks")
+                snaps = await provider.get_snapshots(
+                    stock_syms, asset_type="stocks", user_id=_SERVICE_USER_ID
+                )
                 for snap in snaps:
                     sym = snap.get("symbol", "").upper()
                     if sym:
@@ -605,7 +616,9 @@ class PriceMonitorService:
         # Fetch index snapshots (normalize display → bare)
         if index_syms:
             try:
-                snaps = await provider.get_snapshots(index_syms, asset_type="indices")
+                snaps = await provider.get_snapshots(
+                    index_syms, asset_type="indices", user_id=_SERVICE_USER_ID
+                )
                 for snap in snaps:
                     raw_sym = snap.get("symbol", "").upper()
                     bare = _from_display_symbol(raw_sym)

--- a/tests/unit/server/services/test_price_monitor.py
+++ b/tests/unit/server/services/test_price_monitor.py
@@ -10,7 +10,9 @@ import pytest
 
 from src.server.models.automation import MarketType, PriceConditionType, PriceTriggerConfig, RetriggerMode
 from src.server.services.price_monitor import (
+    ConditionEvaluator,
     PriceMonitorService,
+    _SERVICE_USER_ID,
     _from_display_symbol,
     _from_ws_symbol,
     _seconds_until_next_market_open,
@@ -504,7 +506,9 @@ class TestPollSnapshots:
         ):
             await svc._poll_snapshots(poll_stock=True, poll_index=False)
 
-        mock_provider.get_snapshots.assert_called_once_with(["AAPL"], asset_type="stocks")
+        mock_provider.get_snapshots.assert_called_once_with(
+            ["AAPL"], asset_type="stocks", user_id="langalpha-service"
+        )
         mock_eval.assert_called_once_with(auto, 149.0)
 
     @pytest.mark.asyncio
@@ -526,7 +530,9 @@ class TestPollSnapshots:
         ):
             await svc._poll_snapshots(poll_stock=False, poll_index=True)
 
-        mock_provider.get_snapshots.assert_called_once_with(["SPX"], asset_type="indices")
+        mock_provider.get_snapshots.assert_called_once_with(
+            ["SPX"], asset_type="indices", user_id="langalpha-service"
+        )
         mock_eval.assert_called_once_with(auto, 5100.0)
 
     @pytest.mark.asyncio
@@ -549,6 +555,63 @@ class TestPollSnapshots:
             await svc._poll_snapshots(poll_stock=True, poll_index=False)
 
         mock_eval.assert_not_called()
+
+
+class TestSnapshotAuthAttribution:
+    """Regression: background REST snapshot calls must carry the service-account
+    X-User-Id. ginlix-data rejects service-token calls without a non-empty user_id
+    (401), which silently breaks reference prices and the poll fallback. See
+    shared_ws_manager.py for the matching WS-path principal.
+    """
+
+    def setup_method(self):
+        PriceMonitorService._instance = None
+        SharedWSConnectionManager._instances.clear()
+
+    def test_service_user_id_matches_ws_path(self):
+        """The REST principal must equal the WS principal so both attribute alike."""
+        assert _SERVICE_USER_ID == "langalpha-service"
+
+    @pytest.mark.asyncio
+    async def test_refresh_references_passes_service_user_id(self):
+        """ConditionEvaluator.refresh_references attributes both markets to the service account."""
+        evaluator = ConditionEvaluator()
+        mock_provider = AsyncMock()
+        mock_provider.get_snapshots = AsyncMock(return_value=[])
+
+        with patch("src.data_client.get_market_data_provider", AsyncMock(return_value=mock_provider)):
+            await evaluator.refresh_references(
+                ["AAPL", "SPX"],
+                symbol_markets={"AAPL": MarketType.STOCK, "SPX": MarketType.INDEX},
+            )
+
+        for call in mock_provider.get_snapshots.call_args_list:
+            assert call.kwargs["user_id"] == _SERVICE_USER_ID
+        asset_types = {c.kwargs["asset_type"] for c in mock_provider.get_snapshots.call_args_list}
+        assert asset_types == {"stocks", "indices"}
+
+    @pytest.mark.asyncio
+    async def test_poll_snapshots_passes_service_user_id(self):
+        """_poll_snapshots attributes both markets to the service account."""
+        svc = PriceMonitorService()
+        svc._symbol_automations = {
+            "AAPL": [_make_automation(symbol="AAPL", market="stock")],
+            "SPX": [_make_automation(symbol="SPX", market="index")],
+        }
+        svc._symbol_markets = {"AAPL": MarketType.STOCK, "SPX": MarketType.INDEX}
+
+        mock_provider = AsyncMock()
+        mock_provider.get_snapshots = AsyncMock(return_value=[])
+
+        with (
+            patch("src.data_client.get_market_data_provider", AsyncMock(return_value=mock_provider)),
+            patch.object(svc, "_evaluate_and_trigger", new_callable=AsyncMock),
+        ):
+            await svc._poll_snapshots(poll_stock=True, poll_index=True)
+
+        assert mock_provider.get_snapshots.call_count == 2
+        for call in mock_provider.get_snapshots.call_args_list:
+            assert call.kwargs["user_id"] == _SERVICE_USER_ID
 
 
 class TestSecondsUntilNextMarketOpen:


### PR DESCRIPTION
## What

The price monitor's background snapshot calls — reference-price refresh and the REST poll fallback — were calling the data snapshot endpoint without a user id. That left the service-to-service auth header incomplete, so the calls were rejected and no snapshot data came back.

The live-data WebSocket stream already authenticates with a fixed service-account principal (`shared_ws_manager.py`). The REST snapshot calls now send the same principal, so both transports authenticate the same way.

## Why it matters

Reference prices (`previous_close`, `day_open`) are loaded **only** via these REST snapshots. With the calls rejected:

- **Percent-change automations** (`pct_change_above` / `pct_change_below`) silently never fired — the evaluator returns no-match when a symbol has no reference price.
- **Absolute-price automations** (`price_above` / `price_below`) kept working, since they evaluate against the live WS price directly.

So a whole class of price alerts was quietly dead. No errors surfaced to the user — the automation just never triggered.

## Change

- New module constant `_SERVICE_USER_ID = "langalpha-service"`.
- Pass `user_id=_SERVICE_USER_ID` at the 4 snapshot call sites (`refresh_references`, `_poll_snapshots` — stock + index each).

## Testing

- New `TestSnapshotAuthAttribution` (3 tests) pins the service-account id on both code paths; 2 existing assertions updated to expect it.
- Verified the tests fail without the source fix (assertion shows the call missing the user id) and pass with it.
- `tests/unit/server/services/test_price_monitor.py`: 40 passed.
- Broader `tests/unit/server/services/` + `tests/unit/data_client/`: 558 passed.
- `ruff check src/` clean.

### Verified live against production

Reproduced the failure and confirmed the fix against the live data service:

- Service token **without** the user id → `401 Invalid or missing credentials` (the original failure).
- Service token **with** `X-User-Id: langalpha-service` → `200`, returning the `previous_close` / `open` fields the reference-price refresh depends on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal service identification for price snapshot operations to improve service-to-service tracking and monitoring capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->