### PR TITLE
feat(sandbox,crawler): unify sandbox images, swap to permissive HTML converters

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -11,6 +11,8 @@
 
 FROM ubuntu:24.04
 
+# Keep NODE_VERSION in sync with SANDBOX_NODE_VERSION in
+# src/ptc_agent/core/sandbox/_defaults.py (the Daytona snapshot uses that).
 ARG NODE_VERSION=24.14.1
 
 # ---------- System packages ----------
@@ -48,6 +50,13 @@ RUN apt-get update \
     && tar -xzf /tmp/gh.tar.gz -C /tmp \
     && mv "/tmp/gh_2.87.3_linux_${GH_ARCH}/bin/gh" /usr/local/bin/gh \
     && rm -rf /tmp/gh.tar.gz "/tmp/gh_2.87.3_linux_${GH_ARCH}" \
+    # -- Polymarket CLI (prediction-market data; multi-arch x86_64 / aarch64) --
+    && POLY_ARCH=$(uname -m) \
+    && curl -fsSL "https://github.com/Polymarket/polymarket-cli/releases/download/v0.1.4/polymarket-v0.1.4-${POLY_ARCH}-unknown-linux-gnu.tar.gz" \
+        -o /tmp/polymarket.tar.gz \
+    && tar -xzf /tmp/polymarket.tar.gz -C /tmp \
+    && mv /tmp/polymarket /usr/local/bin/polymarket \
+    && rm -rf /tmp/polymarket.tar.gz \
     # -- Docker Engine (for interactive-dashboard complex tier) --
     && install -m 0755 -d /etc/apt/keyrings \
     && curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
@@ -75,12 +84,14 @@ RUN apt-get update \
 ENV PLAYWRIGHT_BROWSERS_PATH=/usr/local/ms-playwright
 
 # ---------- Python packages ----------
+# Mirrors DEFAULT_DEPENDENCIES in src/ptc_agent/core/sandbox/_defaults.py
+# (the list the Daytona snapshot installs). Keep both in sync.
 # Override curl_cffi cap: yfinance pins <0.14 but works fine with 0.14+
 # (tested). scrapling[all] requires >=0.14. Override resolves the conflict.
 RUN echo 'curl_cffi>=0.14' > /tmp/overrides.txt \
     && uv pip install --system \
     --override /tmp/overrides.txt \
-    mcp fastmcp \
+    mcp fastmcp fastapi \
     pandas requests aiohttp "httpx[http2]" \
     numpy scipy scikit-learn statsmodels \
     yfinance \
@@ -89,7 +100,7 @@ RUN echo 'curl_cffi>=0.14' > /tmp/overrides.txt \
     openpyxl xlrd python-docx pypdf \
     beautifulsoup4 lxml pyyaml \
     defusedxml pdfplumber reportlab "markitdown[pptx]" \
-    "scrapling[all]" html2text \
+    "scrapling[all]" html-to-markdown trafilatura youtube-transcript-api \
     playwright \
     tqdm tabulate \
     && rm /tmp/overrides.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ dependencies = [
     # so a range pin would let `uv lock --upgrade` silently break browser
     # fetches. Bump deliberately after verifying the private API still exists.
     "scrapling[fetchers]==0.4.7",
-    "html2text>=2024.2.26",
+    "html-to-markdown>=3.5.0",
+    "trafilatura>=2.0.0",
     "pdfplumber>=0.10.0",
     "pypdf>=4.0.0",
     "youtube-transcript-api>=1.0.0",

--- a/src/ptc_agent/core/sandbox/_defaults.py
+++ b/src/ptc_agent/core/sandbox/_defaults.py
@@ -1,6 +1,12 @@
-"""Shared constants for sandbox providers and PTCSandbox."""
+"""Shared constants for sandbox providers and PTCSandbox.
+
+NOTE: `Dockerfile.sandbox` (the Docker provider's image) hand-mirrors
+`DEFAULT_DEPENDENCIES` and `SANDBOX_NODE_VERSION` below — it cannot import this
+module at build time. Keep both in sync when editing either.
+"""
 
 SNAPSHOT_PYTHON_VERSION = "3.12"  # Intentionally pinned for stability/compatibility.
+SANDBOX_NODE_VERSION = "24.14.1"  # Pinned; mirrored in Dockerfile.sandbox.
 
 DEFAULT_DEPENDENCIES = [
     # Core
@@ -41,7 +47,8 @@ DEFAULT_DEPENDENCIES = [
     "markitdown[pptx]",
     # Web scraping
     "scrapling[all]",
-    "html2text",
+    "html-to-markdown",
+    "trafilatura",
     "youtube-transcript-api",
     # Browser automation
     "playwright",

--- a/src/ptc_agent/core/sandbox/providers/daytona.py
+++ b/src/ptc_agent/core/sandbox/providers/daytona.py
@@ -17,7 +17,11 @@ from daytona_sdk.common.process import CodeRunParams, SessionExecuteRequest
 from daytona_sdk.common.snapshot import CreateSnapshotParams
 
 from ptc_agent.config.core import DaytonaConfig
-from ptc_agent.core.sandbox._defaults import DEFAULT_DEPENDENCIES, SNAPSHOT_PYTHON_VERSION
+from ptc_agent.core.sandbox._defaults import (
+    DEFAULT_DEPENDENCIES,
+    SANDBOX_NODE_VERSION,
+    SNAPSHOT_PYTHON_VERSION,
+)
 from ptc_agent.core.sandbox.runtime import (
     Artifact,
     CodeRunResult,
@@ -428,6 +432,12 @@ class DaytonaProvider(SandboxProvider):
             "working_dir": self._working_dir,
             "python_version": self.SNAPSHOT_PYTHON_VERSION,
             "dependencies": self.DEFAULT_DEPENDENCIES,
+            # The apt-list strings below (e.g. "nodejs", "playwright") are static
+            # labels — they stay identical when the pinned Node version or the baked
+            # Playwright browser layout changes, so hash those explicitly to force a
+            # rebuild of existing snapshots when either changes.
+            "playwright_browsers_path": "/usr/local/ms-playwright",
+            "node_version": SANDBOX_NODE_VERSION,
             "mcp_packages": sorted(mcp_packages or []),
             "apt_packages": [
                 "curl",
@@ -480,8 +490,15 @@ class DaytonaProvider(SandboxProvider):
                 " fonts-noto-cjk",
                 "curl -LsSf https://astral.sh/uv/install.sh | sh",
                 "mv /root/.local/bin/uv /usr/local/bin/uv",
-                "curl -fsSL https://deb.nodesource.com/setup_24.x | bash -",
-                "apt-get install -y nodejs",
+                # Node.js: pinned direct binary (matches Dockerfile.sandbox;
+                # avoids apt-mirror flakiness and unpinned-version drift).
+                "NODE_ARCH=$([ \"$(dpkg --print-architecture)\" = \"arm64\" ]"
+                " && echo arm64 || echo x64)"
+                f" && curl -fsSL https://nodejs.org/dist/v{SANDBOX_NODE_VERSION}/"
+                f"node-v{SANDBOX_NODE_VERSION}-linux-${{NODE_ARCH}}.tar.xz"
+                " -o /tmp/node.tar.xz"
+                " && tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1"
+                " && rm /tmp/node.tar.xz",
                 *[f"npm install -g {pkg}" for pkg in pkgs],
                 "npm install -g docx pptxgenjs",
                 'GH_ARCH=$(dpkg --print-architecture)'
@@ -516,6 +533,15 @@ class DaytonaProvider(SandboxProvider):
                 "apt-get clean",
                 "rm -rf /var/lib/apt/lists/*",
             )
+            .env(
+                # Persist a single Playwright browser dir shared by both the
+                # npm-side `playwright` (npx, installed above) and the Python
+                # `playwright` that Scrapling drives at runtime. With this set,
+                # `scrapling install` below and the live sandbox resolve
+                # Chromium at the same path npx populated, instead of the
+                # default ~/.cache — the missing-executable split behind #149.
+                {"PLAYWRIGHT_BROWSERS_PATH": "/usr/local/ms-playwright"}
+            )
             .run_commands(
                 # yfinance pins curl_cffi<0.14 but scrapling[all] requires >=0.14.
                 # Override resolves the conflict (tested, yfinance works with 0.14+).
@@ -523,7 +549,8 @@ class DaytonaProvider(SandboxProvider):
                 "uv pip install --system --override /tmp/overrides.txt "
                 + " ".join(dependencies),
                 "rm /tmp/overrides.txt",
-                # Scrapling browser setup (Camoufox for StealthyFetcher)
+                # Scrapling browser setup (Camoufox for StealthyFetcher).
+                # Chromium lands in the shared PLAYWRIGHT_BROWSERS_PATH set above.
                 "scrapling install || true",
             )
             .run_commands(

--- a/src/tools/crawler/scrapling_crawler.py
+++ b/src/tools/crawler/scrapling_crawler.py
@@ -138,9 +138,15 @@ def _financial_figures(text: str) -> set[str]:
 
 
 def _try_trafilatura(html: str) -> Optional[str]:
-    """Extract the main article as markdown, restoring the title trafilatura strips."""
+    """Extract the main article as markdown with a YAML metadata frontmatter.
+
+    `with_metadata=True` keeps trafilatura's title/source/date/author/description
+    block — without it a lone `<h1>` page extracts to body-only and loses the
+    heading. The frontmatter is already clean (junk fields come back empty and are
+    omitted); pass it through and let the agent decide which fields it cares about.
+    """
     try:
-        out = trafilatura.extract(
+        return trafilatura.extract(
             html,
             favor_recall=True,
             output_format="markdown",
@@ -153,37 +159,19 @@ def _try_trafilatura(html: str) -> Optional[str]:
     except Exception as e:
         logger.debug(f"trafilatura extraction failed: {e}")
         return None
-    return _promote_frontmatter_title(out) if out else out
-
-
-def _promote_frontmatter_title(text: str) -> str:
-    """Lift trafilatura's frontmatter title into a Markdown H1, dropping the rest.
-
-    With `with_metadata`, trafilatura pulls the article title/<h1> out of the body
-    into a YAML frontmatter block; without this a page that is just
-    `<h1>Title</h1><p>body</p>` would extract to body-only and lose the heading.
-    """
-    if not text.startswith("---"):
-        return text
-    end = text.find("\n---", 3)
-    if end == -1:
-        return text
-    block = text[3:end]
-    body = text[end + len("\n---") :].lstrip("\n")
-    title = ""
-    for line in block.splitlines():
-        if line.strip().startswith("title:"):
-            title = line.split("title:", 1)[1].strip().strip('"').strip("'")
-            break
-    if title and title.lower() not in body[: len(title) + 16].lower():
-        return f"# {title}\n\n{body}" if body else f"# {title}"
-    return body
 
 
 def _try_full_page(html: str) -> Optional[str]:
-    """Convert the entire page to markdown via html-to-markdown's Rust core."""
+    """Convert the entire page to markdown via html-to-markdown's Rust core.
+
+    `extract_metadata=False` suppresses html-to-markdown's default <head> dump (a
+    `meta-og:*` / gtm-dataLayer frontmatter block) that is pure noise on the hub,
+    listing and error pages this full-page fallback handles.
+    """
     try:
-        return html_to_markdown.convert(html).content
+        return html_to_markdown.convert(
+            html, html_to_markdown.ConversionOptions(extract_metadata=False)
+        ).content
     except Exception as e:
         logger.debug(f"html-to-markdown conversion failed: {e}")
         return None

--- a/src/tools/crawler/scrapling_crawler.py
+++ b/src/tools/crawler/scrapling_crawler.py
@@ -21,9 +21,11 @@ cancelled mid-teardown and orphans Chromium helper processes.
 
 import asyncio
 import logging
+import re
 from typing import Literal, Optional
 
-import html2text
+import html_to_markdown
+import trafilatura
 
 from .backend import CrawlOutput
 
@@ -101,14 +103,148 @@ def _needs_stealth(
     return None
 
 
+# Tuning for the trafilatura-vs-full-page decision, calibrated on a live 10-page
+# sample (financial news, IR releases, explainers, government statements). Well
+# extracted pages retain 88-100% of figures and stay above ~10% of the full-page
+# size; pages where trafilatura silently drops the article body retain <=28% of
+# figures (CNBC card/liveblog layouts) or collapse to <2% of the page (index/
+# listing stubs). Thresholds sit inside those gaps, biased toward preserving
+# content — for a research agent a noisier full page beats silent data loss.
+_STUB_SIZE_RATIO = 0.10       # extraction below this fraction of the full page...
+_STUB_MIN_FULL_LEN = 5000     # ...on a non-trivial page => listing/index stub
+_FIGURE_MIN_SAMPLE = 8        # only trust the figure ratio above this many figures
+_FIGURE_KEEP_RATIO = 0.65     # retaining fewer than this fraction => body dropped
+
+# Context-safety ceiling on the full-page fallback. The fallback returns the
+# entire noisy page, which on liveblog/hub layouts runs to hundreds of KB; cap
+# it to ~100K tokens (~4 chars/token) so a single crawl can't swamp the agent's
+# context. The clean trafilatura extraction is small and never hits this.
+_MAX_FULL_PAGE_CHARS = 400_000
+
+_PCT_RE = re.compile(r"\d+(?:\.\d+)?\s?%")
+_DOLLAR_RE = re.compile(
+    r"\$\s?\d[\d,]*(?:\.\d+)?\s?(?:billion|million|trillion|bn|b|m)?", re.IGNORECASE
+)
+_BIGNUM_RE = re.compile(r"\b\d{1,3}(?:,\d{3})+(?:\.\d+)?\b")
+
+
+def _financial_figures(text: str) -> set[str]:
+    """Normalized set of $/% /comma-grouped numbers — the detail an analyst needs."""
+    figs: set[str] = set()
+    for rx in (_PCT_RE, _DOLLAR_RE, _BIGNUM_RE):
+        for match in rx.findall(text):
+            figs.add(re.sub(r"\s+", "", match.lower()))
+    return figs
+
+
+def _try_trafilatura(html: str) -> Optional[str]:
+    try:
+        return trafilatura.extract(
+            html,
+            favor_recall=True,
+            output_format="markdown",
+            include_links=True,
+            include_images=True,
+            include_formatting=True,
+            include_tables=True,
+        )
+    except Exception as e:
+        logger.debug(f"trafilatura extraction failed: {e}")
+        return None
+
+
+def _try_full_page(html: str) -> Optional[str]:
+    try:
+        return html_to_markdown.convert(html).content
+    except Exception as e:
+        logger.debug(f"html-to-markdown conversion failed: {e}")
+        return None
+
+
+def _cap_full_page(text: str) -> str:
+    """Truncate an oversized full-page fallback to the context-safety ceiling."""
+    if len(text) <= _MAX_FULL_PAGE_CHARS:
+        return text
+    logger.debug(
+        f"full-page fallback {len(text)} chars exceeds cap — truncating to "
+        f"{_MAX_FULL_PAGE_CHARS}"
+    )
+    return text[:_MAX_FULL_PAGE_CHARS] + "\n\n[... truncated: page exceeded ~100K tokens ...]"
+
+
 def _html_to_markdown(html: str) -> str:
-    """Convert HTML to clean markdown using html2text."""
-    converter = html2text.HTML2Text()
-    converter.ignore_links = False
-    converter.ignore_images = False
-    converter.body_width = 0  # No wrapping
-    converter.ignore_emphasis = False
-    return converter.handle(html)
+    """Convert fetched HTML to markdown for the LLM.
+
+    trafilatura extracts the main article and strips nav/ads/boilerplate (cleaner,
+    3-7x cheaper input), but silently under-extracts on two page shapes. We compare
+    it against a faithful full-page conversion (html-to-markdown's Rust core — the
+    cheaper of the two and immune to recursion limits) and prefer the full page when
+    trafilatura returns an index/listing stub or drops most of the page's financial
+    figures. A stdlib text extractor is the last resort.
+    """
+    extracted = _try_trafilatura(html)
+    full = _try_full_page(html)
+
+    # trafilatura found no main content (e.g. legacy table-only filings).
+    if not (extracted and extracted.strip()):
+        return _cap_full_page(full) if (full and full.strip()) else _plain_text(html)
+
+    # No full-page baseline to compare against — trust trafilatura.
+    if not (full and full.strip()):
+        return extracted
+
+    # Index/listing stub: trafilatura kept an intro blurb and dropped the link
+    # list (SEC/Fed newsrooms). The full page preserves the headlines.
+    if len(extracted) < _STUB_SIZE_RATIO * len(full) and len(full) > _STUB_MIN_FULL_LEN:
+        logger.debug(
+            f"trafilatura output {len(extracted)} chars vs full {len(full)} — "
+            "treating as listing stub, using full page"
+        )
+        return _cap_full_page(full)
+
+    # Card/liveblog layout: trafilatura kept the lead card and dropped the body's
+    # figures (CNBC). Compare $/% figure sets; prefer the full page on heavy loss.
+    full_figs = _financial_figures(full)
+    if len(full_figs) >= _FIGURE_MIN_SAMPLE:
+        kept = len(_financial_figures(extracted) & full_figs) / len(full_figs)
+        if kept < _FIGURE_KEEP_RATIO:
+            logger.debug(
+                f"trafilatura retained {kept:.0%} of {len(full_figs)} figures — "
+                "treating as dropped body, using full page"
+            )
+            return _cap_full_page(full)
+
+    return extracted
+
+
+def _plain_text(html: str) -> str:
+    """Last-resort plain-text extraction using the stdlib parser (never recurses)."""
+    from html.parser import HTMLParser
+
+    class _Extractor(HTMLParser):
+        def __init__(self) -> None:
+            super().__init__()
+            self.parts: list[str] = []
+            self._skip = 0
+
+        def handle_starttag(self, tag, attrs):
+            if tag in ("script", "style"):
+                self._skip += 1
+
+        def handle_endtag(self, tag):
+            if tag in ("script", "style") and self._skip:
+                self._skip -= 1
+
+        def handle_data(self, data):
+            if not self._skip and data.strip():
+                self.parts.append(data.strip())
+
+    try:
+        p = _Extractor()
+        p.feed(html)
+        return " ".join(p.parts)
+    except Exception:
+        return html
 
 
 def _extract_title(page) -> str:
@@ -178,7 +314,7 @@ class ScraplingCrawler:
                 )
             if not _needs_browser(html_body, status):
                 title = _extract_title(page)
-                markdown = _html_to_markdown(html_body)
+                markdown = await asyncio.to_thread(_html_to_markdown, html_body)
                 logger.debug(f"Tier 1 (fast) succeeded for {url}")
                 return CrawlOutput(
                     title=title, html=html_body, markdown=markdown, status=status
@@ -222,7 +358,7 @@ class ScraplingCrawler:
             stealth_reason = _needs_stealth(html_body, status)
             if stealth_reason is None:
                 title = _extract_title(page)
-                markdown = _html_to_markdown(html_body)
+                markdown = await asyncio.to_thread(_html_to_markdown, html_body)
                 logger.debug(f"Tier 2 (dynamic) succeeded for {url}")
                 return CrawlOutput(
                     title=title, html=html_body, markdown=markdown, status=status
@@ -245,7 +381,7 @@ class ScraplingCrawler:
             tier3_reason = _needs_stealth(html_body, status)
             if tier3_reason is None:
                 title = _extract_title(page)
-                markdown = _html_to_markdown(html_body)
+                markdown = await asyncio.to_thread(_html_to_markdown, html_body)
                 logger.debug(f"Tier 3 (stealth) completed for {url} (status={status})")
                 return CrawlOutput(
                     title=title, html=html_body, markdown=markdown, status=status

--- a/src/tools/crawler/scrapling_crawler.py
+++ b/src/tools/crawler/scrapling_crawler.py
@@ -138,8 +138,9 @@ def _financial_figures(text: str) -> set[str]:
 
 
 def _try_trafilatura(html: str) -> Optional[str]:
+    """Extract the main article as markdown, restoring the title trafilatura strips."""
     try:
-        return trafilatura.extract(
+        out = trafilatura.extract(
             html,
             favor_recall=True,
             output_format="markdown",
@@ -147,13 +148,40 @@ def _try_trafilatura(html: str) -> Optional[str]:
             include_images=True,
             include_formatting=True,
             include_tables=True,
+            with_metadata=True,
         )
     except Exception as e:
         logger.debug(f"trafilatura extraction failed: {e}")
         return None
+    return _promote_frontmatter_title(out) if out else out
+
+
+def _promote_frontmatter_title(text: str) -> str:
+    """Lift trafilatura's frontmatter title into a Markdown H1, dropping the rest.
+
+    With `with_metadata`, trafilatura pulls the article title/<h1> out of the body
+    into a YAML frontmatter block; without this a page that is just
+    `<h1>Title</h1><p>body</p>` would extract to body-only and lose the heading.
+    """
+    if not text.startswith("---"):
+        return text
+    end = text.find("\n---", 3)
+    if end == -1:
+        return text
+    block = text[3:end]
+    body = text[end + len("\n---") :].lstrip("\n")
+    title = ""
+    for line in block.splitlines():
+        if line.strip().startswith("title:"):
+            title = line.split("title:", 1)[1].strip().strip('"').strip("'")
+            break
+    if title and title.lower() not in body[: len(title) + 16].lower():
+        return f"# {title}\n\n{body}" if body else f"# {title}"
+    return body
 
 
 def _try_full_page(html: str) -> Optional[str]:
+    """Convert the entire page to markdown via html-to-markdown's Rust core."""
     try:
         return html_to_markdown.convert(html).content
     except Exception as e:

--- a/src/tools/sec/parsers/regex_parser.py
+++ b/src/tools/sec/parsers/regex_parser.py
@@ -1,13 +1,15 @@
 """
 SEC filing parser using regex extraction.
 
-Converts HTML to markdown using html2text, then extracts sections using
-regex patterns. Works as a fallback when edgartools parser fails.
+Converts HTML to plain text using html-to-markdown's PLAIN output, then extracts
+sections using regex patterns. Works as a fallback when edgartools parser fails.
 """
 
 import re
 import logging
 from typing import Dict, Optional, Tuple
+
+import html_to_markdown
 
 from .base import BaseSECParser, ParsingFailedError
 from ..types import SECSection, FilingType
@@ -60,7 +62,7 @@ FORM_10Q_PATTERNS: Dict[str, Tuple[str, str]] = {
 
 class RegexParser(BaseSECParser):
     """
-    Parser using html2text for HTML-to-markdown conversion and regex extraction.
+    Parser using html-to-markdown for HTML-to-text conversion and regex extraction.
 
     This parser is a reliable fallback that works for both 10-K and 10-Q filings.
     """
@@ -232,24 +234,25 @@ class RegexParser(BaseSECParser):
 
     def _html_to_markdown(self, html: str) -> str:
         """
-        Convert HTML to markdown using html2text.
+        Convert HTML to plain text using html-to-markdown's PLAIN output.
+
+        PLAIN flattens tables to tab/newline-separated text (no ``|`` pipe-tables
+        that would split ``Item N.`` headers) and drops inline markdown such as
+        ``**bold**``, so the section regexes match cleanly. Falls back to a stdlib
+        text extractor on failure.
 
         Args:
             html: Raw HTML content
 
         Returns:
-            Markdown/text content
+            Plain-text content
         """
         try:
-            import html2text
-
-            converter = html2text.HTML2Text()
-            converter.ignore_links = False
-            converter.ignore_images = False
-            converter.body_width = 0
-            return converter.handle(html)
+            return html_to_markdown.convert(
+                html, html_to_markdown.ConversionOptions(output_format="plain")
+            ).content
         except Exception as e:
-            logger.debug(f"html2text conversion failed: {e}")
+            logger.debug(f"html-to-markdown conversion failed: {e}")
 
         # Fallback: Simple HTML text extraction
         return self._simple_html_to_text(html)

--- a/tests/integration/sandbox/providers/test_scrapling_docker.py
+++ b/tests/integration/sandbox/providers/test_scrapling_docker.py
@@ -133,9 +133,11 @@ class TestSandboxPackages:
         assert r.returncode == 0, f"scrapling fetchers import failed: {r.stderr}"
         assert "OK" in r.stdout
 
-    def test_html2text_import(self, docker_image):
-        r = _run_in_container("python -c 'import html2text; print(\"OK\")'")
-        assert r.returncode == 0, f"html2text import failed: {r.stderr}"
+    def test_html_to_markdown_import(self, docker_image):
+        r = _run_in_container(
+            "python -c 'import html_to_markdown, trafilatura; print(\"OK\")'"
+        )
+        assert r.returncode == 0, f"html-to-markdown/trafilatura import failed: {r.stderr}"
         assert "OK" in r.stdout
 
     def test_curl_cffi_version(self, docker_image):
@@ -233,16 +235,14 @@ class TestSandboxScraplingFetch:
         body_len = int(r.stdout.split("len=")[1].strip())
         assert body_len > 100, f"Body too short: {body_len} bytes"
 
-    def test_html2text_conversion(self, docker_image):
+    def test_html_to_markdown_conversion(self, docker_image):
         """Test HTML to markdown conversion inside container."""
         r = _run_in_container(
             "python -c \""
-            "import html2text; "
-            "h = html2text.HTML2Text(); "
-            "h.body_width = 0; "
-            "md = h.handle('<h1>Hello</h1><p>World</p>'); "
+            "import html_to_markdown; "
+            "md = html_to_markdown.convert('<h1>Hello</h1><p>World</p>'); "
             "print(md)\""
         )
-        assert r.returncode == 0, f"html2text failed: {r.stderr}"
+        assert r.returncode == 0, f"html-to-markdown failed: {r.stderr}"
         assert "hello" in r.stdout.lower()
         assert "world" in r.stdout.lower()

--- a/tests/integration/sandbox/providers/test_scrapling_docker.py
+++ b/tests/integration/sandbox/providers/test_scrapling_docker.py
@@ -241,7 +241,7 @@ class TestSandboxScraplingFetch:
             "python -c \""
             "import html_to_markdown; "
             "md = html_to_markdown.convert('<h1>Hello</h1><p>World</p>'); "
-            "print(md)\""
+            "print(md.content)\""
         )
         assert r.returncode == 0, f"html-to-markdown failed: {r.stderr}"
         assert "hello" in r.stdout.lower()

--- a/tests/unit/tools/crawler/test_scrapling_crawler.py
+++ b/tests/unit/tools/crawler/test_scrapling_crawler.py
@@ -16,7 +16,7 @@ from src.tools.crawler.scrapling_crawler import (
     _html_to_markdown,
     _needs_browser,
     _needs_stealth,
-    _promote_frontmatter_title,
+    _try_full_page,
 )
 
 
@@ -623,30 +623,17 @@ class TestExtractTitle:
         assert _extract_title(page) == ""
 
 
-class TestPromoteFrontmatterTitle:
-    """trafilatura strips the <h1>/title from the body; we promote it back."""
+class TestFullPageNoHeadMetaLeak:
+    """The full-page fallback must not dump <head> meta tags as frontmatter noise."""
 
-    def test_title_promoted_to_heading(self):
-        # The shape that regressed: <h1> + <p>, title only in metadata.
-        text = "---\ntitle: Herman Melville - Moby-Dick\n---\nAvailing himself of the mild weather."
-        result = _promote_frontmatter_title(text)
-        assert result == "# Herman Melville - Moby-Dick\n\nAvailing himself of the mild weather."
-
-    def test_title_already_in_body_not_duplicated(self):
-        text = "---\ntitle: Q1 Earnings Beat\n---\n# Q1 Earnings Beat\n\nRevenue grew."
-        result = _promote_frontmatter_title(text)
-        assert result.lower().count("q1 earnings beat") == 1
-
-    def test_quoted_title_stripped(self):
-        text = '---\ntitle: "Fed holds rates: what it means"\n---\nThe Fed left rates unchanged.'
-        result = _promote_frontmatter_title(text)
-        assert result.startswith("# Fed holds rates: what it means\n\n")
-
-    def test_frontmatter_without_title_dropped(self):
-        text = "---\nauthor: Jane Doe\n---\nBody text with no title field."
-        result = _promote_frontmatter_title(text)
-        assert result == "Body text with no title field."
-
-    def test_plain_body_passthrough(self):
-        # No frontmatter (e.g. mocked extract returning a bare string) is untouched.
-        assert _promote_frontmatter_title("just markdown body") == "just markdown body"
+    def test_head_meta_not_emitted(self):
+        html = (
+            '<html><head>'
+            '<meta name="description" content="seo blurb">'
+            '<meta property="og:title" content="OG Title">'
+            "</head><body><h1>Real Heading</h1><p>Real body content.</p></body></html>"
+        )
+        out = _try_full_page(html)
+        assert "Real Heading" in out and "Real body content." in out
+        assert not out.lstrip().startswith("---")
+        assert "meta-description" not in out and "og:title" not in out

--- a/tests/unit/tools/crawler/test_scrapling_crawler.py
+++ b/tests/unit/tools/crawler/test_scrapling_crawler.py
@@ -16,6 +16,7 @@ from src.tools.crawler.scrapling_crawler import (
     _html_to_markdown,
     _needs_browser,
     _needs_stealth,
+    _promote_frontmatter_title,
 )
 
 
@@ -620,3 +621,32 @@ class TestExtractTitle:
         page = MagicMock()
         page.css.side_effect = AttributeError("no css")
         assert _extract_title(page) == ""
+
+
+class TestPromoteFrontmatterTitle:
+    """trafilatura strips the <h1>/title from the body; we promote it back."""
+
+    def test_title_promoted_to_heading(self):
+        # The shape that regressed: <h1> + <p>, title only in metadata.
+        text = "---\ntitle: Herman Melville - Moby-Dick\n---\nAvailing himself of the mild weather."
+        result = _promote_frontmatter_title(text)
+        assert result == "# Herman Melville - Moby-Dick\n\nAvailing himself of the mild weather."
+
+    def test_title_already_in_body_not_duplicated(self):
+        text = "---\ntitle: Q1 Earnings Beat\n---\n# Q1 Earnings Beat\n\nRevenue grew."
+        result = _promote_frontmatter_title(text)
+        assert result.lower().count("q1 earnings beat") == 1
+
+    def test_quoted_title_stripped(self):
+        text = '---\ntitle: "Fed holds rates: what it means"\n---\nThe Fed left rates unchanged.'
+        result = _promote_frontmatter_title(text)
+        assert result.startswith("# Fed holds rates: what it means\n\n")
+
+    def test_frontmatter_without_title_dropped(self):
+        text = "---\nauthor: Jane Doe\n---\nBody text with no title field."
+        result = _promote_frontmatter_title(text)
+        assert result == "Body text with no title field."
+
+    def test_plain_body_passthrough(self):
+        # No frontmatter (e.g. mocked extract returning a bare string) is untouched.
+        assert _promote_frontmatter_title("just markdown body") == "just markdown body"

--- a/tests/unit/tools/crawler/test_scrapling_crawler.py
+++ b/tests/unit/tools/crawler/test_scrapling_crawler.py
@@ -1,5 +1,6 @@
 """Unit tests for Scrapling crawler backend with tier classification."""
 
+from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import asyncio
@@ -8,8 +9,10 @@ import pytest
 
 from src.tools.crawler.backend import CrawlOutput
 from src.tools.crawler.scrapling_crawler import (
+    _MAX_FULL_PAGE_CHARS,
     ScraplingCrawler,
     _extract_title,
+    _financial_figures,
     _html_to_markdown,
     _needs_browser,
     _needs_stealth,
@@ -102,6 +105,143 @@ class TestHtmlToMarkdown:
 
     def test_empty_html(self):
         assert _html_to_markdown("").strip() == ""
+
+
+def _convert_result(content):
+    """Mimic html_to_markdown.convert()'s return object (has a .content attr)."""
+    result = MagicMock()
+    result.content = content
+    return result
+
+
+@contextmanager
+def _mock_converters(traf_return, full_return=None, full_raises=False):
+    """Patch trafilatura.extract and html_to_markdown.convert at the lib boundary.
+
+    Lets each test drive the trafilatura-vs-full-page decision deterministically
+    without touching the network.
+    """
+    traf_mock = MagicMock(return_value=traf_return)
+    if full_raises:
+        full_mock = MagicMock(side_effect=RuntimeError("convert boom"))
+    else:
+        full_mock = MagicMock(return_value=_convert_result(full_return))
+    with (
+        patch("src.tools.crawler.scrapling_crawler.trafilatura.extract", traf_mock),
+        patch("src.tools.crawler.scrapling_crawler.html_to_markdown.convert", full_mock),
+    ):
+        yield
+
+
+class TestFinancialFigures:
+    def test_extracts_dollars_percents_and_bignums(self):
+        figs = _financial_figures("up 85% to $81.62 billion and index at 66,588.12")
+        assert figs == {"85%", "$81.62billion", "66,588.12"}
+
+    def test_empty_text_has_no_figures(self):
+        assert _financial_figures("purely qualitative prose, no numbers") == set()
+
+
+class TestHtmlToMarkdownDecision:
+    """trafilatura-vs-full-page selection in _html_to_markdown.
+
+    Calibration recap (live 10-page sample): clean extractions keep 88-100% of
+    figures; broken ones keep <=28% (CNBC card/liveblog) or collapse to a stub
+    (<2% of page, SEC/Fed listings). Thresholds: stub < 10% of a >5k page;
+    figure retention < 65% over a >=8-figure page.
+    """
+
+    # --- figure-retention guard (full page < 5k so the stub guard stays out) ---
+
+    def test_clean_extraction_is_kept(self):
+        """High figure retention => trust trafilatura's clean output."""
+        figs = [f"${n}1 billion" for n in range(1, 11)]  # 10 distinct figures
+        full = "Body: " + ", ".join(figs) + ". Footer nav."
+        extracted = "Article: " + ", ".join(figs[:8]) + "."  # keeps 8/10 = 80%
+        with _mock_converters(traf_return=extracted, full_return=full):
+            assert _html_to_markdown("<html>x</html>") == extracted
+
+    def test_figure_loss_falls_back_to_full(self):
+        """CNBC-style body drop (kept <65%) => prefer the full page."""
+        figs = [f"${n}1 billion" for n in range(1, 11)]
+        full = "Body: " + ", ".join(figs) + ". Net income $42 billion."
+        extracted = "Lead card: " + ", ".join(figs[:2]) + "."  # keeps 2/10 = 20%
+        with _mock_converters(traf_return=extracted, full_return=full):
+            result = _html_to_markdown("<html>x</html>")
+        assert result == full
+        assert "$42 billion" in result  # the dropped body figure is recovered
+
+    def test_low_figure_page_is_not_flipped(self):
+        """Below the 8-figure sample gate the ratio is noise — keep trafilatura."""
+        full = "Policy stays accommodative. Rates 1% to 2%. Possibly 3%."  # 3 figures
+        extracted = "Summary: policy unchanged."  # keeps 0, but gate not met
+        with _mock_converters(traf_return=extracted, full_return=full):
+            assert _html_to_markdown("<html>x</html>") == extracted
+
+    # --- stub guard (figure-poor listing pages) ---
+
+    def test_listing_stub_falls_back_to_full(self):
+        """Tiny extraction of a large figure-poor page => listing stub => full."""
+        full = "# Press Releases\n" + "\n".join(
+            f"[SEC Announces New Members Item {i}](/news/{i})" for i in range(300)
+        )
+        extracted = "# Press Releases\nOfficial announcements highlighting actions."
+        assert len(extracted) < 0.10 * len(full) and len(full) > 5000
+        with _mock_converters(traf_return=extracted, full_return=full):
+            result = _html_to_markdown("<html>x</html>")
+        assert result == full
+        assert "SEC Announces New Members" in result  # dropped headlines recovered
+
+    def test_substantial_extraction_of_large_page_is_kept(self):
+        """A healthy fraction of a large page is a real article, not a stub."""
+        full = "Intro. " + "Real article paragraph with detail. " * 400  # ~14k
+        extracted = "Real article paragraph with detail. " * 200  # ~37% of full
+        assert len(extracted) > 0.10 * len(full)
+        with _mock_converters(traf_return=extracted, full_return=full):
+            assert _html_to_markdown("<html>x</html>") == extracted
+
+    # --- empty / error fallbacks ---
+
+    def test_empty_extraction_uses_full(self):
+        with _mock_converters(traf_return=None, full_return="# Article\n$5 billion."):
+            assert _html_to_markdown("<html>x</html>") == "# Article\n$5 billion."
+
+    def test_whitespace_extraction_uses_full(self):
+        with _mock_converters(traf_return="   \n  ", full_return="# Article\nbody."):
+            assert _html_to_markdown("<html>x</html>") == "# Article\nbody."
+
+    def test_empty_extraction_and_full_failure_uses_plain_text(self):
+        html = "<html><body><p>Hello world figure</p><style>.x{color:red}</style></body></html>"
+        with _mock_converters(traf_return=None, full_raises=True):
+            result = _html_to_markdown(html)
+        assert "Hello world figure" in result
+        assert "color:red" not in result  # <style> contents stripped
+
+    def test_no_full_baseline_keeps_trafilatura(self):
+        """full-page conversion raised but trafilatura succeeded => keep extraction."""
+        with _mock_converters(traf_return="Good article $9 billion.", full_raises=True):
+            assert _html_to_markdown("<html>x</html>") == "Good article $9 billion."
+
+    def test_oversized_full_page_fallback_is_capped(self):
+        """A full-page fallback above the ceiling is truncated to protect context."""
+        full = "$1 billion. " * (_MAX_FULL_PAGE_CHARS // 5)  # ~960k chars, over cap
+        extracted = "Tiny stub."  # < 10% of a >5k page => stub guard returns full
+        with _mock_converters(traf_return=extracted, full_return=full):
+            result = _html_to_markdown("<html>x</html>")
+        assert len(result) <= _MAX_FULL_PAGE_CHARS + 100  # cap + short marker
+        assert result.startswith("$1 billion.")
+        assert result.rstrip().endswith("~100K tokens ...]")
+
+    def test_full_page_under_cap_is_not_truncated(self):
+        """A full page within the ceiling passes through untouched."""
+        full = "# Press Releases\n" + "\n".join(
+            f"[Item {i}](/n/{i})" for i in range(300)
+        )  # large stub-trigger, but well under the cap
+        assert len(full) < _MAX_FULL_PAGE_CHARS
+        extracted = "# Press Releases\nIntro blurb."
+        with _mock_converters(traf_return=extracted, full_return=full):
+            result = _html_to_markdown("<html>x</html>")
+        assert result == full  # no truncation marker appended
 
 
 class TestCrawlOutput:

--- a/tests/unit/tools/sec/test_regex_parser.py
+++ b/tests/unit/tools/sec/test_regex_parser.py
@@ -1,6 +1,6 @@
 """Unit tests for RegexParser (SEC filing regex-based section extraction)."""
 
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
 
@@ -452,35 +452,32 @@ class TestHtmlToMarkdown:
         assert "Annual Report" in result
         assert "Company overview paragraph" in result
 
-    def test_links_preserved(self):
+    def test_link_text_preserved(self):
+        """PLAIN output keeps anchor text (URLs are dropped — fine for section regexes)."""
         html = '<p>See <a href="https://sec.gov/filing">the filing</a>.</p>'
         result = self.parser._html_to_markdown(html)
-        assert "https://sec.gov/filing" in result
         assert "the filing" in result
 
-    def test_html2text_exception_falls_back(self):
-        """When html2text raises, falls back to _simple_html_to_text."""
+    def test_conversion_exception_falls_back(self):
+        """When html-to-markdown conversion raises, falls back to _simple_html_to_text."""
         html = "<p>Fallback content here</p>"
 
-        mock_h2t = MagicMock()
-        mock_h2t.HTML2Text.return_value.handle.side_effect = RuntimeError("html2text broken")
-
-        with patch.dict("sys.modules", {"html2text": mock_h2t}):
+        with patch(
+            "src.tools.sec.parsers.regex_parser.html_to_markdown.convert",
+            side_effect=RuntimeError("conversion broken"),
+        ):
             result = self.parser._html_to_markdown(html)
 
         assert "Fallback content here" in result
 
-    def test_html2text_import_error_falls_back(self):
-        """When html2text import fails inside the method, falls back."""
-        html = "<p>Import error content</p>"
+    def test_tables_flattened_not_pipe_syntax(self):
+        """Table cells render as plain text (no pipe-table syntax) so section regexes match."""
+        html = "<table><tr><td>Item 15.</td><td>Exhibits</td></tr></table>"
+        result = self.parser._html_to_markdown(html)
 
-        mock_h2t = MagicMock()
-        mock_h2t.HTML2Text.side_effect = Exception("cannot create converter")
-
-        with patch.dict("sys.modules", {"html2text": mock_h2t}):
-            result = self.parser._html_to_markdown(html)
-
-        assert "Import error content" in result
+        assert "Item 15." in result
+        assert "Exhibits" in result
+        assert "|" not in result  # not a markdown pipe-table
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -261,6 +261,15 @@ wheels = [
 ]
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload_time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload_time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.14.3"
 source = { registry = "https://pypi.org/simple" }
@@ -603,6 +612,20 @@ wheels = [
 ]
 
 [[package]]
+name = "courlan"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "tld" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/16/2a771612ee0b3acaa95ac21cc7e8a3319e815d6360f8ffc5987d1ce28499/courlan-1.4.0.tar.gz", hash = "sha256:fbbac7b7fcde2195ea08e707609503c81cf39c891e8d26cdb1fed4585782d63d", size = 208997, upload_time = "2026-06-01T17:30:17.306Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/38/ce65091ff20a16e06d17418c4353af5f56d3190821b1a06983c79ae79274/courlan-1.4.0-py3-none-any.whl", hash = "sha256:ad1dbdefd912ca7238d4607dc855df5df097f56bac175dd662c84eed3802f49e", size = 34193, upload_time = "2026-06-01T17:30:14.984Z" },
+]
+
+[[package]]
 name = "coverage"
 version = "7.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -841,6 +864,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/45/77/7575be73bf12dee231d0c6e60ce7fb7a7be4fcd58823374fc59a6e48262e/darkdetect-0.8.0.tar.gz", hash = "sha256:b5428e1170263eb5dea44c25dc3895edd75e6f52300986353cd63533fe7df8b1", size = 7681, upload_time = "2022-12-16T14:14:42.113Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/f2/728f041460f1b9739b85ee23b45fa5a505962ea11fd85bdbe2a02b021373/darkdetect-0.8.0-py3-none-any.whl", hash = "sha256:a7509ccf517eaad92b31c214f593dbcf138ea8a43b2935406bbd565e15527a85", size = 8955, upload_time = "2022-12-16T14:14:40.92Z" },
+]
+
+[[package]]
+name = "dateparser"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "regex" },
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/2d/a0ccdb78788064fa0dc901b8524e50615c42be1d78b78d646d0b28d09180/dateparser-1.4.0.tar.gz", hash = "sha256:97a21840d5ecdf7630c584f673338a5afac5dfe84f647baf4d7e8df98f9354a4", size = 321512, upload_time = "2026-03-26T09:56:10.292Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/0b/3c3bb7cbe757279e693a0be6049048012f794d01f81099609ecd53b899f0/dateparser-1.4.0-py3-none-any.whl", hash = "sha256:7902b8e85d603494bf70a5a0b1decdddb2270b9c6e6b2bc8a57b93476c0df378", size = 300379, upload_time = "2026-03-26T09:56:08.409Z" },
 ]
 
 [[package]]
@@ -1441,12 +1479,32 @@ wheels = [
 ]
 
 [[package]]
-name = "html2text"
-version = "2025.4.15"
+name = "html-to-markdown"
+version = "3.5.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f8/27/e158d86ba1e82967cc2f790b0cb02030d4a8bef58e0c79a8590e9678107f/html2text-2025.4.15.tar.gz", hash = "sha256:948a645f8f0bc3abe7fd587019a2197a12436cd73d0d4908af95bfc8da337588", size = 64316, upload_time = "2025-04-15T04:02:30.045Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/e5/bc0e6e6787f49dd37953406941260bb7ed2f8de0c403d450d20b08a3901f/html_to_markdown-3.5.7.tar.gz", hash = "sha256:f2eb59a614830da827e6dcac0aa253d2613735cd104429323682751ecd79b0da", size = 4394226, upload_time = "2026-05-29T14:25:09.944Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/84/1a0f9555fd5f2b1c924ff932d99b40a0f8a6b12f6dd625e2a47f415b00ea/html2text-2025.4.15-py3-none-any.whl", hash = "sha256:00569167ffdab3d7767a4cdf589b7f57e777a5ed28d12907d8c58769ec734acc", size = 34656, upload_time = "2025-04-15T04:02:28.44Z" },
+    { url = "https://files.pythonhosted.org/packages/77/de/3ce5f55ae5163a2d53a616190a2c13d0cf3f96dad50e8c9804237f6f2baa/html_to_markdown-3.5.7-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:4641c566abff4a5faa5a49d2dc4b21b1bf73480f53f45eb9b45b1983fb0dea5d", size = 6092338, upload_time = "2026-05-29T14:25:02.282Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/ca/89fd1ad259591656517a86e702e18c348b145fbc8550708bed9c4325bb58/html_to_markdown-3.5.7-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:0c253e440864a01519031073a534b3838393f6aea6f88957bdf3546f3ee97325", size = 5736293, upload_time = "2026-05-29T14:25:03.962Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/f1/585666b4665156fe2c6183e5a5ca8c512822a1c2c9757ae6ce4b281f735c/html_to_markdown-3.5.7-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f7c9f67c84abb1b86858743b6caed4e714dc32cc4e0ed28bd31aa17ed74eb30e", size = 5890957, upload_time = "2026-05-29T14:25:05.453Z" },
+    { url = "https://files.pythonhosted.org/packages/61/31/e6d7bb7de03570d4622790e90b6519ddac1ee7c943cc3e9eb73327dd8272/html_to_markdown-3.5.7-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0b35cd7e8d0b7687f2c974f8fcaf962c3965248bcfcee740858a2a33833fb67b", size = 6262247, upload_time = "2026-05-29T14:25:08.546Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/7e/26a0a7b74fcffe5e9f3c0a648888bb59aad1bc2efff290e99e4469502d5f/html_to_markdown-3.5.7-cp310-abi3-win_amd64.whl", hash = "sha256:a0eaa429bd3a5b5301a60fde594288c9624ab7791a2f356af4f7b5495b756094", size = 6285999, upload_time = "2026-05-29T14:25:06.984Z" },
+]
+
+[[package]]
+name = "htmldate"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "charset-normalizer" },
+    { name = "dateparser" },
+    { name = "lxml" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/1f/e7cf83e23d7b68105de8b874a8b36ba23b450d6f71388583e4ca3ce475ca/htmldate-1.10.0.tar.gz", hash = "sha256:a38df10772ab5d7dbb11896e3f6a852a8491fb1b0965465bc174e23fc2baae58", size = 44455, upload_time = "2026-06-01T17:43:53.437Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/17/d3356233c826c641f940983d9479eab27faec59d49f4070bc58e80fcc021/htmldate-1.10.0-py3-none-any.whl", hash = "sha256:9211dae35ab94147c8ed9e5fc2c9287a5cf31d2394cb7857e7f5dd814eb2aad6", size = 31561, upload_time = "2026-06-01T17:43:51.797Z" },
 ]
 
 [[package]]
@@ -1774,6 +1832,18 @@ wheels = [
 ]
 
 [[package]]
+name = "justext"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml", extra = ["html-clean"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/f3/45890c1b314f0d04e19c1c83d534e611513150939a7cf039664d9ab1e649/justext-3.0.2.tar.gz", hash = "sha256:13496a450c44c4cd5b5a75a5efcd9996066d2a189794ea99a49949685a0beb05", size = 828521, upload_time = "2025-02-25T20:21:49.934Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/ac/52f4e86d1924a7fc05af3aeb34488570eccc39b4af90530dd6acecdf16b5/justext-3.0.2-py2.py3-none-any.whl", hash = "sha256:62b1c562b15c3c6265e121cc070874243a443bfd53060e869393f09d6b6cc9a7", size = 837940, upload_time = "2025-02-25T20:21:44.179Z" },
+]
+
+[[package]]
 name = "kiwisolver"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1913,7 +1983,7 @@ dependencies = [
     { name = "deepagents" },
     { name = "edgartools" },
     { name = "fastapi" },
-    { name = "html2text" },
+    { name = "html-to-markdown" },
     { name = "httpx", extra = ["http2"] },
     { name = "jinja2" },
     { name = "json-repair" },
@@ -1954,6 +2024,7 @@ dependencies = [
     { name = "structlog" },
     { name = "tabulate" },
     { name = "tavily-python" },
+    { name = "trafilatura" },
     { name = "uvicorn" },
     { name = "websockets" },
     { name = "yfinance" },
@@ -2002,7 +2073,7 @@ requires-dist = [
     { name = "deepagents", specifier = ">=0.5.3" },
     { name = "edgartools", specifier = ">=5.7.2" },
     { name = "fastapi", specifier = ">=0.110.0" },
-    { name = "html2text", specifier = ">=2024.2.26" },
+    { name = "html-to-markdown", specifier = ">=3.5.0" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.28.1" },
     { name = "jinja2", specifier = ">=3.1.3" },
     { name = "json-repair", specifier = ">=0.7.0" },
@@ -2055,6 +2126,7 @@ requires-dist = [
     { name = "structlog" },
     { name = "tabulate" },
     { name = "tavily-python", specifier = ">=0.7.18" },
+    { name = "trafilatura", specifier = ">=2.0.0" },
     { name = "uvicorn", specifier = ">=0.27.1" },
     { name = "websockets", specifier = ">=12.0" },
     { name = "yfinance", specifier = ">=1.2.0" },
@@ -2466,6 +2538,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/68/b30e913340c380ddac9580c6e6230991fc37240ec4f64704833e4f3e2769/lxml-6.1.1-cp314-cp314t-win32.whl", hash = "sha256:649dda677cf3bd6ac9ae14007ba0c824ded8ce5808b53fc7431d9140399118c1", size = 3897345, upload_time = "2026-05-18T19:17:33.562Z" },
     { url = "https://files.pythonhosted.org/packages/3c/4e/9eb2af5335545f9fbcd7af57bcf87c6025d31eaa31b14ec184a6c8675328/lxml-6.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:793033d6c5cdf33a573f910d9bea14ef8f5771820411d118da8e1182edb53d5e", size = 4393350, upload_time = "2026-05-18T19:18:10.076Z" },
     { url = "https://files.pythonhosted.org/packages/7f/2c/0f1e93c636720e8a3eb59af2bfda99d98b55891e1c53bc30c2e0e865f01b/lxml-6.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:58bb955caba94e467d2a96da17660d2d704e0675894cba21ab8a775b8621fd1c", size = 3817223, upload_time = "2026-05-19T19:22:56.823Z" },
+]
+
+[package.optional-dependencies]
+html-clean = [
+    { name = "lxml-html-clean" },
+]
+
+[[package]]
+name = "lxml-html-clean"
+version = "0.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0a/63/195dfdde380a84df309e3bccf4384b034b745dba43426886f7ae623b4fba/lxml_html_clean-0.4.5.tar.gz", hash = "sha256:e2a4c7d5beedd17cd7b484d848a0571e54baa239a4f9df5546e3acba7f990560", size = 24142, upload_time = "2026-05-20T12:17:53.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/bd/6e2b76a6c5dee10397db9c929f0c5066766ec1036046f0335b7ca7ca08b8/lxml_html_clean-0.4.5-py3-none-any.whl", hash = "sha256:c76fcadd1e5bfb9b8bafc2200d51e4e78eb0dad67f56881c21dfb6484c7e7746", size = 14573, upload_time = "2026-05-20T12:17:52.215Z" },
 ]
 
 [[package]]
@@ -5032,6 +5121,24 @@ wheels = [
 ]
 
 [[package]]
+name = "trafilatura"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "courlan" },
+    { name = "htmldate" },
+    { name = "justext" },
+    { name = "lxml" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/19/24833e905df2d80e3bb67424f95febcc17709a1f61a522120bc438afca70/trafilatura-2.1.0.tar.gz", hash = "sha256:f689e2116fc89c7bc0b9a296d01dcfe2eb0b5455f8c371a77dc0db1f06a05643", size = 263876, upload_time = "2026-06-07T17:43:31.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/78/4ad99d79aee2784f49f20fd0a29058ce4c032fe4439047924c43521cd211/trafilatura-2.1.0-py3-none-any.whl", hash = "sha256:0eded5207a806445ddebbe36eae30b9035fe6a2f233c36f6fe82663fca8b9d30", size = 134600, upload_time = "2026-06-07T17:43:28.404Z" },
+]
+
+[[package]]
 name = "truststore"
 version = "0.10.4"
 source = { registry = "https://pypi.org/simple" }
@@ -5068,6 +5175,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload_time = "2026-04-24T15:22:08.651Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload_time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload_time = "2025-03-05T21:17:41.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload_time = "2025-03-05T21:17:39.857Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

**Sandbox provider parity** — the cloud Daytona snapshot and the self-host Docker image had drifted. Both now pin Node 24.14.1 as a direct binary install, ship the polymarket CLI, add `fastapi` and `youtube-transcript-api`, and share a single `PLAYWRIGHT_BROWSERS_PATH`, so a sandbox built either way installs Chromium at the path Scrapling resolves at runtime. The config is hashed into the Daytona snapshot key so existing snapshots rebuild. Closes #149 (missing Chromium executable in Scrapling sessions).

**HTML → markdown conversion** — replaces the GPL-licensed `html2text` with permissively licensed converters. The SEC regex parser renders HTML via `html-to-markdown` (MIT, plain-text output); the web crawler extracts the main article with `trafilatura` (Apache-2.0), falling back to a full-page `html-to-markdown` conversion only when extraction returns empty or drops too much content.

**Crawler robustness** — the full-page fallback runs through `asyncio.to_thread` so the synchronous parse can't block the SSE event loop, and is capped at ~100K tokens so a noisy liveblog or hub page can't overflow agent context.

## Diff Size
- Total: 10 files, 508 insertions(+), 67 deletions(-)
- Net (excl. tests): 7 files, 343 insertions(+), 39 deletions(-)

## Testing
- `uv run pytest tests/unit/tools/crawler tests/unit/tools/sec` — 90 passed
- `uv run pytest tests/unit/core/sandbox tests/unit/core/test_sandbox.py tests/unit/config/test_sandbox_config.py` — 287 passed
- `uv run ruff check` on changed sources — clean
- Docker sandbox integration test (`test_scrapling_docker.py`) requires a Docker daemon and image build; not run locally.

New tests cover the SEC `html-to-markdown` output, the crawler's extraction-vs-full-page decision, and the full-page cap (oversized fallback truncated, under-cap output untouched).

## Notes
- No frontend or prompt files changed.
- No documentation changes in this diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced html2text with html-to-markdown, added trafilatura and youtube-transcript-api; added fastapi to sandbox deps.
  * Pinned Node.js to 24.14.1 and added Polymarket CLI to the sandbox build; ensured Playwright browsers install to a shared path.
  * Noted Dockerfile sandbox sync with snapshot defaults.

* **Tests**
  * Updated integration and unit tests to validate new HTML conversion tools, scraping logic, and sandbox package imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->