### PR TITLE
feat(news): TickerTick dashboard news source + cache-stampede hardening

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -165,6 +165,22 @@ news_data:
     - name: fmp
     - name: yfinance
 
+# News refresh poller — keeps the GLOBAL feeds (curated "Top" + Market general)
+# warm by fetching the latest page every interval and delta-merging new articles
+# (by id) into a rolling buffer stored in the same Redis key the /news endpoint
+# reads. Per-ticker feeds are unbounded and stay on the on-demand cache. One
+# worker polls per tick (Redis-lock leader election); the buffer self-heals via
+# the cache TTL if the poller stops.
+news_poll:
+  enabled: true
+  interval_seconds: 60     # How often to fetch the latest page
+  max_items: 100           # Rolling-buffer cap per feed
+  feeds:
+    - provider: tickertick # Curated "Top" feed (news:tickertick:general:<limit>)
+      limit: 50
+    - provider: null       # Provider-chain general feed / Market tab (news:general:<limit>)
+      limit: 50
+
 
 # =============================================================================
 # MARKET INSIGHT CONFIGURATION

--- a/src/config/models.py
+++ b/src/config/models.py
@@ -180,7 +180,8 @@ class NewsPollFeedConfig(BaseModel):
 
     ``provider`` None targets the provider chain (Market general feed); a name
     (e.g. ``tickertick``) targets that source directly. Always polled with no
-    tickers, so it maps to a global ``news:[provider]:general:<limit>`` key.
+    tickers, so it maps to a global cache key — ``news:tickertick:general:50``
+    with a provider, ``news:general:50`` without one.
     """
 
     provider: str | None = Field(default=None)

--- a/src/config/models.py
+++ b/src/config/models.py
@@ -175,6 +175,27 @@ class NewsDataConfig(BaseModel):
     providers: List[MarketDataProviderConfig] = Field(default_factory=list)
 
 
+class NewsPollFeedConfig(BaseModel):
+    """One global feed kept warm by the news refresh poller.
+
+    ``provider`` None targets the provider chain (Market general feed); a name
+    (e.g. ``tickertick``) targets that source directly. Always polled with no
+    tickers, so it maps to a global ``news:[provider]:general:<limit>`` key.
+    """
+
+    provider: str | None = Field(default=None)
+    limit: int = Field(default=50, ge=1, le=100)
+
+
+class NewsPollConfig(BaseModel):
+    """News refresh poller — delta-merges the latest page into a rolling buffer."""
+
+    enabled: bool = Field(default=True)
+    interval_seconds: int = Field(default=60, ge=10)
+    max_items: int = Field(default=100, ge=1, le=500)
+    feeds: List[NewsPollFeedConfig] = Field(default_factory=list)
+
+
 class InfrastructureConfig(BaseModel):
     """Root model for infrastructure configuration (config.yaml)."""
 
@@ -228,3 +249,4 @@ class InfrastructureConfig(BaseModel):
     # Market Data
     market_data: MarketDataConfig = Field(default_factory=MarketDataConfig)
     news_data: NewsDataConfig = Field(default_factory=NewsDataConfig)
+    news_poll: NewsPollConfig = Field(default_factory=NewsPollConfig)

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -11,6 +11,7 @@ import os
 from typing import Any, Dict, List, Optional
 
 from src.config.core import get_infrastructure_config
+from src.config.models import NewsPollConfig
 
 # Re-export env-var constants for backward compatibility
 from src.config.env import (  # noqa: F401
@@ -171,7 +172,7 @@ def is_redis_cache_enabled() -> bool:
     return get_infrastructure_config().redis.cache_enabled
 
 
-def get_news_poll_config():
+def get_news_poll_config() -> NewsPollConfig:
     """News refresh poller config (enabled / interval / max_items / feeds)."""
     return get_infrastructure_config().news_poll
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -171,6 +171,11 @@ def is_redis_cache_enabled() -> bool:
     return get_infrastructure_config().redis.cache_enabled
 
 
+def get_news_poll_config():
+    """News refresh poller config (enabled / interval / max_items / feeds)."""
+    return get_infrastructure_config().news_poll
+
+
 def get_redis_max_connections() -> int:
     """Get Redis connection pool max connections.
 

--- a/src/data_client/__init__.py
+++ b/src/data_client/__init__.py
@@ -26,5 +26,6 @@ from .registry import (  # noqa: F401 — re-export
     get_financial_data_provider,
     get_market_data_provider,
     get_news_data_provider,
+    get_news_source,
     get_price_provider,
 )

--- a/src/data_client/registry.py
+++ b/src/data_client/registry.py
@@ -46,6 +46,10 @@ def _yfinance_available() -> bool:
         return False
 
 
+def _tickertick_available() -> bool:
+    return True  # free, keyless API
+
+
 # ---------------------------------------------------------------------------
 # Async source constructors
 # ---------------------------------------------------------------------------
@@ -91,6 +95,12 @@ async def _build_yfinance_news_source() -> NewsDataSource:
     return YFinanceNewsSource()
 
 
+async def _build_tickertick_news_source() -> NewsDataSource:
+    from .tickertick.news_source import TickerTickNewsSource
+
+    return TickerTickNewsSource()
+
+
 # ---------------------------------------------------------------------------
 # Source registries — map config name → (availability_check, async_constructor)
 # ---------------------------------------------------------------------------
@@ -105,6 +115,7 @@ _NEWS_SOURCE_REGISTRY: dict[str, tuple[Any, Any]] = {
     "ginlix-data": (_ginlix_data_available, _build_ginlix_data_news_source),
     "fmp": (_fmp_available, _build_fmp_news_source),
     "yfinance": (_yfinance_available, _build_yfinance_news_source),
+    "tickertick": (_tickertick_available, _build_tickertick_news_source),
 }
 
 # ---------------------------------------------------------------------------
@@ -207,6 +218,38 @@ async def get_news_data_provider():
 
         _news_data_provider = NewsDataProvider(sources)
         return _news_data_provider
+
+
+# ---------------------------------------------------------------------------
+# Named single-source access (for providers targeted directly, e.g. TickerTick)
+# ---------------------------------------------------------------------------
+
+_news_sources: dict[str, NewsDataSource] = {}
+_news_sources_lock = asyncio.Lock()
+
+
+async def get_news_source(name: str) -> NewsDataSource:
+    """Return a single named :class:`NewsDataSource`, bypassing the fallback chain.
+
+    Used when a caller wants a specific provider (e.g. ``tickertick`` for the
+    dashboard's curated feed) rather than the configured fallback order.
+    """
+    cached = _news_sources.get(name)
+    if cached is not None:
+        return cached
+
+    async with _news_sources_lock:
+        cached = _news_sources.get(name)
+        if cached is not None:
+            return cached
+
+        reg = _NEWS_SOURCE_REGISTRY.get(name)
+        if not reg or not reg[0]():
+            raise ValueError(f"News source '{name}' is not available")
+
+        source = await reg[1]()
+        _news_sources[name] = source
+        return source
 
 
 # ---------------------------------------------------------------------------

--- a/src/data_client/tickertick/__init__.py
+++ b/src/data_client/tickertick/__init__.py
@@ -1,0 +1,6 @@
+"""TickerTick news backend — free financial news API (api.tickertick.com)."""
+
+from .client import TickerTickClient
+from .news_source import TickerTickNewsSource
+
+__all__ = ["TickerTickClient", "TickerTickNewsSource"]

--- a/src/data_client/tickertick/client.py
+++ b/src/data_client/tickertick/client.py
@@ -1,0 +1,69 @@
+"""Async client for the TickerTick news API (free, no API key).
+
+Base endpoint is ``{BASE}/feed?q=<query>&n=<limit>[&last=<id>]`` where ``q``
+uses TickerTick's query language (``T:curated``, ``tt:<ticker>``,
+``(or tt:A tt:B)``, ``s:<source>``, ``E:<entity>``). Stories carry ``time`` as
+epoch **milliseconds**; we convert it to ISO-8601 UTC so the rest of the news
+stack sees the same ``published_at`` shape as the other providers.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+
+
+def _convert_timestamps(data: dict[str, Any]) -> dict[str, Any]:
+    """Convert each story's millisecond ``time`` to an ISO-8601 UTC string in place."""
+    for story in data.get("stories", []):
+        ts = story.get("time")
+        if isinstance(ts, (int, float)):
+            story["time"] = datetime.fromtimestamp(ts / 1000, timezone.utc).isoformat()
+    return data
+
+
+class TickerTickClient:
+    """Async client for TickerTick's ``/feed`` endpoint."""
+
+    BASE_URL = os.getenv("TICKERTICK_BASE_URL", "https://api.tickertick.com")
+
+    def __init__(self) -> None:
+        self._client: httpx.AsyncClient | None = None
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(timeout=30.0)
+        return self._client
+
+    async def close(self) -> None:
+        if self._client and not self._client.is_closed:
+            await self._client.aclose()
+
+    async def __aenter__(self) -> TickerTickClient:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        await self.close()
+
+    async def get_feed(
+        self, query: str, limit: int = 30, last_id: str | None = None
+    ) -> dict[str, Any]:
+        """Fetch a feed for *query*. Returns ``{"stories": [...]}`` (timestamps ISO-normalized)."""
+        params: dict[str, Any] = {"q": query, "n": limit}
+        if last_id:
+            params["last"] = last_id
+
+        client = await self._get_client()
+        try:
+            response = await client.get(f"{self.BASE_URL}/feed", params=params)
+            response.raise_for_status()
+            return _convert_timestamps(response.json())
+        except httpx.HTTPStatusError as e:
+            raise Exception(f"TickerTick request failed: {e}") from e
+        except httpx.TimeoutException as e:
+            raise Exception(f"TickerTick request timed out: {e}") from e
+        except httpx.RequestError as e:
+            raise Exception(f"TickerTick request failed: {e}") from e

--- a/src/data_client/tickertick/client.py
+++ b/src/data_client/tickertick/client.py
@@ -18,7 +18,13 @@ import httpx
 
 def _convert_timestamps(data: dict[str, Any]) -> dict[str, Any]:
     """Convert each story's millisecond ``time`` to an ISO-8601 UTC string in place."""
+    # TickerTick is an unowned upstream; a 200 with an unexpected body (list,
+    # string, …) shouldn't crash the endpoint — treat it as an empty feed.
+    if not isinstance(data, dict):
+        return {"stories": []}
     for story in data.get("stories", []):
+        if not isinstance(story, dict):
+            continue
         ts = story.get("time")
         if isinstance(ts, (int, float)):
             story["time"] = datetime.fromtimestamp(ts / 1000, timezone.utc).isoformat()

--- a/src/data_client/tickertick/news_source.py
+++ b/src/data_client/tickertick/news_source.py
@@ -1,0 +1,92 @@
+"""News data source backed by TickerTick.
+
+Unlike FMP/ginlix-data, TickerTick provides no article image and no sentiment,
+so those fields are normalized to ``None``. With no tickers the source returns
+TickerTick's curated top-news feed (``T:curated``); with tickers it uses broad
+ticker queries (``tt:``) which include related-entity coverage.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .client import TickerTickClient
+
+logger = logging.getLogger(__name__)
+
+
+def _build_query(tickers: list[str] | None) -> str:
+    """Map a ticker list to a TickerTick feed query."""
+    if not tickers:
+        return "T:curated"
+    if len(tickers) == 1:
+        return f"tt:{tickers[0].lower()}"
+    return "(or " + " ".join(f"tt:{t.lower()}" for t in tickers) + ")"
+
+
+def _normalize_story(raw: dict[str, Any]) -> dict[str, Any]:
+    """Map a TickerTick story → common NewsArticle dict."""
+    return {
+        "id": str(raw.get("id", "")),
+        "title": raw.get("title", ""),
+        "author": None,
+        "description": raw.get("description"),
+        "published_at": raw.get("time", ""),  # already ISO from the client
+        "article_url": raw.get("url", ""),
+        "image_url": None,
+        "source": {
+            "name": raw.get("site", ""),
+            "logo_url": None,
+            "homepage_url": None,
+            "favicon_url": raw.get("favicon_url"),
+        },
+        "tickers": [t.upper() for t in raw.get("tickers", [])],
+        "keywords": raw.get("tags", []),
+        "sentiments": None,
+    }
+
+
+class TickerTickNewsSource:
+    """Fetches news from TickerTick (curated or ticker feeds)."""
+
+    async def get_news(
+        self,
+        tickers: list[str] | None = None,
+        limit: int = 20,
+        published_after: str | None = None,
+        published_before: str | None = None,
+        cursor: str | None = None,
+        order: str | None = None,
+        sort: str | None = None,
+        user_id: str | None = None,
+    ) -> dict[str, Any]:
+        query = _build_query(tickers)
+        async with TickerTickClient() as client:
+            data = await client.get_feed(query, limit=limit, last_id=cursor)
+
+        stories = data.get("stories", []) if isinstance(data, dict) else []
+        results = [_normalize_story(s) for s in stories]
+        # TickerTick paginates via ``last=<id>`` (older stories). Hand the last
+        # story id back as the cursor when we filled the page, so the caller can
+        # request the next page; a short page means we've reached the end.
+        next_cursor = results[-1]["id"] if results and len(results) >= limit else None
+        return {"results": results, "count": len(results), "next_cursor": next_cursor}
+
+    async def get_news_article(
+        self, article_id: str, user_id: str | None = None
+    ) -> dict[str, Any] | None:
+        """Best-effort lookup: scan the curated feed for a matching story id."""
+        try:
+            async with TickerTickClient() as client:
+                data = await client.get_feed("T:curated", limit=50)
+            for story in data.get("stories", []):
+                normalized = _normalize_story(story)
+                if normalized["id"] == article_id:
+                    return normalized
+        except Exception:
+            logger.warning("news.tickertick.article_lookup_failed", exc_info=True)
+        return None
+
+    async def close(self) -> None:
+        pass  # TickerTickClient is used as a context manager per-request

--- a/src/data_client/tickertick/news_source.py
+++ b/src/data_client/tickertick/news_source.py
@@ -9,20 +9,27 @@ ticker queries (``tt:``) which include related-entity coverage.
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 from .client import TickerTickClient
 
 logger = logging.getLogger(__name__)
 
+# Tickers flow into TickerTick's query DSL (``tt:<sym>``), so only let clean
+# ticker tokens through — keeps a crafted ``?tickers=`` value from injecting DSL
+# operators (e.g. ``") (or s:cnn"``) into the feed query.
+_TICKER_RE = re.compile(r"^[A-Za-z0-9.\-]{1,15}$")
+
 
 def _build_query(tickers: list[str] | None) -> str:
-    """Map a ticker list to a TickerTick feed query."""
-    if not tickers:
+    """Map a ticker list to a TickerTick feed query (ignoring non-ticker tokens)."""
+    safe = [t for t in tickers or [] if _TICKER_RE.match(t)]
+    if not safe:
         return "T:curated"
-    if len(tickers) == 1:
-        return f"tt:{tickers[0].lower()}"
-    return "(or " + " ".join(f"tt:{t.lower()}" for t in tickers) + ")"
+    if len(safe) == 1:
+        return f"tt:{safe[0].lower()}"
+    return "(or " + " ".join(f"tt:{t.lower()}" for t in safe) + ")"
 
 
 def _normalize_story(raw: dict[str, Any]) -> dict[str, Any]:

--- a/src/server/app/news.py
+++ b/src/server/app/news.py
@@ -41,6 +41,10 @@ def _compact(article: dict) -> NewsArticleCompact | None:
         source=NewsPublisher(**source),
         tickers=article.get("tickers", []),
         has_sentiment=bool(sentiments and len(sentiments) > 0),
+        author=article.get("author"),
+        description=article.get("description"),
+        keywords=article.get("keywords", []),
+        sentiments=sentiments,
     )
 
 
@@ -54,6 +58,9 @@ async def get_news(
     published_before: str | None = Query(None, description="ISO 8601 date filter"),
     order: str | None = Query(None, description="Sort order: asc or desc"),
     sort: str | None = Query(None, description="Sort field, e.g. published_utc"),
+    provider: str | None = Query(
+        None, description="Target a specific news provider (e.g. 'tickertick')"
+    ),
 ) -> NewsCompactResponse:
     ticker_list = (
         [t.strip().upper() for t in tickers.split(",") if t.strip()]
@@ -63,7 +70,7 @@ async def get_news(
 
     # Check cache (skip when cursor is used — paginated requests bypass cache)
     if not cursor:
-        cached = await _cache.get(tickers=ticker_list, limit=limit)
+        cached = await _cache.get(tickers=ticker_list, limit=limit, provider=provider)
         if cached:
             results = [c for a in cached["results"] if (c := _compact(a)) is not None]
             return NewsCompactResponse(
@@ -72,10 +79,16 @@ async def get_news(
                 next_cursor=cached.get("next_cursor"),
             )
 
-    from src.data_client import get_news_data_provider
+    if provider:
+        from src.data_client import get_news_source
 
-    provider = await get_news_data_provider()
-    data = await provider.get_news(
+        source = await get_news_source(provider)
+    else:
+        from src.data_client import get_news_data_provider
+
+        source = await get_news_data_provider()
+
+    data = await source.get_news(
         tickers=ticker_list,
         limit=limit,
         cursor=cursor,
@@ -88,7 +101,7 @@ async def get_news(
 
     # Populate cache (stores full articles internally)
     if not cursor:
-        await _cache.set(data, tickers=ticker_list, limit=limit)
+        await _cache.set(data, tickers=ticker_list, limit=limit, provider=provider)
 
     results = [c for a in data["results"] if (c := _compact(a)) is not None]
     return NewsCompactResponse(
@@ -112,5 +125,16 @@ async def get_news_article(article_id: str, user_id: CurrentUserId):
     article = await provider.get_news_article(article_id, user_id=user_id)
     if article:
         return NewsArticle(**article)
+
+    # TickerTick is targeted directly (not in the chain) — try it for its rows.
+    try:
+        from src.data_client import get_news_source
+
+        tickertick = await get_news_source("tickertick")
+        article = await tickertick.get_news_article(article_id, user_id=user_id)
+        if article:
+            return NewsArticle(**article)
+    except Exception:
+        logger.debug("news.tickertick.article_lookup_failed", exc_info=True)
 
     raise HTTPException(status_code=404, detail="Article not found")

--- a/src/server/app/news.py
+++ b/src/server/app/news.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import uuid
+from collections.abc import Awaitable, Callable
 
 from fastapi import APIRouter, HTTPException, Query
 
@@ -12,7 +15,7 @@ from src.server.models.news import (
     NewsCompactResponse,
     NewsPublisher,
 )
-from src.server.services.cache.news_cache_service import NewsCacheService
+from src.server.services.cache.news_cache_service import NewsCacheService, news_cache_key
 from src.server.utils.api import CurrentUserId
 
 logger = logging.getLogger(__name__)
@@ -20,6 +23,89 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/v1/news", tags=["News"])
 
 _cache = NewsCacheService()
+
+# Cache-stampede protection has two layers so it holds up under many workers:
+#
+#  1. In-process single-flight (`_inflight`): collapses a burst of concurrent
+#     misses *within one worker/event loop* to a single participant.
+#  2. Distributed refresh lock (`_get_news_data`): collapses across workers and
+#     replicas sharing Redis — exactly one worker fetches a given cold key; the
+#     rest wait for it to fill the cache, then read it.
+#
+# News is public and globally cached (key = provider+tickers+limit, no user),
+# so without this a hot key's TTL expiry would fan out to one upstream fetch per
+# concurrent request. Cursor (paginated) requests are unique and skip both.
+_inflight: dict[str, "asyncio.Future[dict]"] = {}
+
+# Leader holds the refresh lock at most this long — set to cover the upstream
+# request timeout so a slow-but-alive fetch can't have its lock expire and let a
+# second worker double-fetch. It's only an auto-release safety net for a crashed
+# leader; live followers never wait this long (see _FOLLOWER_MAX_WAIT).
+_LOCK_TTL_MS = 30_000
+# A follower (lost the lock race) polls the cache this often, up to this long,
+# for the leader's result before giving up and fetching directly. Bounds tail
+# latency if the leader is slow or died mid-fetch.
+_FOLLOWER_POLL_INTERVAL = 0.05
+_FOLLOWER_MAX_WAIT = 3.0
+
+
+async def _single_flight(key: str, fetch: Callable[[], Awaitable[dict]]) -> dict:
+    """Run *fetch* once per *key*, sharing its result with overlapping callers.
+
+    The shared task is awaited through ``asyncio.shield`` so a caller that gets
+    cancelled (e.g. client disconnect) can't cancel the in-flight fetch and fail
+    every other waiter or leave the cache cold. Cleanup is tied to the task
+    finishing (done-callback), not to any single awaiter's lifecycle.
+    """
+    task = _inflight.get(key)
+    if task is None:
+        task = asyncio.ensure_future(fetch())
+        _inflight[key] = task
+        task.add_done_callback(lambda t: _inflight.pop(key, None))
+    return await asyncio.shield(task)
+
+
+async def _get_news_data(
+    ticker_list: list[str] | None,
+    limit: int,
+    provider: str | None,
+    fetch: Callable[[], Awaitable[dict]],
+) -> dict:
+    """Cross-worker single-flight for one (provider, tickers, limit) cold key.
+
+    The lock winner (leader) fetches upstream and populates the cache; everyone
+    else waits for the cache to fill. Degrades safely: if Redis is unusable the
+    caller fetches directly, and if the leader stalls/dies a follower falls back
+    to its own fetch rather than blocking.
+    """
+    # Lock keys live OUTSIDE the ``news:*`` keyspace that get_article_by_id
+    # scans — their value is a bare token, not JSON, so a ``news:*`` scan over
+    # them would log spurious deserialize errors.
+    lock_key = "newslock:" + news_cache_key(ticker_list, limit, provider)
+    token = uuid.uuid4().hex
+    acquired = await _cache.acquire_lock(lock_key, token, _LOCK_TTL_MS)
+
+    if acquired is None:
+        # Redis unavailable — no coordination possible, just fetch.
+        return await fetch()
+
+    if acquired:
+        try:
+            return await fetch()  # fetch() also populates the cache
+        finally:
+            await _cache.release_lock(lock_key, token)
+
+    # Another worker is fetching — wait for it to fill the cache.
+    waited = 0.0
+    while waited < _FOLLOWER_MAX_WAIT:
+        await asyncio.sleep(_FOLLOWER_POLL_INTERVAL)
+        waited += _FOLLOWER_POLL_INTERVAL
+        cached = await _cache.get(tickers=ticker_list, limit=limit, provider=provider)
+        if cached is not None:
+            return cached
+
+    # Leader too slow or gone — fall back to a direct fetch.
+    return await fetch()
 
 
 def _compact(article: dict) -> NewsArticleCompact | None:
@@ -59,7 +145,10 @@ async def get_news(
     order: str | None = Query(None, description="Sort order: asc or desc"),
     sort: str | None = Query(None, description="Sort field, e.g. published_utc"),
     provider: str | None = Query(
-        None, description="Target a specific news provider (e.g. 'tickertick')"
+        None,
+        max_length=32,
+        pattern=r"^[a-z0-9_-]+$",
+        description="Target a specific news provider (e.g. 'tickertick')",
     ),
 ) -> NewsCompactResponse:
     ticker_list = (
@@ -68,42 +157,66 @@ async def get_news(
         else None
     )
 
-    # Check cache (skip when cursor is used — paginated requests bypass cache)
-    if not cursor:
-        cached = await _cache.get(tickers=ticker_list, limit=limit, provider=provider)
-        if cached:
-            results = [c for a in cached["results"] if (c := _compact(a)) is not None]
-            return NewsCompactResponse(
-                results=results,
-                count=len(results),
-                next_cursor=cached.get("next_cursor"),
-            )
-
-    if provider:
-        from src.data_client import get_news_source
-
-        source = await get_news_source(provider)
-    else:
-        from src.data_client import get_news_data_provider
-
-        source = await get_news_data_provider()
-
-    data = await source.get_news(
-        tickers=ticker_list,
-        limit=limit,
-        cursor=cursor,
-        published_after=published_after,
-        published_before=published_before,
-        order=order,
-        sort=sort,
-        user_id=user_id,
+    # Cursors and date/sort filters make a request unique, but the cache and
+    # single-flight/lock keys only carry (provider, tickers, limit). Sharing
+    # them would serve wrong (filter-blind) results and let a filtered cold-miss
+    # poison the global feed, so these requests bypass the shared path entirely.
+    bypass_cache = bool(
+        cursor or published_after or published_before or order or sort
     )
 
-    # Populate cache (stores full articles internally)
-    if not cursor:
-        await _cache.set(data, tickers=ticker_list, limit=limit, provider=provider)
+    async def _fetch_from_provider() -> dict:
+        if provider:
+            from src.data_client import get_news_source
 
-    results = [c for a in data["results"] if (c := _compact(a)) is not None]
+            try:
+                source = await get_news_source(provider)
+            except ValueError as e:
+                # Unknown/unavailable provider is a client error, not a 500.
+                raise HTTPException(status_code=400, detail=str(e)) from e
+        else:
+            from src.data_client import get_news_data_provider
+
+            source = await get_news_data_provider()
+
+        data = await source.get_news(
+            tickers=ticker_list,
+            limit=limit,
+            cursor=cursor,
+            published_after=published_after,
+            published_before=published_before,
+            order=order,
+            sort=sort,
+            user_id=user_id,
+        )
+        # Populate cache (stores full articles internally).
+        if not bypass_cache:
+            await _cache.set(data, tickers=ticker_list, limit=limit, provider=provider)
+        return data
+
+    # Cursor / filtered requests go straight to the provider — no cache read,
+    # no cache write, no single-flight or distributed lock.
+    if bypass_cache:
+        data = await _fetch_from_provider()
+    else:
+        cached = await _cache.get(tickers=ticker_list, limit=limit, provider=provider)
+        if cached is not None:
+            data = cached
+        else:
+            # Cache miss: collapse identical concurrent misses into one upstream
+            # fetch — in-process first, then across workers via the Redis lock.
+            sf_key = news_cache_key(ticker_list, limit, provider)
+            data = await _single_flight(
+                sf_key,
+                lambda: _get_news_data(
+                    ticker_list, limit, provider, _fetch_from_provider
+                ),
+            )
+
+    # Slice to the requested limit: the warm buffer the poller maintains can hold
+    # more than one page (max_items > limit), so honor the contract on read.
+    articles = data["results"][:limit]
+    results = [c for a in articles if (c := _compact(a)) is not None]
     return NewsCompactResponse(
         results=results,
         count=len(results),

--- a/src/server/app/setup.py
+++ b/src/server/app/setup.py
@@ -375,10 +375,27 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.warning(f"Failed to start MarketInsightService: {e}")
 
+    # Start NewsRefreshService (delta-poll global news feeds keep-warm)
+    try:
+        from src.server.services.news_refresh_service import NewsRefreshService
+
+        news_refresh = NewsRefreshService.get_instance()
+        await news_refresh.start()
+    except Exception as e:
+        logger.warning(f"Failed to start NewsRefreshService: {e}")
+
     yield  # Server is running
 
     # Shutdown
     logger.info("Application shutdown started...")
+
+    # 0. Shutdown NewsRefreshService
+    try:
+        from src.server.services.news_refresh_service import NewsRefreshService
+
+        await NewsRefreshService.get_instance().stop()
+    except Exception as e:
+        logger.warning(f"Error shutting down NewsRefreshService: {e}")
 
     # 0. Shutdown MarketInsightService
     try:

--- a/src/server/models/news.py
+++ b/src/server/models/news.py
@@ -47,6 +47,12 @@ class NewsArticleCompact(BaseModel):
     source: NewsPublisher
     tickers: list[str] = []
     has_sentiment: bool = False
+    # Inlined so the detail modal renders straight from the list row without a
+    # second by-id round-trip (the body fields are already fetched and cached).
+    author: str | None = None
+    description: str | None = None
+    keywords: list[str] = []
+    sentiments: list[NewsSentiment] | None = None
 
 
 class NewsCompactResponse(BaseModel):

--- a/src/server/services/cache/news_cache_service.py
+++ b/src/server/services/cache/news_cache_service.py
@@ -74,12 +74,24 @@ class NewsCacheService:
         return None
 
     async def acquire_lock(self, key: str, token: str, ttl_ms: int) -> bool | None:
-        """Distributed refresh lock (see RedisCacheClient.acquire_lock)."""
-        return await get_cache_client().acquire_lock(key, token, ttl_ms)
+        """Distributed refresh lock (see RedisCacheClient.acquire_lock).
+
+        Guards the client lookup like every other method here: a failure returns
+        None ("uncoordinated — fetch directly") rather than propagating through
+        the shared single-flight task and 500-ing every waiter.
+        """
+        try:
+            return await get_cache_client().acquire_lock(key, token, ttl_ms)
+        except Exception:
+            logger.debug("news_cache.acquire_lock.failed", exc_info=True)
+            return None
 
     async def release_lock(self, key: str, token: str) -> None:
-        """Release a refresh lock held under ``key`` with ``token``."""
-        await get_cache_client().release_lock(key, token)
+        """Release a refresh lock held under ``key`` with ``token`` (best-effort)."""
+        try:
+            await get_cache_client().release_lock(key, token)
+        except Exception:
+            logger.debug("news_cache.release_lock.failed", exc_info=True)
 
     async def set(
         self,

--- a/src/server/services/cache/news_cache_service.py
+++ b/src/server/services/cache/news_cache_service.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import logging
 from typing import Any
 
@@ -47,9 +46,8 @@ class NewsCacheService:
         try:
             cache = get_cache_client()
             key = _cache_key(tickers, limit, provider)
-            raw = await cache.get(key)
-            if raw is not None:
-                return json.loads(raw)
+            # RedisCacheClient.get already JSON-decodes — the value is a dict.
+            return await cache.get(key)
         except Exception:
             logger.debug("news_cache.get.miss", exc_info=True)
         return None
@@ -66,9 +64,8 @@ class NewsCacheService:
             cache = get_cache_client()
             keys = await cache.scan_keys("news:*")
             for key in keys:
-                raw = await cache.get(key)
-                if raw:
-                    data = json.loads(raw)
+                data = await cache.get(key)
+                if data:
                     for article in data.get("results", []):
                         if article.get("id") == article_id:
                             return article
@@ -95,6 +92,6 @@ class NewsCacheService:
             cache = get_cache_client()
             key = _cache_key(tickers, limit, provider)
             ttl = _TICKER_TTL if tickers else _GENERAL_TTL
-            await cache.set(key, json.dumps(data), ttl=ttl)
+            await cache.set(key, data, ttl=ttl)
         except Exception:
             logger.debug("news_cache.set.failed", exc_info=True)

--- a/src/server/services/cache/news_cache_service.py
+++ b/src/server/services/cache/news_cache_service.py
@@ -15,11 +15,14 @@ _GENERAL_TTL = 300  # 5 min for general news
 _TICKER_TTL = 180  # 3 min for ticker-specific news
 
 
-def _cache_key(tickers: list[str] | None, limit: int) -> str:
+def _cache_key(tickers: list[str] | None, limit: int, provider: str | None = None) -> str:
+    # Keep the ``news:`` root so get_article_by_id's ``news:*`` scan still
+    # covers provider-scoped lists.
+    prefix = f"news:{provider}" if provider else "news"
     if tickers:
         tag = ",".join(sorted(t.upper() for t in tickers))
-        return f"news:tickers:{tag}:{limit}"
-    return f"news:general:{limit}"
+        return f"{prefix}:tickers:{tag}:{limit}"
+    return f"{prefix}:general:{limit}"
 
 
 class NewsCacheService:
@@ -34,10 +37,11 @@ class NewsCacheService:
         self,
         tickers: list[str] | None = None,
         limit: int = 20,
+        provider: str | None = None,
     ) -> dict[str, Any] | None:
         try:
             cache = get_cache_client()
-            key = _cache_key(tickers, limit)
+            key = _cache_key(tickers, limit, provider)
             raw = await cache.get(key)
             if raw is not None:
                 return json.loads(raw)
@@ -66,10 +70,11 @@ class NewsCacheService:
         data: dict[str, Any],
         tickers: list[str] | None = None,
         limit: int = 20,
+        provider: str | None = None,
     ) -> None:
         try:
             cache = get_cache_client()
-            key = _cache_key(tickers, limit)
+            key = _cache_key(tickers, limit, provider)
             ttl = _TICKER_TTL if tickers else _GENERAL_TTL
             await cache.set(key, json.dumps(data), ttl=ttl)
         except Exception:

--- a/src/server/services/cache/news_cache_service.py
+++ b/src/server/services/cache/news_cache_service.py
@@ -25,6 +25,11 @@ def _cache_key(tickers: list[str] | None, limit: int, provider: str | None = Non
     return f"{prefix}:general:{limit}"
 
 
+# Public alias — the news router and refresh poller derive lock / single-flight
+# keys from this, so it's part of the module's intentional surface, not private.
+news_cache_key = _cache_key
+
+
 class NewsCacheService:
     _instance: NewsCacheService | None = None
 
@@ -50,10 +55,16 @@ class NewsCacheService:
         return None
 
     async def get_article_by_id(self, article_id: str) -> dict[str, Any] | None:
-        """Scan all cached news lists for an article matching the given ID."""
+        """Scan all cached news lists for an article matching the given ID.
+
+        Uses a non-blocking SCAN over the ``news:*`` keyspace (short-lived,
+        bounded by provider × ticker-combo × limit), reading each list and
+        returning the first article whose id matches. A miss falls through to
+        the provider in the caller, so this is a best-effort fast path.
+        """
         try:
             cache = get_cache_client()
-            keys = await cache.keys("news:*")
+            keys = await cache.scan_keys("news:*")
             for key in keys:
                 raw = await cache.get(key)
                 if raw:
@@ -64,6 +75,14 @@ class NewsCacheService:
         except Exception:
             logger.debug("news_cache.get_article_by_id.failed", exc_info=True)
         return None
+
+    async def acquire_lock(self, key: str, token: str, ttl_ms: int) -> bool | None:
+        """Distributed refresh lock (see RedisCacheClient.acquire_lock)."""
+        return await get_cache_client().acquire_lock(key, token, ttl_ms)
+
+    async def release_lock(self, key: str, token: str) -> None:
+        """Release a refresh lock held under ``key`` with ``token``."""
+        await get_cache_client().release_lock(key, token)
 
     async def set(
         self,

--- a/src/server/services/news_refresh_service.py
+++ b/src/server/services/news_refresh_service.py
@@ -1,0 +1,188 @@
+"""Background news refresh poller.
+
+Keeps the GLOBAL news feeds (curated "Top" + the Market general feed) warm by
+fetching the latest page every interval and delta-merging new articles (by id)
+into a rolling buffer, stored under the same Redis key the ``/news`` endpoint
+reads. Reads stay always-warm (no cold-miss stampede) and the buffer self-heals
+via the cache TTL if the poller stops.
+
+Multi-worker safe: each feed is polled by exactly one worker per tick via a
+Redis lock held for the interval (leader election), so N workers don't each
+hammer the upstream every minute. Per-ticker feeds are unbounded and are left
+on the on-demand cache path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from typing import Any
+
+from src.config.settings import get_news_poll_config
+from src.server.services.cache.news_cache_service import NewsCacheService, news_cache_key
+
+logger = logging.getLogger(__name__)
+
+
+def _merge_delta(
+    existing: list[dict[str, Any]],
+    fetched: list[dict[str, Any]],
+    max_items: int,
+) -> tuple[list[dict[str, Any]], int]:
+    """Merge the freshly fetched page into the existing rolling buffer.
+
+    Dedupes by article id (the fetched copy wins so updated metadata sticks),
+    sorts newest-first by ``published_at`` (UTC ISO strings sort chronologically),
+    and trims to ``max_items``. Returns the merged buffer and the count of
+    genuinely new articles (ids not previously in the buffer).
+    """
+    existing_ids = {a.get("id") for a in existing if a.get("id")}
+
+    combined: dict[str, dict[str, Any]] = {}
+    for article in (*fetched, *existing):  # fetched first → freshest copy wins
+        aid = article.get("id")
+        if aid and aid not in combined:
+            combined[aid] = article
+
+    merged = sorted(
+        combined.values(),
+        key=lambda a: a.get("published_at") or "",
+        reverse=True,
+    )[:max_items]
+
+    new_count = len({a.get("id") for a in fetched if a.get("id")} - existing_ids)
+    return merged, new_count
+
+
+class NewsRefreshService:
+    """Singleton background poller that delta-refreshes global news feeds."""
+
+    _instance: NewsRefreshService | None = None
+
+    @classmethod
+    def get_instance(cls) -> NewsRefreshService:
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    def __init__(self) -> None:
+        self._cache = NewsCacheService()
+        self._shutdown_event = asyncio.Event()
+        self._task: asyncio.Task | None = None
+        self._interval = 60
+        self._max_items = 100
+        self._feeds: list[Any] = []
+
+    async def start(self) -> None:
+        """Load config and launch the poll loop (no-op if disabled / no feeds)."""
+        cfg = get_news_poll_config()
+        if not cfg.enabled:
+            logger.info("[NewsRefresh] disabled by config")
+            return
+        if not cfg.feeds:
+            logger.info("[NewsRefresh] no feeds configured — not starting")
+            return
+
+        self._interval = cfg.interval_seconds
+        self._max_items = cfg.max_items
+        self._feeds = list(cfg.feeds)
+        self._shutdown_event.clear()
+        self._task = asyncio.create_task(self._poll_loop(), name="news_refresh_poll")
+        logger.info(
+            "[NewsRefresh] started — %d feed(s), every %ds, buffer<=%d",
+            len(self._feeds), self._interval, self._max_items,
+        )
+
+    async def stop(self) -> None:
+        """Signal shutdown and cancel the poll loop."""
+        self._shutdown_event.set()
+        if self._task and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        logger.info("[NewsRefresh] stopped")
+
+    # ─── Loop ────────────────────────────────────────────────────────────
+
+    async def _poll_loop(self) -> None:
+        """Poll on start, then every interval — one failed cycle never kills it."""
+        while not self._shutdown_event.is_set():
+            try:
+                await self._poll_once()
+            except Exception:
+                logger.error("[NewsRefresh] poll cycle failed", exc_info=True)
+
+            try:
+                await asyncio.wait_for(
+                    self._shutdown_event.wait(), timeout=self._interval
+                )
+                return  # shutdown requested during the sleep
+            except asyncio.TimeoutError:
+                pass
+
+    async def _poll_once(self) -> None:
+        for feed in self._feeds:
+            try:
+                await self._refresh_feed(feed)
+            except Exception:
+                logger.error(
+                    "[NewsRefresh] feed refresh failed (provider=%s)",
+                    getattr(feed, "provider", None), exc_info=True,
+                )
+
+    async def _refresh_feed(self, feed: Any) -> None:
+        provider = feed.provider
+        limit = feed.limit
+
+        # Leader election: hold the lock for the interval (don't release) so
+        # only one worker polls this feed per tick. None/False → skip. The
+        # ``newspolllock:`` prefix keeps it out of the ``news:*`` keyspace that
+        # get_article_by_id scans (its value is a token, not JSON).
+        lock_key = "newspolllock:" + news_cache_key(None, limit, provider)
+        acquired = await self._cache.acquire_lock(
+            lock_key, uuid.uuid4().hex, self._interval * 1000
+        )
+        if not acquired:
+            return
+
+        source = await self._resolve_source(provider)
+        data = await source.get_news(tickers=None, limit=limit)
+        fetched = data.get("results", []) if isinstance(data, dict) else []
+
+        existing_wrap = await self._cache.get(
+            tickers=None, limit=limit, provider=provider
+        )
+        existing = existing_wrap.get("results", []) if existing_wrap else []
+
+        merged, new_count = _merge_delta(existing, fetched, self._max_items)
+        # Continuation cursor for infinite scroll: the id at the served-page
+        # boundary (the endpoint slices the buffer to `limit`), so page 2 picks
+        # up exactly where page 1 ends — no gap, no overlap. Only named
+        # providers (e.g. tickertick) paginate by cursor; the chain feed
+        # (provider=None → FMP/yfinance) can't honor one, so leave it None.
+        cursor_capable = provider is not None
+        next_cursor = (
+            merged[limit - 1].get("id")
+            if cursor_capable and len(merged) >= limit
+            else None
+        )
+        await self._cache.set(
+            {"results": merged, "count": len(merged), "next_cursor": next_cursor},
+            tickers=None, limit=limit, provider=provider,
+        )
+        logger.info(
+            "[NewsRefresh] %s: +%d new, buffer=%d",
+            provider or "chain", new_count, len(merged),
+        )
+
+    async def _resolve_source(self, provider: str | None) -> Any:
+        if provider:
+            from src.data_client import get_news_source
+
+            return await get_news_source(provider)
+        from src.data_client import get_news_data_provider
+
+        return await get_news_data_provider()

--- a/src/utils/cache/redis_cache.py
+++ b/src/utils/cache/redis_cache.py
@@ -38,6 +38,16 @@ class DateTimeEncoder(json.JSONEncoder):
         return super().default(obj)
 
 
+# Compare-and-delete: only release a lock we still own, so a request whose lock
+# already expired can't delete the lock a later holder acquired.
+_RELEASE_LOCK_LUA = """
+if redis.call('get', KEYS[1]) == ARGV[1] then
+    return redis.call('del', KEYS[1])
+end
+return 0
+"""
+
+
 class RedisCacheClient:
     """
     Async Redis cache client with connection pooling.
@@ -319,6 +329,54 @@ class RedisCacheClient:
             logger.error(f"Cache delete pattern error for {pattern}: {e}")
             self.stats["errors"] += 1
             return 0
+
+    async def scan_keys(self, pattern: str) -> list[str]:
+        """Return all keys matching *pattern* using non-blocking SCAN.
+
+        Uses SCAN (via ``scan_iter``) rather than KEYS so a large keyspace can't
+        block the Redis event loop on a shared instance.
+        """
+        if not self.enabled or not self.client:
+            return []
+
+        try:
+            keys: list[str] = []
+            async for key in self.client.scan_iter(match=pattern, count=100):
+                keys.append(key.decode("utf-8") if isinstance(key, bytes) else key)
+            return keys
+        except Exception as e:
+            self._log_error(f"Cache scan error for {pattern}", e)
+            self.stats["errors"] += 1
+            return []
+
+    async def acquire_lock(self, key: str, token: str, ttl_ms: int) -> bool | None:
+        """Try to acquire a short-lived distributed lock via ``SET key NX PX``.
+
+        Returns True if acquired (caller is the leader), False if another holder
+        owns it, or None if Redis is unavailable — in which case the caller
+        should proceed without coordination rather than block.
+        """
+        if not self.enabled or not self.client:
+            return None
+
+        try:
+            ok = await self.client.set(key, token, nx=True, px=ttl_ms)
+            return bool(ok)
+        except Exception as e:
+            self._log_error(f"Lock acquire error for {key}", e)
+            self.stats["errors"] += 1
+            return None
+
+    async def release_lock(self, key: str, token: str) -> None:
+        """Release a lock only if this caller still owns it (compare-and-delete)."""
+        if not self.enabled or not self.client:
+            return
+
+        try:
+            await self.client.eval(_RELEASE_LOCK_LUA, 1, key, token)
+        except Exception as e:
+            self._log_error(f"Lock release error for {key}", e)
+            self.stats["errors"] += 1
 
     async def exists(self, key: str) -> bool:
         """

--- a/tests/unit/data_client/tickertick/test_news_source.py
+++ b/tests/unit/data_client/tickertick/test_news_source.py
@@ -1,0 +1,148 @@
+"""Tests for the TickerTick news source: query building + normalization."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.data_client.tickertick.client import _convert_timestamps
+from src.data_client.tickertick.news_source import (
+    TickerTickNewsSource,
+    _build_query,
+    _normalize_story,
+)
+
+RAW_STORY = {
+    "id": 8045485333109595178,
+    "title": "Tesla sets a record",
+    "url": "https://example.com/a",
+    "site": "investing.com",
+    "time": "2025-12-01T09:12:29+00:00",  # already ISO (client converts ms upstream)
+    "favicon_url": "https://static.example.com/f.ico",
+    "tags": ["tsla", "ev"],
+    "tickers": ["tsla"],
+    "description": "Full summary.",
+}
+
+
+class TestBuildQuery:
+    def test_no_tickers_is_curated(self):
+        assert _build_query(None) == "T:curated"
+        assert _build_query([]) == "T:curated"
+
+    def test_single_ticker_is_broad(self):
+        assert _build_query(["AAPL"]) == "tt:aapl"
+
+    def test_multi_ticker_is_or(self):
+        assert _build_query(["AAPL", "MSFT"]) == "(or tt:aapl tt:msft)"
+
+
+class TestNormalize:
+    def test_field_mapping(self):
+        n = _normalize_story(RAW_STORY)
+        assert n["id"] == "8045485333109595178"  # numeric id stringified
+        assert n["title"] == "Tesla sets a record"
+        assert n["article_url"] == "https://example.com/a"
+        assert n["published_at"] == "2025-12-01T09:12:29+00:00"
+        assert n["description"] == "Full summary."
+        assert n["source"] == {
+            "name": "investing.com",
+            "logo_url": None,
+            "homepage_url": None,
+            "favicon_url": "https://static.example.com/f.ico",
+        }
+        assert n["tickers"] == ["TSLA"]  # upper-cased
+        assert n["keywords"] == ["tsla", "ev"]  # tags → keywords
+
+    def test_no_image_or_sentiment(self):
+        n = _normalize_story(RAW_STORY)
+        assert n["image_url"] is None
+        assert n["sentiments"] is None
+
+    def test_missing_optional_fields(self):
+        n = _normalize_story({"id": 1, "title": "x"})
+        assert n["id"] == "1"
+        assert n["description"] is None
+        assert n["tickers"] == []
+        assert n["keywords"] == []
+        assert n["source"]["favicon_url"] is None
+
+
+class TestConvertTimestamps:
+    def test_ms_to_iso(self):
+        out = _convert_timestamps({"stories": [{"time": 1764580349000}]})
+        assert out["stories"][0]["time"].startswith("2025-12-01T")
+
+    def test_already_iso_untouched(self):
+        out = _convert_timestamps({"stories": [{"time": "2025-12-01T00:00:00+00:00"}]})
+        assert out["stories"][0]["time"] == "2025-12-01T00:00:00+00:00"
+
+
+class TestGetNews:
+    @pytest.mark.asyncio
+    async def test_get_news_curated(self, monkeypatch):
+        captured: dict = {}
+
+        async def fake_get_feed(self, query, limit=30, last_id=None):
+            captured["query"] = query
+            captured["limit"] = limit
+            return {"stories": [RAW_STORY]}
+
+        monkeypatch.setattr(
+            "src.data_client.tickertick.news_source.TickerTickClient.get_feed",
+            fake_get_feed,
+        )
+
+        result = await TickerTickNewsSource().get_news(limit=10)
+        assert captured["query"] == "T:curated"
+        assert captured["limit"] == 10
+        assert result["count"] == 1
+        assert result["next_cursor"] is None
+        assert result["results"][0]["id"] == "8045485333109595178"
+
+    @pytest.mark.asyncio
+    async def test_get_news_multi_ticker(self, monkeypatch):
+        captured: dict = {}
+
+        async def fake_get_feed(self, query, limit=30, last_id=None):
+            captured["query"] = query
+            return {"stories": []}
+
+        monkeypatch.setattr(
+            "src.data_client.tickertick.news_source.TickerTickClient.get_feed",
+            fake_get_feed,
+        )
+
+        await TickerTickNewsSource().get_news(tickers=["AAPL", "MSFT"], limit=5)
+        assert captured["query"] == "(or tt:aapl tt:msft)"
+
+    @pytest.mark.asyncio
+    async def test_full_page_sets_next_cursor(self, monkeypatch):
+        """A full page hands back the last story id as the pagination cursor."""
+
+        async def fake_get_feed(self, query, limit=30, last_id=None):
+            stories = [{**RAW_STORY, "id": 100 + i} for i in range(limit)]
+            return {"stories": stories}
+
+        monkeypatch.setattr(
+            "src.data_client.tickertick.news_source.TickerTickClient.get_feed",
+            fake_get_feed,
+        )
+        result = await TickerTickNewsSource().get_news(limit=3)
+        assert result["count"] == 3
+        assert result["next_cursor"] == "102"  # last of ids 100,101,102 stringified
+
+    @pytest.mark.asyncio
+    async def test_cursor_forwarded_as_last_id(self, monkeypatch):
+        """A provided cursor is sent to TickerTick as ``last`` for the next page."""
+        captured: dict = {}
+
+        async def fake_get_feed(self, query, limit=30, last_id=None):
+            captured["last_id"] = last_id
+            return {"stories": []}
+
+        monkeypatch.setattr(
+            "src.data_client.tickertick.news_source.TickerTickClient.get_feed",
+            fake_get_feed,
+        )
+        await TickerTickNewsSource().get_news(limit=5, cursor="abc-cursor")
+        assert captured["last_id"] == "abc-cursor"

--- a/tests/unit/data_client/tickertick/test_news_source.py
+++ b/tests/unit/data_client/tickertick/test_news_source.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import httpx
 import pytest
 
-from src.data_client.tickertick.client import _convert_timestamps
+from src.data_client.tickertick.client import TickerTickClient, _convert_timestamps
 from src.data_client.tickertick.news_source import (
     TickerTickNewsSource,
     _build_query,
@@ -34,6 +35,13 @@ class TestBuildQuery:
 
     def test_multi_ticker_is_or(self):
         assert _build_query(["AAPL", "MSFT"]) == "(or tt:aapl tt:msft)"
+
+    def test_injection_tokens_are_dropped(self):
+        # Tokens carrying DSL operators are ignored, not interpolated into the query.
+        assert _build_query(["AAPL) (or s:cnn"]) == "T:curated"
+        assert _build_query(["AAPL) x", "MSFT"]) == "tt:msft"
+        # Legitimate dotted/hyphenated tickers still pass through.
+        assert _build_query(["BRK.B", "BF-B"]) == "(or tt:brk.b tt:bf-b)"
 
 
 class TestNormalize:
@@ -146,3 +154,34 @@ class TestGetNews:
         )
         await TickerTickNewsSource().get_news(limit=5, cursor="abc-cursor")
         assert captured["last_id"] == "abc-cursor"
+
+
+class TestGetFeedErrors:
+    """The HTTP client wraps transport/status failures in a clear Exception."""
+
+    @pytest.mark.asyncio
+    async def test_http_status_error_wrapped(self, monkeypatch):
+        async def fake_get(self, url, params=None):
+            return httpx.Response(500, request=httpx.Request("GET", url))
+
+        monkeypatch.setattr("httpx.AsyncClient.get", fake_get)
+        async with TickerTickClient() as client:
+            with pytest.raises(Exception, match="TickerTick request failed"):
+                await client.get_feed("T:curated")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("exc", "match"),
+        [
+            (httpx.TimeoutException("slow"), "TickerTick request timed out"),
+            (httpx.ConnectError("down"), "TickerTick request failed"),
+        ],
+    )
+    async def test_transport_error_wrapped(self, monkeypatch, exc, match):
+        async def boom(self, url, params=None):
+            raise exc
+
+        monkeypatch.setattr("httpx.AsyncClient.get", boom)
+        async with TickerTickClient() as client:
+            with pytest.raises(Exception, match=match):
+                await client.get_feed("T:curated")

--- a/tests/unit/server/app/test_news_api.py
+++ b/tests/unit/server/app/test_news_api.py
@@ -1,0 +1,120 @@
+"""Tests for the News API router (src/server/app/news.py).
+
+Focus: the ``provider`` query param routes to a single named source
+(``get_news_source``) and bypasses the fallback chain
+(``get_news_data_provider``), with a provider-scoped cache key.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from tests.conftest import create_test_app
+
+pytestmark = pytest.mark.asyncio
+
+ARTICLE = {
+    "id": "abc123",
+    "title": "Top story",
+    "author": None,
+    "description": "d",
+    "published_at": "2025-12-01T00:00:00+00:00",
+    "article_url": "https://example.com/a",
+    "image_url": None,
+    "source": {"name": "investing.com", "logo_url": None, "homepage_url": None, "favicon_url": None},
+    "tickers": ["TSLA"],
+    "keywords": [],
+    "sentiments": None,
+}
+
+
+@pytest_asyncio.fixture
+async def client():
+    from src.server.app.news import router
+
+    app = create_test_app(router)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c
+
+
+async def test_provider_routes_to_named_source(client):
+    """provider=tickertick → get_news_source, NOT the fallback chain."""
+    source = AsyncMock()
+    source.get_news.return_value = {"results": [ARTICLE], "count": 1, "next_cursor": None}
+    cache = AsyncMock()
+    cache.get = AsyncMock(return_value=None)
+    cache.set = AsyncMock()
+
+    with (
+        patch("src.server.app.news._cache", cache),
+        patch("src.data_client.get_news_source", AsyncMock(return_value=source)) as get_source,
+        patch("src.data_client.get_news_data_provider", AsyncMock()) as get_chain,
+    ):
+        resp = await client.get("/api/v1/news?provider=tickertick&limit=5")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["count"] == 1
+    assert body["results"][0]["id"] == "abc123"
+    get_source.assert_awaited_once_with("tickertick")
+    get_chain.assert_not_called()
+    # Cache key is provider-scoped.
+    assert cache.get.await_args.kwargs.get("provider") == "tickertick"
+    assert cache.set.await_args.kwargs.get("provider") == "tickertick"
+
+
+async def test_compact_inlines_article_body(client):
+    """The compact list response carries description/keywords/sentiments/author so
+    the detail modal renders without a by-id round-trip."""
+    rich = {
+        **ARTICLE,
+        "author": "Jane Doe",
+        "description": "A full summary paragraph.",
+        "keywords": ["ev", "earnings"],
+        "sentiments": [{"ticker": "TSLA", "sentiment": "positive", "reasoning": "beat"}],
+    }
+    source = AsyncMock()
+    source.get_news.return_value = {"results": [rich], "count": 1, "next_cursor": None}
+    cache = AsyncMock()
+    cache.get = AsyncMock(return_value=None)
+    cache.set = AsyncMock()
+
+    with (
+        patch("src.server.app.news._cache", cache),
+        patch("src.data_client.get_news_source", AsyncMock(return_value=source)),
+        patch("src.data_client.get_news_data_provider", AsyncMock()),
+    ):
+        resp = await client.get("/api/v1/news?provider=tickertick&limit=5")
+
+    assert resp.status_code == 200
+    row = resp.json()["results"][0]
+    assert row["author"] == "Jane Doe"
+    assert row["description"] == "A full summary paragraph."
+    assert row["keywords"] == ["ev", "earnings"]
+    assert row["sentiments"][0]["ticker"] == "TSLA"
+    assert row["has_sentiment"] is True
+
+
+async def test_no_provider_uses_chain(client):
+    """No provider → the fallback chain, provider passed as None to the cache."""
+    chain = AsyncMock()
+    chain.get_news.return_value = {"results": [ARTICLE], "count": 1, "next_cursor": None}
+    cache = AsyncMock()
+    cache.get = AsyncMock(return_value=None)
+    cache.set = AsyncMock()
+
+    with (
+        patch("src.server.app.news._cache", cache),
+        patch("src.data_client.get_news_source", AsyncMock()) as get_source,
+        patch("src.data_client.get_news_data_provider", AsyncMock(return_value=chain)) as get_chain,
+    ):
+        resp = await client.get("/api/v1/news?limit=5")
+
+    assert resp.status_code == 200
+    get_chain.assert_awaited_once()
+    get_source.assert_not_called()
+    assert cache.get.await_args.kwargs.get("provider") is None

--- a/tests/unit/server/app/test_news_api.py
+++ b/tests/unit/server/app/test_news_api.py
@@ -5,6 +5,7 @@ Focus: the ``provider`` query param routes to a single named source
 (``get_news_data_provider``), with a provider-scoped cache key.
 """
 
+import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -118,3 +119,291 @@ async def test_no_provider_uses_chain(client):
     get_chain.assert_awaited_once()
     get_source.assert_not_called()
     assert cache.get.await_args.kwargs.get("provider") is None
+
+
+async def test_unknown_provider_returns_400(client):
+    """An unknown ?provider value is a client error (400), not an unhandled 500.
+
+    Exercises the real registry get_news_source, which raises ValueError for a
+    name absent from _NEWS_SOURCE_REGISTRY.
+    """
+    cache = AsyncMock()
+    cache.get = AsyncMock(return_value=None)
+    cache.set = AsyncMock()
+
+    with patch("src.server.app.news._cache", cache):
+        resp = await client.get("/api/v1/news?provider=not-a-real-provider&limit=5")
+
+    assert resp.status_code == 400
+    assert "not available" in resp.json()["detail"]
+
+
+async def test_article_by_id_tickertick_fallback(client):
+    """Cache miss → chain returns None → the TickerTick source resolves the row."""
+    cache = AsyncMock()
+    cache.get_article_by_id = AsyncMock(return_value=None)
+    chain = AsyncMock()
+    chain.get_news_article = AsyncMock(return_value=None)
+    tickertick = AsyncMock()
+    tickertick.get_news_article = AsyncMock(return_value=ARTICLE)
+
+    with (
+        patch("src.server.app.news._cache", cache),
+        patch("src.data_client.get_news_data_provider", AsyncMock(return_value=chain)),
+        patch("src.data_client.get_news_source", AsyncMock(return_value=tickertick)) as get_source,
+    ):
+        resp = await client.get("/api/v1/news/abc123")
+
+    assert resp.status_code == 200
+    assert resp.json()["id"] == "abc123"
+    get_source.assert_awaited_once_with("tickertick")
+
+
+async def test_concurrent_misses_collapse_to_one_fetch(client):
+    """A burst of identical cache-miss requests hits the upstream provider once.
+
+    Exercises the in-process single-flight: while the leader's fetch is in
+    flight, the 4 followers attach to the same task instead of each stampeding
+    the provider.
+    """
+    call_count = 0
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow_get_news(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        started.set()
+        await release.wait()
+        return {"results": [ARTICLE], "count": 1, "next_cursor": None}
+
+    source = AsyncMock()
+    source.get_news = slow_get_news
+    cache = AsyncMock()
+    cache.get = AsyncMock(return_value=None)  # every request misses
+    cache.set = AsyncMock()
+
+    async def releaser():
+        await started.wait()  # leader fetch is running
+        await asyncio.sleep(0.02)  # let the followers attach to the inflight task
+        release.set()
+
+    with (
+        patch("src.server.app.news._cache", cache),
+        patch("src.data_client.get_news_source", AsyncMock(return_value=source)),
+        patch("src.data_client.get_news_data_provider", AsyncMock()),
+    ):
+        reqs = [
+            client.get("/api/v1/news?provider=tickertick&limit=5") for _ in range(5)
+        ]
+        results = await asyncio.gather(releaser(), *reqs)
+
+    resps = results[1:]
+    assert all(r.status_code == 200 for r in resps)
+    assert all(r.json()["results"][0]["id"] == "abc123" for r in resps)
+    assert call_count == 1  # 5 concurrent misses → 1 upstream fetch
+
+
+async def test_distributed_leader_fetches_and_releases(client):
+    """The worker that wins the Redis lock fetches upstream and releases it."""
+    source = AsyncMock()
+    source.get_news = AsyncMock(
+        return_value={"results": [ARTICLE], "count": 1, "next_cursor": None}
+    )
+    cache = AsyncMock()
+    cache.get = AsyncMock(return_value=None)
+    cache.set = AsyncMock()
+    cache.acquire_lock = AsyncMock(return_value=True)  # we are the leader
+    cache.release_lock = AsyncMock()
+
+    with (
+        patch("src.server.app.news._cache", cache),
+        patch("src.data_client.get_news_source", AsyncMock(return_value=source)),
+        patch("src.data_client.get_news_data_provider", AsyncMock()),
+    ):
+        resp = await client.get("/api/v1/news?provider=tickertick&limit=5")
+
+    assert resp.status_code == 200
+    source.get_news.assert_awaited_once()
+    cache.set.assert_awaited_once()
+    cache.release_lock.assert_awaited_once()
+
+
+async def test_distributed_follower_waits_for_leader(client):
+    """A contended worker serves the leader's cached result without fetching."""
+    source = AsyncMock()
+    source.get_news = AsyncMock(
+        return_value={"results": [ARTICLE], "count": 1, "next_cursor": None}
+    )
+    cache = AsyncMock()
+    # Initial miss → None; first poll → None; second poll → leader filled it.
+    cache.get = AsyncMock(
+        side_effect=[None, None, {"results": [ARTICLE], "count": 1, "next_cursor": None}]
+    )
+    cache.set = AsyncMock()
+    cache.acquire_lock = AsyncMock(return_value=False)  # someone else holds it
+    cache.release_lock = AsyncMock()
+
+    with (
+        patch("src.server.app.news._cache", cache),
+        patch("src.data_client.get_news_source", AsyncMock(return_value=source)),
+        patch("src.data_client.get_news_data_provider", AsyncMock()),
+    ):
+        resp = await client.get("/api/v1/news?provider=tickertick&limit=5")
+
+    assert resp.status_code == 200
+    assert resp.json()["results"][0]["id"] == "abc123"
+    source.get_news.assert_not_awaited()  # follower never hit the upstream
+    cache.release_lock.assert_not_awaited()  # didn't own the lock
+
+
+async def test_distributed_redis_down_fetches_directly(client):
+    """If the lock can't be evaluated (Redis down) the request fetches directly."""
+    source = AsyncMock()
+    source.get_news = AsyncMock(
+        return_value={"results": [ARTICLE], "count": 1, "next_cursor": None}
+    )
+    cache = AsyncMock()
+    cache.get = AsyncMock(return_value=None)
+    cache.set = AsyncMock()
+    cache.acquire_lock = AsyncMock(return_value=None)  # Redis unusable
+    cache.release_lock = AsyncMock()
+
+    with (
+        patch("src.server.app.news._cache", cache),
+        patch("src.data_client.get_news_source", AsyncMock(return_value=source)),
+        patch("src.data_client.get_news_data_provider", AsyncMock()),
+    ):
+        resp = await client.get("/api/v1/news?provider=tickertick&limit=5")
+
+    assert resp.status_code == 200
+    source.get_news.assert_awaited_once()
+    cache.release_lock.assert_not_awaited()  # no lock was held
+
+
+async def test_distributed_follower_fallback_when_leader_stalls(client, monkeypatch):
+    """A follower that never sees the cache fill falls back to a direct fetch."""
+    monkeypatch.setattr("src.server.app.news._FOLLOWER_MAX_WAIT", 0.1)
+    monkeypatch.setattr("src.server.app.news._FOLLOWER_POLL_INTERVAL", 0.02)
+    source = AsyncMock()
+    source.get_news = AsyncMock(
+        return_value={"results": [ARTICLE], "count": 1, "next_cursor": None}
+    )
+    cache = AsyncMock()
+    cache.get = AsyncMock(return_value=None)  # leader never fills the cache
+    cache.set = AsyncMock()
+    cache.acquire_lock = AsyncMock(return_value=False)
+    cache.release_lock = AsyncMock()
+
+    with (
+        patch("src.server.app.news._cache", cache),
+        patch("src.data_client.get_news_source", AsyncMock(return_value=source)),
+        patch("src.data_client.get_news_data_provider", AsyncMock()),
+    ):
+        resp = await client.get("/api/v1/news?provider=tickertick&limit=5")
+
+    assert resp.status_code == 200
+    source.get_news.assert_awaited_once()  # fell back rather than blocking
+
+
+async def test_filtered_request_bypasses_cache(client):
+    """A date/sort-filtered request must NOT read or write the shared cache.
+
+    The cache key is filter-blind, so caching a filtered result would serve
+    wrong data to unfiltered callers and poison the global feed.
+    """
+    source = AsyncMock()
+    source.get_news = AsyncMock(
+        return_value={"results": [ARTICLE], "count": 1, "next_cursor": None}
+    )
+    cache = AsyncMock()
+    cache.get = AsyncMock(return_value={"results": [ARTICLE]})  # would be wrong to read
+    cache.set = AsyncMock()
+    cache.acquire_lock = AsyncMock()
+
+    with (
+        patch("src.server.app.news._cache", cache),
+        patch("src.data_client.get_news_source", AsyncMock(return_value=source)),
+        patch("src.data_client.get_news_data_provider", AsyncMock()),
+    ):
+        resp = await client.get(
+            "/api/v1/news?provider=tickertick&limit=5&published_after=2025-01-01"
+        )
+
+    assert resp.status_code == 200
+    source.get_news.assert_awaited_once()
+    assert source.get_news.await_args.kwargs["published_after"] == "2025-01-01"
+    cache.get.assert_not_awaited()  # did not read the filter-blind key
+    cache.set.assert_not_awaited()  # did not poison it
+    cache.acquire_lock.assert_not_awaited()  # no single-flight/lock either
+
+
+async def test_warm_buffer_sliced_to_requested_limit(client):
+    """A cached buffer larger than `limit` (the poller keeps up to max_items) is
+    sliced down on read so the response honors the requested limit."""
+    buffer = [{**ARTICLE, "id": f"a{i}"} for i in range(100)]
+    cache = AsyncMock()
+    cache.get = AsyncMock(return_value={"results": buffer, "next_cursor": None})
+    cache.set = AsyncMock()
+
+    with (
+        patch("src.server.app.news._cache", cache),
+        patch("src.data_client.get_news_source", AsyncMock()),
+        patch("src.data_client.get_news_data_provider", AsyncMock()),
+    ):
+        resp = await client.get("/api/v1/news?provider=tickertick&limit=50")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["results"]) == 50  # not 100
+    assert body["count"] == 50
+
+
+async def test_single_flight_leader_cancel_does_not_fail_followers():
+    """A cancelled leader (client disconnect) must not cancel the shared fetch or
+    fail the followers waiting on it; the fetch still runs exactly once."""
+    from src.server.app.news import _inflight, _single_flight
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+    calls = 0
+
+    async def slow():
+        nonlocal calls
+        calls += 1
+        started.set()
+        await release.wait()
+        return {"results": [ARTICLE]}
+
+    key = "cancel-test-key"
+    leader = asyncio.ensure_future(_single_flight(key, slow))
+    await started.wait()  # leader's fetch is in flight
+    follower = asyncio.ensure_future(_single_flight(key, slow))
+    await asyncio.sleep(0.01)  # let the follower attach to the shared task
+
+    leader.cancel()  # client disconnects mid-fetch
+    with pytest.raises(asyncio.CancelledError):
+        await leader
+
+    release.set()
+    result = await follower
+    assert result["results"][0]["id"] == "abc123"  # follower still got the result
+    assert calls == 1  # shared fetch ran once, never re-run
+    assert key not in _inflight  # cleaned up via the done-callback
+
+
+async def test_article_by_id_fallback_swallows_and_404s(client):
+    """If the TickerTick fallback raises, the except swallows it → 404, not 500."""
+    cache = AsyncMock()
+    cache.get_article_by_id = AsyncMock(return_value=None)
+    chain = AsyncMock()
+    chain.get_news_article = AsyncMock(return_value=None)
+
+    with (
+        patch("src.server.app.news._cache", cache),
+        patch("src.data_client.get_news_data_provider", AsyncMock(return_value=chain)),
+        patch("src.data_client.get_news_source", AsyncMock(side_effect=Exception("boom"))),
+    ):
+        resp = await client.get("/api/v1/news/missing")
+
+    assert resp.status_code == 404

--- a/tests/unit/server/services/test_news_cache_service.py
+++ b/tests/unit/server/services/test_news_cache_service.py
@@ -57,3 +57,18 @@ async def test_get_article_by_id_miss_returns_none(monkeypatch):
 async def test_get_article_by_id_empty_keyspace(monkeypatch):
     monkeypatch.setattr(_GET_CACHE, lambda: _StubCache({}))
     assert await NewsCacheService().get_article_by_id("abc") is None
+
+
+@pytest.mark.asyncio
+async def test_lock_helpers_degrade_when_client_unavailable(monkeypatch):
+    # get_cache_client() blowing up (e.g. pool not ready on a cold start) must
+    # not propagate: acquire_lock returns None so the single-flight leader falls
+    # back to a direct fetch instead of 500-ing every concurrent waiter, and
+    # release_lock stays a no-op.
+    def _boom():
+        raise RuntimeError("cache client unavailable")
+
+    monkeypatch.setattr(_GET_CACHE, _boom)
+    svc = NewsCacheService()
+    assert await svc.acquire_lock("newslock:k", "tok", 30_000) is None
+    await svc.release_lock("newslock:k", "tok")  # must not raise

--- a/tests/unit/server/services/test_news_cache_service.py
+++ b/tests/unit/server/services/test_news_cache_service.py
@@ -8,8 +8,6 @@ SCAN-based ``scan_keys`` helper.
 
 from __future__ import annotations
 
-import json
-
 import pytest
 
 from src.server.services.cache.news_cache_service import NewsCacheService
@@ -20,11 +18,11 @@ _GET_CACHE = "src.server.services.cache.news_cache_service.get_cache_client"
 class _StubCache:
     """Minimal stand-in: scan_keys + get over an in-memory keyspace.
 
-    Values are JSON strings, matching what RedisCacheClient.get returns for
-    NewsCacheService entries (which are stored json.dumps-encoded).
+    Values are decoded dicts, matching what RedisCacheClient.get returns — it
+    JSON-decodes before handing the value back to NewsCacheService.
     """
 
-    def __init__(self, store: dict[str, str]):
+    def __init__(self, store: dict[str, dict]):
         self._store = store
 
     async def scan_keys(self, pattern: str) -> list[str]:
@@ -38,8 +36,8 @@ class _StubCache:
 async def test_get_article_by_id_finds_match(monkeypatch):
     article = {"id": "abc", "title": "Top story", "article_url": "https://x/a"}
     store = {
-        "news:general:20": json.dumps({"results": [{"id": "zzz"}]}),
-        "news:tickertick:general:50": json.dumps({"results": [article]}),
+        "news:general:20": {"results": [{"id": "zzz"}]},
+        "news:tickertick:general:50": {"results": [article]},
     }
     monkeypatch.setattr(_GET_CACHE, lambda: _StubCache(store))
 
@@ -49,7 +47,7 @@ async def test_get_article_by_id_finds_match(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_get_article_by_id_miss_returns_none(monkeypatch):
-    store = {"news:general:20": json.dumps({"results": [{"id": "zzz"}]})}
+    store = {"news:general:20": {"results": [{"id": "zzz"}]}}
     monkeypatch.setattr(_GET_CACHE, lambda: _StubCache(store))
 
     assert await NewsCacheService().get_article_by_id("abc") is None

--- a/tests/unit/server/services/test_news_cache_service.py
+++ b/tests/unit/server/services/test_news_cache_service.py
@@ -1,0 +1,61 @@
+"""Unit tests for NewsCacheService.get_article_by_id.
+
+Regression guard: the by-id scan previously called ``cache.keys()`` — a method
+RedisCacheClient does not define — so it always raised AttributeError, was
+swallowed, and returned None (the fast path never fired). It now uses the
+SCAN-based ``scan_keys`` helper.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.server.services.cache.news_cache_service import NewsCacheService
+
+_GET_CACHE = "src.server.services.cache.news_cache_service.get_cache_client"
+
+
+class _StubCache:
+    """Minimal stand-in: scan_keys + get over an in-memory keyspace.
+
+    Values are JSON strings, matching what RedisCacheClient.get returns for
+    NewsCacheService entries (which are stored json.dumps-encoded).
+    """
+
+    def __init__(self, store: dict[str, str]):
+        self._store = store
+
+    async def scan_keys(self, pattern: str) -> list[str]:
+        return list(self._store)
+
+    async def get(self, key: str):
+        return self._store.get(key)
+
+
+@pytest.mark.asyncio
+async def test_get_article_by_id_finds_match(monkeypatch):
+    article = {"id": "abc", "title": "Top story", "article_url": "https://x/a"}
+    store = {
+        "news:general:20": json.dumps({"results": [{"id": "zzz"}]}),
+        "news:tickertick:general:50": json.dumps({"results": [article]}),
+    }
+    monkeypatch.setattr(_GET_CACHE, lambda: _StubCache(store))
+
+    found = await NewsCacheService().get_article_by_id("abc")
+    assert found == article
+
+
+@pytest.mark.asyncio
+async def test_get_article_by_id_miss_returns_none(monkeypatch):
+    store = {"news:general:20": json.dumps({"results": [{"id": "zzz"}]})}
+    monkeypatch.setattr(_GET_CACHE, lambda: _StubCache(store))
+
+    assert await NewsCacheService().get_article_by_id("abc") is None
+
+
+@pytest.mark.asyncio
+async def test_get_article_by_id_empty_keyspace(monkeypatch):
+    monkeypatch.setattr(_GET_CACHE, lambda: _StubCache({}))
+    assert await NewsCacheService().get_article_by_id("abc") is None

--- a/tests/unit/server/services/test_news_refresh_service.py
+++ b/tests/unit/server/services/test_news_refresh_service.py
@@ -1,0 +1,191 @@
+"""Unit tests for the news refresh poller (delta merge + leader election)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.config.models import NewsPollFeedConfig
+from src.server.services.news_refresh_service import NewsRefreshService, _merge_delta
+
+
+def _article(aid: str, hour: int) -> dict:
+    return {"id": aid, "published_at": f"2025-12-01T{hour:02d}:00:00+00:00", "title": aid}
+
+
+class TestMergeDelta:
+    def test_dedupe_sort_and_new_count(self):
+        existing = [_article("b", 8), _article("c", 7)]
+        fetched = [
+            _article("a", 9),  # genuinely new, newest
+            {**_article("b", 8), "title": "b-updated"},  # updated copy of existing
+        ]
+        merged, new_count = _merge_delta(existing, fetched, max_items=10)
+
+        assert [m["id"] for m in merged] == ["a", "b", "c"]  # newest-first
+        assert merged[1]["title"] == "b-updated"  # fetched copy wins on dup
+        assert new_count == 1  # only 'a' was not already in the buffer
+
+    def test_trims_to_max_items_keeping_newest(self):
+        fetched = [_article(str(i), i) for i in range(5)]
+        merged, _ = _merge_delta([], fetched, max_items=3)
+        assert [m["id"] for m in merged] == ["4", "3", "2"]
+
+    def test_empty_fetch_keeps_existing(self):
+        existing = [_article("a", 9)]
+        merged, new_count = _merge_delta(existing, [], max_items=10)
+        assert [m["id"] for m in merged] == ["a"]
+        assert new_count == 0
+
+
+def _make_service() -> NewsRefreshService:
+    svc = NewsRefreshService()
+    svc._interval = 60
+    svc._max_items = 100
+    return svc
+
+
+class TestRefreshFeed:
+    @pytest.mark.asyncio
+    async def test_leader_fetches_merges_writes(self, monkeypatch):
+        svc = _make_service()
+        cache = AsyncMock()
+        cache.acquire_lock = AsyncMock(return_value=True)  # we win the lock
+        cache.get = AsyncMock(return_value={"results": [_article("old", 7)]})
+        cache.set = AsyncMock()
+        svc._cache = cache
+
+        source = AsyncMock()
+        source.get_news = AsyncMock(
+            return_value={"results": [_article("new", 9)], "count": 1, "next_cursor": "x"}
+        )
+        monkeypatch.setattr(svc, "_resolve_source", AsyncMock(return_value=source))
+
+        await svc._refresh_feed(NewsPollFeedConfig(provider="tickertick", limit=50))
+
+        source.get_news.assert_awaited_once_with(tickers=None, limit=50)
+        payload, kwargs = cache.set.await_args.args[0], cache.set.await_args.kwargs
+        assert [r["id"] for r in payload["results"]] == ["new", "old"]
+        assert payload["next_cursor"] is None  # only 2 items < limit 50
+        assert kwargs == {"tickers": None, "limit": 50, "provider": "tickertick"}
+
+        # Lock key mirrors the cache identity; TTL is the poll interval (ms).
+        lock_args = cache.acquire_lock.await_args.args
+        assert lock_args[0] == "newspolllock:news:tickertick:general:50"
+        assert lock_args[2] == 60000
+
+    @pytest.mark.asyncio
+    async def test_full_buffer_sets_continuation_cursor(self, monkeypatch):
+        """Cursor-capable provider + full buffer → cursor at the served-page boundary."""
+        svc = _make_service()
+        cache = AsyncMock()
+        cache.acquire_lock = AsyncMock(return_value=True)
+        cache.get = AsyncMock(return_value=None)  # cold start
+        cache.set = AsyncMock()
+        svc._cache = cache
+
+        fetched = [_article(f"s{i}", i) for i in range(3)]
+        source = AsyncMock()
+        source.get_news = AsyncMock(
+            return_value={"results": fetched, "count": 3, "next_cursor": None}
+        )
+        monkeypatch.setattr(svc, "_resolve_source", AsyncMock(return_value=source))
+
+        await svc._refresh_feed(NewsPollFeedConfig(provider="tickertick", limit=3))
+
+        payload = cache.set.await_args.args[0]
+        assert [r["id"] for r in payload["results"]] == ["s2", "s1", "s0"]
+        assert payload["next_cursor"] == "s0"  # boundary id (merged[limit-1])
+        assert (
+            cache.acquire_lock.await_args.args[0]
+            == "newspolllock:news:tickertick:general:3"
+        )
+
+    @pytest.mark.asyncio
+    async def test_chain_feed_never_sets_cursor(self, monkeypatch):
+        """provider=None resolves to the chain (FMP/yfinance), which can't honor a
+        cursor — so the buffer is served without one even when full."""
+        svc = _make_service()
+        cache = AsyncMock()
+        cache.acquire_lock = AsyncMock(return_value=True)
+        cache.get = AsyncMock(return_value=None)
+        cache.set = AsyncMock()
+        svc._cache = cache
+
+        fetched = [_article(f"s{i}", i) for i in range(3)]
+        source = AsyncMock()
+        source.get_news = AsyncMock(return_value={"results": fetched})
+        monkeypatch.setattr(svc, "_resolve_source", AsyncMock(return_value=source))
+
+        await svc._refresh_feed(NewsPollFeedConfig(provider=None, limit=3))
+
+        payload = cache.set.await_args.args[0]
+        assert payload["next_cursor"] is None  # full buffer but chain feed
+        assert cache.acquire_lock.await_args.args[0] == "newspolllock:news:general:3"
+
+    @pytest.mark.asyncio
+    async def test_cursor_is_page_boundary_not_buffer_tail(self, monkeypatch):
+        """When the buffer holds more than one page (max_items > limit), the cursor
+        is the served-page boundary id, not the oldest buffered id."""
+        svc = _make_service()
+        svc._max_items = 5
+        cache = AsyncMock()
+        cache.acquire_lock = AsyncMock(return_value=True)
+        cache.get = AsyncMock(return_value=None)
+        cache.set = AsyncMock()
+        svc._cache = cache
+
+        fetched = [_article(f"s{i}", i) for i in range(5)]  # hours 0..4
+        source = AsyncMock()
+        source.get_news = AsyncMock(return_value={"results": fetched})
+        monkeypatch.setattr(svc, "_resolve_source", AsyncMock(return_value=source))
+
+        await svc._refresh_feed(NewsPollFeedConfig(provider="tickertick", limit=3))
+
+        payload = cache.set.await_args.args[0]
+        # merged newest-first: s4,s3,s2,s1,s0 (5 items, max_items=5)
+        assert [r["id"] for r in payload["results"]] == ["s4", "s3", "s2", "s1", "s0"]
+        # served page is limit=3 → boundary is merged[2] == "s2", NOT the tail "s0"
+        assert payload["next_cursor"] == "s2"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("lock_result", [False, None])
+    async def test_skips_when_not_leader(self, monkeypatch, lock_result):
+        """False (another worker holds it) or None (Redis down) → skip, no fetch."""
+        svc = _make_service()
+        cache = AsyncMock()
+        cache.acquire_lock = AsyncMock(return_value=lock_result)
+        cache.get = AsyncMock()
+        cache.set = AsyncMock()
+        svc._cache = cache
+
+        resolve = AsyncMock()
+        monkeypatch.setattr(svc, "_resolve_source", resolve)
+
+        await svc._refresh_feed(NewsPollFeedConfig(provider="tickertick", limit=50))
+
+        resolve.assert_not_called()
+        cache.get.assert_not_called()
+        cache.set.assert_not_called()
+
+
+class TestPollOnce:
+    @pytest.mark.asyncio
+    async def test_one_feed_error_does_not_skip_the_rest(self):
+        svc = _make_service()
+        svc._feeds = [
+            NewsPollFeedConfig(provider="tickertick", limit=50),
+            NewsPollFeedConfig(provider=None, limit=50),
+        ]
+        seen = []
+
+        async def fake_refresh(feed):
+            seen.append(feed.provider)
+            if feed.provider == "tickertick":
+                raise RuntimeError("boom")
+
+        svc._refresh_feed = fake_refresh
+        await svc._poll_once()
+
+        assert seen == ["tickertick", None]  # second feed still ran

--- a/tests/unit/utils/cache/test_locks.py
+++ b/tests/unit/utils/cache/test_locks.py
@@ -1,0 +1,78 @@
+"""Unit tests for RedisCacheClient.acquire_lock / release_lock."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.utils.cache.redis_cache import RedisCacheClient
+
+
+def _make_client() -> RedisCacheClient:
+    client = RedisCacheClient.__new__(RedisCacheClient)
+    client.enabled = True
+    client.stats = {"hits": 0, "misses": 0, "sets": 0, "deletes": 0, "errors": 0}
+    client.client = None
+    return client
+
+
+@pytest.mark.asyncio
+async def test_acquire_lock_acquired():
+    cache = _make_client()
+    redis_mock = MagicMock()
+    redis_mock.set = AsyncMock(return_value=True)  # SET NX succeeded
+    cache.client = redis_mock
+
+    assert await cache.acquire_lock("news:lock:k", "tok", 1000) is True
+    redis_mock.set.assert_awaited_once_with("news:lock:k", "tok", nx=True, px=1000)
+
+
+@pytest.mark.asyncio
+async def test_acquire_lock_contended_returns_false():
+    cache = _make_client()
+    redis_mock = MagicMock()
+    redis_mock.set = AsyncMock(return_value=None)  # key already held
+    cache.client = redis_mock
+
+    assert await cache.acquire_lock("news:lock:k", "tok", 1000) is False
+
+
+@pytest.mark.asyncio
+async def test_acquire_lock_redis_error_returns_none():
+    cache = _make_client()
+    redis_mock = MagicMock()
+    redis_mock.set = AsyncMock(side_effect=RuntimeError("down"))
+    cache.client = redis_mock
+
+    assert await cache.acquire_lock("news:lock:k", "tok", 1000) is None
+    assert cache.stats["errors"] == 1
+
+
+@pytest.mark.asyncio
+async def test_acquire_lock_disabled_returns_none():
+    cache = _make_client()
+    cache.enabled = False
+    assert await cache.acquire_lock("news:lock:k", "tok", 1000) is None
+
+
+@pytest.mark.asyncio
+async def test_release_lock_compare_and_deletes():
+    cache = _make_client()
+    redis_mock = MagicMock()
+    redis_mock.eval = AsyncMock(return_value=1)
+    cache.client = redis_mock
+
+    await cache.release_lock("news:lock:k", "tok")
+    args = redis_mock.eval.await_args.args
+    # eval(script, numkeys, key, token)
+    assert args[1] == 1
+    assert args[2] == "news:lock:k"
+    assert args[3] == "tok"
+
+
+@pytest.mark.asyncio
+async def test_release_lock_disabled_is_noop():
+    cache = _make_client()
+    cache.enabled = False
+    await cache.release_lock("news:lock:k", "tok")  # must not raise

--- a/tests/unit/utils/cache/test_scan_keys.py
+++ b/tests/unit/utils/cache/test_scan_keys.py
@@ -1,0 +1,56 @@
+"""Unit tests for RedisCacheClient.scan_keys (non-blocking SCAN helper)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.utils.cache.redis_cache import RedisCacheClient
+
+
+def _make_client() -> RedisCacheClient:
+    client = RedisCacheClient.__new__(RedisCacheClient)
+    client.enabled = True
+    client.stats = {"hits": 0, "misses": 0, "sets": 0, "deletes": 0, "errors": 0}
+    client.client = None
+    return client
+
+
+@pytest.mark.asyncio
+async def test_scan_keys_returns_decoded_matches():
+    cache = _make_client()
+
+    async def fake_scan_iter(match=None, count=None):
+        assert match == "news:*"
+        for k in (b"news:general:20", b"news:tickertick:general:50"):
+            yield k
+
+    redis_mock = MagicMock()
+    redis_mock.scan_iter = fake_scan_iter
+    cache.client = redis_mock
+
+    keys = await cache.scan_keys("news:*")
+    assert keys == ["news:general:20", "news:tickertick:general:50"]
+
+
+@pytest.mark.asyncio
+async def test_scan_keys_disabled_returns_empty():
+    cache = _make_client()
+    cache.enabled = False
+    assert await cache.scan_keys("news:*") == []
+
+
+@pytest.mark.asyncio
+async def test_scan_keys_swallows_errors():
+    cache = _make_client()
+
+    def boom(match=None, count=None):
+        raise RuntimeError("redis down")
+
+    redis_mock = MagicMock()
+    redis_mock.scan_iter = boom
+    cache.client = redis_mock
+
+    assert await cache.scan_keys("news:*") == []
+    assert cache.stats["errors"] == 1

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -671,7 +671,8 @@
       },
       "newsFeed": {
         "title": "News Feed",
-        "description": "Market / Portfolio / Watchlist news with ticker + time filters.",
+        "description": "Top / Market / Portfolio / Watchlist news with ticker, source + time filters.",
+        "tab_top": "Top",
         "tab_market": "Market",
         "tab_portfolio": "Portfolio",
         "tab_watchlist": "Watchlist",
@@ -684,8 +685,11 @@
         "tickerPlaceholder": "Ticker…",
         "clearTicker": "Clear ticker filter",
         "clear": "Clear",
+        "sourceLabel": "Filter by source",
+        "allSources": "All sources",
         "emptyFiltered": "No news matching filters",
         "emptyMarket": "No market news",
+        "emptyTop": "No top news",
         "emptyAddTo": "Add to {{label}} to see news"
       },
       "earningsCalendar": {

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -671,7 +671,8 @@
       },
       "newsFeed": {
         "title": "新闻动态",
-        "description": "市场 / 持仓 / 自选新闻，支持标的与时间筛选。",
+        "description": "热门 / 市场 / 持仓 / 自选新闻，支持标的、来源与时间筛选。",
+        "tab_top": "热门",
         "tab_market": "市场",
         "tab_portfolio": "持仓",
         "tab_watchlist": "自选",
@@ -684,8 +685,11 @@
         "tickerPlaceholder": "标的…",
         "clearTicker": "清除标的筛选",
         "clear": "清除",
+        "sourceLabel": "按来源筛选",
+        "allSources": "全部来源",
         "emptyFiltered": "无符合筛选条件的新闻",
         "emptyMarket": "暂无市场新闻",
+        "emptyTop": "暂无热门新闻",
         "emptyAddTo": "添加到{{label}}以查看新闻"
       },
       "earningsCalendar": {

--- a/web/src/pages/Dashboard/DashboardCustom.tsx
+++ b/web/src/pages/Dashboard/DashboardCustom.tsx
@@ -259,7 +259,7 @@ function CustomInner({ mode, onModeChange }: DashboardCustomProps) {
       <NewsDetailModal
         newsId={modals.selectedNewsId}
         onClose={modals.closeNews}
-        fallbackUrl={modals.selectedNewsFallbackUrl}
+        fallback={modals.selectedNewsFallback}
       />
       <InsightDetailModal
         marketInsightId={modals.selectedMarketInsightId}

--- a/web/src/pages/Dashboard/components/NewsDetailModal.tsx
+++ b/web/src/pages/Dashboard/components/NewsDetailModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   X, Calendar, Hash, ExternalLink, TrendingUp, TrendingDown, Minus, Tag,
   Paperclip,
@@ -38,10 +38,46 @@ interface Article {
   [key: string]: unknown;
 }
 
+/** The clicked row's full body. The list inlines description/keywords/sentiments,
+ *  so a seed with a description renders the complete modal with no by-id fetch.
+ *  Rows without one still fall back to the fetch (optional enrichment). */
+interface NewsFallback {
+  title?: string;
+  source?: string;
+  publishedAt?: string | null;
+  tickers?: string[];
+  articleUrl?: string | null;
+  author?: string | null;
+  description?: string | null;
+  keywords?: string[];
+  sentiments?: ArticleSentiment[] | null;
+  imageUrl?: string | null;
+  favicon?: string | null;
+}
+
 interface NewsDetailModalProps {
   newsId: string | null;
   onClose: () => void;
+  /** Legacy (Classic dashboard): URL-only fallback for the empty state. */
   fallbackUrl?: string | null;
+  /** Rich fallback from the clicked row — preferred. */
+  fallback?: NewsFallback | null;
+}
+
+function fallbackToArticle(fb: NewsFallback | null | undefined): Article | null {
+  if (!fb?.title) return null;
+  return {
+    title: fb.title,
+    description: fb.description ?? undefined,
+    image_url: fb.imageUrl ?? undefined,
+    article_url: fb.articleUrl ?? undefined,
+    author: fb.author ?? undefined,
+    published_at: fb.publishedAt ?? undefined,
+    source: fb.source ? { name: fb.source, favicon_url: fb.favicon ?? undefined } : undefined,
+    keywords: fb.keywords ?? [],
+    tickers: fb.tickers ?? [],
+    sentiments: fb.sentiments ?? undefined,
+  };
 }
 
 function attachArticleToContext(article: Article, articleId: string): void {
@@ -125,7 +161,7 @@ function NewsBody({
   onAttach?: () => void;
 }) {
   const { t: trans } = useTranslation();
-  if (loading) {
+  if (loading && !article) {
     return (
       <div className="flex items-center justify-center py-24">
         <div
@@ -211,6 +247,39 @@ function NewsBody({
 
       {/* Body */}
       <div className={isMobile ? 'pt-4' : 'p-6 md:p-8'}>
+        {/* Title fallback — sources without a hero image (e.g. TickerTick) still
+            need the headline + source rendered, since the hero block above is
+            skipped when there's no image_url. */}
+        {!article.image_url && (
+          <div className="mb-5 sm:mb-6">
+            {article.source?.name && (
+              <span
+                className="inline-flex items-center gap-1.5 text-[10px] font-bold px-2 py-0.5 rounded uppercase tracking-wider mb-2 sm:mb-3"
+                style={{
+                  backgroundColor: 'var(--color-accent-soft)',
+                  color: 'var(--color-accent-primary)',
+                }}
+              >
+                {article.source.favicon_url && (
+                  <img
+                    src={article.source.favicon_url}
+                    alt=""
+                    className="w-3.5 h-3.5 rounded-sm"
+                    onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                  />
+                )}
+                {article.source.name}
+              </span>
+            )}
+            <h1
+              className={`${isMobile ? 'text-lg' : 'text-2xl md:text-3xl'} font-bold leading-tight`}
+              style={{ color: 'var(--color-text-primary)' }}
+            >
+              {article.title}
+            </h1>
+          </div>
+        )}
+
         {/* Meta */}
         <div
           className={`flex items-center ${isMobile ? 'gap-3 text-xs' : 'gap-6 text-sm'} mb-6 sm:mb-8 pb-3 sm:pb-4 border-b flex-wrap`}
@@ -452,7 +521,7 @@ function NewsBody({
   );
 }
 
-function NewsDetailModal({ newsId, onClose, fallbackUrl }: NewsDetailModalProps) {
+function NewsDetailModal({ newsId, onClose, fallbackUrl, fallback }: NewsDetailModalProps) {
   const { t } = useTranslation();
   const { toast } = useToast();
   const [article, setArticle] = useState<Article | null>(null);
@@ -460,6 +529,11 @@ function NewsDetailModal({ newsId, onClose, fallbackUrl }: NewsDetailModalProps)
   const [fetchFailed, setFetchFailed] = useState(false);
   const [expandedSentiment, setExpandedSentiment] = useState<number | null>(null);
   const isMobile = useIsMobile();
+
+  // Read the latest fallback at fetch time without re-running the effect when
+  // the parent hands us a fresh object for the same newsId.
+  const fallbackRef = useRef(fallback);
+  fallbackRef.current = fallback;
 
   const handleAttach = () => {
     if (!article || !newsId) return;
@@ -478,17 +552,33 @@ function NewsDetailModal({ newsId, onClose, fallbackUrl }: NewsDetailModalProps)
       setExpandedSentiment(null);
       return;
     }
+    // Seed with the clicked row's known fields so the modal renders instantly.
+    const seed = fallbackToArticle(fallbackRef.current);
     let cancelled = false;
-    setLoading(true);
+    setArticle(seed);
     setFetchFailed(false);
     setExpandedSentiment(null);
+
+    // The list now inlines the full article body, so when the row already
+    // carries a description we render straight from it — no by-id round-trip.
+    if (seed?.description) {
+      setLoading(false);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    // Optional enrichment: rows without an inlined body (or the Classic
+    // dashboard's URL-only path) still fetch the full article by id.
+    setLoading(true);
     getNewsArticle(newsId)
       .then((data) => {
         if (!cancelled) setArticle(data as Article);
       })
       .catch((err) => {
         console.error('[NewsDetailModal] fetch failed:', err?.message);
-        if (!cancelled) {
+        if (!cancelled && !seed) {
+          // No fallback to show → surface the empty state.
           setArticle(null);
           setFetchFailed(true);
         }

--- a/web/src/pages/Dashboard/components/NewsDetailModal.tsx
+++ b/web/src/pages/Dashboard/components/NewsDetailModal.tsx
@@ -139,6 +139,19 @@ function formatDate(dateString: string | undefined): string {
   }
 }
 
+/** Only allow http(s) URLs into an <a href>. Article/fallback URLs come from
+ *  external news feeds, and React does NOT block javascript:/data: schemes,
+ *  which would execute on click. Returns undefined for anything non-http(s). */
+function safeHttpUrl(url: string | null | undefined): string | undefined {
+  if (!url) return undefined;
+  try {
+    const protocol = new URL(url, window.location.origin).protocol;
+    return protocol === 'http:' || protocol === 'https:' ? url : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /** Shared inner content for both mobile bottom sheet and desktop dialog */
 function NewsBody({
   article,
@@ -161,6 +174,8 @@ function NewsBody({
   onAttach?: () => void;
 }) {
   const { t: trans } = useTranslation();
+  const safeFallbackUrl = safeHttpUrl(fallbackUrl);
+  const safeArticleUrl = safeHttpUrl(article?.article_url);
   if (loading && !article) {
     return (
       <div className="flex items-center justify-center py-24">
@@ -178,9 +193,9 @@ function NewsBody({
         <p style={{ color: 'var(--color-text-secondary)' }}>
           {fetchFailed ? 'Article details not available' : 'Article not found'}
         </p>
-        {fetchFailed && fallbackUrl && (
+        {fetchFailed && safeFallbackUrl && (
           <a
-            href={fallbackUrl}
+            href={safeFallbackUrl}
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium transition-colors"
@@ -323,9 +338,9 @@ function NewsBody({
                 {trans('dashboard.widgets.frame.addToContext', { defaultValue: 'Attach to chat' })}
               </button>
             )}
-            {article.article_url && (
+            {safeArticleUrl && (
               <a
-                href={article.article_url}
+                href={safeArticleUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="flex items-center gap-1.5 transition-opacity hover:opacity-80"
@@ -563,9 +578,7 @@ function NewsDetailModal({ newsId, onClose, fallbackUrl, fallback }: NewsDetailM
     // carries a description we render straight from it — no by-id round-trip.
     if (seed?.description) {
       setLoading(false);
-      return () => {
-        cancelled = true;
-      };
+      return;
     }
 
     // Optional enrichment: rows without an inlined body (or the Classic

--- a/web/src/pages/Dashboard/components/__tests__/NewsDetailModal.test.tsx
+++ b/web/src/pages/Dashboard/components/__tests__/NewsDetailModal.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string, o?: { defaultValue?: string }) => o?.defaultValue ?? k }),
+}));
+vi.mock('@/hooks/useIsMobile', () => ({ useIsMobile: () => false }));
+vi.mock('@/components/ui/use-toast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+
+// Mirrors the TickerTick detail shape: no image_url, no author, no sentiments —
+// the sparse article that previously rendered without a headline.
+const IMAGELESS_ARTICLE = {
+  id: 'article-1',
+  title: 'Sample Headline Without An Image',
+  author: null,
+  description: 'A short summary paragraph that appears under Executive Summary.',
+  published_at: '2026-06-02T02:01:05+00:00',
+  article_url: 'https://example.com/sample-article',
+  image_url: null,
+  source: { name: 'example.com', logo_url: null, homepage_url: null, favicon_url: null },
+  tickers: [],
+  keywords: [],
+  sentiments: null,
+};
+
+const getNewsArticle = vi.fn();
+vi.mock('../../utils/api', () => ({ getNewsArticle: (...a: unknown[]) => getNewsArticle(...a) }));
+
+import NewsDetailModal from '../NewsDetailModal';
+
+describe('NewsDetailModal — imageless (TickerTick) article', () => {
+  beforeEach(() => {
+    getNewsArticle.mockClear();
+  });
+
+  it('renders from the row with no by-id fetch when the body is inlined', async () => {
+    render(
+      <NewsDetailModal
+        newsId="inlined-1"
+        onClose={vi.fn()}
+        fallback={{
+          title: 'Inlined Body Story',
+          source: 'example.com',
+          publishedAt: '2026-06-02T00:00:00+00:00',
+          tickers: ['MSFT'],
+          articleUrl: 'https://example.com/inlined',
+          description: 'The full summary that shipped in the list payload.',
+          keywords: ['cloud'],
+        }}
+      />,
+    );
+
+    expect(
+      await screen.findByRole('heading', { name: 'Inlined Body Story' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/shipped in the list payload/i)).toBeInTheDocument();
+    // The whole point of Option A: no second round-trip when the row is complete.
+    expect(getNewsArticle).not.toHaveBeenCalled();
+  });
+
+  it('renders the headline even when the article has no hero image', async () => {
+    getNewsArticle.mockResolvedValue(IMAGELESS_ARTICLE);
+
+    render(<NewsDetailModal newsId="article-1" onClose={vi.fn()} />);
+
+    // The title (regression: was only rendered inside the skipped hero block).
+    const heading = await screen.findByRole('heading', {
+      name: 'Sample Headline Without An Image',
+    });
+    expect(heading).toBeInTheDocument();
+    // Description still shows under Executive Summary.
+    expect(screen.getByText(/short summary paragraph/i)).toBeInTheDocument();
+  });
+
+  it('falls back to the clicked row when the by-id fetch 404s (TickerTick rotation)', async () => {
+    getNewsArticle.mockRejectedValue(new Error('Request failed with status code 404'));
+
+    render(
+      <NewsDetailModal
+        newsId="rotated-1"
+        onClose={vi.fn()}
+        fallback={{
+          title: 'Rotated Ticker Story',
+          source: 'example.com',
+          publishedAt: '2026-06-02T00:00:00+00:00',
+          tickers: ['AAPL'],
+          articleUrl: 'https://example.com/rotated',
+        }}
+      />,
+    );
+
+    // Renders the row's known data instead of the "details not available" state.
+    expect(
+      await screen.findByRole('heading', { name: 'Rotated Ticker Story' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('AAPL')).toBeInTheDocument();
+    expect(screen.getByText('Source')).toBeInTheDocument();
+    expect(screen.queryByText(/Article details not available/i)).not.toBeInTheDocument();
+  });
+
+  it('shows the empty state only when there is no fallback', async () => {
+    getNewsArticle.mockRejectedValue(new Error('404'));
+
+    render(<NewsDetailModal newsId="x" onClose={vi.fn()} fallbackUrl="https://example.com/x" />);
+
+    expect(await screen.findByText(/Article details not available/i)).toBeInTheDocument();
+    expect(screen.getByText(/Open article/i)).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/Dashboard/hooks/__tests__/useTickerNews.test.tsx
+++ b/web/src/pages/Dashboard/hooks/__tests__/useTickerNews.test.tsx
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Mock } from 'vitest';
+import type { ReactNode } from 'react';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useTickerNews } from '../useTickerNews';
+
+vi.mock('../../utils/api', () => ({ getNews: vi.fn() }));
+import { getNews } from '../../utils/api';
+
+const mockGetNews = getNews as Mock;
+
+// Fresh client per test so cache from one case can't suppress another's fetch.
+function makeWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+const rowsFor = (...syms: string[]) => syms.map((symbol) => ({ symbol }));
+
+describe('useTickerNews (React Query)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetNews.mockResolvedValue({ results: [] });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('eagerly fetches once with the provider, then re-polls every 60s', async () => {
+    vi.useFakeTimers();
+    renderHook(() => useTickerNews(rowsFor('AAPL'), 'portfolio', 'tickertick'), { wrapper: makeWrapper() });
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+    expect(mockGetNews).toHaveBeenCalledTimes(1);
+    expect(mockGetNews).toHaveBeenCalledWith({ tickers: ['AAPL'], limit: 50, provider: 'tickertick' });
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(60000); });
+    expect(mockGetNews).toHaveBeenCalledTimes(2);
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(60000); });
+    expect(mockGetNews).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not fetch when there are no tickers', async () => {
+    const { result } = renderHook(() => useTickerNews([], 'portfolio', 'tickertick'), {
+      wrapper: makeWrapper(),
+    });
+    await act(async () => { await Promise.resolve(); });
+
+    expect(mockGetNews).not.toHaveBeenCalled();
+    expect(result.current.items).toEqual([]);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('stops polling after unmount', async () => {
+    vi.useFakeTimers();
+    const { unmount } = renderHook(() => useTickerNews(rowsFor('MSFT'), 'watchlist', 'tickertick'), {
+      wrapper: makeWrapper(),
+    });
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+    expect(mockGetNews).toHaveBeenCalledTimes(1);
+
+    unmount();
+    await act(async () => { await vi.advanceTimersByTimeAsync(180000); });
+    expect(mockGetNews).toHaveBeenCalledTimes(1); // no further polls
+  });
+
+  it('keeps Classic (no provider) and Custom (tickertick) feeds in separate cache entries', async () => {
+    // Same QueryClient + same tickers/cacheKey, differing only by provider. The
+    // provider is part of the query key, so the two must NOT serve each other's
+    // articles — the invariant a prior review flagged as critical.
+    const Wrapper = makeWrapper();
+    mockGetNews.mockImplementation(({ provider }: { provider?: string }) =>
+      Promise.resolve({ results: [{ id: provider ?? 'classic', title: provider ?? 'classic' }] }),
+    );
+    const rows = rowsFor('AAPL');
+    const classic = renderHook(() => useTickerNews(rows, 'portfolio'), { wrapper: Wrapper });
+    const custom = renderHook(() => useTickerNews(rows, 'portfolio', 'tickertick'), { wrapper: Wrapper });
+
+    await waitFor(() => expect(classic.result.current.loading).toBe(false));
+    await waitFor(() => expect(custom.result.current.loading).toBe(false));
+
+    expect(mockGetNews).toHaveBeenCalledWith({ tickers: ['AAPL'], limit: 50, provider: undefined });
+    expect(mockGetNews).toHaveBeenCalledWith({ tickers: ['AAPL'], limit: 50, provider: 'tickertick' });
+    expect(classic.result.current.items[0].id).toBe('classic');
+    expect(custom.result.current.items[0].id).toBe('tickertick');
+  });
+
+  it('keys cache by cacheKey so portfolio and watchlist feeds stay separate', async () => {
+    // Same provider + tickers but different cacheKey → two distinct cache
+    // entries (two fetches), not deduped into one.
+    const Wrapper = makeWrapper();
+    const rows = rowsFor('AAPL');
+    renderHook(() => useTickerNews(rows, 'portfolio', 'tickertick'), { wrapper: Wrapper });
+    renderHook(() => useTickerNews(rows, 'watchlist', 'tickertick'), { wrapper: Wrapper });
+
+    await waitFor(() => expect(mockGetNews).toHaveBeenCalledTimes(2));
+  });
+
+  it('maps raw results into the normalized item shape with field fallbacks', async () => {
+    mockGetNews.mockResolvedValue({
+      results: [{ id: '1', title: 'T', published_at: null, has_sentiment: true, author: null, source: undefined }],
+    });
+    const { result } = renderHook(() => useTickerNews(rowsFor('AAPL'), 'portfolio', 'tickertick'), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.items).toHaveLength(1));
+
+    expect(result.current.items[0]).toMatchObject({
+      id: '1', title: 'T', isHot: true, author: null,
+      source: '', favicon: null, image: null, keywords: [], publishedAt: null, time: '',
+    });
+  });
+
+  it('surfaces an empty list when the fetch yields no results', async () => {
+    mockGetNews.mockResolvedValue({ results: [], count: 0, next_cursor: null });
+    const { result } = renderHook(() => useTickerNews(rowsFor('AAPL'), 'portfolio', 'tickertick'), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(mockGetNews).toHaveBeenCalledTimes(1);
+    expect(result.current.items).toEqual([]);
+  });
+
+  it('keeps the last good list when a poll fails (getNews rejects)', async () => {
+    vi.useFakeTimers();
+    mockGetNews
+      .mockResolvedValueOnce({ results: [{ id: 'good', title: 'g' }] })
+      .mockRejectedValue(new Error('boom'));
+    const { result } = renderHook(() => useTickerNews(rowsFor('AAPL'), 'portfolio', 'tickertick'), {
+      wrapper: makeWrapper(),
+    });
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+    expect(result.current.items.map((i) => i.id)).toEqual(['good']);
+
+    // 60s poll fails — the feed must NOT blank; React Query retains last data.
+    await act(async () => { await vi.advanceTimersByTimeAsync(60000); });
+    expect(mockGetNews).toHaveBeenCalledTimes(2);
+    expect(result.current.items.map((i) => i.id)).toEqual(['good']);
+  });
+});

--- a/web/src/pages/Dashboard/hooks/useDashboardData.ts
+++ b/web/src/pages/Dashboard/hooks/useDashboardData.ts
@@ -1,39 +1,22 @@
 import { useQuery, useInfiniteQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
-import i18n from '@/i18n';
 import { getNews, getIndices, INDEX_SYMBOLS, fallbackIndex, normalizeIndexSymbol } from '../utils/api';
 import { fetchMarketStatus } from '@/lib/marketUtils';
 import type { IndexData } from '@/types/market';
+import {
+  type DashboardNewsItem,
+  NEWS_POLL_INTERVAL_MS,
+  NEWS_STALE_MS,
+  mapNewsResults,
+} from '../utils/newsItem';
+
+type NewsItem = DashboardNewsItem;
 
 interface MarketStatusData {
   market?: string;
   afterHours?: boolean;
   earlyHours?: boolean;
   [key: string]: unknown;
-}
-
-interface NewsSentimentItem {
-  ticker: string;
-  sentiment: string;
-  reasoning?: string;
-}
-
-interface NewsItem {
-  id: string;
-  title: string;
-  time: string;
-  publishedAt: string | null;
-  isHot: boolean;
-  source: string;
-  favicon: string | null;
-  image: string | null;
-  tickers: string[];
-  articleUrl?: string | null;
-  // Inlined article body — lets the detail modal render without a by-id fetch.
-  author?: string | null;
-  description?: string | null;
-  keywords?: string[];
-  sentiments?: NewsSentimentItem[] | null;
 }
 
 interface DashboardData {
@@ -48,48 +31,6 @@ interface DashboardData {
   curatedFetchNextPage: () => void;
   marketStatus: MarketStatusData | null;
   marketStatusRef: { current: MarketStatusData | null };
-}
-
-function mapNewsResults(results: Record<string, unknown>[]): NewsItem[] {
-  return results.map((r) => ({
-    id: r.id as string,
-    title: r.title as string,
-    time: formatRelativeTime(r.published_at as string | null | undefined),
-    publishedAt: (r.published_at as string) || null,
-    isHot: r.has_sentiment as boolean,
-    source: (r.source as Record<string, unknown> | undefined)?.name as string || '',
-    favicon: (r.source as Record<string, unknown> | undefined)?.favicon_url as string || null,
-    image: r.image_url as string || null,
-    tickers: (r.tickers as string[]) || [],
-    articleUrl: (r.article_url as string) || null,
-    author: (r.author as string) ?? null,
-    description: (r.description as string) ?? null,
-    keywords: (r.keywords as string[]) || [],
-    sentiments: (r.sentiments as NewsSentimentItem[]) ?? null,
-  }));
-}
-
-/**
- * Formats a given timestamp to a relative time string. Outside React render —
- * components consuming the result via this hook re-render on locale switch
- * because their parent calls useTranslation, which is what makes the freshly
- * resolved string reach the DOM.
- */
-function formatRelativeTime(timestamp: string | number | null | undefined): string {
-  if (!timestamp) return '';
-  const now = new Date();
-  const then = new Date(timestamp);
-  const diffMs = now.getTime() - then.getTime();
-  const diffMin = Math.floor(diffMs / 60000);
-  if (diffMin < 1) return i18n.t('dashboard.widgets.common.relativeNow');
-  let when: string;
-  if (diffMin < 60) when = `${diffMin}m`;
-  else {
-    const diffHr = Math.floor(diffMin / 60);
-    if (diffHr < 24) when = `${diffHr}h`;
-    else when = `${Math.floor(diffHr / 24)}d`;
-  }
-  return i18n.t('dashboard.widgets.common.relativePast', { when });
 }
 
 /**
@@ -125,23 +66,33 @@ export function useDashboardData(): DashboardData {
     staleTime: 10000,
   });
 
-  // 3. News Feed (Fetched once, cached for 5 minutes)
+  // 3. Market General Feed — kept warm server-side by the news poller, so we
+  //    re-poll every 60s to surface the latest articles in an open tab.
   const { data: newsItems = [], isLoading: newsLoading } = useQuery<NewsItem[]>({
     queryKey: ['dashboard', 'news'],
     queryFn: async (): Promise<NewsItem[]> => {
       const data = await getNews({ limit: 50 });
       return data.results?.length ? mapNewsResults(data.results) : [];
     },
-    staleTime: 5 * 60 * 1000, // 5 minutes fresh cache
+    staleTime: NEWS_STALE_MS,
+    refetchInterval: NEWS_POLL_INTERVAL_MS,
+    refetchIntervalInBackground: false,
   });
 
-  // 4. Curated "Top" Feed (TickerTick) — cursor-paginated for infinite scroll.
+  // 4. Curated "Top" Feed (TickerTick) — cursor-paginated for infinite scroll,
+  //    also kept warm server-side. Auto-refresh ONLY page 1 (the warm buffer):
+  //    refetchInterval refetches every loaded page, and pages 2+ bypass the
+  //    server cache and hit upstream directly, so we stop polling once the user
+  //    scrolls past page 1.
   const curated = useInfiniteQuery({
     queryKey: ['dashboard', 'curatedNews'],
     queryFn: ({ pageParam }) => getNews({ provider: 'tickertick', limit: 50, cursor: pageParam }),
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage) => lastPage.next_cursor ?? undefined,
-    staleTime: 5 * 60 * 1000, // 5 minutes fresh cache
+    staleTime: NEWS_STALE_MS,
+    refetchInterval: (query) =>
+      (query.state.data?.pages.length ?? 0) <= 1 ? NEWS_POLL_INTERVAL_MS : false,
+    refetchIntervalInBackground: false,
   });
 
   // Flatten loaded pages, de-duping by id (guards against feed rotation between

--- a/web/src/pages/Dashboard/hooks/useDashboardData.ts
+++ b/web/src/pages/Dashboard/hooks/useDashboardData.ts
@@ -1,4 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useInfiniteQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
 import i18n from '@/i18n';
 import { getNews, getIndices, INDEX_SYMBOLS, fallbackIndex, normalizeIndexSymbol } from '../utils/api';
 import { fetchMarketStatus } from '@/lib/marketUtils';
@@ -11,16 +12,28 @@ interface MarketStatusData {
   [key: string]: unknown;
 }
 
+interface NewsSentimentItem {
+  ticker: string;
+  sentiment: string;
+  reasoning?: string;
+}
+
 interface NewsItem {
   id: string;
   title: string;
   time: string;
+  publishedAt: string | null;
   isHot: boolean;
   source: string;
   favicon: string | null;
   image: string | null;
   tickers: string[];
   articleUrl?: string | null;
+  // Inlined article body — lets the detail modal render without a by-id fetch.
+  author?: string | null;
+  description?: string | null;
+  keywords?: string[];
+  sentiments?: NewsSentimentItem[] | null;
 }
 
 interface DashboardData {
@@ -28,8 +41,32 @@ interface DashboardData {
   indicesLoading: boolean;
   newsItems: NewsItem[];
   newsLoading: boolean;
+  curatedItems: NewsItem[];
+  curatedLoading: boolean;
+  curatedHasNextPage: boolean;
+  curatedIsFetchingNextPage: boolean;
+  curatedFetchNextPage: () => void;
   marketStatus: MarketStatusData | null;
   marketStatusRef: { current: MarketStatusData | null };
+}
+
+function mapNewsResults(results: Record<string, unknown>[]): NewsItem[] {
+  return results.map((r) => ({
+    id: r.id as string,
+    title: r.title as string,
+    time: formatRelativeTime(r.published_at as string | null | undefined),
+    publishedAt: (r.published_at as string) || null,
+    isHot: r.has_sentiment as boolean,
+    source: (r.source as Record<string, unknown> | undefined)?.name as string || '',
+    favicon: (r.source as Record<string, unknown> | undefined)?.favicon_url as string || null,
+    image: r.image_url as string || null,
+    tickers: (r.tickers as string[]) || [],
+    articleUrl: (r.article_url as string) || null,
+    author: (r.author as string) ?? null,
+    description: (r.description as string) ?? null,
+    keywords: (r.keywords as string[]) || [],
+    sentiments: (r.sentiments as NewsSentimentItem[]) ?? null,
+  }));
 }
 
 /**
@@ -93,29 +130,46 @@ export function useDashboardData(): DashboardData {
     queryKey: ['dashboard', 'news'],
     queryFn: async (): Promise<NewsItem[]> => {
       const data = await getNews({ limit: 50 });
-      if (data.results && data.results.length > 0) {
-        return data.results.map((r: Record<string, unknown>) => ({
-          id: r.id as string,
-          title: r.title as string,
-          time: formatRelativeTime(r.published_at as string | null | undefined),
-          isHot: r.has_sentiment as boolean,
-          source: (r.source as Record<string, unknown> | undefined)?.name as string || '',
-          favicon: (r.source as Record<string, unknown> | undefined)?.favicon_url as string || null,
-          image: r.image_url as string || null,
-          tickers: (r.tickers as string[]) || [],
-          articleUrl: (r.article_url as string) || null,
-        }));
-      }
-      return [];
+      return data.results?.length ? mapNewsResults(data.results) : [];
     },
     staleTime: 5 * 60 * 1000, // 5 minutes fresh cache
   });
+
+  // 4. Curated "Top" Feed (TickerTick) — cursor-paginated for infinite scroll.
+  const curated = useInfiniteQuery({
+    queryKey: ['dashboard', 'curatedNews'],
+    queryFn: ({ pageParam }) => getNews({ provider: 'tickertick', limit: 50, cursor: pageParam }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.next_cursor ?? undefined,
+    staleTime: 5 * 60 * 1000, // 5 minutes fresh cache
+  });
+
+  // Flatten loaded pages, de-duping by id (guards against feed rotation between
+  // page fetches reintroducing a story).
+  const curatedItems = useMemo<NewsItem[]>(() => {
+    const rows = curated.data?.pages.flatMap((p) => p.results) ?? [];
+    const seen = new Set<string>();
+    const unique = rows.filter((r) => {
+      const id = r.id as string;
+      if (!id || seen.has(id)) return false;
+      seen.add(id);
+      return true;
+    });
+    return mapNewsResults(unique);
+  }, [curated.data]);
 
   return {
     indices,
     indicesLoading,
     newsItems,
     newsLoading,
+    curatedItems,
+    curatedLoading: curated.isLoading,
+    curatedHasNextPage: !!curated.hasNextPage,
+    curatedIsFetchingNextPage: curated.isFetchingNextPage,
+    curatedFetchNextPage: () => {
+      void curated.fetchNextPage();
+    },
     marketStatus,
     // Kept for backward compatibility with components that might use MarketStatusRef
     marketStatusRef: { current: marketStatus }

--- a/web/src/pages/Dashboard/hooks/useTickerNews.ts
+++ b/web/src/pages/Dashboard/hooks/useTickerNews.ts
@@ -1,120 +1,50 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { getNews } from '../utils/api';
+import {
+  type DashboardNewsItem,
+  NEWS_POLL_INTERVAL_MS,
+  NEWS_STALE_MS,
+  mapNewsResults,
+} from '../utils/newsItem';
 
-interface NewsSentimentItem {
-  ticker: string;
-  sentiment: string;
-  reasoning?: string;
-}
-
-export interface TickerNewsItem {
-  id: string;
-  title: string;
-  time: string;
-  publishedAt: string | null;
-  isHot: boolean;
-  image: string | null;
-  source: string;
-  favicon: string | null;
-  tickers: string[];
-  articleUrl?: string | null;
-  // Inlined article body — lets the detail modal render without a by-id fetch.
-  author?: string | null;
-  description?: string | null;
-  keywords?: string[];
-  sentiments?: NewsSentimentItem[] | null;
-}
+// Back-compat alias — the news-item shape is shared across all dashboard feeds.
+export type TickerNewsItem = DashboardNewsItem;
 
 interface TickerRow {
   symbol: string;
   [key: string]: unknown;
 }
 
-interface CacheEntry {
-  items: TickerNewsItem[];
-  tickerKey: string;
-}
-
-// Module-level caches keyed by caller-provided cacheKey
-const cacheMap = new Map<string, CacheEntry>();
-
-function formatRelativeTime(timestamp: string | number | null | undefined): string {
-  if (!timestamp) return '';
-  const now = new Date();
-  const then = new Date(timestamp);
-  const diffMs = now.getTime() - then.getTime();
-  const diffMin = Math.floor(diffMs / 60000);
-  if (diffMin < 1) return 'just now';
-  if (diffMin < 60) return `${diffMin} min ago`;
-  const diffHr = Math.floor(diffMin / 60);
-  if (diffHr < 24) return `${diffHr} hr${diffHr > 1 ? 's' : ''} ago`;
-  const diffDay = Math.floor(diffHr / 24);
-  return `${diffDay} day${diffDay > 1 ? 's' : ''} ago`;
-}
-
-function mapNewsResults(results: Record<string, unknown>[]): TickerNewsItem[] {
-  return results.map((r) => ({
-    id: r.id as string,
-    title: r.title as string,
-    time: formatRelativeTime(r.published_at as string | null | undefined),
-    publishedAt: (r.published_at as string) || null,
-    isHot: r.has_sentiment as boolean,
-    image: r.image_url as string || null,
-    source: (r.source as Record<string, unknown> | undefined)?.name as string || '',
-    favicon: (r.source as Record<string, unknown> | undefined)?.favicon_url as string || null,
-    tickers: (r.tickers as string[]) || [],
-    articleUrl: (r.article_url as string) || null,
-    author: (r.author as string) ?? null,
-    description: (r.description as string) ?? null,
-    keywords: (r.keywords as string[]) || [],
-    sentiments: (r.sentiments as NewsSentimentItem[]) ?? null,
-  }));
-}
-
 /**
- * Hook to fetch news for a list of ticker rows.
+ * Fetches news for a list of ticker rows via React Query — same cache/poll
+ * mechanism as useDashboardData (no hand-rolled module cache or setInterval).
  * @param rows - Array of objects with a `symbol` property
- * @param cacheKey - Unique key for module-level caching (e.g. 'portfolio', 'watchlist')
+ * @param cacheKey - Distinguishes feeds that share tickers (e.g. 'portfolio', 'watchlist')
  * @param provider - Optional news provider to target (e.g. 'tickertick')
  */
 export function useTickerNews(rows: TickerRow[], cacheKey: string, provider?: string): { items: TickerNewsItem[]; loading: boolean } {
-  const cached = cacheMap.get(cacheKey);
-  const [items, setItems] = useState<TickerNewsItem[]>(() => cached?.items || []);
-  const [loading, setLoading] = useState(!cached);
+  const tickers = (rows || []).map((r) => r.symbol).filter(Boolean);
+  // Sorted so row reordering doesn't churn the query key. The ticker set,
+  // cacheKey, and provider are all in the key, so a change refetches and the
+  // Classic (chain) and Custom ('tickertick') feeds never serve each other's
+  // articles.
+  const tickerKey = [...tickers].sort().join(',');
+  const hasTickers = tickers.length > 0;
 
-  const fetchNews = useCallback(async (): Promise<void> => {
-    const tickers = (rows || []).map((r) => r.symbol).filter(Boolean);
-    const tickerKey = [...tickers].sort().join(',');
-
-    if (!tickers.length) {
-      setItems([]);
-      setLoading(false);
-      cacheMap.set(cacheKey, { items: [], tickerKey: '' });
-      return;
-    }
-
-    setLoading(true);
-    try {
+  const query = useQuery<TickerNewsItem[]>({
+    queryKey: ['dashboard', 'tickerNews', cacheKey, provider ?? null, tickerKey],
+    queryFn: async () => {
       const data = await getNews({ tickers, limit: 50, provider });
-      const mapped: TickerNewsItem[] = data.results?.length > 0 ? mapNewsResults(data.results) : [];
-      setItems(mapped);
-      cacheMap.set(cacheKey, { items: mapped, tickerKey });
-    } catch {
-      setItems([]);
-    } finally {
-      setLoading(false);
-    }
-  }, [rows, cacheKey, provider]);
+      return data.results?.length > 0 ? mapNewsResults(data.results) : [];
+    },
+    enabled: hasTickers,
+    staleTime: NEWS_STALE_MS,
+    refetchInterval: NEWS_POLL_INTERVAL_MS,
+    refetchIntervalInBackground: false,
+  });
 
-  useEffect(() => {
-    const tickers = (rows || []).map((r) => r.symbol).filter(Boolean);
-    const tickerKey = [...tickers].sort().join(',');
-    const cached = cacheMap.get(cacheKey);
-    if (cached?.tickerKey !== tickerKey) {
-      cacheMap.delete(cacheKey);
-    }
-    if (!cacheMap.has(cacheKey)) fetchNews();
-  }, [fetchNews, rows, cacheKey]);
-
-  return { items, loading };
+  return {
+    items: hasTickers ? (query.data ?? []) : [],
+    loading: hasTickers && query.isLoading,
+  };
 }

--- a/web/src/pages/Dashboard/hooks/useTickerNews.ts
+++ b/web/src/pages/Dashboard/hooks/useTickerNews.ts
@@ -1,16 +1,28 @@
 import { useCallback, useEffect, useState } from 'react';
 import { getNews } from '../utils/api';
 
+interface NewsSentimentItem {
+  ticker: string;
+  sentiment: string;
+  reasoning?: string;
+}
+
 export interface TickerNewsItem {
   id: string;
   title: string;
   time: string;
+  publishedAt: string | null;
   isHot: boolean;
   image: string | null;
   source: string;
   favicon: string | null;
   tickers: string[];
   articleUrl?: string | null;
+  // Inlined article body — lets the detail modal render without a by-id fetch.
+  author?: string | null;
+  description?: string | null;
+  keywords?: string[];
+  sentiments?: NewsSentimentItem[] | null;
 }
 
 interface TickerRow {
@@ -45,12 +57,17 @@ function mapNewsResults(results: Record<string, unknown>[]): TickerNewsItem[] {
     id: r.id as string,
     title: r.title as string,
     time: formatRelativeTime(r.published_at as string | null | undefined),
+    publishedAt: (r.published_at as string) || null,
     isHot: r.has_sentiment as boolean,
     image: r.image_url as string || null,
     source: (r.source as Record<string, unknown> | undefined)?.name as string || '',
     favicon: (r.source as Record<string, unknown> | undefined)?.favicon_url as string || null,
     tickers: (r.tickers as string[]) || [],
     articleUrl: (r.article_url as string) || null,
+    author: (r.author as string) ?? null,
+    description: (r.description as string) ?? null,
+    keywords: (r.keywords as string[]) || [],
+    sentiments: (r.sentiments as NewsSentimentItem[]) ?? null,
   }));
 }
 
@@ -58,8 +75,9 @@ function mapNewsResults(results: Record<string, unknown>[]): TickerNewsItem[] {
  * Hook to fetch news for a list of ticker rows.
  * @param rows - Array of objects with a `symbol` property
  * @param cacheKey - Unique key for module-level caching (e.g. 'portfolio', 'watchlist')
+ * @param provider - Optional news provider to target (e.g. 'tickertick')
  */
-export function useTickerNews(rows: TickerRow[], cacheKey: string): { items: TickerNewsItem[]; loading: boolean } {
+export function useTickerNews(rows: TickerRow[], cacheKey: string, provider?: string): { items: TickerNewsItem[]; loading: boolean } {
   const cached = cacheMap.get(cacheKey);
   const [items, setItems] = useState<TickerNewsItem[]>(() => cached?.items || []);
   const [loading, setLoading] = useState(!cached);
@@ -77,7 +95,7 @@ export function useTickerNews(rows: TickerRow[], cacheKey: string): { items: Tic
 
     setLoading(true);
     try {
-      const data = await getNews({ tickers, limit: 50 });
+      const data = await getNews({ tickers, limit: 50, provider });
       const mapped: TickerNewsItem[] = data.results?.length > 0 ? mapNewsResults(data.results) : [];
       setItems(mapped);
       cacheMap.set(cacheKey, { items: mapped, tickerKey });
@@ -86,7 +104,7 @@ export function useTickerNews(rows: TickerRow[], cacheKey: string): { items: Tic
     } finally {
       setLoading(false);
     }
-  }, [rows, cacheKey]);
+  }, [rows, cacheKey, provider]);
 
   useEffect(() => {
     const tickers = (rows || []).map((r) => r.symbol).filter(Boolean);

--- a/web/src/pages/Dashboard/utils/api.ts
+++ b/web/src/pages/Dashboard/utils/api.ts
@@ -537,8 +537,8 @@ export async function disconnectClaudeOAuth(): Promise<Record<string, unknown>> 
 
 /**
  * Fetch news articles from the native news endpoint.
- * GET /api/v1/news?tickers=...&limit=...&cursor=...
- * @param {{ tickers?: string[], limit?: number, cursor?: string }} opts
+ * GET /api/v1/news?tickers=...&limit=...&cursor=...&provider=...
+ * @param {{ tickers?: string[], limit?: number, cursor?: string, provider?: string }} opts
  * @returns {Promise<{ results: Array, count: number, next_cursor: string|null }>}
  */
 export async function getNews({ tickers, limit = 20, cursor, provider }: NewsParams = {}): Promise<NewsResponse> {
@@ -553,7 +553,9 @@ export async function getNews({ tickers, limit = 20, cursor, provider }: NewsPar
   } catch (e: unknown) {
     const err = e as { message?: string };
     console.error('[API] getNews failed:', err?.message);
-    return { results: [], count: 0, next_cursor: null };
+    // Re-throw so the React Query callers retry (retry:1) and KEEP the last
+    // good list instead of overwriting a live feed with [] on a transient blip.
+    throw e;
   }
 }
 

--- a/web/src/pages/Dashboard/utils/api.ts
+++ b/web/src/pages/Dashboard/utils/api.ts
@@ -72,6 +72,7 @@ interface NewsParams {
   tickers?: string[];
   limit?: number;
   cursor?: string;
+  provider?: string;
 }
 
 interface NewsResponse {
@@ -540,12 +541,13 @@ export async function disconnectClaudeOAuth(): Promise<Record<string, unknown>> 
  * @param {{ tickers?: string[], limit?: number, cursor?: string }} opts
  * @returns {Promise<{ results: Array, count: number, next_cursor: string|null }>}
  */
-export async function getNews({ tickers, limit = 20, cursor }: NewsParams = {}): Promise<NewsResponse> {
+export async function getNews({ tickers, limit = 20, cursor, provider }: NewsParams = {}): Promise<NewsResponse> {
   try {
     const params: Record<string, string | number> = {};
     if (tickers && tickers.length) params.tickers = tickers.join(',');
     if (limit) params.limit = limit;
     if (cursor) params.cursor = cursor;
+    if (provider) params.provider = provider;
     const { data } = await api.get('/api/v1/news', { params });
     return data || { results: [], count: 0, next_cursor: null };
   } catch (e: unknown) {

--- a/web/src/pages/Dashboard/utils/newsItem.ts
+++ b/web/src/pages/Dashboard/utils/newsItem.ts
@@ -1,0 +1,75 @@
+import i18n from '@/i18n';
+
+/** How often the dashboard news feeds re-poll their warm server buffer. */
+export const NEWS_POLL_INTERVAL_MS = 60000;
+/** Staleness window for news queries — just under the poll interval so an open
+ *  tab refetches on the poll cadence, not on every remount. */
+export const NEWS_STALE_MS = 55000;
+
+export interface NewsSentimentItem {
+  ticker: string;
+  sentiment: string;
+  reasoning?: string;
+}
+
+/** Normalized news row shared by every dashboard news feed (market, curated,
+ *  portfolio, watchlist). Produced by mapNewsResults from the /news payload. */
+export interface DashboardNewsItem {
+  id: string;
+  title: string;
+  time: string;
+  publishedAt: string | null;
+  isHot: boolean;
+  source: string;
+  favicon: string | null;
+  image: string | null;
+  tickers: string[];
+  articleUrl?: string | null;
+  // Inlined article body — lets the detail modal render without a by-id fetch.
+  author?: string | null;
+  description?: string | null;
+  keywords?: string[];
+  sentiments?: NewsSentimentItem[] | null;
+}
+
+/**
+ * Formats a timestamp to a localized relative time string. Computed outside
+ * React render — consumers re-render on locale switch because their parent calls
+ * useTranslation, which is what makes the freshly resolved string reach the DOM.
+ */
+export function formatRelativeTime(timestamp: string | number | null | undefined): string {
+  if (!timestamp) return '';
+  const now = new Date();
+  const then = new Date(timestamp);
+  const diffMs = now.getTime() - then.getTime();
+  const diffMin = Math.floor(diffMs / 60000);
+  if (diffMin < 1) return i18n.t('dashboard.widgets.common.relativeNow');
+  let when: string;
+  if (diffMin < 60) when = `${diffMin}m`;
+  else {
+    const diffHr = Math.floor(diffMin / 60);
+    if (diffHr < 24) when = `${diffHr}h`;
+    else when = `${Math.floor(diffHr / 24)}d`;
+  }
+  return i18n.t('dashboard.widgets.common.relativePast', { when });
+}
+
+/** Map raw /news results into the normalized DashboardNewsItem shape. */
+export function mapNewsResults(results: Record<string, unknown>[]): DashboardNewsItem[] {
+  return results.map((r) => ({
+    id: r.id as string,
+    title: r.title as string,
+    time: formatRelativeTime(r.published_at as string | null | undefined),
+    publishedAt: (r.published_at as string) || null,
+    isHot: r.has_sentiment as boolean,
+    source: (r.source as Record<string, unknown> | undefined)?.name as string || '',
+    favicon: (r.source as Record<string, unknown> | undefined)?.favicon_url as string || null,
+    image: r.image_url as string || null,
+    tickers: (r.tickers as string[]) || [],
+    articleUrl: (r.article_url as string) || null,
+    author: (r.author as string) ?? null,
+    description: (r.description as string) ?? null,
+    keywords: (r.keywords as string[]) || [],
+    sentiments: (r.sentiments as NewsSentimentItem[]) ?? null,
+  }));
+}

--- a/web/src/pages/Dashboard/widgets/definitions/NewsFeedWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/NewsFeedWidget.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AnimatePresence, motion } from 'framer-motion';
 import { Newspaper, Clock, Search, X } from 'lucide-react';
@@ -15,18 +15,19 @@ import { buildNewsArticleSnapshot } from '../../utils/newsArticleFetch';
 import { RowAttachButton } from '../../components/RowAttachButton';
 import type { WidgetRenderProps } from '../types';
 
-type NewsFeedSource = 'market' | 'portfolio' | 'watchlist';
+type NewsFeedSource = 'top' | 'market' | 'portfolio' | 'watchlist';
 type NewsFeedConfig = { source?: NewsFeedSource; limit?: number };
 
 type DateRangeKey = 'all' | '1h' | '6h' | '24h' | '7d';
 
 const SOURCE_KEY: Record<NewsFeedSource, string> = {
+  top: 'dashboard.widgets.newsFeed.tab_top',
   market: 'dashboard.widgets.newsFeed.tab_market',
   portfolio: 'dashboard.widgets.newsFeed.tab_portfolio',
   watchlist: 'dashboard.widgets.newsFeed.tab_watchlist',
 };
 
-const SOURCES: NewsFeedSource[] = ['market', 'portfolio', 'watchlist'];
+const SOURCES: NewsFeedSource[] = ['top', 'market', 'portfolio', 'watchlist'];
 
 const DATE_RANGES: { key: DateRangeKey; labelKey: string }[] = [
   { key: 'all', labelKey: 'dashboard.widgets.newsFeed.range_all' },
@@ -36,31 +37,27 @@ const DATE_RANGES: { key: DateRangeKey; labelKey: string }[] = [
   { key: '7d', labelKey: 'dashboard.widgets.newsFeed.range_7d' },
 ];
 
+interface NewsSentimentItem {
+  ticker: string;
+  sentiment: string;
+  reasoning?: string;
+}
+
 interface NewsItem {
   id?: string | number;
   title: string;
   source?: string;
   time?: string;
+  publishedAt?: string | null;
   image?: string | null;
   favicon?: string | null;
   tickers?: string[];
   isHot?: boolean;
   articleUrl?: string | null;
-}
-
-function parseRelativeTime(timeStr: string | undefined | null): number | null {
-  if (!timeStr) return null;
-  const now = Date.now();
-  const m = timeStr.match(/^(\d+)\s*(min|hr|hrs|hour|hours|day|days)/i);
-  // Unparseable strings return null (not now). Otherwise items with odd time
-  // formats silently bucket into every recent-window filter.
-  if (!m) return null;
-  const val = parseInt(m[1], 10);
-  const unit = m[2].toLowerCase();
-  if (unit === 'min') return now - val * 60 * 1000;
-  if (unit.startsWith('hr') || unit.startsWith('hour')) return now - val * 3600 * 1000;
-  if (unit.startsWith('day')) return now - val * 86400 * 1000;
-  return null;
+  author?: string | null;
+  description?: string | null;
+  keywords?: string[];
+  sentiments?: NewsSentimentItem[] | null;
 }
 
 function getDateRangeCutoff(key: DateRangeKey): number {
@@ -187,22 +184,59 @@ function NewsFeedWidget({ instance, updateConfig }: WidgetRenderProps<NewsFeedCo
   const [activeTab, setActiveTab] = useState<NewsFeedSource>(initialSource);
   const [tickerFilter, setTickerFilter] = useState('');
   const [dateRange, setDateRange] = useState<DateRangeKey>('all');
+  const [sourceFilter, setSourceFilter] = useState('all');
 
   const sources: Record<NewsFeedSource, { items: NewsItem[]; loading: boolean }> = {
+    top: { items: dashboard.curatedItems as NewsItem[], loading: dashboard.curatedLoading },
     market: { items: dashboard.newsItems as NewsItem[], loading: dashboard.newsLoading },
     portfolio: { items: portfolioNews.items as NewsItem[], loading: portfolioNews.loading },
     watchlist: { items: watchlistNews.items as NewsItem[], loading: watchlistNews.loading },
   };
   const { items, loading } = sources[activeTab];
 
+  // Infinite scroll — only the Top feed is cursor-paginated (TickerTick). As the
+  // user nears the end (rootMargin below), prefetch the next page.
+  const hasNextPage = activeTab === 'top' && !!dashboard.curatedHasNextPage;
+  const isFetchingNextPage = activeTab === 'top' && !!dashboard.curatedIsFetchingNextPage;
+  const fetchNextPage = activeTab === 'top' ? dashboard.curatedFetchNextPage : undefined;
+
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  // Read the latest paging state inside the observer without re-creating it on
+  // every page (which would re-fire on an already-visible sentinel and cascade).
+  const pageStateRef = useRef({ hasNextPage, isFetchingNextPage, fetchNextPage });
+  pageStateRef.current = { hasNextPage, isFetchingNextPage, fetchNextPage };
+
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+    const obs = new IntersectionObserver(
+      (entries) => {
+        if (!entries[0]?.isIntersecting) return;
+        const s = pageStateRef.current;
+        if (s.hasNextPage && !s.isFetchingNextPage && s.fetchNextPage) s.fetchNextPage();
+      },
+      { root: scrollRef.current, rootMargin: '500px' },
+    );
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, [activeTab]);
+
+  // Publisher facet derived from the active feed (pre-filter), for the source dropdown.
+  const sourceOptions = useMemo(
+    () => Array.from(new Set(items.map((i) => i.source).filter((s): s is string => !!s))).sort(),
+    [items],
+  );
+
   const switchTab = (key: NewsFeedSource) => {
     setActiveTab(key);
     setTickerFilter('');
     setDateRange('all');
+    setSourceFilter('all');
     updateConfig({ source: key });
   };
 
-  const hasFilters = tickerFilter.trim() !== '' || dateRange !== 'all';
+  const hasFilters = tickerFilter.trim() !== '' || dateRange !== 'all' || sourceFilter !== 'all';
 
   const filteredItems = useMemo(() => {
     let result = items;
@@ -210,15 +244,21 @@ function NewsFeedWidget({ instance, updateConfig }: WidgetRenderProps<NewsFeedCo
     if (query) {
       result = result.filter((item) => item.tickers?.some((t) => t.toUpperCase().includes(query)));
     }
+    if (sourceFilter !== 'all') {
+      result = result.filter((item) => item.source === sourceFilter);
+    }
     if (dateRange !== 'all') {
       const cutoff = getDateRangeCutoff(dateRange);
       result = result.filter((item) => {
-        const ts = parseRelativeTime(item.time);
-        return ts !== null && ts >= cutoff;
+        // Filter on the raw ISO timestamp — not the "24m ago" display string,
+        // whose unit format ("24m" vs "24 min") and wording vary by source and
+        // locale, which silently broke the Top/Market tabs' time filter.
+        const ts = item.publishedAt ? new Date(item.publishedAt).getTime() : NaN;
+        return Number.isFinite(ts) && ts >= cutoff;
       });
     }
     return result;
-  }, [items, tickerFilter, dateRange]);
+  }, [items, tickerFilter, sourceFilter, dateRange]);
 
   // Snapshot exporter: full = visible filtered list, rows = single headline.
   useWidgetContextExport(instance.id, {
@@ -233,7 +273,13 @@ function NewsFeedWidget({ instance, updateConfig }: WidgetRenderProps<NewsFeedCo
       const body = serializeNewsItemsToMarkdown(newsItems);
       const text = wrapWidgetContext(
         'news.feed',
-        { tab: activeTab, count: newsItems.length, dateRange, tickerFilter: tickerFilter || undefined },
+        {
+          tab: activeTab,
+          count: newsItems.length,
+          dateRange,
+          tickerFilter: tickerFilter || undefined,
+          sourceFilter: sourceFilter !== 'all' ? sourceFilter : undefined,
+        },
         body,
       );
       return {
@@ -243,7 +289,7 @@ function NewsFeedWidget({ instance, updateConfig }: WidgetRenderProps<NewsFeedCo
         description: `${newsItems.length} headline${newsItems.length === 1 ? '' : 's'}`,
         captured_at: new Date().toISOString(),
         text,
-        data: { items: newsItems, tab: activeTab, dateRange, tickerFilter },
+        data: { items: newsItems, tab: activeTab, dateRange, tickerFilter, sourceFilter },
       };
     },
     rows: async (rowId) => {
@@ -370,12 +416,34 @@ function NewsFeedWidget({ instance, updateConfig }: WidgetRenderProps<NewsFeedCo
           })}
         </div>
 
+        {sourceOptions.length > 0 ? (
+          <select
+            value={sourceFilter}
+            onChange={(e) => setSourceFilter(e.target.value)}
+            aria-label={t('dashboard.widgets.newsFeed.sourceLabel')}
+            className="h-7 px-2 rounded-md border text-[11px] outline-none cursor-pointer max-w-[140px]"
+            style={{
+              backgroundColor: 'var(--color-bg-subtle)',
+              borderColor: 'var(--color-border-muted)',
+              color: sourceFilter === 'all' ? 'var(--color-text-tertiary)' : 'var(--color-text-primary)',
+            }}
+          >
+            <option value="all">{t('dashboard.widgets.newsFeed.allSources')}</option>
+            {sourceOptions.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+        ) : null}
+
         {hasFilters ? (
           <button
             type="button"
             onClick={() => {
               setTickerFilter('');
               setDateRange('all');
+              setSourceFilter('all');
             }}
             className="text-[10px] uppercase tracking-wider transition-colors"
             style={{ color: 'var(--color-text-tertiary)' }}
@@ -391,7 +459,7 @@ function NewsFeedWidget({ instance, updateConfig }: WidgetRenderProps<NewsFeedCo
         ) : null}
       </div>
 
-      <div className="flex-1 min-h-0 overflow-y-auto -mx-1 px-1">
+      <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto -mx-1 px-1">
         <AnimatePresence mode="wait">
           <motion.div
             key={activeTab}
@@ -436,7 +504,9 @@ function NewsFeedWidget({ instance, updateConfig }: WidgetRenderProps<NewsFeedCo
                     ? t('dashboard.widgets.newsFeed.emptyFiltered')
                     : activeTab === 'market'
                       ? t('dashboard.widgets.newsFeed.emptyMarket')
-                      : t('dashboard.widgets.newsFeed.emptyAddTo', { label: t(SOURCE_KEY[activeTab]).toLowerCase() })}
+                      : activeTab === 'top'
+                        ? t('dashboard.widgets.newsFeed.emptyTop')
+                        : t('dashboard.widgets.newsFeed.emptyAddTo', { label: t(SOURCE_KEY[activeTab]).toLowerCase() })}
                 </div>
               </div>
             ) : (
@@ -451,7 +521,21 @@ function NewsFeedWidget({ instance, updateConfig }: WidgetRenderProps<NewsFeedCo
                       item={item}
                       idx={idx}
                       onClick={() => {
-                        if (item.id != null) modals.openNews(item.id, item.articleUrl ?? null);
+                        if (item.id != null) {
+                          modals.openNews(item.id, {
+                            title: item.title,
+                            source: item.source,
+                            publishedAt: item.publishedAt ?? null,
+                            tickers: item.tickers,
+                            articleUrl: item.articleUrl ?? null,
+                            author: item.author ?? null,
+                            description: item.description ?? null,
+                            keywords: item.keywords,
+                            sentiments: item.sentiments ?? null,
+                            imageUrl: item.image ?? null,
+                            favicon: item.favicon ?? null,
+                          });
+                        }
                       }}
                     />
                     <span className="absolute right-1 top-1/2 -translate-y-1/2 z-10">
@@ -463,6 +547,18 @@ function NewsFeedWidget({ instance, updateConfig }: WidgetRenderProps<NewsFeedCo
             )}
           </motion.div>
         </AnimatePresence>
+
+        {/* Infinite-scroll trigger (Top feed). Sits below the list so the
+            observer fires as the user nears the end and prefetches the next page. */}
+        <div ref={sentinelRef} aria-hidden className="h-px w-full" />
+        {isFetchingNextPage ? (
+          <div className="flex justify-center py-3">
+            <div
+              className="h-5 w-5 border-2 rounded-full animate-spin"
+              style={{ borderColor: 'var(--color-border-default)', borderTopColor: 'var(--color-accent-primary)' }}
+            />
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/web/src/pages/Dashboard/widgets/definitions/NewsFeedWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/NewsFeedWidget.tsx
@@ -12,6 +12,7 @@ import {
   type NewsArticleDetail,
 } from '../framework/snapshotSerializers';
 import { buildNewsArticleSnapshot } from '../../utils/newsArticleFetch';
+import type { NewsSentimentItem } from '../../utils/newsItem';
 import { RowAttachButton } from '../../components/RowAttachButton';
 import type { WidgetRenderProps } from '../types';
 
@@ -36,12 +37,6 @@ const DATE_RANGES: { key: DateRangeKey; labelKey: string }[] = [
   { key: '24h', labelKey: 'dashboard.widgets.newsFeed.range_24h' },
   { key: '7d', labelKey: 'dashboard.widgets.newsFeed.range_7d' },
 ];
-
-interface NewsSentimentItem {
-  ticker: string;
-  sentiment: string;
-  reasoning?: string;
-}
 
 interface NewsItem {
   id?: string | number;

--- a/web/src/pages/Dashboard/widgets/definitions/__tests__/NewsFeedWidget.test.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/__tests__/NewsFeedWidget.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+
+// i18n passthrough — assert on raw keys / publisher strings, not translations.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+// Peripheral widget plumbing the test doesn't exercise.
+vi.mock('@/pages/Dashboard/widgets/framework/contextSnapshot', () => ({
+  useWidgetContextExport: () => {},
+}));
+vi.mock('@/pages/Dashboard/components/RowAttachButton', () => ({
+  RowAttachButton: () => null,
+}));
+
+const openNews = vi.fn();
+let ctx: Record<string, unknown>;
+vi.mock('@/pages/Dashboard/widgets/framework/DashboardDataContext', () => ({
+  useDashboardContext: () => ctx,
+}));
+
+import '../../index'; // populate widget registry
+import { getWidget } from '../../framework/WidgetRegistry';
+
+function makeItem(id: string, title: string, source: string) {
+  return { id, title, source, time: '1h', tickers: [], favicon: null, image: null, isHot: false, articleUrl: 'https://x' };
+}
+
+function baseCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    dashboard: {
+      curatedItems: [makeItem('c1', 'Curated headline one', 'Bloomberg'), makeItem('c2', 'Curated headline two', 'Reuters')],
+      curatedLoading: false,
+      newsItems: [makeItem('m1', 'Market headline', 'CNBC')],
+      newsLoading: false,
+    },
+    portfolioNews: { items: [], loading: false },
+    watchlistNews: { items: [], loading: false },
+    modals: { openNews },
+    ...overrides,
+  };
+}
+
+function renderWidget(config: { source?: string }) {
+  const def = getWidget('news.feed');
+  if (!def) throw new Error('news.feed not registered');
+  const Component = def.component;
+  return render(
+    <Component instance={{ id: 'nf-1', type: 'news.feed', config }} updateConfig={vi.fn()} />,
+  );
+}
+
+describe('NewsFeedWidget', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    ctx = baseCtx();
+  });
+
+  it('Top tab renders TickerTick curated items', () => {
+    ctx = baseCtx();
+    renderWidget({ source: 'top' });
+    expect(screen.getByText('Curated headline one')).toBeInTheDocument();
+    expect(screen.getByText('Curated headline two')).toBeInTheDocument();
+  });
+
+  it('by-source dropdown filters the active feed to a publisher', () => {
+    ctx = baseCtx();
+    renderWidget({ source: 'top' });
+
+    const select = screen.getByRole('combobox') as HTMLSelectElement;
+    // Facet derives from loaded items: All + Bloomberg + Reuters.
+    const optionValues = within(select).getAllByRole('option').map((o) => (o as HTMLOptionElement).value);
+    expect(optionValues).toEqual(['all', 'Bloomberg', 'Reuters']);
+
+    fireEvent.change(select, { target: { value: 'Reuters' } });
+    expect(screen.queryByText('Curated headline one')).not.toBeInTheDocument();
+    expect(screen.getByText('Curated headline two')).toBeInTheDocument();
+  });
+
+  it('time filter buckets on the ISO publishedAt, not the "10m ago" display string', () => {
+    const now = Date.now();
+    const recent = {
+      id: 'r1', title: 'Recent story', source: 'Bloomberg', time: '10m',
+      publishedAt: new Date(now - 10 * 60 * 1000).toISOString(),
+      tickers: [], favicon: null, image: null, isHot: false, articleUrl: 'https://x',
+    };
+    const old = {
+      id: 'o1', title: 'Old story', source: 'Bloomberg', time: '3d',
+      publishedAt: new Date(now - 3 * 86400 * 1000).toISOString(),
+      tickers: [], favicon: null, image: null, isHot: false, articleUrl: 'https://x',
+    };
+    ctx = baseCtx({
+      dashboard: { curatedItems: [recent, old], curatedLoading: false, newsItems: [], newsLoading: false },
+    });
+    renderWidget({ source: 'top' });
+
+    // Both visible under ALL.
+    expect(screen.getByText('Recent story')).toBeInTheDocument();
+    expect(screen.getByText('Old story')).toBeInTheDocument();
+
+    // Switch to 1H. The "10m" display string would not have matched the old
+    // parser (it expected "10 min"); filtering on publishedAt keeps the recent
+    // story and drops the 3-day-old one.
+    fireEvent.click(screen.getByText('dashboard.widgets.newsFeed.range_1h'));
+    expect(screen.getByText('Recent story')).toBeInTheDocument();
+    expect(screen.queryByText('Old story')).not.toBeInTheDocument();
+  });
+
+  it('exposes "top" in the Zod source enum and the default config round-trips', () => {
+    const def = getWidget('news.feed')!;
+    expect(def.configSchema!.safeParse({ source: 'top', limit: 50 }).success).toBe(true);
+    expect(def.configSchema!.safeParse(def.defaultConfig).success).toBe(true);
+  });
+});

--- a/web/src/pages/Dashboard/widgets/framework/DashboardDataContext.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/DashboardDataContext.tsx
@@ -18,10 +18,33 @@ type WatchlistData = ReturnType<typeof useWatchlistData>;
 type PortfolioData = ReturnType<typeof usePortfolioData>;
 type TickerNews = ReturnType<typeof useTickerNews>;
 
+interface NewsModalSentiment {
+  ticker: string;
+  sentiment: string;
+  reasoning?: string;
+}
+
+/** The clicked news row's full body — the list now inlines description/keywords/
+ *  sentiments, so the detail modal renders straight from this with no by-id
+ *  round-trip (and still survives one for any future richer-body provider). */
+export interface NewsModalFallback {
+  title?: string;
+  source?: string;
+  publishedAt?: string | null;
+  tickers?: string[];
+  articleUrl?: string | null;
+  author?: string | null;
+  description?: string | null;
+  keywords?: string[];
+  sentiments?: NewsModalSentiment[] | null;
+  imageUrl?: string | null;
+  favicon?: string | null;
+}
+
 interface ModalActions {
   selectedNewsId: string | null;
-  selectedNewsFallbackUrl: string | null;
-  openNews: (id: string | number, fallbackUrl?: string | null) => void;
+  selectedNewsFallback: NewsModalFallback | null;
+  openNews: (id: string | number, fallback?: NewsModalFallback) => void;
   closeNews: () => void;
   selectedMarketInsightId: string | null;
   openInsight: (id: string) => void;
@@ -56,11 +79,11 @@ export function DashboardDataProvider({ children }: { children: ReactNode }) {
   const dashboard = useDashboardData();
   const watchlist = useWatchlistData();
   const portfolio = usePortfolioData();
-  const portfolioNews = useTickerNews(portfolio.rows, 'portfolio');
-  const watchlistNews = useTickerNews(watchlist.rows, 'watchlist');
+  const portfolioNews = useTickerNews(portfolio.rows, 'portfolio', 'tickertick');
+  const watchlistNews = useTickerNews(watchlist.rows, 'watchlist', 'tickertick');
 
   const [selectedNewsId, setSelectedNewsId] = useState<string | null>(null);
-  const [selectedNewsFallbackUrl, setSelectedNewsFallbackUrl] = useState<string | null>(null);
+  const [selectedNewsFallback, setSelectedNewsFallback] = useState<NewsModalFallback | null>(null);
   const [selectedMarketInsightId, setSelectedMarketInsightId] = useState<string | null>(null);
   const [deleteConfirm, setDeleteConfirm] = useState<DeleteConfirmState>({
     open: false,
@@ -69,13 +92,13 @@ export function DashboardDataProvider({ children }: { children: ReactNode }) {
     onConfirm: null,
   });
 
-  const openNews = useCallback((id: string | number, fallbackUrl?: string | null) => {
+  const openNews = useCallback((id: string | number, fallback?: NewsModalFallback) => {
     setSelectedNewsId(String(id));
-    setSelectedNewsFallbackUrl(fallbackUrl ?? null);
+    setSelectedNewsFallback(fallback ?? null);
   }, []);
   const closeNews = useCallback(() => {
     setSelectedNewsId(null);
-    setSelectedNewsFallbackUrl(null);
+    setSelectedNewsFallback(null);
   }, []);
 
   const requestDeleteConfirm = useCallback((state: Omit<DeleteConfirmState, 'open'>) => {
@@ -115,7 +138,7 @@ export function DashboardDataProvider({ children }: { children: ReactNode }) {
   const modals = useMemo<ModalActions>(
     () => ({
       selectedNewsId,
-      selectedNewsFallbackUrl,
+      selectedNewsFallback,
       openNews,
       closeNews,
       selectedMarketInsightId,
@@ -128,7 +151,7 @@ export function DashboardDataProvider({ children }: { children: ReactNode }) {
     }),
     [
       selectedNewsId,
-      selectedNewsFallbackUrl,
+      selectedNewsFallback,
       openNews,
       closeNews,
       selectedMarketInsightId,

--- a/web/src/pages/Dashboard/widgets/framework/configSchemas.ts
+++ b/web/src/pages/Dashboard/widgets/framework/configSchemas.ts
@@ -256,7 +256,7 @@ export const MarketsOverviewConfigSchema = z.object({
   indices: z.array(z.string().min(1)).optional().catch([]),
 });
 
-export const NEWS_FEED_SOURCES = ['market', 'portfolio', 'watchlist'] as const;
+export const NEWS_FEED_SOURCES = ['top', 'market', 'portfolio', 'watchlist'] as const;
 export const NewsFeedConfigSchema = z.object({
   source: z.enum(NEWS_FEED_SOURCES).optional().catch('market'),
   limit: intInRange(50, 1, 200).optional().catch(50),


### PR DESCRIPTION
## Summary

Adds **TickerTick** as a dashboard news source and hardens the whole `/news`
read path for production load. Four logical pieces:

**News feature (TickerTick)**
- New `TickerTickNewsSource` (keyless `api.tickertick.com`) wired into the data-client
  registry as a directly-addressable provider. Powers a new curated **"Top"** tab and
  re-points the Portfolio/Watchlist tabs at TickerTick's entity-aware ticker coverage.
- `/news` gains a validated `provider` query param; a by-source publisher filter and a
  detail modal round out the News widget. EN + zh-CN locales.

**Cache-stampede protection** (`3649c0ac`)
- Two-layer single-flight on cold-cache misses: in-process per `(provider,tickers,limit)`
  key, then a cross-worker `SET NX PX` Redis lock so exactly one worker fetches a cold key
  while the rest read the filled cache. Cursor/date/sort-filtered requests bypass the shared
  path. `get_article_by_id` now scans via non-blocking `SCAN` instead of `KEYS`.

**Keep-warm poller** (`35c211e8`)
- `NewsRefreshService`: a singleton background poller that delta-merges the latest page of
  the curated + Market general feeds into a rolling buffer (by id, newest-first, capped) under
  the same Redis key `/news` reads — global feeds stay warm and never cold-miss upstream. One
  worker polls per tick via a Redis leader lock. Config under `news_poll` in `config.yaml`.

**Hardening**
- TickerTick adapter (`0fd053d0`): non-dict upstream bodies degrade to an empty feed instead
  of crashing; ticker tokens are sanitized before entering the query DSL (injection guard).
- News modal (`a8a7380f`): article/fallback URLs routed through a `safeHttpUrl` guard that
  blocks `javascript:`/`data:` schemes before they reach an `<a href>`.

**Frontend cleanup** (`b6f8ee8b`)
- `useTickerNews` migrated off its hand-rolled module cache + `setInterval` onto React Query,
  sharing one cache/poll mechanism with `useDashboardData`. Duplicated mapper/formatter/types
  extracted to a shared `newsItem` module (fixes zh-CN relative-time on the portfolio/watchlist
  path). `getNews` re-throws on error so callers retry and retain the last good list instead of
  blanking the feed.

## Diff Size
- Total: 35 files changed, +2,545 / -232
- Net (excl. tests): 25 files changed, +1,191 / -232

## Test Coverage
- Backend: Redis lock/scan primitives, `/news` single-flight + distributed-lock paths,
  delta-merge poller, provider-scoped cache keys, TickerTick query-injection + timestamp guards.
- Frontend: `useTickerNews` React Query migration (eager fetch + 60s repoll, provider/cacheKey
  isolation, no-ticker short-circuit, unmount stops polling, field fallbacks, failed-poll
  retains last list).
- Full backend unit suite: **3670 passed**. Frontend Dashboard: **264 passed**.

## Pre-Landing Review
Focused delta review (this code was reviewed twice pre-merge). No functional bugs found.
One known gap:
- **`safeHttpUrl` XSS guard has no regression test.** The guard works, but `NewsDetailModal.test.tsx`
  has no scheme coverage — a future refactor could silently drop it. Trivial to cover; tracked as
  a follow-up.

## Verification
- [x] `uv run pytest tests/unit/` — 3670 passed
- [x] `pnpm vitest run src/pages/Dashboard` — 264 passed
- [x] `ruff check` (changed files) — clean
- [x] `tsc --noEmit` — clean
- [x] `eslint` (changed files) — clean

## Notes
- `agent_config.yaml` intentionally **not** included.
- Rebased onto `origin/main`; linear history, no conflicts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Top" curated news tab with infinite-scroll (warmed, de-duplicated results)
  * Optional provider selection for news requests (including a new curated provider)
  * Modal accepts row fallback so article details render instantly without a by-id fetch

* **Improvements**
  * Background poller keeps Top feed hot for faster loads and rolling buffer merges
  * Article list now inlines author, description, keywords and sentiment details
  * Safer article links via stricter URL validation; updated dashboard/localization strings

* **Tests**
  * Extensive unit tests covering polling, caching, locking, provider routing, and UI behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->