### PR TITLE
Avoid treating missing dashboard quotes as zero

### DIFF
--- a/web/src/pages/Dashboard/components/AddWatchlistItemDialog.tsx
+++ b/web/src/pages/Dashboard/components/AddWatchlistItemDialog.tsx
@@ -95,7 +95,7 @@ function AddWatchlistItemDialog({
       getStockPrices([selectedStock.symbol])
         .then((prices) => {
           const priceData = prices?.[0];
-          if (priceData) {
+          if (priceData && priceData.quoteAvailable !== false) {
             setCurrentPrice(priceData.price);
           } else {
             setCurrentPrice(null);

--- a/web/src/pages/Dashboard/components/PortfolioWatchlistCard.tsx
+++ b/web/src/pages/Dashboard/components/PortfolioWatchlistCard.tsx
@@ -8,6 +8,7 @@ import { useIsMobile } from '@/hooks/useIsMobile';
 import { createFormatter } from '@/lib/format';
 import { ContextMenu, ContextMenuTrigger, ContextMenuContent, ContextMenuItem } from '@/components/ui/context-menu';
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from '@/components/ui/dropdown-menu';
+import { portfolioSummary } from '../widgets/definitions/_holdingsHelpers';
 
 const fmt2 = createFormatter({ minimumFractionDigits: 2, maximumFractionDigits: 2 });
 const fmt1 = createFormatter({ minimumFractionDigits: 1, maximumFractionDigits: 1 });
@@ -396,19 +397,8 @@ function PortfolioWatchlistCard({
     });
   };
 
-  // Compute portfolio summary
-  const pricedRows = portfolioRows.filter(
-    (r) => r.quoteAvailable !== false && r.marketValue != null,
-  );
-  const hasPricedRows = pricedRows.length > 0;
-  const totalValue = pricedRows.reduce((sum, r) => sum + (r.marketValue || 0), 0);
-  const totalCost = pricedRows.reduce(
-    (sum, r) => sum + (r.average_cost != null ? r.average_cost * (r.quantity || 0) : 0),
-    0
-  );
-  const totalPl = totalCost > 0 ? totalValue - totalCost : 0;
-  const totalPlPct = totalCost > 0 ? ((totalValue - totalCost) / totalCost) * 100 : 0;
-  const isPlPositive = totalPl >= 0;
+  const summary = React.useMemo(() => portfolioSummary(portfolioRows), [portfolioRows]);
+  const isPlPositive = summary.totalPl >= 0;
 
   return (
     <div
@@ -519,9 +509,9 @@ function PortfolioWatchlistCard({
                     className="text-2xl font-bold mb-2 dashboard-mono"
                     style={{ color: 'var(--color-text-primary)' }}
                   >
-                    {valuesHidden ? '********' : hasPricedRows ? `$${fmt2(totalValue)}` : 'N/A'}
+                    {valuesHidden ? '********' : summary.hasPricedRows ? `$${fmt2(summary.totalValue)}` : 'N/A'}
                   </div>
-                  {!valuesHidden && hasPricedRows && totalCost > 0 && (
+                  {!valuesHidden && summary.hasPricedRows && summary.totalCost > 0 && (
                     <div
                       className="flex items-center gap-2 text-xs font-medium w-fit px-2 py-1 rounded-full"
                       style={{
@@ -530,7 +520,7 @@ function PortfolioWatchlistCard({
                       }}
                     >
                       {isPlPositive ? <ArrowUpRight size={12} /> : <ArrowDownRight size={12} />}
-                      {isPlPositive ? '+' : '-'}${fmt2(Math.abs(totalPl))} ({fmt1(totalPlPct)}%)
+                      {isPlPositive ? '+' : '-'}${fmt2(Math.abs(summary.totalPl))} ({fmt1(summary.totalPlPct)}%)
                     </div>
                   )}
                 </div>

--- a/web/src/pages/Dashboard/components/PortfolioWatchlistCard.tsx
+++ b/web/src/pages/Dashboard/components/PortfolioWatchlistCard.tsx
@@ -521,7 +521,7 @@ function PortfolioWatchlistCard({
                   >
                     {valuesHidden ? '********' : hasPricedRows ? `$${fmt2(totalValue)}` : 'N/A'}
                   </div>
-                  {!valuesHidden && hasPricedRows && (
+                  {!valuesHidden && hasPricedRows && totalCost > 0 && (
                     <div
                       className="flex items-center gap-2 text-xs font-medium w-fit px-2 py-1 rounded-full"
                       style={{

--- a/web/src/pages/Dashboard/components/PortfolioWatchlistCard.tsx
+++ b/web/src/pages/Dashboard/components/PortfolioWatchlistCard.tsx
@@ -20,6 +20,7 @@ interface WatchlistRow {
   change: number;
   changePercent: number;
   isPositive: boolean;
+  quoteAvailable?: boolean;
   previousClose?: number | null;
   earlyTradingChangePercent?: number | null;
   lateTradingChangePercent?: number | null;
@@ -32,9 +33,10 @@ interface PortfolioRow {
   price: number;
   quantity?: number | null;
   average_cost?: number | null;
-  marketValue?: number;
+  marketValue?: number | null;
   unrealizedPlPercent?: number | null;
   isPositive?: boolean;
+  quoteAvailable?: boolean;
   previousClose?: number | null;
   earlyTradingChangePercent?: number | null;
   lateTradingChangePercent?: number | null;
@@ -55,8 +57,9 @@ interface WatchlistItemProps {
 function WatchlistItem({ item, index, onDelete, marketStatus, isMobile }: WatchlistItemProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const pos = item.isPositive;
-  const pctStr = (pos ? '+' : '') + fmt2(Number(item.changePercent)) + '%';
+  const hasQuote = item.quoteAvailable !== false;
+  const pos = hasQuote ? item.isPositive ?? true : true;
+  const pctStr = hasQuote ? (pos ? '+' : '') + fmt2(Number(item.changePercent)) + '%' : 'N/A';
   const hasId = !!item.watchlist_item_id;
 
   // Extended hours: show when not regular session and data available
@@ -91,10 +94,19 @@ function WatchlistItem({ item, index, onDelete, marketStatus, isMobile }: Watchl
       <div className="flex items-center gap-4">
         <div className="text-right">
           <div className="text-sm font-medium dashboard-mono" style={{ color: 'var(--color-text-primary)' }}>
-            {fmt2(Number(extType && item.previousClose != null ? item.previousClose : item.price))}
+            {hasQuote
+              ? fmt2(Number(extType && item.previousClose != null ? item.previousClose : item.price))
+              : 'N/A'}
           </div>
-          <div className="text-xs font-medium dashboard-mono" style={{ color: pos ? 'var(--color-profit)' : 'var(--color-loss)' }}>
-            {(pos ? '+' : '') + fmt2(Number(item.change))}
+          <div
+            className="text-xs font-medium dashboard-mono"
+            style={{
+              color: hasQuote
+                ? pos ? 'var(--color-profit)' : 'var(--color-loss)'
+                : 'var(--color-text-secondary)',
+            }}
+          >
+            {hasQuote ? (pos ? '+' : '') + fmt2(Number(item.change)) : '—'}
           </div>
         </div>
 
@@ -102,13 +114,17 @@ function WatchlistItem({ item, index, onDelete, marketStatus, isMobile }: Watchl
           <div
             className="w-16 py-1 rounded-lg text-center text-xs font-bold"
             style={{
-              backgroundColor: pos ? 'var(--color-profit-soft)' : 'var(--color-loss-soft)',
-              color: pos ? 'var(--color-profit)' : 'var(--color-loss)',
+              backgroundColor: hasQuote
+                ? pos ? 'var(--color-profit-soft)' : 'var(--color-loss-soft)'
+                : 'var(--color-bg-subtle)',
+              color: hasQuote
+                ? pos ? 'var(--color-profit)' : 'var(--color-loss)'
+                : 'var(--color-text-secondary)',
             }}
           >
             {pctStr}
           </div>
-          {extType && extPct != null && (
+          {hasQuote && extType && extPct != null && (
             <div className="text-[10px] mt-0.5 text-center flex items-center justify-center gap-0.5" style={{ color: extColor }}>
               {extType === 'pre' ? <Sunrise size={10} /> : <Sunset size={10} />}
               {fmt2(Number(item.price))} {extPct >= 0 ? '+' : ''}{fmt2(extPct)}%
@@ -171,9 +187,10 @@ interface PortfolioItemProps {
 function PortfolioItem({ item, index, onEdit, onDelete, valuesHidden, marketStatus, isMobile }: PortfolioItemProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const pos = item.isPositive;
+  const hasQuote = item.quoteAvailable !== false;
+  const pos = hasQuote ? item.isPositive ?? true : true;
   const plStr =
-    item.unrealizedPlPercent != null
+    hasQuote && item.unrealizedPlPercent != null
       ? (pos ? '+' : '') + fmt2(Number(item.unrealizedPlPercent)) + '%'
       : '—';
   const hasId = !!item.user_portfolio_id;
@@ -216,10 +233,18 @@ function PortfolioItem({ item, index, onEdit, onDelete, valuesHidden, marketStat
       <div className="flex items-center gap-4">
         <div className="text-right">
           <div className="text-sm font-medium dashboard-mono" style={{ color: 'var(--color-text-primary)' }}>
-            {valuesHidden ? '******' : `$${fmt2(Number(item.marketValue || 0))}`}
+            {valuesHidden
+              ? '******'
+              : hasQuote && item.marketValue != null
+                ? `$${fmt2(Number(item.marketValue))}`
+                : 'N/A'}
           </div>
           <div className="text-xs dashboard-mono" style={{ color: 'var(--color-text-secondary)' }}>
-            {valuesHidden ? '***' : `@${fmt2(Number(extType && item.previousClose != null ? item.previousClose : item.price))}`}
+            {valuesHidden
+              ? '***'
+              : hasQuote
+                ? `@${fmt2(Number(extType && item.previousClose != null ? item.previousClose : item.price))}`
+                : '@N/A'}
           </div>
         </div>
 
@@ -227,13 +252,17 @@ function PortfolioItem({ item, index, onEdit, onDelete, valuesHidden, marketStat
           <div
             className="w-16 py-1 rounded-lg text-center text-xs font-bold"
             style={{
-              backgroundColor: pos ? 'var(--color-profit-soft)' : 'var(--color-loss-soft)',
-              color: pos ? 'var(--color-profit)' : 'var(--color-loss)',
+              backgroundColor: hasQuote
+                ? pos ? 'var(--color-profit-soft)' : 'var(--color-loss-soft)'
+                : 'var(--color-bg-subtle)',
+              color: hasQuote
+                ? pos ? 'var(--color-profit)' : 'var(--color-loss)'
+                : 'var(--color-text-secondary)',
             }}
           >
             {plStr}
           </div>
-          {extType && extPct != null && (
+          {hasQuote && extType && extPct != null && (
             <div className="text-[10px] mt-0.5 text-center flex items-center justify-center gap-0.5" style={{ color: extColor }}>
               {extType === 'pre' ? <Sunrise size={10} /> : <Sunset size={10} />}
               {fmt2(Number(item.price))} {extPct >= 0 ? '+' : ''}{fmt2(extPct)}%
@@ -368,8 +397,12 @@ function PortfolioWatchlistCard({
   };
 
   // Compute portfolio summary
-  const totalValue = portfolioRows.reduce((sum, r) => sum + (r.marketValue || 0), 0);
-  const totalCost = portfolioRows.reduce(
+  const pricedRows = portfolioRows.filter(
+    (r) => r.quoteAvailable !== false && r.marketValue != null,
+  );
+  const hasPricedRows = pricedRows.length > 0;
+  const totalValue = pricedRows.reduce((sum, r) => sum + (r.marketValue || 0), 0);
+  const totalCost = pricedRows.reduce(
     (sum, r) => sum + (r.average_cost != null ? r.average_cost * (r.quantity || 0) : 0),
     0
   );
@@ -486,9 +519,9 @@ function PortfolioWatchlistCard({
                     className="text-2xl font-bold mb-2 dashboard-mono"
                     style={{ color: 'var(--color-text-primary)' }}
                   >
-                    {valuesHidden ? '********' : `$${fmt2(totalValue)}`}
+                    {valuesHidden ? '********' : hasPricedRows ? `$${fmt2(totalValue)}` : 'N/A'}
                   </div>
-                  {!valuesHidden && (
+                  {!valuesHidden && hasPricedRows && (
                     <div
                       className="flex items-center gap-2 text-xs font-medium w-fit px-2 py-1 rounded-full"
                       style={{

--- a/web/src/pages/Dashboard/hooks/usePortfolioData.ts
+++ b/web/src/pages/Dashboard/hooks/usePortfolioData.ts
@@ -18,9 +18,10 @@ export interface PortfolioRow {
   average_cost?: number | null;
   notes?: string;
   price: number;
-  marketValue?: number;
+  marketValue?: number | null;
   unrealizedPlPercent?: number | null;
   isPositive?: boolean;
+  quoteAvailable?: boolean;
   previousClose?: number | null;
   earlyTradingChangePercent?: number | null;
   lateTradingChangePercent?: number | null;
@@ -86,9 +87,10 @@ export function usePortfolioData() {
           const p = bySym[sym] || {} as Partial<StockPrice>;
           const q = Number(h.quantity || 0);
           const ac = h.average_cost != null ? Number(h.average_cost) : null;
-          const price = p.price ?? 0;
-          const marketValue = q * price;
-          const plPct = ac != null && ac > 0 ? ((price - ac) / ac) * 100 : null;
+          const quoteAvailable = p.quoteAvailable !== false && p.price != null;
+          const price = quoteAvailable ? p.price ?? 0 : 0;
+          const marketValue = quoteAvailable ? q * price : null;
+          const plPct = quoteAvailable && ac != null && ac > 0 ? ((price - ac) / ac) * 100 : null;
           return {
             user_portfolio_id: h.user_portfolio_id,
             symbol: sym,
@@ -98,7 +100,8 @@ export function usePortfolioData() {
             price,
             marketValue,
             unrealizedPlPercent: plPct,
-            isPositive: plPct == null ? true : plPct >= 0,
+            isPositive: quoteAvailable && plPct != null ? plPct >= 0 : true,
+            quoteAvailable,
             previousClose: p.previousClose ?? null,
             earlyTradingChangePercent: p.earlyTradingChangePercent ?? null,
             lateTradingChangePercent: p.lateTradingChangePercent ?? null,

--- a/web/src/pages/Dashboard/hooks/useWatchlistData.ts
+++ b/web/src/pages/Dashboard/hooks/useWatchlistData.ts
@@ -17,6 +17,7 @@ export interface WatchlistRow {
   change: number;
   changePercent: number;
   isPositive: boolean;
+  quoteAvailable?: boolean;
   previousClose: number | null;
   earlyTradingChangePercent: number | null;
   lateTradingChangePercent: number | null;
@@ -72,13 +73,15 @@ export function useWatchlistData() {
         ? items.map((i) => {
           const sym = String(i.symbol || '').trim().toUpperCase();
           const p = bySym[sym] || {} as Partial<StockPrice>;
+          const quoteAvailable = p.quoteAvailable !== false && p.price != null;
           return {
             watchlist_item_id: i.watchlist_item_id,
             symbol: sym,
-            price: p.price ?? 0,
-            change: p.change ?? 0,
-            changePercent: p.changePercent ?? 0,
-            isPositive: p.isPositive ?? true,
+            price: quoteAvailable ? p.price ?? 0 : 0,
+            change: quoteAvailable ? p.change ?? 0 : 0,
+            changePercent: quoteAvailable ? p.changePercent ?? 0 : 0,
+            isPositive: quoteAvailable ? p.isPositive ?? true : true,
+            quoteAvailable,
             previousClose: p.previousClose ?? null,
             earlyTradingChangePercent: p.earlyTradingChangePercent ?? null,
             lateTradingChangePercent: p.lateTradingChangePercent ?? null,

--- a/web/src/pages/Dashboard/utils/__tests__/api.test.ts
+++ b/web/src/pages/Dashboard/utils/__tests__/api.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const apiMock = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  delete: vi.fn(),
+}));
+
+vi.mock('@/api/client', () => ({ api: apiMock }));
+
+import { getStockPrices } from '../api';
+
+describe('getStockPrices', () => {
+  beforeEach(() => {
+    apiMock.get.mockReset();
+  });
+
+  it('marks symbols missing from the snapshot response as unavailable quotes', async () => {
+    apiMock.get.mockResolvedValueOnce({
+      data: {
+        snapshots: [
+          {
+            symbol: 'AAPL',
+            price: 190.12,
+            change: 1.23,
+            change_percent: 0.65,
+          },
+        ],
+      },
+    });
+
+    const rows = await getStockPrices(['AAPL', '301189.SZ']);
+
+    expect(rows[0]).toMatchObject({
+      symbol: 'AAPL',
+      price: 190.12,
+      quoteAvailable: true,
+    });
+    expect(rows[1]).toMatchObject({
+      symbol: '301189.SZ',
+      price: 0,
+      change: 0,
+      changePercent: 0,
+      quoteAvailable: false,
+    });
+  });
+
+  it('marks all requested symbols unavailable when the snapshot request fails', async () => {
+    apiMock.get.mockRejectedValueOnce(new Error('network'));
+
+    const rows = await getStockPrices(['301189.SZ']);
+
+    expect(rows).toEqual([
+      {
+        symbol: '301189.SZ',
+        price: 0,
+        change: 0,
+        changePercent: 0,
+        isPositive: true,
+        quoteAvailable: false,
+      },
+    ]);
+  });
+});

--- a/web/src/pages/Dashboard/utils/api.ts
+++ b/web/src/pages/Dashboard/utils/api.ts
@@ -41,6 +41,7 @@ interface StockPrice {
   change: number;
   changePercent: number;
   isPositive: boolean;
+  quoteAvailable?: boolean;
   previousClose?: number | null;
   earlyTradingChangePercent?: number | null;
   lateTradingChangePercent?: number | null;
@@ -416,15 +417,16 @@ export async function getStockPrices(symbols: string[]): Promise<StockPrice[]> {
           change: Math.round(change * 100) / 100,
           changePercent: Math.round(changePct * 100) / 100,
           isPositive: change >= 0,
+          quoteAvailable: true,
           previousClose: snap.previous_close ?? null,
           earlyTradingChangePercent: snap.early_trading_change_percent ?? null,
           lateTradingChangePercent: snap.late_trading_change_percent ?? null,
         };
       }
-      return { symbol: sym, price: 0, change: 0, changePercent: 0, isPositive: true };
+      return { symbol: sym, price: 0, change: 0, changePercent: 0, isPositive: true, quoteAvailable: false };
     });
   } catch {
-    return list.map((sym: string) => ({ symbol: sym, price: 0, change: 0, changePercent: 0, isPositive: true }));
+    return list.map((sym: string) => ({ symbol: sym, price: 0, change: 0, changePercent: 0, isPositive: true, quoteAvailable: false }));
   }
 }
 

--- a/web/src/pages/Dashboard/widgets/definitions/PortfolioWatchlistWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/PortfolioWatchlistWidget.tsx
@@ -32,21 +32,23 @@ type PortfolioWatchlistConfig = {
 };
 
 function watchlistRowToQuote(r: WatchlistRow) {
+  const hasQuote = r.quoteAvailable !== false;
   return {
     symbol: r.symbol,
-    price: r.price,
-    change: r.change,
-    changePercent: r.changePercent,
+    price: hasQuote ? r.price : undefined,
+    change: hasQuote ? r.change : undefined,
+    changePercent: hasQuote ? r.changePercent : undefined,
   };
 }
 
 function portfolioRowToQuote(r: PortfolioRow) {
+  const hasQuote = r.quoteAvailable !== false;
   return {
     symbol: r.symbol,
-    price: r.price,
+    price: hasQuote ? r.price : undefined,
     shares: r.quantity ?? undefined,
-    marketValue: r.marketValue,
-    changePercent: r.unrealizedPlPercent ?? undefined,
+    marketValue: hasQuote ? r.marketValue ?? undefined : undefined,
+    changePercent: hasQuote ? r.unrealizedPlPercent ?? undefined : undefined,
   };
 }
 
@@ -126,7 +128,7 @@ function PortfolioWatchlistWidget({
           widget_id: `${instance.id}/${rowId}`,
           label:
             row.symbol +
-            (row.changePercent !== undefined
+            (row.quoteAvailable !== false && row.changePercent !== undefined
               ? ` · ${row.changePercent >= 0 ? '+' : ''}${row.changePercent.toFixed(2)}%`
               : ''),
           description: t('dashboard.widgets.portfolioWatchlist.headerWatchlist'),
@@ -149,7 +151,7 @@ function PortfolioWatchlistWidget({
         widget_id: `${instance.id}/${rowId}`,
         label:
           row.symbol +
-          (row.unrealizedPlPercent != null
+          (row.quoteAvailable !== false && row.unrealizedPlPercent != null
             ? ` · ${row.unrealizedPlPercent >= 0 ? '+' : ''}${row.unrealizedPlPercent.toFixed(2)}%`
             : ''),
         description: t('dashboard.widgets.portfolioWatchlist.headerHoldings'),

--- a/web/src/pages/Dashboard/widgets/definitions/PortfolioWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/PortfolioWidget.tsx
@@ -25,12 +25,13 @@ import { formatPortfolioNavMarkdownLine, portfolioSummary } from './_holdingsHel
 type PortfolioConfig = { valuesHidden?: boolean };
 
 function rowToQuote(r: PortfolioRow) {
+  const hasQuote = r.quoteAvailable !== false;
   return {
     symbol: r.symbol,
-    price: r.price,
+    price: hasQuote ? r.price : undefined,
     shares: r.quantity ?? undefined,
-    marketValue: r.marketValue,
-    changePercent: r.unrealizedPlPercent ?? undefined,
+    marketValue: hasQuote ? r.marketValue ?? undefined : undefined,
+    changePercent: hasQuote ? r.unrealizedPlPercent ?? undefined : undefined,
   };
 }
 
@@ -68,7 +69,7 @@ function PortfolioWidget({ instance, updateConfig }: WidgetRenderProps<Portfolio
         widget_id: `${instance.id}/${rowId}`,
         label:
           row.symbol +
-          (row.unrealizedPlPercent != null
+          (row.quoteAvailable !== false && row.unrealizedPlPercent != null
             ? ` · ${row.unrealizedPlPercent >= 0 ? '+' : ''}${row.unrealizedPlPercent.toFixed(2)}%`
             : ''),
         description: t('dashboard.widgets.portfolio.title'),

--- a/web/src/pages/Dashboard/widgets/definitions/WatchlistWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/WatchlistWidget.tsx
@@ -30,9 +30,9 @@ function WatchlistWidget({ instance }: WidgetRenderProps<WatchlistConfig>) {
     full: () => {
       const rows = watchlist.rows.map((r) => ({
         symbol: r.symbol,
-        price: r.price,
-        change: r.change,
-        changePercent: r.changePercent,
+        price: r.quoteAvailable !== false ? r.price : undefined,
+        change: r.quoteAvailable !== false ? r.change : undefined,
+        changePercent: r.quoteAvailable !== false ? r.changePercent : undefined,
       }));
       const body = serializeQuoteRowsToMarkdown(rows);
       const text = wrapWidgetContext('watchlist.list', { count: rows.length }, body);
@@ -57,16 +57,20 @@ function WatchlistWidget({ instance }: WidgetRenderProps<WatchlistConfig>) {
       // hours info would need marketStatus + getExtendedHoursInfo here.
       const cleaned = {
         symbol: row.symbol,
-        price: row.price,
-        change: row.change,
-        changePercent: row.changePercent,
+        price: row.quoteAvailable !== false ? row.price : undefined,
+        change: row.quoteAvailable !== false ? row.change : undefined,
+        changePercent: row.quoteAvailable !== false ? row.changePercent : undefined,
       };
       const body = serializeQuoteRowToMarkdown(cleaned);
       const text = wrapWidgetContext('watchlist.list/row', { symbol: row.symbol }, body);
       return {
         widget_type: 'watchlist.list/row',
         widget_id: `${instance.id}/${rowId}`,
-        label: row.symbol + (row.changePercent !== undefined ? ` · ${row.changePercent >= 0 ? '+' : ''}${row.changePercent.toFixed(2)}%` : ''),
+        label:
+          row.symbol +
+          (row.quoteAvailable !== false && row.changePercent !== undefined
+            ? ` · ${row.changePercent >= 0 ? '+' : ''}${row.changePercent.toFixed(2)}%`
+            : ''),
         description: t('dashboard.widgets.watchlist.title'),
         captured_at: new Date().toISOString(),
         text,

--- a/web/src/pages/Dashboard/widgets/definitions/__tests__/holdingsHelpers.test.ts
+++ b/web/src/pages/Dashboard/widgets/definitions/__tests__/holdingsHelpers.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { portfolioSummary } from '../_holdingsHelpers';
+
+describe('portfolioSummary', () => {
+  it('excludes holdings without available quotes from NAV and P/L math', () => {
+    const summary = portfolioSummary([
+      {
+        symbol: 'AAPL',
+        price: 12,
+        quantity: 10,
+        average_cost: 10,
+        marketValue: 120,
+        quoteAvailable: true,
+      },
+      {
+        symbol: '301189.SZ',
+        price: 0,
+        quantity: 10,
+        average_cost: 30,
+        marketValue: null,
+        quoteAvailable: false,
+      },
+    ]);
+
+    expect(summary.totalValue).toBe(120);
+    expect(summary.totalCost).toBe(100);
+    expect(summary.totalPl).toBe(20);
+    expect(summary.totalPlPct).toBe(20);
+  });
+});

--- a/web/src/pages/Dashboard/widgets/definitions/__tests__/holdingsHelpers.test.ts
+++ b/web/src/pages/Dashboard/widgets/definitions/__tests__/holdingsHelpers.test.ts
@@ -27,5 +27,25 @@ describe('portfolioSummary', () => {
     expect(summary.totalCost).toBe(100);
     expect(summary.totalPl).toBe(20);
     expect(summary.totalPlPct).toBe(20);
+    expect(summary.hasPricedRows).toBe(true);
+  });
+
+  it('reports when no holdings have available quotes', () => {
+    const summary = portfolioSummary([
+      {
+        symbol: '301189.SZ',
+        price: 0,
+        quantity: 10,
+        average_cost: 30,
+        marketValue: null,
+        quoteAvailable: false,
+      },
+    ]);
+
+    expect(summary.totalValue).toBe(0);
+    expect(summary.totalCost).toBe(0);
+    expect(summary.totalPl).toBe(0);
+    expect(summary.totalPlPct).toBe(0);
+    expect(summary.hasPricedRows).toBe(false);
   });
 });

--- a/web/src/pages/Dashboard/widgets/definitions/_holdingsHelpers.ts
+++ b/web/src/pages/Dashboard/widgets/definitions/_holdingsHelpers.ts
@@ -16,6 +16,7 @@ export interface PortfolioSummary {
   totalCost: number;
   totalPl: number;
   totalPlPct: number;
+  hasPricedRows: boolean;
 }
 
 export function portfolioSummary(rows: PortfolioRow[]): PortfolioSummary {
@@ -29,7 +30,7 @@ export function portfolioSummary(rows: PortfolioRow[]): PortfolioSummary {
   );
   const totalPl = totalCost > 0 ? totalValue - totalCost : 0;
   const totalPlPct = totalCost > 0 ? ((totalValue - totalCost) / totalCost) * 100 : 0;
-  return { totalValue, totalCost, totalPl, totalPlPct };
+  return { totalValue, totalCost, totalPl, totalPlPct, hasPricedRows: pricedRows.length > 0 };
 }
 
 /** Render the portfolio summary as the leading markdown line for snapshot

--- a/web/src/pages/Dashboard/widgets/definitions/_holdingsHelpers.ts
+++ b/web/src/pages/Dashboard/widgets/definitions/_holdingsHelpers.ts
@@ -19,8 +19,11 @@ export interface PortfolioSummary {
 }
 
 export function portfolioSummary(rows: PortfolioRow[]): PortfolioSummary {
-  const totalValue = rows.reduce((s, r) => s + (r.marketValue || 0), 0);
-  const totalCost = rows.reduce(
+  const pricedRows = rows.filter(
+    (r) => r.quoteAvailable !== false && r.marketValue != null,
+  );
+  const totalValue = pricedRows.reduce((s, r) => s + (r.marketValue || 0), 0);
+  const totalCost = pricedRows.reduce(
     (s, r) => s + (r.average_cost != null ? r.average_cost * (r.quantity || 0) : 0),
     0,
   );

--- a/web/src/pages/Dashboard/widgets/definitions/_holdingsPrimitives.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/_holdingsPrimitives.tsx
@@ -40,8 +40,9 @@ interface WatchlistRowItemProps {
 export function WatchlistRowItem({ item, index, marketStatus, onDelete }: WatchlistRowItemProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const pos = item.isPositive;
-  const pctStr = (pos ? '+' : '') + fmt2(Number(item.changePercent)) + '%';
+  const hasQuote = item.quoteAvailable !== false;
+  const pos = hasQuote ? item.isPositive ?? true : true;
+  const pctStr = hasQuote ? (pos ? '+' : '') + fmt2(Number(item.changePercent)) + '%' : 'N/A';
   const hasId = !!item.watchlist_item_id;
 
   const { extPct, extType } = getExtendedHoursInfo(marketStatus, item, { shortLabels: true });
@@ -77,26 +78,36 @@ export function WatchlistRowItem({ item, index, marketStatus, onDelete }: Watchl
             className="text-sm font-medium dashboard-mono"
             style={{ color: 'var(--color-text-primary)' }}
           >
-            {fmt2(Number(extType && item.previousClose != null ? item.previousClose : item.price))}
+            {hasQuote
+              ? fmt2(Number(extType && item.previousClose != null ? item.previousClose : item.price))
+              : 'N/A'}
           </div>
           <div
             className="text-xs font-medium dashboard-mono"
-            style={{ color: pos ? 'var(--color-profit)' : 'var(--color-loss)' }}
+            style={{
+              color: hasQuote
+                ? pos ? 'var(--color-profit)' : 'var(--color-loss)'
+                : 'var(--color-text-secondary)',
+            }}
           >
-            {(pos ? '+' : '') + fmt2(Number(item.change))}
+            {hasQuote ? (pos ? '+' : '') + fmt2(Number(item.change)) : '—'}
           </div>
         </div>
         <div className="text-right">
           <div
             className="w-16 py-1 rounded-lg text-center text-xs font-bold"
             style={{
-              backgroundColor: pos ? 'var(--color-profit-soft)' : 'var(--color-loss-soft)',
-              color: pos ? 'var(--color-profit)' : 'var(--color-loss)',
+              backgroundColor: hasQuote
+                ? pos ? 'var(--color-profit-soft)' : 'var(--color-loss-soft)'
+                : 'var(--color-bg-subtle)',
+              color: hasQuote
+                ? pos ? 'var(--color-profit)' : 'var(--color-loss)'
+                : 'var(--color-text-secondary)',
             }}
           >
             {pctStr}
           </div>
-          {extType && extPct != null && (
+          {hasQuote && extType && extPct != null && (
             <div
               className="text-[10px] mt-0.5 text-center flex items-center justify-center gap-0.5"
               style={{ color: extColor }}
@@ -146,9 +157,10 @@ export function PortfolioRowItem({
 }: PortfolioRowItemProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const pos = item.isPositive;
+  const hasQuote = item.quoteAvailable !== false;
+  const pos = hasQuote ? item.isPositive ?? true : true;
   const plStr =
-    item.unrealizedPlPercent != null
+    hasQuote && item.unrealizedPlPercent != null
       ? (pos ? '+' : '') + fmt2(Number(item.unrealizedPlPercent)) + '%'
       : '—';
   const hasId = !!item.user_portfolio_id;
@@ -192,25 +204,33 @@ export function PortfolioRowItem({
           >
             {valuesHidden
               ? '******'
-              : `$${fmt2(Number(item.marketValue || 0))}`}
+              : hasQuote && item.marketValue != null
+                ? `$${fmt2(Number(item.marketValue))}`
+                : 'N/A'}
           </div>
           <div className="text-xs dashboard-mono" style={{ color: 'var(--color-text-secondary)' }}>
             {valuesHidden
               ? '***'
-              : `@${fmt2(Number(extType && item.previousClose != null ? item.previousClose : item.price))}`}
+              : hasQuote
+                ? `@${fmt2(Number(extType && item.previousClose != null ? item.previousClose : item.price))}`
+                : '@N/A'}
           </div>
         </div>
         <div className="text-right">
           <div
             className="w-16 py-1 rounded-lg text-center text-xs font-bold"
             style={{
-              backgroundColor: pos ? 'var(--color-profit-soft)' : 'var(--color-loss-soft)',
-              color: pos ? 'var(--color-profit)' : 'var(--color-loss)',
+              backgroundColor: hasQuote
+                ? pos ? 'var(--color-profit-soft)' : 'var(--color-loss-soft)'
+                : 'var(--color-bg-subtle)',
+              color: hasQuote
+                ? pos ? 'var(--color-profit)' : 'var(--color-loss)'
+                : 'var(--color-text-secondary)',
             }}
           >
             {plStr}
           </div>
-          {extType && extPct != null && (
+          {hasQuote && extType && extPct != null && (
             <div
               className="text-[10px] mt-0.5 text-center flex items-center justify-center gap-0.5"
               style={{ color: extColor }}
@@ -285,6 +305,9 @@ interface PortfolioNavSummaryProps {
 export function PortfolioNavSummary({ rows, valuesHidden, onToggleHidden }: PortfolioNavSummaryProps) {
   const { t } = useTranslation();
   const { totalValue, totalCost, totalPl, totalPlPct } = portfolioSummary(rows);
+  const hasPricedRows = rows.some(
+    (r) => r.quoteAvailable !== false && r.marketValue != null,
+  );
   const isPlPositive = totalPl >= 0;
 
   return (
@@ -319,9 +342,9 @@ export function PortfolioNavSummary({ rows, valuesHidden, onToggleHidden }: Port
         className="text-2xl font-bold mb-2 dashboard-mono"
         style={{ color: 'var(--color-text-primary)' }}
       >
-        {valuesHidden ? '********' : `$${fmt2(totalValue)}`}
+        {valuesHidden ? '********' : hasPricedRows ? `$${fmt2(totalValue)}` : 'N/A'}
       </div>
-      {!valuesHidden && totalCost > 0 && (
+      {!valuesHidden && hasPricedRows && totalCost > 0 && (
         <div
           className="flex items-center gap-2 text-xs font-medium w-fit px-2 py-1 rounded-full"
           style={{

--- a/web/src/types/market.ts
+++ b/web/src/types/market.ts
@@ -56,6 +56,7 @@ export interface StockPrice {
   change: number;
   changePercent: number;
   isPositive: boolean;
+  quoteAvailable?: boolean;
   previousClose?: number | null;
   earlyTradingChangePercent?: number | null;
   lateTradingChangePercent?: number | null;


### PR DESCRIPTION
## Summary
- mark missing stock snapshots as unavailable quotes instead of indistinguishable zero prices
- keep watchlist and portfolio rows visible while rendering missing quotes as N/A / blank context fields
- exclude unpriced holdings from NAV and unrealized P/L calculations so missing A-share quotes do not show as -100%
- apply the handling to both classic dashboard cards and custom dashboard widgets
- add regression tests for missing snapshot handling and portfolio summary math

Addresses #248.

Related follow-up to #253: that PR fixes backend provider routing for batch snapshots; this PR protects the frontend when a snapshot is still missing.

## Tests
- `corepack pnpm exec vitest run src/pages/Dashboard/utils/__tests__/api.test.ts src/pages/Dashboard/widgets/definitions/__tests__/holdingsHelpers.test.ts`
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm exec eslint src/pages/Dashboard/utils/api.ts src/pages/Dashboard/utils/__tests__/api.test.ts src/pages/Dashboard/hooks/useWatchlistData.ts src/pages/Dashboard/hooks/usePortfolioData.ts src/pages/Dashboard/components/AddWatchlistItemDialog.tsx src/pages/Dashboard/components/PortfolioWatchlistCard.tsx src/pages/Dashboard/widgets/definitions/WatchlistWidget.tsx src/pages/Dashboard/widgets/definitions/PortfolioWidget.tsx src/pages/Dashboard/widgets/definitions/PortfolioWatchlistWidget.tsx src/pages/Dashboard/widgets/definitions/_holdingsHelpers.ts src/pages/Dashboard/widgets/definitions/_holdingsPrimitives.tsx src/pages/Dashboard/widgets/definitions/__tests__/holdingsHelpers.test.ts src/types/market.ts`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI now treats missing quote data as "N/A" and hides quote-derived values (price, change, %, extended-hours); per-row labels omit percent suffix when quotes are unavailable.

* **Bug Fixes**
  * Portfolio totals, NAV and P/L calculations exclude holdings without valid quotes to avoid misleading values; neutral styling used when quotes are absent.

* **Tests**
  * Added tests validating behavior and fallbacks for missing or failed price fetches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->