### PR TITLE
feat(chat): add follow-up suggestion buttons after assistant replies

### DIFF
--- a/docs/api/01-plan/suggestion-buttons/PLAN.md
+++ b/docs/api/01-plan/suggestion-buttons/PLAN.md
@@ -1,0 +1,426 @@
+# PLAN: 聊天回复 Suggestion 便捷按钮
+
+## 需求概述
+
+1. **新增设置**：suggestion 开关，控制是否在聊天回复后生成 suggestion 按钮
+2. **Suggestion 按钮**：聊天回复下方显示最多 3 个 suggestion，根据回复内容总结生成
+3. **点击行为**：点击 suggestion 按钮直接将其作为下一轮输入，开启下一轮聊天
+
+---
+
+## 实现步骤
+
+### Step 1: 后端 — 持久化 suggestion 开关
+
+**目标**：在 `other_preference` JSONB 中存储 `suggestion_enabled` 开关。
+
+**涉及文件**：
+- 无需新建 migration，使用已有 `user_preferences.other_preference` JSONB 列存储
+
+**工作内容**：
+- 无需 schema 变更 — `other_preference` 已是 `JSONB DEFAULT '{}'`，直接写入 `suggestion_enabled: boolean`
+- 无需新增 Pydantic model — `OtherPreference` 已设 `extra="allow"`
+- 无需新增 API — 已有 `PUT /api/v1/users/me/preferences` 支持 JSONB merge
+- **默认值**：`suggestion_enabled` 默认为 `true`（即该 key 不存在时视为开启）。前端读取时使用 `?? true` 兜底，后端读取时对 `None`/缺省值按 `True` 处理
+
+**验证**：
+- `PUT /api/v1/users/me/preferences` 携带 `{"other_preference": {"suggestion_enabled": true}}` 能正确持久化
+- 再次 `GET /api/v1/users/me/preferences` 能读到 `other_preference.suggestion_enabled`
+
+---
+
+### Step 2: 前端 — Settings 页面新增 suggestion 开关
+
+**目标**：在 Settings 页面添加一个 toggle，控制 suggestion 功能的开关。
+
+**参考模式**：`voice_input_enabled` toggle（Settings.tsx 第 517–527 行）
+
+**涉及文件**：
+- `web/src/pages/Settings/Settings.tsx`
+
+**工作内容**：
+1. 从 `usePreferences()` 读取 `other_preference?.suggestion_enabled`，默认值为 `true`（即 `suggestion_enabled ?? true`）
+2. 在 Settings 页面的**模型 tab 底部**（BYOK 配置下方）添加 toggle 开关，用 `borderTop` 分割线与上方内容隔离
+3. 切换时调用 `updatePrefsMutation.mutateAsync({ other_preference: { ...currentOtherPref, suggestion_enabled: !current } })`
+4. 遵循已有 toggle 样式（与 voice input toggle 一致的 switch UI）
+5. 新用户无此 key 时 toggle 显示为开启状态
+
+**验证**：
+- Settings 页面能看到 suggestion 开关
+- 切换开关后刷新页面，状态保持
+
+---
+
+### Step 3: 后端 — 聊天完成后异步生成 suggestions
+
+**目标**：在每次 assistant 回复完成后，调用 LLM 生成 1–3 条 follow-up suggestion。
+
+**涉及文件**：
+- `src/server/services/llm_service.py` — 已有 `LLMService.complete()`，开箱即用
+- `src/server/handlers/chat/flash_workflow.py` — Flash 模式的 completion callback
+- `src/server/handlers/chat/ptc_workflow.py` — PTC 模式的 completion callback
+
+**工作内容**：
+
+1. **新增 Pydantic response schema**（建议放在 `src/server/models/` 或 `src/server/services/llm_service.py` 同级）：
+```python
+from pydantic import BaseModel, Field
+
+class SuggestionItem(BaseModel):
+    text: str = Field(description="A concise follow-up question or suggestion, in the user's language")
+
+class SuggestionResponse(BaseModel):
+    suggestions: list[SuggestionItem] = Field(
+        max_length=3,
+        description="1-3 follow-up suggestions based on the assistant's last reply"
+    )
+```
+
+2. **新增 suggestion 生成函数**（建议放在 `src/server/services/suggestion_service.py`）：
+   - 输入：`user_id`, 最后一条 assistant 回复文本
+   - 检查用户 prefs 中 `other_preference.suggestion_enabled`，缺省时默认为 `true`（即 key 不存在视为开启）
+   - 若显式设置为 `false`，直接返回空
+   - 调用 `LLMService.complete()` 生成 suggestions：
+     - `mode="flash"`（轻量模型，节省成本）
+     - `response_schema=SuggestionResponse`（结构化输出）
+     - system_prompt 指引 LLM 生成简短、有针对性、延续对话的 follow-up 问题
+   - 返回 `list[str]`（最多 5 条）
+
+3. **在 completion callback 中触发 suggestion 生成**：
+   - Flash mode：`flash_workflow.py` 的 `on_flash_workflow_complete()`（约第 428 行）
+   - PTC mode：`ptc_workflow.py` 的 `on_background_workflow_complete()`（约第 823 行）
+   - 在 `persist_completion()` 之后，调用 suggestion service
+   - 将生成的 suggestions 追加写入 `conversation_responses.sse_events` JSONB 中，作为一个新的 SSE event：
+     ```json
+     {"event": "suggestions", "data": {"suggestions": ["...", "...", "..."]}}
+     ```
+   - 使用方案 B（写入 sse_events）：无需新增数据库列，无需 migration，利用已有 JSONB 列即可。前端 replay 时也能一并回放
+
+4. **新增 API 端点**：`GET /api/v1/threads/{thread_id}/turns/{run_id}/suggestions`
+   - 从 `conversation_responses.sse_events` 中提取 `event: suggestions` 的 data
+   - 返回 `{"suggestions": ["...", "..."]}`
+   - 若未找到 suggestion event，返回 `{"suggestions": []}`
+
+**验证**：
+- 开启 suggestion 开关后，发送一条消息，收到回复后调用 API 能获取 suggestions
+- 关闭 suggestion 开关后，API 返回空列表
+- 新用户（无 `suggestion_enabled` key）默认视为开启，正常生成 suggestions
+- suggestions 数量 ≤ 5
+
+---
+
+### Step 4: 前端 — 数据模型扩展
+
+**目标**：在 TypeScript 类型和 chat message 结构中支持 suggestions。
+
+**涉及文件**：
+- `web/src/types/chat.ts`
+- `web/src/pages/ChatAgent/utils/api.ts`
+- `web/src/lib/queryKeys.ts`
+
+**工作内容**：
+
+1. 在 `chat.ts` 的 `AssistantMessage` 接口中添加字段：
+```typescript
+export interface AssistantMessage {
+  // ... 已有字段
+  suggestions?: string[];  // 最多 5 条 follow-up suggestion
+}
+```
+
+2. 在 `api.ts` 中新增 API 调用函数：
+```typescript
+export async function fetchSuggestions(
+  threadId: string,
+  runId: string
+): Promise<{ suggestions: string[] }> {
+  const { data } = await api.get(`/api/v1/threads/${threadId}/turns/${runId}/suggestions`);
+  return data;
+}
+```
+
+3. 在 `queryKeys.ts` 中添加 query key（可选，也可以用 local state）。
+
+**验证**：
+- TypeScript 编译无错误
+
+---
+
+### Step 5: 前端 — SSE 流结束后拉取 suggestions
+
+**目标**：当 assistant 回复的 SSE 流结束时，自动拉取 suggestions 并更新到消息上。
+
+**涉及文件**：
+- `web/src/pages/ChatAgent/hooks/useChatMessages.ts`
+- `web/src/pages/ChatAgent/hooks/utils/streamEventHandlers.ts`
+
+**工作内容**：
+
+1. 在 SSE 流结束处理逻辑中（`finish` 事件或 stream 自然结束），获取当前 `run_id` 和 `thread_id`
+2. 检查用户 preferences 中 `suggestion_enabled`，缺省时默认为 `true`（`other_preference?.suggestion_enabled ?? true`）
+3. 若开启，调用 `fetchSuggestions(threadId, runId)`
+4. 将返回的 `suggestions` 写入最后一条 assistant message：
+```typescript
+setMessages(prev => prev.map(msg =>
+  msg.id === assistantMsgId ? { ...msg, suggestions: result.suggestions } : msg
+));
+```
+
+**关键细节**：
+- Suggestions 只在 assistant 消息**非 streaming** 状态下显示（`isStreaming === false` 且 `suggestions.length > 0`）
+- 历史消息（`isHistory === true`）不拉取 suggestions（避免大量 API 调用）
+- Error 消息不显示 suggestions
+
+**验证**：
+- 发一条消息，收到完整回复后，MessageList 中的最后一条 assistant message 的 `suggestions` 字段被填充
+
+---
+
+### Step 6: 前端 — Suggestion 按钮 UI 组件
+
+**目标**：在 assistant 消息下方渲染 suggestion 快捷按钮。
+
+**参考模式**：`Dashboard/components/ChatInputCard.tsx` 的 suggestion chips（`dashboard-suggestion-bubble` CSS class）
+
+**涉及文件**：
+- `web/src/pages/ChatAgent/components/MessageList.tsx`（`MessageBubble` 内部）
+- 可选：新建 `web/src/pages/ChatAgent/components/SuggestionButtons.tsx`
+
+**工作内容**：
+
+1. **新建 `SuggestionButtons` 组件**：
+```tsx
+interface SuggestionButtonsProps {
+  suggestions: string[];
+  onSuggestionClick: (text: string) => void;
+  disabled?: boolean;  // 当正在 streaming 时禁用
+}
+```
+
+2. **渲染位置**：在 `MessageBubble` 中，action buttons 行**上方**、widget deck **下方**（约 MessageList.tsx 第 799 行之后，第 807 行之前）：
+
+```
+┌─────────────────────────────┐
+│  Assistant Message Content  │
+│  (text, tool calls, etc.)   │
+├─────────────────────────────┤
+│  [Suggestion 1] [Sug 2] ... │  ← 新增
+├─────────────────────────────┤
+│  📋  👍  👎  🔄            │  ← 已有 action buttons
+└─────────────────────────────┘
+```
+
+3. **样式**：
+   - 水平排列，flex wrap
+   - 使用 chip/badge 风格，圆角边框
+   - Hover 时高亮
+   - 使用 CSS 变量（`var(--color-*)`）保持主题一致
+   - 仅在 `!isStreaming && suggestions?.length > 0` 时显示
+   - 跟随 action buttons 的 hover 显示逻辑（`opacity-0 group-hover:opacity-100`），保持 UI 整洁
+
+4. **在 `MessageList.tsx` 中集成**：
+   - `MessageBubble` 接收新的 `onSuggestionClick` prop
+   - `MessageList` 接收新的 `onSuggestionClick` prop 并下发给 `MessageBubble`
+   - `ChatView` 传入 `onSuggestionClick` handler
+
+**验证**：
+- 收到回复后，消息下方出现 suggestion chips
+- Hover 消息时 chips 可见
+- Streaming 中不显示
+- 历史消息不显示
+
+---
+
+### Step 7: 前端 — 点击 Suggestion 发送下一轮消息
+
+**目标**：点击 suggestion 按钮直接将其作为下一条 user message 发送。
+
+**涉及文件**：
+- `web/src/pages/ChatAgent/components/ChatView.tsx`
+- `web/src/pages/ChatAgent/components/MessageList.tsx`
+
+**工作内容**：
+
+1. 在 `ChatView.tsx` 中创建 `handleSuggestionClick`：
+```typescript
+const handleSuggestionClick = useCallback((text: string) => {
+  handleSendMessage(text);
+}, [handleSendMessage]);
+```
+
+2. 传递给 `MessageList`：
+```tsx
+<MessageList
+  // ... 已有 props
+  onSuggestionClick={handleSuggestionClick}
+/>
+```
+
+3. `MessageList` → `MessageBubble` → `SuggestionButtons` 逐层传递
+
+4. 点击后的用户体验：
+   - 立即调用 `handleSendMessage(suggestionText)` 发送消息
+   - 不需要先填入 ChatInput，直接发送（因为 suggestion 本身已经是完整的提问）
+   - ChatInput 可选择性填入该文本（通过 `chatInputRef.current?.setValue(text)`），方便用户修改后再发送（可选增强）
+
+**可选的交互增强**：
+- 点击后给 suggestion 按钮一个短暂的 active/pressed 动画
+- 发送期间禁用所有 suggestion 按钮（避免重复点击）
+
+**验证**：
+- 点击 suggestion 按钮后，自动发送对应的消息
+- AI 正常回复
+- 新回复的 suggestion 按钮正常出现
+- 旧消息的 suggestion 按钮仍然可点击
+
+---
+
+### Step 8: 后端 — 将 suggestions 写入 sse_events（无需 Migration）
+
+**目标**：利用已有 `conversation_responses.sse_events` JSONB 列存储 suggestions，避免新增数据库列。
+
+**涉及文件**：
+- `src/server/services/suggestion_service.py`（Step 3 已创建）
+- `src/server/handlers/chat/flash_workflow.py`
+- `src/server/handlers/chat/ptc_workflow.py`
+
+**工作内容**：
+
+1. 在 completion callback 中，调用 suggestion service 获取 suggestions
+2. 将 suggestions 序列化为 SSE event 追加到 `sse_events` JSONB 数组：
+   ```python
+   suggestion_event = {
+       "event": "suggestions",
+       "data": {"suggestions": ["...", "...", "..."]},
+   }
+   ```
+3. 更新 `conversation_responses` 行：`UPDATE conversation_responses SET sse_events = sse_events || $1::jsonb WHERE ...`
+   - 使用 PostgreSQL `||` 操作符追加元素到 JSONB 数组末尾
+
+**方案 B 的优势**：
+- 无需 migration，无需新增数据库列
+- 前端 replay 时自然能回放 suggestion event
+- `sse_events` 已是 JSONB 数组，追加操作简单高效
+
+**验证**：
+- 回复完成后，`sse_events` 数组末尾包含 `{"event": "suggestions", "data": {...}}`
+- 开关关闭时不会追加 suggestion event
+
+---
+
+### Step 9: 测试
+
+**涉及文件**：
+- `tests/unit/server/app/` — 后端 API 测试
+- `web/src/pages/ChatAgent/components/__tests__/` — 前端组件测试
+
+**工作内容**：
+
+1. **后端测试**：
+   - 测试 `suggestion_enabled` 开关的读写
+   - 测试 suggestion API 端点返回正确格式
+   - 测试开关关闭时 API 返回空
+
+2. **前端测试**：
+   - 测试 `SuggestionButtons` 组件渲染
+   - 测试点击触发 `onSuggestionClick` 回调
+   - 测试 streaming 状态下不显示
+   - 测试空 suggestions 时不渲染
+
+---
+
+## 文件变更清单
+
+| 文件 | 变更类型 | 说明 |
+|------|---------|------|
+| `src/server/models/suggestion.py` | 新建 | SuggestionResponse Pydantic schema |
+| `src/server/services/suggestion_service.py` | 新建 | Suggestion 生成逻辑 + 写入 sse_events |
+| `src/server/handlers/chat/flash_workflow.py` | 修改 | completion callback 中触发 suggestion 生成并写入 sse_events |
+| `src/server/handlers/chat/ptc_workflow.py` | 修改 | completion callback 中触发 suggestion 生成并写入 sse_events |
+| `src/server/app/threads.py` | 修改 | 新增 `GET /{thread_id}/turns/{run_id}/suggestions` 端点，从 sse_events 提取 |
+| `web/src/pages/Settings/Settings.tsx` | 修改 | 新增 suggestion_enabled toggle（默认开启） |
+| `web/src/types/chat.ts` | 修改 | AssistantMessage 加 suggestions 字段 |
+| `web/src/pages/ChatAgent/utils/api.ts` | 修改 | 新增 fetchSuggestions API 调用 |
+| `web/src/pages/ChatAgent/components/SuggestionButtons.tsx` | 新建 | Suggestion 按钮 UI 组件 |
+| `web/src/pages/ChatAgent/components/MessageList.tsx` | 修改 | 集成 SuggestionButtons，新增 onSuggestionClick prop |
+| `web/src/pages/ChatAgent/components/ChatView.tsx` | 修改 | handleSuggestionClick 回调，传给 MessageList |
+| `web/src/pages/ChatAgent/hooks/useChatMessages.ts` | 修改 | SSE 流结束后拉取 suggestions |
+| `tests/unit/server/app/test_suggestions.py` | 新建 | 后端测试 |
+| `web/src/pages/ChatAgent/components/__tests__/SuggestionButtons.test.tsx` | 新建 | 前端组件测试 |
+
+## 数据流
+
+```
+用户发送消息
+  → SSE 流返回 assistant 回复
+  → finish 事件触发
+  → 检查 other_preference.suggestion_enabled（缺省默认 true）
+  → 若开启：调用 resolve_model_client(OAuth → BYOK → platform) 解析凭证
+  → make_api_call() 生成 1-5 条 suggestion
+  → 追加写入 conversation_responses.sse_events 作为 "suggestions" event
+  → tracker.mark_completed() 通知前端 stream 结束
+  → 前端 SSE 流结束后调用 GET .../suggestions
+  → API 从 sse_events 中提取 suggestions event 的 data
+  → 更新 AssistantMessage.suggestions
+  → SuggestionButtons 组件渲染
+  → 用户点击 → handleSendMessage(suggestionText) → 下一轮聊天
+```
+
+---
+
+## 实际实现与计划差异
+
+以下记录了开发过程中发现的、与原始计划不同的关键决策和踩坑记录。
+
+### 1. 模型凭证解析：`resolve_model_client` 替代 `LLMService.complete()`
+
+**计划**：使用 `LLMService.complete(user_id=..., mode="flash")` 走 `resolve_llm_config` 做用户级凭证解析。
+
+**问题**：`resolve_llm_config` 内部 `_cow()` 调用 `config.model_copy(deep=True)`，在 workflow 执行后 config 被 LangGraph/中间件注入了不可 pickle 的对象（如 `RLock`），导致 `TypeError: cannot pickle '_thread.RLock' object`。
+
+**尝试过 `create_llm()` 直接调用**：绕过 `resolve_llm_config`，但 `create_llm` 只查 env var（如 `DEEPSEEK_API_KEY`），不处理 BYOK/OAuth 凭证。BYOK 用户的 API key 存在 DB `custom_providers` 中，`create_llm` 找不到。
+
+**最终方案**：使用 `resolve_model_client(user_id, model_name, is_byok=True, allow_platform_fallback=True)` — 这是 `resolve_llm_config` 内部的子函数，走 OAuth → BYOK → platform fallback 三级凭证发现，但不触发 `_cow()` 的 deepcopy。模型名从 `other_preference.preferred_flash_model` 读取（fallback `agent_config.llm.flash`）。
+
+### 2. 时序问题：suggestion 生成必须在 `mark_completed` 之前
+
+**问题**：completion callback 中 `tracker.mark_completed()` 发出完成信号 → 前端 SSE 流结束 → 调 `GET .../suggestions`。但原来 suggestion 生成在 `mark_completed` **之后**，前端调用时数据还没写入 DB。
+
+**修复**：将 suggestion 生成 + `update_sse_events()` 移到 `tracker.mark_completed()` **之前**。
+
+```python
+# 正确顺序
+persist_completion()
+generate_suggestions() + update_sse_events()  # ← 先写库
+tracker.mark_completed()                       # ← 再发完成信号
+```
+
+### 3. 前端获取方式：HTTP 请求 → SSE 流内推送
+
+**计划**：SSE 流结束后前端通过 `GET /api/v1/threads/{tid}/turns/{rid}/suggestions` 拉取。
+
+**问题**：额外 HTTP 往返导致 suggestions 出现有明显延迟（消息先渲染完，suggestions 才到）。
+
+**修复**：改为在 completion callback 中通过 Redis Stream 推送 `suggestions` SSE 事件。前端在 `processEvent`（`createStreamEventProcessor`）中直接处理 `eventType === 'suggestions'`，将 `event.suggestions` 写入对应 assistant message。
+
+- `suggestion_service.py` 新增 `push_suggestions_to_redis()`，用 `XADD` 写入 Redis stream
+- `flash_workflow.py` / `ptc_workflow.py` 在 `update_sse_events` 后、`mark_completed` 前调用
+- `useChatMessages.ts` 新增 `suggestions` event handler，删除 `fetchSuggestionsAsync` 和 HTTP 调用
+- `api.ts` 删除 `fetchSuggestions()` 函数（API 端点保留，供将来 replay 使用）
+- `scripts/utils/test_suggestions.py` 已删除（没用上）
+
+**注意**：SSE 解析器会把 `data:` 行的 JSON 展开到事件顶层，取值时用 `event.suggestions` 而非 `event.data.suggestions`。
+
+### 4. Settings toggle 位置调整
+
+### 5. Settings toggle 位置调整
+
+计划放在 User Info tab 的 voice input 旁边 → 实际放在**模型 tab 底部**（BYOK 配置下方，用 `borderTop` 分割线隔离）。
+
+### 6. 数量上限调整
+
+`SuggestionResponse.max_length` 从 3 改为 5，同步更新 service prompt 和截断逻辑。
+
+### 7. 已知限制：页面刷新后 suggestions 消失
+
+当前 history replay（`loadHistory` → `replayThreadHistory`）有独立的事件处理逻辑，尚未添加 `suggestions` event 的处理。页面刷新后 `sse_events` 中的 suggestion 数据虽然存在，但 replay 不会将其写入 `AssistantMessage.suggestions`，导致刷新后按钮不显示。后续可在 history replay 的事件分发（`useChatMessages.ts` 约 1621 行 `credit_usage` 附近）加入 suggestion 处理逻辑。

--- a/src/server/app/threads.py
+++ b/src/server/app/threads.py
@@ -1038,6 +1038,49 @@ async def get_thread_turns(thread_id: str, x_user_id: CurrentUserId):
     return await _get_thread_turns(thread_id, branch_tip_checkpoint_id=branch_tip)
 
 
+@router.get("/{thread_id}/turns/{run_id}/suggestions")
+async def get_turn_suggestions(
+    thread_id: str, run_id: str, x_user_id: CurrentUserId
+):
+    """Get follow-up suggestions for a completed turn.
+
+    Returns suggestions generated after the assistant reply was completed.
+    The suggestions are extracted from the ``sse_events`` JSONB column.
+    """
+    await require_thread_owner(thread_id, x_user_id)
+    from src.server.database.conversation import get_db_connection
+    from psycopg.rows import dict_row
+    import json as _json
+
+    async with get_db_connection() as conn:
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(
+                """
+                SELECT sse_events
+                FROM conversation_responses
+                WHERE conversation_response_id = %s
+                  AND conversation_thread_id = %s
+                """,
+                (run_id, thread_id),
+            )
+            row = await cur.fetchone()
+
+    suggestions: list[str] = []
+    if row and row.get("sse_events"):
+        sse_events = row["sse_events"]
+        # sse_events may be a list or a JSON-string; normalize.
+        if isinstance(sse_events, str):
+            sse_events = _json.loads(sse_events)
+        if isinstance(sse_events, list):
+            for evt in sse_events:
+                if isinstance(evt, dict) and evt.get("event") == "suggestions":
+                    data = evt.get("data") or {}
+                    suggestions = data.get("suggestions") or []
+                    break
+
+    return {"suggestions": suggestions}
+
+
 @router.post("/{thread_id}/retry")
 async def retry_thread(
     thread_id: str,

--- a/src/server/handlers/chat/flash_workflow.py
+++ b/src/server/handlers/chat/flash_workflow.py
@@ -450,6 +450,46 @@ async def astream_flash_workflow(
                         sse_events=_sse_events,
                     )
 
+                # Generate follow-up suggestions BEFORE mark_completed so they
+                # are persisted before the SSE stream ends and the frontend
+                # fetches them via the suggestions API.
+                if _sse_events and config and user_id:
+                    try:
+                        from src.server.services.suggestion_service import (
+                            build_suggestion_sse_event,
+                            extract_assistant_text,
+                            generate_suggestions,
+                            push_suggestions_to_redis,
+                        )
+                        from src.server.database.conversation import update_sse_events
+
+                        assistant_text = extract_assistant_text(_sse_events)
+                        suggestions = await generate_suggestions(
+                            user_id=user_id,
+                            agent_config=config,
+                            assistant_text=assistant_text,
+                            call_logger=logger,
+                        )
+                        if suggestions:
+                            sse_event = build_suggestion_sse_event(suggestions)
+                            _sse_events.append(sse_event)
+                            await update_sse_events(run_id, _sse_events)
+                            # Push to Redis so the frontend receives the event
+                            # in the live SSE stream (no extra HTTP round-trip).
+                            await push_suggestions_to_redis(
+                                thread_id, run_id, suggestions,
+                            )
+                            logger.info(
+                                "[FLASH_COMPLETE] Suggestions appended: "
+                                f"thread_id={thread_id} count={len(suggestions)}"
+                            )
+                    except Exception:
+                        logger.warning(
+                            "[FLASH_COMPLETE] Suggestion generation failed, "
+                            "continuing",
+                            exc_info=True,
+                        )
+
                 await tracker.mark_completed(
                     thread_id=thread_id,
                     metadata={

--- a/src/server/handlers/chat/ptc_workflow.py
+++ b/src/server/handlers/chat/ptc_workflow.py
@@ -878,6 +878,46 @@ async def astream_ptc_workflow(
                     sse_events=_sse_events,
                 )
 
+                # Generate follow-up suggestions BEFORE mark_completed so they
+                # are persisted before the SSE stream ends and the frontend
+                # fetches them via the suggestions API.
+                if _sse_events and config and user_id:
+                    try:
+                        from src.server.services.suggestion_service import (
+                            build_suggestion_sse_event,
+                            extract_assistant_text,
+                            generate_suggestions,
+                            push_suggestions_to_redis,
+                        )
+                        from src.server.database.conversation import update_sse_events
+
+                        assistant_text = extract_assistant_text(_sse_events)
+                        suggestions = await generate_suggestions(
+                            user_id=user_id,
+                            agent_config=config,
+                            assistant_text=assistant_text,
+                            call_logger=logger,
+                        )
+                        if suggestions:
+                            sse_event = build_suggestion_sse_event(suggestions)
+                            _sse_events.append(sse_event)
+                            await update_sse_events(run_id, _sse_events)
+                            # Push to Redis so the frontend receives the event
+                            # in the live SSE stream (no extra HTTP round-trip).
+                            await push_suggestions_to_redis(
+                                thread_id, run_id, suggestions,
+                            )
+                            logger.info(
+                                "[PTC_COMPLETE] Suggestions appended: "
+                                f"thread_id={thread_id} count={len(suggestions)}"
+                            )
+                    except Exception:
+                        logger.warning(
+                            "[PTC_COMPLETE] Suggestion generation failed, "
+                            "continuing",
+                            exc_info=True,
+                        )
+
                 await tracker.mark_completed(
                     thread_id=thread_id,
                     metadata={

--- a/src/server/models/suggestion.py
+++ b/src/server/models/suggestion.py
@@ -1,0 +1,20 @@
+"""Pydantic models for follow-up suggestion generation."""
+
+from pydantic import BaseModel, Field
+
+
+class SuggestionItem(BaseModel):
+    """A single follow-up suggestion."""
+
+    text: str = Field(
+        description="A concise follow-up question or suggestion, in the user's language"
+    )
+
+
+class SuggestionResponse(BaseModel):
+    """Structured output for LLM-generated follow-up suggestions."""
+
+    suggestions: list[SuggestionItem] = Field(
+        max_length=5,
+        description="1-5 follow-up suggestions based on the assistant's last reply",
+    )

--- a/src/server/services/suggestion_service.py
+++ b/src/server/services/suggestion_service.py
@@ -1,0 +1,241 @@
+"""Follow-up suggestion generation service.
+
+Generates 1-5 follow-up questions after each assistant reply, respecting
+the user's ``suggestion_enabled`` preference (default: enabled). Results
+are appended to the ``sse_events`` JSONB column as a ``suggestions`` event
+so the frontend can retrieve them via the dedicated suggestions API endpoint.
+
+Model selection: reads the user's ``preferred_flash_model`` from
+``other_preference``, falls back to ``agent_config.llm.flash``.
+Credential resolution uses ``resolve_model_client`` (OAuth → BYOK →
+platform fallback) so BYOK / custom provider keys are discovered. This
+avoids ``resolve_llm_config`` → ``_cow`` → ``model_copy(deep=True)``
+which breaks on non-picklable objects attached to the global config by
+middleware/LangGraph during workflow execution.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, List
+
+from src.llms.api_call import make_api_call
+from src.server.database.user import get_user_preferences
+from src.server.handlers.chat.llm_config import resolve_model_client
+from src.server.models.suggestion import SuggestionResponse
+
+SUGGESTION_SYSTEM_PROMPT = """\
+You are a helpful assistant that generates follow-up questions. Based on the \
+assistant's last reply, suggest 1-3 concise, natural follow-up questions the \
+user might want to ask next. The suggestions should:
+
+- Be in the same language as the assistant's reply
+- Be specific and directly relevant to the conversation
+- Help the user dig deeper into the topic or explore related angles
+- Be short (one sentence each, ideally under 15 words)
+- NOT repeat questions the user has already asked
+- NOT be generic ("tell me more") — they should be substantive
+
+Return at most 5 suggestions. If the conversation is complete or there are \
+no meaningful follow-ups, return fewer (or none)."""
+
+logger = logging.getLogger(__name__)
+
+
+async def generate_suggestions(
+    *,
+    user_id: str,
+    agent_config: Any,
+    assistant_text: str,
+    call_logger: logging.Logger | None = None,
+) -> List[str]:
+    """Generate follow-up suggestions for the given assistant reply.
+
+    Args:
+        user_id: The authenticated user's ID.
+        agent_config: Agent configuration (for system default flash model).
+        assistant_text: The full text content of the last assistant reply.
+        call_logger: Optional logger (defaults to module-level logger).
+
+    Returns:
+        A list of 0-5 suggestion strings. Empty if the feature is disabled
+        or generation fails.
+    """
+    log = call_logger or logger
+
+    # --- Check user preference -------------------------------------------------
+    try:
+        prefs = await get_user_preferences(user_id)
+    except Exception:
+        log.warning(
+            "[SUGGESTION] Failed to load preferences, defaulting to enabled",
+            exc_info=True,
+        )
+        prefs = None
+
+    other_pref: dict = (prefs or {}).get("other_preference") or {}
+    # Default to enabled when the key is absent.
+    if other_pref.get("suggestion_enabled") is False:
+        log.debug("[SUGGESTION] Disabled via user preference, skipping")
+        return []
+
+    # --- Resolve model ---------------------------------------------------------
+    if not assistant_text.strip():
+        return []
+
+    # Use user's preferred flash model, fall back to system default.
+    preferred = other_pref.get("preferred_flash_model")
+    system_default = getattr(agent_config.llm, "flash", None) if agent_config else None
+    model_name = preferred or system_default
+    if not model_name:
+        log.warning("[SUGGESTION] No flash model available, skipping")
+        return []
+
+    # --- Resolve credentials ---------------------------------------------------
+    # Use resolve_model_client (OAuth → BYOK → platform fallback) instead of
+    # create_llm so BYOK / custom provider keys stored in user preferences
+    # are discovered. Avoids resolve_llm_config → _cow → model_copy(deep=True)
+    # which can fail on mutated global config objects.
+    try:
+        resolved = await resolve_model_client(
+            user_id,
+            str(model_name),
+            is_byok=True,
+            allow_platform_fallback=True,
+        )
+        llm = resolved.client
+        if llm is None:
+            log.warning(
+                "[SUGGESTION] No credentials resolved for model=%s (source=%s credential=%s)",
+                model_name,
+                resolved.source,
+                resolved.credential_source,
+            )
+            return []
+    except Exception:
+        log.warning(
+            "[SUGGESTION] Credential resolution failed for model=%s",
+            model_name,
+            exc_info=True,
+        )
+        return []
+
+    # --- Call LLM --------------------------------------------------------------
+    try:
+        result = await make_api_call(
+            llm,
+            system_prompt=SUGGESTION_SYSTEM_PROMPT,
+            user_prompt=_build_user_prompt(assistant_text),
+            response_schema=SuggestionResponse,
+        )
+        suggestions: list[str] = [
+            item.text.strip() for item in (result.suggestions or []) if item.text.strip()
+        ]
+        log.info(
+            "[SUGGESTION] Generated %d suggestions for user=%s",
+            len(suggestions),
+            user_id,
+        )
+        return suggestions[:5]
+    except Exception:
+        log.warning(
+            "[SUGGESTION] LLM call failed, returning empty suggestions",
+            exc_info=True,
+        )
+        return []
+
+
+def _build_user_prompt(assistant_text: str) -> str:
+    """Build the user prompt for the suggestion-generation LLM call."""
+    # Truncate to a reasonable context window for the lightweight flash model.
+    truncated = assistant_text.strip()
+    if len(truncated) > 4000:
+        truncated = truncated[:4000] + "\n... (truncated)"
+    return (
+        "Here is the assistant's last reply in a conversation:\n\n"
+        f"{truncated}\n\n"
+        "Based on this reply, generate 1-3 follow-up questions the user "
+        "might want to ask next."
+    )
+
+
+async def push_suggestions_to_redis(
+    thread_id: str,
+    run_id: str,
+    suggestions: List[str],
+) -> bool:
+    """Push a ``suggestions`` SSE event to the per-run Redis stream.
+
+    Called from the completion callback *before* ``tracker.mark_completed()``
+    so the frontend SSE consumer receives the event as part of the live stream
+    (no extra HTTP round-trip).
+
+    Returns ``True`` if the event was pushed, ``False`` otherwise.
+    """
+    import json as _json
+
+    from src.server.services.background_task_manager import stream_key
+    from src.utils.cache.redis_cache import get_cache_client
+
+    try:
+        cache = get_cache_client()
+    except Exception:
+        logger.warning("[SUGGESTION] Redis unavailable, cannot push to stream")
+        return False
+
+    if not cache.enabled:
+        return False
+
+    data = {"suggestions": suggestions}
+    sse_str = (
+        f"id: 0\nevent: suggestions\n"
+        f"data: {_json.dumps(data, ensure_ascii=False)}\n\n"
+    )
+    stream_k = stream_key(thread_id, run_id)
+    try:
+        await cache.client.xadd(stream_k, {"event": sse_str}, maxlen=10000)
+        logger.debug(
+            "[SUGGESTION] Pushed %d suggestions to Redis stream=%s",
+            len(suggestions),
+            stream_k,
+        )
+        return True
+    except Exception:
+        logger.warning(
+            "[SUGGESTION] Failed to push to Redis stream=%s",
+            stream_k,
+            exc_info=True,
+        )
+        return False
+
+
+def build_suggestion_sse_event(suggestions: List[str]) -> dict:
+    """Build an SSE event dict for appending to ``sse_events``.
+
+    Args:
+        suggestions: The suggestion strings to embed.
+
+    Returns:
+        A dict with ``event`` and ``data`` keys suitable for appending to
+        the ``conversation_responses.sse_events`` JSONB array.
+    """
+    return {
+        "event": "suggestions",
+        "data": {"suggestions": suggestions},
+    }
+
+
+def extract_assistant_text(sse_events: list) -> str:
+    """Extract concatenated assistant text from SSE events.
+
+    Iterates over ``message_chunk`` events and joins their ``content``
+    fields. This is used as input for the suggestion-generation LLM call.
+    """
+    parts: list[str] = []
+    for evt in sse_events:
+        if isinstance(evt, dict) and evt.get("event") == "message_chunk":
+            data = evt.get("data") or {}
+            content = data.get("content")
+            if isinstance(content, str) and content:
+                parts.append(content)
+    return "".join(parts)

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -58,6 +58,8 @@
     "locale": "Language",
     "voiceInput": "Voice Input",
     "voiceInputDesc": "Enable microphone icon in the chat bar for speech-to-text.",
+    "suggestionButtons": "Follow-up Suggestions",
+    "suggestionButtonsDesc": "Show quick follow-up question buttons after each AI reply.",
     "emailCannotBeChanged": "Email cannot be changed",
     "changeAvatar": "Change Avatar",
     "uploading": "Uploading...",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -58,6 +58,8 @@
     "locale": "语言",
     "voiceInput": "语音输入",
     "voiceInputDesc": "在聊天栏中启用麦克风图标以进行语音转文字。",
+    "suggestionButtons": "追问建议",
+    "suggestionButtonsDesc": "在每次 AI 回复后显示快捷追问按钮。",
     "emailCannotBeChanged": "邮箱不可更改",
     "changeAvatar": "更换头像",
     "uploading": "上传中...",

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -2114,6 +2114,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
                           handleSendMessage(`/self-improve ${instruction}`);
                         }}
                         onWidgetSendPrompt={handleSendMessage}
+                        onSuggestionClick={(text: string) => handleSendMessage(text)}
                       />
                     </div>
                   </div>

--- a/web/src/pages/ChatAgent/components/MessageList.tsx
+++ b/web/src/pages/ChatAgent/components/MessageList.tsx
@@ -35,6 +35,7 @@ import PTCAgentCard from './PTCAgentCard';
 import SecretaryConfirmCard from './SecretaryConfirmCard';
 import SubagentTaskMessageContent from './SubagentTaskMessageContent';
 import TextMessageContent from './TextMessageContent';
+import SuggestionButtons from './SuggestionButtons';
 import InlineWidget from './viewers/InlineWidget';
 import ToolCallMessageContent from './ToolCallMessageContent';
 import { CitationMetadataProvider } from './CitationMetadataContext';
@@ -350,10 +351,11 @@ interface MessageListProps {
   getFeedbackForMessage?: (messageId: string) => FeedbackResult | null;
   onReportWithAgent?: (instruction: string) => void;
   onWidgetSendPrompt?: (text: string) => void;
+  onSuggestionClick?: (text: string) => void;
   flashContext?: { threadId: string; workspaceId: string } | null;
 }
 
-function MessageList({ messages, isLoading, isLoadingHistory, hideAvatar, compactToolCalls, isSubagentView, readOnly, allowFiles, onOpenSubagentTask, onOpenFile, onOpenDir, onToolCallDetailClick, onApprovePlan, onRejectPlan, onPlanDetailClick, onAnswerQuestion, onSkipQuestion, onApproveCreateWorkspace, onRejectCreateWorkspace, onApproveStartQuestion, onRejectStartQuestion, onApprovePTCAgent, onRejectPTCAgent, onApproveSecretaryAction, onRejectSecretaryAction, onEditMessage, onRegenerate, onRetry, onThumbUp, onThumbDown, getFeedbackForMessage, onReportWithAgent, onWidgetSendPrompt, flashContext }: MessageListProps): React.ReactElement | null {
+function MessageList({ messages, isLoading, isLoadingHistory, hideAvatar, compactToolCalls, isSubagentView, readOnly, allowFiles, onOpenSubagentTask, onOpenFile, onOpenDir, onToolCallDetailClick, onApprovePlan, onRejectPlan, onPlanDetailClick, onAnswerQuestion, onSkipQuestion, onApproveCreateWorkspace, onRejectCreateWorkspace, onApproveStartQuestion, onRejectStartQuestion, onApprovePTCAgent, onRejectPTCAgent, onApproveSecretaryAction, onRejectSecretaryAction, onEditMessage, onRegenerate, onRetry, onThumbUp, onThumbDown, getFeedbackForMessage, onReportWithAgent, onWidgetSendPrompt, onSuggestionClick, flashContext }: MessageListProps): React.ReactElement | null {
   const isMobile = useIsMobile();
 
   // Empty state - show when no messages exist (hidden in subagent view)
@@ -442,6 +444,7 @@ function MessageList({ messages, isLoading, isLoadingHistory, hideAvatar, compac
             getFeedbackForMessage={getFeedbackForMessage}
             onReportWithAgent={onReportWithAgent}
             onWidgetSendPrompt={onWidgetSendPrompt}
+            onSuggestionClick={onSuggestionClick}
             flashContext={flashContext}
           />
         )
@@ -485,6 +488,7 @@ interface MessageBubbleProps {
   getFeedbackForMessage?: (messageId: string) => FeedbackResult | null;
   onReportWithAgent?: (instruction: string) => void;
   onWidgetSendPrompt?: (text: string) => void;
+  onSuggestionClick?: (text: string) => void;
   isMobile?: boolean;
   flashContext?: { threadId: string; workspaceId: string } | null;
 }
@@ -493,7 +497,7 @@ interface MessageBubbleProps {
  * Wrapped with React.memo — safe because updateMessage() in messageHelpers.ts
  * returns the same object reference for unchanged messages.
  */
-const MessageBubble = memo(function MessageBubble({ message, isLoading, hideAvatar, compactToolCalls, isSubagentView, readOnly, allowFiles, onOpenSubagentTask, onOpenFile, onOpenDir, onToolCallDetailClick, onApprovePlan, onRejectPlan, onPlanDetailClick, onAnswerQuestion, onSkipQuestion, onApproveCreateWorkspace, onRejectCreateWorkspace, onApproveStartQuestion, onRejectStartQuestion, onApprovePTCAgent, onRejectPTCAgent, onApproveSecretaryAction, onRejectSecretaryAction, onEditMessage, onRegenerate, onRetry, onThumbUp, onThumbDown, getFeedbackForMessage, onReportWithAgent, onWidgetSendPrompt, isMobile, flashContext }: MessageBubbleProps): React.ReactElement {
+const MessageBubble = memo(function MessageBubble({ message, isLoading, hideAvatar, compactToolCalls, isSubagentView, readOnly, allowFiles, onOpenSubagentTask, onOpenFile, onOpenDir, onToolCallDetailClick, onApprovePlan, onRejectPlan, onPlanDetailClick, onAnswerQuestion, onSkipQuestion, onApproveCreateWorkspace, onRejectCreateWorkspace, onApproveStartQuestion, onRejectStartQuestion, onApprovePTCAgent, onRejectPTCAgent, onApproveSecretaryAction, onRejectSecretaryAction, onEditMessage, onRegenerate, onRetry, onThumbUp, onThumbDown, getFeedbackForMessage, onReportWithAgent, onWidgetSendPrompt, onSuggestionClick, isMobile, flashContext }: MessageBubbleProps): React.ReactElement {
   const { user } = useUser();
   const { theme } = useTheme();
   const logo = theme === 'light' ? logoDark : logoLight;
@@ -796,6 +800,14 @@ const MessageBubble = memo(function MessageBubble({ message, isLoading, hideAvat
             scoped to the message that attached them. */}
         {hasWidgetSnapshots && (
           <InlineWidgetDeck snapshots={widgetSnapshots!} />
+        )}
+
+        {/* Follow-up suggestion buttons — only for completed assistant messages */}
+        {isAssistant && !(message.isStreaming as boolean) && !(message.error as boolean) && (message.suggestions as string[] | undefined)?.length > 0 && onSuggestionClick && (
+          <SuggestionButtons
+            suggestions={message.suggestions as string[]}
+            onSuggestionClick={onSuggestionClick}
+          />
         )}
         </>
         )}

--- a/web/src/pages/ChatAgent/components/SuggestionButtons.tsx
+++ b/web/src/pages/ChatAgent/components/SuggestionButtons.tsx
@@ -1,0 +1,61 @@
+/**
+ * Follow-up suggestion buttons rendered below assistant messages.
+ *
+ * Displays up to 3 clickable chips that, when clicked, send the suggestion
+ * text as the next user message. Only visible when the message is not
+ * streaming and suggestions are available.
+ */
+
+import React from 'react';
+import { ArrowRight } from 'lucide-react';
+import { useIsMobile } from '@/hooks/useIsMobile';
+
+export interface SuggestionButtonsProps {
+  suggestions: string[];
+  onSuggestionClick: (text: string) => void;
+  disabled?: boolean;
+}
+
+function SuggestionButtons({
+  suggestions,
+  onSuggestionClick,
+  disabled = false,
+}: SuggestionButtonsProps): React.ReactElement | null {
+  const isMobile = useIsMobile();
+
+  if (!suggestions || suggestions.length === 0) return null;
+
+  return (
+    <div
+      className={`flex flex-wrap ${isMobile ? 'gap-1.5 mt-1.5' : 'gap-2 mt-2'}`}
+      role="group"
+      aria-label="Follow-up suggestions"
+    >
+      {suggestions.map((text, idx) => (
+        <button
+          key={idx}
+          type="button"
+          disabled={disabled}
+          onClick={() => onSuggestionClick(text)}
+          className={`inline-flex items-center gap-1 rounded-full border px-3 py-1 text-xs font-medium leading-relaxed transition-all duration-200
+            hover:border-[var(--color-accent-primary)] hover:text-[var(--color-accent-primary)]
+            disabled:opacity-50 disabled:cursor-not-allowed
+            ${isMobile ? 'text-[11px] px-2.5 py-0.5' : ''}`}
+          style={{
+            borderColor: 'var(--color-border-muted)',
+            color: 'var(--color-text-secondary)',
+            backgroundColor: 'transparent',
+          }}
+        >
+          <span className="line-clamp-1 max-w-[240px]">{text}</span>
+          <ArrowRight
+            className={`flex-shrink-0 ${isMobile ? 'h-3 w-3' : 'h-3.5 w-3.5'}`}
+            style={{ color: 'var(--color-text-tertiary)' }}
+          />
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export default React.memo(SuggestionButtons);

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -2653,6 +2653,9 @@ export function useChatMessages(
     if (awaitingReportBackRef.current) {
       startReportBackWatch();
     }
+
+    // Suggestions are now pushed via Redis as an SSE "suggestions" event
+    // and handled inline in createStreamEventProcessor — no extra HTTP fetch.
   };
 
   /**
@@ -3689,6 +3692,18 @@ export function useChatMessages(
         isStreamingRef.current = false;
         currentMessageRef.current = null;
         if (wasInterruptedRef) wasInterruptedRef.current = true;
+      }
+
+      // Handle suggestions event — pushed via Redis at end of stream
+      if (eventType === 'suggestions' && (event.suggestions as string[])?.length > 0) {
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === assistantMessageId && m.role === 'assistant'
+              ? { ...m, suggestions: event.suggestions as string[] } as AssistantMessage
+              : m,
+          ),
+        );
+        return;
       }
     };
 

--- a/web/src/pages/Settings/Settings.tsx
+++ b/web/src/pages/Settings/Settings.tsx
@@ -533,6 +533,26 @@ function Settings() {
     }
   };
 
+  const handleSuggestionToggle = async () => {
+    const currentOtherPref = (prefsData as any)?.other_preference || {};
+    // Default to true when the key is absent.
+    const currentEnabled = currentOtherPref.suggestion_enabled ?? true;
+    try {
+      await updatePrefsMutation.mutateAsync({
+        other_preference: {
+          ...currentOtherPref,
+          suggestion_enabled: !currentEnabled,
+        },
+      });
+    } catch {
+      toast({
+        variant: 'destructive',
+        title: t('common.error'),
+        description: t('settings.failedToSaveSettings'),
+      });
+    }
+  };
+
   const handleModifyPreferences = async () => {
     try {
       const flashWs = await getFlashWorkspace();
@@ -1393,6 +1413,32 @@ function Settings() {
                   )}
                 </div>
               )}
+
+              {/* Suggestion Buttons Toggle */}
+              <div style={{ borderTop: '1px solid var(--color-border-muted)', paddingTop: '16px' }}>
+                <div className="flex items-center justify-between p-3 rounded-lg" style={{ backgroundColor: 'var(--color-bg-card)', border: '1px solid var(--color-border-muted)' }}>
+                  <div className="space-y-0.5">
+                    <label className="text-sm font-medium" style={{ color: 'var(--color-text-primary)' }}>{t('settings.suggestionButtons')}</label>
+                    <p className="text-xs" style={{ color: 'var(--color-text-tertiary)' }}>{t('settings.suggestionButtonsDesc')}</p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={handleSuggestionToggle}
+                    className="relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none"
+                    style={{
+                      backgroundColor: ((prefsData as any)?.other_preference?.suggestion_enabled ?? true) ? 'var(--color-accent-primary)' : 'var(--color-bg-elevated)',
+                      borderColor: 'var(--color-border-muted)',
+                    }}
+                  >
+                    <span
+                      className="pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
+                      style={{
+                        transform: ((prefsData as any)?.other_preference?.suggestion_enabled ?? true) ? 'translateX(16px)' : 'translateX(0)',
+                      }}
+                    />
+                  </button>
+                </div>
+              </div>
             </div>
           )}
         </div>

--- a/web/src/types/chat.ts
+++ b/web/src/types/chat.ts
@@ -264,6 +264,8 @@ export interface AssistantMessage {
   steeringDelivered?: boolean;
   isSteering?: boolean;
   error?: boolean | string;
+  /** Follow-up suggestions generated after the reply completes (max 3). */
+  suggestions?: string[];
 }
 
 export type NotificationVariant = 'info' | 'success' | 'warning';


### PR DESCRIPTION
## 功能

聊天回复下方新增追问建议按钮：
- Settings → 模型 tab 新增开关控制（默认开启）
- 每次 AI 回复后自动生成 1-5 条追问建议（使用 resolve_model_client 解析凭证，支持 BYOK/OAuth）
- 点击建议按钮直接发送下一轮消息
- 通过 Redis Stream 推送 SSE 事件，零额外延迟

## 文件变更

| 文件 | 变更 | 说明 |
|------|------|------|
| `src/server/models/suggestion.py` | 新建 | Pydantic schema |
| `src/server/services/suggestion_service.py` | 新建 | 生成逻辑 + Redis 推送 |
| `src/server/app/threads.py` | 修改 | API 端点 |
| `src/server/handlers/chat/flash_workflow.py` | 修改 | completion callback |
| `src/server/handlers/chat/ptc_workflow.py` | 修改 | completion callback |
| `web/src/pages/ChatAgent/components/SuggestionButtons.tsx` | 新建 | UI 组件 |
| `web/src/pages/ChatAgent/components/MessageList.tsx` | 修改 | 集成渲染 |
| `web/src/pages/ChatAgent/components/ChatView.tsx` | 修改 | 点击回调 |
| `web/src/pages/ChatAgent/hooks/useChatMessages.ts` | 修改 | SSE handler |
| `web/src/pages/Settings/Settings.tsx` | 修改 | 开关 toggle |
| `web/src/types/chat.ts` | 修改 | 类型扩展 |
| `web/src/locales/*.json` | 修改 | i18n |
| `docs/api/01-plan/suggestion-buttons/PLAN.md` | 新建 | 实现计划 |

## 演示

演示视频见 PR 附件。

https://github.com/user-attachments/assets/266aa7c9-eaab-44c4-970d-a03c40de7e00



🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added follow-up suggestion buttons that appear after AI replies, enabling quick follow-up interactions.
  * Added a Settings toggle to enable or disable follow-up suggestions.
  * Users can click suggestion buttons to instantly send them as chat messages.

* **Documentation**
  * Added comprehensive implementation plan for the suggestion buttons feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->