### PR TITLE
feat(onboarding): in-app welcome guides + what's-new system

### DIFF
--- a/web/intro-preview.html
+++ b/web/intro-preview.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Page-intro modal — dev preview</title>
+    <!-- Dev-only design-iteration harness for the onboarding PageIntroModal.
+         Served by `pnpm dev` at /intro-preview.html; NOT part of the
+         production build (rollup input is index.html only). -->
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/pages/Onboarding/__preview__/main.tsx"></script>
+  </body>
+</html>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,6 +11,7 @@ import { useIsMobile } from './hooks/useIsMobile';
 import { useSetupGate } from './hooks/useSetupGate';
 import { isPlatformMode } from './config/hostMode';
 import { OAUTH_BROADCAST_CHANNEL, type OAuthPopupMessage } from './lib/oauthPopup';
+import { OnboardingProvider, OnboardingHostGate } from './pages/Onboarding';
 import './App.css';
 
 const SetupWizard = React.lazy(() => import('./pages/Setup/SetupWizard'));
@@ -114,13 +115,16 @@ function AuthenticatedShell() {
   }
 
   return (
-    <div className="app-layout">
-      {!isMobile && <Sidebar />}
-      {isMobile && !hideTabBar && <BottomTabBar />}
-      <main className={`app-main${hideTabBar ? ' app-main--no-tab' : ''}`}>
-        <Main />
-      </main>
-    </div>
+    <OnboardingProvider>
+      <div className="app-layout">
+        {!isMobile && <Sidebar />}
+        {isMobile && !hideTabBar && <BottomTabBar />}
+        <main className={`app-main${hideTabBar ? ' app-main--no-tab' : ''}`}>
+          <Main />
+        </main>
+      </div>
+      <OnboardingHostGate />
+    </OnboardingProvider>
   );
 }
 

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -2000,5 +2000,133 @@
       "startConversation": "Start a conversation by typing a message below",
       "defaultPlaceholder": "What would you like to know?"
     }
+  },
+  "onboarding": {
+    "badge": "Quick tour",
+    "back": "Back",
+    "next": "Continue",
+    "done": "Start exploring",
+    "step": "Step {{n}}",
+    "intros": {
+      "chat": {
+        "steps": {
+          "modes": {
+            "title": "Two modes: Flash and PTC",
+            "body": "The agent works in two modes: Flash for everyday coordination and quick questions, and PTC for deep analysis that produces real deliverables. The next steps show what each one is best at."
+          },
+          "workspace": {
+            "title": "Meet workspaces",
+            "body": "Every workspace is a project desk: the conversations about one task live there together, sharing the same files, data, and results — completely separate from other workspaces. The built-in Flash workspace collects all your quick questions; every workspace you create yourself runs PTC."
+          },
+          "flash": {
+            "title": "Flash — your personal assistant",
+            "body": "Flash keeps the whole desk running: just say what you need, and it creates and manages workspaces for you, dispatches heavy tasks to a PTC workspace to run, and manages your automations. It also handles quick questions — a stock price, a news lookup, a fast fact-check — in seconds. Every Flash thread is collected in the first workspace card, so past sessions are always easy to find."
+          },
+          "ptc": {
+            "title": "PTC — where the real work happens",
+            "body": "PTC workspaces host our most capable agent. Every thread inside shares the same files, data, and prior work, so research compounds. It processes large datasets, coordinates teams of subagents — something Flash can't do — and produces any deliverable: Excel models, Word docs, PDFs, dashboards."
+          },
+          "create": {
+            "title": "Give real tasks a PTC workspace",
+            "body": "If it involves data work or ends in a deliverable, don't leave it in Flash. Hit \"New workspace\", name it after the task — the agent boots a dedicated sandbox and brings its full capability to it."
+          }
+        }
+      },
+      "thread": {
+        "steps": {
+          "filePanel": {
+            "title": "Every artifact lands in the file panel",
+            "body": "Word docs, Excel models, PDFs, charts — whatever the agent produces is saved to the workspace. Open the folder icon up top to browse, preview, and download."
+          },
+          "memory": {
+            "title": "The agent remembers how you work",
+            "body": "The agent keeps long-term memory across threads: your preferences, conventions, and conclusions worth reusing. Say \"remember this\" and it persists."
+          },
+          "memo": {
+            "title": "Ground it with your memos",
+            "body": "Upload PDFs, notes, or spreadsheets as memos. The agent reads them on demand — your private research becomes part of its context."
+          }
+        }
+      },
+      "dashboard": {
+        "steps": {
+          "overview": {
+            "title": "Your market homepage",
+            "body": "Watchlist, portfolio, news, and live charts in one place — a real-time overview that's ready before you ask anything."
+          },
+          "customize": {
+            "title": "Make it yours",
+            "body": "Switch to Custom mode to add, remove, resize, and rearrange widgets. Build the exact monitor you want to wake up to."
+          },
+          "attach": {
+            "title": "Clip any widget into chat",
+            "body": "See something worth digging into? Hit the paperclip on a row to attach it to chat as context — the agent picks up exactly what you're looking at."
+          }
+        }
+      }
+    },
+    "gettingStarted": {
+      "title": "Get started",
+      "dismiss": "Hide guide",
+      "tasks": {
+        "dashboard": {
+          "title": "Explore the dashboard",
+          "desc": "Watchlist, portfolio, news, and live widgets in one place."
+        },
+        "market": {
+          "title": "Check live markets",
+          "desc": "Real-time charts with streaming market data."
+        },
+        "stocks": {
+          "title": "Share your watchlist & portfolio",
+          "desc": "A short chat — tell the agent the tickers you watch and hold."
+        },
+        "preferences": {
+          "title": "Share your investing preferences",
+          "desc": "Set your risk tolerance, investing style, and how you want answers framed."
+        },
+        "createWorkspace": {
+          "title": "Create your first workspace",
+          "desc": "Spin up a dedicated PTC workspace — the agent gets a full sandbox for real research."
+        },
+        "firstChat": {
+          "title": "Run your first analysis",
+          "desc": "Open a chat and ask about any ticker, sector, or filing."
+        },
+        "models": {
+          "title": "Visit the model configuration",
+          "desc": "Choose default models and connect providers in Settings."
+        },
+        "integrations": {
+          "title": "Use LangAlpha on other platforms",
+          "desc": "Reach the agent from Slack, email, and more via platform integrations."
+        }
+      },
+      "interview": {
+        "title": "A quick chat to personalize your experience",
+        "body": "We'll open a chat where the agent asks a few questions about your portfolio, watchlist, risk tolerance, and investment preferences — so its answers fit you. You can change any of it later in Settings, or simply ask the agent to update it.",
+        "cancel": "Not now",
+        "confirm": "Start the chat"
+      }
+    },
+    "announce": {
+      "dashCustom": {
+        "modalTitle": "Customizable dashboard",
+        "modalBody": "Switch your dashboard to Custom mode to rearrange, resize, and add widgets — then attach any of them to chat."
+      }
+    },
+    "whatsNew": {
+      "title": "What's new",
+      "subtitle": "A few updates since you were last here.",
+      "gotIt": "Got it"
+    },
+    "settings": {
+      "sectionTitle": "Tips & guides",
+      "description": "Re-show the page tips and the getting-started guide.",
+      "replayGuides": "Show tips again",
+      "replayDone": "Page tips and the getting-started guide will show again.",
+      "reset": "Reset onboarding",
+      "resetDone": "Onboarding reset — tips and the guide start fresh."
+    }
   }
 }

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -73,15 +73,15 @@
     "timezone": "时区",
     "selectTimezone": "选择时区...",
     "selectLocale": "选择语言...",
-    "preferencesDesc": "偏好设置通过与智能体对话来管理。点击下方按钮进行更新。",
+    "preferencesDesc": "偏好设置通过与 Agent 对话来管理。点击下方按钮进行更新。",
     "noPreferencesYet": "暂无偏好设置。点击下方按钮进行设置。",
     "riskTolerance": "风险偏好",
     "investmentStyle": "投资风格",
-    "agentSettings": "智能体设置",
+    "agentSettings": "Agent 设置",
     "resetPreferences": "重置偏好",
-    "resetConfirmMsg": "这将清除您所有的偏好设置（风险偏好、投资风格、智能体设置）。您可以随时通过智能体重新设置。确定吗？",
+    "resetConfirmMsg": "这将清除您所有的偏好设置（风险偏好、投资风格、Agent 设置）。您可以随时通过 Agent 重新设置。确定吗？",
     "resetting": "重置中...",
-    "modifyWithAgent": "通过智能体修改",
+    "modifyWithAgent": "通过 Agent 修改",
     "completeProfile": "完善个人资料",
     "completeProfileDesc": "通过简短对话设置您的股票、风险偏好和其他偏好。",
     "startOnboarding": "开始设置",
@@ -175,11 +175,11 @@
     "starredModelsDesc": "标星的模型会显示在聊天输入框中方便快速切换",
     "addModels": "添加",
     "searchProvider": "网络搜索引擎",
-    "searchProviderDesc": "智能体进行网络搜索时使用的搜索引擎。",
+    "searchProviderDesc": "Agent 进行网络搜索时使用的搜索引擎。",
     "searchProviderDefault": "默认",
     "searchProviderUpgradeHint": "部分搜索引擎需要更高级的套餐。",
     "searchDepth": "搜索深度",
-    "searchDepthDesc": "智能体搜索网络的深入程度。更深的级别每次搜索消耗更多积分。",
+    "searchDepthDesc": "Agent 搜索网络的深入程度。更深的级别每次搜索消耗更多积分。",
     "searchDepthDefault": "默认",
     "searchDepthUpgradeHint": "更深的搜索级别需要更高级的套餐。",
     "searchDepthLevel": {
@@ -284,7 +284,7 @@
         "contextUnavailableHint": "该小组件尚未注册上下文导出器。",
         "addRowToContext": "把这一行加入上下文",
         "addRowToContextTitle": "把此条目加入聊天上下文",
-        "contextUnsupportedTradingView": "无法添加：该内容由 TradingView 提供，智能体无法访问。"
+        "contextUnsupportedTradingView": "无法添加：该内容由 TradingView 提供，Agent 无法访问。"
       },
       "addDialog": {
         "eyebrow": "小组件库",
@@ -317,7 +317,7 @@
           "intelligenceBlurb": "AI 生成的简报与精选新闻流。",
           "personalLabel": "个人持仓",
           "personalBlurb": "您的投资组合、自选股与持仓。",
-          "agentLabel": "智能体",
+          "agentLabel": "Agent",
           "agentBlurb": "从仪表板启动一次研究会话。",
           "workspaceLabel": "工作区",
           "workspaceBlurb": "进入往期对话或工作区。"
@@ -369,10 +369,10 @@
           }
         },
         "agentDesk": {
-          "name": "智能体工作台",
-          "tag": "智能体主导",
-          "description": "智能体的工作面板。全宽提问控制台坐镇顶部——先把问题摆上桌，再往下读今日 AI 简报。工作区、近期对话、自动化与您的持仓一并陈列。",
-          "bestFor": "与智能体并肩工作——阅读、提问、运行自动化、跨工作区切换。",
+          "name": "Agent 工作台",
+          "tag": "Agent 主导",
+          "description": "Agent 的工作面板。全宽提问控制台坐镇顶部——先把问题摆上桌，再往下读今日 AI 简报。工作区、近期对话、自动化与您的持仓一并陈列。",
+          "bestFor": "与 Agent 并肩工作——阅读、提问、运行自动化、跨工作区切换。",
           "pills": {
             "aiBrief": "AI 简报",
             "askConsole": "提问控制台",
@@ -1092,9 +1092,9 @@
     "runningStatus": "运行中",
     "initializing": "初始化中",
     "worker": "工作者",
-    "agentNotFound": "未找到智能体",
+    "agentNotFound": "未找到 Agent",
     "planFeedbackHint": "输入您的反馈意见来修改计划，然后发送。",
-    "interruptedHint": "智能体已中断。请随时提供新的指令。",
+    "interruptedHint": "Agent 已中断。请随时提供新的指令。",
     "errorUpstreamHeadline": "模型提供商返回错误",
     "errorUpstreamHeadlineStatus": "模型提供商返回错误 ({{status}})",
     "errorInternalHeadline": "服务内部出错",
@@ -1110,7 +1110,7 @@
     "loadingHistory": "加载历史记录...",
     "workspaceFiles": "工作区文件",
     "workspaceSettings": "工作区设置",
-    "agents": "智能体",
+    "agents": "Agent",
     "questionStarted": "问题已开始",
     "questionDeclined": "问题已跳过",
     "startQuestion": "开始提问",
@@ -1128,7 +1128,7 @@
     "offloading": "正在转存上下文...",
     "placeholderDefault": "输入 / 调用技能，@ 引用文件",
     "placeholderPendingRejection": "说说希望怎么调整...",
-    "placeholderInterrupted": "输入新指令继续引导智能体...",
+    "placeholderInterrupted": "输入新指令继续引导 Agent...",
     "placeholderLoading": "可以继续输入，消息会排队发送...",
     "placeholderSubagentsRunning": "工作者仍在运行，可输入消息或点击工作者单独指令",
     "slashCommand": {
@@ -1196,7 +1196,7 @@
     "addLineToContext": "添加 L{{line}} 到上下文",
     "addNLinesToContext": "添加 {{count}} 行到上下文",
     "openFile": "打开文件",
-    "fromAgentResponse": "来自智能体回复",
+    "fromAgentResponse": "来自 Agent 回复",
     "addToMemo": "添加到备忘录",
     "syncWithMemo": "同步到备忘录",
     "memoAdding": "正在将 \"{{name}}\" 添加到备忘录",
@@ -1308,7 +1308,7 @@
     "loadingList": "正在加载记忆…",
     "emptyUser": "暂无用户记忆。",
     "emptyWorkspace": "暂无工作区记忆。",
-    "emptyHint": "当有值得记住的内容时，智能体会创建 memory.md。",
+    "emptyHint": "当有值得记住的内容时，Agent 会创建 memory.md。",
     "loadError": "记忆加载失败",
     "readError": "记忆文件读取失败",
     "notFound": "记忆 “{{key}}” 已不存在，已显示全部条目。",
@@ -1316,7 +1316,7 @@
   },
   "memoPanel": {
     "title": "备忘文档",
-    "description": "上传研究备忘、原始资料或参考文件。按用户归档，在任一工作区智能体都可读取。",
+    "description": "上传研究备忘、原始资料或参考文件。按用户归档，在任一工作区 Agent 都可读取。",
     "uploadButton": "上传",
     "uploadHint": "支持 Markdown、TXT、CSV、JSON、PDF · 单文件不超过 5 MB",
     "dragOverlayText": "松开鼠标以上传文件",
@@ -1403,13 +1403,13 @@
     "cronExpression": "Cron 表达式",
     "cronHelp": "5字段 cron: 分钟 小时 日 月 星期",
     "runAt": "运行时间",
-    "agentMode": "智能体模式",
+    "agentMode": "Agent 模式",
     "flash": "快速",
     "ptcSandbox": "PTC（沙箱）",
     "selectWorkspace": "选择工作区...",
     "workspaceRequired": "PTC 模式需要选择工作区。",
     "instruction": "指令",
-    "instructionPlaceholder": "智能体应该做什么？",
+    "instructionPlaceholder": "Agent 应该做什么？",
     "threadStrategy": "对话策略",
     "newThreadEachRun": "每次新建对话",
     "continueExisting": "继续现有对话",
@@ -1581,7 +1581,7 @@
     "next": "下次：{{time}}",
     "instruction": "指令",
     "configuration": "配置",
-    "agentMode": "智能体模式",
+    "agentMode": "Agent 模式",
     "triggerType": "触发类型",
     "trigger": "触发条件",
     "retrigger": "重复触发",
@@ -1979,6 +1979,134 @@
       "noWorkspacePrompt": "未选择工作区。请在输入框中选择一个。",
       "startConversation": "在下方输入消息开始对话",
       "defaultPlaceholder": "你想了解什么？"
+    }
+  },
+  "onboarding": {
+    "badge": "页面导览",
+    "back": "上一步",
+    "next": "继续",
+    "done": "开始探索",
+    "step": "第 {{n}} 步",
+    "intros": {
+      "chat": {
+        "steps": {
+          "modes": {
+            "title": "两种模式：Flash 与 PTC",
+            "body": "Agent 以两种模式工作：Flash 负责日常协调与快速问答；PTC 负责深度分析，产出真正的交付物。接下来分别介绍两者的分工。"
+          },
+          "workspace": {
+            "title": "认识工作区",
+            "body": "每一个工作区都是一个项目空间：围绕同一任务的对话都集中在这里，共享文件、数据和成果；不同工作区之间完全独立，互不干扰。其中 Flash 工作区由平台统一管理，汇集所有快速问答；你自己创建的每个工作区都运行 PTC。"
+          },
+          "flash": {
+            "title": "Flash：你的个人助理",
+            "body": "Flash 负责统筹日常：你只管提出需求，它会替你创建和管理工作区、将复杂任务分派到 PTC 工作区执行、管理自动化。快速问答也交给它——查股价、看新闻、快速核实信息，几秒内给出答案。所有 Flash 对话统一归入第一张工作区卡片，方便查找历史会话。"
+          },
+          "ptc": {
+            "title": "PTC：完整的分析工作区",
+            "body": "PTC 工作区运行能力最强的 Agent。同一工作区内的所有对话共享文件、数据与已有成果，分析可以持续积累。它能处理大规模数据，并行调度多个子 Agent 完成 Flash 无法胜任的复杂任务，还能生成各类交付物：Excel 模型、Word 文档、PDF、仪表盘。"
+          },
+          "create": {
+            "title": "为正式任务创建 PTC 工作区",
+            "body": "涉及数据处理或需要产出交付物的任务，建议交给 PTC 工作区完成，而不是全部留在 Flash。点击“新建工作区”并按任务命名，Agent 会启动专属沙盒，以完整能力执行。"
+          }
+        }
+      },
+      "thread": {
+        "steps": {
+          "filePanel": {
+            "title": "文件统一保存在文件面板",
+            "body": "Word 文档、Excel 模型、PDF、图表等 Agent 生成的文件都会保存在工作区中。点击顶部的文件夹图标，即可浏览、预览和下载。"
+          },
+          "memory": {
+            "title": "Agent 会记住你的偏好",
+            "body": "Agent 具备跨对话的长期记忆，可以保存你的偏好、惯例和值得复用的结论。对它说“记住这个”，相关内容便会长期保留。"
+          },
+          "memo": {
+            "title": "上传备忘录，补充分析资料",
+            "body": "可以将 PDF、笔记或表格上传为备忘录。Agent 会在需要时读取，把你的私有资料纳入分析上下文。"
+          }
+        }
+      },
+      "dashboard": {
+        "steps": {
+          "overview": {
+            "title": "行情总览",
+            "body": "自选股、投资组合、新闻与实时图表集中呈现，打开页面即可掌握市场概况。"
+          },
+          "customize": {
+            "title": "自定义布局",
+            "body": "切换到自定义模式后，可以添加、删除、调整和排列小组件，搭建符合自己需求的监控面板。"
+          },
+          "attach": {
+            "title": "将组件内容附加到对话",
+            "body": "看到值得深入分析的内容时，点击该行的回形针图标，即可将其作为上下文附加到对话，Agent 会基于这一内容继续分析。"
+          }
+        }
+      }
+    },
+    "gettingStarted": {
+      "title": "快速上手",
+      "dismiss": "隐藏引导",
+      "tasks": {
+        "dashboard": {
+          "title": "探索仪表盘",
+          "desc": "自选股、组合、新闻与实时组件一站集齐。"
+        },
+        "market": {
+          "title": "查看实时行情",
+          "desc": "实时数据流驱动的行情图表。"
+        },
+        "stocks": {
+          "title": "告诉 Agent 你的自选股与持仓",
+          "desc": "与 Agent 简单聊聊你关注和持有的股票。"
+        },
+        "preferences": {
+          "title": "设置投资偏好",
+          "desc": "设定风险承受度、投资风格与回答方式。"
+        },
+        "createWorkspace": {
+          "title": "创建第一个工作区",
+          "desc": "新建一个专属 PTC 工作区，Agent 将在完整沙盒中执行正式分析任务。"
+        },
+        "firstChat": {
+          "title": "开始第一次分析",
+          "desc": "打开对话，询问任意股票、行业或财报。"
+        },
+        "models": {
+          "title": "查看模型配置",
+          "desc": "在设置的模型页选择默认模型并连接服务商。"
+        },
+        "integrations": {
+          "title": "在其他平台使用 LangAlpha",
+          "desc": "通过平台集成，在 Slack、邮件等平台使用 LangAlpha。"
+        }
+      },
+      "interview": {
+        "title": "聊几句，让 Agent 更懂你",
+        "body": "即将打开一段对话，Agent 会简单了解你的持仓、自选股、风险承受度与投资偏好，让之后的回答更贴合你的情况。这些信息可在设置中修改，也可以直接让它更新。",
+        "cancel": "暂不",
+        "confirm": "开始对话"
+      }
+    },
+    "announce": {
+      "dashCustom": {
+        "modalTitle": "可自定义的仪表盘",
+        "modalBody": "将仪表盘切换到自定义模式，即可重新排列、调整大小并添加小组件，还能将它们附加到对话中。"
+      }
+    },
+    "whatsNew": {
+      "title": "新功能",
+      "subtitle": "你上次访问以来的一些更新。",
+      "gotIt": "知道了"
+    },
+    "settings": {
+      "sectionTitle": "提示与引导",
+      "description": "重新显示页面提示和快速上手指南。",
+      "replayGuides": "再次显示提示",
+      "replayDone": "页面提示与快速上手指南将重新显示。",
+      "reset": "重置新手引导",
+      "resetDone": "新手引导已重置，提示与指南将重新开始。"
     }
   }
 }

--- a/web/src/pages/Dashboard/DashboardRouter.tsx
+++ b/web/src/pages/Dashboard/DashboardRouter.tsx
@@ -35,18 +35,18 @@ export default function DashboardRouter() {
 
   const onModeChange = useCallback(
     (next: 'classic' | 'custom') => {
-      // Cold-cache gate: refuse the toggle until prefs load so we don't PUT
-      // `{ other_preference: { dashboard: {...} } }` and clobber sibling
-      // server-side keys (theme, locale). The toggle is disabled in the UI
-      // while isLoading, so this branch is defense-in-depth.
+      // Cold-cache gate: refuse the toggle until prefs load so we don't build
+      // the dashboard payload from nothing and overwrite the user's saved
+      // layout (the server replaces the dashboard key wholesale). The toggle
+      // is disabled in the UI while isLoading, so this is defense-in-depth.
       if (isLoading) return;
       // Replay-aware: re-read the freshest cache so a cross-tab edit (or
       // pending debounce in this tab) that already updated the dashboard
       // sub-object isn't replaced with the render-time snapshot. Without
       // this, `firstFlipToCustom` could mis-trigger the morning-brief seed
       // because `parsed` (render-time) saw an empty widget list while the
-      // cache already has widgets. The writer also reads cache for sibling
-      // preservation; this read is for the dashboard sub-object only.
+      // cache already has widgets. (Siblings aren't in the payload at all —
+      // the server-side merge preserves them.)
       const fresh = queryClient.getQueryData<UserPreferences>(queryKeys.user.preferences());
       const freshOther = (fresh?.other_preference as Record<string, unknown> | undefined) ?? rawOther;
       const freshDashboardRaw = (freshOther?.dashboard as unknown) ?? null;
@@ -63,7 +63,7 @@ export default function DashboardRouter() {
         history: baseDashboard.history,
       };
       writeDashboardPrefs(dashboard, {
-        // undefined = cold (writer refuses); null = warm w/ empty siblings.
+        // undefined = cold (writer refuses); null = warm, no saved prefs yet.
         fallbackOther: preferences === null
           ? undefined
           : ((rawOther as Record<string, unknown> | undefined) ?? null),

--- a/web/src/pages/Dashboard/__tests__/DashboardRouter.test.tsx
+++ b/web/src/pages/Dashboard/__tests__/DashboardRouter.test.tsx
@@ -121,9 +121,11 @@ describe('DashboardRouter', () => {
         },
       });
     });
-    // User clicks mode toggle. Without replay-aware fix, the write would
-    // spread the stale render-time `rawOther` and clobber theme=light + the
-    // remote-added widget array.
+    // User clicks mode toggle. The dashboard key is replaced wholesale
+    // server-side, so `next` must be built from the FRESH cache (the
+    // remote-added widget survives) — while siblings like theme stay out of
+    // the payload entirely (the server merge preserves them; replaying the
+    // stale render-time copy is how a write used to revert them).
     act(() => {
       lastDashboardProps.current!.onModeChange('custom');
     });
@@ -134,7 +136,7 @@ describe('DashboardRouter', () => {
         dashboard?: { mode: string; widgets?: unknown[] };
       };
     };
-    expect(payload.other_preference.theme).toBe('light');
+    expect(Object.keys(payload.other_preference)).toEqual(['dashboard']);
     expect(payload.other_preference.dashboard?.mode).toBe('custom');
     // The remote-added widget must survive the mode-toggle write.
     expect(payload.other_preference.dashboard?.widgets?.length).toBe(1);
@@ -175,9 +177,9 @@ describe('DashboardRouter', () => {
   });
 
   it('cold-cache gate: onModeChange is a no-op while preferences are still loading', () => {
-    // Regression: a fast click before the GET resolves would PUT
-    // { other_preference: { dashboard: {...} } } and clobber sibling
-    // server-side keys (theme, locale).
+    // Regression: a fast click before the GET resolves would PUT a dashboard
+    // built from nothing and wipe the user's saved layout (the server
+    // replaces the dashboard key wholesale).
     loadingState.isLoading = true;
     prefsState.current = null;
     const queryClient = new QueryClient({

--- a/web/src/pages/Dashboard/hooks/useOnboarding.ts
+++ b/web/src/pages/Dashboard/hooks/useOnboarding.ts
@@ -34,12 +34,23 @@ export function isPersonalizationSnoozed(): boolean {
     }
 }
 
+const PERSONALIZATION_SNOOZE_EVENT = 'langalpha:personalization-snoozed';
+
 export function snoozePersonalization(): void {
     try {
         localStorage.setItem(PERSONALIZATION_SNOOZE_KEY, String(Date.now()));
     } catch (e) {
         console.warn('[Dashboard] Could not persist personalization snooze', e);
     }
+    // Same-tab listeners (the onboarding provider) re-read the snooze state —
+    // a localStorage write alone doesn't re-render other components.
+    window.dispatchEvent(new Event(PERSONALIZATION_SNOOZE_EVENT));
+}
+
+/** Subscribe to same-tab snooze changes (for useSyncExternalStore). */
+export function subscribePersonalizationSnooze(callback: () => void): () => void {
+    window.addEventListener(PERSONALIZATION_SNOOZE_EVENT, callback);
+    return () => window.removeEventListener(PERSONALIZATION_SNOOZE_EVENT, callback);
 }
 
 /** @deprecated Use isPersonalizationSnoozed instead */

--- a/web/src/pages/Dashboard/widgets/framework/__tests__/useDashboardPrefs.test.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/__tests__/useDashboardPrefs.test.tsx
@@ -26,9 +26,8 @@ import { useDashboardPrefs } from '../useDashboardPrefs';
 
 /**
  * Build a queryClient pre-seeded with the same prefs the mocked usePreferences
- * returns. The replay-aware flush reads from this cache, not from the hook
- * snapshot, so we have to keep them in sync for "preserves sibling keys"
- * assertions to mean what they say.
+ * returns. The writer's cold-cache check reads this cache, not the hook
+ * snapshot, so they have to stay in sync for writes to be accepted.
  */
 function makePrimedClient(): QueryClient {
   // gcTime: Infinity so seeded data survives vi.advanceTimersByTime() ticks.
@@ -57,8 +56,8 @@ describe('useDashboardPrefs', () => {
 
   it('cold-cache gate: update() is a no-op while preferences are still loading', () => {
     // Regression: without the gate, a fast click before the GET resolves
-    // would PUT { other_preference: { dashboard: {...} } } and clobber
-    // sibling server-side keys (theme, locale).
+    // would PUT a dashboard built from `{}` and wipe the user's saved layout
+    // (the server replaces the dashboard key wholesale).
     loadingState.isLoading = true;
     prefsState.current = null;
     const { result } = renderHookWithProviders(() => useDashboardPrefs(), { queryClient: makePrimedClient() });
@@ -91,7 +90,10 @@ describe('useDashboardPrefs', () => {
     expect(mockMutate).toHaveBeenCalledTimes(1);
   });
 
-  it('preserves sibling other_preference keys (theme) when flushing', () => {
+  // The backend shallow-merges top-level other_preference keys (JSONB ||) —
+  // re-sending cached siblings would replay a stale value over a newer write
+  // from another tab. The payload must carry ONLY the dashboard key.
+  it('sends only the dashboard key — siblings are preserved by the server merge', () => {
     const { result } = renderHookWithProviders(() => useDashboardPrefs(), { queryClient: makePrimedClient() });
     act(() => {
       result.current.setMode('custom');
@@ -99,7 +101,7 @@ describe('useDashboardPrefs', () => {
     const payload = mockMutate.mock.calls[0][0] as {
       other_preference: { theme?: string; dashboard?: { mode: string } };
     };
-    expect(payload.other_preference.theme).toBe('dark');
+    expect(Object.keys(payload.other_preference)).toEqual(['dashboard']);
     expect(payload.other_preference.dashboard?.mode).toBe('custom');
   });
 
@@ -132,10 +134,12 @@ describe('useDashboardPrefs', () => {
     expect(result.current.prefs.history?.length ?? 0).toBeLessThanOrEqual(3);
   });
 
-  it('replay-aware flush reads the freshest queryClient snapshot, not the queue-time ref', () => {
-    // Tab A queues an edit. While the debounce is pending, Tab B writes and
-    // we receive the broadcast → cache gets a NEW theme value. Tab A's flush
-    // must use the new theme, not the snapshot it captured at queue time.
+  it('a cross-tab cache update mid-debounce never leaks siblings into the flush payload', () => {
+    // Tab A queues an edit. While the debounce is pending, Tab B's write lands
+    // in the cache (new theme + a key this tab has never seen). Tab A's flush
+    // must still PUT only the dashboard key: Tab B's values are preserved by
+    // the server-side merge, not replayed from this tab's cache — replaying
+    // them is how a stale cache used to revert another tab's settings.
     const queryClient = makePrimedClient();
     const { result } = renderHookWithProviders(() => useDashboardPrefs(), { queryClient });
     act(() => {
@@ -147,17 +151,13 @@ describe('useDashboardPrefs', () => {
         other_preference: { theme: 'light', remoteAddedKey: 'remote' },
       });
     });
-    // Sanity: confirm cache has the cross-tab value before flush fires.
-    const cachedNow = queryClient.getQueryData(queryKeys.user.preferences()) as { other_preference: Record<string, unknown> };
-    expect(cachedNow.other_preference.theme).toBe('light');
     act(() => {
       vi.advanceTimersByTime(800);
     });
     const payload = mockMutate.mock.calls[0][0] as {
       other_preference: { theme?: string; remoteAddedKey?: string; dashboard?: { mode: string } };
     };
-    expect(payload.other_preference.theme).toBe('light');
-    expect(payload.other_preference.remoteAddedKey).toBe('remote');
+    expect(Object.keys(payload.other_preference)).toEqual(['dashboard']);
     expect(payload.other_preference.dashboard?.mode).toBe('custom');
   });
 

--- a/web/src/pages/Dashboard/widgets/framework/dashboardPrefsWriter.ts
+++ b/web/src/pages/Dashboard/widgets/framework/dashboardPrefsWriter.ts
@@ -11,19 +11,21 @@ export const BROADCAST_CHANNEL = 'dashboard-prefs';
  * Single writer for `other_preference.dashboard`. Centralizes three concerns
  * that every dashboard prefs mutation needs to do correctly:
  *
- * 1. **Replay-aware sibling preservation.** Read the freshest cache snapshot
- *    at write time (not at queue/render time) so a cross-tab update or a
- *    concurrent write to a sibling key (theme, locale, provider) isn't
- *    clobbered by spreading a stale `other_preference` blob.
+ * 1. **Minimal payload.** The PUT carries ONLY the dashboard key: the backend
+ *    shallow-merges top-level `other_preference` keys (JSONB `||`), so
+ *    sibling keys (theme, locale, onboarding, providers) are preserved
+ *    server-side. Re-sending them from this tab's cache would replay a stale
+ *    sibling over a newer write from another tab or an in-flight settings
+ *    change.
  *
  * 2. **Cross-tab broadcast.** Post `{type:'updated'}` to the dashboard-prefs
  *    BroadcastChannel on success so other tabs invalidate their cache and
  *    refetch — covers cross-tab consistency without relying on alt-tab focus.
  *
  * 3. **Cold-cache safety.** Refuse the write when the cache is cold AND no
- *    fallback dashboard snapshot was supplied. Without this, a fast click on
- *    cold load PUTs `{ other_preference: { dashboard: {...} } }` and wipes
- *    every sibling key on the server (irreversible — no prefs undo).
+ *    fallback snapshot was supplied. The server replaces the `dashboard` key
+ *    wholesale, and a `next` computed without ever seeing the real prefs
+ *    would erase the user's saved layout (irreversible — no prefs undo).
  *
  * Used by `useDashboardPrefs.flush()` (debounced widget edits) and
  * `DashboardRouter.onModeChange()` (mode toggle).
@@ -49,7 +51,8 @@ export function useDashboardPrefsWriter() {
     (
       next: DashboardPrefs,
       opts?: {
-        /** `null` = warm prefs with empty other_preference (new users).
+        /** Cold-cache sentinel (content unused — the payload is minimal).
+         *  `null` = caller vouches the user has no saved prefs (new users).
          *  `undefined` = no info — writer refuses the write. */
         fallbackOther?: Record<string, unknown> | null;
         onSuccess?: () => void;
@@ -58,11 +61,9 @@ export function useDashboardPrefsWriter() {
     ): boolean => {
       const fresh = queryClient.getQueryData<UserPreferences>(queryKeys.user.preferences());
       if (fresh === undefined && opts?.fallbackOther === undefined) return false;
-      const freshOther = (fresh?.other_preference as Record<string, unknown> | undefined) ?? null;
-      const baseOther = freshOther ?? opts?.fallbackOther ?? {};
       updatePrefs.mutate(
         {
-          other_preference: { ...baseOther, dashboard: next },
+          other_preference: { dashboard: next },
         },
         {
           onSuccess: () => {

--- a/web/src/pages/Dashboard/widgets/framework/useDashboardPrefs.ts
+++ b/web/src/pages/Dashboard/widgets/framework/useDashboardPrefs.ts
@@ -117,7 +117,7 @@ export function useDashboardPrefs() {
         }
       }
       const accepted = writeDashboardPrefs(next, {
-        // undefined = cold (writer refuses); null = warm w/ empty siblings.
+        // undefined = cold (writer refuses); null = warm, no saved prefs yet.
         fallbackOther: preferences === null
           ? undefined
           : ((preferences as { other_preference?: Record<string, unknown> }).other_preference ?? null),
@@ -147,8 +147,8 @@ export function useDashboardPrefs() {
   const update = useCallback(
     (patch: Partial<DashboardPrefs> | ((prev: DashboardPrefs) => DashboardPrefs), opts?: { immediate?: boolean }) => {
       // Cold-cache gate: drop edits before the initial GET resolves so we
-      // don't construct a payload from `{}` and clobber server-side
-      // sibling other_preference keys (theme, locale, etc.).
+      // don't build `next` from `{}` and overwrite the user's saved dashboard
+      // (the server replaces the dashboard key wholesale).
       if (isLoading) return;
       setLocal((prev) => {
         const next = typeof patch === 'function' ? patch(prev) : { ...prev, ...patch };

--- a/web/src/pages/Onboarding/OnboardingHost.tsx
+++ b/web/src/pages/Onboarding/OnboardingHost.tsx
@@ -1,0 +1,26 @@
+import { useOnboarding } from './OnboardingProvider';
+import { PageIntroModal } from './engine/PageIntroModal';
+import { WhatsNewModal } from './engine/WhatsNewModal';
+import { GettingStartedCard } from './engine/GettingStartedCard';
+
+/**
+ * Renders the active onboarding surfaces: the contextual page intro or the
+ * versioned What's-New modal (one popup at a time), plus the persistent
+ * getting-started checklist card. Mounted once inside the authenticated shell.
+ */
+export function OnboardingHost() {
+  const { phase, activeIntro, unseen, dismissPageIntro, acknowledgeWhatsNew } = useOnboarding();
+
+  return (
+    <>
+      {phase === 'pageIntro' && activeIntro && (
+        // Keyed so step state never leaks between two different intros.
+        <PageIntroModal key={activeIntro.id} intro={activeIntro} onClose={dismissPageIntro} />
+      )}
+      {phase === 'whatsNew' && (
+        <WhatsNewModal announcements={unseen} onAcknowledge={acknowledgeWhatsNew} />
+      )}
+      <GettingStartedCard />
+    </>
+  );
+}

--- a/web/src/pages/Onboarding/OnboardingHostGate.tsx
+++ b/web/src/pages/Onboarding/OnboardingHostGate.tsx
@@ -1,0 +1,26 @@
+import { lazy, Suspense, useRef } from 'react';
+import { useOnboarding } from './OnboardingProvider';
+
+// Lazy so the modal + visual-mockup graph (the bulk of the onboarding code)
+// stays out of the main chunk.
+const OnboardingHost = lazy(() =>
+  import('./OnboardingHost').then((m) => ({ default: m.OnboardingHost }))
+);
+
+/**
+ * Mounts the lazy OnboardingHost only when a surface needs the screen, so a
+ * fully-onboarded user never downloads the chunk. Latched: once needed it
+ * stays mounted for the session, so phase flips back to idle don't churn the
+ * mount.
+ */
+export function OnboardingHostGate() {
+  const { phase, gettingStarted } = useOnboarding();
+  const neededRef = useRef(false);
+  if (phase !== 'idle' || gettingStarted.visible) neededRef.current = true;
+  if (!neededRef.current) return null;
+  return (
+    <Suspense fallback={null}>
+      <OnboardingHost />
+    </Suspense>
+  );
+}

--- a/web/src/pages/Onboarding/OnboardingProvider.tsx
+++ b/web/src/pages/Onboarding/OnboardingProvider.tsx
@@ -69,9 +69,10 @@ interface OnboardingContextValue {
   gettingStarted: GettingStartedState;
   // What's-New
   acknowledgeWhatsNew: () => void;
-  // settings affordances
-  replayGuides: () => void;
-  resetOnboarding: () => void;
+  // settings affordances — return false when the persist write was refused
+  // (cold cache), so Settings can skip a "done" toast it can't honor.
+  replayGuides: () => boolean;
+  resetOnboarding: () => boolean;
 }
 
 const OnboardingContext = createContext<OnboardingContextValue | null>(null);
@@ -198,7 +199,11 @@ export function OnboardingProvider({ children }: { children: ReactNode }) {
   }, [phase, unseen.length]);
 
   /** Re-show every page tip + the getting-started card (Settings affordance). */
-  const replayGuides = useCallback(() => {
+  const replayGuides = useCallback((): boolean => {
+    // Persist first: a refused write (cold cache) makes this a no-op rather
+    // than clearing local state for a change the server never recorded — the
+    // caller then skips the toast and the user can retry once prefs settle.
+    if (!replayGuidesPrefs()) return false;
     // Eligibility checks the mount-time mirror snapshot and the session guard
     // before prefs, so without clearing both the replay would silently
     // suppress the very tips it just cleared until reload.
@@ -206,10 +211,11 @@ export function OnboardingProvider({ children }: { children: ReactNode }) {
     mirrorRef.current = null;
     setActiveIntroId(null);
     setPhase('idle');
-    replayGuidesPrefs();
+    return true;
   }, [replayGuidesPrefs]);
 
-  const resetOnboarding = useCallback(() => {
+  const resetOnboarding = useCallback((): boolean => {
+    if (!resetAll()) return false;
     shownIntrosRef.current.clear();
     mirrorRef.current = null;
     // Re-arm the first-run stamp so a reset behaves like a fresh user in this
@@ -217,7 +223,7 @@ export function OnboardingProvider({ children }: { children: ReactNode }) {
     firstRunStampedRef.current = false;
     setActiveIntroId(null);
     setPhase('idle');
-    resetAll();
+    return true;
   }, [resetAll]);
 
   // The interview thread starts as /chat/t/__default__ but is renamed to a

--- a/web/src/pages/Onboarding/OnboardingProvider.tsx
+++ b/web/src/pages/Onboarding/OnboardingProvider.tsx
@@ -253,9 +253,7 @@ export function OnboardingProvider({ children }: { children: ReactNode }) {
   // "Personalize" navigates to /chat/t/__default__ and no intro must pop over
   // it (snooze is irrelevant mid-flow).
   const personalizationCompleted =
-    (user as { personalization_completed?: boolean; onboarding_completed?: boolean } | null)
-      ?.personalization_completed === true ||
-    (user as { onboarding_completed?: boolean } | null)?.onboarding_completed === true;
+    user?.personalization_completed === true || user?.onboarding_completed === true;
   const suppress =
     inInterview ||
     (!personalizationCompleted &&

--- a/web/src/pages/Onboarding/OnboardingProvider.tsx
+++ b/web/src/pages/Onboarding/OnboardingProvider.tsx
@@ -292,25 +292,27 @@ export function OnboardingProvider({ children }: { children: ReactNode }) {
     // within the same QueryClient lifetime.
     queryKey: ['onboarding', 'hasStocks', userId],
     queryFn: async () => {
+      // listPortfolio is independent of the watchlists result — start it in
+      // parallel so a user with no watchlists (the common new-user case)
+      // resolves in one round-trip instead of listWatchlists → listPortfolio in
+      // series. .catch keeps it a settled boolean so an early listWatchlists
+      // rejection can't leave it floating unhandled.
+      const portfolioProbe = listPortfolio()
+        .then((r) => ((r as { holdings?: unknown[] }).holdings?.length ?? 0) > 0)
+        .catch(() => false);
       const { watchlists } = (await listWatchlists()) as {
         watchlists?: Array<{ watchlist_id: string }>;
       };
-      // One parallel burst instead of a serial walk: total latency is two
-      // round-trips regardless of watchlist count.
-      const probes = [
-        ...(watchlists ?? []).map(async (wl) => {
-          const { items } = (await listWatchlistItems(wl.watchlist_id)) as { items?: unknown[] };
-          return (items?.length ?? 0) > 0;
-        }),
-        (async () => {
-          const { holdings } = (await listPortfolio()) as { holdings?: unknown[] };
-          return (holdings?.length ?? 0) > 0;
-        })(),
-      ];
+      // Item probes fire the moment listWatchlists resolves, in parallel with
+      // the still-in-flight portfolio probe.
+      const itemProbes = (watchlists ?? []).map(async (wl) => {
+        const { items } = (await listWatchlistItems(wl.watchlist_id)) as { items?: unknown[] };
+        return (items?.length ?? 0) > 0;
+      });
       // allSettled: one failed watchlist probe must not mask stocks another
       // probe found — the result is one-way and gets stamped, so a transient
       // error returning false would stick the task incomplete for the session.
-      const results = await Promise.allSettled(probes);
+      const results = await Promise.allSettled([portfolioProbe, ...itemProbes]);
       return results.some((r) => r.status === 'fulfilled' && r.value);
     },
     enabled: userId != null && !isLoading && prefs.gettingStartedDismissedAt === null && !stocksStamped,

--- a/web/src/pages/Onboarding/OnboardingProvider.tsx
+++ b/web/src/pages/Onboarding/OnboardingProvider.tsx
@@ -1,0 +1,405 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  type ReactNode,
+} from 'react';
+import { useLocation } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { useUser } from '@/hooks/useUser';
+import { usePreferences } from '@/hooks/usePreferences';
+import { useWorkspaces } from '@/hooks/useWorkspaces';
+import { useIsMobile } from '@/hooks/useIsMobile';
+import {
+  isPersonalizationSnoozed,
+  subscribePersonalizationSnooze,
+} from '@/pages/Dashboard/hooks/useOnboarding';
+import { listWatchlists, listWatchlistItems, listPortfolio } from '@/pages/Dashboard/utils/api';
+import { isPlatformMode } from '@/config/hostMode';
+import { useOnboardingPrefs } from './useOnboardingPrefs';
+import { readMirror, type OnboardingMirror } from './mirror';
+import { ANNOUNCEMENTS, PAGE_INTROS, GETTING_STARTED_TASKS } from './registry';
+import { unseenReleases, latestReleaseVersion } from './engine/whatsNew';
+import {
+  useOnboardingOrchestrator,
+  type OnboardingPhase,
+} from './engine/useOnboardingOrchestrator';
+import type { AnnouncementDef, GettingStartedTaskDef, PageIntroDef } from './registry';
+
+export interface GettingStartedTaskState {
+  def: GettingStartedTaskDef;
+  done: boolean;
+}
+
+interface GettingStartedState {
+  visible: boolean;
+  tasks: GettingStartedTaskState[];
+  doneCount: number;
+  dismiss: () => void;
+  /** Stamp a task done (external tasks complete on click — no route to observe). */
+  completeTask: (id: string) => void;
+}
+
+/** Tasks offered in this deployment — channel integrations are platform-hosted. */
+const OFFERED_TASKS = GETTING_STARTED_TASKS.filter((t) => !t.platformOnly || isPlatformMode);
+
+/** Any non-empty string value in a preference object (mirrors the backend's check). */
+function hasFilledField(section: unknown): boolean {
+  return (
+    typeof section === 'object' &&
+    section !== null &&
+    Object.values(section as Record<string, unknown>).some(
+      (v) => typeof v === 'string' && v.trim() !== ''
+    )
+  );
+}
+
+interface OnboardingContextValue {
+  phase: OnboardingPhase;
+  unseen: AnnouncementDef[];
+  // page intros
+  activeIntro: PageIntroDef | null;
+  dismissPageIntro: () => void;
+  // getting-started checklist
+  gettingStarted: GettingStartedState;
+  // What's-New
+  acknowledgeWhatsNew: () => void;
+  // settings affordances
+  replayGuides: () => void;
+  resetOnboarding: () => void;
+}
+
+const OnboardingContext = createContext<OnboardingContextValue | null>(null);
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useOnboarding(): OnboardingContextValue {
+  const ctx = useContext(OnboardingContext);
+  if (!ctx) throw new Error('useOnboarding must be used within <OnboardingProvider>');
+  return ctx;
+}
+
+export function OnboardingProvider({ children }: { children: ReactNode }) {
+  const { pathname, search } = useLocation();
+  const { user } = useUser();
+  const { preferences } = usePreferences();
+  const {
+    prefs,
+    isLoading,
+    markPageIntroSeen,
+    markTaskDone,
+    dismissGettingStarted,
+    replayGuides: replayGuidesPrefs,
+    setLastSeenReleaseVersion,
+    ensureFirstRun,
+    resetAll,
+  } = useOnboardingPrefs();
+
+  // Synchronous, read once the user resolves: anti-flash suppression source
+  // for page intros. The mirror is keyed per user, so the read waits for the
+  // user id; until then intros stay suppressed (mirror "not ready"), which
+  // preserves the suppress-only invariant. Lazy init — useRef(readMirror())
+  // would re-read+parse localStorage on every render of this shell-wrapping
+  // provider (it re-renders per route change).
+  const userId = user?.user_id ?? null;
+  const mirrorRef = useRef<OnboardingMirror | null | undefined>(undefined);
+  if (mirrorRef.current === undefined && userId) mirrorRef.current = readMirror(userId);
+
+  // Intros opened this session. Authoritative the instant one closes, unlike
+  // the async prefs write + mount-time mirror — prevents the orchestrator from
+  // re-opening an intro the moment it's dismissed (loop).
+  const shownIntrosRef = useRef(new Set<string>());
+
+  const [phase, setPhase] = useState<OnboardingPhase>('idle');
+  const [activeIntroId, setActiveIntroId] = useState<string | null>(null);
+
+  const unseen = useMemo(() => unseenReleases(prefs, ANNOUNCEMENTS), [prefs]);
+
+  // Stamp first-run once prefs resolve, so brand-new users start "caught up"
+  // (page intros, not a What's-New backlog).
+  const firstRunStampedRef = useRef(false);
+  useEffect(() => {
+    if (isLoading || firstRunStampedRef.current) return;
+    if (prefs.firstRunAt === null) {
+      firstRunStampedRef.current = true;
+      // Re-arm on a refused or failed write so the stamp isn't lost for the
+      // whole session — the next prefs/route change retries it.
+      const accepted = ensureFirstRun(latestReleaseVersion(ANNOUNCEMENTS), {
+        onError: () => {
+          firstRunStampedRef.current = false;
+        },
+      });
+      if (!accepted) firstRunStampedRef.current = false;
+    }
+  }, [isLoading, prefs.firstRunAt, ensureFirstRun]);
+
+  // First intro for the current route that nothing (server, mirror, session)
+  // has recorded as seen. The mirror only suppresses — never triggers.
+  // Computed per render, NOT memoized: it reads two refs (mirror, session
+  // guard) that a dismissal mutates without changing pathname/prefs — a memo
+  // would serve the stale pre-dismiss intro and re-open it.
+  // Page intros are a desktop surface: the visual half is hidden on small
+  // screens (copy would read as captions for invisible mockups), matching the
+  // desktop-only getting-started card. Suppressed — never marked seen — so a
+  // later desktop session still offers them.
+  const isMobile = useIsMobile();
+  const mirror = mirrorRef.current ?? null;
+  const mirrorReady = mirrorRef.current !== undefined;
+  const eligibleIntro = mirrorReady && !isMobile
+    ? (PAGE_INTROS.find(
+        (intro) =>
+          intro.matchRoute(pathname) &&
+          prefs.pageIntrosSeen[intro.id] == null &&
+          mirror?.pageIntrosSeen?.[intro.id] == null &&
+          !shownIntrosRef.current.has(intro.id)
+      ) ?? null)
+    : null;
+
+  const activeIntro = useMemo(
+    () => PAGE_INTROS.find((intro) => intro.id === activeIntroId) ?? null,
+    [activeIntroId]
+  );
+
+  const dismissPageIntro = useCallback(() => {
+    if (activeIntroId !== null) {
+      shownIntrosRef.current.add(activeIntroId);
+      markPageIntroSeen(activeIntroId);
+    }
+    setActiveIntroId(null);
+    setPhase('idle');
+  }, [activeIntroId, markPageIntroSeen]);
+
+  const acknowledgeWhatsNew = useCallback(() => {
+    const latest = latestReleaseVersion(ANNOUNCEMENTS);
+    if (latest) setLastSeenReleaseVersion(latest);
+    setPhase('idle');
+  }, [setLastSeenReleaseVersion]);
+
+  // An intro must not outlive its page: browser back/forward or a programmatic
+  // redirect can change the route under an open intro. Close WITHOUT marking
+  // seen — the user didn't finish it, so it re-offers on its own page.
+  useEffect(() => {
+    if (phase === 'pageIntro' && activeIntro && !activeIntro.matchRoute(pathname)) {
+      setActiveIntroId(null);
+      setPhase('idle');
+    }
+  }, [phase, activeIntro, pathname]);
+
+  // Cross-tab acknowledge: another tab stamping What's-New empties `unseen`
+  // while this tab's modal is open. The modal renders null on an empty list
+  // and only acknowledging leaves the phase — reset to idle so this tab isn't
+  // stuck popup-less (which would block every intro for the session).
+  useEffect(() => {
+    if (phase === 'whatsNew' && unseen.length === 0) setPhase('idle');
+  }, [phase, unseen.length]);
+
+  /** Re-show every page tip + the getting-started card (Settings affordance). */
+  const replayGuides = useCallback(() => {
+    // Eligibility checks the mount-time mirror snapshot and the session guard
+    // before prefs, so without clearing both the replay would silently
+    // suppress the very tips it just cleared until reload.
+    shownIntrosRef.current.clear();
+    mirrorRef.current = null;
+    setActiveIntroId(null);
+    setPhase('idle');
+    replayGuidesPrefs();
+  }, [replayGuidesPrefs]);
+
+  const resetOnboarding = useCallback(() => {
+    shownIntrosRef.current.clear();
+    mirrorRef.current = null;
+    // Re-arm the first-run stamp so a reset behaves like a fresh user in this
+    // session (caught-up What's-New stamp re-applies once the reset settles).
+    firstRunStampedRef.current = false;
+    setActiveIntroId(null);
+    setPhase('idle');
+    resetAll();
+  }, [resetAll]);
+
+  // The interview thread starts as /chat/t/__default__ but is renamed to a
+  // real thread id on the first message — and that navigate drops the
+  // personalization route state. Remember WHICH thread the interview became
+  // and suppress intros only there: the thread intro can't pop mid-interview,
+  // but a different thread opened later the same session shows it normally.
+  const interviewThreadRef = useRef<string | null>(null);
+  const wasInInterviewRef = useRef(false);
+  const threadId = pathname.match(/^\/chat\/t\/([^/]+)/)?.[1] ?? null;
+  if (threadId === '__default__') {
+    wasInInterviewRef.current = true;
+  } else if (wasInInterviewRef.current) {
+    // First route after the interview: the rename lands on the real thread id
+    // (null when the user left the thread view without sending a message).
+    interviewThreadRef.current = threadId;
+    wasInInterviewRef.current = false;
+  }
+  const inInterview =
+    threadId === '__default__' ||
+    (threadId !== null && threadId === interviewThreadRef.current);
+
+  // Reactive snooze: snoozing the dashboard banner fires an event; without it
+  // the provider wouldn't re-render and the dashboard intro would stay
+  // suppressed until some unrelated navigation.
+  const personalizationSnoozed = useSyncExternalStore(
+    subscribePersonalizationSnooze,
+    isPersonalizationSnoozed
+  );
+
+  // Suppress while the personalization flow owns the screen: the dashboard
+  // banner (unless snoozed), and the personalization chat itself — clicking
+  // "Personalize" navigates to /chat/t/__default__ and no intro must pop over
+  // it (snooze is irrelevant mid-flow).
+  const personalizationCompleted =
+    (user as { personalization_completed?: boolean; onboarding_completed?: boolean } | null)
+      ?.personalization_completed === true ||
+    (user as { onboarding_completed?: boolean } | null)?.onboarding_completed === true;
+  const suppress =
+    inInterview ||
+    (!personalizationCompleted &&
+      ((pathname === '/dashboard' && !personalizationSnoozed) ||
+        pathname === '/chat/t/__default__'));
+
+  // Getting-started: auto-complete route-visit tasks. markTaskDone aborts when
+  // already stamped, so repeat visits are write-free.
+  useEffect(() => {
+    if (isLoading) return;
+    for (const task of OFFERED_TASKS) {
+      if (task.visitRoute?.(pathname, search) && prefs.gettingStartedDoneAt[task.id] == null) {
+        markTaskDone(task.id);
+      }
+    }
+  }, [isLoading, pathname, search, prefs, markTaskDone]);
+
+  // "Tell us your preferences" — live from the prefs the interview writes, so
+  // a preferences reset un-checks it. Deliberately NOT the user-row completion
+  // flags: personalization_completed means "has BYOK key", and a reset clears
+  // onboarding_completed without clearing this data's siblings.
+  const hasPreferences = useMemo(
+    () =>
+      ['risk_preference', 'investment_preference', 'agent_preference'].some((k) =>
+        hasFilledField((preferences as Record<string, unknown> | null)?.[k])
+      ),
+    [preferences]
+  );
+
+  // "Tell us your watchlist & portfolio" — does any stock exist? Fetched only
+  // while the card still needs it (not dismissed, not yet stamped); once true
+  // it's stamped into prefs so later sessions skip the lookup entirely.
+  const stocksStamped = prefs.gettingStartedDoneAt['stocks'] != null;
+  const { data: hasStocks = false } = useQuery({
+    // User-scoped key: the result must never be served to another account
+    // within the same QueryClient lifetime.
+    queryKey: ['onboarding', 'hasStocks', userId],
+    queryFn: async () => {
+      const { watchlists } = (await listWatchlists()) as {
+        watchlists?: Array<{ watchlist_id: string }>;
+      };
+      // One parallel burst instead of a serial walk: total latency is two
+      // round-trips regardless of watchlist count.
+      const probes = [
+        ...(watchlists ?? []).map(async (wl) => {
+          const { items } = (await listWatchlistItems(wl.watchlist_id)) as { items?: unknown[] };
+          return (items?.length ?? 0) > 0;
+        }),
+        (async () => {
+          const { holdings } = (await listPortfolio()) as { holdings?: unknown[] };
+          return (holdings?.length ?? 0) > 0;
+        })(),
+      ];
+      // allSettled: one failed watchlist probe must not mask stocks another
+      // probe found — the result is one-way and gets stamped, so a transient
+      // error returning false would stick the task incomplete for the session.
+      const results = await Promise.allSettled(probes);
+      return results.some((r) => r.status === 'fulfilled' && r.value);
+    },
+    enabled: userId != null && !isLoading && prefs.gettingStartedDismissedAt === null && !stocksStamped,
+    staleTime: 60_000,
+    retry: false,
+    // The probe fans out one request per watchlist; don't re-run the burst on
+    // every tab refocus — the result is one-way (false → true → stamped).
+    refetchOnWindowFocus: false,
+  });
+  useEffect(() => {
+    if (hasStocks && !stocksStamped) markTaskDone('stocks');
+  }, [hasStocks, stocksStamped, markTaskDone]);
+
+  // "Create your first workspace" — any non-flash workspace exists. An
+  // independent lightweight probe (limit:1 keys its own cache entry, distinct
+  // from the gallery's limit:20); only fetched while the card needs it, and
+  // stamped once true like the stocks task.
+  const workspaceStamped = prefs.gettingStartedDoneAt['createWorkspace'] != null;
+  const { data: workspacesData } = useWorkspaces({
+    limit: 1,
+    enabled: !isLoading && prefs.gettingStartedDismissedAt === null && !workspaceStamped,
+  });
+  const hasWorkspace =
+    ((workspacesData as { workspaces?: unknown[] } | undefined)?.workspaces?.length ?? 0) > 0;
+  useEffect(() => {
+    if (hasWorkspace && !workspaceStamped) markTaskDone('createWorkspace');
+  }, [hasWorkspace, workspaceStamped, markTaskDone]);
+
+  const gettingStarted = useMemo<GettingStartedState>(() => {
+    const tasks = OFFERED_TASKS.map((def) => ({
+      def,
+      done:
+        def.doneWhen === 'hasPreferences'
+          ? hasPreferences
+          : prefs.gettingStartedDoneAt[def.id] != null ||
+            (def.doneWhen === 'hasStocks' && hasStocks) ||
+            (def.doneWhen === 'hasWorkspace' && hasWorkspace),
+    }));
+    const doneCount = tasks.filter((t) => t.done).length;
+    return {
+      visible:
+        !isLoading && prefs.gettingStartedDismissedAt === null && doneCount < tasks.length,
+      tasks,
+      doneCount,
+      dismiss: dismissGettingStarted,
+      completeTask: markTaskDone,
+    };
+  }, [prefs, hasPreferences, hasStocks, hasWorkspace, isLoading, dismissGettingStarted, markTaskDone]);
+
+  useOnboardingOrchestrator({
+    isLoading,
+    phase,
+    pathname,
+    eligibleIntroId: eligibleIntro?.id ?? null,
+    hasUnseenWhatsNew: unseen.length > 0,
+    suppress,
+    showPageIntro: () => {
+      if (eligibleIntro) {
+        setActiveIntroId(eligibleIntro.id);
+        setPhase('pageIntro');
+      }
+    },
+    showWhatsNew: () => setPhase('whatsNew'),
+  });
+
+  const value = useMemo<OnboardingContextValue>(
+    () => ({
+      phase,
+      unseen,
+      activeIntro,
+      dismissPageIntro,
+      gettingStarted,
+      acknowledgeWhatsNew,
+      replayGuides,
+      resetOnboarding,
+    }),
+    [
+      phase,
+      unseen,
+      activeIntro,
+      dismissPageIntro,
+      gettingStarted,
+      acknowledgeWhatsNew,
+      replayGuides,
+      resetOnboarding,
+    ]
+  );
+
+  return <OnboardingContext.Provider value={value}>{children}</OnboardingContext.Provider>;
+}

--- a/web/src/pages/Onboarding/__preview__/main.tsx
+++ b/web/src/pages/Onboarding/__preview__/main.tsx
@@ -1,0 +1,156 @@
+/* eslint-disable react-refresh/only-export-components -- entry file, not a module */
+import { StrictMode, useEffect, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import i18n from '@/i18n';
+import '@/index.css';
+import { ANNOUNCEMENTS, PAGE_INTROS } from '@/pages/Onboarding/registry';
+import { PageIntroModal } from '@/pages/Onboarding/engine/PageIntroModal';
+import { WhatsNewModal } from '@/pages/Onboarding/engine/WhatsNewModal';
+
+/**
+ * Dev-only harness rendering the REAL PageIntroModal and WhatsNewModal for
+ * design iteration. Open /intro-preview.html on the dev server. Not bundled
+ * in production (vite builds index.html only) and not mounted anywhere in
+ * the app.
+ *
+ * Note: the dialogs are modal, so clicking the toolbar counts as an
+ * outside-click and re-mounts the modal at step 1 — which conveniently
+ * replays the entrance animations after every control change.
+ */
+
+// Synthetic newer release (copy reused from the real entry) so the modal's
+// multi-release grouping is previewable before a second announcement exists.
+const SECOND_RELEASE = ANNOUNCEMENTS.map((a) => ({
+  ...a,
+  key: `${a.key}-preview2`,
+  releaseVersion: '2026.06.12',
+}));
+
+const THEMES = ['light', 'dark'] as const;
+const LOCALES = ['en-US', 'zh-CN'] as const;
+
+function Btn({
+  on,
+  onClick,
+  children,
+}: {
+  on: boolean;
+  onClick: () => void;
+  children: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        font: 'inherit',
+        fontSize: 12,
+        cursor: 'pointer',
+        padding: '5px 12px',
+        borderRadius: 999,
+        border: '1px solid var(--color-border-default)',
+        background: on ? 'var(--color-accent-primary)' : 'var(--color-bg-card)',
+        color: on ? 'var(--color-text-on-accent)' : 'var(--color-text-secondary)',
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+function Preview() {
+  const [surface, setSurface] = useState<'intro' | 'whatsNew'>('intro');
+  const [twoReleases, setTwoReleases] = useState(false);
+  const [introId, setIntroId] = useState(PAGE_INTROS[0].id);
+  const [theme, setTheme] = useState<(typeof THEMES)[number]>('light');
+  const [locale, setLocale] = useState<(typeof LOCALES)[number]>('en-US');
+  const [run, setRun] = useState(0); // bump = remount modal at step 1
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    document.body.style.background = 'var(--color-bg-page)';
+  }, [theme]);
+  useEffect(() => {
+    i18n.changeLanguage(locale);
+  }, [locale]);
+
+  const intro = PAGE_INTROS.find((i) => i.id === introId) ?? PAGE_INTROS[0];
+
+  return (
+    <>
+      <div
+        style={{
+          position: 'fixed',
+          top: 12,
+          left: '50%',
+          transform: 'translateX(-50%)',
+          zIndex: 2000,
+          pointerEvents: 'auto',
+          display: 'flex',
+          gap: 8,
+          alignItems: 'center',
+          padding: '8px 14px',
+          borderRadius: 999,
+          border: '1px solid var(--color-border-default)',
+          background: 'var(--color-bg-card)',
+          boxShadow: '0 4px 24px rgba(0,0,0,.25)',
+          fontFamily: 'system-ui, sans-serif',
+          fontSize: 12,
+          color: 'var(--color-text-tertiary)',
+        }}
+      >
+        {PAGE_INTROS.map((i) => (
+          <Btn
+            key={i.id}
+            on={surface === 'intro' && i.id === introId}
+            onClick={() => {
+              setSurface('intro');
+              setIntroId(i.id);
+            }}
+          >
+            {`${i.id} (${i.steps.length})`}
+          </Btn>
+        ))}
+        <Btn on={surface === 'whatsNew'} onClick={() => setSurface('whatsNew')}>
+          whatsNew
+        </Btn>
+        {surface === 'whatsNew' && (
+          <Btn on={twoReleases} onClick={() => setTwoReleases((v) => !v)}>
+            +2nd release
+          </Btn>
+        )}
+        <span style={{ width: 1, height: 18, background: 'var(--color-border-default)' }} />
+        {THEMES.map((t) => (
+          <Btn key={t} on={t === theme} onClick={() => setTheme(t)}>
+            {t}
+          </Btn>
+        ))}
+        <span style={{ width: 1, height: 18, background: 'var(--color-border-default)' }} />
+        {LOCALES.map((l) => (
+          <Btn key={l} on={l === locale} onClick={() => setLocale(l)}>
+            {l}
+          </Btn>
+        ))}
+      </div>
+      {surface === 'intro' ? (
+        <PageIntroModal
+          key={`${intro.id}-${locale}-${run}`}
+          intro={intro}
+          onClose={() => setRun((n) => n + 1)}
+        />
+      ) : (
+        <WhatsNewModal
+          key={`wn-${locale}-${twoReleases}-${run}`}
+          announcements={twoReleases ? [...ANNOUNCEMENTS, ...SECOND_RELEASE] : ANNOUNCEMENTS}
+          onAcknowledge={() => setRun((n) => n + 1)}
+        />
+      )}
+    </>
+  );
+}
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <Preview />
+  </StrictMode>
+);

--- a/web/src/pages/Onboarding/__tests__/GettingStartedCard.test.tsx
+++ b/web/src/pages/Onboarding/__tests__/GettingStartedCard.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import { GETTING_STARTED_TASKS } from '../registry';
+import type { GettingStartedTaskState } from '../OnboardingProvider';
+
+const dismiss = vi.fn();
+const completeTask = vi.fn();
+let mockTasks: GettingStartedTaskState[] = [];
+let mockVisible = true;
+vi.mock('../OnboardingProvider', () => ({
+  useOnboarding: () => ({
+    gettingStarted: {
+      visible: mockVisible,
+      tasks: mockTasks,
+      doneCount: mockTasks.filter((t) => t.done).length,
+      dismiss,
+      completeTask,
+    },
+  }),
+}));
+
+const navigateToPersonalization = vi.fn(async () => {});
+vi.mock('@/pages/Dashboard/hooks/useOnboarding', () => ({
+  useOnboarding: () => ({ navigateToPersonalization }),
+}));
+
+import { GettingStartedCard } from '../engine/GettingStartedCard';
+
+function LocationProbe() {
+  return <span data-testid="loc">{useLocation().pathname}</span>;
+}
+
+function renderCard() {
+  return render(
+    <MemoryRouter initialEntries={['/settings']}>
+      <GettingStartedCard />
+      <Routes>
+        <Route path="*" element={<LocationProbe />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('GettingStartedCard', () => {
+  beforeEach(() => {
+    dismiss.mockClear();
+    completeTask.mockClear();
+    navigateToPersonalization.mockClear();
+    mockVisible = true;
+    mockTasks = GETTING_STARTED_TASKS.map((def, i) => ({ def, done: i === 0 }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders nothing when not visible', () => {
+    mockVisible = false;
+    const { container } = renderCard();
+    expect(container.querySelector('aside')).toBeNull();
+  });
+
+  it('shows progress and strikes through completed tasks', () => {
+    renderCard();
+    expect(screen.getByText(`1 / ${GETTING_STARTED_TASKS.length}`)).toBeInTheDocument();
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toHaveAttribute('aria-valuenow', '1');
+    // done task is disabled and struck through; pending ones show descriptions
+    const doneBtn = screen.getByRole('button', {
+      name: /Explore the dashboard/,
+    });
+    expect(doneBtn).toBeDisabled();
+    expect(screen.getByText('Explore the dashboard')).toHaveClass('line-through');
+    expect(screen.getByText(/tell the agent the tickers you watch/)).toBeInTheDocument();
+  });
+
+  it('clicking a pending task navigates to its target', () => {
+    renderCard();
+    fireEvent.click(screen.getByRole('button', { name: /Run your first analysis/ }));
+    expect(screen.getByTestId('loc').textContent).toBe('/chat');
+  });
+
+  it('an interview task explains the flow first, then confirm opens it — not a bare route', () => {
+    mockTasks = GETTING_STARTED_TASKS.map((def) => ({ def, done: false }));
+    renderCard();
+    fireEvent.click(screen.getByRole('button', { name: /Share your investing preferences/ }));
+    // explainer dialog, nothing launched yet
+    expect(screen.getByText(/agent asks a few questions about your portfolio/)).toBeInTheDocument();
+    expect(navigateToPersonalization).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start the chat' }));
+    expect(navigateToPersonalization).toHaveBeenCalledTimes(1);
+    // a plain navigate to /chat/t/__default__ would bounce back to /chat
+    expect(screen.getByTestId('loc').textContent).toBe('/settings');
+  });
+
+  it('declining the interview dialog launches nothing', () => {
+    mockTasks = GETTING_STARTED_TASKS.map((def) => ({ def, done: false }));
+    renderCard();
+    fireEvent.click(screen.getByRole('button', { name: /Share your watchlist/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Not now' }));
+    expect(navigateToPersonalization).not.toHaveBeenCalled();
+    expect(screen.queryByText(/agent asks a few questions/)).toBeNull();
+  });
+
+  it('clicking an external task stamps it done and opens a new tab, no in-app navigation', () => {
+    // No 'noopener' feature string — that would make open() return null even
+    // on success (reading as "blocked"). The opener is severed on the handle.
+    const handle = { opener: window } as unknown as Window;
+    const open = vi.spyOn(window, 'open').mockReturnValue(handle);
+    renderCard();
+    fireEvent.click(screen.getByRole('button', { name: /Use LangAlpha on other platforms/ }));
+    expect(completeTask).toHaveBeenCalledWith('integrations');
+    expect(open).toHaveBeenCalledWith(expect.stringMatching(/\/integrations$/), '_blank');
+    expect(handle.opener).toBeNull();
+    expect(screen.getByTestId('loc').textContent).toBe('/settings');
+  });
+
+  it('a blocked popup leaves the external task pending so the user can retry', () => {
+    vi.spyOn(window, 'open').mockReturnValue(null);
+    renderCard();
+    fireEvent.click(screen.getByRole('button', { name: /Use LangAlpha on other platforms/ }));
+    expect(completeTask).not.toHaveBeenCalled();
+  });
+
+  it('the X dismisses the card', () => {
+    renderCard();
+    fireEvent.click(screen.getByRole('button', { name: 'Hide guide' }));
+    expect(dismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/pages/Onboarding/__tests__/OnboardingHostGate.test.tsx
+++ b/web/src/pages/Onboarding/__tests__/OnboardingHostGate.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+let mockPhase = 'idle';
+let mockVisible = false;
+vi.mock('../OnboardingProvider', () => ({
+  useOnboarding: () => ({ phase: mockPhase, gettingStarted: { visible: mockVisible } }),
+}));
+
+// Spy on the chunk boundary: the factory runs only if the lazy import fires.
+const hostChunkLoaded = vi.hoisted(() => vi.fn());
+vi.mock('../OnboardingHost', () => {
+  hostChunkLoaded();
+  return { OnboardingHost: () => <div data-testid="onboarding-host" /> };
+});
+
+import { OnboardingHostGate } from '../OnboardingHostGate';
+
+describe('OnboardingHostGate', () => {
+  beforeEach(() => {
+    mockPhase = 'idle';
+    mockVisible = false;
+    hostChunkLoaded.mockClear();
+  });
+
+  it('renders nothing — and never imports the chunk — when no surface is needed', () => {
+    const { container } = render(<OnboardingHostGate />);
+    expect(container).toBeEmptyDOMElement();
+    expect(hostChunkLoaded).not.toHaveBeenCalled();
+  });
+
+  it('mounts the host when a phase is active', async () => {
+    mockPhase = 'pageIntro';
+    render(<OnboardingHostGate />);
+    await waitFor(() => expect(screen.getByTestId('onboarding-host')).toBeInTheDocument());
+  });
+
+  it('mounts the host when the getting-started card is visible', async () => {
+    mockVisible = true;
+    render(<OnboardingHostGate />);
+    await waitFor(() => expect(screen.getByTestId('onboarding-host')).toBeInTheDocument());
+  });
+
+  it('latches: stays mounted after the surfaces go quiet', async () => {
+    mockVisible = true;
+    const { rerender } = render(<OnboardingHostGate />);
+    await waitFor(() => expect(screen.getByTestId('onboarding-host')).toBeInTheDocument());
+
+    mockVisible = false;
+    rerender(<OnboardingHostGate />);
+    expect(screen.getByTestId('onboarding-host')).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/Onboarding/__tests__/OnboardingProvider.test.tsx
+++ b/web/src/pages/Onboarding/__tests__/OnboardingProvider.test.tsx
@@ -1,0 +1,425 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter, useNavigate } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { emptyOnboardingPrefs } from '../onboardingPrefsSchema';
+import type { OnboardingPrefs } from '../types';
+
+let mockPrefs: OnboardingPrefs = emptyOnboardingPrefs();
+let mockLoading = false;
+const markPageIntroSeen = vi.fn();
+const markTaskDone = vi.fn();
+const dismissGettingStarted = vi.fn();
+const replayGuides = vi.fn();
+const setLastSeenReleaseVersion = vi.fn();
+const ensureFirstRun = vi.fn();
+const resetAll = vi.fn();
+vi.mock('../useOnboardingPrefs', () => ({
+  useOnboardingPrefs: () => ({
+    prefs: mockPrefs,
+    isLoading: mockLoading,
+    markPageIntroSeen,
+    markTaskDone,
+    dismissGettingStarted,
+    replayGuides,
+    setLastSeenReleaseVersion,
+    ensureFirstRun,
+    resetAll,
+  }),
+}));
+
+let mockUser: Record<string, unknown> | null = { user_id: 'u1', personalization_completed: true };
+vi.mock('@/hooks/useUser', () => ({ useUser: () => ({ user: mockUser }) }));
+
+let mockPreferences: Record<string, unknown> | null = null;
+vi.mock('@/hooks/usePreferences', () => ({
+  usePreferences: () => ({ preferences: mockPreferences, isLoading: false }),
+}));
+
+let mockSnoozed = false;
+vi.mock('@/pages/Dashboard/hooks/useOnboarding', () => ({
+  isPersonalizationSnoozed: () => mockSnoozed,
+  subscribePersonalizationSnooze: () => () => {},
+}));
+
+let mockIsMobile = false;
+vi.mock('@/hooks/useIsMobile', () => ({ useIsMobile: () => mockIsMobile }));
+
+// Deterministic regardless of the .env loaded by vitest: provider tests run in
+// OSS mode (platform-only tasks filtered out).
+vi.mock('@/config/hostMode', () => ({ HOST_MODE: 'oss', isPlatformMode: false }));
+
+const listWatchlists = vi.fn(async () => ({ watchlists: [] as Array<{ watchlist_id: string }> }));
+const listWatchlistItems = vi.fn(async () => ({ items: [] as unknown[] }));
+const listPortfolio = vi.fn(async () => ({ holdings: [] as unknown[] }));
+vi.mock('@/pages/Dashboard/utils/api', () => ({
+  listWatchlists: (...a: unknown[]) => listWatchlists(...(a as [])),
+  listWatchlistItems: (...a: unknown[]) => listWatchlistItems(...(a as [])),
+  listPortfolio: (...a: unknown[]) => listPortfolio(...(a as [])),
+}));
+
+let mockWorkspaces: unknown[] = [];
+const useWorkspacesSpy = vi.fn((opts: { enabled?: boolean } = {}) => ({
+  data: opts.enabled === false ? undefined : { workspaces: mockWorkspaces },
+}));
+vi.mock('@/hooks/useWorkspaces', () => ({
+  useWorkspaces: (opts?: { enabled?: boolean }) => useWorkspacesSpy(opts),
+}));
+
+import { OnboardingProvider, useOnboarding } from '../OnboardingProvider';
+
+function Harness() {
+  const {
+    phase,
+    activeIntro,
+    gettingStarted,
+    dismissPageIntro,
+    acknowledgeWhatsNew,
+    replayGuides: replay,
+    resetOnboarding,
+  } = useOnboarding();
+  return (
+    <div>
+      <span data-testid="phase">{phase}</span>
+      <span data-testid="intro">{activeIntro?.id ?? 'none'}</span>
+      <span data-testid="card">{gettingStarted.visible ? 'visible' : 'hidden'}</span>
+      <span data-testid="done">{gettingStarted.doneCount}</span>
+      <span data-testid="taskIds">{gettingStarted.tasks.map((t) => t.def.id).join(',')}</span>
+      <button onClick={dismissPageIntro}>dismiss</button>
+      <button onClick={acknowledgeWhatsNew}>ack</button>
+      <button onClick={replay}>replay</button>
+      <button onClick={resetOnboarding}>reset</button>
+      <NavButtons />
+    </div>
+  );
+}
+
+function NavButtons() {
+  const navigate = useNavigate();
+  return (
+    <>
+      <button onClick={() => navigate('/chat/t/resolved-guid', { replace: true })}>
+        go-resolved
+      </button>
+      <button onClick={() => navigate('/chat')}>go-gallery</button>
+      <button onClick={() => navigate('/chat/t/another-thread')}>go-thread</button>
+    </>
+  );
+}
+
+function renderAt(route: string) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[route]}>
+        <OnboardingProvider>
+          <Harness />
+        </OnboardingProvider>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+const phase = () => screen.getByTestId('phase').textContent;
+const intro = () => screen.getByTestId('intro').textContent;
+const card = () => screen.getByTestId('card').textContent;
+
+describe('OnboardingProvider', () => {
+  beforeEach(() => {
+    mockPrefs = emptyOnboardingPrefs();
+    mockLoading = false;
+    mockUser = { user_id: 'u1', personalization_completed: true };
+    mockPreferences = null;
+    mockWorkspaces = [];
+    mockSnoozed = false;
+    mockIsMobile = false;
+    vi.clearAllMocks();
+    // drop any leftover mockResolvedValueOnce queues (clearAllMocks keeps them)
+    listWatchlists.mockReset();
+    listWatchlistItems.mockReset();
+    listPortfolio.mockReset();
+    localStorage.clear();
+  });
+
+  it('opens the chat intro for a fresh user on /chat and stamps first-run once', () => {
+    renderAt('/chat');
+    expect(phase()).toBe('pageIntro');
+    expect(intro()).toBe('chat');
+    expect(ensureFirstRun).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens the thread intro on a real thread — pages get their own intro', () => {
+    renderAt('/chat/t/abc123');
+    expect(intro()).toBe('thread');
+  });
+
+  it('shows the dashboard intro even after the chat intro was seen (scattered, per page)', () => {
+    mockPrefs = { ...emptyOnboardingPrefs(), pageIntrosSeen: { chat: 1, thread: 2 } };
+    renderAt('/dashboard');
+    expect(phase()).toBe('pageIntro');
+    expect(intro()).toBe('dashboard');
+  });
+
+  it('shows nothing on pages with no matching intro', () => {
+    renderAt('/settings');
+    expect(phase()).toBe('idle');
+  });
+
+  it('dismissPageIntro stamps that intro seen and does not re-open this session', () => {
+    renderAt('/chat');
+    fireEvent.click(screen.getByText('dismiss'));
+    expect(markPageIntroSeen).toHaveBeenCalledWith('chat');
+    // prefs are still "unseen" (write is async + non-optimistic) — the session
+    // guard alone must prevent the orchestrator from re-opening it.
+    expect(phase()).toBe('idle');
+  });
+
+  it('does not open an intro the localStorage mirror marks seen', () => {
+    localStorage.setItem(
+      'langalpha-onboarding-v1:u1',
+      JSON.stringify({ pageIntrosSeen: { chat: 5 }, lastSeenReleaseVersion: null, firstRunAt: 1 })
+    );
+    renderAt('/chat');
+    expect(phase()).toBe('idle');
+  });
+
+  it('suppresses intros on the dashboard while the personalization banner owns it', () => {
+    mockUser = { user_id: 'u1' }; // personalization not completed
+    renderAt('/dashboard');
+    expect(phase()).toBe('idle');
+  });
+
+  it('shows the dashboard intro once the banner is snoozed', () => {
+    mockUser = { user_id: 'u1' };
+    mockSnoozed = true;
+    renderAt('/dashboard');
+    expect(intro()).toBe('dashboard');
+  });
+
+  it('never pops an intro over the personalization chat', () => {
+    mockUser = { user_id: 'u1' };
+    mockSnoozed = true;
+    renderAt('/chat/t/__default__');
+    expect(phase()).toBe('idle');
+  });
+
+  it('keeps suppressing after __default__ resolves to a real thread id mid-interview', () => {
+    mockPrefs = { ...emptyOnboardingPrefs(), pageIntrosSeen: { chat: 1 } };
+    renderAt('/chat/t/__default__');
+    expect(phase()).toBe('idle');
+
+    // ChatView renames the URL on the first message and drops the
+    // personalization route state — the thread intro must not pop here.
+    fireEvent.click(screen.getByText('go-resolved'));
+    expect(phase()).toBe('idle');
+
+    // Leaving the thread view ends the interview; the intro is still unseen
+    // and fires on the next real thread.
+    fireEvent.click(screen.getByText('go-gallery'));
+    fireEvent.click(screen.getByText('go-thread'));
+    expect(intro()).toBe('thread');
+  });
+
+  it('shows the thread intro on a different thread opened right after the interview', () => {
+    mockPrefs = { ...emptyOnboardingPrefs(), pageIntrosSeen: { chat: 1 } };
+    renderAt('/chat/t/__default__');
+    fireEvent.click(screen.getByText('go-resolved')); // interview renamed → suppressed
+    expect(phase()).toBe('idle');
+    // Switching directly to ANOTHER thread (never leaving the thread view)
+    // must show the intro — only the interview's own thread stays suppressed.
+    fireEvent.click(screen.getByText('go-thread'));
+    expect(intro()).toBe('thread');
+  });
+
+  it('an open intro closes unseen when navigation leaves its page, and re-offers later', () => {
+    renderAt('/chat');
+    expect(intro()).toBe('chat');
+    // Browser back / redirect mid-intro: the chat intro must not float over
+    // the thread page. It closes WITHOUT being stamped seen.
+    fireEvent.click(screen.getByText('go-thread'));
+    expect(markPageIntroSeen).not.toHaveBeenCalled();
+    expect(intro()).toBe('thread');
+    // Returning to /chat re-offers the unfinished chat intro.
+    fireEvent.click(screen.getByText('go-gallery'));
+    expect(intro()).toBe('chat');
+  });
+
+  it("resets a stranded What's-New phase when another tab acknowledges it", () => {
+    mockPrefs = { ...emptyOnboardingPrefs(), firstRunAt: 1, lastSeenReleaseVersion: '2026.1' };
+    renderAt('/settings');
+    expect(phase()).toBe('whatsNew');
+    // Cross-tab acknowledge lands: prefs refresh, unseen recomputes to [] while
+    // this tab's (now-invisible) modal is still "open".
+    mockPrefs = {
+      ...mockPrefs,
+      lastSeenReleaseVersion: '9999.1',
+      pageIntrosSeen: { chat: 1, thread: 1, dashboard: 1 },
+    };
+    fireEvent.click(screen.getByText('go-gallery')); // any re-render vehicle
+    expect(phase()).toBe('idle');
+  });
+
+  it('never opens a page intro on mobile — and never marks it seen', () => {
+    mockIsMobile = true;
+    renderAt('/chat');
+    expect(phase()).toBe('idle');
+    expect(markPageIntroSeen).not.toHaveBeenCalled();
+  });
+
+  it("shows What's-New when no intro matches and acknowledge stamps the latest version", () => {
+    mockPrefs = {
+      ...emptyOnboardingPrefs(),
+      firstRunAt: 1,
+      lastSeenReleaseVersion: '2026.1', // older than the registry's announcement
+    };
+    renderAt('/settings');
+    expect(phase()).toBe('whatsNew');
+    fireEvent.click(screen.getByText('ack'));
+    expect(setLastSeenReleaseVersion).toHaveBeenCalledTimes(1);
+    expect(setLastSeenReleaseVersion.mock.calls[0][0]).toMatch(/^\d{4}\.\d+/);
+    expect(phase()).toBe('idle');
+  });
+
+  it('replayGuides clears state so tips re-show without a reload', () => {
+    // Returning user with a stale mirror — the replay must clear BOTH the
+    // session guard and the mount-time mirror snapshot, or it would suppress
+    // the very tips it just cleared until reload.
+    localStorage.setItem(
+      'langalpha-onboarding-v1:u1',
+      JSON.stringify({ pageIntrosSeen: { chat: 5 }, lastSeenReleaseVersion: null, firstRunAt: 1 })
+    );
+    mockPrefs = { ...emptyOnboardingPrefs(), pageIntrosSeen: { chat: 5 }, firstRunAt: 1 };
+    const { rerender } = renderAt('/chat');
+    expect(phase()).toBe('idle');
+
+    fireEvent.click(screen.getByText('replay'));
+    expect(replayGuides).toHaveBeenCalledTimes(1);
+
+    // Simulate the server write landing: seen map empties, provider re-renders.
+    mockPrefs = { ...emptyOnboardingPrefs(), firstRunAt: 1 };
+    rerender(
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+        <MemoryRouter initialEntries={['/chat']}>
+          <OnboardingProvider>
+            <Harness />
+          </OnboardingProvider>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+    expect(intro()).toBe('chat');
+  });
+
+  it('resetOnboarding clears everything via resetAll', () => {
+    renderAt('/settings');
+    fireEvent.click(screen.getByText('reset'));
+    expect(resetAll).toHaveBeenCalledTimes(1);
+    expect(phase()).toBe('idle');
+  });
+
+  it('getting-started: visible for a fresh user, platform-only tasks filtered out in OSS', () => {
+    renderAt('/settings');
+    expect(card()).toBe('visible');
+    expect(screen.getByTestId('done').textContent).toBe('0');
+    expect(screen.getByTestId('taskIds').textContent).toBe(
+      'dashboard,market,stocks,preferences,createWorkspace,firstChat,models'
+    );
+  });
+
+  it('getting-started: the BYOK personalization flag does NOT complete any task', () => {
+    mockUser = { user_id: 'u1', personalization_completed: true, onboarding_completed: false };
+    renderAt('/settings');
+    expect(screen.getByTestId('done').textContent).toBe('0');
+  });
+
+  it('getting-started: preferences task derives live from filled preference fields', () => {
+    mockPreferences = { risk_preference: { risk_tolerance: 'aggressive' } };
+    const { unmount } = renderAt('/settings');
+    expect(screen.getByTestId('done').textContent).toBe('1');
+    unmount();
+
+    // A preferences reset empties the fields — the task un-checks.
+    mockPreferences = { risk_preference: { risk_tolerance: null } };
+    renderAt('/settings');
+    expect(screen.getByTestId('done').textContent).toBe('0');
+  });
+
+  it('getting-started: stocks task stamps once the watchlist has an item', async () => {
+    listWatchlists.mockResolvedValueOnce({ watchlists: [{ watchlist_id: 'wl1' }] });
+    listWatchlistItems.mockResolvedValueOnce({ items: [{ symbol: 'NVDA' }] });
+    renderAt('/settings');
+    await waitFor(() => expect(markTaskDone).toHaveBeenCalledWith('stocks'));
+  });
+
+  it('getting-started: stocks task stamps from a portfolio holding when watchlists are empty', async () => {
+    listPortfolio.mockResolvedValueOnce({ holdings: [{ symbol: 'AVGO' }] });
+    renderAt('/settings');
+    await waitFor(() => expect(markTaskDone).toHaveBeenCalledWith('stocks'));
+  });
+
+  it('getting-started: stocks lookup is skipped once stamped or dismissed', () => {
+    mockPrefs = { ...emptyOnboardingPrefs(), gettingStartedDoneAt: { stocks: 1 } };
+    const { unmount } = renderAt('/settings');
+    expect(listWatchlists).not.toHaveBeenCalled();
+    unmount();
+
+    mockPrefs = { ...emptyOnboardingPrefs(), gettingStartedDismissedAt: 1 };
+    renderAt('/settings');
+    expect(listWatchlists).not.toHaveBeenCalled();
+  });
+
+  it('getting-started: createWorkspace stamps when a non-flash workspace exists', () => {
+    mockWorkspaces = [{ workspace_id: 'ws1' }];
+    renderAt('/settings');
+    expect(markTaskDone).toHaveBeenCalledWith('createWorkspace');
+  });
+
+  it('getting-started: workspace lookup is disabled once stamped', () => {
+    mockPrefs = { ...emptyOnboardingPrefs(), gettingStartedDoneAt: { createWorkspace: 1 } };
+    renderAt('/settings');
+    expect(useWorkspacesSpy).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }));
+  });
+
+  it('getting-started: stamps route-visit tasks when their page is visited', () => {
+    renderAt('/dashboard');
+    expect(markTaskDone).toHaveBeenCalledWith('dashboard');
+    expect(markTaskDone).not.toHaveBeenCalledWith('market');
+  });
+
+  it('getting-started: model configuration stamps on the settings model tab only', () => {
+    const { unmount } = renderAt('/settings');
+    expect(markTaskDone).not.toHaveBeenCalledWith('models');
+    unmount();
+
+    renderAt('/settings?tab=model');
+    expect(markTaskDone).toHaveBeenCalledWith('models');
+  });
+
+  it('getting-started: hidden once dismissed, and hidden when every task is done', () => {
+    mockPrefs = { ...emptyOnboardingPrefs(), gettingStartedDismissedAt: 1 };
+    const { unmount } = renderAt('/settings');
+    expect(card()).toBe('hidden');
+    unmount();
+
+    mockPreferences = { agent_preference: { output_style: 'concise' } };
+    mockPrefs = {
+      ...emptyOnboardingPrefs(),
+      gettingStartedDoneAt: {
+        stocks: 1,
+        firstChat: 2,
+        dashboard: 3,
+        market: 4,
+        models: 5,
+        createWorkspace: 6,
+      },
+    };
+    renderAt('/settings'); // preferences done via derived signal → all 7 complete
+    expect(card()).toBe('hidden');
+  });
+
+  it('shows nothing while prefs are loading', () => {
+    mockLoading = true;
+    renderAt('/chat');
+    expect(phase()).toBe('idle');
+    expect(card()).toBe('hidden');
+  });
+});

--- a/web/src/pages/Onboarding/__tests__/OnboardingProvider.test.tsx
+++ b/web/src/pages/Onboarding/__tests__/OnboardingProvider.test.tsx
@@ -10,10 +10,12 @@ let mockLoading = false;
 const markPageIntroSeen = vi.fn();
 const markTaskDone = vi.fn();
 const dismissGettingStarted = vi.fn();
-const replayGuides = vi.fn();
+// replayGuides/resetAll return whether the persist write was issued (true) or
+// refused on a cold cache (false); the provider only clears local state on true.
+const replayGuides = vi.fn(() => true);
 const setLastSeenReleaseVersion = vi.fn();
 const ensureFirstRun = vi.fn();
-const resetAll = vi.fn();
+const resetAll = vi.fn(() => true);
 vi.mock('../useOnboardingPrefs', () => ({
   useOnboardingPrefs: () => ({
     prefs: mockPrefs,
@@ -307,6 +309,38 @@ describe('OnboardingProvider', () => {
       </QueryClientProvider>
     );
     expect(intro()).toBe('chat');
+  });
+
+  it('replayGuides leaves tips suppressed when the persist write is refused', () => {
+    // Cold-cache refusal: the prefs write returns false, so the provider must
+    // NOT clear local state — otherwise tips would re-show this session while
+    // the server kept them seen, then snap back on the next login (and Settings
+    // would have toasted "done" for a change that never persisted).
+    replayGuides.mockReturnValueOnce(false);
+    localStorage.setItem(
+      'langalpha-onboarding-v1:u1',
+      JSON.stringify({ pageIntrosSeen: { chat: 5 }, lastSeenReleaseVersion: null, firstRunAt: 1 })
+    );
+    mockPrefs = { ...emptyOnboardingPrefs(), pageIntrosSeen: { chat: 5 }, firstRunAt: 1 };
+    const { rerender } = renderAt('/chat');
+    expect(phase()).toBe('idle');
+
+    fireEvent.click(screen.getByText('replay'));
+    expect(replayGuides).toHaveBeenCalledTimes(1);
+
+    // Even with server prefs cleared, the un-cleared mirror still suppresses:
+    // the refusal left local state intact, so the intro must NOT re-show.
+    mockPrefs = { ...emptyOnboardingPrefs(), firstRunAt: 1 };
+    rerender(
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+        <MemoryRouter initialEntries={['/chat']}>
+          <OnboardingProvider>
+            <Harness />
+          </OnboardingProvider>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+    expect(intro()).toBe('none');
   });
 
   it('resetOnboarding clears everything via resetAll', () => {

--- a/web/src/pages/Onboarding/__tests__/PageIntroModal.reducedMotion.test.tsx
+++ b/web/src/pages/Onboarding/__tests__/PageIntroModal.reducedMotion.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { PageIntroDef } from '../registry';
+
+// framer-motion's useReducedMotion initializes a module-level matchMedia
+// subscription on FIRST use, so the reduced-motion override must be in place
+// before the engine (and framer-motion) is imported — hence the separate test
+// file and the dynamic import below.
+window.matchMedia = ((query: string) => ({
+  matches: query.includes('prefers-reduced-motion'),
+  media: query,
+  onchange: null,
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  dispatchEvent: vi.fn(),
+})) as unknown as typeof window.matchMedia;
+
+const { PageIntroModal } = await import('../engine/PageIntroModal');
+
+const intro: PageIntroDef = {
+  id: 'chat',
+  matchRoute: () => true,
+  steps: [
+    { id: 's1', titleKey: 'title-1', bodyKey: 'body-1', visual: 'workspaceGrid' },
+    { id: 's2', titleKey: 'title-2', bodyKey: 'body-2', visual: 'flashAnswer' },
+  ],
+};
+
+describe('PageIntroModal under prefers-reduced-motion', () => {
+  it('renders and navigates via the instant-crossfade path', async () => {
+    render(<PageIntroModal intro={intro} onClose={vi.fn()} />);
+    expect(screen.getByText('title-1')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+    expect(await screen.findByText('title-2')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+    expect(await screen.findByText('title-1')).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/Onboarding/__tests__/PageIntroModal.test.tsx
+++ b/web/src/pages/Onboarding/__tests__/PageIntroModal.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PageIntroModal } from '../engine/PageIntroModal';
+import type { PageIntroDef } from '../registry';
+
+const intro: PageIntroDef = {
+  id: 'chat',
+  matchRoute: () => true,
+  steps: [
+    { id: 's1', titleKey: 'title-1', bodyKey: 'body-1', visual: 'workspaceGrid' },
+    { id: 's2', titleKey: 'title-2', bodyKey: 'body-2', visual: 'flashAnswer' },
+    { id: 's3', titleKey: 'title-3', bodyKey: 'body-3', visual: 'ptcSandbox' },
+  ],
+};
+
+describe('PageIntroModal', () => {
+  it('renders the first step with progress and the illustration panel', () => {
+    render(<PageIntroModal intro={intro} onClose={vi.fn()} />);
+    expect(screen.getByText('title-1')).toBeInTheDocument();
+    expect(screen.getByText('body-1')).toBeInTheDocument();
+    expect(screen.getByText('1 / 3')).toBeInTheDocument();
+    expect(screen.getByTestId('intro-illustration')).toBeInTheDocument();
+    // no Back on the first step
+    expect(screen.queryByRole('button', { name: 'Back' })).toBeNull();
+  });
+
+  // step copy swaps behind an exit animation — await the incoming title
+  it('Continue advances through steps and Back returns', async () => {
+    render(<PageIntroModal intro={intro} onClose={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+    expect(await screen.findByText('title-2')).toBeInTheDocument();
+    expect(screen.getByText('2 / 3')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+    expect(await screen.findByText('title-1')).toBeInTheDocument();
+  });
+
+  it('step dots jump directly to a stage', async () => {
+    render(<PageIntroModal intro={intro} onClose={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Step 3' }));
+    expect(await screen.findByText('title-3')).toBeInTheDocument();
+  });
+
+  it('intermediate steps never close — only the last CTA does', () => {
+    const onClose = vi.fn();
+    render(<PageIntroModal intro={intro} onClose={onClose} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+    expect(onClose).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Start exploring' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  // When every step anchors its visual right (the thread intro), the visual
+  // panel takes the LEFT half: copy gets sm:order-2, illustration sm:order-1.
+  it('a fully right-anchored intro puts the visual panel first', () => {
+    const rightIntro: PageIntroDef = {
+      id: 'thread',
+      matchRoute: () => true,
+      steps: [
+        { id: 'a', titleKey: 'title-1', bodyKey: 'body-1', visual: 'filePanel' },
+        { id: 'b', titleKey: 'title-2', bodyKey: 'body-2', visual: 'memory' },
+      ],
+    };
+    render(<PageIntroModal intro={rightIntro} onClose={vi.fn()} />);
+    expect(screen.getByTestId('intro-illustration').className).toMatch(/sm:order-1/);
+  });
+
+  it('left-anchored intros keep the copy panel first', () => {
+    render(<PageIntroModal intro={intro} onClose={vi.fn()} />);
+    expect(screen.getByTestId('intro-illustration').className).not.toMatch(/sm:order-1/);
+  });
+
+  it('the dialog X closes at any step — every close path marks seen', () => {
+    const onClose = vi.fn();
+    render(<PageIntroModal intro={intro} onClose={onClose} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/pages/Onboarding/__tests__/WhatsNewModal.test.tsx
+++ b/web/src/pages/Onboarding/__tests__/WhatsNewModal.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { WhatsNewModal } from '../engine/WhatsNewModal';
+import type { AnnouncementDef } from '../registry/types';
+
+function ann(key: string, releaseVersion: string): AnnouncementDef {
+  return { key, releaseVersion, modalTitleKey: `${key}-title`, modalBodyKey: `${key}-body` };
+}
+
+describe('WhatsNewModal', () => {
+  it('renders nothing when there are no announcements', () => {
+    const { container } = render(<WhatsNewModal announcements={[]} onAcknowledge={vi.fn()} />);
+    expect(container).toBeEmptyDOMElement();
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it('groups announcements by release, newest version first', () => {
+    render(
+      <WhatsNewModal
+        announcements={[ann('older', '2026.4'), ann('newer', '2026.6'), ann('sibling', '2026.6')]}
+        onAcknowledge={vi.fn()}
+      />
+    );
+    const versions = screen.getAllByText(/^2026\.\d+$/).map((el) => el.textContent);
+    expect(versions).toEqual(['2026.6', '2026.4']);
+    // both 2026.6 items render under one group
+    expect(screen.getByText('newer-title')).toBeInTheDocument();
+    expect(screen.getByText('sibling-title')).toBeInTheDocument();
+    expect(screen.getByText('older-body')).toBeInTheDocument();
+  });
+
+  it('Got it acknowledges once', () => {
+    const onAcknowledge = vi.fn();
+    render(<WhatsNewModal announcements={[ann('a', '2026.5')]} onAcknowledge={onAcknowledge} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Got it' }));
+    expect(onAcknowledge).toHaveBeenCalledTimes(1);
+  });
+
+  it('closing via the dialog X also acknowledges (no un-acknowledged dismissal path)', () => {
+    const onAcknowledge = vi.fn();
+    render(<WhatsNewModal announcements={[ann('a', '2026.5')]} onAcknowledge={onAcknowledge} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(onAcknowledge).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/pages/Onboarding/__tests__/mirror.test.ts
+++ b/web/src/pages/Onboarding/__tests__/mirror.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { readMirror, writeMirror, clearMirror } from '../mirror';
+import { emptyOnboardingPrefs } from '../onboardingPrefsSchema';
+import type { OnboardingPrefs } from '../types';
+
+const USER = 'u1';
+const KEY = `langalpha-onboarding-v1:${USER}`;
+
+describe('onboarding mirror', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('returns null when absent', () => {
+    expect(readMirror(USER)).toBeNull();
+  });
+
+  it('round-trips pageIntrosSeen, lastSeen, and firstRunAt', () => {
+    const prefs: OnboardingPrefs = {
+      ...emptyOnboardingPrefs(),
+      pageIntrosSeen: { chat: 555, dashboard: 600 },
+      lastSeenReleaseVersion: '2026.5',
+      firstRunAt: 123,
+    };
+    writeMirror(USER, prefs);
+    expect(readMirror(USER)).toEqual({
+      pageIntrosSeen: { chat: 555, dashboard: 600 },
+      lastSeenReleaseVersion: '2026.5',
+      firstRunAt: 123,
+    });
+  });
+
+  it('is scoped per user — another user reads nothing, and a falsy id is a safe no-op', () => {
+    writeMirror(USER, { ...emptyOnboardingPrefs(), pageIntrosSeen: { chat: 5 } });
+    expect(readMirror('someone-else')).toBeNull();
+    expect(readMirror(null)).toBeNull();
+    writeMirror(null, emptyOnboardingPrefs()); // must not throw or write anything
+    expect(localStorage.length).toBe(1);
+    clearMirror(null); // must not clear another user's entry
+    expect(readMirror(USER)?.pageIntrosSeen).toEqual({ chat: 5 });
+  });
+
+  it('clears', () => {
+    writeMirror(USER, emptyOnboardingPrefs());
+    clearMirror(USER);
+    expect(readMirror(USER)).toBeNull();
+  });
+
+  it('returns null on malformed JSON instead of throwing', () => {
+    localStorage.setItem(KEY, '{not json');
+    expect(readMirror(USER)).toBeNull();
+  });
+
+  it('returns null for non-object JSON values', () => {
+    localStorage.setItem(KEY, '"a string"');
+    expect(readMirror(USER)).toBeNull();
+    localStorage.setItem(KEY, '42');
+    expect(readMirror(USER)).toBeNull();
+    localStorage.setItem(KEY, 'null');
+    expect(readMirror(USER)).toBeNull();
+  });
+
+  it('coerces wrong-typed fields instead of trusting them', () => {
+    localStorage.setItem(
+      KEY,
+      JSON.stringify({
+        pageIntrosSeen: { chat: '5', dashboard: 7 }, // string entry dropped
+        lastSeenReleaseVersion: 7,
+        firstRunAt: true,
+      })
+    );
+    expect(readMirror(USER)).toEqual({
+      pageIntrosSeen: { dashboard: 7 },
+      lastSeenReleaseVersion: null,
+      firstRunAt: null,
+    });
+  });
+
+  it('treats a pre-rewrite mirror (old shape) as nothing seen', () => {
+    localStorage.setItem(
+      KEY,
+      JSON.stringify({ welcomeSeenAt: 5, lastSeenReleaseVersion: '2026.4', firstRunAt: 1 })
+    );
+    expect(readMirror(USER)).toEqual({
+      pageIntrosSeen: {},
+      lastSeenReleaseVersion: '2026.4',
+      firstRunAt: 1,
+    });
+  });
+});

--- a/web/src/pages/Onboarding/__tests__/onboardingPrefsSchema.test.ts
+++ b/web/src/pages/Onboarding/__tests__/onboardingPrefsSchema.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { migrateOnboardingPrefs, emptyOnboardingPrefs } from '../onboardingPrefsSchema';
+import { ONBOARDING_PREFS_VERSION } from '../types';
+
+describe('migrateOnboardingPrefs', () => {
+  it('returns a complete empty object from undefined', () => {
+    expect(migrateOnboardingPrefs(undefined)).toEqual(emptyOnboardingPrefs());
+  });
+
+  it('returns empty from a non-object blob', () => {
+    expect(migrateOnboardingPrefs('garbage')).toEqual(emptyOnboardingPrefs());
+    expect(migrateOnboardingPrefs(42)).toEqual(emptyOnboardingPrefs());
+  });
+
+  it('keeps valid values, recovers bad fields, drops unknown keys', () => {
+    const result = migrateOnboardingPrefs({
+      version: 99, // wrong literal → coerced to current
+      pageIntrosSeen: { chat: 1700 },
+      gettingStartedDoneAt: 'garbage', // wrong type → {}
+      gettingStartedDismissedAt: 9,
+      lastSeenReleaseVersion: 123, // wrong type → null
+      firstRunAt: 42,
+      foo: 'ignored',
+    });
+
+    expect(result.version).toBe(ONBOARDING_PREFS_VERSION);
+    expect(result.pageIntrosSeen).toEqual({ chat: 1700 });
+    expect(result.gettingStartedDoneAt).toEqual({});
+    expect(result.gettingStartedDismissedAt).toBe(9);
+    expect(result.lastSeenReleaseVersion).toBeNull();
+    expect(result.firstRunAt).toBe(42);
+    expect(result).not.toHaveProperty('foo');
+  });
+
+  it('coerces a negative dismissal timestamp to null', () => {
+    const result = migrateOnboardingPrefs({ gettingStartedDismissedAt: -5 });
+    expect(result.gettingStartedDismissedAt).toBeNull();
+  });
+
+  // One corrupt entry must not wipe the whole map — that would re-pop every
+  // intro / un-check every task the user already cleared.
+  it('a single corrupt epoch-map entry drops only that key', () => {
+    const result = migrateOnboardingPrefs({
+      pageIntrosSeen: { chat: 1700, thread: 'bad', dashboard: -1, market: 2.5 },
+      gettingStartedDoneAt: { stocks: 100, firstChat: null },
+    });
+    expect(result.pageIntrosSeen).toEqual({ chat: 1700 });
+    expect(result.gettingStartedDoneAt).toEqual({ stocks: 100 });
+  });
+});

--- a/web/src/pages/Onboarding/__tests__/onboardingPrefsWriter.test.ts
+++ b/web/src/pages/Onboarding/__tests__/onboardingPrefsWriter.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest';
+import { act } from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import { renderHookWithProviders } from '@/test/utils';
+import { queryKeys } from '@/lib/queryKeys';
+
+const mockMutate = vi.fn();
+vi.mock('@/hooks/useUpdatePreferences', () => ({
+  useUpdatePreferences: () => ({ mutate: mockMutate, isPending: false }),
+}));
+
+import { useOnboardingPrefsWriter } from '../onboardingPrefsWriter';
+import { emptyOnboardingPrefs } from '../onboardingPrefsSchema';
+import { readMirror } from '../mirror';
+
+// jsdom has no BroadcastChannel; a same-name in-process bus is enough to test
+// both halves of the cross-tab sync (a channel never receives its own posts).
+class MockBroadcastChannel {
+  static registry = new Map<string, Set<MockBroadcastChannel>>();
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  constructor(public name: string) {
+    const set = MockBroadcastChannel.registry.get(name) ?? new Set();
+    set.add(this);
+    MockBroadcastChannel.registry.set(name, set);
+  }
+  postMessage(data: unknown) {
+    for (const chan of MockBroadcastChannel.registry.get(this.name) ?? []) {
+      if (chan !== this) chan.onmessage?.({ data } as MessageEvent);
+    }
+  }
+  close() {
+    MockBroadcastChannel.registry.get(this.name)?.delete(this);
+  }
+}
+
+const originalBC = globalThis.BroadcastChannel;
+beforeAll(() => {
+  (globalThis as Record<string, unknown>).BroadcastChannel = MockBroadcastChannel;
+});
+afterAll(() => {
+  (globalThis as Record<string, unknown>).BroadcastChannel = originalBC;
+});
+
+const USER = 'u1';
+
+function makeClient(seed?: unknown): QueryClient {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: Infinity }, mutations: { retry: false } },
+  });
+  if (seed !== undefined) qc.setQueryData(queryKeys.user.preferences(), seed);
+  qc.setQueryData(queryKeys.user.me(), { user_id: USER });
+  return qc;
+}
+
+describe('useOnboardingPrefsWriter', () => {
+  beforeEach(() => {
+    mockMutate.mockReset();
+    localStorage.clear();
+    MockBroadcastChannel.registry.clear();
+  });
+
+  it('refuses to write on a cold cache with no fallback (unknown-state guard)', () => {
+    const { result } = renderHookWithProviders(() => useOnboardingPrefsWriter(), {
+      queryClient: makeClient(undefined),
+    });
+    let accepted: boolean | undefined;
+    act(() => {
+      accepted = result.current.writeOnboardingPrefs(emptyOnboardingPrefs());
+    });
+    expect(accepted).toBe(false);
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  // The backend shallow-merges top-level other_preference keys (JSONB ||) —
+  // re-sending cached siblings would replay a stale value over a newer write
+  // from another tab. The payload must carry ONLY the onboarding key.
+  it('sends only the onboarding key — siblings are preserved by the server merge', () => {
+    const seed = { other_preference: { dashboard: { mode: 'custom' }, theme: 'dark' } };
+    const { result } = renderHookWithProviders(() => useOnboardingPrefsWriter(), {
+      queryClient: makeClient(seed),
+    });
+    const next = { ...emptyOnboardingPrefs(), firstRunAt: 1 };
+    act(() => {
+      result.current.writeOnboardingPrefs(next, { fallbackOther: null });
+    });
+    expect(mockMutate).toHaveBeenCalledTimes(1);
+    const [payload] = mockMutate.mock.calls[0];
+    expect(payload).toEqual({ other_preference: { onboarding: next } });
+  });
+
+  it('writes the localStorage mirror on success', () => {
+    mockMutate.mockImplementation((_vars, opts?: { onSuccess?: () => void }) => opts?.onSuccess?.());
+    const { result } = renderHookWithProviders(() => useOnboardingPrefsWriter(), {
+      queryClient: makeClient({ other_preference: {} }),
+    });
+    const next = { ...emptyOnboardingPrefs(), firstRunAt: 7, lastSeenReleaseVersion: '2026.5' };
+    act(() => {
+      result.current.writeOnboardingPrefs(next, { fallbackOther: null });
+    });
+    expect(readMirror(USER)).toEqual({ pageIntrosSeen: {}, lastSeenReleaseVersion: '2026.5', firstRunAt: 7 });
+  });
+
+  it('functional updater builds on the cached onboarding state', () => {
+    const stored = { ...emptyOnboardingPrefs(), firstRunAt: 5, lastSeenReleaseVersion: '2026.4' };
+    const { result } = renderHookWithProviders(() => useOnboardingPrefsWriter(), {
+      queryClient: makeClient({ other_preference: { onboarding: stored } }),
+    });
+    act(() => {
+      result.current.writeOnboardingPrefs(
+        (cur) => ({ ...cur, pageIntrosSeen: { ...cur.pageIntrosSeen, chat: 99 } }),
+        { fallbackOther: null }
+      );
+    });
+    const [payload] = mockMutate.mock.calls[0];
+    expect(payload.other_preference.onboarding).toEqual({
+      ...stored,
+      pageIntrosSeen: { chat: 99 },
+    });
+  });
+
+  it('a write mid-flight coalesces into one trailing PUT carrying both changes (in order)', () => {
+    // mutate stays in flight until we settle it — as with the real PUT
+    const { result } = renderHookWithProviders(() => useOnboardingPrefsWriter(), {
+      queryClient: makeClient({ other_preference: {} }),
+    });
+    act(() => {
+      result.current.writeOnboardingPrefs(
+        (cur) => ({ ...cur, firstRunAt: 5, lastSeenReleaseVersion: '2026.5' }),
+        { fallbackOther: null }
+      );
+      result.current.writeOnboardingPrefs(
+        (cur) => ({ ...cur, pageIntrosSeen: { ...cur.pageIntrosSeen, chat: 9 } }),
+        { fallbackOther: null }
+      );
+    });
+    // serialized: the second write must NOT race the first as a parallel PUT —
+    // overlapping full-object writes could commit out of order server-side
+    expect(mockMutate).toHaveBeenCalledTimes(1);
+    const [, firstOpts] = mockMutate.mock.calls[0];
+    act(() => firstOpts.onSuccess());
+    expect(mockMutate).toHaveBeenCalledTimes(2);
+    const [secondPayload] = mockMutate.mock.calls[1];
+    expect(secondPayload.other_preference.onboarding).toEqual({
+      ...emptyOnboardingPrefs(),
+      firstRunAt: 5,
+      lastSeenReleaseVersion: '2026.5',
+      pageIntrosSeen: { chat: 9 },
+    });
+  });
+
+  it('after settling, the next write builds from the cache — an external reset is respected', () => {
+    mockMutate.mockImplementation((_vars, opts?: { onSuccess?: () => void }) => opts?.onSuccess?.());
+    const qc = makeClient({ other_preference: {} });
+    const { result } = renderHookWithProviders(() => useOnboardingPrefsWriter(), {
+      queryClient: qc,
+    });
+    act(() => {
+      result.current.writeOnboardingPrefs(
+        (cur) => ({ ...cur, pageIntrosSeen: { chat: 1 } }),
+        { fallbackOther: null }
+      );
+    });
+    // External replacement of the prefs (Settings "Reset Preferences" DELETE,
+    // or another tab's write landing via invalidate+refetch).
+    qc.setQueryData(queryKeys.user.preferences(), { other_preference: {} });
+    act(() => {
+      result.current.writeOnboardingPrefs(
+        (cur) => ({ ...cur, gettingStartedDismissedAt: 2 }),
+        { fallbackOther: null }
+      );
+    });
+    const [payload] = mockMutate.mock.calls[1];
+    // must NOT resurrect the pre-reset pageIntrosSeen from the stale local copy
+    expect(payload.other_preference.onboarding).toEqual({
+      ...emptyOnboardingPrefs(),
+      gettingStartedDismissedAt: 2,
+    });
+  });
+
+  it('a failed write is dropped — a later write does not silently re-send it', () => {
+    mockMutate.mockImplementationOnce((_vars, opts?: { onError?: (e: unknown) => void }) =>
+      opts?.onError?.(new Error('rejected'))
+    );
+    const { result } = renderHookWithProviders(() => useOnboardingPrefsWriter(), {
+      queryClient: makeClient({ other_preference: {} }),
+    });
+    act(() => {
+      result.current.writeOnboardingPrefs(
+        (cur) => ({ ...cur, pageIntrosSeen: { chat: 1 } }),
+        { fallbackOther: null }
+      );
+    });
+    act(() => {
+      result.current.writeOnboardingPrefs(
+        (cur) => ({ ...cur, gettingStartedDismissedAt: 2 }),
+        { fallbackOther: null }
+      );
+    });
+    const [payload] = mockMutate.mock.calls[1];
+    expect(payload.other_preference.onboarding).toEqual({
+      ...emptyOnboardingPrefs(),
+      gettingStartedDismissedAt: 2,
+    });
+  });
+
+  it('clearMirror opt removes the per-user mirror before writing', () => {
+    localStorage.setItem(
+      `langalpha-onboarding-v1:${USER}`,
+      JSON.stringify({ pageIntrosSeen: { chat: 5 }, lastSeenReleaseVersion: null, firstRunAt: 1 })
+    );
+    const { result } = renderHookWithProviders(() => useOnboardingPrefsWriter(), {
+      queryClient: makeClient({ other_preference: {} }),
+    });
+    act(() => {
+      result.current.writeOnboardingPrefs(emptyOnboardingPrefs(), {
+        fallbackOther: null,
+        clearMirror: true,
+      });
+    });
+    expect(readMirror(USER)).toBeNull();
+  });
+
+  it('updater returning null aborts the write', () => {
+    const { result } = renderHookWithProviders(() => useOnboardingPrefsWriter(), {
+      queryClient: makeClient({ other_preference: {} }),
+    });
+    let accepted: boolean | undefined;
+    act(() => {
+      accepted = result.current.writeOnboardingPrefs(() => null, { fallbackOther: null });
+    });
+    expect(accepted).toBe(false);
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it('optimisticMirror writes the mirror before the server confirms', () => {
+    // mutate never resolves — without the flag the mirror would stay empty
+    const { result } = renderHookWithProviders(() => useOnboardingPrefsWriter(), {
+      queryClient: makeClient({ other_preference: {} }),
+    });
+    act(() => {
+      result.current.writeOnboardingPrefs(
+        { ...emptyOnboardingPrefs(), pageIntrosSeen: { chat: 42 } },
+        { fallbackOther: null, optimisticMirror: true }
+      );
+    });
+    expect(readMirror(USER)?.pageIntrosSeen).toEqual({ chat: 42 });
+  });
+
+  it('on error: forwards onError, writes no mirror, broadcasts nothing', () => {
+    const boom = new Error('put failed');
+    mockMutate.mockImplementation((_vars, opts?: { onError?: (e: unknown) => void }) =>
+      opts?.onError?.(boom)
+    );
+    const { result } = renderHookWithProviders(() => useOnboardingPrefsWriter(), {
+      queryClient: makeClient({ other_preference: {} }),
+    });
+    const peer = new MockBroadcastChannel('onboarding-prefs');
+    const received = vi.fn();
+    peer.onmessage = received;
+    const onError = vi.fn();
+    act(() => {
+      result.current.writeOnboardingPrefs(
+        { ...emptyOnboardingPrefs(), pageIntrosSeen: { chat: 1 } },
+        { fallbackOther: null, onError }
+      );
+    });
+    expect(onError).toHaveBeenCalledWith(boom);
+    expect(readMirror(USER)).toBeNull();
+    expect(received).not.toHaveBeenCalled();
+  });
+
+  it('broadcasts {type: updated} to other tabs on success', () => {
+    mockMutate.mockImplementation((_vars, opts?: { onSuccess?: () => void }) => opts?.onSuccess?.());
+    const { result } = renderHookWithProviders(() => useOnboardingPrefsWriter(), {
+      queryClient: makeClient({ other_preference: {} }),
+    });
+    const peer = new MockBroadcastChannel('onboarding-prefs');
+    const received = vi.fn();
+    peer.onmessage = received;
+    act(() => {
+      result.current.writeOnboardingPrefs(emptyOnboardingPrefs(), { fallbackOther: null });
+    });
+    expect(received).toHaveBeenCalledTimes(1);
+    expect(received.mock.calls[0][0].data).toEqual({ type: 'updated' });
+  });
+
+  it('invalidates the prefs query on a cross-tab update, ignoring other message types', () => {
+    const qc = makeClient({ other_preference: {} });
+    const invalidate = vi.spyOn(qc, 'invalidateQueries');
+    renderHookWithProviders(() => useOnboardingPrefsWriter(), { queryClient: qc });
+    const peer = new MockBroadcastChannel('onboarding-prefs');
+    act(() => {
+      peer.postMessage({ type: 'something-else' });
+    });
+    expect(invalidate).not.toHaveBeenCalled();
+    act(() => {
+      peer.postMessage({ type: 'updated' });
+    });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: queryKeys.user.preferences() });
+  });
+});

--- a/web/src/pages/Onboarding/__tests__/orchestrator.test.tsx
+++ b/web/src/pages/Onboarding/__tests__/orchestrator.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useOnboardingOrchestrator } from '../engine/useOnboardingOrchestrator';
+
+type Params = Parameters<typeof useOnboardingOrchestrator>[0];
+
+function run(overrides: Partial<Params> = {}) {
+  const showPageIntro = vi.fn();
+  const showWhatsNew = vi.fn();
+  const params: Params = {
+    isLoading: false,
+    phase: 'idle',
+    pathname: '/chat',
+    eligibleIntroId: 'chat',
+    hasUnseenWhatsNew: false,
+    suppress: false,
+    showPageIntro,
+    showWhatsNew,
+    ...overrides,
+  };
+  renderHook(() => useOnboardingOrchestrator(params));
+  return { showPageIntro, showWhatsNew };
+}
+
+describe('useOnboardingOrchestrator', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('opens the intro for the current page when one is eligible', () => {
+    const { showPageIntro, showWhatsNew } = run();
+    expect(showPageIntro).toHaveBeenCalledTimes(1);
+    expect(showWhatsNew).not.toHaveBeenCalled();
+  });
+
+  it('shows What\'s-New (not an intro) when no intro matches', () => {
+    const { showPageIntro, showWhatsNew } = run({
+      eligibleIntroId: null,
+      hasUnseenWhatsNew: true,
+    });
+    expect(showPageIntro).not.toHaveBeenCalled();
+    expect(showWhatsNew).toHaveBeenCalledTimes(1);
+  });
+
+  it('the intro outranks What\'s-New when both are pending', () => {
+    const { showPageIntro, showWhatsNew } = run({ hasUnseenWhatsNew: true });
+    expect(showPageIntro).toHaveBeenCalledTimes(1);
+    expect(showWhatsNew).not.toHaveBeenCalled();
+  });
+
+  it('suppresses everything while another flow owns the screen', () => {
+    const { showPageIntro, showWhatsNew } = run({ suppress: true, hasUnseenWhatsNew: true });
+    expect(showPageIntro).not.toHaveBeenCalled();
+    expect(showWhatsNew).not.toHaveBeenCalled();
+  });
+
+  it('does nothing while a popup is already open (phase not idle)', () => {
+    const { showPageIntro } = run({ phase: 'pageIntro' });
+    expect(showPageIntro).not.toHaveBeenCalled();
+  });
+
+  it('defers to an open app dialog', () => {
+    const dialog = document.createElement('div');
+    dialog.setAttribute('role', 'dialog');
+    dialog.setAttribute('data-state', 'open');
+    document.body.appendChild(dialog);
+    const { showPageIntro, showWhatsNew } = run({ hasUnseenWhatsNew: true });
+    expect(showPageIntro).not.toHaveBeenCalled();
+    expect(showWhatsNew).not.toHaveBeenCalled();
+  });
+
+  it('does nothing while prefs are still loading', () => {
+    const { showPageIntro, showWhatsNew } = run({ isLoading: true });
+    expect(showPageIntro).not.toHaveBeenCalled();
+    expect(showWhatsNew).not.toHaveBeenCalled();
+  });
+
+  it("shows What's-New only once across re-renders (session guard)", () => {
+    const showWhatsNew = vi.fn();
+    const params: Params = {
+      isLoading: false,
+      phase: 'idle',
+      pathname: '/chat',
+      eligibleIntroId: null,
+      hasUnseenWhatsNew: true,
+      suppress: false,
+      showPageIntro: vi.fn(),
+      showWhatsNew,
+    };
+    const { rerender } = renderHook((p: Params) => useOnboardingOrchestrator(p), {
+      initialProps: params,
+    });
+    // new params identity + changed dep so the effect actually re-runs
+    rerender({ ...params, pathname: '/dashboard' });
+    rerender({ ...params, pathname: '/settings' });
+    expect(showWhatsNew).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-evaluates on navigation after being deferred by an open dialog', () => {
+    const dialog = document.createElement('div');
+    dialog.setAttribute('role', 'dialog');
+    dialog.setAttribute('data-state', 'open');
+    document.body.appendChild(dialog);
+
+    const showPageIntro = vi.fn();
+    const params: Params = {
+      isLoading: false,
+      phase: 'idle',
+      pathname: '/chat',
+      eligibleIntroId: 'chat',
+      hasUnseenWhatsNew: false,
+      suppress: false,
+      showPageIntro,
+      showWhatsNew: vi.fn(),
+    };
+    const { rerender } = renderHook((p: Params) => useOnboardingOrchestrator(p), {
+      initialProps: params,
+    });
+    expect(showPageIntro).not.toHaveBeenCalled(); // deferred by the open dialog
+
+    dialog.remove();
+    // closing the dialog changes no dep — only the next navigation re-runs the effect
+    rerender({ ...params, pathname: '/dashboard', eligibleIntroId: 'dashboard' });
+    expect(showPageIntro).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/pages/Onboarding/__tests__/useOnboardingPrefs.test.tsx
+++ b/web/src/pages/Onboarding/__tests__/useOnboardingPrefs.test.tsx
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+const mockWrite = vi.fn().mockReturnValue(true);
+vi.mock('../onboardingPrefsWriter', () => ({
+  useOnboardingPrefsWriter: () => ({ writeOnboardingPrefs: mockWrite }),
+}));
+
+let mockPreferences: unknown = { other_preference: {} };
+let mockLoading = false;
+vi.mock('@/hooks/usePreferences', () => ({
+  usePreferences: () => ({ preferences: mockPreferences, isLoading: mockLoading }),
+}));
+
+import { useOnboardingPrefs } from '../useOnboardingPrefs';
+import { emptyOnboardingPrefs } from '../onboardingPrefsSchema';
+import type { OnboardingPrefs } from '../types';
+
+/** Run the functional updater the hook handed to the writer against `cur`. */
+function applyUpdater(callIndex: number, cur: OnboardingPrefs): OnboardingPrefs | null {
+  const arg = mockWrite.mock.calls[callIndex][0];
+  expect(typeof arg).toBe('function');
+  return (arg as (c: OnboardingPrefs) => OnboardingPrefs | null)(cur);
+}
+
+describe('useOnboardingPrefs', () => {
+  beforeEach(() => {
+    mockWrite.mockClear();
+    mockPreferences = { other_preference: {} };
+    mockLoading = false;
+    localStorage.clear();
+  });
+
+  it('every mutator no-ops while prefs are loading (cold-cache guard)', () => {
+    mockLoading = true;
+    const { result } = renderHook(() => useOnboardingPrefs());
+    act(() => {
+      result.current.markPageIntroSeen('chat');
+      result.current.markTaskDone('firstChat');
+      result.current.dismissGettingStarted();
+      result.current.replayGuides();
+      result.current.setLastSeenReleaseVersion('2026.6');
+      result.current.ensureFirstRun('2026.6');
+      result.current.resetAll();
+    });
+    expect(mockWrite).not.toHaveBeenCalled();
+  });
+
+  it('markPageIntroSeen stamps once per intro and is idempotent', () => {
+    const { result } = renderHook(() => useOnboardingPrefs());
+    act(() => result.current.markPageIntroSeen('chat'));
+    expect(mockWrite).toHaveBeenCalledTimes(1);
+    // requests local suppression even if the server write later fails
+    expect(mockWrite.mock.calls[0][1]).toMatchObject({ optimisticMirror: true });
+
+    const fresh = applyUpdater(0, emptyOnboardingPrefs());
+    expect(fresh?.pageIntrosSeen.chat).toEqual(expect.any(Number));
+    // another intro's stamp survives the merge
+    const merged = applyUpdater(0, {
+      ...emptyOnboardingPrefs(),
+      pageIntrosSeen: { dashboard: 4 },
+    });
+    expect(merged?.pageIntrosSeen).toMatchObject({ dashboard: 4, chat: expect.any(Number) });
+    // already-seen state → updater aborts the write instead of re-stamping
+    expect(
+      applyUpdater(0, { ...emptyOnboardingPrefs(), pageIntrosSeen: { chat: 5 } })
+    ).toBeNull();
+  });
+
+  it('markTaskDone stamps once and aborts when already done', () => {
+    const { result } = renderHook(() => useOnboardingPrefs());
+    act(() => result.current.markTaskDone('firstChat'));
+    const fresh = applyUpdater(0, emptyOnboardingPrefs());
+    expect(fresh?.gettingStartedDoneAt.firstChat).toEqual(expect.any(Number));
+    expect(
+      applyUpdater(0, { ...emptyOnboardingPrefs(), gettingStartedDoneAt: { firstChat: 5 } })
+    ).toBeNull();
+  });
+
+  it('dismissGettingStarted stamps once and aborts when already dismissed', () => {
+    const { result } = renderHook(() => useOnboardingPrefs());
+    act(() => result.current.dismissGettingStarted());
+    const fresh = applyUpdater(0, emptyOnboardingPrefs());
+    expect(fresh?.gettingStartedDismissedAt).toEqual(expect.any(Number));
+    expect(
+      applyUpdater(0, { ...emptyOnboardingPrefs(), gettingStartedDismissedAt: 1 })
+    ).toBeNull();
+  });
+
+  it('replayGuides clears the mirror, seen intros, and the card dismissal — keeps the rest', () => {
+    const { result } = renderHook(() => useOnboardingPrefs());
+    act(() => result.current.replayGuides());
+    // the writer owns the per-user mirror; replay asks it to clear first
+    expect(mockWrite.mock.calls[0][1]).toMatchObject({ clearMirror: true });
+    const next = applyUpdater(0, {
+      ...emptyOnboardingPrefs(),
+      pageIntrosSeen: { chat: 1, dashboard: 2 },
+      gettingStartedDismissedAt: 3,
+      gettingStartedDoneAt: { firstChat: 4 },
+      firstRunAt: 5,
+      lastSeenReleaseVersion: '2026.5',
+    });
+    expect(next).toEqual({
+      ...emptyOnboardingPrefs(),
+      gettingStartedDoneAt: { firstChat: 4 }, // progress preserved
+      firstRunAt: 5,
+      lastSeenReleaseVersion: '2026.5',
+    });
+  });
+
+  it('ensureFirstRun stamps caught-up version only when lastSeen is null', () => {
+    const { result } = renderHook(() => useOnboardingPrefs());
+    act(() => result.current.ensureFirstRun('2026.6'));
+
+    const fromNew = applyUpdater(0, emptyOnboardingPrefs());
+    expect(fromNew?.firstRunAt).toEqual(expect.any(Number));
+    expect(fromNew?.lastSeenReleaseVersion).toBe('2026.6');
+
+    const fromReturning = applyUpdater(0, {
+      ...emptyOnboardingPrefs(),
+      lastSeenReleaseVersion: '2026.2',
+    });
+    expect(fromReturning?.lastSeenReleaseVersion).toBe('2026.2'); // preserved, not bumped
+
+    // already stamped → abort
+    expect(applyUpdater(0, { ...emptyOnboardingPrefs(), firstRunAt: 1 })).toBeNull();
+  });
+
+  it('setLastSeenReleaseVersion overwrites onto the freshest state', () => {
+    const { result } = renderHook(() => useOnboardingPrefs());
+    act(() => result.current.setLastSeenReleaseVersion('2026.7'));
+    const next = applyUpdater(0, { ...emptyOnboardingPrefs(), pageIntrosSeen: { chat: 3 } });
+    expect(next).toEqual({
+      ...emptyOnboardingPrefs(),
+      pageIntrosSeen: { chat: 3 },
+      lastSeenReleaseVersion: '2026.7',
+    });
+  });
+
+  it('resetAll clears the mirror and writes empty prefs', () => {
+    const { result } = renderHook(() => useOnboardingPrefs());
+    act(() => result.current.resetAll());
+    expect(mockWrite).toHaveBeenCalledWith(
+      emptyOnboardingPrefs(),
+      expect.objectContaining({ clearMirror: true })
+    );
+  });
+
+  it('migrates whatever is stored into a complete prefs object', () => {
+    mockPreferences = {
+      other_preference: { onboarding: { pageIntrosSeen: { chat: 7 }, junk: true } },
+    };
+    const { result } = renderHook(() => useOnboardingPrefs());
+    expect(result.current.prefs).toEqual({
+      ...emptyOnboardingPrefs(),
+      pageIntrosSeen: { chat: 7 },
+    });
+  });
+});

--- a/web/src/pages/Onboarding/__tests__/whatsNew.test.ts
+++ b/web/src/pages/Onboarding/__tests__/whatsNew.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { compareReleaseVersions, latestReleaseVersion, unseenReleases } from '../engine/whatsNew';
+import { emptyOnboardingPrefs } from '../onboardingPrefsSchema';
+import { ANNOUNCEMENTS } from '../registry/announcements';
+import type { AnnouncementDef } from '../registry/types';
+import type { OnboardingPrefs } from '../types';
+
+function ann(key: string, releaseVersion: string): AnnouncementDef {
+  return { key, releaseVersion, modalTitleKey: 't', modalBodyKey: 'b' };
+}
+
+describe('compareReleaseVersions', () => {
+  it('orders by major then minor then patch', () => {
+    expect(compareReleaseVersions('2026.4', '2026.5')).toBeLessThan(0);
+    expect(compareReleaseVersions('2026.5', '2026.4')).toBeGreaterThan(0);
+    expect(compareReleaseVersions('2026.5', '2026.5')).toBe(0);
+    expect(compareReleaseVersions('2026.10', '2026.9')).toBeGreaterThan(0); // numeric, not lexical
+    expect(compareReleaseVersions('2026.5.1', '2026.5')).toBeGreaterThan(0);
+  });
+
+  it('absorbs malformed segments (NaN → 0) and pads missing segments', () => {
+    expect(compareReleaseVersions('2026.x', '2026.0')).toBe(0); // non-numeric → 0
+    expect(compareReleaseVersions('2026', '2026.0')).toBe(0); // missing segment padded
+    expect(compareReleaseVersions('2026.x', '2026.1')).toBeLessThan(0);
+  });
+
+  it('treats zero-padded and bare CalVer segments as equal', () => {
+    expect(compareReleaseVersions('2026.04.26', '2026.4.26')).toBe(0);
+    expect(compareReleaseVersions('2026.04.26.1', '2026.04.26')).toBeGreaterThan(0);
+  });
+});
+
+describe('ANNOUNCEMENTS registry convention', () => {
+  it('every releaseVersion is CalVer YYYY.MM.DD[.N] (release tag minus the v)', () => {
+    for (const a of ANNOUNCEMENTS) {
+      expect(a.releaseVersion).toMatch(/^\d{4}\.\d{2}\.\d{2}(\.\d+)?$/);
+    }
+  });
+
+  it('keys are unique', () => {
+    const keys = ANNOUNCEMENTS.map((a) => a.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});
+
+describe('latestReleaseVersion', () => {
+  it('returns the highest version', () => {
+    expect(latestReleaseVersion([ann('a', '2026.4'), ann('b', '2026.6'), ann('c', '2026.5')])).toBe('2026.6');
+    expect(latestReleaseVersion([])).toBeNull();
+  });
+});
+
+describe('unseenReleases', () => {
+  const list = [ann('older', '2026.4'), ann('newer', '2026.6')];
+
+  it('returns nothing for a caught-up / brand-new user (lastSeen null)', () => {
+    const prefs: OnboardingPrefs = emptyOnboardingPrefs();
+    expect(unseenReleases(prefs, list)).toEqual([]);
+  });
+
+  it('returns only releases newer than lastSeen, newest first', () => {
+    const prefs: OnboardingPrefs = { ...emptyOnboardingPrefs(), lastSeenReleaseVersion: '2026.4' };
+    const result = unseenReleases(prefs, list);
+    expect(result.map((a) => a.key)).toEqual(['newer']);
+  });
+
+  it('returns all releases newer than an old lastSeen, newest first', () => {
+    const prefs: OnboardingPrefs = { ...emptyOnboardingPrefs(), lastSeenReleaseVersion: '2026.0' };
+    expect(unseenReleases(prefs, list).map((a) => a.key)).toEqual(['newer', 'older']);
+  });
+
+  it('returns nothing when lastSeen equals the latest', () => {
+    const prefs: OnboardingPrefs = { ...emptyOnboardingPrefs(), lastSeenReleaseVersion: '2026.6' };
+    expect(unseenReleases(prefs, list)).toEqual([]);
+  });
+
+  it('handles an empty announcement registry', () => {
+    const prefs: OnboardingPrefs = { ...emptyOnboardingPrefs(), lastSeenReleaseVersion: '2026.0' };
+    expect(unseenReleases(prefs, [])).toEqual([]);
+  });
+});

--- a/web/src/pages/Onboarding/engine/GettingStartedCard.tsx
+++ b/web/src/pages/Onboarding/engine/GettingStartedCard.tsx
@@ -10,6 +10,7 @@ import {
   DialogDescription,
   DialogFooter,
 } from '@/components/ui/dialog';
+import { cn } from '@/lib/utils';
 import { useOnboarding as usePersonalizationNav } from '@/pages/Dashboard/hooks/useOnboarding';
 import { useOnboarding } from '../OnboardingProvider';
 
@@ -129,7 +130,7 @@ export function GettingStartedCard() {
               </span>
               <span className="min-w-0">
                 <span
-                  className={`block text-sm font-medium ${done ? 'line-through' : ''}`}
+                  className={cn('block text-sm font-medium', done && 'line-through')}
                   style={{
                     color: done ? 'var(--color-text-tertiary)' : 'var(--color-text-primary)',
                   }}

--- a/web/src/pages/Onboarding/engine/GettingStartedCard.tsx
+++ b/web/src/pages/Onboarding/engine/GettingStartedCard.tsx
@@ -1,0 +1,200 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { Check, X } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { useOnboarding as usePersonalizationNav } from '@/pages/Dashboard/hooks/useOnboarding';
+import { useOnboarding } from '../OnboardingProvider';
+
+/**
+ * Floating "Get started" checklist (bottom-left, desktop only). Tasks complete
+ * via route visits or the personalization flag; clicking a pending task
+ * navigates to it. Hidden once dismissed or when every task is done.
+ */
+export function GettingStartedCard() {
+  const { gettingStarted } = useOnboarding();
+  const navigate = useNavigate();
+  // Same flow as the dashboard banner: resolve the flash workspace and pass it
+  // as router state — /chat/t/__default__ without state bounces back to /chat.
+  const { navigateToPersonalization } = usePersonalizationNav();
+  // Interview tasks confirm first: the click opens a live agent conversation,
+  // which is a bigger jump than the navigation the other tasks do.
+  const [interviewPromptOpen, setInterviewPromptOpen] = useState(false);
+  const { t } = useTranslation();
+
+  if (!gettingStarted.visible) return null;
+  const { tasks, doneCount, dismiss, completeTask } = gettingStarted;
+
+  return (
+    <aside
+      className="fixed bottom-4 z-40 hidden w-80 rounded-2xl border p-4 shadow-lg md:block"
+      style={{
+        left: 'calc(var(--sidebar-width) + 1rem)',
+        backgroundColor: 'var(--color-bg-card)',
+        borderColor: 'var(--color-border-muted)',
+      }}
+      aria-label={t('onboarding.gettingStarted.title', 'Get started')}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <h2 className="text-sm font-semibold" style={{ color: 'var(--color-text-primary)' }}>
+          {t('onboarding.gettingStarted.title', 'Get started')}
+        </h2>
+        <div className="flex items-center gap-2">
+          <span className="text-xs tabular-nums" style={{ color: 'var(--color-text-tertiary)' }}>
+            {doneCount} / {tasks.length}
+          </span>
+          <button
+            type="button"
+            onClick={dismiss}
+            aria-label={t('onboarding.gettingStarted.dismiss', 'Hide guide')}
+            className="rounded-md p-1 transition-colors hover:bg-[var(--color-bg-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-primary)]"
+            style={{ color: 'var(--color-text-tertiary)' }}
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      </div>
+
+      <div
+        className="mt-2.5 h-1.5 w-full overflow-hidden rounded-full"
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={tasks.length}
+        aria-valuenow={doneCount}
+        style={{ backgroundColor: 'var(--color-bg-subtle)' }}
+      >
+        <div
+          className="h-full rounded-full transition-all duration-300"
+          style={{
+            width: `${(doneCount / tasks.length) * 100}%`,
+            backgroundColor: 'var(--color-accent-primary)',
+          }}
+        />
+      </div>
+
+      <ul className="mt-3 flex flex-col gap-1">
+        {tasks.map(({ def, done }) => (
+          <li key={def.id}>
+            <button
+              type="button"
+              disabled={done}
+              onClick={() => {
+                if (def.interview) {
+                  setInterviewPromptOpen(true);
+                } else if (def.external) {
+                  // Cross-app page — no route of ours to observe, so a
+                  // successful open is the completion signal. null = popup
+                  // blocked; leave the task pending so the user can retry.
+                  // No 'noopener' feature string: that makes open() return
+                  // null even on success, which would read as "blocked" and
+                  // leave the task permanently pending. Sever the opener on
+                  // the returned handle instead.
+                  const win = window.open(def.to, '_blank');
+                  if (win) {
+                    win.opener = null;
+                    completeTask(def.id);
+                  }
+                } else {
+                  navigate(def.to);
+                }
+              }}
+              className="flex w-full items-start gap-3 rounded-lg p-2 text-left transition-colors enabled:hover:bg-[var(--color-bg-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-primary)]"
+            >
+              <span
+                className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border"
+                style={
+                  done
+                    ? {
+                        backgroundColor: 'var(--color-accent-primary)',
+                        borderColor: 'var(--color-accent-primary)',
+                      }
+                    : { borderColor: 'var(--color-border-default)' }
+                }
+                aria-hidden
+              >
+                {done && (
+                  <Check
+                    className="h-3 w-3"
+                    strokeWidth={3}
+                    style={{ color: 'var(--color-text-on-accent)' }}
+                  />
+                )}
+              </span>
+              <span className="min-w-0">
+                <span
+                  className={`block text-sm font-medium ${done ? 'line-through' : ''}`}
+                  style={{
+                    color: done ? 'var(--color-text-tertiary)' : 'var(--color-text-primary)',
+                  }}
+                >
+                  {t(def.titleKey)}
+                </span>
+                {!done && (
+                  <span
+                    className="mt-0.5 block text-xs leading-relaxed"
+                    style={{ color: 'var(--color-text-tertiary)' }}
+                  >
+                    {t(def.descKey)}
+                  </span>
+                )}
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      <Dialog open={interviewPromptOpen} onOpenChange={setInterviewPromptOpen}>
+        <DialogContent variant="centered" className="sm:max-w-md">
+          <DialogHeader className="space-y-2 text-left">
+            <DialogTitle style={{ color: 'var(--color-text-primary)' }}>
+              {t('onboarding.gettingStarted.interview.title', 'A quick chat to personalize your experience')}
+            </DialogTitle>
+            <DialogDescription
+              className="text-sm leading-relaxed"
+              style={{ color: 'var(--color-text-secondary)' }}
+            >
+              {t(
+                'onboarding.gettingStarted.interview.body',
+                "We'll open a chat where the agent asks a few questions about your portfolio, watchlist, risk tolerance, and investment preferences — so its answers fit you. You can change any of it later in Settings, or simply ask the agent to update it."
+              )}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="gap-2 sm:gap-3">
+            <button
+              type="button"
+              onClick={() => setInterviewPromptOpen(false)}
+              className="rounded-lg border px-4 py-2 text-sm font-medium transition-colors hover:bg-[var(--color-bg-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-primary)]"
+              style={{
+                borderColor: 'var(--color-border-default)',
+                color: 'var(--color-text-secondary)',
+              }}
+            >
+              {t('onboarding.gettingStarted.interview.cancel', 'Not now')}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setInterviewPromptOpen(false);
+                void navigateToPersonalization();
+              }}
+              className="rounded-lg px-4 py-2 text-sm font-semibold transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-primary)] focus-visible:ring-offset-2"
+              style={{
+                background: 'var(--color-accent-primary)',
+                color: 'var(--color-text-on-accent)',
+              }}
+            >
+              {t('onboarding.gettingStarted.interview.confirm', 'Start the chat')}
+            </button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </aside>
+  );
+}

--- a/web/src/pages/Onboarding/engine/PageIntroModal.tsx
+++ b/web/src/pages/Onboarding/engine/PageIntroModal.tsx
@@ -1,0 +1,219 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { AnimatePresence, motion, useReducedMotion, type Variants } from 'framer-motion';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { cn } from '@/lib/utils';
+import { INTRO_VISUALS, INTRO_VISUAL_ANCHOR } from './introVisuals';
+import type { PageIntroDef } from '../registry';
+import './pageIntro.css';
+
+/**
+ * One-time contextual intro for the page the user just landed on. Large
+ * half-screen two-panel layout: stepped copy + navigation on the left, a
+ * blueprint-style product mockup on the right. Seen-state is per-intro —
+ * any close path (final CTA, X, Esc) at any step marks the intro seen.
+ */
+export function PageIntroModal({ intro, onClose }: { intro: PageIntroDef; onClose: () => void }) {
+  const { t } = useTranslation();
+  const reduceMotion = useReducedMotion();
+  const [stepIdx, setStepIdx] = useState(0);
+  // +1 forward / -1 back — drives which side the copy slides from. Updated on
+  // every navigation (dots can jump non-adjacent steps in either direction).
+  const [dir, setDir] = useState(1);
+  const goTo = (i: number) => {
+    setDir(i > stepIdx ? 1 : -1);
+    setStepIdx(Math.min(Math.max(i, 0), intro.steps.length - 1));
+  };
+  // Slide distance collapses to a pure (instant) crossfade under reduced motion.
+  const slide = reduceMotion ? 0 : 28;
+  const copyVariants: Variants = {
+    enter: (d: number) => ({ opacity: 0, x: slide * d }),
+    center: {
+      opacity: 1,
+      x: 0,
+      transition: { duration: reduceMotion ? 0 : 0.3, ease: [0.16, 1, 0.3, 1] },
+    },
+    exit: (d: number) => ({
+      opacity: 0,
+      x: -slide * d,
+      transition: { duration: reduceMotion ? 0 : 0.15, ease: 'easeIn' },
+    }),
+  };
+  const step = intro.steps[Math.min(stepIdx, intro.steps.length - 1)];
+  const isLast = stepIdx >= intro.steps.length - 1;
+  const Visual = INTRO_VISUALS[step.visual];
+  const anchor = INTRO_VISUAL_ANCHOR[step.visual];
+  // When every step's mockup anchors right (e.g. the thread intro), the
+  // visual takes the LEFT half: the anchored hot region then sits beside the
+  // copy and the wireframe bleeds off the modal's outer edge. Per-intro, not
+  // per-step, so the panel never jumps sides mid-intro.
+  const visualFirst = intro.steps.every((s) => INTRO_VISUAL_ANCHOR[s.visual] === 'right');
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+    >
+      <DialogContent
+        variant="centered"
+        className="intro-dialog w-[min(94vw,980px)] max-w-none gap-0 overflow-hidden p-0"
+      >
+        <div className="grid sm:min-h-[min(580px,76vh)] sm:grid-cols-2" key={intro.id}>
+          {/* Copy + step navigation */}
+          <div className={cn('flex flex-col gap-4 p-6 sm:p-10', visualFirst && 'sm:order-2')}>
+            <span
+              className="w-fit rounded-full px-2.5 py-0.5 text-xs font-medium"
+              style={{
+                backgroundColor: 'color-mix(in srgb, var(--color-accent-primary) 12%, transparent)',
+                color: 'var(--color-accent-primary)',
+              }}
+            >
+              {t('onboarding.badge', 'Quick tour')}
+            </span>
+
+            {/* Directional slide-fade per stage: the old copy eases out the way
+                travel is headed, the new copy follows it in. */}
+            <AnimatePresence mode="wait" initial={false} custom={dir}>
+              <motion.div
+                key={step.id}
+                custom={dir}
+                variants={copyVariants}
+                initial="enter"
+                animate="center"
+                exit="exit"
+              >
+                <DialogHeader className="space-y-3 text-left">
+                  <DialogTitle
+                    className="text-2xl font-semibold leading-tight sm:text-3xl"
+                    style={{ color: 'var(--color-text-primary)' }}
+                  >
+                    {t(step.titleKey)}
+                  </DialogTitle>
+                  <DialogDescription
+                    className="text-sm leading-relaxed sm:text-[15px]"
+                    style={{ color: 'var(--color-text-secondary)' }}
+                  >
+                    {t(step.bodyKey)}
+                  </DialogDescription>
+                </DialogHeader>
+              </motion.div>
+            </AnimatePresence>
+
+            <div className="mt-auto flex flex-col gap-4 pt-6">
+              <div className="flex items-center gap-1.5">
+                {intro.steps.map((s, i) => (
+                  <button
+                    key={s.id}
+                    type="button"
+                    aria-label={t('onboarding.step', 'Step {{n}}', { n: i + 1 })}
+                    aria-current={i === stepIdx ? 'step' : undefined}
+                    onClick={() => goTo(i)}
+                    className={cn(
+                      'h-1.5 rounded-full transition-all duration-300 hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-primary)] focus-visible:ring-offset-2',
+                      i === stepIdx ? 'w-6' : 'w-1.5'
+                    )}
+                    style={{
+                      background:
+                        i === stepIdx
+                          ? 'var(--color-accent-primary)'
+                          : 'var(--color-border-default)',
+                    }}
+                  />
+                ))}
+                <span
+                  className="ml-auto font-mono text-xs tabular-nums"
+                  style={{ color: 'var(--color-text-tertiary)' }}
+                >
+                  {stepIdx + 1} / {intro.steps.length}
+                </span>
+              </div>
+
+              <div className="flex gap-3">
+                {stepIdx > 0 && (
+                  <button
+                    type="button"
+                    onClick={() => goTo(stepIdx - 1)}
+                    className="rounded-lg border px-4 py-2.5 text-sm font-medium transition-colors hover:bg-[var(--color-bg-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-primary)]"
+                    style={{
+                      borderColor: 'var(--color-border-default)',
+                      color: 'var(--color-text-secondary)',
+                    }}
+                  >
+                    {t('onboarding.back', 'Back')}
+                  </button>
+                )}
+                <button
+                  type="button"
+                  onClick={() => (isLast ? onClose() : goTo(stepIdx + 1))}
+                  className="flex-1 rounded-lg px-4 py-2.5 text-sm font-semibold transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-primary)] focus-visible:ring-offset-2"
+                  style={{
+                    background: 'var(--color-accent-primary)',
+                    color: 'var(--color-text-on-accent)',
+                  }}
+                >
+                  {isLast
+                    ? t('onboarding.done', 'Start exploring')
+                    : t('onboarding.next', 'Continue')}
+                </button>
+              </div>
+            </div>
+          </div>
+
+          {/* Blueprint mockup panel — hidden on small screens where the copy
+              needs the room. The mockup keeps its 400px design size and is
+              scaled up on a static wrapper (intro-rv animates `transform`,
+              so the scale cannot live on an animated element), bleeding off
+              the panel's clipped edge opposite its anchor. Keyed by step:
+              the outgoing scene crossfades out, then the incoming one fades
+              in and its CSS stagger replays. The motion wrapper only animates
+              opacity, so the scale transform stays on the static inner div. */}
+          <div
+            className={cn('intro-visual hidden items-center sm:flex', visualFirst && 'sm:order-1')}
+            aria-hidden
+            data-testid="intro-illustration"
+          >
+            <AnimatePresence mode="wait" initial={false}>
+              <motion.div
+                key={step.id}
+                className="flex w-full items-center"
+                initial={{ opacity: 0 }}
+                animate={{
+                  opacity: 1,
+                  transition: { duration: reduceMotion ? 0 : 0.25, ease: 'easeOut' },
+                }}
+                exit={{
+                  opacity: 0,
+                  transition: { duration: reduceMotion ? 0 : 0.15, ease: 'easeIn' },
+                }}
+              >
+                <div
+                  className={cn(
+                    'w-[400px] shrink-0',
+                    anchor === 'left' && 'ml-8',
+                    anchor === 'right' && 'ml-auto mr-8',
+                    anchor === 'center' && 'mx-auto'
+                  )}
+                  style={{
+                    transform: 'scale(1.45)',
+                    transformOrigin:
+                      anchor === 'center' ? 'center center' : `${anchor} center`,
+                  }}
+                >
+                  <Visual />
+                </div>
+              </motion.div>
+            </AnimatePresence>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/pages/Onboarding/engine/WhatsNewModal.tsx
+++ b/web/src/pages/Onboarding/engine/WhatsNewModal.tsx
@@ -1,0 +1,91 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import type { AnnouncementDef } from '../registry/types';
+import { compareReleaseVersions } from './whatsNew';
+
+/**
+ * Versioned "What's New" modal. Lists unseen announcements grouped by release
+ * (newest first). Acknowledge → caller stamps `lastSeenReleaseVersion`, which
+ * is what marks them seen.
+ */
+export function WhatsNewModal({
+  announcements,
+  onAcknowledge,
+}: {
+  announcements: AnnouncementDef[];
+  onAcknowledge: () => void;
+}) {
+  const { t } = useTranslation();
+
+  const groups = useMemo(() => {
+    const byVersion = new Map<string, AnnouncementDef[]>();
+    for (const a of announcements) {
+      const list = byVersion.get(a.releaseVersion) ?? [];
+      list.push(a);
+      byVersion.set(a.releaseVersion, list);
+    }
+    return [...byVersion.entries()].sort((a, b) => compareReleaseVersions(b[0], a[0]));
+  }, [announcements]);
+
+  if (announcements.length === 0) return null;
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(next) => {
+        if (!next) onAcknowledge();
+      }}
+    >
+      <DialogContent variant="centered" className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t('onboarding.whatsNew.title', "What's new")}</DialogTitle>
+          <DialogDescription>
+            {t('onboarding.whatsNew.subtitle', 'A few updates since you were last here.')}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          {groups.map(([version, items]) => (
+            <div key={version} className="flex flex-col gap-3">
+              <span
+                className="text-xs font-medium uppercase tracking-wide"
+                style={{ color: 'var(--color-text-tertiary)' }}
+              >
+                {version}
+              </span>
+              {items.map((a) => (
+                <div key={a.key} className="rounded-lg border p-3" style={{ borderColor: 'var(--color-border-default)' }}>
+                  <h4 className="text-sm font-semibold" style={{ color: 'var(--color-text-primary)' }}>
+                    {t(a.modalTitleKey)}
+                  </h4>
+                  <p className="mt-1 text-sm leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
+                    {t(a.modalBodyKey)}
+                  </p>
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+
+        <DialogFooter>
+          <button
+            type="button"
+            onClick={onAcknowledge}
+            className="rounded-md px-4 py-2 text-sm font-semibold transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-primary)] focus-visible:ring-offset-2"
+            style={{ background: 'var(--color-accent-primary)', color: 'var(--color-text-on-accent)' }}
+          >
+            {t('onboarding.whatsNew.gotIt', 'Got it')}
+          </button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/pages/Onboarding/engine/introVisuals.tsx
+++ b/web/src/pages/Onboarding/engine/introVisuals.tsx
@@ -1,0 +1,1020 @@
+import type { CSSProperties, ReactNode } from 'react';
+import {
+  ArrowLeft,
+  ArrowUp,
+  ChevronDown,
+  ChevronRight,
+  Clock,
+  FileText,
+  Folder,
+  MousePointer2,
+  Paperclip,
+  Plus,
+  Search,
+  Upload,
+  X,
+  Zap,
+} from 'lucide-react';
+import type { IntroVisualId } from '../registry';
+import './pageIntro.css';
+
+/*
+ * Mockup scenes for the page-intro visual panel: zoomed-out wireframes of the
+ * WHOLE page (app rail + topbar + skeleton regions), with the region the
+ * current step talks about highlighted. Landing-page blueprint style; all
+ * data is invented placeholder skeleton.
+ */
+/* eslint-disable react-refresh/only-export-components -- visual library: many
+   private scene components, one Record export */
+
+const rv = (s: number): CSSProperties => ({ '--rv': `${s}s` } as CSSProperties);
+
+/** Grey skeleton bar standing in for text. */
+function Ln({ w, h = 3, c }: { w: string; h?: number; c?: string }) {
+  return (
+    <span
+      className="block rounded-full"
+      style={{ width: w, height: h, background: c ?? 'var(--iv-line)' }}
+    />
+  );
+}
+
+function Tag({ children, color = 'var(--iv-blue)' }: { children: ReactNode; color?: string }) {
+  return (
+    <span
+      className="w-fit shrink-0 rounded px-1 py-0.5 font-mono text-[8px] leading-none"
+      style={{ background: `color-mix(in srgb, ${color} 18%, transparent)`, color }}
+    >
+      {children}
+    </span>
+  );
+}
+
+/** One region of the page wireframe; `hot` = what this step is about. */
+function Region({
+  hot = false,
+  dashed = false,
+  delay,
+  className = '',
+  style,
+  children,
+}: {
+  hot?: boolean;
+  dashed?: boolean;
+  delay?: number;
+  className?: string;
+  style?: CSSProperties;
+  children?: ReactNode;
+}) {
+  return (
+    <div
+      className={`intro-region ${hot ? 'intro-region--hot' : ''} ${
+        dashed ? 'intro-region--dashed' : ''
+      } ${delay != null ? 'intro-rv' : ''} ${className}`}
+      style={{ ...(delay != null ? rv(delay) : null), ...style }}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** The whole-app chrome: icon rail + topbar + content. */
+function Frame({ children, topbar }: { children: ReactNode; topbar?: ReactNode }) {
+  return (
+    <div className="intro-mk intro-rv w-full max-w-[400px] overflow-hidden" style={rv(0)}>
+      <div className="flex">
+        {/* icon rail */}
+        <div
+          className="flex w-7 shrink-0 flex-col items-center gap-2 border-r py-2.5"
+          style={{ borderColor: 'var(--iv-border)' }}
+        >
+          <span className="h-2.5 w-2.5 rounded" style={{ background: 'var(--iv-blue)' }} />
+          {[0, 1, 2].map((i) => (
+            <span key={i} className="h-2.5 w-2.5 rounded" style={{ background: 'var(--iv-fill)' }} />
+          ))}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div
+            className="flex h-7 items-center gap-2 border-b px-2.5"
+            style={{ borderColor: 'var(--iv-border)' }}
+          >
+            {topbar ?? <Ln w="34%" />}
+          </div>
+          <div className="flex min-h-[300px] flex-col p-2.5">{children}</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** The chat input dock: composer line + plus / plan / model / send row. */
+function InputDock({ hot = false, delay, chip }: { hot?: boolean; delay?: number; chip?: ReactNode }) {
+  return (
+    <Region hot={hot} delay={delay} className="mt-auto flex flex-col gap-1.5 p-1.5">
+      {chip}
+      <Ln w="46%" c="var(--iv-line-3)" />
+      <div className="flex items-center gap-1.5">
+        <Plus className="h-2.5 w-2.5 shrink-0" style={{ color: 'var(--iv-text-3)' }} />
+        <span className="font-mono text-[8px]" style={{ color: 'var(--iv-text-3)' }}>
+          plan
+        </span>
+        <span className="ml-auto">
+          <Ln w="30px" h={3} c="var(--iv-line-3)" />
+        </span>
+        <span
+          className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full"
+          style={{ background: 'var(--iv-blue-deep)' }}
+        >
+          <ArrowUp className="h-2 w-2 text-white" />
+        </span>
+      </div>
+    </Region>
+  );
+}
+
+/** A workspace card in the gallery wireframe: title, blurb, updated-at.
+    The Flash card is fully color-filled — that's how users tell it apart
+    from regular (unfilled) workspace cards in the real gallery. */
+function WsCard({ hot = false, flash = false, delay }: { hot?: boolean; flash?: boolean; delay: number }) {
+  return (
+    <Region
+      hot={hot}
+      delay={delay}
+      className="flex flex-col gap-1 p-2"
+      style={
+        flash
+          ? {
+              background:
+                'linear-gradient(135deg, rgba(90,130,216,0.22), rgba(90,130,216,0.08))',
+              borderColor: 'rgba(90,130,216,0.3)',
+            }
+          : undefined
+      }
+    >
+      <div className="flex items-center gap-1">
+        {flash && <Zap className="h-2 w-2 shrink-0" style={{ color: 'var(--iv-blue)' }} />}
+        <Ln w="52%" h={4} c="var(--iv-line-2)" />
+      </div>
+      <Ln w="88%" />
+      <Ln w="64%" />
+      <div className="mt-auto pt-0.5">
+        <Ln w="32%" h={2} c="var(--iv-line-3)" />
+      </div>
+    </Region>
+  );
+}
+
+/* ── chat · step 1: the agent's two modes, side by side ────────────────── */
+
+/** Split scene: Flash (instant answer) vs PTC (subagents → deliverable). */
+function TwoModes() {
+  return (
+    <Frame topbar={<Ln w="26%" />}>
+      <div className="flex flex-1 gap-2">
+        {/* Flash half: coordinating the desk, with quick answers on the side */}
+        <Region hot delay={0.12} className="flex flex-1 flex-col gap-1.5 p-2">
+          <div className="flex items-center gap-1.5" style={{ color: 'var(--iv-blue)' }}>
+            <Zap className="h-2.5 w-2.5" />
+            <span className="font-mono text-[8px]">Flash</span>
+          </div>
+          <OrchRow
+            icon={<Folder className="h-2 w-2 shrink-0" style={{ color: 'var(--iv-blue)' }} />}
+            label="workspace created"
+            delay={0.22}
+          />
+          <OrchRow
+            icon={<ChevronRight className="h-2 w-2 shrink-0" style={{ color: 'var(--iv-blue)' }} />}
+            label="dispatched to PTC"
+            delay={0.3}
+          />
+          <div className="grid grid-cols-2 gap-1.5 pt-0.5">
+            <Ln w="90%" h={2} c="var(--iv-line-3)" />
+            <Ln w="74%" h={2} c="var(--iv-line-3)" />
+          </div>
+          <span className="mt-auto font-mono text-[7px]" style={{ color: 'var(--iv-text-3)' }}>
+            coordination · quick answers
+          </span>
+        </Region>
+        {/* PTC half: subagents fanning out toward a deliverable. Plain region
+            + teal tag — the blue accent belongs to Flash in this comparison */}
+        <Region delay={0.28} className="flex flex-1 flex-col gap-1.5 p-2">
+          <div className="flex items-center">
+            <Tag color="var(--iv-teal)">PTC</Tag>
+          </div>
+          <SubagentCard name="data-prep" tools="23 tools" delay={0.4} />
+          <SubagentCard name="valuation" tools="17 tools" delay={0.48} />
+          <div className="intro-rv flex items-center gap-1" style={rv(0.56)}>
+            <FileText className="h-2 w-2 shrink-0" style={{ color: 'var(--iv-teal)' }} />
+            <Ln w="48%" h={2} c="var(--iv-line-3)" />
+          </div>
+          <span className="mt-auto font-mono text-[7px]" style={{ color: 'var(--iv-text-3)' }}>
+            deep analysis &amp; deliverables
+          </span>
+        </Region>
+      </div>
+      <div className="mt-2.5 flex items-center gap-1.5 font-mono text-[8px]" style={{ color: 'var(--iv-text-3)' }}>
+        <span className="intro-pulse" style={{ width: 5, height: 5 }} />
+        one agent · two modes
+      </div>
+    </Frame>
+  );
+}
+
+/* ── chat · step 4: the workspace gallery page ─────────────────────────── */
+
+function WorkspaceGrid() {
+  return (
+    <Frame topbar={<Ln w="20%" />}>
+      <div className="flex flex-1 flex-col gap-2">
+        {/* page title + new-workspace button */}
+        <div className="intro-rv flex items-center justify-between" style={rv(0.08)}>
+          <Ln w="22%" h={5} c="var(--iv-line-2)" />
+          <span
+            className="flex items-center gap-1 rounded px-1.5 py-1"
+            style={{ background: 'var(--iv-blue-deep)' }}
+          >
+            <Plus className="h-2 w-2 text-white" />
+            <Ln w="30px" h={3} c="rgba(255,255,255,0.8)" />
+          </span>
+        </div>
+        {/* search */}
+        <Region delay={0.16} className="flex items-center gap-1.5 p-1.5">
+          <Search className="h-2 w-2 shrink-0" style={{ color: 'var(--iv-text-3)' }} />
+          <Ln w="30%" c="var(--iv-line-3)" />
+        </Region>
+        {/* no hot card here — the step is about the gallery as a whole, and a
+            highlighted card would read as a second Flash card */}
+        <div className="grid flex-1 auto-rows-fr grid-cols-2 gap-2">
+          <WsCard flash delay={0.24} />
+          <WsCard delay={0.32} />
+          <WsCard delay={0.4} />
+          <WsCard delay={0.48} />
+        </div>
+      </div>
+      <div className="mt-2.5 flex items-center gap-1.5 font-mono text-[8px]" style={{ color: 'var(--iv-text-3)' }}>
+        <span className="intro-pulse" style={{ width: 5, height: 5 }} />
+        one desk per company, sector, or strategy
+      </div>
+    </Frame>
+  );
+}
+
+/* ── chat · step 2: a Flash chat page ──────────────────────────────────── */
+
+/** Compact live-quote card, echoing the real quote tool-result card. */
+function QuoteCard({
+  ticker,
+  price,
+  change,
+  up,
+  delay,
+}: {
+  ticker: string;
+  price: string;
+  change: string;
+  up: boolean;
+  delay: number;
+}) {
+  return (
+    <Region delay={delay} className="flex flex-col gap-1 p-1.5">
+      <div className="flex items-center gap-1">
+        <span className="font-mono text-[8px] leading-none" style={{ color: 'var(--iv-text)' }}>
+          {ticker}
+        </span>
+        <Ln w="26%" h={2} c="var(--iv-line-3)" />
+      </div>
+      <div className="flex items-baseline gap-1">
+        <span
+          className="font-mono text-[9px] font-semibold leading-none"
+          style={{ color: 'var(--iv-text)' }}
+        >
+          {price}
+        </span>
+        <span
+          className="font-mono text-[7px] leading-none"
+          style={{ color: up ? 'var(--iv-teal)' : 'var(--iv-red)' }}
+        >
+          {change}
+        </span>
+      </div>
+      {/* open / range / volume stat grid stays skeleton */}
+      <div className="grid grid-cols-2 gap-x-2 gap-y-1 pt-0.5">
+        <Ln w="80%" h={2} c="var(--iv-line-3)" />
+        <Ln w="64%" h={2} c="var(--iv-line-3)" />
+        <Ln w="56%" h={2} c="var(--iv-line-3)" />
+        <Ln w="72%" h={2} c="var(--iv-line-3)" />
+      </div>
+    </Region>
+  );
+}
+
+/** One line of Flash's orchestration run: icon · action · ✓. */
+function OrchRow({
+  icon,
+  label,
+  delay,
+}: {
+  icon: ReactNode;
+  label: string;
+  delay: number;
+}) {
+  return (
+    <div className="intro-rv flex items-center gap-1.5" style={rv(delay)}>
+      {icon}
+      <span className="font-mono text-[8px] leading-none" style={{ color: 'var(--iv-text-2)' }}>
+        {label}
+      </span>
+      <span className="ml-auto font-mono text-[7px] leading-none" style={{ color: 'var(--iv-teal)' }}>
+        ✓
+      </span>
+    </div>
+  );
+}
+
+/** Orchestration first: Flash sets up a workspace, dispatches the heavy task
+    to PTC, and schedules an automation; a quick price check follows so fast
+    QA reads as part of the job, not the whole job. */
+function FlashAnswer() {
+  return (
+    <Frame topbar={<><Ln w="22%" /><Tag>Flash</Tag></>}>
+      <div className="flex flex-1 flex-col gap-2">
+        {/* mr keeps the bubbles clear of the bleed crop (scene anchors left) */}
+        <div className="intro-rv mr-24 flex justify-end" style={rv(0.12)}>
+          <div
+            className="rounded-md rounded-br-sm px-2 py-1.5"
+            style={{ background: 'rgba(90,130,216,0.22)' }}
+          >
+            <span
+              className="block font-mono text-[8px] leading-none"
+              style={{ color: 'var(--iv-text)' }}
+            >
+              Set up a deep dive on NVDA earnings
+            </span>
+          </div>
+        </div>
+        <Region hot delay={0.2} className="flex flex-col gap-1.5 p-2">
+          <div className="flex items-center gap-1.5" style={{ color: 'var(--iv-blue)' }}>
+            <Zap className="h-2.5 w-2.5" />
+            <span className="font-mono text-[8px]">flash · orchestrating</span>
+          </div>
+          <OrchRow
+            icon={<Folder className="h-2 w-2 shrink-0" style={{ color: 'var(--iv-blue)' }} />}
+            label="workspace created · NVDA deep dive"
+            delay={0.3}
+          />
+          <OrchRow
+            icon={<ChevronRight className="h-2 w-2 shrink-0" style={{ color: 'var(--iv-blue)' }} />}
+            label="task dispatched to PTC"
+            delay={0.38}
+          />
+          <OrchRow
+            icon={<Clock className="h-2 w-2 shrink-0" style={{ color: 'var(--iv-blue)' }} />}
+            label="automation · daily earnings brief"
+            delay={0.46}
+          />
+        </Region>
+        {/* quick QA rides along below */}
+        <div className="intro-rv mr-24 flex justify-end" style={rv(0.54)}>
+          <div
+            className="rounded-md rounded-br-sm px-2 py-1.5"
+            style={{ background: 'rgba(90,130,216,0.22)' }}
+          >
+            <span
+              className="block font-mono text-[8px] leading-none"
+              style={{ color: 'var(--iv-text)' }}
+            >
+              NVDA price?
+            </span>
+          </div>
+        </div>
+        <Region delay={0.62} className="flex flex-col gap-1.5 p-2">
+          <div className="flex items-center gap-1.5" style={{ color: 'var(--iv-blue)' }}>
+            <Zap className="h-2.5 w-2.5" />
+            <span className="font-mono text-[8px]">flash · 0.9s</span>
+          </div>
+          <div className="grid grid-cols-2 gap-1.5">
+            <QuoteCard ticker="NVDA" price="$142.10" change="+1.8%" up delay={0.7} />
+            <QuoteCard ticker="AVGO" price="$310.51" change="-0.4%" up={false} delay={0.78} />
+          </div>
+        </Region>
+        <InputDock delay={0.88} />
+      </div>
+    </Frame>
+  );
+}
+
+/* ── chat · step 3: a PTC thread page running code ─────────────────────── */
+
+/** A subagent task card, echoing the real run cards (name · ✓ · n tools). */
+function SubagentCard({ name, tools, delay }: { name: string; tools: string; delay: number }) {
+  return (
+    <Region delay={delay} className="flex flex-col gap-1 p-1.5">
+      <div className="flex items-center">
+        <span className="font-mono text-[8px] leading-none" style={{ color: 'var(--iv-text-2)' }}>
+          {name}
+        </span>
+        <span
+          className="ml-auto font-mono text-[7px] leading-none"
+          style={{ color: 'var(--iv-teal)' }}
+        >
+          ✓ completed
+        </span>
+      </div>
+      <Ln w="72%" h={2} c="var(--iv-line-3)" />
+      <span className="font-mono text-[7px] leading-none" style={{ color: 'var(--iv-text-3)' }}>
+        {tools}
+      </span>
+    </Region>
+  );
+}
+
+/** No user bubble here — the scene is the agent mid-run: parallel subagents,
+    an inline chart, deliverables, and the file panel previewing the Excel
+    they produced (the panel bleeds off the cropped right edge). */
+function PtcSandbox() {
+  const bars = [38, 56, 46, 86, 60, 70];
+  const accent = 3;
+  return (
+    <Frame topbar={<><Ln w="22%" /><Tag>PTC</Tag></>}>
+      <div className="flex flex-1 gap-2">
+        {/* chat column */}
+        <div className="flex min-w-0 flex-[1.5] flex-col gap-2">
+          {/* parallel subagents (Flash can't do this) */}
+          <SubagentCard name="data-prep" tools="23 tools" delay={0.1} />
+          <SubagentCard name="report-builder" tools="10 tools" delay={0.18} />
+          {/* narration, blurred */}
+          <Ln w="58%" />
+          {/* inline visualization in the reply */}
+          <Region hot delay={0.32} className="flex flex-col gap-1 p-2">
+            <Ln w="34%" h={2} c="var(--iv-line-3)" />
+            <div className="mt-0.5 flex h-9 items-end gap-1">
+              {bars.map((h, i) => (
+                <span
+                  key={i}
+                  className="intro-bar flex-1 rounded-t-sm"
+                  style={{
+                    ...rv(0.42 + i * 0.05),
+                    height: `${h}%`,
+                    background: i === accent ? 'var(--iv-teal)' : 'rgba(90,130,216,0.7)',
+                  }}
+                />
+              ))}
+            </div>
+          </Region>
+          {/* the deliverables */}
+          <div className="intro-rv flex flex-wrap items-center gap-1.5" style={rv(0.52)}>
+            <Region className="flex items-center gap-1 px-1.5 py-1">
+              <FileText className="h-2 w-2 shrink-0" style={{ color: 'var(--iv-text-3)' }} />
+              <span className="font-mono text-[7px] leading-none" style={{ color: 'var(--iv-text-2)' }}>
+                comps.xlsx
+              </span>
+              <Tag color="var(--iv-teal)">✓</Tag>
+            </Region>
+            <Region className="flex items-center gap-1 px-1.5 py-1">
+              <FileText className="h-2 w-2 shrink-0" style={{ color: 'var(--iv-text-3)' }} />
+              <span className="font-mono text-[7px] leading-none" style={{ color: 'var(--iv-text-2)' }}>
+                report.pdf
+              </span>
+              <Tag color="var(--iv-teal)">✓</Tag>
+            </Region>
+          </div>
+          <InputDock delay={0.6} />
+        </div>
+        {/* file panel previewing the Excel deliverable */}
+        <Region delay={0.44} className="flex flex-1 flex-col gap-1.5 p-1.5">
+          <div className="flex items-center gap-1">
+            <FileText className="h-2 w-2 shrink-0" style={{ color: 'var(--iv-text-3)' }} />
+            <span className="font-mono text-[7px] leading-none" style={{ color: 'var(--iv-text-2)' }}>
+              comps.xlsx
+            </span>
+          </div>
+          {/* sheet tabs */}
+          <div className="flex gap-1">
+            <Tag>AI Semi Comps</Tag>
+            <Tag color="var(--iv-text-3)">Mega-Cap</Tag>
+          </div>
+          {/* spreadsheet grid: hairline-divided cells */}
+          <div
+            className="grid flex-1 auto-rows-fr grid-cols-3 gap-px overflow-hidden rounded border"
+            style={{ background: 'var(--iv-border)', borderColor: 'var(--iv-border)' }}
+          >
+            {Array.from({ length: 21 }, (_, i) => (
+              <span
+                key={i}
+                className="flex items-center px-1"
+                style={{ background: i < 3 ? 'var(--iv-fill)' : 'var(--iv-mk-bg)' }}
+              >
+                <Ln w={i < 3 ? '80%' : `${[64, 40, 52][i % 3]}%`} h={2} c="var(--iv-line-3)" />
+              </span>
+            ))}
+          </div>
+        </Region>
+      </div>
+    </Frame>
+  );
+}
+
+/* ── chat · step 5: the new-workspace modal over the gallery ───────────── */
+
+function CreateWorkspace() {
+  return (
+    <div className="relative w-full max-w-[400px]">
+      {/* this scene is center-anchored: the dimmed gallery fades into the
+          panel at both edges instead of hard-cropping on one side */}
+      <div
+        style={{
+          opacity: 0.45,
+          WebkitMaskImage:
+            'linear-gradient(90deg, transparent 0, black 18%, black 82%, transparent 100%)',
+          maskImage:
+            'linear-gradient(90deg, transparent 0, black 18%, black 82%, transparent 100%)',
+        }}
+      >
+        <Frame>
+          <div className="flex flex-col gap-2">
+            {/* the new-workspace button the scripted cursor clicks */}
+            <div className="flex items-center">
+              <Ln w="22%" h={5} c="var(--iv-line-2)" />
+              <span
+                className="ml-auto mr-16 flex items-center gap-1 rounded px-1.5 py-1"
+                style={{ background: 'var(--iv-blue-deep)' }}
+              >
+                <Plus className="h-2 w-2 text-white" />
+                <Ln w="30px" h={3} c="rgba(255,255,255,0.8)" />
+              </span>
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              <WsCard flash delay={0} />
+              <WsCard delay={0} />
+              <WsCard delay={0} />
+              <WsCard delay={0} />
+            </div>
+          </div>
+        </Frame>
+      </div>
+      {/* scripted click: cursor slides onto the button, ripple fires, then
+          the modal pops. Lives outside the dimmed layer so the gesture reads
+          at full strength; coordinates match the button above (fixed-size
+          mockup, so they're deterministic). */}
+      <div className="pointer-events-none absolute" style={{ left: 299, top: 46 }}>
+        <span className="intro-click absolute -left-3 -top-3 h-6 w-6" style={rv(0.62)} />
+        <MousePointer2
+          className="intro-rv absolute h-3 w-3"
+          style={{ ...rv(0.28), color: 'var(--iv-text)', fill: 'currentColor' }}
+        />
+      </div>
+      {/* the modal the click opens: name, description, drop-zone, create.
+          Centering transform lives on a static wrapper — the pop animates
+          `transform` and would clobber translate utilities on itself. */}
+      <div className="absolute left-1/2 top-1/2 w-[72%] -translate-x-1/2 -translate-y-1/2">
+        <div className="intro-mk intro-mk--accent intro-pop p-2.5" style={rv(0.95)}>
+          <div className="flex items-center justify-between">
+            <span className="font-mono text-[9px]">New workspace</span>
+            <X className="h-2.5 w-2.5" style={{ color: 'var(--iv-text-3)' }} />
+          </div>
+          <div className="mt-2 flex flex-col gap-1.5">
+            {/* name field */}
+            <span className="font-mono text-[8px]" style={{ color: 'var(--iv-text-3)' }}>
+              name
+            </span>
+            <Region className="flex items-center px-1.5 py-1" style={{ borderRadius: 5 }}>
+              <span className="font-mono text-[8px] leading-none" style={{ color: 'var(--iv-text)' }}>
+                NVDA earnings deep-dive
+              </span>
+            </Region>
+            {/* description */}
+            <span className="font-mono text-[8px]" style={{ color: 'var(--iv-text-3)' }}>
+              description
+            </span>
+            <span className="font-mono text-[8px]" style={{ color: 'var(--iv-text-2)' }}>
+              Q1 print vs. guidance, data-center demand…
+            </span>
+            {/* files queued for the new workspace */}
+            <span className="font-mono text-[8px]" style={{ color: 'var(--iv-text-3)' }}>
+              files
+            </span>
+            <Region dashed className="flex items-center justify-center gap-1.5 p-1.5">
+              <Upload className="h-2.5 w-2.5" style={{ color: 'var(--iv-text-3)' }} />
+              <Ln w="38%" />
+            </Region>
+            <div className="intro-rv flex items-center gap-1.5" style={rv(0.45)}>
+              <FileText className="h-2 w-2 shrink-0" style={{ color: 'var(--iv-text-3)' }} />
+              <Ln w="34%" c="var(--iv-line-2)" />
+              <span className="ml-auto">
+                <Tag color="var(--iv-teal)">ready</Tag>
+              </span>
+            </div>
+            <div className="intro-rv flex items-center gap-1.5" style={rv(0.55)}>
+              <FileText className="h-2 w-2 shrink-0" style={{ color: 'var(--iv-text-3)' }} />
+              <Ln w="26%" c="var(--iv-line-2)" />
+              <span className="ml-auto w-8">
+                <Ln w="64%" h={2} c="var(--iv-teal)" />
+              </span>
+            </div>
+            <div className="flex items-center justify-end gap-2">
+              <span className="font-mono text-[8px]" style={{ color: 'var(--iv-text-3)' }}>
+                cancel
+              </span>
+              <span
+                className="flex items-center px-2 py-1"
+                style={{ background: 'var(--iv-blue-deep)', borderRadius: 5 }}
+              >
+                <span className="font-mono text-[8px] leading-none text-white">create</span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── thread page base: chat column + tabbed right panel ────────────────── */
+
+function PanelTabs({ active }: { active: 'files' | 'memory' | 'memos' }) {
+  const tabs = ['files', 'memory', 'memos'] as const;
+  return (
+    <div className="flex items-center gap-1">
+      {tabs.map((t) => (
+        <span
+          key={t}
+          className="rounded px-1.5 py-0.5 font-mono text-[8px] leading-none"
+          style={
+            t === active
+              ? { background: 'var(--iv-blue-deep)', color: '#fff' }
+              : { color: 'var(--iv-text-3)' }
+          }
+        >
+          {t}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+/** A row in the workspace file tree. */
+function TreeRow({
+  depth = 0,
+  kind = 'file',
+  open = false,
+  w,
+  dot = false,
+  delay,
+}: {
+  depth?: number;
+  kind?: 'file' | 'folder';
+  open?: boolean;
+  w: string;
+  dot?: boolean;
+  delay: number;
+}) {
+  const Chevron = open ? ChevronDown : ChevronRight;
+  return (
+    <div className="intro-rv flex items-center gap-1" style={{ ...rv(delay), paddingLeft: depth * 8 }}>
+      {kind === 'folder' ? (
+        <>
+          <Chevron className="h-2 w-2 shrink-0" style={{ color: 'var(--iv-text-3)' }} />
+          <Folder className="h-2 w-2 shrink-0" style={{ color: 'var(--iv-text-3)' }} />
+        </>
+      ) : (
+        <FileText className="h-2 w-2 shrink-0" style={{ color: 'var(--iv-text-3)' }} />
+      )}
+      <Ln w={w} />
+      {dot && <span className="ml-auto h-1 w-1 shrink-0 rounded-full" style={{ background: 'var(--iv-teal)' }} />}
+    </div>
+  );
+}
+
+function ThreadFrame({
+  tab,
+  panel,
+  bubble,
+}: {
+  tab: 'files' | 'memory' | 'memos';
+  panel: ReactNode;
+  bubble?: ReactNode;
+}) {
+  return (
+    <Frame
+      topbar={
+        <>
+          <ArrowLeft className="h-2.5 w-2.5 shrink-0" style={{ color: 'var(--iv-text-3)' }} />
+          <Ln w="24%" />
+          <span className="ml-auto">
+            <Tag>PTC</Tag>
+          </span>
+        </>
+      }
+    >
+      <div className="flex flex-1 gap-2">
+        <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+          <Ln w="70%" />
+          <Ln w="86%" />
+          <Ln w="52%" />
+          {bubble}
+          <Ln w="78%" />
+          <Ln w="84%" />
+          <Ln w="60%" />
+          <Ln w="72%" />
+          <Ln w="40%" />
+          <InputDock delay={0.55} />
+        </div>
+        {/* the panel is the subject — give it the wider column (the chat
+            side bleeds off the left edge anyway) */}
+        <Region hot delay={0.2} className="flex flex-[1.25] flex-col gap-1.5 p-1.5">
+          <div className="flex items-center justify-between gap-1">
+            <PanelTabs active={tab} />
+            <span className="intro-pulse" style={{ width: 5, height: 5 }} />
+          </div>
+          {panel}
+        </Region>
+      </div>
+    </Frame>
+  );
+}
+
+/* ── thread · step 1: file panel ───────────────────────────────────────── */
+
+function FilePanel() {
+  return (
+    <ThreadFrame
+      tab="files"
+      panel={
+        <>
+          <TreeRow w="34%" dot delay={0.3} />
+          <TreeRow kind="folder" open w="30%" delay={0.38} />
+          <TreeRow depth={1} w="58%" dot delay={0.46} />
+          <TreeRow depth={1} w="48%" dot delay={0.54} />
+          <TreeRow kind="folder" w="26%" delay={0.62} />
+          <Tag color="var(--iv-teal)">deliverables → results/</Tag>
+        </>
+      }
+    />
+  );
+}
+
+/* ── thread · step 2: long-term memory ─────────────────────────────────── */
+
+function Memory() {
+  return (
+    <ThreadFrame
+      tab="memory"
+      bubble={
+        <div className="intro-rv flex justify-end" style={rv(0.1)}>
+          <div className="rounded-md rounded-br-sm px-1.5 py-1" style={{ background: 'rgba(90,130,216,0.22)' }}>
+            <span className="block font-mono text-[8px] leading-none" style={{ color: 'var(--iv-text-2)' }}>
+              remember this…
+            </span>
+          </div>
+        </div>
+      }
+      panel={
+        <>
+          {['82%', '68%', '74%'].map((w, i) => (
+            <div key={i} className="intro-rv flex items-center gap-1.5" style={rv(0.3 + i * 0.1)}>
+              <span className="h-1 w-1 shrink-0 rounded-full" style={{ background: 'var(--iv-teal)' }} />
+              <Ln w={w} />
+            </div>
+          ))}
+          <Tag color="var(--iv-teal)">applies to every thread</Tag>
+        </>
+      }
+    />
+  );
+}
+
+/* ── thread · step 3: memos ────────────────────────────────────────────── */
+
+function Memo() {
+  return (
+    <ThreadFrame
+      tab="memos"
+      panel={
+        <>
+          <Region dashed className="intro-rv flex items-center justify-center gap-1 p-1.5" style={rv(0.3)}>
+            <Upload className="h-2.5 w-2.5" style={{ color: 'var(--iv-text-3)' }} />
+            <Ln w="42%" />
+          </Region>
+          {['76%', '60%'].map((w, i) => (
+            <div key={i} className="intro-rv flex items-center gap-1.5" style={rv(0.42 + i * 0.1)}>
+              <span className="h-2 w-2 shrink-0 rounded-sm" style={{ background: 'var(--iv-blue)' }} />
+              <Ln w={w} />
+              <span className="ml-auto">
+                <Tag color="var(--iv-teal)">ready</Tag>
+              </span>
+            </div>
+          ))}
+        </>
+      }
+    />
+  );
+}
+
+/* ── dashboard base: ticker strip + widget grid ────────────────────────── */
+
+function TickerStrip({ delay = 0.1 }: { delay?: number }) {
+  const chips = ['var(--iv-teal)', 'var(--iv-teal)', 'var(--iv-red)', 'var(--iv-teal)', 'var(--iv-red)'];
+  return (
+    <div className="intro-rv flex gap-1.5" style={rv(delay)}>
+      {chips.map((c, i) => (
+        <Region key={i} className="flex flex-1 flex-col gap-1 p-1.5">
+          <Ln w="70%" h={3} c="var(--iv-line-2)" />
+          <Ln w="50%" h={3} c={`color-mix(in srgb, ${c} 65%, transparent)`} />
+        </Region>
+      ))}
+    </div>
+  );
+}
+
+function Watchlist({
+  hot = false,
+  delay = 0,
+  className = '',
+}: {
+  hot?: boolean;
+  delay?: number;
+  className?: string;
+}) {
+  const rows = ['var(--iv-teal)', 'var(--iv-red)', 'var(--iv-teal)'];
+  return (
+    <Region hot={hot} delay={delay} className={`flex flex-col gap-1.5 p-1.5 ${className}`}>
+      <Ln w="46%" h={4} c="var(--iv-line-2)" />
+      {rows.map((c, i) => (
+        <div key={i} className="flex items-center justify-between gap-2">
+          <Ln w="38%" />
+          <Ln w="22%" c={`color-mix(in srgb, ${c} 65%, transparent)`} />
+        </div>
+      ))}
+    </Region>
+  );
+}
+
+/* ── dashboard · step 1: the whole page ────────────────────────────────── */
+
+function DashboardGrid() {
+  return (
+    <Frame topbar={<Ln w="30%" />}>
+      <div className="flex flex-1 flex-col gap-1.5">
+        <TickerStrip />
+        <div className="flex flex-1 gap-1.5">
+          {/* brief / news canvas */}
+          <Region delay={0.22} className="flex flex-[1.5] flex-col gap-1.5 p-2">
+            <Ln w="36%" h={4} c="var(--iv-line-2)" />
+            <Ln w="92%" />
+            <Ln w="84%" />
+            <Ln w="88%" />
+            <Ln w="58%" />
+            <Ln w="76%" />
+            <Ln w="90%" />
+            <Ln w="68%" />
+            <Ln w="82%" />
+            <Ln w="40%" />
+          </Region>
+          <div className="flex flex-1 flex-col gap-1.5">
+            <Watchlist delay={0.32} />
+            <Region delay={0.42} className="flex flex-1 flex-col justify-center p-1.5">
+              <svg viewBox="0 0 100 30" className="h-8 w-full" aria-hidden>
+                <polyline
+                  className="intro-wire"
+                  points="0,24 16,20 32,25 48,13 64,17 80,8 100,4"
+                  fill="none"
+                  stroke="var(--iv-teal)"
+                  strokeWidth="1.6"
+                />
+              </svg>
+            </Region>
+          </div>
+        </div>
+      </div>
+    </Frame>
+  );
+}
+
+/* ── dashboard · step 2: customize (Custom mode + add/drag widgets) ────── */
+
+function DashboardCustomize() {
+  return (
+    <Frame
+      topbar={
+        <>
+          <Ln w="22%" />
+          <span className="ml-auto flex items-center gap-1 rounded p-0.5" style={{ background: 'var(--iv-line-3)' }}>
+            <span className="rounded px-1.5 py-0.5 font-mono text-[8px]" style={{ color: 'var(--iv-text-3)' }}>
+              Classic
+            </span>
+            <span className="rounded px-1.5 py-0.5 font-mono text-[8px] text-white" style={{ background: 'var(--iv-blue-deep)' }}>
+              Custom
+            </span>
+          </span>
+          <span className="intro-pulse" style={{ width: 5, height: 5 }} />
+        </>
+      }
+    >
+      <div className="flex flex-1 flex-col gap-1.5">
+        <TickerStrip />
+        <div className="grid flex-1 auto-rows-fr grid-cols-3 gap-1.5">
+          <Region delay={0.22} className="flex flex-col gap-1.5 p-1.5">
+            <Ln w="50%" h={4} c="var(--iv-line-2)" />
+            <Ln w="84%" />
+            <Ln w="62%" />
+          </Region>
+          {/* widget mid-drag — rotation sits on a static wrapper because
+              intro-rv animates `transform` and would override it */}
+          <div className="rotate-[-2deg]">
+            <Region hot delay={0.32} className="flex h-full flex-col gap-1.5 p-1.5">
+              <div className="flex items-center justify-between">
+                <Ln w="44%" h={4} c="var(--iv-line-2)" />
+                <Tag>drag</Tag>
+              </div>
+              <Ln w="78%" />
+              <Ln w="56%" />
+            </Region>
+          </div>
+          <Region dashed delay={0.42} className="flex items-center justify-center gap-1 p-1.5">
+            <Plus className="h-3 w-3" style={{ color: 'var(--iv-text-3)' }} />
+            <Ln w="36%" />
+          </Region>
+        </div>
+      </div>
+    </Frame>
+  );
+}
+
+/* ── dashboard · step 3: clip a row into chat context ──────────────────── */
+
+function DashboardAttach() {
+  return (
+    <Frame topbar={<Ln w="30%" />}>
+      <div className="flex flex-1 flex-col gap-1.5">
+        <div className="flex flex-1 gap-1.5">
+          {/* news widget with the paperclip row */}
+          <Region hot delay={0.12} className="flex flex-[1.5] flex-col gap-1.5 p-2">
+            <Ln w="34%" h={4} c="var(--iv-line-2)" />
+            <div className="flex items-center gap-2">
+              <div className="flex min-w-0 flex-1 flex-col gap-1">
+                <Ln w="92%" />
+                <Ln w="64%" />
+              </div>
+              <span className="relative flex h-5 w-5 shrink-0 items-center justify-center rounded-full" style={{ background: 'rgba(90,130,216,0.25)' }}>
+                <Paperclip className="h-2.5 w-2.5" style={{ color: 'var(--iv-blue)' }} />
+                <span className="intro-pulse intro-pulse--blue absolute -right-0.5 -top-0.5" style={{ width: 5, height: 5 }} />
+              </span>
+            </div>
+            <Ln w="84%" />
+            <Ln w="70%" />
+          </Region>
+          <Watchlist delay={0.24} className="flex-1" />
+        </div>
+        {/* chat dock receiving the clipped row */}
+        <InputDock
+          hot
+          delay={0.36}
+          chip={
+            /* right-aligned: this scene bleeds off the left edge */
+            <span className="ml-auto flex w-fit items-center gap-1 rounded px-1.5 py-0.5" style={{ background: 'rgba(90,130,216,0.2)' }}>
+              <Paperclip className="h-2 w-2" style={{ color: 'var(--iv-blue)' }} />
+              <span className="font-mono text-[8px]" style={{ color: 'var(--iv-blue)' }}>
+                attached
+              </span>
+            </span>
+          }
+        />
+      </div>
+    </Frame>
+  );
+}
+
+export const INTRO_VISUALS: Record<IntroVisualId, () => ReactNode> = {
+  twoModes: TwoModes,
+  workspaceGrid: WorkspaceGrid,
+  flashAnswer: FlashAnswer,
+  ptcSandbox: PtcSandbox,
+  createWorkspace: CreateWorkspace,
+  filePanel: FilePanel,
+  memory: Memory,
+  memo: Memo,
+  dashboardGrid: DashboardGrid,
+  dashboardCustomize: DashboardCustomize,
+  dashboardAttach: DashboardAttach,
+};
+
+/**
+ * The mockup is rendered oversized and bleeds off one edge of the visual
+ * panel (landing-page style). The anchored side stays fully visible, so each
+ * scene anchors the side its hot region lives on; the other side crops.
+ */
+export const INTRO_VISUAL_ANCHOR: Record<IntroVisualId, 'left' | 'right' | 'center'> = {
+  // centered: symmetric comparison, fades its own edges
+  twoModes: 'center',
+  workspaceGrid: 'left',
+  flashAnswer: 'left',
+  ptcSandbox: 'left',
+  // centered: the scene fades its own edges instead of bleeding one side
+  createWorkspace: 'center',
+  filePanel: 'right',
+  memory: 'right',
+  memo: 'right',
+  dashboardGrid: 'left',
+  dashboardCustomize: 'right',
+  dashboardAttach: 'right',
+};

--- a/web/src/pages/Onboarding/engine/pageIntro.css
+++ b/web/src/pages/Onboarding/engine/pageIntro.css
@@ -1,0 +1,271 @@
+/*
+ * Page-intro modal visual panel — blueprint style lifted from the
+ * ginlix-platform landing page: blue radial glow, faint drafting grid, teal
+ * pulse accents, mono-labelled product mockups. The panel follows the app
+ * theme: near-black blueprint in dark mode, paper-light in light mode. All
+ * surface/line colors below are tokens so the scenes render in both.
+ */
+
+.intro-visual {
+  --iv-blue: #5a82d8;
+  --iv-blue-deep: #4161a4;
+  --iv-teal: #0fedbe;
+  --iv-amber: #ffc400;
+  --iv-red: #ff6b6e;
+  --iv-edge: rgba(232, 238, 248, 0.55);
+  --iv-text: rgba(255, 255, 255, 0.86);
+  --iv-text-2: rgba(255, 255, 255, 0.6);
+  --iv-text-3: rgba(255, 255, 255, 0.36);
+  /* wireframe surfaces + skeleton lines */
+  --iv-line: rgba(255, 255, 255, 0.14);
+  --iv-line-2: rgba(255, 255, 255, 0.3);
+  --iv-line-3: rgba(255, 255, 255, 0.1);
+  --iv-border: rgba(255, 255, 255, 0.08);
+  --iv-fill: rgba(255, 255, 255, 0.13);
+  --iv-grid: rgba(232, 238, 248, 0.05);
+  --iv-mk-bg: rgba(10, 11, 14, 0.82);
+  --iv-mk-border: rgba(255, 255, 255, 0.12);
+  --iv-mk-shadow: 0 16px 44px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(90, 130, 216, 0.07);
+  --iv-region-bg: rgba(255, 255, 255, 0.03);
+  --iv-ease: cubic-bezier(0.16, 1, 0.3, 1);
+
+  position: relative;
+  overflow: hidden;
+  background:
+    radial-gradient(ellipse 95% 70% at 78% 12%, rgba(65, 97, 164, 0.4), transparent 70%),
+    radial-gradient(ellipse 70% 55% at 18% 112%, rgba(15, 237, 190, 0.1), transparent 70%),
+    #060709;
+  color: var(--iv-text);
+}
+
+/* Light theme: paper panel, ink lines, accents darkened for contrast. */
+[data-theme='light'] .intro-visual {
+  --iv-teal: #0a9f7c;
+  --iv-amber: #c27c00;
+  --iv-red: #d8494c;
+  --iv-text: rgba(18, 22, 30, 0.88);
+  --iv-text-2: rgba(18, 22, 30, 0.62);
+  --iv-text-3: rgba(18, 22, 30, 0.4);
+  --iv-line: rgba(18, 22, 30, 0.14);
+  --iv-line-2: rgba(18, 22, 30, 0.34);
+  --iv-line-3: rgba(18, 22, 30, 0.1);
+  --iv-border: rgba(18, 22, 30, 0.1);
+  --iv-fill: rgba(18, 22, 30, 0.14);
+  --iv-grid: rgba(18, 22, 30, 0.05);
+  --iv-mk-bg: rgba(255, 255, 255, 0.9);
+  --iv-mk-border: rgba(18, 22, 30, 0.12);
+  --iv-mk-shadow: 0 16px 44px rgba(18, 22, 30, 0.14), 0 0 0 1px rgba(90, 130, 216, 0.08);
+  --iv-region-bg: rgba(18, 22, 30, 0.03);
+
+  background:
+    radial-gradient(ellipse 95% 70% at 78% 12%, rgba(90, 130, 216, 0.16), transparent 70%),
+    radial-gradient(ellipse 70% 55% at 18% 112%, rgba(10, 159, 124, 0.08), transparent 70%),
+    #f4f1ea;
+}
+
+/* Radix's built-in close button sits over the visual panel — follow the
+   panel's theme rather than the default dialog foreground. */
+.intro-dialog > button {
+  color: rgba(255, 255, 255, 0.7);
+}
+.intro-dialog > button:hover {
+  color: #fff;
+}
+[data-theme='light'] .intro-dialog > button {
+  color: rgba(18, 22, 30, 0.55);
+}
+[data-theme='light'] .intro-dialog > button:hover {
+  color: rgba(18, 22, 30, 0.85);
+}
+
+/* Drafting grid, faded toward the edges. */
+.intro-visual::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(var(--iv-grid) 1px, transparent 1px),
+    linear-gradient(90deg, var(--iv-grid) 1px, transparent 1px);
+  background-size: 28px 28px;
+  -webkit-mask-image: radial-gradient(ellipse 95% 85% at 55% 42%, black 25%, transparent 78%);
+  mask-image: radial-gradient(ellipse 95% 85% at 55% 42%, black 25%, transparent 78%);
+  pointer-events: none;
+}
+
+/* Mockup card — landing `.mk` style. */
+.intro-mk {
+  position: relative;
+  border: 1px solid var(--iv-mk-border);
+  border-radius: 10px;
+  background: var(--iv-mk-bg);
+  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
+  box-shadow: var(--iv-mk-shadow);
+}
+
+.intro-mk--accent {
+  border-color: rgba(90, 130, 216, 0.55);
+  box-shadow: var(--iv-mk-shadow), 0 0 18px rgba(90, 130, 216, 0.28);
+}
+
+/* A region inside the zoomed-out page wireframe. Dim by default; `--hot`
+   marks the area the current step is talking about. */
+.intro-region {
+  border: 1px solid var(--iv-border);
+  border-radius: 8px;
+  background: var(--iv-region-bg);
+}
+
+.intro-region--hot {
+  border-color: rgba(90, 130, 216, 0.6);
+  background: rgba(90, 130, 216, 0.07);
+  box-shadow: 0 0 14px rgba(90, 130, 216, 0.22);
+}
+
+.intro-region--dashed {
+  border-style: dashed;
+  background: transparent;
+}
+
+/* Staggered reveal — set `--rv` per element. */
+.intro-rv {
+  animation: intro-rv-enter 0.65s var(--iv-ease, cubic-bezier(0.16, 1, 0.3, 1)) both;
+  animation-delay: var(--rv, 0s);
+}
+
+@keyframes intro-rv-enter {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Bars growing from the baseline (mini charts). */
+.intro-bar {
+  transform-origin: bottom;
+  animation: intro-bar-grow 0.7s var(--iv-ease) both;
+  animation-delay: var(--rv, 0s);
+}
+
+@keyframes intro-bar-grow {
+  from {
+    transform: scaleY(0.12);
+    opacity: 0.35;
+  }
+  to {
+    transform: scaleY(1);
+    opacity: 1;
+  }
+}
+
+/* Sparkline wire-draw — landing `bp-wire-draw`. */
+.intro-wire {
+  stroke-dasharray: 240;
+  stroke-dashoffset: 240;
+  animation: intro-wire-draw 1.1s var(--iv-ease) both;
+  animation-delay: var(--rv, 0.15s);
+}
+
+@keyframes intro-wire-draw {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
+/* Teal attention dot — landing `la-pulse`. */
+.intro-pulse {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--iv-teal);
+  box-shadow: 0 0 0 0 rgba(15, 237, 190, 0.55);
+  animation: intro-pulse 2s var(--iv-ease) infinite;
+}
+
+.intro-pulse--blue {
+  background: var(--iv-blue);
+  box-shadow: 0 0 0 0 rgba(90, 130, 216, 0.6);
+  animation-name: intro-pulse-blue;
+}
+
+@keyframes intro-pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(15, 237, 190, 0.55);
+  }
+  70% {
+    box-shadow: 0 0 0 10px rgba(15, 237, 190, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(15, 237, 190, 0);
+  }
+}
+
+@keyframes intro-pulse-blue {
+  0% {
+    box-shadow: 0 0 0 0 rgba(90, 130, 216, 0.6);
+  }
+  70% {
+    box-shadow: 0 0 0 10px rgba(90, 130, 216, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(90, 130, 216, 0);
+  }
+}
+
+/* One-shot click ripple — fired by the scripted cursor in a scene. */
+.intro-click {
+  border-radius: 50%;
+  border: 1.5px solid var(--iv-blue);
+  opacity: 0;
+  animation: intro-click 0.55s var(--iv-ease) both;
+  animation-delay: var(--rv, 0s);
+}
+
+@keyframes intro-click {
+  0% {
+    transform: scale(0.3);
+    opacity: 0;
+  }
+  25% {
+    opacity: 0.9;
+  }
+  100% {
+    transform: scale(1.7);
+    opacity: 0;
+  }
+}
+
+/* Element popping in after a scripted click (e.g. the created modal). */
+.intro-pop {
+  animation: intro-pop 0.45s var(--iv-ease) both;
+  animation-delay: var(--rv, 0s);
+}
+
+@keyframes intro-pop {
+  from {
+    opacity: 0;
+    transform: scale(0.9);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .intro-rv,
+  .intro-bar,
+  .intro-wire,
+  .intro-pulse,
+  .intro-click,
+  .intro-pop {
+    animation: none;
+  }
+  .intro-wire {
+    stroke-dashoffset: 0;
+  }
+}

--- a/web/src/pages/Onboarding/engine/useOnboardingOrchestrator.ts
+++ b/web/src/pages/Onboarding/engine/useOnboardingOrchestrator.ts
@@ -60,6 +60,10 @@ export function useOnboardingOrchestrator(p: OrchestratorParams): void {
       p.showWhatsNew();
       return;
     }
+    // showPageIntro / showWhatsNew are intentionally omitted: the provider
+    // recreates them every render in lockstep with eligibleIntroId / phase
+    // (both deps below), so the effect always re-runs with a fresh closure.
+    // Listing them would just re-fire on every render with no behavior change.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [p.isLoading, p.phase, p.eligibleIntroId, p.hasUnseenWhatsNew, p.suppress, p.pathname]);
 }

--- a/web/src/pages/Onboarding/engine/useOnboardingOrchestrator.ts
+++ b/web/src/pages/Onboarding/engine/useOnboardingOrchestrator.ts
@@ -1,0 +1,65 @@
+import { useEffect, useRef } from 'react';
+
+export type OnboardingPhase = 'idle' | 'pageIntro' | 'whatsNew';
+
+interface OrchestratorParams {
+  isLoading: boolean;
+  phase: OnboardingPhase;
+  /**
+   * Drives intro matching upstream, and doubles as the effect re-trigger: the
+   * hard suppressors below (open app dialog, personalization banner) can block
+   * at the moment prefs resolve, and their clearing doesn't change any other
+   * dep — without re-evaluating on navigation a deferred popup would never get
+   * a second chance this session.
+   */
+  pathname: string;
+  /**
+   * The first intro matching the current route that neither the server prefs,
+   * the localStorage mirror, nor this session has seen — null when none.
+   * Computed by the provider; the mirror can only suppress, never trigger.
+   */
+  eligibleIntroId: string | null;
+  hasUnseenWhatsNew: boolean;
+  /** True when another flow (e.g. the personalization banner) owns the screen. */
+  suppress: boolean;
+  showPageIntro: () => void;
+  showWhatsNew: () => void;
+}
+
+/**
+ * Decides what to show once prefs resolve. Runs only when idle (an open popup
+ * owns the screen). Order: hard suppressors → page intro for the current
+ * route → What's-New (once/session). New users are stamped caught-up, so they
+ * get intros and no What's-New backlog; the two are mutually exclusive in
+ * practice.
+ */
+export function useOnboardingOrchestrator(p: OrchestratorParams): void {
+  const whatsNewShownRef = useRef(false);
+
+  useEffect(() => {
+    if (p.isLoading || p.phase !== 'idle') return;
+
+    // Hard suppressors.
+    if (p.suppress) return;
+    if (
+      typeof document !== 'undefined' &&
+      document.querySelector('[role="dialog"][data-state="open"]')
+    ) {
+      return;
+    }
+
+    // Contextual intro for the page the user just landed on.
+    if (p.eligibleIntroId !== null) {
+      p.showPageIntro();
+      return;
+    }
+
+    // What's-New: returning users, once per session.
+    if (!whatsNewShownRef.current && p.hasUnseenWhatsNew) {
+      whatsNewShownRef.current = true;
+      p.showWhatsNew();
+      return;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [p.isLoading, p.phase, p.eligibleIntroId, p.hasUnseenWhatsNew, p.suppress, p.pathname]);
+}

--- a/web/src/pages/Onboarding/engine/whatsNew.ts
+++ b/web/src/pages/Onboarding/engine/whatsNew.ts
@@ -3,10 +3,9 @@ import type { OnboardingPrefs } from '../types';
 
 /** Parse CalVer 'YYYY.MM.DD[.N]' into a numeric tuple for total ordering. */
 function parseVersion(v: string): number[] {
-  return v.split('.').map((part) => {
-    const n = parseInt(part, 10);
-    return Number.isFinite(n) ? n : 0;
-  });
+  // Only pure-digit segments count — a malformed part like '04beta' is treated
+  // as 0, not silently parsed to 4 (parseInt would stop at the first letter).
+  return v.split('.').map((part) => (/^\d+$/.test(part) ? parseInt(part, 10) : 0));
 }
 
 /** Total order over calendar-ish release strings. <0, 0, >0 like a comparator. */

--- a/web/src/pages/Onboarding/engine/whatsNew.ts
+++ b/web/src/pages/Onboarding/engine/whatsNew.ts
@@ -1,0 +1,48 @@
+import type { AnnouncementDef } from '../registry/types';
+import type { OnboardingPrefs } from '../types';
+
+/** Parse CalVer 'YYYY.MM.DD[.N]' into a numeric tuple for total ordering. */
+function parseVersion(v: string): number[] {
+  return v.split('.').map((part) => {
+    const n = parseInt(part, 10);
+    return Number.isFinite(n) ? n : 0;
+  });
+}
+
+/** Total order over calendar-ish release strings. <0, 0, >0 like a comparator. */
+export function compareReleaseVersions(a: string, b: string): number {
+  const pa = parseVersion(a);
+  const pb = parseVersion(b);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (diff !== 0) return diff < 0 ? -1 : 1;
+  }
+  return 0;
+}
+
+/** Highest release version across all announcements, or null if none. */
+export function latestReleaseVersion(announcements: AnnouncementDef[]): string | null {
+  let max: string | null = null;
+  for (const a of announcements) {
+    if (max === null || compareReleaseVersions(a.releaseVersion, max) > 0) max = a.releaseVersion;
+  }
+  return max;
+}
+
+/**
+ * Announcements newer than the user's acknowledged version, sorted newest-first.
+ * A user with `lastSeenReleaseVersion === null` (pre-stamp window) gets nothing —
+ * `ensureFirstRun` stamps new users caught-up so they see the page intros, not
+ * a backlog. Acknowledging the modal bumps `lastSeenReleaseVersion`, which is the
+ * only dismissal mechanism (no per-announcement state needed).
+ */
+export function unseenReleases(
+  prefs: OnboardingPrefs,
+  announcements: AnnouncementDef[]
+): AnnouncementDef[] {
+  const since = prefs.lastSeenReleaseVersion;
+  return announcements
+    .filter((a) => (since === null ? false : compareReleaseVersions(a.releaseVersion, since) > 0))
+    .sort((x, y) => compareReleaseVersions(y.releaseVersion, x.releaseVersion));
+}

--- a/web/src/pages/Onboarding/index.ts
+++ b/web/src/pages/Onboarding/index.ts
@@ -1,0 +1,5 @@
+// OnboardingHost is intentionally NOT re-exported: it pulls the heavy modal +
+// visuals graph. OnboardingHostGate lazy-imports it on demand, so the chunk is
+// never fetched in a session where no onboarding surface shows.
+export { OnboardingProvider, useOnboarding } from './OnboardingProvider';
+export { OnboardingHostGate } from './OnboardingHostGate';

--- a/web/src/pages/Onboarding/mirror.ts
+++ b/web/src/pages/Onboarding/mirror.ts
@@ -1,5 +1,5 @@
 import { safeLocalStorage } from '@/lib/utils';
-import type { OnboardingPrefs } from './types';
+import { ONBOARDING_PREFS_VERSION, type OnboardingPrefs } from './types';
 
 /**
  * Non-authoritative localStorage projection of the server prefs, read
@@ -12,7 +12,10 @@ import type { OnboardingPrefs } from './types';
  * userId is a no-op/null read — suppress-only means that's always safe.
  */
 
-const MIRROR_KEY_PREFIX = 'langalpha-onboarding-v1';
+// Versioned with the prefs shape: bumping ONBOARDING_PREFS_VERSION changes the
+// key, so a stale mirror from an older shape is silently ignored (read as null)
+// rather than mis-suppressing — safe because the mirror is suppress-only.
+const MIRROR_KEY_PREFIX = `langalpha-onboarding-v${ONBOARDING_PREFS_VERSION}`;
 
 function mirrorKey(userId: string): string {
   return `${MIRROR_KEY_PREFIX}:${userId}`;

--- a/web/src/pages/Onboarding/mirror.ts
+++ b/web/src/pages/Onboarding/mirror.ts
@@ -1,0 +1,69 @@
+import { safeLocalStorage } from '@/lib/utils';
+import type { OnboardingPrefs } from './types';
+
+/**
+ * Non-authoritative localStorage projection of the server prefs, read
+ * synchronously before the prefs GET resolves. Invariant: it can only
+ * SUPPRESS a page intro (already seen), never trigger one — so a stale
+ * mirror can at worst delay a popup, never spuriously launch it.
+ *
+ * Keyed per user: on a shared browser, user B must not inherit user A's
+ * seen-state (logout clears the query cache but not localStorage). A falsy
+ * userId is a no-op/null read — suppress-only means that's always safe.
+ */
+
+const MIRROR_KEY_PREFIX = 'langalpha-onboarding-v1';
+
+function mirrorKey(userId: string): string {
+  return `${MIRROR_KEY_PREFIX}:${userId}`;
+}
+
+export interface OnboardingMirror {
+  pageIntrosSeen: Record<string, number>;
+  // Only pageIntrosSeen is read today; the two below are mirrored for a future
+  // anti-flash gate on What's-New. Don't treat them as load-bearing.
+  lastSeenReleaseVersion: string | null;
+  firstRunAt: number | null;
+}
+
+function coerceEpochMap(value: unknown): Record<string, number> {
+  if (!value || typeof value !== 'object') return {};
+  const out: Record<string, number> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof v === 'number') out[k] = v;
+  }
+  return out;
+}
+
+export function readMirror(userId: string | null | undefined): OnboardingMirror | null {
+  if (!userId) return null;
+  const raw = safeLocalStorage.getItem(mirrorKey(userId));
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<OnboardingMirror> | null;
+    if (!parsed || typeof parsed !== 'object') return null;
+    return {
+      pageIntrosSeen: coerceEpochMap(parsed.pageIntrosSeen),
+      lastSeenReleaseVersion:
+        typeof parsed.lastSeenReleaseVersion === 'string' ? parsed.lastSeenReleaseVersion : null,
+      firstRunAt: typeof parsed.firstRunAt === 'number' ? parsed.firstRunAt : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function writeMirror(userId: string | null | undefined, prefs: OnboardingPrefs): void {
+  if (!userId) return;
+  const mirror: OnboardingMirror = {
+    pageIntrosSeen: prefs.pageIntrosSeen,
+    lastSeenReleaseVersion: prefs.lastSeenReleaseVersion,
+    firstRunAt: prefs.firstRunAt,
+  };
+  safeLocalStorage.setItem(mirrorKey(userId), JSON.stringify(mirror));
+}
+
+export function clearMirror(userId: string | null | undefined): void {
+  if (!userId) return;
+  safeLocalStorage.removeItem(mirrorKey(userId));
+}

--- a/web/src/pages/Onboarding/onboardingPrefsSchema.ts
+++ b/web/src/pages/Onboarding/onboardingPrefsSchema.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+import { ONBOARDING_PREFS_VERSION, type OnboardingPrefs } from './types';
+
+/**
+ * Zod-at-the-boundary, mirroring the dashboard prefs precedent
+ * (`widgets/framework/configSchemas.ts`): per-field `.catch()` recovers
+ * individual bad values, and a non-object blob falls back to empty prefs. Never
+ * throws.
+ */
+
+// Per-entry recovery: one corrupt value drops only its key. A whole-record
+// `.catch({})` would discard the entire map on a single bad entry — re-popping
+// every page intro / un-checking every task a user has already cleared.
+const epochMap = z
+  .record(z.string(), z.unknown())
+  .catch({})
+  .transform(
+    (m) =>
+      Object.fromEntries(
+        Object.entries(m).filter(
+          ([, v]) => typeof v === 'number' && Number.isInteger(v) && v >= 0
+        )
+      ) as Record<string, number>
+  );
+
+const OnboardingPrefsSchema = z.object({
+  version: z.literal(ONBOARDING_PREFS_VERSION).catch(ONBOARDING_PREFS_VERSION),
+  pageIntrosSeen: epochMap,
+  gettingStartedDoneAt: epochMap,
+  gettingStartedDismissedAt: z.number().int().nonnegative().nullable().catch(null),
+  lastSeenReleaseVersion: z.string().min(1).nullable().catch(null),
+  firstRunAt: z.number().int().nonnegative().nullable().catch(null),
+});
+
+export function emptyOnboardingPrefs(): OnboardingPrefs {
+  return {
+    version: ONBOARDING_PREFS_VERSION,
+    pageIntrosSeen: {},
+    gettingStartedDoneAt: {},
+    gettingStartedDismissedAt: null,
+    lastSeenReleaseVersion: null,
+    firstRunAt: null,
+  };
+}
+
+/**
+ * Bring any stored onboarding prefs up to the current shape. Never throws;
+ * returns a complete, valid object even from `undefined` or garbage.
+ */
+export function migrateOnboardingPrefs(raw: unknown): OnboardingPrefs {
+  const parsed = OnboardingPrefsSchema.safeParse(raw ?? {});
+  return parsed.success ? (parsed.data as OnboardingPrefs) : emptyOnboardingPrefs();
+}

--- a/web/src/pages/Onboarding/onboardingPrefsWriter.ts
+++ b/web/src/pages/Onboarding/onboardingPrefsWriter.ts
@@ -113,7 +113,7 @@ export function useOnboardingPrefsWriter() {
         }
       );
     },
-    [mutate, queryClient, currentUserId]
+    [mutate, currentUserId]
   );
 
   const writeOnboardingPrefs = useCallback(

--- a/web/src/pages/Onboarding/onboardingPrefsWriter.ts
+++ b/web/src/pages/Onboarding/onboardingPrefsWriter.ts
@@ -92,15 +92,23 @@ export function useOnboardingPrefsWriter() {
           onSuccess: () => {
             writeMirror(currentUserId(), resolved);
             bcRef.current?.postMessage({ type: 'updated' });
-            for (const cb of batch.onSuccess) cb();
-            settle();
+            // settle() in finally: a throwing callback must not strand the
+            // queue with inFlightRef stuck true (no further write would send).
+            try {
+              for (const cb of batch.onSuccess) cb();
+            } finally {
+              settle();
+            }
           },
           onError: (err) => {
             // No mirror write, no broadcast — and `settle` drops the rejected
             // payload once idle, so a failed write can't be silently re-sent
             // on top of fresh server state by a later unrelated write.
-            for (const cb of batch.onError) cb(err);
-            settle();
+            try {
+              for (const cb of batch.onError) cb(err);
+            } finally {
+              settle();
+            }
           },
         }
       );

--- a/web/src/pages/Onboarding/onboardingPrefsWriter.ts
+++ b/web/src/pages/Onboarding/onboardingPrefsWriter.ts
@@ -1,0 +1,157 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useUpdatePreferences } from '@/hooks/useUpdatePreferences';
+import { queryKeys } from '@/lib/queryKeys';
+import type { UserPreferences } from '@/types/api';
+import type { OnboardingPrefs } from './types';
+import { migrateOnboardingPrefs } from './onboardingPrefsSchema';
+import { writeMirror, clearMirror } from './mirror';
+
+const ONBOARDING_BROADCAST_CHANNEL = 'onboarding-prefs';
+
+interface PendingBatch {
+  onSuccess: Array<() => void>;
+  onError: Array<(err: unknown) => void>;
+}
+
+/**
+ * Single writer for `other_preference.onboarding`. The PUT carries ONLY the
+ * onboarding key: the backend shallow-merges top-level `other_preference`
+ * keys (JSONB `||`), so sibling keys (dashboard, theme, locale) are preserved
+ * server-side — re-sending them from this tab's cache would replay a stale
+ * sibling over a newer write from another tab.
+ *
+ * The cold-cache refusal protects the onboarding key itself: the server
+ * replaces `onboarding` wholesale, and a functional update applied to an
+ * unknown current state would erase previously-seen intros/tasks.
+ *
+ * One PUT in flight at a time: writes that arrive mid-flight coalesce into a
+ * single trailing PUT carrying the accumulated state. Full-object writes
+ * therefore commit strictly in order — a slow early response can't erase a
+ * later write's fields server-side.
+ */
+export function useOnboardingPrefsWriter() {
+  // Destructure `mutate` (stable across renders) rather than depending on the
+  // whole mutation result object (new identity every render) — otherwise the
+  // writer callback churns and destabilizes every downstream callback.
+  const { mutate } = useUpdatePreferences();
+  const queryClient = useQueryClient();
+
+  // Accumulated onboarding state of the in-flight PUT (plus writes coalesced
+  // behind it). Trusted ONLY while a write is in flight: useUpdatePreferences
+  // syncs the cache to server truth on settle (setQueryData on success,
+  // invalidate on error), so once idle the cache is authoritative again and
+  // external changes — another tab's write, a Settings preferences reset —
+  // are picked up instead of being clobbered by a stale local copy.
+  const lastWrittenRef = useRef<OnboardingPrefs | null>(null);
+  const inFlightRef = useRef(false);
+  const pendingRef = useRef<PendingBatch | null>(null);
+
+  const bcRef = useRef<BroadcastChannel | null>(null);
+  useEffect(() => {
+    if (typeof BroadcastChannel === 'undefined') return;
+    const chan = new BroadcastChannel(ONBOARDING_BROADCAST_CHANNEL);
+    bcRef.current = chan;
+    // Listen on the same channel we post to (a channel never receives its own
+    // messages, so this only fires for OTHER tabs): invalidate prefs so a tab
+    // that didn't make the write pulls the fresh onboarding state instead of
+    // re-opening a popup another tab already dismissed. Mirrors useDashboardPrefs.
+    chan.onmessage = (e: MessageEvent) => {
+      if ((e.data as { type?: string } | null)?.type !== 'updated') return;
+      queryClient.invalidateQueries({ queryKey: queryKeys.user.preferences() });
+    };
+    return () => {
+      chan.close();
+      bcRef.current = null;
+    };
+  }, [queryClient]);
+
+  // The mirror is per-user; the user is resolved long before any onboarding
+  // write can happen, so a write-time cache read is sufficient.
+  const currentUserId = useCallback(
+    () =>
+      queryClient.getQueryData<{ user_id?: string }>(queryKeys.user.me())?.user_id ?? null,
+    [queryClient]
+  );
+
+  const send = useCallback(
+    function send() {
+      const batch = pendingRef.current;
+      const resolved = lastWrittenRef.current;
+      if (!batch || resolved === null) return;
+      pendingRef.current = null;
+      inFlightRef.current = true;
+      const settle = () => {
+        inFlightRef.current = false;
+        if (pendingRef.current) send(); // writes coalesced mid-flight → trailing PUT
+        else lastWrittenRef.current = null; // idle: the cache is authoritative again
+      };
+      mutate(
+        { other_preference: { onboarding: resolved } },
+        {
+          onSuccess: () => {
+            writeMirror(currentUserId(), resolved);
+            bcRef.current?.postMessage({ type: 'updated' });
+            for (const cb of batch.onSuccess) cb();
+            settle();
+          },
+          onError: (err) => {
+            // No mirror write, no broadcast — and `settle` drops the rejected
+            // payload once idle, so a failed write can't be silently re-sent
+            // on top of fresh server state by a later unrelated write.
+            for (const cb of batch.onError) cb(err);
+            settle();
+          },
+        }
+      );
+    },
+    [mutate, queryClient, currentUserId]
+  );
+
+  const writeOnboardingPrefs = useCallback(
+    (
+      next: OnboardingPrefs | ((current: OnboardingPrefs) => OnboardingPrefs | null),
+      opts?: {
+        /**
+         * Base for reading the CURRENT onboarding state when the prefs cache
+         * is cold. `null` = treat as a new user (empty state). `undefined` =
+         * cold → refuse the write (an updater applied to unknown state would
+         * clobber the server's onboarding key).
+         */
+        fallbackOther?: Record<string, unknown> | null;
+        /**
+         * Write the localStorage mirror BEFORE the server confirms. The mirror
+         * is suppress-only by design, so this is safe — it just means a failed
+         * PUT can't make the page intro re-nag locally every session.
+         */
+        optimisticMirror?: boolean;
+        /** Remove the local mirror before writing (replay/reset affordances). */
+        clearMirror?: boolean;
+        onSuccess?: () => void;
+        onError?: (err: unknown) => void;
+      }
+    ): boolean => {
+      const fresh = queryClient.getQueryData<UserPreferences>(queryKeys.user.preferences());
+      if (fresh === undefined && opts?.fallbackOther === undefined) return false;
+      const freshOther = (fresh?.other_preference as Record<string, unknown> | undefined) ?? null;
+      const baseOther = freshOther ?? opts?.fallbackOther ?? {};
+      const current =
+        (inFlightRef.current ? lastWrittenRef.current : null) ??
+        migrateOnboardingPrefs(baseOther['onboarding']);
+      const resolved = typeof next === 'function' ? next(current) : next;
+      if (resolved === null) return false; // updater decided it's a no-op
+      if (opts?.clearMirror) clearMirror(currentUserId());
+      lastWrittenRef.current = resolved;
+      if (opts?.optimisticMirror) writeMirror(currentUserId(), resolved);
+      const batch: PendingBatch = pendingRef.current ?? { onSuccess: [], onError: [] };
+      if (opts?.onSuccess) batch.onSuccess.push(opts.onSuccess);
+      if (opts?.onError) batch.onError.push(opts.onError);
+      pendingRef.current = batch;
+      if (!inFlightRef.current) send();
+      return true;
+    },
+    [queryClient, send, currentUserId]
+  );
+
+  return { writeOnboardingPrefs };
+}

--- a/web/src/pages/Onboarding/registry/announcements.ts
+++ b/web/src/pages/Onboarding/registry/announcements.ts
@@ -1,0 +1,23 @@
+import type { AnnouncementDef } from './types';
+
+/**
+ * Feature announcements that drive the versioned "What's New" modal. Adding one
+ * = an entry here + i18n keys under `onboarding.announce.*`.
+ *
+ * Versioning is CalVer `YYYY.MM.DD[.N]`, reserved for large features — routine
+ * releases add no entry and the version stands still. `releaseVersion` is simply
+ * the date the feature ships (matching the GitHub release tag minus the `v`
+ * when one exists, but no tag is required). A new entry must be strictly newer
+ * than the current max across this array — that max is the app's announcement
+ * version (`latestReleaseVersion`), which `ensureFirstRun` stamps on new users.
+ */
+
+const dashboardCustomizeAnnouncement: AnnouncementDef = {
+  key: 'dashboard-custom-mode',
+  // Custom widget layout (#167) + widget framework (#172), released v2026.04.26.
+  releaseVersion: '2026.04.26',
+  modalTitleKey: 'onboarding.announce.dashCustom.modalTitle',
+  modalBodyKey: 'onboarding.announce.dashCustom.modalBody',
+};
+
+export const ANNOUNCEMENTS: AnnouncementDef[] = [dashboardCustomizeAnnouncement];

--- a/web/src/pages/Onboarding/registry/gettingStarted.ts
+++ b/web/src/pages/Onboarding/registry/gettingStarted.ts
@@ -1,0 +1,77 @@
+import type { GettingStartedTaskDef } from './types';
+
+const ACCOUNT_URL = (import.meta.env.VITE_ACCOUNT_URL as string | undefined) || '/account';
+
+/**
+ * The getting-started checklist, in presentation order: tour the pages first,
+ * then the Flash interview, then create a PTC workspace and run a first
+ * research in it, then model configuration, then channel integrations. Tasks
+ * complete via a route visit (stamped into prefs), a derived signal
+ * (`doneWhen`), or — for external destinations — the click itself; clicking a
+ * pending task navigates to `to`.
+ *
+ * The two interview tasks both open the Flash personalization chat: it covers
+ * watchlist/portfolio and preferences in one conversation, but each half has
+ * its own completion signal so a partial interview shows what's still missing.
+ */
+export const GETTING_STARTED_TASKS: GettingStartedTaskDef[] = [
+  {
+    id: 'dashboard',
+    titleKey: 'onboarding.gettingStarted.tasks.dashboard.title',
+    descKey: 'onboarding.gettingStarted.tasks.dashboard.desc',
+    to: '/dashboard',
+    visitRoute: (p) => p === '/dashboard',
+  },
+  {
+    id: 'market',
+    titleKey: 'onboarding.gettingStarted.tasks.market.title',
+    descKey: 'onboarding.gettingStarted.tasks.market.desc',
+    to: '/market',
+    visitRoute: (p) => p === '/market',
+  },
+  {
+    id: 'stocks',
+    titleKey: 'onboarding.gettingStarted.tasks.stocks.title',
+    descKey: 'onboarding.gettingStarted.tasks.stocks.desc',
+    to: '/chat/t/__default__',
+    interview: true,
+    doneWhen: 'hasStocks',
+  },
+  {
+    id: 'preferences',
+    titleKey: 'onboarding.gettingStarted.tasks.preferences.title',
+    descKey: 'onboarding.gettingStarted.tasks.preferences.desc',
+    to: '/chat/t/__default__',
+    interview: true,
+    doneWhen: 'hasPreferences',
+  },
+  {
+    id: 'createWorkspace',
+    titleKey: 'onboarding.gettingStarted.tasks.createWorkspace.title',
+    descKey: 'onboarding.gettingStarted.tasks.createWorkspace.desc',
+    to: '/chat',
+    doneWhen: 'hasWorkspace',
+  },
+  {
+    id: 'firstChat',
+    titleKey: 'onboarding.gettingStarted.tasks.firstChat.title',
+    descKey: 'onboarding.gettingStarted.tasks.firstChat.desc',
+    to: '/chat',
+    visitRoute: (p) => /^\/chat\/t\/(?!__default__)/.test(p),
+  },
+  {
+    id: 'models',
+    titleKey: 'onboarding.gettingStarted.tasks.models.title',
+    descKey: 'onboarding.gettingStarted.tasks.models.desc',
+    to: '/settings?tab=model',
+    visitRoute: (p, s) => p === '/settings' && new URLSearchParams(s).get('tab') === 'model',
+  },
+  {
+    id: 'integrations',
+    titleKey: 'onboarding.gettingStarted.tasks.integrations.title',
+    descKey: 'onboarding.gettingStarted.tasks.integrations.desc',
+    to: `${ACCOUNT_URL}/integrations`,
+    external: true,
+    platformOnly: true,
+  },
+];

--- a/web/src/pages/Onboarding/registry/index.ts
+++ b/web/src/pages/Onboarding/registry/index.ts
@@ -1,0 +1,4 @@
+export { ANNOUNCEMENTS } from './announcements';
+export { PAGE_INTROS } from './pageIntros';
+export { GETTING_STARTED_TASKS } from './gettingStarted';
+export * from './types';

--- a/web/src/pages/Onboarding/registry/pageIntros.ts
+++ b/web/src/pages/Onboarding/registry/pageIntros.ts
@@ -1,0 +1,95 @@
+import type { PageIntroDef } from './types';
+
+/**
+ * One contextual intro per page area, shown the first time the user lands
+ * there (not all at once). Order matters only when several match one route —
+ * the first unseen match wins.
+ */
+export const PAGE_INTROS: PageIntroDef[] = [
+  {
+    id: 'chat',
+    // Workspace gallery + a workspace's thread gallery — where modes are picked.
+    matchRoute: (p) => p === '/chat' || /^\/chat\/(?!t\/)[^/]+$/.test(p),
+    steps: [
+      {
+        id: 'modes',
+        titleKey: 'onboarding.intros.chat.steps.modes.title',
+        bodyKey: 'onboarding.intros.chat.steps.modes.body',
+        visual: 'twoModes',
+      },
+      {
+        id: 'flash',
+        titleKey: 'onboarding.intros.chat.steps.flash.title',
+        bodyKey: 'onboarding.intros.chat.steps.flash.body',
+        visual: 'flashAnswer',
+      },
+      {
+        id: 'ptc',
+        titleKey: 'onboarding.intros.chat.steps.ptc.title',
+        bodyKey: 'onboarding.intros.chat.steps.ptc.body',
+        visual: 'ptcSandbox',
+      },
+      {
+        id: 'workspace',
+        titleKey: 'onboarding.intros.chat.steps.workspace.title',
+        bodyKey: 'onboarding.intros.chat.steps.workspace.body',
+        visual: 'workspaceGrid',
+      },
+      {
+        id: 'create',
+        titleKey: 'onboarding.intros.chat.steps.create.title',
+        bodyKey: 'onboarding.intros.chat.steps.create.body',
+        visual: 'createWorkspace',
+      },
+    ],
+  },
+  {
+    id: 'thread',
+    // Any real thread; the personalization chat (__default__) keeps its own flow.
+    matchRoute: (p) => /^\/chat\/t\/(?!__default__)/.test(p),
+    steps: [
+      {
+        id: 'filePanel',
+        titleKey: 'onboarding.intros.thread.steps.filePanel.title',
+        bodyKey: 'onboarding.intros.thread.steps.filePanel.body',
+        visual: 'filePanel',
+      },
+      {
+        id: 'memory',
+        titleKey: 'onboarding.intros.thread.steps.memory.title',
+        bodyKey: 'onboarding.intros.thread.steps.memory.body',
+        visual: 'memory',
+      },
+      {
+        id: 'memo',
+        titleKey: 'onboarding.intros.thread.steps.memo.title',
+        bodyKey: 'onboarding.intros.thread.steps.memo.body',
+        visual: 'memo',
+      },
+    ],
+  },
+  {
+    id: 'dashboard',
+    matchRoute: (p) => p === '/dashboard',
+    steps: [
+      {
+        id: 'overview',
+        titleKey: 'onboarding.intros.dashboard.steps.overview.title',
+        bodyKey: 'onboarding.intros.dashboard.steps.overview.body',
+        visual: 'dashboardGrid',
+      },
+      {
+        id: 'customize',
+        titleKey: 'onboarding.intros.dashboard.steps.customize.title',
+        bodyKey: 'onboarding.intros.dashboard.steps.customize.body',
+        visual: 'dashboardCustomize',
+      },
+      {
+        id: 'attach',
+        titleKey: 'onboarding.intros.dashboard.steps.attach.title',
+        bodyKey: 'onboarding.intros.dashboard.steps.attach.body',
+        visual: 'dashboardAttach',
+      },
+    ],
+  },
+];

--- a/web/src/pages/Onboarding/registry/types.ts
+++ b/web/src/pages/Onboarding/registry/types.ts
@@ -56,7 +56,8 @@ export interface PageIntroDef {
   id: string;
   /** Which pages this intro belongs to. */
   matchRoute: (pathname: string) => boolean;
-  steps: PageIntroStepDef[];
+  /** At least one step — the modal indexes steps[0], so empty would crash. */
+  steps: [PageIntroStepDef, ...PageIntroStepDef[]];
 }
 
 /** A task on the getting-started checklist card. Copy is i18n keys. */

--- a/web/src/pages/Onboarding/registry/types.ts
+++ b/web/src/pages/Onboarding/registry/types.ts
@@ -1,0 +1,90 @@
+/**
+ * A versioned feature announcement. Drives the "What's New" modal only — copy
+ * is i18n keys under `onboarding.announce.*`. Adding one = this object + i18n
+ * keys; no engine changes.
+ */
+export interface AnnouncementDef {
+  /** Stable identifier (React keys, analytics). Unseen-ness is version-granular. */
+  key: string;
+  /**
+   * CalVer ship date — 'YYYY.MM.DD' with an optional '.N' for same-day releases
+   * (e.g. '2026.04.26'); just the date the feature ships, no git tag or GitHub
+   * release required. The sole driver of unseen-ness: anything newer than the
+   * user's lastSeenReleaseVersion shows, so a new entry must be strictly newer
+   * than the current max or it will NOT surface (users are already stamped at
+   * the max).
+   */
+  releaseVersion: string;
+  modalTitleKey: string;
+  modalBodyKey: string;
+}
+
+/**
+ * Illustration scene rendered in the intro modal's visual panel. Implemented
+ * in `engine/introVisuals.tsx` — the Record there is typed against this union,
+ * so adding an id without a scene is a compile error.
+ */
+export type IntroVisualId =
+  | 'twoModes'
+  | 'workspaceGrid'
+  | 'flashAnswer'
+  | 'ptcSandbox'
+  | 'createWorkspace'
+  | 'filePanel'
+  | 'memory'
+  | 'memo'
+  | 'dashboardGrid'
+  | 'dashboardCustomize'
+  | 'dashboardAttach';
+
+/** One stage of a page intro. Copy is i18n keys under `onboarding.intros.*`. */
+export interface PageIntroStepDef {
+  /** Stable id — React key + i18n path segment. */
+  id: string;
+  titleKey: string;
+  bodyKey: string;
+  visual: IntroVisualId;
+}
+
+/**
+ * A one-time contextual intro, shown the first time the user lands on a
+ * matching page. Multi-stage: each step pairs copy with a mockup scene.
+ * Seen-state is per-intro — closing at any step marks the whole intro seen.
+ */
+export interface PageIntroDef {
+  /** Stable id — keys the per-user seen map in prefs. */
+  id: string;
+  /** Which pages this intro belongs to. */
+  matchRoute: (pathname: string) => boolean;
+  steps: PageIntroStepDef[];
+}
+
+/** A task on the getting-started checklist card. Copy is i18n keys. */
+export interface GettingStartedTaskDef {
+  id: string;
+  titleKey: string;
+  descKey: string;
+  /** Where clicking the task navigates (router path, or a full URL when external). */
+  to: string;
+  /**
+   * Opens the Flash personalization interview instead of a plain navigation —
+   * `/chat/t/__default__` bounces back to /chat unless the flash workspace is
+   * resolved and passed as router state first.
+   */
+  interview?: boolean;
+  /** Cross-app destination: opens in a new tab and is stamped done on click. */
+  external?: boolean;
+  /** Only offered on the hosted platform (e.g. channel integrations). */
+  platformOnly?: boolean;
+  /** Auto-completes when a visited location matches (stamped into prefs). */
+  visitRoute?: (pathname: string, search: string) => boolean;
+  /**
+   * Derived completion signal — live done state without a prefs stamp.
+   * `hasStocks`: watchlist or portfolio has at least one entry (stamped once
+   * true so the lookup stops re-running). `hasWorkspace`: at least one
+   * non-flash workspace exists (also stamped once true). `hasPreferences`:
+   * any risk / investment / agent preference field is filled (never stamped,
+   * so a preferences reset un-checks it).
+   */
+  doneWhen?: 'hasStocks' | 'hasPreferences' | 'hasWorkspace';
+}

--- a/web/src/pages/Onboarding/types.ts
+++ b/web/src/pages/Onboarding/types.ts
@@ -1,0 +1,17 @@
+/** Persisted onboarding state. Lives in `user_preferences.other_preference.onboarding`. */
+
+export const ONBOARDING_PREFS_VERSION = 1 as const;
+
+export interface OnboardingPrefs {
+  version: typeof ONBOARDING_PREFS_VERSION;
+  /** Per-page intro popups already seen: intro id → epoch ms. */
+  pageIntrosSeen: Record<string, number>;
+  /** Getting-started checklist tasks completed: task id → epoch ms. */
+  gettingStartedDoneAt: Record<string, number>;
+  /** When the user hid the getting-started card; null = still visible. */
+  gettingStartedDismissedAt: number | null;
+  /** Highest release version acknowledged in the What's-New modal. */
+  lastSeenReleaseVersion: string | null;
+  /** First time the engine ran for this user; only its presence is used, to gate the one-time caught-up stamp. */
+  firstRunAt: number | null;
+}

--- a/web/src/pages/Onboarding/useOnboardingPrefs.ts
+++ b/web/src/pages/Onboarding/useOnboardingPrefs.ts
@@ -77,10 +77,14 @@ export function useOnboardingPrefs() {
     );
   }, [writeOnboardingPrefs, fallbackOther, isLoading]);
 
-  /** Re-show all page tips and the getting-started card (Settings affordance). */
-  const replayGuides = useCallback(() => {
-    if (isLoading) return;
-    writeOnboardingPrefs(
+  /**
+   * Re-show all page tips and the getting-started card (Settings affordance).
+   * Returns false if the write was refused (cold cache) so the caller can skip
+   * a "done" toast it can't honor — the server state would be unchanged.
+   */
+  const replayGuides = useCallback((): boolean => {
+    if (isLoading) return false;
+    return writeOnboardingPrefs(
       (cur) => ({ ...cur, pageIntrosSeen: {}, gettingStartedDismissedAt: null }),
       { fallbackOther, clearMirror: true }
     );
@@ -119,10 +123,11 @@ export function useOnboardingPrefs() {
     [writeOnboardingPrefs, fallbackOther, isLoading]
   );
 
-  /** Clear all onboarding state ("reset onboarding"). */
-  const resetAll = useCallback(() => {
-    if (isLoading) return;
-    writeOnboardingPrefs(emptyOnboardingPrefs(), { fallbackOther, clearMirror: true });
+  /** Clear all onboarding state ("reset onboarding"). Returns false if the
+   * write was refused (cold cache), so the caller can skip an empty toast. */
+  const resetAll = useCallback((): boolean => {
+    if (isLoading) return false;
+    return writeOnboardingPrefs(emptyOnboardingPrefs(), { fallbackOther, clearMirror: true });
   }, [writeOnboardingPrefs, fallbackOther, isLoading]);
 
   return {

--- a/web/src/pages/Onboarding/useOnboardingPrefs.ts
+++ b/web/src/pages/Onboarding/useOnboardingPrefs.ts
@@ -1,0 +1,139 @@
+import { useCallback, useMemo } from 'react';
+import { usePreferences } from '@/hooks/usePreferences';
+import { migrateOnboardingPrefs, emptyOnboardingPrefs } from './onboardingPrefsSchema';
+import { useOnboardingPrefsWriter } from './onboardingPrefsWriter';
+import type { OnboardingPrefs } from './types';
+
+function readOnboarding(preferences: unknown): unknown {
+  const prefs = preferences as { other_preference?: { onboarding?: unknown } } | null;
+  return prefs?.other_preference?.onboarding;
+}
+
+/**
+ * Reads + migrates `other_preference.onboarding` and exposes the mutators the
+ * engine needs. Every mutator is gated on `isLoading` (cold-cache guard, same
+ * as `useDashboardPrefs.update`) and routed through the guarded writer.
+ */
+export function useOnboardingPrefs() {
+  const { preferences, isLoading } = usePreferences();
+  const { writeOnboardingPrefs } = useOnboardingPrefsWriter();
+
+  const prefs = useMemo<OnboardingPrefs>(
+    () => migrateOnboardingPrefs(readOnboarding(preferences)),
+    [preferences]
+  );
+
+  const fallbackOther =
+    preferences === null
+      ? undefined
+      : ((preferences as { other_preference?: Record<string, unknown> }).other_preference ?? null);
+
+  // Mutators use FUNCTIONAL updates: the writer applies them to the freshest
+  // onboarding state it knows (last in-flight write, else the cache), so two
+  // quick writes (ensureFirstRun then an immediate markPageIntroSeen)
+  // field-merge instead of the second clobbering the first from a stale render.
+
+  /** Mark a page intro as seen so it shows once per page. */
+  const markPageIntroSeen = useCallback(
+    (id: string) => {
+      if (isLoading) return;
+      writeOnboardingPrefs(
+        (cur) =>
+          cur.pageIntrosSeen[id] != null
+            ? null
+            : { ...cur, pageIntrosSeen: { ...cur.pageIntrosSeen, [id]: Date.now() } },
+        // Suppress locally even if the PUT fails — otherwise a flaky save makes
+        // the intro re-nag every session until a write finally lands.
+        { fallbackOther, optimisticMirror: true }
+      );
+    },
+    [writeOnboardingPrefs, fallbackOther, isLoading]
+  );
+
+  /** Stamp a getting-started task complete. */
+  const markTaskDone = useCallback(
+    (id: string) => {
+      if (isLoading) return;
+      writeOnboardingPrefs(
+        (cur) =>
+          cur.gettingStartedDoneAt[id] != null
+            ? null
+            : { ...cur, gettingStartedDoneAt: { ...cur.gettingStartedDoneAt, [id]: Date.now() } },
+        { fallbackOther }
+      );
+    },
+    [writeOnboardingPrefs, fallbackOther, isLoading]
+  );
+
+  /** Hide the getting-started card permanently. */
+  const dismissGettingStarted = useCallback(() => {
+    if (isLoading) return;
+    writeOnboardingPrefs(
+      (cur) =>
+        cur.gettingStartedDismissedAt !== null
+          ? null
+          : { ...cur, gettingStartedDismissedAt: Date.now() },
+      { fallbackOther }
+    );
+  }, [writeOnboardingPrefs, fallbackOther, isLoading]);
+
+  /** Re-show all page tips and the getting-started card (Settings affordance). */
+  const replayGuides = useCallback(() => {
+    if (isLoading) return;
+    writeOnboardingPrefs(
+      (cur) => ({ ...cur, pageIntrosSeen: {}, gettingStartedDismissedAt: null }),
+      { fallbackOther, clearMirror: true }
+    );
+  }, [writeOnboardingPrefs, fallbackOther, isLoading]);
+
+  const setLastSeenReleaseVersion = useCallback(
+    (version: string) => {
+      if (isLoading) return;
+      writeOnboardingPrefs((cur) => ({ ...cur, lastSeenReleaseVersion: version }), {
+        fallbackOther,
+      });
+    },
+    [writeOnboardingPrefs, fallbackOther, isLoading]
+  );
+
+  /**
+   * Set `firstRunAt` once. For a brand-new user (no `lastSeenReleaseVersion`)
+   * we also stamp the current release so they start "caught up" and get the
+   * page intros instead of a What's-New backlog.
+   */
+  const ensureFirstRun = useCallback(
+    (caughtUpVersion: string | null, opts?: { onError?: (err: unknown) => void }): boolean => {
+      if (isLoading) return false;
+      return writeOnboardingPrefs(
+        (cur) =>
+          cur.firstRunAt !== null
+            ? null
+            : {
+                ...cur,
+                firstRunAt: Date.now(),
+                lastSeenReleaseVersion: cur.lastSeenReleaseVersion ?? caughtUpVersion,
+              },
+        { fallbackOther, onError: opts?.onError }
+      );
+    },
+    [writeOnboardingPrefs, fallbackOther, isLoading]
+  );
+
+  /** Clear all onboarding state ("reset onboarding"). */
+  const resetAll = useCallback(() => {
+    if (isLoading) return;
+    writeOnboardingPrefs(emptyOnboardingPrefs(), { fallbackOther, clearMirror: true });
+  }, [writeOnboardingPrefs, fallbackOther, isLoading]);
+
+  return {
+    prefs,
+    isLoading,
+    markPageIntroSeen,
+    markTaskDone,
+    dismissGettingStarted,
+    replayGuides,
+    setLastSeenReleaseVersion,
+    ensureFirstRun,
+    resetAll,
+  };
+}

--- a/web/src/pages/Settings/Settings.tsx
+++ b/web/src/pages/Settings/Settings.tsx
@@ -938,8 +938,7 @@ function Settings() {
                   <button
                     type="button"
                     onClick={() => {
-                      resetOnboarding();
-                      toast({ description: t('onboarding.settings.resetDone') });
+                      if (resetOnboarding()) toast({ description: t('onboarding.settings.resetDone') });
                     }}
                     className="shrink-0 rounded text-xs font-medium transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-primary)]"
                     style={{ color: 'var(--color-text-tertiary)' }}
@@ -951,8 +950,7 @@ function Settings() {
                   <button
                     type="button"
                     onClick={() => {
-                      replayGuides();
-                      toast({ description: t('onboarding.settings.replayDone') });
+                      if (replayGuides()) toast({ description: t('onboarding.settings.replayDone') });
                     }}
                     className="px-3 py-1.5 rounded-md text-xs font-medium transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-primary)]"
                     style={{ border: '1px solid var(--color-border-muted)', color: 'var(--color-text-secondary)' }}

--- a/web/src/pages/Settings/Settings.tsx
+++ b/web/src/pages/Settings/Settings.tsx
@@ -23,6 +23,7 @@ import type { CompactionProfileName } from '@/hooks/useAllModels';
 import { useDebouncedSave } from '@/hooks/useDebouncedSave';
 import { isSupported, setLocaleCookie } from '@/lib/locale';
 import { isPlatformMode } from '@/config/hostMode';
+import { useOnboarding } from '@/pages/Onboarding';
 import './Settings.css';
 
 interface CodexDeviceCode {
@@ -70,6 +71,7 @@ function Settings() {
   const { theme: _theme, preference, setTheme: setThemePref } = useTheme();
   const { models: visibleModels, modelAccessMap, systemDefaults: hookSystemDefaults, validModelNames, compactionProfiles, searchProviders, isLoading: isModelsLoading } = useAllModels();
   const { t, i18n } = useTranslation();
+  const { replayGuides, resetOnboarding } = useOnboarding();
 
   const tabParam = searchParams.get('tab') || 'userInfo';
   const [activeTab, setActiveTab] = useState(tabParam);
@@ -919,6 +921,46 @@ function Settings() {
               <p className="text-xs" style={{ color: 'var(--color-text-tertiary)' }}>
                 {t('settings.preferencesDesc')}
               </p>
+
+              <div
+                className="rounded-md px-4 py-4"
+                style={{ backgroundColor: 'var(--color-bg-card)', border: '1px solid var(--color-border-muted)' }}
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-medium" style={{ color: 'var(--color-text-primary)' }}>
+                      {t('onboarding.settings.sectionTitle')}
+                    </p>
+                    <p className="text-xs mt-0.5" style={{ color: 'var(--color-text-tertiary)' }}>
+                      {t('onboarding.settings.description')}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      resetOnboarding();
+                      toast({ description: t('onboarding.settings.resetDone') });
+                    }}
+                    className="shrink-0 rounded text-xs font-medium transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-primary)]"
+                    style={{ color: 'var(--color-text-tertiary)' }}
+                  >
+                    {t('onboarding.settings.reset')}
+                  </button>
+                </div>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      replayGuides();
+                      toast({ description: t('onboarding.settings.replayDone') });
+                    }}
+                    className="px-3 py-1.5 rounded-md text-xs font-medium transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-primary)]"
+                    style={{ border: '1px solid var(--color-border-muted)', color: 'var(--color-text-secondary)' }}
+                  >
+                    {t('onboarding.settings.replayGuides')}
+                  </button>
+                </div>
+              </div>
 
               {preferences && (preferences.risk_preference || preferences.investment_preference || preferences.agent_preference) ? (
                 <div className="space-y-4">

--- a/web/src/pages/Settings/__tests__/Settings.searchProvider.test.tsx
+++ b/web/src/pages/Settings/__tests__/Settings.searchProvider.test.tsx
@@ -159,6 +159,11 @@ vi.mock('@/pages/ChatAgent/utils/api', () => ({
   getFlashWorkspace: vi.fn(async () => ({ workspace_id: 'ws-flash' })),
 }));
 
+// Onboarding — Settings renders replay/reset buttons; no provider in this harness.
+vi.mock('@/pages/Onboarding', () => ({
+  useOnboarding: () => ({ replayGuides: vi.fn(), resetOnboarding: vi.fn() }),
+}));
+
 // Import after mocks are registered.
 import Settings from '../Settings';
 

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -13,6 +13,10 @@ export interface User {
   has_oauth_token?: boolean;
   access_tier?: number;
   plan_display_name?: string | null;
+  /** Completed the personalization flow (i.e. configured a BYOK key). */
+  personalization_completed?: boolean;
+  /** Completed the legacy first-run onboarding flow. */
+  onboarding_completed?: boolean;
   created_at?: string;
   updated_at?: string;
   [key: string]: unknown;

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -15,6 +15,10 @@ export default defineConfig({
   },
   build: {
     rollupOptions: {
+      // Explicit single entry: dev-only harness pages (e.g. intro-preview.html)
+      // must never ship in the production build, even if a future Vite version
+      // or multi-page config change starts picking up root .html files.
+      input: path.resolve(__dirname, 'index.html'),
       output: {
         manualChunks: {
           'vendor-react': ['react', 'react-dom', 'react-router-dom'],


### PR DESCRIPTION
## Summary

In-app onboarding for new langalpha users: a lightweight modal system that introduces the
product's core surfaces and announces new features. No new runtime dependencies.

**Onboarding**
- Per-page intro modals for chat, thread, and dashboard — multi-step, with illustrated
  mockups, reduced-motion aware, keyboard/focus accessible.
- Persistent "Getting started" checklist card; task completion derived from route visits
  and live signals.
- Versioned "What's New" modal (CalVer), shown once per session for unseen releases.
- State persisted in `user_preferences.other_preference.onboarding` behind a Zod boundary;
  a suppress-only `localStorage` mirror prevents first-paint flash. Mounted in
  `AuthenticatedShell` behind a lazy gate, after the auth/setup early returns. Settings
  gains "Replay guides" / "Reset onboarding".

**Dashboard prefs correctness fix**
- The prefs PUT does a shallow JSONB top-key merge. The dashboard writer was re-sending
  cached sibling keys, which could replay stale values over a newer cross-tab write
  (silent settings revert). It now sends only `{dashboard}` and lets the server preserve
  siblings; the new onboarding writer follows the same minimal-payload rule.

## Diff Size
- Total: 46 files changed, +5209 / −73
- Net (excl. tests): 32 files changed, +3639 / −50

## Test Coverage
AI-assessed ~88% of changed logic-bearing code. State/orchestration layers (schema,
writer, mirror, prefs hook, the provider with 29 scenario tests, orchestrator, what's-new)
are fully covered, including the cross-tab sibling-leak regression. Gaps cluster at thin
mount/wiring edges (OnboardingHost render conditionals, Settings replay/reset buttons
mocked-only, dashboard snooze event dispatch/subscribe) — low logic risk.
Full frontend suite: 131 files / 1479 tests passing. Lint 0 errors, tsc clean.

## Pre-Landing Review
Eng review + adversarial (Claude subagent + Codex) ran at HEAD. All CRITICAL findings
fixed; Codex structured review GATE: PASS; only informational items skipped.

## Design Review
Design (lite) ran on the frontend diff — findings auto-fixed/addressed.

## Eval Results
No prompt-related files changed — evals skipped.

## Plan Completion
Core plan goals delivered: per-page guides (chat/thread/dashboard), the getting-started
checklist, a versioned what's-new modal, and server-persisted seen-state with the
anti-flash mirror and cold-cache-safe writer. Remaining open item is the manual-E2E
walkthrough (see Verification).

## Verification Results
Plan verification is manual fresh-user E2E (requires cleared `langalpha-onboarding-v1` +
reset `other_preference.onboarding`). Deferred to manual; not run automatically.
Production build verified to exclude the dev preview harness (dist/ contains only
index.html; no intro-preview / __preview__ references).

## Test plan
- [x] Frontend: 1479 vitest tests pass (131 files)
- [x] Lint 0 errors; tsc clean
- [x] Production build succeeds; dev harness confirmed excluded from dist/
- [x] Manual: fresh-user walkthrough of chat/thread/dashboard intros; What's-New bump;
      replay/reset from Settings; dark mode; reduced motion


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-step onboarding tours with illustrated visuals, a "What's New" modal, and a getting-started checklist; onboarding is now integrated into the authenticated app, lazily loaded, and can be replayed or reset from Settings.

* **Updates**
  * Dashboard preference saves now send minimal payloads to avoid overwriting user layouts.
  * New onboarding orchestration and cross-tab sync for consistent behavior.

* **Localization**
  * New English onboarding strings; Chinese translations updated to use consistent "Agent" wording.

* **Dev**
  * Dev-only onboarding preview page/entry added.

* **Tests**
  * Extensive test coverage for onboarding flows, persistence, migration, and utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->