### PR TITLE
feat(web): chat streaming lifecycle + navigation polish (+ subagent reasoning separators)

### DIFF
--- a/src/llms/content_utils.py
+++ b/src/llms/content_utils.py
@@ -213,6 +213,32 @@ def _extract_text_from_summary(summary: Any) -> Optional[str]:
     return combined_text if combined_text else None
 
 
+def extract_reasoning_summary_index(content: Any) -> Optional[int]:
+    """Extract the summary_text item index from reasoning content.
+
+    OpenAI Response API streams reasoning chunks where each ``summary_text``
+    item carries an ``index`` (0, 1, 2…) identifying its reasoning "thought
+    step". When that index changes across chunks (e.g. 0→1) a new reasoning
+    section has started, so streaming callers insert a blank-line separator
+    before it — otherwise the next section's ``**Title**`` glues onto the end
+    of the previous section's prose. Returns None when the content is not
+    reasoning or carries no summary index.
+
+    Note: the top-level reasoning dict also has an ``index`` field, but that is
+    the position in the content array (always 0) — NOT the thought-step index.
+    """
+    items = [content] if isinstance(content, dict) else (content if isinstance(content, list) else [])
+    for item in items:
+        if not isinstance(item, dict) or item.get("type") != "reasoning":
+            continue
+        summary = item.get("summary")
+        if isinstance(summary, list):
+            for s in summary:
+                if isinstance(s, dict) and "index" in s:
+                    return s["index"]
+    return None
+
+
 # ============================================================================
 # LangChain Message Content Extraction
 # ============================================================================

--- a/src/ptc_agent/agent/middleware/background_subagent/subagent.py
+++ b/src/ptc_agent/agent/middleware/background_subagent/subagent.py
@@ -26,6 +26,7 @@ from ptc_agent.agent.middleware.background_subagent.middleware import (
 )
 from ptc_agent.agent.middleware.background_subagent.registry import BackgroundTaskRegistry
 from ptc_agent.agent.middleware._utils import append_to_system_message
+from src.llms.content_utils import extract_reasoning_summary_index
 from src.llms.llm import narrow_prompt_cache_key
 from src.server.utils.content_normalizer import normalize_text_content
 
@@ -65,6 +66,12 @@ class _SubagentTokenForwarder:
         self.agent_id = agent_id
         self._reasoning_active = False
         self._last_msg_id: str | None = None
+        # Track the OpenAI reasoning summary_text index to separate sections.
+        # When it changes (0→1) a new reasoning section starts; we prepend a
+        # blank line so its `**Title**` header doesn't glue onto the previous
+        # section's prose. Mirrors WorkflowStreamHandler's main-agent path.
+        self._reasoning_block_index: int | None = None
+        self._reasoning_separator_pending = False
 
     def _signal_record(self, msg_id: str, content: str) -> dict[str, Any]:
         return {
@@ -133,6 +140,30 @@ class _SubagentTokenForwarder:
         if metadata is not None and metadata.get("langgraph_node") == "tools":
             return
 
+        msg_id = message_chunk.id or f"sg-{self.tool_call_id}"
+
+        # A new assistant message begins a fresh reasoning stream — drop any
+        # carried-over section index / pending separator so the first chunk of
+        # the new message isn't falsely prefixed with a blank line.
+        if self._last_msg_id is not None and msg_id != self._last_msg_id:
+            self._reasoning_block_index = None
+            self._reasoning_separator_pending = False
+
+        # Detect reasoning summary_text index transitions (mirror of the main
+        # streaming handler): when the OpenAI summary index changes (0→1) a new
+        # reasoning section started — queue a separator so its `**Title**` header
+        # lands on its own line instead of gluing onto the previous section's
+        # prose. The flag is pending because the index can arrive before the
+        # chunk that carries the new section's first emittable text.
+        reasoning_idx = extract_reasoning_summary_index(message_chunk.content)
+        if reasoning_idx is not None:
+            if (
+                self._reasoning_block_index is not None
+                and reasoning_idx != self._reasoning_block_index
+            ):
+                self._reasoning_separator_pending = True
+            self._reasoning_block_index = reasoning_idx
+
         # Reasoning content can ride on either ``content`` or
         # ``additional_kwargs.reasoning[_content]`` depending on provider.
         text, content_type = normalize_text_content(message_chunk.content)
@@ -145,8 +176,6 @@ class _SubagentTokenForwarder:
             if r_text:
                 text = r_text
                 content_type = "reasoning"
-
-        msg_id = message_chunk.id or f"sg-{self.tool_call_id}"
 
         # New message id with reasoning still active → close out the old one.
         if (
@@ -172,6 +201,14 @@ class _SubagentTokenForwarder:
                     self.tool_call_id, self._signal_record(msg_id, "complete")
                 )
                 self._reasoning_active = False
+                # Reasoning ended — reset section tracking for the next stream.
+                self._reasoning_block_index = None
+                self._reasoning_separator_pending = False
+
+            # Prepend the blank-line separator queued by a section transition.
+            if content_type == "reasoning" and self._reasoning_separator_pending:
+                text = "\n\n" + text
+                self._reasoning_separator_pending = False
 
             await self.registry.append_captured_event(
                 self.tool_call_id,

--- a/src/server/handlers/streaming_handler.py
+++ b/src/server/handlers/streaming_handler.py
@@ -21,6 +21,7 @@ from src.server.utils.content_normalizer import (
     normalize_text_content,
     is_thinking_status_signal,
 )
+from src.llms.content_utils import extract_reasoning_summary_index
 from src.utils.tracking import ExecutionTracker
 from src.config.settings import (
     get_workflow_timeout,
@@ -1329,25 +1330,11 @@ class WorkflowStreamHandler:
     def _extract_reasoning_summary_index(content: Any) -> Optional[int]:
         """Extract the summary_text item index from reasoning content.
 
-        During streaming, OpenAI Response API sends reasoning chunks where each
-        summary_text item has an 'index' field (0, 1, 2...) identifying which
-        reasoning "thought step" it belongs to. When this index changes (e.g., 0→1),
-        a new reasoning thought has started and we need to emit a separator.
-
-        Note: The top-level reasoning dict also has an 'index' field, but that's
-        the position in the content array (always 0) — NOT the thought step index.
+        Thin delegate to ``content_utils.extract_reasoning_summary_index`` —
+        the shared implementation is reused by the subagent token forwarder so
+        both streaming paths separate reasoning sections identically.
         """
-        items = [content] if isinstance(content, dict) else (content if isinstance(content, list) else [])
-        for item in items:
-            if not isinstance(item, dict) or item.get("type") != "reasoning":
-                continue
-            # Extract index from summary_text items (the thought step index)
-            summary = item.get("summary")
-            if isinstance(summary, list):
-                for s in summary:
-                    if isinstance(s, dict) and "index" in s:
-                        return s["index"]
-        return None
+        return extract_reasoning_summary_index(content)
 
     def _format_reasoning_signal(
         self,

--- a/tests/unit/middleware/test_subagent_token_forwarder.py
+++ b/tests/unit/middleware/test_subagent_token_forwarder.py
@@ -150,6 +150,71 @@ async def test_reasoning_lifecycle_emits_inline_start_and_complete_on_transition
     ]
 
 
+def _reasoning_summary(text, index, msg_id="msg-1"):
+    """OpenAI Response API reasoning chunk: a summary_text item carrying the
+    thought-step ``index`` the forwarder uses to detect section boundaries."""
+    return _chunk(
+        {
+            "type": "reasoning",
+            "summary": [{"index": index, "type": "summary_text", "text": text}],
+        },
+        msg_id=msg_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_reasoning_section_transition_inserts_separator():
+    """When the summary_text index advances (0→1) a new reasoning section
+    started: the forwarder must prepend a blank line so the next section's
+    ``**Title**`` header lands on its own line instead of gluing onto the
+    previous section's prose. Mirrors WorkflowStreamHandler's main-agent path."""
+    registry = BackgroundTaskRegistry()
+    task = await _register(registry)
+    fw = _SubagentTokenForwarder(registry, task.tool_call_id, "task:abc")
+
+    await fw.forward(_reasoning_summary("I want to keep things organized!", 0))
+    await fw.forward(_reasoning_summary("**Evaluating DCF Calculation**", 1))
+    await fw.forward(_chunk("here is the answer"))
+    await fw.finalize()
+
+    timeline = [
+        (e["data"].get("content_type"), e["data"].get("content"))
+        for e in task._test_records
+        if e["event"] == "message_chunk"
+    ]
+    assert timeline == [
+        ("reasoning_signal", "start"),
+        ("reasoning", "I want to keep things organized!"),
+        # 0→1 transition → blank line before the new section's title.
+        ("reasoning", "\n\n**Evaluating DCF Calculation**"),
+        ("reasoning_signal", "complete"),
+        ("text", "here is the answer"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_reasoning_same_section_index_no_separator():
+    """Consecutive chunks within the same reasoning section (index unchanged)
+    must NOT gain a separator — only true section boundaries break."""
+    registry = BackgroundTaskRegistry()
+    task = await _register(registry)
+    fw = _SubagentTokenForwarder(registry, task.tool_call_id, "task:abc")
+
+    await fw.forward(_reasoning_summary("Part one ", 0))
+    await fw.forward(_reasoning_summary("continues here.", 0))
+    await fw.finalize()
+
+    contents = [
+        e["data"].get("content")
+        for e in task._test_records
+        if e["event"] == "message_chunk"
+        and e["data"].get("content_type") == "reasoning"
+    ]
+    # No leading "\n\n" on the first chunk (no prior section) or the second
+    # (same index → same section).
+    assert contents == ["Part one ", "continues here."]
+
+
 @pytest.mark.asyncio
 async def test_finalize_closes_dangling_reasoning_signal():
     """If a run ends while reasoning is still active (LLM returned reasoning

--- a/web/package.json
+++ b/web/package.json
@@ -26,6 +26,7 @@
     "@radix-ui/react-hover-card": "^1.1.15",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-toast": "^1.2.5",
+    "@radix-ui/react-tooltip": "^1.2.9",
     "@supabase/ssr": "^0.10.3",
     "@supabase/supabase-js": "^2.106.1",
     "@tanstack/react-query": "^5.90.21",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@radix-ui/react-toast':
         specifier: ^1.2.5
         version: 1.2.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-tooltip':
+        specifier: ^1.2.9
+        version: 1.2.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@supabase/ssr':
         specifier: ^0.10.3
         version: 0.10.3(@supabase/supabase-js@2.106.1)
@@ -777,8 +780,24 @@ packages:
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
+  '@radix-ui/primitive@1.1.4':
+    resolution: {integrity: sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==}
+
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-arrow@1.1.9':
+    resolution: {integrity: sha512-yqHW5WQ/cTpU/un7dqqIKNy2iRU8BC0JB78PEzTfCCYvZu1U6W9KwObAniMk9nhSfyotKPQTYaUD/HB0f5muig==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -812,6 +831,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-compose-refs@1.1.3':
+    resolution: {integrity: sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-context-menu@2.2.16':
     resolution: {integrity: sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==}
     peerDependencies:
@@ -827,6 +855,15 @@ packages:
 
   '@radix-ui/react-context@1.1.2':
     resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.4':
+    resolution: {integrity: sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -858,6 +895,19 @@ packages:
 
   '@radix-ui/react-dismissable-layer@1.1.11':
     resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.12':
+    resolution: {integrity: sha512-MhoruH6xEzsbvOmo4TNgMfmtvRGyDZw4MDSdf4ybMHfezjqwzv6hyd4lsMzBp8K9Sn6sGzCF62x1I7BYUECXOg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -926,6 +976,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-id@1.1.2':
+    resolution: {integrity: sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-menu@2.1.16':
     resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
     peerDependencies:
@@ -965,6 +1024,32 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-popper@1.3.0':
+    resolution: {integrity: sha512-9PB589e1aWZbrlFUHdz6WiPCL+xLZHQFX7oibqG/6Q0SwOkxDyQX9W/cyPa+sAPPKuC8cpLCpRczE5a/1DiwVQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.11':
+    resolution: {integrity: sha512-UEytdjgEh2tJGgD/gZK4FUx6t1rNIlM3U0DENhSrG7I75FGm1DnaDuVUWF1pWAWUwGmn1sCJ1VGHn8LhN1aTOw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-portal@1.1.9':
     resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
     peerDependencies:
@@ -991,8 +1076,34 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-presence@1.1.6':
+    resolution: {integrity: sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-primitive@2.1.3':
     resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.5':
+    resolution: {integrity: sha512-zifXeB8Y88qCYx8PLZ5oQb32KwZub+s925mMoZsBBq9KUQqWKkREubTfs6ASjRPPBe7Jt9O8OHH89+95VG+grA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1026,8 +1137,30 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-slot@1.2.5':
+    resolution: {integrity: sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-toast@1.2.15':
     resolution: {integrity: sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tooltip@1.2.9':
+    resolution: {integrity: sha512-u6F9MmTtBSLkiXNVDrtB/yPCZarM9smNswC24YYLV/M+bth6J3Gs3vlJezEoFwKZvPvxhCpUYdUnOsNG/0XOlA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1048,8 +1181,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-callback-ref@1.1.2':
+    resolution: {integrity: sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-controllable-state@1.2.2':
     resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.3':
+    resolution: {integrity: sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1066,8 +1217,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-effect-event@0.0.3':
+    resolution: {integrity: sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-escape-keydown@1.1.1':
     resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.2':
+    resolution: {integrity: sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1084,6 +1253,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-layout-effect@1.1.2':
+    resolution: {integrity: sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-rect@1.1.1':
     resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
     peerDependencies:
@@ -1093,8 +1271,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-rect@1.1.2':
+    resolution: {integrity: sha512-d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-size@1.1.1':
     resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.2':
+    resolution: {integrity: sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1115,8 +1311,24 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-visually-hidden@1.2.5':
+    resolution: {integrity: sha512-tPcHNI3FajdDBFpl/Ez1m2WL0ufJqBKyHxMDBvKitopamK36WwBGOMicuMEZKkM5Wce41QxUyv6BsiqfrWBiGg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
+
+  '@radix-ui/rect@1.1.2':
+    resolution: {integrity: sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==}
 
   '@react-aria/autocomplete@3.0.0-rc.6':
     resolution: {integrity: sha512-uymUNJ8NW+dX7lmgkHE+SklAbxwktycAJcI5lBBw6KPZyc0EdMHC+/Fc5CUz3enIAhNwd2oxxogcSHknquMzQA==}
@@ -5210,9 +5422,20 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
+  '@radix-ui/primitive@1.1.4': {}
+
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-arrow@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
@@ -5237,6 +5460,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-compose-refs@1.1.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-context-menu@2.2.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -5252,6 +5481,12 @@ snapshots:
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.1.4(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       react: 19.2.4
     optionalDependencies:
@@ -5292,6 +5527,19 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-dismissable-layer@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-escape-keydown': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
@@ -5350,6 +5598,13 @@ snapshots:
   '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-id@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
@@ -5421,6 +5676,34 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-popper@1.3.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-arrow': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-rect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/rect': 1.1.2
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-portal@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -5441,9 +5724,27 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-presence@1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-primitive@2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.5(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
@@ -5474,6 +5775,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-slot@1.2.5(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-toast@1.2.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -5494,7 +5802,33 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-tooltip@1.2.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-popper': 1.3.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.5(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-callback-ref@1.1.2(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       react: 19.2.4
     optionalDependencies:
@@ -5508,9 +5842,24 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-use-controllable-state@1.2.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-effect-event@0.0.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
@@ -5522,7 +5871,20 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-use-escape-keydown@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-layout-effect@1.1.2(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       react: 19.2.4
     optionalDependencies:
@@ -5535,9 +5897,23 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-use-rect@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/rect': 1.1.2
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-size@1.1.1(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-size@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
@@ -5551,7 +5927,18 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-visually-hidden@1.2.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/rect@1.1.1': {}
+
+  '@radix-ui/rect@1.1.2': {}
 
   '@react-aria/autocomplete@3.0.0-rc.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:

--- a/web/src/components/BottomTabBar/BottomTabBar.tsx
+++ b/web/src/components/BottomTabBar/BottomTabBar.tsx
@@ -1,20 +1,16 @@
-import { ChartCandlestick, LayoutDashboard, MessageSquareText, Timer, Settings } from 'lucide-react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { NAV_ITEMS, SETTINGS_ITEM } from '../nav/navItems';
+import { useNavActive } from '../nav/useNavActive';
 import './BottomTabBar.css';
 
-const menuItems = [
-  { key: '/dashboard', icon: LayoutDashboard, labelKey: 'sidebar.dashboard' },
-  { key: '/chat', icon: MessageSquareText, labelKey: 'sidebar.chatAgent' },
-  { key: '/market', icon: ChartCandlestick, labelKey: 'sidebar.marketView' },
-  { key: '/automations', icon: Timer, labelKey: 'sidebar.automations' },
-  { key: '/settings', icon: Settings, labelKey: 'sidebar.settings' },
-];
+const menuItems = [...NAV_ITEMS, SETTINGS_ITEM];
 
 export default function BottomTabBar() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
+  const isActive = useNavActive();
   const handleItemClick = (path: string) => {
     if (location.pathname === path) return;
     navigate(path);
@@ -25,17 +21,15 @@ export default function BottomTabBar() {
       <div className="bottom-tab-bar-pill">
         {menuItems.map((item) => {
           const Icon = item.icon;
-          const isActive = item.key === '/chat'
-            ? location.pathname.startsWith('/chat')
-            : location.pathname === item.key || location.pathname.startsWith(item.key + '/');
+          const active = isActive(item);
 
           return (
             <button
               key={item.key}
-              className={`bottom-tab-item ${isActive ? 'active' : ''}`}
+              className={`bottom-tab-item ${active ? 'active' : ''}`}
               onClick={() => handleItemClick(item.key)}
               aria-label={t(item.labelKey)}
-              aria-current={isActive ? 'page' : undefined}
+              aria-current={active ? 'page' : undefined}
             >
               <Icon className="bottom-tab-item-icon" />
             </button>

--- a/web/src/components/Sidebar/AccountMenu.tsx
+++ b/web/src/components/Sidebar/AccountMenu.tsx
@@ -181,6 +181,8 @@ const AccountMenu: React.FC = () => {
             </DropdownMenuItem>
           )}
 
+          <DropdownMenuSeparator />
+
           <DropdownMenuItem onSelect={() => navigate('/settings')}>
             <Settings className="h-4 w-4" />
             {t('sidebar.settings', 'Settings')}

--- a/web/src/components/Sidebar/AccountMenu.tsx
+++ b/web/src/components/Sidebar/AccountMenu.tsx
@@ -181,7 +181,10 @@ const AccountMenu: React.FC = () => {
             </DropdownMenuItem>
           )}
 
-          <DropdownMenuSeparator />
+          {/* Only divide when the Usage & Plan item above actually rendered;
+              OSS mode hides it (accountUrl === null) and an unconditional
+              separator would stack against the profile divider. */}
+          {accountUrl && <DropdownMenuSeparator />}
 
           <DropdownMenuItem onSelect={() => navigate('/settings')}>
             <Settings className="h-4 w-4" />

--- a/web/src/components/Sidebar/Sidebar.css
+++ b/web/src/components/Sidebar/Sidebar.css
@@ -44,6 +44,7 @@
 }
 
 .sidebar-nav-item {
+  position: relative;
   width: 48px;
   height: 48px;
   border-radius: 12px;
@@ -61,9 +62,26 @@
   background: hsl(var(--sidebar-hover));
 }
 
+.sidebar-nav-item:active {
+  transform: scale(0.94);
+}
+
 .sidebar-nav-item.active {
   background: hsl(var(--sidebar-active));
   color: hsl(var(--sidebar-icon-active));
+}
+
+/* Left accent bar hugging the rail edge (-14px = .sidebar-nav horizontal padding) */
+.sidebar-nav-item.active::before {
+  content: '';
+  position: absolute;
+  left: -14px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 3px;
+  height: 24px;
+  border-radius: 0 3px 3px 0;
+  background: hsl(var(--sidebar-icon-active));
 }
 
 .sidebar-nav-icon {
@@ -74,7 +92,9 @@
 
 .sidebar-bottom {
   margin-top: auto;
-  padding: 0 14px 16px;
+  width: 100%;
+  padding: 12px 14px 16px;
+  border-top: 1px solid hsl(var(--sidebar-border));
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/web/src/components/Sidebar/Sidebar.tsx
+++ b/web/src/components/Sidebar/Sidebar.tsx
@@ -1,42 +1,21 @@
-import { ChartCandlestick, LayoutDashboard, MessageSquareText, Timer } from 'lucide-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import logoLight from '../../assets/img/logo.svg';
 import logoDark from '../../assets/img/logo-dark.svg';
 import { useTheme } from '../../contexts/ThemeContext';
+import { NAV_ITEMS } from '../nav/navItems';
+import { useNavActive } from '../nav/useNavActive';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import AccountMenu from './AccountMenu';
 import './Sidebar.css';
 
 function Sidebar() {
   const navigate = useNavigate();
-  const location = useLocation();
   const { t } = useTranslation();
   const { theme } = useTheme();
+  const isActive = useNavActive();
   const logo = theme === 'light' ? logoDark : logoLight;
-
-  const menuItems = [
-    {
-      key: '/dashboard',
-      icon: LayoutDashboard,
-      label: t('sidebar.dashboard'),
-    },
-    {
-      key: '/chat',
-      icon: MessageSquareText,
-      label: t('sidebar.chatAgent'),
-    },
-    {
-      key: '/market',
-      icon: ChartCandlestick,
-      label: t('sidebar.marketView'),
-    },
-    {
-      key: '/automations',
-      icon: Timer,
-      label: t('sidebar.automations'),
-    },
-  ];
 
   const handleItemClick = (path: string) => {
     navigate(path);
@@ -51,26 +30,30 @@ function Sidebar() {
 
       {/* Navigation Items */}
       <nav className="sidebar-nav">
-        {menuItems.map((item) => {
-          const Icon = item.icon;
-          // For chat route, check if pathname starts with '/chat' to include workspace routes
-          // For other routes, use exact match
-          const isActive = item.key === '/chat'
-            ? location.pathname.startsWith('/chat')
-            : location.pathname === item.key;
+        <TooltipProvider delayDuration={300}>
+          {NAV_ITEMS.map((item) => {
+            const Icon = item.icon;
+            const label = t(item.labelKey);
+            const active = isActive(item);
 
-          return (
-            <button
-              key={item.key}
-              className={`sidebar-nav-item ${isActive ? 'active' : ''}`}
-              onClick={() => handleItemClick(item.key)}
-              aria-label={item.label}
-              title={item.label}
-            >
-              <Icon className="sidebar-nav-icon" />
-            </button>
-          );
-        })}
+            return (
+              <Tooltip key={item.key}>
+                <TooltipTrigger asChild>
+                  <button
+                    className={`sidebar-nav-item ${active ? 'active' : ''}`}
+                    onClick={() => handleItemClick(item.key)}
+                    aria-label={label}
+                  >
+                    <Icon className="sidebar-nav-icon" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="right" sideOffset={8}>
+                  {label}
+                </TooltipContent>
+              </Tooltip>
+            );
+          })}
+        </TooltipProvider>
       </nav>
 
       {/* Account menu — pinned to bottom */}

--- a/web/src/components/nav/__tests__/useNavActive.test.tsx
+++ b/web/src/components/nav/__tests__/useNavActive.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * Active-state matrix for the shared nav config:
+ *  - every item is active at its exact path
+ *  - 'exact-or-sub' items are active at sub-paths (key + '/...') only
+ *  - the 'prefix' item (/chat) is active at any deeper path
+ *  - sibling items never light up for each other's routes
+ */
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { NAV_ITEMS, SETTINGS_ITEM } from '../navItems';
+import { useNavActive } from '../useNavActive';
+
+const ALL_ITEMS = [...NAV_ITEMS, SETTINGS_ITEM];
+
+function matcherAt(pathname: string) {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <MemoryRouter initialEntries={[pathname]}>{children}</MemoryRouter>
+  );
+  const { result } = renderHook(() => useNavActive(), { wrapper });
+  return result.current;
+}
+
+describe('useNavActive', () => {
+  it.each(ALL_ITEMS.map((item) => [item.key, item] as const))(
+    'marks %s active at its exact path',
+    (_key, item) => {
+      expect(matcherAt(item.key)(item)).toBe(true);
+    },
+  );
+
+  it.each(
+    ALL_ITEMS.filter((item) => item.match === 'exact-or-sub').map(
+      (item) => [item.key, item] as const,
+    ),
+  )('marks exact-or-sub item %s active at a sub-path', (key, item) => {
+    expect(matcherAt(`${key}/details`)(item)).toBe(true);
+  });
+
+  it('marks the prefix item /chat active at deep paths', () => {
+    const chatItem = NAV_ITEMS.find((item) => item.match === 'prefix');
+    expect(chatItem).toBeDefined();
+    expect(matcherAt('/chat/whatever/deeper')(chatItem!)).toBe(true);
+  });
+
+  it.each(ALL_ITEMS.map((item) => [item.key, item] as const))(
+    'does not mark siblings active at %s',
+    (key, item) => {
+      const isActive = matcherAt(key);
+      for (const sibling of ALL_ITEMS) {
+        if (sibling === item) continue;
+        expect(isActive(sibling)).toBe(false);
+      }
+    },
+  );
+
+  it('does not match a route that merely shares the key as a string prefix (exact-or-sub)', () => {
+    const dashboard = NAV_ITEMS.find((item) => item.key === '/dashboard')!;
+    expect(matcherAt('/dashboard-archive')(dashboard)).toBe(false);
+  });
+});

--- a/web/src/components/nav/navItems.ts
+++ b/web/src/components/nav/navItems.ts
@@ -1,0 +1,28 @@
+import { ChartCandlestick, LayoutDashboard, MessageSquareText, Settings, Timer } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+
+export interface NavItem {
+  /** Route path. */
+  key: string;
+  icon: LucideIcon;
+  /** i18n key resolved via t(). */
+  labelKey: string;
+  /** Active-state strategy: 'prefix' = pathname.startsWith(key); 'exact-or-sub' = exact match or key + '/' sub-path. */
+  match: 'prefix' | 'exact-or-sub';
+}
+
+// Single source of truth for primary navigation (rail + mobile tab bar).
+export const NAV_ITEMS: NavItem[] = [
+  { key: '/dashboard', icon: LayoutDashboard, labelKey: 'sidebar.dashboard', match: 'exact-or-sub' },
+  { key: '/chat', icon: MessageSquareText, labelKey: 'sidebar.chatAgent', match: 'prefix' },
+  { key: '/market', icon: ChartCandlestick, labelKey: 'sidebar.marketView', match: 'exact-or-sub' },
+  { key: '/automations', icon: Timer, labelKey: 'sidebar.automations', match: 'exact-or-sub' },
+];
+
+// Settings only appears in the mobile tab bar (desktop reaches it via AccountMenu).
+export const SETTINGS_ITEM: NavItem = {
+  key: '/settings',
+  icon: Settings,
+  labelKey: 'sidebar.settings',
+  match: 'exact-or-sub',
+};

--- a/web/src/components/nav/useNavActive.ts
+++ b/web/src/components/nav/useNavActive.ts
@@ -1,0 +1,11 @@
+import { useLocation } from 'react-router-dom';
+import type { NavItem } from './navItems';
+
+/** Returns a matcher that reports whether a nav item is active for the current pathname. */
+export function useNavActive() {
+  const { pathname } = useLocation();
+  return (item: NavItem): boolean => {
+    if (item.match === 'prefix') return pathname.startsWith(item.key);
+    return pathname === item.key || pathname.startsWith(item.key + '/');
+  };
+}

--- a/web/src/components/ui/tooltip.tsx
+++ b/web/src/components/ui/tooltip.tsx
@@ -1,0 +1,37 @@
+import * as React from "react"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+
+import { cn } from "@/lib/utils"
+
+const TooltipProvider = TooltipPrimitive.Provider
+
+const Tooltip = TooltipPrimitive.Root
+
+const TooltipTrigger = TooltipPrimitive.Trigger
+
+const TooltipContent = React.forwardRef<
+  React.ComponentRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, collisionPadding = 8, style, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      collisionPadding={collisionPadding}
+      className={cn(
+        "z-[1030] overflow-hidden rounded-md px-2.5 py-1.5 text-xs shadow-md animate-fade-in",
+        className
+      )}
+      style={{
+        backgroundColor: "var(--color-bg-elevated)",
+        border: "1px solid var(--color-border-muted)",
+        color: "var(--color-text-primary)",
+        ...style,
+      }}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
+))
+TooltipContent.displayName = TooltipPrimitive.Content.displayName
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -50,6 +50,7 @@
   "nav": {
     "pin": "Pin panel",
     "unpin": "Unpin panel",
+    "minimize": "Minimize panel",
     "displayOptions": "Display options",
     "newThread": "New thread",
     "orderBy": "Order by",

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -47,6 +47,18 @@
   "account": {
     "menuLabel": "Account menu"
   },
+  "nav": {
+    "pin": "Pin panel",
+    "unpin": "Unpin panel",
+    "displayOptions": "Display options",
+    "newThread": "New thread",
+    "orderBy": "Order by",
+    "workspacesShown": "Workspaces shown",
+    "threadsPerWorkspace": "Threads per workspace",
+    "all": "All",
+    "showMore": "Show more",
+    "loadAll": "Load all"
+  },
   "settings": {
     "title": "User Settings",
     "userInfo": "User Info",
@@ -55,6 +67,7 @@
     "theme": "Theme",
     "dark": "Dark",
     "light": "Light",
+    "auto": "Auto",
     "locale": "Language",
     "voiceInput": "Voice Input",
     "voiceInputDesc": "Enable microphone icon in the chat bar for speech-to-text.",
@@ -1015,6 +1028,8 @@
     "dragToReorder": "Drag to reorder",
     "pinToTop": "Pin to top",
     "unpin": "Unpin",
+    "rename": "Rename",
+    "options": "Options",
     "noWorkspacesFound": "No workspaces found",
     "welcomeTitle": "Welcome to LangAlpha",
     "welcomeDesc": "Get started by setting up your preferences or creating a workspace.",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -50,6 +50,7 @@
   "nav": {
     "pin": "固定面板",
     "unpin": "取消固定",
+    "minimize": "最小化面板",
     "displayOptions": "显示选项",
     "newThread": "新建对话",
     "orderBy": "排序方式",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -47,6 +47,18 @@
   "account": {
     "menuLabel": "账号菜单"
   },
+  "nav": {
+    "pin": "固定面板",
+    "unpin": "取消固定",
+    "displayOptions": "显示选项",
+    "newThread": "新建对话",
+    "orderBy": "排序方式",
+    "workspacesShown": "显示的工作区数量",
+    "threadsPerWorkspace": "每个工作区显示的对话数",
+    "all": "全部",
+    "showMore": "显示更多",
+    "loadAll": "加载全部"
+  },
   "settings": {
     "title": "用户设置",
     "userInfo": "用户信息",
@@ -55,6 +67,7 @@
     "theme": "主题",
     "dark": "深色",
     "light": "浅色",
+    "auto": "自动",
     "locale": "语言",
     "voiceInput": "语音输入",
     "voiceInputDesc": "在聊天栏中启用麦克风图标以进行语音转文字。",
@@ -1015,6 +1028,8 @@
     "dragToReorder": "拖拽排序",
     "pinToTop": "置顶",
     "unpin": "取消置顶",
+    "rename": "重命名",
+    "options": "选项",
     "noWorkspacesFound": "未找到工作区",
     "welcomeTitle": "欢迎使用 LangAlpha",
     "welcomeDesc": "开始设置您的偏好或创建工作区。",

--- a/web/src/pages/ChatAgent/components/ActivityBlock.css
+++ b/web/src/pages/ChatAgent/components/ActivityBlock.css
@@ -32,6 +32,9 @@
   background: var(--color-bg-page);
   border-radius: 999px;
   padding: 1px;
+  /* Hairline ring masks the icon underneath so the ✕ reads as a deliberate
+   * status chip rather than a stray glyph. Monochrome by design. */
+  box-shadow: 0 0 0 1px var(--color-bg-page);
 }
 
 /* --- Accordion timeline --------------------------------------------------- */

--- a/web/src/pages/ChatAgent/components/ActivityBlock.tsx
+++ b/web/src/pages/ChatAgent/components/ActivityBlock.tsx
@@ -71,6 +71,10 @@ const INLINE_ARTIFACT_MAP: Record<string, React.ComponentType<{ artifact: Record
 /** Spring config matching radix-accordion feel */
 const SPRING = { type: 'spring' as const, stiffness: 150, damping: 17 };
 const SPRING_SNAPPY = { type: 'spring' as const, stiffness: 200, damping: 22 };
+/** Higher damping for height settles (accordion fold) — no overshoot on multi-row batches. */
+const SPRING_FOLD = { type: 'spring' as const, stiffness: 260, damping: 30 };
+/** Quick tween for live rows clearing out — exits shouldn't draw the eye. */
+const EXIT_TWEEN = { duration: 0.18, ease: 'easeIn' as const };
 
 type LiveState = 'active' | 'completing' | 'completed' | 'failed';
 
@@ -324,7 +328,7 @@ const ActivityBlock = memo(function ActivityBlock({ items, preparingToolCall, is
             className="-mt-2"
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: 'auto' }}
-            transition={SPRING_SNAPPY}
+            transition={SPRING_FOLD}
             style={{ overflow: 'hidden' }}
           >
             <button
@@ -382,7 +386,7 @@ const ActivityBlock = memo(function ActivityBlock({ items, preparingToolCall, is
                             key={itemKey}
                             initial={{ opacity: 0, height: 0 }}
                             animate={{ opacity: 1, height: 'auto' }}
-                            transition={SPRING_SNAPPY}
+                            transition={SPRING_FOLD}
                             style={{ overflow: 'hidden', listStyle: 'none' }}
                           >
                             {content}
@@ -424,8 +428,8 @@ const ActivityBlock = memo(function ActivityBlock({ items, preparingToolCall, is
                     <motion.div
                       key={`live-r-${item.id}`}
                       initial={{ opacity: 0, height: 0 }}
-                      animate={{ opacity: item._liveState === 'completing' ? 0.6 : 1, height: 'auto' }}
-                      exit={{ opacity: 0, height: 0, paddingTop: 0, paddingBottom: 0 }}
+                      animate={{ opacity: item._liveState === 'completing' ? 0.7 : 1, height: 'auto' }}
+                      exit={{ opacity: 0, height: 0, paddingTop: 0, paddingBottom: 0, transition: EXIT_TWEEN }}
                       transition={SPRING_SNAPPY}
                       style={{ overflow: 'hidden', paddingTop: '8px', paddingBottom: '8px' }}
                       className="px-3"
@@ -463,7 +467,7 @@ const ActivityBlock = memo(function ActivityBlock({ items, preparingToolCall, is
                       key={`live-t-${item.id || item.toolCallId}`}
                       initial={{ opacity: 0, height: 0 }}
                       animate={{ opacity: 1, height: 'auto' }}
-                      exit={{ opacity: 0, height: 0 }}
+                      exit={{ opacity: 0, height: 0, transition: EXIT_TWEEN }}
                       transition={SPRING_SNAPPY}
                       style={{ overflow: 'hidden' }}
                     >
@@ -589,14 +593,14 @@ const ToolCallLiveRow = memo(function ToolCallLiveRow({ tc, liveState }: ToolCal
   return (
     <motion.div
       className={`nrow ${stateClass} flex items-center gap-2 pl-3 pr-3 py-1.5`}
-      animate={{ opacity: isInProgress ? 1 : 0.7 }}
-      transition={{ duration: 0.3, ease: 'easeOut' }}
+      animate={{ opacity: isInProgress ? 1 : 0.7, y: isInProgress ? 0 : 1 }}
+      transition={{ duration: 0.25, ease: 'easeOut' }}
       style={{ fontSize: '13px', color: 'var(--Labels-Secondary)' }}
     >
       <div className="relative flex-shrink-0 flex items-center justify-center h-5 w-5">
         <motion.span
-          animate={isInProgress ? { opacity: [0.7, 1, 0.7] } : { opacity: 1 }}
-          transition={isInProgress ? { duration: 1.4, repeat: Infinity, ease: 'easeInOut' } : { duration: 0.2 }}
+          animate={isInProgress ? { opacity: [0.85, 1, 0.85] } : { opacity: 1 }}
+          transition={isInProgress ? { duration: 1.5, repeat: Infinity, ease: 'easeInOut' } : { duration: 0.2 }}
           style={{ display: 'inline-flex' }}
         >
           <IconComponent className="h-4 w-4" />

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -2116,7 +2116,8 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
                             alignItems: 'center',
                             justifyContent: 'center',
                           }}
-                          title={!isMobile && navPinned ? t('nav.unpin') : 'Minimize panel'}
+                          title={!isMobile && navPinned ? t('nav.unpin') : t('nav.minimize')}
+                          aria-label={!isMobile && navPinned ? t('nav.unpin') : t('nav.minimize')}
                         >
                           <Minus className="h-4 w-4" style={{ color: 'var(--color-text-tertiary)' }} />
                         </button>

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense, useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { ArrowLeft, FolderOpen, StopCircle, ScrollText, CheckCircle2, Circle, Loader2, TextSelect, Minus, PanelLeftOpen, Menu, Info } from 'lucide-react';
+import { ArrowLeft, FolderOpen, StopCircle, ScrollText, CheckCircle2, Circle, Loader2, TextSelect, Minus, PanelLeftOpen, Menu, Info, Pin, PinOff } from 'lucide-react';
 import { HoverCard, HoverCardTrigger, HoverCardContent } from '@/components/ui/hover-card';
 import { useIsMobile, getIsMobileSnapshot } from '@/hooks/useIsMobile';
 import { useNarrowContainer } from '@/hooks/useNarrowContainer';
@@ -35,6 +35,7 @@ import MessageList, { normalizeSubagentText } from './MessageList';
 import { SubagentTelemetryContext } from './SubagentTelemetryContext';
 import Markdown from './Markdown';
 import NavigationPanel from './NavigationPanel';
+import NavDisplayOptions from './NavDisplayOptions';
 import ChatMinimap from './ChatMinimap';
 import { useNavigationData } from '../hooks/useNavigationData';
 import ShareButton from './ShareButton';
@@ -213,7 +214,18 @@ interface SubagentStatusIndicatorProps {
 
 // Shared nav panel state across ChatView instances — when switching threads,
 // the newly active instance inherits this so the panel stays open.
-const _sharedNav = { visible: false, locked: false };
+// `pinned` is persisted and read synchronously at module load so a reload
+// mounts the panel docked without a flash. Pinning is desktop-only; mobile
+// keeps the hamburger/drawer flow and ignores `pinned`.
+const NAV_PIN_KEY = 'nav.pinned';
+function readNavPinned(): boolean {
+  try {
+    return localStorage.getItem(NAV_PIN_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+const _sharedNav = { visible: false, locked: false, pinned: readNavPinned() };
 
 // Static main agent object — never changes, so defined once at module level
 const MAIN_AGENT: AgentInfo = {
@@ -358,16 +370,23 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
   const [activeAgentId, setActiveAgentId] = useState(
     initialTaskId ? `task:${initialTaskId}` : 'main'
   );
-  // Navigation panel visibility (hover-triggered overlay)
+  // Navigation panel visibility (hover-triggered overlay, or docked when pinned)
   // Initialize from shared state so thread switches inherit the panel's open/closed state.
-  const [navPanelVisible, setNavPanelVisible] = useState(_sharedNav.visible);
-  const navPanelVisibleRef = useRef(_sharedNav.visible);
+  // Pinned (desktop only) forces the panel visible from first paint.
+  const initialNavOpen = _sharedNav.visible || (_sharedNav.pinned && !isMobile);
+  const [navPanelVisible, setNavPanelVisible] = useState(initialNavOpen);
+  const navPanelVisibleRef = useRef(initialNavOpen);
+  const [navPinned, setNavPinned] = useState(_sharedNav.pinned);
+  const navPinnedRef = useRef(_sharedNav.pinned);
   const navHideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const navLockedRef = useRef(_sharedNav.locked);
   const contentAreaRef = useRef<HTMLDivElement>(null);
   const contentAreaWidthRef = useRef<number>(0);
-  // Skip nav panel slide-in on mount if already open (inherited from previous thread).
-  const skipNavAnimRef = useRef(_sharedNav.visible);
+  // True when the content area is too narrow for the docked push layout; a
+  // pinned panel then stays visible but overlays without pushing content.
+  const [contentNarrow, setContentNarrow] = useState(false);
+  // Skip nav panel slide-in on mount if already open (inherited from previous thread or pinned).
+  const skipNavAnimRef = useRef(initialNavOpen);
   useEffect(() => { skipNavAnimRef.current = false; return () => { if (navHideTimerRef.current) clearTimeout(navHideTimerRef.current); }; }, []);
   // Auto-close nav panel when content area shrinks below threshold (e.g., right panel opens)
   useEffect(() => {
@@ -381,7 +400,9 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
       // Skip when view is hidden (display:none reports width 0) to avoid
       // corrupting _sharedNav for the incoming active view.
       if (!isActiveRef.current) return;
-      if (width < 1100 && navPanelVisibleRef.current) {
+      setContentNarrow(width < 1100);
+      // Pinned panels never auto-collapse — they fall back to overlay-without-push instead.
+      if (width < 1100 && navPanelVisibleRef.current && !navPinnedRef.current) {
         if (navHideTimerRef.current) clearTimeout(navHideTimerRef.current);
         navPanelVisibleRef.current = false;
         _sharedNav.visible = false;
@@ -576,6 +597,11 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     expandWorkspace: navExpandWorkspace,
     hasMore: navHasMore,
     loadAll: navLoadAll,
+    loadMoreThreads: navLoadMoreThreads,
+    reorderWorkspace: navReorderWorkspace,
+    canReorderWorkspaces: navCanReorderWorkspaces,
+    pinWorkspace: navPinWorkspace,
+    renameWorkspace: navRenameWorkspace,
   } = useNavigationData(workspaceId);
 
   // Navigate to a different thread from the navigation panel
@@ -591,6 +617,23 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
       },
     });
   }, [navigate, navWorkspaces, workspaceName]);
+
+  // Open a fresh thread in a workspace from the nav panel. `__default__` + a
+  // workspaceId in route state resolves to a brand-new thread (ChatAgent only
+  // restores a stored session for the bare /chat route), mirroring the new-
+  // workspace navigation path.
+  const handleNewThread = useCallback((wsId: string) => {
+    const ws = (navWorkspaces as Record<string, unknown>[]).find((w) => (w as Record<string, unknown>).workspace_id === wsId) as Record<string, unknown> | undefined;
+    const status = (ws?.status as string) || null;
+    navigate('/chat/t/__default__', {
+      state: {
+        workspaceId: wsId,
+        workspaceName: (ws?.name as string) || '',
+        workspaceStatus: status,
+        agentMode: status === 'flash' ? 'flash' : 'ptc',
+      },
+    });
+  }, [navigate, navWorkspaces]);
 
   // Stable ref-based callback for opening preview URLs from SSE events.
   // Defined here so it can be passed to useChatMessages; assigned after
@@ -1361,6 +1404,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
 
   // Navigation panel hover handlers with 30s hide delay
   const handleNavEnter = useCallback(() => {
+    if (navPinnedRef.current) return; // pinned panel ignores the hover dance
     if (navLockedRef.current) return; // locked after explicit minimize
     // Don't open if content area is too narrow (e.g., right panel consuming space)
     if ((contentAreaRef.current?.offsetWidth ?? Infinity) < 1100) return;
@@ -1371,6 +1415,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
   }, []);
 
   const handleNavLeave = useCallback(() => {
+    if (navPinnedRef.current) return; // pinned panel never auto-hides
     if (navLockedRef.current) return;
     navHideTimerRef.current = setTimeout(() => {
       if (!isActiveRef.current) return;
@@ -1397,6 +1442,31 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     const container = getScrollContainer(ref);
     container?.scrollTo({ top: 0, behavior: 'smooth' });
   }, [isMobile, activeAgentId, getScrollContainer]);
+
+  // Pin toggle: pin docks the panel open (persisted); unpin returns to hover mode.
+  const handleTogglePin = useCallback(() => {
+    const next = !navPinnedRef.current;
+    navPinnedRef.current = next;
+    _sharedNav.pinned = next;
+    try {
+      localStorage.setItem(NAV_PIN_KEY, String(next));
+    } catch {
+      // localStorage unavailable (private mode) — pin still works for the session
+    }
+    setNavPinned(next);
+    if (next) {
+      if (navHideTimerRef.current) clearTimeout(navHideTimerRef.current);
+      navLockedRef.current = false;
+      _sharedNav.locked = false;
+      navPanelVisibleRef.current = true;
+      _sharedNav.visible = true;
+      setNavPanelVisible(true);
+    } else {
+      navPanelVisibleRef.current = false;
+      _sharedNav.visible = false;
+      setNavPanelVisible(false);
+    }
+  }, []);
 
   // Expand button explicitly unlocks and opens the panel
   const handleNavExpand = useCallback(() => {
@@ -1535,7 +1605,6 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
   // Hidden views notify parent via onThreadResolved but skip URL navigate.
   useEffect(() => {
     if (currentThreadId && currentThreadId !== '__default__' && currentThreadId !== threadId && workspaceId) {
-      console.log('[ChatView] Thread ID changed from', threadId, 'to', currentThreadId, '- updating URL');
       // Notify parent so the cache key updates in-place (preserves instanceId)
       onThreadResolved?.(threadId, currentThreadId);
       if (isActive) {
@@ -1793,14 +1862,19 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
       // hover trigger zone works again after a minimize + thread switch.
       navLockedRef.current = false;
       _sharedNav.locked = false;
+      // Sync pin state — it may have been toggled in another instance.
+      // Pinned forces visibility on desktop; mobile ignores it (drawer flow).
+      navPinnedRef.current = _sharedNav.pinned;
+      setNavPinned(_sharedNav.pinned);
+      const wantNavVisible = _sharedNav.visible || (_sharedNav.pinned && !getIsMobileSnapshot());
       // Sync nav panel from shared state
-      navPanelVisibleRef.current = _sharedNav.visible;
-      setNavPanelVisible(_sharedNav.visible);
+      navPanelVisibleRef.current = wantNavVisible;
+      setNavPanelVisible(wantNavVisible);
       // Skip slide-in animation if inheriting open state
-      if (_sharedNav.visible) skipNavAnimRef.current = true;
+      if (wantNavVisible) skipNavAnimRef.current = true;
 
       requestAnimationFrame(() => {
-        if (_sharedNav.visible) skipNavAnimRef.current = false;
+        if (wantNavVisible) skipNavAnimRef.current = false;
         const container = getScrollContainer(scrollAreaRef);
         if (container) {
           container.scrollTo({ top: container.scrollHeight });
@@ -1843,16 +1917,6 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
         {/* Top bar */}
         <div className="flex items-center justify-between px-4 py-2 border-b min-w-0 flex-shrink-0" style={{ borderColor: 'var(--color-border-muted)', cursor: isMobile ? 'pointer' : undefined }} onClick={handleTopBarTap}>
           <div className="flex items-center gap-4 min-w-0 flex-shrink">
-            {isMobile && (
-              <button
-                onClick={handleNavExpand}
-                className="p-2 rounded-md transition-colors flex-shrink-0"
-                style={{ color: 'var(--color-text-primary)' }}
-                title="Menu"
-              >
-                <Menu className="h-5 w-5" />
-              </button>
-            )}
             <button
               onClick={() => {
                 if (activeAgentId !== 'main') {
@@ -1880,6 +1944,16 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
             >
               <ArrowLeft className="h-5 w-5" />
             </button>
+            {isMobile && (
+              <button
+                onClick={handleNavExpand}
+                className="p-2 rounded-md transition-colors flex-shrink-0"
+                style={{ color: 'var(--color-text-primary)' }}
+                title="Menu"
+              >
+                <Menu className="h-5 w-5" />
+              </button>
+            )}
             <h1 className="text-base font-semibold whitespace-nowrap title-font truncate" style={{ color: 'var(--color-text-primary)' }}>
               {workspaceName || t('thread.workspace')}
             </h1>
@@ -1995,29 +2069,59 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
                   } : {})}
                   style={{ width: '100%', height: '100%', position: 'absolute', left: 0, top: 0 }}
                 >
-                  {/* Minimize button — top right corner */}
-                  <button
-                    onClick={handleNavMinimize}
-                    className="nav-panel-dismiss-btn"
-                    style={{
-                      position: 'absolute',
-                      top: 8,
-                      right: 8,
-                      zIndex: 2,
-                      padding: 4,
-                      background: 'transparent',
-                      border: 'none',
-                      cursor: 'pointer',
-                      borderRadius: 4,
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                    }}
-                    title="Minimize panel"
-                  >
-                    <Minus className="h-4 w-4" style={{ color: 'var(--color-text-tertiary)' }} />
-                  </button>
                   <NavigationPanel
+                    headerActions={
+                      <>
+                        {/* Sidebar display options (workspace/thread visibility) —
+                            pinned to the left edge; margin-right:auto pushes the pin +
+                            minimize controls to the right of the header row. */}
+                        <div style={{ marginRight: 'auto', display: 'flex', alignItems: 'center' }}>
+                          <NavDisplayOptions />
+                        </div>
+                        {/* Pin toggle — desktop only, next to the minimize button */}
+                        {!isMobile && (
+                          <button
+                            onClick={handleTogglePin}
+                            className="nav-panel-dismiss-btn"
+                            aria-pressed={navPinned}
+                            style={{
+                              padding: 4,
+                              background: 'transparent',
+                              border: 'none',
+                              cursor: 'pointer',
+                              borderRadius: 4,
+                              display: 'flex',
+                              alignItems: 'center',
+                              justifyContent: 'center',
+                            }}
+                            title={navPinned ? t('nav.unpin') : t('nav.pin')}
+                            aria-label={navPinned ? t('nav.unpin') : t('nav.pin')}
+                          >
+                            {navPinned
+                              ? <PinOff className="h-4 w-4" style={{ color: 'var(--color-accent-primary)' }} />
+                              : <Pin className="h-4 w-4" style={{ color: 'var(--color-text-tertiary)' }} />}
+                          </button>
+                        )}
+                        {/* Minimize button — while pinned it unpins (un-docks) */}
+                        <button
+                          onClick={!isMobile && navPinned ? handleTogglePin : handleNavMinimize}
+                          className="nav-panel-dismiss-btn"
+                          style={{
+                            padding: 4,
+                            background: 'transparent',
+                            border: 'none',
+                            cursor: 'pointer',
+                            borderRadius: 4,
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                          }}
+                          title={!isMobile && navPinned ? t('nav.unpin') : 'Minimize panel'}
+                        >
+                          <Minus className="h-4 w-4" style={{ color: 'var(--color-text-tertiary)' }} />
+                        </button>
+                      </>
+                    }
                     workspaces={navWorkspaces}
                     workspaceThreads={navWorkspaceThreads}
                     currentWorkspaceId={workspaceId}
@@ -2030,17 +2134,26 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
                     onNavigateThread={handleNavigateThread}
                     hasMore={navHasMore}
                     onLoadMore={navLoadAll}
+                    onLoadMoreThreads={navLoadMoreThreads}
+                    onReorderWorkspace={navCanReorderWorkspaces ? navReorderWorkspace : undefined}
+                    onPinWorkspace={navPinWorkspace}
+                    onRenameWorkspace={navRenameWorkspace}
+                    onNewThread={handleNewThread}
                   />
                 </motion.div>
               )}
             </AnimatePresence>
           </div>
 
-          {/* Chat Window — nudge right when nav panel is open so content clears the overlay */}
+          {/* Chat Window — nudge right when nav panel is open so content clears the overlay.
+              Pinned + narrow content (e.g. right panel open): keep the panel visible but
+              drop the push so chat isn't crushed — the panel overlays instead. */}
           <div
             className="flex-1 flex flex-col overflow-hidden min-w-0"
             style={{
-              paddingLeft: !isMobile && navPanelVisible ? 'min(320px, max(0px, calc(1424px - 100%)))' : 0,
+              paddingLeft: !isMobile && navPanelVisible && !(navPinned && contentNarrow)
+                ? 'min(320px, max(0px, calc(1424px - 100%)))'
+                : 0,
               transition: 'padding-left 0.2s cubic-bezier(0.22, 1, 0.36, 1)',
             }}
           >

--- a/web/src/pages/ChatAgent/components/MessageList.tsx
+++ b/web/src/pages/ChatAgent/components/MessageList.tsx
@@ -966,8 +966,8 @@ interface MessageContentSegmentsProps {
   flashContext?: { threadId: string; workspaceId: string } | null;
 }
 
-const MIN_LIVE_EXPOSURE_MS = 5000; // minimum time an item stays in the live zone
-const MAX_IN_PROGRESS_MS = 15000; // max time a tool call can stay in-progress in live view before archiving
+const MIN_LIVE_EXPOSURE_MS = 1800; // minimum time a just-completed item stays in the live zone before folding
+const MAX_IN_PROGRESS_MS = 15000; // max time a tool call can stay in-progress in live view before archiving (independent of MIN_LIVE_EXPOSURE_MS)
 /** Tools that should stay in the live zone for their entire duration (no MAX_IN_PROGRESS_MS cap) */
 const ALWAYS_LIVE_TOOLS = new Set(['TaskOutput', 'WebFetch']);
 /** Tool calls that are never rendered as visible activity items — they have dedicated UI or are internal */
@@ -1172,6 +1172,13 @@ const MessageContentSegments = memo(function MessageContentSegments({ segments, 
       let computedNextExpiry: number | null = null;
 
       const now = Date.now();
+      // Stream end folds just-COMPLETED items into the accordion immediately
+      // instead of waiting out the cooldown. It does NOT evict in-progress work:
+      // always-live tools (TaskOutput) are kept live by the active branch below
+      // regardless of isStreaming, so a running subagent stays visible after the
+      // main stream ends. History/replay items (isStreaming always false) land
+      // directly in the accordion regardless of timestamps.
+      const streamEnded = !isStreaming;
 
       const flushActivity = () => {
         if (pendingItems.length > 0) {
@@ -1203,7 +1210,7 @@ const MessageContentSegments = memo(function MessageContentSegments({ segments, 
             const completedAt = proc._completedAt as number | undefined;
             const completedAge = completedAt ? now - completedAt : Infinity;
 
-            if (completedAge < MIN_LIVE_EXPOSURE_MS) {
+            if (!streamEnded && completedAge < MIN_LIVE_EXPOSURE_MS) {
               pendingItems.push({
                 type: 'reasoning',
                 id: seg.reasoningId,
@@ -1239,7 +1246,14 @@ const MessageContentSegments = memo(function MessageContentSegments({ segments, 
 
           const isAlwaysLive = ALWAYS_LIVE_TOOLS.has(proc.toolName as string);
 
-          if ((proc.isInProgress as boolean) && isStreaming && (isAlwaysLive || age < MAX_IN_PROGRESS_MS)) {
+          // Always-live tools (TaskOutput / WebFetch) stay pinned in the live zone
+          // for their entire in-progress duration — including after the main stream
+          // ends (isStreaming false) while a background subagent keeps running, so
+          // the "waiting on a subagent" indicator never disappears. Safe on history/
+          // replay: reconstructed tool calls are always isInProgress=false, so this
+          // branch can't fire there. Regular in-progress tools still require a live
+          // stream and fold once age passes MAX_IN_PROGRESS_MS.
+          if ((proc.isInProgress as boolean) && (isAlwaysLive || (isStreaming && age < MAX_IN_PROGRESS_MS))) {
             pendingItems.push({
               type: 'tool_call',
               id: seg.toolCallId,
@@ -1261,7 +1275,7 @@ const MessageContentSegments = memo(function MessageContentSegments({ segments, 
               toolCallId: seg.toolCallId!,
               proc,
             });
-          } else if (age < MIN_LIVE_EXPOSURE_MS && !INLINE_ARTIFACT_TOOLS.has(proc.toolName as string)) {
+          } else if (!streamEnded && age < MIN_LIVE_EXPOSURE_MS && !INLINE_ARTIFACT_TOOLS.has(proc.toolName as string)) {
             pendingItems.push({
               type: 'tool_call',
               id: seg.toolCallId,

--- a/web/src/pages/ChatAgent/components/NavDisplayOptions.tsx
+++ b/web/src/pages/ChatAgent/components/NavDisplayOptions.tsx
@@ -1,0 +1,101 @@
+import { useTranslation } from 'react-i18next';
+import { SlidersHorizontal } from 'lucide-react';
+import { Popover, PopoverTrigger, PopoverContent } from '../../../components/ui/popover';
+import { useNavPrefs, setNavPrefs, type NavOrderBy } from '../utils/navPrefs';
+
+const WORKSPACE_CHOICES: readonly (number | 'all')[] = [5, 10, 'all'];
+const THREAD_CHOICES: readonly number[] = [5, 10, 20];
+const ORDER_CHOICES: readonly NavOrderBy[] = ['activity', 'name', 'custom'];
+
+interface ChoiceGroupProps<T extends string | number> {
+  label: string;
+  choices: readonly T[];
+  value: T;
+  format: (choice: T) => string;
+  onSelect: (choice: T) => void;
+}
+
+function ChoiceGroup<T extends string | number>({ label, choices, value, format, onSelect }: ChoiceGroupProps<T>) {
+  return (
+    <div>
+      <div className="text-xs font-medium mb-1.5" style={{ color: 'var(--color-text-secondary)' }}>
+        {label}
+      </div>
+      <div
+        className="flex rounded-lg overflow-hidden"
+        style={{ border: '1px solid var(--color-border-muted)' }}
+      >
+        {choices.map((choice) => (
+          <button
+            key={String(choice)}
+            onClick={() => onSelect(choice)}
+            aria-pressed={value === choice}
+            className="flex-1 flex items-center justify-center px-2 py-1.5 text-xs font-medium transition-colors"
+            style={{
+              backgroundColor: value === choice ? 'var(--color-accent-soft)' : 'transparent',
+              color: value === choice ? 'var(--color-accent-primary)' : 'var(--color-text-tertiary)',
+            }}
+          >
+            {format(choice)}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Display options for the navigation panel — how many workspaces stay visible
+ * and the thread page size per workspace. Persisted via navPrefs.
+ */
+export default function NavDisplayOptions() {
+  const { t } = useTranslation();
+  const { workspaceLimit, threadPageSize, orderBy } = useNavPrefs();
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          className="nav-panel-dismiss-btn"
+          style={{
+            padding: 4,
+            background: 'transparent',
+            border: 'none',
+            cursor: 'pointer',
+            borderRadius: 4,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+          title={t('nav.displayOptions')}
+          aria-label={t('nav.displayOptions')}
+        >
+          <SlidersHorizontal className="h-4 w-4" style={{ color: 'var(--color-text-tertiary)' }} />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" sideOffset={6} className="w-56 p-3 space-y-3">
+        <ChoiceGroup
+          label={t('nav.orderBy')}
+          choices={ORDER_CHOICES}
+          value={orderBy}
+          format={(c) => (c === 'activity' ? t('workspace.activity') : c === 'name' ? t('common.name') : t('workspace.custom'))}
+          onSelect={(c) => setNavPrefs({ orderBy: c })}
+        />
+        <ChoiceGroup
+          label={t('nav.workspacesShown')}
+          choices={WORKSPACE_CHOICES}
+          value={workspaceLimit}
+          format={(c) => (c === 'all' ? t('nav.all') : String(c))}
+          onSelect={(c) => setNavPrefs({ workspaceLimit: c })}
+        />
+        <ChoiceGroup
+          label={t('nav.threadsPerWorkspace')}
+          choices={THREAD_CHOICES}
+          value={threadPageSize}
+          format={(c) => String(c)}
+          onSelect={(c) => setNavPrefs({ threadPageSize: c })}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/web/src/pages/ChatAgent/components/NavDisplayOptions.tsx
+++ b/web/src/pages/ChatAgent/components/NavDisplayOptions.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { SlidersHorizontal } from 'lucide-react';
-import { Popover, PopoverTrigger, PopoverContent } from '../../../components/ui/popover';
+import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
 import { useNavPrefs, setNavPrefs, type NavOrderBy } from '../utils/navPrefs';
 
 const WORKSPACE_CHOICES: readonly (number | 'all')[] = [5, 10, 'all'];
@@ -27,6 +27,7 @@ function ChoiceGroup<T extends string | number>({ label, choices, value, format,
       >
         {choices.map((choice) => (
           <button
+            type="button"
             key={String(choice)}
             onClick={() => onSelect(choice)}
             aria-pressed={value === choice}

--- a/web/src/pages/ChatAgent/components/NavigationPanel.css
+++ b/web/src/pages/ChatAgent/components/NavigationPanel.css
@@ -43,9 +43,12 @@
   background-color: var(--color-border-muted);
 }
 
-/* Agent group — visually nested under thread with a left guide line */
+/* Agent group — visually nested under thread with a left guide line.
+   margin-right matches .nav-panel-row's 6px so the agent pills' tails align
+   with the thread/workspace pills above instead of overhanging to the edge. */
 .nav-panel-agent-group {
   margin-left: 44px;
+  margin-right: 6px;
   margin-top: 2px;
   margin-bottom: 2px;
   padding-left: 10px;
@@ -82,6 +85,36 @@
    participates in the selection state alongside the label. */
 .nav-panel-agent-row.is-selected .nav-panel-agent-glyph {
   color: var(--color-text-secondary);
+}
+
+/* Drag lift preview — a single header row rendered in a DragOverlay portal so
+   the dragged workspace follows the cursor at a fixed size instead of the tall
+   expanded section distorting in place. Override the panel's right border (the
+   chip is free-floating) and give it a lifted shadow. */
+.nav-panel-drag-chip {
+  width: 300px;
+  max-width: 90vw;
+  border: 1px solid var(--color-border-muted);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+  cursor: grabbing;
+  overflow: hidden;
+}
+
+.nav-panel-drag-chip .nav-panel-row {
+  cursor: grabbing;
+  margin: 0;
+}
+
+/* Header row holding the panel controls (pin, minimize) — its own row above
+   the list so the buttons don't overlay the first workspace row. */
+.nav-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+  padding: 8px 12px 0;
+  flex-shrink: 0;
 }
 
 /* Dismiss buttons (minimize + fold) */

--- a/web/src/pages/ChatAgent/components/NavigationPanel.tsx
+++ b/web/src/pages/ChatAgent/components/NavigationPanel.tsx
@@ -1,9 +1,16 @@
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useState, useCallback, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { motion, AnimatePresence } from 'framer-motion';
+import { DndContext, DragOverlay, closestCenter, PointerSensor, MeasuringStrategy, useSensor, useSensors } from '@dnd-kit/core';
+import type { DragStartEvent, DragEndEvent } from '@dnd-kit/core';
+import { SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import {
-  ChevronRight, ChevronDown, Folder, Zap, Pin, MessageSquareText,
-  Check, Circle, Loader2, X, ChevronsDown,
+  ChevronRight, Folder, FolderOpen, Zap, Pin, MessageSquareText,
+  Check, Circle, Loader2, X, ChevronsDown, MoreHorizontal, SquarePen, Pencil,
 } from 'lucide-react';
 import { ScrollArea } from '../../../components/ui/scroll-area';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '../../../components/ui/dropdown-menu';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import './NavigationPanel.css';
 
@@ -25,6 +32,7 @@ interface ThreadEntry {
 interface ThreadsData {
   threads: ThreadEntry[];
   loading?: boolean;
+  total?: number;
 }
 
 interface AgentMessage {
@@ -57,6 +65,47 @@ interface NavigationPanelProps {
   onNavigateThread: (wsId: string, threadId: string) => void;
   hasMore?: boolean;
   onLoadMore?: () => void;
+  /** Fetch the next page of threads for a workspace ("Show more" row). */
+  onLoadMoreThreads?: (wsId: string) => void;
+  /** Drag-reorder handler: persist `activeId` dropped onto `overId`'s slot. */
+  onReorderWorkspace?: (activeId: string, overId: string) => void;
+  /** Pin/unpin a workspace to the top of the list (options menu). */
+  onPinWorkspace?: (wsId: string, pinned: boolean) => void;
+  /** Persist a workspace rename (options menu → inline edit). */
+  onRenameWorkspace?: (wsId: string, name: string) => void;
+  /** Open a fresh thread in the given workspace. */
+  onNewThread?: (wsId: string) => void;
+  /** Right-aligned controls (pin, minimize) rendered in a header row above the list. */
+  headerActions?: React.ReactNode;
+}
+
+/**
+ * Sortable wrapper for one workspace section (header row + thread sub-list).
+ * The header row receives the drag listeners via the render prop, which also
+ * gets `isDragging` so the section can collapse to header height while lifted.
+ *
+ * Translate-only (not Transform) so displaced siblings never pick up the
+ * scaleX/scaleY that distorts variable-height rows; the lifted item itself is
+ * hidden here and shown as a fixed-size DragOverlay chip instead.
+ */
+function SortableWorkspace({ wsId, disabled, children }: {
+  wsId: string;
+  disabled: boolean;
+  children: (args: { dragHandleProps: Record<string, unknown>; isDragging: boolean }) => React.ReactNode;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: wsId, disabled });
+  const style: React.CSSProperties = {
+    transform: CSS.Translate.toString(transform),
+    transition,
+    opacity: isDragging ? 0 : 1,
+    position: 'relative',
+    zIndex: isDragging ? 5 : undefined,
+  };
+  return (
+    <div ref={setNodeRef} style={style}>
+      {children({ dragHandleProps: disabled ? {} : { ...attributes, ...listeners }, isDragging })}
+    </div>
+  );
 }
 
 /**
@@ -66,6 +115,16 @@ interface NavigationPanelProps {
  * Follows the collapsible tree pattern from FilePanel's DirectoryNode:
  * ChevronRight/Down toggles, indented rows, Lucide icons throughout.
  */
+// Expansion state shared across panel instances (one mounts per cached
+// ChatView), so user-opened folders survive thread switches within a session.
+const _expandedWorkspaces = new Set<string>();
+const _expandedThreads = new Set<string>();
+
+export function resetNavPanelExpansion() {
+  _expandedWorkspaces.clear();
+  _expandedThreads.clear();
+}
+
 function NavigationPanel({
   workspaces,
   workspaceThreads,
@@ -79,20 +138,46 @@ function NavigationPanel({
   onNavigateThread,
   hasMore,
   onLoadMore,
+  onLoadMoreThreads,
+  onReorderWorkspace,
+  onPinWorkspace,
+  onRenameWorkspace,
+  onNewThread,
+  headerActions,
 }: NavigationPanelProps) {
+  const { t } = useTranslation();
   const isMobile = useIsMobile();
-  // Track expanded workspaces and threads via Sets
-  // Current workspace is expanded by default
-  const [expandedWorkspaces, setExpandedWorkspaces] = useState<Set<string>>(
-    () => new Set(currentWorkspaceId ? [currentWorkspaceId] : [])
-  );
-  const [expandedThreads, setExpandedThreads] = useState<Set<string>>(
-    () => new Set(currentThreadId && currentThreadId !== '__default__' ? [currentThreadId] : [])
-  );
+  // 8px activation distance (same as the gallery's reorder mode) keeps plain
+  // clicks toggling expand/collapse instead of starting a drag.
+  const dndSensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
+  // Id of the workspace currently being dragged — drives the DragOverlay chip.
+  const [activeDragId, setActiveDragId] = useState<string | null>(null);
+  // Expanded workspaces/threads. Backed by module-level sets because one
+  // NavigationPanel mounts per cached ChatView instance — without them, every
+  // thread switch would remount the panel and collapse the folders the user
+  // opened. Current workspace/thread are expanded by default. Resets on reload.
+  const [expandedWorkspaces, setExpandedWorkspaces] = useState<Set<string>>(() => {
+    if (currentWorkspaceId) _expandedWorkspaces.add(currentWorkspaceId);
+    return new Set(_expandedWorkspaces);
+  });
+  const [expandedThreads, setExpandedThreads] = useState<Set<string>>(() => {
+    if (currentThreadId && currentThreadId !== '__default__') _expandedThreads.add(currentThreadId);
+    return new Set(_expandedThreads);
+  });
+
+  // Repopulate thread lists for folders that were already open — the thread
+  // data lives in per-instance hook state, so a fresh mount must re-request it
+  // (served from the React Query cache when warm).
+  React.useEffect(() => {
+    _expandedWorkspaces.forEach((wsId) => expandWorkspace(wsId));
+    // Mount-only: expandWorkspace is stable and re-running on its identity churn would be redundant.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Keep current workspace and thread expanded when they change
   React.useEffect(() => {
     if (currentWorkspaceId) {
+      _expandedWorkspaces.add(currentWorkspaceId);
       setExpandedWorkspaces((prev) => {
         if (prev.has(currentWorkspaceId)) return prev;
         const next = new Set(prev);
@@ -105,6 +190,7 @@ function NavigationPanel({
 
   React.useEffect(() => {
     if (currentThreadId && currentThreadId !== '__default__') {
+      _expandedThreads.add(currentThreadId);
       setExpandedThreads((prev) => {
         if (prev.has(currentThreadId)) return prev;
         const next = new Set(prev);
@@ -115,31 +201,83 @@ function NavigationPanel({
   }, [currentThreadId]);
 
   const toggleWorkspace = useCallback((wsId: string) => {
-    setExpandedWorkspaces((prev) => {
-      const next = new Set(prev);
-      if (next.has(wsId)) {
-        next.delete(wsId);
-      } else {
-        next.add(wsId);
-      }
-      return next;
-    });
+    if (_expandedWorkspaces.has(wsId)) {
+      _expandedWorkspaces.delete(wsId);
+    } else {
+      _expandedWorkspaces.add(wsId);
+    }
+    setExpandedWorkspaces(new Set(_expandedWorkspaces));
     // Lazy-load threads when expanding -- called outside updater to avoid setState-during-render warning.
     // expandWorkspace is a no-op when data is already cached, so calling unconditionally is safe.
     expandWorkspace(wsId);
   }, [expandWorkspace]);
 
   const toggleThread = useCallback((threadId: string) => {
-    setExpandedThreads((prev) => {
-      const next = new Set(prev);
-      if (next.has(threadId)) {
-        next.delete(threadId);
-      } else {
-        next.add(threadId);
-      }
-      return next;
-    });
+    if (_expandedThreads.has(threadId)) {
+      _expandedThreads.delete(threadId);
+    } else {
+      _expandedThreads.add(threadId);
+    }
+    setExpandedThreads(new Set(_expandedThreads));
   }, []);
+
+  // Inline workspace rename — the name span becomes a text input while editing.
+  // Refs shadow the editing state so the blur/Enter commit reads fresh values and
+  // stays idempotent: Enter clears the id, the trailing blur then no-ops.
+  const [renamingWsId, setRenamingWsId] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState('');
+  const renamingWsIdRef = useRef<string | null>(null);
+  const renameValueRef = useRef('');
+  const renameOriginalRef = useRef('');
+  const renameInputRef = useRef<HTMLInputElement>(null);
+
+  const startRename = useCallback((wsId: string, currentName: string) => {
+    renamingWsIdRef.current = wsId;
+    renameOriginalRef.current = currentName;
+    renameValueRef.current = currentName;
+    setRenameValue(currentName);
+    setRenamingWsId(wsId);
+  }, []);
+
+  const cancelRename = useCallback(() => {
+    renamingWsIdRef.current = null;
+    setRenamingWsId(null);
+  }, []);
+
+  const commitRename = useCallback(() => {
+    const wsId = renamingWsIdRef.current;
+    if (!wsId) return; // already committed — the trailing blur after Enter is a no-op
+    renamingWsIdRef.current = null;
+    setRenamingWsId(null);
+    const name = renameValueRef.current.trim();
+    if (name && name !== renameOriginalRef.current) onRenameWorkspace?.(wsId, name);
+  }, [onRenameWorkspace]);
+
+  // Focus + select the rename input once it mounts. rAF defers past Radix's
+  // focus-restore-to-trigger when the rename is launched from the options menu.
+  React.useEffect(() => {
+    if (!renamingWsId) return;
+    const raf = requestAnimationFrame(() => {
+      renameInputRef.current?.focus();
+      renameInputRef.current?.select();
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [renamingWsId]);
+
+  const handleWorkspaceDragStart = useCallback((event: DragStartEvent) => {
+    setActiveDragId(String(event.active.id));
+  }, []);
+
+  const handleWorkspaceDragEnd = useCallback((event: DragEndEvent) => {
+    setActiveDragId(null);
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    onReorderWorkspace?.(String(active.id), String(over.id));
+  }, [onReorderWorkspace]);
+
+  const handleWorkspaceDragCancel = useCallback(() => setActiveDragId(null), []);
+
+  const activeDragWs = activeDragId ? workspaces.find((ws) => ws.workspace_id === activeDragId) : null;
 
   // Derive agent status for display
   const getAgentStatus = useCallback((agent: AgentEntry): string => {
@@ -157,21 +295,27 @@ function NavigationPanel({
     return agent.status || 'pending';
   }, []);
 
-  // Sorted workspaces: current workspace first, then the rest in hook-provided order
-  const sortedWorkspaces = useMemo(() => {
-    if (!workspaces.length) return [];
-    const current = workspaces.find((ws) => ws.workspace_id === currentWorkspaceId);
-    const rest = workspaces.filter((ws) => ws.workspace_id !== currentWorkspaceId);
-    return current ? [current, ...rest] : workspaces;
-  }, [workspaces, currentWorkspaceId]);
-
   return (
     <div
       className="nav-panel h-full flex flex-col"
     >
+      {headerActions && (
+        <div className="nav-panel-header">
+          {headerActions}
+        </div>
+      )}
       <ScrollArea className="flex-1">
         <div className="py-2">
-          {sortedWorkspaces.map((ws) => {
+          <DndContext
+            sensors={dndSensors}
+            collisionDetection={closestCenter}
+            measuring={{ droppable: { strategy: MeasuringStrategy.Always } }}
+            onDragStart={handleWorkspaceDragStart}
+            onDragEnd={handleWorkspaceDragEnd}
+            onDragCancel={handleWorkspaceDragCancel}
+          >
+          <SortableContext items={workspaces.map((ws) => ws.workspace_id)} strategy={verticalListSortingStrategy}>
+          {workspaces.map((ws) => {
             const wsId = ws.workspace_id;
             const isExpanded = expandedWorkspaces.has(wsId);
             const isFlash = ws.status === 'flash';
@@ -181,39 +325,134 @@ function NavigationPanel({
             const allThreads = threadsData?.threads || [];
             const threads = isFlash ? allThreads.slice(0, 3) : allThreads;
             const threadsLoading = threadsData?.loading || false;
+            const isRenaming = renamingWsId === wsId;
+            // Pin / rename / new-thread aren't offered on the flash workspace
+            // (shared, immutable) — mirrors the gallery hiding its card menu there.
+            const showWsActions = !isFlash && (onNewThread || onPinWorkspace || onRenameWorkspace);
 
             return (
-              <div key={wsId}>
-                {/* Workspace row */}
+              <SortableWorkspace key={wsId} wsId={wsId} disabled={isFlash || isMobile || !onReorderWorkspace}>
+                {({ dragHandleProps, isDragging: isThisDragging }) => (<>
+                {/* Workspace row — doubles as the drag handle for reordering.
+                    While renaming, click-to-toggle and drag are suppressed so the
+                    inline input owns the row. */}
                 <div
-                  className="nav-panel-row"
+                  className="nav-panel-row group"
                   style={{ paddingLeft: 10 }}
-                  onClick={() => toggleWorkspace(wsId)}
+                  onClick={() => { if (!isRenaming) toggleWorkspace(wsId); }}
+                  {...(isRenaming ? {} : dragHandleProps)}
                 >
-                  {isExpanded
-                    ? <ChevronDown className="h-4 w-4 flex-shrink-0" style={{ color: 'var(--color-text-tertiary)' }} />
-                    : <ChevronRight className="h-4 w-4 flex-shrink-0" style={{ color: 'var(--color-text-tertiary)' }} />
-                  }
                   {isFlash
                     ? <Zap className="h-4 w-4 flex-shrink-0" style={{ color: 'var(--color-text-tertiary)' }} />
                     : isPinned
                       ? <Pin className="h-4 w-4 flex-shrink-0" style={{ color: 'var(--color-text-tertiary)' }} />
-                      : <Folder className="h-4 w-4 flex-shrink-0" style={{ color: 'var(--color-text-tertiary)' }} />
+                      : isExpanded
+                        ? <FolderOpen className="h-4 w-4 flex-shrink-0" style={{ color: 'var(--color-text-tertiary)' }} />
+                        : <Folder className="h-4 w-4 flex-shrink-0" style={{ color: 'var(--color-text-tertiary)' }} />
                   }
-                  <span
-                    className="text-sm font-medium truncate"
-                    style={{ color: isCurrent ? 'var(--color-text-primary)' : 'var(--color-text-tertiary)' }}
-                  >
-                    {ws.name || 'Workspace'}
-                  </span>
-                  {threadsLoading && (
-                    <Loader2 className="h-3.5 w-3.5 animate-spin flex-shrink-0 ml-auto" style={{ color: 'var(--color-text-tertiary)' }} />
+                  {isRenaming ? (
+                    <input
+                      ref={renameInputRef}
+                      className="text-sm font-medium bg-transparent outline-none border-b flex-1 min-w-0"
+                      style={{ color: 'var(--color-text-primary)', borderColor: 'var(--color-border-muted)' }}
+                      value={renameValue}
+                      onChange={(e) => { setRenameValue(e.target.value); renameValueRef.current = e.target.value; }}
+                      onClick={(e) => e.stopPropagation()}
+                      onPointerDown={(e) => e.stopPropagation()}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') { e.preventDefault(); commitRename(); }
+                        else if (e.key === 'Escape') { e.preventDefault(); cancelRename(); }
+                      }}
+                      onBlur={commitRename}
+                      aria-label={t('workspace.rename')}
+                    />
+                  ) : (
+                    <>
+                      <span
+                        className="text-sm font-medium truncate"
+                        style={{ color: isCurrent ? 'var(--color-text-primary)' : 'var(--color-text-tertiary)' }}
+                      >
+                        {ws.name || 'Workspace'}
+                      </span>
+                      {/* initial={false}: thread switches remount the panel; the
+                          chevron must render at its resting angle, not animate to it.
+                          Hidden until the row is hovered (always visible on touch). */}
+                      <motion.span
+                        className={`flex-shrink-0 flex items-center ${isMobile ? '' : 'opacity-0 group-hover:opacity-100 transition-opacity'}`}
+                        initial={false}
+                        animate={{ rotate: isExpanded ? 90 : 0 }}
+                        transition={{ duration: 0.15, ease: 'easeOut' }}
+                      >
+                        <ChevronRight className="h-4 w-4" style={{ color: 'var(--color-text-tertiary)' }} />
+                      </motion.span>
+                      {/* Right-aligned row actions: new thread + options (pin / rename).
+                          Hover-revealed on desktop, always shown on touch. */}
+                      {showWsActions && (
+                        <div className={`flex items-center gap-0.5 ml-auto flex-shrink-0 ${isMobile ? '' : 'opacity-0 group-hover:opacity-100 transition-opacity'}`}>
+                          {onNewThread && (
+                            <button
+                              type="button"
+                              onPointerDown={(e) => e.stopPropagation()}
+                              onClick={(e) => { e.stopPropagation(); onNewThread(wsId); }}
+                              className="flex items-center justify-center p-0.5 rounded bg-transparent border-none cursor-pointer hover:bg-[var(--color-border-muted)]"
+                              title={t('nav.newThread')}
+                              aria-label={t('nav.newThread')}
+                            >
+                              <SquarePen className="h-3.5 w-3.5" style={{ color: 'var(--color-text-tertiary)' }} />
+                            </button>
+                          )}
+                          {(onPinWorkspace || onRenameWorkspace) && (
+                            <DropdownMenu modal={false}>
+                              <DropdownMenuTrigger asChild>
+                                <button
+                                  type="button"
+                                  onPointerDown={(e) => e.stopPropagation()}
+                                  onClick={(e) => e.stopPropagation()}
+                                  className="flex items-center justify-center p-0.5 rounded bg-transparent border-none cursor-pointer hover:bg-[var(--color-border-muted)]"
+                                  title={t('workspace.options')}
+                                  aria-label={t('workspace.options')}
+                                >
+                                  <MoreHorizontal className="h-3.5 w-3.5" style={{ color: 'var(--color-text-tertiary)' }} />
+                                </button>
+                              </DropdownMenuTrigger>
+                              <DropdownMenuContent align="end" sideOffset={4} onClick={(e) => e.stopPropagation()}>
+                                {onPinWorkspace && (
+                                  <DropdownMenuItem onSelect={() => onPinWorkspace(wsId, !isPinned)}>
+                                    <Pin className="h-4 w-4" />
+                                    {isPinned ? t('workspace.unpin') : t('workspace.pinToTop')}
+                                  </DropdownMenuItem>
+                                )}
+                                {onRenameWorkspace && (
+                                  <DropdownMenuItem onSelect={() => startRename(wsId, ws.name || '')}>
+                                    <Pencil className="h-4 w-4" />
+                                    {t('workspace.rename')}
+                                  </DropdownMenuItem>
+                                )}
+                              </DropdownMenuContent>
+                            </DropdownMenu>
+                          )}
+                        </div>
+                      )}
+                      {threadsLoading && (
+                        <Loader2 className={`h-3.5 w-3.5 animate-spin flex-shrink-0 ${showWsActions ? '' : 'ml-auto'}`} style={{ color: 'var(--color-text-tertiary)' }} />
+                      )}
+                    </>
                   )}
                 </div>
 
-                {/* Threads under this workspace */}
-                {isExpanded && (
-                  <div>
+                {/* Threads under this workspace — animated expand/collapse.
+                    Hidden while this section is the one being dragged so the
+                    lifted item shrinks to header height (clean gap), and the
+                    DragOverlay chip below carries the visual instead. */}
+                <AnimatePresence initial={false}>
+                  {isExpanded && !isThisDragging && (
+                    <motion.div
+                      initial={{ height: 0, opacity: 0 }}
+                      animate={{ height: 'auto', opacity: 1 }}
+                      exit={{ height: 0, opacity: 0 }}
+                      transition={{ duration: 0.2, ease: 'easeInOut' }}
+                      style={{ overflow: 'hidden' }}
+                    >
                     {!threadsLoading && threads.length === 0 && (
                       <div
                         className="text-xs px-2 py-1"
@@ -234,7 +473,7 @@ function NavigationPanel({
                         <div key={tid}>
                           {/* Thread row */}
                           <div
-                            className={`nav-panel-row ${isCurrentThread ? 'nav-panel-row-active' : ''}`}
+                            className={`nav-panel-row group ${isCurrentThread ? 'nav-panel-row-active' : ''}`}
                             style={{ paddingLeft: 28 }}
                             onClick={() => {
                               if (isCurrentThread) {
@@ -245,20 +484,6 @@ function NavigationPanel({
                               }
                             }}
                           >
-                            {/* Chevron for expanding agents -- only on current thread */}
-                            {hasSubagents ? (
-                              <button
-                                onClick={(e) => { e.stopPropagation(); toggleThread(tid); }}
-                                className="flex-shrink-0 p-0 bg-transparent border-none cursor-pointer"
-                              >
-                                {isThreadExpanded
-                                  ? <ChevronDown className="h-4 w-4" style={{ color: 'var(--color-text-tertiary)' }} />
-                                  : <ChevronRight className="h-4 w-4" style={{ color: 'var(--color-text-tertiary)' }} />
-                                }
-                              </button>
-                            ) : (
-                              <span style={{ width: 16, flexShrink: 0 }} />
-                            )}
                             <MessageSquareText className="h-4 w-4 flex-shrink-0" style={{ color: 'var(--color-text-tertiary)' }} />
                             <span
                               className="text-sm truncate"
@@ -267,6 +492,25 @@ function NavigationPanel({
                             >
                               {title}
                             </span>
+                            {/* Expand-agents chevron — immediately right of the thread
+                                name, mirroring the workspace row. Only on the current
+                                thread when it has subagents. Hover-revealed (always shown
+                                on touch); rotates 90° when expanded. initial={false}:
+                                thread switches remount the panel, so the chevron renders
+                                at its resting angle. */}
+                            {hasSubagents && (
+                              <motion.button
+                                type="button"
+                                onClick={(e) => { e.stopPropagation(); toggleThread(tid); }}
+                                className={`flex-shrink-0 flex items-center p-0 bg-transparent border-none cursor-pointer ${isMobile ? '' : 'opacity-0 group-hover:opacity-100 transition-opacity'}`}
+                                initial={false}
+                                animate={{ rotate: isThreadExpanded ? 90 : 0 }}
+                                transition={{ duration: 0.15, ease: 'easeOut' }}
+                                aria-label={isThreadExpanded ? 'Collapse agents' : 'Expand agents'}
+                              >
+                                <ChevronRight className="h-4 w-4" style={{ color: 'var(--color-text-tertiary)' }} />
+                              </motion.button>
+                            )}
                           </div>
 
                           {/* Agent rows -- only when subagents exist, for current thread when expanded */}
@@ -342,11 +586,46 @@ function NavigationPanel({
                         </div>
                       );
                     })}
-                  </div>
-                )}
-              </div>
+                    {/* Show more — next page of threads for this workspace */}
+                    {!isFlash && onLoadMoreThreads && typeof threadsData?.total === 'number'
+                      && allThreads.length < threadsData.total && !threadsLoading && (
+                      <div
+                        className="nav-panel-row"
+                        style={{ paddingLeft: 44 }}
+                        onClick={(e) => { e.stopPropagation(); onLoadMoreThreads(wsId); }}
+                      >
+                        <ChevronsDown className="h-3.5 w-3.5 flex-shrink-0" style={{ color: 'var(--color-text-tertiary)' }} />
+                        <span className="text-xs" style={{ color: 'var(--color-text-tertiary)' }}>
+                          {t('nav.showMore')}
+                        </span>
+                      </div>
+                    )}
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+                </>)}
+              </SortableWorkspace>
             );
           })}
+          </SortableContext>
+          {/* Fixed-size lift preview — a clean header chip that follows the
+              cursor, so the dragged section's real height never distorts. */}
+          <DragOverlay dropAnimation={null}>
+            {activeDragWs ? (
+              <div className="nav-panel nav-panel-drag-chip">
+                <div className="nav-panel-row" style={{ paddingLeft: 10 }}>
+                  {activeDragWs.is_pinned
+                    ? <Pin className="h-4 w-4 flex-shrink-0" style={{ color: 'var(--color-text-tertiary)' }} />
+                    : <Folder className="h-4 w-4 flex-shrink-0" style={{ color: 'var(--color-text-tertiary)' }} />
+                  }
+                  <span className="text-sm font-medium truncate" style={{ color: 'var(--color-text-primary)' }}>
+                    {activeDragWs.name || 'Workspace'}
+                  </span>
+                </div>
+              </div>
+            ) : null}
+          </DragOverlay>
+          </DndContext>
           {hasMore && (
             <div
               className="nav-panel-row"
@@ -355,7 +634,7 @@ function NavigationPanel({
             >
               <ChevronsDown className="h-3.5 w-3.5 flex-shrink-0" style={{ color: 'var(--color-text-tertiary)' }} />
               <span className="text-xs" style={{ color: 'var(--color-text-tertiary)' }}>
-                Load all
+                {t('nav.loadAll')}
               </span>
             </div>
           )}

--- a/web/src/pages/ChatAgent/components/NavigationPanel.tsx
+++ b/web/src/pages/ChatAgent/components/NavigationPanel.tsx
@@ -125,6 +125,14 @@ export function resetNavPanelExpansion() {
   _expandedThreads.clear();
 }
 
+// Forget a deleted workspace so the mount-effect doesn't re-expand it (and fire
+// a spurious threads 404) on the next panel remount. Only deletion is a safe
+// prune signal — `workspaces` is a paged/limited slice, so absence there can
+// mean "scrolled out", not "gone".
+export function forgetNavPanelExpansion(workspaceId: string) {
+  _expandedWorkspaces.delete(workspaceId);
+}
+
 function NavigationPanel({
   workspaces,
   workspaceThreads,

--- a/web/src/pages/ChatAgent/components/WorkspaceGallery.tsx
+++ b/web/src/pages/ChatAgent/components/WorkspaceGallery.tsx
@@ -19,6 +19,7 @@ import { createWorkspace, deleteWorkspace, getFlashWorkspace, updateWorkspace, r
 import { removeStoredThreadId } from '../hooks/useChatMessages';
 import { clearAllMarketThreadsForWorkspace } from '../../MarketView/utils/threadPersistence';
 import { forgetNavPanelExpansion } from './NavigationPanel';
+import { forgetStableNavOrder } from '../hooks/useNavigationData';
 import { clearChatSession } from '../hooks/utils/chatSessionRestore';
 
 const DEFAULT_PAGE_SIZE = 8;
@@ -31,6 +32,12 @@ interface WorkspaceRecord {
   is_pinned?: boolean;
   sort_order?: number;
   updated_at?: string;
+  [key: string]: unknown;
+}
+
+// Shape of a cached workspace-list query entry (queryKeys.workspaces.lists()).
+interface CachedWorkspaceList {
+  workspaces: WorkspaceRecord[];
   [key: string]: unknown;
 }
 
@@ -561,8 +568,10 @@ function WorkspaceGallery({ onWorkspaceSelect, prefetchThreads }: WorkspaceGalle
       removeStoredThreadId(workspaceId);
       clearAllMarketThreadsForWorkspace(workspaceId);
       // Drop the nav panel's remembered expansion so a later remount doesn't
-      // re-expand the now-deleted workspace and fire a spurious threads 404.
+      // re-expand the now-deleted workspace and fire a spurious threads 404,
+      // and clear its frozen-order entries so they don't linger all session.
       forgetNavPanelExpansion(workspaceId);
+      forgetStableNavOrder(workspaceId);
 
       // Invalidate workspace list cache
       queryClient.invalidateQueries({ queryKey: queryKeys.workspaces.lists() });
@@ -608,15 +617,15 @@ function WorkspaceGallery({ onWorkspaceSelect, prefetchThreads }: WorkspaceGalle
 
     // Snapshot + optimistic flip across all cached workspace lists
     const previous = queryClient.getQueriesData({ queryKey: queryKeys.workspaces.lists() });
-    previous.forEach(([key, data]: [unknown, any]) => {
-      if (data?.workspaces) {
-        queryClient.setQueryData(key as any, {
-          ...data,
-          workspaces: data.workspaces.map((ws: WorkspaceRecord) =>
-            ws.workspace_id === wsId ? { ...ws, is_pinned: newPinned } : ws
-          ),
-        });
-      }
+    previous.forEach(([key, data]: [unknown, unknown]) => {
+      const d = data as CachedWorkspaceList | undefined;
+      if (!d?.workspaces) return;
+      queryClient.setQueryData(key as readonly unknown[], {
+        ...d,
+        workspaces: d.workspaces.map((ws) =>
+          ws.workspace_id === wsId ? { ...ws, is_pinned: newPinned } : ws
+        ),
+      });
     });
 
     try {
@@ -630,7 +639,7 @@ function WorkspaceGallery({ onWorkspaceSelect, prefetchThreads }: WorkspaceGalle
       queryClient.invalidateQueries({ queryKey: queryKeys.workspaces.lists() });
     } catch (err) {
       // Rollback optimistic update
-      previous.forEach(([key, data]: [unknown, any]) => queryClient.setQueryData(key as any, data));
+      previous.forEach(([key, data]: [unknown, unknown]) => queryClient.setQueryData(key as readonly unknown[], data));
       console.error('Error toggling pin:', err);
     }
   };
@@ -661,15 +670,15 @@ function WorkspaceGallery({ onWorkspaceSelect, prefetchThreads }: WorkspaceGalle
     if (!trimmed) return;
 
     const previous = queryClient.getQueriesData({ queryKey: queryKeys.workspaces.lists() });
-    previous.forEach(([key, data]: [unknown, any]) => {
-      if (data?.workspaces) {
-        queryClient.setQueryData(key as any, {
-          ...data,
-          workspaces: data.workspaces.map((ws: WorkspaceRecord) =>
-            ws.workspace_id === wsId ? { ...ws, name: trimmed } : ws
-          ),
-        });
-      }
+    previous.forEach(([key, data]: [unknown, unknown]) => {
+      const d = data as CachedWorkspaceList | undefined;
+      if (!d?.workspaces) return;
+      queryClient.setQueryData(key as readonly unknown[], {
+        ...d,
+        workspaces: d.workspaces.map((ws) =>
+          ws.workspace_id === wsId ? { ...ws, name: trimmed } : ws
+        ),
+      });
     });
 
     try {
@@ -677,7 +686,7 @@ function WorkspaceGallery({ onWorkspaceSelect, prefetchThreads }: WorkspaceGalle
       queryClient.invalidateQueries({ queryKey: queryKeys.workspaces.lists() });
       queryClient.invalidateQueries({ queryKey: queryKeys.workspaces.detail(wsId) });
     } catch (err) {
-      previous.forEach(([key, data]: [unknown, any]) => queryClient.setQueryData(key as any, data));
+      previous.forEach(([key, data]: [unknown, unknown]) => queryClient.setQueryData(key as readonly unknown[], data));
       console.error('Error renaming workspace:', err);
     }
   };

--- a/web/src/pages/ChatAgent/components/WorkspaceGallery.tsx
+++ b/web/src/pages/ChatAgent/components/WorkspaceGallery.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
-import { Plus, Loader2, Search, ArrowDownUp, MoreHorizontal, Zap, MessageSquareText, Pin, Trash2, GripVertical, Check } from 'lucide-react';
+import { Plus, Loader2, Search, ArrowDownUp, MoreHorizontal, Zap, MessageSquareText, Pin, Trash2, GripVertical, Check, Pencil } from 'lucide-react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -65,10 +65,11 @@ const slideTransition = {
 interface CardMenuProps {
   workspace: WorkspaceRecord;
   onTogglePin: (workspace: WorkspaceRecord) => void;
+  onRename: (workspace: WorkspaceRecord) => void;
   onDelete: (workspace: WorkspaceRecord) => void;
 }
 
-function CardMenu({ workspace, onTogglePin, onDelete }: CardMenuProps) {
+function CardMenu({ workspace, onTogglePin, onRename, onDelete }: CardMenuProps) {
   const { t } = useTranslation();
 
   return (
@@ -86,6 +87,10 @@ function CardMenu({ workspace, onTogglePin, onDelete }: CardMenuProps) {
         <DropdownMenuItem onSelect={() => onTogglePin(workspace)}>
           <Pin className="h-4 w-4" />
           {workspace.is_pinned ? t('workspace.unpin') : t('workspace.pinToTop')}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => onRename(workspace)}>
+          <Pencil className="h-4 w-4" />
+          {t('workspace.rename')}
         </DropdownMenuItem>
         <DropdownMenuItem variant="destructive" onSelect={() => onDelete(workspace)}>
           <Trash2 className="h-4 w-4" />
@@ -169,15 +174,38 @@ interface WorkspaceCardProps {
   workspace: WorkspaceRecord;
   onSelect: (wsId: string, name?: string, status?: string) => void;
   onTogglePin: (workspace: WorkspaceRecord) => void;
+  onRenameStart: (workspace: WorkspaceRecord) => void;
+  onRenameSubmit: (wsId: string, name: string) => void;
+  onRenameCancel: () => void;
   onDelete: (workspace: WorkspaceRecord) => void;
+  isRenaming?: boolean;
   prefetchThreads?: (wsId: string) => void;
   index?: number;
 }
 
-function WorkspaceCard({ workspace, onSelect, onTogglePin, onDelete, prefetchThreads, index }: WorkspaceCardProps) {
+function WorkspaceCard({ workspace, onSelect, onTogglePin, onRenameStart, onRenameSubmit, onRenameCancel, onDelete, isRenaming, prefetchThreads, index }: WorkspaceCardProps) {
   const { t, i18n } = useTranslation();
   const isMobile = useIsMobile();
   const isFlash = workspace.status === 'flash';
+
+  // Inline rename — the title becomes a text input while editing. Commit on
+  // Enter/blur, cancel on Escape; the parent guards the trailing blur-after-Enter.
+  const [renameDraft, setRenameDraft] = useState(workspace.name);
+  const renameInputRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (!isRenaming) return;
+    setRenameDraft(workspace.name);
+    const raf = requestAnimationFrame(() => {
+      renameInputRef.current?.focus();
+      renameInputRef.current?.select();
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [isRenaming, workspace.name]);
+  const commitRename = () => {
+    const name = renameDraft.trim();
+    if (name && name !== workspace.name) onRenameSubmit(workspace.workspace_id, name);
+    else onRenameCancel();
+  };
 
   return (
     <div
@@ -189,7 +217,7 @@ function WorkspaceCard({ workspace, onSelect, onTogglePin, onDelete, prefetchThr
         onMouseEnter={!isMobile ? () => prefetchThreads?.(workspace.workspace_id) : undefined}
       >
         <div
-          onClick={() => onSelect(workspace.workspace_id, workspace.name, workspace.status)}
+          onClick={() => { if (!isRenaming) onSelect(workspace.workspace_id, workspace.name, workspace.status); }}
           className="relative flex cursor-pointer flex-col overflow-hidden rounded-xl py-4 pl-5 pr-4 transition-all ease-in-out hover:shadow-sm active:scale-[0.98] h-full w-full"
           style={{
             background: isFlash
@@ -210,9 +238,26 @@ function WorkspaceCard({ workspace, onSelect, onTogglePin, onDelete, prefetchThr
               {!isFlash && workspace.is_pinned && (
                 <Pin className="h-3.5 w-3.5 flex-shrink-0 rotate-45" style={{ color: 'var(--color-text-tertiary)' }} />
               )}
-              <div className="font-medium truncate" style={{ color: 'var(--color-text-primary)' }}>
-                {workspace.name}
-              </div>
+              {isRenaming ? (
+                <input
+                  ref={renameInputRef}
+                  className="font-medium bg-transparent outline-none border-b min-w-0 flex-1"
+                  style={{ color: 'var(--color-text-primary)', borderColor: 'var(--color-border-muted)' }}
+                  value={renameDraft}
+                  onChange={(e) => setRenameDraft(e.target.value)}
+                  onClick={(e) => e.stopPropagation()}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') { e.preventDefault(); commitRename(); }
+                    else if (e.key === 'Escape') { e.preventDefault(); onRenameCancel(); }
+                  }}
+                  onBlur={commitRename}
+                  aria-label={t('workspace.rename')}
+                />
+              ) : (
+                <div className="font-medium truncate" style={{ color: 'var(--color-text-primary)' }}>
+                  {workspace.name}
+                </div>
+              )}
             </div>
             <div className="text-sm line-clamp-2 flex-grow" style={{ color: 'var(--color-text-tertiary)' }}>
               {workspace.description || ''}
@@ -228,7 +273,7 @@ function WorkspaceCard({ workspace, onSelect, onTogglePin, onDelete, prefetchThr
         {/* Menu (no drag handle in normal mode) */}
         {!isFlash && (
           <div className={`absolute top-3 right-3 z-10 transition-opacity ${isMobile ? 'opacity-60' : 'opacity-0 group-focus-within:opacity-100 group-hover:opacity-100'}`}>
-            <CardMenu workspace={workspace} onTogglePin={onTogglePin} onDelete={onDelete} />
+            <CardMenu workspace={workspace} onTogglePin={onTogglePin} onRename={onRenameStart} onDelete={onDelete} />
           </div>
         )}
       </div>
@@ -256,10 +301,17 @@ function WorkspaceGallery({ onWorkspaceSelect, prefetchThreads }: WorkspaceGalle
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
-  const [sortBy, setSortBy] = useState<'activity' | 'name' | 'custom'>('activity');
+  // Default to the manual ('custom') order so the gallery matches the in-chat
+  // nav panel, which always shows the user's drag order. With no manual reorder
+  // the server's custom sort falls back to updated_at DESC, so this looks
+  // identical to 'activity' until the user actually reorders. Activity/Name
+  // remain available via the Sort-by toggle.
+  const [sortBy, setSortBy] = useState<'activity' | 'name' | 'custom'>('custom');
   const [currentPage, setCurrentPage] = useState(0);
   const [isReorderMode, setIsReorderMode] = useState(false);
   const [allWorkspaces, setAllWorkspaces] = useState<WorkspaceRecord[]>([]);
+  const [renamingWsId, setRenamingWsId] = useState<string | null>(null);
+  const renamingWsIdRef = useRef<string | null>(null); // shadows state so the trailing blur-after-Enter no-ops
   const navigate = useNavigate();
   const { workspaceId: currentWorkspaceId } = useParams();
   const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -576,6 +628,53 @@ function WorkspaceGallery({ onWorkspaceSelect, prefetchThreads }: WorkspaceGalle
   };
 
   /**
+   * Start an inline rename on a card (opens the title input).
+   */
+  const handleRenameStart = (workspace: WorkspaceRecord) => {
+    renamingWsIdRef.current = workspace.workspace_id;
+    setRenamingWsId(workspace.workspace_id);
+  };
+
+  const handleRenameCancel = () => {
+    renamingWsIdRef.current = null;
+    setRenamingWsId(null);
+  };
+
+  /**
+   * Commit a rename: optimistic update across cached lists, persist, then
+   * invalidate the list + detail caches so every surface (gallery, nav panel,
+   * FilePanel header) reflects the new name. Rolls back on error.
+   */
+  const handleRenameSubmit = async (wsId: string, name: string) => {
+    if (renamingWsIdRef.current !== wsId) return; // idempotent: trailing blur after Enter no-ops
+    renamingWsIdRef.current = null;
+    setRenamingWsId(null);
+    const trimmed = name.trim();
+    if (!trimmed) return;
+
+    const previous = queryClient.getQueriesData({ queryKey: queryKeys.workspaces.lists() });
+    previous.forEach(([key, data]: [unknown, any]) => {
+      if (data?.workspaces) {
+        queryClient.setQueryData(key as any, {
+          ...data,
+          workspaces: data.workspaces.map((ws: WorkspaceRecord) =>
+            ws.workspace_id === wsId ? { ...ws, name: trimmed } : ws
+          ),
+        });
+      }
+    });
+
+    try {
+      await updateWorkspace(wsId, { name: trimmed });
+      queryClient.invalidateQueries({ queryKey: queryKeys.workspaces.lists() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.workspaces.detail(wsId) });
+    } catch (err) {
+      previous.forEach(([key, data]: [unknown, any]) => queryClient.setQueryData(key as any, data));
+      console.error('Error renaming workspace:', err);
+    }
+  };
+
+  /**
    * Enter reorder mode -- fetch all workspaces
    */
   const enterReorderMode = () => {
@@ -635,7 +734,7 @@ function WorkspaceGallery({ onWorkspaceSelect, prefetchThreads }: WorkspaceGalle
     setAllWorkspaces(updated);
 
     try {
-      await reorderWorkspaces(items.map(it => ({ workspace_id: it.workspace_id, position: it.sort_order })));
+      await reorderWorkspaces(items);
       didReorderRef.current = true;
       queryClient.invalidateQueries({ queryKey: queryKeys.workspaces.lists() });
     } catch (err) {
@@ -810,6 +909,10 @@ function WorkspaceGallery({ onWorkspaceSelect, prefetchThreads }: WorkspaceGalle
               index={index}
               onSelect={onWorkspaceSelect}
               onTogglePin={handleTogglePin}
+              onRenameStart={handleRenameStart}
+              onRenameSubmit={handleRenameSubmit}
+              onRenameCancel={handleRenameCancel}
+              isRenaming={renamingWsId === workspace.workspace_id}
               onDelete={handleDeleteClick}
               prefetchThreads={prefetchThreads}
             />

--- a/web/src/pages/ChatAgent/components/WorkspaceGallery.tsx
+++ b/web/src/pages/ChatAgent/components/WorkspaceGallery.tsx
@@ -18,6 +18,7 @@ import { queryKeys } from '../../../lib/queryKeys';
 import { createWorkspace, deleteWorkspace, getFlashWorkspace, updateWorkspace, reorderWorkspaces } from '../utils/api';
 import { removeStoredThreadId } from '../hooks/useChatMessages';
 import { clearAllMarketThreadsForWorkspace } from '../../MarketView/utils/threadPersistence';
+import { forgetNavPanelExpansion } from './NavigationPanel';
 import { clearChatSession } from '../hooks/utils/chatSessionRestore';
 
 const DEFAULT_PAGE_SIZE = 8;
@@ -559,6 +560,9 @@ function WorkspaceGallery({ onWorkspaceSelect, prefetchThreads }: WorkspaceGalle
       // (workspace, symbol) pair).
       removeStoredThreadId(workspaceId);
       clearAllMarketThreadsForWorkspace(workspaceId);
+      // Drop the nav panel's remembered expansion so a later remount doesn't
+      // re-expand the now-deleted workspace and fire a spurious threads 404.
+      forgetNavPanelExpansion(workspaceId);
 
       // Invalidate workspace list cache
       queryClient.invalidateQueries({ queryKey: queryKeys.workspaces.lists() });

--- a/web/src/pages/ChatAgent/components/WorkspaceGallery.tsx
+++ b/web/src/pages/ChatAgent/components/WorkspaceGallery.tsx
@@ -194,13 +194,17 @@ function WorkspaceCard({ workspace, onSelect, onTogglePin, onRenameStart, onRena
   const renameInputRef = useRef<HTMLInputElement>(null);
   useEffect(() => {
     if (!isRenaming) return;
+    // Seed the draft once on entry only. Re-running on workspace.name would let a
+    // background refetch (e.g. another session's rename) clobber the in-progress
+    // input mid-edit, so it's intentionally absent from the deps.
     setRenameDraft(workspace.name);
     const raf = requestAnimationFrame(() => {
       renameInputRef.current?.focus();
       renameInputRef.current?.select();
     });
     return () => cancelAnimationFrame(raf);
-  }, [isRenaming, workspace.name]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isRenaming]);
   const commitRename = () => {
     const name = renameDraft.trim();
     if (name && name !== workspace.name) onRenameSubmit(workspace.workspace_id, name);

--- a/web/src/pages/ChatAgent/components/__tests__/ActivityBlock.lifecycle.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/ActivityBlock.lifecycle.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * Live-row lifecycle states + replay parity for ActivityBlock.
+ *
+ * Live rows: `active` gets the left-rule class hook + shimmer label,
+ * `completing` is a neutral dimmed row (no badge), `failed` gets the gray ✕
+ * badge with the toolCallFailed a11y label — all in the live zone, no
+ * accordion interaction required.
+ *
+ * Replay parity: with `isStreaming={false}` (history / reconnect replay),
+ * completed rows must render WITHOUT the motion.li entrance wrapper —
+ * `newlyCompletedIds` is gated on isStreaming, so replayed timelines are
+ * animation-free. The motion.li wrapper carries `overflow: hidden` inline
+ * style while the plain <li> does not; we assert on that distinction.
+ *
+ * Strategy mirrors ActivityBlock.failed.test.tsx: render `ActivityBlock`
+ * directly with synthesized items and an identity t() mock. All data is
+ * neutral placeholder data.
+ */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ActivityBlock from '../ActivityBlock';
+
+// ---------------------------------------------------------------------------
+// Mocks — keep the component mountable in jsdom and surface i18n keys.
+// ---------------------------------------------------------------------------
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (opts && typeof opts === 'object') {
+        let out = key;
+        for (const [k, v] of Object.entries(opts)) {
+          out = out.replace(new RegExp(`{{\\s*${k}\\s*}}`, 'g'), String(v));
+        }
+        return out;
+      }
+      return key;
+    },
+  }),
+}));
+
+vi.mock('../Markdown', () => ({
+  default: ({ content }: { content: string }) => (
+    <div data-testid="markdown-content">{content}</div>
+  ),
+}));
+
+vi.mock('../charts/InlineArtifactCards', () => ({
+  INLINE_ARTIFACT_TOOLS: new Set<string>(),
+  InlineStockPriceCard: () => null,
+  InlineCompanyOverviewCard: () => null,
+  InlineMarketIndicesCard: () => null,
+  InlineSectorPerformanceCard: () => null,
+  InlineSecFilingCard: () => null,
+  InlineStockScreenerCard: () => null,
+  InlineWebSearchCard: () => null,
+}));
+
+vi.mock('../charts/InlineAutomationCards', () => ({
+  InlineAutomationCard: () => null,
+}));
+
+vi.mock('../charts/InlinePreviewCard', () => ({
+  InlinePreviewCard: () => null,
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type ActivityItem = Parameters<typeof ActivityBlock>[0]['items'][number];
+
+function toolItem(liveState: ActivityItem['_liveState'], opts: Partial<ActivityItem> = {}): ActivityItem {
+  return {
+    type: 'tool_call',
+    id: opts.id ?? 'tc-1',
+    toolName: 'Read',
+    toolCall: { args: { file_path: 'work/sample-notes.md' } },
+    _liveState: liveState,
+    ...opts,
+  } as ActivityItem;
+}
+
+const SUMMARY_BUTTON_RE = /toolArtifact/i;
+
+// ---------------------------------------------------------------------------
+// Live-row lifecycle states
+// ---------------------------------------------------------------------------
+
+describe('ActivityBlock — live-row lifecycle states', () => {
+  it('renders an active tool row with the state-active left-rule hook and no badge', () => {
+    const items = [toolItem('active', { isComplete: false })];
+    const { container } = render(<ActivityBlock items={items} isStreaming={true} />);
+
+    const row = container.querySelector('.nrow.state-active');
+    expect(row).not.toBeNull();
+    expect(container.querySelector('.nrow-badge')).toBeNull();
+    // Active rows live in the live zone — no accordion summary yet.
+    expect(screen.queryByRole('button', { name: SUMMARY_BUTTON_RE })).toBeNull();
+  });
+
+  it('renders a completing tool row without the active rule and without a badge', () => {
+    const items = [toolItem('completing', { isComplete: true, _recentlyCompleted: true })];
+    const { container } = render(<ActivityBlock items={items} isStreaming={true} />);
+
+    const row = container.querySelector('.nrow');
+    expect(row).not.toBeNull();
+    expect(container.querySelector('.nrow.state-active')).toBeNull();
+    expect(container.querySelector('.nrow-badge')).toBeNull();
+  });
+
+  it('renders the failed ✕ badge on a live failed row with the a11y label', () => {
+    const items = [toolItem('failed', { isComplete: true, isFailed: true, _recentlyCompleted: true })];
+    const { container } = render(<ActivityBlock items={items} isStreaming={true} />);
+
+    const badge = container.querySelector('.nrow .nrow-badge');
+    expect(badge).not.toBeNull();
+    expect(badge!.getAttribute('aria-label')).toBe('toolArtifact.a11y.toolCallFailed');
+    // Failed rows stay neutral — no active rule.
+    expect(container.querySelector('.nrow.state-active')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Replay parity — no entrance animation on history / reconnect replay
+// ---------------------------------------------------------------------------
+
+describe('ActivityBlock — replay parity', () => {
+  it('renders completed rows without the motion.li entrance wrapper when not streaming', () => {
+    const items = [
+      toolItem('completed', { id: 'tc-1', isComplete: true }),
+      toolItem('completed', { id: 'tc-2', isComplete: true }),
+    ];
+    const { container } = render(<ActivityBlock items={items} isStreaming={false} />);
+
+    fireEvent.click(screen.getByRole('button', { name: SUMMARY_BUTTON_RE }));
+
+    const rows = container.querySelectorAll('.timeline > li');
+    expect(rows.length).toBe(2);
+    for (const row of rows) {
+      // motion.li entrance wrapper carries overflow:hidden; plain <li> does not.
+      expect((row as HTMLElement).style.overflow).not.toBe('hidden');
+    }
+  });
+
+  it('renders newly completed rows WITH the entrance wrapper while streaming (contrast case)', () => {
+    const items = [toolItem('completed', { id: 'tc-1', isComplete: true })];
+    const { container } = render(<ActivityBlock items={items} isStreaming={true} />);
+
+    fireEvent.click(screen.getByRole('button', { name: SUMMARY_BUTTON_RE }));
+
+    const rows = container.querySelectorAll('.timeline > li');
+    expect(rows.length).toBe(1);
+    expect((rows[0] as HTMLElement).style.overflow).toBe('hidden');
+  });
+});

--- a/web/src/pages/ChatAgent/components/__tests__/MessageList.lifecycle.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/MessageList.lifecycle.test.tsx
@@ -1,0 +1,315 @@
+/**
+ * Partition-timing coverage for the live → accordion lifecycle in
+ * MessageContentSegments (textOnly mode).
+ *
+ * The partition memo in MessageList.tsx decides whether each reasoning /
+ * tool-call item renders in the live zone (`active` / `completing` /
+ * `failed`) or folds into the accordion (`completed`):
+ *
+ *  - Stream end overrides the age-based cooldown: when `isStreaming` flips
+ *    false, everything folds immediately — no timer advancement required.
+ *    This also guarantees history/replay items (isStreaming always false)
+ *    never enter the live zone.
+ *  - While streaming, a just-completed item lingers in the live zone for
+ *    the MIN_LIVE_EXPOSURE_MS cooldown, then folds when the internal tick
+ *    timer fires.
+ *  - Inline-artifact tools with a ready artifact render as compact artifact
+ *    blocks — never in the live zone, never in the accordion timeline.
+ *
+ * Driven through the public `MessageContentSegments` export with fake
+ * timers. framer-motion is stubbed so AnimatePresence unmounts exiting
+ * nodes synchronously — these tests assert partition output, not animation.
+ * All data is neutral placeholder data.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MessageContentSegments } from '../MessageList';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// Stub framer-motion: motion.* render as plain elements (framer-only props
+// stripped), AnimatePresence is a passthrough (exits unmount synchronously),
+// `animate` (used by useAnimatedText) is a no-op. `motion.create` mirrors the
+// real API used by TextShimmer.
+vi.mock('framer-motion', async () => {
+  const React = await vi.importActual<typeof import('react')>('react');
+  const FRAMER_ONLY_PROPS = new Set([
+    'initial', 'animate', 'exit', 'transition', 'variants',
+    'whileHover', 'whileTap', 'whileInView', 'layout', 'layoutId',
+    'onAnimationComplete', 'onAnimationStart',
+  ]);
+  // Loosened createElement signature — the stub forwards arbitrary tag names
+  // and components without modeling their prop types.
+  const createEl = React.createElement as (type: unknown, props?: unknown, ...children: unknown[]) => React.ReactElement;
+  const make = (Comp: React.ElementType | string) =>
+    function MotionStub({ children, ...props }: { children?: React.ReactNode } & Record<string, unknown>) {
+      const domProps: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(props)) {
+        if (!FRAMER_ONLY_PROPS.has(k)) domProps[k] = v;
+      }
+      return createEl(Comp, domProps, children);
+    };
+  return {
+    motion: new Proxy({} as Record<string, unknown>, {
+      get: (_target, key: string) => (key === 'create' ? make : make(key)),
+    }),
+    AnimatePresence: ({ children }: { children?: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+    animate: () => ({ stop: () => {} }),
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (opts && typeof opts === 'object') {
+        let out = key;
+        for (const [k, v] of Object.entries(opts)) {
+          out = out.replace(new RegExp(`{{\\s*${k}\\s*}}`, 'g'), String(v));
+        }
+        return out;
+      }
+      return key;
+    },
+  }),
+}));
+
+// Markdown is heavy and irrelevant to partition logic.
+vi.mock('../Markdown', () => ({
+  default: ({ content }: { content: string }) => (
+    <div data-testid="markdown-content">{content}</div>
+  ),
+}));
+
+// Control the inline-artifact tool set so the no-flash test doesn't depend on
+// production tool names. `stock_prices` is a key of INLINE_ARTIFACT_MAP in
+// MessageList, so the mocked card below is what a ready artifact renders as.
+vi.mock('../charts/InlineArtifactCards', async () => {
+  const React = await vi.importActual<typeof import('react')>('react');
+  return {
+    INLINE_ARTIFACT_TOOLS: new Set<string>(['fetch_sample_chart']),
+    InlineStockPriceCard: () => React.createElement('div', { 'data-testid': 'inline-chart' }),
+    InlineCompanyOverviewCard: () => null,
+    InlineMarketIndicesCard: () => null,
+    InlineSectorPerformanceCard: () => null,
+    InlineSecFilingCard: () => null,
+    InlineStockScreenerCard: () => null,
+    InlineWebSearchCard: () => null,
+  };
+});
+
+vi.mock('../charts/InlineAutomationCards', () => ({
+  InlineAutomationCard: () => null,
+}));
+
+vi.mock('../charts/InlinePreviewCard', () => ({
+  InlinePreviewCard: () => null,
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type SegmentsProps = React.ComponentProps<typeof MessageContentSegments>;
+
+const baseProps = {
+  reasoningProcesses: {},
+  toolCallProcesses: {},
+  todoListProcesses: {},
+  subagentTasks: {},
+  hasError: false,
+  isAssistant: true,
+  textOnly: true,
+} satisfies Partial<SegmentsProps>;
+
+const SUMMARY_BUTTON_RE = /toolArtifact/i;
+
+function completedToolProc(createdAt: number, over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    toolName: 'Read',
+    toolCall: { args: { file_path: 'docs/sample-notes.md' } },
+    isInProgress: false,
+    isComplete: true,
+    isFailed: false,
+    _createdAt: createdAt,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  // Date is faked alongside setTimeout so the partition's Date.now() ages and
+  // the tick timer advance together under vi.advanceTimersByTime.
+  vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ---------------------------------------------------------------------------
+// Immediate fold on stream end
+// ---------------------------------------------------------------------------
+
+describe('MessageContentSegments — immediate fold on stream end', () => {
+  it('folds completing items into the accordion as soon as isStreaming flips false, with no timer advance', () => {
+    const now = Date.now();
+    const props: SegmentsProps = {
+      ...baseProps,
+      segments: [
+        { type: 'reasoning', order: 0, reasoningId: 'rs-1' },
+        { type: 'tool_call', order: 1, toolCallId: 'tc-1' },
+      ],
+      reasoningProcesses: {
+        'rs-1': { isReasoning: false, content: 'placeholder reasoning text', reasoningComplete: true, _completedAt: now },
+      },
+      toolCallProcesses: { 'tc-1': completedToolProc(now) },
+      isStreaming: true,
+    };
+
+    const view = render(<MessageContentSegments {...props} />);
+
+    // Both items just completed → inside the exposure window → live zone.
+    expect(view.container.querySelector('.nrow')).not.toBeNull();
+    expect(screen.queryByRole('button', { name: SUMMARY_BUTTON_RE })).toBeNull();
+
+    // Stream ends. No timers advanced — the fold must be immediate.
+    view.rerender(<MessageContentSegments {...props} isStreaming={false} />);
+
+    expect(screen.getByRole('button', { name: SUMMARY_BUTTON_RE })).toBeInTheDocument();
+    expect(view.container.querySelector('.nrow')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Always-live tools survive stream end while still in progress
+// ---------------------------------------------------------------------------
+
+describe('MessageContentSegments — always-live in-progress tools', () => {
+  it('keeps an in-progress TaskOutput in the live zone after isStreaming flips false (subagent still running)', () => {
+    const now = Date.now();
+    const props: SegmentsProps = {
+      ...baseProps,
+      segments: [{ type: 'tool_call', order: 0, toolCallId: 'tc-task' }],
+      toolCallProcesses: {
+        // TaskOutput is in ALWAYS_LIVE_TOOLS. In-progress = the agent is waiting
+        // on a background subagent. The main stream may end before the subagent
+        // finishes — the indicator must stay visible, not fold into the accordion.
+        'tc-task': {
+          toolName: 'TaskOutput',
+          toolCall: { args: {} },
+          isInProgress: true,
+          isComplete: false,
+          isFailed: false,
+          _createdAt: now,
+        },
+      },
+      isStreaming: true,
+    };
+
+    const view = render(<MessageContentSegments {...props} />);
+
+    // Streaming: live row present, no accordion.
+    expect(view.container.querySelector('.nrow')).not.toBeNull();
+    expect(screen.queryByRole('button', { name: SUMMARY_BUTTON_RE })).toBeNull();
+
+    // Main stream ends but the tool is still in progress (subagent running).
+    // It must STAY in the live zone — not fold into the accordion.
+    view.rerender(<MessageContentSegments {...props} isStreaming={false} />);
+
+    expect(view.container.querySelector('.nrow')).not.toBeNull();
+    expect(screen.queryByRole('button', { name: SUMMARY_BUTTON_RE })).toBeNull();
+
+    // When the subagent finishes, the tool completes → it folds to the accordion.
+    const completedProps: SegmentsProps = {
+      ...props,
+      isStreaming: false,
+      toolCallProcesses: {
+        'tc-task': {
+          toolName: 'TaskOutput', toolCall: { args: {} },
+          isInProgress: false, isComplete: true, isFailed: false, _createdAt: now,
+        },
+      },
+    };
+    view.rerender(<MessageContentSegments {...completedProps} />);
+
+    expect(view.container.querySelector('.nrow')).toBeNull();
+    expect(screen.getByRole('button', { name: SUMMARY_BUTTON_RE })).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cooldown boundary while streaming
+// ---------------------------------------------------------------------------
+
+describe('MessageContentSegments — live-zone cooldown while streaming', () => {
+  it('keeps a just-completed item in the live zone through the cooldown, then folds it when the window elapses', () => {
+    // Item completed 1000ms ago — still inside the exposure window. The ages
+    // below track MIN_LIVE_EXPOSURE_MS (currently 1800ms): first advance stays
+    // inside the window, second crosses the boundary. Adjust both together if
+    // the constant is tuned.
+    const createdAt = Date.now() - 1000;
+    const props: SegmentsProps = {
+      ...baseProps,
+      segments: [{ type: 'tool_call', order: 0, toolCallId: 'tc-1' }],
+      toolCallProcesses: { 'tc-1': completedToolProc(createdAt) },
+      isStreaming: true,
+    };
+
+    const view = render(<MessageContentSegments {...props} />);
+
+    // Inside the window: live row, no accordion.
+    expect(view.container.querySelector('.nrow')).not.toBeNull();
+    expect(screen.queryByRole('button', { name: SUMMARY_BUTTON_RE })).toBeNull();
+
+    // Still inside the window — nothing folds.
+    act(() => { vi.advanceTimersByTime(600); });
+    expect(view.container.querySelector('.nrow')).not.toBeNull();
+    expect(screen.queryByRole('button', { name: SUMMARY_BUTTON_RE })).toBeNull();
+
+    // Crossing the boundary fires the tick timer and folds the item.
+    act(() => { vi.advanceTimersByTime(1000); });
+    expect(screen.getByRole('button', { name: SUMMARY_BUTTON_RE })).toBeInTheDocument();
+    expect(view.container.querySelector('.nrow')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Inline-artifact tools never flash through live zone or accordion
+// ---------------------------------------------------------------------------
+
+describe('MessageContentSegments — inline-artifact tools', () => {
+  it('renders a ready artifact as a compact chart block, never in the live zone or accordion — streaming and after stream end', () => {
+    const now = Date.now();
+    const props: SegmentsProps = {
+      ...baseProps,
+      segments: [{ type: 'tool_call', order: 0, toolCallId: 'tc-art' }],
+      toolCallProcesses: {
+        // Fresh completion (inside the cooldown window) with a ready artifact:
+        // the artifact branch must win over the completing branch.
+        'tc-art': completedToolProc(now, {
+          toolName: 'fetch_sample_chart',
+          toolCall: { args: {} },
+          toolCallResult: { artifact: { type: 'stock_prices', data: [] } },
+        }),
+      },
+      isStreaming: true,
+    };
+
+    const view = render(<MessageContentSegments {...props} />);
+
+    expect(screen.getByTestId('inline-chart')).toBeInTheDocument();
+    expect(view.container.querySelector('.nrow')).toBeNull();
+    expect(screen.queryByRole('button', { name: SUMMARY_BUTTON_RE })).toBeNull();
+
+    // Same invariants after the stream ends.
+    view.rerender(<MessageContentSegments {...props} isStreaming={false} />);
+
+    expect(screen.getByTestId('inline-chart')).toBeInTheDocument();
+    expect(view.container.querySelector('.nrow')).toBeNull();
+    expect(screen.queryByRole('button', { name: SUMMARY_BUTTON_RE })).toBeNull();
+  });
+});

--- a/web/src/pages/ChatAgent/components/__tests__/NavigationPanel.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/NavigationPanel.test.tsx
@@ -11,8 +11,9 @@
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
-import NavigationPanel from '../NavigationPanel';
+import NavigationPanel, { resetNavPanelExpansion } from '../NavigationPanel';
 
 // `t()` identity mock — we don't depend on bundled English copy here, but
 // the component reads i18n keys for some labels and we want the fallback
@@ -159,5 +160,163 @@ describe('NavigationPanel — hierarchy markers', () => {
     const glyph = Array.from(subRow.children).find((c) => c.textContent === '└─');
     expect(glyph).toBeTruthy();
     expect(glyph!.getAttribute('aria-hidden')).toBe('true');
+  });
+});
+
+describe('NavigationPanel — workspace render order', () => {
+  it('renders workspaces in prop order without hoisting the current one', () => {
+    render(
+      <NavigationPanel
+        workspaces={[
+          { workspace_id: 'ws-a', name: 'Workspace A' },
+          { workspace_id: 'ws-b', name: 'Workspace B' },
+          { workspace_id: 'ws-c', name: 'Workspace C' },
+        ]}
+        workspaceThreads={{}}
+        currentWorkspaceId="ws-c"
+        currentThreadId={null}
+        agents={[]}
+        activeAgentId={null}
+        expandWorkspace={vi.fn()}
+        onSelectAgent={vi.fn()}
+        onRemoveAgent={vi.fn()}
+        onNavigateThread={vi.fn()}
+      />,
+    );
+
+    const names = screen.getAllByText(/^Workspace [ABC]$/).map((el) => el.textContent);
+    expect(names).toEqual(['Workspace A', 'Workspace B', 'Workspace C']);
+  });
+});
+
+describe('NavigationPanel — show more threads', () => {
+  function renderWithThreads(threadsData: { threads: { thread_id: string; title: string }[]; loading: boolean; total?: number }, onLoadMoreThreads = vi.fn()) {
+    resetNavPanelExpansion();
+    render(
+      <NavigationPanel
+        workspaces={[{ workspace_id: WS_ID, name: 'Test workspace' }]}
+        workspaceThreads={{ [WS_ID]: threadsData }}
+        currentWorkspaceId={WS_ID}
+        currentThreadId={null}
+        agents={[]}
+        activeAgentId={null}
+        expandWorkspace={vi.fn()}
+        onSelectAgent={vi.fn()}
+        onRemoveAgent={vi.fn()}
+        onNavigateThread={vi.fn()}
+        onLoadMoreThreads={onLoadMoreThreads}
+      />,
+    );
+    return onLoadMoreThreads;
+  }
+
+  it('renders a show-more row when more threads exist server-side and pages on click', async () => {
+    const user = userEvent.setup();
+    const onLoadMoreThreads = renderWithThreads({
+      threads: [
+        { thread_id: 't-1', title: 'Thread one' },
+        { thread_id: 't-2', title: 'Thread two' },
+      ],
+      loading: false,
+      total: 5,
+    });
+
+    const row = screen.getByText('nav.showMore');
+    await user.click(row);
+    expect(onLoadMoreThreads).toHaveBeenCalledWith(WS_ID);
+  });
+
+  it('hides the show-more row when every thread is already shown or total is unknown', () => {
+    renderWithThreads({
+      threads: [{ thread_id: 't-1', title: 'Thread one' }],
+      loading: false,
+      total: 1,
+    });
+    expect(screen.queryByText('nav.showMore')).toBeNull();
+
+    renderWithThreads({
+      threads: [{ thread_id: 't-1', title: 'Thread one' }],
+      loading: false,
+    });
+    expect(screen.queryByText('nav.showMore')).toBeNull();
+  });
+});
+
+describe('NavigationPanel — workspace drag-reorder affordances', () => {
+  function renderReorderPanel(onReorderWorkspace?: (a: string, b: string) => void) {
+    return render(
+      <NavigationPanel
+        workspaces={[
+          { workspace_id: 'ws-flash', name: 'Flash workspace', status: 'flash' },
+          { workspace_id: 'ws-a', name: 'Workspace A' },
+        ]}
+        workspaceThreads={{}}
+        currentWorkspaceId="ws-a"
+        currentThreadId={null}
+        agents={[]}
+        activeAgentId={null}
+        expandWorkspace={vi.fn()}
+        onSelectAgent={vi.fn()}
+        onRemoveAgent={vi.fn()}
+        onNavigateThread={vi.fn()}
+        onReorderWorkspace={onReorderWorkspace}
+      />,
+    );
+  }
+
+  it('marks workspace header rows sortable, but never the flash workspace', () => {
+    renderReorderPanel(vi.fn());
+
+    const sortable = screen.getByText('Workspace A').closest('[aria-roledescription="sortable"]');
+    expect(sortable).not.toBeNull();
+    expect(screen.getByText('Flash workspace').closest('[aria-roledescription="sortable"]')).toBeNull();
+  });
+
+  it('renders plain rows when no reorder handler is provided', () => {
+    renderReorderPanel(undefined);
+
+    expect(screen.getByText('Workspace A').closest('[aria-roledescription="sortable"]')).toBeNull();
+  });
+});
+
+describe('NavigationPanel — expansion survives remounts', () => {
+  function renderOrderPanel(currentWorkspaceId: string) {
+    return render(
+      <NavigationPanel
+        workspaces={[
+          { workspace_id: 'ws-a', name: 'Workspace A' },
+          { workspace_id: 'ws-b', name: 'Workspace B' },
+        ]}
+        workspaceThreads={{
+          'ws-a': { threads: [{ thread_id: 'ta-1', title: 'Thread A1' }], loading: false },
+          'ws-b': { threads: [{ thread_id: 'tb-1', title: 'Thread B1' }], loading: false },
+        }}
+        currentWorkspaceId={currentWorkspaceId}
+        currentThreadId={null}
+        agents={[]}
+        activeAgentId={null}
+        expandWorkspace={vi.fn()}
+        onSelectAgent={vi.fn()}
+        onRemoveAgent={vi.fn()}
+        onNavigateThread={vi.fn()}
+      />,
+    );
+  }
+
+  it('keeps a manually opened folder expanded after the panel remounts', async () => {
+    resetNavPanelExpansion();
+    const user = userEvent.setup();
+    const first = renderOrderPanel('ws-a');
+
+    // ws-b starts collapsed; open it manually.
+    expect(screen.queryByText('Thread B1')).toBeNull();
+    await user.click(screen.getByText('Workspace B'));
+    expect(screen.getByText('Thread B1')).toBeInTheDocument();
+
+    // Thread switch remounts the panel (fresh ChatView instance) — the folder
+    // the user opened must not auto-collapse.
+    first.unmount();
+    renderOrderPanel('ws-a');
+    expect(screen.getByText('Thread B1')).toBeInTheDocument();
   });
 });

--- a/web/src/pages/ChatAgent/components/__tests__/NavigationPanel.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/NavigationPanel.test.tsx
@@ -13,7 +13,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
-import NavigationPanel, { resetNavPanelExpansion } from '../NavigationPanel';
+import NavigationPanel, { resetNavPanelExpansion, forgetNavPanelExpansion } from '../NavigationPanel';
 
 // `t()` identity mock — we don't depend on bundled English copy here, but
 // the component reads i18n keys for some labels and we want the fallback
@@ -280,7 +280,7 @@ describe('NavigationPanel — workspace drag-reorder affordances', () => {
 });
 
 describe('NavigationPanel — expansion survives remounts', () => {
-  function renderOrderPanel(currentWorkspaceId: string) {
+  function renderOrderPanel(currentWorkspaceId: string, expandWorkspace: (wsId: string) => void = vi.fn()) {
     return render(
       <NavigationPanel
         workspaces={[
@@ -295,7 +295,7 @@ describe('NavigationPanel — expansion survives remounts', () => {
         currentThreadId={null}
         agents={[]}
         activeAgentId={null}
-        expandWorkspace={vi.fn()}
+        expandWorkspace={expandWorkspace}
         onSelectAgent={vi.fn()}
         onRemoveAgent={vi.fn()}
         onNavigateThread={vi.fn()}
@@ -318,5 +318,24 @@ describe('NavigationPanel — expansion survives remounts', () => {
     first.unmount();
     renderOrderPanel('ws-a');
     expect(screen.getByText('Thread B1')).toBeInTheDocument();
+  });
+
+  it('does not re-expand a forgotten (deleted) workspace on remount', async () => {
+    resetNavPanelExpansion();
+    const user = userEvent.setup();
+    const first = renderOrderPanel('ws-a');
+
+    // Open ws-b, then forget it as the delete path does.
+    await user.click(screen.getByText('Workspace B'));
+    expect(screen.getByText('Thread B1')).toBeInTheDocument();
+    forgetNavPanelExpansion('ws-b');
+
+    // On remount the mount-effect must not re-expand ws-b (no spurious 404) and
+    // its folder stays collapsed.
+    first.unmount();
+    const expandSpy = vi.fn();
+    renderOrderPanel('ws-a', expandSpy);
+    expect(screen.queryByText('Thread B1')).toBeNull();
+    expect(expandSpy).not.toHaveBeenCalledWith('ws-b');
   });
 });

--- a/web/src/pages/ChatAgent/hooks/__tests__/useNavigationData.test.tsx
+++ b/web/src/pages/ChatAgent/hooks/__tests__/useNavigationData.test.tsx
@@ -1,0 +1,635 @@
+/**
+ * Stable nav ordering in useNavigationData.
+ *
+ * The backend returns threads (and unpinned workspaces within the 'custom'
+ * sort) `updated_at DESC`, so the item being chatted in would hoist to the
+ * top whenever React Query refetches mid-conversation. The hook freezes the
+ * order seen first in the page session (module-level, surviving the per-thread
+ * ChatView remounts); refetches reorder to the frozen sequence, genuinely new
+ * ids surface at the top, paginated-in ids append below, deleted ids drop out.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { createTestQueryClient } from '../../../../test/utils';
+import {
+  useNavigationData,
+  applyStableOrder,
+  applyStableOrderBy,
+  resetStableNavOrder,
+  bumpThreadNavOrder,
+} from '../useNavigationData';
+import { resetNavPrefs, setNavPrefs } from '../../utils/navPrefs';
+
+vi.mock('../../utils/api', () => ({
+  getWorkspaces: vi.fn(),
+  getWorkspaceThreads: vi.fn(),
+  reorderWorkspaces: vi.fn(),
+  updateWorkspace: vi.fn(),
+}));
+
+import { getWorkspaces, getWorkspaceThreads, reorderWorkspaces, updateWorkspace } from '../../utils/api';
+
+const mockGetWorkspaces = getWorkspaces as Mock;
+const mockGetWorkspaceThreads = getWorkspaceThreads as Mock;
+const mockReorderWorkspaces = reorderWorkspaces as Mock;
+const mockUpdateWorkspace = updateWorkspace as Mock;
+
+interface TestThread {
+  thread_id: string;
+  title: string;
+  [key: string]: unknown;
+}
+
+const thread = (id: string): TestThread => ({ thread_id: id, title: `Thread ${id}` });
+const threads = (...ids: string[]) => ids.map(thread);
+
+describe('applyStableOrder (pure)', () => {
+  it('snapshots server order on first sight (no frozen order yet)', () => {
+    const server = threads('t-3', 't-1', 't-2');
+    const { order, threads: result } = applyStableOrder(undefined, server);
+
+    expect(order).toEqual(['t-3', 't-1', 't-2']);
+    expect(result).toEqual(server);
+  });
+
+  it('keeps the frozen order when the server reshuffles by recency', () => {
+    const frozen = ['t-3', 't-1', 't-2'];
+    // t-1 was active, so the server now lists it first.
+    const server = threads('t-1', 't-3', 't-2');
+    const { order, threads: result } = applyStableOrder(frozen, server);
+
+    expect(order).toEqual(frozen);
+    expect(result.map((t) => t.thread_id)).toEqual(frozen);
+  });
+
+  it('surfaces a genuinely new thread id at the top and adds it to the order', () => {
+    const frozen = ['t-3', 't-1', 't-2'];
+    const server = threads('t-new', 't-1', 't-3', 't-2');
+    const { order, threads: result } = applyStableOrder(frozen, server);
+
+    expect(order).toEqual(['t-new', 't-3', 't-1', 't-2']);
+    expect(result.map((t) => t.thread_id)).toEqual(['t-new', 't-3', 't-1', 't-2']);
+  });
+
+  it('drops ids missing from the server response (deleted threads) without error', () => {
+    const frozen = ['t-3', 't-1', 't-2'];
+    const server = threads('t-3', 't-2'); // t-1 deleted server-side
+    const { threads: result } = applyStableOrder(frozen, server);
+
+    expect(result.map((t) => t.thread_id)).toEqual(['t-3', 't-2']);
+  });
+
+  it('handles an empty server response', () => {
+    const { order, threads: result } = applyStableOrder(['t-1'], []);
+
+    expect(order).toEqual(['t-1']);
+    expect(result).toEqual([]);
+  });
+
+  it('appends unseen ids that arrive after known ids (pagination) below the stable block', () => {
+    const frozen = ['t-3', 't-1'];
+    // t-old arrives after known ids — a paginated-in older entry, not a new thread.
+    const server = threads('t-1', 't-3', 't-old');
+    const { order } = applyStableOrderBy(frozen, server, (t) => t.thread_id);
+
+    expect(order).toEqual(['t-3', 't-1', 't-old']);
+  });
+});
+
+describe('useNavigationData — stable thread ordering', () => {
+  let threadsByWs: Record<string, TestThread[]>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStableNavOrder();
+    resetNavPrefs();
+    threadsByWs = {
+      'ws-1': threads('t-3', 't-1', 't-2'),
+      'ws-2': threads('u-2', 'u-1'),
+    };
+    mockGetWorkspaces.mockResolvedValue({
+      workspaces: [{ workspace_id: 'ws-1' }, { workspace_id: 'ws-2' }],
+      total: 2,
+    });
+    mockGetWorkspaceThreads.mockImplementation((wsId: string) =>
+      Promise.resolve({ threads: threadsByWs[wsId] ?? [] }),
+    );
+  });
+
+  function setup(initialWsId = 'ws-1') {
+    const queryClient = createTestQueryClient();
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const rendered = renderHook(({ wsId }) => useNavigationData(wsId), {
+      wrapper,
+      initialProps: { wsId: initialWsId },
+    });
+    const idsFor = (wsId: string) =>
+      (rendered.result.current.workspaceThreads[wsId]?.threads ?? []).map((t) => t.thread_id);
+    return { ...rendered, queryClient, idsFor };
+  }
+
+  it('first load preserves server (recency) order', async () => {
+    const { idsFor } = setup();
+
+    await waitFor(() => expect(idsFor('ws-1')).toEqual(['t-3', 't-1', 't-2']));
+  });
+
+  it('refetch with reshuffled updated_at keeps the frozen order', async () => {
+    const { idsFor, queryClient } = setup();
+    await waitFor(() => expect(idsFor('ws-1')).toEqual(['t-3', 't-1', 't-2']));
+
+    // User chats in t-1 → server now returns it first.
+    threadsByWs['ws-1'] = threads('t-1', 't-3', 't-2');
+    await act(async () => {
+      await queryClient.invalidateQueries();
+    });
+
+    await waitFor(() => expect(mockGetWorkspaceThreads.mock.calls.length).toBeGreaterThan(1));
+    expect(idsFor('ws-1')).toEqual(['t-3', 't-1', 't-2']);
+  });
+
+  it('a new thread id surfaces at the top', async () => {
+    const { idsFor, queryClient } = setup();
+    await waitFor(() => expect(idsFor('ws-1')).toEqual(['t-3', 't-1', 't-2']));
+
+    threadsByWs['ws-1'] = threads('t-new', 't-1', 't-3', 't-2');
+    await act(async () => {
+      await queryClient.invalidateQueries();
+    });
+
+    await waitFor(() => expect(idsFor('ws-1')).toEqual(['t-new', 't-3', 't-1', 't-2']));
+  });
+
+  it('a deleted thread id drops out without error', async () => {
+    const { idsFor, queryClient } = setup();
+    await waitFor(() => expect(idsFor('ws-1')).toEqual(['t-3', 't-1', 't-2']));
+
+    threadsByWs['ws-1'] = threads('t-3', 't-2');
+    await act(async () => {
+      await queryClient.invalidateQueries();
+    });
+
+    await waitFor(() => expect(idsFor('ws-1')).toEqual(['t-3', 't-2']));
+  });
+
+  it('keeps the frozen order when leaving and returning to a workspace', async () => {
+    const { idsFor, rerender } = setup();
+    await waitFor(() => expect(idsFor('ws-1')).toEqual(['t-3', 't-1', 't-2']));
+
+    // Recency changed while the user was away, but within a page session the
+    // order stays frozen — it refreshes on reload, like other chat apps.
+    threadsByWs['ws-1'] = threads('t-1', 't-3', 't-2');
+
+    rerender({ wsId: 'ws-2' });
+    await waitFor(() => expect(idsFor('ws-2')).toEqual(['u-2', 'u-1']));
+
+    rerender({ wsId: 'ws-1' });
+    await waitFor(() => expect((idsFor('ws-1')).length).toBeGreaterThan(0));
+    expect(idsFor('ws-1')).toEqual(['t-3', 't-1', 't-2']);
+  });
+
+  it('chatting in a thread bumps it to the top (bumpThreadNavOrder)', async () => {
+    const { idsFor } = setup();
+    await waitFor(() => expect(idsFor('ws-1')).toEqual(['t-3', 't-1', 't-2']));
+
+    act(() => {
+      bumpThreadNavOrder('ws-1', 't-2');
+    });
+
+    expect(idsFor('ws-1')).toEqual(['t-2', 't-3', 't-1']);
+  });
+
+  it('a bumped position survives later refetch reshuffles', async () => {
+    const { idsFor, queryClient } = setup();
+    await waitFor(() => expect(idsFor('ws-1')).toEqual(['t-3', 't-1', 't-2']));
+
+    act(() => {
+      bumpThreadNavOrder('ws-1', 't-1');
+    });
+    expect(idsFor('ws-1')).toEqual(['t-1', 't-3', 't-2']);
+
+    threadsByWs['ws-1'] = threads('t-2', 't-1', 't-3');
+    await act(async () => {
+      await queryClient.invalidateQueries();
+    });
+
+    await waitFor(() => expect(mockGetWorkspaceThreads.mock.calls.length).toBeGreaterThan(1));
+    expect(idsFor('ws-1')).toEqual(['t-1', 't-3', 't-2']);
+  });
+
+  it('bump is a no-op before the workspace order is snapshotted', () => {
+    expect(() => bumpThreadNavOrder('ws-never-loaded', 't-1')).not.toThrow();
+  });
+
+  it('keeps the frozen order across hook remounts (per-thread ChatView instances)', async () => {
+    const first = setup();
+    await waitFor(() => expect(first.idsFor('ws-1')).toEqual(['t-3', 't-1', 't-2']));
+    first.unmount();
+
+    // A thread switch mounts a fresh ChatView (fresh hook instance) and the
+    // active thread is now first in the server response — order must not move.
+    threadsByWs['ws-1'] = threads('t-1', 't-3', 't-2');
+    const second = setup();
+    await waitFor(() => expect(second.idsFor('ws-1').length).toBeGreaterThan(0));
+    expect(second.idsFor('ws-1')).toEqual(['t-3', 't-1', 't-2']);
+  });
+});
+
+describe('useNavigationData — stable workspace ordering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStableNavOrder();
+    resetNavPrefs();
+    mockGetWorkspaceThreads.mockResolvedValue({ threads: [] });
+  });
+
+  function setup(initialWsId = 'ws-1') {
+    const queryClient = createTestQueryClient();
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const rendered = renderHook(({ wsId }) => useNavigationData(wsId), {
+      wrapper,
+      initialProps: { wsId: initialWsId },
+    });
+    const wsIds = () => rendered.result.current.workspaces.map((ws) => ws.workspace_id);
+    return { ...rendered, queryClient, wsIds };
+  }
+
+  it('does not hoist the active workspace when refetches reshuffle recency', async () => {
+    mockGetWorkspaces.mockResolvedValue({
+      workspaces: [{ workspace_id: 'ws-1' }, { workspace_id: 'ws-2' }, { workspace_id: 'ws-3' }],
+      total: 3,
+    });
+    const { wsIds, queryClient } = setup('ws-3');
+    await waitFor(() => expect(wsIds()).toEqual(['ws-1', 'ws-2', 'ws-3']));
+
+    // Chatting in ws-3 bumps its updated_at → server now returns it first.
+    mockGetWorkspaces.mockResolvedValue({
+      workspaces: [{ workspace_id: 'ws-3' }, { workspace_id: 'ws-1' }, { workspace_id: 'ws-2' }],
+      total: 3,
+    });
+    await act(async () => {
+      await queryClient.invalidateQueries();
+    });
+
+    await waitFor(() => expect(mockGetWorkspaces.mock.calls.length).toBeGreaterThan(1));
+    expect(wsIds()).toEqual(['ws-1', 'ws-2', 'ws-3']);
+  });
+
+  it('re-snapshots when a refetch changes sort_order (reorder made in the gallery)', async () => {
+    mockGetWorkspaces.mockResolvedValue({
+      workspaces: [
+        { workspace_id: 'ws-1', sort_order: 0 },
+        { workspace_id: 'ws-2', sort_order: 1 },
+        { workspace_id: 'ws-3', sort_order: 2 },
+      ],
+      total: 3,
+    });
+    const { wsIds, queryClient } = setup('ws-1');
+    await waitFor(() => expect(wsIds()).toEqual(['ws-1', 'ws-2', 'ws-3']));
+
+    // The user reorders in the workspace gallery: ws-3 moves to the top. That
+    // persists new sort_order values and invalidates the shared list query.
+    mockGetWorkspaces.mockResolvedValue({
+      workspaces: [
+        { workspace_id: 'ws-3', sort_order: 0 },
+        { workspace_id: 'ws-1', sort_order: 1 },
+        { workspace_id: 'ws-2', sort_order: 2 },
+      ],
+      total: 3,
+    });
+    await act(async () => {
+      await queryClient.invalidateQueries();
+    });
+
+    await waitFor(() => expect(mockGetWorkspaces.mock.calls.length).toBeGreaterThan(1));
+    // The nav must adopt the gallery's new manual order, not freeze it out.
+    expect(wsIds()).toEqual(['ws-3', 'ws-1', 'ws-2']);
+  });
+
+  it('keeps the frozen order when only updated_at recency shifts, even with sort_order present', async () => {
+    // sort_order is stable across refetches; only the recency tiebreak moves.
+    // The nav must hold its frozen order (no hoist) — sort_order didn't change.
+    mockGetWorkspaces.mockResolvedValue({
+      workspaces: [
+        { workspace_id: 'ws-1', sort_order: 0 },
+        { workspace_id: 'ws-2', sort_order: 0 },
+        { workspace_id: 'ws-3', sort_order: 0 },
+      ],
+      total: 3,
+    });
+    const { wsIds, queryClient } = setup('ws-3');
+    await waitFor(() => expect(wsIds()).toEqual(['ws-1', 'ws-2', 'ws-3']));
+
+    // Same sort_order values, server reshuffles by recency (ws-3 chatted in).
+    mockGetWorkspaces.mockResolvedValue({
+      workspaces: [
+        { workspace_id: 'ws-3', sort_order: 0 },
+        { workspace_id: 'ws-1', sort_order: 0 },
+        { workspace_id: 'ws-2', sort_order: 0 },
+      ],
+      total: 3,
+    });
+    await act(async () => {
+      await queryClient.invalidateQueries();
+    });
+
+    await waitFor(() => expect(mockGetWorkspaces.mock.calls.length).toBeGreaterThan(1));
+    expect(wsIds()).toEqual(['ws-1', 'ws-2', 'ws-3']);
+  });
+
+  it("under 'activity' order, follows server recency instead of freezing", async () => {
+    // 'activity' mirrors the gallery's recency sort — the server's order is
+    // authoritative, so a recency reshuffle DOES reorder the nav (unlike
+    // 'custom', which freezes to avoid hoisting the active workspace).
+    setNavPrefs({ orderBy: 'activity' });
+    mockGetWorkspaces.mockResolvedValue({
+      workspaces: [{ workspace_id: 'ws-1' }, { workspace_id: 'ws-2' }, { workspace_id: 'ws-3' }],
+      total: 3,
+    });
+    const { wsIds, queryClient } = setup('ws-3');
+    await waitFor(() => expect(wsIds()).toEqual(['ws-1', 'ws-2', 'ws-3']));
+
+    // ws-3 chatted in → server returns it first; activity adopts the new order.
+    mockGetWorkspaces.mockResolvedValue({
+      workspaces: [{ workspace_id: 'ws-3' }, { workspace_id: 'ws-1' }, { workspace_id: 'ws-2' }],
+      total: 3,
+    });
+    await act(async () => {
+      await queryClient.invalidateQueries();
+    });
+
+    await waitFor(() => expect(mockGetWorkspaces.mock.calls.length).toBeGreaterThan(1));
+    expect(wsIds()).toEqual(['ws-3', 'ws-1', 'ws-2']);
+  });
+
+  it('exposes drag-reorder only under the custom order', async () => {
+    mockGetWorkspaces.mockResolvedValue({ workspaces: [{ workspace_id: 'ws-1' }], total: 1 });
+    const { result } = setup('ws-1');
+    await waitFor(() => expect(result.current.workspaces.length).toBe(1));
+    // Default order is 'custom' → reorder available.
+    expect(result.current.canReorderWorkspaces).toBe(true);
+
+    act(() => { setNavPrefs({ orderBy: 'name' }); });
+    await waitFor(() => expect(result.current.canReorderWorkspaces).toBe(false));
+  });
+
+  it('shows every workspace by default (workspaceLimit "all")', async () => {
+    const all = Array.from({ length: 12 }, (_, i) => ({ workspace_id: `ws-${i + 1}` }));
+    mockGetWorkspaces.mockResolvedValue({ workspaces: all, total: 12 });
+    const { wsIds, result } = setup('ws-1');
+
+    await waitFor(() => expect(wsIds().length).toBe(12));
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it('pages in the remainder automatically when the first fetch is partial', async () => {
+    const firstPage = Array.from({ length: 20 }, (_, i) => ({ workspace_id: `ws-${i + 1}` }));
+    const rest = Array.from({ length: 5 }, (_, i) => ({ workspace_id: `ws-${i + 21}` }));
+    mockGetWorkspaces.mockImplementation((_limit: number, offset: number) =>
+      Promise.resolve(offset === 0
+        ? { workspaces: firstPage, total: 25 }
+        : { workspaces: rest, total: 25 }),
+    );
+    const { wsIds } = setup('ws-1');
+
+    await waitFor(() => expect(wsIds().length).toBe(25));
+    expect(wsIds()[24]).toBe('ws-25');
+  });
+
+  it('keeps the current workspace in view at the bottom with a numeric limit', async () => {
+    // 10 workspaces, limit 9 — the current one (ws-10) is outside the visible
+    // slice and must join at the bottom.
+    setNavPrefs({ workspaceLimit: 9 });
+    const all = Array.from({ length: 10 }, (_, i) => ({ workspace_id: `ws-${i + 1}` }));
+    mockGetWorkspaces.mockResolvedValue({ workspaces: all, total: 10 });
+    const { wsIds } = setup('ws-10');
+
+    await waitFor(() => expect(wsIds().length).toBe(10));
+    expect(wsIds()[0]).toBe('ws-1');
+    expect(wsIds()[9]).toBe('ws-10');
+  });
+});
+
+describe('useNavigationData — drag-reorder workspaces', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStableNavOrder();
+    resetNavPrefs();
+    mockGetWorkspaceThreads.mockResolvedValue({ threads: [] });
+    mockReorderWorkspaces.mockResolvedValue(undefined);
+    mockGetWorkspaces.mockResolvedValue({
+      workspaces: [
+        { workspace_id: 'ws-pin', is_pinned: true },
+        { workspace_id: 'ws-flash', status: 'flash' },
+        { workspace_id: 'ws-1' },
+        { workspace_id: 'ws-2' },
+        { workspace_id: 'ws-3' },
+      ],
+      total: 5,
+    });
+  });
+
+  function setup() {
+    const queryClient = createTestQueryClient();
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const rendered = renderHook(() => useNavigationData('ws-1'), { wrapper });
+    const wsIds = () => rendered.result.current.workspaces.map((ws) => ws.workspace_id);
+    return { ...rendered, wsIds };
+  }
+
+  it('moves the dragged workspace and persists sequential sort_order without flash', async () => {
+    const { wsIds, result } = setup();
+    await waitFor(() => expect(wsIds().length).toBe(5));
+
+    await act(async () => {
+      await result.current.reorderWorkspace('ws-3', 'ws-1');
+    });
+
+    expect(wsIds()).toEqual(['ws-pin', 'ws-flash', 'ws-3', 'ws-1', 'ws-2']);
+    expect(mockReorderWorkspaces).toHaveBeenCalledWith([
+      { workspace_id: 'ws-pin', sort_order: 0 },
+      { workspace_id: 'ws-3', sort_order: 1 },
+      { workspace_id: 'ws-1', sort_order: 2 },
+      { workspace_id: 'ws-2', sort_order: 3 },
+    ]);
+  });
+
+  it('refuses a drop across the pinned/unpinned boundary', async () => {
+    const { wsIds, result } = setup();
+    await waitFor(() => expect(wsIds().length).toBe(5));
+
+    await act(async () => {
+      await result.current.reorderWorkspace('ws-1', 'ws-pin');
+    });
+
+    expect(wsIds()).toEqual(['ws-pin', 'ws-flash', 'ws-1', 'ws-2', 'ws-3']);
+    expect(mockReorderWorkspaces).not.toHaveBeenCalled();
+  });
+
+  it('refuses to move the flash workspace or drop onto it', async () => {
+    const { wsIds, result } = setup();
+    await waitFor(() => expect(wsIds().length).toBe(5));
+
+    await act(async () => {
+      await result.current.reorderWorkspace('ws-flash', 'ws-2');
+      await result.current.reorderWorkspace('ws-2', 'ws-flash');
+    });
+
+    expect(wsIds()).toEqual(['ws-pin', 'ws-flash', 'ws-1', 'ws-2', 'ws-3']);
+    expect(mockReorderWorkspaces).not.toHaveBeenCalled();
+  });
+
+  it('rolls the optimistic order back when persisting fails', async () => {
+    const { wsIds, result } = setup();
+    await waitFor(() => expect(wsIds().length).toBe(5));
+    mockReorderWorkspaces.mockRejectedValueOnce(new Error('boom'));
+
+    await act(async () => {
+      await result.current.reorderWorkspace('ws-3', 'ws-1');
+    });
+
+    expect(wsIds()).toEqual(['ws-pin', 'ws-flash', 'ws-1', 'ws-2', 'ws-3']);
+  });
+});
+
+describe('useNavigationData — pin & rename workspace', () => {
+  // A stateful "server": updateWorkspace mutates it and the invalidate-driven
+  // refetch reads it back, so the post-commit view reflects the persisted change
+  // (a static mock would clobber the optimistic patch on refetch).
+  let server: { workspace_id: string; name: string; is_pinned: boolean }[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStableNavOrder();
+    resetNavPrefs();
+    mockGetWorkspaceThreads.mockResolvedValue({ threads: [] });
+    server = [
+      { workspace_id: 'ws-1', name: 'Alpha', is_pinned: false },
+      { workspace_id: 'ws-2', name: 'Beta', is_pinned: false },
+    ];
+    mockGetWorkspaces.mockImplementation(async () => ({
+      workspaces: server.map((w) => ({ ...w })),
+      total: server.length,
+    }));
+    mockUpdateWorkspace.mockImplementation(async (id: string, patch: Record<string, unknown>) => {
+      const w = server.find((s) => s.workspace_id === id);
+      if (w) Object.assign(w, patch);
+    });
+  });
+
+  function setup() {
+    const queryClient = createTestQueryClient();
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const rendered = renderHook(() => useNavigationData('ws-1'), { wrapper });
+    const byId = (id: string) => rendered.result.current.workspaces.find((ws) => ws.workspace_id === id);
+    return { ...rendered, byId };
+  }
+
+  it('optimistically pins a workspace and persists is_pinned', async () => {
+    const { result, byId } = setup();
+    await waitFor(() => expect(result.current.workspaces.length).toBe(2));
+
+    await act(async () => {
+      await result.current.pinWorkspace('ws-2', true);
+    });
+
+    await waitFor(() => expect(byId('ws-2')?.is_pinned).toBe(true));
+    expect(mockUpdateWorkspace).toHaveBeenCalledWith('ws-2', { is_pinned: true });
+  });
+
+  it('optimistically renames a workspace and persists the trimmed name', async () => {
+    const { result, byId } = setup();
+    await waitFor(() => expect(result.current.workspaces.length).toBe(2));
+
+    await act(async () => {
+      await result.current.renameWorkspace('ws-1', '  Gamma  ');
+    });
+
+    await waitFor(() => expect(byId('ws-1')?.name).toBe('Gamma'));
+    expect(mockUpdateWorkspace).toHaveBeenCalledWith('ws-1', { name: 'Gamma' });
+  });
+
+  it('skips the rename request for a blank name', async () => {
+    const { result } = setup();
+    await waitFor(() => expect(result.current.workspaces.length).toBe(2));
+
+    await act(async () => {
+      await result.current.renameWorkspace('ws-1', '   ');
+    });
+
+    expect(mockUpdateWorkspace).not.toHaveBeenCalled();
+  });
+
+  it('rolls back the optimistic rename when persisting fails', async () => {
+    const { result, byId } = setup();
+    await waitFor(() => expect(result.current.workspaces.length).toBe(2));
+    mockUpdateWorkspace.mockRejectedValueOnce(new Error('boom'));
+
+    await act(async () => {
+      await result.current.renameWorkspace('ws-1', 'Gamma');
+    });
+
+    expect(byId('ws-1')?.name).toBe('Alpha');
+  });
+});
+
+describe('useNavigationData — thread paging', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStableNavOrder();
+    resetNavPrefs();
+    mockGetWorkspaces.mockResolvedValue({
+      workspaces: [{ workspace_id: 'ws-1' }],
+      total: 1,
+    });
+  });
+
+  function setup() {
+    const queryClient = createTestQueryClient();
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const rendered = renderHook(() => useNavigationData('ws-1'), { wrapper });
+    const entry = () => rendered.result.current.workspaceThreads['ws-1'];
+    return { ...rendered, entry };
+  }
+
+  it('fetches the first page with the configured page size and exposes the total', async () => {
+    setNavPrefs({ threadPageSize: 5 });
+    mockGetWorkspaceThreads.mockResolvedValue({ threads: threads('t-1', 't-2'), total: 2 });
+    const { entry } = setup();
+
+    await waitFor(() => expect(entry()?.threads.length).toBe(2));
+    expect(mockGetWorkspaceThreads).toHaveBeenCalledWith('ws-1', 5, 0);
+    expect(entry()?.total).toBe(2);
+  });
+
+  it('loadMoreThreads appends the next page below the already-shown threads', async () => {
+    mockGetWorkspaceThreads.mockImplementation((_wsId: string, _limit: number, offset: number) =>
+      Promise.resolve(offset === 0
+        ? { threads: threads('t-3', 't-1', 't-2'), total: 5 }
+        : { threads: threads('t-old-1', 't-old-2'), total: 5 }),
+    );
+    const { entry, result } = setup();
+    await waitFor(() => expect(entry()?.threads.length).toBe(3));
+
+    await act(async () => {
+      await result.current.loadMoreThreads('ws-1');
+    });
+
+    await waitFor(() => expect(entry()?.threads.length).toBe(5));
+    expect(entry()?.threads.map((t) => t.thread_id)).toEqual(['t-3', 't-1', 't-2', 't-old-1', 't-old-2']);
+    expect(mockGetWorkspaceThreads).toHaveBeenLastCalledWith('ws-1', 10, 3);
+  });
+});

--- a/web/src/pages/ChatAgent/hooks/__tests__/useNavigationData.test.tsx
+++ b/web/src/pages/ChatAgent/hooks/__tests__/useNavigationData.test.tsx
@@ -647,4 +647,27 @@ describe('useNavigationData — thread paging', () => {
     expect(entry()?.threads.map((t) => t.thread_id)).toEqual(['t-3', 't-1', 't-2', 't-old-1', 't-old-2']);
     expect(mockGetWorkspaceThreads).toHaveBeenLastCalledWith('ws-1', 10, 3);
   });
+
+  it('loadMoreThreads is single-flight per workspace under a rapid double-tap', async () => {
+    mockGetWorkspaceThreads.mockImplementation((_wsId: string, _limit: number, offset: number) =>
+      Promise.resolve(offset === 0
+        ? { threads: threads('t-3', 't-1', 't-2'), total: 5 }
+        : { threads: threads('t-old-1', 't-old-2'), total: 5 }),
+    );
+    const { entry, result } = setup();
+    await waitFor(() => expect(entry()?.threads.length).toBe(3));
+
+    // Both taps fire before the first resolves. The offset is snapshotted before
+    // the await, so without the guard both would fetch the same offset-3 page.
+    await act(async () => {
+      await Promise.all([
+        result.current.loadMoreThreads('ws-1'),
+        result.current.loadMoreThreads('ws-1'),
+      ]);
+    });
+
+    const offset3Calls = mockGetWorkspaceThreads.mock.calls.filter(([, , offset]) => offset === 3);
+    expect(offset3Calls.length).toBe(1);
+    await waitFor(() => expect(entry()?.threads.length).toBe(5));
+  });
 });

--- a/web/src/pages/ChatAgent/hooks/__tests__/useNavigationData.test.tsx
+++ b/web/src/pages/ChatAgent/hooks/__tests__/useNavigationData.test.tsx
@@ -13,7 +13,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Mock } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { QueryClientProvider } from '@tanstack/react-query';
-import { createTestQueryClient } from '../../../../test/utils';
+import { createTestQueryClient } from '@/test/utils';
 import {
   useNavigationData,
   applyStableOrder,
@@ -137,6 +137,21 @@ describe('useNavigationData — stable thread ordering', () => {
     const { idsFor } = setup();
 
     await waitFor(() => expect(idsFor('ws-1')).toEqual(['t-3', 't-1', 't-2']));
+  });
+
+  it('refetches the current workspace when the thread page size pref changes', async () => {
+    // Regression: the threads query key must carry threadPageSize. The queryFn
+    // fetches `threadPageSize` rows, so a key that ignored it would replay the
+    // cached page instead of fetching the newly-requested size.
+    const { idsFor } = setup();
+    await waitFor(() => expect(idsFor('ws-1')).toEqual(['t-3', 't-1', 't-2']));
+    expect(mockGetWorkspaceThreads).toHaveBeenCalledWith('ws-1', 10, 0);
+
+    await act(async () => {
+      setNavPrefs({ threadPageSize: 20 });
+    });
+
+    await waitFor(() => expect(mockGetWorkspaceThreads).toHaveBeenCalledWith('ws-1', 20, 0));
   });
 
   it('refetch with reshuffled updated_at keeps the frozen order', async () => {

--- a/web/src/pages/ChatAgent/hooks/useCardState.ts
+++ b/web/src/pages/ChatAgent/hooks/useCardState.ts
@@ -101,13 +101,7 @@ export function useCardState(initialCards: CardsMap = {}): UseCardStateResult {
         // history data. This prevents clicking a resumed inline card from replacing
         // the live streaming messages with an old pre-resume snapshot.
         if (!isCurrentlyInactive && subagentDataUpdate.isHistory) {
-          if (import.meta.env.DEV) {
-            console.log('[updateSubagentCard] Skipping history overwrite on active card:', {
-              agentId,
-              cardId,
-              reason: 'Card is active (live streaming) — history push rejected',
-            });
-          }
+          // Card is active (live streaming) — reject the stale history push.
           return prev;
         }
 
@@ -122,13 +116,7 @@ export function useCardState(initialCards: CardsMap = {}): UseCardStateResult {
           subagentDataUpdate.messages !== undefined ||
           subagentDataUpdate.tokenUsage !== undefined;
         if (isCurrentlyInactive && !isBeingReactivated && !hasContentUpdate) {
-          if (import.meta.env.DEV) {
-            console.log('[updateSubagentCard] Skipping update to inactive card:', {
-              agentId,
-              cardId,
-              reason: 'Card is inactive and not being reactivated (no content update)',
-            });
-          }
+          // Card is inactive and not being reactivated — drop the pure status update.
           return prev;
         }
         // Compute resolved values before building the card
@@ -148,24 +136,10 @@ export function useCardState(initialCards: CardsMap = {}): UseCardStateResult {
           const existingStatus = existingSubagentData.status;
 
           if (newStatus !== undefined) {
-            if (import.meta.env.DEV) {
-              console.log('[updateSubagentCard] Status update:', {
-                agentId,
-                newStatus,
-                previousStatus: existingStatus,
-                willUpdate: newStatus !== existingStatus,
-              });
-            }
             return newStatus;
           }
 
           const preservedStatus = existingStatus || 'active';
-          if (import.meta.env.DEV && existingStatus === 'completed') {
-            console.log('[updateSubagentCard] Preserving completed status:', {
-              agentId,
-              preservedStatus,
-            });
-          }
           return preservedStatus;
         })();
 
@@ -221,15 +195,7 @@ export function useCardState(initialCards: CardsMap = {}): UseCardStateResult {
         const isCompletedFromLiveStream = subagentDataUpdate.isActive === false && subagentDataUpdate.isHistory !== true && subagentDataUpdate.isReconnect !== true;
 
         if (isCompletedFromLiveStream) {
-          if (import.meta.env.DEV) {
-            console.log('[updateSubagentCard] Skipping creation of new card for completed task from live streaming:', {
-              agentId,
-              cardId,
-              reason: 'Completed tasks from live streaming should only update existing cards, not create new ones',
-              isActive: subagentDataUpdate.isActive,
-              isHistory: subagentDataUpdate.isHistory,
-            });
-          }
+          // Completed tasks from live streaming should only update existing cards, not create new ones.
           return prev;
         }
 
@@ -304,13 +270,6 @@ export function useCardState(initialCards: CardsMap = {}): UseCardStateResult {
               },
             };
             hasChanges = true;
-            if (import.meta.env.DEV) {
-              console.log('[inactivateAllSubagents] Marking subagent as inactive:', {
-                taskId: card.subagentData!.taskId,
-                cardId,
-                previousStatus: card.subagentData!.status,
-              });
-            }
           }
         }
       });

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -16,6 +16,7 @@ import { getStoredThreadId, setStoredThreadId } from './utils/threadStorage';
 import { countToolCalls } from '../utils/subagentMetrics';
 import { type SubagentTokenUsage, ZERO_USAGE, extractTokenUsageDelta, accumulateTokenUsage } from '../utils/tokenUsage';
 import { computeSteeringBoundary, shouldSkipSteeringRollback } from '../utils/steeringRollback';
+import { bumpThreadNavOrder } from './useNavigationData';
 export { removeStoredThreadId } from './utils/threadStorage';
 import { createUserMessage, createAssistantMessage, createNotificationMessage, appendMessage, updateMessage, type AttachmentMeta } from './utils/messageHelpers';
 import type { ChatMessage, AssistantMessage, UserMessage } from '@/types/chat';
@@ -741,7 +742,6 @@ export function useChatMessages(
       lastEventIdRef.current = null;
 
       const threadIdToUse = threadId;
-      console.log('[History] Loading history for thread:', threadIdToUse);
 
       // Track pairs being processed - use Map to handle multiple pairs
       const assistantMessagesByPair = new Map<number, string>(); // Map<turn_index, assistantMessageId>
@@ -796,7 +796,6 @@ export function useChatMessages(
           const pairIndex = event.turn_index!;
           currentActivePairIndex = pairIndex;
           currentActivePairState = pairStateByPair.get(pairIndex);
-          console.log('[History] Updated active pair to:', pairIndex, 'counter:', currentActivePairState?.contentOrderCounter);
         }
 
         // Handle context_window events from history (token_usage, summarize, offload)
@@ -1076,7 +1075,6 @@ export function useChatMessages(
                 return;
               }
 
-              console.log('[History] Processing todo_update artifact for pair:', pairIndex, 'counter:', pairState.contentOrderCounter);
               handleHistoryTodoUpdate({
                 assistantMessageId: currentAssistantMessageId,
                 artifactType: artifactType as string,
@@ -1614,42 +1612,27 @@ export function useChatMessages(
         // Handle replay_done event (final event)
         if (eventType === 'replay_done') {
           if (event.thread_id && event.thread_id !== threadId && event.thread_id !== '__default__') {
-            console.log('[History] Final thread_id event:', event.thread_id);
             setThreadId(event.thread_id);
             setStoredThreadId(workspaceId, event.thread_id);
           }
         } else if (eventType === 'credit_usage') {
-          // credit_usage indicates the end of one conversation pair
-          console.log('[History] Credit usage event (end of pair):', event.turn_index);
+          // credit_usage indicates the end of one conversation pair — no-op boundary marker
         } else if (!eventType) {
           // Fallback: Handle events without event type
           if (event.thread_id && !hasRole && !contentType) {
-            console.log('[History] Fallback: thread_id only event:', event.thread_id);
             if (event.thread_id !== threadId && event.thread_id !== '__default__') {
               setThreadId(event.thread_id);
               setStoredThreadId(workspaceId, event.thread_id);
             }
           }
-        } else {
-          // Log unhandled event types for debugging
-          console.log('[History] Unhandled event type:', {
-            eventType,
-            contentType,
-            hasRole,
-            role: event.role,
-            hasPairIndex,
-          });
         }
       });
-
-        console.log('[History] Replay completed');
 
         // If there's still a pending interrupt after replay (no subsequent user_message
         // resolved it), store it in a ref. loadAndMaybeReconnect will decide whether to
         // make it interactive (workflow paused) or reconnect to get resolution events
         // (workflow active = interrupt was answered but resolution is in Redis buffer).
         if (pendingHistoryInterrupts.length > 0) {
-          console.log('[History] Unresolved interrupts detected:', pendingHistoryInterrupts.length, pendingHistoryInterrupts.map((p) => p.type));
           historyHasUnresolvedInterruptRef.current = true;
           unresolvedHistoryInterruptRef.current = pendingHistoryInterrupts.map((p) => ({ ...p }));
           pendingHistoryInterrupts.length = 0;
@@ -1660,8 +1643,6 @@ export function useChatMessages(
         // We only build per-task message history here; cards are created lazily
         // when the user clicks \"Open subagent details\" in the main chat view.
         if (subagentHistoryByTaskId.size > 0) {
-          console.log('[History] Processing subagent history for', subagentHistoryByTaskId.size, 'tasks');
-          
           // Process each subagent's events
           for (const [taskId, subagentHistory] of subagentHistoryByTaskId.entries()) {
             // Create temporary refs structure for processing
@@ -1705,7 +1686,6 @@ export function useChatMessages(
             let lastTurnIndex = null;
 
             // Process each event in chronological order
-            console.log('[History] Processing', subagentHistory.events.length, 'events for task:', taskId, 'resumePoints:', resumePoints.length);
             for (let i = 0; i < subagentHistory.events.length; i++) {
               const event = subagentHistory.events[i];
               const eventType = event.event;
@@ -1748,8 +1728,6 @@ export function useChatMessages(
                 taskRefsLocal.contentOrderCounterRef.current = 0;
                 taskRefsLocal.currentReasoningIdRef.current = null;
                 taskRefsLocal.currentToolCallIdRef.current = null;
-
-                console.log('[History] Resume boundary detected at turn_index:', eventTurnIndex, 'runIndex:', currentRunIndex);
               }
               if (eventTurnIndex != null) {
                 lastTurnIndex = eventTurnIndex;
@@ -1758,17 +1736,8 @@ export function useChatMessages(
               // Use per-run assistant message ID
               const assistantMessageId = `subagent-${taskId}-assistant-${currentRunIndex}`;
 
-              console.log('[History] Processing subagent event', i + 1, 'of', subagentHistory.events.length, ':', {
-                taskId,
-                eventType,
-                contentType,
-                hasContent: !!event.content,
-                hasToolCalls: !!event.tool_calls,
-                toolCallId: event.tool_call_id,
-              });
-
               if (eventType === 'message_chunk' && event.role === 'assistant') {
-                const result = handleSubagentMessageChunk({
+                handleSubagentMessageChunk({
                   taskId,
                   assistantMessageId,
                   contentType: contentType as string,
@@ -1777,18 +1746,16 @@ export function useChatMessages(
                   refs: tempRefs,
                   updateSubagentCard: historyUpdateSubagentCard,
                 });
-                console.log('[History] handleSubagentMessageChunk result:', result);
               } else if (eventType === 'tool_calls' && event.tool_calls) {
-                const result = handleSubagentToolCalls({
+                handleSubagentToolCalls({
                   taskId,
                   assistantMessageId,
                   toolCalls: event.tool_calls as unknown as Record<string, unknown>[],
                   refs: tempRefs,
                   updateSubagentCard: historyUpdateSubagentCard,
                 });
-                console.log('[History] handleSubagentToolCalls result:', result);
               } else if (eventType === 'tool_call_result') {
-                const result = handleSubagentToolCallResult({
+                handleSubagentToolCallResult({
                   taskId,
                   assistantMessageId,
                   toolCallId: event.tool_call_id as string,
@@ -1801,7 +1768,6 @@ export function useChatMessages(
                   refs: tempRefs,
                   updateSubagentCard: historyUpdateSubagentCard,
                 });
-                console.log('[History] handleSubagentToolCallResult result:', result);
               } else if (eventType === 'subagent_followup_injected' || eventType === 'turn_start') {
                 // Legacy subagent_followup_injected had content (steering user message).
                 // turn_start was an inter-model-call boundary — no longer emitted,
@@ -1925,14 +1891,12 @@ export function useChatMessages(
               messages: finalMessages,
               runIndex: currentRunIndex,
             };
-
-            console.log('[History] Stored subagent history for task:', taskId, 'with', finalMessages.length, 'messages, runIndex:', currentRunIndex);
           }
         }
       } catch (replayError: unknown) {
         // Handle 404 gracefully - it's expected for brand new threads that haven't been fully initialized yet
         if ((replayError as Error).message && (replayError as Error).message.includes('404')) {
-          console.log('[History] Thread not found (404) - this is normal for new threads, skipping history load');
+          // Thread not found (404) is expected for brand-new threads — skip silently.
           // Don't set error message for 404 - it's expected for new threads
         } else {
           throw replayError; // Re-throw other errors
@@ -2304,23 +2268,9 @@ export function useChatMessages(
 
   // Load history when workspace or threadId changes, then check for reconnection
   useEffect(() => {
-    console.log('[History] useEffect triggered, workspaceId:', workspaceId, 'threadId:', threadId, 'isStreaming:', isStreamingRef.current);
-
     // Guard: Only load if we have a workspaceId and a valid threadId (not '__default__')
     // Also skip if streaming is in progress (prevents race condition when thread ID changes during streaming)
     if (!workspaceId || !threadId || threadId === '__default__' || historyLoadingRef.current || isStreamingRef.current) {
-      console.log('[History] Skipping load:', {
-        workspaceId,
-        threadId,
-        isLoading: historyLoadingRef.current,
-        isStreaming: isStreamingRef.current,
-        reason: !workspaceId ? 'no workspaceId' :
-          !threadId ? 'no threadId' :
-            threadId === '__default__' ? 'default thread' :
-              historyLoadingRef.current ? 'already loading' :
-                isStreamingRef.current ? 'streaming in progress' :
-                  'unknown'
-      });
       return;
     }
 
@@ -2330,15 +2280,12 @@ export function useChatMessages(
     // history-assistant bubbles after a stream completes).
     const loadKey = `${workspaceId}::${threadId}::${reloadTrigger}`;
     if (historyLoadedKeyRef.current === loadKey) {
-      console.log('[History] Skipping load: already loaded for key', loadKey);
       return;
     }
 
     let cancelled = false;
 
     const loadAndMaybeReconnect = async () => {
-      console.log('[History] Calling loadConversationHistory for thread:', threadId);
-
       // Check workflow status FIRST, then load history.
       // Sequential order avoids a race where /replay lands before the backend
       // persists Turn N (on_background_workflow_complete) while /status already
@@ -2507,7 +2454,6 @@ export function useChatMessages(
 
     // Cleanup: Cancel loading if workspace or thread changes or component unmounts
     return () => {
-      console.log('[History] Cleanup: canceling history load for workspace:', workspaceId, 'thread:', threadId);
       cancelled = true;
       historyLoadingRef.current = false;
       closeAllSubagentStreams();
@@ -2703,11 +2649,6 @@ export function useChatMessages(
         return;
       }
 
-      // Debug: Log all events to see what we're receiving
-      if (event.artifact_type || eventType === 'artifact') {
-        console.log('[Stream] Artifact event detected:', { eventType, event, artifact_type: event.artifact_type });
-      }
-
       // Update thread_id if provided in the event (ref = synchronous for closures)
       if (event.thread_id && event.thread_id !== '__default__') {
         threadIdRef.current = event.thread_id;
@@ -2732,16 +2673,6 @@ export function useChatMessages(
 
       // Check if this is a subagent event - filter it out from main chat view
       const isSubagent = isSubagentEvent(event);
-
-      // Debug: Log subagent event detection
-      if (import.meta.env.DEV && isSubagent) {
-        console.log('[Stream] Subagent event detected:', {
-          eventType,
-          agent: event.agent,
-          id: event.id,
-          content_type: event.content_type,
-        });
-      }
 
       // Handle steering_accepted events for the MAIN agent (user sent a message while agent streams).
       // Subagent steering_accepted events are handled below in the isSubagent block.
@@ -3026,16 +2957,6 @@ export function useChatMessages(
           } else if (eventType === 'tool_call_result') {
             const toolCallId = event.tool_call_id as string;
 
-            if (import.meta.env.DEV) {
-              console.log('[Stream] Subagent tool_call_result event:', {
-                taskId,
-                assistantMessageId: subagentAssistantMessageId,
-                toolCallId,
-                eventId: event.id,
-                hasContent: !!event.content,
-              });
-            }
-
             handleSubagentToolCallResult({
               taskId,
               assistantMessageId: subagentAssistantMessageId,
@@ -3050,13 +2971,7 @@ export function useChatMessages(
               updateSubagentCard,
             });
           } else if (eventType === 'artifact') {
-            if (import.meta.env.DEV) {
-              console.log('[Stream] Filtering out subagent artifact event:', {
-                artifactType: event.artifact_type,
-                taskId,
-                agent: event.agent,
-              });
-            }
+            // Subagent artifact events are intentionally filtered out of the main chat view.
           } else if (eventType === 'steering_delivered') {
             if (event.content) {
               handleTaskSteeringAccepted({
@@ -3173,10 +3088,8 @@ export function useChatMessages(
         return;
       } else if (eventType === 'artifact') {
         const artifactType = event.artifact_type as string;
-        console.log('[Stream] Received artifact event:', { artifactType, artifactId: event.artifact_id, payload: event.payload });
         if (artifactType === 'todo_update') {
-          console.log('[Stream] Processing todo_update artifact for assistant message:', assistantMessageId);
-          const result = handleTodoUpdate({
+          handleTodoUpdate({
             assistantMessageId,
             artifactType,
             artifactId: event.artifact_id as string,
@@ -3185,7 +3098,6 @@ export function useChatMessages(
             setMessages: setMessagesForHandlers,
             eventId: event._eventId as number,
           });
-          console.log('[Stream] handleTodoUpdate result:', result);
         } else if (artifactType === 'html_widget') {
           handleHtmlWidget({
             assistantMessageId,
@@ -3391,13 +3303,6 @@ export function useChatMessages(
         if (event.artifact?.task_id && toolCallId) {
           const agentId = `task:${event.artifact.task_id}`;
           toolCallIdToTaskIdMapRef.current.set(toolCallId, agentId);
-          if (import.meta.env.DEV) {
-            console.log('[Stream] Mapped toolCallId to agentId from artifact:', {
-              toolCallId,
-              agentId,
-              description: event.artifact.description,
-            });
-          }
         }
 
         handleToolCallResult({
@@ -3432,14 +3337,6 @@ export function useChatMessages(
         // After HITL resume, the tool_call_result arrives on a NEW assistant message
         // while the proposals live on the OLD one (from the interrupt turn).
         // Match by tool_call_id for exact correlation (safe under concurrent dispatches).
-        if (import.meta.env.DEV) {
-          console.log('[Stream] tool_call_result received:', {
-            pendingBackfill: [...pendingPTCBackfillRef.current.entries()],
-            toolCallId,
-            contentType: typeof event.content,
-            content: typeof event.content === 'string' ? event.content.slice(0, 100) : event.content,
-          });
-        }
         if (pendingPTCBackfillRef.current.size > 0 && typeof event.content === 'string') {
           const backfillPid = toolCallId ? pendingPTCBackfillRef.current.get(toolCallId) : undefined;
           if (backfillPid) {
@@ -3872,6 +3769,10 @@ export function useChatMessages(
     if (!workspaceId || !hasContent) {
       return;
     }
+
+    // Chat activity bumps the thread to the top of the nav panel's list
+    // (clicking around never reorders; new threads surface via the new-id rule).
+    bumpThreadNavOrder(workspaceId, threadIdRef.current);
 
     // If agent is already streaming, send as steering message
     if (isLoading) {
@@ -4426,6 +4327,9 @@ export function useChatMessages(
    */
   const streamFromCheckpoint = useCallback(async (message: string | null, checkpointId: string, truncateIndex: number, forkFromTurn: number | null = null, modelOptions: ModelOptions = {}) => {
     if (isStreamingRef.current) return;
+
+    // Edit/regenerate/retry are chat activity — bump like a fresh send.
+    bumpThreadNavOrder(workspaceId, threadIdRef.current);
 
     setIsLoading(true);
     setMessageError(null);

--- a/web/src/pages/ChatAgent/hooks/useNavigationData.ts
+++ b/web/src/pages/ChatAgent/hooks/useNavigationData.ts
@@ -1,12 +1,12 @@
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useWorkspaces } from '../../../hooks/useWorkspaces';
 import { queryKeys } from '../../../lib/queryKeys';
-import { getWorkspaces, getWorkspaceThreads } from '../utils/api';
+import { getWorkspaces, getWorkspaceThreads, reorderWorkspaces, updateWorkspace } from '../utils/api';
+import { useNavPrefs } from '../utils/navPrefs';
 
 interface WorkspaceRecord {
   workspace_id: string;
-  is_pinned?: boolean;
   [key: string]: unknown;
 }
 
@@ -18,6 +18,7 @@ interface ThreadRecord {
 interface ThreadsData {
   threads: ThreadRecord[];
   loading: boolean;
+  total?: number;
 }
 
 interface WorkspacesResponse {
@@ -27,121 +28,423 @@ interface WorkspacesResponse {
 
 interface ThreadsResponse {
   threads: ThreadRecord[];
+  total?: number;
   [key: string]: unknown;
 }
 
-const NAV_WS_PARAMS = { limit: 20, sortBy: 'custom', includeFlash: true };
+const NAV_WS_PARAMS = { limit: 20, includeFlash: true };
+
+// Session-stable nav ordering. The server sorts threads (and, within the
+// 'custom' workspace sort, unpinned workspaces) by updated_at DESC, so the item
+// being chatted in would hoist to the top on every refetch. We snapshot the
+// order seen first in this page session and reorder later responses to match.
+// The stores are module-level because ChatAgent caches one ChatView instance
+// per thread — hook-local refs would re-snapshot on every thread switch,
+// defeating the freeze. Reload starts a fresh session (fresh recency order).
+const _frozenThreadOrders: Record<string, string[]> = {};
+let _frozenWorkspaceOrder: string[] | null = null;
+
+// Last-seen manual arrangement (sort_order + pin state) per workspace. The
+// frozen order above neutralizes recency hoisting, but a reorder/pin made in
+// the workspace gallery also lands as a refetch — we must NOT freeze that out.
+// When an existing workspace's sort_order or pin state changes between
+// refetches, we re-snapshot so the nav tracks the gallery's 'custom' sort.
+// Recency (updated_at) bumps and newly paged-in workspaces don't change these
+// values, so the active workspace still never hoists itself.
+const _lastWorkspaceArrangement = new Map<string, { sortOrder: number | null; pinned: boolean }>();
+
+export function resetStableNavOrder() {
+  for (const key of Object.keys(_frozenThreadOrders)) delete _frozenThreadOrders[key];
+  _frozenWorkspaceOrder = null;
+  _lastWorkspaceArrangement.clear();
+}
+
+// Bump notifications: chatting in a thread moves it to the top of its
+// workspace's list (like normal chat apps), while clicking around never
+// reorders. Subscribed hooks re-apply the frozen orders when the version ticks.
+let _navOrderVersion = 0;
+const _navOrderListeners = new Set<() => void>();
+
+function subscribeNavOrder(fn: () => void): () => void {
+  _navOrderListeners.add(fn);
+  return () => _navOrderListeners.delete(fn);
+}
+
+/**
+ * Move a thread to the top of its workspace's frozen order. Called when the
+ * user sends a message (new turn, steering, edit/regenerate/retry). No-op if
+ * the workspace's order hasn't been snapshotted yet — the initial snapshot is
+ * recency-sorted, so the thread lands on top anyway.
+ */
+export function bumpThreadNavOrder(wsId: string, threadId: string | null | undefined) {
+  if (!wsId || !threadId || threadId === '__default__') return;
+  const frozen = _frozenThreadOrders[wsId];
+  if (!frozen) return;
+  const idx = frozen.indexOf(threadId);
+  if (idx === 0) return;
+  if (idx > 0) frozen.splice(idx, 1);
+  frozen.unshift(threadId);
+  _navOrderVersion++;
+  _navOrderListeners.forEach((fn) => fn());
+}
+
+// Reorder `items` to a frozen id sequence. Unseen ids appearing before any
+// known id are genuinely new (the server lists them first) and surface on top;
+// unseen ids after a known id are paginated-in older entries and stay below
+// the stable block. Ids missing from `items` (deleted) drop out via map-miss.
+export function applyStableOrderBy<T>(
+  frozen: string[] | null | undefined,
+  items: T[],
+  getId: (item: T) => string,
+): { order: string[]; items: T[] } {
+  const ids = items.map(getId);
+  if (!frozen) return { order: ids, items };
+  const byId = new Map(items.map((item) => [getId(item), item]));
+  const frozenSet = new Set(frozen);
+  const firstKnownIdx = ids.findIndex((id) => frozenSet.has(id));
+  const newIds: string[] = [];
+  const trailingIds: string[] = [];
+  ids.forEach((id, idx) => {
+    if (frozenSet.has(id)) return;
+    if (firstKnownIdx === -1 || idx < firstKnownIdx) newIds.push(id);
+    else trailingIds.push(id);
+  });
+  const order = [...newIds, ...frozen, ...trailingIds];
+  const merged = order
+    .map((id) => byId.get(id))
+    .filter((item): item is T => item !== undefined);
+  return { order, items: merged };
+}
+
+export function applyStableOrder(
+  frozen: string[] | undefined,
+  serverThreads: ThreadRecord[],
+): { order: string[]; threads: ThreadRecord[] } {
+  const { order, items } = applyStableOrderBy(frozen, serverThreads, (thread) => thread.thread_id);
+  return { order, threads: items };
+}
 
 export function useNavigationData(currentWorkspaceId: string) {
   const queryClient = useQueryClient();
+  const { workspaceLimit, threadPageSize, orderBy } = useNavPrefs();
+  const orderVersion = useSyncExternalStore(subscribeNavOrder, () => _navOrderVersion);
 
-  // Workspace list via React Query
-  const { data: wsData, isLoading } = useWorkspaces(NAV_WS_PARAMS);
+  const orderThreads = useCallback((wsId: string, serverThreads: ThreadRecord[]): ThreadRecord[] => {
+    const { order, threads } = applyStableOrder(_frozenThreadOrders[wsId], serverThreads);
+    _frozenThreadOrders[wsId] = order;
+    return threads;
+    // orderVersion isn't read in the body, but a bump rewrites the frozen
+    // orders this callback closes over — its identity must change so the
+    // memos downstream re-apply the new order.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [orderVersion]);
+
+  // Workspace list via React Query. sortBy mirrors the gallery's order-by
+  // selection; changing it swaps the query key and refetches in the new order.
+  const wsParams = useMemo(() => ({ ...NAV_WS_PARAMS, sortBy: orderBy }), [orderBy]);
+  const { data: wsData, isLoading } = useWorkspaces(wsParams);
   const allFetched: WorkspaceRecord[] = (wsData as WorkspacesResponse | undefined)?.workspaces || [];
   const totalCount = (wsData as WorkspacesResponse | undefined)?.total || 0;
 
   const [workspaceThreads, setWorkspaceThreads] = useState<Record<string, ThreadsData>>({});
-  const [visibleCount, setVisibleCount] = useState(9);
+  // "Load all" clicked this session — overrides a numeric workspaceLimit pref.
+  const [showAllWorkspaces, setShowAllWorkspaces] = useState(false);
+  const showAll = workspaceLimit === 'all' || showAllWorkspaces;
 
-  // Build ordered workspace list: 2 most recent → remaining pinned → rest
+  // When showing all workspaces, page in the remainder beyond the first fetch.
+  // Each completed page grows allFetched, re-running the effect until total is
+  // reached. A failure stops the loop for the session (avoids a retry storm).
+  const wsFetchRef = useRef({ inflight: false, failed: false });
+  useEffect(() => {
+    if (!showAll || isLoading) return;
+    if (!totalCount || allFetched.length >= totalCount) return;
+    if (wsFetchRef.current.inflight || wsFetchRef.current.failed) return;
+    wsFetchRef.current.inflight = true;
+    getWorkspaces(100, allFetched.length, orderBy, true)
+      .then((data: unknown) => {
+        const page = data as WorkspacesResponse;
+        queryClient.setQueryData(queryKeys.workspaces.list({ ...NAV_WS_PARAMS, sortBy: orderBy, offset: 0 }), (old: unknown) => {
+          const oldData = old as WorkspacesResponse | undefined;
+          if (!oldData) return page;
+          const existingIds = new Set(oldData.workspaces.map(w => w.workspace_id));
+          const unique = (page.workspaces || []).filter(w => !existingIds.has(w.workspace_id));
+          return { ...oldData, workspaces: [...oldData.workspaces, ...unique], total: page.total || oldData.total };
+        });
+      })
+      .catch((e: unknown) => {
+        wsFetchRef.current.failed = true;
+        console.warn('[useNavigationData] Failed to load all workspaces:', e);
+      })
+      .finally(() => {
+        wsFetchRef.current.inflight = false;
+      });
+  }, [showAll, isLoading, allFetched.length, totalCount, queryClient, orderBy]);
+
+  // Workspace list in server order (pinned first, then manual sort_order, then
+  // recency), frozen to its first-session arrangement so the active workspace's
+  // updated_at bumps (which reorder the server response) don't hoist it.
   const workspaces = useMemo(() => {
     if (!allFetched.length) return [];
 
-    const recentTwo = allFetched.slice(0, 2);
-    const recentIds = new Set(recentTwo.map((ws) => ws.workspace_id));
+    let ordered: WorkspaceRecord[];
+    if (orderBy === 'custom') {
+      // If an existing workspace's manual arrangement (sort_order or pin state)
+      // changed since the last render, a reorder/pin happened — here or in the
+      // workspace gallery — so drop the frozen order and re-snapshot from the
+      // fresh server order, keeping the nav in sync with the gallery's 'custom'
+      // sort. Recency bumps and paged-in workspaces don't change these fields.
+      let manualOrderChanged = false;
+      for (const ws of allFetched) {
+        const sortOrder = (ws.sort_order as number | null | undefined) ?? null;
+        const pinned = Boolean(ws.is_pinned);
+        const prev = _lastWorkspaceArrangement.get(ws.workspace_id);
+        if (prev && (prev.sortOrder !== sortOrder || prev.pinned !== pinned)) manualOrderChanged = true;
+        _lastWorkspaceArrangement.set(ws.workspace_id, { sortOrder, pinned });
+      }
+      if (manualOrderChanged) _frozenWorkspaceOrder = null;
 
-    const remainingPinned = allFetched.filter((ws) => ws.is_pinned && !recentIds.has(ws.workspace_id));
-    const pinnedIds = new Set(remainingPinned.map((ws) => ws.workspace_id));
+      const { order, items: stable } = applyStableOrderBy(_frozenWorkspaceOrder, allFetched, (ws) => ws.workspace_id);
+      _frozenWorkspaceOrder = order;
+      ordered = stable;
+    } else {
+      // 'activity' / 'name': the server already returned the list in this order
+      // (the query's sortBy). Trust it and don't freeze — recency hoisting is
+      // the point of 'activity'. Drop any custom snapshot so switching back to
+      // 'custom' re-snapshots fresh from the server's manual order.
+      _frozenWorkspaceOrder = null;
+      ordered = allFetched;
+    }
 
-    const rest = allFetched.filter((ws) => !recentIds.has(ws.workspace_id) && !pinnedIds.has(ws.workspace_id));
+    if (showAll) return ordered;
 
-    const ordered = [...recentTwo, ...remainingPinned, ...rest];
-    const sliced = ordered.slice(0, visibleCount);
+    const sliced = ordered.slice(0, workspaceLimit as number);
     if (currentWorkspaceId && !sliced.some((ws) => ws.workspace_id === currentWorkspaceId)) {
       const currentWs = allFetched.find((ws) => ws.workspace_id === currentWorkspaceId);
-      if (currentWs) sliced.unshift(currentWs);
+      // Keep the current workspace in view without hoisting it to the top —
+      // it joins at the bottom of the visible slice, holding the list stable.
+      if (currentWs) sliced.push(currentWs);
     }
     return sliced;
-  }, [allFetched, visibleCount, currentWorkspaceId]);
+    // orderVersion isn't read in the body, but drag-reorder rewrites the frozen
+    // workspace order this memo reads — it must recompute when the version ticks.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [allFetched, showAll, workspaceLimit, currentWorkspaceId, orderVersion, orderBy]);
+
+  // Drag-reorder a workspace in the nav list. Optimistically rewrites the
+  // frozen nav order, then persists sequential sort_order values so the
+  // workspace gallery's 'custom' sort shows the same arrangement. Mirrors the
+  // gallery's reorder-mode rules: flash is immovable, and crossing the
+  // pinned/unpinned boundary is refused (the server sort would undo it —
+  // is_pinned DESC dominates sort_order).
+  const reorderWorkspace = useCallback(async (activeId: string, overId: string) => {
+    const frozen = _frozenWorkspaceOrder;
+    if (!frozen || !activeId || !overId || activeId === overId) return;
+    const byId = new Map(allFetched.map((ws) => [ws.workspace_id, ws]));
+    const active = byId.get(activeId);
+    const over = byId.get(overId);
+    if (!active || !over) return;
+    if (active.status === 'flash' || over.status === 'flash') return;
+    if (Boolean(active.is_pinned) !== Boolean(over.is_pinned)) return;
+    const fromIdx = frozen.indexOf(activeId);
+    const toIdx = frozen.indexOf(overId);
+    if (fromIdx === -1 || toIdx === -1) return;
+
+    const snapshot = [...frozen];
+    frozen.splice(fromIdx, 1);
+    frozen.splice(toIdx, 0, activeId);
+    _navOrderVersion++;
+    _navOrderListeners.forEach((fn) => fn());
+
+    const items = frozen
+      .map((id) => byId.get(id))
+      .filter((ws): ws is WorkspaceRecord => !!ws && ws.status !== 'flash')
+      .map((ws, i) => ({ workspace_id: ws.workspace_id, sort_order: i }));
+    try {
+      await reorderWorkspaces(items);
+      queryClient.invalidateQueries({ queryKey: queryKeys.workspaces.lists() });
+    } catch (e) {
+      console.warn('[useNavigationData] Failed to persist workspace order:', e);
+      _frozenWorkspaceOrder = snapshot;
+      _navOrderVersion++;
+      _navOrderListeners.forEach((fn) => fn());
+    }
+  }, [allFetched, queryClient]);
+
+  // Optimistically patch one workspace across every cached list, persist via
+  // `updateWorkspace`, then invalidate so the server's re-sort lands. Rolls the
+  // caches back on failure. Shared by pin and rename — the only difference is
+  // the patch payload and the persisted field.
+  const patchWorkspace = useCallback(async (wsId: string, patch: Partial<WorkspaceRecord>) => {
+    const previous = queryClient.getQueriesData({ queryKey: queryKeys.workspaces.lists() });
+    previous.forEach(([key, data]: [unknown, unknown]) => {
+      const d = data as WorkspacesResponse | undefined;
+      if (!d?.workspaces) return;
+      queryClient.setQueryData(key as readonly unknown[], {
+        ...d,
+        workspaces: d.workspaces.map((ws) => (ws.workspace_id === wsId ? { ...ws, ...patch } : ws)),
+      });
+    });
+    try {
+      await updateWorkspace(wsId, patch);
+      queryClient.invalidateQueries({ queryKey: queryKeys.workspaces.lists() });
+      // The detail cache (useWorkspace → FilePanel header) carries the name, so
+      // a rename must refresh it too; harmless for a pin-only patch.
+      queryClient.invalidateQueries({ queryKey: queryKeys.workspaces.detail(wsId) });
+    } catch (e) {
+      previous.forEach(([key, data]: [unknown, unknown]) => queryClient.setQueryData(key as readonly unknown[], data));
+      console.warn('[useNavigationData] Failed to update workspace:', e);
+    }
+  }, [queryClient]);
+
+  // Pin/unpin a workspace. The server sorts pinned-first, so the invalidate
+  // refetch reorders the list; the 'custom' freeze re-snapshots on the pin-state
+  // change (manualOrderChanged detection above).
+  const pinWorkspace = useCallback((wsId: string, pinned: boolean) => {
+    return patchWorkspace(wsId, { is_pinned: pinned });
+  }, [patchWorkspace]);
+
+  // Rename a workspace. No-op on blank/unchanged names is enforced by the caller.
+  const renameWorkspace = useCallback((wsId: string, name: string) => {
+    const trimmed = name.trim();
+    if (!trimmed) return Promise.resolve();
+    return patchWorkspace(wsId, { name: trimmed });
+  }, [patchWorkspace]);
 
   const hasMore = useMemo(() => {
-    if (visibleCount < allFetched.length) return true;
+    if (showAll) return false;
+    if ((workspaceLimit as number) < allFetched.length) return true;
     if (allFetched.length < totalCount) return true;
     return false;
-  }, [visibleCount, allFetched.length, totalCount]);
+  }, [showAll, workspaceLimit, allFetched.length, totalCount]);
 
   const { data: currentWsThreadData, isLoading: currentWsThreadsLoading } = useQuery({
     queryKey: queryKeys.threads.byWorkspace(currentWorkspaceId),
-    queryFn: () => getWorkspaceThreads(currentWorkspaceId, 10, 0),
+    queryFn: () => getWorkspaceThreads(currentWorkspaceId, threadPageSize, 0),
     enabled: !!currentWorkspaceId,
     staleTime: 30_000,
   });
 
-  const mergedThreads = useMemo(() => ({
-    ...workspaceThreads,
-    ...(currentWorkspaceId && currentWsThreadData !== undefined ? {
+  const mergedThreads = useMemo(() => {
+    if (!currentWorkspaceId) return workspaceThreads;
+    const stored = workspaceThreads[currentWorkspaceId];
+    if (currentWsThreadData === undefined) {
+      return {
+        ...workspaceThreads,
+        [currentWorkspaceId]: {
+          threads: stored?.threads || [],
+          loading: true,
+          total: stored?.total,
+        },
+      };
+    }
+    // The query holds the first page; "Show more" pages land in workspaceThreads.
+    // Union them (query page wins on overlap) so paging the current workspace
+    // survives the query refetching its first page.
+    const page = (currentWsThreadData as ThreadsResponse)?.threads || [];
+    const pageIds = new Set(page.map((t) => t.thread_id));
+    const extras = (stored?.threads || []).filter((t) => !pageIds.has(t.thread_id));
+    return {
+      ...workspaceThreads,
       [currentWorkspaceId]: {
-        threads: (currentWsThreadData as ThreadsResponse)?.threads || [],
-        loading: currentWsThreadsLoading,
+        threads: orderThreads(currentWorkspaceId, [...page, ...extras]),
+        loading: currentWsThreadsLoading || stored?.loading || false,
+        total: (currentWsThreadData as ThreadsResponse)?.total ?? stored?.total,
       },
-    } : currentWorkspaceId ? {
-      [currentWorkspaceId]: {
-        threads: workspaceThreads[currentWorkspaceId]?.threads || [],
-        loading: true,
-      },
-    } : {}),
-  }), [workspaceThreads, currentWorkspaceId, currentWsThreadData, currentWsThreadsLoading]);
+    };
+  }, [workspaceThreads, currentWorkspaceId, currentWsThreadData, currentWsThreadsLoading, orderThreads]);
 
   const expandWorkspace = useCallback((wsId: string) => {
+    const mergeFetched = (data: ThreadsResponse) => {
+      setWorkspaceThreads(prev => {
+        const have = prev[wsId]?.threads || [];
+        // Keep already-paged-in threads; the fetched first page wins on overlap.
+        const pageIds = new Set((data.threads || []).map((t) => t.thread_id));
+        const extras = have.filter((t) => !pageIds.has(t.thread_id));
+        return {
+          ...prev,
+          [wsId]: {
+            threads: orderThreads(wsId, [...(data.threads || []), ...extras]),
+            loading: false,
+            total: data.total ?? prev[wsId]?.total,
+          },
+        };
+      });
+    };
+
     const cached = queryClient.getQueryData(queryKeys.threads.byWorkspace(wsId)) as ThreadsResponse | undefined;
     if (cached) {
-      setWorkspaceThreads(prev => ({
-        ...prev,
-        [wsId]: { threads: cached.threads || [], loading: false },
-      }));
+      mergeFetched(cached);
       return;
     }
 
     setWorkspaceThreads(prev => ({
       ...prev,
-      [wsId]: { threads: prev[wsId]?.threads || [], loading: true },
+      [wsId]: { threads: prev[wsId]?.threads || [], loading: true, total: prev[wsId]?.total },
     }));
 
     queryClient.fetchQuery({
       queryKey: queryKeys.threads.byWorkspace(wsId),
-      queryFn: () => getWorkspaceThreads(wsId, 10, 0),
+      queryFn: () => getWorkspaceThreads(wsId, threadPageSize, 0),
       staleTime: 30_000,
     }).then((data: unknown) => {
-      setWorkspaceThreads(prev => ({
-        ...prev,
-        [wsId]: { threads: (data as ThreadsResponse).threads || [], loading: false },
-      }));
+      mergeFetched(data as ThreadsResponse);
     }).catch(() => {
       setWorkspaceThreads(prev => ({
         ...prev,
-        [wsId]: { threads: [], loading: false },
+        [wsId]: { threads: prev[wsId]?.threads || [], loading: false, total: prev[wsId]?.total },
       }));
     });
-  }, [queryClient]);
+  }, [queryClient, orderThreads, threadPageSize]);
 
-  const loadAll = useCallback(async () => {
-    setVisibleCount(Infinity);
-
-    if (allFetched.length < totalCount) {
-      try {
-        const data = await getWorkspaces(100, allFetched.length, 'custom', true) as WorkspacesResponse;
-        queryClient.setQueryData(queryKeys.workspaces.list({ ...NAV_WS_PARAMS, offset: 0 }), (old: unknown) => {
-          const oldData = old as WorkspacesResponse | undefined;
-          if (!oldData) return data;
-          const existingIds = new Set(oldData.workspaces.map(w => w.workspace_id));
-          const unique = (data.workspaces || []).filter(w => !existingIds.has(w.workspace_id));
-          return { ...oldData, workspaces: [...oldData.workspaces, ...unique], total: data.total || oldData.total };
-        });
-      } catch (e) {
-        console.warn('[useNavigationData] Failed to load all workspaces:', e);
-      }
+  // Fetch the next page of threads for a workspace and append it below the
+  // already-shown ones (the stable order keeps paginated-in ids at the bottom).
+  const loadMoreThreads = useCallback(async (wsId: string) => {
+    const shown = mergedThreads[wsId]?.threads || [];
+    setWorkspaceThreads(prev => ({
+      ...prev,
+      [wsId]: {
+        threads: prev[wsId]?.threads || shown,
+        loading: true,
+        total: prev[wsId]?.total ?? mergedThreads[wsId]?.total,
+      },
+    }));
+    try {
+      const data = await getWorkspaceThreads(wsId, threadPageSize, shown.length) as ThreadsResponse;
+      setWorkspaceThreads(prev => {
+        const have = prev[wsId]?.threads?.length ? prev[wsId].threads : shown;
+        const haveIds = new Set(have.map((t) => t.thread_id));
+        const fresh = (data.threads || []).filter((t) => !haveIds.has(t.thread_id));
+        return {
+          ...prev,
+          [wsId]: {
+            threads: orderThreads(wsId, [...have, ...fresh]),
+            loading: false,
+            total: data.total ?? prev[wsId]?.total,
+          },
+        };
+      });
+    } catch (e) {
+      console.warn('[useNavigationData] Failed to load more threads:', e);
+      setWorkspaceThreads(prev => ({
+        ...prev,
+        [wsId]: {
+          threads: prev[wsId]?.threads || shown,
+          loading: false,
+          total: prev[wsId]?.total,
+        },
+      }));
     }
-  }, [allFetched.length, totalCount, queryClient]);
+  }, [mergedThreads, threadPageSize, orderThreads]);
 
-  return { workspaces, workspaceThreads: mergedThreads, loading: isLoading, hasMore, loadAll, expandWorkspace };
+  const loadAll = useCallback(() => {
+    // The page-in effect above fetches the remainder once this flips.
+    setShowAllWorkspaces(true);
+    wsFetchRef.current.failed = false;
+  }, []);
+
+  // `canReorderWorkspaces` is false under activity/name: drag-reorder is a
+  // 'custom'-order action (a drop persists sort_order the view wouldn't
+  // reflect), so the consumer withholds the handler to disable the affordance.
+  // Mirrors the gallery, where reordering only applies to the custom arrangement.
+  return { workspaces, workspaceThreads: mergedThreads, loading: isLoading, hasMore, loadAll, expandWorkspace, loadMoreThreads, reorderWorkspace, canReorderWorkspaces: orderBy === 'custom', pinWorkspace, renameWorkspace };
 }

--- a/web/src/pages/ChatAgent/hooks/useNavigationData.ts
+++ b/web/src/pages/ChatAgent/hooks/useNavigationData.ts
@@ -59,6 +59,19 @@ export function resetStableNavOrder() {
   _lastWorkspaceArrangement.clear();
 }
 
+// Drop a deleted workspace from the frozen-order stores so they don't retain
+// ghost ids for the rest of the session. Deleted ids are already filtered out
+// of the rendered list (applyStableOrderBy drops map-misses), so this is
+// housekeeping, not a correctness fix — call it from the workspace delete path.
+export function forgetStableNavOrder(workspaceId: string) {
+  delete _frozenThreadOrders[workspaceId];
+  _lastWorkspaceArrangement.delete(workspaceId);
+  if (_frozenWorkspaceOrder) {
+    const idx = _frozenWorkspaceOrder.indexOf(workspaceId);
+    if (idx !== -1) _frozenWorkspaceOrder.splice(idx, 1);
+  }
+}
+
 // Bump notifications: chatting in a thread moves it to the top of its
 // workspace's list (like normal chat apps), while clicking around never
 // reorders. Subscribed hooks re-apply the frozen orders when the version ticks.
@@ -186,6 +199,14 @@ export function useNavigationData(currentWorkspaceId: string) {
   // Workspace list in server order (pinned first, then manual sort_order, then
   // recency), frozen to its first-session arrangement so the active workspace's
   // updated_at bumps (which reorder the server response) don't hoist it.
+  //
+  // NOTE: this memo intentionally reads AND writes the module-level frozen-order
+  // stores during render (an impure useMemo). That is safe ONLY because this
+  // tree renders synchronously — no StrictMode, no useTransition/Suspense on the
+  // nav path — so the factory runs once per render and can't interleave or be
+  // discarded. If concurrent features are ever adopted on this path, rework the
+  // ordering subsystem (this memo + orderThreads + reorderWorkspace) to
+  // pure-compute + an effect-commit before they can tear the snapshot.
   const workspaces = useMemo(() => {
     if (!allFetched.length) return [];
 

--- a/web/src/pages/ChatAgent/hooks/useNavigationData.ts
+++ b/web/src/pages/ChatAgent/hooks/useNavigationData.ts
@@ -318,7 +318,10 @@ export function useNavigationData(currentWorkspaceId: string) {
   }, [showAll, workspaceLimit, allFetched.length, totalCount]);
 
   const { data: currentWsThreadData, isLoading: currentWsThreadsLoading } = useQuery({
-    queryKey: queryKeys.threads.byWorkspace(currentWorkspaceId),
+    // Page size is part of the key (mirrors the dashboard widgets' thread keys):
+    // the queryFn fetches `threadPageSize` rows, so changing that pref must miss
+    // the cache and refetch instead of replaying the previous page size.
+    queryKey: [...queryKeys.threads.byWorkspace(currentWorkspaceId), threadPageSize, 0],
     queryFn: () => getWorkspaceThreads(currentWorkspaceId, threadPageSize, 0),
     enabled: !!currentWorkspaceId,
     staleTime: 30_000,
@@ -371,7 +374,7 @@ export function useNavigationData(currentWorkspaceId: string) {
       });
     };
 
-    const cached = queryClient.getQueryData(queryKeys.threads.byWorkspace(wsId)) as ThreadsResponse | undefined;
+    const cached = queryClient.getQueryData([...queryKeys.threads.byWorkspace(wsId), threadPageSize, 0]) as ThreadsResponse | undefined;
     if (cached) {
       mergeFetched(cached);
       return;
@@ -383,7 +386,7 @@ export function useNavigationData(currentWorkspaceId: string) {
     }));
 
     queryClient.fetchQuery({
-      queryKey: queryKeys.threads.byWorkspace(wsId),
+      queryKey: [...queryKeys.threads.byWorkspace(wsId), threadPageSize, 0],
       queryFn: () => getWorkspaceThreads(wsId, threadPageSize, 0),
       staleTime: 30_000,
     }).then((data: unknown) => {

--- a/web/src/pages/ChatAgent/hooks/useNavigationData.ts
+++ b/web/src/pages/ChatAgent/hooks/useNavigationData.ts
@@ -155,6 +155,9 @@ export function useNavigationData(currentWorkspaceId: string) {
   // Each completed page grows allFetched, re-running the effect until total is
   // reached. A failure stops the loop for the session (avoids a retry storm).
   const wsFetchRef = useRef({ inflight: false, failed: false });
+  // Per-workspace single-flight for "Show more": the page offset is snapshotted
+  // before the await, so two rapid taps would otherwise fetch the same page.
+  const loadMoreInflightRef = useRef<Set<string>>(new Set());
   useEffect(() => {
     if (!showAll || isLoading) return;
     if (!totalCount || allFetched.length >= totalCount) return;
@@ -402,6 +405,8 @@ export function useNavigationData(currentWorkspaceId: string) {
   // Fetch the next page of threads for a workspace and append it below the
   // already-shown ones (the stable order keeps paginated-in ids at the bottom).
   const loadMoreThreads = useCallback(async (wsId: string) => {
+    if (loadMoreInflightRef.current.has(wsId)) return;
+    loadMoreInflightRef.current.add(wsId);
     const shown = mergedThreads[wsId]?.threads || [];
     setWorkspaceThreads(prev => ({
       ...prev,
@@ -436,6 +441,8 @@ export function useNavigationData(currentWorkspaceId: string) {
           total: prev[wsId]?.total,
         },
       }));
+    } finally {
+      loadMoreInflightRef.current.delete(wsId);
     }
   }, [mergedThreads, threadPageSize, orderThreads]);
 

--- a/web/src/pages/ChatAgent/hooks/utils/streamEventHandlers.ts
+++ b/web/src/pages/ChatAgent/hooks/utils/streamEventHandlers.ts
@@ -529,32 +529,19 @@ export function handleTodoUpdate({ assistantMessageId, artifactType, artifactId,
 }): boolean {
   const { contentOrderCounterRef, updateTodoListCard, isNewConversation } = refs;
 
-  if (import.meta.env.DEV) {
-    console.log('[handleTodoUpdate] Called with:', { assistantMessageId, artifactType, artifactId, payload, isNewConversation });
-  }
-
   // Only handle todo_update artifacts
   if (artifactType !== 'todo_update' || !payload) {
-    if (import.meta.env.DEV) {
-      console.log('[handleTodoUpdate] Skipping - artifactType:', artifactType, 'hasPayload:', !!payload);
-    }
     return false;
   }
 
   const { total, completed, in_progress, pending } = payload;
   const todos = Array.isArray(payload.todos) ? payload.todos : [];
-  if (import.meta.env.DEV) {
-    console.log('[handleTodoUpdate] Extracted data:', { todos, total, completed, in_progress, pending });
-  }
 
   // Update floating card with todo list data (only during live streaming, not history)
   // Do this before setMessages to ensure we have the latest data
   // Always update the card if updateTodoListCard is available, even if todos array is empty
   // This ensures the card persists and shows the latest state
   if (updateTodoListCard) {
-    if (import.meta.env.DEV) {
-      console.log('[handleTodoUpdate] Updating todo list card, isNewConversation:', isNewConversation, 'todos count:', todos?.length || 0);
-    }
     updateTodoListCard(
       {
         todos,
@@ -572,28 +559,16 @@ export function handleTodoUpdate({ assistantMessageId, artifactType, artifactId,
   const baseTodoListId = artifactId || `todo-list-base-${Date.now()}`;
   // Create a unique segment ID that includes timestamp to ensure chronological ordering
   const segmentId = `${baseTodoListId}-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
-  if (import.meta.env.DEV) {
-    console.log('[handleTodoUpdate] Using baseTodoListId:', baseTodoListId, 'segmentId:', segmentId);
-  }
 
   setMessages((prev: MessageRecord[]) => {
-    if (import.meta.env.DEV) {
-      console.log('[handleTodoUpdate] Current messages:', prev.map((m: MessageRecord) => ({ id: m.id, role: m.role, hasSegments: !!m.contentSegments, hasTodoProcesses: !!m.todoListProcesses })));
-    }
     const updated = prev.map((msg: MessageRecord) => {
       if (msg.id !== assistantMessageId) return msg;
 
-      if (import.meta.env.DEV) {
-        console.log('[handleTodoUpdate] Found matching message:', msg.id);
-      }
       const todoListProcesses = { ...((msg.todoListProcesses as Record<string, unknown>) || {}) };
       const contentSegments = [...((msg.contentSegments as Record<string, unknown>[]) || [])];
 
       // Always create a new segment for each todo_update event to preserve chronological order
       const currentOrder = eventId != null ? eventId : ++contentOrderCounterRef.current;
-      if (import.meta.env.DEV) {
-        console.log('[handleTodoUpdate] Creating new todo list segment with order:', currentOrder, 'segmentId:', segmentId);
-      }
 
       // Add new segment at the current chronological position
       contentSegments.push({
@@ -614,27 +589,14 @@ export function handleTodoUpdate({ assistantMessageId, artifactType, artifactId,
         order: currentOrder,
         baseTodoListId: baseTodoListId, // Keep reference to base ID for potential future use
       };
-      if (import.meta.env.DEV) {
-        console.log('[handleTodoUpdate] Created new todo list process:', todoListProcesses[segmentId]);
-      }
 
       const updatedMsg: MessageRecord = {
         ...msg,
         contentSegments,
         todoListProcesses,
       };
-      if (import.meta.env.DEV) {
-        console.log('[handleTodoUpdate] Updated message:', {
-          id: updatedMsg.id,
-          segmentsCount: (updatedMsg.contentSegments as unknown[])?.length,
-          todoListIds: Object.keys((updatedMsg.todoListProcesses as Record<string, unknown>) || {})
-        });
-      }
       return updatedMsg;
     });
-    if (import.meta.env.DEV) {
-      console.log('[handleTodoUpdate] Final messages after update:', updated.map((m: MessageRecord) => ({ id: m.id, segmentsCount: (m.contentSegments as unknown[])?.length, todoListIds: Object.keys((m.todoListProcesses as Record<string, unknown>) || {}) })));
-    }
     return updated;
   });
 
@@ -932,16 +894,6 @@ export function handleSubagentMessageChunk({
     const existingContent = (reasoningProcesses[reasoningId]?.content as string) || '';
     const newContent = existingContent + content;
 
-    if (import.meta.env.DEV) {
-      console.log('[handleSubagentMessageChunk] Updating reasoning content:', {
-        taskId,
-        reasoningId,
-        existingContentLength: existingContent.length,
-        newChunkLength: content.length,
-        newContentLength: newContent.length,
-      });
-    }
-
     const reasoningTitle = extractLastReasoningTitle(newContent) ?? (reasoningProcesses[reasoningId].reasoningTitle as string | null) ?? null;
     reasoningProcesses[reasoningId] = {
       ...reasoningProcesses[reasoningId],
@@ -1093,15 +1045,6 @@ export function handleSubagentToolCalls({ taskId, assistantMessageId, toolCalls,
   const taskRefs = getOrCreateTaskRefs(refs, taskId);
   const { contentOrderCounterRef } = taskRefs;
 
-  if (import.meta.env.DEV) {
-    console.log('[handleSubagentToolCalls] Processing tool calls:', {
-      taskId,
-      assistantMessageId,
-      toolCallsCount: toolCalls.length,
-      toolCallIds: toolCalls.map((tc: ToolCallRecord) => tc.id),
-    });
-  }
-
   toolCalls.forEach((toolCall: ToolCallRecord) => {
     const toolCallId = toolCall.id;
     if (toolCallId) {
@@ -1142,16 +1085,6 @@ export function handleSubagentToolCalls({ taskId, assistantMessageId, toolCalls,
           isComplete: false,
           order: currentOrder,
         };
-
-        if (import.meta.env.DEV) {
-          console.log('[handleSubagentToolCalls] Created new tool call:', {
-            taskId,
-            assistantMessageId,
-            toolCallId,
-            toolName: toolCall.name,
-            order: currentOrder,
-          });
-        }
       } else {
         toolCallProcesses[toolCallId] = {
           ...toolCallProcesses[toolCallId],
@@ -1215,18 +1148,6 @@ export function handleSubagentToolCallResult({ taskId, assistantMessageId, toolC
   let messageIndex = -1;
   let targetMessage: MessageRecord | null = null;
 
-  if (import.meta.env.DEV) {
-    console.log('[handleSubagentToolCallResult] Searching for tool call:', {
-      taskId,
-      toolCallId,
-      assistantMessageId,
-      existingMessages: updatedMessages.map((m: MessageRecord) => ({
-        id: m.id,
-        toolCallIds: Object.keys((m.toolCallProcesses as Record<string, unknown>) || {}),
-      })),
-    });
-  }
-
   // First, try to find message by assistantMessageId (if provided and matches)
   if (assistantMessageId) {
     messageIndex = updatedMessages.findIndex((m: MessageRecord) => m.id === assistantMessageId);
@@ -1254,12 +1175,6 @@ export function handleSubagentToolCallResult({ taskId, assistantMessageId, toolC
       if ((msg.toolCallProcesses as Record<string, unknown>)?.[toolCallId]) {
         messageIndex = i;
         targetMessage = msg;
-        if (import.meta.env.DEV) {
-          console.log('[handleSubagentToolCallResult] Found message by tool call ID:', {
-            messageId: msg.id,
-            toolCallId,
-          });
-        }
         break;
       }
     }
@@ -1365,7 +1280,6 @@ export function handleSubagentToolCallResult({ taskId, assistantMessageId, toolC
   // Detect if the tool call that just completed was a failure
   // We need to check the tool call process that was just updated
   let justCompletedToolFailed = false;
-  let justCompletedToolName = '';
 
   // Find the tool call that just completed (it should be in updatedMessages now)
   for (const msg of updatedMessages) {
@@ -1374,7 +1288,6 @@ export function handleSubagentToolCallResult({ taskId, assistantMessageId, toolC
     if (completedToolCall && completedToolCall.isComplete) {
       // This is the tool call that just completed
       justCompletedToolFailed = (completedToolCall.isFailed as boolean) || false;
-      justCompletedToolName = (completedToolCall.toolName as string) || '';
       break;
     }
   }
@@ -1407,15 +1320,6 @@ export function handleSubagentToolCallResult({ taskId, assistantMessageId, toolC
   // - If there's an in-progress tool, show it
   // - Otherwise, clear it
   const finalCurrentTool = justCompletedToolFailed ? '' : (hasInProgressTool ? currentToolName : '');
-
-  if (import.meta.env.DEV && justCompletedToolFailed) {
-    console.log('[handleSubagentToolCallResult] Tool call failed, clearing currentTool immediately:', {
-      taskId,
-      toolCallId,
-      failedToolName: justCompletedToolName,
-      reason: 'Tool call failed, clearing currentTool immediately',
-    });
-  }
 
   // Update currentTool: clear if tool failed, otherwise use in-progress tool if any
   updateSubagentCard(taskId, {

--- a/web/src/pages/ChatAgent/utils/api.ts
+++ b/web/src/pages/ChatAgent/utils/api.ts
@@ -84,7 +84,7 @@ export async function updateWorkspace(workspaceId: string, updates: Record<strin
   return data;
 }
 
-export async function reorderWorkspaces(items: Array<{ workspace_id: string; position: number }>) {
+export async function reorderWorkspaces(items: Array<{ workspace_id: string; sort_order: number }>) {
   if (!items?.length) throw new Error('Reorder items are required');
   await api.post('/api/v1/workspaces/reorder', { items });
 }

--- a/web/src/pages/ChatAgent/utils/navPrefs.ts
+++ b/web/src/pages/ChatAgent/utils/navPrefs.ts
@@ -1,0 +1,89 @@
+import { useSyncExternalStore } from 'react';
+
+/**
+ * Navigation panel display preferences, persisted to localStorage.
+ * Module-level store (like the panel's pin state) so every panel instance —
+ * one mounts per cached ChatView — sees the same values.
+ */
+/** Workspace ordering — mirrors the workspace gallery's sort modes. */
+export type NavOrderBy = 'activity' | 'name' | 'custom';
+
+export interface NavDisplayPrefs {
+  /** Workspaces visible before the "Load all" row; 'all' shows everything. */
+  workspaceLimit: number | 'all';
+  /** Threads fetched/shown per workspace page ("Show more" loads another page). */
+  threadPageSize: number;
+  /** Workspace order: recency ('activity'), alphabetical ('name'), or the
+   *  manual/pinned arrangement ('custom', synced with the gallery). */
+  orderBy: NavOrderBy;
+}
+
+const STORAGE_KEY = 'nav.display';
+
+export const NAV_PREFS_DEFAULTS: NavDisplayPrefs = {
+  workspaceLimit: 'all',
+  threadPageSize: 10,
+  orderBy: 'custom',
+};
+
+function sanitize(raw: unknown): NavDisplayPrefs {
+  const prefs = { ...NAV_PREFS_DEFAULTS };
+  if (raw && typeof raw === 'object') {
+    const { workspaceLimit, threadPageSize, orderBy } = raw as Record<string, unknown>;
+    if (workspaceLimit === 'all' || (typeof workspaceLimit === 'number' && Number.isInteger(workspaceLimit) && workspaceLimit > 0)) {
+      prefs.workspaceLimit = workspaceLimit;
+    }
+    if (typeof threadPageSize === 'number' && Number.isInteger(threadPageSize) && threadPageSize > 0) {
+      prefs.threadPageSize = threadPageSize;
+    }
+    if (orderBy === 'activity' || orderBy === 'name' || orderBy === 'custom') {
+      prefs.orderBy = orderBy;
+    }
+  }
+  return prefs;
+}
+
+function load(): NavDisplayPrefs {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? sanitize(JSON.parse(raw)) : { ...NAV_PREFS_DEFAULTS };
+  } catch {
+    return { ...NAV_PREFS_DEFAULTS };
+  }
+}
+
+let _prefs: NavDisplayPrefs = load();
+const _listeners = new Set<() => void>();
+
+export function getNavPrefs(): NavDisplayPrefs {
+  return _prefs;
+}
+
+export function setNavPrefs(update: Partial<NavDisplayPrefs>): void {
+  _prefs = sanitize({ ..._prefs, ...update });
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(_prefs));
+  } catch {
+    // Storage unavailable (private mode) — prefs still apply for the session.
+  }
+  _listeners.forEach((fn) => fn());
+}
+
+export function resetNavPrefs(): void {
+  _prefs = { ...NAV_PREFS_DEFAULTS };
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+  _listeners.forEach((fn) => fn());
+}
+
+function subscribe(fn: () => void): () => void {
+  _listeners.add(fn);
+  return () => _listeners.delete(fn);
+}
+
+export function useNavPrefs(): NavDisplayPrefs {
+  return useSyncExternalStore(subscribe, getNavPrefs);
+}

--- a/web/src/pages/ChatAgent/utils/navPrefs.ts
+++ b/web/src/pages/ChatAgent/utils/navPrefs.ts
@@ -21,6 +21,9 @@ export interface NavDisplayPrefs {
 const STORAGE_KEY = 'nav.display';
 
 export const NAV_PREFS_DEFAULTS: NavDisplayPrefs = {
+  // 'all' by default so the nav reads as a browsable workspace tree. Only names
+  // are paged (100 at a time beyond the first 20) and threads stay lazy per
+  // expand, so the first-load cost is metadata-only — intentional, not a cap bug.
   workspaceLimit: 'all',
   threadPageSize: 10,
   orderBy: 'custom',

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -9,6 +9,10 @@ export default defineConfig(({ mode }) => {
   // process.env entries, so `VITE_FOO=bar pnpm dev` keeps working too.
   const env = loadEnv(mode, process.cwd())
   const backendTarget = env.VITE_PROXY_BACKEND || 'http://localhost:8000'
+  // Only honor a well-formed port; a non-numeric VITE_HMR_CLIENT_PORT would
+  // otherwise yield NaN and silently break the HMR socket.
+  const hmrClientPort = Number(env.VITE_HMR_CLIENT_PORT)
+  const hasHmrClientPort = Number.isFinite(hmrClientPort) && hmrClientPort > 0
 
   return {
     base: env.VITE_CDN_BASE || '/',
@@ -47,8 +51,8 @@ export default defineConfig(({ mode }) => {
       // proxy's `location = /` session redirect (/ → /home|/app), which would
       // 302 the upgrade and surface as "WebSocket closed without opened". The
       // non-root path falls through nginx's `location /` to this Vite server.
-      hmr: env.VITE_HMR_CLIENT_PORT
-        ? { clientPort: Number(env.VITE_HMR_CLIENT_PORT), path: '/vite-hmr' }
+      hmr: hasHmrClientPort
+        ? { clientPort: hmrClientPort, path: '/vite-hmr' }
         : undefined,
       proxy: {
         '/api/v1': {

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -1,43 +1,62 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
-const backendTarget = process.env.VITE_PROXY_BACKEND || 'http://localhost:8000'
-
 // https://vitejs.dev/config/
-export default defineConfig({
-  base: process.env.VITE_CDN_BASE || '/',
-  plugins: [react()],
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
+export default defineConfig(({ mode }) => {
+  // Load VITE_-prefixed vars from .env files (.env, .env.local, …) so they can
+  // be seeded on disk instead of passed inline. loadEnv also merges matching
+  // process.env entries, so `VITE_FOO=bar pnpm dev` keeps working too.
+  const env = loadEnv(mode, process.cwd())
+  const backendTarget = env.VITE_PROXY_BACKEND || 'http://localhost:8000'
+
+  return {
+    base: env.VITE_CDN_BASE || '/',
+    plugins: [react()],
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+      },
     },
-  },
-  build: {
-    rollupOptions: {
-      output: {
-        manualChunks: {
-          'vendor-react': ['react', 'react-dom', 'react-router-dom'],
-          'vendor-markdown': ['react-markdown', 'remark-gfm', 'remark-math', 'remark-cjk-friendly', 'rehype-katex', 'rehype-raw', 'katex'],
-          'vendor-charts': ['recharts', 'lightweight-charts'],
-          'vendor-motion': ['framer-motion'],
-          'vendor-dnd': ['@dnd-kit/core', '@dnd-kit/sortable', '@dnd-kit/utilities'],
+    build: {
+      rollupOptions: {
+        output: {
+          manualChunks: {
+            'vendor-react': ['react', 'react-dom', 'react-router-dom'],
+            'vendor-markdown': ['react-markdown', 'remark-gfm', 'remark-math', 'remark-cjk-friendly', 'rehype-katex', 'rehype-raw', 'katex'],
+            'vendor-charts': ['recharts', 'lightweight-charts'],
+            'vendor-motion': ['framer-motion'],
+            'vendor-dnd': ['@dnd-kit/core', '@dnd-kit/sortable', '@dnd-kit/utilities'],
+          },
         },
       },
     },
-  },
-  server: {
-    host: '127.0.0.1',
-    proxy: {
-      '/api/v1': {
-        target: backendTarget,
-        changeOrigin: true,
+    server: {
+      host: '127.0.0.1',
+      // When served behind the nginx dev proxy (oss.localhost etc.), the HMR
+      // WebSocket must dial the proxy port, not the Vite port. Seed
+      // VITE_HMR_CLIENT_PORT (e.g. =80) in .env.local, or pass it inline.
+      // Unset leaves Vite's default HMR behavior untouched (dev-only; ignored
+      // by `vite build`).
+      //
+      // `path` moves the HMR socket off "/" so it doesn't collide with the
+      // proxy's `location = /` session redirect (/ → /home|/app), which would
+      // 302 the upgrade and surface as "WebSocket closed without opened". The
+      // non-root path falls through nginx's `location /` to this Vite server.
+      hmr: env.VITE_HMR_CLIENT_PORT
+        ? { clientPort: Number(env.VITE_HMR_CLIENT_PORT), path: '/vite-hmr' }
+        : undefined,
+      proxy: {
+        '/api/v1': {
+          target: backendTarget,
+          changeOrigin: true,
+        },
+        '/ws/v1': {
+          target: backendTarget.replace(/^http/, 'ws'),
+          ws: true,
+        },
       },
-      '/ws/v1': {
-        target: backendTarget.replace(/^http/, 'ws'),
-        ws: true,
-      },
+      cors: true,
     },
-    cors: true,
-  },
+  }
 })


### PR DESCRIPTION
## Summary

Frontend polish across the chat streaming UI and in-chat navigation, plus a small
backend fix for how subagent reasoning streams. Three areas:

**Streaming live→accordion lifecycle** (`MessageList.tsx`, `ActivityBlock.tsx/.css`)
- Completed tool/reasoning rows now fold into the accordion **immediately on stream
  end** instead of lingering up to 5s. Cooldown shortened (5000ms → 1800ms) so
  sub-second tool calls still register without flicker.
- Smoother handoff: spring-based accordion container + per-row entrance, tightened
  live-row exit, icon pulse synced to the shimmer, completing-state dim + settle.
- Replay/reconnect parity: history threads (`isStreaming=false`) render pre-folded
  with no entrance animation.

**Navigation** (`NavigationPanel.tsx`, `useNavigationData.ts`, `ChatView.tsx`,
`components/nav/`, `WorkspaceGallery.tsx`)
- Workspace **rename** (inline edit) wired into both the nav pill options menu and the
  gallery card menu, with optimistic update + cache invalidation (`lists()` + `detail(id)`).
- **Pin-to-top**, a **new-thread** button (opens a fresh thread in that workspace),
  an **options** (⋯) menu, and **display options** on the nav pill.
- **Stable thread ordering** — the active thread no longer jumps to the top mid-
  conversation; recency order refreshes on workspace switch / reload.
- Unified rail + `BottomTabBar` nav config (`components/nav/navItems.ts`,
  `useNavActive.ts`) with Radix tooltips on the icon rail.
- Removed the AccountMenu theme switcher (theme still lives in Settings).
- Mobile top bar: swapped back-arrow and hamburger order.

**Console cleanup** (`useChatMessages.ts`, `streamEventHandlers.ts`, `useCardState.ts`,
`ChatView.tsx`)
- Stripped the high-frequency `[History]` / `[Stream]` / subagent / card-update debug
  logs that flooded the console during streaming and history replay (one log fired
  16k+ times on a large thread). Kept all `console.warn` / `console.error` diagnostics.

**Backend — subagent reasoning section separators** (`subagent.py`, `content_utils.py`,
`streaming_handler.py`)
- The subagent token forwarder now tracks the OpenAI `summary_text` index and prepends
  a blank line when it changes (0→1), so a new reasoning section's bold title no longer
  glues onto the previous section's prose. Mirrors the main-agent streaming handler.

## Diff Size
- Total: 35 files changed, +3343 / −578
- Net (excl. tests): 29 files changed, +1948 / −577

## Test Coverage
- Frontend: **1544 tests pass** (135 files), tsc clean, `vite build` succeeds.
  New test files: `MessageList.lifecycle.test.tsx`, `ActivityBlock.lifecycle.test.tsx`,
  `useNavigationData.test.tsx`, `nav/useNavActive.test.tsx`, plus expanded
  `NavigationPanel.test.tsx` (lifecycle fold timing, stable ordering with optimistic
  pin/rename rollback, nav active-state matching, workspace controls).
- Backend: **20 forwarder tests pass** (`test_subagent_token_forwarder.py`), ruff clean —
  cover the summary-index separator (inserts on transition, skips within a section),
  reasoning lifecycle signals, and message-id reset.

## Pre-Landing Review
Two parallel adversarial review passes (frontend + backend):
- **Backend:** no findings. Verified the separator-pending flag can't get stuck, the
  top-level vs `summary_text` `index` fields are correctly distinguished, and the moved
  `msg_id` assignment is safe.
- **Frontend:** P0 was a staging issue (new source/test files untracked) — fixed by
  committing them. Two P2 (informational): the `vite.config.js` `input` guard — reconciled
  in the `origin/main` merge and verified by a clean production build; a low-probability
  rename-draft clobber in `WorkspaceGallery` if a background refetch returns a *different*
  name mid-edit (same-value refetch won't trigger it).

## Test plan
- [x] Frontend: 1544 Vitest tests pass; tsc clean; `vite build` succeeds
- [x] Backend: 20 subagent-forwarder tests pass; ruff clean
- [x] Merged latest `main` (incl. #264 onboarding); conflict in `vite.config.js` resolved + build-verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop nav pin/unpin, persistent pin state, drag‑and‑drop workspace reordering, inline workspace rename, navigation display options (workspace limit, thread page size, sort modes), tooltips on nav items, workspace/thread paging and “load more”.

* **Bug Fixes**
  * Streaming message formatting: reasoning summary sections now include proper separators to prevent header/prose concatenation.

* **Behavior Changes**
  * Chat folding/live‑row timing adjusted to fold completed items sooner when streams end.

* **Style**
  * Refined animations, badges, sidebar accents and layout tweaks.

* **Tests & Localization**
  * Expanded test coverage and added English/Chinese UI strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->