### PR TITLE
feat(llms): model rating metadata and derived price tier

### DIFF
--- a/scripts/ops/calibrate_model_ratings.py
+++ b/scripts/ops/calibrate_model_ratings.py
@@ -107,9 +107,9 @@ def band(value: float, bands: list[tuple[float, int]]) -> int:
 
 
 def get_key(env_file: Path) -> str:
-    key = os.environ.get("ARTIFICIAL_ANALYSIS_API_KEY")
+    key = (os.environ.get("ARTIFICIAL_ANALYSIS_API_KEY") or "").strip()
     if key:
-        return key.strip()
+        return key
     if env_file.exists():
         for line in env_file.read_text().splitlines():
             if line.startswith("ARTIFICIAL_ANALYSIS_API_KEY="):
@@ -241,6 +241,11 @@ def main() -> None:
     manifest = json.loads(MANIFEST.read_text())
     visible = [k for k, v in manifest.items() if v.get("visible")]
 
+    # MANUAL overrides: applied (on --apply) to every visible variant of each
+    # base, for the listed fields only — computed up front so dry-run rows can
+    # show the value --apply would actually write.
+    overrides = {k: MANUAL[collapse_base(k)] for k in visible if collapse_base(k) in MANUAL}
+
     matched, unmatched, changes = [], [], 0
     print(f"basis={args.basis}  fields={','.join(sorted(write_fields))}\n")
     print(f"{'model':30s} {'cur s/i':>7}  {'AA II':>6} {'AA tps':>7}  {'new s/i':>7}  AA row (effort matched)")
@@ -251,8 +256,14 @@ def main() -> None:
         rows = by_tokens.get(tokens(k)) or by_tokens.get(tokens(base_name(k)))
         row = pick_row(rows, target_effort_rank(cur), args.basis) if rows else {}
         if not row:
+            ov = overrides.get(k, {})
+            new_s = ov["speed"] if ("speed" in ov and "speed" in write_fields) else cur_s
+            new_i = ov["intelligence"] if ("intelligence" in ov and "intelligence" in write_fields) else cur_i
+            label = "(manual)" if (new_s, new_i) != (cur_s, cur_i) else "(keep)"
+            if label == "(manual)":
+                changes += 1
             unmatched.append(k)
-            print(f"{k:30s} {f'{cur_s}/{cur_i}':>7}  {'—':>6} {'—':>7}  {'(keep)':>7}  — no AA match")
+            print(f"{k:30s} {f'{cur_s}/{cur_i}':>7}  {'—':>6} {'—':>7}  {f'{new_s}/{new_i}' if label == '(manual)' else label:>8}  — no AA match")
             continue
         ii, tps, name = ii_of(row), _num(row.get("performance", {}).get("median_output_tokens_per_second")), row["name"]
         new_i = band(ii, INTEL_BANDS) if ("intelligence" in write_fields and ii is not None) else cur_i
@@ -270,9 +281,6 @@ def main() -> None:
     if unmatched:
         print("UNMATCHED (AA has no row; see MANUAL below for any covered): " + ", ".join(unmatched))
 
-    # MANUAL overrides: applied to every visible variant of each base, for the
-    # listed fields only (so AA-derived fields on matched models survive).
-    overrides = {k: MANUAL[collapse_base(k)] for k in visible if collapse_base(k) in MANUAL}
     if overrides:
         print("\nMANUAL OVERRIDES (sourced; AA-untracked or no-throughput):")
         for b, ov in MANUAL.items():

--- a/scripts/ops/calibrate_model_ratings.py
+++ b/scripts/ops/calibrate_model_ratings.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Calibrate per-model ``speed`` and ``intelligence`` (1-5) in models.json from
+Artificial Analysis's free Data API.
+
+Source of truth for the two genuinely-subjective editorial fields in the
+model-detail flyout:
+  - ``intelligence`` <- AA ``artificial_analysis_intelligence_index``
+  - ``speed``        <- AA ``median_output_tokens_per_second`` (throughput)
+
+AA lists one row PER reasoning-effort per model (xhigh/high/medium/low/
+non-reasoning). Two ways to read an "intelligence" number off that:
+
+  --basis served  (default) pick the AA row whose effort matches how WE run the
+                  model (from manifest ``parameters``), nearest-effort fallback.
+                  Honest: gpt-5.4@medium rates below gpt-5.5, not tied to it.
+  --basis ceiling pick the highest-intelligence row. Simpler, but mid-tier
+                  "full" models look near-flagship.
+
+The AA index spans the whole AA universe (~5..62 in v4); our manifest is all
+frontier models, so a global quantile collapses to 5. We bucket with
+FRONTIER-CALIBRATED absolute thresholds (INTEL_BANDS / SPEED_BANDS) so a "5"
+always means the same thing and the lineup still spreads across 1-5.
+
+Usage:
+  python scripts/ops/calibrate_model_ratings.py                  # dry-run, served basis
+  python scripts/ops/calibrate_model_ratings.py --basis ceiling  # dry-run, ceiling
+  python scripts/ops/calibrate_model_ratings.py --apply --fields intelligence
+  python scripts/ops/calibrate_model_ratings.py --apply --fields intelligence,speed
+  python scripts/ops/calibrate_model_ratings.py --no-cache       # force refetch
+
+Key resolution: $ARTIFICIAL_ANALYSIS_API_KEY, else --env-file (defaults to the
+repo's .env). Free tier = 100 req/day; the 3-page fetch is cached to
+/tmp/aa_models_cache.json.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+AA_BASE = "https://artificialanalysis.ai/api/v2/language/models/free"
+CACHE = Path("/tmp/aa_models_cache.json")
+
+REPO = Path(__file__).resolve().parents[2]  # .../langalpha
+MANIFEST = REPO / "src/llms/manifest/models.json"
+DEFAULT_ENV = REPO / ".env"
+
+# Frontier-calibrated bands. (lower_bound_inclusive, tier) high->low.
+INTEL_BANDS = [(56, 5), (49, 4), (42, 3), (35, 2), (0, 1)]   # <- AA intelligence index
+SPEED_BANDS = [(150, 5), (110, 4), (75, 3), (50, 2), (0, 1)]  # <- AA output tokens/sec
+
+# Our access/region/serving variants that map onto a base model's AA rating.
+VARIANT_SUFFIXES = (
+    "-oauth-1m", "-oauth", "-anthropic", "-cn", "-intl",
+    "-coding", "-highspeed", "-spark",
+)
+# Noise tokens dropped during name matching (release qualifiers, not identity).
+STOP_TOKENS = {"preview", "experimental", "exp"}
+
+# Models AA's language endpoint doesn't track (or tracks without throughput).
+# Hand-grounded from the cited sources; applied to every visible variant of the
+# base, and only for the fields present (so AA-derived fields survive otherwise).
+MANUAL = {
+    # Qwen commercial SKUs <- their OSS siblings on AA (per request).
+    "qwen3.5-plus":  {"speed": 2, "intelligence": 3,
+                      "ref": "AA Qwen3.5 397B-A17B (Reasoning): II 45, 51.8 tok/s"},
+    "qwen3.6-flash": {"speed": 5, "intelligence": 3,
+                      "ref": "AA Qwen3.6 35B-A3B (Reasoning): II 43.5, 172 tok/s"},
+    # GLM turbo throughput <- OpenRouter/Fireworks (~48-70 tok/s). 'turbo' is
+    # cheap/agentic, not high-throughput. Intelligence stays AA-derived.
+    "glm-5-turbo":  {"speed": 2, "ref": "OpenRouter ~48 / Fireworks 70 tok/s -> band 2"},
+    "glm-5v-turbo": {"speed": 2, "ref": "GLM-turbo family throughput ~48-70 tok/s"},
+    # Doubao Seed 2.0 <- LMArena + ByteDance Seed2.0 Model Card (Feb 2026); no
+    # AA index yet, no public tok/s, speed left as hand estimate (Pro slow ->
+    # Mini fast).
+    "doubao-seed-2.0-pro":  {"intelligence": 4,
+                             "ref": "LMArena Elo ~1466 (~21st), ~40 below the frontier cluster "
+                                    "(GPT-5.5/Opus-4.7/Gemini-3.1-Pro ~1505). ByteDance's model card "
+                                    "benches only vs the Feb-2026 frontier (GPT-5.2/Opus-4.5/"
+                                    "Gemini-3-Pro) and concedes coding + long-tail gaps: GPQA 88.9 "
+                                    "vs 92.4, SimpleQA 36 vs 72, SWE-Verified 76.5 vs Opus-4.5 80.9"},
+    "doubao-seed-2.0-lite": {"intelligence": 3,
+                             "ref": "ByteDance benches Lite vs GPT-5-mini/Gemini-3-Flash (efficient "
+                                    "tier, not flagships): MMLU-Pro 87.7, AIME25 93.0, GPQA 85.1, "
+                                    "SWE-Verified 73.5; strong for its class, no independent data"},
+    "doubao-seed-2.0-code": {"intelligence": 4,
+                             "ref": "self-report SWE-Verified 76.5 / LiveCodeBench-v6 87.8, Pro-equal "
+                                    "coding but below Opus-4.5 (80.9). NB: AA's 'Doubao Seed Code' "
+                                    "II-34/#10 entry is the older Nov-2025 model, not Seed-2.0-Code"},
+    "doubao-seed-2.0-mini": {"intelligence": 3,
+                             "ref": "smallest Seed 2.0 SKU: self-report AIME25 87.0, GPQA 79.0, "
+                                    "SWE-Verified 67.9, benched vs GPT-5-mini/Gemini-3-Flash"},
+}
+
+
+def band(value: float, bands: list[tuple[float, int]]) -> int:
+    for lo, tier in bands:
+        if value >= lo:
+            return tier
+    return 1
+
+
+def get_key(env_file: Path) -> str:
+    key = os.environ.get("ARTIFICIAL_ANALYSIS_API_KEY")
+    if key:
+        return key.strip()
+    if env_file.exists():
+        for line in env_file.read_text().splitlines():
+            if line.startswith("ARTIFICIAL_ANALYSIS_API_KEY="):
+                return line.split("=", 1)[1].strip().strip("'\"")
+    sys.exit(f"No ARTIFICIAL_ANALYSIS_API_KEY in env or {env_file}")
+
+
+def fetch_aa(key: str, use_cache: bool) -> list[dict]:
+    if use_cache and CACHE.exists():
+        return json.loads(CACHE.read_text())
+    out: list[dict] = []
+    page = 1
+    while True:
+        req = urllib.request.Request(f"{AA_BASE}?page={page}", headers={"x-api-key": key})
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = json.loads(resp.read())
+        out.extend(payload["data"])
+        if not payload.get("pagination", {}).get("has_more"):
+            break
+        page += 1
+    CACHE.write_text(json.dumps(out))
+    return out
+
+
+def tokens(s: str) -> frozenset[str]:
+    """Order-insensitive token set, parens + release qualifiers dropped:
+    'claude-haiku-4-5' ~ 'Claude 4.5 Haiku', 'gemini-3.1-pro' ~ 'Gemini 3.1 Pro Preview'."""
+    s = re.sub(r"\(.*?\)", "", s.lower())
+    return frozenset(t for t in re.findall(r"[a-z]+|\d+", s) if t and t not in STOP_TOKENS)
+
+
+def base_name(model_key: str) -> str:
+    for suf in VARIANT_SUFFIXES:
+        if model_key.endswith(suf):
+            return model_key[: -len(suf)]
+    return model_key
+
+
+def collapse_base(model_key: str) -> str:
+    """Strip ALL variant suffixes iteratively, for matching against MANUAL keys
+    (e.g. 'qwen3.5-plus-intl' -> 'qwen3.5-plus')."""
+    changed = True
+    while changed:
+        changed = False
+        for suf in VARIANT_SUFFIXES:
+            if model_key.endswith(suf):
+                model_key = model_key[: -len(suf)]
+                changed = True
+    return model_key
+
+
+def _num(v) -> float | None:
+    """Coerce an AA value to a finite float; None for missing/str-garbage/NaN
+    so a schema drift can't crash the run or silently band to 1."""
+    try:
+        f = float(v)
+    except (TypeError, ValueError):
+        return None
+    return f if math.isfinite(f) else None
+
+
+def ii_of(row: dict) -> float | None:
+    return _num(row.get("evaluations", {}).get("artificial_analysis_intelligence_index"))
+
+
+def target_effort_rank(cfg: dict) -> int | None:
+    """How hard WE run the model, 0 (non-reasoning) .. 4 (xhigh/max)."""
+    p = cfg.get("parameters", {}) or {}
+    eff = (p.get("reasoning") or {}).get("effort")
+    if eff:
+        return {"xhigh": 4, "high": 3, "medium": 2, "low": 1, "minimal": 0}.get(eff, 2)
+    oc = (p.get("output_config") or {}).get("effort")
+    if oc:
+        return {"xhigh": 4, "high": 3, "medium": 2, "low": 1}.get(oc, 4)
+    th = p.get("thinking") or (cfg.get("extra_body", {}) or {}).get("thinking") or {}
+    if th:
+        return {"adaptive": 4, "enabled": 3, "disabled": 0}.get(th.get("type"), 3)
+    if p.get("thinking_level") == "high" or p.get("include_thoughts"):
+        return 3
+    return None  # unknown -> ceiling
+
+
+def aa_effort_rank(name: str) -> int | None:
+    n = name.lower()
+    if "instant" in n or "non-reasoning" in n or "non reasoning" in n:
+        return 0
+    if "xhigh" in n or "max effort" in n:
+        return 4
+    if "high" in n:
+        return 3
+    if "medium" in n:
+        return 2
+    if "low" in n:
+        return 1
+    return None  # no effort qualifier on this row
+
+
+def pick_row(rows: list[dict], target: int | None, basis: str) -> dict:
+    rows = [r for r in rows if ii_of(r) is not None]
+    if not rows:
+        return {}
+    if basis == "ceiling" or target is None:
+        return max(rows, key=ii_of)
+    ranked = [(aa_effort_rank(r["name"]), r) for r in rows]
+    cand = [(rk, r) for rk, r in ranked if rk is not None]
+    if not cand:
+        return max(rows, key=ii_of)
+    # nearest effort to how we serve it; tie-break on higher intelligence
+    return min(cand, key=lambda x: (abs(x[0] - target), -(ii_of(x[1]) or -1)))[1]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--apply", action="store_true", help="write models.json (default: dry-run)")
+    ap.add_argument("--basis", choices=("served", "ceiling"), default="served")
+    ap.add_argument("--fields", default="intelligence,speed",
+                    help="comma list of fields to write on --apply")
+    ap.add_argument("--no-cache", action="store_true")
+    ap.add_argument("--env-file", type=Path, default=DEFAULT_ENV)
+    args = ap.parse_args()
+    write_fields = {f.strip() for f in args.fields.split(",") if f.strip()}
+
+    aa = fetch_aa(get_key(args.env_file), use_cache=not args.no_cache)
+    by_tokens: dict[frozenset[str], list[dict]] = {}
+    for m in aa:
+        for label in (m["slug"], m["name"]):
+            by_tokens.setdefault(tokens(label), []).append(m)
+
+    manifest = json.loads(MANIFEST.read_text())
+    visible = [k for k, v in manifest.items() if v.get("visible")]
+
+    matched, unmatched, changes = [], [], 0
+    print(f"basis={args.basis}  fields={','.join(sorted(write_fields))}\n")
+    print(f"{'model':30s} {'cur s/i':>7}  {'AA II':>6} {'AA tps':>7}  {'new s/i':>7}  AA row (effort matched)")
+    print("-" * 100)
+    for k in sorted(visible):
+        cur = manifest[k]
+        cur_s, cur_i = cur.get("speed"), cur.get("intelligence")
+        rows = by_tokens.get(tokens(k)) or by_tokens.get(tokens(base_name(k)))
+        row = pick_row(rows, target_effort_rank(cur), args.basis) if rows else {}
+        if not row:
+            unmatched.append(k)
+            print(f"{k:30s} {f'{cur_s}/{cur_i}':>7}  {'—':>6} {'—':>7}  {'(keep)':>7}  — no AA match")
+            continue
+        ii, tps, name = ii_of(row), _num(row.get("performance", {}).get("median_output_tokens_per_second")), row["name"]
+        new_i = band(ii, INTEL_BANDS) if ("intelligence" in write_fields and ii is not None) else cur_i
+        new_s = band(tps, SPEED_BANDS) if ("speed" in write_fields and tps is not None) else cur_s
+        flag = "" if (new_s == cur_s and new_i == cur_i) else "  *"
+        if flag:
+            changes += 1
+        matched.append((k, new_s, new_i))
+        ii_s = f"{ii:.1f}" if ii is not None else "—"
+        tps_s = f"{tps:.0f}" if tps is not None else "—"
+        print(f"{k:30s} {f'{cur_s}/{cur_i}':>7}  {ii_s:>6} {tps_s:>7}  {f'{new_s}/{new_i}':>7}{flag}  {name[:46]}")
+
+    print("-" * 100)
+    print(f"matched={len(matched)}  changed={changes}  unmatched(kept as-is)={len(unmatched)}")
+    if unmatched:
+        print("UNMATCHED (AA has no row; see MANUAL below for any covered): " + ", ".join(unmatched))
+
+    # MANUAL overrides: applied to every visible variant of each base, for the
+    # listed fields only (so AA-derived fields on matched models survive).
+    overrides = {k: MANUAL[collapse_base(k)] for k in visible if collapse_base(k) in MANUAL}
+    if overrides:
+        print("\nMANUAL OVERRIDES (sourced; AA-untracked or no-throughput):")
+        for b, ov in MANUAL.items():
+            sets = ", ".join(f"{f}={ov[f]}" for f in ("speed", "intelligence") if f in ov)
+            print(f"  {b:24s} {sets:24s} <- {ov['ref']}")
+
+    if args.apply:
+        for k, s, i in matched:
+            if "speed" in write_fields:
+                manifest[k]["speed"] = s
+            if "intelligence" in write_fields:
+                manifest[k]["intelligence"] = i
+        for k, ov in overrides.items():
+            for f in ("speed", "intelligence"):
+                if f in ov and f in write_fields:
+                    manifest[k][f] = ov[f]
+        # Match the manifest's canonical format exactly so the diff is values-only.
+        MANIFEST.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n")
+        print(f"\nWROTE {MANIFEST} — fields={','.join(sorted(write_fields))}; "
+              f"{len(matched)} AA models + {len(overrides)} manual-override variants")
+    else:
+        print("\nDRY-RUN — re-run with --apply to write models.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/llms/llm.py
+++ b/src/llms/llm.py
@@ -151,7 +151,7 @@ class ModelConfig:
             return parent_info.get("display_name", parent.title())
         return provider.title()
 
-    def get_model_metadata(self) -> dict[str, dict[str, str | int]]:
+    def get_model_metadata(self) -> dict[str, dict[str, Any]]:
         """Return {model_key: {sdk, provider, access_type, ...}} for all visible models."""
         result = {}
         for model_name, model_info in self.llm_config.items():
@@ -161,10 +161,28 @@ class ModelConfig:
             provider_info = self.get_provider_info(provider)
             sdk = provider_info.get("sdk", "unknown")
             access_type = provider_info.get("access_type", "api_key")
-            entry: dict[str, str | int] = {"sdk": sdk, "provider": provider, "access_type": access_type}
+            entry: dict[str, Any] = {"sdk": sdk, "provider": provider, "access_type": access_type}
             # Only include tier when explicitly set — absence means "not platform-managed"
             if "tier" in model_info:
                 entry["tier"] = model_info["tier"]
+            # Optional editorial metadata for the model-detail flyout. Additive —
+            # only surfaced for models that authored it in models.json; the
+            # frontend renders only the rows that are present.
+            for key in (
+                "speed",
+                "intelligence",
+                "context",
+                "input_modalities",
+            ):
+                if key in model_info:
+                    entry[key] = model_info[key]
+            # Cost tier (1-5) derived live from canonical providers.json pricing —
+            # not stored in models.json, so it auto-syncs when prices change.
+            from .pricing_utils import get_price_tier
+
+            price_tier = get_price_tier(model_info.get("model_id", model_name), provider)
+            if price_tier is not None:
+                entry["price"] = price_tier
             # Mark variants that require their own API key (different env_key from parent).
             # e.g. z-ai-cn needs ZAI_CN_API_KEY, not ZAI_API_KEY.
             parent_provider = provider_info.get("parent_provider")

--- a/src/llms/llm.py
+++ b/src/llms/llm.py
@@ -8,6 +8,8 @@ from langchain_core.language_models import BaseChatModel
 from langchain_deepseek import ChatDeepSeek
 from langchain_qwq import ChatQwen
 
+from .pricing_utils import get_price_tier
+
 load_dotenv()
 
 
@@ -178,8 +180,6 @@ class ModelConfig:
                     entry[key] = model_info[key]
             # Cost tier (1-5) derived live from canonical providers.json pricing —
             # not stored in models.json, so it auto-syncs when prices change.
-            from .pricing_utils import get_price_tier
-
             price_tier = get_price_tier(model_info.get("model_id", model_name), provider)
             if price_tier is not None:
                 entry["price"] = price_tier

--- a/src/llms/manifest/models.json
+++ b/src/llms/manifest/models.json
@@ -4,6 +4,9 @@
     "provider": "openai",
     "display_name": "GPT-5.5",
     "visible": true,
+    "speed": 2,
+    "intelligence": 5,
+    "context": 400000,
     "input_modalities": [
       "text",
       "image",
@@ -21,6 +24,9 @@
     "provider": "openai",
     "display_name": "GPT-5.4",
     "visible": true,
+    "speed": 3,
+    "intelligence": 5,
+    "context": 400000,
     "input_modalities": [
       "text",
       "image",
@@ -38,6 +44,9 @@
     "provider": "openai",
     "display_name": "GPT-5.4 Mini",
     "visible": true,
+    "speed": 5,
+    "intelligence": 3,
+    "context": 400000,
     "input_modalities": [
       "text",
       "image",
@@ -55,6 +64,9 @@
     "provider": "openai",
     "display_name": "GPT-5.4 Nano",
     "visible": true,
+    "speed": 5,
+    "intelligence": 3,
+    "context": 400000,
     "input_modalities": [
       "text",
       "image",
@@ -71,6 +83,9 @@
     "model_id": "claude-opus-4-8",
     "provider": "anthropic",
     "visible": true,
+    "speed": 2,
+    "intelligence": 5,
+    "context": 200000,
     "input_modalities": [
       "text",
       "image",
@@ -91,6 +106,9 @@
     "model_id": "claude-sonnet-4-6",
     "provider": "anthropic",
     "visible": true,
+    "speed": 2,
+    "intelligence": 4,
+    "context": 200000,
     "input_modalities": [
       "text",
       "image",
@@ -107,6 +125,9 @@
     "model_id": "claude-haiku-4-5-20251001",
     "provider": "anthropic",
     "visible": true,
+    "speed": 3,
+    "intelligence": 2,
+    "context": 200000,
     "input_modalities": [
       "text",
       "image",
@@ -123,6 +144,9 @@
     "model_id": "gemini-3.1-pro-preview",
     "provider": "gemini",
     "visible": true,
+    "speed": 4,
+    "intelligence": 5,
+    "context": 1000000,
     "input_modalities": [
       "text",
       "image",
@@ -138,6 +162,9 @@
     "model_id": "gemini-3-flash-preview",
     "provider": "gemini",
     "visible": true,
+    "speed": 5,
+    "intelligence": 3,
+    "context": 1000000,
     "input_modalities": [
       "text",
       "image",
@@ -153,6 +180,9 @@
     "model_id": "gemini-3.1-flash-lite-preview",
     "provider": "gemini",
     "visible": true,
+    "speed": 5,
+    "intelligence": 1,
+    "context": 1000000,
     "input_modalities": [
       "text",
       "image",
@@ -168,6 +198,9 @@
     "model_id": "gemini-3.1-flash-image-preview",
     "provider": "gemini",
     "visible": true,
+    "speed": 5,
+    "intelligence": 3,
+    "context": 32000,
     "input_modalities": [
       "text",
       "image"
@@ -273,6 +306,9 @@
     "model_id": "doubao-seed-2-0-pro-260215",
     "provider": "volcengine",
     "visible": true,
+    "speed": 3,
+    "intelligence": 4,
+    "context": 256000,
     "input_modalities": [
       "text",
       "image",
@@ -291,6 +327,9 @@
     "model_id": "doubao-seed-2-0-lite-260215",
     "provider": "volcengine",
     "visible": true,
+    "speed": 4,
+    "intelligence": 3,
+    "context": 256000,
     "input_modalities": [
       "text",
       "image",
@@ -309,6 +348,9 @@
     "model_id": "doubao-seed-2-0-mini-260215",
     "provider": "volcengine",
     "visible": true,
+    "speed": 5,
+    "intelligence": 3,
+    "context": 256000,
     "input_modalities": [
       "text",
       "image",
@@ -327,6 +369,9 @@
     "model_id": "doubao-seed-2-0-code-preview-260215",
     "provider": "volcengine",
     "visible": true,
+    "speed": 4,
+    "intelligence": 4,
+    "context": 256000,
     "input_modalities": [
       "text",
       "image",
@@ -345,6 +390,9 @@
     "model_id": "doubao-seed-2-0-pro-260215",
     "provider": "doubao-anthropic",
     "visible": true,
+    "speed": 3,
+    "intelligence": 4,
+    "context": 256000,
     "input_modalities": [
       "text",
       "image",
@@ -360,6 +408,9 @@
     "model_id": "doubao-seed-2-0-lite-260215",
     "provider": "doubao-anthropic",
     "visible": true,
+    "speed": 4,
+    "intelligence": 3,
+    "context": 256000,
     "input_modalities": [
       "text",
       "image",
@@ -375,6 +426,9 @@
     "model_id": "doubao-seed-2-0-mini-260215",
     "provider": "doubao-anthropic",
     "visible": true,
+    "speed": 5,
+    "intelligence": 3,
+    "context": 256000,
     "input_modalities": [
       "text",
       "image",
@@ -390,6 +444,9 @@
     "model_id": "doubao-seed-2-0-code-preview-260215",
     "provider": "doubao-anthropic",
     "visible": true,
+    "speed": 4,
+    "intelligence": 4,
+    "context": 256000,
     "input_modalities": [
       "text",
       "image",
@@ -405,6 +462,9 @@
     "model_id": "deepseek-v4-pro",
     "provider": "deepseek",
     "visible": true,
+    "speed": 2,
+    "intelligence": 4,
+    "context": 1000000,
     "input_modalities": [
       "text"
     ],
@@ -419,6 +479,9 @@
     "model_id": "deepseek-v4-flash",
     "provider": "deepseek",
     "visible": true,
+    "speed": 3,
+    "intelligence": 3,
+    "context": 1000000,
     "input_modalities": [
       "text"
     ],
@@ -433,6 +496,9 @@
     "model_id": "glm-5.1",
     "provider": "z-ai",
     "visible": true,
+    "speed": 3,
+    "intelligence": 4,
+    "context": 200000,
     "parameters": {
       "max_tokens": 128000,
       "thinking": {
@@ -447,6 +513,9 @@
     "model_id": "glm-5v-turbo",
     "provider": "z-ai",
     "visible": true,
+    "speed": 2,
+    "intelligence": 3,
+    "context": 200000,
     "parameters": {
       "max_tokens": 128000,
       "thinking": {
@@ -463,6 +532,9 @@
     "model_id": "glm-5-turbo",
     "provider": "z-ai",
     "visible": true,
+    "speed": 2,
+    "intelligence": 3,
+    "context": 200000,
     "parameters": {
       "max_tokens": 128000,
       "thinking": {
@@ -477,6 +549,9 @@
     "model_id": "glm-5-turbo",
     "provider": "z-ai-cn",
     "visible": true,
+    "speed": 2,
+    "intelligence": 3,
+    "context": 200000,
     "parameters": {
       "max_tokens": 128000,
       "thinking": {
@@ -491,6 +566,9 @@
     "model_id": "glm-5.1",
     "provider": "z-ai-cn",
     "visible": true,
+    "speed": 3,
+    "intelligence": 4,
+    "context": 200000,
     "parameters": {
       "max_tokens": 128000,
       "thinking": {
@@ -505,6 +583,9 @@
     "model_id": "glm-5v-turbo",
     "provider": "z-ai-cn",
     "visible": true,
+    "speed": 2,
+    "intelligence": 3,
+    "context": 200000,
     "parameters": {
       "max_tokens": 128000,
       "thinking": {
@@ -521,6 +602,9 @@
     "model_id": "MiniMax-M3",
     "provider": "minimax",
     "visible": true,
+    "speed": 1,
+    "intelligence": 4,
+    "context": 512000,
     "parameters": {
       "max_tokens": 128000,
       "thinking": {
@@ -536,6 +620,9 @@
     "model_id": "MiniMax-M2.7",
     "provider": "minimax",
     "visible": true,
+    "speed": 2,
+    "intelligence": 4,
+    "context": 200000,
     "parameters": {
       "max_tokens": 128000,
       "thinking": {
@@ -550,6 +637,9 @@
     "model_id": "MiniMax-M2.7-highspeed",
     "provider": "minimax",
     "visible": true,
+    "speed": 2,
+    "intelligence": 4,
+    "context": 200000,
     "parameters": {
       "max_tokens": 128000,
       "thinking": {
@@ -564,6 +654,9 @@
     "model_id": "qwen3.7-max",
     "provider": "dashscope",
     "visible": true,
+    "speed": 4,
+    "intelligence": 5,
+    "context": 1000000,
     "input_modalities": [
       "text"
     ],
@@ -575,6 +668,9 @@
     "model_id": "qwen3.6-plus",
     "provider": "dashscope",
     "visible": true,
+    "speed": 2,
+    "intelligence": 4,
+    "context": 1000000,
     "input_modalities": [
       "text",
       "image",
@@ -589,6 +685,9 @@
     "model_id": "qwen3.5-plus",
     "provider": "dashscope",
     "visible": true,
+    "speed": 2,
+    "intelligence": 3,
+    "context": 1000000,
     "input_modalities": [
       "text",
       "image",
@@ -602,6 +701,9 @@
     "model_id": "qwen3.5-plus",
     "provider": "dashscope-coding",
     "visible": true,
+    "speed": 2,
+    "intelligence": 3,
+    "context": 1000000,
     "input_modalities": [
       "text",
       "image",
@@ -612,6 +714,9 @@
     "model_id": "qwen3.6-flash",
     "provider": "dashscope",
     "visible": true,
+    "speed": 5,
+    "intelligence": 3,
+    "context": 1000000,
     "input_modalities": [
       "text",
       "image",
@@ -625,6 +730,9 @@
     "model_id": "qwen3.7-max",
     "provider": "dashscope-intl",
     "visible": true,
+    "speed": 4,
+    "intelligence": 5,
+    "context": 1000000,
     "input_modalities": [
       "text"
     ],
@@ -636,6 +744,9 @@
     "model_id": "qwen3.6-plus",
     "provider": "dashscope-intl",
     "visible": true,
+    "speed": 2,
+    "intelligence": 4,
+    "context": 1000000,
     "input_modalities": [
       "text",
       "image",
@@ -650,6 +761,9 @@
     "model_id": "qwen3.5-plus",
     "provider": "dashscope-intl",
     "visible": true,
+    "speed": 2,
+    "intelligence": 3,
+    "context": 1000000,
     "input_modalities": [
       "text",
       "image",
@@ -663,6 +777,9 @@
     "model_id": "qwen3.6-flash",
     "provider": "dashscope-intl",
     "visible": true,
+    "speed": 5,
+    "intelligence": 3,
+    "context": 1000000,
     "input_modalities": [
       "text",
       "image",
@@ -724,6 +841,9 @@
     "model_id": "kimi-k2.6",
     "provider": "moonshot",
     "visible": true,
+    "speed": 2,
+    "intelligence": 4,
+    "context": 256000,
     "input_modalities": [
       "text",
       "image"
@@ -738,6 +858,9 @@
     "model_id": "kimi-k2.6",
     "provider": "moonshot-coding",
     "visible": true,
+    "speed": 2,
+    "intelligence": 4,
+    "context": 256000,
     "input_modalities": [
       "text",
       "image"
@@ -752,6 +875,9 @@
     "model_id": "kimi-k2.5",
     "provider": "moonshot",
     "visible": true,
+    "speed": 1,
+    "intelligence": 3,
+    "context": 256000,
     "input_modalities": [
       "text",
       "image"
@@ -766,6 +892,9 @@
     "model_id": "kimi-for-coding",
     "provider": "moonshot-coding",
     "visible": true,
+    "speed": 1,
+    "intelligence": 3,
+    "context": 256000,
     "input_modalities": [
       "text",
       "image"
@@ -780,6 +909,9 @@
     "model_id": "gpt-5.3-codex",
     "provider": "codex-oauth",
     "visible": true,
+    "speed": 3,
+    "intelligence": 4,
+    "context": 400000,
     "input_modalities": [
       "text",
       "image",
@@ -800,6 +932,9 @@
     "model_id": "gpt-5.3-codex-spark",
     "provider": "codex-oauth",
     "visible": true,
+    "speed": 5,
+    "intelligence": 4,
+    "context": 400000,
     "input_modalities": [
       "text",
       "image",
@@ -820,6 +955,9 @@
     "model_id": "gpt-5.5",
     "provider": "codex-oauth",
     "visible": true,
+    "speed": 2,
+    "intelligence": 5,
+    "context": 400000,
     "input_modalities": [
       "text",
       "image",
@@ -840,6 +978,9 @@
     "model_id": "gpt-5.4",
     "provider": "codex-oauth",
     "visible": true,
+    "speed": 3,
+    "intelligence": 5,
+    "context": 400000,
     "input_modalities": [
       "text",
       "image",
@@ -860,6 +1001,9 @@
     "model_id": "gpt-5.4-mini",
     "provider": "codex-oauth",
     "visible": true,
+    "speed": 5,
+    "intelligence": 3,
+    "context": 400000,
     "input_modalities": [
       "text",
       "image",
@@ -880,6 +1024,9 @@
     "model_id": "claude-sonnet-4-6",
     "provider": "claude-oauth",
     "visible": true,
+    "speed": 2,
+    "intelligence": 4,
+    "context": 200000,
     "input_modalities": [
       "text",
       "image",
@@ -896,6 +1043,9 @@
     "model_id": "claude-opus-4-8",
     "provider": "claude-oauth",
     "visible": true,
+    "speed": 2,
+    "intelligence": 5,
+    "context": 200000,
     "input_modalities": [
       "text",
       "image",
@@ -916,6 +1066,9 @@
     "model_id": "claude-haiku-4-5-20251001",
     "provider": "claude-oauth",
     "visible": true,
+    "speed": 3,
+    "intelligence": 2,
+    "context": 200000,
     "input_modalities": [
       "text",
       "image",
@@ -954,6 +1107,9 @@
     "model_id": "claude-opus-4-8",
     "provider": "claude-oauth",
     "visible": true,
+    "speed": 2,
+    "intelligence": 5,
+    "context": 1000000,
     "input_modalities": [
       "text",
       "image",

--- a/src/llms/manifest/providers.json
+++ b/src/llms/manifest/providers.json
@@ -969,7 +969,7 @@
           "input": 2.677,
           "cached_input": 0.535,
           "cache_5m": 3.346,
-          "output": 8.030,
+          "output": 8.03,
           "unit": "per_1m_tokens"
         }
       },

--- a/src/llms/pricing_utils.py
+++ b/src/llms/pricing_utils.py
@@ -283,6 +283,47 @@ def find_model_pricing(model_name: str, provider: Optional[str] = None) -> Optio
     return None
 
 
+# Coarse cost tier (1-5) for the model-detail flyout, from blended $/1M tokens
+# (3:1 input:output). Credits are linear in USD (credit_conversion), so this tier
+# reads the same whether the user pays per-token (BYOK) or in credits.
+PRICE_TIER_BANDS = [(8.0, 5), (4.0, 4), (1.5, 3), (0.5, 2), (0.0, 1)]
+
+
+def _representative_rate(pricing: Dict[str, Any], flat_key: str, tier_key: str) -> Optional[float]:
+    """A single $/1M rate for tiering: the flat rate, else the base (first) tier.
+
+    Base tier is deliberate: it's the standard-context rate nearly all requests
+    pay; long-context surcharge tiers are excluded from the headline cost dot.
+    """
+    if pricing.get(flat_key) is not None:
+        return pricing[flat_key]
+    tiers = pricing.get(tier_key)
+    if tiers:
+        return tiers[0].get('rate')
+    return None
+
+
+def get_price_tier(model_name: str, provider: Optional[str] = None) -> Optional[int]:
+    """Map a model's canonical providers.json pricing to a 1-5 cost tier.
+
+    Resolves pricing through :func:`find_model_pricing` (provider→parent fallback,
+    aliases, tiered rates). Returns None when no price is known so the flyout omits
+    the row. Blends input/output 3:1 then buckets via ``PRICE_TIER_BANDS``.
+    """
+    pricing = find_model_pricing(model_name, provider)
+    if not pricing:
+        return None
+    pin = _representative_rate(pricing, 'input', 'input_tiers')
+    pout = _representative_rate(pricing, 'output', 'output_tiers')
+    if pin is None or pout is None:
+        return None
+    blended = pin * 0.75 + pout * 0.25
+    for lo, tier in PRICE_TIER_BANDS:
+        if blended >= lo:
+            return tier
+    return 1
+
+
 def calculate_tiered_cost(tokens: int, tiers: List[Dict[str, Any]]) -> float:
     """
     Calculate cost for tiered pricing based on cumulative token count.

--- a/tests/unit/llms/test_model_rating_metadata.py
+++ b/tests/unit/llms/test_model_rating_metadata.py
@@ -54,7 +54,8 @@ class TestRatingMetadataSurfacing:
                 if field in entry:
                     assert entry[field] in range(1, 6), f"{key}: {field} must be 1-5"
             if "context" in entry:
-                assert isinstance(entry["context"], int) and entry["context"] > 0
+                assert isinstance(entry["context"], int), f"{key}: context must be an int"
+                assert entry["context"] > 0, f"{key}: context must be positive"
 
 
 class TestPriceTier:

--- a/tests/unit/llms/test_model_rating_metadata.py
+++ b/tests/unit/llms/test_model_rating_metadata.py
@@ -1,0 +1,114 @@
+"""Editorial rating metadata (speed/intelligence/context) and derived price tier."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.llms.llm import ModelConfig
+from src.llms import pricing_utils
+from src.llms.pricing_utils import PRICE_TIER_BANDS, _representative_rate, get_price_tier
+
+MANIFEST = Path(__file__).resolve().parents[3] / "src/llms/manifest/models.json"
+
+
+@pytest.fixture(scope="module")
+def manifest() -> dict:
+    return json.loads(MANIFEST.read_text())
+
+
+@pytest.fixture(scope="module")
+def metadata() -> dict:
+    return ModelConfig().get_model_metadata()
+
+
+class TestRatingMetadataSurfacing:
+    def test_authored_ratings_passed_through(self, manifest, metadata):
+        """Every visible model that authors speed/intelligence/context in
+        models.json must surface them verbatim in get_model_metadata()."""
+        rated = {
+            k: v for k, v in manifest.items()
+            if v.get("visible") and any(f in v for f in ("speed", "intelligence", "context"))
+        }
+        assert rated, "Expected at least one visible model with rating fields in manifest"
+        for key, entry in rated.items():
+            for field in ("speed", "intelligence", "context"):
+                if field in entry:
+                    assert metadata[key][field] == entry[field], (
+                        f"{key}: metadata {field} should mirror manifest"
+                    )
+
+    def test_unrated_models_omit_fields(self, manifest, metadata):
+        """Models without authored ratings must not grow them — the flyout
+        renders only the rows that are present."""
+        for key, entry in metadata.items():
+            for field in ("speed", "intelligence", "context"):
+                if field in entry:
+                    assert field in manifest[key], (
+                        f"{key}: {field} surfaced but not authored in manifest"
+                    )
+
+    def test_rating_values_in_range(self, metadata):
+        for key, entry in metadata.items():
+            for field in ("speed", "intelligence"):
+                if field in entry:
+                    assert entry[field] in range(1, 6), f"{key}: {field} must be 1-5"
+            if "context" in entry:
+                assert isinstance(entry["context"], int) and entry["context"] > 0
+
+
+class TestPriceTier:
+    def test_metadata_price_is_valid_tier(self, metadata):
+        priced = {k: v for k, v in metadata.items() if "price" in v}
+        assert priced, "Expected at least one model with derived price tier"
+        for key, entry in priced.items():
+            assert entry["price"] in range(1, 6), f"{key}: price tier must be 1-5"
+
+    def test_unknown_model_returns_none(self):
+        assert get_price_tier("no-such-model-xyz") is None
+
+    def test_oauth_variant_inherits_parent_tier(self, manifest):
+        """OAuth variants have no own pricing list; the tier must resolve to
+        whatever the parent provider's rates give (None when the parent has no
+        per-token pricing either, e.g. subscription-only providers)."""
+        mc = ModelConfig()
+        oauth = {
+            k: v for k, v in manifest.items()
+            if v.get("visible") and v.get("provider", "").endswith("oauth")
+        }
+        if not oauth:
+            pytest.skip("no visible oauth variants in manifest")
+        inherited = []
+        for key, entry in oauth.items():
+            parent = mc.get_provider_info(entry["provider"]).get("parent_provider")
+            tier = get_price_tier(entry["model_id"], entry["provider"])
+            assert tier == get_price_tier(entry["model_id"], parent), (
+                f"{key}: oauth tier should match parent provider resolution"
+            )
+            if tier is not None:
+                inherited.append(key)
+        assert inherited, "Expected at least one oauth variant inheriting per-token pricing"
+
+    def test_bands_are_descending_and_cover_zero(self):
+        lows = [lo for lo, _ in PRICE_TIER_BANDS]
+        assert lows == sorted(lows, reverse=True)
+        assert lows[-1] == 0.0
+
+    def test_priced_pricing_without_usable_rates_returns_none(self, monkeypatch):
+        """When pricing resolves but has neither flat rate nor tiers (e.g. a
+        2d_matrix-only entry), the tier must be None — distinct from the
+        'no pricing at all' early return."""
+        monkeypatch.setattr(
+            pricing_utils, "find_model_pricing",
+            lambda name, provider=None: {"pricing_mode": "2d_matrix", "matrix": []},
+        )
+        assert get_price_tier("placeholder-model", "placeholder-provider") is None
+
+    def test_representative_rate_prefers_flat_then_base_tier(self):
+        """Flat rate wins when present; otherwise fall back to the first tier's
+        rate; None when neither exists."""
+        assert _representative_rate({"input": 2.0}, "input", "input_tiers") == 2.0
+        assert _representative_rate(
+            {"input_tiers": [{"rate": 0.9}, {"rate": 1.8}]}, "input", "input_tiers"
+        ) == 0.9
+        assert _representative_rate({}, "input", "input_tiers") is None


### PR DESCRIPTION
## Summary

**Metadata surfacing**
- `get_model_metadata()` now passes through optional editorial `speed`, `intelligence`, `context` fields (plus `input_modalities`) from `models.json`, and adds a derived `price` field — a 1–5 cost tier computed live from `providers.json` pricing via the new `get_price_tier()` (`32ed3f93`)
- Fields are additive: only models that author them surface them; the frontend renders only the rows present

**Ratings data**
- `models.json` gains `speed`/`intelligence`/`context` on all 52 visible models, calibrated from Artificial Analysis intelligence index + median output throughput with frontier-calibrated bands, plus hand-grounded sourced overrides for AA-untracked models (`8f25f1a0`)

**Ops tooling**
- `scripts/ops/calibrate_model_ratings.py`: derives speed/intelligence from AA's free Data API, reasoning-effort-aware (rates models as we actually serve them, not their ceiling); dry-run by default, `--apply` to write (`ef9f0055`)

**Tests + hygiene**
- New test file covering metadata pass-through, value ranges, price-tier banding, OAuth pricing inheritance, and no-usable-rate edge cases (`d5ce2c10`)
- `providers.json` normalized to canonical `json.dumps` output so programmatic rewrites stay diff-clean (`6f7beced`)

## Diff Size
- Total: 6 files changed, 624 insertions(+), 3 deletions(-)
- Net (excl. tests): 5 files changed, 511 insertions(+), 3 deletions(-)

## Test Coverage

Coverage audit traced all changed `src/` branches: **12/12 reachable branches tested (100%)**. Two gaps found and closed during ship review (the `pin/pout is None → None` path for matrix-priced entries, and direct assertion of `_representative_rate`'s flat→tier→None selection). The ops script is a manual CLI tool, intentionally untested. Backend suite: 3,683 passed.

## Pre-Landing Review

Adversarial review (Claude subagent) findings and resolutions:
- **Tiered-pricing representative rate** — `_representative_rate` uses the base (standard-context) tier for the 12 models with long-context surcharge tiers. Reviewed and **kept by decision**: the base tier is what nearly all requests pay; surcharge tiers are deliberately excluded from the headline cost dot (documented in the docstring).
- **Calibration script robustness** — fixed: AA API values now coerced through a finite-float guard so a string or NaN in the response can't crash the run or silently band a model to 1.
- **Uncached metadata recompute** (informational) — `/models`-style endpoints recompute `get_price_tier` per model per request. Sub-millisecond on current catalog size; flagged for an endpoint-level cache if the catalog grows.
- **2D-matrix-priced models** (informational) — entries with only matrix pricing get no price dot (returns `None`, row omitted). Graceful, but worth a representative-rate mapping if matrix pricing spreads.

## Test plan
- [x] Full backend unit suite passes (3,683 tests)
- [x] `uv run ruff check` clean on all changed files
- [x] Metadata verified live: 52 visible models surface ratings, 48 surface price tiers (4 omitted have no per-token pricing upstream — Codex OAuth subscription models, doubao code-preview)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Models now show speed, intelligence, and context ratings.
  * Models surface a derived price tier (1–5) for easier cost comparison.

* **Tools**
  * Added a CLI tool to fetch and calibrate model rating data (dry-run or apply updates).

* **Tests**
  * Added unit tests covering rating metadata and price-tier behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->