### PR TITLE
fix(news): authenticate the background poller's data-service calls

### DIFF
--- a/src/server/services/news_refresh_service.py
+++ b/src/server/services/news_refresh_service.py
@@ -24,6 +24,11 @@ from src.server.services.cache.news_cache_service import NewsCacheService, news_
 
 logger = logging.getLogger(__name__)
 
+# Service-account identity for the poller's background service-to-service data
+# calls. Matches the principal price_monitor and the live-data WS already send,
+# so every background transport authenticates the same way.
+_SERVICE_USER_ID = "langalpha-service"
+
 
 def _merge_delta(
     existing: list[dict[str, Any]],
@@ -149,7 +154,9 @@ class NewsRefreshService:
             return
 
         source = await self._resolve_source(provider)
-        data = await source.get_news(tickers=None, limit=limit)
+        data = await source.get_news(
+            tickers=None, limit=limit, user_id=_SERVICE_USER_ID
+        )
         fetched = data.get("results", []) if isinstance(data, dict) else []
 
         existing_wrap = await self._cache.get(

--- a/tests/unit/server/services/test_news_refresh_service.py
+++ b/tests/unit/server/services/test_news_refresh_service.py
@@ -7,7 +7,11 @@ from unittest.mock import AsyncMock
 import pytest
 
 from src.config.models import NewsPollFeedConfig
-from src.server.services.news_refresh_service import NewsRefreshService, _merge_delta
+from src.server.services.news_refresh_service import (
+    _SERVICE_USER_ID,
+    NewsRefreshService,
+    _merge_delta,
+)
 
 
 def _article(aid: str, hour: int) -> dict:
@@ -64,7 +68,9 @@ class TestRefreshFeed:
 
         await svc._refresh_feed(NewsPollFeedConfig(provider="tickertick", limit=50))
 
-        source.get_news.assert_awaited_once_with(tickers=None, limit=50)
+        source.get_news.assert_awaited_once_with(
+            tickers=None, limit=50, user_id=_SERVICE_USER_ID
+        )
         payload, kwargs = cache.set.await_args.args[0], cache.set.await_args.kwargs
         assert [r["id"] for r in payload["results"]] == ["new", "old"]
         assert payload["next_cursor"] is None  # only 2 items < limit 50
@@ -148,6 +154,28 @@ class TestRefreshFeed:
         assert [r["id"] for r in payload["results"]] == ["s4", "s3", "s2", "s1", "s0"]
         # served page is limit=3 → boundary is merged[2] == "s2", NOT the tail "s0"
         assert payload["next_cursor"] == "s2"
+
+    @pytest.mark.asyncio
+    async def test_poller_names_service_user_on_every_feed(self, monkeypatch):
+        """Regression: the user-less poller must send a service-account identity
+        so its background data call authenticates. Without it the request is
+        rejected and the provider chain silently falls back (news.fallback).
+        """
+        svc = _make_service()
+        cache = AsyncMock()
+        cache.acquire_lock = AsyncMock(return_value=True)
+        cache.get = AsyncMock(return_value=None)
+        cache.set = AsyncMock()
+        svc._cache = cache
+
+        source = AsyncMock()
+        source.get_news = AsyncMock(return_value={"results": []})
+        monkeypatch.setattr(svc, "_resolve_source", AsyncMock(return_value=source))
+
+        # The chain feed (provider=None) is the path that hits the data service.
+        await svc._refresh_feed(NewsPollFeedConfig(provider=None, limit=50))
+
+        assert source.get_news.await_args.kwargs["user_id"] == _SERVICE_USER_ID
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("lock_result", [False, None])


### PR DESCRIPTION
## What

The background news poller fetches the global news feed without a service-account
identity, so each request to the configured data service is rejected and the
provider chain silently falls back to the next source. The `news.fallback` warning
repeats every poll interval.

## Root cause

The data service authenticates service-to-service requests by principal — a service
token alone is not enough, the request must also name a user. The data client only
attaches that identity when a `user_id` is passed. The poller
(`news_refresh_service.py`) fetches the user-less global feed, so no identity was
sent and the request was rejected. The chain then fell back to the next provider, so
news still resolved, but every poll logged a warning and paid a wasted round-trip.

Interactive news for signed-in users was never affected: the `/news` endpoint passes
the authenticated user.

## Fix

Declare the service-account identity and pass it on the poller's `get_news` call,
matching the existing convention for user-less background callers:

- `price_monitor.py` — passes `_SERVICE_USER_ID` on every snapshot fetch
- `shared_ws_manager.py` — sends the same principal on the live-data WS

The news poller was the only background data-service caller missing it.

## Why this approach

Passing the identity at the call site (vs defaulting it inside the client) keeps the
"caller declares its identity" pattern the codebase already uses, and avoids silently
substituting a service identity on calls that should carry a real user. Verified no
other user-less callers remain affected: the market-intel source threads `user_id`
through every method, and the insight service is per-user.

## Testing

- New regression test `test_poller_names_service_user_on_every_feed` — asserts the
  poller sends the service identity. Confirmed it fails without the fix and passes
  with it.
- Existing poller tests updated; 11/11 pass, lint clean.
- Safe across all feeds: the news-source interface requires a `user_id` param, so
  sources that don't need it accept and ignore it — no regression for other providers.

## Follow-up (not in this PR)

The service-account identity is a local constant in three modules. A small follow-up
could lift it to a single shared constant under `src/config/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced background feed refresh operations to properly authenticate service-to-service requests with the correct service identity, ensuring authenticated access to upstream data sources.

* **Tests**
  * Updated unit tests to verify that service identity is correctly propagated during background refresh operations across different data source paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->