### PR TITLE
feat(provenance): refine how the Sources panel displays sources

### DIFF
--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -1233,6 +1233,7 @@
       "workspaceRoot": "Workspace root",
       "viewDetails": "View details",
       "expand": "Expand",
+      "collapse": "Collapse",
       "actions": {
         "openLink": "Open link",
         "openFile": "Open file"
@@ -1243,6 +1244,8 @@
         "thread": "All sources"
       },
       "sourceCount": "{{count}} sources",
+      "resultCount": "{{count}} results",
+      "pageCount": "{{count}} pages",
       "kind": {
         "company_overview": "Company overview",
         "daily_prices": "Daily prices",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -1233,6 +1233,7 @@
       "workspaceRoot": "工作区根目录",
       "viewDetails": "查看详情",
       "expand": "展开",
+      "collapse": "折叠",
       "actions": {
         "openLink": "打开链接",
         "openFile": "打开文件"
@@ -1243,6 +1244,8 @@
         "thread": "全部"
       },
       "sourceCount": "{{count}} 个来源",
+      "resultCount": "{{count}} 条结果",
+      "pageCount": "{{count}} 个页面",
       "kind": {
         "company_overview": "公司概况",
         "daily_prices": "每日价格",

--- a/web/src/pages/ChatAgent/components/MessageList.tsx
+++ b/web/src/pages/ChatAgent/components/MessageList.tsx
@@ -559,8 +559,9 @@ const MessageBubble = memo(function MessageBubble({ message, isLoading, hideAvat
   // Provenance count for the Sources pill, deduped by (source_type, identifier)
   // — the same URL fetched twice in one turn counts once. The pill lives in its
   // own always-visible row (not the hover-gated footer), so it shows mid-stream.
-  // Shares countDedupedSources with SourcesPanel so the pill and panel counts
-  // can never silently diverge.
+  // This counts distinct sources (every result URL), so it intentionally runs
+  // ahead of the panel's visible row count: the panel groups a whole web search
+  // into one deck, but the pill still reports how many pages were actually read.
   const sourceCount = useMemo(() => {
     if (!isAssistant || isSubagentView) return 0;
     return countDedupedSources(message.provenanceRecords as Record<string, ProvenanceRecord> | undefined);

--- a/web/src/pages/ChatAgent/components/SourcesPanel.tsx
+++ b/web/src/pages/ChatAgent/components/SourcesPanel.tsx
@@ -46,12 +46,14 @@ const GROUP_ORDER: ProvenanceSourceType[] = [
   'memory_read',
 ];
 
-/** Deck geometry — kept in step with the widget-context deck so a provenance
- *  stack fans out with the same spacing/peek as the chat-input snapshot deck. */
+/** Deck geometry — spacing/fan motion kept in step with the widget-context deck
+ *  (the chat-input snapshot deck). MAX_PEEK_LAYERS is intentionally shallower
+ *  here: provenance decks can hold many results, so a collapsed deck only hints
+ *  "there's more behind" with a couple of peek cards rather than a deep stack. */
 const CARD_HEIGHT = 52;
 const CARD_GAP = 6;
 const PEEK_STEP = 6;
-const MAX_PEEK_LAYERS = 4;
+const MAX_PEEK_LAYERS = 2;
 
 /** Shared card chrome (visuals only — positioning/height is set per use). Every
  *  card is filled with `--color-bg-card` so a leaf card and the front of a
@@ -120,6 +122,19 @@ function domainFromUrl(url: string): string {
   }
 }
 
+/** pathname + query of a URL — the part after the origin, used to label a page
+ *  within a domain deck (the domain is already the deck label). '' for a bare
+ *  origin or an unparseable URL, so callers can fall back to the full URL. */
+function urlPath(url: string): string {
+  try {
+    const u = new URL(url);
+    const p = u.pathname + u.search;
+    return p === '/' ? '' : p;
+  } catch {
+    return '';
+  }
+}
+
 function shortSha(sha?: string): string {
   if (!sha) return '';
   return sha.length > 12 ? sha.slice(0, 12) : sha;
@@ -157,19 +172,25 @@ function humanizeType(type: string): string {
 const REDACTED = '[redacted]';
 
 /**
- * One-line render of ALL captured args as `key: value` pairs joined by ` · `,
- * shown verbatim (no curation) so every card surfaces exactly what the tool was
- * called with. Redaction sentinels pass through as-is (the whole subtitle is
- * already muted). Empty/null values are dropped. Returns null when there is
- * nothing to show.
+ * One-line render of the captured args as `key: value` pairs joined by ` · `,
+ * shown verbatim (no curation) so every card surfaces what the tool was called
+ * with. Redaction sentinels pass through as-is (the whole subtitle is already
+ * muted). Empty/null values are dropped. `omit` skips keys already conveyed
+ * elsewhere (e.g. a domain deck's `url`, since the card title is the path).
+ * Returns null when there is nothing to show.
  */
-function argsSummary(a?: Record<string, unknown> | null): string | null {
+function argsSummary(a?: Record<string, unknown> | null, omit?: Set<string>): string | null {
   if (!a) return null;
   const parts = Object.entries(a)
-    .filter(([, v]) => v !== undefined && v !== null && v !== '')
+    .filter(([k, v]) => v !== undefined && v !== null && v !== '' && !omit?.has(k))
     .map(([k, v]) => `${k}: ${argValueText(v)}`);
   return parts.length ? parts.join(' · ') : null;
 }
+
+/** Arg keys already shown by a URL-derived card title (the page path, or the
+ *  full URL on a lone web_fetch), so they're dropped from the subtitle rather
+ *  than repeating the URL. */
+const URL_REDUNDANT_ARGS = new Set(['url']);
 
 /** Compact display for an args value: redaction sentinel verbatim, strings as
  *  themselves, everything else JSON-stringified. */
@@ -212,21 +233,50 @@ interface SourceGroup {
   rows: SourceRowData[];
 }
 
+/** The search query captured on a web_search record (its `args.query`), if any. */
+function queryText(record: ProvenanceRecord): string {
+  const q = record.args?.query;
+  return typeof q === 'string' ? q : '';
+}
+
+/**
+ * Row-grouping key. Two source types collapse beyond plain identifier dedup:
+ *  - `web_search`: results from one query share a `tool_call_id`, so a whole
+ *    search (20 links) becomes one row labeled by the query.
+ *  - `web_fetch`: pages from the same origin collapse into one row labeled by
+ *    the domain, so reading several pages off one site doesn't spread into a
+ *    wall of rows. A lone page from a domain stays a single (leaf) row.
+ * Both fall back to the `(source_type, identifier)` dedup when there's nothing
+ * to group under (no tool_call_id/query; an unparseable URL). Note this
+ * intentionally diverges from the Sources pill's {@link countDedupedSources}:
+ * the pill still counts distinct URLs (how many pages were read), while the
+ * panel groups them by search / by site.
+ */
+function rowKey(record: ProvenanceRecord): string {
+  if (record.source_type === 'web_search') {
+    const search = record.tool_call_id || queryText(record) || record.identifier;
+    return `web_search:${search}`;
+  }
+  if (record.source_type === 'web_fetch') {
+    const domain = domainFromUrl(record.identifier);
+    if (domain) return `web_fetch@${domain}`;
+  }
+  return provenanceDisplayKey(record);
+}
+
 /**
  * Group records by `source_type` in {@link GROUP_ORDER}, then collapse to one
- * row per {@link provenanceDisplayKey} (e.g. one row per ticker). Records that
- * share a key are NOT dropped — they're collected on the row so it can become a
- * deck of the distinct data products behind it. Unrecognized types are appended
- * so nothing is silently dropped.
+ * row per {@link rowKey} (one row per ticker; one row per web search). Records
+ * that share a key are NOT dropped — they're collected on the row so it can
+ * become a deck of the distinct accesses/results behind it. Unrecognized types
+ * are appended so nothing is silently dropped.
  */
 function buildGroups(records?: Record<string, ProvenanceRecord>): SourceGroup[] {
   const all = Object.values(records || {});
   const byType = new Map<ProvenanceSourceType, SourceRowData[]>();
   const rowByKey = new Map<string, SourceRowData>();
   for (const record of all) {
-    // Shares provenanceDisplayKey with the Sources pill's countDedupedSources
-    // so the panel's row count matches the pill's number.
-    const dedupKey = provenanceDisplayKey(record);
+    const dedupKey = rowKey(record);
     const existing = rowByKey.get(dedupKey);
     if (existing) {
       existing.records.push(record);
@@ -260,16 +310,27 @@ function kindLabel(t: TFunction, slug?: string): string {
   return t(`chat.sources.kind.${slug}`, { defaultValue: humanizeType(slug) });
 }
 
-/** Distinct records by content hash (so identical re-fetches collapse but
- *  different data products / periods stay), preserving arrival order. Falls
- *  back to the data-kind when a record carries no sha; records that share an
- *  identifier with neither a hash nor a kind are indistinguishable, so they
- *  collapse to one rather than padding the deck with look-alikes. */
-function distinctByContent(records: ProvenanceRecord[]): ProvenanceRecord[] {
+/** Distinct records, preserving arrival order. `byIdentifier` picks what
+ *  "distinct" means for the deck's shape:
+ *   - List decks (web_search/web_fetch) — each card is a distinct URL, so key on
+ *     `identifier`. Two different URLs that happen to return byte-identical
+ *     content (block/paywall/redirect pages share a hash) stay separate cards
+ *     rather than one silently swallowing the other; a true re-fetch of the same
+ *     URL still collapses.
+ *   - Entity decks (a shared identifier, e.g. a ticker read several ways) — key
+ *     on content hash so the same data product collapses but different
+ *     products/periods stay; fall back to data-kind, then identifier, so a
+ *     hash-less, kind-less pair collapses rather than padding with look-alikes. */
+function distinctByContent(
+  records: ProvenanceRecord[],
+  byIdentifier = false,
+): ProvenanceRecord[] {
   const seen = new Set<string>();
   const out: ProvenanceRecord[] = [];
   for (const r of records) {
-    const k = r.result_sha256 || r.detail || '';
+    const k = byIdentifier
+      ? r.identifier || r.result_sha256 || r.detail || ''
+      : r.result_sha256 || r.detail || r.identifier || '';
     if (seen.has(k)) continue;
     seen.add(k);
     out.push(r);
@@ -313,6 +374,23 @@ export default function SourcesPanel({
   const [selected, setSelected] = useState<ProvenanceRecord | null>(null);
   // Only one deck fans at a time (matches the widget deck's single-deck model).
   const [fannedKey, setFannedKey] = useState<string | null>(null);
+  // Per-category fold: a source-type in this set has its whole group collapsed
+  // to just its header, so a noisy category can be tucked away entirely.
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<ProvenanceSourceType>>(
+    () => new Set(),
+  );
+
+  const toggleGroup = (type: ProvenanceSourceType) => {
+    // Folding unmounts the group's rows; drop any fanned deck so it can't linger
+    // open behind a collapsed header.
+    setFannedKey(null);
+    setCollapsedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(type)) next.delete(type);
+      else next.add(type);
+      return next;
+    });
+  };
 
   const turnCount = useMemo(() => countDedupedSources(provenanceRecords), [provenanceRecords]);
   const threadCount = useMemo(() => countDedupedSources(allRecords), [allRecords]);
@@ -363,9 +441,21 @@ export default function SourcesPanel({
       <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
         {groups.map((group) => {
           const groupLabel = t(`chat.sources.groups.${group.type}`, { defaultValue: humanizeType(group.type) });
+          const collapsed = collapsedGroups.has(group.type);
           return (
             <div key={group.type} className="mb-4">
-              <div className="mb-1.5 flex items-center gap-2 px-1">
+              <button
+                type="button"
+                onClick={() => toggleGroup(group.type)}
+                aria-expanded={!collapsed}
+                aria-label={`${groupLabel} — ${t(collapsed ? 'chat.sources.expand' : 'chat.sources.collapse')}`}
+                className="mb-1.5 flex w-full items-center gap-2 rounded-md px-1 py-0.5 text-left outline-none transition-colors hover:bg-[var(--color-bg-subtle)] focus-visible:ring-2 focus-visible:ring-[var(--color-accent-primary)]"
+              >
+                {collapsed ? (
+                  <ChevronRight className="h-3.5 w-3.5 flex-shrink-0" style={TERTIARY} />
+                ) : (
+                  <ChevronDown className="h-3.5 w-3.5 flex-shrink-0" style={TERTIARY} />
+                )}
                 <span
                   className="text-xs font-semibold uppercase tracking-wide"
                   style={TERTIARY}
@@ -373,24 +463,27 @@ export default function SourcesPanel({
                   {groupLabel}
                 </span>
                 <span
+                  data-testid={`group-count-${group.type}`}
                   className="inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium"
                   style={{ backgroundColor: 'var(--color-border-muted)', color: 'var(--color-text-tertiary)' }}
                 >
                   {group.rows.length}
                 </span>
-              </div>
-              <div className="flex flex-col gap-1.5">
-                {group.rows.map((row) => (
-                  <SourceRow
-                    key={row.key}
-                    row={row}
-                    fanned={fannedKey === row.key}
-                    onToggleFan={() => setFannedKey((k) => (k === row.key ? null : row.key))}
-                    onCollapse={() => setFannedKey((k) => (k === row.key ? null : k))}
-                    onOpenRecord={setSelected}
-                  />
-                ))}
-              </div>
+              </button>
+              {!collapsed && (
+                <div className="flex flex-col gap-1.5">
+                  {group.rows.map((row) => (
+                    <SourceRow
+                      key={row.key}
+                      row={row}
+                      fanned={fannedKey === row.key}
+                      onToggleFan={() => setFannedKey((k) => (k === row.key ? null : row.key))}
+                      onCollapse={() => setFannedKey((k) => (k === row.key ? null : k))}
+                      onOpenRecord={setSelected}
+                    />
+                  ))}
+                </div>
+              )}
             </div>
           );
         })}
@@ -475,14 +568,18 @@ function SourceRow({
 }): React.ReactElement {
   const { t } = useTranslation();
   const { record, records } = row;
-  const distinct = distinctByContent(records);
+  const isWebSearch = record.source_type === 'web_search';
+  const isWebFetch = record.source_type === 'web_fetch';
+  // List decks dedup by URL; entity decks dedup by content hash (see distinctByContent).
+  const distinct = distinctByContent(records, isWebSearch || isWebFetch);
   const title = recordTitle(t, record);
 
   if (distinct.length <= 1) {
     const kind = kindLabel(t, record.detail);
-    // Always surface the full captured args (not a curated subset). Fall back to
-    // the data-kind, then the identifier, only when there are no args to show.
-    let subtitle = argsSummary(record.args) ?? '';
+    // Surface the captured args (not a curated subset). For a lone web_fetch the
+    // title is already the full URL, so drop the redundant `url` arg. Fall back
+    // to the data-kind, then the identifier, only when there are no args to show.
+    let subtitle = argsSummary(record.args, isWebFetch ? URL_REDUNDANT_ARGS : undefined) ?? '';
     if (!subtitle) {
       if (kind) subtitle = kind;
       // For file rows the title already encodes the (normalized) identifier, so
@@ -513,10 +610,22 @@ function SourceRow({
     );
   }
 
+  // Three deck shapes, by how the row was grouped (see rowKey):
+  //  - 'query' (web_search): labeled by the query; each card is a result page.
+  //  - 'domain' (web_fetch): labeled by the site; each card is a page on it.
+  //  - 'entity' (default, e.g. a ticker): labeled by the entity; cards share it.
+  const variant = isWebSearch ? 'query' : isWebFetch ? 'domain' : 'entity';
+  const frontLabel = isWebSearch
+    ? queryText(record) || t('chat.sources.groups.web_search')
+    : isWebFetch
+      ? domainFromUrl(record.identifier) || title
+      : title;
+
   return (
     <SourceDeck
       records={distinct}
-      ticker={title}
+      frontLabel={frontLabel}
+      variant={variant}
       fanned={fanned}
       onToggleFan={onToggleFan}
       onCollapse={onCollapse}
@@ -526,34 +635,61 @@ function SourceRow({
 }
 
 /**
- * A deck of cards — one per distinct access of a single source (e.g. a ticker
- * read via company overview + daily prices + options chain). Collapsed, the
- * cards peek behind the front one and the front shows the access count; clicking
- * fans them out (the widget-context deck's exact motion) and each card then
- * opens its own detail dialog. Clicking outside, or pressing Escape, collapses.
+ * A deck of cards behind one front card. Three shapes, set by `variant`:
+ *  - `entity`: one source read several ways (e.g. a ticker via company overview
+ *    + daily prices + options chain). Every card shares `frontLabel` (the
+ *    entity); cards differ by their data-kind/args subtitle.
+ *  - `query`: one web search's many results. The front is labeled by the query;
+ *    each card keeps its own result title and shows its domain.
+ *  - `domain`: pages fetched from one site. The front is labeled by the domain;
+ *    each card shows its page path (the domain is already on the front).
+ *
+ * Collapsed, the cards peek behind the front one and the front shows the count;
+ * clicking fans them out (the widget-context deck's exact motion) and each card
+ * then opens its own detail dialog. Clicking outside, or pressing Escape,
+ * collapses.
  */
 function SourceDeck({
   records,
-  ticker,
+  frontLabel,
+  variant,
   fanned,
   onToggleFan,
   onCollapse,
   onOpenRecord,
 }: {
   records: ProvenanceRecord[];
-  ticker: string;
+  frontLabel: string;
+  variant: 'entity' | 'query' | 'domain';
   fanned: boolean;
   onToggleFan: () => void;
   onCollapse: () => void;
   onOpenRecord: (record: ProvenanceRecord) => void;
 }): React.ReactElement {
   const { t } = useTranslation();
+  // A "list" deck (query/domain) labels each card by its own page; an entity
+  // deck shares the front label across cards and subtitles by data-kind.
+  const isEntity = variant === 'entity';
   const rootRef = useRef<HTMLDivElement | null>(null);
   const n = records.length;
   const peekLayers = Math.min(n - 1, MAX_PEEK_LAYERS);
   const stackHeight = fanned
     ? n * (CARD_HEIGHT + CARD_GAP) - CARD_GAP
     : CARD_HEIGHT + peekLayers * PEEK_STEP;
+  // Collapsed, only render the front + a capped number of peek cards so a big
+  // deck doesn't stack arbitrarily deep (the true count stays on the front
+  // badge). Fanned, render every card. Capping the rendered set — not just the
+  // stack height — keeps the deepest peek card flush with the stack's bottom.
+  const visible = fanned ? records : records.slice(0, peekLayers + 1);
+  // The collapsed front card's count noun tracks the grouping (sources /
+  // results / pages). It's deck-level — depends only on variant — so compute
+  // it once here rather than per card in the map below.
+  const countKey =
+    variant === 'query'
+      ? 'chat.sources.resultCount'
+      : variant === 'domain'
+        ? 'chat.sources.pageCount'
+        : 'chat.sources.sourceCount';
 
   // Outside-click / Escape collapse while fanned, deferred one frame so the
   // click that fanned the deck can't immediately re-collapse it. Clicks inside
@@ -594,24 +730,42 @@ function SourceDeck({
       data-fanned={fanned}
       style={{ height: stackHeight }}
     >
-      {records.map((r, i) => {
+      {visible.map((r, i) => {
         const top = fanned ? i * (CARD_HEIGHT + CARD_GAP) : 0;
         const peekY = fanned ? 0 : i * PEEK_STEP;
         const peekScale = fanned ? 1 : Math.max(1 - i * 0.03, 0.85);
         const peekOpacity = fanned ? 1 : i === 0 ? 1 : Math.max(0.85 - (i - 1) * 0.2, 0.25);
         const interactive = fanned || i === 0;
         const isTop = i === 0;
+        const collapsedFront = !fanned && isTop;
         const kind = kindLabel(t, r.detail);
-        // Always show the full captured args; fall back to the data-kind.
-        const cardLabel = argsSummary(r.args) ?? kind;
+        // Per-card title: entity cards share the front label; query cards show
+        // the result's own page title; domain cards show the page path (the
+        // domain is already on the front).
+        const cardTitle =
+          variant === 'query'
+            ? recordTitle(t, r)
+            : variant === 'domain'
+              ? urlPath(r.identifier) || recordTitle(t, r)
+              : frontLabel;
+        // Per-card subtitle (fanned): entity → full args / data-kind; query →
+        // the result's domain; domain → the args (minus the redundant `url`), so
+        // a page's fetch prompt still shows even though the path is the title.
+        const cardLabel =
+          variant === 'query'
+            ? domainFromUrl(r.identifier)
+            : variant === 'domain'
+              ? (argsSummary(r.args, URL_REDUNDANT_ARGS) ?? '')
+              : (argsSummary(r.args) ?? kind);
 
-        // Collapsed, the front card summarizes the deck ("N sources"); fanned,
-        // every card shows its full args (or data-kind when it has none).
-        const subtitle = !fanned && isTop ? t('chat.sources.sourceCount', { count: n }) : cardLabel;
-        const ariaLabel =
-          !fanned && isTop
-            ? `${ticker} — ${t('chat.sources.expand')}`
-            : `${ticker}${kind ? ` · ${kind}` : ''} — ${t('chat.sources.viewDetails')}`;
+        // Collapsed, the front card summarizes the deck (count noun via
+        // countKey above); fanned, each card shows its own label.
+        const subtitle = collapsedFront ? t(countKey, { count: n }) : cardLabel;
+        const ariaLabel = collapsedFront
+          ? `${frontLabel} — ${t('chat.sources.expand')}`
+          : !isEntity
+            ? `${cardTitle} — ${t('chat.sources.viewDetails')}`
+            : `${frontLabel}${kind ? ` · ${kind}` : ''} — ${t('chat.sources.viewDetails')}`;
         const trailing =
           !fanned && isTop ? (
             <span className="inline-flex flex-shrink-0 items-center gap-1">
@@ -655,13 +809,19 @@ function SourceDeck({
                   : 'none',
             }}
           >
-            <SourceCardBody
-              record={r}
-              title={ticker}
-              subtitle={subtitle}
-              subagent={isSubagentRecord(r.agent)}
-              trailing={trailing}
-            />
+            {/* Collapsed peek cards (behind the front) render as blank card
+                surfaces — showing their content would bleed favicons/titles out
+                below the front card as a garbled "tail". Only the front card (or
+                every card once fanned) shows its body. */}
+            {interactive && (
+              <SourceCardBody
+                record={r}
+                title={collapsedFront ? frontLabel : cardTitle}
+                subtitle={subtitle}
+                subagent={isSubagentRecord(r.agent)}
+                trailing={trailing}
+              />
+            )}
           </button>
         );
       })}

--- a/web/src/pages/ChatAgent/components/__tests__/SourcesPanel.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/SourcesPanel.test.tsx
@@ -6,7 +6,7 @@
  * action inside that dialog.
  */
 import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
-import { render, screen, fireEvent, within } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import SourcesPanel from '../SourcesPanel';
 import type { ProvenanceRecord } from '@/types/chat';
@@ -64,10 +64,8 @@ describe('SourcesPanel', () => {
     expect(mcp).toBeInTheDocument();
 
     // Per-group count badge: web_search → 2, mcp_tool → 1.
-    const webGroup = webSearch.closest('div')!.parentElement!;
-    expect(within(webGroup).getByText('2')).toBeInTheDocument();
-    const mcpGroup = mcp.closest('div')!.parentElement!;
-    expect(within(mcpGroup).getByText('1')).toBeInTheDocument();
+    expect(screen.getByTestId('group-count-web_search')).toHaveTextContent('2');
+    expect(screen.getByTestId('group-count-mcp_tool')).toHaveTextContent('1');
   });
 
   it('stacks a ticker into a deck that fans on click, each access opening its own detail', () => {
@@ -80,9 +78,7 @@ describe('SourcesPanel', () => {
     render(<SourcesPanel provenanceRecords={records} />);
 
     // Group count is by ticker (1 row), not by access.
-    const market = screen.getByText('Market data');
-    const marketGroup = market.closest('div')!.parentElement!;
-    expect(within(marketGroup).getByText('1')).toBeInTheDocument();
+    expect(screen.getByTestId('group-count-market_data')).toHaveTextContent('1');
 
     // Collapsed deck: one stack, not fanned, front card summarizes the count.
     const stack = screen.getByTestId('source-stack');
@@ -338,5 +334,213 @@ describe('SourcesPanel', () => {
     render(<SourcesPanel provenanceRecords={records} />);
     expect(screen.getByText('Custom Future Source')).toBeInTheDocument();
     expect(screen.queryByText('custom_future_source')).not.toBeInTheDocument();
+  });
+
+  it('groups one web search (shared tool_call_id) into a single deck labeled by the query', () => {
+    // A real search emits one record per result, all sharing the tool_call_id.
+    const records = asMap([
+      rec({ record_id: 'r1', source_type: 'web_search', tool_call_id: 'call-1', identifier: 'https://alpha.test/a', title: 'Result A', args: { query: 'spacex funding 2024' }, result_sha256: 'a'.repeat(20) }),
+      rec({ record_id: 'r2', source_type: 'web_search', tool_call_id: 'call-1', identifier: 'https://beta.test/b', title: 'Result B', args: { query: 'spacex funding 2024' }, result_sha256: 'b'.repeat(20) }),
+      rec({ record_id: 'r3', source_type: 'web_search', tool_call_id: 'call-1', identifier: 'https://gamma.test/c', title: 'Result C', args: { query: 'spacex funding 2024' }, result_sha256: 'c'.repeat(20) }),
+    ]);
+    render(<SourcesPanel provenanceRecords={records} />);
+
+    // One row for the whole search, not three.
+    expect(screen.getByTestId('group-count-web_search')).toHaveTextContent('1');
+
+    // Collapsed deck: labeled by the query, summarizing the result count.
+    const stack = screen.getByTestId('source-stack');
+    expect(stack).toHaveAttribute('data-fanned', 'false');
+    expect(screen.getByText('spacex funding 2024')).toBeInTheDocument();
+    expect(screen.getByText('3 results')).toBeInTheDocument();
+    // Collapsed, only the query + count show. The peek cards behind the front
+    // render blank, so individual result titles are absent from the DOM entirely
+    // (not merely aria-hidden) — otherwise they bleed out below the front card as
+    // a garbled "tail".
+    expect(screen.queryByText('Result A')).not.toBeInTheDocument();
+    expect(screen.queryByText('Result B')).not.toBeInTheDocument();
+    expect(screen.queryByText('Result C')).not.toBeInTheDocument();
+  });
+
+  it('fans a web-search deck into a card per result, each opening its own detail', () => {
+    const records = asMap([
+      rec({ record_id: 'r1', source_type: 'web_search', tool_call_id: 'call-1', identifier: 'https://alpha.test/a', title: 'Result A', args: { query: 'q' }, result_sha256: 'a'.repeat(20), result_snippet: 'snippet A' }),
+      rec({ record_id: 'r2', source_type: 'web_search', tool_call_id: 'call-1', identifier: 'https://beta.test/b', title: 'Result B', args: { query: 'q' }, result_sha256: 'b'.repeat(20) }),
+    ]);
+    render(<SourcesPanel provenanceRecords={records} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /q — Expand/ }));
+    expect(screen.getByTestId('source-stack')).toHaveAttribute('data-fanned', 'true');
+
+    // Each result is now its own card (per-result title + domain subtitle).
+    expect(screen.getByRole('button', { name: /Result A — View details/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Result B — View details/ })).toBeInTheDocument();
+    expect(screen.getByText('alpha.test')).toBeInTheDocument();
+    expect(screen.getByText('beta.test')).toBeInTheDocument();
+
+    // A result card opens its own fingerprint detail.
+    fireEvent.click(screen.getByRole('button', { name: /Result A — View details/ }));
+    expect(screen.getByText('snippet A')).toBeInTheDocument();
+  });
+
+  it('stacks web_fetch pages from the same domain into a domain deck', () => {
+    // Real web_fetch records carry no title — identifier is the URL.
+    const records = asMap([
+      rec({ record_id: 'r1', source_type: 'web_fetch', identifier: 'https://sec.gov/a', args: { url: 'https://sec.gov/a', prompt: 'filings detail' }, result_sha256: 'a'.repeat(20) }),
+      rec({ record_id: 'r2', source_type: 'web_fetch', identifier: 'https://sec.gov/b', args: { url: 'https://sec.gov/b', prompt: 'debut coverage' }, result_sha256: 'b'.repeat(20) }),
+      rec({ record_id: 'r3', source_type: 'web_fetch', identifier: 'https://other.test/x', args: { url: 'https://other.test/x' }, result_sha256: 'c'.repeat(20) }),
+    ]);
+    render(<SourcesPanel provenanceRecords={records} />);
+
+    // Two rows under "Web pages": one sec.gov deck + one lone other.test page.
+    expect(screen.getByTestId('group-count-web_fetch')).toHaveTextContent('2');
+
+    // Only the repeated domain stacks; it's labeled by the domain + page count.
+    expect(screen.getAllByTestId('source-stack')).toHaveLength(1);
+    expect(screen.getByText('sec.gov')).toBeInTheDocument();
+    expect(screen.getByText('2 pages')).toBeInTheDocument();
+
+    // Fanned: each card is a page path on that domain (the domain is the front),
+    // and still surfaces its args (e.g. the fetch prompt) as a subtitle.
+    fireEvent.click(screen.getByRole('button', { name: /sec\.gov — Expand/ }));
+    expect(screen.getByRole('button', { name: /\/a — View details/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /\/b — View details/ })).toBeInTheDocument();
+    expect(screen.getByText('prompt: filings detail')).toBeInTheDocument();
+    expect(screen.getByText('prompt: debut coverage')).toBeInTheDocument();
+    // The redundant url arg is omitted — the path title already conveys it.
+    expect(screen.queryByText(/url: https/)).not.toBeInTheDocument();
+  });
+
+  it('renders a single-result web search as a flat result card (the page, not the query)', () => {
+    const records = asMap([
+      rec({ record_id: 'r1', source_type: 'web_search', tool_call_id: 'call-1', identifier: 'https://alpha.test/a', title: 'Lone Result', args: { query: 'q' }, result_sha256: 'a'.repeat(20) }),
+    ]);
+    render(<SourcesPanel provenanceRecords={records} />);
+    expect(screen.queryByTestId('source-stack')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Lone Result — View details/ })).toBeInTheDocument();
+  });
+
+  it('keeps two separate searches as two decks', () => {
+    const records = asMap([
+      rec({ record_id: 'r1', source_type: 'web_search', tool_call_id: 'call-1', identifier: 'https://a.test/1', title: 'A1', args: { query: 'first' }, result_sha256: '1'.repeat(20) }),
+      rec({ record_id: 'r2', source_type: 'web_search', tool_call_id: 'call-1', identifier: 'https://a.test/2', title: 'A2', args: { query: 'first' }, result_sha256: '2'.repeat(20) }),
+      rec({ record_id: 'r3', source_type: 'web_search', tool_call_id: 'call-2', identifier: 'https://b.test/1', title: 'B1', args: { query: 'second' }, result_sha256: '3'.repeat(20) }),
+      rec({ record_id: 'r4', source_type: 'web_search', tool_call_id: 'call-2', identifier: 'https://b.test/2', title: 'B2', args: { query: 'second' }, result_sha256: '4'.repeat(20) }),
+    ]);
+    render(<SourcesPanel provenanceRecords={records} />);
+    // One row per query (header badge), two decks.
+    expect(screen.getByTestId('group-count-web_search')).toHaveTextContent('2');
+    expect(screen.getAllByTestId('source-stack')).toHaveLength(2);
+    expect(screen.getByText('first')).toBeInTheDocument();
+    expect(screen.getByText('second')).toBeInTheDocument();
+  });
+
+  it('caps the collapsed stack to a few peek cards but reports the true count', () => {
+    const results = Array.from({ length: 9 }, (_, i) =>
+      rec({ record_id: `r${i}`, source_type: 'web_search', tool_call_id: 'c1', identifier: `https://x.test/${i}`, title: `R${i}`, args: { query: 'many' }, result_sha256: String(i).repeat(20) }),
+    );
+    render(<SourcesPanel provenanceRecords={asMap(results)} />);
+
+    const stack = screen.getByTestId('source-stack');
+    // Collapsed: front + a capped number of peek cards (MAX_PEEK_LAYERS = 2),
+    // not all nine — so the stack never grows arbitrarily deep.
+    expect(stack.querySelectorAll('.source-deck-card')).toHaveLength(3);
+    // ...but the front card still reports the true count.
+    expect(screen.getByText('9 results')).toBeInTheDocument();
+
+    // Fanned, every result is rendered.
+    fireEvent.click(screen.getByRole('button', { name: /many — Expand/ }));
+    expect(stack.querySelectorAll('.source-deck-card')).toHaveLength(9);
+  });
+
+  it('folds and unfolds a whole category via its header arrow, independently', () => {
+    const records = asMap([
+      rec({ record_id: 'r1', source_type: 'web_search', tool_call_id: 'c1', identifier: 'https://a.test/1', title: 'Alpha Result', args: { query: 'q' }, result_sha256: '1'.repeat(20) }),
+      rec({ record_id: 'r2', source_type: 'mcp_tool', identifier: 'srv:get_x', title: 'Tool X' }),
+    ]);
+    render(<SourcesPanel provenanceRecords={records} />);
+
+    // Both categories start expanded with their rows visible.
+    const header = screen.getByRole('button', { name: /Web search/ });
+    expect(header).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('Alpha Result')).toBeInTheDocument();
+
+    // Folding web search hides only its rows; the count badge stays so a folded
+    // category still shows its size, and other categories are untouched.
+    fireEvent.click(header);
+    expect(header).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByText('Alpha Result')).not.toBeInTheDocument();
+    expect(screen.getByTestId('group-count-web_search')).toHaveTextContent('1');
+    expect(screen.getByText('Tool X')).toBeInTheDocument();
+
+    // Unfolding restores its rows.
+    fireEvent.click(header);
+    expect(header).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('Alpha Result')).toBeInTheDocument();
+  });
+
+  it('clears a fanned deck when its category is folded, so it returns collapsed', () => {
+    const records = asMap([
+      rec({ record_id: 'r1', source_type: 'web_search', tool_call_id: 'c1', identifier: 'https://a.test/1', title: 'R1', args: { query: 'q' }, result_sha256: '1'.repeat(20) }),
+      rec({ record_id: 'r2', source_type: 'web_search', tool_call_id: 'c1', identifier: 'https://a.test/2', title: 'R2', args: { query: 'q' }, result_sha256: '2'.repeat(20) }),
+    ]);
+    render(<SourcesPanel provenanceRecords={records} />);
+
+    // Fan the deck open.
+    fireEvent.click(screen.getByRole('button', { name: /q — Expand/ }));
+    expect(screen.getByTestId('source-stack')).toHaveAttribute('data-fanned', 'true');
+
+    // Folding the category unmounts the deck entirely...
+    const header = screen.getByRole('button', { name: /Web search/ });
+    fireEvent.click(header);
+    expect(screen.queryByTestId('source-stack')).not.toBeInTheDocument();
+
+    // ...and unfolding brings it back COLLAPSED, not still-fanned (the fan state
+    // is dropped on fold so it can't linger open behind a collapsed header).
+    fireEvent.click(header);
+    expect(screen.getByTestId('source-stack')).toHaveAttribute('data-fanned', 'false');
+    expect(screen.getByText('2 results')).toBeInTheDocument();
+  });
+
+  it('keeps two different URLs with identical content as separate cards in a domain deck', () => {
+    // Two distinct pages on one site return byte-identical content (same sha) —
+    // e.g. both redirect to the same block/login page. A list deck dedups by URL,
+    // so both stay and the page count is not undercounted (entity decks, which
+    // share an identifier, still collapse by content hash).
+    const records = asMap([
+      rec({ record_id: 'r1', source_type: 'web_fetch', identifier: 'https://site.test/a', args: { url: 'https://site.test/a' }, result_sha256: 'same'.repeat(5) }),
+      rec({ record_id: 'r2', source_type: 'web_fetch', identifier: 'https://site.test/b', args: { url: 'https://site.test/b' }, result_sha256: 'same'.repeat(5) }),
+    ]);
+    render(<SourcesPanel provenanceRecords={records} />);
+
+    // Both pages survive: a 2-card deck, not a single collapsed card.
+    expect(screen.getByText('2 pages')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /site\.test — Expand/ }));
+    expect(screen.getByRole('button', { name: /\/a — View details/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /\/b — View details/ })).toBeInTheDocument();
+  });
+
+  it('renders a web_fetch with an unparseable URL as a flat leaf row without crashing', () => {
+    const records = asMap([
+      rec({ record_id: 'r1', source_type: 'web_fetch', identifier: 'not a url', args: { url: 'not a url' } }),
+    ]);
+    render(<SourcesPanel provenanceRecords={records} />);
+    // No domain to group under → a single leaf row labeled by the raw identifier.
+    expect(screen.queryByTestId('source-stack')).not.toBeInTheDocument();
+    expect(screen.getByText('not a url')).toBeInTheDocument();
+  });
+
+  it('does not merge web searches that lack both a tool_call_id and a query', () => {
+    const records = asMap([
+      rec({ record_id: 'r1', source_type: 'web_search', identifier: 'https://x.test/1', title: 'X1' }),
+      rec({ record_id: 'r2', source_type: 'web_search', identifier: 'https://y.test/2', title: 'X2' }),
+    ]);
+    render(<SourcesPanel provenanceRecords={records} />);
+    // With no shared grouping key, each falls back to its identifier → two
+    // distinct leaf rows, not one deck mislabeled by an arbitrary query.
+    expect(screen.getByTestId('group-count-web_search')).toHaveTextContent('2');
+    expect(screen.queryByTestId('source-stack')).not.toBeInTheDocument();
+    expect(screen.getByText('X1')).toBeInTheDocument();
+    expect(screen.getByText('X2')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
Refines the provenance "Sources" panel so high-volume sources stop dominating the panel.

- **web_search** results group into one deck per search (labeled by query; each card is a result URL).
- **web_fetch** pages group into one deck per origin domain (each card is a page path).
- **Per-category fold** arrow on each source-type group header collapses a noisy category entirely.
- Collapsed decks cap to 2 blank peek cards while the true count stays on the front badge, fixing the "blurred tail" where many items bled content below the front card.
- Fanned (expanded) cards show per-item detail (args / query / domain).
- List decks (web_search/web_fetch) dedup by URL, so two different pages that return identical content stay separate cards instead of one silently swallowing the other (the page count no longer undercounts). Entity decks (e.g. a ticker read several ways) keep content-hash dedup.

The "Sources (N)" pill keeps counting distinct URLs (how many pages were read) and intentionally runs ahead of the panel's grouped row count — documented in code.

## Diff Size
- Total: 5 files changed, 446 insertions(+), 78 deletions(-)
- Net (excl. tests): 4 files changed, 234 insertions(+), 70 deletions(-)

## Test Coverage
29 SourcesPanel tests (+4 new): folding a category clears a fanned deck; two different URLs with identical content stay separate cards; a malformed web_fetch URL renders as a flat leaf row; web searches lacking both tool_call_id and query don't merge into a mislabeled deck. Full frontend suite: 1696 pass / 0 fail.

## Pre-Landing Review
Clean. One logic fix applied (list-deck dedup by URL) plus the 4 covering tests above. Two findings skipped as intended behavior: web_search query-collision only when tool_call_id is absent (LangChain always sets it), and the group badge counting decks rather than distinct URLs (the deliberate pill/panel divergence).

## Design Review
Not run separately — the change is structural (grouping / folding / capping), no new visual components. Run /design-review for a full visual audit if wanted.

## Plan Completion
No applicable plan file for this branch — it is a follow-up refinement to the already-merged provenance-tracing feature.

## Test plan
- [x] Full frontend Vitest suite passes (1696 tests, 0 failures)
- [x] ESLint clean (0 errors)
- [x] No NUL bytes in changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added collapsible source groups in the Sources panel, including clickable headers with expand/collapse chevrons and count badges.
  * Improved how sources are organized into decks (e.g., by query and domain) and refined the “peek” behavior.
  * Added result and page count displays for query results.

* **Localization**
  * Updated English and Chinese UI strings with new collapse labels and pagination/count wording.

* **Bug Fixes**
  * Improved grouping/deduping so distinct web fetch URLs and edge cases don’t incorrectly merge or fail to render.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->