### PR TITLE
Route batch snapshots by symbol market

### DIFF
--- a/src/data_client/market_data_provider.py
+++ b/src/data_client/market_data_provider.py
@@ -211,7 +211,7 @@ class MarketDataProvider:
             user_id=user_id,
         )
 
-    # -- Snapshot interface (batch; no per-symbol routing) --------------------
+    # -- Snapshot interface ---------------------------------------------------
 
     async def get_snapshots(
         self,
@@ -219,22 +219,70 @@ class MarketDataProvider:
         asset_type: str = "stocks",
         user_id: str | None = None,
     ) -> list[dict[str, Any]]:
-        """Fetch batch snapshots, trying providers in order."""
+        """Fetch batch snapshots with per-symbol market routing and fallback."""
+        pending = [s for s in symbols if str(s).strip()]
+        if not pending:
+            return []
+
+        results_by_symbol: dict[str, dict[str, Any]] = {}
+        extras: list[dict[str, Any]] = []
         last_exc: Exception | None = None
+        tried_any = False
+
         for entry in self.entries:
             fn = getattr(entry.source, "get_snapshots", None)
             if fn is None:
                 continue
+
+            batch = [
+                s
+                for s in pending
+                if "all" in entry.markets or symbol_market(s) in entry.markets
+            ]
+            if not batch:
+                continue
+
+            tried_any = True
             try:
-                return await fn(symbols=symbols, asset_type=asset_type, user_id=user_id)
+                snapshots = await fn(
+                    symbols=batch,
+                    asset_type=asset_type,
+                    user_id=user_id,
+                )
             except Exception as exc:
                 logger.warning(
                     "market_data.snapshot.fallback | source=%s error=%s",
                     entry.name, exc,
                 )
                 last_exc = exc
+                continue
+
+            resolved: set[str] = set()
+            for snap in snapshots or []:
+                symbol = str(snap.get("symbol") or "").upper()
+                if symbol:
+                    results_by_symbol[symbol] = snap
+                    resolved.add(symbol)
+                else:
+                    extras.append(snap)
+
+            if resolved:
+                pending = [s for s in pending if str(s).upper() not in resolved]
+                if not pending:
+                    break
+
+        if results_by_symbol or extras:
+            ordered = [
+                results_by_symbol[str(symbol).upper()]
+                for symbol in symbols
+                if str(symbol).upper() in results_by_symbol
+            ]
+            return ordered + extras
+
         if last_exc:
             raise last_exc
+        if tried_any:
+            return []
         raise RuntimeError("No data source supports get_snapshots")
 
     async def get_market_status(

--- a/src/data_client/market_data_provider.py
+++ b/src/data_client/market_data_provider.py
@@ -256,12 +256,19 @@ class MarketDataProvider:
                 last_exc = exc
                 continue
 
+            requested = {str(s).strip().upper() for s in batch}
             resolved: set[str] = set()
             for snap in snapshots or []:
-                symbol = str(snap.get("symbol") or "").upper()
-                if symbol:
+                symbol = str(snap.get("symbol") or "").strip().upper()
+                if symbol in requested:
                     results_by_symbol[symbol] = snap
                     resolved.add(symbol)
+                elif symbol:
+                    logger.warning(
+                        "market_data.snapshot.drop_unrequested | source=%s symbol=%s",
+                        entry.name,
+                        symbol,
+                    )
                 else:
                     logger.warning(
                         "market_data.snapshot.drop_unkeyed | source=%s item=%s",

--- a/src/data_client/market_data_provider.py
+++ b/src/data_client/market_data_provider.py
@@ -240,7 +240,8 @@ class MarketDataProvider:
             batch = [
                 s
                 for s in pending
-                if "all" in entry.markets or symbol_market(s) in entry.markets
+                if "all" in entry.markets
+                or symbol_market(normalize_symbol(s)) in entry.markets
             ]
             if not batch:
                 continue

--- a/src/data_client/market_data_provider.py
+++ b/src/data_client/market_data_provider.py
@@ -220,6 +220,9 @@ class MarketDataProvider:
         user_id: str | None = None,
     ) -> list[dict[str, Any]]:
         """Fetch batch snapshots with per-symbol market routing and fallback."""
+        def normalize_symbol(value: Any) -> str:
+            return str(value).strip().upper()
+
         pending = [s for s in symbols if str(s).strip()]
         if not pending:
             return []
@@ -256,10 +259,10 @@ class MarketDataProvider:
                 last_exc = exc
                 continue
 
-            requested = {str(s).strip().upper() for s in batch}
+            requested = {normalize_symbol(s) for s in batch}
             resolved: set[str] = set()
             for snap in snapshots or []:
-                symbol = str(snap.get("symbol") or "").strip().upper()
+                symbol = normalize_symbol(snap.get("symbol") or "")
                 if symbol in requested:
                     results_by_symbol[symbol] = snap
                     resolved.add(symbol)
@@ -277,15 +280,15 @@ class MarketDataProvider:
                     )
 
             if resolved:
-                pending = [s for s in pending if str(s).upper() not in resolved]
+                pending = [s for s in pending if normalize_symbol(s) not in resolved]
                 if not pending:
                     break
 
         if results_by_symbol:
             return [
-                results_by_symbol[str(symbol).upper()]
+                results_by_symbol[normalize_symbol(symbol)]
                 for symbol in symbols
-                if str(symbol).upper() in results_by_symbol
+                if normalize_symbol(symbol) in results_by_symbol
             ]
 
         if last_exc:

--- a/src/data_client/market_data_provider.py
+++ b/src/data_client/market_data_provider.py
@@ -225,14 +225,14 @@ class MarketDataProvider:
             return []
 
         results_by_symbol: dict[str, dict[str, Any]] = {}
-        extras: list[dict[str, Any]] = []
         last_exc: Exception | None = None
-        tried_any = False
+        supports_snapshots = False
 
         for entry in self.entries:
             fn = getattr(entry.source, "get_snapshots", None)
             if fn is None:
                 continue
+            supports_snapshots = True
 
             batch = [
                 s
@@ -242,7 +242,6 @@ class MarketDataProvider:
             if not batch:
                 continue
 
-            tried_any = True
             try:
                 snapshots = await fn(
                     symbols=batch,
@@ -264,24 +263,27 @@ class MarketDataProvider:
                     results_by_symbol[symbol] = snap
                     resolved.add(symbol)
                 else:
-                    extras.append(snap)
+                    logger.warning(
+                        "market_data.snapshot.drop_unkeyed | source=%s item=%s",
+                        entry.name,
+                        snap,
+                    )
 
             if resolved:
                 pending = [s for s in pending if str(s).upper() not in resolved]
                 if not pending:
                     break
 
-        if results_by_symbol or extras:
-            ordered = [
+        if results_by_symbol:
+            return [
                 results_by_symbol[str(symbol).upper()]
                 for symbol in symbols
                 if str(symbol).upper() in results_by_symbol
             ]
-            return ordered + extras
 
         if last_exc:
             raise last_exc
-        if tried_any:
+        if supports_snapshots:
             return []
         raise RuntimeError("No data source supports get_snapshots")
 

--- a/tests/unit/data_client/test_market_data_provider.py
+++ b/tests/unit/data_client/test_market_data_provider.py
@@ -265,6 +265,34 @@ class TestMarketDataProvider:
         assert global_src.calls[0][1]["symbols"] == ["301189.SZ"]
 
     @pytest.mark.asyncio
+    async def test_get_snapshots_partial_resolution_fallback(self):
+        primary_src = SnapshotSource(
+            "primary",
+            {"AAPL": {"symbol": "AAPL", "price": 190.0}},
+        )
+        fallback_src = SnapshotSource(
+            "fallback",
+            {"MSFT": {"symbol": "MSFT", "price": 420.0}},
+        )
+        provider = MarketDataProvider(
+            [
+                ProviderEntry("primary", primary_src, {"all"}),
+                ProviderEntry("fallback", fallback_src, {"all"}),
+            ]
+        )
+
+        result = await provider.get_snapshots(["AAPL", "MSFT"])
+
+        assert result == [
+            {"symbol": "AAPL", "price": 190.0},
+            {"symbol": "MSFT", "price": 420.0},
+        ]
+        assert len(primary_src.calls) == 1
+        assert len(fallback_src.calls) == 1
+        assert primary_src.calls[0][1]["symbols"] == ["AAPL", "MSFT"]
+        assert fallback_src.calls[0][1]["symbols"] == ["MSFT"]
+
+    @pytest.mark.asyncio
     async def test_get_snapshots_falls_back_when_provider_returns_no_rows(self):
         empty_src = SnapshotSource("primary")
         fallback_src = SnapshotSource(

--- a/tests/unit/data_client/test_market_data_provider.py
+++ b/tests/unit/data_client/test_market_data_provider.py
@@ -48,10 +48,12 @@ class SnapshotSource(FakeSource):
         name: str,
         snapshots: dict[str, dict] | None = None,
         *,
+        extra_rows: list[dict] | None = None,
         fail: bool = False,
     ):
         super().__init__(name, fail=fail)
         self.snapshots = {k.upper(): v for k, v in (snapshots or {}).items()}
+        self.extra_rows = extra_rows or []
 
     async def get_snapshots(self, **kwargs):
         self.calls.append(("get_snapshots", kwargs))
@@ -61,7 +63,7 @@ class SnapshotSource(FakeSource):
             self.snapshots[s.upper()]
             for s in kwargs.get("symbols", [])
             if s.upper() in self.snapshots
-        ]
+        ] + list(self.extra_rows)
 
 
 # ---------------------------------------------------------------------------
@@ -311,6 +313,59 @@ class TestMarketDataProvider:
         assert result == [{"symbol": "301189.SZ", "price": 42.0}]
         assert empty_src.calls[0][1]["symbols"] == ["301189.SZ"]
         assert fallback_src.calls[0][1]["symbols"] == ["301189.SZ"]
+
+    @pytest.mark.asyncio
+    async def test_get_snapshots_drops_symbol_less_rows_and_keeps_symbol_pending(self, caplog):
+        bad_src = SnapshotSource(
+            "bad",
+            extra_rows=[{"price": 999.0}],
+        )
+        fallback_src = SnapshotSource(
+            "fallback",
+            {"AAPL": {"symbol": "AAPL", "price": 190.0}},
+        )
+        provider = MarketDataProvider(
+            [
+                ProviderEntry("bad", bad_src, {"all"}),
+                ProviderEntry("fallback", fallback_src, {"all"}),
+            ]
+        )
+
+        result = await provider.get_snapshots(["AAPL"])
+
+        assert result == [{"symbol": "AAPL", "price": 190.0}]
+        assert bad_src.calls[0][1]["symbols"] == ["AAPL"]
+        assert fallback_src.calls[0][1]["symbols"] == ["AAPL"]
+        assert "market_data.snapshot.drop_unkeyed" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_get_snapshots_returns_partial_results_when_other_symbols_have_no_matching_market(self):
+        us_src = SnapshotSource(
+            "ginlix",
+            {"AAPL": {"symbol": "AAPL", "price": 190.0}},
+        )
+        provider = MarketDataProvider(
+            [ProviderEntry("ginlix", us_src, {"us"})]
+        )
+
+        result = await provider.get_snapshots(["AAPL", "XYZ.ZZ"])
+
+        assert result == [{"symbol": "AAPL", "price": 190.0}]
+        assert us_src.calls[0][1]["symbols"] == ["AAPL"]
+
+    @pytest.mark.asyncio
+    async def test_get_snapshots_all_provider_errors_raise_last_exception(self):
+        src1 = SnapshotSource("a", fail=True)
+        src2 = SnapshotSource("b", fail=True)
+        provider = MarketDataProvider(
+            [
+                ProviderEntry("a", src1, {"all"}),
+                ProviderEntry("b", src2, {"all"}),
+            ]
+        )
+
+        with pytest.raises(RuntimeError, match="b snapshots error"):
+            await provider.get_snapshots(["AAPL"])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/data_client/test_market_data_provider.py
+++ b/tests/unit/data_client/test_market_data_provider.py
@@ -40,6 +40,30 @@ class FakeSource:
         self.closed = True
 
 
+class SnapshotSource(FakeSource):
+    """Fake source that returns configured snapshots for requested symbols."""
+
+    def __init__(
+        self,
+        name: str,
+        snapshots: dict[str, dict] | None = None,
+        *,
+        fail: bool = False,
+    ):
+        super().__init__(name, fail=fail)
+        self.snapshots = {k.upper(): v for k, v in (snapshots or {}).items()}
+
+    async def get_snapshots(self, **kwargs):
+        self.calls.append(("get_snapshots", kwargs))
+        if self.fail:
+            raise RuntimeError(f"{self.name} snapshots error")
+        return [
+            self.snapshots[s.upper()]
+            for s in kwargs.get("symbols", [])
+            if s.upper() in self.snapshots
+        ]
+
+
 # ---------------------------------------------------------------------------
 # symbol_market tests
 # ---------------------------------------------------------------------------
@@ -216,6 +240,49 @@ class TestMarketDataProvider:
         await provider.get_intraday(symbol="AAPL", interval="1min")
         assert len(asia_src.calls) == 2  # unchanged
         assert len(global_src.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_get_snapshots_routes_each_symbol_by_market(self):
+        us_src = SnapshotSource(
+            "ginlix",
+            {"AAPL": {"symbol": "AAPL", "price": 190.0}},
+        )
+        global_src = SnapshotSource(
+            "fmp",
+            {"301189.SZ": {"symbol": "301189.SZ", "price": 42.0}},
+        )
+        provider = MarketDataProvider(
+            [
+                ProviderEntry("ginlix", us_src, {"us"}),
+                ProviderEntry("fmp", global_src, {"all"}),
+            ]
+        )
+
+        result = await provider.get_snapshots(["AAPL", "301189.SZ"])
+
+        assert [r["symbol"] for r in result] == ["AAPL", "301189.SZ"]
+        assert us_src.calls[0][1]["symbols"] == ["AAPL"]
+        assert global_src.calls[0][1]["symbols"] == ["301189.SZ"]
+
+    @pytest.mark.asyncio
+    async def test_get_snapshots_falls_back_when_provider_returns_no_rows(self):
+        empty_src = SnapshotSource("primary")
+        fallback_src = SnapshotSource(
+            "fallback",
+            {"301189.SZ": {"symbol": "301189.SZ", "price": 42.0}},
+        )
+        provider = MarketDataProvider(
+            [
+                ProviderEntry("primary", empty_src, {"all"}),
+                ProviderEntry("fallback", fallback_src, {"all"}),
+            ]
+        )
+
+        result = await provider.get_snapshots(["301189.SZ"])
+
+        assert result == [{"symbol": "301189.SZ", "price": 42.0}]
+        assert empty_src.calls[0][1]["symbols"] == ["301189.SZ"]
+        assert fallback_src.calls[0][1]["symbols"] == ["301189.SZ"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/data_client/test_market_data_provider.py
+++ b/tests/unit/data_client/test_market_data_provider.py
@@ -52,7 +52,9 @@ class SnapshotSource(FakeSource):
         fail: bool = False,
     ):
         super().__init__(name, fail=fail)
-        self.snapshots = {k.upper(): v for k, v in (snapshots or {}).items()}
+        self.snapshots = {
+            str(k).strip().upper(): v for k, v in (snapshots or {}).items()
+        }
         self.extra_rows = extra_rows or []
 
     async def get_snapshots(self, **kwargs):
@@ -60,9 +62,9 @@ class SnapshotSource(FakeSource):
         if self.fail:
             raise RuntimeError(f"{self.name} snapshots error")
         return [
-            self.snapshots[s.upper()]
+            self.snapshots[str(s).strip().upper()]
             for s in kwargs.get("symbols", [])
-            if s.upper() in self.snapshots
+            if str(s).strip().upper() in self.snapshots
         ] + list(self.extra_rows)
 
 
@@ -293,6 +295,32 @@ class TestMarketDataProvider:
         assert len(fallback_src.calls) == 1
         assert primary_src.calls[0][1]["symbols"] == ["AAPL", "MSFT"]
         assert fallback_src.calls[0][1]["symbols"] == ["MSFT"]
+
+    @pytest.mark.asyncio
+    async def test_get_snapshots_normalizes_whitespace_padded_input_symbols(self):
+        primary_src = SnapshotSource(
+            "primary",
+            {"AAPL": {"symbol": "AAPL", "price": 190.0}},
+        )
+        fallback_src = SnapshotSource(
+            "fallback",
+            {"MSFT": {"symbol": "MSFT", "price": 420.0}},
+        )
+        provider = MarketDataProvider(
+            [
+                ProviderEntry("primary", primary_src, {"all"}),
+                ProviderEntry("fallback", fallback_src, {"all"}),
+            ]
+        )
+
+        result = await provider.get_snapshots(["  AAPL  ", " MSFT "])
+
+        assert result == [
+            {"symbol": "AAPL", "price": 190.0},
+            {"symbol": "MSFT", "price": 420.0},
+        ]
+        assert primary_src.calls[0][1]["symbols"] == ["  AAPL  ", " MSFT "]
+        assert fallback_src.calls[0][1]["symbols"] == [" MSFT "]
 
     @pytest.mark.asyncio
     async def test_get_snapshots_extra_from_wrong_market_does_not_resolve_pending(self, caplog):

--- a/tests/unit/data_client/test_market_data_provider.py
+++ b/tests/unit/data_client/test_market_data_provider.py
@@ -295,6 +295,34 @@ class TestMarketDataProvider:
         assert fallback_src.calls[0][1]["symbols"] == ["MSFT"]
 
     @pytest.mark.asyncio
+    async def test_get_snapshots_extra_from_wrong_market_does_not_resolve_pending(self, caplog):
+        us_src = SnapshotSource(
+            "ginlix",
+            {"AAPL": {"symbol": "AAPL", "price": 190.0}},
+            extra_rows=[{"symbol": "300059.SZ", "price": 0.0}],
+        )
+        cn_src = SnapshotSource(
+            "cn",
+            {"300059.SZ": {"symbol": "300059.SZ", "price": 42.0}},
+        )
+        provider = MarketDataProvider(
+            [
+                ProviderEntry("ginlix", us_src, {"us"}),
+                ProviderEntry("cn", cn_src, {"cn"}),
+            ]
+        )
+
+        result = await provider.get_snapshots(["AAPL", "300059.SZ"])
+
+        assert result == [
+            {"symbol": "AAPL", "price": 190.0},
+            {"symbol": "300059.SZ", "price": 42.0},
+        ]
+        assert us_src.calls[0][1]["symbols"] == ["AAPL"]
+        assert cn_src.calls[0][1]["symbols"] == ["300059.SZ"]
+        assert "market_data.snapshot.drop_unrequested" in caplog.text
+
+    @pytest.mark.asyncio
     async def test_get_snapshots_falls_back_when_provider_returns_no_rows(self):
         empty_src = SnapshotSource("primary")
         fallback_src = SnapshotSource(

--- a/tests/unit/data_client/test_market_data_provider.py
+++ b/tests/unit/data_client/test_market_data_provider.py
@@ -323,6 +323,21 @@ class TestMarketDataProvider:
         assert fallback_src.calls[0][1]["symbols"] == [" MSFT "]
 
     @pytest.mark.asyncio
+    async def test_get_snapshots_routes_whitespace_padded_suffix_symbols(self):
+        cn_src = SnapshotSource(
+            "cn",
+            {"301189.SZ": {"symbol": "301189.SZ", "price": 42.0}},
+        )
+        provider = MarketDataProvider(
+            [ProviderEntry("cn", cn_src, {"cn"})]
+        )
+
+        result = await provider.get_snapshots([" 301189.SZ "])
+
+        assert result == [{"symbol": "301189.SZ", "price": 42.0}]
+        assert cn_src.calls[0][1]["symbols"] == [" 301189.SZ "]
+
+    @pytest.mark.asyncio
     async def test_get_snapshots_extra_from_wrong_market_does_not_resolve_pending(self, caplog):
         us_src = SnapshotSource(
             "ginlix",


### PR DESCRIPTION
## Summary
- route batch stock snapshots through provider entries that cover each symbol market
- continue fallback when a provider returns no rows or only resolves part of a batch
- preserve requested symbol order for resolved snapshots
- add regression tests for mixed US/CN batches and empty-result fallback

Addresses #248.

## Tests
- `python -m pytest tests\unit\data_client\test_market_data_provider.py -q -k "not ConfigAccessor"`
- `git diff --check`

Attempted:
- `$env:PYTHONPATH='.;src'; python -m pytest tests\unit\data_client\test_market_data_provider.py -q`
  - local system Python is missing project dependency `structlog`, so the two existing `TestConfigAccessor` tests fail during config import; the 24 provider-routing tests pass.

Note: this fixes the backend batch snapshot routing path behind the A-share zero-price issue. The frontend missing-snapshot display fallback can be handled separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Market snapshot retrieval now routes requests per symbol across providers, preserves original symbol order, drops provider-returned rows missing or not matching requested symbols (with warnings), logs targeted fallbacks, returns empty when providers supported the call but none resolved, or surfaces the final error when providers fail.

* **Tests**
  * New unit tests for per-symbol routing, partial/full fallbacks, normalization, dropped/unkeyed rows, and error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->