### PR TITLE
feat(web): persist locale in a shared cookie instead of localStorage

### DIFF
--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -98,7 +98,7 @@ The ChatAgent page has side-by-side panels (ChatView + FilePanel). Their headers
 - **Path alias:** `@` → `src/` (configured in both `vite.config.js` and `vitest.config.js`)
 - **Tests:** Co-located in `__tests__/` subdirectories next to the code they test. Vitest + jsdom + Testing Library + `@testing-library/jest-dom`. Global setup mocks `matchMedia`, `IntersectionObserver`, `ResizeObserver` (`src/test/setup.ts`).
 - **UI primitives:** `components/ui/` has Radix-based primitives (dialog, toast, button, card, etc.) using `class-variance-authority` for variant props.
-- **i18n:** `i18next` + `react-i18next`. Setup in `src/i18n.ts` (cross-tab locale sync via `storage` event). Locale-aware number/date formatting via `createFormatter` / `createDateFormatter` in `src/lib/format.ts` — components MUST also call `useTranslation()` so they re-render on locale switch.
+- **i18n:** `i18next` + `react-i18next`. Setup in `src/i18n.ts`; locale persists in a `locale` cookie (helpers + `isSupported`/`SUPPORTED_LOCALES` in `src/lib/locale.ts`), resolved cookie → browser language → `en-US`. No live cross-tab sync — other tabs adopt a change on next navigation. Locale-aware number/date formatting via `createFormatter` / `createDateFormatter` in `src/lib/format.ts` — components MUST also call `useTranslation()` so they re-render on locale switch.
 - **WebSocket:** Real-time market data via `pages/MarketView/contexts/MarketDataWSContext.tsx`.
 
 ### Env Variables
@@ -110,3 +110,4 @@ The ChatAgent page has side-by-side panels (ChatView + FilePanel). Their headers
 | `VITE_SUPABASE_PUBLISHABLE_KEY` | — | Supabase publishable (anon) key |
 | `VITE_AUTH_USER_ID` | `local-dev-user` | User ID when Supabase auth is disabled |
 | `VITE_CDN_BASE` | `/` | Asset base URL for CDN deployments |
+| `VITE_COOKIE_DOMAIN` | (unset = host-only) | Parent domain for first-party cookies (auth + locale); set to share across subdomains (SSO) |

--- a/web/src/__tests__/i18n.test.ts
+++ b/web/src/__tests__/i18n.test.ts
@@ -1,68 +1,45 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import i18n from '../i18n';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getLocaleCookie, setLocaleCookie, detectLocale } from '../lib/locale';
 
-// The cross-tab `storage` listener in i18n.ts is the only locale-sync mechanism
-// between tabs. Browsers fire `storage` only in OTHER tabs, never the writer,
-// so the handler doesn't need to dedupe its own writes — but it MUST ignore
-// foreign keys, junk values, unsupported locales, and same-locale events
-// (the last is a recursion guard against synthetic re-dispatches).
-describe('i18n cross-tab storage listener', () => {
-  let originalLang: string;
+// localStorage-based locale + the cross-tab `storage` listener were replaced by a
+// single shared `locale` cookie (readable server-side, unlike localStorage).
+// These cover the cookie helpers + cookie-first detection.
+function clearLocaleCookie() {
+  document.cookie = 'locale=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+}
 
-  beforeEach(() => {
-    originalLang = i18n.language;
+describe('locale cookie helpers', () => {
+  beforeEach(() => clearLocaleCookie());
+
+  it('returns null when no locale cookie is set', () => {
+    expect(getLocaleCookie()).toBeNull();
   });
 
-  afterEach(async () => {
-    if (i18n.language !== originalLang) {
-      await i18n.changeLanguage(originalLang);
-    }
+  it('round-trips a supported locale', () => {
+    setLocaleCookie('zh-CN');
+    expect(getLocaleCookie()).toBe('zh-CN');
   });
 
-  function fire(key: string | null, newValue: string | null) {
-    window.dispatchEvent(
-      new StorageEvent('storage', { key, newValue, storageArea: localStorage }),
-    );
-  }
-
-  it('ignores storage events for unrelated keys', async () => {
-    await i18n.changeLanguage('en-US');
-    const spy = vi.spyOn(i18n, 'changeLanguage');
-    fire('user-prefs', 'zh-CN');
-    expect(spy).not.toHaveBeenCalled();
-    spy.mockRestore();
+  it('ignores unsupported values on write', () => {
+    setLocaleCookie('fr-FR');
+    expect(getLocaleCookie()).toBeNull();
   });
 
-  it('ignores storage events with null/empty newValue (key was removed)', async () => {
-    await i18n.changeLanguage('en-US');
-    const spy = vi.spyOn(i18n, 'changeLanguage');
-    fire('locale', null);
-    fire('locale', '');
-    expect(spy).not.toHaveBeenCalled();
-    spy.mockRestore();
+  it('treats an unsupported cookie value as absent on read', () => {
+    document.cookie = 'locale=zh-TW; path=/'; // valid BCP-47, not supported
+    expect(getLocaleCookie()).toBeNull();
   });
 
-  it('ignores storage events with unsupported locales', async () => {
-    await i18n.changeLanguage('en-US');
-    const spy = vi.spyOn(i18n, 'changeLanguage');
-    fire('locale', 'fr-FR');
-    fire('locale', 'zh-TW'); // valid BCP-47 but not in SUPPORTED_LOCALES
-    fire('locale', '<script>alert(1)</script>');
-    expect(spy).not.toHaveBeenCalled();
-    spy.mockRestore();
+  it('treats a malformed percent-encoded cookie as absent instead of throwing', () => {
+    // getLocaleCookie runs at module load via detectLocale → a throw here
+    // would white-screen the app on every load until cookies are cleared.
+    document.cookie = 'locale=%E0%A4%A; path=/';
+    expect(getLocaleCookie()).toBeNull();
+    expect(() => detectLocale()).not.toThrow();
   });
 
-  it('switches language when a supported locale lands via storage', async () => {
-    await i18n.changeLanguage('en-US');
-    fire('locale', 'zh-CN');
-    expect(i18n.language).toBe('zh-CN');
-  });
-
-  it('no-ops when the storage value matches the current language', async () => {
-    await i18n.changeLanguage('zh-CN');
-    const spy = vi.spyOn(i18n, 'changeLanguage');
-    fire('locale', 'zh-CN');
-    expect(spy).not.toHaveBeenCalled();
-    spy.mockRestore();
+  it('detectLocale prefers a valid cookie', () => {
+    setLocaleCookie('zh-CN');
+    expect(detectLocale()).toBe('zh-CN');
   });
 });

--- a/web/src/hooks/__tests__/useSyncUserLocale.test.ts
+++ b/web/src/hooks/__tests__/useSyncUserLocale.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Mock } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useSyncUserLocale } from '../useSyncUserLocale';
+import { getLocaleCookie, setLocaleCookie } from '../../lib/locale';
 
 vi.mock('../useUser', () => ({
   useUser: vi.fn(),
@@ -31,24 +32,28 @@ function makeI18n(language = 'en-US'): I18nStub {
   return stub;
 }
 
+function clearLocaleCookie() {
+  document.cookie = 'locale=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+}
+
 let mockI18n: I18nStub;
 
 describe('useSyncUserLocale', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    localStorage.clear();
+    clearLocaleCookie();
     mockI18n = makeI18n('en-US');
     mockUseTranslation.mockReturnValue({ i18n: mockI18n });
   });
 
-  it('applies the server locale on first render', () => {
+  it('seeds locale from the server on first render (no cookie yet)', () => {
     mockUseUser.mockReturnValue({ user: { locale: 'zh-CN' } });
 
     renderHook(() => useSyncUserLocale());
 
     expect(mockI18n.changeLanguage).toHaveBeenCalledTimes(1);
     expect(mockI18n.changeLanguage).toHaveBeenCalledWith('zh-CN');
-    expect(localStorage.getItem('locale')).toBe('zh-CN');
+    expect(getLocaleCookie()).toBe('zh-CN');
   });
 
   it('does not re-apply when user.locale changes after the first sync (regression: locale race)', () => {
@@ -57,35 +62,41 @@ describe('useSyncUserLocale', () => {
     const { rerender } = renderHook(() => useSyncUserLocale());
 
     expect(mockI18n.changeLanguage).toHaveBeenCalledTimes(1);
-    expect(localStorage.getItem('locale')).toBe('zh-CN');
+    expect(getLocaleCookie()).toBe('zh-CN');
 
-    // Simulate a stale /users/me refetch returning the prior server value while
-    // the user has just picked a different locale locally.
+    // Stale /users/me refetch returns the prior server value after a local pick.
     mockUseUser.mockReturnValue({ user: { locale: 'en-US' } });
     rerender();
 
-    // Latch must hold: no second changeLanguage, localStorage untouched.
+    // Latch holds: no second changeLanguage, cookie untouched.
     expect(mockI18n.changeLanguage).toHaveBeenCalledTimes(1);
-    expect(localStorage.getItem('locale')).toBe('zh-CN');
+    expect(getLocaleCookie()).toBe('zh-CN');
   });
 
-  it('latches even when the first render is a no-op (user.locale already matches i18n.language)', () => {
-    mockI18n = makeI18n('en-US');
-    mockUseTranslation.mockReturnValue({ i18n: mockI18n });
+  it('an existing cookie wins — the DB value does not override it', () => {
+    setLocaleCookie('en-US');
+    mockUseUser.mockReturnValue({ user: { locale: 'zh-CN' } });
+
+    renderHook(() => useSyncUserLocale());
+
+    expect(mockI18n.changeLanguage).not.toHaveBeenCalled();
+    expect(getLocaleCookie()).toBe('en-US');
+  });
+
+  it('seeds the cookie even when i18n already matches (no changeLanguage needed), and latches', () => {
     mockUseUser.mockReturnValue({ user: { locale: 'en-US' } });
 
     const { rerender } = renderHook(() => useSyncUserLocale());
 
-    // First render: locale matches i18n.language, so changeLanguage is not
-    // called, but the latch must still trip.
+    // i18n.language already 'en-US' → no changeLanguage, but the cookie is seeded.
     expect(mockI18n.changeLanguage).not.toHaveBeenCalled();
-    expect(localStorage.getItem('locale')).toBeNull();
+    expect(getLocaleCookie()).toBe('en-US');
 
-    // Later refetch returns a different locale: latch must block the sync.
+    // Latch blocks a later differing refetch.
     mockUseUser.mockReturnValue({ user: { locale: 'zh-CN' } });
     rerender();
 
     expect(mockI18n.changeLanguage).not.toHaveBeenCalled();
-    expect(localStorage.getItem('locale')).toBeNull();
+    expect(getLocaleCookie()).toBe('en-US');
   });
 });

--- a/web/src/hooks/useSyncUserLocale.ts
+++ b/web/src/hooks/useSyncUserLocale.ts
@@ -1,13 +1,14 @@
 import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useUser } from './useUser';
-
-const SUPPORTED = new Set(['en-US', 'zh-CN']);
+import { getLocaleCookie, isSupported, setLocaleCookie } from '../lib/locale';
 
 /**
- * Apply the user's DB-stored locale once, on the first user payload we see.
- * Subsequent refetches must not override the local value — otherwise a stale
- * /users/me response can clobber a locale the user just picked in Settings.
+ * Seed the locale from the user's DB value on first load — but only when there's
+ * no `locale` cookie yet (a browser-level cookie choice wins, and the cookie is
+ * what servers can read). Latched so a later /users/me refetch can't clobber a
+ * value the user just picked. Writing the cookie makes the DB preference
+ * server-readable on a fresh device.
  */
 export function useSyncUserLocale() {
   const { user } = useUser();
@@ -17,12 +18,10 @@ export function useSyncUserLocale() {
   useEffect(() => {
     if (synced.current) return;
     const stored = user?.locale as string | undefined;
-    if (!stored || !SUPPORTED.has(stored)) return;
+    if (!isSupported(stored)) return;
     synced.current = true; // latch even if no-op, so a later refetch can't trigger sync
-    if (i18n.language === stored) return;
-    i18n.changeLanguage(stored);
-    if (typeof localStorage !== 'undefined') {
-      localStorage.setItem('locale', stored);
-    }
+    if (getLocaleCookie()) return; // browser cookie wins; already applied at init
+    if (i18n.language !== stored) i18n.changeLanguage(stored);
+    setLocaleCookie(stored);
   }, [user?.locale, i18n]);
 }

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -2,29 +2,13 @@ import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import enUS from './locales/en-US.json';
 import zhCN from './locales/zh-CN.json';
+import { detectLocale } from './lib/locale';
 
-const SUPPORTED_LOCALES = ['en-US', 'zh-CN'] as const;
-
-function detectLocale(): string {
-  // 1. Explicit user choice persisted in localStorage
-  const stored = localStorage.getItem('locale');
-  if (stored && SUPPORTED_LOCALES.includes(stored as typeof SUPPORTED_LOCALES[number])) {
-    return stored;
-  }
-
-  // 2. Browser language — try exact match first, then prefix match
-  const browserLang = navigator.language; // e.g. "zh-CN", "zh-TW", "en-GB"
-  if (SUPPORTED_LOCALES.includes(browserLang as typeof SUPPORTED_LOCALES[number])) {
-    return browserLang;
-  }
-  const prefix = browserLang.split('-')[0]; // "zh", "en"
-  const prefixMatch = SUPPORTED_LOCALES.find((l) => l.startsWith(prefix + '-'));
-  if (prefixMatch) return prefixMatch;
-
-  // 3. Fallback
-  return 'en-US';
-}
-
+// Locale resolution (cookie → browser language → English) lives in ./lib/locale,
+// shared with the cookie helpers that components use. The cross-tab `storage`
+// listener was removed along with localStorage-based locale: locale now rides a
+// shared cookie (readable server-side, unlike localStorage); other tabs adopt a
+// change on their next navigation.
 i18n.use(initReactI18next).init({
   resources: {
     'en-US': { translation: enUS },
@@ -34,16 +18,5 @@ i18n.use(initReactI18next).init({
   fallbackLng: 'en-US',
   interpolation: { escapeValue: false },
 });
-
-// Cross-tab locale sync: `storage` events fire only in OTHER tabs (not the
-// writer), so this won't recurse.
-if (typeof window !== 'undefined') {
-  window.addEventListener('storage', (e) => {
-    if (e.key !== 'locale' || !e.newValue) return;
-    if (!SUPPORTED_LOCALES.includes(e.newValue as typeof SUPPORTED_LOCALES[number])) return;
-    if (i18n.language === e.newValue) return;
-    i18n.changeLanguage(e.newValue);
-  });
-}
 
 export default i18n;

--- a/web/src/lib/locale.ts
+++ b/web/src/lib/locale.ts
@@ -1,0 +1,51 @@
+// Shared locale helpers — deliberately standalone (no i18next/react-i18next
+// import) so hooks/components that are unit-tested with react-i18next mocked can
+// import these without booting i18n.
+//
+// The `locale` cookie is the single client-side carrier for locale, and because
+// a cookie is server/edge-readable (unlike localStorage) the same choice can
+// also drive server-side routing — e.g. a locale-aware redirect at a reverse
+// proxy. Host-only by default; set VITE_COOKIE_DOMAIN — the same knob that
+// scopes the auth cookie — to share it across subdomains.
+export const SUPPORTED_LOCALES = ['en-US', 'zh-CN'] as const;
+export type Locale = (typeof SUPPORTED_LOCALES)[number];
+
+export const isSupported = (v: string | null | undefined): v is Locale =>
+  !!v && (SUPPORTED_LOCALES as readonly string[]).includes(v);
+
+const COOKIE_DOMAIN: string = import.meta.env.VITE_COOKIE_DOMAIN ?? '';
+
+export function getLocaleCookie(): Locale | null {
+  if (typeof document === 'undefined') return null;
+  const m = document.cookie.match(/(?:^|;\s*)locale=([^;]+)/);
+  if (!m) return null;
+  let v: string;
+  try {
+    v = decodeURIComponent(m[1]);
+  } catch {
+    // Malformed %XX — treat as absent. This runs at module load (i18n init),
+    // so throwing here would white-screen the app with no recovery path.
+    return null;
+  }
+  return isSupported(v) ? v : null;
+}
+
+export function setLocaleCookie(locale: string): void {
+  if (typeof document === 'undefined' || !isSupported(locale)) return;
+  const attrs = [`locale=${locale}`, 'path=/', 'max-age=31536000', 'samesite=lax'];
+  if (COOKIE_DOMAIN) attrs.push(`domain=${COOKIE_DOMAIN}`);
+  if (window.location.protocol === 'https:') attrs.push('secure');
+  document.cookie = attrs.join('; ');
+}
+
+// Resolution order: cookie (explicit / DB-mirrored choice) → browser language
+// (exact, then prefix) → English.
+export function detectLocale(): string {
+  const cookie = getLocaleCookie();
+  if (cookie) return cookie;
+  const browserLang = typeof navigator !== 'undefined' ? navigator.language : '';
+  if (isSupported(browserLang)) return browserLang;
+  const prefix = browserLang.split('-')[0];
+  const prefixMatch = SUPPORTED_LOCALES.find((l) => l.startsWith(prefix + '-'));
+  return prefixMatch || 'en-US';
+}

--- a/web/src/lib/supabase.ts
+++ b/web/src/lib/supabase.ts
@@ -4,10 +4,11 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseKey = import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY;
 /**
- * Parent domain for the auth cookie. Unset (dev) → host-scoped. In platform
- * prod set to ".ginlix.ai" so every subdomain shares one session — SSO.
+ * Parent domain for first-party cookies, via the shared VITE_COOKIE_DOMAIN knob
+ * (also scopes the locale cookie). Unset → host-only (the default). Set to a
+ * parent domain so every subdomain shares one session — SSO.
  */
-const cookieDomain = import.meta.env.VITE_AUTH_COOKIE_DOMAIN as string | undefined;
+const cookieDomain = import.meta.env.VITE_COOKIE_DOMAIN as string | undefined;
 
 if (supabaseUrl && !supabaseKey) {
   console.warn('[supabase] VITE_SUPABASE_URL is set but VITE_SUPABASE_PUBLISHABLE_KEY is missing');

--- a/web/src/pages/Settings/Settings.tsx
+++ b/web/src/pages/Settings/Settings.tsx
@@ -21,6 +21,7 @@ import type { ByokProvider, CustomModelEntry } from '@/components/model/types';
 import { useAllModels } from '@/hooks/useAllModels';
 import type { CompactionProfileName } from '@/hooks/useAllModels';
 import { useDebouncedSave } from '@/hooks/useDebouncedSave';
+import { isSupported, setLocaleCookie } from '@/lib/locale';
 import './Settings.css';
 
 interface CodexDeviceCode {
@@ -506,9 +507,9 @@ function Settings() {
 
   const handleLocaleChange = (newLocale: string) => {
     setLocale(newLocale);
-    if (newLocale === 'en-US' || newLocale === 'zh-CN') {
+    if (isSupported(newLocale)) {
       i18n.changeLanguage(newLocale);
-      localStorage.setItem('locale', newLocale);
+      setLocaleCookie(newLocale);
     }
     userInfoRef.current = { ...userInfoRef.current, locale: newLocale };
     flushUserInfoSave();

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -7,7 +7,9 @@ interface ImportMetaEnv {
   readonly VITE_SUPABASE_PUBLISHABLE_KEY?: string;
   readonly VITE_AUTH_USER_ID?: string;
   readonly VITE_CDN_BASE?: string;
-  readonly VITE_AUTH_COOKIE_DOMAIN?: string;
+  // Parent domain shared by all first-party cookies (auth + locale). Unset →
+  // host-only (the default); set to a parent domain for cross-subdomain SSO.
+  readonly VITE_COOKIE_DOMAIN?: string;
 }
 interface ImportMeta {
   readonly env: ImportMetaEnv;


### PR DESCRIPTION
## Summary

**Locale persistence** (4bff6f6b)
- Locale now lives in a `locale` cookie instead of localStorage, managed by a new
  standalone module `web/src/lib/locale.ts` (`getLocaleCookie` / `setLocaleCookie` /
  `detectLocale` / `isSupported` / `SUPPORTED_LOCALES`). Cookies are readable
  server-side, so the same choice can drive locale-aware routing at a reverse proxy.
- Resolution order: cookie → browser language (exact, then prefix) → `en-US`.
  An existing cookie wins over the DB-stored preference; the DB value now only
  seeds fresh devices (latched against stale `/users/me` refetches).
- The cross-tab `storage` listener is removed — other tabs adopt a locale change
  on their next navigation.
- Auth + locale cookie domains consolidated under a single optional
  `VITE_COOKIE_DOMAIN` (unset → host-only, current behavior unchanged; set to a
  parent domain for cross-subdomain SSO).
- Hardening: malformed percent-encoded cookie values read as absent instead of
  throwing during i18n init (which would white-screen the app with no recovery);
  `Secure` flag added on HTTPS, matching the auth cookie writer.

**Docs** (2a1968ba)
- `web/CLAUDE.md`: i18n convention updated for the cookie mechanism;
  `VITE_COOKIE_DOMAIN` added to the env table.

## Diff Size
- Total: 9 files changed, 136 insertions(+), 120 deletions(-)
- Net (excl. tests): 7 files changed, ~84 insertions(+), ~51 deletions(-)

## Test Coverage
- `getLocaleCookie`: absent / valid round-trip / unsupported value / malformed
  percent-encoding (regression for the boot-crash path) — covered
- `setLocaleCookie`: valid write / unsupported rejected — covered
- `detectLocale`: cookie-first preference, no-throw on malformed cookie — covered
- `useSyncUserLocale`: DB seed on fresh device / cookie-beats-DB / latch vs stale
  refetch / seed-without-changeLanguage — covered
- Tests: 9 → 10 in the touched suites (+1 malformed-cookie regression)

## Pre-Landing Review
Two in-session review passes (structured checklist + adversarial second pass with
parallel reviewers and a codebase-wide call-site sweep). All findings fixed:
- Boot crash on malformed cookie (try/catch + regression test)
- Untyped `import.meta` access → declared in `vite-env.d.ts`
- Supported-locale validation consolidated into one `isSupported` source of truth
- `VITE_AUTH_COOKIE_DOMAIN` + `VITE_LOCALE_COOKIE_DOMAIN` → one `VITE_COOKIE_DOMAIN`
- Conditional `Secure` cookie flag on HTTPS
Call-site sweep confirmed zero lingering `localStorage('locale')` readers/writers.

## Behavioral notes for reviewers
- `supabase.ts` now reads `VITE_COOKIE_DOMAIN` (renamed from
  `VITE_AUTH_COOKIE_DOMAIN`). The old variable was referenced nowhere in the
  repo, so this is a no-op — but any deployment that exports the old name in
  its environment should switch to the new one (otherwise the auth cookie
  falls back to host-only).
- No live cross-tab locale sync anymore; tabs converge on next navigation.

## Test plan
- [x] Full frontend suite: 1187/1187 pass (108 files)
- [x] ESLint: 0 errors on touched files; tsc clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated i18n behavior documentation to reflect that locale persistence no longer includes live cross-tab synchronization; other tabs now adopt locale changes only on next navigation.

* **Chores**
  * Migrated locale persistence from localStorage to cookie-based storage for improved subdomain sharing support.
  * Added `VITE_COOKIE_DOMAIN` environment variable to configure parent domain for sharing first-party cookies (auth + locale) across subdomains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->