### PR TITLE
test(e2e): seed onboarding-seen prefs so welcome guides don't block tests

### DIFF
--- a/web/e2e/helpers/mockResponses.js
+++ b/web/e2e/helpers/mockResponses.js
@@ -17,6 +17,27 @@ export const defaultResponses = {
     theme: 'dark',
     locale: 'en-US',
     timezone: 'America/New_York',
+    // Onboarding state of a fully-caught-up returning user, so the welcome
+    // guides added in #264 (page-intro modals + getting-started card) never
+    // pop over the UI under test and intercept clicks. Without this, every
+    // page intro is eligible (empty pageIntrosSeen) and its [role="dialog"]
+    // overlay blocks Playwright clicks -> 30s timeouts. Page-intro ids come
+    // from src/pages/Onboarding/registry/pageIntros.ts -- add new ids here
+    // when intros are added. lastSeenReleaseVersion stays null because
+    // unseenReleases() returns [] for null (no What's-New backlog); firstRunAt
+    // is stamped so the provider treats this as an established user.
+    // Tests that exercise onboarding (e.g. the personalization banner) override
+    // the relevant fields locally.
+    other_preference: {
+      onboarding: {
+        version: 1,
+        pageIntrosSeen: { chat: 1, thread: 1, dashboard: 1 },
+        gettingStartedDoneAt: {},
+        gettingStartedDismissedAt: 1,
+        lastSeenReleaseVersion: null,
+        firstRunAt: 1,
+      },
+    },
   },
   'GET /workspaces': { workspaces: [], total: 0, limit: 20, offset: 0 },
   'POST /workspaces/flash': {


### PR DESCRIPTION
## Problem

The `frontend-e2e` job has been getting **cancelled at the 20-minute cap on `main`** since #264 ([run 27470055111](https://github.com/ginlix-ai/LangAlpha/actions/runs/27470055111/job/81199361916), and the #264 merge before it). It was green (~13 min) through #263.

## Root cause

#264 added the onboarding page-intro system. The intros render a `[role="dialog"]` modal on `/chat`, `/chat/{workspaceId}`, `/chat/t/{threadId}`, and `/dashboard` (`src/pages/Onboarding/registry/pageIntros.ts`) — exactly the routes the e2e suite drives.

The shared mock `GET /users/me/preferences` returns only `{theme, locale, timezone}`, so `other_preference.onboarding` is absent → `pageIntrosSeen` is empty → every intro is eligible. `chat.spec.js` does bare `page.goto()` with no seeded state, so the modal pops on load and intercepts clicks. Each affected test waits the full 30s, retries once in CI (another 30s), and 42 tests on 1 worker blow past the 20-minute limit. (`onboarding_completed: true` only disables the separate *personalization banner*, not page intros.)

This is a test-fixture gap, not a product regression — the modal behaves correctly for real users.

## Fix

Seed `other_preference.onboarding` in the shared mock prefs as a fully-caught-up returning user (all page intros seen, getting-started dismissed, `firstRunAt` stamped). No onboarding surface renders during tests. Test-only change, one file, +21 lines. The one test that *exercises* onboarding (the personalization banner) overrides the relevant fields locally and is unaffected.

## Verification

Full suite locally: **42 passed (50.9s)**, exit 0 — vs the prior 20-minute timeout.

## Follow-up (not in this PR)

The seed lists the current three intro ids; a new page intro added later would reopen the gap. Left a comment pointing at `registry/pageIntros.ts`. A sturdier guard would be a regression test asserting no intro modal appears for a seeded user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced mock user preference data in E2E tests for improved simulation of returning user scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->