### PR TITLE
feat: retire soft interrupt — make stop an immediate hard cancel

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ flowchart TB
 
 ### Agent Swarm
 
-The core agent runs on [LangGraph](https://github.com/langchain-ai/langgraph) and spawns parallel async subagents via a `Task()` tool. Subagents execute concurrently with isolated context windows, preventing drift in long reasoning chains. Each subagent returns synthesized results back to the main agent, keeping the orchestrator lean. The main agent can choose to wait for a subagent's result or continue other pending work. Interrupting the main agent does not stop running subagents, so you can halt the orchestrator, update your requirements, or dispatch additional subagents while existing ones finish in the background. You can also switch to the **Subagents** view in the UI to see their progress in real time (web frontend only).
+The core agent runs on [LangGraph](https://github.com/langchain-ai/langgraph) and spawns parallel async subagents via a `Task()` tool. Subagents execute concurrently with isolated context windows, preventing drift in long reasoning chains. Each subagent returns synthesized results back to the main agent, keeping the orchestrator lean. The main agent can choose to wait for a subagent's result or continue other pending work. You can also switch to the **Subagents** view in the UI to see their progress in real time (web frontend only).
 
 Beyond simple dispatch, the main agent can send follow-up instructions to a still-running subagent via `Task(action="update")`, or resume a completed subagent with full checkpoint context via `Task(action="resume")` for iterative refinement. If the server restarts, subagent state is automatically reconstructed from LangGraph checkpoints.
 
@@ -325,7 +325,7 @@ Acknowledgement: some of middleware components are adapted or inspired by the im
 
 The server streams all agent activity over SSE: text chunks, tool calls with arguments and results, subagent status updates, file operation artifacts, and human-in-the-loop interrupts. Every agent decision is fully traceable in the UI.
 
-Workflows run as independent background tasks behind `asyncio.shield()`, fully decoupled from the HTTP/SSE connection. If the browser tab closes or the network drops, the agent keeps working. On reconnect, up to 150,000 buffered events replay from Redis with `last_event_id` deduplication, picking up exactly where the client left off. A background cleanup task auto-purges abandoned workflows after one hour. Soft interrupts pause the main agent while background subagents continue running.
+Workflows run as independent background tasks behind `asyncio.shield()`, fully decoupled from the HTTP/SSE connection. If the browser tab closes or the network drops, the agent keeps working. On reconnect, up to 150,000 buffered events replay from Redis with `last_event_id` deduplication, picking up exactly where the client left off. A background cleanup task auto-purges abandoned workflows after one hour.
 
 PostgreSQL backs LangGraph checkpointing, conversation history, and user data (watchlists, portfolios, preferences), so agent state and user context persist across sessions. Redis buffers SSE events so that browser refreshes and network drops do not lose in-flight messages: the client reconnects and replays automatically. The server also handles synchronization between local data and sandbox data, keeping MCP, skills, and user context in sync. See the full [API reference](docs/api/README.md) for details.
 

--- a/config.yaml
+++ b/config.yaml
@@ -90,7 +90,7 @@ background_execution:
   shutdown_timeout: 50                  # Max seconds for graceful shutdown of running workflows
   checkpoint_flush_timeout: 10          # Timeout for checkpoint state reads/writes
   wait_for_persistence_timeout: 30      # Max seconds callers block waiting for persistence
-  soft_interrupt_wait_timeout: 30       # Max seconds to wait for soft-interrupted workflow to finish
+  stop_drain_timeout: 1.5               # Max seconds to drain killed-subagent events before teardown sentinel
   max_workflow_retries: 3               # Max transient-error retry count
   merged_chunk_max_bytes: 16384         # Max bytes for merged SSE event chunks (16 KB)
 

--- a/src/config/models.py
+++ b/src/config/models.py
@@ -75,8 +75,9 @@ class BackgroundExecutionConfig(BaseModel):
     wait_for_persistence_timeout: float = Field(
         default=30.0, description="Max seconds callers block waiting for persistence completion"
     )
-    soft_interrupt_wait_timeout: float = Field(
-        default=30.0, description="Max seconds to wait for soft-interrupted workflow to finish"
+    stop_drain_timeout: float = Field(
+        default=1.5,
+        description="Max seconds to drain killed-subagent events before the stop teardown sentinel",
     )
     max_workflow_retries: int = Field(
         default=3, description="Max transient-error retry count for workflow execution"

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -380,8 +380,8 @@ def get_wait_for_persistence_timeout() -> float:
     return get_infrastructure_config().background_execution.wait_for_persistence_timeout
 
 
-def get_soft_interrupt_wait_timeout() -> float:
-    return get_infrastructure_config().background_execution.soft_interrupt_wait_timeout
+def get_stop_drain_timeout() -> float:
+    return get_infrastructure_config().background_execution.stop_drain_timeout
 
 
 def get_max_workflow_retries() -> int:

--- a/src/ptc_agent/agent/middleware/background_subagent/registry.py
+++ b/src/ptc_agent/agent/middleware/background_subagent/registry.py
@@ -901,21 +901,36 @@ class BackgroundTaskRegistry:
             for ns in stale_ns:
                 del self._ns_uuid_to_tool_call_id[ns]
 
-    def clear(self) -> None:
-        """Clear all tasks and results from the registry.
-
-        Note: This does NOT cancel running tasks. Call cancel_all() first
-        if you want to stop running tasks.
-
-        This method is intentionally synchronous and does not acquire the async lock
-        because it is called by the orchestrator after wait_for_all() completes,
-        when no concurrent modifications are possible.
-        """
+    def _clear_unlocked(self) -> None:
+        """Drop all task/result/lookup state. Caller owns concurrency control."""
         self._tasks.clear()
         self._task_id_to_tool_call_id.clear()
         self._ns_uuid_to_tool_call_id.clear()
         self._results.clear()
         logger.debug("Cleared background task registry")
+
+    def clear(self) -> None:
+        """Clear all tasks and results from the registry (synchronous).
+
+        Note: This does NOT cancel running tasks. Call cancel_all() first
+        if you want to stop running tasks.
+
+        Intentionally lock-free: called by the orchestrator after
+        wait_for_all() completes, when no concurrent modifications are
+        possible. For the stop teardown path — which CAN race concurrent
+        registry reads — use ``clear_locked`` instead.
+        """
+        self._clear_unlocked()
+
+    async def clear_locked(self) -> None:
+        """Lock-held variant of ``clear`` for the stop teardown path.
+
+        The single-owner teardown wipes the registry while a concurrent drain
+        / collector may still be reading it, so this acquires the registry lock
+        the orchestrator path can safely skip.
+        """
+        async with self._lock:
+            self._clear_unlocked()
 
     def has_pending_tasks(self) -> bool:
         """Return True if any tasks are still pending (synchronous)."""

--- a/src/ptc_agent/agent/middleware/background_subagent/tools.py
+++ b/src/ptc_agent/agent/middleware/background_subagent/tools.py
@@ -82,7 +82,14 @@ def create_task_output_tool(middleware: BackgroundSubagentMiddleware) -> Structu
         if task_id is not None:
             task = await registry.get_by_task_id(task_id)
             if not task:
-                return f"Task-{task_id} not found"
+                # The registry is wiped on a user stop, so a resumed turn that
+                # follows its own pseudo-result instruction and re-asks for a
+                # killed subagent lands here. Tell the agent it was cancelled
+                # rather than implying it never existed.
+                return (
+                    f"Task-{task_id} was cancelled by a user stop (no result "
+                    f"was produced). It is not running and cannot be resumed."
+                )
 
             # Sync completion status from asyncio task
             _sync_task_completion(task)
@@ -129,7 +136,10 @@ def create_task_output_tool(middleware: BackgroundSubagentMiddleware) -> Structu
                     f"**{task.display_id}** ({task.subagent_type}) completed:\n\n"
                     f"{_format_result(result)}"
                 )
-            return f"Task-{task_id} not found"
+            return (
+                f"Task-{task_id} was cancelled by a user stop (no result "
+                f"was produced). It is not running and cannot be resumed."
+            )
 
         # --- All tasks ---
 

--- a/src/server/app/threads.py
+++ b/src/server/app/threads.py
@@ -595,11 +595,10 @@ async def _handle_send_message(
             from src.server.services.background_task_manager import BackgroundTaskManager
             manager = BackgroundTaskManager.get_instance()
             # Fail-fast admission at the HTTP boundary: if another run is
-            # still active on this thread, wait for it to settle (up to
-            # the soft-interrupt timeout). If it doesn't settle, return
-            # 409 here rather than dispatching a doomed background task.
+            # still active (running or stopping) on this thread, return 409
+            # here rather than dispatching a doomed background task.
             #
-            # The admission_lock is held across wait_for_soft_interrupted +
+            # The admission_lock is held across wait_for_admission +
             # pre_register so two concurrent dispatched POSTs on the same
             # thread can't both pass the gate and start workflows on the
             # same LangGraph thread_id (the foreground branch acquires
@@ -609,10 +608,10 @@ async def _handle_send_message(
             # schedules the background workflow.
             admission_lock = await manager.get_admission_lock(thread_id)
             async with admission_lock:
-                settled = await manager.wait_for_soft_interrupted(
+                state = await manager.wait_for_admission(
                     thread_id, exclude_run_id=run_id
                 )
-                if not settled:
+                if state != "fresh":
                     await release_burst_slot(user_id)
                     raise HTTPException(
                         status_code=409,
@@ -680,10 +679,10 @@ async def _handle_send_message(
         tracker = WorkflowTracker.get_instance()
         manager = BackgroundTaskManager.get_instance()
         # Fail-fast admission at the HTTP boundary: if another run is still
-        # active on this thread, wait for it to settle. If it doesn't,
-        # return 409 here rather than dispatching a doomed background task.
+        # active (running or stopping) on this thread, return 409 here rather
+        # than dispatching a doomed background task.
         #
-        # The admission_lock is held across wait_for_soft_interrupted +
+        # The admission_lock is held across wait_for_admission +
         # mark_active + pre_register so two concurrent dispatched POSTs on
         # the same thread can't both pass the gate and start workflows on
         # the same LangGraph thread_id (the foreground branch acquires
@@ -693,10 +692,10 @@ async def _handle_send_message(
         # the background workflow.
         admission_lock = await manager.get_admission_lock(thread_id)
         async with admission_lock:
-            settled = await manager.wait_for_soft_interrupted(
+            state = await manager.wait_for_admission(
                 thread_id, exclude_run_id=run_id
             )
-            if not settled:
+            if state != "fresh":
                 await release_burst_slot(user_id)
                 raise HTTPException(
                     status_code=409,
@@ -980,15 +979,6 @@ async def cancel_thread(thread_id: str, x_user_id: CurrentUserId):
     from src.server.handlers.workflow_handler import cancel_workflow
 
     return await cancel_workflow(thread_id)
-
-
-@router.post("/{thread_id}/interrupt", status_code=200)
-async def interrupt_thread(thread_id: str, x_user_id: CurrentUserId):
-    """Soft interrupt — pause main agent, keep subagents running."""
-    await require_thread_owner(thread_id, x_user_id)
-    from src.server.handlers.workflow_handler import soft_interrupt_workflow
-
-    return await soft_interrupt_workflow(thread_id)
 
 
 @router.post("/{thread_id}/summarize", status_code=200)

--- a/src/server/app/threads.py
+++ b/src/server/app/threads.py
@@ -973,12 +973,20 @@ async def get_thread_status(thread_id: str, x_user_id: CurrentUserId):
 
 
 @router.post("/{thread_id}/cancel", status_code=200)
-async def cancel_thread(thread_id: str, x_user_id: CurrentUserId):
-    """Cancel a running workflow for this thread."""
+async def cancel_thread(
+    thread_id: str,
+    x_user_id: CurrentUserId,
+    run_id: Optional[str] = Query(None),
+):
+    """Cancel a running workflow for this thread.
+
+    ``run_id`` targets a specific run so a retried stop can't cancel a newer
+    turn started after the stopped one ended (defaults to latest active run).
+    """
     await require_thread_owner(thread_id, x_user_id)
     from src.server.handlers.workflow_handler import cancel_workflow
 
-    return await cancel_workflow(thread_id)
+    return await cancel_workflow(thread_id, run_id)
 
 
 @router.post("/{thread_id}/summarize", status_code=200)

--- a/src/server/handlers/chat/_common.py
+++ b/src/server/handlers/chat/_common.py
@@ -624,22 +624,37 @@ async def wait_or_steer(
     user_input: str,
     user_id: str,
 ) -> tuple[bool, str | None]:
-    """Wait for a soft-interrupted workflow, or steer the running workflow.
+    """Admit a new turn, or steer the genuinely-running one.
 
     Returns ``(ready, steering_event)`` where ``ready=True`` means the caller
     should proceed with a new workflow.  If ``ready=False`` and
     ``steering_event`` is not None, the caller should yield that SSE string
     and return.  If neither succeeds, raises HTTP 409.
+
+    Admission states (see ``BackgroundTaskManager.wait_for_admission``):
+    - ``"fresh"``    → start a new turn ``(True, None)``.
+    - ``"stopping"`` → an explicitly-cancelled turn is still tearing down;
+      409 "stopping, retry" (never start a second checkpoint writer).
+    - ``"running"``  → steer immediately (no wait); 409 only if steering fails.
     """
     # Deferred to avoid circular import: steering imports _common at
     # module level, so _common must not import steering at module level.
     from src.server.handlers.chat.steering import steer_thread
 
-    ready_for_new_request = await manager.wait_for_soft_interrupted(thread_id)
-    if ready_for_new_request:
+    state = await manager.wait_for_admission(thread_id)
+    if state == "fresh":
         return True, None
 
-    # Try to steer the running workflow
+    if state == "stopping":
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Workflow {thread_id} is stopping. "
+                "Wait a moment, then retry your message."
+            ),
+        )
+
+    # state == "running" → steer the running workflow immediately.
     result = await steer_thread(thread_id, user_input, user_id)
     if result:
         event_data = json.dumps(

--- a/src/server/handlers/chat/flash_workflow.py
+++ b/src/server/handlers/chat/flash_workflow.py
@@ -136,24 +136,23 @@ async def astream_flash_workflow(
         # =================================================================
         # Early steering routing
         # =================================================================
-        # If a workflow is already running (or soft-interrupted) for this
-        # thread, route this POST through the steering queue *before* any DB
-        # write. The persistence singleton's ``_turn_index_cache`` is shared
-        # across concurrent POSTs on the same thread, and
-        # ``qr_db.create_query`` uses ``ON CONFLICT (thread_id, turn_index)
-        # DO UPDATE``, so a second ``persist_query_start`` here would
-        # overwrite the running turn's query content with the steering text.
-        # Dispatched flow owns the BTM placeholder ``threads.py`` already
-        # reserved for it under the same ``(thread_id, run_id)`` key. We
-        # still must guarantee at most one in-flight LangGraph ``astream``
-        # per ``thread_id`` (the checkpointer is thread-keyed), so wait for
-        # any OTHER active run on the thread to settle. ``exclude_run_id``
-        # skips our own placeholder.
+        # If a workflow is already running for this thread, route this POST
+        # through the steering queue *before* any DB write. The persistence
+        # singleton's ``_turn_index_cache`` is shared across concurrent POSTs
+        # on the same thread, and ``qr_db.create_query`` uses ``ON CONFLICT
+        # (thread_id, turn_index) DO UPDATE``, so a second ``persist_query_start``
+        # here would overwrite the running turn's query content with the
+        # steering text. Dispatched flow owns the BTM placeholder ``threads.py``
+        # already reserved for it under the same ``(thread_id, run_id)`` key. We
+        # still must guarantee at most one in-flight LangGraph ``astream`` per
+        # ``thread_id`` (the checkpointer is thread-keyed), so admit only when
+        # no OTHER run is active on the thread. ``exclude_run_id`` skips our own
+        # placeholder; a running or still-stopping peer means 409.
         if dispatched:
-            settled = await manager.wait_for_soft_interrupted(
+            state = await manager.wait_for_admission(
                 thread_id, exclude_run_id=run_id
             )
-            if not settled:
+            if state != "fresh":
                 raise HTTPException(
                     status_code=409,
                     detail=(

--- a/src/server/handlers/chat/flash_workflow.py
+++ b/src/server/handlers/chat/flash_workflow.py
@@ -153,13 +153,13 @@ async def astream_flash_workflow(
                 thread_id, exclude_run_id=run_id
             )
             if state != "fresh":
-                raise HTTPException(
-                    status_code=409,
-                    detail=(
-                        f"Workflow {thread_id} is still running; dispatched "
-                        "follow-up could not be admitted."
-                    ),
+                detail = (
+                    f"Workflow {thread_id} is stopping; retry shortly."
+                    if state == "stopping"
+                    else f"Workflow {thread_id} is still running; dispatched "
+                    "follow-up could not be admitted."
                 )
+                raise HTTPException(status_code=409, detail=detail)
             ready, steering_event = True, None
         else:
             ready, steering_event = await wait_or_steer(

--- a/src/server/handlers/chat/ptc_workflow.py
+++ b/src/server/handlers/chat/ptc_workflow.py
@@ -265,35 +265,34 @@ async def astream_ptc_workflow(
         # =====================================================================
         # Early steering routing
         # =====================================================================
-        # If a workflow is already running (or soft-interrupted) for this
-        # thread, route this POST through the steering queue *before* any DB
-        # write. ``persist_query_start`` uses ``ON CONFLICT (thread_id,
-        # turn_index) DO UPDATE`` and the persistence singleton's cached
-        # ``_turn_index_cache`` is shared across concurrent POSTs on the same
-        # thread, so a second persist_query_start here would overwrite the
-        # currently-running turn's original query content with the steering
-        # text. Detecting steering here keeps ``conversation_queries`` clean
-        # and lets ``backfill_steering_queries`` write the canonical
-        # ``type='steering'`` row after the workflow completes.
+        # If a workflow is already running for this thread, route this POST
+        # through the steering queue *before* any DB write. ``persist_query_start``
+        # uses ``ON CONFLICT (thread_id, turn_index) DO UPDATE`` and the
+        # persistence singleton's cached ``_turn_index_cache`` is shared across
+        # concurrent POSTs on the same thread, so a second persist_query_start
+        # here would overwrite the currently-running turn's original query
+        # content with the steering text. Detecting steering here keeps
+        # ``conversation_queries`` clean and lets ``backfill_steering_queries``
+        # write the canonical ``type='steering'`` row after the workflow completes.
         workspace_manager = WorkspaceManager.get_instance()
         needs_startup = not workspace_manager.has_ready_session(workspace_id)
         # When the workspace was evicted/restarted, any in-BTM TaskInfo for
-        # this thread holds a stale sandbox reference. ``wait_or_steer``
-        # would block up to ~5s waiting on that zombie before timing out —
-        # cancel it first so steering routes against live state only.
+        # this thread holds a stale sandbox reference — cancel it first so
+        # admission/steering routes against live state only.
         if needs_startup:
             await manager.cancel_stale_workflow(thread_id)
         # Dispatched flow owns the BTM placeholder ``threads.py`` already
         # reserved for it under the same ``(thread_id, run_id)`` key.
         # We still must guarantee at most one in-flight LangGraph ``astream``
-        # per ``thread_id`` (the checkpointer is thread-keyed), so wait for
-        # any OTHER active run on the thread to settle. ``exclude_run_id``
-        # skips our own placeholder.
+        # per ``thread_id`` (the checkpointer is thread-keyed), so admit only
+        # when no OTHER run is active on the thread. ``exclude_run_id`` skips
+        # our own placeholder; a running or still-stopping peer means 409
+        # (dispatched flows can't steer).
         if dispatched:
-            settled = await manager.wait_for_soft_interrupted(
+            state = await manager.wait_for_admission(
                 thread_id, exclude_run_id=run_id
             )
-            if not settled:
+            if state != "fresh":
                 raise HTTPException(
                     status_code=409,
                     detail=(

--- a/src/server/handlers/chat/ptc_workflow.py
+++ b/src/server/handlers/chat/ptc_workflow.py
@@ -293,13 +293,13 @@ async def astream_ptc_workflow(
                 thread_id, exclude_run_id=run_id
             )
             if state != "fresh":
-                raise HTTPException(
-                    status_code=409,
-                    detail=(
-                        f"Workflow {thread_id} is still running; dispatched "
-                        "follow-up could not be admitted."
-                    ),
+                detail = (
+                    f"Workflow {thread_id} is stopping; retry shortly."
+                    if state == "stopping"
+                    else f"Workflow {thread_id} is still running; dispatched "
+                    "follow-up could not be admitted."
                 )
+                raise HTTPException(status_code=409, detail=detail)
             ready, steering_event = True, None
         else:
             ready, steering_event = await wait_or_steer(

--- a/src/server/handlers/streaming_handler.py
+++ b/src/server/handlers/streaming_handler.py
@@ -383,6 +383,18 @@ class WorkflowStreamHandler:
         # instead of message_chunk.
         self._compaction_windows: set[tuple] = set()
 
+        # ---- Stop reconciliation state (decision T3-A) -------------------
+        # Open artifacts whose last-emitted status was not terminal. Keyed by
+        # artifact_id → the last artifact event payload. Closed out on stop.
+        self._open_artifacts: dict[str, dict] = {}
+        # Per-message id of the most recent open assistant message that has not
+        # yet emitted a finish_reason — used to synthesize a "stopped" close.
+        # Maps agent → message_id of the in-flight message.
+        self._open_message_ids: dict[str, str] = {}
+        # Idempotency guard: once stop reconciliation has run, re-entry / a
+        # second stop must not append synthetic closes again.
+        self._stop_finalized: bool = False
+
     async def stream_workflow(
         self,
         graph: Any,
@@ -619,6 +631,7 @@ class WorkflowStreamHandler:
                                 f"[ARTIFACT_CUSTOM] Emitting {artifact_type} artifact "
                                 f"(agent={agent_name}, status={artifact_event.get('status')})"
                             )
+                            self._track_artifact_state(artifact_event)
                             yield self._format_sse_event("artifact", artifact_event)
                     continue
 
@@ -642,6 +655,7 @@ class WorkflowStreamHandler:
                                         # Enrich event with agent if not already present
                                         if "agent" not in event_payload or not event_payload["agent"]:
                                             event_payload["agent"] = agent_name
+                                        self._track_artifact_state(event_payload)
                                         yield self._format_sse_event("artifact", event_payload)
                     continue
 
@@ -1253,6 +1267,8 @@ class WorkflowStreamHandler:
                         )
 
             event_stream_message["finish_reason"] = finish_reason
+            # Message reached a terminal finish — no longer an open structure.
+            self._open_message_ids.pop(agent_name, None)
         else:
             # Log when response_metadata exists but no finish reason is found
             # This helps debug cases where completion signals might be missing
@@ -1335,7 +1351,31 @@ class WorkflowStreamHandler:
                 if has_content:
                     if is_chunk and event_stream_message.get("content"):
                         self._streamed_content_ids.add(message_id)
+                    # Track an open assistant message (content but no terminal
+                    # finish_reason) so a stop can synthesize its close.
+                    if (
+                        event_stream_message.get("content")
+                        and not event_stream_message.get("finish_reason")
+                        and content_type != "reasoning_signal"
+                    ):
+                        self._open_message_ids[agent_name] = message_id
                     yield self._format_sse_event(chunk_event_type, event_stream_message)
+
+    def _track_artifact_state(self, artifact_event: dict) -> None:
+        """Track open/closed artifact state for stop reconciliation.
+
+        An artifact is "open" until it emits a terminal status. Keyed by
+        artifact_id so a later terminal status closes the same entry.
+        """
+        artifact_id = artifact_event.get("artifact_id")
+        if not artifact_id:
+            return
+        status = (artifact_event.get("status") or "").lower()
+        terminal = {"completed", "complete", "error", "failed", "cancelled", "stopped"}
+        if status in terminal:
+            self._open_artifacts.pop(artifact_id, None)
+        else:
+            self._open_artifacts[artifact_id] = copy.deepcopy(artifact_event)
 
     def _filter_tool_calls(self, tool_calls: list) -> list:
         """Remove tool calls with empty names or already-seen IDs."""
@@ -1534,6 +1574,77 @@ class WorkflowStreamHandler:
         """Return merged SSE events for persistence."""
         events = self._stream_event_accumulator.get_events()
         return events or None
+
+    def finalize_stopped_events(self) -> Optional[List[Dict[str, Any]]]:
+        """Close all open streaming structures at a user-stop point (decision T3-A).
+
+        A mid-step stop leaves the persisted ``sse_events`` with open blocks: a
+        reasoning block stuck "thinking", a tool call frozen mid-arguments, an
+        artifact mid-progress, a message without a finish_reason. Append
+        synthetic close events so replay renders the partial fragment marked
+        "stopped" instead of a live-looking zombie.
+
+        Idempotent: a per-handler ``_stop_finalized`` marker makes a second call
+        (double-stop / handler re-entry) a no-op. Returns the reconciled merged
+        events (same shape as ``get_sse_events``).
+        """
+        if self._stop_finalized:
+            return self.get_sse_events()
+        self._stop_finalized = True
+
+        try:
+            # 1. Close every open reasoning block.
+            for agent_name in list(self.reasoning_active):
+                msg_id = self._open_message_ids.get(agent_name) or f"{agent_name}:stopped"
+                self._format_reasoning_signal(agent_name, msg_id, "complete")
+            self.reasoning_active.clear()
+
+            # 2. Close any in-flight tool-call streaming state with a terminal
+            #    "stopped" close. Cover both Response API and Anthropic states.
+            for state_key in list(self.function_call_state.keys()) + list(
+                self.anthropic_tool_call_state.keys()
+            ):
+                agent_name = state_key[0]
+                self._format_sse_event(
+                    "tool_call_chunks",
+                    {
+                        "thread_id": self.thread_id,
+                        "agent": agent_name,
+                        "id": self._open_message_ids.get(agent_name)
+                        or f"{agent_name}:stopped",
+                        "role": "assistant",
+                        "finish_reason": "stopped",
+                    },
+                )
+            self.function_call_state.clear()
+            self.anthropic_tool_call_state.clear()
+
+            # 3. Close any open artifacts with a terminal "stopped" status.
+            for artifact_id, artifact_event in list(self._open_artifacts.items()):
+                closed = copy.deepcopy(artifact_event)
+                closed["status"] = "stopped"
+                self._format_sse_event("artifact", closed)
+            self._open_artifacts.clear()
+
+            # 4. Close every open assistant message with finish_reason "stopped".
+            for agent_name, msg_id in list(self._open_message_ids.items()):
+                self._format_sse_event(
+                    "message_chunk",
+                    {
+                        "thread_id": self.thread_id,
+                        "agent": agent_name,
+                        "id": msg_id,
+                        "role": "assistant",
+                        "finish_reason": "stopped",
+                    },
+                )
+            self._open_message_ids.clear()
+        except Exception as e:
+            logger.warning(
+                f"[WorkflowStreamHandler] finalize_stopped_events failed: {e}"
+            )
+
+        return self.get_sse_events()
 
     _DEFAULT_TOKEN_THRESHOLD = 120000
 

--- a/src/server/handlers/streaming_handler.py
+++ b/src/server/handlers/streaming_handler.py
@@ -1601,10 +1601,17 @@ class WorkflowStreamHandler:
 
             # 2. Close any in-flight tool-call streaming state with a terminal
             #    "stopped" close. Cover both Response API and Anthropic states.
+            #    An agent uses one LLM format per call, but a mid-turn provider
+            #    fallback can leave state in both dicts — dedup by agent so the
+            #    stop emits exactly one tool-call close per agent, not two.
+            closed_tool_agents: set = set()
             for state_key in list(self.function_call_state.keys()) + list(
                 self.anthropic_tool_call_state.keys()
             ):
                 agent_name = state_key[0]
+                if agent_name in closed_tool_agents:
+                    continue
+                closed_tool_agents.add(agent_name)
                 self._format_sse_event(
                     "tool_call_chunks",
                     {

--- a/src/server/handlers/streaming_handler.py
+++ b/src/server/handlers/streaming_handler.py
@@ -1612,6 +1612,13 @@ class WorkflowStreamHandler:
                 if agent_name in closed_tool_agents:
                     continue
                 closed_tool_agents.add(agent_name)
+                # The `id` here is the open *message* id, not the tool-call id —
+                # intentional. The frontend ignores both `id` and `finish_reason`
+                # on a tool_call_chunks event (handleToolCallChunks only iterates
+                # the `tool_call_chunks` array, absent here → no-op). The preparing
+                # shimmer actually clears off the step-4 message_chunk
+                # finish_reason:"stopped" below (matched by message id). This close
+                # event just keeps the persisted transcript internally consistent.
                 self._format_sse_event(
                     "tool_call_chunks",
                     {
@@ -1648,7 +1655,8 @@ class WorkflowStreamHandler:
             self._open_message_ids.clear()
         except Exception as e:
             logger.warning(
-                f"[WorkflowStreamHandler] finalize_stopped_events failed: {e}"
+                f"[WorkflowStreamHandler] finalize_stopped_events failed: {e}",
+                exc_info=True,
             )
 
         return self.get_sse_events()

--- a/src/server/handlers/workflow_handler.py
+++ b/src/server/handlers/workflow_handler.py
@@ -6,6 +6,7 @@ Extracted from src/server/app/workflow.py to separate business logic from route 
 
 import asyncio
 import logging
+from typing import Optional
 
 from fastapi import HTTPException
 
@@ -57,7 +58,7 @@ def extract_state_values(checkpoint_tuple) -> dict:
     return channel_values
 
 
-async def cancel_workflow(thread_id: str) -> dict:
+async def cancel_workflow(thread_id: str, run_id: Optional[str] = None) -> dict:
     """
     Explicitly cancel a workflow execution (user stop).
 
@@ -70,8 +71,13 @@ async def cancel_workflow(thread_id: str) -> dict:
     crash), so the deterministic teardown sequence (flush → drain → clear →
     persist) isn't raced.
 
+    ``run_id`` targets a specific run so a slow/retried stop can't cancel a
+    *newer* turn the user started after the stopped one finished (the manager
+    otherwise falls back to "latest active run"). Omitted = latest active run.
+
     Args:
         thread_id: Thread ID to cancel
+        run_id: Specific run to cancel; None falls back to the latest active run
 
     Returns:
         Confirmation of cancellation with thread_id
@@ -98,9 +104,11 @@ async def cancel_workflow(thread_id: str) -> dict:
         )
 
         manager = BackgroundTaskManager.get_instance()
-        cancel_success = await manager.cancel_workflow(thread_id)
+        cancel_success = await manager.cancel_workflow(thread_id, run_id)
 
-        if not cancel_success:
+        if not cancel_success and not await manager.has_active_task_for_thread(
+            thread_id
+        ):
             logger.warning(
                 f"Could not cancel background task for {thread_id} "
                 "(may be already completed or not found)"
@@ -108,7 +116,8 @@ async def cancel_workflow(thread_id: str) -> dict:
             # Safety net: no active task owns the teardown, so wipe any
             # orphaned registry left behind (e.g. after a crash). When a task
             # IS active, its except-handler teardown owns cancel_and_clear and
-            # we must NOT race it here.
+            # we must NOT race it here — nor wipe a *different* still-running
+            # turn's registry when a run-targeted cancel missed its run.
             from src.server.services.background_registry_store import (
                 BackgroundRegistryStore,
             )

--- a/src/server/handlers/workflow_handler.py
+++ b/src/server/handlers/workflow_handler.py
@@ -59,9 +59,16 @@ def extract_state_values(checkpoint_tuple) -> dict:
 
 async def cancel_workflow(thread_id: str) -> dict:
     """
-    Explicitly cancel a workflow execution.
+    Explicitly cancel a workflow execution (user stop).
 
-    Sets cancellation flag that the streaming generator will check.
+    Signal-only: sets the cancel flag, marks status, and force-cancels the
+    in-flight task via ``manager.cancel_workflow`` (which interrupts the
+    current step immediately). The subagent kill + registry wipe is owned by
+    the single-owner teardown in ``BackgroundTaskManager`` when the
+    ``CancelledError`` lands — this handler only runs ``cancel_and_clear`` as a
+    safety net when no active task exists (e.g. an orphaned registry left by a
+    crash), so the deterministic teardown sequence (flush → drain → clear →
+    persist) isn't raced.
 
     Args:
         thread_id: Thread ID to cancel
@@ -98,18 +105,21 @@ async def cancel_workflow(thread_id: str) -> dict:
                 f"Could not cancel background task for {thread_id} "
                 "(may be already completed or not found)"
             )
+            # Safety net: no active task owns the teardown, so wipe any
+            # orphaned registry left behind (e.g. after a crash). When a task
+            # IS active, its except-handler teardown owns cancel_and_clear and
+            # we must NOT race it here.
+            from src.server.services.background_registry_store import (
+                BackgroundRegistryStore,
+            )
+
+            registry_store = BackgroundRegistryStore.get_instance()
+            await registry_store.cancel_and_clear(thread_id, force=True)
 
         if not success:
             logger.warning(
                 f"Failed to set cancel flag for {thread_id} (Redis may be unavailable)"
             )
-
-        from src.server.services.background_registry_store import (
-            BackgroundRegistryStore,
-        )
-
-        registry_store = BackgroundRegistryStore.get_instance()
-        await registry_store.cancel_and_clear(thread_id, force=True)
 
         logger.info(f"Workflow cancelled: {thread_id}")
 
@@ -123,37 +133,6 @@ async def cancel_workflow(thread_id: str) -> dict:
         logger.exception(f"Error cancelling workflow {thread_id}: {e}")
         raise HTTPException(
             status_code=500, detail=f"Failed to cancel workflow: {str(e)}"
-        )
-
-
-async def soft_interrupt_workflow(thread_id: str) -> dict:
-    """
-    Soft interrupt a workflow - pause main agent, keep subagents running.
-
-    Args:
-        thread_id: Thread ID to soft interrupt
-
-    Returns:
-        Status including whether workflow can be resumed and active subagents
-    """
-    try:
-        from src.server.services.background_task_manager import BackgroundTaskManager
-
-        manager = BackgroundTaskManager.get_instance()
-
-        result = await manager.soft_interrupt_workflow(thread_id)
-
-        logger.info(
-            f"Workflow soft interrupted: {thread_id}, "
-            f"background_tasks={result.get('background_tasks', [])}"
-        )
-
-        return result
-
-    except Exception as e:
-        logger.exception(f"Error soft interrupting workflow {thread_id}: {e}")
-        raise HTTPException(
-            status_code=500, detail=f"Failed to soft interrupt workflow: {str(e)}"
         )
 
 
@@ -224,7 +203,6 @@ async def get_workflow_status(thread_id: str) -> dict:
 
         # Get subagent info from background task manager
         active_tasks = []
-        soft_interrupted = False
         run_id = None
 
         try:
@@ -236,7 +214,6 @@ async def get_workflow_status(thread_id: str) -> dict:
             bg_status = await manager.get_workflow_status(thread_id)
             if bg_status.get("status") != "not_found":
                 active_tasks = bg_status.get("active_tasks", [])
-                soft_interrupted = bg_status.get("soft_interrupted", False)
                 run_id = bg_status.get("run_id")
             elif can_reconnect:
                 # Redis says active/disconnected but BackgroundTaskManager has no
@@ -293,7 +270,6 @@ async def get_workflow_status(thread_id: str) -> dict:
             "user_id": user_id,
             "progress": checkpoint_info,
             "active_tasks": active_tasks,
-            "soft_interrupted": soft_interrupted,
             "is_shared": is_shared,
             "pending_report_back": pending_report_back,
         }

--- a/src/server/services/background_registry_store.py
+++ b/src/server/services/background_registry_store.py
@@ -53,7 +53,9 @@ class BackgroundRegistryStore:
                 return 0
 
         cancelled = await registry.cancel_all(force=force)
-        registry.clear()
+        # Lock-held clear: the stop teardown can race a concurrent drain /
+        # collector still reading the registry.
+        await registry.clear_locked()
 
         async with self._lock:
             self._registries.pop(thread_id, None)

--- a/src/server/services/background_task_manager.py
+++ b/src/server/services/background_task_manager.py
@@ -20,7 +20,7 @@ import json
 import logging
 import time
 from datetime import datetime, timedelta
-from typing import Dict, Any, AsyncIterator, Optional, Callable, Coroutine
+from typing import Dict, Any, AsyncIterator, Literal, Optional, Callable, Coroutine
 from enum import Enum
 from dataclasses import dataclass, field
 from contextlib import suppress
@@ -640,6 +640,12 @@ class BackgroundTaskManager:
                 explicit = bool(ti.explicit_cancel) if ti else False
 
             try:
+                # NB: suppress(Exception) below catches flush/teardown FAILURES
+                # only — NOT CancelledError (a BaseException). A second external
+                # cancel landing mid-teardown still propagates to `finally`; the
+                # asyncio.shield wrappers, not suppress, are what let these awaits
+                # finish across that re-cancel. Don't drop a shield assuming
+                # suppress already covers the cancellation case.
                 if explicit:
                     # 1. Flush the LangGraph checkpoint so the next message
                     #    resumes from the last committed boundary. Gated on
@@ -2008,7 +2014,7 @@ class BackgroundTaskManager:
         self,
         thread_id: str,
         exclude_run_id: Optional[str] = None,
-    ) -> str:
+    ) -> Literal["fresh", "running", "stopping"]:
         """Decide whether a new turn can start on ``thread_id``.
 
         Returns one of:

--- a/src/server/services/background_task_manager.py
+++ b/src/server/services/background_task_manager.py
@@ -843,10 +843,13 @@ class BackgroundTaskManager:
     async def _drain_killed_subagent_events(
         self, thread_id: str, tasks: list
     ) -> list[dict]:
-        """Synchronously read each task's already-captured events (non-blocking).
+        """Best-effort bounded snapshot of in-flight subagent events pre-teardown.
 
-        Reads the in-memory tail + Redis spill and marks each killed subagent
-        "stopped". No wait loop — never starts new work.
+        Async-reads each subagent's in-memory tail + Redis spill via
+        ``iter_subagent_events_full`` and appends a synthetic "stopped" close per
+        task. Runs BEFORE ``cancel_and_clear`` (ordering at the teardown call
+        site) so the registry is still intact; the caller bounds it with
+        ``asyncio.wait_for``. Starts no new agent work — it only reads and closes.
         """
         merged: list[dict] = []
         for task in tasks:

--- a/src/server/services/background_task_manager.py
+++ b/src/server/services/background_task_manager.py
@@ -516,6 +516,8 @@ class BackgroundTaskManager:
     ) -> TaskInfo:
         """Start a workflow as a background task."""
         key = (thread_id, run_id)
+        cancelled_placeholder: Optional[TaskInfo] = None
+        cancelled_uid: Optional[str] = None
         async with self.task_lock:
             if key in self.tasks:
                 existing = self.tasks[key]
@@ -529,78 +531,87 @@ class BackgroundTaskManager:
                         # would tear down on its first cancel-event check —
                         # flushing a stale checkpoint and marking the thread
                         # CANCELLED over the new turn. Settle the placeholder
-                        # terminally and release its burst slot here (no task is
-                        # created, so the BTM finalizer that normally releases it
-                        # never runs).
+                        # terminally; its burst slot is released after the lock
+                        # (no task is created, so the BTM finalizer that normally
+                        # releases it never runs).
                         existing.status = TaskStatus.CANCELLED
                         existing.completed_at = datetime.now()
                         existing.persistence_complete.set()
-                        uid = (metadata or {}).get("user_id")
-                        if uid:
-                            await release_burst_slot(uid)
+                        cancelled_placeholder = existing
+                        cancelled_uid = (metadata or {}).get("user_id")
                         logger.info(
                             f"[BackgroundTaskManager] Placeholder {key} cancelled "
                             "before start; settled without resurrecting"
                         )
-                        return existing
-                    # Upgrade pre-registered placeholder in-place.
-                    existing.metadata = metadata or {}
-                    existing.completion_callback = completion_callback
-                    existing.graph = graph
-                    existing.task = asyncio.create_task(
-                        self._run_workflow(
-                            thread_id, run_id, workflow_generator,
-                            cancel_event=existing.cancel_event,
+                    else:
+                        # Upgrade pre-registered placeholder in-place.
+                        existing.metadata = metadata or {}
+                        existing.completion_callback = completion_callback
+                        existing.graph = graph
+                        existing.task = asyncio.create_task(
+                            self._run_workflow(
+                                thread_id, run_id, workflow_generator,
+                                cancel_event=existing.cancel_event,
+                            )
                         )
+                        existing.status = TaskStatus.RUNNING
+                        existing.started_at = datetime.now()
+                        logger.info(
+                            f"[BackgroundTaskManager] Upgraded pre-registered "
+                            f"workflow thread_id={thread_id} run_id={run_id} to RUNNING"
+                        )
+                        return existing
+                else:
+                    raise RuntimeError(
+                        f"Workflow {key} already exists with status {existing.status}"
                     )
-                    existing.status = TaskStatus.RUNNING
-                    existing.started_at = datetime.now()
-                    logger.info(
-                        f"[BackgroundTaskManager] Upgraded pre-registered "
-                        f"workflow thread_id={thread_id} run_id={run_id} to RUNNING"
+            else:
+                running_count = sum(
+                    1 for t in self.tasks.values()
+                    if t.status in [TaskStatus.QUEUED, TaskStatus.RUNNING]
+                )
+                if running_count >= self.max_concurrent:
+                    raise ValueError(
+                        f"Max concurrent workflows reached ({self.max_concurrent}). "
+                        f"Currently running: {running_count}"
                     )
-                    return existing
-                raise RuntimeError(
-                    f"Workflow {key} already exists with status {existing.status}"
+
+                task_info = TaskInfo(
+                    thread_id=thread_id,
+                    run_id=run_id,
+                    status=TaskStatus.QUEUED,
+                    created_at=datetime.now(),
+                    metadata=metadata or {},
+                    completion_callback=completion_callback,
+                    graph=graph,
                 )
 
-            running_count = sum(
-                1 for t in self.tasks.values()
-                if t.status in [TaskStatus.QUEUED, TaskStatus.RUNNING]
-            )
-            if running_count >= self.max_concurrent:
-                raise ValueError(
-                    f"Max concurrent workflows reached ({self.max_concurrent}). "
-                    f"Currently running: {running_count}"
+                task_info.task = asyncio.create_task(
+                    self._run_workflow(
+                        thread_id, run_id, workflow_generator,
+                        cancel_event=task_info.cancel_event,
+                    )
+                )
+                task_info.status = TaskStatus.RUNNING
+                task_info.started_at = datetime.now()
+
+                self.tasks[key] = task_info
+
+                logger.info(
+                    f"[BackgroundTaskManager] Started workflow thread_id={thread_id} "
+                    f"run_id={run_id} (running: {running_count + 1}/{self.max_concurrent})"
                 )
 
-            task_info = TaskInfo(
-                thread_id=thread_id,
-                run_id=run_id,
-                status=TaskStatus.QUEUED,
-                created_at=datetime.now(),
-                metadata=metadata or {},
-                completion_callback=completion_callback,
-                graph=graph,
-            )
+                return task_info
 
-            task_info.task = asyncio.create_task(
-                self._run_workflow(
-                    thread_id, run_id, workflow_generator,
-                    cancel_event=task_info.cancel_event,
-                )
-            )
-            task_info.status = TaskStatus.RUNNING
-            task_info.started_at = datetime.now()
-
-            self.tasks[key] = task_info
-
-            logger.info(
-                f"[BackgroundTaskManager] Started workflow thread_id={thread_id} "
-                f"run_id={run_id} (running: {running_count + 1}/{self.max_concurrent})"
-            )
-
-            return task_info
+        # Cancelled-before-start placeholder: release its burst slot OUTSIDE the
+        # lock, mirroring every other release_burst_slot in this file. Holding
+        # task_lock across the Redis DECR would delay a concurrent /cancel, which
+        # also needs the lock. (Reached only via the fall-through above; all other
+        # branches return or raise inside the lock.)
+        if cancelled_uid:
+            await release_burst_slot(cancelled_uid)
+        return cancelled_placeholder
 
     async def _run_workflow(
         self,

--- a/src/server/services/background_task_manager.py
+++ b/src/server/services/background_task_manager.py
@@ -304,6 +304,17 @@ class BackgroundTaskManager:
                     return True
         return False
 
+    async def has_active_task_for_thread(self, thread_id: str) -> bool:
+        """True if any QUEUED/RUNNING task exists for the thread.
+
+        Used by the /cancel safety net so it only wipes a thread's registry
+        when nothing else owns it — a run-targeted cancel that misses (the run
+        already tore down) must NOT clear a *different*, still-running turn's
+        subagents.
+        """
+        async with self.task_lock:
+            return self._find_active_for_thread(thread_id) is not None
+
     async def start_cleanup_task(self):
         """Start periodic cleanup background task."""
         if self.cleanup_task is None or self.cleanup_task.done():
@@ -855,9 +866,37 @@ class BackgroundTaskManager:
         for task in tasks:
             if getattr(task, "captured_event_count", 0) <= 0:
                 continue
+            # Track reasoning blocks left open at the kill point so we can close
+            # them, mirroring the main agent's finalize_stopped_events. Keyed by
+            # the subagent's own (agent, message id) so the synthetic close
+            # matches the unpaired start exactly.
+            open_reasoning: dict[tuple[str, str], None] = {}
             async for record in iter_subagent_events_full(thread_id, task):
                 enriched = _record_to_persist_event(record, thread_id)
                 merged.append(enriched)
+                data = enriched.get("data") or {}
+                if data.get("content_type") == "reasoning_signal":
+                    rk = (data.get("agent", ""), data.get("id", ""))
+                    if data.get("content") == "start":
+                        open_reasoning[rk] = None
+                    elif data.get("content") == "complete":
+                        open_reasoning.pop(rk, None)
+            # Close any reasoning block still open when the subagent was killed,
+            # else replay renders the card stuck "thinking" indefinitely.
+            for r_agent, r_id in open_reasoning:
+                merged.append(
+                    {
+                        "event": "message_chunk",
+                        "data": {
+                            "thread_id": thread_id,
+                            "agent": r_agent,
+                            "id": r_id,
+                            "role": "assistant",
+                            "content": "complete",
+                            "content_type": "reasoning_signal",
+                        },
+                    }
+                )
             # Mark the killed subagent's stream "stopped" for replay.
             agent_id = f"task:{getattr(task, 'task_id', '')}"
             merged.append(

--- a/src/server/services/background_task_manager.py
+++ b/src/server/services/background_task_manager.py
@@ -38,7 +38,7 @@ from src.config.settings import (
     get_checkpoint_flush_timeout,
     get_sse_drain_timeout,
     get_wait_for_persistence_timeout,
-    get_soft_interrupt_wait_timeout,
+    get_stop_drain_timeout,
     get_subagent_collector_timeout,
     get_subagent_orphan_collector_timeout,
 )
@@ -161,7 +161,6 @@ class TaskStatus(str, Enum):
     COMPLETED = "completed"
     FAILED = "failed"
     CANCELLED = "cancelled"
-    SOFT_INTERRUPTED = "soft_interrupted"
 
 
 @dataclass
@@ -180,10 +179,12 @@ class TaskInfo:
     error: Optional[str] = None
 
     explicit_cancel: bool = False
+    # True only when the user pressed Stop (HTTP /cancel). System cancels
+    # (graceful shutdown, stale-sandbox recovery) set ``explicit_cancel`` for
+    # the flush+teardown gate but leave this False so they are NOT persisted as
+    # user-cancelled "Stopped" turns. See ``_mark_cancelled``.
+    user_stop: bool = False
     cancel_event: asyncio.Event = field(default_factory=asyncio.Event)
-
-    soft_interrupt_event: asyncio.Event = field(default_factory=asyncio.Event)
-    soft_interrupted: bool = False
 
     final_result: Optional[Any] = None
 
@@ -196,10 +197,6 @@ class TaskInfo:
     persistence_complete: asyncio.Event = field(default_factory=asyncio.Event)
 
     graph: Optional[Any] = None
-
-
-class SoftInterruptError(Exception):
-    """Internal control-flow exception for user ESC soft-interrupt."""
 
 
 # Type alias for the key used throughout the manager.
@@ -239,6 +236,11 @@ class BackgroundTaskManager:
 
         self.cleanup_task: Optional[asyncio.Task] = None
 
+        # Per-thread set of live orphan-collector tasks. Tracked so the stop
+        # teardown can cancel any collector that would otherwise mutate the
+        # persisted response after the user has stopped the turn.
+        self._orphan_collectors: Dict[str, set[asyncio.Task]] = {}
+
     @classmethod
     def get_instance(cls) -> 'BackgroundTaskManager':
         if cls._instance is None:
@@ -273,7 +275,7 @@ class BackgroundTaskManager:
         ignoring their own pre-registered placeholder.
         """
         best: Optional[TaskInfo] = None
-        live = (TaskStatus.QUEUED, TaskStatus.RUNNING, TaskStatus.SOFT_INTERRUPTED)
+        live = (TaskStatus.QUEUED, TaskStatus.RUNNING)
         for (tid, rid), info in self.tasks.items():
             if tid != thread_id or info.status not in live:
                 continue
@@ -286,7 +288,7 @@ class BackgroundTaskManager:
     async def has_active_tasks_for_workspace(self, workspace_id: str) -> bool:
         """Check if any active tasks exist for a workspace."""
         async with self.task_lock:
-            active = (TaskStatus.RUNNING, TaskStatus.QUEUED, TaskStatus.SOFT_INTERRUPTED)
+            active = (TaskStatus.RUNNING, TaskStatus.QUEUED)
             for info in self.tasks.values():
                 if (
                     info.metadata.get("workspace_id") == workspace_id
@@ -340,7 +342,9 @@ class BackgroundTaskManager:
         )
 
         for (thread_id, run_id), _info in running_tasks:
-            await self.cancel_workflow(thread_id, run_id)
+            # System shutdown, NOT a user stop: flush + kill subagents, but do
+            # not persist the interrupted turn as a user-cancelled "Stopped".
+            await self.cancel_workflow(thread_id, run_id, user_initiated=False)
 
         try:
             async with asyncio.timeout(timeout):
@@ -403,7 +407,6 @@ class BackgroundTaskManager:
                     TaskStatus.COMPLETED,
                     TaskStatus.FAILED,
                     TaskStatus.CANCELLED,
-                    TaskStatus.SOFT_INTERRUPTED,
                 ]:
                     if info.completed_at and info.completed_at < completed_threshold:
                         to_remove.append(key)
@@ -518,7 +521,6 @@ class BackgroundTaskManager:
                         self._run_workflow(
                             thread_id, run_id, workflow_generator,
                             cancel_event=existing.cancel_event,
-                            soft_interrupt_event=existing.soft_interrupt_event,
                         )
                     )
                     existing.status = TaskStatus.RUNNING
@@ -556,7 +558,6 @@ class BackgroundTaskManager:
                 self._run_workflow(
                     thread_id, run_id, workflow_generator,
                     cancel_event=task_info.cancel_event,
-                    soft_interrupt_event=task_info.soft_interrupt_event,
                 )
             )
             task_info.status = TaskStatus.RUNNING
@@ -577,13 +578,15 @@ class BackgroundTaskManager:
         run_id: str,
         workflow_generator: Any,
         cancel_event: asyncio.Event,
-        soft_interrupt_event: asyncio.Event,
     ):
-        """Drive the workflow generator with cooperative cancellation.
+        """Drive the workflow generator with cooperative + forced cancellation.
 
-        Lifecycle is driven solely by ``cancel_event`` / ``soft_interrupt_event``;
-        no SSE consumer holds a reference to this task post-Streams cutover,
-        so disconnect cannot cascade and the inner task is awaited directly.
+        Lifecycle is driven solely by ``cancel_event``; no SSE consumer holds a
+        reference to this task post-Streams cutover, so disconnect cannot
+        cascade and the inner task is awaited directly. A user stop force-cancels
+        only ``inner_task`` (see ``cancel_workflow``), so the ``CancelledError``
+        handler below runs in a non-cancelled context and can ``await`` the
+        single-owner teardown.
         """
         key = (thread_id, run_id)
         try:
@@ -593,11 +596,6 @@ class BackgroundTaskManager:
                         with suppress(Exception):
                             await wf_gen.aclose()
                         raise asyncio.CancelledError("Explicitly cancelled by user")
-
-                    if soft_interrupt_event and soft_interrupt_event.is_set():
-                        with suppress(Exception):
-                            await wf_gen.aclose()
-                        raise SoftInterruptError("Soft-interrupted by user")
 
                     if self.enable_storage:
                         await self._buffer_event_redis(thread_id, run_id, event)
@@ -613,13 +611,57 @@ class BackgroundTaskManager:
 
             await self._mark_completed(thread_id, run_id)
 
-        except SoftInterruptError:
-            await self._flush_checkpoint(thread_id, run_id)
-            await self._mark_soft_interrupted(thread_id, run_id)
-            return
-
+        # =====================================================================
+        # Single-owner stop teardown (decision 1A). On a user stop only
+        # ``inner_task`` is force-cancelled, so this handler runs uncancelled
+        # and owns the entire deterministic sequence:
+        #
+        #   except asyncio.CancelledError (consume_workflow):
+        #     1. _flush_checkpoint(thread_id)        # if explicit_cancel
+        #     2. drain killed-subagent events        # bounded (~stop_drain_timeout)
+        #     3. cancel orphan collector tasks       # no post-stop mutation
+        #     4. cancel_and_clear(force=True)        # kill subagents, wipe registry
+        #     5. _mark_cancelled(thread_id)          # persist merged sse_events + SSE sentinel
+        #     6. raise
+        #
+        # Drain MUST run before cancel_and_clear wipes the registry, and
+        # cancel_and_clear must run before _mark_cancelled so the merged
+        # subagent events are in place before persistence reads them.
+        # =====================================================================
         except asyncio.CancelledError:
-            await self._mark_cancelled(thread_id, run_id)
+            async with self.task_lock:
+                ti = self.tasks.get(key)
+                explicit = bool(ti.explicit_cancel) if ti else False
+
+            try:
+                if explicit:
+                    # 1. Flush the LangGraph checkpoint so the next message
+                    #    resumes from the last committed boundary. Gated on
+                    #    explicit_cancel (set by the user stop, graceful
+                    #    shutdown, and stale-sandbox recovery — all of which
+                    #    cancel the INNER task, leaving this handler live to
+                    #    flush). Abandoned-task cleanup cancels the OUTER task
+                    #    with the flag unset and skips this. Best-effort: a
+                    #    flush failure must not block persistence (step 5).
+                    with suppress(Exception):
+                        await asyncio.shield(self._flush_checkpoint(thread_id, run_id))
+
+                    # 2-4. Drain killed-subagent events, cancel orphan
+                    #      collectors, then kill subagents + wipe the registry.
+                    #      Merged events are stashed on metadata so
+                    #      _mark_cancelled persists them.
+                    with suppress(Exception):
+                        await asyncio.shield(
+                            self._teardown_subagents_on_stop(thread_id, run_id)
+                        )
+            finally:
+                # 5. Persist the cancellation. In a ``finally`` + ``shield`` so a
+                #    SECOND cancel (graceful shutdown force-cancelling the OUTER
+                #    task at its timeout, or abandoned cleanup) lands DURING
+                #    teardown can't skip or tear a mid-write: burst-slot release,
+                #    tracker status, and registry cleanup always run to
+                #    completion rather than leaving half-state.
+                await asyncio.shield(self._mark_cancelled(thread_id, run_id))
             raise
 
         except Exception as e:
@@ -630,7 +672,11 @@ class BackgroundTaskManager:
             await self._mark_failed(thread_id, run_id, str(e))
 
     async def _flush_checkpoint(self, thread_id: str, run_id: str) -> None:
-        """Force a checkpoint write for the current thread state on ESC."""
+        """Force a checkpoint write for the current thread state on user stop.
+
+        Persists state up to the last completed step so the next message
+        resumes from it. The in-flight step is discarded and re-run on resume.
+        """
         async with self.task_lock:
             task_info = self.tasks.get((thread_id, run_id))
             graph = task_info.graph if task_info else None
@@ -662,6 +708,101 @@ class BackgroundTaskManager:
             logger.warning(
                 f"[BackgroundTaskManager] Failed to flush checkpoint for {thread_id}: {e}"
             )
+
+    def _track_orphan_collector(self, thread_id: str, task: asyncio.Task) -> None:
+        """Register a live orphan-collector task for stop-time cancellation."""
+        bucket = self._orphan_collectors.setdefault(thread_id, set())
+        bucket.add(task)
+        task.add_done_callback(lambda t: bucket.discard(t))
+
+    async def _teardown_subagents_on_stop(self, thread_id: str, run_id: str) -> None:
+        """Single-owner subagent teardown on a user stop.
+
+        Order (decision 1A): drain killed-subagent events (bounded) → cancel
+        orphan collectors → cancel_and_clear(force) → stash merged events on
+        metadata for _mark_cancelled to persist. Drain MUST precede
+        cancel_and_clear so the registry still holds the captured events.
+        """
+        from src.server.services.background_registry_store import BackgroundRegistryStore
+
+        registry_store = BackgroundRegistryStore.get_instance()
+        registry = await registry_store.get_registry(thread_id)
+
+        # --- 2. Drain killed-subagent events (best-effort, hard timeout) ---
+        merged_subagent_events: list[dict] = []
+        if registry is not None:
+            try:
+                tasks = await registry.get_all_tasks()
+            except Exception:
+                tasks = []
+            try:
+                merged_subagent_events = await asyncio.wait_for(
+                    self._drain_killed_subagent_events(thread_id, tasks),
+                    timeout=get_stop_drain_timeout(),
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    f"[StopTeardown] Subagent drain exceeded "
+                    f"{get_stop_drain_timeout()}s for thread_id={thread_id}; "
+                    "proceeding without drained events"
+                )
+            except Exception as exc:
+                logger.warning(
+                    f"[StopTeardown] Subagent drain failed for "
+                    f"thread_id={thread_id}: {exc}"
+                )
+
+        # --- 3. Cancel orphan collectors so they can't mutate the response ---
+        collectors = list(self._orphan_collectors.get(thread_id, set()))
+        for collector in collectors:
+            if not collector.done():
+                collector.cancel()
+        if collectors:
+            with suppress(Exception):
+                await asyncio.gather(*collectors, return_exceptions=True)
+        self._orphan_collectors.pop(thread_id, None)
+
+        # --- 4. Kill subagents + wipe the registry ---
+        with suppress(Exception):
+            await registry_store.cancel_and_clear(thread_id, force=True)
+
+        # Stash merged events for _mark_cancelled to fold into persisted sse_events.
+        if merged_subagent_events:
+            async with self.task_lock:
+                ti = self.tasks.get((thread_id, run_id))
+                if ti is not None:
+                    ti.metadata["_stop_subagent_events"] = merged_subagent_events
+
+    async def _drain_killed_subagent_events(
+        self, thread_id: str, tasks: list
+    ) -> list[dict]:
+        """Synchronously read each task's already-captured events (non-blocking).
+
+        Reads the in-memory tail + Redis spill and marks each killed subagent
+        "stopped". No wait loop — never starts new work.
+        """
+        merged: list[dict] = []
+        for task in tasks:
+            if getattr(task, "captured_event_count", 0) <= 0:
+                continue
+            async for record in iter_subagent_events_full(thread_id, task):
+                enriched = _record_to_persist_event(record, thread_id)
+                merged.append(enriched)
+            # Mark the killed subagent's stream "stopped" for replay.
+            agent_id = f"task:{getattr(task, 'task_id', '')}"
+            merged.append(
+                {
+                    "event": "message_chunk",
+                    "data": {
+                        "thread_id": thread_id,
+                        "agent": agent_id,
+                        "id": f"{agent_id}:stopped",
+                        "role": "assistant",
+                        "finish_reason": "stopped",
+                    },
+                }
+            )
+        return merged
 
     async def _buffer_event_redis(self, thread_id: str, run_id: str, event: str):
         """Append a workflow event to the per-run Redis Stream."""
@@ -836,7 +977,7 @@ class BackgroundTaskManager:
                     f"[SubagentCollector] Spawning orphan collector for "
                     f"{len(orphaned_tasks)} timed-out task(s), thread_id={thread_id}"
                 )
-                asyncio.create_task(
+                orphan_task = asyncio.create_task(
                     self._collect_orphaned_subagent_results(
                         thread_id=thread_id,
                         response_id=response_id,
@@ -850,6 +991,7 @@ class BackgroundTaskManager:
                     ),
                     name=f"subagent-orphan-collector-{thread_id}",
                 )
+                self._track_orphan_collector(thread_id, orphan_task)
 
             collected_tasks = [t for t in tasks if t not in pending.values()]
             await self._persist_subagent_usage(
@@ -1287,8 +1429,8 @@ class BackgroundTaskManager:
         """Wait until _mark_completed has finished persisting for the given turn.
 
         Captures the ``persistence_complete`` event reference under the lock
-        so a concurrent ``wait_for_soft_interrupted`` deletion of the entry
-        doesn't make us drop a still-pending wait on the floor.
+        so a concurrent admission deletion of the entry doesn't make us drop a
+        still-pending wait on the floor.
         """
         if timeout is None:
             timeout = get_wait_for_persistence_timeout()
@@ -1395,272 +1537,6 @@ class BackgroundTaskManager:
         task_info.persistence_complete.set()
         async with self.task_lock:
             self._release_terminal_refs(thread_id, run_id)
-
-    async def _mark_soft_interrupted(self, thread_id: str, run_id: str) -> None:
-        """Mark workflow as soft-interrupted (ESC)."""
-        key = (thread_id, run_id)
-        async with self.task_lock:
-            task_info = self.tasks.get(key)
-            if not task_info:
-                return
-
-            task_info.status = TaskStatus.SOFT_INTERRUPTED
-            task_info.completed_at = datetime.now()
-            metadata = task_info.metadata
-
-        logger.info(f"[BackgroundTaskManager] Marked as soft-interrupted: {key}")
-
-        workspace_id = metadata.get("workspace_id")
-        user_id = metadata.get("user_id")
-
-        if workspace_id and user_id:
-            try:
-                from src.server.services.persistence.conversation import ConversationPersistenceService
-
-                persistence_service = metadata.get("persistence_service")
-                if persistence_service is None:
-                    persistence_service = ConversationPersistenceService.get_instance(
-                        thread_id, run_id,
-                        workspace_id=workspace_id, user_id=user_id,
-                    )
-                persistence_service._on_pair_persisted = (
-                    lambda: self.clear_event_buffer(thread_id, run_id)
-                )
-
-                _, per_call_records = get_token_usage_from_callback(
-                    metadata, "interrupt", thread_id
-                )
-                tool_usage = get_tool_usage_from_handler(
-                    metadata, "interrupt", thread_id
-                )
-                sse_events = get_sse_events_from_handler(
-                    metadata, "interrupt", thread_id
-                )
-                execution_time = calculate_execution_time(metadata)
-
-                persist_metadata = {
-                    "msg_type": metadata.get("msg_type"),
-                    "stock_code": metadata.get("stock_code"),
-                    "agent_llm_preset": metadata.get("agent_llm_preset", "default"),
-                    "deepthinking": metadata.get("deepthinking", False),
-                    "is_byok": metadata.get("is_byok", False),
-                    "soft_interrupted": True,
-                }
-
-                response_id = await persistence_service.persist_interrupt(
-                    interrupt_reason="soft_interrupt",
-                    execution_time=execution_time,
-                    metadata=persist_metadata,
-                    per_call_records=per_call_records,
-                    tool_usage=tool_usage,
-                    sse_events=sse_events,
-                )
-                logger.info(f"[WorkflowPersistence] Soft interrupt persisted for {key}")
-
-                from src.server.services.background_registry_store import BackgroundRegistryStore
-                bg_store = BackgroundRegistryStore.get_instance()
-                bg_registry = await bg_store.get_registry(thread_id)
-
-                if bg_registry and bg_registry.has_pending_tasks():
-                    logger.info(
-                        f"[WorkflowPersistence] {bg_registry.pending_count} subagents still running, "
-                        f"spawning result collector for {key}"
-                    )
-                    asyncio.create_task(
-                        self._collect_subagent_results_after_interrupt(
-                            thread_id=thread_id,
-                            response_id=response_id,
-                            original_chunks=sse_events or [],
-                            bg_registry=bg_registry,
-                            workspace_id=workspace_id,
-                            user_id=user_id,
-                            timeout=get_subagent_collector_timeout(),
-                            is_byok=metadata.get("is_byok", False),
-                        ),
-                        name=f"subagent-collector-{thread_id}-{run_id}",
-                    )
-            except Exception as persist_error:
-                logger.error(
-                    f"[WorkflowPersistence] Failed to persist soft interrupt for {key}: {persist_error}",
-                    exc_info=True,
-                )
-
-        if user_id:
-            await release_burst_slot(user_id)
-
-        try:
-            tracker = WorkflowTracker.get_instance()
-            await tracker.mark_soft_interrupted(thread_id, run_id=run_id)
-        except Exception as tracker_err:
-            logger.warning(
-                f"[BackgroundTaskManager] tracker.mark_soft_interrupted failed for {key}: {tracker_err}"
-            )
-
-        task_info.persistence_complete.set()
-        async with self.task_lock:
-            self._release_terminal_refs(thread_id, run_id)
-
-    async def _collect_subagent_results_after_interrupt(
-        self,
-        thread_id: str,
-        response_id: str,
-        original_chunks: list[dict[str, Any]],
-        bg_registry: Any,
-        workspace_id: str,
-        user_id: str,
-        timeout: float | None = None,
-        is_byok: bool = False,
-    ) -> None:
-        if timeout is None:
-            timeout = get_subagent_collector_timeout()
-
-        try:
-            # Same identity-safe claim as _mark_completed: hold the registry
-            # lock and filter by spawned_run_id so concurrent collectors can't
-            # double-claim and prior-turn subagents can't leak into this turn.
-            async with bg_registry._lock:
-                all_tasks = []
-                for t in bg_registry._tasks.values():
-                    if t.collector_response_id:
-                        continue
-                    if t.spawned_run_id is not None and t.spawned_run_id != response_id:
-                        continue
-                    t.collector_response_id = response_id
-                    all_tasks.append(t)
-
-            for task in all_tasks:
-                if not task.completed and task.asyncio_task and task.asyncio_task.done():
-                    task.completed = True
-                    try:
-                        task.result = task.asyncio_task.result()
-                    except Exception as e:
-                        task.error = str(e)
-                        task.result = {"success": False, "error": str(e)}
-
-            subagent_agent_ids = {f"task:{t.task_id}" for t in all_tasks}
-
-            logger.info(
-                f"[SubagentCollector] Starting incremental collection for "
-                f"thread_id={thread_id}, total_tasks={len(all_tasks)}, "
-                f"pending={bg_registry.pending_count}"
-            )
-
-            main_chunks = [
-                c for c in original_chunks
-                if c.get("data", {}).get("agent", "") not in subagent_agent_ids
-            ]
-
-            all_subagent_events: list[dict] = []
-
-            for task in all_tasks:
-                if task.completed and task.captured_event_count > 0:
-                    async for record in iter_subagent_events_full(thread_id, task):
-                        enriched = _record_to_persist_event(record, thread_id)
-                        all_subagent_events.append(enriched)
-
-            pending = {
-                t.asyncio_task: t for t in all_tasks
-                if t.is_pending and t.asyncio_task
-            }
-
-            if all_subagent_events:
-                await self._persist_collected_events(
-                    main_chunks, all_subagent_events, response_id,
-                    thread_id, workspace_id, user_id,
-                )
-
-            if not pending:
-                if not all_subagent_events:
-                    logger.info(
-                        f"[SubagentCollector] No subagent events captured "
-                        f"for thread_id={thread_id}"
-                    )
-                await self._persist_subagent_usage(
-                    response_id, all_tasks, thread_id, workspace_id, user_id,
-                    is_byok=is_byok,
-                )
-                await self._await_drain_and_cleanup_tasks(all_tasks, thread_id)
-                return
-
-            deadline = time.time() + timeout
-
-            while pending:
-                remaining_timeout = deadline - time.time()
-                if remaining_timeout <= 0:
-                    logger.warning(
-                        f"[SubagentCollector] Timeout for thread_id={thread_id}, "
-                        f"{len(pending)} tasks still pending"
-                    )
-                    break
-
-                done, _ = await asyncio.wait(
-                    pending.keys(),
-                    timeout=remaining_timeout,
-                    return_when=asyncio.FIRST_COMPLETED,
-                )
-
-                if not done:
-                    break
-
-                for asyncio_task in done:
-                    task = pending.pop(asyncio_task)
-
-                    async with bg_registry._lock:
-                        task.completed = True
-                        try:
-                            task.result = asyncio_task.result()
-                        except Exception as e:
-                            task.error = str(e)
-                            task.result = {"success": False, "error": str(e)}
-
-                    if task.captured_event_count > 0:
-                        async for record in iter_subagent_events_full(thread_id, task):
-                            enriched = _record_to_persist_event(record, thread_id)
-                            all_subagent_events.append(enriched)
-
-                    logger.info(
-                        f"[SubagentCollector] {task.display_id} completed, "
-                        f"persisting {len(all_subagent_events)} total events"
-                    )
-
-                if all_subagent_events:
-                    await self._persist_collected_events(
-                        main_chunks, all_subagent_events, response_id,
-                        thread_id, workspace_id, user_id,
-                    )
-
-            if pending:
-                orphaned_tasks = list(pending.values())
-                logger.info(
-                    f"[SubagentCollector] Spawning orphan collector for "
-                    f"{len(orphaned_tasks)} timed-out task(s), thread_id={thread_id}"
-                )
-                asyncio.create_task(
-                    self._collect_orphaned_subagent_results(
-                        thread_id=thread_id,
-                        response_id=response_id,
-                        main_chunks=main_chunks,
-                        prior_subagent_events=list(all_subagent_events),
-                        tasks=orphaned_tasks,
-                        workspace_id=workspace_id,
-                        user_id=user_id,
-                        is_byok=is_byok,
-                    ),
-                    name=f"subagent-orphan-collector-{thread_id}",
-                )
-
-            collected_tasks = [t for t in all_tasks if t not in pending.values()]
-            await self._persist_subagent_usage(
-                response_id, collected_tasks, thread_id, workspace_id, user_id,
-                is_byok=is_byok,
-            )
-            await self._await_drain_and_cleanup_tasks(collected_tasks, thread_id)
-
-        except Exception as e:
-            logger.error(
-                f"[SubagentCollector] Failed for thread_id={thread_id}: {e}",
-                exc_info=True,
-            )
 
     async def _persist_collected_events(
         self,
@@ -1820,10 +1696,13 @@ class BackgroundTaskManager:
             task_info.status = TaskStatus.CANCELLED
             task_info.completed_at = datetime.now()
             metadata = task_info.metadata
-            # Only user-driven cancels set explicit_cancel; system force-cancels
-            # (shutdown timeout, abandoned-task cleanup) reach here via task.cancel()
-            # with the flag unset and must not be persisted as user actions.
-            cancelled_by_user = bool(task_info.explicit_cancel)
+            # Persist as a user action ONLY for a user-pressed Stop. Both user
+            # stops and system cancels (graceful shutdown via cancel_workflow,
+            # stale-sandbox recovery via cancel_stale_workflow) set
+            # ``explicit_cancel``, so keying off that would mislabel a pod-roll
+            # or workspace eviction as a user "Stopped" turn. ``user_stop`` is
+            # set only by the HTTP /cancel path.
+            cancelled_by_user = bool(task_info.user_stop)
 
         logger.debug(f"[BackgroundTaskManager] Marked as cancelled: {key}")
 
@@ -1850,9 +1729,32 @@ class BackgroundTaskManager:
                 tool_usage = get_tool_usage_from_handler(
                     metadata, "cancellation", thread_id
                 )
-                sse_events = get_sse_events_from_handler(
-                    metadata, "cancellation", thread_id
-                )
+                # Reconcile the transcript at the stop point: close any open
+                # reasoning / tool-call / artifact / message structures so replay
+                # doesn't render zombies. Only for user-driven stops; system
+                # cancels (shutdown/abandoned) leave the raw events untouched.
+                handler = metadata.get("handler")
+                if cancelled_by_user and handler is not None and hasattr(
+                    handler, "finalize_stopped_events"
+                ):
+                    try:
+                        sse_events = handler.finalize_stopped_events()
+                    except Exception as recon_err:
+                        logger.warning(
+                            f"[WorkflowPersistence] finalize_stopped_events failed "
+                            f"for {key}: {recon_err}"
+                        )
+                        sse_events = get_sse_events_from_handler(
+                            metadata, "cancellation", thread_id
+                        )
+                else:
+                    sse_events = get_sse_events_from_handler(
+                        metadata, "cancellation", thread_id
+                    )
+                # Fold in killed-subagent events drained during teardown.
+                stop_subagent_events = metadata.get("_stop_subagent_events")
+                if stop_subagent_events:
+                    sse_events = (sse_events or []) + stop_subagent_events
                 execution_time = calculate_execution_time(metadata)
 
                 persist_metadata = {
@@ -1975,12 +1877,24 @@ class BackgroundTaskManager:
             )
 
     async def cancel_workflow(
-        self, thread_id: str, run_id: Optional[str] = None
+        self, thread_id: str, run_id: Optional[str] = None,
+        *, user_initiated: bool = True,
     ) -> bool:
-        """Cancel a running workflow.
+        """Cancel a running workflow immediately.
+
+        ``user_initiated`` distinguishes a user pressing Stop (HTTP /cancel,
+        the default) from a system-driven cancel (graceful shutdown). Only
+        user stops are persisted as cancelled-by-user "Stopped" turns.
 
         ``run_id`` may be omitted — falls back to the most recent active
         run on the thread.
+
+        Sets the cooperative cancel flag AND force-cancels the in-flight
+        ``inner_task`` so a long LLM/tool/sandbox step is interrupted now
+        rather than at the next event boundary. Only ``inner_task`` is
+        cancelled (mirroring ``cancel_stale_workflow``), so the outer task's
+        ``except asyncio.CancelledError`` teardown runs uncancelled and can
+        flush + persist. Does NOT block the HTTP response on exit.
         """
         async with self.task_lock:
             if run_id is not None:
@@ -2005,6 +1919,9 @@ class BackgroundTaskManager:
 
             task_info.cancel_event.set()
             task_info.explicit_cancel = True
+            task_info.user_stop = user_initiated
+            if task_info.inner_task and not task_info.inner_task.done():
+                task_info.inner_task.cancel()
             logger.debug(
                 f"[BackgroundTaskManager] Cancellation signaled: "
                 f"thread_id={thread_id} run_id={task_info.run_id}"
@@ -2036,71 +1953,6 @@ class BackgroundTaskManager:
                 )
         return True
 
-    async def soft_interrupt_workflow(self, thread_id: str) -> Dict[str, Any]:
-        """Soft interrupt the latest running workflow on the given thread."""
-        async with self.task_lock:
-            task_info = self._find_active_for_thread(thread_id)
-            if not task_info:
-                logger.warning(
-                    f"[BackgroundTaskManager] Cannot soft interrupt {thread_id}: "
-                    f"workflow not found"
-                )
-                return {
-                    "status": "not_found",
-                    "thread_id": thread_id,
-                    "can_resume": False,
-                    "background_tasks": [],
-                    "active_subagents": [],
-                    "completed_subagents": [],
-                }
-
-            active_tasks: list[str] = []
-            completed_tasks: list[str] = []
-            try:
-                from src.server.services.background_registry_store import BackgroundRegistryStore
-                registry = await BackgroundRegistryStore.get_instance().get_registry(thread_id)
-                if registry:
-                    for task in await registry.get_all_tasks():
-                        if task.is_pending:
-                            active_tasks.append(task.task_id)
-                        else:
-                            completed_tasks.append(task.task_id)
-            except Exception:
-                pass
-
-            if task_info.status not in [TaskStatus.QUEUED, TaskStatus.RUNNING]:
-                logger.info(
-                    f"[BackgroundTaskManager] Cannot soft interrupt {thread_id}: "
-                    f"status={task_info.status}"
-                )
-                return {
-                    "status": task_info.status.value,
-                    "thread_id": thread_id,
-                    "run_id": task_info.run_id,
-                    "can_resume": False,
-                    "background_tasks": active_tasks,
-                    "active_subagents": active_tasks,
-                    "completed_subagents": completed_tasks,
-                }
-
-            task_info.soft_interrupt_event.set()
-            task_info.soft_interrupted = True
-            logger.info(
-                f"[BackgroundTaskManager] Soft interrupt signaled: "
-                f"thread_id={thread_id} run_id={task_info.run_id}, "
-                f"active_subagents={active_tasks}"
-            )
-
-            return {
-                "status": "soft_interrupted",
-                "thread_id": thread_id,
-                "run_id": task_info.run_id,
-                "can_resume": True,
-                "background_tasks": active_tasks,
-                "active_subagents": active_tasks,
-                "completed_subagents": completed_tasks,
-            }
-
     async def get_workflow_status(self, thread_id: str) -> Dict[str, Any]:
         """Get detailed status for the latest run on a thread."""
         async with self.task_lock:
@@ -2126,7 +1978,6 @@ class BackgroundTaskManager:
                 "status": task_info.status.value,
                 "thread_id": thread_id,
                 "run_id": task_info.run_id,
-                "soft_interrupted": task_info.soft_interrupted,
                 "active_tasks": active_tasks,
                 "created_at": task_info.created_at.isoformat() if task_info.created_at else None,
                 "started_at": task_info.started_at.isoformat() if task_info.started_at else None,
@@ -2134,83 +1985,66 @@ class BackgroundTaskManager:
                 "active_connections": task_info.active_connections,
             }
 
-    async def wait_for_soft_interrupted(
+    async def wait_for_admission(
         self,
         thread_id: str,
-        timeout: float | None = None,
         exclude_run_id: Optional[str] = None,
-    ) -> bool:
-        """Wait for the latest active workflow on the thread to settle.
+    ) -> str:
+        """Decide whether a new turn can start on ``thread_id``.
 
-        Called before starting a new workflow on the same ``thread_id`` to
-        ensure clean continuation after an ESC interrupt. Per-thread (not
-        per-run) because callers are deciding whether a new run is admissible.
+        Returns one of:
+        - ``"fresh"``  — no active task (or a cancelled one finished winding
+          down within the wait): start a new turn.
+        - ``"running"`` — a turn is genuinely running: the caller should steer
+          it (or 409 if steering fails).
+        - ``"stopping"`` — a turn was explicitly cancelled and is still tearing
+          down past the wait: 409 "stopping, retry" (never start a second
+          writer while ``_flush_checkpoint`` may still be writing this thread).
 
         ``exclude_run_id`` lets dispatched callers ignore their own
         pre-registered placeholder while checking for OTHER active runs.
         """
-        if timeout is None:
-            timeout = get_soft_interrupt_wait_timeout()
         async with self.task_lock:
             task_info = self._find_active_for_thread(
                 thread_id, exclude_run_id=exclude_run_id
             )
             if not task_info:
-                return True
-
-            if task_info.status not in [
-                TaskStatus.QUEUED, TaskStatus.RUNNING,
-                TaskStatus.SOFT_INTERRUPTED,
-            ]:
-                return True
-
-            if not task_info.soft_interrupted and task_info.status != TaskStatus.SOFT_INTERRUPTED:
-                timeout = min(timeout, 5.0)
-
+                return "fresh"
+            if task_info.status not in (TaskStatus.QUEUED, TaskStatus.RUNNING):
+                return "fresh"
+            explicit = bool(task_info.explicit_cancel)
             task = task_info.task
             key = (task_info.thread_id, task_info.run_id)
 
-        if not task:
-            return True
+        if not explicit:
+            # Genuinely running — caller routes to steering.
+            return "running"
 
+        if task is None:
+            return "fresh"
+
+        # Explicitly cancelled and winding down. NEVER bare-await the task: it
+        # ends via ``raise CancelledError``, and a bare await would re-raise
+        # that into this (new) request handler. ``asyncio.wait`` swallows the
+        # task's exception so the caller is unaffected.
+        timeout = get_checkpoint_flush_timeout() + 2.0
         logger.info(
-            f"[BackgroundTaskManager] Waiting for soft-interrupted workflow "
-            f"{key} to complete (timeout={timeout}s)"
+            f"[BackgroundTaskManager] Waiting for stopping workflow {key} "
+            f"to finish teardown (timeout={timeout}s)"
         )
-
-        try:
-            await asyncio.wait_for(asyncio.shield(task), timeout=timeout)
-
+        done, _ = await asyncio.wait({task}, timeout=timeout)
+        if done:
             async with self.task_lock:
-                task_info = self.tasks.get(key)
-                if task_info and task_info.status in (
-                    TaskStatus.SOFT_INTERRUPTED, TaskStatus.COMPLETED,
-                ):
-                    logger.info(
-                        f"[BackgroundTaskManager] Cleaning up {task_info.status.value} "
-                        f"task {key}"
-                    )
+                ti = self.tasks.get(key)
+                if ti and ti.status in (TaskStatus.CANCELLED, TaskStatus.COMPLETED):
                     del self.tasks[key]
+            return "fresh"
 
-            logger.info(
-                f"[BackgroundTaskManager] Previous workflow {key} "
-                f"completed, ready for new request"
-            )
-            return True
-        except asyncio.TimeoutError:
-            logger.warning(
-                f"[BackgroundTaskManager] Timeout waiting for soft-interrupted "
-                f"workflow {key} after {timeout}s"
-            )
-            return False
-        except asyncio.CancelledError:
-            return True
-        except Exception as e:
-            logger.warning(
-                f"[BackgroundTaskManager] Error waiting for soft-interrupted "
-                f"workflow {key}: {e}"
-            )
-            return True
+        logger.warning(
+            f"[BackgroundTaskManager] Stopping workflow {key} still tearing "
+            f"down after {timeout}s; rejecting new turn with 409"
+        )
+        return "stopping"
 
     async def get_stats(self) -> Dict[str, Any]:
         async with self.task_lock:

--- a/src/server/services/background_task_manager.py
+++ b/src/server/services/background_task_manager.py
@@ -752,10 +752,23 @@ class BackgroundTaskManager:
             )
 
     def _track_orphan_collector(self, thread_id: str, task: asyncio.Task) -> None:
-        """Register a live orphan-collector task for stop-time cancellation."""
+        """Register a live orphan-collector task for stop-time cancellation.
+
+        The done-callback discards the finished task and drops the per-thread
+        bucket once it empties, so threads whose collectors complete naturally
+        (turn ends without a user stop) don't leak empty sets on a long-lived
+        server. The ``is bucket`` guard keeps a fresh bucket from a later turn
+        on the same thread from being removed by this callback.
+        """
         bucket = self._orphan_collectors.setdefault(thread_id, set())
         bucket.add(task)
-        task.add_done_callback(lambda t: bucket.discard(t))
+
+        def _discard(t: asyncio.Task) -> None:
+            bucket.discard(t)
+            if not bucket and self._orphan_collectors.get(thread_id) is bucket:
+                self._orphan_collectors.pop(thread_id, None)
+
+        task.add_done_callback(_discard)
 
     async def _teardown_subagents_on_stop(self, thread_id: str, run_id: str) -> None:
         """Single-owner subagent teardown on a user stop.

--- a/src/server/services/background_task_manager.py
+++ b/src/server/services/background_task_manager.py
@@ -607,6 +607,12 @@ class BackgroundTaskManager:
                 if task_info:
                     task_info.inner_task = inner_task
 
+            # A stop that landed before inner_task was published set cancel_event
+            # but couldn't cancel the not-yet-created task; honor it now so a long
+            # first step doesn't run to its next event boundary uncancelled.
+            if cancel_event.is_set() and not inner_task.done():
+                inner_task.cancel()
+
             await inner_task
 
             await self._mark_completed(thread_id, run_id)
@@ -1919,7 +1925,11 @@ class BackgroundTaskManager:
 
             task_info.cancel_event.set()
             task_info.explicit_cancel = True
-            task_info.user_stop = user_initiated
+            # Only ever raise user_stop; never let a later system cancel
+            # (user_initiated=False, e.g. graceful shutdown) downgrade a turn the
+            # user explicitly stopped — that would mislabel it as system-cancelled.
+            if user_initiated:
+                task_info.user_stop = True
             if task_info.inner_task and not task_info.inner_task.done():
                 task_info.inner_task.cancel()
             logger.debug(
@@ -1962,28 +1972,37 @@ class BackgroundTaskManager:
                     "status": "not_found",
                     "thread_id": thread_id,
                 }
+            # Snapshot under the lock, then release it BEFORE the registry/Redis
+            # lookup below. Holding task_lock across that await would let a slow
+            # registry path block /cancel from acquiring the lock to signal a stop.
+            status = task_info.status.value
+            run_id = task_info.run_id
+            created_at = task_info.created_at
+            started_at = task_info.started_at
+            completed_at = task_info.completed_at
+            active_connections = task_info.active_connections
 
-            active_tasks: list[str] = []
-            try:
-                from src.server.services.background_registry_store import BackgroundRegistryStore
-                registry = await BackgroundRegistryStore.get_instance().get_registry(thread_id)
-                if registry:
-                    for task in await registry.get_all_tasks():
-                        if task.is_pending:
-                            active_tasks.append(task.task_id)
-            except Exception:
-                pass
+        active_tasks: list[str] = []
+        try:
+            from src.server.services.background_registry_store import BackgroundRegistryStore
+            registry = await BackgroundRegistryStore.get_instance().get_registry(thread_id)
+            if registry:
+                for task in await registry.get_all_tasks():
+                    if task.is_pending:
+                        active_tasks.append(task.task_id)
+        except Exception:
+            pass
 
-            return {
-                "status": task_info.status.value,
-                "thread_id": thread_id,
-                "run_id": task_info.run_id,
-                "active_tasks": active_tasks,
-                "created_at": task_info.created_at.isoformat() if task_info.created_at else None,
-                "started_at": task_info.started_at.isoformat() if task_info.started_at else None,
-                "completed_at": task_info.completed_at.isoformat() if task_info.completed_at else None,
-                "active_connections": task_info.active_connections,
-            }
+        return {
+            "status": status,
+            "thread_id": thread_id,
+            "run_id": run_id,
+            "active_tasks": active_tasks,
+            "created_at": created_at.isoformat() if created_at else None,
+            "started_at": started_at.isoformat() if started_at else None,
+            "completed_at": completed_at.isoformat() if completed_at else None,
+            "active_connections": active_connections,
+        }
 
     async def wait_for_admission(
         self,

--- a/src/server/services/background_task_manager.py
+++ b/src/server/services/background_task_manager.py
@@ -213,6 +213,13 @@ class BackgroundTaskManager:
 
     _instance: Optional['BackgroundTaskManager'] = None
 
+    # Margin added to the checkpoint-flush timeout when a new turn waits for a
+    # stopping turn's teardown to finish. Teardown does more than flush (subagent
+    # drain, registry clear, persist), so the wait must outlast the flush alone;
+    # past it, admission returns "stopping" → 409 retry rather than racing a
+    # second checkpoint writer.
+    _ADMISSION_TEARDOWN_MARGIN_S = 2.0
+
     def __init__(self):
         # Keyed by (thread_id, run_id). One slot per turn; no cross-turn
         # aliasing because run_id is fresh per POST.
@@ -742,6 +749,7 @@ class BackgroundTaskManager:
 
         # --- 2. Drain killed-subagent events (best-effort, hard timeout) ---
         merged_subagent_events: list[dict] = []
+        drain_timeout = get_stop_drain_timeout()
         if registry is not None:
             try:
                 tasks = await registry.get_all_tasks()
@@ -750,12 +758,12 @@ class BackgroundTaskManager:
             try:
                 merged_subagent_events = await asyncio.wait_for(
                     self._drain_killed_subagent_events(thread_id, tasks),
-                    timeout=get_stop_drain_timeout(),
+                    timeout=drain_timeout,
                 )
             except asyncio.TimeoutError:
                 logger.warning(
                     f"[StopTeardown] Subagent drain exceeded "
-                    f"{get_stop_drain_timeout()}s for thread_id={thread_id}; "
+                    f"{drain_timeout}s for thread_id={thread_id}; "
                     "proceeding without drained events"
                 )
             except Exception as exc:
@@ -2052,7 +2060,7 @@ class BackgroundTaskManager:
         # ends via ``raise CancelledError``, and a bare await would re-raise
         # that into this (new) request handler. ``asyncio.wait`` swallows the
         # task's exception so the caller is unaffected.
-        timeout = get_checkpoint_flush_timeout() + 2.0
+        timeout = get_checkpoint_flush_timeout() + self._ADMISSION_TEARDOWN_MARGIN_S
         logger.info(
             f"[BackgroundTaskManager] Waiting for stopping workflow {key} "
             f"to finish teardown (timeout={timeout}s)"

--- a/src/server/services/background_task_manager.py
+++ b/src/server/services/background_task_manager.py
@@ -520,6 +520,29 @@ class BackgroundTaskManager:
             if key in self.tasks:
                 existing = self.tasks[key]
                 if existing.status == TaskStatus.QUEUED and existing.task is None:
+                    if existing.cancel_event.is_set():
+                        # Cancelled in the pre_register → start_workflow window
+                        # (dispatched flow). Do NOT resurrect it into a RUNNING
+                        # task: wait_for_admission returns "fresh" for a
+                        # task-less cancelled placeholder, so a new turn may
+                        # already be RUNNING on this thread. A resurrected run
+                        # would tear down on its first cancel-event check —
+                        # flushing a stale checkpoint and marking the thread
+                        # CANCELLED over the new turn. Settle the placeholder
+                        # terminally and release its burst slot here (no task is
+                        # created, so the BTM finalizer that normally releases it
+                        # never runs).
+                        existing.status = TaskStatus.CANCELLED
+                        existing.completed_at = datetime.now()
+                        existing.persistence_complete.set()
+                        uid = (metadata or {}).get("user_id")
+                        if uid:
+                            await release_burst_slot(uid)
+                        logger.info(
+                            f"[BackgroundTaskManager] Placeholder {key} cancelled "
+                            "before start; settled without resurrecting"
+                        )
+                        return existing
                     # Upgrade pre-registered placeholder in-place.
                     existing.metadata = metadata or {}
                     existing.completion_callback = completion_callback

--- a/src/server/services/background_task_manager.py
+++ b/src/server/services/background_task_manager.py
@@ -838,6 +838,11 @@ class BackgroundTaskManager:
         if collectors:
             with suppress(Exception):
                 await asyncio.gather(*collectors, return_exceptions=True)
+        # This explicit drain runs only on the explicit_cancel paths (user stop
+        # / graceful shutdown / stale-sandbox recovery — the only callers of
+        # this method). On non-explicit cancels (abandoned-task cleanup, which
+        # cancels the OUTER task with the flag unset) collectors are left to the
+        # per-task done-callback (`_discard`) to drain — no leak, different owner.
         self._orphan_collectors.pop(thread_id, None)
 
         # --- 4. Kill subagents + wipe the registry ---

--- a/src/server/services/workflow_tracker.py
+++ b/src/server/services/workflow_tracker.py
@@ -5,7 +5,7 @@ Manages workflow execution state in Redis to support background execution
 and reconnection after client disconnect.
 
 Key Features:
-- Track workflow status (active/completed/cancelled/failed/soft_interrupted)
+- Track workflow status (active/completed/cancelled/failed)
 - TTL-based cleanup of completed workflows
 - Graceful degradation if Redis unavailable
 - Retry count tracking for transient error handling (max 3 retries)
@@ -29,7 +29,6 @@ class WorkflowStatus(str, Enum):
     INTERRUPTED = "interrupted"
     CANCELLED = "cancelled"
     FAILED = "failed"
-    SOFT_INTERRUPTED = "soft_interrupted"
     UNKNOWN = "unknown"
 
 
@@ -42,7 +41,6 @@ TERMINAL_STATUSES: frozenset[WorkflowStatus] = frozenset({
     WorkflowStatus.COMPLETED,
     WorkflowStatus.CANCELLED,
     WorkflowStatus.FAILED,
-    WorkflowStatus.SOFT_INTERRUPTED,
 })
 
 
@@ -325,35 +323,6 @@ class WorkflowTracker:
         if success:
             logger.info(
                 f"[WorkflowTracker] Marked workflow as failed: {thread_id}"
-            )
-
-        return success
-
-    async def mark_soft_interrupted(
-        self,
-        thread_id: str,
-        run_id: Optional[str] = None,
-    ) -> bool:
-        """Mark workflow as soft-interrupted (main agent paused, subagents can still complete).
-
-        Distinct from INTERRUPTED (HITL pause, indefinite TTL): SOFT_INTERRUPTED
-        is a terminal-for-the-turn state with bounded TTL.
-        """
-        if not self.enabled:
-            return False
-
-        success = await self._update_status_with_metadata(
-            thread_id=thread_id,
-            new_status=WorkflowStatus.SOFT_INTERRUPTED,
-            timestamp_field="soft_interrupted_at",
-            metadata=None,
-            ttl=get_redis_ttl_workflow_status(),
-            run_id=run_id,
-        )
-
-        if success:
-            logger.info(
-                f"[WorkflowTracker] Marked workflow as soft-interrupted: {thread_id}"
             )
 
         return success

--- a/tests/unit/core/sandbox/test_sandbox_shutdown_race.py
+++ b/tests/unit/core/sandbox/test_sandbox_shutdown_race.py
@@ -123,18 +123,6 @@ class TestHasActiveTasksForWorkspace:
         assert await mgr.has_active_tasks_for_workspace("ws-1") is False
 
     @pytest.mark.asyncio
-    async def test_soft_interrupted_task_matches(self):
-        mgr = BackgroundTaskManager()
-        mgr.tasks[("thread-1", "run-1")] = TaskInfo(
-            run_id="run-1",
-            thread_id="thread-1",
-            status=TaskStatus.SOFT_INTERRUPTED,
-            created_at=datetime.now(),
-            metadata={"workspace_id": "ws-1"},
-        )
-        assert await mgr.has_active_tasks_for_workspace("ws-1") is True
-
-    @pytest.mark.asyncio
     async def test_different_workspace_does_not_match(self):
         mgr = BackgroundTaskManager()
         mgr.tasks[("thread-1", "run-1")] = TaskInfo(

--- a/tests/unit/ptc_agent/middleware/test_task_output_cancelled.py
+++ b/tests/unit/ptc_agent/middleware/test_task_output_cancelled.py
@@ -1,0 +1,29 @@
+"""TaskOutput for a stop-killed subagent returns a clear cancelled message.
+
+After a user stop wipes the registry, a resumed turn that follows its own
+pseudo-result instruction and re-asks for the killed subagent must be told it
+was cancelled — not that it "never existed".
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ptc_agent.agent.middleware.background_subagent.tools import (
+    create_task_output_tool,
+)
+
+
+@pytest.mark.asyncio
+async def test_task_output_missing_task_reports_cancelled():
+    middleware = MagicMock()
+    registry = MagicMock()
+    registry.get_by_task_id = AsyncMock(return_value=None)
+    middleware.registry = registry
+
+    tool = create_task_output_tool(middleware)
+
+    result = await tool.coroutine(task_id="k7Xm2p")
+
+    assert "cancelled by a user stop" in result.lower()
+    assert "not found" not in result.lower()

--- a/tests/unit/server/handlers/test_chat_common.py
+++ b/tests/unit/server/handlers/test_chat_common.py
@@ -782,28 +782,31 @@ class TestBuildGraphConfig:
 
 class TestWaitOrSteer:
     @pytest.mark.asyncio
-    async def test_ready_returns_true(self):
+    async def test_fresh_returns_true(self):
         from src.server.handlers.chat._common import wait_or_steer
 
         manager = AsyncMock()
-        manager.wait_for_soft_interrupted = AsyncMock(return_value=True)
+        manager.wait_for_admission = AsyncMock(return_value="fresh")
 
         ready, event = await wait_or_steer(manager, "t-1", "hello", "u-1")
         assert ready is True
         assert event is None
 
     @pytest.mark.asyncio
-    async def test_steered_returns_false_with_event(self):
+    async def test_running_steers_immediately_with_no_wait(self):
+        """CRITICAL regression: a genuinely-running turn is steered immediately
+        — admission returns "running" and steer_thread is called without any
+        wait on the running task."""
         from src.server.handlers.chat._common import wait_or_steer
 
         manager = AsyncMock()
-        manager.wait_for_soft_interrupted = AsyncMock(return_value=False)
+        manager.wait_for_admission = AsyncMock(return_value="running")
 
         with patch(
             "src.server.handlers.chat.steering.steer_thread",
             new_callable=AsyncMock,
             return_value={"position": 1},
-        ):
+        ) as mock_steer:
             ready, event = await wait_or_steer(
                 manager, "t-1", "hello", "u-1"
             )
@@ -812,15 +815,41 @@ class TestWaitOrSteer:
         assert event is not None
         assert "steering_accepted" in event
         assert '"position": 1' in event
+        mock_steer.assert_awaited_once()
+        # No wait helper exists anymore — admission decided immediately.
+        manager.wait_for_admission.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_raises_409_when_queue_fails(self):
+    async def test_stopping_raises_409_without_steering(self):
+        """An explicitly-cancelled turn still winding down → 409 'stopping',
+        never steered (a second checkpoint writer would corrupt state)."""
         from fastapi import HTTPException
 
         from src.server.handlers.chat._common import wait_or_steer
 
         manager = AsyncMock()
-        manager.wait_for_soft_interrupted = AsyncMock(return_value=False)
+        manager.wait_for_admission = AsyncMock(return_value="stopping")
+
+        with (
+            patch(
+                "src.server.handlers.chat.steering.steer_thread",
+                new_callable=AsyncMock,
+            ) as mock_steer,
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await wait_or_steer(manager, "t-1", "hello", "u-1")
+
+        assert exc_info.value.status_code == 409
+        mock_steer.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_raises_409_when_steering_fails(self):
+        from fastapi import HTTPException
+
+        from src.server.handlers.chat._common import wait_or_steer
+
+        manager = AsyncMock()
+        manager.wait_for_admission = AsyncMock(return_value="running")
 
         with (
             patch(

--- a/tests/unit/server/handlers/test_streaming_handler.py
+++ b/tests/unit/server/handlers/test_streaming_handler.py
@@ -1021,6 +1021,28 @@ class TestFinalizeStoppedEvents:
         )
         assert not handler.anthropic_tool_call_state
 
+    def test_same_agent_in_both_tool_states_closes_once(self):
+        """A mid-turn provider fallback can leave the same agent in both the
+        Response-API and Anthropic tool-call dicts; the stop must emit exactly
+        one tool-call close for that agent, not two."""
+        handler = self._handler()
+        handler.function_call_state[("agent", 0)] = {"name": "execute_code", "id": "c1"}
+        handler.anthropic_tool_call_state[("agent", 1)] = {"name": "execute_code", "id": "c2"}
+        handler._open_message_ids["agent"] = "msg-tool"
+
+        out = handler.finalize_stopped_events()
+
+        tool_closes = [
+            e
+            for e in out
+            if e["event"] == "tool_call_chunks"
+            and e["data"].get("agent") == "agent"
+            and e["data"].get("finish_reason") == "stopped"
+        ]
+        assert len(tool_closes) == 1
+        assert not handler.function_call_state
+        assert not handler.anthropic_tool_call_state
+
     def test_mid_artifact_gets_stopped_status(self):
         handler = self._handler()
         # Simulate an in-progress artifact.

--- a/tests/unit/server/handlers/test_streaming_handler.py
+++ b/tests/unit/server/handlers/test_streaming_handler.py
@@ -965,3 +965,133 @@ class TestCompactionChunkRouting:
         # Simulate the error-signal discard path
         handler._compaction_windows.discard(ns)
         assert ns not in handler._compaction_windows
+
+
+# ---------------------------------------------------------------------------
+# Stop-point reconciliation (decision 1b / T3-A): finalize_stopped_events
+# ---------------------------------------------------------------------------
+
+
+class TestFinalizeStoppedEvents:
+    """A user stop must close every open streaming structure so replay shows
+    partial fragments marked 'stopped' instead of live-looking zombies."""
+
+    def _handler(self, thread_id="t-stop"):
+        from src.server.handlers.streaming_handler import WorkflowStreamHandler
+
+        return WorkflowStreamHandler(thread_id=thread_id, run_id="r-stop")
+
+    def _events(self, handler):
+        return handler.get_sse_events() or []
+
+    def test_mid_reasoning_gets_reasoning_complete(self):
+        handler = self._handler()
+        # Simulate an open reasoning block on the main agent.
+        handler.reasoning_active.add("agent")
+        handler._open_message_ids["agent"] = "msg-1"
+
+        out = handler.finalize_stopped_events()
+
+        # A reasoning_signal:"complete" was appended for the open block.
+        assert any(
+            e["event"] in ("message_chunk", "compaction_chunk")
+            and e["data"].get("content_type") == "reasoning_signal"
+            and e["data"].get("content") == "complete"
+            for e in out
+        )
+        # Reasoning state cleared.
+        assert not handler.reasoning_active
+
+    def test_mid_tool_args_gets_terminal_close(self):
+        handler = self._handler()
+        # Simulate an in-flight Anthropic tool-call stream.
+        handler.anthropic_tool_call_state[("agent", 0)] = {
+            "name": "execute_code",
+            "id": "call-1",
+            "args_accumulated": '{"code": "import pa',
+        }
+        handler._open_message_ids["agent"] = "msg-tool"
+
+        out = handler.finalize_stopped_events()
+
+        assert any(
+            e["event"] == "tool_call_chunks"
+            and e["data"].get("finish_reason") == "stopped"
+            for e in out
+        )
+        assert not handler.anthropic_tool_call_state
+
+    def test_mid_artifact_gets_stopped_status(self):
+        handler = self._handler()
+        # Simulate an in-progress artifact.
+        handler._open_artifacts["art-1"] = {
+            "artifact_type": "chart",
+            "artifact_id": "art-1",
+            "agent": "agent",
+            "status": "in_progress",
+            "payload": {},
+        }
+
+        out = handler.finalize_stopped_events()
+
+        assert any(
+            e["event"] == "artifact"
+            and e["data"].get("artifact_id") == "art-1"
+            and e["data"].get("status") == "stopped"
+            for e in out
+        )
+        assert not handler._open_artifacts
+
+    def test_open_message_gets_finish_reason_stopped(self):
+        handler = self._handler()
+        handler._open_message_ids["agent"] = "msg-open"
+
+        out = handler.finalize_stopped_events()
+
+        assert any(
+            e["event"] == "message_chunk"
+            and e["data"].get("id") == "msg-open"
+            and e["data"].get("finish_reason") == "stopped"
+            for e in out
+        )
+        assert not handler._open_message_ids
+
+    def test_clean_boundary_appends_no_synthetic_events(self):
+        """Negative case: nothing open ⇒ no synthetic close events."""
+        handler = self._handler()
+        # A clean, already-closed message with a terminal finish_reason.
+        handler._format_sse_event(
+            "message_chunk",
+            {
+                "thread_id": "t-stop",
+                "agent": "agent",
+                "id": "msg-done",
+                "role": "assistant",
+                "content": "done.",
+                "finish_reason": "stop",
+            },
+        )
+        before = self._events(handler)
+
+        out = handler.finalize_stopped_events()
+
+        # No new events were appended.
+        assert len(out) == len(before)
+        assert not any(
+            e["data"].get("finish_reason") == "stopped" for e in out
+        )
+
+    def test_idempotent_double_stop_no_duplicate_closes(self):
+        """The stop-finalized marker prevents duplicate synthetic closes on a
+        second stop / handler re-entry."""
+        handler = self._handler()
+        handler.reasoning_active.add("agent")
+        handler._open_message_ids["agent"] = "msg-1"
+
+        first = handler.finalize_stopped_events()
+        first_len = len(first)
+
+        second = handler.finalize_stopped_events()
+
+        assert len(second) == first_len
+        assert handler._stop_finalized is True

--- a/tests/unit/server/handlers/test_workflow_handler_cancel.py
+++ b/tests/unit/server/handlers/test_workflow_handler_cancel.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
-def _patch_common(*, manager_cancel_returns: bool):
+def _patch_common(*, manager_cancel_returns: bool, has_active_returns: bool = False):
     """Patch the collaborators of workflow_handler.cancel_workflow.
 
     Returns a context manager and the mocked registry_store so the test can
@@ -24,6 +24,7 @@ def _patch_common(*, manager_cancel_returns: bool):
 
     manager = MagicMock()
     manager.cancel_workflow = AsyncMock(return_value=manager_cancel_returns)
+    manager.has_active_task_for_thread = AsyncMock(return_value=has_active_returns)
 
     registry_store = MagicMock()
     registry_store.cancel_and_clear = AsyncMock(return_value=0)
@@ -70,11 +71,13 @@ async def test_cancel_with_active_task_is_signal_only():
 
 @pytest.mark.asyncio
 async def test_cancel_with_no_active_task_runs_safety_net():
-    """No active task (manager.cancel_workflow → False) ⇒ the safety-net
-    cancel_and_clear runs to wipe any orphaned registry."""
+    """No active task (manager.cancel_workflow → False, none active) ⇒ the
+    safety-net cancel_and_clear runs to wipe any orphaned registry."""
     from src.server.handlers.workflow_handler import cancel_workflow
 
-    patches, registry_store, _manager = _patch_common(manager_cancel_returns=False)
+    patches, registry_store, _manager = _patch_common(
+        manager_cancel_returns=False, has_active_returns=False
+    )
     for p in patches:
         p.start()
     try:
@@ -85,3 +88,28 @@ async def test_cancel_with_no_active_task_runs_safety_net():
 
     assert result["cancelled"] is True
     registry_store.cancel_and_clear.assert_awaited_once_with("t-1", force=True)
+
+
+@pytest.mark.asyncio
+async def test_run_targeted_miss_with_other_active_task_skips_safety_net():
+    """A run-targeted cancel that misses its run (manager.cancel_workflow →
+    False) but where ANOTHER turn is still active must NOT wipe the registry —
+    that would kill the other turn's subagents."""
+    from src.server.handlers.workflow_handler import cancel_workflow
+
+    patches, registry_store, manager = _patch_common(
+        manager_cancel_returns=False, has_active_returns=True
+    )
+    for p in patches:
+        p.start()
+    try:
+        result = await cancel_workflow("t-1", "run-A")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert result["cancelled"] is True
+    # run_id threaded through to the manager so it targets the stopped run.
+    manager.cancel_workflow.assert_awaited_once_with("t-1", "run-A")
+    # Another turn owns the thread → safety net must be skipped.
+    registry_store.cancel_and_clear.assert_not_awaited()

--- a/tests/unit/server/handlers/test_workflow_handler_cancel.py
+++ b/tests/unit/server/handlers/test_workflow_handler_cancel.py
@@ -1,0 +1,87 @@
+"""Tests for the workflow_handler cancel path (signal-only + safety net).
+
+Covers decision 1A/1C:
+- cancel_workflow is signal-only when a task is active (the except-handler
+  teardown owns cancel_and_clear).
+- cancel_workflow runs the safety-net cancel_and_clear only when NO active
+  task exists (orphaned registry after a crash).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _patch_common(*, manager_cancel_returns: bool):
+    """Patch the collaborators of workflow_handler.cancel_workflow.
+
+    Returns a context manager and the mocked registry_store so the test can
+    assert on cancel_and_clear.
+    """
+    tracker = MagicMock()
+    tracker.set_cancel_flag = AsyncMock(return_value=True)
+    tracker.mark_cancelled = AsyncMock(return_value=True)
+
+    manager = MagicMock()
+    manager.cancel_workflow = AsyncMock(return_value=manager_cancel_returns)
+
+    registry_store = MagicMock()
+    registry_store.cancel_and_clear = AsyncMock(return_value=0)
+
+    patches = [
+        patch(
+            "src.server.services.workflow_tracker.WorkflowTracker.get_instance",
+            return_value=tracker,
+        ),
+        patch(
+            "src.server.services.background_task_manager.BackgroundTaskManager.get_instance",
+            return_value=manager,
+        ),
+        patch(
+            "src.server.services.background_registry_store.BackgroundRegistryStore.get_instance",
+            return_value=registry_store,
+        ),
+        patch(
+            "src.server.database.conversation.update_thread_status",
+            new=AsyncMock(),
+        ),
+    ]
+    return patches, registry_store, manager
+
+
+@pytest.mark.asyncio
+async def test_cancel_with_active_task_is_signal_only():
+    """When a task is active (manager.cancel_workflow → True), the handler must
+    NOT call cancel_and_clear — the except-handler teardown owns it."""
+    from src.server.handlers.workflow_handler import cancel_workflow
+
+    patches, registry_store, _manager = _patch_common(manager_cancel_returns=True)
+    for p in patches:
+        p.start()
+    try:
+        result = await cancel_workflow("t-1")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert result["cancelled"] is True
+    registry_store.cancel_and_clear.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cancel_with_no_active_task_runs_safety_net():
+    """No active task (manager.cancel_workflow → False) ⇒ the safety-net
+    cancel_and_clear runs to wipe any orphaned registry."""
+    from src.server.handlers.workflow_handler import cancel_workflow
+
+    patches, registry_store, _manager = _patch_common(manager_cancel_returns=False)
+    for p in patches:
+        p.start()
+    try:
+        result = await cancel_workflow("t-1")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert result["cancelled"] is True
+    registry_store.cancel_and_clear.assert_awaited_once_with("t-1", force=True)

--- a/tests/unit/server/services/test_background_task_manager.py
+++ b/tests/unit/server/services/test_background_task_manager.py
@@ -832,6 +832,96 @@ class TestStopTeardownOrdering:
 
 
 # ---------------------------------------------------------------------------
+# Drain closes open subagent reasoning blocks (replay zombie fix)
+# ---------------------------------------------------------------------------
+
+class TestDrainReasoningClose:
+
+    def _task(self, task_id: str, count: int) -> MagicMock:
+        task = MagicMock()
+        task.task_id = task_id
+        task.captured_event_count = count
+        return task
+
+    @pytest.mark.asyncio
+    async def test_open_reasoning_block_gets_synthetic_close(self):
+        """A subagent killed mid-reasoning (start with no complete) gets a
+        synthetic reasoning_signal 'complete' — matching its own agent+id —
+        before the stopped close, so replay isn't stuck 'thinking'."""
+        btm = _make_btm()
+        records = [
+            {"event": "message_chunk", "data": {
+                "agent": "task:abc", "id": "m1",
+                "content": "start", "content_type": "reasoning_signal"}},
+        ]
+
+        async def fake_iter(thread_id, task):
+            for r in records:
+                yield r
+
+        with patch(
+            "src.server.services.background_task_manager.iter_subagent_events_full",
+            side_effect=fake_iter,
+        ):
+            merged = await btm._drain_killed_subagent_events(
+                "t-x", [self._task("abc", 1)]
+            )
+
+        completes = [
+            e for e in merged
+            if e["data"].get("content_type") == "reasoning_signal"
+            and e["data"].get("content") == "complete"
+        ]
+        assert len(completes) == 1
+        assert completes[0]["data"]["agent"] == "task:abc"
+        assert completes[0]["data"]["id"] == "m1"
+        # The synthetic complete precedes the finish_reason 'stopped' close.
+        idx_complete = next(
+            i for i, e in enumerate(merged)
+            if e["data"].get("content") == "complete"
+        )
+        idx_stop = next(
+            i for i, e in enumerate(merged)
+            if e["data"].get("finish_reason") == "stopped"
+        )
+        assert idx_complete < idx_stop
+
+    @pytest.mark.asyncio
+    async def test_already_completed_reasoning_not_double_closed(self):
+        """A subagent whose reasoning block already closed gets no extra
+        synthetic complete appended."""
+        btm = _make_btm()
+        records = [
+            {"event": "message_chunk", "data": {
+                "agent": "task:abc", "id": "m1",
+                "content": "start", "content_type": "reasoning_signal"}},
+            {"event": "message_chunk", "data": {
+                "agent": "task:abc", "id": "m1",
+                "content": "complete", "content_type": "reasoning_signal"}},
+        ]
+
+        async def fake_iter(thread_id, task):
+            for r in records:
+                yield r
+
+        with patch(
+            "src.server.services.background_task_manager.iter_subagent_events_full",
+            side_effect=fake_iter,
+        ):
+            merged = await btm._drain_killed_subagent_events(
+                "t-x", [self._task("abc", 2)]
+            )
+
+        completes = [
+            e for e in merged
+            if e["data"].get("content_type") == "reasoning_signal"
+            and e["data"].get("content") == "complete"
+        ]
+        # Only the original complete survives — no synthetic duplicate.
+        assert len(completes) == 1
+
+
+# ---------------------------------------------------------------------------
 # wait_for_admission decisions (decision 2A)
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/server/services/test_background_task_manager.py
+++ b/tests/unit/server/services/test_background_task_manager.py
@@ -163,6 +163,40 @@ class TestCancelWorkflowForceCancelsInner:
         assert result is True
         mock_inner.cancel.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_system_cancel_does_not_downgrade_user_stop(self):
+        """A later system cancel (user_initiated=False) must NOT clear a
+        user_stop already set by the user's HTTP /cancel. Otherwise a graceful
+        shutdown racing the stop teardown (before status flips off RUNNING)
+        would mislabel the turn as system-cancelled."""
+        btm = _make_btm()
+        task_info = _make_task_info(status=TaskStatus.RUNNING)
+        btm.tasks[("thread-1", "run-1")] = task_info
+
+        # User presses Stop.
+        assert await btm.cancel_workflow("thread-1", user_initiated=True) is True
+        assert task_info.user_stop is True
+
+        # Graceful shutdown fires a system cancel on the same still-RUNNING task.
+        assert await btm.cancel_workflow(
+            "thread-1", "run-1", user_initiated=False
+        ) is True
+        assert task_info.user_stop is True  # not downgraded
+
+    @pytest.mark.asyncio
+    async def test_system_only_cancel_leaves_user_stop_false(self):
+        """A system-only cancel (no preceding user stop) keeps user_stop False
+        so it persists cancelled_by_user=False."""
+        btm = _make_btm()
+        task_info = _make_task_info(status=TaskStatus.RUNNING)
+        btm.tasks[("thread-1", "run-1")] = task_info
+
+        assert await btm.cancel_workflow(
+            "thread-1", "run-1", user_initiated=False
+        ) is True
+        assert task_info.explicit_cancel is True
+        assert task_info.user_stop is False
+
 
 # ---------------------------------------------------------------------------
 # cancel_stale_workflow — COMPLETED (no-op)

--- a/tests/unit/server/services/test_background_task_manager.py
+++ b/tests/unit/server/services/test_background_task_manager.py
@@ -3,10 +3,13 @@ Tests for BackgroundTaskManager.cancel_stale_workflow and consume_workflow event
 
 Covers:
 - cancel_stale_workflow no-ops for missing or completed tasks
-- cancel_stale_workflow cancels RUNNING and SOFT_INTERRUPTED tasks
+- cancel_stale_workflow cancels RUNNING tasks
 - cancel_stale_workflow handles timeout when task won't exit
 - _run_workflow uses closure-captured events (not re-acquired from lock)
 - Outer-task .cancel() propagates into inner consume_workflow (post-shield-removal)
+- user cancel_workflow force-cancels inner_task + flushes checkpoint on explicit_cancel
+- single-owner stop teardown ordering (drain before cancel_and_clear)
+- wait_for_admission: fresh / running / stopping decisions
 """
 
 import asyncio
@@ -115,35 +118,50 @@ class TestCancelStaleWorkflowRunning:
 
 
 # ---------------------------------------------------------------------------
-# cancel_stale_workflow — SOFT_INTERRUPTED
+# cancel_workflow — user stop force-cancels inner_task (immediacy)
 # ---------------------------------------------------------------------------
 
-class TestCancelStaleWorkflowSoftInterrupted:
+class TestCancelWorkflowForceCancelsInner:
 
     @pytest.mark.asyncio
-    async def test_cancel_stale_workflow_soft_interrupted(self):
-        """cancel_stale_workflow handles SOFT_INTERRUPTED the same as RUNNING."""
+    async def test_user_cancel_force_cancels_inner_task(self):
+        """cancel_workflow force-cancels a not-done inner_task immediately."""
         btm = _make_btm()
 
         mock_inner = MagicMock(spec=asyncio.Task)
         mock_inner.done.return_value = False
         mock_inner.cancel = MagicMock()
 
-        outer_future = asyncio.get_event_loop().create_future()
-        outer_future.set_result(None)
-
         task_info = _make_task_info(
-            status=TaskStatus.SOFT_INTERRUPTED,
-            task=outer_future,
-            inner_task=mock_inner,
+            status=TaskStatus.RUNNING, inner_task=mock_inner
         )
         btm.tasks[("thread-1", "run-1")] = task_info
 
-        result = await btm.cancel_stale_workflow("thread-1")
+        result = await btm.cancel_workflow("thread-1")
 
         assert result is True
         assert task_info.cancel_event.is_set()
+        assert task_info.explicit_cancel is True
         mock_inner.cancel.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_user_cancel_skips_done_inner_task(self):
+        """A done inner_task is not re-cancelled."""
+        btm = _make_btm()
+
+        mock_inner = MagicMock(spec=asyncio.Task)
+        mock_inner.done.return_value = True
+        mock_inner.cancel = MagicMock()
+
+        task_info = _make_task_info(
+            status=TaskStatus.RUNNING, inner_task=mock_inner
+        )
+        btm.tasks[("thread-1", "run-1")] = task_info
+
+        result = await btm.cancel_workflow("thread-1")
+
+        assert result is True
+        mock_inner.cancel.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -304,19 +322,18 @@ class TestConsumeWorkflowUsesClosureEvents:
                 yield f"event-{i}"
 
         cancel_event = asyncio.Event()
-        soft_interrupt_event = asyncio.Event()
 
         # Pre-register a RUNNING task so _run_workflow can find it
         task_info = _make_task_info(thread_id="thread-closure", status=TaskStatus.RUNNING)
         btm.tasks[("thread-closure", "run-1")] = task_info
 
-        # Patch _mark_completed, _mark_cancelled, _mark_failed, _mark_soft_interrupted
-        # so they don't try to do real persistence work
+        # Patch _mark_completed, _mark_cancelled, _mark_failed so they don't
+        # try to do real persistence work
         with patch.object(btm, "_mark_completed", new_callable=AsyncMock) as mock_mark_completed, \
              patch.object(btm, "_mark_cancelled", new_callable=AsyncMock) as mock_mark_cancelled, \
              patch.object(btm, "_mark_failed", new_callable=AsyncMock), \
-             patch.object(btm, "_mark_soft_interrupted", new_callable=AsyncMock), \
-             patch.object(btm, "_flush_checkpoint", new_callable=AsyncMock):
+             patch.object(btm, "_flush_checkpoint", new_callable=AsyncMock), \
+             patch.object(btm, "_teardown_subagents_on_stop", new_callable=AsyncMock):
 
             # Schedule setting the cancel_event after a brief delay
             async def set_cancel_after_delay():
@@ -333,7 +350,6 @@ class TestConsumeWorkflowUsesClosureEvents:
                     run_id="run-1",
                     workflow_generator=fake_workflow(),
                     cancel_event=cancel_event,
-                    soft_interrupt_event=soft_interrupt_event,
                 )
 
             await cancel_task
@@ -381,7 +397,6 @@ class TestOuterTaskCancelPropagatesToInner:
                 generator_closed.set()
 
         cancel_event = asyncio.Event()
-        soft_interrupt_event = asyncio.Event()
 
         task_info = _make_task_info(
             thread_id="thread-outer", run_id="run-outer", status=TaskStatus.RUNNING
@@ -391,8 +406,8 @@ class TestOuterTaskCancelPropagatesToInner:
         with patch.object(btm, "_mark_completed", new_callable=AsyncMock), \
              patch.object(btm, "_mark_cancelled", new_callable=AsyncMock) as mock_mark_cancelled, \
              patch.object(btm, "_mark_failed", new_callable=AsyncMock), \
-             patch.object(btm, "_mark_soft_interrupted", new_callable=AsyncMock), \
-             patch.object(btm, "_flush_checkpoint", new_callable=AsyncMock):
+             patch.object(btm, "_flush_checkpoint", new_callable=AsyncMock), \
+             patch.object(btm, "_teardown_subagents_on_stop", new_callable=AsyncMock):
 
             outer_task = asyncio.create_task(
                 btm._run_workflow(
@@ -400,7 +415,6 @@ class TestOuterTaskCancelPropagatesToInner:
                     run_id="run-outer",
                     workflow_generator=fake_workflow(),
                     cancel_event=cancel_event,
-                    soft_interrupt_event=soft_interrupt_event,
                 )
             )
 
@@ -433,12 +447,15 @@ class TestOuterTaskCancelPropagatesToInner:
 # ---------------------------------------------------------------------------
 
 class TestMarkCancelledUserLabeling:
-    """``cancelled_by_user`` must reflect ``task_info.explicit_cancel``.
+    """``cancelled_by_user`` must reflect ``task_info.user_stop``, NOT
+    ``explicit_cancel``.
 
-    User cancels (cancel_workflow / cancel_stale_workflow) set explicit_cancel.
-    System force-cancels (shutdown timeout, abandoned-task cleanup) reach
-    _mark_cancelled via task.cancel() with the flag unset and must persist
-    cancelled_by_user=False so analytics don't attribute them to the user.
+    A user pressing Stop (HTTP /cancel) sets both explicit_cancel AND user_stop.
+    System cancels — graceful shutdown (cancel_workflow with user_initiated=
+    False) and stale-sandbox recovery (cancel_stale_workflow) — also set
+    explicit_cancel (to gate flush+teardown) but leave user_stop False, so they
+    must persist cancelled_by_user=False. Keying off explicit_cancel would
+    mislabel a pod-roll or workspace eviction as a user "Stopped" turn.
     """
 
     async def _run_mark_cancelled(self, btm, task_info):
@@ -466,11 +483,12 @@ class TestMarkCancelledUserLabeling:
         return persistence_service.persist_cancelled.await_args.kwargs["metadata"]
 
     @pytest.mark.asyncio
-    async def test_system_cancel_persists_not_user(self):
-        """explicit_cancel unset (force-cancel) → cancelled_by_user=False."""
+    async def test_abandoned_cancel_persists_not_user(self):
+        """Bare force-cancel (abandoned cleanup): neither flag → not user."""
         btm = _make_btm()
         task_info = _make_task_info(thread_id="thread-sys", run_id="run-sys")
         assert task_info.explicit_cancel is False
+        assert task_info.user_stop is False
 
         persist_metadata = await self._run_mark_cancelled(btm, task_info)
 
@@ -478,11 +496,349 @@ class TestMarkCancelledUserLabeling:
 
     @pytest.mark.asyncio
     async def test_user_cancel_persists_user(self):
-        """explicit_cancel set (cancel_workflow) → cancelled_by_user=True."""
+        """user_stop set (HTTP /cancel) → cancelled_by_user=True."""
         btm = _make_btm()
         task_info = _make_task_info(thread_id="thread-usr", run_id="run-usr")
         task_info.explicit_cancel = True
+        task_info.user_stop = True
 
         persist_metadata = await self._run_mark_cancelled(btm, task_info)
 
         assert persist_metadata["cancelled_by_user"] is True
+
+    @pytest.mark.asyncio
+    async def test_system_cancel_with_explicit_flag_not_user(self):
+        """REGRESSION (C1): graceful shutdown / stale-sandbox recovery set
+        explicit_cancel (to flush+teardown) but user_stop=False, so the
+        interrupted turn must NOT be persisted as a user-cancelled Stop. A
+        pod-roll or workspace eviction mid-stream previously wrote fake
+        "Stopped" turns into chat history."""
+        btm = _make_btm()
+        task_info = _make_task_info(thread_id="thread-shutdown", run_id="run-sd")
+        task_info.explicit_cancel = True   # shutdown/stale set this...
+        assert task_info.user_stop is False  # ...but NOT user_stop
+
+        persist_metadata = await self._run_mark_cancelled(btm, task_info)
+
+        assert persist_metadata["cancelled_by_user"] is False
+
+
+# ---------------------------------------------------------------------------
+# _run_workflow stop path: flush + teardown gated on explicit_cancel
+# ---------------------------------------------------------------------------
+
+class TestStopPathFlushGating:
+    """The except-CancelledError handler flushes the checkpoint and tears down
+    subagents ONLY when the cancel was user-initiated (explicit_cancel)."""
+
+    async def _drive_stop(self, btm, *, explicit: bool):
+        async def fake_workflow():
+            for i in range(1000):
+                await asyncio.sleep(0.01)
+                yield f"event-{i}"
+
+        cancel_event = asyncio.Event()
+        task_info = _make_task_info(
+            thread_id="t-stop", run_id="r-stop", status=TaskStatus.RUNNING
+        )
+        task_info.explicit_cancel = explicit
+        btm.tasks[("t-stop", "r-stop")] = task_info
+
+        with patch.object(btm, "_mark_completed", new_callable=AsyncMock), \
+             patch.object(btm, "_mark_cancelled", new_callable=AsyncMock), \
+             patch.object(btm, "_mark_failed", new_callable=AsyncMock), \
+             patch.object(btm, "_flush_checkpoint", new_callable=AsyncMock) as flush, \
+             patch.object(btm, "_teardown_subagents_on_stop", new_callable=AsyncMock) as teardown:
+
+            outer = asyncio.create_task(
+                btm._run_workflow(
+                    thread_id="t-stop",
+                    run_id="r-stop",
+                    workflow_generator=fake_workflow(),
+                    cancel_event=cancel_event,
+                )
+            )
+            await asyncio.sleep(0.05)
+            inner = task_info.inner_task
+            inner.cancel()
+            with suppress(asyncio.CancelledError):
+                await outer
+        return flush, teardown
+
+    @pytest.mark.asyncio
+    async def test_explicit_cancel_flushes_and_tears_down(self):
+        btm = _make_btm()
+        flush, teardown = await self._drive_stop(btm, explicit=True)
+        flush.assert_awaited_once_with("t-stop", "r-stop")
+        teardown.assert_awaited_once_with("t-stop", "r-stop")
+
+    @pytest.mark.asyncio
+    async def test_system_cancel_does_not_flush_or_teardown(self):
+        btm = _make_btm()
+        flush, teardown = await self._drive_stop(btm, explicit=False)
+        flush.assert_not_awaited()
+        teardown.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_flush_failure_still_marks_cancelled(self):
+        """A raising _flush_checkpoint must not prevent _mark_cancelled."""
+        btm = _make_btm()
+
+        async def fake_workflow():
+            for i in range(1000):
+                await asyncio.sleep(0.01)
+                yield f"event-{i}"
+
+        cancel_event = asyncio.Event()
+        task_info = _make_task_info(
+            thread_id="t-flushfail", run_id="r-flushfail", status=TaskStatus.RUNNING
+        )
+        task_info.explicit_cancel = True
+        btm.tasks[("t-flushfail", "r-flushfail")] = task_info
+
+        with patch.object(btm, "_mark_completed", new_callable=AsyncMock), \
+             patch.object(btm, "_mark_cancelled", new_callable=AsyncMock) as mark, \
+             patch.object(btm, "_mark_failed", new_callable=AsyncMock), \
+             patch.object(btm, "_flush_checkpoint", new_callable=AsyncMock,
+                          side_effect=RuntimeError("flush boom")), \
+             patch.object(btm, "_teardown_subagents_on_stop", new_callable=AsyncMock):
+
+            outer = asyncio.create_task(
+                btm._run_workflow(
+                    thread_id="t-flushfail",
+                    run_id="r-flushfail",
+                    workflow_generator=fake_workflow(),
+                    cancel_event=cancel_event,
+                )
+            )
+            await asyncio.sleep(0.05)
+            task_info.inner_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await outer
+
+        mark.assert_awaited_once_with("t-flushfail", "r-flushfail")
+
+    @pytest.mark.asyncio
+    async def test_recancel_during_teardown_still_marks_cancelled(self):
+        """REGRESSION (C2): a second CancelledError landing in teardown (e.g.
+        graceful shutdown force-cancelling the OUTER task while the single-owner
+        teardown is mid-flight) must NOT skip _mark_cancelled. The finally +
+        asyncio.shield guarantee persistence/burst-slot release/registry cleanup
+        run rather than leaving half-state."""
+        btm = _make_btm()
+
+        async def fake_workflow():
+            for i in range(1000):
+                await asyncio.sleep(0.01)
+                yield f"event-{i}"
+
+        cancel_event = asyncio.Event()
+        task_info = _make_task_info(
+            thread_id="t-recancel", run_id="r-recancel", status=TaskStatus.RUNNING
+        )
+        task_info.explicit_cancel = True
+        btm.tasks[("t-recancel", "r-recancel")] = task_info
+
+        with patch.object(btm, "_mark_completed", new_callable=AsyncMock), \
+             patch.object(btm, "_mark_cancelled", new_callable=AsyncMock) as mark, \
+             patch.object(btm, "_mark_failed", new_callable=AsyncMock), \
+             patch.object(btm, "_flush_checkpoint", new_callable=AsyncMock), \
+             patch.object(btm, "_teardown_subagents_on_stop", new_callable=AsyncMock,
+                          side_effect=asyncio.CancelledError()):
+
+            outer = asyncio.create_task(
+                btm._run_workflow(
+                    thread_id="t-recancel",
+                    run_id="r-recancel",
+                    workflow_generator=fake_workflow(),
+                    cancel_event=cancel_event,
+                )
+            )
+            await asyncio.sleep(0.05)
+            task_info.inner_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await outer
+
+        # Even though teardown raised CancelledError, persistence still ran.
+        mark.assert_awaited_once_with("t-recancel", "r-recancel")
+
+
+# ---------------------------------------------------------------------------
+# Single-owner teardown ordering (decision 1A): drain BEFORE cancel_and_clear
+# ---------------------------------------------------------------------------
+
+class TestStopTeardownOrdering:
+
+    @pytest.mark.asyncio
+    async def test_drain_runs_before_cancel_and_clear(self):
+        """_teardown_subagents_on_stop drains killed-subagent events and stashes
+        them on metadata, and the drain happens BEFORE cancel_and_clear wipes
+        the registry."""
+        btm = _make_btm()
+
+        order: list[str] = []
+
+        task_info = _make_task_info(
+            thread_id="t-order", run_id="r-order", status=TaskStatus.RUNNING
+        )
+        btm.tasks[("t-order", "r-order")] = task_info
+
+        fake_registry = MagicMock()
+        fake_registry.get_all_tasks = AsyncMock(return_value=["task-a"])
+
+        async def fake_drain(thread_id, tasks):
+            order.append("drain")
+            return [{"event": "message_chunk", "data": {"agent": "task:x"}}]
+
+        fake_store = MagicMock()
+        fake_store.get_registry = AsyncMock(return_value=fake_registry)
+
+        async def fake_cancel_and_clear(thread_id, *, force):
+            order.append("cancel_and_clear")
+            return 1
+
+        fake_store.cancel_and_clear = AsyncMock(side_effect=fake_cancel_and_clear)
+
+        with patch(
+            "src.server.services.background_registry_store.BackgroundRegistryStore.get_instance",
+            return_value=fake_store,
+        ), patch.object(btm, "_drain_killed_subagent_events", side_effect=fake_drain):
+            await btm._teardown_subagents_on_stop("t-order", "r-order")
+
+        assert order == ["drain", "cancel_and_clear"]
+        stashed = task_info.metadata.get("_stop_subagent_events")
+        assert stashed and stashed[0]["data"]["agent"] == "task:x"
+
+    @pytest.mark.asyncio
+    async def test_drain_timeout_proceeds_without_events(self):
+        """A drain that exceeds stop_drain_timeout doesn't block teardown."""
+        btm = _make_btm()
+
+        task_info = _make_task_info(
+            thread_id="t-tmo", run_id="r-tmo", status=TaskStatus.RUNNING
+        )
+        btm.tasks[("t-tmo", "r-tmo")] = task_info
+
+        fake_registry = MagicMock()
+        fake_registry.get_all_tasks = AsyncMock(return_value=["task-a"])
+
+        async def slow_drain(thread_id, tasks):
+            await asyncio.sleep(5)
+            return [{"event": "x"}]
+
+        fake_store = MagicMock()
+        fake_store.get_registry = AsyncMock(return_value=fake_registry)
+        fake_store.cancel_and_clear = AsyncMock(return_value=1)
+
+        with patch(
+            "src.server.services.background_registry_store.BackgroundRegistryStore.get_instance",
+            return_value=fake_store,
+        ), patch.object(btm, "_drain_killed_subagent_events", side_effect=slow_drain), \
+           patch(
+               "src.server.services.background_task_manager.get_stop_drain_timeout",
+               return_value=0.05,
+           ):
+            await btm._teardown_subagents_on_stop("t-tmo", "r-tmo")
+
+        # No drained events stashed, but cancel_and_clear still ran.
+        assert "_stop_subagent_events" not in task_info.metadata
+        fake_store.cancel_and_clear.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_orphan_collectors_cancelled_on_stop(self):
+        """Tracked orphan collectors are cancelled during teardown so they
+        can't mutate the response after the stop."""
+        btm = _make_btm()
+
+        task_info = _make_task_info(
+            thread_id="t-orph", run_id="r-orph", status=TaskStatus.RUNNING
+        )
+        btm.tasks[("t-orph", "r-orph")] = task_info
+
+        started = asyncio.Event()
+
+        async def long_collector():
+            started.set()
+            await asyncio.sleep(100)
+
+        collector = asyncio.create_task(long_collector())
+        btm._track_orphan_collector("t-orph", collector)
+        await started.wait()
+
+        fake_store = MagicMock()
+        fake_store.get_registry = AsyncMock(return_value=None)
+        fake_store.cancel_and_clear = AsyncMock(return_value=0)
+
+        with patch(
+            "src.server.services.background_registry_store.BackgroundRegistryStore.get_instance",
+            return_value=fake_store,
+        ):
+            await btm._teardown_subagents_on_stop("t-orph", "r-orph")
+
+        assert collector.cancelled()
+        assert "t-orph" not in btm._orphan_collectors
+
+
+# ---------------------------------------------------------------------------
+# wait_for_admission decisions (decision 2A)
+# ---------------------------------------------------------------------------
+
+class TestWaitForAdmission:
+
+    @pytest.mark.asyncio
+    async def test_no_active_task_is_fresh(self):
+        btm = _make_btm()
+        assert await btm.wait_for_admission("t-none") == "fresh"
+
+    @pytest.mark.asyncio
+    async def test_running_task_is_running(self):
+        btm = _make_btm()
+        ti = _make_task_info(thread_id="t-run", status=TaskStatus.RUNNING)
+        btm.tasks[("t-run", ti.run_id)] = ti
+        assert await btm.wait_for_admission("t-run") == "running"
+
+    @pytest.mark.asyncio
+    async def test_cancelled_completing_within_wait_is_fresh(self):
+        """An explicitly-cancelled task that finishes winding down within the
+        wait → fresh turn, and no CancelledError reaches the caller."""
+        btm = _make_btm()
+
+        async def dies():
+            raise asyncio.CancelledError()
+
+        task = asyncio.ensure_future(dies())
+        with suppress(asyncio.CancelledError):
+            await asyncio.sleep(0)  # let it schedule
+        ti = _make_task_info(thread_id="t-stop", status=TaskStatus.RUNNING, task=task)
+        ti.explicit_cancel = True
+        btm.tasks[("t-stop", ti.run_id)] = ti
+
+        # Caller is unaffected by the task's CancelledError.
+        state = await btm.wait_for_admission("t-stop")
+        assert state == "fresh"
+        # Terminal-marked task evicted so a fresh turn proceeds.
+
+    @pytest.mark.asyncio
+    async def test_cancelled_still_winding_down_is_stopping(self):
+        """An explicitly-cancelled task still tearing down past the wait → 409
+        'stopping'."""
+        btm = _make_btm()
+
+        never = asyncio.get_event_loop().create_future()
+        ti = _make_task_info(thread_id="t-slow", status=TaskStatus.RUNNING, task=never)
+        ti.explicit_cancel = True
+        btm.tasks[("t-slow", ti.run_id)] = ti
+
+        with patch(
+            "src.server.services.background_task_manager.get_checkpoint_flush_timeout",
+            return_value=0.01,
+        ):
+            state = await btm.wait_for_admission("t-slow")
+        assert state == "stopping"
+
+    @pytest.mark.asyncio
+    async def test_terminal_task_is_fresh(self):
+        btm = _make_btm()
+        ti = _make_task_info(thread_id="t-done", status=TaskStatus.COMPLETED)
+        btm.tasks[("t-done", ti.run_id)] = ti
+        assert await btm.wait_for_admission("t-done") == "fresh"

--- a/tests/unit/server/services/test_background_task_manager.py
+++ b/tests/unit/server/services/test_background_task_manager.py
@@ -812,6 +812,24 @@ class TestStopTeardownOrdering:
         assert collector.cancelled()
         assert "t-orph" not in btm._orphan_collectors
 
+    @pytest.mark.asyncio
+    async def test_orphan_collector_bucket_cleared_on_natural_completion(self):
+        """A collector that finishes without a stop drops its empty bucket — no
+        unbounded empty-set leak on long-lived servers."""
+        btm = _make_btm()
+
+        async def quick_collector():
+            return None
+
+        collector = asyncio.create_task(quick_collector())
+        btm._track_orphan_collector("t-nat", collector)
+        assert "t-nat" in btm._orphan_collectors  # tracked while running
+
+        await collector
+        await asyncio.sleep(0)  # let the done-callback run
+
+        assert "t-nat" not in btm._orphan_collectors
+
 
 # ---------------------------------------------------------------------------
 # wait_for_admission decisions (decision 2A)

--- a/tests/unit/server/services/test_background_task_manager.py
+++ b/tests/unit/server/services/test_background_task_manager.py
@@ -876,3 +876,76 @@ class TestWaitForAdmission:
         ti = _make_task_info(thread_id="t-done", status=TaskStatus.COMPLETED)
         btm.tasks[("t-done", ti.run_id)] = ti
         assert await btm.wait_for_admission("t-done") == "fresh"
+
+
+class TestStartWorkflowCancelledPlaceholder:
+    """A dispatched placeholder cancelled in the pre_register → start_workflow
+    window must NOT be resurrected into a RUNNING task. wait_for_admission
+    returns 'fresh' for a task-less cancelled placeholder, so a new turn can
+    already be RUNNING on the thread; resurrecting would flush a stale
+    checkpoint and mark the thread CANCELLED over that new turn."""
+
+    @pytest.mark.asyncio
+    async def test_cancelled_placeholder_not_resurrected(self):
+        btm = _make_btm()
+        thread_id, run_id = "t-zombie", "run-zombie"
+
+        # Dispatched pre-register: QUEUED, task=None.
+        await btm.pre_register(thread_id, run_id)
+        # User cancels before the generator reaches start_workflow.
+        assert await btm.cancel_workflow(thread_id, run_id) is True
+
+        consumed = False
+
+        async def gen():
+            nonlocal consumed
+            consumed = True
+            yield {}
+
+        mod = "src.server.services.background_task_manager"
+        with patch(f"{mod}.release_burst_slot", new_callable=AsyncMock) as rel:
+            ti = await btm.start_workflow(
+                thread_id=thread_id,
+                run_id=run_id,
+                workflow_generator=gen(),
+                metadata={"user_id": "u-1"},
+            )
+
+        # Settled terminally; no resurrected task; generator never consumed.
+        assert ti.status == TaskStatus.CANCELLED
+        assert ti.task is None
+        assert consumed is False
+        # Burst slot released here — no BTM task will finalize to release it.
+        rel.assert_awaited_once_with("u-1")
+        # No second workflow lingers active on the thread.
+        assert await btm.wait_for_admission(thread_id) == "fresh"
+
+    @pytest.mark.asyncio
+    async def test_uncancelled_placeholder_still_upgrades(self):
+        """Negative case: a normal (uncancelled) placeholder still upgrades to
+        RUNNING — the guard must not break the happy path."""
+        btm = _make_btm()
+        thread_id, run_id = "t-ok", "run-ok"
+        await btm.pre_register(thread_id, run_id)
+
+        started = asyncio.Event()
+
+        async def gen():
+            started.set()
+            yield {}
+            await asyncio.sleep(0)
+
+        ti = await btm.start_workflow(
+            thread_id=thread_id,
+            run_id=run_id,
+            workflow_generator=gen(),
+            metadata={"user_id": "u-1"},
+        )
+        try:
+            assert ti.status == TaskStatus.RUNNING
+            assert ti.task is not None
+        finally:
+            if ti.task and not ti.task.done():
+                ti.task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await ti.task

--- a/tests/unit/server/services/test_background_task_terminal_cleanup.py
+++ b/tests/unit/server/services/test_background_task_terminal_cleanup.py
@@ -199,27 +199,8 @@ class TestMarkCancelledReleases:
         assert info.persistence_complete.is_set()
         assert info.graph is None
         # Wiring: tracker.mark_cancelled called from the canonical site so
-        # stale-cancel reaper / soft-interrupt-abort paths also update Redis.
+        # the stale-cancel reaper path also updates Redis.
         mock_tracker.mark_cancelled.assert_awaited_once_with("t-1", run_id="r-1")
-
-
-class TestMarkSoftInterruptedReleases:
-
-    @pytest.mark.asyncio
-    async def test_mark_soft_interrupted_releases_and_signals(self):
-        btm = _make_btm()
-        info = _make_info()
-        info.metadata["workspace_id"] = None  # Skip persistence body
-        btm.tasks[("t-1", "r-1")] = info
-
-        tracker_patch, mock_tracker = _patch_tracker()
-        with patch("src.server.services.background_task_manager.release_burst_slot", new=AsyncMock()), \
-             tracker_patch:
-            await btm._mark_soft_interrupted("t-1", "r-1")
-
-        assert info.persistence_complete.is_set()
-        assert info.graph is None
-        mock_tracker.mark_soft_interrupted.assert_awaited_once_with("t-1", run_id="r-1")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/server/services/test_workflow_tracker.py
+++ b/tests/unit/server/services/test_workflow_tracker.py
@@ -58,7 +58,6 @@ async def _call_get_workflow_status(status: WorkflowStatus, bg_status: str) -> d
     bg_manager.get_workflow_status = AsyncMock(return_value={
         "status": bg_status,
         "active_tasks": [],
-        "soft_interrupted": False,
     })
 
     cache = MagicMock()
@@ -247,23 +246,6 @@ class TestMarkTransitions:
         assert "metadata" not in persisted
 
     @pytest.mark.asyncio
-    async def test_mark_soft_interrupted_sets_ttl(self):
-        tracker, mock_cache = _make_tracker(enabled=True)
-        thread_id = str(uuid.uuid4())
-
-        result = await tracker.mark_soft_interrupted(thread_id)
-
-        assert result is True
-        call_args = mock_cache.set.call_args
-        persisted = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("value")
-        assert persisted["status"] == "soft_interrupted"
-        ttl = call_args.kwargs.get("ttl") or (
-            call_args.args[2] if len(call_args.args) > 2 else None
-        )
-        # Distinct from INTERRUPTED (which uses ttl=None) — bounded TTL.
-        assert ttl == get_redis_ttl_workflow_status()
-
-    @pytest.mark.asyncio
     async def test_all_methods_disabled(self):
         tracker, _ = _make_tracker(enabled=False)
         tid = "t-1"
@@ -272,7 +254,6 @@ class TestMarkTransitions:
         assert await tracker.mark_interrupted(tid) is False
         assert await tracker.mark_cancelled(tid) is False
         assert await tracker.mark_failed(tid, error="x") is False
-        assert await tracker.mark_soft_interrupted(tid) is False
 
 
 # ---------------------------------------------------------------------------

--- a/web/e2e/chat.spec.js
+++ b/web/e2e/chat.spec.js
@@ -473,9 +473,11 @@ test.describe('Chat View -- SSE Streaming', () => {
     await expect(page.getByText('Starting analysis...')).toBeVisible({ timeout: 10000 });
     await page.locator('button[title="Stop"]').click();
 
-    // Wait for the button to change to "Stopping..." (deterministic signal that
-    // the click handler ran), then confirm the cancel POST was sent.
-    await expect(page.locator('button[title="Stopping..."]')).toBeVisible({ timeout: 5000 });
+    // stopWorkflow optimistically clears loading so the stop feels instant, which
+    // immediately swaps the Stop button back to Send (the transient "Stopping..."
+    // title is never observable). Assert that swap as the deterministic signal the
+    // handler ran, then confirm the cancel POST fired.
+    await expect(page.locator('button[aria-label="Send message"]')).toBeVisible({ timeout: 5000 });
     await expect.poll(() => cancelCalled, { timeout: 5000 }).toBe(true);
   });
 

--- a/web/e2e/chat.spec.js
+++ b/web/e2e/chat.spec.js
@@ -394,7 +394,6 @@ test.describe('Chat View -- SSE Streaming', () => {
   test('approve plan resumes workflow', async ({ page }) => {
     await mockAPI(page, {
       ...chatViewOverrides(),
-      'POST /threads/th-1/interrupt': { success: true },
     });
 
     // Replay with interrupt
@@ -433,12 +432,12 @@ test.describe('Chat View -- SSE Streaming', () => {
     await expect(page.getByText('Plan Approved')).toBeVisible({ timeout: 10000 });
   });
 
-  test('stop button interrupts streaming', async ({ page }) => {
-    let interruptCalled = false;
+  test('stop button cancels streaming', async ({ page }) => {
+    let cancelCalled = false;
     await mockAPI(page, {
       ...chatViewOverrides(),
-      'POST /threads/*/interrupt': (route) => {
-        interruptCalled = true;
+      'POST /threads/*/cancel': (route) => {
+        cancelCalled = true;
         return route.fulfill({
           status: 200,
           contentType: 'application/json',
@@ -474,10 +473,10 @@ test.describe('Chat View -- SSE Streaming', () => {
     await expect(page.getByText('Starting analysis...')).toBeVisible({ timeout: 10000 });
     await page.locator('button[title="Stop"]').click();
 
-    // Verify the interrupt was sent (via page.route capture)
-    // Wait for the button to change to "Stopping..." (deterministic signal that the click handler ran)
+    // Wait for the button to change to "Stopping..." (deterministic signal that
+    // the click handler ran), then confirm the cancel POST was sent.
     await expect(page.locator('button[title="Stopping..."]')).toBeVisible({ timeout: 5000 });
-    expect(interruptCalled).toBe(true);
+    await expect.poll(() => cancelCalled, { timeout: 5000 }).toBe(true);
   });
 
   test('403 on thread shows access denied', async ({ page }) => {

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -1112,7 +1112,7 @@
     "worker": "Worker",
     "agentNotFound": "Agent not found",
     "planFeedbackHint": "Type your feedback to revise the plan, then send.",
-    "stoppedChip": "⏹ Stopped",
+    "stoppedChip": "Stopped",
     "stopFailed": "Couldn't stop the run — it may still be running.",
     "errorUpstreamHeadline": "The model provider returned an error",
     "errorUpstreamHeadlineStatus": "The model provider returned an error ({{status}})",
@@ -1147,7 +1147,7 @@
     "offloading": "Offloading context...",
     "placeholderDefault": "Type / for skills, @ for files",
     "placeholderPendingRejection": "Describe how to revise the plan...",
-    "placeholderInterrupted": "Stopped — send a message to continue",
+    "placeholderStopped": "Stopped — send a message to continue",
     "placeholderLoading": "Type a follow-up to steer the agent...",
     "placeholderSubagentsRunning": "Workers still running. Send a message or click a worker to instruct it.",
     "slashCommand": {

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -1112,7 +1112,8 @@
     "worker": "Worker",
     "agentNotFound": "Agent not found",
     "planFeedbackHint": "Type your feedback to revise the plan, then send.",
-    "interruptedHint": "Agent interrupted. Feel free to provide new instructions.",
+    "stoppedChip": "⏹ Stopped",
+    "stopFailed": "Couldn't stop the run — it may still be running.",
     "errorUpstreamHeadline": "The model provider returned an error",
     "errorUpstreamHeadlineStatus": "The model provider returned an error ({{status}})",
     "errorInternalHeadline": "Something went wrong on our end",
@@ -1146,7 +1147,7 @@
     "offloading": "Offloading context...",
     "placeholderDefault": "Type / for skills, @ for files",
     "placeholderPendingRejection": "Describe how to revise the plan...",
-    "placeholderInterrupted": "Send new instructions to the agent...",
+    "placeholderInterrupted": "Stopped — send a message to continue",
     "placeholderLoading": "Type a follow-up to steer the agent...",
     "placeholderSubagentsRunning": "Workers still running. Send a message or click a worker to instruct it.",
     "slashCommand": {

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -1112,7 +1112,7 @@
     "worker": "工作者",
     "agentNotFound": "未找到 Agent",
     "planFeedbackHint": "输入您的反馈意见来修改计划，然后发送。",
-    "stoppedChip": "⏹ 已停止",
+    "stoppedChip": "已停止",
     "stopFailed": "无法停止本次运行，它可能仍在运行。",
     "errorUpstreamHeadline": "模型提供商返回错误",
     "errorUpstreamHeadlineStatus": "模型提供商返回错误 ({{status}})",
@@ -1147,7 +1147,7 @@
     "offloading": "正在转存上下文...",
     "placeholderDefault": "输入 / 调用技能，@ 引用文件",
     "placeholderPendingRejection": "说说希望怎么调整...",
-    "placeholderInterrupted": "已停止，发送消息即可继续",
+    "placeholderStopped": "已停止，发送消息即可继续",
     "placeholderLoading": "可以继续输入，消息会排队发送...",
     "placeholderSubagentsRunning": "工作者仍在运行，可输入消息或点击工作者单独指令",
     "slashCommand": {

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -1112,7 +1112,8 @@
     "worker": "工作者",
     "agentNotFound": "未找到 Agent",
     "planFeedbackHint": "输入您的反馈意见来修改计划，然后发送。",
-    "interruptedHint": "Agent 已中断。请随时提供新的指令。",
+    "stoppedChip": "⏹ 已停止",
+    "stopFailed": "无法停止本次运行，它可能仍在运行。",
     "errorUpstreamHeadline": "模型提供商返回错误",
     "errorUpstreamHeadlineStatus": "模型提供商返回错误 ({{status}})",
     "errorInternalHeadline": "服务内部出错",
@@ -1146,7 +1147,7 @@
     "offloading": "正在转存上下文...",
     "placeholderDefault": "输入 / 调用技能，@ 引用文件",
     "placeholderPendingRejection": "说说希望怎么调整...",
-    "placeholderInterrupted": "输入新指令继续引导 Agent...",
+    "placeholderInterrupted": "已停止，发送消息即可继续",
     "placeholderLoading": "可以继续输入，消息会排队发送...",
     "placeholderSubagentsRunning": "工作者仍在运行，可输入消息或点击工作者单独指令",
     "slashCommand": {

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -711,7 +711,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
   const chatPlaceholder = useMemo(() => {
     if (pendingRejection) return t('chat.placeholderPendingRejection');
     if (wasStopped && !isLoading && !pendingInterrupt && !pendingRejection)
-      return t('chat.placeholderInterrupted');
+      return t('chat.placeholderStopped');
     if (isLoading) return t('chat.placeholderLoading');
     if (hasActiveSubagents) return t('chat.placeholderSubagentsRunning');
     return t('chat.placeholderDefault');

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense, useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { ArrowLeft, FolderOpen, StopCircle, ScrollText, CheckCircle2, Circle, Loader2, TextSelect, Minus, PanelLeftOpen, Menu, Info, Pin, PinOff } from 'lucide-react';
+import { ArrowLeft, FolderOpen, ScrollText, CheckCircle2, Circle, Loader2, TextSelect, Minus, PanelLeftOpen, Menu, Info, Pin, PinOff } from 'lucide-react';
 import { HoverCard, HoverCardTrigger, HoverCardContent } from '@/components/ui/hover-card';
 import { useIsMobile, getIsMobileSnapshot } from '@/hooks/useIsMobile';
 import { useNarrowContainer } from '@/hooks/useNarrowContainer';
@@ -10,7 +10,7 @@ import { usePreferences } from '@/hooks/usePreferences';
 import { useQueryClient } from '@tanstack/react-query';
 import { queryKeys } from '@/lib/queryKeys';
 import { updateCurrentUser } from '../../Dashboard/utils/api';
-import { softInterruptWorkflow, getWorkspace, summarizeThread, offloadThread, getPreviewUrl, getThreadShareStatus, updateThreadSharing } from '../utils/api';
+import { getWorkspace, summarizeThread, offloadThread, getPreviewUrl, getThreadShareStatus, updateThreadSharing } from '../utils/api';
 import { buildSharedServeUrl, buildWsfilesUrl } from './viewers/html/wsfilesUrl';
 import ShareReportLinkModal from './ShareReportLinkModal';
 import { toast } from '@/components/ui/use-toast';
@@ -431,8 +431,9 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
   const [showSystemFiles, setShowSystemFiles] = useState(
     () => localStorage.getItem('filePanel.showSystemFiles') === 'true'
   );
-  // Track whether the agent was soft-interrupted
-  const [wasInterrupted, setWasInterrupted] = useState(false);
+  // Track whether the user hard-stopped the current turn (drives the
+  // "⏹ Stopped" marker + placeholder). Cleared on the next send.
+  const [wasStopped, setWasStopped] = useState(false);
   // Track intentional back navigation (skip session save on unmount)
   const intentionalExitRef = useRef(false);
   // Ref mirrors isActive prop for use in unmount cleanup closures (R1)
@@ -666,6 +667,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     returnedSteering,
     clearReturnedSteering,
     handleSendMessage,
+    stopWorkflow,
     pendingInterrupt,
     pendingRejection,
     handleApproveInterrupt,
@@ -708,12 +710,12 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
 
   const chatPlaceholder = useMemo(() => {
     if (pendingRejection) return t('chat.placeholderPendingRejection');
-    if (wasInterrupted && !isLoading && !pendingInterrupt && !pendingRejection)
+    if (wasStopped && !isLoading && !pendingInterrupt && !pendingRejection)
       return t('chat.placeholderInterrupted');
     if (isLoading) return t('chat.placeholderLoading');
     if (hasActiveSubagents) return t('chat.placeholderSubagentsRunning');
     return t('chat.placeholderDefault');
-  }, [pendingRejection, wasInterrupted, isLoading, pendingInterrupt, hasActiveSubagents, t]);
+  }, [pendingRejection, wasStopped, isLoading, pendingInterrupt, hasActiveSubagents, t]);
 
   // Restore steering text to input when agent finishes without consuming it
   useEffect(() => {
@@ -821,17 +823,14 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     }
   }, [workspaceId]);
 
-  // Soft-interrupt handler: pauses main agent while keeping subagents running
-  const handleSoftInterrupt = useCallback(async () => {
-    const tid = currentThreadId || threadId;
-    if (!tid || tid === '__default__') return;
-    try {
-      await softInterruptWorkflow(tid);
-      setWasInterrupted(true);
-    } catch (e) {
-      console.warn('[ChatView] Failed to soft-interrupt workflow:', e);
-    }
-  }, [currentThreadId, threadId]);
+  // Hard-stop handler: terminates the current turn immediately (main agent +
+  // all subagents) while preserving state. The hook's stopWorkflow aborts the
+  // client reader, finalizes the open message, and POSTs /cancel; we flip the
+  // "⏹ Stopped" marker here.
+  const handleStop = useCallback(() => {
+    setWasStopped(true);
+    void stopWorkflow();
+  }, [stopWorkflow]);
 
   // Wrapper: converts ChatInput's (message, planMode, attachments, slashCommands) into
   // handleSendMessage(message, planMode, additionalContext, attachmentMeta)
@@ -953,7 +952,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     const wasLoading = prevLoadingRef.current;
     prevLoadingRef.current = isLoading;
     if (isLoading && !wasLoading) {
-      setWasInterrupted(false);
+      setWasStopped(false);
     }
     if (!isLoading && wasLoading) {
       refreshFiles();
@@ -2471,18 +2470,11 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
                         <span>{t('chat.planFeedbackHint')}</span>
                       </div>
                     )}
-                    {wasInterrupted && !isLoading && !pendingInterrupt && !pendingRejection && (
-                      <div
-                        className="flex items-center gap-2 px-3 py-2 rounded-md text-sm"
-                        style={{ backgroundColor: 'var(--color-loss-soft)', color: 'var(--color-text-tertiary)' }}
-                      >
-                        <StopCircle className="h-4 w-4 flex-shrink-0" style={{ color: 'var(--color-loss)' }} />
-                        <span>{t('chat.interruptedHint')}</span>
-                      </div>
-                    )}
                     {messageError && !isLoading && (
                       <ErrorBanner error={messageError} />
                     )}
+                    {/* Tail mode: main turn finished but a dispatched subagent is
+                        still running in the backend. Independent of stop. */}
                     {hasActiveSubagents && !isLoading && (
                       <div className="flex items-center gap-2 px-3 py-1.5 text-xs text-muted-foreground">
                         <span className="relative flex h-2 w-2">
@@ -2535,7 +2527,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
                       ref={chatInputRef}
                       onSend={handleSendWithAttachments}
                       disabled={isLoadingHistory || !workspaceId || !!pendingInterrupt}
-                      onStop={handleSoftInterrupt}
+                      onStop={handleStop}
                       isLoading={isLoading}
                       placeholder={chatPlaceholder}
                       files={workspaceFiles}

--- a/web/src/pages/ChatAgent/components/MessageList.tsx
+++ b/web/src/pages/ChatAgent/components/MessageList.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useMemo, memo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Bot, User, FileText, FileSearch, ImageIcon, Pencil, RefreshCw, RotateCcw, Copy, Check, Info, ThumbsUp, ThumbsDown } from 'lucide-react';
+import { Bot, User, FileText, FileSearch, ImageIcon, Pencil, RefreshCw, RotateCcw, Copy, Check, Info, ThumbsUp, ThumbsDown, StopCircle } from 'lucide-react';
 import { type WidgetContextPreviewShape } from '@/pages/Dashboard/widgets/framework/WidgetContextPreview';
 import { WidgetContextDeck } from '@/pages/Dashboard/widgets/framework/WidgetContextDeck';
 import { useIsMobile } from '@/hooks/useIsMobile';
@@ -815,6 +815,18 @@ const MessageBubble = memo(function MessageBubble({ message, isLoading, hideAvat
               <FileSearch className="h-3.5 w-3.5" />
               {t('chat.sources.pill', { count: sourceCount })}
             </button>
+          </div>
+        )}
+
+        {/* Per-message "⏹ Stopped" chip — the turn was hard-stopped by the
+            user (live finalize or replay of a stopped turn). */}
+        {isAssistant && (message.stopped as boolean) && (
+          <div
+            className="inline-flex items-center gap-1 self-start px-2 py-0.5 rounded text-xs"
+            style={{ backgroundColor: 'var(--color-loss-soft)', color: 'var(--color-loss)' }}
+          >
+            <StopCircle className="h-3 w-3 flex-shrink-0" />
+            <span>{t('chat.stoppedChip')}</span>
           </div>
         )}
 

--- a/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.stop.test.ts
+++ b/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.stop.test.ts
@@ -102,7 +102,10 @@ describe('useChatMessages — stopWorkflow (hard stop)', () => {
     mockSendStream.mockImplementation(
       async (...args: unknown[]) => {
         const onEvent = args[5] as OnEvent;
-        capturedSignal = args[17] as AbortSignal;
+        // signal is the trailing positional arg of sendChatMessageStream; find
+        // it by type so inserting a new param before it can't silently break
+        // this capture (the mock isn't typed against the real signature).
+        capturedSignal = args.find((a): a is AbortSignal => a instanceof AbortSignal);
         // metadata first (latches run_id), then open a reasoning block.
         onEvent({ event: 'metadata', thread_id: 'th-stop', run_id: 'run-1' });
         onEvent({ event: 'message_chunk', role: 'assistant', agent: 'main', content_type: 'reasoning_signal', content: 'start' });

--- a/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.stop.test.ts
+++ b/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.stop.test.ts
@@ -149,9 +149,11 @@ describe('useChatMessages — stopWorkflow (hard stop)', () => {
     expect(findReasoning(after)?.isReasoning).toBe(false);
     expect((after as { stopped?: boolean }).stopped).toBe(true);
     expect(after.isStreaming).toBe(false);
-    // (c) cancel POSTed once (success → no retry, no toast).
+    // (c) cancel POSTed once (success → no retry, no toast). Second arg is the
+    // run id captured at stop entry, so a slow/retried cancel can't hit a newer
+    // turn (the send latched run-1 from its metadata event).
     expect(mockCancel).toHaveBeenCalledTimes(1);
-    expect(mockCancel).toHaveBeenCalledWith('th-stop');
+    expect(mockCancel).toHaveBeenCalledWith('th-stop', 'run-1');
     expect(toastMock).not.toHaveBeenCalled();
     // No error banner from the aborted stream.
     expect(result.current.messageError).toBeNull();
@@ -382,7 +384,8 @@ describe('useChatMessages — stopWorkflow (hard stop)', () => {
     await act(async () => {
       await result.current.stopWorkflow();
     });
-    expect(mockCancel).toHaveBeenCalledWith('th-a');
+    // Second arg is the run id captured at stop entry (null — none latched).
+    expect(mockCancel).toHaveBeenCalledWith('th-a', null);
 
     // Switch to live thread B → mount effect fires reconnectToStream.
     ws = 'ws-b';

--- a/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.stop.test.ts
+++ b/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.stop.test.ts
@@ -1,0 +1,357 @@
+/**
+ * Tests for the hard-stop flow (stopWorkflow) in useChatMessages.
+ *
+ * stopWorkflow() turns the chat "stop" control into an immediate,
+ * state-preserving hard cancel:
+ *  (a) aborts the main stream reader (the signal threaded into
+ *      sendChatMessageStream) so the stop feels instant;
+ *  (b) finalizes the open assistant message through the real handler pipeline —
+ *      the open reasoning block closes (reasoningComplete) and the message gets
+ *      a `stopped` flag — and clears isLoading;
+ *  (c) POSTs /cancel with ONE retry, then an error toast on failure;
+ *  (d) is idempotent on a double-click (no duplicate synthetic events).
+ *
+ * An aborted stream is swallowed: no error banner, no double cleanup.
+ *
+ * We use the REAL streamEventHandlers so the reasoning-close + stopped flag are
+ * observable on result.current.messages, but mock the api + toast modules.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+import { act, waitFor } from '@testing-library/react';
+import { renderHookWithProviders } from '@/test/utils';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+vi.mock('@/lib/supabase', () => ({ supabase: null }));
+
+vi.mock('../utils/threadStorage', () => ({
+  getStoredThreadId: vi.fn().mockReturnValue(null),
+  setStoredThreadId: vi.fn(),
+  removeStoredThreadId: vi.fn(),
+}));
+
+const toastMock = vi.fn();
+vi.mock('@/components/ui/use-toast', () => ({
+  toast: (...args: unknown[]) => toastMock(...args),
+}));
+
+vi.mock('../../utils/api', () => ({
+  sendChatMessageStream: vi.fn(),
+  sendHitlResponse: vi.fn(),
+  cancelWorkflow: vi.fn().mockResolvedValue({ success: true }),
+  replayThreadHistory: vi.fn().mockResolvedValue(undefined),
+  getWorkflowStatus: vi.fn().mockResolvedValue({ can_reconnect: false, status: 'completed' }),
+  reconnectToWorkflowStream: vi.fn(),
+  streamSubagentTaskEvents: vi.fn(),
+  fetchThreadTurns: vi.fn().mockResolvedValue({ turns: [], retry_checkpoint_id: null }),
+  submitFeedback: vi.fn(),
+  removeFeedback: vi.fn(),
+  getThreadFeedback: vi.fn().mockResolvedValue([]),
+  watchThread: vi.fn(),
+}));
+
+import { sendChatMessageStream, cancelWorkflow, getWorkflowStatus, reconnectToWorkflowStream } from '../../utils/api';
+import { useChatMessages } from '../useChatMessages';
+import type { AssistantMessage } from '@/types/chat';
+
+const mockSendStream = sendChatMessageStream as Mock;
+const mockCancel = cancelWorkflow as Mock;
+const mockStatus = getWorkflowStatus as Mock;
+const mockReconnect = reconnectToWorkflowStream as Mock;
+
+type OnEvent = (e: Record<string, unknown>) => void;
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (v: T) => void;
+}
+function deferred<T>(): Deferred<T> {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => { resolve = r; });
+  return { promise, resolve };
+}
+
+/** Find the open reasoning process across the assistant message. */
+function findReasoning(msg: AssistantMessage | undefined) {
+  if (!msg) return null;
+  const procs = (msg.reasoningProcesses as Record<string, Record<string, unknown>>) || {};
+  const keys = Object.keys(procs);
+  return keys.length ? procs[keys[keys.length - 1]] : null;
+}
+
+describe('useChatMessages — stopWorkflow (hard stop)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCancel.mockResolvedValue({ success: true });
+  });
+
+  /**
+   * Drive a send that opens a reasoning block, then leaves the stream hanging
+   * so isLoading stays true and the reasoning block stays open.
+   * Returns the captured signal + assistant message id + the hang deferred.
+   */
+  async function startHangingSendWithReasoning(
+    result: { current: ReturnType<typeof useChatMessages> },
+  ) {
+    const hang = deferred<{ disconnected: boolean; aborted: boolean }>();
+    let capturedSignal: AbortSignal | undefined;
+
+    mockSendStream.mockImplementation(
+      async (...args: unknown[]) => {
+        const onEvent = args[5] as OnEvent;
+        capturedSignal = args[17] as AbortSignal;
+        // metadata first (latches run_id), then open a reasoning block.
+        onEvent({ event: 'metadata', thread_id: 'th-stop', run_id: 'run-1' });
+        onEvent({ event: 'message_chunk', role: 'assistant', agent: 'main', content_type: 'reasoning_signal', content: 'start' });
+        onEvent({ event: 'message_chunk', role: 'assistant', agent: 'main', content_type: 'reasoning', content: 'thinking hard...' });
+        return hang.promise;
+      },
+    );
+
+    let send: Promise<unknown> = Promise.resolve();
+    await act(async () => {
+      send = result.current.handleSendMessage('analyze AAPL', false);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(true));
+
+    return { hang, getSignal: () => capturedSignal, send };
+  }
+
+  it('aborts the controller, clears isLoading, and closes the open reasoning block synchronously', async () => {
+    const { result } = renderHookWithProviders(() => useChatMessages('ws-stop', 'th-stop'));
+    const { hang, getSignal, send } = await startHangingSendWithReasoning(result);
+
+    // Sanity: the reasoning block is open before stop.
+    const before = result.current.messages.find((m) => m.role === 'assistant') as AssistantMessage;
+    expect(findReasoning(before)?.reasoningComplete).toBeFalsy();
+    expect(getSignal()?.aborted).toBe(false);
+
+    await act(async () => {
+      await result.current.stopWorkflow();
+    });
+
+    // (a) the reader's signal was aborted.
+    expect(getSignal()?.aborted).toBe(true);
+    // (b) loading cleared.
+    expect(result.current.isLoading).toBe(false);
+    // (b) open reasoning block closed + message stamped stopped.
+    const after = result.current.messages.find((m) => m.role === 'assistant') as AssistantMessage;
+    expect(findReasoning(after)?.reasoningComplete).toBe(true);
+    expect(findReasoning(after)?.isReasoning).toBe(false);
+    expect((after as { stopped?: boolean }).stopped).toBe(true);
+    expect(after.isStreaming).toBe(false);
+    // (c) cancel POSTed once (success → no retry, no toast).
+    expect(mockCancel).toHaveBeenCalledTimes(1);
+    expect(mockCancel).toHaveBeenCalledWith('th-stop');
+    expect(toastMock).not.toHaveBeenCalled();
+    // No error banner from the aborted stream.
+    expect(result.current.messageError).toBeNull();
+
+    // Resolve the hanging send as aborted; the finally must not re-toggle state.
+    hang.resolve({ disconnected: false, aborted: true });
+    await act(async () => { await send.catch(() => undefined); });
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.messageError).toBeNull();
+  });
+
+  it('clears the in-flight tool-call "generating" row on stop (no lingering shimmer)', async () => {
+    const { result } = renderHookWithProviders(() => useChatMessages('ws-stop', 'th-stop'));
+
+    const hang = deferred<{ disconnected: boolean; aborted: boolean }>();
+    mockSendStream.mockImplementation(async (...args: unknown[]) => {
+      const onEvent = args[5] as OnEvent;
+      onEvent({ event: 'metadata', thread_id: 'th-stop', run_id: 'run-1' });
+      // An in-flight tool call: args still streaming, no tool_calls completion
+      // and no result — this is what renders the "generating (~N chars)…" shimmer.
+      onEvent({ event: 'tool_call_chunks', tool_call_chunks: [{ name: 'web_search', args: '{"query":"AAPL ' }] });
+      return hang.promise;
+    });
+
+    let send: Promise<unknown> = Promise.resolve();
+    await act(async () => {
+      send = result.current.handleSendMessage('analyze AAPL', false);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(true));
+
+    // Before stop: the preparing tool-call chunks are present (shimmer on).
+    const before = result.current.messages.find((m) => m.role === 'assistant') as AssistantMessage;
+    expect(Object.keys((before.pendingToolCallChunks as Record<string, unknown>) || {}).length).toBeGreaterThan(0);
+
+    await act(async () => {
+      await result.current.stopWorkflow();
+    });
+
+    // After stop: chunks cleared → preparingToolCall is null → no shimmer.
+    const after = result.current.messages.find((m) => m.role === 'assistant') as AssistantMessage;
+    expect(Object.keys((after.pendingToolCallChunks as Record<string, unknown>) || {})).toHaveLength(0);
+    expect((after as { stopped?: boolean }).stopped).toBe(true);
+    expect(after.isStreaming).toBe(false);
+
+    hang.resolve({ disconnected: false, aborted: true });
+    await act(async () => { await send.catch(() => undefined); });
+  });
+
+  it('double-click stop is idempotent (one cancel, no duplicate synthetic events)', async () => {
+    const { result } = renderHookWithProviders(() => useChatMessages('ws-stop', 'th-stop'));
+    const { hang, send } = await startHangingSendWithReasoning(result);
+
+    await act(async () => {
+      await result.current.stopWorkflow();
+      await result.current.stopWorkflow(); // second click no-ops
+    });
+
+    // Only one reasoning process exists (no duplicate synthetic close appended).
+    const after = result.current.messages.find((m) => m.role === 'assistant') as AssistantMessage;
+    const procCount = Object.keys((after.reasoningProcesses as Record<string, unknown>) || {}).length;
+    expect(procCount).toBe(1);
+    // cancel fired exactly once despite two stop calls.
+    expect(mockCancel).toHaveBeenCalledTimes(1);
+
+    hang.resolve({ disconnected: false, aborted: true });
+    await act(async () => { await send.catch(() => undefined); });
+  });
+
+  it('cancel POST failing twice triggers one retry then an error toast', async () => {
+    mockCancel
+      .mockRejectedValueOnce(new Error('net'))
+      .mockRejectedValueOnce(new Error('net again'));
+
+    const { result } = renderHookWithProviders(() => useChatMessages('ws-stop', 'th-stop'));
+    const { hang, send } = await startHangingSendWithReasoning(result);
+
+    await act(async () => {
+      await result.current.stopWorkflow();
+    });
+
+    // Two attempts (original + one retry), then a destructive toast.
+    expect(mockCancel).toHaveBeenCalledTimes(2);
+    expect(toastMock).toHaveBeenCalledTimes(1);
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: 'destructive', description: 'chat.stopFailed' }),
+    );
+    // Stop still cleared loading even though cancel failed.
+    expect(result.current.isLoading).toBe(false);
+
+    hang.resolve({ disconnected: false, aborted: true });
+    await act(async () => { await send.catch(() => undefined); });
+  });
+
+  it('an aborted stream is swallowed — no error banner, no double cleanup', async () => {
+    const { result } = renderHookWithProviders(() => useChatMessages('ws-stop', 'th-stop'));
+    const { hang, send } = await startHangingSendWithReasoning(result);
+
+    await act(async () => {
+      await result.current.stopWorkflow();
+    });
+
+    // Simulate the real api returning the aborted marker for the hung send.
+    hang.resolve({ disconnected: false, aborted: true });
+    await act(async () => { await send.catch(() => undefined); });
+
+    expect(result.current.messageError).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+    // cancel still fired exactly once (the aborted-send finally did not re-run it).
+    expect(mockCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('stop during a reconnect aborts the reconnect reader and skips its cleanup', async () => {
+    // Mount-effect reconnect: status says reconnectable and the reconnect
+    // stream hangs, so we can press stop while the reader is mid-reconnect.
+    mockStatus.mockResolvedValue({ can_reconnect: true, status: 'running', active_tasks: [] });
+
+    const hang = deferred<{ disconnected: boolean; aborted: boolean }>();
+    let reconnectSignal: AbortSignal | undefined;
+    mockReconnect.mockImplementation(async (...args: unknown[]) => {
+      // reconnectToWorkflowStream(threadId, runId, lastEventId, onEvent, signal)
+      reconnectSignal = args[4] as AbortSignal;
+      const onEvent = args[3] as OnEvent;
+      onEvent({ event: 'metadata', thread_id: 'th-stop', run_id: 'run-1' });
+      onEvent({ event: 'message_chunk', role: 'assistant', agent: 'main', content_type: 'reasoning_signal', content: 'start' });
+      onEvent({ event: 'message_chunk', role: 'assistant', agent: 'main', content_type: 'reasoning', content: 'resuming...' });
+      return hang.promise;
+    });
+
+    const { result } = renderHookWithProviders(() => useChatMessages('ws-stop', 'th-stop'));
+
+    // Mount effect kicks off the reconnect.
+    await waitFor(() => expect(result.current.isReconnecting).toBe(true));
+    // The reconnect reader was handed a live, un-aborted signal (the fix:
+    // without it, stopWorkflow's abort would be a no-op during reconnect).
+    expect(reconnectSignal).toBeDefined();
+    expect(reconnectSignal?.aborted).toBe(false);
+
+    await act(async () => {
+      await result.current.stopWorkflow();
+    });
+
+    // Stop aborted the reconnect reader and cleared loading.
+    expect(reconnectSignal?.aborted).toBe(true);
+    expect(result.current.isLoading).toBe(false);
+    expect(mockCancel).toHaveBeenCalledTimes(1);
+
+    // Resolve the hung reader as aborted; the reconnect finally must NOT re-run
+    // cleanupAfterStreamEnd (wasStoppedRef guard) — no error banner, no re-toggle.
+    hang.resolve({ disconnected: false, aborted: true });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    expect(result.current.messageError).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isReconnecting).toBe(false);
+  });
+
+  it('a reconnect after a prior stop runs to completion (resets the stale stop flag)', async () => {
+    // Regression: stopWorkflow sets wasStoppedRef=true and it is only reset on a
+    // new send/resume/steer — NOT on a reconnect. Switching to a live thread B
+    // after stopping thread A drives reconnectToStream with a stale true flag,
+    // which (before the fix) bailed the legitimate reconnect and left isLoading
+    // stuck. reconnectToStream must reset the flag on entry.
+    let ws = 'ws-a';
+    let tid = 'th-a';
+    // Thread A is not reconnectable; thread B is live.
+    mockStatus.mockImplementation(async (t: string) =>
+      t === 'th-b'
+        ? { can_reconnect: true, status: 'running', active_tasks: [] }
+        : { can_reconnect: false, status: 'completed' },
+    );
+    // Thread B's reconnect streams content and completes normally (not aborted).
+    mockReconnect.mockImplementation(async (...args: unknown[]) => {
+      const onEvent = args[3] as OnEvent;
+      onEvent({ event: 'metadata', thread_id: 'th-b', run_id: 'run-b' });
+      onEvent({ event: 'message_chunk', role: 'assistant', agent: 'main', content_type: 'text', content: 'resumed content' });
+      return { disconnected: false, aborted: false };
+    });
+
+    const { result, rerender } = renderHookWithProviders(() => useChatMessages(ws, tid));
+
+    // Stop on thread A with no active turn → sets wasStoppedRef=true (else branch).
+    await act(async () => {
+      await result.current.stopWorkflow();
+    });
+    expect(mockCancel).toHaveBeenCalledWith('th-a');
+
+    // Switch to live thread B → mount effect fires reconnectToStream.
+    ws = 'ws-b';
+    tid = 'th-b';
+    await act(async () => {
+      rerender();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(mockReconnect).toHaveBeenCalled());
+    // The reconnect must complete (NOT bail on the stale flag): loading clears
+    // and the resumed bubble is not left streaming forever.
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    const bubble = result.current.messages.find(
+      (m) => m.role === 'assistant' && (m as AssistantMessage).isStreaming,
+    );
+    expect(bubble).toBeUndefined();
+    expect(result.current.messageError).toBeNull();
+  });
+});

--- a/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.stop.test.ts
+++ b/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.stop.test.ts
@@ -77,7 +77,7 @@ function deferred<T>(): Deferred<T> {
 /** Find the open reasoning process across the assistant message. */
 function findReasoning(msg: AssistantMessage | undefined) {
   if (!msg) return null;
-  const procs = (msg.reasoningProcesses as Record<string, Record<string, unknown>>) || {};
+  const procs = (msg.reasoningProcesses as unknown as Record<string, Record<string, unknown>>) || {};
   const keys = Object.keys(procs);
   return keys.length ? procs[keys[keys.length - 1]] : null;
 }

--- a/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.stop.test.ts
+++ b/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.stop.test.ts
@@ -199,6 +199,51 @@ describe('useChatMessages — stopWorkflow (hard stop)', () => {
     await act(async () => { await send.catch(() => undefined); });
   });
 
+  it('folds an in-progress tool-call process on stop (no row left spinning)', async () => {
+    const { result } = renderHookWithProviders(() => useChatMessages('ws-stop', 'th-stop'));
+
+    const hang = deferred<{ disconnected: boolean; aborted: boolean }>();
+    mockSendStream.mockImplementation(async (...args: unknown[]) => {
+      const onEvent = args[5] as OnEvent;
+      onEvent({ event: 'metadata', thread_id: 'th-stop', run_id: 'run-1' });
+      // A started tool call with no result yet → toolCallProcesses entry with
+      // isInProgress:true. Always-live tools (TaskOutput/WebFetch) render their
+      // spinner off this flag regardless of isStreaming, so it must be folded.
+      onEvent({
+        event: 'tool_calls',
+        tool_calls: [{ id: 'tc-1', name: 'TaskOutput', args: '{}' }],
+        _eventId: 1,
+      });
+      return hang.promise;
+    });
+
+    let send: Promise<unknown> = Promise.resolve();
+    await act(async () => {
+      send = result.current.handleSendMessage('check on the subagent', false);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(true));
+
+    // Before stop: the process is in progress.
+    const before = result.current.messages.find((m) => m.role === 'assistant') as AssistantMessage;
+    const beforeProc = before.toolCallProcesses['tc-1'];
+    expect(beforeProc?.isInProgress).toBe(true);
+
+    await act(async () => {
+      await result.current.stopWorkflow();
+    });
+
+    // After stop: folded to complete so it stops spinning.
+    const after = result.current.messages.find((m) => m.role === 'assistant') as AssistantMessage;
+    const afterProc = after.toolCallProcesses['tc-1'];
+    expect(afterProc?.isInProgress).toBe(false);
+    expect(afterProc?.isComplete).toBe(true);
+
+    hang.resolve({ disconnected: false, aborted: true });
+    await act(async () => { await send.catch(() => undefined); });
+  });
+
   it('double-click stop is idempotent (one cancel, no duplicate synthetic events)', async () => {
     const { result } = renderHookWithProviders(() => useChatMessages('ws-stop', 'th-stop'));
     const { hang, send } = await startHangingSendWithReasoning(result);

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -2797,6 +2797,10 @@ export function useChatMessages(
    */
   const stopWorkflow = async () => {
     const tid = threadIdRef.current;
+    // Capture the run we're stopping NOW, before any await. If the cancel POST
+    // is slow and the user sends a new turn before the retry fires, this keeps
+    // the retry pinned to the stopped run instead of cancelling the new one.
+    const stoppedRunId = currentRunIdRef.current;
     if (wasStoppedRef.current) return; // double-click stop is idempotent
 
     // (a) Abort the main reader NOW so the stop feels instant. The aborted
@@ -2834,10 +2838,10 @@ export function useChatMessages(
     // toast so a failed cancel doesn't silently diverge UI from backend.
     if (tid && tid !== '__default__') {
       try {
-        await cancelWorkflow(tid);
+        await cancelWorkflow(tid, stoppedRunId);
       } catch {
         try {
-          await cancelWorkflow(tid);
+          await cancelWorkflow(tid, stoppedRunId);
         } catch {
           toast({ description: t('chat.stopFailed'), variant: 'destructive' });
         }

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -2221,8 +2221,12 @@ export function useChatMessages(
     } finally {
       setIsReconnecting(false);
 
-      // Clean up empty reconnect messages (no content segments = nothing was streamed)
+      // Clean up empty reconnect messages (no content segments = nothing was
+      // streamed). Skip on a user stop: finalizeStreamingMessage just stamped
+      // this bubble `stopped: true` (with the "⏹ Stopped" chip) but left it
+      // content-empty, so removing it here would erase the stop marker.
       setMessages((prev) => {
+        if (wasStoppedRef.current) return prev;
         const msg = prev.find((m) => m.id === assistantMessageId);
         if (msg && msg.role === 'assistant' && (!(msg as AssistantMessage).contentSegments || (msg as AssistantMessage).contentSegments.length === 0) && !msg.content) {
           return prev.filter((m) => m.id !== assistantMessageId);
@@ -2714,14 +2718,21 @@ export function useChatMessages(
       setMessages: setMessagesForHandlers,
     });
 
-    // Stamp the stopped flag so the per-message "⏹ Stopped" chip renders, and
-    // force isStreaming off (defensive: covers any branch that left it on).
+    // Stamp the stopped flag so the per-message "⏹ Stopped" chip renders, force
+    // isStreaming off (defensive: covers any branch that left it on), and fold
+    // any still-in-progress tool rows. Always-live tools (TaskOutput/WebFetch)
+    // render their spinner off `isInProgress` regardless of `isStreaming`, so
+    // without this they'd spin forever after the stop. Mirrors the steering
+    // finalize.
     setMessages((prev) =>
-      updateMessage(prev, assistantMessageId, (msg) => ({
-        ...msg,
-        isStreaming: false,
-        stopped: true,
-      })),
+      updateMessage(prev, assistantMessageId, (msg) => {
+        const aMsg = msg as AssistantMessage;
+        const tp: typeof aMsg.toolCallProcesses = {};
+        for (const [id, val] of Object.entries(aMsg.toolCallProcesses || {})) {
+          tp[id] = val.isInProgress ? { ...val, isInProgress: false, isComplete: true } : val;
+        }
+        return { ...aMsg, isStreaming: false, stopped: true, toolCallProcesses: tp };
+      }),
     );
 
     // Finalize each active subagent card: close its open reasoning block and
@@ -2754,13 +2765,18 @@ export function useChatMessages(
         taskRefs.messages = msgs;
         taskRefs.currentReasoningIdRef.current = null;
       }
-      // Mark the subagent's last streaming message complete + stopped, and
-      // clear any in-flight tool-call chunks so its preparing row stops
-      // shimmering (same finalize as the main message).
+      // Mark the subagent's last streaming message complete + stopped, clear any
+      // in-flight tool-call chunks so its preparing row stops shimmering, and
+      // fold still-in-progress tool rows (same finalize as the main message).
       const msgs = [...taskRefs.messages];
       for (let i = msgs.length - 1; i >= 0; i--) {
         if (msgs[i].role === 'assistant' && msgs[i].isStreaming) {
-          msgs[i] = { ...msgs[i], isStreaming: false, stopped: true, pendingToolCallChunks: {} };
+          const tcp = (msgs[i].toolCallProcesses as Record<string, Record<string, unknown>>) || {};
+          const tp: Record<string, Record<string, unknown>> = {};
+          for (const [id, val] of Object.entries(tcp)) {
+            tp[id] = val.isInProgress ? { ...val, isInProgress: false, isComplete: true } : val;
+          }
+          msgs[i] = { ...msgs[i], isStreaming: false, stopped: true, pendingToolCallChunks: {}, toolCallProcesses: tp };
           break;
         }
       }
@@ -2800,6 +2816,11 @@ export function useChatMessages(
     }
     setIsLoading(false);
     setHasActiveSubagents(false);
+    // Stopping mid-bringup or mid-compaction must clear these too — otherwise a
+    // stuck "starting sandbox" / "compacting" indicator outlives the stop.
+    // cleanupAfterStreamEnd resets them, but the stop path skips that cleanup.
+    setWorkspaceStarting(false);
+    setIsCompacting(false);
     isStreamingRef.current = false;
     currentMessageRef.current = null;
 
@@ -4163,11 +4184,17 @@ export function useChatMessages(
         reasoningEffort || null,
         fastMode || null,
         platform,
-        // Latch run_id from Content-Location BEFORE the first SSE body byte —
-        // closes the reconnect race window if the stream drops between our
-        // pre-POST clear (line ~3916) and the new turn's first metadata event.
-        (runId) => {
+        // Latch run_id AND the server-assigned thread_id from Content-Location
+        // BEFORE the first SSE body byte. run_id closes the reconnect race
+        // window; the thread_id latch lets an early stop on a brand-new thread
+        // ('__default__' until the first event) still hard-cancel the backend
+        // run instead of skipping cancel. The first event still drives the
+        // route/storage update (see the thread_id branch in processEvent).
+        (runId, resolvedThreadId) => {
           currentRunIdRef.current = runId;
+          if (resolvedThreadId && resolvedThreadId !== '__default__') {
+            threadIdRef.current = resolvedThreadId;
+          }
         },
         abortController.signal,
       );

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -3887,6 +3887,12 @@ export function useChatMessages(
     let pendingRunIdFromHeader: string | null = null;
 
     const demoteToNewTurn = (): void => {
+      // If the user already hit stop, do NOT promote this in-flight steering
+      // POST into a fresh turn: clearing wasStoppedRef + re-enabling the
+      // spinner here would make the stop look undone (the backend tore the
+      // prior turn down and routed this POST as new). Drop it instead — the
+      // finally below honors wasStoppedRef and returns.
+      if (wasStoppedRef.current) return;
       demotedToNewTurn = true;
       if (pendingRunIdFromHeader) {
         currentRunIdRef.current = pendingRunIdFromHeader;
@@ -4285,7 +4291,19 @@ export function useChatMessages(
           if (mainStreamAbortRef.current === abortController) {
             mainStreamAbortRef.current = null;
           }
-          if (!wasDisconnected && !wasInterruptedRef.current && !wasStoppedRef.current) {
+          // wasStoppedRef is shared across streams: if the user stopped THIS
+          // stream then sent a new one, the new send resets wasStoppedRef to
+          // false, so this stale finally would otherwise run cleanup against
+          // currentMessageRef — now the NEW stream's message — clobbering it
+          // mid-flight. The per-stream abort signal is the reliable guard: an
+          // aborted stream's teardown is always owned elsewhere (stopWorkflow
+          // or the superseding send), never this finally.
+          if (
+            !wasDisconnected &&
+            !wasInterruptedRef.current &&
+            !wasStoppedRef.current &&
+            !abortController.signal.aborted
+          ) {
             // Mark message as complete (use live ref in case steering_delivered switched it)
             const finalId = currentMessageRef.current || assistantMessageId;
             setMessages((prev) =>

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -10,7 +10,8 @@ import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
 import { queryKeys } from '@/lib/queryKeys';
 import { useUser } from '@/hooks/useUser';
-import { sendChatMessageStream, replayThreadHistory, getWorkflowStatus, reconnectToWorkflowStream, sendHitlResponse, streamSubagentTaskEvents, fetchThreadTurns, submitFeedback, removeFeedback, getThreadFeedback, watchThread } from '../utils/api';
+import { sendChatMessageStream, replayThreadHistory, getWorkflowStatus, reconnectToWorkflowStream, sendHitlResponse, streamSubagentTaskEvents, fetchThreadTurns, submitFeedback, removeFeedback, getThreadFeedback, watchThread, cancelWorkflow } from '../utils/api';
+import { toast } from '@/components/ui/use-toast';
 import { buildRateLimitError, isUpstreamHint, type StructuredError } from '@/utils/rateLimitError';
 import { getStoredThreadId, setStoredThreadId } from './utils/threadStorage';
 import { countToolCalls } from '../utils/subagentMetrics';
@@ -558,6 +559,14 @@ export function useChatMessages(
   const currentReasoningIdRef = useRef<string | null>(null);
   const currentToolCallIdRef = useRef<string | null>(null);
   const steeringAtOrderRef = useRef<number | null>(null); // Shared across streams for steering rollback
+  // AbortController for the active main-agent stream. stopWorkflow() aborts it so
+  // the client-side reader stops immediately (instant stop) — the matching POST
+  // /cancel tears down the backend run. Null when no main stream is in flight.
+  const mainStreamAbortRef = useRef<AbortController | null>(null);
+  // Guards finalizeStreamingMessage / stopWorkflow so a double-click stop (or
+  // handler re-entry) doesn't append duplicate synthetic close events. Cleared
+  // on the next send.
+  const wasStoppedRef = useRef(false);
 
   // Refs for history loading state
   const historyLoadingRef = useRef(false);
@@ -2001,6 +2010,12 @@ export function useChatMessages(
     setIsLoading(true);
     setIsReconnecting(true);
     isStreamingRef.current = true;
+    // Fresh stream: clear any stale stop flag from a PRIOR turn (e.g. user
+    // hard-stopped thread A, then switched to live thread B). Without this the
+    // stop-during-reconnect guards below (result.aborted || wasStoppedRef) would
+    // bail this legitimate reconnect and leave isLoading stuck. Matches the reset
+    // every other stream entry point does (handleSendMessage, resume, steering).
+    wasStoppedRef.current = false;
 
     // Create assistant message placeholder for reconnection
     const assistantMessageId = `assistant-reconnect-${Date.now()}`;
@@ -2118,6 +2133,14 @@ export function useChatMessages(
     const wasInterruptedRef = { current: false };
     const processEvent = createStreamEventProcessor(assistantMessageId, refs, getTaskIdFromEvent, wasInterruptedRef);
 
+    // Register the reconnect reader on mainStreamAbortRef so a user stop aborts
+    // it. Without this, stopWorkflow's abort is a no-op during a reconnect: the
+    // reader keeps consuming SSE + mutating messages and the finally below
+    // re-runs cleanup (re-toggling isLoading / re-opening report-back) after the
+    // stop already tore everything down.
+    const abortController = new AbortController();
+    mainStreamAbortRef.current = abortController;
+
     try {
       // Replay buffered events first — this processes artifact{task,spawned} events
       // which create subagent cards with the correct description/type. Per-task streams
@@ -2127,7 +2150,12 @@ export function useChatMessages(
         currentRunIdRef.current,
         lastEventIdRef.current as number | null,
         processEvent,
+        abortController.signal,
       );
+      // User stop aborted the reader — stopWorkflow owns teardown; bail.
+      if (result?.aborted || wasStoppedRef.current) {
+        return;
+      }
       if (result?.disconnected) {
         throw new Error('Reconnection stream disconnected');
       }
@@ -2177,6 +2205,11 @@ export function useChatMessages(
         }
       }
     } catch (err: unknown) {
+      // User stop aborted the reader — stopWorkflow owns teardown; bail before
+      // surfacing this as a reconnect error.
+      if ((err as Error)?.name === 'AbortError' || wasStoppedRef.current) {
+        return;
+      }
       // 404/410 = workflow no longer available, not a real error
       const status = (err as Error).message?.match(/status:\s*(\d+)/)?.[1];
       if (status === '404' || status === '410') {
@@ -2197,8 +2230,14 @@ export function useChatMessages(
         return prev;
       });
 
-      if (!wasInterruptedRef.current) {
+      // Skip cleanup on a user stop — stopWorkflow already cleared isLoading /
+      // hasActiveSubagents and ran finalize; re-running it here would re-toggle
+      // loading and re-open the report-back watch after the stop.
+      if (!wasInterruptedRef.current && !wasStoppedRef.current) {
         cleanupAfterStreamEnd(assistantMessageId);
+      }
+      if (mainStreamAbortRef.current === abortController) {
+        mainStreamAbortRef.current = null;
       }
     }
   };
@@ -2624,6 +2663,164 @@ export function useChatMessages(
     // Open watch connection for report-back if a PTC agent was dispatched with report_back enabled
     if (awaitingReportBackRef.current) {
       startReportBackWatch();
+    }
+  };
+
+  /**
+   * Synthesizes terminal events for a stopped turn and dispatches them through
+   * the EXISTING handler pipeline so the open streaming structures close the
+   * same way a server-driven terminal event would (no hand-rolled state
+   * surgery). Aborting the reader means no server terminal event arrives, so
+   * without this the open blocks would render "thinking"/half-streamed forever.
+   *
+   * Closes, for the main message: the open reasoning block (synthetic
+   * `reasoning_signal: 'complete'` via handleReasoningSignal) and the message
+   * itself (synthetic `finish_reason: 'stopped'` via the handleTextContent
+   * finishReason branch). Also stamps a `stopped` flag for the per-message chip.
+   * Then closes every active subagent card's open reasoning + marks its last
+   * streaming message complete.
+   *
+   * Idempotent: guarded by wasStoppedRef so a double-stop (or re-entry) is a
+   * no-op and synthetic closes can't append twice.
+   */
+  const finalizeStreamingMessage = (assistantMessageId: string) => {
+    if (wasStoppedRef.current) return;
+    wasStoppedRef.current = true;
+
+    const refs = {
+      contentOrderCounterRef,
+      currentReasoningIdRef,
+      currentToolCallIdRef,
+      steeringAtOrderRef,
+      subagentStateRefs: subagentStateRefsRef.current,
+    };
+
+    // Close the main message's open reasoning block (no-op if none open).
+    handleReasoningSignal({
+      assistantMessageId,
+      signalContent: 'complete',
+      refs,
+      setMessages: setMessagesForHandlers,
+    });
+
+    // Drive the message to a terminal "stopped" state through the same
+    // finishReason branch the server stream uses. This flips isStreaming off
+    // for any open tool-call/artifact rendering that keyed off isStreaming.
+    handleTextContent({
+      assistantMessageId,
+      content: '',
+      finishReason: 'stopped',
+      refs,
+      setMessages: setMessagesForHandlers,
+    });
+
+    // Stamp the stopped flag so the per-message "⏹ Stopped" chip renders, and
+    // force isStreaming off (defensive: covers any branch that left it on).
+    setMessages((prev) =>
+      updateMessage(prev, assistantMessageId, (msg) => ({
+        ...msg,
+        isStreaming: false,
+        stopped: true,
+      })),
+    );
+
+    // Finalize each active subagent card: close its open reasoning block and
+    // mark its last streaming message complete. Per-task state lives in
+    // subagentStateRefsRef, separate from the main message refs.
+    const activeShortIds = new Set(subagentStreamsRef.current.keys());
+    for (const shortId of activeShortIds) {
+      const agentId = `task:${shortId}`;
+      const taskRefs = subagentStateRefsRef.current[agentId];
+      if (!taskRefs) continue;
+      // Close an open subagent reasoning block.
+      if (taskRefs.currentReasoningIdRef.current) {
+        const reasoningId = taskRefs.currentReasoningIdRef.current;
+        const msgs = [...taskRefs.messages];
+        for (let i = msgs.length - 1; i >= 0; i--) {
+          const rp = (msgs[i].reasoningProcesses as Record<string, Record<string, unknown>>) || {};
+          if (rp[reasoningId]) {
+            const next = { ...rp };
+            next[reasoningId] = {
+              ...next[reasoningId],
+              isReasoning: false,
+              reasoningComplete: true,
+              reasoningTitle: null,
+              _completedAt: Date.now(),
+            };
+            msgs[i] = { ...msgs[i], reasoningProcesses: next };
+            break;
+          }
+        }
+        taskRefs.messages = msgs;
+        taskRefs.currentReasoningIdRef.current = null;
+      }
+      // Mark the subagent's last streaming message complete + stopped, and
+      // clear any in-flight tool-call chunks so its preparing row stops
+      // shimmering (same finalize as the main message).
+      const msgs = [...taskRefs.messages];
+      for (let i = msgs.length - 1; i >= 0; i--) {
+        if (msgs[i].role === 'assistant' && msgs[i].isStreaming) {
+          msgs[i] = { ...msgs[i], isStreaming: false, stopped: true, pendingToolCallChunks: {} };
+          break;
+        }
+      }
+      taskRefs.messages = msgs;
+      if (updateSubagentCard) {
+        updateSubagentCard(agentId, { messages: taskRefs.messages, status: 'completed', isActive: false });
+      }
+    }
+  };
+
+  /**
+   * Hard stop: terminates the current turn immediately while preserving state.
+   * (a) aborts the main reader (stop feels instant); (b) finalizes the open
+   * message to a stopped state + clears loading + active-subagent flag;
+   * (c) aborts per-task subagent streams + the report-back watch; (d) fires
+   * POST /cancel with one retry, then an error toast on failure so a diverged
+   * UI/backend state is visible. Double-stop is a no-op (wasStoppedRef guard).
+   */
+  const stopWorkflow = async () => {
+    const tid = threadIdRef.current;
+    if (wasStoppedRef.current) return; // double-click stop is idempotent
+
+    // (a) Abort the main reader NOW so the stop feels instant. The aborted
+    // stream resolves with { aborted: true } and the send finally skips
+    // cleanup (it checks wasStoppedRef), so we own the teardown here.
+    mainStreamAbortRef.current?.abort();
+    mainStreamAbortRef.current = null;
+
+    // (b) Finalize the open message (closes reasoning/tool/artifact + stopped
+    // chip) and clear loading + the active-subagent indicator. finalizeStreaming-
+    // Message sets wasStoppedRef, so this whole block runs at most once.
+    const finalId = currentMessageRef.current;
+    if (finalId) {
+      finalizeStreamingMessage(finalId);
+    } else {
+      wasStoppedRef.current = true;
+    }
+    setIsLoading(false);
+    setHasActiveSubagents(false);
+    isStreamingRef.current = false;
+    currentMessageRef.current = null;
+
+    // (c) Abort per-task subagent streams + the report-back watch so no
+    // background work lingers on the client after the stop.
+    closeAllSubagentStreams();
+    stopReportBackWatch();
+    awaitingReportBackRef.current = false;
+
+    // (d) Tell the backend to hard-cancel: one retry, then a visible error
+    // toast so a failed cancel doesn't silently diverge UI from backend.
+    if (tid && tid !== '__default__') {
+      try {
+        await cancelWorkflow(tid);
+      } catch {
+        try {
+          await cancelWorkflow(tid);
+        } catch {
+          toast({ description: t('chat.stopFailed'), variant: 'destructive' });
+        }
+      }
     }
   };
 
@@ -3657,6 +3854,10 @@ export function useChatMessages(
     let demotedProcessor: ((event: SSEEvent) => void) | null = null;
     let demotedAssistantId: string | null = null;
     const demotedInterruptedRef = { current: false };
+    // Controller for the steering POST. If this POST is demoted to a fresh
+    // turn it becomes the active main stream, so we register it on
+    // mainStreamAbortRef in demoteToNewTurn — stopWorkflow can then abort it.
+    const steeringAbort = new AbortController();
     // Stash the Content-Location run_id but DO NOT commit it to
     // currentRunIdRef until we've seen evidence that this POST actually
     // started a new workflow (i.e., demoteToNewTurn fires). Committing
@@ -3689,6 +3890,10 @@ export function useChatMessages(
       currentMessageRef.current = newAssistantId;
       isStreamingRef.current = true;
       setIsLoading(true);
+      // This demoted POST is now the active main turn; clear the stopped guard
+      // and register its controller so stopWorkflow can abort it.
+      wasStoppedRef.current = false;
+      mainStreamAbortRef.current = steeringAbort;
       const refs = {
         contentOrderCounterRef,
         currentReasoningIdRef,
@@ -3760,7 +3965,15 @@ export function useChatMessages(
         (runId) => {
           pendingRunIdFromHeader = runId;
         },
+        steeringAbort.signal,
       );
+      if (mainStreamAbortRef.current === steeringAbort) {
+        mainStreamAbortRef.current = null;
+      }
+      // User hit stop on the demoted turn: stopWorkflow owns the teardown.
+      if (wasStoppedRef.current) {
+        return;
+      }
       if (demotedToNewTurn) {
         const finalId = currentMessageRef.current || demotedAssistantId;
         if (finalId) {
@@ -3776,6 +3989,12 @@ export function useChatMessages(
         }
       }
     } catch (err: unknown) {
+      if (mainStreamAbortRef.current === steeringAbort) {
+        mainStreamAbortRef.current = null;
+      }
+      if ((err as Error)?.name === 'AbortError' || wasStoppedRef.current) {
+        return;
+      }
       console.error('Error sending steering:', err);
       if (demotedToNewTurn && demotedAssistantId) {
         // Demoted path: the failure belongs to the new turn's assistant, not the steering badge.
@@ -3882,6 +4101,8 @@ export function useChatMessages(
     setMessageError(null);
     setHasActiveSubagents(false);
     completedTaskIdsRef.current.clear();
+    // Clear the stopped guard so a fresh send can finalize again on stop.
+    wasStoppedRef.current = false;
     // Mark streaming as in progress to prevent history loading during streaming
     isStreamingRef.current = true;
 
@@ -3895,6 +4116,9 @@ export function useChatMessages(
     // it. Prevents a stale run_id from biasing a reconnect into an older
     // ``workflow:stream:{tid}:{rid}`` key.
     currentRunIdRef.current = null;
+    // Fresh AbortController so stopWorkflow can abort this stream's reader.
+    const abortController = new AbortController();
+    mainStreamAbortRef.current = abortController;
 
     const assistantMessage = createAssistantMessage(assistantMessageId);
 
@@ -3945,7 +4169,14 @@ export function useChatMessages(
         (runId) => {
           currentRunIdRef.current = runId;
         },
+        abortController.signal,
       );
+
+      // The user hit stop: stopWorkflow already finalized the message and ran
+      // teardown. Skip reconnect/cleanup so we don't double-fire.
+      if (result?.aborted || wasStoppedRef.current) {
+        return;
+      }
 
       if (result?.disconnected) {
         console.log('[Send] Stream disconnected, attempting reconnect');
@@ -3965,6 +4196,12 @@ export function useChatMessages(
         );
       }
     } catch (err: unknown) {
+          // An aborted stream (user hit stop) is intentional, not a failure.
+          // streamFetch normally swallows AbortError and returns { aborted },
+          // but guard here too so a stop never surfaces an error banner.
+          if ((err as Error)?.name === 'AbortError' || wasStoppedRef.current) {
+            return;
+          }
           // Handle rate limit (429) — show limit message and remove optimistic assistant message
           const errObj = err as Record<string, unknown>;
           if (errObj.status === 429) {
@@ -4015,7 +4252,13 @@ export function useChatMessages(
             }
           }
         } finally {
-          if (!wasDisconnected && !wasInterruptedRef.current) {
+          // Skip cleanup on a user stop — stopWorkflow owns the teardown and a
+          // second cleanup here would re-toggle loading/subagent state. Also
+          // clear the abort ref so a later stop can't abort a finished stream.
+          if (mainStreamAbortRef.current === abortController) {
+            mainStreamAbortRef.current = null;
+          }
+          if (!wasDisconnected && !wasInterruptedRef.current && !wasStoppedRef.current) {
             // Mark message as complete (use live ref in case steering_delivered switched it)
             const finalId = currentMessageRef.current || assistantMessageId;
             setMessages((prev) =>
@@ -4055,7 +4298,11 @@ export function useChatMessages(
 
     setIsLoading(true);
     setMessageError(null);
+    wasStoppedRef.current = false;
     isStreamingRef.current = true;
+    // Fresh AbortController so stopWorkflow can abort this resumed stream.
+    const abortController = new AbortController();
+    mainStreamAbortRef.current = abortController;
 
     // Prepare refs for event handlers — use persistent subagent state
     const refs = {
@@ -4084,13 +4331,19 @@ export function useChatMessages(
         agentMode,
         // Latch the fresh run_id from response headers before the first SSE
         // body byte. Without this, an early disconnect (between the pre-POST
-        // clear at line ~4063 and the metadata frame) would let
-        // attemptReconnectAfterDisconnect fall back to the prior
-        // SOFT_INTERRUPTED TaskInfo and silently hang.
+        // clear above and the metadata frame) would let
+        // attemptReconnectAfterDisconnect fall back to the prior run's
+        // TaskInfo and silently hang.
         (runId) => {
           currentRunIdRef.current = runId;
         },
+        abortController.signal,
       );
+
+      // User hit stop: stopWorkflow already finalized + tore down.
+      if (result?.aborted || wasStoppedRef.current) {
+        return;
+      }
 
       if (result?.disconnected) {
         console.log('[HITL] Stream disconnected, attempting reconnect');
@@ -4110,6 +4363,9 @@ export function useChatMessages(
         );
       }
     } catch (err: unknown) {
+      if ((err as Error)?.name === 'AbortError' || wasStoppedRef.current) {
+        return;
+      }
       console.error('[HITL] Error resuming workflow:', err);
       setMessageError((err as Error).message || 'Failed to resume workflow');
       setMessages((prev) =>
@@ -4121,7 +4377,10 @@ export function useChatMessages(
         }))
       );
     } finally {
-      if (!wasDisconnected && !wasInterruptedRef.current) {
+      if (mainStreamAbortRef.current === abortController) {
+        mainStreamAbortRef.current = null;
+      }
+      if (!wasDisconnected && !wasInterruptedRef.current && !wasStoppedRef.current) {
         const finalId = currentMessageRef.current || assistantMessageId;
         cleanupAfterStreamEnd(finalId);
       }
@@ -4375,6 +4634,7 @@ export function useChatMessages(
     setMessageError(null);
     setHasActiveSubagents(false);
     completedTaskIdsRef.current.clear();
+    wasStoppedRef.current = false;
     isStreamingRef.current = true;
 
     // Truncate messages and add new user message (if editing) + assistant placeholder
@@ -4385,6 +4645,9 @@ export function useChatMessages(
     // Edit/regenerate opens a fresh backend run; clear the prior run_id so
     // the new metadata frame becomes the source of truth.
     currentRunIdRef.current = null;
+    // Fresh AbortController so stopWorkflow can abort this stream's reader.
+    const abortController = new AbortController();
+    mainStreamAbortRef.current = abortController;
 
     const assistantMessage = createAssistantMessage(assistantMessageId);
     const userMessage = message ? createUserMessage(message) : null;
@@ -4443,7 +4706,13 @@ export function useChatMessages(
         (runId) => {
           currentRunIdRef.current = runId;
         },
+        abortController.signal,
       );
+
+      // User hit stop: stopWorkflow already finalized + tore down.
+      if (result?.aborted || wasStoppedRef.current) {
+        return;
+      }
 
       if (result?.disconnected) {
         wasDisconnected = true;
@@ -4459,6 +4728,9 @@ export function useChatMessages(
         }))
       );
     } catch (err: unknown) {
+      if ((err as Error)?.name === 'AbortError' || wasStoppedRef.current) {
+        return;
+      }
       console.error('[streamFromCheckpoint] Error:', err);
       setMessageError((err as Error).message || 'Failed to process request');
       setMessages((prev) =>
@@ -4470,7 +4742,10 @@ export function useChatMessages(
         }))
       );
     } finally {
-      if (!wasDisconnected && !wasInterruptedRef.current) {
+      if (mainStreamAbortRef.current === abortController) {
+        mainStreamAbortRef.current = null;
+      }
+      if (!wasDisconnected && !wasInterruptedRef.current && !wasStoppedRef.current) {
         const finalId = currentMessageRef.current || assistantMessageId;
         setMessages((prev) =>
           updateMessage(prev,finalId, (msg) => ({
@@ -4654,6 +4929,7 @@ export function useChatMessages(
     returnedSteering,
     clearReturnedSteering: () => setReturnedSteering(null),
     handleSendMessage,
+    stopWorkflow,
     pendingInterrupt,
     pendingRejection,
     handleApproveInterrupt,

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -2839,7 +2839,11 @@ export function useChatMessages(
     if (tid && tid !== '__default__') {
       try {
         await cancelWorkflow(tid, stoppedRunId);
-      } catch {
+      } catch (firstErr) {
+        // Log the first failure — when both attempts fail the toast only
+        // reflects the second, so a degraded-network first error would
+        // otherwise vanish from diagnostics.
+        console.warn('[stopWorkflow] cancel failed, retrying once:', firstErr);
         try {
           await cancelWorkflow(tid, stoppedRunId);
         } catch {

--- a/web/src/pages/ChatAgent/hooks/utils/__tests__/historyEventHandlers.stopped.test.ts
+++ b/web/src/pages/ChatAgent/hooks/utils/__tests__/historyEventHandlers.stopped.test.ts
@@ -1,0 +1,88 @@
+/**
+ * History replay of a stopped turn.
+ *
+ * A hard-stopped turn persists synthetic close events to sse_events:
+ *   reasoning_signal:"complete"  → closes the reasoning block
+ *   finish_reason:"stopped"      → stamps the message stopped
+ *
+ * On reload these flow through handleHistoryReasoningSignal /
+ * handleHistoryTextContent with no special-casing, so the replayed message
+ * renders the closed reasoning fragment + the per-message "⏹ Stopped" chip
+ * (driven by the `stopped` flag) — matching the live finalize.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  handleHistoryReasoningSignal,
+  handleHistoryReasoningContent,
+  handleHistoryTextContent,
+} from '../historyEventHandlers';
+import type { MessageRecord } from '../types';
+
+interface PairState {
+  contentOrderCounter: number;
+  reasoningId: string | null;
+  toolCallId: string | null;
+}
+
+function makeStore(initial: MessageRecord[]) {
+  const store = { messages: initial.slice() };
+  const setMessages = (
+    updater: ((prev: MessageRecord[]) => MessageRecord[]) | MessageRecord[],
+  ) => {
+    store.messages = typeof updater === 'function' ? updater(store.messages) : updater;
+  };
+  return { store, setMessages };
+}
+
+describe('historyEventHandlers — stopped turn replay', () => {
+  it('renders a closed reasoning fragment and stamps the message stopped', () => {
+    const assistantMessageId = 'history-assistant-0';
+    const { store, setMessages } = makeStore([
+      {
+        id: assistantMessageId,
+        role: 'assistant',
+        content: '',
+        contentType: 'text',
+        isStreaming: false,
+        isHistory: true,
+        contentSegments: [],
+        reasoningProcesses: {},
+        toolCallProcesses: {},
+      },
+    ]);
+    const pairState: PairState = { contentOrderCounter: 0, reasoningId: null, toolCallId: null };
+
+    // Replay: reasoning starts, gets content, then the synthetic close events.
+    handleHistoryReasoningSignal({ assistantMessageId, signalContent: 'start', pairIndex: 0, pairState, setMessages });
+    handleHistoryReasoningContent({ assistantMessageId, content: 'partial thought before stop', pairState, setMessages });
+    handleHistoryReasoningSignal({ assistantMessageId, signalContent: 'complete', pairIndex: 0, pairState, setMessages });
+    // Synthetic terminal: finish_reason "stopped" with no content.
+    handleHistoryTextContent({ assistantMessageId, content: '', finishReason: 'stopped', pairState, setMessages });
+
+    const msg = store.messages.find((m) => m.id === assistantMessageId)!;
+    const procs = msg.reasoningProcesses as Record<string, Record<string, unknown>>;
+    const reasoning = procs[Object.keys(procs)[0]];
+
+    // The reasoning fragment is closed (not stuck "thinking"), with its content.
+    expect(reasoning.reasoningComplete).toBe(true);
+    expect(reasoning.isReasoning).toBe(false);
+    expect(reasoning.content).toContain('partial thought before stop');
+    // The message is stamped stopped (drives the chip) and not streaming.
+    expect((msg as { stopped?: boolean }).stopped).toBe(true);
+    expect(msg.isStreaming).toBe(false);
+  });
+
+  it('a normal (non-stopped) finish_reason does NOT stamp stopped', () => {
+    const assistantMessageId = 'history-assistant-1';
+    const { store, setMessages } = makeStore([
+      { id: assistantMessageId, role: 'assistant', content: 'done', isStreaming: false, reasoningProcesses: {} },
+    ]);
+    const pairState: PairState = { contentOrderCounter: 0, reasoningId: null, toolCallId: null };
+
+    handleHistoryTextContent({ assistantMessageId, content: '', finishReason: 'stop', pairState, setMessages });
+
+    const msg = store.messages.find((m) => m.id === assistantMessageId)!;
+    expect((msg as { stopped?: boolean }).stopped).toBeUndefined();
+    expect(msg.isStreaming).toBe(false);
+  });
+});

--- a/web/src/pages/ChatAgent/hooks/utils/historyEventHandlers.ts
+++ b/web/src/pages/ChatAgent/hooks/utils/historyEventHandlers.ts
@@ -353,10 +353,14 @@ export function handleHistoryTextContent({ assistantMessageId, content, finishRe
     );
     return true;
   } else if (finishReason) {
+    // A stopped turn persists a synthetic finish_reason:"stopped" — stamp the
+    // message so the per-message "⏹ Stopped" chip renders on reload, matching
+    // the live finalize. Any other finish_reason just closes the message.
+    const isStopped = finishReason === 'stopped';
     setMessages((prev: MessageRecord[]) =>
       prev.map((msg: MessageRecord) =>
         msg.id === assistantMessageId
-          ? { ...msg, isStreaming: false }
+          ? { ...msg, isStreaming: false, ...(isStopped ? { stopped: true } : {}) }
           : msg
       )
     );

--- a/web/src/pages/ChatAgent/hooks/utils/streamEventHandlers.ts
+++ b/web/src/pages/ChatAgent/hooks/utils/streamEventHandlers.ts
@@ -275,11 +275,16 @@ export function handleTextContent({ assistantMessageId, content, finishReason, r
       // Message is requesting tool calls, don't mark as complete yet
       return false; // Let tool_calls handler process this
     } else if (!content) {
-      // Metadata chunk with finish_reason but no content
+      // Metadata chunk with finish_reason but no content. A "stopped" reason
+      // (synthetic from a user stop, live or replayed) also stamps the message
+      // so the per-message "⏹ Stopped" chip renders, and clears any in-flight
+      // tool-call chunks so the "generating (~N chars)…" preparing row stops
+      // shimmering (the partial tool call never completed and is discarded).
+      const isStopped = finishReason === 'stopped';
       setMessages((prev: MessageRecord[]) =>
         prev.map((msg: MessageRecord) =>
           msg.id === assistantMessageId
-            ? { ...msg, isStreaming: false }
+            ? { ...msg, isStreaming: false, ...(isStopped ? { stopped: true, pendingToolCallChunks: {} } : {}) }
             : msg
         )
       );

--- a/web/src/pages/ChatAgent/utils/__tests__/api.stop.test.ts
+++ b/web/src/pages/ChatAgent/utils/__tests__/api.stop.test.ts
@@ -45,7 +45,10 @@ describe('cancelWorkflow', () => {
   it('POSTs to /threads/{id}/cancel and returns response data', async () => {
     mockPost.mockResolvedValue({ data: { success: true } });
     const result = await cancelWorkflow('t-1');
-    expect(mockPost).toHaveBeenCalledWith('/api/v1/threads/t-1/cancel');
+    // Bounded by a 5s timeout so a network-level hang can't block the stop retries.
+    expect(mockPost).toHaveBeenCalledWith('/api/v1/threads/t-1/cancel', undefined, {
+      timeout: 5000,
+    });
     expect(result).toEqual({ success: true });
   });
 });

--- a/web/src/pages/ChatAgent/utils/__tests__/api.stop.test.ts
+++ b/web/src/pages/ChatAgent/utils/__tests__/api.stop.test.ts
@@ -46,10 +46,23 @@ describe('cancelWorkflow', () => {
     mockPost.mockResolvedValue({ data: { success: true } });
     const result = await cancelWorkflow('t-1');
     // Bounded by a 5s timeout so a network-level hang can't block the stop retries.
+    // No runId → no run_id query param (backend falls back to latest active run).
     expect(mockPost).toHaveBeenCalledWith('/api/v1/threads/t-1/cancel', undefined, {
       timeout: 5000,
+      params: undefined,
     });
     expect(result).toEqual({ success: true });
+  });
+
+  it('targets a specific run via the run_id query param when given a runId', async () => {
+    mockPost.mockResolvedValue({ data: { success: true } });
+    // Pinning the run prevents a slow/retried cancel from hard-cancelling a
+    // newer turn the user started after the stopped one tore down.
+    await cancelWorkflow('t-1', 'run-9');
+    expect(mockPost).toHaveBeenCalledWith('/api/v1/threads/t-1/cancel', undefined, {
+      timeout: 5000,
+      params: { run_id: 'run-9' },
+    });
   });
 });
 

--- a/web/src/pages/ChatAgent/utils/__tests__/api.stop.test.ts
+++ b/web/src/pages/ChatAgent/utils/__tests__/api.stop.test.ts
@@ -29,7 +29,7 @@ vi.mock('@/lib/supabase', () => ({ supabase: null }));
 
 import { api } from '@/api/client';
 import * as apiModule from '../api';
-import { cancelWorkflow, sendChatMessageStream } from '../api';
+import { cancelWorkflow, sendChatMessageStream, parseThreadIdFromContentLocation } from '../api';
 
 const mockPost = api.post as Mock;
 
@@ -122,5 +122,30 @@ describe('sendChatMessageStream — AbortError handling', () => {
     await expect(
       sendChatMessageStream('hi', 'ws-1', 't-1', [], false, () => {}),
     ).rejects.toThrow('kaboom');
+  });
+});
+
+describe('parseThreadIdFromContentLocation', () => {
+  it('extracts the thread id from a Content-Location stream URL', () => {
+    expect(
+      parseThreadIdFromContentLocation(
+        '/api/v1/threads/abc-123/messages/stream?run_id=run-9',
+      ),
+    ).toBe('abc-123');
+  });
+
+  it('decodes percent-encoded ids and ignores the query string', () => {
+    expect(
+      parseThreadIdFromContentLocation(
+        '/api/v1/threads/t%2F1/messages/stream?run_id=r',
+      ),
+    ).toBe('t/1');
+  });
+
+  it('returns null for missing / malformed values', () => {
+    expect(parseThreadIdFromContentLocation(null)).toBeNull();
+    expect(parseThreadIdFromContentLocation(undefined)).toBeNull();
+    expect(parseThreadIdFromContentLocation('')).toBeNull();
+    expect(parseThreadIdFromContentLocation('/api/v1/threads/messages')).toBeNull();
   });
 });

--- a/web/src/pages/ChatAgent/utils/__tests__/api.stop.test.ts
+++ b/web/src/pages/ChatAgent/utils/__tests__/api.stop.test.ts
@@ -148,4 +148,12 @@ describe('parseThreadIdFromContentLocation', () => {
     expect(parseThreadIdFromContentLocation('')).toBeNull();
     expect(parseThreadIdFromContentLocation('/api/v1/threads/messages')).toBeNull();
   });
+
+  it('returns null (does not throw) on malformed percent-encoding', () => {
+    expect(
+      parseThreadIdFromContentLocation(
+        '/api/v1/threads/%ZZ/messages/stream?run_id=r',
+      ),
+    ).toBeNull();
+  });
 });

--- a/web/src/pages/ChatAgent/utils/__tests__/api.stop.test.ts
+++ b/web/src/pages/ChatAgent/utils/__tests__/api.stop.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for the hard-stop API surface: cancelWorkflow() and the AbortError
+ * handling threaded through streamFetch via sendChatMessageStream.
+ *
+ * - cancelWorkflow POSTs to /threads/{id}/cancel.
+ * - An AbortController.abort() during the stream is treated as an intentional
+ *   stop: streamFetch returns { aborted: true } instead of throwing, so callers
+ *   never show an error toast or run double cleanup.
+ * - The retired softInterruptWorkflow export is gone.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Mock } from 'vitest';
+
+vi.mock('@/api/client', () => {
+  const mockPost = vi.fn().mockResolvedValue({ data: {} });
+  return {
+    api: {
+      get: vi.fn().mockResolvedValue({ data: {} }),
+      post: mockPost,
+      put: vi.fn().mockResolvedValue({ data: {} }),
+      delete: vi.fn().mockResolvedValue({ data: {} }),
+      patch: vi.fn().mockResolvedValue({ data: {} }),
+      defaults: { baseURL: 'http://localhost:8000' },
+    },
+  };
+});
+
+vi.mock('@/lib/supabase', () => ({ supabase: null }));
+
+import { api } from '@/api/client';
+import * as apiModule from '../api';
+import { cancelWorkflow, sendChatMessageStream } from '../api';
+
+const mockPost = api.post as Mock;
+
+describe('cancelWorkflow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('throws when threadId is falsy', async () => {
+    await expect(cancelWorkflow('')).rejects.toThrow('Thread ID is required');
+  });
+
+  it('POSTs to /threads/{id}/cancel and returns response data', async () => {
+    mockPost.mockResolvedValue({ data: { success: true } });
+    const result = await cancelWorkflow('t-1');
+    expect(mockPost).toHaveBeenCalledWith('/api/v1/threads/t-1/cancel');
+    expect(result).toEqual({ success: true });
+  });
+});
+
+describe('softInterruptWorkflow removal', () => {
+  it('is no longer exported', () => {
+    expect(
+      (apiModule as Record<string, unknown>).softInterruptWorkflow,
+    ).toBeUndefined();
+  });
+});
+
+describe('sendChatMessageStream — AbortError handling', () => {
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('returns { aborted: true } when the reader is aborted (no throw)', async () => {
+    const abortErr = new DOMException('aborted', 'AbortError');
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      body: {
+        getReader: () => ({
+          read: vi.fn().mockRejectedValue(abortErr),
+        }),
+      },
+    }) as unknown as typeof fetch;
+
+    const controller = new AbortController();
+    const result = await sendChatMessageStream(
+      'hi', 'ws-1', 't-1', [], false, () => {}, null, 'ptc',
+      'en-US', 'America/New_York', null, null, null, null, null, null, null,
+      controller.signal,
+    );
+
+    expect(result).toMatchObject({ aborted: true, disconnected: false });
+  });
+
+  it('returns { aborted: true } when fetch itself rejects with AbortError', async () => {
+    const abortErr = new DOMException('aborted', 'AbortError');
+    global.fetch = vi.fn().mockRejectedValue(abortErr) as unknown as typeof fetch;
+
+    const controller = new AbortController();
+    const result = await sendChatMessageStream(
+      'hi', 'ws-1', 't-1', [], false, () => {}, null, 'ptc',
+      'en-US', 'America/New_York', null, null, null, null, null, null, null,
+      controller.signal,
+    );
+
+    expect(result).toMatchObject({ aborted: true });
+  });
+
+  it('still rethrows non-abort stream errors', async () => {
+    const boom = new Error('kaboom');
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      body: {
+        getReader: () => ({
+          read: vi.fn().mockRejectedValue(boom),
+        }),
+      },
+    }) as unknown as typeof fetch;
+
+    await expect(
+      sendChatMessageStream('hi', 'ws-1', 't-1', [], false, () => {}),
+    ).rejects.toThrow('kaboom');
+  });
+});

--- a/web/src/pages/ChatAgent/utils/__tests__/api.test.ts
+++ b/web/src/pages/ChatAgent/utils/__tests__/api.test.ts
@@ -237,7 +237,9 @@ describe('ChatAgent API utilities', () => {
       );
 
       expect(onRunIdResolved).toHaveBeenCalledTimes(1);
-      expect(onRunIdResolved).toHaveBeenCalledWith('abc-123');
+      // Now also carries the server-assigned thread_id parsed from the same
+      // Content-Location path, so an early stop can hard-cancel the run.
+      expect(onRunIdResolved).toHaveBeenCalledWith('abc-123', 't-1');
       // The run_id MUST be latched before any body byte is read.
       expect(callOrder[0]).toBe('run-id:abc-123');
     });

--- a/web/src/pages/ChatAgent/utils/api.ts
+++ b/web/src/pages/ChatAgent/utils/api.ts
@@ -520,10 +520,17 @@ export async function sendChatMessageStream(
  * Hard-cancel the workflow for a thread (stops the main agent AND kills all
  * subagents immediately, flushing the checkpoint so the next message resumes
  * from the last committed step).
+ *
+ * Pass ``runId`` to target a specific run. Without it the backend cancels the
+ * latest active run — which, if a slow/retried cancel lands after the stopped
+ * turn already tore down and the user started a new one, would hard-cancel that
+ * *new* turn. The stop flow captures the run id at stop entry to avoid this.
+ *
  * @param {string} threadId - The thread ID to cancel
+ * @param {string|null} runId - The specific run to cancel; null = latest active
  * @returns {Promise<Object>} Response data
  */
-export async function cancelWorkflow(threadId: string) {
+export async function cancelWorkflow(threadId: string, runId: string | null = null) {
   if (!threadId) throw new Error('Thread ID is required');
   // Bound the request: the shared axios instance sets no global timeout, so a
   // network-level hang (not a 4xx) would block each stopWorkflow retry until the
@@ -531,6 +538,7 @@ export async function cancelWorkflow(threadId: string) {
   // is ample for a cancel POST.
   const { data } = await api.post(`/api/v1/threads/${threadId}/cancel`, undefined, {
     timeout: 5000,
+    params: runId ? { run_id: runId } : undefined,
   });
   return data;
 }

--- a/web/src/pages/ChatAgent/utils/api.ts
+++ b/web/src/pages/ChatAgent/utils/api.ts
@@ -525,7 +525,13 @@ export async function sendChatMessageStream(
  */
 export async function cancelWorkflow(threadId: string) {
   if (!threadId) throw new Error('Thread ID is required');
-  const { data } = await api.post(`/api/v1/threads/${threadId}/cancel`);
+  // Bound the request: the shared axios instance sets no global timeout, so a
+  // network-level hang (not a 4xx) would block each stopWorkflow retry until the
+  // browser's ~60s default — delaying the "couldn't stop" toast by minutes. 5s
+  // is ample for a cancel POST.
+  const { data } = await api.post(`/api/v1/threads/${threadId}/cancel`, undefined, {
+    timeout: 5000,
+  });
   return data;
 }
 

--- a/web/src/pages/ChatAgent/utils/api.ts
+++ b/web/src/pages/ChatAgent/utils/api.ts
@@ -285,6 +285,22 @@ export function parseRunIdFromContentLocation(
   }
 }
 
+/**
+ * Parse the `{tid}` path segment out of a backend `Content-Location` header
+ * value such as `/api/v1/threads/{tid}/messages/stream?run_id={uuid}`.
+ * Lets a new-thread send latch the server-assigned thread id from the response
+ * headers — before the first SSE event — so an early stop can still cancel it.
+ * Returns `null` when the value is missing or doesn't match the expected shape.
+ */
+export function parseThreadIdFromContentLocation(
+  contentLocation: string | null | undefined,
+): string | null {
+  if (!contentLocation) return null;
+  const match = contentLocation.match(/\/threads\/([^/?]+)\//);
+  const tid = match?.[1];
+  return tid && tid.length > 0 ? decodeURIComponent(tid) : null;
+}
+
 async function streamFetch(
   url: string,
   opts: RequestInit,
@@ -437,7 +453,7 @@ export async function sendChatMessageStream(
   reasoningEffort: string | null = null,
   fastMode: boolean | null = null,
   platform: string | null = null,
-  onRunIdResolved: ((runId: string) => void) | null = null,
+  onRunIdResolved: ((runId: string, threadId: string | null) => void) | null = null,
   signal: AbortSignal | null = null,
 ) {
   // For checkpoint replay (regenerate/retry), send empty messages
@@ -487,7 +503,7 @@ export async function sendChatMessageStream(
     onRunIdResolved
       ? (contentLocation) => {
           const runId = parseRunIdFromContentLocation(contentLocation);
-          if (runId) onRunIdResolved(runId);
+          if (runId) onRunIdResolved(runId, parseThreadIdFromContentLocation(contentLocation));
         }
       : undefined,
   );
@@ -756,7 +772,7 @@ export async function sendHitlResponse(
   planMode: boolean = false,
   modelOptions: { model?: string; reasoningEffort?: string; fastMode?: boolean } = {},
   agentMode: string = 'ptc',
-  onRunIdResolved: ((runId: string) => void) | null = null,
+  onRunIdResolved: ((runId: string, threadId: string | null) => void) | null = null,
   signal: AbortSignal | null = null,
 ) {
   const body: Record<string, unknown> = {
@@ -786,7 +802,7 @@ export async function sendHitlResponse(
     onRunIdResolved
       ? (contentLocation) => {
           const runId = parseRunIdFromContentLocation(contentLocation);
-          if (runId) onRunIdResolved(runId);
+          if (runId) onRunIdResolved(runId, parseThreadIdFromContentLocation(contentLocation));
         }
       : undefined,
   );

--- a/web/src/pages/ChatAgent/utils/api.ts
+++ b/web/src/pages/ChatAgent/utils/api.ts
@@ -290,8 +290,21 @@ async function streamFetch(
   opts: RequestInit,
   onEvent: (event: Record<string, unknown>) => void,
   onHeaders?: (contentLocation: string | null) => void,
-): Promise<{ disconnected: boolean; contentLocation: string | null }> {
-  const res = await fetch(`${baseURL}${url}`, opts);
+): Promise<{ disconnected: boolean; aborted: boolean; contentLocation: string | null }> {
+  let res: Response;
+  try {
+    res = await fetch(`${baseURL}${url}`, opts);
+  } catch (error: unknown) {
+    // An AbortController.abort() during the initial fetch (e.g. the user hit
+    // stop before the response headers arrived) surfaces as AbortError (a
+    // DOMException, which is not always an Error instance — match on name).
+    // Treat it as an intentional stop rather than a network failure so callers
+    // don't show an error toast or run double cleanup.
+    if ((error as { name?: string })?.name === 'AbortError') {
+      return { disconnected: false, aborted: true, contentLocation: null };
+    }
+    throw error;
+  }
   // Snapshot Content-Location before body errors so callers can recover the
   // canonical reconnect URL (carries ?run_id=…) even when a 4xx aborts later.
   const contentLocation = res.headers.get('Content-Location');
@@ -371,6 +384,7 @@ async function streamFetch(
   };
 
   let disconnected = false;
+  let aborted = false;
   try {
     while (true) {
       const { done, value } = await reader.read();
@@ -383,15 +397,21 @@ async function streamFetch(
     // Process any remaining buffer
     buffer.split('\n').forEach(processLine);
   } catch (error: unknown) {
-    // Handle incomplete chunked encoding or other stream errors
-    if (error instanceof Error && error.name === 'TypeError' && error.message.includes('network')) {
+    // An AbortController.abort() on the reader (the user hit stop) surfaces as
+    // AbortError (a DOMException — match on name, not instanceof Error). This
+    // is an INTENTIONAL stop, not a failure — return an aborted marker so
+    // callers skip reconnect/error-toast/double-cleanup.
+    if ((error as { name?: string })?.name === 'AbortError') {
+      aborted = true;
+    } else if (error instanceof Error && error.name === 'TypeError' && error.message.includes('network')) {
+      // Handle incomplete chunked encoding or other stream errors
       console.warn('[api] Stream interrupted (network error):', error.message);
       disconnected = true;
     } else {
       throw error;
     }
   }
-  return { disconnected, contentLocation };
+  return { disconnected, aborted, contentLocation };
 }
 
 export async function replayThreadHistory(threadId: string, onEvent: (event: Record<string, unknown>) => void = () => {}) {
@@ -418,6 +438,7 @@ export async function sendChatMessageStream(
   fastMode: boolean | null = null,
   platform: string | null = null,
   onRunIdResolved: ((runId: string) => void) | null = null,
+  signal: AbortSignal | null = null,
 ) {
   // For checkpoint replay (regenerate/retry), send empty messages
   const messages = checkpointId && !message
@@ -460,6 +481,7 @@ export async function sendChatMessageStream(
         ...authHeaders,
       },
       body: JSON.stringify(body),
+      ...(signal ? { signal } : {}),
     },
     onEvent,
     onRunIdResolved
@@ -469,6 +491,19 @@ export async function sendChatMessageStream(
         }
       : undefined,
   );
+}
+
+/**
+ * Hard-cancel the workflow for a thread (stops the main agent AND kills all
+ * subagents immediately, flushing the checkpoint so the next message resumes
+ * from the last committed step).
+ * @param {string} threadId - The thread ID to cancel
+ * @returns {Promise<Object>} Response data
+ */
+export async function cancelWorkflow(threadId: string) {
+  if (!threadId) throw new Error('Thread ID is required');
+  const { data } = await api.post(`/api/v1/threads/${threadId}/cancel`);
+  return data;
 }
 
 /**
@@ -554,12 +589,14 @@ export function watchThread(
  * @param {string|null} runId - The specific run to target; null = latest
  * @param {number|null} lastEventId - Last received event ID for deduplication
  * @param {Function} onEvent - Callback for each SSE event
+ * @param {AbortSignal|null} signal - Abort the reader on a user stop
  */
 export async function reconnectToWorkflowStream(
   threadId: string,
   runId: string | null = null,
   lastEventId: number | null = null,
-  onEvent: (event: Record<string, unknown>) => void = () => {}
+  onEvent: (event: Record<string, unknown>) => void = () => {},
+  signal: AbortSignal | null = null
 ) {
   if (!threadId) throw new Error('Thread ID is required');
   const params = new URLSearchParams();
@@ -570,7 +607,7 @@ export async function reconnectToWorkflowStream(
   const authHeaders = await getAuthHeaders();
   return await streamFetch(
     `/api/v1/threads/${threadId}/messages/stream${queryParam}`,
-    { method: 'GET', headers: { ...authHeaders } },
+    { method: 'GET', headers: { ...authHeaders }, ...(signal ? { signal } : {}) },
     onEvent
   );
 }
@@ -625,17 +662,6 @@ export async function sendSubagentMessage(threadId: string, taskId: string, cont
     `/api/v1/threads/${threadId}/tasks/${taskId}/messages`,
     { content }
   );
-  return data;
-}
-
-/**
- * Soft-interrupt the workflow for a thread (pauses main agent, keeps subagents running)
- * @param {string} threadId - The thread ID to interrupt
- * @returns {Promise<Object>} Response data
- */
-export async function softInterruptWorkflow(threadId: string) {
-  if (!threadId) throw new Error('Thread ID is required');
-  const { data } = await api.post(`/api/v1/threads/${threadId}/interrupt`);
   return data;
 }
 
@@ -731,6 +757,7 @@ export async function sendHitlResponse(
   modelOptions: { model?: string; reasoningEffort?: string; fastMode?: boolean } = {},
   agentMode: string = 'ptc',
   onRunIdResolved: ((runId: string) => void) | null = null,
+  signal: AbortSignal | null = null,
 ) {
   const body: Record<string, unknown> = {
     workspace_id: workspaceId,
@@ -753,6 +780,7 @@ export async function sendHitlResponse(
         ...authHeaders,
       },
       body: JSON.stringify(body),
+      ...(signal ? { signal } : {}),
     },
     onEvent,
     onRunIdResolved

--- a/web/src/pages/ChatAgent/utils/api.ts
+++ b/web/src/pages/ChatAgent/utils/api.ts
@@ -298,7 +298,14 @@ export function parseThreadIdFromContentLocation(
   if (!contentLocation) return null;
   const match = contentLocation.match(/\/threads\/([^/?]+)\//);
   const tid = match?.[1];
-  return tid && tid.length > 0 ? decodeURIComponent(tid) : null;
+  if (!tid || tid.length === 0) return null;
+  try {
+    return decodeURIComponent(tid);
+  } catch {
+    // Malformed percent-encoding (e.g. "%ZZ") throws URIError. The contract is
+    // non-throwing/return-null for unusable input — a bad id can't be latched.
+    return null;
+  }
 }
 
 async function streamFetch(

--- a/web/src/types/chat.ts
+++ b/web/src/types/chat.ts
@@ -325,6 +325,9 @@ export interface AssistantMessage {
   steeringDelivered?: boolean;
   isSteering?: boolean;
   error?: boolean | string;
+  // Set when the user hard-stopped this turn (live finalize or history replay
+  // of a stopped turn). Drives the per-message "⏹ Stopped" chip.
+  stopped?: boolean;
 }
 
 export type NotificationVariant = 'info' | 'success' | 'warning';


### PR DESCRIPTION
## Summary

Retires the soft-interrupt mechanism (`POST /interrupt`, which paused the main agent but left subagents running and the stream open) and turns the chat **stop** control into an immediate, state-preserving **hard cancel**. Steering already covers the "inject guidance mid-run" need that soft interrupt was built for.

**Backend** (`feat(server)`)
- Stop force-cancels the in-flight task, flushes the LangGraph checkpoint (so the next message resumes from the last completed step), and tears subagents down under a **single owner**: drain captured subagent events → cancel orphan collectors → `cancel_and_clear(force)` → `_mark_cancelled`.
- New `user_stop` flag separates the user's HTTP `/cancel` (persisted as a "Stopped" turn, `cancelled_by_user=true`) from system cancels (graceful shutdown, stale-sandbox recovery), which still flush + persist but are **not** mislabeled as user stops.
- Transcript reconciliation: open reasoning/tool-call/artifact blocks at the stop point get synthetic close events (`reasoning_signal:"complete"`, `finish_reason:"stopped"`) so replay isn't stuck "thinking", guarded by an idempotency marker.
- Removes `/interrupt`, `SoftInterruptError`, `SOFT_INTERRUPTED` statuses, the soft-interrupt collector, and the soft-interrupt wait from message admission (steering latency floor gone). Config `soft_interrupt_wait_timeout` → `stop_drain_timeout`.

**Frontend** (`feat(web)`)
- Stop aborts the stream reader, finalizes the open message (closes blocks + "⏹ Stopped" chip), clears the in-flight tool-call shimmer, and POSTs `/cancel` with one retry then an error toast.
- Reconnect registers its reader on the stop `AbortController` and resets the stop flag on entry — so a stop *during* a reconnect aborts cleanly, and a later reconnect (e.g. thread switch after a stop) isn't bailed by a stale flag.
- Tail-mode "background tasks running" indicator retained (main turn finished while a dispatched subagent keeps streaming — independent of stop).

**Docs** — drops the two retired soft-interrupt claims from README.

## Diff Size
- **Total:** 36 files changed, +2138 / −743
- **Net (excl. tests):** 24 files changed, +890 / −646

## Test Coverage
- **Backend:** single-owner teardown ordering (drain-before-clear), flush-failure still persists, user-vs-system cancel labeling, re-cancel during teardown still marks cancelled, new admission states, stopped-event reconciliation matrix, `TaskOutput` for a stop-killed subagent.
- **Frontend:** stop flow (abort + finalize + cancel retry/toast, idempotent double-stop, in-flight tool-call clear), reconnect-abort (stop during reconnect; stale-flag reset on a later reconnect — verified to fail without the fix), stopped-state history replay.

## Pre-Landing Review
Adversarial review (Claude subagent) on the diff:
- **CRITICAL (fixed):** reconnect didn't reset `wasStoppedRef` on entry → a stop on thread A then switch to live thread B left B's spinner stuck. Fixed (reset on reconnect entry, matching the other 4 stream entry points) + regression test that fails without the fix.
- **INFORMATIONAL (not blocking):** during graceful shutdown, if a turn's teardown exceeds `shutdown_timeout` (50s), the shielded `_mark_cancelled` can run detached while shutdown closes DB pools — narrow window, shutdown is already best-effort. Noted for follow-up.
- Clean: no stray `soft_interrupt`/`/interrupt` references remain in `src/` or `web/src/` (ptc-cli deferred to a follow-up PR per plan).

## Verification Results (live e2e, real Redis + PG + LLM)
- Stop mid-`ExecuteCode` → `/cancel` 200, stream closed, no result.
- **Follow-up on the stopped thread → HTTP 200, coherent resume, no Anthropic 400.** Checkpoint decode confirms the dangling `ExecuteCode` tool_use is satisfied by a synthetic cancellation `ToolMessage` before the next model call. (Clears the "dangling tool_use" risk empirically.)

## Plan Completion
Implements the "Retire soft interrupt → immediate hard stop" plan in full (backend + frontend). ptc-cli ESC repoint is a deferred follow-up PR (TODO.md item 2).

## Test plan
- [x] Backend `tests/unit/`: **4317 passed**, `ruff check src/` clean
- [x] Frontend `vitest`: **1635 passed** (146 files), `pnpm lint` 0 errors
- [x] Live e2e: stop mid-tool + resume-after-stop verified against the running backend


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hard-stop workflow cancellation with end-of-turn reconciliation, including history replay and improved “⏹ Stopped” finalization.
* **API Changes**
  * Replaced the thread interrupt endpoint with a thread cancel endpoint.
* **UI/UX Improvements**
  * Added per-message “⏹ Stopped” indicators and updated stop-state copy (including stop-failure messaging).
* **Backend & Reliability**
  * Updated dispatched-work admission/teardown behavior and clarified task messaging when a stopped task can’t be resumed; added configurable stop-drain timeout.  
* **Documentation**
  * Refreshed README to match the updated stop semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->