### PR TITLE
fix(server): return 404 for non-UUID workspace/thread ids instead of 500

### DIFF
--- a/src/server/app/setup.py
+++ b/src/server/app/setup.py
@@ -636,7 +636,7 @@ class MalformedIdDiagnosticMiddleware:
                     # embedded CR/LF (the ASGI path is percent-decoded, so a
                     # %0a in the URL would otherwise forge a log line); length
                     # caps bound the log volume an attacker can spam.
-                    path = scope.get("path", "")
+                    path = scope.get("path", "")[:512]
                     referer = headers.get("referer", "")[:256]
                     user_id = headers.get("x-user-id", "")[:128]
                     ua = headers.get("user-agent", "")[:256]

--- a/src/server/app/setup.py
+++ b/src/server/app/setup.py
@@ -44,6 +44,7 @@ from src.config.settings import (
 from src.observability import init_otel, init_otel_runtime, shutdown_otel_runtime
 from src.server.services.background_task_manager import BackgroundTaskManager
 from src.server.services.background_registry_store import BackgroundRegistryStore
+from src.server.utils.api import find_malformed_route_ids  # TEMP (malformed-id-diag)
 
 # Phase 1: install fork-safe class-level instrumentor patches BEFORE FastAPI(...)
 # is constructed. FastAPIInstrumentor patches the FastAPI class — must run
@@ -607,8 +608,66 @@ class RequestIDMiddleware:
         await self.app(scope, receive, send_wrapper)
 
 
+class MalformedIdDiagnosticMiddleware:
+    """TEMP (malformed-id-diag): log non-UUID workspace/thread ids with their Referer.
+
+    Pairs with the ``db_get_workspace`` UUID guard. When a file/dir name from the
+    SPA file tree reaches a workspace_id/thread_id slot the request now 404s
+    cleanly; this records the bad value, route, and Referer/User-Agent so the
+    next real prod occurrence names the SPA page that built it. Remove (with
+    ``find_malformed_route_ids``) once the frontend writer is identified.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "http" and scope.get("method") != "OPTIONS":
+            try:
+                findings = find_malformed_route_ids(
+                    scope.get("path", ""), scope.get("query_string", b"")
+                )
+                if findings:
+                    headers = {
+                        k.decode("latin-1").lower(): v.decode("latin-1")
+                        for k, v in scope.get("headers", [])
+                    }
+                    # %r on every user-controlled field so repr() escapes any
+                    # embedded CR/LF (the ASGI path is percent-decoded, so a
+                    # %0a in the URL would otherwise forge a log line); length
+                    # caps bound the log volume an attacker can spam.
+                    path = scope.get("path", "")
+                    referer = headers.get("referer", "")[:256]
+                    user_id = headers.get("x-user-id", "")[:128]
+                    ua = headers.get("user-agent", "")[:256]
+                    for slot, value in findings:
+                        logger.warning(
+                            "[malformed-id-diag] %s=%r path=%r "
+                            "referer=%r user_id=%r ua=%r",
+                            slot,
+                            value[:256],
+                            path,
+                            referer,
+                            user_id,
+                            ua,
+                        )
+            except Exception:  # noqa: BLE001 — diagnostics must never break a request
+                pass
+        await self.app(scope, receive, send)
+
+
 # Register GZip compression middleware (compresses JSON responses >= 1KB)
 app.add_middleware(GZipMiddleware, minimum_size=1000)
+
+# TEMP (malformed-id-diag): log malformed workspace/thread ids + Referer so the next
+# real prod occurrence names the SPA route that built the bad request.
+# To remove (once the frontend writer is identified): delete this call, the
+# MalformedIdDiagnosticMiddleware class above, the setup.py import of
+# find_malformed_route_ids, then find_malformed_route_ids + its module
+# constants in src/server/utils/api.py and the test file
+# tests/unit/server/utils/test_malformed_route_ids.py. Every site is tagged
+# `malformed-id-diag` — `grep -rn malformed-id-diag src tests` lists them all.
+app.add_middleware(MalformedIdDiagnosticMiddleware)
 
 # Register request ID middleware (will be executed after CORS)
 # Note: In FastAPI, middleware is executed in reverse order (last added = first executed)

--- a/src/server/database/conversation.py
+++ b/src/server/database/conversation.py
@@ -16,7 +16,7 @@ from psycopg.types.json import Json
 from psycopg_pool import AsyncConnectionPool
 
 from src.config.settings import get_conversation_pool_max
-from src.server.utils.pg_sanitize import SafeJson, strip_pg_nul_str
+from src.server.utils.pg_sanitize import SafeJson, normalize_uuid, strip_pg_nul_str
 
 logger = logging.getLogger(__name__)
 
@@ -1690,6 +1690,14 @@ async def get_thread_by_id(conversation_thread_id: str) -> Optional[Dict[str, An
 
 async def get_thread_owner_id(thread_id: str) -> Optional[str]:
     """Return the user_id that owns the thread's workspace, or None if not found."""
+    # Normalize before querying: postgres' uuid type rejects forms uuid.UUID()
+    # accepts (e.g. urn:uuid:...), so binding the raw value risks
+    # InvalidTextRepresentation (22P02) → 500. A non-UUID thread_id (e.g. a
+    # file/dir name from the SPA tree) can't match the column; treat it as
+    # not-found so require_thread_owner returns a clean 404.
+    thread_id = normalize_uuid(thread_id)
+    if thread_id is None:
+        return None
     try:
         async with get_db_connection() as conn:
             async with conn.cursor() as cur:

--- a/src/server/database/workspace.py
+++ b/src/server/database/workspace.py
@@ -14,6 +14,7 @@ from psycopg.rows import dict_row
 
 from src.server.database.conversation import get_db_connection
 from src.server.services.workspace_status_pubsub import publish_status_change
+from src.server.utils.pg_sanitize import normalize_uuid
 
 logger = logging.getLogger(__name__)
 
@@ -162,6 +163,14 @@ async def get_workspace(
     Returns:
         Workspace record as dict, or None if not found
     """
+    # Normalize before querying: postgres' uuid type rejects some forms that
+    # uuid.UUID() accepts (e.g. urn:uuid:...), so binding the raw value risks
+    # InvalidTextRepresentation (22P02) → 500. A non-UUID id (e.g. a memory-file
+    # key from the SPA tree) can never match the pk, so treat it as not-found.
+    workspace_id = normalize_uuid(workspace_id)
+    if workspace_id is None:
+        return None
+
     try:
         async def _execute(cur):
             await cur.execute(

--- a/src/server/utils/api.py
+++ b/src/server/utils/api.py
@@ -11,7 +11,7 @@ import logging
 import os
 import re
 from typing import Annotated, Callable, Optional, TypeVar
-from urllib.parse import parse_qs, unquote
+from urllib.parse import parse_qs
 
 from fastapi import Depends, HTTPException, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -180,12 +180,15 @@ def find_malformed_route_ids(
         ):
             findings.append((slot, value))
 
+    # scope["path"] arrives already percent-decoded per the ASGI spec, so the
+    # segment is used verbatim — a second unquote() here would double-decode a
+    # literal %XX in the id.
     ws = _WS_PATH_RE.match(path)
     if ws:
-        _flag("workspace_path_id", unquote(ws.group(1)))
+        _flag("workspace_path_id", ws.group(1))
     th = _THREAD_PATH_RE.match(path)
     if th:
-        _flag("thread_path_id", unquote(th.group(1)))
+        _flag("thread_path_id", th.group(1))
     if query_string:
         try:
             params = parse_qs(query_string.decode("latin-1"))

--- a/src/server/utils/api.py
+++ b/src/server/utils/api.py
@@ -9,7 +9,9 @@ import hmac
 import inspect
 import logging
 import os
+import re
 from typing import Annotated, Callable, Optional, TypeVar
+from urllib.parse import parse_qs, unquote
 
 from fastapi import Depends, HTTPException, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -143,3 +145,53 @@ def raise_not_found(resource: str, resource_id: Optional[str] = None) -> None:
     """
     detail = f"{resource} not found"
     raise HTTPException(status_code=404, detail=detail)
+
+
+# TEMP diagnostic (malformed-id-diag): a file/dir name from the SPA file tree sometimes
+# lands in a workspace_id or thread_id slot (e.g. /workspaces/<file>.md,
+# /threads/results), which the backend now short-circuits to a clean 404. This
+# pure helper lets MalformedIdDiagnosticMiddleware log such ids + Referer so the
+# next real prod occurrence names the SPA route. Remove with the middleware once
+# the frontend writer is identified.
+_ROUTE_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE
+)
+# Literal (non-UUID) path segments that are valid endpoints, not ids.
+_ROUTE_ID_ALLOWLIST = frozenset({"messages", "flash", "reorder"})
+_WS_PATH_RE = re.compile(r"^/api/v1/workspaces/([^/]+)")
+_THREAD_PATH_RE = re.compile(r"^/api/v1/threads/([^/]+)")
+
+
+def find_malformed_route_ids(
+    path: str, query_string: bytes = b""
+) -> list[tuple[str, str]]:
+    """Return (slot, value) pairs where a workspace/thread id isn't a UUID.
+
+    Inspects the workspaces/threads path segment and the ``workspace_id`` query
+    param; allowlisted literal segments (messages/flash/reorder) are ignored.
+    """
+    findings: list[tuple[str, str]] = []
+
+    def _flag(slot: str, value: str) -> None:
+        if (
+            value
+            and value not in _ROUTE_ID_ALLOWLIST
+            and not _ROUTE_UUID_RE.match(value)
+        ):
+            findings.append((slot, value))
+
+    ws = _WS_PATH_RE.match(path)
+    if ws:
+        _flag("workspace_path_id", unquote(ws.group(1)))
+    th = _THREAD_PATH_RE.match(path)
+    if th:
+        _flag("thread_path_id", unquote(th.group(1)))
+    if query_string:
+        try:
+            params = parse_qs(query_string.decode("latin-1"))
+        except (UnicodeDecodeError, ValueError):
+            params = {}
+        for value in params.get("workspace_id", []):
+            _flag("workspace_id_param", value)
+
+    return findings

--- a/src/server/utils/pg_sanitize.py
+++ b/src/server/utils/pg_sanitize.py
@@ -12,6 +12,7 @@ replacement for `psycopg.types.json.Json` when binding JSONB.
 from __future__ import annotations
 
 import json
+import uuid
 from typing import Any
 
 from psycopg.types.json import Json
@@ -22,6 +23,22 @@ def strip_pg_nul_str(value: str | None) -> str | None:
     if not value or "\x00" not in value:
         return value
     return value.replace("\x00", "")
+
+
+def normalize_uuid(value: object) -> str | None:
+    """Canonical UUID string for binding to a Postgres ``uuid`` column, or None.
+
+    Postgres' ``uuid`` type rejects forms that Python's ``uuid.UUID`` accepts
+    (notably the ``urn:uuid:`` prefix), so binding the raw input risks
+    ``InvalidTextRepresentation`` (22P02), which API handlers surface as a 500.
+    Re-stringifying the parsed value yields the canonical 36-char hyphenated form
+    Postgres always accepts; a value that isn't a UUID returns None so callers
+    can short-circuit to "not found".
+    """
+    try:
+        return str(uuid.UUID(str(value)))
+    except (ValueError, TypeError):
+        return None
 
 
 def _safe_dumps(value: Any) -> str:

--- a/tests/unit/server/app/test_malformed_id_middleware.py
+++ b/tests/unit/server/app/test_malformed_id_middleware.py
@@ -1,0 +1,106 @@
+"""Tests for MalformedIdDiagnosticMiddleware (src/server/app/setup.py).
+
+TEMP diagnostic (malformed-id-diag). These guard the prod-logging contract: if the
+middleware silently logged nothing, the next real occurrence would teach us
+nothing, so we pin that it (a) logs malformed ids with their Referer, (b) stays
+silent on valid UUIDs / OPTIONS / non-http scopes, and (c) never breaks a
+request even if the detector raises. Remove with the middleware.
+"""
+
+import logging
+
+import pytest
+
+from src.server.app.setup import MalformedIdDiagnosticMiddleware
+
+MALFORMED_WS = "/api/v1/workspaces/my_notes.md"
+VALID_WS = "/api/v1/workspaces/12345678-1234-5678-1234-567812345678"
+
+
+def _scope(path, method="GET", headers=None, query=b""):
+    return {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "query_string": query,
+        "headers": [(k.encode(), v.encode()) for k, v in (headers or {}).items()],
+    }
+
+
+def _downstream():
+    state = {"calls": 0}
+
+    async def app(scope, receive, send):
+        state["calls"] += 1
+
+    return app, state
+
+
+async def _noop_receive():  # pragma: no cover - unused by the middleware
+    return {}
+
+
+async def _noop_send(_message):  # pragma: no cover - unused by the middleware
+    return None
+
+
+@pytest.mark.asyncio
+async def test_logs_malformed_id_with_referer(caplog):
+    app, state = _downstream()
+    mw = MalformedIdDiagnosticMiddleware(app)
+    referer = "https://app.example.com/chat/some-workspace"
+    with caplog.at_level(logging.WARNING):
+        await mw(_scope(MALFORMED_WS, headers={"referer": referer}), _noop_receive, _noop_send)
+
+    assert state["calls"] == 1  # request always passes through
+    warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("malformed-id-diag" in m for m in warnings)
+    assert any(referer in m for m in warnings)
+    assert any("my_notes.md" in m for m in warnings)
+
+
+@pytest.mark.asyncio
+async def test_valid_uuid_is_silent(caplog):
+    app, state = _downstream()
+    mw = MalformedIdDiagnosticMiddleware(app)
+    with caplog.at_level(logging.WARNING):
+        await mw(_scope(VALID_WS), _noop_receive, _noop_send)
+
+    assert state["calls"] == 1
+    assert not [r for r in caplog.records if "malformed-id-diag" in r.getMessage()]
+
+
+@pytest.mark.asyncio
+async def test_options_preflight_is_skipped(caplog):
+    app, state = _downstream()
+    mw = MalformedIdDiagnosticMiddleware(app)
+    with caplog.at_level(logging.WARNING):
+        await mw(_scope(MALFORMED_WS, method="OPTIONS"), _noop_receive, _noop_send)
+
+    assert state["calls"] == 1
+    assert not [r for r in caplog.records if "malformed-id-diag" in r.getMessage()]
+
+
+@pytest.mark.asyncio
+async def test_non_http_scope_passes_through(caplog):
+    app, state = _downstream()
+    mw = MalformedIdDiagnosticMiddleware(app)
+    with caplog.at_level(logging.WARNING):
+        await mw({"type": "websocket", "path": MALFORMED_WS}, _noop_receive, _noop_send)
+        await mw({"type": "lifespan"}, _noop_receive, _noop_send)
+
+    assert state["calls"] == 2
+    assert not [r for r in caplog.records if "malformed-id-diag" in r.getMessage()]
+
+
+@pytest.mark.asyncio
+async def test_detector_error_never_breaks_request(monkeypatch):
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("detector exploded")
+
+    monkeypatch.setattr("src.server.app.setup.find_malformed_route_ids", _boom)
+    app, state = _downstream()
+    mw = MalformedIdDiagnosticMiddleware(app)
+
+    await mw(_scope(MALFORMED_WS), _noop_receive, _noop_send)  # must not raise
+    assert state["calls"] == 1

--- a/tests/unit/server/app/test_threads_malformed_id.py
+++ b/tests/unit/server/app/test_threads_malformed_id.py
@@ -1,0 +1,40 @@
+"""Route-level regression: a non-UUID thread id is a clean 404, not a 500.
+
+Mirrors the workspace malformed-id tests for the ``get_thread_owner_id`` guard.
+A file/dir name from the SPA tree reaching the uuid column used to raise psycopg
+InvalidTextRepresentation (22P02) → 500; ``require_thread_owner`` must now return
+a clean 404 (the guard short-circuits to None before any DB access).
+"""
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from tests.conftest import create_test_app
+
+
+@pytest_asyncio.fixture
+async def threads_client():
+    from src.server.app.threads import router
+
+    app = create_test_app(router)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c
+
+
+@pytest.mark.asyncio
+async def test_get_thread_malformed_id_returns_404(threads_client):
+    # Directory-name variant (e.g. the `results` dir from the agent file tree).
+    resp = await threads_client.get("/api/v1/threads/results")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_thread_status_malformed_id_returns_404(threads_client):
+    # Memory-file-key variant on a sub-route that also guards via require_thread_owner.
+    resp = await threads_client.get(
+        "/api/v1/threads/my_notes.md/status"
+    )
+    assert resp.status_code == 404

--- a/tests/unit/server/app/test_workspaces.py
+++ b/tests/unit/server/app/test_workspaces.py
@@ -290,6 +290,28 @@ async def test_get_workspace_forbidden(client):
     assert resp.status_code == 403
 
 
+@pytest.mark.asyncio
+async def test_get_workspace_malformed_id_returns_404(client):
+    """A non-UUID id is a clean 404, not a 500.
+
+    Regression: a memory-file key reaching the uuid column raised psycopg
+    InvalidTextRepresentation (22P02) in prod, surfaced as a 500. The guard in
+    db_get_workspace must short-circuit to None (→ 404) before any DB access.
+    """
+    resp = await client.get("/api/v1/workspaces/my_notes.md")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_workspace_events_malformed_id_returns_404(client):
+    """The /events endpoint has no try/except, so a malformed id used to be a
+    raw 500. The db_get_workspace guard makes it a clean 404."""
+    resp = await client.get(
+        "/api/v1/workspaces/my_notes.md/events"
+    )
+    assert resp.status_code == 404
+
+
 # ---------------------------------------------------------------------------
 # PUT /api/v1/workspaces/{workspace_id}
 # ---------------------------------------------------------------------------

--- a/tests/unit/server/database/test_conversation_db.py
+++ b/tests/unit/server/database/test_conversation_db.py
@@ -405,3 +405,46 @@ async def test_get_thread_checkpoint_id_none(mock_db_connection, mock_cursor):
 
     result = await get_thread_checkpoint_id("nonexistent")
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_thread_owner_id_invalid_uuid_short_circuits(
+    mock_db_connection, mock_cursor
+):
+    """A non-UUID thread_id returns None without touching the DB.
+
+    Regression: a directory name (e.g. ``results``) reaching ``WHERE
+    conversation_thread_id = %s`` against the uuid column raised psycopg
+    InvalidTextRepresentation (22P02), which require_thread_owner surfaced as a
+    spurious 500. The guard must short-circuit to None (→ clean 404) before any
+    query.
+    """
+    from src.server.database.conversation import get_thread_owner_id
+
+    for bad_id in ("results", "my_notes.md", "", None):
+        assert await get_thread_owner_id(bad_id) is None
+
+    mock_cursor.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_thread_owner_id_normalizes_noncanonical_uuid(
+    mock_db_connection, mock_cursor
+):
+    """A Python-parseable but non-canonical thread_id is bound to the query in
+    canonical form, never raw.
+
+    Regression: ``uuid.UUID()`` accepts forms postgres' uuid type rejects (e.g.
+    ``urn:uuid:...``); a validate-only guard let those reach postgres →
+    InvalidTextRepresentation (22P02) → spurious 500. The guard must normalize
+    and bind the canonical string.
+    """
+    from src.server.database.conversation import get_thread_owner_id
+
+    canonical = "12345678-1234-5678-1234-567812345678"
+    mock_cursor.fetchone.return_value = None
+    for variant in (f"urn:uuid:{canonical}", "{%s}" % canonical, canonical.upper()):
+        mock_cursor.execute.reset_mock()
+        await get_thread_owner_id(variant)
+        params = mock_cursor.execute.call_args[0][1]
+        assert params == (canonical,), f"{variant!r} bound {params!r}, not canonical"

--- a/tests/unit/server/database/test_workspace_db.py
+++ b/tests/unit/server/database/test_workspace_db.py
@@ -165,13 +165,14 @@ async def test_get_workspace_found(ws_mock_db, mock_cursor):
     """get_workspace returns dict when row exists."""
     from src.server.database.workspace import get_workspace
 
-    row = _workspace_row(workspace_id="ws-1")
+    ws_id = str(uuid.uuid4())
+    row = _workspace_row(workspace_id=ws_id)
     mock_cursor.fetchone.return_value = row
 
-    result = await get_workspace("ws-1")
+    result = await get_workspace(ws_id)
 
     assert result is not None
-    assert result["workspace_id"] == "ws-1"
+    assert result["workspace_id"] == ws_id
     sql = mock_cursor.execute.call_args[0][0]
     assert "status != 'deleted'" in sql
 
@@ -183,8 +184,51 @@ async def test_get_workspace_not_found(ws_mock_db, mock_cursor):
 
     mock_cursor.fetchone.return_value = None
 
-    result = await get_workspace("nonexistent")
+    result = await get_workspace(str(uuid.uuid4()))
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_workspace_invalid_uuid_short_circuits(ws_mock_db, mock_cursor):
+    """A non-UUID id returns None without touching the DB.
+
+    Regression: a memory-file key (e.g. ``my_notes.md``)
+    reaching ``WHERE workspace_id = %s`` against the uuid column raised
+    psycopg InvalidTextRepresentation (22P02), which handlers surfaced as a
+    spurious 500. The guard must short-circuit to None before any query.
+    """
+    from src.server.database.workspace import get_workspace
+
+    for bad_id in ("my_notes.md", "ws-1", "nonexistent", "", None):
+        assert await get_workspace(bad_id) is None
+
+    mock_cursor.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_workspace_normalizes_noncanonical_uuid(ws_mock_db, mock_cursor):
+    """A Python-parseable but non-canonical id is bound to the query in canonical
+    form, never raw.
+
+    Regression: ``uuid.UUID()`` accepts forms postgres' uuid type rejects (e.g.
+    ``urn:uuid:...``), so a validate-only guard let those reach postgres →
+    InvalidTextRepresentation (22P02) → 500. The guard must normalize and bind
+    the canonical string so postgres always accepts it.
+    """
+    from src.server.database.workspace import get_workspace
+
+    canonical = "12345678-1234-5678-1234-567812345678"
+    mock_cursor.fetchone.return_value = None
+    for variant in (
+        f"urn:uuid:{canonical}",
+        "{%s}" % canonical,
+        canonical.replace("-", ""),
+        canonical.upper(),
+    ):
+        mock_cursor.execute.reset_mock()
+        await get_workspace(variant)
+        params = mock_cursor.execute.call_args[0][1]
+        assert params == (canonical,), f"{variant!r} bound {params!r}, not canonical"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/server/utils/test_malformed_route_ids.py
+++ b/tests/unit/server/utils/test_malformed_route_ids.py
@@ -1,0 +1,69 @@
+"""
+Tests for find_malformed_route_ids (src/server/utils/api.py).
+
+TEMP diagnostic helper (malformed-id-diag): flags non-UUID workspace/thread ids so a
+middleware can log them with their Referer. Remove with the helper once the
+frontend writer that feeds file/dir names into id slots is fixed.
+"""
+
+import uuid
+
+from src.server.utils.api import find_malformed_route_ids
+
+
+def test_valid_uuid_path_is_not_flagged():
+    wid = str(uuid.uuid4())
+    assert find_malformed_route_ids(f"/api/v1/workspaces/{wid}") == []
+    assert find_malformed_route_ids(f"/api/v1/workspaces/{wid}/files") == []
+    assert find_malformed_route_ids(f"/api/v1/threads/{wid}/status") == []
+
+
+def test_uppercase_uuid_is_not_flagged():
+    # Pins the load-bearing re.IGNORECASE on _ROUTE_UUID_RE: without it every
+    # uppercase UUID would be logged as malformed and spam the diagnostic.
+    wid = str(uuid.uuid4()).upper()
+    assert find_malformed_route_ids(f"/api/v1/workspaces/{wid}") == []
+    assert find_malformed_route_ids("/api/v1/threads", f"workspace_id={wid}".encode()) == []
+
+
+def test_non_uuid_workspace_path_is_flagged():
+    findings = find_malformed_route_ids(
+        "/api/v1/workspaces/my_notes.md/files"
+    )
+    assert findings == [("workspace_path_id", "my_notes.md")]
+
+
+def test_non_uuid_thread_path_is_flagged():
+    # The directory-name variant: GET /threads/results.
+    assert find_malformed_route_ids("/api/v1/threads/results") == [
+        ("thread_path_id", "results")
+    ]
+
+
+def test_workspace_id_query_param_is_flagged():
+    findings = find_malformed_route_ids(
+        "/api/v1/threads", b"workspace_id=my_notes.md&limit=20"
+    )
+    assert findings == [("workspace_id_param", "my_notes.md")]
+
+
+def test_valid_workspace_id_query_param_is_not_flagged():
+    wid = str(uuid.uuid4())
+    assert find_malformed_route_ids("/api/v1/threads", f"workspace_id={wid}".encode()) == []
+
+
+def test_literal_endpoint_segments_allowlisted():
+    # POST /threads/messages and /workspaces/{flash,reorder} are endpoints, not ids.
+    assert find_malformed_route_ids("/api/v1/threads/messages") == []
+    assert find_malformed_route_ids("/api/v1/workspaces/flash") == []
+    assert find_malformed_route_ids("/api/v1/workspaces/reorder") == []
+
+
+def test_list_endpoints_without_id_are_not_flagged():
+    assert find_malformed_route_ids("/api/v1/workspaces") == []
+    assert find_malformed_route_ids("/api/v1/threads") == []
+
+
+def test_url_encoded_segment_is_decoded_before_check():
+    findings = find_malformed_route_ids("/api/v1/workspaces/my%20file.md")
+    assert findings == [("workspace_path_id", "my file.md")]

--- a/tests/unit/server/utils/test_malformed_route_ids.py
+++ b/tests/unit/server/utils/test_malformed_route_ids.py
@@ -64,6 +64,9 @@ def test_list_endpoints_without_id_are_not_flagged():
     assert find_malformed_route_ids("/api/v1/threads") == []
 
 
-def test_url_encoded_segment_is_decoded_before_check():
-    findings = find_malformed_route_ids("/api/v1/workspaces/my%20file.md")
+def test_already_decoded_segment_is_flagged_verbatim():
+    # ASGI delivers scope["path"] already percent-decoded, so the function
+    # receives literal characters (a space, not %20) and flags the value
+    # verbatim — no second decode.
+    findings = find_malformed_route_ids("/api/v1/workspaces/my file.md")
     assert findings == [("workspace_path_id", "my file.md")]


### PR DESCRIPTION
## Summary

Authenticated users hit HTTP 500s across several workspace/thread endpoints when a
non-UUID string (e.g. a memory-file key or a directory name from the file tree) landed
in a `workspace_id` / `thread_id` slot.

Root cause: the raw string reached a postgres `uuid` column, psycopg raised
`InvalidTextRepresentation` (22P02), and the API handlers surfaced it as a 500 instead
of a clean 404.

**Fix** — `get_workspace` (`database/workspace.py`) and `get_thread_owner_id`
(`database/conversation.py`) now run the id through a shared `normalize_uuid()` helper
(`utils/pg_sanitize.py`) before querying:
- Non-parseable ids → `None` → `require_workspace_owner` / `require_thread_owner` raise a clean **404**.
- Parseable-but-non-canonical ids (`urn:uuid:…`, `{braces}`, 32-hex, uppercase) are bound
  in **canonical form**. This is the key correctness point: postgres rejects some forms
  that Python's `uuid.UUID()` accepts (notably `urn:uuid:`), so a validate-only guard
  would still 500 on those. Normalizing closes that hole. *(Verified against a live postgres.)*

**Temporary diagnostic** (removable as one unit) — a middleware logs malformed ids +
`Referer` + route at WARNING (`[malformed-id-diag]`) so the client route that builds these
requests can be identified, then removed. Every site is tagged `malformed-id-diag`
(`grep -rn malformed-id-diag src tests`).

## Diff Size
- Total: 11 files changed, 474 insertions(+), 5 deletions(-)
- Net (excl. tests): 5 files changed, 146 insertions(+), 1 deletion(-)

## Test Coverage
Tests across 6 files (3 new):
- `test_workspace_db.py` / `test_conversation_db.py` — non-UUID short-circuits to `None`
  without touching the DB; `urn:uuid:`/braces/32-hex/uppercase bind the **canonical** form
  (regression for the validate-only bypass).
- `test_workspaces.py` / `test_threads_malformed_id.py` — route-level 404s for both the
  workspace and thread variants.
- `test_malformed_id_middleware.py` — middleware logs bad id + Referer, silent on
  valid/OPTIONS/non-http scopes, never breaks a request even if the detector raises.
- `test_malformed_route_ids.py` — the pure diagnostic helper (allowlist, query param,
  url-decode, uppercase-not-flagged).

All 102 affected tests pass; full server unit suite: 1885 passed.

## Pre-Landing Review
Ran the specialist review (testing, maintainability, security, adversarial). It caught a
**P1 the first cut missed** — the `urn:uuid:` bypass above — now fixed and regression-tested.
Also applied: shared `normalize_uuid()` (DRY), `%r` formatting + length caps on the
diagnostic log line (log-forging / log-flood defense), and a removal inventory for the
temp code. No open findings.

## Documentation
None needed — the only architectural addition (the diagnostic middleware) is temporary
and slated for removal, so it's deliberately not added to `src/server/CLAUDE.md`.

## Test plan
- [x] 102 affected unit tests pass
- [x] Full server unit suite: 1885 passed (1 pre-existing failure on `main`, unrelated)
- [x] Ruff clean on changed source
- [x] `urn:uuid:` rejection confirmed against a live postgres


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Malformed workspace and thread identifiers now consistently return clean **404** responses (including workspace events).
  * Identifier handling now safely normalizes valid UUID variants and treats invalid values as not found, preventing server errors.

* **Chores**
  * Added non-disruptive request diagnostics that warn when malformed identifier values are detected (skipping preflight `OPTIONS`).

* **Tests**
  * Expanded unit/regression coverage for malformed-id detection, warning-log expectations, and ensuring the diagnostics never block requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->