### PR TITLE
feat(llms): add minimax-m3 flagship model to manifest

### DIFF
--- a/agent_config.yaml
+++ b/agent_config.yaml
@@ -13,6 +13,7 @@ llm:
   fetch: "qwen3.6-flash"         # defaults to flash model
   fallback:
     - "kimi-k2.5"
+    - "minimax-m3"
     - "minimax-m2.7"
     - "glm-5-turbo"
 

--- a/libs/ptc-cli/ptc_cli/api/client.py
+++ b/libs/ptc-cli/ptc_cli/api/client.py
@@ -382,7 +382,7 @@ class SSEStreamClient:
             thread_id: Thread identifier for conversation continuity
             hitl_response: HITL interrupt response (for resume)
             plan_mode: Whether to enable plan mode (agent submits plan for approval)
-            llm_model: LLM model name from models.json (e.g., 'minimax-m2.1')
+            llm_model: LLM model name from models.json (e.g., 'minimax-m3')
             agent_mode: Agent mode ('flash' for Flash Agent, None for default)
             **kwargs: Additional request parameters
 

--- a/libs/ptc-cli/ptc_cli/core/config.py
+++ b/libs/ptc-cli/ptc_cli/core/config.py
@@ -81,7 +81,7 @@ PTC_AGENT_ASCII = """
 MODEL_OPTIONS = [
     {"name": "gpt-5.2", "description": "OpenAI GPT-5.2 with reasoning"},
     {"name": "glm-4.7", "description": "Z.AI GLM-4.7 with thinking"},
-    {"name": "minimax-m2.1", "description": "MiniMax M2.1 for coding"},
+    {"name": "minimax-m3", "description": "MiniMax M3 flagship model"},
     {"name": "claude-sonnet-4-5-proxy", "description": "Claude 4.5 Sonnet via proxy"},
     {"name": "claude-opus-4-5-proxy", "description": "Claude 4.5 Opus via proxy"},
     {"name": "claude-haiku-4-5-proxy", "description": "Claude 4.5 Haiku via proxy"},

--- a/libs/ptc-cli/ptc_cli/core/state.py
+++ b/libs/ptc-cli/ptc_cli/core/state.py
@@ -202,7 +202,7 @@ class SessionState:
             no_splash: Whether to skip the splash screen
             persist_session: Whether to persist sandbox sessions
             plan_mode: Whether to inject plan mode reminder
-            llm_model: LLM model name from models.json (e.g., 'minimax-m2.1')
+            llm_model: LLM model name from models.json (e.g., 'minimax-m3')
             flash_mode: Whether to use Flash Agent (no sandbox)
         """
         self.auto_approve = auto_approve

--- a/libs/ptc-cli/ptc_cli/main.py
+++ b/libs/ptc-cli/ptc_cli/main.py
@@ -188,7 +188,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--model",
-        help="LLM model name from models.json (e.g., 'minimax-m2.1', 'claude-sonnet-4-5')",
+        help="LLM model name from models.json (e.g., 'minimax-m3', 'claude-sonnet-4-5')",
     )
     parser.add_argument(
         "--flash",

--- a/src/llms/manifest/models.json
+++ b/src/llms/manifest/models.json
@@ -517,6 +517,21 @@
       "pdf"
     ]
   },
+  "minimax-m3": {
+    "model_id": "MiniMax-M3",
+    "provider": "minimax",
+    "visible": true,
+    "parameters": {
+      "max_tokens": 128000,
+      "thinking": {
+        "type": "enabled"
+      }
+    },
+    "input_modalities": [
+      "text",
+      "image"
+    ]
+  },
   "minimax-m2.7": {
     "model_id": "MiniMax-M2.7",
     "provider": "minimax",

--- a/src/llms/manifest/providers.json
+++ b/src/llms/manifest/providers.json
@@ -482,6 +482,22 @@
     ],
     "minimax": [
       {
+        "id": "minimax-m3",
+        "name": "MiniMax-M3",
+        "alias": [
+          "MiniMax-M3",
+          "minimax-m3"
+        ],
+        "is_reasoning": false,
+        "description": "MiniMax's flagship M3 model with 512K context and image input",
+        "pricing": {
+          "input": 0.6,
+          "output": 2.4,
+          "cached_input": 0.12,
+          "unit": "per_1m_tokens"
+        }
+      },
+      {
         "id": "minimax-m2.7",
         "name": "MiniMax-M2.7",
         "alias": [

--- a/src/server/models/chat.py
+++ b/src/server/models/chat.py
@@ -241,7 +241,7 @@ class ChatRequest(BaseModel):
     # LLM selection (optional - defaults to agent_config.yaml setting)
     llm_model: Optional[str] = Field(
         default=None,
-        description="LLM model name from models.json (e.g., 'minimax-m2.1', 'claude-sonnet-4-5')",
+        description="LLM model name from models.json (e.g., 'minimax-m3', 'claude-sonnet-4-5')",
     )
 
     # Reasoning effort override (optional - defaults to model's configured level)

--- a/tests/unit/llms/test_input_modalities.py
+++ b/tests/unit/llms/test_input_modalities.py
@@ -41,6 +41,11 @@ class TestGetInputModalities:
         result = model_config.get_input_modalities("minimax-m2.7")
         assert result == ["text"]
 
+    def test_minimax_m3_supports_image(self, model_config):
+        result = model_config.get_input_modalities("minimax-m3")
+        assert "text" in result
+        assert "image" in result
+
     def test_moonshot_supports_image_not_pdf(self, model_config):
         result = model_config.get_input_modalities("kimi-k2.5")
         assert "image" in result


### PR DESCRIPTION
## Summary
Adds the new MiniMax M3 model alongside the existing M2.7 entries. M3 brings a 512K context window, 128K max output, and image input over the same Anthropic-compatible endpoint already used by `minimax` here, so no provider plumbing changes are needed.

## Changes
- Register `minimax-m3` in `src/llms/manifest/models.json` with `text` + `image` modalities (same `parameters` shape as M2.7).
- Add the matching provider entry in `src/llms/manifest/providers.json` with pricing `input $0.6/M`, `output $2.4/M`, `cached_input $0.12/M` (per the published payg pricing table).
- Place `minimax-m3` ahead of `minimax-m2.7` in `agent_config.yaml`'s fallback chain so the new flagship is reached first when fallback fires.
- Refresh stale `minimax-m2.1` references (CLI `MODEL_OPTIONS`, docstrings, `--model` help) to `minimax-m3` — the old ID is not defined anywhere in the manifest, so listing it in `MODEL_OPTIONS` would surface an invalid choice in the CLI picker.
- Add a focused modality test confirming M3 reports `text` + `image`.

## Why M3 here
- 512K context fits the `compaction.token_threshold: 120000` ceiling with plenty of headroom; long PTC traces / large memo grounding stay under the cap.
- Image input lines up with the multimodal expectations already declared for OAuth/proxy Claude variants in `models.json`.
- Keeping M2.7 + M2.7-Highspeed avoids breaking BYOK users still on the prior default.

## Testing
- `python -c "import json; json.load(open('src/llms/manifest/models.json')); json.load(open('src/llms/manifest/providers.json'))"` — JSON parses.
- Shape parity check: `set(models['minimax-m3'].keys()) == set(models['minimax-m2.7'].keys())`.
- Added `test_minimax_m3_supports_image` to `tests/unit/llms/test_input_modalities.py`.
- Existing `test_every_model_has_valid_modalities` continues to cover the new entry (text in modalities, non-empty list).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MiniMax M3 model with support for text and image inputs, including reasoning capabilities.

* **Documentation**
  * Updated examples and help text to reflect the newly available model option.

* **Tests**
  * Added test coverage for MiniMax M3 input modality support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->