### PR TITLE
fix(storage): pin virtual-hosted addressing for object uploads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,6 +84,13 @@ LANGSMITH_PROJECT=langalpha
 # S3_REGION=us-east-1
 # S3_PUBLIC_URL_BASE=https://d1234.cloudfront.net
 
+# Bucket addressing: virtual (default) | path | auto.
+# Most cloud S3-compatible services use virtual-hosted addressing; self-hosted /
+# path-only backends (e.g. MinIO) must set this to "path". For a custom endpoint,
+# give the BARE host with no bucket subdomain — embedding the bucket doubles the key.
+# STORAGE_ADDRESSING_STYLE=virtual
+# STORAGE_ENDPOINT_URL=https://{bare-host}
+
 # --- Cloudflare R2 ---
 # R2_ACCOUNT_ID=
 # R2_ACCESS_KEY_ID=

--- a/src/server/services/memo_binary_storage.py
+++ b/src/server/services/memo_binary_storage.py
@@ -1,7 +1,7 @@
 """Object-storage adapter for memo binaries (e.g. original PDF bytes).
 
 Thin wrapper over ``src.utils.storage`` that routes memo binaries to the
-configured object storage (Cloudflare R2, Tencent COS, AWS S3, MinIO...)
+configured object storage (Cloudflare R2, AWS S3, MinIO...)
 when one is configured, and otherwise signals the caller to fall back to
 inline base64 in the store value.
 
@@ -28,7 +28,7 @@ from src.utils.storage import (
 logger = logging.getLogger(__name__)
 
 # Storage identifier stamped into ``binary_ref``. Kept stable across providers
-# (R2/S3/COS) because the adapter is what knows how to fetch it back — the
+# (R2/S3/etc.) because the adapter is what knows how to fetch it back — the
 # caller never needs to vary behavior on this value.
 _BINARY_STORAGE_ID = "r2"
 
@@ -56,7 +56,7 @@ class MemoBinaryFetchError(MemoBinaryStorageError):
 def is_configured() -> bool:
     """Return True iff an object-storage backend is usable for memo binaries.
 
-    Every supported provider (R2, S3, COS, Alibaba OSS) now exposes
+    Every supported provider (R2, S3, Alibaba OSS) now exposes
     ``upload_bytes`` + ``get_bytes`` + ``delete_object``, so any enabled
     backend can round-trip memo binaries.
 

--- a/src/utils/storage/__init__.py
+++ b/src/utils/storage/__init__.py
@@ -1,6 +1,6 @@
 """Unified cloud storage upload module.
 
-Supports any S3-compatible service (AWS S3, Cloudflare R2, Tencent COS, MinIO, etc.)
+Supports any S3-compatible service (AWS S3, Cloudflare R2, MinIO, etc.)
 and Alibaba Cloud OSS via a single interface.
 
 Configuration priority:
@@ -9,7 +9,7 @@ Configuration priority:
     3. Default: "none" (disabled)
 
 Provider options:
-    provider: "s3"    # Any S3-compatible service (S3, R2, COS, MinIO)
+    provider: "s3"    # Any S3-compatible service (S3, R2, MinIO, etc.)
     provider: "oss"   # Alibaba Cloud OSS
     provider: "none"  # Disable uploads
 

--- a/src/utils/storage/s3_compatible.py
+++ b/src/utils/storage/s3_compatible.py
@@ -1,7 +1,7 @@
 """S3-compatible cloud storage uploader.
 
 A single module for all S3-compatible services: AWS S3, Cloudflare R2,
-Tencent COS, MinIO, and any other service supporting the S3 API.
+MinIO, and any other service supporting the S3 API.
 
 The only difference between providers is configuration (endpoint, credentials).
 All use boto3 under the hood.
@@ -19,13 +19,19 @@ Environment Variables:
     STORAGE_MAX_UPLOAD_SIZE   - Max upload size in bytes (default: 10MB)
     STORAGE_CONNECT_TIMEOUT_S - boto3 connect timeout in seconds (default: 5)
     STORAGE_READ_TIMEOUT_S    - boto3 read timeout in seconds (default: 30)
+    STORAGE_ADDRESSING_STYLE  - Bucket addressing: virtual (default) | path | auto
 
-Provider-specific examples:
-    AWS S3:      No endpoint needed, just credentials + bucket + region
+Endpoint / addressing:
+    AWS S3:        No endpoint needed, just credentials + bucket + region
     Cloudflare R2: STORAGE_ENDPOINT_URL=https://{account_id}.r2.cloudflarestorage.com
                    STORAGE_REGION=auto
-    Tencent COS:   STORAGE_ENDPOINT_URL=https://cos.{region}.myqcloud.com
-    MinIO:         STORAGE_ENDPOINT_URL=http://localhost:9000
+    MinIO:         STORAGE_ENDPOINT_URL=http://localhost:9000  + STORAGE_ADDRESSING_STYLE=path
+    Other S3-compatible: STORAGE_ENDPOINT_URL=https://{bare-host}  (no bucket subdomain)
+
+Most cloud S3-compatible services use virtual-hosted addressing (the default);
+self-hosted / path-only backends (e.g. MinIO) require STORAGE_ADDRESSING_STYLE=path.
+For a custom endpoint, give the bare host with no bucket subdomain — embedding the
+bucket double-prefixes object keys under virtual addressing.
 """
 
 import base64
@@ -86,6 +92,14 @@ class StorageConfig:
     CONNECT_TIMEOUT_S = int(os.getenv("STORAGE_CONNECT_TIMEOUT_S", "5"))
     READ_TIMEOUT_S = int(os.getenv("STORAGE_READ_TIMEOUT_S", "30"))
 
+    # boto3 bucket addressing. Defaults to "virtual" because most cloud
+    # S3-compatible services require/prefer virtual-hosted addressing, whereas
+    # boto3's own default ("path" for custom endpoints) double-prefixes keys
+    # against an endpoint that already embeds the bucket. Self-hosted / path-only
+    # backends (e.g. MinIO) should set STORAGE_ADDRESSING_STYLE=path.
+    _ADDR = (os.getenv("STORAGE_ADDRESSING_STYLE") or "virtual").lower()
+    ADDRESSING_STYLE = _ADDR if _ADDR in {"virtual", "path", "auto"} else "virtual"
+
     @classmethod
     def get_public_url_base(cls) -> str:
         """Get the public URL base for the bucket."""
@@ -113,6 +127,7 @@ def _get_client() -> Any:
         "region_name": StorageConfig.REGION,
         "config": Config(
             signature_version="s3v4",
+            s3={"addressing_style": StorageConfig.ADDRESSING_STYLE},
             retries={"max_attempts": 3, "mode": "standard"},
             connect_timeout=StorageConfig.CONNECT_TIMEOUT_S,
             read_timeout=StorageConfig.READ_TIMEOUT_S,

--- a/src/utils/storage/s3_compatible.py
+++ b/src/utils/storage/s3_compatible.py
@@ -71,6 +71,26 @@ def _get_content_type(key: str) -> str | None:
     return mime_type
 
 
+_VALID_ADDRESSING_STYLES = {"virtual", "path", "auto"}
+
+
+def _resolve_addressing_style() -> str:
+    """Read STORAGE_ADDRESSING_STYLE, trimmed and validated; default 'virtual'.
+
+    Warns on an unrecognized value rather than silently coercing it, so a typo
+    or stray whitespace on a path-only backend surfaces instead of reintroducing
+    key doubling.
+    """
+    raw = (os.getenv("STORAGE_ADDRESSING_STYLE") or "virtual").strip().lower()
+    if raw not in _VALID_ADDRESSING_STYLES:
+        logger.warning(
+            "Invalid STORAGE_ADDRESSING_STYLE=%r; falling back to 'virtual' (valid: virtual, path, auto)",
+            raw,
+        )
+        return "virtual"
+    return raw
+
+
 class StorageConfig:
     """Storage configuration loaded from environment variables.
 
@@ -97,8 +117,7 @@ class StorageConfig:
     # boto3's own default ("path" for custom endpoints) double-prefixes keys
     # against an endpoint that already embeds the bucket. Self-hosted / path-only
     # backends (e.g. MinIO) should set STORAGE_ADDRESSING_STYLE=path.
-    _ADDR = (os.getenv("STORAGE_ADDRESSING_STYLE") or "virtual").lower()
-    ADDRESSING_STYLE = _ADDR if _ADDR in {"virtual", "path", "auto"} else "virtual"
+    ADDRESSING_STYLE = _resolve_addressing_style()
 
     @classmethod
     def get_public_url_base(cls) -> str:

--- a/tests/unit/utils/storage/test_s3_compatible.py
+++ b/tests/unit/utils/storage/test_s3_compatible.py
@@ -85,6 +85,27 @@ def test_addressing_style_env_override(monkeypatch):
     assert captured["config"].s3 == {"addressing_style": "path"}
 
 
+def test_addressing_style_trims_and_rejects_invalid(monkeypatch):
+    """Whitespace is stripped; unrecognized values fall back to virtual."""
+
+    def addressing_for(value):
+        monkeypatch.setenv("STORAGE_ADDRESSING_STYLE", value)
+        mod = _reload_module()
+        mod._reset_client_for_test()
+        captured: dict = {}
+
+        def fake_client(*_args, **kwargs):
+            captured["config"] = kwargs.get("config")
+            return object()
+
+        with patch.object(mod.boto3, "client", side_effect=fake_client):
+            mod._get_client()
+        return captured["config"].s3
+
+    assert addressing_for("  path  ") == {"addressing_style": "path"}
+    assert addressing_for("bogus") == {"addressing_style": "virtual"}
+
+
 # --- E2E timeout → upload error mapping ----------------------------------
 # The Config(...) wiring above is necessary but not sufficient. These tests
 # go through the real upload_bytes() path so we verify both halves:

--- a/tests/unit/utils/storage/test_s3_compatible.py
+++ b/tests/unit/utils/storage/test_s3_compatible.py
@@ -51,6 +51,40 @@ def test_env_overrides_timeouts(monkeypatch):
     assert cfg.read_timeout == 11
 
 
+def test_default_addressing_style_is_virtual():
+    """Default addressing is virtual — most cloud S3-compatible providers need it,
+    and it avoids boto3's path-style default doubling keys against the endpoint."""
+    mod = _reload_module()
+    mod._reset_client_for_test()
+    captured: dict = {}
+
+    def fake_client(*_args, **kwargs):
+        captured["config"] = kwargs.get("config")
+        return object()
+
+    with patch.object(mod.boto3, "client", side_effect=fake_client):
+        mod._get_client()
+
+    assert captured["config"].s3 == {"addressing_style": "virtual"}
+
+
+def test_addressing_style_env_override(monkeypatch):
+    """STORAGE_ADDRESSING_STYLE=path is honored (e.g. MinIO / path-only backends)."""
+    monkeypatch.setenv("STORAGE_ADDRESSING_STYLE", "path")
+    mod = _reload_module()
+    mod._reset_client_for_test()
+    captured: dict = {}
+
+    def fake_client(*_args, **kwargs):
+        captured["config"] = kwargs.get("config")
+        return object()
+
+    with patch.object(mod.boto3, "client", side_effect=fake_client):
+        mod._get_client()
+
+    assert captured["config"].s3 == {"addressing_style": "path"}
+
+
 # --- E2E timeout → upload error mapping ----------------------------------
 # The Config(...) wiring above is necessary but not sufficient. These tests
 # go through the real upload_bytes() path so we verify both halves:


### PR DESCRIPTION
## Summary

Object-storage uploads (charts, avatars, chat attachments, memo binaries) were writing to a **doubled key** — `<bucket>/<key>` instead of `<key>`. When the configured `STORAGE_ENDPOINT_URL` embeds the bucket as a subdomain, boto3 defaults to **path-style** addressing for custom endpoints and appends the bucket to the path a second time, so every upload silently landed one prefix too deep.

The bug was self-consistent (reads used the same misconfigured client), so it surfaced only when objects were served through the CDN or read by a correctly-configured client.

**Fix:**
- **`s3_compatible.py`** — new `STORAGE_ADDRESSING_STYLE` config (default `virtual`), wired into the boto3 client `Config(s3={"addressing_style": ...})`. Virtual-hosted addressing is correct for cloud S3-compatible providers; path-only backends (e.g. MinIO) can set `path`. The default lives in code, so it survives env-file regeneration on deploy.
- **`.env.example`** — documents the knob and the bare-host endpoint rule.
- **tests** — assert the client is built with virtual addressing by default and honors the `path` override.

Pairs with a config change (not in this PR): set `STORAGE_ENDPOINT_URL` to the bare regional host (no bucket subdomain). Existing mis-keyed objects were already backfilled to the true key out-of-band.

## Diff Size
- Total: 5 files changed, 66 insertions(+), 10 deletions(-)
- Net (excl. tests): 4 files changed, 32 insertions(+), 10 deletions(-)

## Test Coverage
- `test_default_addressing_style_is_virtual` — client built with `addressing_style=virtual` by default
- `test_addressing_style_env_override` — `STORAGE_ADDRESSING_STYLE=path` honored
- Storage + memo unit tests: 25 passed

## Pre-Landing Review
No issues. No SQL or LLM trust-boundary surface. No secrets in committed files (real credentials remain in the gitignored env files; `.env.example` is placeholders only). The default-`virtual` behavior change is intentional, documented, and configurable; no path-style usage exists in the repo.

## Verification
Verified end-to-end against the live bucket via the shipped code path (read-only + a scoped write→read→delete on a throwaway key):
- Deterministic presign: new client builds `https://<bucket-host>/<key>` (true key); old config built `/<bucket>/<key>` (doubled).
- A fresh upload lands at the true key and **not** the doubled key; CDN serves the true key; delete confirmed.

## Test plan
- [x] Storage + memo unit tests pass (25)
- [x] Ruff clean on changed files
- [ ] Post-deploy: rebuild + restart backend (boto3 client is cached at module level), then confirm a fresh upload writes the un-doubled key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable S3 addressing style support (STORAGE_ADDRESSING_STYLE) with virtual/path/auto modes.

* **Documentation**
  * Clarified storage config and provider guidance (S3-compatible services such as MinIO, R2) and updated environment template with addressing and custom endpoint examples.

* **Tests**
  * Added unit tests covering addressing-style defaults, overrides, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->