### PR TITLE
fix(crawler): recognize podman-init as a valid init reaper

### DIFF
--- a/src/server/app/setup.py
+++ b/src/server/app/setup.py
@@ -72,9 +72,11 @@ llm_service = None  # Generic one-shot LLM call wrapper (BYOK/OAuth-aware)
 
 # PID 1 process names that correctly reap orphaned subprocesses.
 # `docker-init` is Docker's bundled tini wrapper (what `init: true` in compose
-# launches when no explicit entrypoint uses tini). Must be in the allowlist or
-# the reaper safety guard refuses to run in every standard Docker deployment.
-_ACCEPTABLE_INIT_COMMS = ("tini", "docker-init", "catatonit", "dumb-init")
+# launches when no explicit entrypoint uses tini); `podman-init` is the
+# equivalent shim rootless podman injects for `init: true` (catatonit under the
+# hood). Must be in the allowlist or this diagnostic logs a false "init: true
+# failed" warning on every startup of an otherwise-correctly-hardened container.
+_ACCEPTABLE_INIT_COMMS = ("tini", "docker-init", "catatonit", "dumb-init", "podman-init")
 
 
 def _log_container_hardening() -> None:

--- a/src/tools/crawler/safe_wrapper.py
+++ b/src/tools/crawler/safe_wrapper.py
@@ -43,7 +43,7 @@ _STAT_STARTTIME_IDX = 19  # /proc/[pid]/stat field 22, 0-indexed after comm
 # means "orphan reaped to init" when init actually reaps. If PID 1 is our python
 # worker (init: true silently failed), ppid==1 matches direct children including
 # LIVE browsers of in-flight workflows — the reaper would then SIGKILL healthy crawls.
-_SAFE_INIT_PROCESSES = ("tini", "docker-init", "catatonit", "dumb-init")
+_SAFE_INIT_PROCESSES = ("tini", "docker-init", "catatonit", "dumb-init", "podman-init")
 
 # Three-layer health model tunables.
 _BLOCKED_TTL_SECONDS = 900.0       # 15-min blocked-host cache entry

--- a/tests/unit/tools/crawler/test_orphan_reaper.py
+++ b/tests/unit/tools/crawler/test_orphan_reaper.py
@@ -208,14 +208,17 @@ class TestOrphanReaper:
         assert kills == []  # safety guard engaged — no kills
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("init_comm", ["tini", "docker-init", "catatonit", "dumb-init"])
+    @pytest.mark.parametrize(
+        "init_comm", ["tini", "docker-init", "catatonit", "dumb-init", "podman-init"]
+    )
     async def test_accepts_all_supported_init_processes(self, patched_proc, init_comm):
-        """REGRESSION: docker-init is what `init: true` actually launches.
+        """REGRESSION: the init shim varies by runtime; all must be accepted.
 
         Observed in staging: Docker Desktop and Docker CE set PID 1 to
-        `docker-init` (their bundled tini wrapper), not bare `tini`. The
-        allowlist must include it or the reaper refuses to run on every
-        standard Docker deployment.
+        `docker-init` (their bundled tini wrapper), not bare `tini`. In
+        production under rootless podman, `init: true` injects `podman-init`
+        (catatonit under the hood). The allowlist must include each or the
+        reaper refuses to run on that deployment and orphan browsers leak.
         """
         (patched_proc / "1" / "comm").write_text(f"{init_comm}\n")
         _write_stat(patched_proc, pid=6000, comm="chrome", ppid=1, start_ticks=5000)


### PR DESCRIPTION
## Summary
Adds `podman-init` to the crawler's init-reaper allowlist so the browser-orphan
reaper actually runs under rootless podman.

When the runtime is rootless podman, PID 1 is `podman-init` (podman's `--init`
shim). The reaper (`SafeCrawlerWrapper._reap_orphan_browsers_sync`) refuses to run
unless PID 1 is a recognized init process, and `podman-init` was missing from the
allowlist. As a result every circuit-breaker-triggered browser reset aborted,
leaving orphaned chrome/firefox/camoufox processes uncollected — which in turn
surfaces downstream as `TargetClosedError` future leaks and long-running workflow
timeouts.

The allowlist add is provably safe: podman's `--init` shim is catatonit under the
hood, and `catatonit` is already trusted. The reaper body is unchanged and stays
conservative (SIGKILLs only `ppid==1` browser procs aged >5s). Note that `init: true`
in compose plus a tini entrypoint does NOT resolve this on rootless podman — that
configuration still yields `podman-init` as PID 1, so recognizing it in the
allowlist is the actual fix.

**Changes**
- **crawler:** add `podman-init` to `_SAFE_INIT_PROCESSES` (`src/tools/crawler/safe_wrapper.py`) — the reaper gate.
- **server:** add `podman-init` to `_ACCEPTABLE_INIT_COMMS` (`src/server/app/setup.py`) — stops a false "init: true silently failed" warning on every startup under rootless podman.
- **tests:** extend the parametrized `test_accepts_all_supported_init_processes` to cover `podman-init`.

## Diff Size
- Total: 3 files changed, 14 insertions(+), 9 deletions(-)
- Net (excl. tests): 2 files changed, 6 insertions(+), 4 deletions(-)

## Test Coverage
The reaper already has dedicated coverage in `test_orphan_reaper.py` (15 tests). The
new value rides the existing parametrized accept-test, so
`test_accepts_all_supported_init_processes[podman-init]` now asserts the reaper runs
and SIGKILLs the orphan when PID 1 is `podman-init`. The abort-safety test
(`test_aborts_when_pid1_is_not_init`, uses `python`) is unaffected.

Tests: 197 crawler unit tests pass (15 reaper, incl. the new case).

## Pre-Landing Review
No issues found.
- Enum/value completeness: `podman-init` added to both allowlist consumers + the hardcoded test list; grep confirms no third consumer.
- Concurrency: reaper only kills `ppid==1` browser procs aged >5s; with podman-init reaping, `ppid==1` is a genuine orphan, never a live workflow browser.
- Adversarial (Claude): no path to killing a live browser; rebase auto-merge with origin's `setup.py` verified clean (ruff + AST parse + 197 tests).

## Design Review
No frontend files changed — design review skipped.

## Plan Completion
All planned items done. A second copy of the init allowlist in `setup.py` was caught
during implementation and updated alongside the crawler one.

## Test plan
- [x] `uv run pytest tests/unit/tools/crawler/ -q` — 197 passed (incl. `[podman-init]`)
- [x] `uv run ruff check` on changed files — clean
- [x] `setup.py` syntax valid after rebase auto-merge with origin/main

Post-deploy (manual): the "Browser reset aborted" log line should stop recurring, and
circuit-open events should log `Circuit reset reaped N orphaned browser processes`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded container initialization process allowlists in diagnostics and browser process management to recognize rootless Podman's init system alongside existing Docker and other container runtime options.

* **Tests**
  * Updated test suite to verify proper handling of rootless Podman initialization processes and associated orphaned browser process cleanup routines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->