### PR TITLE
feat(chat): surface default models in quick-access menu

### DIFF
--- a/web/src/components/ui/__tests__/chat-input.quickAccess.test.ts
+++ b/web/src/components/ui/__tests__/chat-input.quickAccess.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from 'vitest';
+import { deriveQuickAccessModels, areModelsCompatible, type QuickAccessParams, type ModelMetadata } from '../chat-input.models';
+
+const META: ModelMetadata = {
+  'claude-opus': { sdk: 'anthropic', provider: 'anthropic' },
+  'claude-sonnet': { sdk: 'anthropic', provider: 'anthropic' },
+  'gpt-5': { sdk: 'openai', provider: 'openai' },
+  'gpt-5-azure': { sdk: 'openai', provider: 'azure' },
+  'codex-openai': { sdk: 'codex', provider: 'openai' },
+  'codex-openai-2': { sdk: 'codex', provider: 'openai' },
+  'codex-azure': { sdk: 'codex', provider: 'azure' },
+};
+
+function params(overrides: Partial<QuickAccessParams> = {}): QuickAccessParams {
+  return {
+    preferredModel: null,
+    preferredFlashModel: null,
+    starredModels: [],
+    validModelNames: new Set(),
+    initialModel: null,
+    selectedModel: null,
+    modelMetadata: META,
+    ...overrides,
+  };
+}
+
+describe('deriveQuickAccessModels', () => {
+  it('surfaces the current primary + flash defaults even when not starred', () => {
+    expect(
+      deriveQuickAccessModels(params({
+        preferredModel: 'claude-opus',
+        preferredFlashModel: 'claude-sonnet',
+        starredModels: ['gpt-5'],
+      })),
+    ).toEqual(['claude-opus', 'claude-sonnet', 'gpt-5']);
+  });
+
+  it('dedupes when defaults overlap each other or a star', () => {
+    expect(
+      deriveQuickAccessModels(params({
+        preferredModel: 'claude-opus',
+        preferredFlashModel: 'claude-opus',
+        starredModels: ['claude-opus', 'gpt-5'],
+      })),
+    ).toEqual(['claude-opus', 'gpt-5']);
+  });
+
+  it('leaves no stale entry after switching a default (old default not in result)', () => {
+    // User switched primary from claude-opus → claude-sonnet; claude-opus was
+    // never starred, so it simply isn't passed in and never appears.
+    expect(
+      deriveQuickAccessModels(params({
+        preferredModel: 'claude-sonnet',
+        starredModels: ['gpt-5'],
+      })),
+    ).toEqual(['claude-sonnet', 'gpt-5']);
+  });
+
+  it('drops models the user can no longer access once the list has loaded', () => {
+    expect(
+      deriveQuickAccessModels(params({
+        preferredModel: 'claude-opus',
+        starredModels: ['gpt-5', 'revoked-model'],
+        validModelNames: new Set(['claude-opus', 'gpt-5']),
+      })),
+    ).toEqual(['claude-opus', 'gpt-5']);
+  });
+
+  it('skips the availability gate while the model list is still loading (empty set)', () => {
+    expect(
+      deriveQuickAccessModels(params({
+        starredModels: ['some-model'],
+        validModelNames: new Set(),
+      })),
+    ).toEqual(['some-model']);
+  });
+
+  it('mid-thread, drops models from a different SDK than the thread model', () => {
+    expect(
+      deriveQuickAccessModels(params({
+        preferredModel: 'gpt-5', // openai → incompatible with anthropic thread
+        starredModels: ['claude-sonnet'], // anthropic → compatible
+        initialModel: 'claude-opus',
+        selectedModel: 'claude-opus',
+      })),
+    ).toEqual(['claude-sonnet']);
+  });
+
+  it('mid-thread, drops same-SDK openai models from a different provider', () => {
+    expect(
+      deriveQuickAccessModels(params({
+        starredModels: ['gpt-5', 'gpt-5-azure'],
+        initialModel: 'gpt-5',
+        selectedModel: 'gpt-5',
+      })),
+    ).toEqual(['gpt-5']);
+  });
+
+  it('in a fresh thread (no initialModel), keeps incompatible models', () => {
+    expect(
+      deriveQuickAccessModels(params({
+        preferredModel: 'gpt-5',
+        starredModels: ['claude-opus'],
+        initialModel: null,
+        selectedModel: 'claude-opus',
+      })),
+    ).toEqual(['gpt-5', 'claude-opus']);
+  });
+
+  it('anchors the compatibility filter on selectedModel, not initialModel', () => {
+    // initialModel is anthropic but the user switched selectedModel to gpt-5.
+    // The gpt-5 star (compatible with the current selection) survives; the
+    // anthropic star (compatible with initialModel, not the selection) drops.
+    expect(
+      deriveQuickAccessModels(params({
+        starredModels: ['gpt-5', 'claude-sonnet'],
+        initialModel: 'claude-opus',
+        selectedModel: 'gpt-5',
+      })),
+    ).toEqual(['gpt-5']);
+  });
+
+  it('mid-thread with a null selectedModel, keeps everything (null anchor is compatible)', () => {
+    expect(
+      deriveQuickAccessModels(params({
+        starredModels: ['gpt-5'], // incompatible with the anthropic thread
+        initialModel: 'claude-opus',
+        selectedModel: null,
+      })),
+    ).toEqual(['gpt-5']);
+  });
+
+  it('applies the availability and compatibility gates together', () => {
+    // revoked-anthropic dropped by availability; gpt-5 dropped by SDK mismatch.
+    expect(
+      deriveQuickAccessModels(params({
+        preferredModel: 'claude-opus',
+        starredModels: ['claude-sonnet', 'gpt-5', 'revoked-anthropic'],
+        validModelNames: new Set(['claude-opus', 'claude-sonnet', 'gpt-5']),
+        initialModel: 'claude-opus',
+        selectedModel: 'claude-opus',
+      })),
+    ).toEqual(['claude-opus', 'claude-sonnet']);
+  });
+
+  it('excludes models already shown in the primary section (no duplicate rows)', () => {
+    // preferredModel is the selected/thread model, so it must not also appear
+    // in the quick-access submenu.
+    expect(
+      deriveQuickAccessModels(params({
+        preferredModel: 'claude-opus',
+        preferredFlashModel: 'claude-sonnet',
+        starredModels: ['gpt-5'],
+        excludeModels: ['claude-opus'],
+      })),
+    ).toEqual(['claude-sonnet', 'gpt-5']);
+  });
+
+  it('returns an empty list when there are no defaults or stars', () => {
+    expect(deriveQuickAccessModels(params())).toEqual([]);
+  });
+});
+
+describe('areModelsCompatible', () => {
+  it('treats a null model as compatible', () => {
+    expect(areModelsCompatible(null, 'claude-opus', META)).toBe(true);
+    expect(areModelsCompatible('claude-opus', null, META)).toBe(true);
+  });
+
+  it('allows unknown models (missing metadata), either side', () => {
+    expect(areModelsCompatible('claude-opus', 'mystery-model', META)).toBe(true);
+    expect(areModelsCompatible('mystery-model', 'claude-opus', META)).toBe(true);
+  });
+
+  it('matches on SDK for non-openai SDKs', () => {
+    expect(areModelsCompatible('claude-opus', 'claude-sonnet', META)).toBe(true);
+  });
+
+  it('rejects across different SDKs', () => {
+    expect(areModelsCompatible('claude-opus', 'gpt-5', META)).toBe(false);
+  });
+
+  it('requires the same provider for openai SDKs', () => {
+    expect(areModelsCompatible('gpt-5', 'gpt-5-azure', META)).toBe(false);
+    expect(areModelsCompatible('gpt-5', 'gpt-5', META)).toBe(true);
+  });
+
+  it('requires the same provider for codex SDK', () => {
+    expect(areModelsCompatible('codex-openai', 'codex-azure', META)).toBe(false);
+    expect(areModelsCompatible('codex-openai', 'codex-openai-2', META)).toBe(true);
+  });
+});

--- a/web/src/components/ui/__tests__/chat-input.quickAccess.test.ts
+++ b/web/src/components/ui/__tests__/chat-input.quickAccess.test.ts
@@ -159,6 +159,16 @@ describe('deriveQuickAccessModels', () => {
   it('returns an empty list when there are no defaults or stars', () => {
     expect(deriveQuickAccessModels(params())).toEqual([]);
   });
+
+  it('drops non-string entries from a malformed starred_models pref', () => {
+    // A corrupt pref could carry non-string truthy values; they must not reach
+    // getModelDisplayName (key.startsWith) and crash the composer.
+    expect(
+      deriveQuickAccessModels(params({
+        starredModels: [123, '', null, {}, 'gpt-5'] as unknown as string[],
+      })),
+    ).toEqual(['gpt-5']);
+  });
 });
 
 describe('areModelsCompatible', () => {

--- a/web/src/components/ui/chat-input.models.ts
+++ b/web/src/components/ui/chat-input.models.ts
@@ -1,0 +1,68 @@
+/**
+ * Pure model-selection helpers for the chat input's model menu.
+ *
+ * Kept dependency-free (no React, no API/auth imports) so the logic is unit
+ * testable without pulling in the full `chat-input` component graph.
+ */
+
+export type ModelMetadata = Record<string, { sdk?: string; provider?: string }>;
+
+/**
+ * Check if two models are compatible for mid-session switching.
+ * - Different SDKs → incompatible
+ * - openai/codex SDK → must be same provider (sub-provider)
+ * - Other SDKs (anthropic, gemini, etc.) → compatible if same SDK
+ */
+export function areModelsCompatible(modelA: string | null, modelB: string | null, metadata: ModelMetadata): boolean {
+  if (!modelA || !modelB) return true;
+  const a = metadata[modelA], b = metadata[modelB];
+  if (!a || !b) return true; // unknown models → allow
+  if (a.sdk !== b.sdk) return false;
+  if (a.sdk === 'openai' || a.sdk === 'codex') {
+    return a.provider === b.provider;
+  }
+  return true;
+}
+
+export interface QuickAccessParams {
+  preferredModel: string | null;
+  preferredFlashModel: string | null;
+  starredModels: string[];
+  validModelNames: Set<string>;
+  initialModel: string | null;
+  selectedModel: string | null;
+  modelMetadata: ModelMetadata;
+  /** Models already shown in the menu's primary section; excluded to avoid duplicate rows. */
+  excludeModels?: string[];
+}
+
+/**
+ * Quick-access models for the chat model menu — the current primary + flash
+ * defaults unioned with the user's manual stars, gated by availability (drops
+ * removed/revoked models) and, mid-thread, by SDK compatibility. Derived
+ * per-render so switching a default never leaves a stale pin behind.
+ */
+export function deriveQuickAccessModels({
+  preferredModel,
+  preferredFlashModel,
+  starredModels,
+  validModelNames,
+  initialModel,
+  selectedModel,
+  modelMetadata,
+  excludeModels = [],
+}: QuickAccessParams): string[] {
+  const exclude = new Set(excludeModels);
+  const union = [...new Set(
+    [preferredModel, preferredFlashModel, ...starredModels].filter((m): m is string => !!m),
+  )];
+  return union.filter((m) => {
+    // Already rendered in the primary section (selected + thread models).
+    if (exclude.has(m)) return false;
+    // Skip the availability gate while the model list is still loading (empty
+    // set) so a slow/failed fetch can't blank the menu.
+    if (validModelNames.size > 0 && !validModelNames.has(m)) return false;
+    // Mid-thread, only offer models compatible with the thread's model.
+    return !initialModel || areModelsCompatible(selectedModel, m, modelMetadata);
+  });
+}

--- a/web/src/components/ui/chat-input.models.ts
+++ b/web/src/components/ui/chat-input.models.ts
@@ -16,7 +16,7 @@ export type ModelMetadata = Record<string, { sdk?: string; provider?: string }>;
 export function areModelsCompatible(modelA: string | null, modelB: string | null, metadata: ModelMetadata): boolean {
   if (!modelA || !modelB) return true;
   const a = metadata[modelA], b = metadata[modelB];
-  if (!a || !b) return true; // unknown models → allow
+  if (!a || !b) return true; // allow unknown models (no metadata on either side)
   if (a.sdk !== b.sdk) return false;
   if (a.sdk === 'openai' || a.sdk === 'codex') {
     return a.provider === b.provider;
@@ -54,7 +54,11 @@ export function deriveQuickAccessModels({
 }: QuickAccessParams): string[] {
   const exclude = new Set(excludeModels);
   const union = [...new Set(
-    [preferredModel, preferredFlashModel, ...starredModels].filter((m): m is string => !!m),
+    // typeof check (not just `!!m`) so a malformed pref with non-string entries
+    // can't reach getModelDisplayName's `key.startsWith` and crash the composer.
+    [preferredModel, preferredFlashModel, ...starredModels].filter(
+      (m): m is string => typeof m === 'string' && m.length > 0,
+    ),
   )];
   return union.filter((m) => {
     // Already rendered in the primary section (selected + thread models).

--- a/web/src/components/ui/chat-input.tsx
+++ b/web/src/components/ui/chat-input.tsx
@@ -13,7 +13,9 @@ import {
   DropdownMenuSeparator, DropdownMenuSub, DropdownMenuSubTrigger, DropdownMenuSubContent,
 } from './dropdown-menu';
 import { usePreferences } from '@/hooks/usePreferences';
+import { useAllModels } from '@/hooks/useAllModels';
 import { useIsMobile } from '@/hooks/useIsMobile';
+import { areModelsCompatible, deriveQuickAccessModels, type ModelMetadata } from './chat-input.models';
 import { supportsXhighEffort } from '@/lib/modelCapabilities';
 import { getSkills, getModelMetadata } from '../../pages/ChatAgent/utils/api';
 import { useToast } from './use-toast';
@@ -213,23 +215,6 @@ function getModelDisplayName(key: string | null): string {
   return name;
 }
 
-/**
- * Check if two models are compatible for mid-session switching.
- * - Different SDKs → incompatible
- * - openai/codex SDK → must be same provider (sub-provider)
- * - Other SDKs (anthropic, gemini, etc.) → compatible if same SDK
- */
-function areModelsCompatible(modelA: string | null, modelB: string | null, metadata: Record<string, { sdk?: string; provider?: string }>): boolean {
-  if (!modelA || !modelB) return true;
-  const a = metadata[modelA], b = metadata[modelB];
-  if (!a || !b) return true; // unknown models → allow
-  if (a.sdk !== b.sdk) return false;
-  if (a.sdk === 'openai' || a.sdk === 'codex') {
-    return a.provider === b.provider;
-  }
-  return true;
-}
-
 /* --- MAIN COMPONENT --- */
 
 const speechSupported = typeof window !== 'undefined' && !!(window.SpeechRecognition || window.webkitSpeechRecognition);
@@ -366,8 +351,9 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
   const { toast } = useToast();
   const isMobile = useIsMobile();
   const { preferences } = usePreferences();
+  const { validModelNames } = useAllModels();
   const otherPref = (preferences as Record<string, Record<string, unknown>> | null)?.other_preference;
-  const starredModels = (otherPref?.starred_models as string[] | undefined) || [];
+  const starredModels = Array.isArray(otherPref?.starred_models) ? (otherPref.starred_models as string[]) : [];
   const preferredModel = (otherPref?.preferred_model as string | undefined) || null;
   const preferredFlashModel = (otherPref?.preferred_flash_model as string | undefined) || null;
   const [message, setMessage] = useState('');
@@ -384,7 +370,7 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
   const [showMoreModels, setShowMoreModels] = useState(false);
   const [modelMenuOpen, setModelMenuOpen] = useState(false);
 
-  const [modelMetadata, setModelMetadata] = useState<Record<string, { sdk?: string; provider?: string }>>({});
+  const [modelMetadata, setModelMetadata] = useState<ModelMetadata>({});
   const navigate = useNavigate();
 
   // Sync selectedModel when initialModel or preferredModel changes
@@ -1160,10 +1146,16 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
 
   const showWorkspaceSelector = hasModeToggle && mode === 'ptc' && workspaces && workspaces.length > 0;
 
-  /** Render starred model items — used by both desktop submenu and mobile inline expand */
-  const moreModelsItems = useMemo(() => {
-    return starredModels.filter((m) => !initialModel || areModelsCompatible(selectedModel, m, modelMetadata));
-  }, [starredModels, initialModel, selectedModel, modelMetadata]);
+  /** Quick-access models for both the desktop submenu and mobile inline expand */
+  const moreModelsItems = useMemo(
+    () => deriveQuickAccessModels({
+      preferredModel, preferredFlashModel, starredModels,
+      validModelNames, initialModel, selectedModel, modelMetadata,
+      // Don't repeat models already shown in the primary (selected + thread) section.
+      excludeModels: [selectedModel, ...threadModelsProp].filter((m): m is string => !!m),
+    }),
+    [preferredModel, preferredFlashModel, starredModels, validModelNames, initialModel, selectedModel, modelMetadata, threadModelsProp],
+  );
 
   return (
     <div
@@ -1531,7 +1523,7 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
             {/* Right Tools */}
             <div className="flex flex-row items-center min-w-0 gap-1">
               {/* Model Selector */}
-              {(starredModels.length > 0 || selectedModel) && (
+              {(moreModelsItems.length > 0 || starredModels.length > 0 || selectedModel) && (
                 <DropdownMenu modal={false} open={modelMenuOpen} onOpenChange={(open) => { setModelMenuOpen(open); if (!open) setShowMoreModels(false); }}>
                   <DropdownMenuTrigger asChild>
                     <button

--- a/web/src/components/ui/chat-input.tsx
+++ b/web/src/components/ui/chat-input.tsx
@@ -353,7 +353,9 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
   const { preferences } = usePreferences();
   const { validModelNames } = useAllModels();
   const otherPref = (preferences as Record<string, Record<string, unknown>> | null)?.other_preference;
-  const starredModels = Array.isArray(otherPref?.starred_models) ? (otherPref.starred_models as string[]) : [];
+  const starredModels = Array.isArray(otherPref?.starred_models)
+    ? (otherPref.starred_models as unknown[]).filter((m): m is string => typeof m === 'string')
+    : [];
   const preferredModel = (otherPref?.preferred_model as string | undefined) || null;
   const preferredFlashModel = (otherPref?.preferred_flash_model as string | undefined) || null;
   const [message, setMessage] = useState('');
@@ -1522,7 +1524,9 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
 
             {/* Right Tools */}
             <div className="flex flex-row items-center min-w-0 gap-1">
-              {/* Model Selector */}
+              {/* Model Selector — show if there's anything to pick (quick-access
+                  list or current selection), or if the user has stars to manage
+                  even when they all filter out (keeps the settings link reachable). */}
               {(moreModelsItems.length > 0 || starredModels.length > 0 || selectedModel) && (
                 <DropdownMenu modal={false} open={modelMenuOpen} onOpenChange={(open) => { setModelMenuOpen(open); if (!open) setShowMoreModels(false); }}>
                   <DropdownMenuTrigger asChild>


### PR DESCRIPTION
## Summary

**Frontend — chat model menu**
- The quick-access model list is now **derived**: the union of the user's current primary + flash model defaults and their manually-starred models, instead of starred models alone (`ec8cd4b6`). A newly chosen default now appears automatically, and switching a default never leaves a stale pin behind since nothing is persisted.
- Filtered by **current availability** (`validModelNames` — drops models removed from the manifest or whose access was revoked; the gate is skipped while the list is still loading so a slow/failed fetch can't blank the menu) and, **mid-thread, by SDK/provider compatibility** (same SDK; same provider for openai/codex).
- **De-duplicated** against the primary "thread models" section so the default model no longer renders twice; the render guard keeps the menu (and its "Manage models" link) reachable when every derived item filters out.
- Pure helpers extracted into `chat-input.models.ts` so the logic is unit-testable without importing the full component graph.

**Tests** (`efb53b89`)
- 19 unit tests for `deriveQuickAccessModels` + `areModelsCompatible`.

## Diff Size
- Total: 3 files, +276 / -24
- Net (excl. tests): 2 files, +84 / -24

## Test Coverage
- New module `chat-input.models.ts` is fully covered by `chat-input.quickAccess.test.ts` (19 tests): union/dedup, availability gating including the still-loading skip, SDK/provider compatibility (incl. codex), primary-section exclusion, `selectedModel`-as-anchor, and fresh-thread vs mid-thread behavior.
- Regression: existing `chat-input.contextBus` suite (9 tests) still green. 28 frontend tests pass on the merged state.

## Pre-Landing Review
Ran `/review` (testing + maintainability + performance specialists, plus Claude adversarial). Two medium regressions were caught and fixed before commit:
1. Model dropdown could vanish entirely when a user had starred models but no `preferred_model` and every star filtered out — restored the `starredModels.length` guard fallback so the menu and settings link stay reachable.
2. The default model rendered twice (primary section + "more models" submenu) — added an `excludeModels` exclusion.

Also hardened against a malformed (non-array) `starred_models` crashing the composer, and filled test gaps. Performance specialist confirmed `useAllModels()` adds **0 net-new network calls** (React Query dedupes app-wide) and `validModelNames` is reference-stable.

One informational item accepted, not fixed: during the brief models-loading window the availability gate is skipped, so a revoked star is momentarily selectable and the send path doesn't re-check membership. Left as-is because blanking the menu during load is worse UX. Worth confirming the backend rejects an unavailable model with a clean error.

## Design Review
No visual or markup changes — pure model-list logic. Design review skipped.

## Test plan
- [x] Frontend unit tests pass (28 tests: 19 new + 9 regression) on merged state
- [x] `tsc` typecheck clean for changed files
- [x] ESLint: 0 errors (1 pre-existing warning on `starredModels`, unchanged from main)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model selector “more models” list now populates dynamically and shows the dropdown when additional models are available; mid-thread options respect compatibility rules.

* **Tests**
  * Added thorough tests for quick-access model derivation and model compatibility scenarios.

* **Refactor**
  * Model-selection logic extracted to a dedicated module for clearer behavior and easier testing.

* **Bug Fixes**
  * Hardened preference parsing to ignore malformed starred entries and avoid duplicate/stale suggestions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->