### PR TITLE
ci: keep claude[bot] identity for same-repo PR reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,21 +1,40 @@
 name: Claude Code Review
 
-# pull_request_target runs in the BASE-repo context, so the Claude OAuth token
-# is available even for fork PRs. We deliberately do NOT check out the PR head:
-# the review reads the diff via `gh`, and CLAUDE.md comes from the trusted base
-# branch. Fork PRs additionally get a minimal read + `gh pr comment` allowlist
-# (see ALLOWLIST_FORK) so a prompt-injected diff can't reach gh api / pr edit.
+# Split triggers by PR origin:
+#
+# - Same-repo PRs run on `pull_request`. The action's OIDC -> app-token
+#   exchange works there, so reviews post as claude[bot] (Anthropic's backend
+#   rejects OIDC tokens from pull_request_target events with "Invalid OIDC
+#   token" — see anthropics/claude-code-action#713).
+# - Fork PRs run on `pull_request_target`, which executes in the BASE-repo
+#   context so the Claude OAuth token is available. The broken OIDC exchange
+#   is bypassed by passing the run-scoped GITHUB_TOKEN, so fork reviews post
+#   as github-actions[bot]. We deliberately do NOT check out the PR head:
+#   the review reads the diff via `gh`, and CLAUDE.md comes from the trusted
+#   base branch. Fork PRs additionally get a minimal read + `gh pr comment`
+#   allowlist (see ALLOWLIST_FORK) so a prompt-injected diff can't reach
+#   gh api / pr edit.
 on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
   pull_request_target:
     types: [opened, synchronize, ready_for_review, reopened]
 
+# The event name MUST be part of the group: a same-repo PR fires both events,
+# and with a shared group the no-op pull_request_target run would cancel the
+# real pull_request run.
 concurrency:
-  group: claude-review-${{ github.event.pull_request.number }}
+  group: claude-review-${{ github.event_name }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   claude-review:
-    if: github.event.pull_request.draft == false
+    # Each event handles exactly one PR origin: pull_request -> same-repo,
+    # pull_request_target -> forks. The mismatched run is skipped.
+    if: |
+      github.event.pull_request.draft == false &&
+      ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+       (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -43,6 +62,11 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Fork runs (pull_request_target) pass the run-scoped GITHUB_TOKEN so
+          # the action skips the OIDC exchange that Anthropic's backend rejects
+          # for this event (claude-code-action#713). Same-repo runs leave it
+          # empty so the OIDC path mints the claude[bot] app token.
+          github_token: ${{ github.event_name == 'pull_request_target' && secrets.GITHUB_TOKEN || '' }}
           allowed_bots: 'claude[bot]'
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

Since #257 moved the Claude review onto `pull_request_target`, every review run fails at startup with `401 Unauthorized - Invalid OIDC token` and no review is posted. Anthropic's OIDC → app-token exchange rejects tokens from `pull_request_target` events (upstream: anthropics/claude-code-action#713). This PR restores working reviews and keeps the `claude[bot]` identity for same-repo PRs by splitting the triggers by PR origin.

## Changes

- Dual triggers: same-repo PRs run on `pull_request` (OIDC exchange works → posts as `claude[bot]`, full trusted allowlist — identical to pre-#257 behavior); fork PRs stay on `pull_request_target`.
- Fork runs pass `github_token: ${{ secrets.GITHUB_TOKEN }}`, which makes the action skip the broken OIDC exchange entirely. Fork reviews post as `github-actions[bot]` — unavoidable without the exchange, and strictly better than the zero reviews forks got pre-#257. The restricted fork allowlist and no-head-checkout model from #257 are unchanged.
- Job-level `if` routes each event to exactly one PR origin, so the mismatched duplicate run is skipped.
- Concurrency group now includes `github.event_name`: a same-repo PR fires both events, and with the old shared group + `cancel-in-progress: true` the skipped `pull_request_target` run could cancel the real review.

## Test Plan

- YAML validated locally.
- **The red X on this PR's own review runs is expected — ignore it.** Anthropic's OIDC exchange additionally requires the workflow file to be byte-identical to the default-branch version (anthropics/claude-code-action#522), so any PR that modifies this workflow fails its own review run. The error message itself says this is normal. The `pull_request_target` run also fails one last time because that event executes the old file from `main`.
- Post-merge verification: the next same-repo PR push should get a review posted by `claude[bot]`; the first fork PR confirms the `github-actions[bot]` fallback path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code review automation reliability for pull requests from both the same repository and external forks, with improved workflow trigger handling and authentication configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->