### PR TITLE
feat(chart-annotation): agent-drawn chart annotations on MarketView

### DIFF
--- a/migrations/versions/013_add_chart_annotations.py
+++ b/migrations/versions/013_add_chart_annotations.py
@@ -1,0 +1,57 @@
+"""Add durable storage for agent-drawn chart annotations.
+
+Each row is one annotation belonging to a chart instance. A chart instance is
+identified by ``(workspace_id, chart_id)`` where ``chart_id`` is the disclosed
+key ``"{SYMBOL}:{timeframe}"`` — so re-drawing with the same symbol+timeframe
+edits the same chart, and a different ticker or timeframe is a new chart. The
+``(workspace_id, symbol, timeframe)`` index serves the MarketView lookup that
+renders the active workspace's chart.
+
+Replaces the previous Redis-backed store (7-day TTL): annotations are a durable
+workspace artifact set now, cascading away only when the workspace is deleted.
+
+Revision ID: 013
+Revises: 012
+"""
+
+from alembic import op
+
+
+revision = "013"
+down_revision = "012"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS chart_annotations (
+            workspace_id UUID NOT NULL REFERENCES workspaces(workspace_id) ON DELETE CASCADE,
+            chart_id VARCHAR(128) NOT NULL,
+            symbol VARCHAR(32) NOT NULL,
+            timeframe VARCHAR(16) NOT NULL,
+            annotation_id VARCHAR(64) NOT NULL,
+            payload JSONB NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            PRIMARY KEY (workspace_id, chart_id, annotation_id)
+        )
+    """)
+
+    # MarketView renders the active workspace's (symbol, timeframe) chart; this
+    # index serves that lookup and the per-instance list/clear operations.
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS idx_chart_annotations_view
+        ON chart_annotations(workspace_id, symbol, timeframe)
+    """)
+
+    op.execute("DROP TRIGGER IF EXISTS update_chart_annotations_updated_at ON chart_annotations")
+    op.execute("""
+        CREATE TRIGGER update_chart_annotations_updated_at
+        BEFORE UPDATE ON chart_annotations
+        FOR EACH ROW EXECUTE FUNCTION update_updated_at_column()
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS chart_annotations CASCADE")

--- a/migrations/versions/014_add_chart_annotations.py
+++ b/migrations/versions/014_add_chart_annotations.py
@@ -10,15 +10,15 @@ renders the active workspace's chart.
 Replaces the previous Redis-backed store (7-day TTL): annotations are a durable
 workspace artifact set now, cascading away only when the workspace is deleted.
 
-Revision ID: 013
-Revises: 012
+Revision ID: 014
+Revises: 013
 """
 
 from alembic import op
 
 
-revision = "013"
-down_revision = "012"
+revision = "014"
+down_revision = "013"
 branch_labels = None
 depends_on = None
 

--- a/migrations/versions/014_add_chart_annotations.py
+++ b/migrations/versions/014_add_chart_annotations.py
@@ -45,6 +45,8 @@ def upgrade() -> None:
         ON chart_annotations(workspace_id, symbol, timeframe)
     """)
 
+    # update_updated_at_column() is defined in migration 001 (initial schema)
+    # and reused here (as in 003 and 012); no redeclaration needed.
     op.execute("DROP TRIGGER IF EXISTS update_chart_annotations_updated_at ON chart_annotations")
     op.execute("""
         CREATE TRIGGER update_chart_annotations_updated_at

--- a/skills/chart-annotation/SKILL.md
+++ b/skills/chart-annotation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: chart-annotation
-description: Annotate a stock's price chart with price lines, trendlines, zones, and event markers. Drawings appear live on the MarketView chart and as a clickable preview card in any other chat.
+description: Draw price lines, trendlines, zones, and event markers directly on a stock's price chart — reach for it whenever you'd otherwise describe a level, pattern, or event in prose. Renders live on MarketView and as a clickable preview card in any other chat.
 ---
 
 # Chart Annotation Skill
@@ -13,16 +13,33 @@ describing it in prose. Reach for this skill whenever you would otherwise
 say "look at the level around 205" or "notice the downtrend from October to
 December".
 
-You do **not** need the user to be on the MarketView page. If they are, the
-drawing appears on their live chart immediately. If they are in any other
-chat, the same drawing renders as a clickable preview card that expands into
-MarketView — so annotate freely whenever it helps, then mention the user can
-click it to open the full chart.
+**MarketView** is the app's live, TradingView-style price chart page (pan,
+zoom, switch timeframes). You do **not** need the user to be on it to
+annotate. If they are, the drawing appears on their live chart immediately. If
+they are in any other chat, the same drawing renders as a clickable preview
+card that expands into MarketView — so annotate freely whenever it helps, then
+mention the user can click it to open the full chart.
 
 This skill provides two tools:
 
 - `draw_chart_annotation` — add a single annotation to a chart.
 - `manage_chart_annotations` — list, remove, or clear annotations.
+
+## Interactive chart vs. a Python chart (deliverable)
+
+There are two ways to show price information visually — pick by what the user
+needs:
+
+- **This skill (interactive).** Annotations land on the live, pannable
+  MarketView chart (or a preview card that opens it). Best when the user just
+  wants to *see and explore* a level, pattern, or event themselves — quick,
+  in-the-moment, nothing to hand off.
+- **A Python chart (deliverable).** A static image you render with code and
+  embed in a report or document. Best when the output is a *deliverable* the
+  user keeps, shares, or exports — a research note, PDF, or deck.
+
+The two aren't exclusive: draw on the live chart for a quick look, render a
+Python chart when it belongs in a written artifact, or do both.
 
 ## Charts are identified by `SYMBOL:timeframe`
 
@@ -40,6 +57,12 @@ Always pass the ticker the user is discussing. `timeframe` defaults to
 `5min`, `15min`, `30min`, `1hour`, `4hour`, `1day`). Annotations are scoped to
 that one chart instance — a line drawn on `NVDA:1day` does **not** appear on
 `NVDA:1hour`.
+
+**Time format (any annotation with a `time` field).** Pass ISO 8601 datetimes
+(e.g. `2024-11-14T00:00:00Z`) aligned to a bar on the chart — for daily bars,
+midnight UTC of that day is safest. A time that doesn't land on a bar still
+renders but may look offset. Applies to `trendline`, `marker`, `vertical_line`,
+`text`, `event`, and `fib_retracement`.
 
 ---
 
@@ -66,9 +89,6 @@ stop, an analyst price target, a 52-week high.
 
 Use to connect two `(time, price)` points on the chart: channel tops,
 pattern boundaries, connecting highs/lows across dates.
-
-`time` must be an ISO 8601 datetime aligned to a bar on the chart (daily
-bars: midnight UTC of that day is safest).
 
 ```json
 {
@@ -205,11 +225,9 @@ manage_chart_annotations(symbol="NVDA", action="clear_all")
   ("Resistance 205", "Entry", not "Strong resistance level we should
   watch"). Put the reasoning in the chat message, not the label.
 - **One annotation per tool call.** If you want three levels, call
-  `draw_chart_annotation` three times. Each call is cheap.
-- **Bar alignment matters for trendline/marker.** If the time doesn't
-  match a bar on the chart (e.g. you pass a minute-resolution time on a
-  daily chart), the drawing still renders but may look offset.
+  `draw_chart_annotation` three times.
 - **Clean up stale work.** If you drew provisional levels and the
   conversation moved on, offer to `clear_all` before drawing a fresh set.
-- **Provenance is visible.** Agent-drawn items render with a subtle
-  dashed style so the user can tell them apart from their own drawings.
+- **No need to flag your drawings.** Agent-drawn items render with a subtle
+  dashed style, so the user can already tell them apart from their own — you
+  don't have to call out which annotations you added.

--- a/skills/chart-annotation/SKILL.md
+++ b/skills/chart-annotation/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: chart-annotation
+description: Annotate a stock's price chart with price lines, trendlines, zones, and event markers. Drawings appear live on the MarketView chart and as a clickable preview card in any other chat.
+---
+
+# Chart Annotation Skill
+
+## When to use
+
+You want to call out a technical level, a pattern, or an event on a stock's
+price chart. Drawing directly on the chart is almost always clearer than
+describing it in prose. Reach for this skill whenever you would otherwise
+say "look at the level around 205" or "notice the downtrend from October to
+December".
+
+You do **not** need the user to be on the MarketView page. If they are, the
+drawing appears on their live chart immediately. If they are in any other
+chat, the same drawing renders as a clickable preview card that expands into
+MarketView — so annotate freely whenever it helps, then mention the user can
+click it to open the full chart.
+
+This skill provides two tools:
+
+- `draw_chart_annotation` — add a single annotation to a chart.
+- `manage_chart_annotations` — list, remove, or clear annotations.
+
+## Charts are identified by `SYMBOL:timeframe`
+
+Every annotation belongs to a chart identified by its **ticker + timeframe**
+(e.g. `NVDA:1day`) — that pair *is* the chart's id:
+
+- Pass the same `symbol` + `timeframe` again to **add to / edit that same
+  chart** (annotations accumulate on it).
+- Use a **different ticker or timeframe** to start a **separate** chart — so
+  you can draw several charts in one turn (e.g. `AAPL:1day` and `AAPL:1hour`,
+  or `AAPL:1day` and `MSFT:1day`), each rendered as its own preview.
+
+Always pass the ticker the user is discussing. `timeframe` defaults to
+`1day`; set it to match the interval the user is viewing (one of `1min`,
+`5min`, `15min`, `30min`, `1hour`, `4hour`, `1day`). Annotations are scoped to
+that one chart instance — a line drawn on `NVDA:1day` does **not** appear on
+`NVDA:1hour`.
+
+---
+
+## Picking the right variant
+
+`draw_chart_annotation` takes an `annotation` object discriminated by its
+`type` field.
+
+### `price_line` — horizontal level
+
+Use for anything flat on the y-axis: support, resistance, a target, a
+stop, an analyst price target, a 52-week high.
+
+```json
+{
+  "type": "price_line",
+  "price": 205.0,
+  "label": "Resistance 205",
+  "style": "dashed"
+}
+```
+
+### `trendline` — two anchor points
+
+Use to connect two `(time, price)` points on the chart: channel tops,
+pattern boundaries, connecting highs/lows across dates.
+
+`time` must be an ISO 8601 datetime aligned to a bar on the chart (daily
+bars: midnight UTC of that day is safest).
+
+```json
+{
+  "type": "trendline",
+  "point1": {"time": "2024-10-16T00:00:00Z", "price": 145.2},
+  "point2": {"time": "2024-12-20T00:00:00Z", "price": 138.7},
+  "label": "Descending trend"
+}
+```
+
+### `marker` — single-bar event
+
+Use for a callout at one specific date: earnings beat, entry signal,
+news event, grade change.
+
+```json
+{
+  "type": "marker",
+  "time": "2024-11-14T00:00:00Z",
+  "shape": "arrowUp",
+  "position": "belowBar",
+  "text": "Earnings beat"
+}
+```
+
+`shape` options: `arrowUp`, `arrowDown`, `circle`, `square`.
+`position` options: `aboveBar`, `belowBar`, `inBar`.
+
+### `vertical_line` — a moment in time
+
+Use to mark a single date across the whole chart: an earnings date, a
+split, an FOMC meeting, the start of a move.
+
+```json
+{
+  "type": "vertical_line",
+  "time": "2024-11-14T00:00:00Z",
+  "label": "Earnings",
+  "style": "dashed"
+}
+```
+
+### `rectangle` — a zone
+
+Use for supply/demand zones, consolidation ranges, or any box over a
+region of the chart. `point1` and `point2` are two opposite corners (the
+fill is translucent so candles stay visible).
+
+```json
+{
+  "type": "rectangle",
+  "point1": {"time": "2024-10-16T00:00:00Z", "price": 150.0},
+  "point2": {"time": "2024-11-20T00:00:00Z", "price": 140.0},
+  "label": "Demand zone"
+}
+```
+
+### `text` — a free-floating label
+
+Use for a callout that isn't tied to a marker or level. Anchored at a
+`(time, price)` point.
+
+```json
+{
+  "type": "text",
+  "time": "2024-11-14T00:00:00Z",
+  "price": 205.0,
+  "text": "Breakout"
+}
+```
+
+### `fib_retracement` — Fibonacci levels
+
+Use to map retracement targets of a move. Pass the two ends of the swing
+(e.g. swing low → swing high); standard levels (0, 0.236, 0.382, 0.5,
+0.618, 0.786, 1.0) are drawn between them automatically.
+
+```json
+{
+  "type": "fib_retracement",
+  "point1": {"time": "2024-10-16T00:00:00Z", "price": 100.0},
+  "point2": {"time": "2024-12-20T00:00:00Z", "price": 200.0},
+  "label": "Oct–Dec move"
+}
+```
+
+---
+
+## Managing annotations
+
+`manage_chart_annotations` covers list / remove / clear_all:
+
+```python
+# See what's there
+manage_chart_annotations(symbol="NVDA", action="list")
+
+# Remove specific ones (get ids from `list`)
+manage_chart_annotations(symbol="NVDA", action="remove", ids=["ann_ab12..."])
+
+# Wipe everything for the symbol
+manage_chart_annotations(symbol="NVDA", action="clear_all")
+```
+
+- `remove` requires a non-empty `ids` list. The tool will reject an empty
+  call.
+- `clear_all` must not be given `ids`. Use `remove` for partial deletion.
+- Existing chart primitives the user set up themselves (52W high,
+  analyst target lines, earnings markers) are **not** managed by this
+  skill and are never touched by clear_all.
+
+---
+
+## Tips
+
+- **Short labels.** Chart space is tight — aim for a few words
+  ("Resistance 205", "Entry", not "Strong resistance level we should
+  watch"). Put the reasoning in the chat message, not the label.
+- **One annotation per tool call.** If you want three levels, call
+  `draw_chart_annotation` three times. Each call is cheap.
+- **Bar alignment matters for trendline/marker.** If the time doesn't
+  match a bar on the chart (e.g. you pass a minute-resolution time on a
+  daily chart), the drawing still renders but may look offset.
+- **Clean up stale work.** If you drew provisional levels and the
+  conversation moved on, offer to `clear_all` before drawing a fresh set.
+- **Provenance is visible.** Agent-drawn items render with a subtle
+  dashed style so the user can tell them apart from their own drawings.

--- a/skills/chart-annotation/SKILL.md
+++ b/skills/chart-annotation/SKILL.md
@@ -140,6 +140,24 @@ Use for a callout that isn't tied to a marker or level. Anchored at a
 }
 ```
 
+### `event` — news/event badge with detail
+
+Use when a callout needs more than a one-line label: an earnings report, an
+acquisition, an analyst upgrade, a product launch. Anchored at a `(time,
+price)` point, it shows a short `title` badge on the chart; the `detail` (a
+few sentences) is revealed on hover (desktop) or tap (mobile). Prefer this
+over `marker`/`text` when you want to explain *why* the event matters.
+
+```json
+{
+  "type": "event",
+  "time": "2024-11-14T00:00:00Z",
+  "price": 205.0,
+  "title": "Q3 earnings beat",
+  "detail": "Reported EPS of $1.40 vs $1.25 consensus and raised full-year guidance ~5%. Shares gapped up the next session on the print and the brighter outlook."
+}
+```
+
 ### `fib_retracement` — Fibonacci levels
 
 Use to map retracement targets of a move. Pass the two ends of the swing

--- a/src/ptc_agent/agent/middleware/skills/registry.py
+++ b/src/ptc_agent/agent/middleware/skills/registry.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from typing import Any, Literal
 
 from src.tools.automation import AUTOMATION_TOOLS
+from src.tools.chart_annotation import CHART_ANNOTATION_TOOLS
 from src.tools.onboarding import ONBOARDING_TOOLS
 from src.tools.user_profile import USER_PROFILE_TOOLS
 
@@ -92,6 +93,21 @@ SKILL_REGISTRY: dict[str, SkillDefinition] = {
         tools=ONBOARDING_TOOLS,
         skill_md_path="skills/onboarding/SKILL.md",
         exposure="hidden",
+    ),
+    "chart-annotation": SkillDefinition(
+        name="chart-annotation",
+        description=(
+            "Draw price lines, trendlines, zones, and event markers on a stock's "
+            "price chart. Annotations render live on the MarketView chart and as a "
+            "clickable preview card in any other chat."
+        ),
+        tools=CHART_ANNOTATION_TOOLS,
+        skill_md_path="skills/chart-annotation/SKILL.md",
+        # Discoverable in both modes so the agent can self-load it whenever the
+        # user asks to annotate — including from the standalone chat page, where
+        # the result renders as a preview card. MarketView also injects it
+        # proactively (with the active symbol) for turn-1 availability.
+        exposure="both",
     ),
     "secretary": SkillDefinition(
         name="secretary",

--- a/src/ptc_agent/agent/middleware/skills/registry.py
+++ b/src/ptc_agent/agent/middleware/skills/registry.py
@@ -96,9 +96,14 @@ SKILL_REGISTRY: dict[str, SkillDefinition] = {
     ),
     "chart-annotation": SkillDefinition(
         name="chart-annotation",
+        # Keep this text in sync with the `description:` in
+        # skills/chart-annotation/SKILL.md frontmatter — both are live (this one
+        # drives PTC discovery; the frontmatter drives the sandbox/Flash skill
+        # manifest), so they must not drift.
         description=(
-            "Draw price lines, trendlines, zones, and event markers on a stock's "
-            "price chart. Annotations render live on the MarketView chart and as a "
+            "Draw price lines, trendlines, zones, and event markers directly on a "
+            "stock's price chart — reach for it whenever you'd otherwise describe a "
+            "level, pattern, or event in prose. Renders live on MarketView and as a "
             "clickable preview card in any other chat."
         ),
         tools=CHART_ANNOTATION_TOOLS,
@@ -108,6 +113,7 @@ SKILL_REGISTRY: dict[str, SkillDefinition] = {
         # the result renders as a preview card. MarketView also injects it
         # proactively (with the active symbol) for turn-1 availability.
         exposure="both",
+        command="chart-annotation",
     ),
     "secretary": SkillDefinition(
         name="secretary",

--- a/src/server/app/chart_annotations.py
+++ b/src/server/app/chart_annotations.py
@@ -84,8 +84,9 @@ async def list_chart_annotations(
     """
     await _ensure_owner(workspace_id, x_user_id)
     sym = _normalize_symbol(symbol)
-    tf = timeframe.strip() if timeframe is not None else None
-    charts = await list_charts(workspace_id, sym, tf)
+    # ``timeframe`` is a validated ``Timeframe`` literal (no surrounding
+    # whitespace possible), so it's passed straight through.
+    charts = await list_charts(workspace_id, sym, timeframe)
     return ChartAnnotationListResponse(
         workspace_id=workspace_id,
         charts=[ChartInstance(**c) for c in charts],

--- a/src/server/app/chart_annotations.py
+++ b/src/server/app/chart_annotations.py
@@ -71,13 +71,17 @@ async def list_chart_annotations(
     workspace_id: str,
     x_user_id: CurrentUserId,
     symbol: str = Query(..., max_length=32, description="Ticker symbol (case-insensitive)"),
-    timeframe: str | None = Query(
+    timeframe: Timeframe | None = Query(
         None,
-        max_length=16,
         description="Chart interval; omit to return every timeframe for the symbol",
     ),
 ):
-    """List chart instances for a workspace + symbol (optionally one timeframe)."""
+    """List chart instances for a workspace + symbol (optionally one timeframe).
+
+    ``timeframe`` is constrained to the supported set (symmetric with DELETE): a
+    typo yields 422 rather than silently returning an empty list. Omit it to get
+    every timeframe for the symbol.
+    """
     await _ensure_owner(workspace_id, x_user_id)
     sym = _normalize_symbol(symbol)
     tf = timeframe.strip() if timeframe is not None else None

--- a/src/server/app/chart_annotations.py
+++ b/src/server/app/chart_annotations.py
@@ -25,6 +25,7 @@ from src.server.database.chart_annotation import (
 )
 from src.server.database.workspace import get_workspace as db_get_workspace
 from src.server.utils.api import CurrentUserId, require_workspace_owner
+from src.tools.chart_annotation.schemas import Timeframe
 
 logger = logging.getLogger(__name__)
 
@@ -95,9 +96,14 @@ async def clear_chart_annotations(
     workspace_id: str,
     x_user_id: CurrentUserId,
     symbol: str = Query(..., max_length=32, description="Ticker symbol (case-insensitive)"),
-    timeframe: str = Query("1day", max_length=16, description="Chart interval"),
+    timeframe: Timeframe = Query("1day", description="Chart interval"),
 ):
-    """Delete every annotation on one chart instance (workspace + symbol + timeframe)."""
+    """Delete every annotation on one chart instance (workspace + symbol + timeframe).
+
+    ``timeframe`` is constrained to the supported set (it is part of the chart
+    identity, unlike the GET filter) so a typo yields 422 rather than a silent
+    no-op delete.
+    """
     await _ensure_owner(workspace_id, x_user_id)
     sym = _normalize_symbol(symbol)
     chart_id = make_chart_id(sym, timeframe)

--- a/src/server/app/chart_annotations.py
+++ b/src/server/app/chart_annotations.py
@@ -1,0 +1,106 @@
+"""Chart Annotation API Router.
+
+Workspace-scoped endpoints for reading and clearing chart annotations the
+agent drew. A chart instance is ``(workspace_id, chart_id)`` where
+``chart_id = "{SYMBOL}:{timeframe}"`` — persisted durably in Postgres (see
+``src/server/database/chart_annotation.py``).
+
+Writes happen through the agent tool only — this router is read / bulk
+delete only.
+
+Endpoints:
+- GET    /api/v1/workspaces/{workspace_id}/chart-annotations?symbol=&timeframe=
+- DELETE /api/v1/workspaces/{workspace_id}/chart-annotations?symbol=&timeframe=
+"""
+
+import logging
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel
+
+from src.server.database.chart_annotation import (
+    clear_chart,
+    list_charts,
+    make_chart_id,
+)
+from src.server.database.workspace import get_workspace as db_get_workspace
+from src.server.utils.api import CurrentUserId, require_workspace_owner
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/workspaces", tags=["Chart Annotations"])
+
+
+class ChartInstance(BaseModel):
+    chart_id: str
+    symbol: str
+    timeframe: str
+    annotations: list[dict]
+
+
+class ChartAnnotationListResponse(BaseModel):
+    workspace_id: str
+    charts: list[ChartInstance]
+
+
+class ChartAnnotationClearResponse(BaseModel):
+    workspace_id: str
+    chart_id: str
+    cleared: int
+
+
+def _normalize_symbol(symbol: str) -> str:
+    sym = symbol.strip().upper()
+    if not sym:
+        raise HTTPException(status_code=400, detail="symbol is required")
+    return sym
+
+
+async def _ensure_owner(workspace_id: str, user_id: str) -> None:
+    """Look up the workspace and verify the caller owns it (404 / 403)."""
+    workspace = await db_get_workspace(workspace_id)
+    require_workspace_owner(workspace, user_id=user_id)
+
+
+@router.get(
+    "/{workspace_id}/chart-annotations",
+    response_model=ChartAnnotationListResponse,
+)
+async def list_chart_annotations(
+    workspace_id: str,
+    x_user_id: CurrentUserId,
+    symbol: str = Query(..., description="Ticker symbol (case-insensitive)"),
+    timeframe: str | None = Query(
+        None, description="Chart interval; omit to return every timeframe for the symbol"
+    ),
+):
+    """List chart instances for a workspace + symbol (optionally one timeframe)."""
+    await _ensure_owner(workspace_id, x_user_id)
+    sym = _normalize_symbol(symbol)
+    charts = await list_charts(workspace_id, sym, timeframe)
+    return ChartAnnotationListResponse(
+        workspace_id=workspace_id,
+        charts=[ChartInstance(**c) for c in charts],
+    )
+
+
+@router.delete(
+    "/{workspace_id}/chart-annotations",
+    response_model=ChartAnnotationClearResponse,
+)
+async def clear_chart_annotations(
+    workspace_id: str,
+    x_user_id: CurrentUserId,
+    symbol: str = Query(..., description="Ticker symbol (case-insensitive)"),
+    timeframe: str = Query("1day", description="Chart interval"),
+):
+    """Delete every annotation on one chart instance (workspace + symbol + timeframe)."""
+    await _ensure_owner(workspace_id, x_user_id)
+    sym = _normalize_symbol(symbol)
+    chart_id = make_chart_id(sym, timeframe)
+    cleared = await clear_chart(workspace_id, chart_id)
+    return ChartAnnotationClearResponse(
+        workspace_id=workspace_id,
+        chart_id=chart_id,
+        cleared=cleared,
+    )

--- a/src/server/app/chart_annotations.py
+++ b/src/server/app/chart_annotations.py
@@ -69,15 +69,18 @@ async def _ensure_owner(workspace_id: str, user_id: str) -> None:
 async def list_chart_annotations(
     workspace_id: str,
     x_user_id: CurrentUserId,
-    symbol: str = Query(..., description="Ticker symbol (case-insensitive)"),
+    symbol: str = Query(..., max_length=32, description="Ticker symbol (case-insensitive)"),
     timeframe: str | None = Query(
-        None, description="Chart interval; omit to return every timeframe for the symbol"
+        None,
+        max_length=16,
+        description="Chart interval; omit to return every timeframe for the symbol",
     ),
 ):
     """List chart instances for a workspace + symbol (optionally one timeframe)."""
     await _ensure_owner(workspace_id, x_user_id)
     sym = _normalize_symbol(symbol)
-    charts = await list_charts(workspace_id, sym, timeframe)
+    tf = timeframe.strip() if timeframe is not None else None
+    charts = await list_charts(workspace_id, sym, tf)
     return ChartAnnotationListResponse(
         workspace_id=workspace_id,
         charts=[ChartInstance(**c) for c in charts],
@@ -91,8 +94,8 @@ async def list_chart_annotations(
 async def clear_chart_annotations(
     workspace_id: str,
     x_user_id: CurrentUserId,
-    symbol: str = Query(..., description="Ticker symbol (case-insensitive)"),
-    timeframe: str = Query("1day", description="Chart interval"),
+    symbol: str = Query(..., max_length=32, description="Ticker symbol (case-insensitive)"),
+    timeframe: str = Query("1day", max_length=16, description="Chart interval"),
 ):
     """Delete every annotation on one chart instance (workspace + symbol + timeframe)."""
     await _ensure_owner(workspace_id, x_user_id)

--- a/src/server/app/setup.py
+++ b/src/server/app/setup.py
@@ -709,6 +709,7 @@ from src.server.app.workspaces import router as workspaces_router
 from src.server.app.workspace_files import router as workspace_files_router
 from src.server.app.workspace_files import wsfiles_router
 from src.server.app.workspace_sandbox import router as workspace_sandbox_router
+from src.server.app.chart_annotations import router as chart_annotations_router
 from src.server.app.workspace_sandbox import preview_redirect_router
 from src.server.app.market_data import router as market_data_router
 from src.server.app.users import router as users_router
@@ -759,6 +760,9 @@ app.include_router(
 app.include_router(
     workspace_sandbox_router
 )  # /api/v1/workspaces/{id}/sandbox/* - Sandbox stats & packages
+app.include_router(
+    chart_annotations_router
+)  # /api/v1/workspaces/{id}/chart-annotations - Agent-drawn chart annotations
 app.include_router(cache_router)  # /api/v1/cache/* - Cache management
 app.include_router(market_data_router)  # /api/v1/market-data/* - Market data proxy
 app.include_router(users_router)  # /api/v1/users/* - User management

--- a/src/server/database/chart_annotation.py
+++ b/src/server/database/chart_annotation.py
@@ -13,9 +13,9 @@ import logging
 from typing import Any
 
 from psycopg.rows import dict_row
-from psycopg.types.json import Json
 
 from src.server.database.conversation import get_db_connection
+from src.server.utils.pg_sanitize import SafeJson, strip_pg_nul_str
 
 logger = logging.getLogger(__name__)
 
@@ -55,11 +55,11 @@ async def add_annotation(
                 """,
                 (
                     workspace_id,
-                    chart_id,
-                    symbol.upper(),
+                    strip_pg_nul_str(chart_id),
+                    strip_pg_nul_str(symbol.upper()),
                     timeframe,
                     annotation_id,
-                    Json(annotation),
+                    SafeJson(annotation),
                 ),
             )
 

--- a/src/server/database/chart_annotation.py
+++ b/src/server/database/chart_annotation.py
@@ -170,6 +170,9 @@ async def list_charts(
 
     async with get_db_connection() as conn:
         async with conn.cursor(row_factory=dict_row) as cur:
+            # ``where`` is assembled only from the literal clause strings above;
+            # every user-supplied value is a %s placeholder bound via ``params``,
+            # so this f-string carries no SQL-injection surface.
             await cur.execute(
                 f"""
                 SELECT chart_id, symbol, timeframe, payload

--- a/src/server/database/chart_annotation.py
+++ b/src/server/database/chart_annotation.py
@@ -19,6 +19,12 @@ from src.server.database.conversation import get_db_connection
 
 logger = logging.getLogger(__name__)
 
+# Safety valve for the read paths — far above any legitimate annotation count
+# for one chart / one symbol. Caps an unbounded result set (and the resulting
+# response size) if a runaway agent ever drew an absurd number; truncation is
+# logged so it is never silent.
+_MAX_ANNOTATION_ROWS = 2000
+
 
 def make_chart_id(symbol: str, timeframe: str) -> str:
     """Disclosed instance key: ``{SYMBOL}:{timeframe}`` (uppercased ticker)."""
@@ -68,10 +74,19 @@ async def list_annotations(workspace_id: str, chart_id: str) -> list[dict[str, A
                 FROM chart_annotations
                 WHERE workspace_id = %s AND chart_id = %s
                 ORDER BY created_at
+                LIMIT %s
                 """,
-                (workspace_id, chart_id),
+                (workspace_id, chart_id, _MAX_ANNOTATION_ROWS),
             )
             rows = await cur.fetchall()
+    if len(rows) >= _MAX_ANNOTATION_ROWS:
+        logger.warning(
+            "[chart_annotation] list_annotations hit the %d-row cap "
+            "(workspace=%s chart=%s); some annotations were not returned",
+            _MAX_ANNOTATION_ROWS,
+            workspace_id,
+            chart_id,
+        )
     return [row["payload"] for row in rows]
 
 
@@ -103,10 +118,20 @@ async def list_charts(
                 FROM chart_annotations
                 WHERE {where}
                 ORDER BY chart_id, created_at
+                LIMIT %s
                 """,
-                params,
+                [*params, _MAX_ANNOTATION_ROWS],
             )
             rows = await cur.fetchall()
+
+    if len(rows) >= _MAX_ANNOTATION_ROWS:
+        logger.warning(
+            "[chart_annotation] list_charts hit the %d-row cap "
+            "(workspace=%s symbol=%s); some annotations were not returned",
+            _MAX_ANNOTATION_ROWS,
+            workspace_id,
+            symbol,
+        )
 
     charts: dict[str, dict[str, Any]] = {}
     for row in rows:

--- a/src/server/database/chart_annotation.py
+++ b/src/server/database/chart_annotation.py
@@ -55,11 +55,11 @@ def _upsert_params(
 ) -> tuple[Any, ...]:
     """Bind tuple for ``_UPSERT_SQL`` — same NUL-stripping for every write path."""
     return (
-        workspace_id,
+        strip_pg_nul_str(workspace_id),
         strip_pg_nul_str(chart_id),
         strip_pg_nul_str(symbol.upper()),
-        timeframe,
-        annotation["annotation_id"],
+        strip_pg_nul_str(timeframe),
+        strip_pg_nul_str(annotation["annotation_id"]),
         SafeJson(annotation),
     )
 

--- a/src/server/database/chart_annotation.py
+++ b/src/server/database/chart_annotation.py
@@ -25,6 +25,56 @@ logger = logging.getLogger(__name__)
 # logged so it is never silent.
 _MAX_ANNOTATION_ROWS = 2000
 
+# Shared SQL so the single-write, single-read, and combined write+read paths
+# never drift. ``add_and_list_annotations`` runs both on ONE pooled connection:
+# autocommit makes the read see the just-upserted row, so a draw costs one
+# checkout instead of two.
+_UPSERT_SQL = """
+    INSERT INTO chart_annotations
+        (workspace_id, chart_id, symbol, timeframe, annotation_id, payload)
+    VALUES (%s, %s, %s, %s, %s, %s)
+    ON CONFLICT (workspace_id, chart_id, annotation_id)
+    DO UPDATE SET payload = EXCLUDED.payload, updated_at = NOW()
+"""
+
+_CHART_SELECT_SQL = """
+    SELECT payload
+    FROM chart_annotations
+    WHERE workspace_id = %s AND chart_id = %s
+    ORDER BY created_at
+    LIMIT %s
+"""
+
+
+def _upsert_params(
+    workspace_id: str,
+    chart_id: str,
+    symbol: str,
+    timeframe: str,
+    annotation: dict[str, Any],
+) -> tuple[Any, ...]:
+    """Bind tuple for ``_UPSERT_SQL`` — same NUL-stripping for every write path."""
+    return (
+        workspace_id,
+        strip_pg_nul_str(chart_id),
+        strip_pg_nul_str(symbol.upper()),
+        timeframe,
+        annotation["annotation_id"],
+        SafeJson(annotation),
+    )
+
+
+def _warn_if_capped(row_count: int, workspace_id: str, chart_id: str) -> None:
+    """Log (never silently) when a chart-scoped read hit the row cap."""
+    if row_count >= _MAX_ANNOTATION_ROWS:
+        logger.warning(
+            "[chart_annotation] chart read hit the %d-row cap "
+            "(workspace=%s chart=%s); some annotations were not returned",
+            _MAX_ANNOTATION_ROWS,
+            workspace_id,
+            chart_id,
+        )
+
 
 def make_chart_id(symbol: str, timeframe: str) -> str:
     """Disclosed instance key: ``{SYMBOL}:{timeframe}`` (uppercased ticker)."""
@@ -42,25 +92,11 @@ async def add_annotation(
 
     Raises on any DB failure so the caller can stay fail-closed.
     """
-    annotation_id = annotation["annotation_id"]
     async with get_db_connection() as conn:
         async with conn.cursor() as cur:
             await cur.execute(
-                """
-                INSERT INTO chart_annotations
-                    (workspace_id, chart_id, symbol, timeframe, annotation_id, payload)
-                VALUES (%s, %s, %s, %s, %s, %s)
-                ON CONFLICT (workspace_id, chart_id, annotation_id)
-                DO UPDATE SET payload = EXCLUDED.payload, updated_at = NOW()
-                """,
-                (
-                    workspace_id,
-                    strip_pg_nul_str(chart_id),
-                    strip_pg_nul_str(symbol.upper()),
-                    timeframe,
-                    annotation_id,
-                    SafeJson(annotation),
-                ),
+                _UPSERT_SQL,
+                _upsert_params(workspace_id, chart_id, symbol, timeframe, annotation),
             )
 
 
@@ -69,24 +105,46 @@ async def list_annotations(workspace_id: str, chart_id: str) -> list[dict[str, A
     async with get_db_connection() as conn:
         async with conn.cursor(row_factory=dict_row) as cur:
             await cur.execute(
-                """
-                SELECT payload
-                FROM chart_annotations
-                WHERE workspace_id = %s AND chart_id = %s
-                ORDER BY created_at
-                LIMIT %s
-                """,
+                _CHART_SELECT_SQL,
                 (workspace_id, chart_id, _MAX_ANNOTATION_ROWS),
             )
             rows = await cur.fetchall()
-    if len(rows) >= _MAX_ANNOTATION_ROWS:
-        logger.warning(
-            "[chart_annotation] list_annotations hit the %d-row cap "
-            "(workspace=%s chart=%s); some annotations were not returned",
-            _MAX_ANNOTATION_ROWS,
-            workspace_id,
-            chart_id,
-        )
+    _warn_if_capped(len(rows), workspace_id, chart_id)
+    return [row["payload"] for row in rows]
+
+
+async def add_and_list_annotations(
+    workspace_id: str,
+    chart_id: str,
+    symbol: str,
+    timeframe: str,
+    annotation: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Upsert one annotation and return the instance's full set, oldest first.
+
+    Write and read share one pooled connection (autocommit, so the read sees the
+    just-written row) — one checkout per draw instead of two. Raises on the write
+    so the caller stays fail-closed; the read-back is best-effort and falls back
+    to the just-written annotation so a transient read error can't mask a
+    successful write.
+    """
+    async with get_db_connection() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                _UPSERT_SQL,
+                _upsert_params(workspace_id, chart_id, symbol, timeframe, annotation),
+            )
+        try:
+            async with conn.cursor(row_factory=dict_row) as cur:
+                await cur.execute(
+                    _CHART_SELECT_SQL,
+                    (workspace_id, chart_id, _MAX_ANNOTATION_ROWS),
+                )
+                rows = await cur.fetchall()
+        except Exception:
+            logger.exception("[chart_annotation] read-back after upsert failed")
+            return [annotation]
+    _warn_if_capped(len(rows), workspace_id, chart_id)
     return [row["payload"] for row in rows]
 
 

--- a/src/server/database/chart_annotation.py
+++ b/src/server/database/chart_annotation.py
@@ -1,0 +1,158 @@
+"""Postgres store for agent-drawn chart annotations.
+
+A chart instance is ``(workspace_id, chart_id)`` where
+``chart_id = "{SYMBOL}:{timeframe}"`` — same symbol+timeframe edits the same
+chart; a different ticker or timeframe is a new chart. One row per annotation;
+``payload`` holds the full renderable annotation dict.
+
+Durable (no TTL) and workspace-scoped: annotations cascade away only when the
+workspace is deleted. Reached from the agent tool via the shared app pool.
+"""
+
+import logging
+from typing import Any
+
+from psycopg.rows import dict_row
+from psycopg.types.json import Json
+
+from src.server.database.conversation import get_db_connection
+
+logger = logging.getLogger(__name__)
+
+
+def make_chart_id(symbol: str, timeframe: str) -> str:
+    """Disclosed instance key: ``{SYMBOL}:{timeframe}`` (uppercased ticker)."""
+    return f"{symbol.strip().upper()}:{timeframe.strip()}"
+
+
+async def add_annotation(
+    workspace_id: str,
+    chart_id: str,
+    symbol: str,
+    timeframe: str,
+    annotation: dict[str, Any],
+) -> None:
+    """Upsert one annotation into a chart instance (idempotent on annotation_id).
+
+    Raises on any DB failure so the caller can stay fail-closed.
+    """
+    annotation_id = annotation["annotation_id"]
+    async with get_db_connection() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                """
+                INSERT INTO chart_annotations
+                    (workspace_id, chart_id, symbol, timeframe, annotation_id, payload)
+                VALUES (%s, %s, %s, %s, %s, %s)
+                ON CONFLICT (workspace_id, chart_id, annotation_id)
+                DO UPDATE SET payload = EXCLUDED.payload, updated_at = NOW()
+                """,
+                (
+                    workspace_id,
+                    chart_id,
+                    symbol.upper(),
+                    timeframe,
+                    annotation_id,
+                    Json(annotation),
+                ),
+            )
+
+
+async def list_annotations(workspace_id: str, chart_id: str) -> list[dict[str, Any]]:
+    """Return every annotation for one chart instance, oldest first."""
+    async with get_db_connection() as conn:
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(
+                """
+                SELECT payload
+                FROM chart_annotations
+                WHERE workspace_id = %s AND chart_id = %s
+                ORDER BY created_at
+                """,
+                (workspace_id, chart_id),
+            )
+            rows = await cur.fetchall()
+    return [row["payload"] for row in rows]
+
+
+async def list_charts(
+    workspace_id: str,
+    symbol: str | None = None,
+    timeframe: str | None = None,
+) -> list[dict[str, Any]]:
+    """Return chart instances for a workspace, optionally filtered.
+
+    Each instance is ``{chart_id, symbol, timeframe, annotations: [...]}``,
+    grouped by chart_id with annotations ordered oldest first.
+    """
+    clauses = ["workspace_id = %s"]
+    params: list[Any] = [workspace_id]
+    if symbol:
+        clauses.append("symbol = %s")
+        params.append(symbol.upper())
+    if timeframe:
+        clauses.append("timeframe = %s")
+        params.append(timeframe)
+    where = " AND ".join(clauses)
+
+    async with get_db_connection() as conn:
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(
+                f"""
+                SELECT chart_id, symbol, timeframe, payload
+                FROM chart_annotations
+                WHERE {where}
+                ORDER BY chart_id, created_at
+                """,
+                params,
+            )
+            rows = await cur.fetchall()
+
+    charts: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        cid = row["chart_id"]
+        chart = charts.get(cid)
+        if chart is None:
+            chart = {
+                "chart_id": cid,
+                "symbol": row["symbol"],
+                "timeframe": row["timeframe"],
+                "annotations": [],
+            }
+            charts[cid] = chart
+        chart["annotations"].append(row["payload"])
+    return list(charts.values())
+
+
+async def remove_annotations(
+    workspace_id: str,
+    chart_id: str,
+    ids: list[str],
+) -> int:
+    """Delete specific annotation ids from a chart instance. Returns count removed."""
+    if not ids:
+        return 0
+    async with get_db_connection() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                """
+                DELETE FROM chart_annotations
+                WHERE workspace_id = %s AND chart_id = %s AND annotation_id = ANY(%s)
+                """,
+                (workspace_id, chart_id, list(ids)),
+            )
+            return cur.rowcount or 0
+
+
+async def clear_chart(workspace_id: str, chart_id: str) -> int:
+    """Delete every annotation in a chart instance. Returns count cleared."""
+    async with get_db_connection() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                """
+                DELETE FROM chart_annotations
+                WHERE workspace_id = %s AND chart_id = %s
+                """,
+                (workspace_id, chart_id),
+            )
+            return cur.rowcount or 0

--- a/src/tools/chart_annotation/__init__.py
+++ b/src/tools/chart_annotation/__init__.py
@@ -1,7 +1,8 @@
 """Chart annotation tools — skill-gated tools for drawing on MarketView charts.
 
 Tools:
-- draw_chart_annotation: draw a price line, trendline, or marker on the chart
+- draw_chart_annotation: draw an annotation (price line, trendline, marker,
+  vertical line, rectangle, text, event, or fib retracement) on the chart
 - manage_chart_annotations: list, remove, or clear annotations for a symbol
 """
 

--- a/src/tools/chart_annotation/__init__.py
+++ b/src/tools/chart_annotation/__init__.py
@@ -1,0 +1,22 @@
+"""Chart annotation tools — skill-gated tools for drawing on MarketView charts.
+
+Tools:
+- draw_chart_annotation: draw a price line, trendline, or marker on the chart
+- manage_chart_annotations: list, remove, or clear annotations for a symbol
+"""
+
+from src.tools.chart_annotation.tools import (
+    draw_chart_annotation,
+    manage_chart_annotations,
+)
+
+CHART_ANNOTATION_TOOLS = [
+    draw_chart_annotation,
+    manage_chart_annotations,
+]
+
+__all__ = [
+    "draw_chart_annotation",
+    "manage_chart_annotations",
+    "CHART_ANNOTATION_TOOLS",
+]

--- a/src/tools/chart_annotation/schemas.py
+++ b/src/tools/chart_annotation/schemas.py
@@ -7,7 +7,7 @@ mostly-None fields.
 
 from typing import Annotated, Literal, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 # Bounds keep LLM-generated strings small enough that a runaway agent can't
@@ -26,7 +26,15 @@ Timeframe = Literal[
 ]
 
 
-class TimePricePoint(BaseModel):
+class _AnnotationBase(BaseModel):
+    """Base for annotation models. Rejects NaN/Infinity floats — Pydantic
+    allows them by default but they break JSONB serialization and fail the draw.
+    """
+
+    model_config = ConfigDict(allow_inf_nan=False)
+
+
+class TimePricePoint(_AnnotationBase):
     """A single (time, price) anchor on the chart."""
 
     time: str = Field(
@@ -36,7 +44,7 @@ class TimePricePoint(BaseModel):
     price: float = Field(description="Price (y-axis value) at the given time")
 
 
-class PriceLineAnnotation(BaseModel):
+class PriceLineAnnotation(_AnnotationBase):
     """Horizontal price level — support/resistance/target."""
 
     type: Literal["price_line"]
@@ -54,7 +62,7 @@ class PriceLineAnnotation(BaseModel):
     style: Literal["solid", "dashed", "dotted"] = "solid"
 
 
-class TrendlineAnnotation(BaseModel):
+class TrendlineAnnotation(_AnnotationBase):
     """Trendline connecting two (time, price) anchors."""
 
     type: Literal["trendline"]
@@ -72,7 +80,7 @@ class TrendlineAnnotation(BaseModel):
     )
 
 
-class MarkerAnnotation(BaseModel):
+class MarkerAnnotation(_AnnotationBase):
     """Event callout at a specific bar."""
 
     type: Literal["marker"]
@@ -94,7 +102,7 @@ class MarkerAnnotation(BaseModel):
     )
 
 
-class VerticalLineAnnotation(BaseModel):
+class VerticalLineAnnotation(_AnnotationBase):
     """Vertical line marking a moment in time across the whole chart."""
 
     type: Literal["vertical_line"]
@@ -115,7 +123,7 @@ class VerticalLineAnnotation(BaseModel):
     style: Literal["solid", "dashed", "dotted"] = "dashed"
 
 
-class RectangleAnnotation(BaseModel):
+class RectangleAnnotation(_AnnotationBase):
     """Rectangular zone spanning a time range and a price range.
 
     Use for supply/demand zones, consolidation ranges, or any box that
@@ -138,7 +146,7 @@ class RectangleAnnotation(BaseModel):
     )
 
 
-class TextAnnotation(BaseModel):
+class TextAnnotation(_AnnotationBase):
     """Free-floating text label anchored at a (time, price) point."""
 
     type: Literal["text"]
@@ -158,7 +166,7 @@ class TextAnnotation(BaseModel):
     )
 
 
-class EventAnnotation(BaseModel):
+class EventAnnotation(_AnnotationBase):
     """News/event callout anchored at a (time, price) point.
 
     Renders an always-visible title badge on the chart; the longer ``detail``
@@ -196,7 +204,7 @@ class EventAnnotation(BaseModel):
     )
 
 
-class FibRetracementAnnotation(BaseModel):
+class FibRetracementAnnotation(_AnnotationBase):
     """Fibonacci retracement between a swing high and a swing low.
 
     Standard levels (0, 0.236, 0.382, 0.5, 0.618, 0.786, 1.0) are drawn as
@@ -239,7 +247,8 @@ class DrawChartAnnotationArgs(BaseModel):
     """Arguments for ``draw_chart_annotation``."""
 
     symbol: str = Field(
-        description="Ticker symbol of the chart (e.g. 'NVDA')."
+        max_length=32,
+        description="Ticker symbol of the chart (e.g. 'NVDA').",
     )
     timeframe: Timeframe = Field(
         default="1day",
@@ -263,7 +272,9 @@ class DrawChartAnnotationArgs(BaseModel):
 class ManageChartAnnotationsArgs(BaseModel):
     """Arguments for ``manage_chart_annotations``."""
 
-    symbol: str = Field(description="Ticker symbol (scopes the operation)")
+    symbol: str = Field(
+        max_length=32, description="Ticker symbol (scopes the operation)"
+    )
     timeframe: Timeframe = Field(
         default="1day",
         description=(

--- a/src/tools/chart_annotation/schemas.py
+++ b/src/tools/chart_annotation/schemas.py
@@ -289,8 +289,9 @@ class ManageChartAnnotationsArgs(BaseModel):
             "'clear_all' deletes every annotation on the chart (must not pass ids)."
         )
     )
-    ids: list[str] | None = Field(
+    ids: list[Annotated[str, Field(max_length=64)]] | None = Field(
         default=None,
+        max_length=100,
         description=(
             "Annotation ids to delete. Required when action='remove'. "
             "Must be omitted/None for action='list' or action='clear_all'."

--- a/src/tools/chart_annotation/schemas.py
+++ b/src/tools/chart_annotation/schemas.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, Field
 _MAX_TIME_LEN = 40   # ISO8601 with timezone comfortably fits
 _MAX_LABEL_LEN = 200
 _MAX_COLOR_LEN = 64  # #rrggbb, rgba(...), or CSS name
+_MAX_DETAIL_LEN = 600  # a few sentences of event context, revealed on hover/click
 
 # Intervals the market-data API (and the inline chart card) can fetch. The
 # chart instance is identified by SYMBOL:timeframe, so this is also the set of
@@ -157,6 +158,44 @@ class TextAnnotation(BaseModel):
     )
 
 
+class EventAnnotation(BaseModel):
+    """News/event callout anchored at a (time, price) point.
+
+    Renders an always-visible title badge on the chart; the longer ``detail``
+    is revealed on hover (desktop) or tap (mobile). Use for earnings, M&A,
+    analyst actions, product launches, or any significant news tied to a bar
+    that warrants more than a one-line label.
+    """
+
+    type: Literal["event"]
+    time: str = Field(
+        max_length=_MAX_TIME_LEN,
+        description="ISO8601 datetime of the event, aligned to a bar (e.g. '2024-11-14T00:00:00Z')",
+    )
+    price: float = Field(
+        description=(
+            "Price (y-axis value) the badge anchors to — usually the bar's "
+            "close or the level the news affected"
+        ),
+    )
+    title: str = Field(
+        max_length=_MAX_LABEL_LEN,
+        description="Short headline shown on the badge, e.g. 'Q3 earnings beat'",
+    )
+    detail: str = Field(
+        max_length=_MAX_DETAIL_LEN,
+        description=(
+            "A few sentences shown on hover/click — the context behind the "
+            "event (what happened and why it matters)"
+        ),
+    )
+    color: str | None = Field(
+        default=None,
+        max_length=_MAX_COLOR_LEN,
+        description="CSS color for the badge accent. Default: theme-aware.",
+    )
+
+
 class FibRetracementAnnotation(BaseModel):
     """Fibonacci retracement between a swing high and a swing low.
 
@@ -189,6 +228,7 @@ Annotation = Annotated[
         VerticalLineAnnotation,
         RectangleAnnotation,
         TextAnnotation,
+        EventAnnotation,
         FibRetracementAnnotation,
     ],
     Field(discriminator="type"),
@@ -215,7 +255,7 @@ class DrawChartAnnotationArgs(BaseModel):
         description=(
             "Annotation payload. The 'type' field discriminates the variant: "
             "'price_line', 'trendline', 'marker', 'vertical_line', "
-            "'rectangle', 'text', or 'fib_retracement'."
+            "'rectangle', 'text', 'event', or 'fib_retracement'."
         )
     )
 

--- a/src/tools/chart_annotation/schemas.py
+++ b/src/tools/chart_annotation/schemas.py
@@ -1,0 +1,247 @@
+"""Pydantic schemas for chart annotation tool arguments.
+
+The annotation union uses a discriminated union keyed by ``type`` so the LLM
+sees a clean ``oneOf`` in the JSON schema rather than a flat bag of
+mostly-None fields.
+"""
+
+from typing import Annotated, Literal, Union
+
+from pydantic import BaseModel, Field
+
+
+# Bounds keep LLM-generated strings small enough that a runaway agent can't
+# bloat storage. All fields are cosmetic — the chart has no use for oversized
+# strings, so capping here is lossless.
+_MAX_TIME_LEN = 40   # ISO8601 with timezone comfortably fits
+_MAX_LABEL_LEN = 200
+_MAX_COLOR_LEN = 64  # #rrggbb, rgba(...), or CSS name
+
+# Intervals the market-data API (and the inline chart card) can fetch. The
+# chart instance is identified by SYMBOL:timeframe, so this is also the set of
+# timeframes a chart can exist on.
+Timeframe = Literal[
+    "1min", "5min", "15min", "30min", "1hour", "4hour", "1day"
+]
+
+
+class TimePricePoint(BaseModel):
+    """A single (time, price) anchor on the chart."""
+
+    time: str = Field(
+        max_length=_MAX_TIME_LEN,
+        description="ISO8601 datetime aligned to a bar on the chart (e.g. '2024-10-16T00:00:00Z')",
+    )
+    price: float = Field(description="Price (y-axis value) at the given time")
+
+
+class PriceLineAnnotation(BaseModel):
+    """Horizontal price level — support/resistance/target."""
+
+    type: Literal["price_line"]
+    price: float = Field(description="Price level (y-axis value)")
+    label: str | None = Field(
+        default=None,
+        max_length=_MAX_LABEL_LEN,
+        description="Short label shown with the line, e.g. 'Resistance 205'",
+    )
+    color: str | None = Field(
+        default=None,
+        max_length=_MAX_COLOR_LEN,
+        description="CSS color (hex, rgb, or named). Default: theme-aware.",
+    )
+    style: Literal["solid", "dashed", "dotted"] = "solid"
+
+
+class TrendlineAnnotation(BaseModel):
+    """Trendline connecting two (time, price) anchors."""
+
+    type: Literal["trendline"]
+    point1: TimePricePoint
+    point2: TimePricePoint
+    label: str | None = Field(
+        default=None,
+        max_length=_MAX_LABEL_LEN,
+        description="Short label shown near the line, e.g. 'Channel top'",
+    )
+    color: str | None = Field(
+        default=None,
+        max_length=_MAX_COLOR_LEN,
+        description="CSS color",
+    )
+
+
+class MarkerAnnotation(BaseModel):
+    """Event callout at a specific bar."""
+
+    type: Literal["marker"]
+    time: str = Field(
+        max_length=_MAX_TIME_LEN,
+        description="ISO8601 datetime of the bar to mark",
+    )
+    shape: Literal["arrowUp", "arrowDown", "circle", "square"]
+    position: Literal["aboveBar", "belowBar", "inBar"] = "aboveBar"
+    text: str | None = Field(
+        default=None,
+        max_length=_MAX_LABEL_LEN,
+        description="Short label shown on/near the marker (e.g. 'Earnings beat')",
+    )
+    color: str | None = Field(
+        default=None,
+        max_length=_MAX_COLOR_LEN,
+        description="CSS color",
+    )
+
+
+class VerticalLineAnnotation(BaseModel):
+    """Vertical line marking a moment in time across the whole chart."""
+
+    type: Literal["vertical_line"]
+    time: str = Field(
+        max_length=_MAX_TIME_LEN,
+        description="ISO8601 datetime of the bar to mark (e.g. earnings or FOMC date)",
+    )
+    label: str | None = Field(
+        default=None,
+        max_length=_MAX_LABEL_LEN,
+        description="Short label shown at the top of the line, e.g. 'Earnings'",
+    )
+    color: str | None = Field(
+        default=None,
+        max_length=_MAX_COLOR_LEN,
+        description="CSS color",
+    )
+    style: Literal["solid", "dashed", "dotted"] = "dashed"
+
+
+class RectangleAnnotation(BaseModel):
+    """Rectangular zone spanning a time range and a price range.
+
+    Use for supply/demand zones, consolidation ranges, or any box that
+    calls out a region of the chart. ``point1`` and ``point2`` are two
+    opposite corners — order does not matter.
+    """
+
+    type: Literal["rectangle"]
+    point1: TimePricePoint
+    point2: TimePricePoint
+    label: str | None = Field(
+        default=None,
+        max_length=_MAX_LABEL_LEN,
+        description="Short label shown in the box, e.g. 'Demand zone'",
+    )
+    color: str | None = Field(
+        default=None,
+        max_length=_MAX_COLOR_LEN,
+        description="CSS color for the border and (translucent) fill",
+    )
+
+
+class TextAnnotation(BaseModel):
+    """Free-floating text label anchored at a (time, price) point."""
+
+    type: Literal["text"]
+    time: str = Field(
+        max_length=_MAX_TIME_LEN,
+        description="ISO8601 datetime anchoring the text horizontally",
+    )
+    price: float = Field(description="Price (y-axis value) anchoring the text vertically")
+    text: str = Field(
+        max_length=_MAX_LABEL_LEN,
+        description="The text to display on the chart",
+    )
+    color: str | None = Field(
+        default=None,
+        max_length=_MAX_COLOR_LEN,
+        description="CSS color",
+    )
+
+
+class FibRetracementAnnotation(BaseModel):
+    """Fibonacci retracement between a swing high and a swing low.
+
+    Standard levels (0, 0.236, 0.382, 0.5, 0.618, 0.786, 1.0) are drawn as
+    horizontal lines spanning the two anchor times. ``point1`` and
+    ``point2`` are the two ends of the move (e.g. swing low → swing high).
+    """
+
+    type: Literal["fib_retracement"]
+    point1: TimePricePoint
+    point2: TimePricePoint
+    label: str | None = Field(
+        default=None,
+        max_length=_MAX_LABEL_LEN,
+        description="Short label shown with the retracement, e.g. 'Oct–Dec move'",
+    )
+    color: str | None = Field(
+        default=None,
+        max_length=_MAX_COLOR_LEN,
+        description="CSS color",
+    )
+
+
+# Discriminated union — the LLM sees `oneOf` keyed by `type`.
+Annotation = Annotated[
+    Union[
+        PriceLineAnnotation,
+        TrendlineAnnotation,
+        MarkerAnnotation,
+        VerticalLineAnnotation,
+        RectangleAnnotation,
+        TextAnnotation,
+        FibRetracementAnnotation,
+    ],
+    Field(discriminator="type"),
+]
+
+
+class DrawChartAnnotationArgs(BaseModel):
+    """Arguments for ``draw_chart_annotation``."""
+
+    symbol: str = Field(
+        description="Ticker symbol of the chart (e.g. 'NVDA')."
+    )
+    timeframe: Timeframe = Field(
+        default="1day",
+        description=(
+            "Chart interval. Together with the symbol this is the chart's "
+            "identity (chart_id = 'SYMBOL:timeframe'): drawing again with the "
+            "same symbol + timeframe edits THAT chart, while a different ticker "
+            "or timeframe starts a new one. Match the interval the user is "
+            "viewing (default daily)."
+        ),
+    )
+    annotation: Annotation = Field(
+        description=(
+            "Annotation payload. The 'type' field discriminates the variant: "
+            "'price_line', 'trendline', 'marker', 'vertical_line', "
+            "'rectangle', 'text', or 'fib_retracement'."
+        )
+    )
+
+
+class ManageChartAnnotationsArgs(BaseModel):
+    """Arguments for ``manage_chart_annotations``."""
+
+    symbol: str = Field(description="Ticker symbol (scopes the operation)")
+    timeframe: Timeframe = Field(
+        default="1day",
+        description=(
+            "Chart interval. With the symbol it selects the chart instance "
+            "(chart_id = 'SYMBOL:timeframe') to inspect or modify."
+        ),
+    )
+    action: Literal["list", "remove", "clear_all"] = Field(
+        description=(
+            "What to do: 'list' returns current annotations for the chart, "
+            "'remove' deletes specific ids (requires ids), "
+            "'clear_all' deletes every annotation on the chart (must not pass ids)."
+        )
+    )
+    ids: list[str] | None = Field(
+        default=None,
+        description=(
+            "Annotation ids to delete. Required when action='remove'. "
+            "Must be omitted/None for action='list' or action='clear_all'."
+        ),
+    )

--- a/src/tools/chart_annotation/tools.py
+++ b/src/tools/chart_annotation/tools.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
+from pydantic import TypeAdapter, ValidationError
 
 from src.server.database.chart_annotation import (
     add_annotation,
@@ -21,11 +22,15 @@ from src.server.database.chart_annotation import (
     remove_annotations,
 )
 from src.tools.chart_annotation.schemas import (
+    Annotation,
     DrawChartAnnotationArgs,
     ManageChartAnnotationsArgs,
 )
 
 logger = logging.getLogger(__name__)
+
+# Validates raw-dict annotation payloads against the discriminated union.
+_ANNOTATION_ADAPTER: TypeAdapter = TypeAdapter(Annotation)
 
 
 # --------------------------------------------------------------------------- #
@@ -48,16 +53,21 @@ def _make_annotation_id() -> str:
 
 
 def _normalize_annotation(annotation: Any) -> dict[str, Any] | None:
-    """Turn the incoming annotation arg into a plain dict.
+    """Turn the incoming annotation arg into a validated plain dict.
 
     The ``@tool`` decorator may hand us a Pydantic instance (if args_schema
     validated ahead of call) or a raw dict (if the LLM passed nested JSON).
-    We accept either.
+    Raw dicts are re-validated through the annotation union so this path
+    enforces the same shape + length caps as the args_schema path; an invalid
+    payload returns ``None``.
     """
     if hasattr(annotation, "model_dump"):
         return annotation.model_dump()
     if isinstance(annotation, dict):
-        return dict(annotation)
+        try:
+            return _ANNOTATION_ADAPTER.validate_python(annotation).model_dump()
+        except ValidationError:
+            return None
     return None
 
 
@@ -192,8 +202,8 @@ async def draw_chart_annotation(
     payload = _normalize_annotation(annotation)
     if payload is None:
         return (
-            f"Error: unexpected annotation type {type(annotation).__name__}; "
-            "expected dict or Pydantic model.",
+            "Error: invalid annotation payload — it did not match any known "
+            "annotation type. Pass a valid annotation object (see the tool schema).",
             {},
         )
 

--- a/src/tools/chart_annotation/tools.py
+++ b/src/tools/chart_annotation/tools.py
@@ -50,7 +50,7 @@ def _get_workspace_id(config: RunnableConfig) -> str:
 
 
 def _make_annotation_id() -> str:
-    return f"ann_{uuid.uuid4().hex[:16]}"
+    return f"ann_{uuid.uuid4().hex}"
 
 
 def _normalize_annotation(annotation: Any) -> dict[str, Any] | None:

--- a/src/tools/chart_annotation/tools.py
+++ b/src/tools/chart_annotation/tools.py
@@ -15,7 +15,7 @@ from langchain_core.tools import tool
 from pydantic import TypeAdapter, ValidationError
 
 from src.server.database.chart_annotation import (
-    add_annotation,
+    add_and_list_annotations,
     clear_chart,
     list_annotations,
     make_chart_id,
@@ -221,8 +221,15 @@ async def draw_chart_annotation(
     # Fail-closed: persist first. If the DB write fails, we return an error
     # tuple and do NOT emit an SSE event — the user sees a clear failure in
     # chat and no ghost drawing appears on the chart.
+    # Persist the write and read back the full set in one connection checkout
+    # (autocommit → the read sees the just-written row). Fail closed on the
+    # write so no ghost drawing appears in chat or on the chart. The returned
+    # set is the chart instance's full current annotations so the inline-card
+    # artifact renders the cumulative chart, not just this one shape.
     try:
-        await add_annotation(workspace_id, chart_id, symbol_upper, timeframe, stored)
+        all_items = await add_and_list_annotations(
+            workspace_id, chart_id, symbol_upper, timeframe, stored
+        )
     except Exception as exc:
         logger.exception("[chart_annotation] persistence failed")
         return (
@@ -230,6 +237,8 @@ async def draw_chart_annotation(
             "The drawing was NOT applied. Please try again in a moment.",
             {},
         )
+    if not all_items:
+        all_items = [stored]
 
     _emit(
         _get_writer(),
@@ -245,17 +254,6 @@ async def draw_chart_annotation(
             "annotation": stored,
         },
     )
-
-    # Build the inline-card artifact for the chat transcript. Include the full
-    # current annotation set for this chart so the preview renders the
-    # cumulative annotated chart, not just this one shape. Best-effort: fall
-    # back to the single new annotation if the list read fails.
-    try:
-        all_items = await list_annotations(workspace_id, chart_id)
-    except Exception:
-        all_items = []
-    if not all_items:
-        all_items = [stored]
 
     result_artifact = {
         "type": "chart_annotation",

--- a/src/tools/chart_annotation/tools.py
+++ b/src/tools/chart_annotation/tools.py
@@ -25,12 +25,13 @@ from src.tools.chart_annotation.schemas import (
     Annotation,
     DrawChartAnnotationArgs,
     ManageChartAnnotationsArgs,
+    Timeframe,
 )
 
 logger = logging.getLogger(__name__)
 
 # Validates raw-dict annotation payloads against the discriminated union.
-_ANNOTATION_ADAPTER: TypeAdapter = TypeAdapter(Annotation)
+_ANNOTATION_ADAPTER = TypeAdapter(Annotation)
 
 
 # --------------------------------------------------------------------------- #
@@ -163,7 +164,7 @@ async def draw_chart_annotation(
     symbol: str,
     annotation: Any,
     config: RunnableConfig,
-    timeframe: str = "1day",
+    timeframe: Timeframe = "1day",
 ) -> tuple[str, dict]:
     """Draw on the user's stock chart.
 
@@ -277,7 +278,7 @@ async def manage_chart_annotations(
     symbol: str,
     action: str,
     config: RunnableConfig,
-    timeframe: str = "1day",
+    timeframe: Timeframe = "1day",
     ids: list[str] | None = None,
 ) -> tuple[str, dict]:
     """Inspect or delete annotations on a chart (``SYMBOL:timeframe``).

--- a/src/tools/chart_annotation/tools.py
+++ b/src/tools/chart_annotation/tools.py
@@ -230,10 +230,10 @@ async def draw_chart_annotation(
         all_items = await add_and_list_annotations(
             workspace_id, chart_id, symbol_upper, timeframe, stored
         )
-    except Exception as exc:
+    except Exception:
         logger.exception("[chart_annotation] persistence failed")
         return (
-            f"Could not save annotation (persistence unavailable): {exc}. "
+            "Could not save annotation (persistence unavailable). "
             "The drawing was NOT applied. Please try again in a moment.",
             {},
         )
@@ -306,10 +306,10 @@ async def manage_chart_annotations(
             return "Error: 'list' action does not accept 'ids'.", {}
         try:
             items = await list_annotations(workspace_id, chart_id)
-        except Exception as exc:
+        except Exception:
             logger.exception("[chart_annotation] list failed")
             return (
-                f"Could not list annotations (persistence unavailable): {exc}. "
+                "Could not list annotations (persistence unavailable). "
                 "Please try again in a moment.",
                 {},
             )
@@ -329,10 +329,10 @@ async def manage_chart_annotations(
             )
         try:
             removed = await remove_annotations(workspace_id, chart_id, ids)
-        except Exception as exc:
+        except Exception:
             logger.exception("[chart_annotation] remove failed")
             return (
-                f"Could not remove annotations (persistence unavailable): {exc}. "
+                "Could not remove annotations (persistence unavailable). "
                 "Nothing was deleted. Please try again in a moment.",
                 {},
             )
@@ -356,10 +356,10 @@ async def manage_chart_annotations(
             )
         try:
             cleared = await clear_chart(workspace_id, chart_id)
-        except Exception as exc:
+        except Exception:
             logger.exception("[chart_annotation] clear failed")
             return (
-                f"Could not clear annotations (persistence unavailable): {exc}. "
+                "Could not clear annotations (persistence unavailable). "
                 "Nothing was deleted. Please try again in a moment.",
                 {},
             )

--- a/src/tools/chart_annotation/tools.py
+++ b/src/tools/chart_annotation/tools.py
@@ -306,7 +306,15 @@ async def manage_chart_annotations(
     if action == "list":
         if ids:
             return "Error: 'list' action does not accept 'ids'.", {}
-        items = await list_annotations(workspace_id, chart_id)
+        try:
+            items = await list_annotations(workspace_id, chart_id)
+        except Exception as exc:
+            logger.exception("[chart_annotation] list failed")
+            return (
+                f"Could not list annotations (persistence unavailable): {exc}. "
+                "Please try again in a moment.",
+                {},
+            )
         return (
             f"{len(items)} annotation(s) on {chart_id}.",
             {"chart_id": chart_id, "symbol": symbol_upper, "timeframe": timeframe, "annotations": items},
@@ -321,7 +329,15 @@ async def manage_chart_annotations(
                 "action='clear_all' to wipe the whole chart.",
                 {},
             )
-        removed = await remove_annotations(workspace_id, chart_id, ids)
+        try:
+            removed = await remove_annotations(workspace_id, chart_id, ids)
+        except Exception as exc:
+            logger.exception("[chart_annotation] remove failed")
+            return (
+                f"Could not remove annotations (persistence unavailable): {exc}. "
+                "Nothing was deleted. Please try again in a moment.",
+                {},
+            )
         _emit(
             _get_writer(),
             artifact_type="chart_annotation",
@@ -340,7 +356,15 @@ async def manage_chart_annotations(
                 "Use action='remove' with a specific id list for partial deletion.",
                 {},
             )
-        cleared = await clear_chart(workspace_id, chart_id)
+        try:
+            cleared = await clear_chart(workspace_id, chart_id)
+        except Exception as exc:
+            logger.exception("[chart_annotation] clear failed")
+            return (
+                f"Could not clear annotations (persistence unavailable): {exc}. "
+                "Nothing was deleted. Please try again in a moment.",
+                {},
+            )
         _emit(
             _get_writer(),
             artifact_type="chart_annotation",

--- a/src/tools/chart_annotation/tools.py
+++ b/src/tools/chart_annotation/tools.py
@@ -90,6 +90,8 @@ def _summarize(stored: dict[str, Any]) -> str:
         )
     elif kind == "text":
         base = f"Added text at ({stored.get('time')}, ${stored.get('price')})"
+    elif kind == "event":
+        base = f"Marked event '{stored.get('title')}' at {stored.get('time')} (${stored.get('price')})"
     elif kind == "fib_retracement":
         p1 = stored.get("point1", {})
         p2 = stored.get("point2", {})
@@ -171,6 +173,10 @@ async def draw_chart_annotation(
       corners). Use for supply/demand zones or consolidation ranges.
     - ``text``: a free-floating text label anchored at (time, price).
       Use for a callout that isn't tied to a marker or level.
+    - ``event``: a news/event badge anchored at (time, price) with a short
+      ``title`` and a few-sentence ``detail`` revealed on hover/click. Use
+      when a callout needs more context than a one-line label (e.g. an
+      earnings report, an acquisition, an analyst action).
     - ``fib_retracement``: Fibonacci levels between a swing high and low
       (two anchors). Use to map retracement targets of a move.
 

--- a/src/tools/chart_annotation/tools.py
+++ b/src/tools/chart_annotation/tools.py
@@ -1,0 +1,342 @@
+"""LangChain tools for drawing and managing chart annotations.
+
+These tools belong to the ``chart-annotation`` skill. A chart instance is
+identified by ``chart_id = "{SYMBOL}:{timeframe}"`` and scoped to the agent's
+workspace; drawing again with the same symbol + timeframe edits that chart.
+Annotations persist in Postgres (durable, no TTL).
+"""
+
+import logging
+import uuid
+from typing import Any
+
+from langchain_core.runnables import RunnableConfig
+from langchain_core.tools import tool
+
+from src.server.database.chart_annotation import (
+    add_annotation,
+    clear_chart,
+    list_annotations,
+    make_chart_id,
+    remove_annotations,
+)
+from src.tools.chart_annotation.schemas import (
+    DrawChartAnnotationArgs,
+    ManageChartAnnotationsArgs,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _get_workspace_id(config: RunnableConfig) -> str:
+    configurable = config.get("configurable", {})
+    workspace_id = configurable.get("workspace_id")
+    if not workspace_id:
+        raise ValueError(
+            "workspace_id not found in config. Chart annotations require a workspace."
+        )
+    return workspace_id
+
+
+def _make_annotation_id() -> str:
+    return f"ann_{uuid.uuid4().hex[:16]}"
+
+
+def _normalize_annotation(annotation: Any) -> dict[str, Any] | None:
+    """Turn the incoming annotation arg into a plain dict.
+
+    The ``@tool`` decorator may hand us a Pydantic instance (if args_schema
+    validated ahead of call) or a raw dict (if the LLM passed nested JSON).
+    We accept either.
+    """
+    if hasattr(annotation, "model_dump"):
+        return annotation.model_dump()
+    if isinstance(annotation, dict):
+        return dict(annotation)
+    return None
+
+
+def _summarize(stored: dict[str, Any]) -> str:
+    """Human-readable one-liner for the tool's content return."""
+    kind = stored.get("type", "annotation")
+    symbol = stored.get("symbol", "")
+    timeframe = stored.get("timeframe", "")
+    label = stored.get("label") or stored.get("text") or ""
+
+    if kind == "price_line":
+        base = f"Drew price line at ${stored.get('price')}"
+    elif kind == "trendline":
+        p1 = stored.get("point1", {})
+        p2 = stored.get("point2", {})
+        base = (
+            f"Drew trendline from ({p1.get('time')}, ${p1.get('price')}) "
+            f"to ({p2.get('time')}, ${p2.get('price')})"
+        )
+    elif kind == "marker":
+        base = f"Placed {stored.get('shape', 'marker')} at {stored.get('time')}"
+    elif kind == "vertical_line":
+        base = f"Drew vertical line at {stored.get('time')}"
+    elif kind == "rectangle":
+        p1 = stored.get("point1", {})
+        p2 = stored.get("point2", {})
+        base = (
+            f"Drew zone from ({p1.get('time')}, ${p1.get('price')}) "
+            f"to ({p2.get('time')}, ${p2.get('price')})"
+        )
+    elif kind == "text":
+        base = f"Added text at ({stored.get('time')}, ${stored.get('price')})"
+    elif kind == "fib_retracement":
+        p1 = stored.get("point1", {})
+        p2 = stored.get("point2", {})
+        base = (
+            f"Drew Fibonacci retracement from ({p1.get('time')}, ${p1.get('price')}) "
+            f"to ({p2.get('time')}, ${p2.get('price')})"
+        )
+    else:
+        base = f"Drew {kind}"
+
+    if label:
+        base += f" — {label}"
+    if symbol:
+        base += f" on {symbol}"
+        if timeframe:
+            base += f" ({timeframe})"
+    return base
+
+
+def _emit(writer, artifact_type: str, artifact_id: str, payload: dict[str, Any]) -> None:
+    """Best-effort stream writer call — never raises."""
+    if writer is None:
+        return
+    try:
+        writer(
+            {
+                "artifact_type": artifact_type,
+                "artifact_id": artifact_id,
+                "payload": payload,
+            }
+        )
+    except Exception:
+        logger.warning(
+            "[chart_annotation] stream writer failed", exc_info=True
+        )
+
+
+def _get_writer():
+    """Return the current LangGraph stream writer, or None when unavailable."""
+    try:
+        from langgraph.config import get_stream_writer
+
+        return get_stream_writer()
+    except Exception:
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# Tools
+# --------------------------------------------------------------------------- #
+
+
+@tool(
+    "draw_chart_annotation",
+    args_schema=DrawChartAnnotationArgs,
+    response_format="content_and_artifact",
+)
+async def draw_chart_annotation(
+    symbol: str,
+    annotation: Any,
+    config: RunnableConfig,
+    timeframe: str = "1day",
+) -> tuple[str, dict]:
+    """Draw on the user's stock chart.
+
+    Pick the variant that matches the intent:
+
+    - ``price_line``: a horizontal level across the whole chart. Use for
+      support, resistance, a target, a stop, or any flat price callout
+      (e.g. "resistance at 205", "target 250").
+    - ``trendline``: a line between two (time, price) anchors. Use for
+      channels, pattern boundaries, or connecting two highs/lows across
+      dates (e.g. "connect the Oct high and the Dec low").
+    - ``marker``: an icon at a single bar. Use for event callouts or
+      entry/exit signals (e.g. "earnings beat on Nov 14", "entry").
+    - ``vertical_line``: a vertical line at one date across the whole
+      chart. Use to mark an event in time (earnings, a split, FOMC).
+    - ``rectangle``: a box over a time + price region (two opposite
+      corners). Use for supply/demand zones or consolidation ranges.
+    - ``text``: a free-floating text label anchored at (time, price).
+      Use for a callout that isn't tied to a marker or level.
+    - ``fib_retracement``: Fibonacci levels between a swing high and low
+      (two anchors). Use to map retracement targets of a move.
+
+    The chart is identified by ``SYMBOL:timeframe``: pass the same symbol +
+    timeframe to add to (edit) that chart, or a different ticker/timeframe to
+    start a new one. Annotations on a chart accumulate.
+    """
+    try:
+        workspace_id = _get_workspace_id(config)
+    except ValueError as exc:
+        return f"Error: {exc}", {}
+
+    payload = _normalize_annotation(annotation)
+    if payload is None:
+        return (
+            f"Error: unexpected annotation type {type(annotation).__name__}; "
+            "expected dict or Pydantic model.",
+            {},
+        )
+
+    symbol_upper = symbol.upper()
+    chart_id = make_chart_id(symbol_upper, timeframe)
+    annotation_id = _make_annotation_id()
+    stored = {
+        "annotation_id": annotation_id,
+        "symbol": symbol_upper,
+        "timeframe": timeframe,
+        "chart_id": chart_id,
+        **payload,
+    }
+
+    # Fail-closed: persist first. If the DB write fails, we return an error
+    # tuple and do NOT emit an SSE event — the user sees a clear failure in
+    # chat and no ghost drawing appears on the chart.
+    try:
+        await add_annotation(workspace_id, chart_id, symbol_upper, timeframe, stored)
+    except Exception as exc:
+        logger.exception("[chart_annotation] persistence failed")
+        return (
+            f"Could not save annotation (persistence unavailable): {exc}. "
+            "The drawing was NOT applied. Please try again in a moment.",
+            {},
+        )
+
+    _emit(
+        _get_writer(),
+        artifact_type="chart_annotation",
+        artifact_id=annotation_id,
+        payload={
+            "op": "add",
+            "workspace_id": workspace_id,
+            "chart_id": chart_id,
+            "symbol": symbol_upper,
+            "timeframe": timeframe,
+            "annotation_id": annotation_id,
+            "annotation": stored,
+        },
+    )
+
+    # Build the inline-card artifact for the chat transcript. Include the full
+    # current annotation set for this chart so the preview renders the
+    # cumulative annotated chart, not just this one shape. Best-effort: fall
+    # back to the single new annotation if the list read fails.
+    try:
+        all_items = await list_annotations(workspace_id, chart_id)
+    except Exception:
+        all_items = []
+    if not all_items:
+        all_items = [stored]
+
+    result_artifact = {
+        "type": "chart_annotation",
+        "op": "add",
+        "chart_id": chart_id,
+        "symbol": symbol_upper,
+        "timeframe": timeframe,
+        "workspace_id": workspace_id,
+        "annotation_id": annotation_id,
+        "annotations": all_items,
+    }
+    return _summarize(stored), result_artifact
+
+
+@tool(
+    "manage_chart_annotations",
+    args_schema=ManageChartAnnotationsArgs,
+    response_format="content_and_artifact",
+)
+async def manage_chart_annotations(
+    symbol: str,
+    action: str,
+    config: RunnableConfig,
+    timeframe: str = "1day",
+    ids: list[str] | None = None,
+) -> tuple[str, dict]:
+    """Inspect or delete annotations on a chart (``SYMBOL:timeframe``).
+
+    Actions:
+
+    - ``list``: return all annotations currently on the chart. Do not pass
+      ``ids``. Use this first if you need ids for a later remove call.
+    - ``remove``: delete specific annotations by id. ``ids`` is required
+      and must be non-empty. Use ``clear_all`` instead if you want to
+      wipe everything.
+    - ``clear_all``: delete every annotation on the chart. Do not pass
+      ``ids`` — the tool will reject the call. Use ``remove`` for
+      partial deletion.
+    """
+    try:
+        workspace_id = _get_workspace_id(config)
+    except ValueError as exc:
+        return f"Error: {exc}", {}
+
+    symbol_upper = symbol.upper()
+    chart_id = make_chart_id(symbol_upper, timeframe)
+
+    if action == "list":
+        if ids:
+            return "Error: 'list' action does not accept 'ids'.", {}
+        items = await list_annotations(workspace_id, chart_id)
+        return (
+            f"{len(items)} annotation(s) on {chart_id}.",
+            {"chart_id": chart_id, "symbol": symbol_upper, "timeframe": timeframe, "annotations": items},
+        )
+
+    if action == "remove":
+        if not ids:
+            return (
+                "Error: 'remove' requires a non-empty 'ids' list. "
+                "Call manage_chart_annotations(action='list', symbol=..., "
+                "timeframe=...) first to discover ids, or use "
+                "action='clear_all' to wipe the whole chart.",
+                {},
+            )
+        removed = await remove_annotations(workspace_id, chart_id, ids)
+        _emit(
+            _get_writer(),
+            artifact_type="chart_annotation",
+            artifact_id=f"remove:{chart_id}:{','.join(ids)}",
+            payload={"op": "remove", "workspace_id": workspace_id, "chart_id": chart_id, "symbol": symbol_upper, "timeframe": timeframe, "ids": ids},
+        )
+        return (
+            f"Removed {removed} annotation(s) from {chart_id}.",
+            {"chart_id": chart_id, "symbol": symbol_upper, "timeframe": timeframe, "removed": removed, "ids": ids},
+        )
+
+    if action == "clear_all":
+        if ids:
+            return (
+                "Error: 'clear_all' does not accept 'ids'. "
+                "Use action='remove' with a specific id list for partial deletion.",
+                {},
+            )
+        cleared = await clear_chart(workspace_id, chart_id)
+        _emit(
+            _get_writer(),
+            artifact_type="chart_annotation",
+            artifact_id=f"clear:{chart_id}",
+            payload={"op": "clear", "workspace_id": workspace_id, "chart_id": chart_id, "symbol": symbol_upper, "timeframe": timeframe},
+        )
+        return (
+            f"Cleared {cleared} annotation(s) from {chart_id}.",
+            {"chart_id": chart_id, "symbol": symbol_upper, "timeframe": timeframe, "cleared": cleared},
+        )
+
+    return (
+        f"Error: unknown action '{action}'. Use 'list', 'remove', or 'clear_all'.",
+        {},
+    )

--- a/tests/unit/server/app/test_chart_annotations.py
+++ b/tests/unit/server/app/test_chart_annotations.py
@@ -1,0 +1,224 @@
+"""Tests for the Chart Annotations API router (src/server/app/chart_annotations.py).
+
+The router is read / bulk-delete only (writes go through the agent tool). These
+tests cover the ownership guards (404 / 403), symbol validation (400 / 422), and
+the happy-path mapping into the response models for both verbs.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from tests.conftest import create_test_app
+
+OWNER = "test-user-123"  # what create_test_app injects as the current user
+
+
+def _ws(user_id=OWNER, workspace_id=None):
+    """Minimal workspace row — require_workspace_owner only reads user_id."""
+    return {"workspace_id": workspace_id or str(uuid.uuid4()), "user_id": user_id}
+
+
+@pytest_asyncio.fixture
+async def client():
+    from src.server.app.chart_annotations import router
+
+    app = create_test_app(router)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c
+
+
+def _url(workspace_id: str) -> str:
+    return f"/api/v1/workspaces/{workspace_id}/chart-annotations"
+
+
+# ---------------------------------------------------------------------------
+# GET — list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_success_maps_charts(client):
+    ws = _ws()
+    chart = {
+        "chart_id": "AAPL:1day",
+        "symbol": "AAPL",
+        "timeframe": "1day",
+        "annotations": [{"annotation_id": "a1", "type": "price_line", "price": 205}],
+    }
+    with (
+        patch(
+            "src.server.app.chart_annotations.db_get_workspace",
+            new_callable=AsyncMock,
+            return_value=ws,
+        ),
+        patch(
+            "src.server.app.chart_annotations.list_charts",
+            new_callable=AsyncMock,
+            return_value=[chart],
+        ) as mock_list,
+    ):
+        resp = await client.get(_url(ws["workspace_id"]), params={"symbol": "aapl"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["workspace_id"] == ws["workspace_id"]
+    assert body["charts"] == [chart]
+    # Symbol is uppercased before hitting the store; timeframe omitted -> None.
+    mock_list.assert_awaited_once_with(ws["workspace_id"], "AAPL", None)
+
+
+@pytest.mark.asyncio
+async def test_list_passes_timeframe_filter(client):
+    ws = _ws()
+    with (
+        patch(
+            "src.server.app.chart_annotations.db_get_workspace",
+            new_callable=AsyncMock,
+            return_value=ws,
+        ),
+        patch(
+            "src.server.app.chart_annotations.list_charts",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as mock_list,
+    ):
+        resp = await client.get(
+            _url(ws["workspace_id"]), params={"symbol": "nvda", "timeframe": "1hour"}
+        )
+
+    assert resp.status_code == 200
+    mock_list.assert_awaited_once_with(ws["workspace_id"], "NVDA", "1hour")
+
+
+@pytest.mark.asyncio
+async def test_list_not_found(client):
+    wid = str(uuid.uuid4())
+    with patch(
+        "src.server.app.chart_annotations.db_get_workspace",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        resp = await client.get(_url(wid), params={"symbol": "AAPL"})
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_list_forbidden(client):
+    ws = _ws(user_id="someone-else")
+    with patch(
+        "src.server.app.chart_annotations.db_get_workspace",
+        new_callable=AsyncMock,
+        return_value=ws,
+    ):
+        resp = await client.get(_url(ws["workspace_id"]), params={"symbol": "AAPL"})
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_list_empty_symbol_400_after_owner_check(client):
+    """Owner check passes, then a blank symbol is rejected with 400 (not 422)."""
+    ws = _ws()
+    with (
+        patch(
+            "src.server.app.chart_annotations.db_get_workspace",
+            new_callable=AsyncMock,
+            return_value=ws,
+        ),
+        patch(
+            "src.server.app.chart_annotations.list_charts",
+            new_callable=AsyncMock,
+        ) as mock_list,
+    ):
+        resp = await client.get(_url(ws["workspace_id"]), params={"symbol": "   "})
+    assert resp.status_code == 400
+    mock_list.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_list_missing_symbol_422(client):
+    """symbol is a required query param — omitting it is a validation error."""
+    resp = await client.get(_url(str(uuid.uuid4())))
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# DELETE — clear
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_clear_success_uppercases_chart_id(client):
+    ws = _ws()
+    with (
+        patch(
+            "src.server.app.chart_annotations.db_get_workspace",
+            new_callable=AsyncMock,
+            return_value=ws,
+        ),
+        patch(
+            "src.server.app.chart_annotations.clear_chart",
+            new_callable=AsyncMock,
+            return_value=3,
+        ) as mock_clear,
+    ):
+        resp = await client.delete(
+            _url(ws["workspace_id"]), params={"symbol": "aapl", "timeframe": "1hour"}
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["cleared"] == 3
+    assert body["chart_id"] == "AAPL:1hour"
+    mock_clear.assert_awaited_once_with(ws["workspace_id"], "AAPL:1hour")
+
+
+@pytest.mark.asyncio
+async def test_clear_defaults_timeframe_to_1day(client):
+    ws = _ws()
+    with (
+        patch(
+            "src.server.app.chart_annotations.db_get_workspace",
+            new_callable=AsyncMock,
+            return_value=ws,
+        ),
+        patch(
+            "src.server.app.chart_annotations.clear_chart",
+            new_callable=AsyncMock,
+            return_value=0,
+        ) as mock_clear,
+    ):
+        resp = await client.delete(_url(ws["workspace_id"]), params={"symbol": "AAPL"})
+
+    assert resp.status_code == 200
+    assert resp.json()["chart_id"] == "AAPL:1day"
+    mock_clear.assert_awaited_once_with(ws["workspace_id"], "AAPL:1day")
+
+
+@pytest.mark.asyncio
+async def test_clear_not_found(client):
+    wid = str(uuid.uuid4())
+    with patch(
+        "src.server.app.chart_annotations.db_get_workspace",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        resp = await client.delete(_url(wid), params={"symbol": "AAPL"})
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_clear_forbidden(client):
+    ws = _ws(user_id="someone-else")
+    with patch(
+        "src.server.app.chart_annotations.db_get_workspace",
+        new_callable=AsyncMock,
+        return_value=ws,
+    ):
+        resp = await client.delete(_url(ws["workspace_id"]), params={"symbol": "AAPL"})
+    assert resp.status_code == 403

--- a/tests/unit/tools/test_chart_annotation.py
+++ b/tests/unit/tools/test_chart_annotation.py
@@ -20,6 +20,7 @@ from src.tools.chart_annotation.schemas import (
     VerticalLineAnnotation,
 )
 from src.tools.chart_annotation.tools import (
+    _normalize_annotation,
     draw_chart_annotation,
     manage_chart_annotations,
 )
@@ -320,6 +321,115 @@ class TestAnnotationSchemas:
         # invalid action
         with pytest.raises(ValidationError):
             ManageChartAnnotationsArgs(symbol="NVDA", action="flush")
+
+
+class TestSchemaBounds:
+    """Numeric and length guards that keep LLM-generated payloads sane.
+
+    The annotation models set ``allow_inf_nan=False`` (NaN/Inf break JSONB
+    serialization) and cap every string field, so a runaway agent can't poison
+    storage or the chart with non-finite numbers or oversized strings.
+    """
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+    def test_price_line_rejects_non_finite_price(self, bad):
+        with pytest.raises(ValidationError):
+            DrawChartAnnotationArgs(
+                symbol="NVDA",
+                annotation={"type": "price_line", "price": bad},
+            )
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf")])
+    def test_point_rejects_non_finite_price(self, bad):
+        """Non-finite floats are rejected on nested (time, price) anchors too."""
+        with pytest.raises(ValidationError):
+            DrawChartAnnotationArgs(
+                symbol="NVDA",
+                annotation={
+                    "type": "trendline",
+                    "point1": {"time": "2024-10-16T00:00:00Z", "price": bad},
+                    "point2": {"time": "2024-12-20T00:00:00Z", "price": 1.0},
+                },
+            )
+
+    def test_label_exceeding_max_length_rejected(self):
+        with pytest.raises(ValidationError):
+            DrawChartAnnotationArgs(
+                symbol="NVDA",
+                annotation={"type": "price_line", "price": 1.0, "label": "x" * 201},
+            )
+
+    def test_label_at_max_length_accepted(self):
+        """The cap is inclusive — exactly the max length is fine."""
+        args = DrawChartAnnotationArgs(
+            symbol="NVDA",
+            annotation={"type": "price_line", "price": 1.0, "label": "x" * 200},
+        )
+        assert isinstance(args.annotation, PriceLineAnnotation)
+
+    def test_color_exceeding_max_length_rejected(self):
+        with pytest.raises(ValidationError):
+            DrawChartAnnotationArgs(
+                symbol="NVDA",
+                annotation={"type": "price_line", "price": 1.0, "color": "x" * 65},
+            )
+
+    def test_time_exceeding_max_length_rejected(self):
+        with pytest.raises(ValidationError):
+            DrawChartAnnotationArgs(
+                symbol="NVDA",
+                annotation={"type": "marker", "time": "x" * 41, "shape": "circle"},
+            )
+
+    def test_event_detail_exceeding_max_length_rejected(self):
+        with pytest.raises(ValidationError):
+            DrawChartAnnotationArgs(
+                symbol="NVDA",
+                annotation={
+                    "type": "event",
+                    "time": "2024-11-14T00:00:00Z",
+                    "price": 1.0,
+                    "title": "Earnings",
+                    "detail": "x" * 601,
+                },
+            )
+
+
+class TestNormalizeAnnotation:
+    """`_normalize_annotation` — the raw-dict revalidation branch.
+
+    The ``@tool`` decorator may hand the tool a validated Pydantic instance or
+    a raw dict (nested JSON from the LLM). Both must land as the same validated
+    plain dict, and an invalid payload must return ``None`` (the tool turns that
+    into a clear error rather than persisting garbage).
+    """
+
+    def test_model_instance_branch(self):
+        out = _normalize_annotation(PriceLineAnnotation(type="price_line", price=1.0))
+        assert out is not None
+        assert out["type"] == "price_line"
+        assert out["price"] == 1.0
+
+    def test_raw_dict_branch_revalidates(self):
+        out = _normalize_annotation({"type": "price_line", "price": 205.0})
+        assert out is not None
+        assert out["type"] == "price_line"
+        assert out["price"] == 205.0
+        # default fields are materialized through the model
+        assert out["style"] == "solid"
+
+    def test_raw_dict_missing_required_field_returns_none(self):
+        assert _normalize_annotation({"type": "price_line"}) is None  # no price
+
+    def test_raw_dict_unknown_type_returns_none(self):
+        assert _normalize_annotation({"type": "bogus", "price": 1.0}) is None
+
+    def test_raw_dict_non_finite_returns_none(self):
+        assert _normalize_annotation({"type": "price_line", "price": float("nan")}) is None
+
+    def test_non_dict_non_model_returns_none(self):
+        assert _normalize_annotation("not an annotation") is None
+        assert _normalize_annotation(None) is None
 
 
 # --------------------------------------------------------------------------- #
@@ -645,6 +755,25 @@ class TestDrawChartAnnotation:
         assert result.artifact == {}
         writer.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_invalid_raw_dict_returns_error_no_write(self, fake_db):
+        """A raw dict that bypasses args_schema and fails revalidation in the
+        tool body returns the invalid-payload error and persists nothing."""
+        writer = MagicMock()
+        with patch("langgraph.config.get_stream_writer", return_value=writer):
+            # `.coroutine` skips the args_schema, so the raw (invalid) dict
+            # reaches the tool body and exercises the `payload is None` branch.
+            content, artifact = await draw_chart_annotation.coroutine(
+                symbol="NVDA",
+                annotation={"type": "price_line"},  # missing required price
+                config=_config(),
+            )
+
+        assert "invalid annotation" in content.lower()
+        assert artifact == {}
+        writer.assert_not_called()
+        assert fake_db.instances == {}
+
 
 # --------------------------------------------------------------------------- #
 # manage_chart_annotations tool
@@ -823,6 +952,19 @@ class TestManageChartAnnotations:
         )
         assert "does not accept" in result.content.lower()
         assert result.artifact == {}
+
+    @pytest.mark.asyncio
+    async def test_unknown_action_defensive_branch(self, fake_db):
+        """The args_schema constrains action to a Literal, but the tool body
+        still fails safe if an unknown action ever reaches it."""
+        # `.coroutine` skips the args_schema so the bogus action hits the body.
+        content, artifact = await manage_chart_annotations.coroutine(
+            symbol="NVDA",
+            action="flush",
+            config=_config(),
+        )
+        assert "unknown action" in content.lower()
+        assert artifact == {}
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/tools/test_chart_annotation.py
+++ b/tests/unit/tools/test_chart_annotation.py
@@ -1013,3 +1013,56 @@ class TestSkillRegistryVisibility:
             skill = get_skill("chart-annotation", mode=mode)
             assert skill is not None, f"get_skill returned None for mode={mode}"
             assert skill.name == "chart-annotation"
+
+
+# --------------------------------------------------------------------------- #
+# Storage-envelope parity (complements test_chart_annotation_schema_parity.py)
+# --------------------------------------------------------------------------- #
+
+
+class TestStorageEnvelopeParity:
+    """Pin the storage envelope the tool wraps every annotation in.
+
+    The schema-parity test pins the 8 pydantic *variant* shapes, but the
+    persisted / SSE / inline-card payload is the variant PLUS an envelope —
+    ``annotation_id``, ``symbol``, ``timeframe``, ``chart_id`` (tools.py
+    ``stored``). The frontend ``BaseAnnotation`` (chartAnnotationStore.ts)
+    hand-mirrors that envelope and the store guard hard-requires
+    ``annotation_id`` + ``symbol`` as strings. A rename/drop of an envelope
+    field passes every schema test but silently breaks the live ``add`` path,
+    so pin the wire shape the tool actually emits.
+
+    WHEN THIS FAILS: you changed the envelope in tools.py / the DB layer.
+    Update EXPECTED_STORAGE_ENVELOPE here AND the frontend BaseAnnotation in
+    chartAnnotationStore.ts in lockstep.
+    """
+
+    # Mirrors the frontend BaseAnnotation envelope fields.
+    EXPECTED_STORAGE_ENVELOPE = {"annotation_id", "symbol", "timeframe", "chart_id"}
+
+    @pytest.mark.asyncio
+    async def test_persisted_payload_carries_the_full_envelope(self, fake_db):
+        with patch("langgraph.config.get_stream_writer", return_value=MagicMock()):
+            result = await draw_chart_annotation.ainvoke(
+                _tool_call(
+                    "draw_chart_annotation",
+                    {
+                        "symbol": "NVDA",
+                        "annotation": {"type": "price_line", "price": 205.0},
+                    },
+                ),
+                config=_config(),
+            )
+
+        stored = _drawn(result)
+        missing = self.EXPECTED_STORAGE_ENVELOPE - set(stored)
+        assert not missing, (
+            f"Annotation storage envelope dropped/renamed field(s) {missing}. "
+            "Update EXPECTED_STORAGE_ENVELOPE and the frontend BaseAnnotation "
+            "in chartAnnotationStore.ts in lockstep."
+        )
+        # The store guard rejects an add unless these are non-empty strings.
+        assert isinstance(stored["annotation_id"], str) and stored["annotation_id"]
+        assert stored["symbol"] == "NVDA"
+        assert stored["timeframe"] == "1day"
+        assert stored["chart_id"] == "NVDA:1day"

--- a/tests/unit/tools/test_chart_annotation.py
+++ b/tests/unit/tools/test_chart_annotation.py
@@ -74,6 +74,14 @@ class FakeChartDB:
     async def list_annotations(self, workspace_id, chart_id):
         return list(self.instances.get((workspace_id, chart_id), {}).values())
 
+    async def add_and_list_annotations(
+        self, workspace_id, chart_id, symbol, timeframe, annotation
+    ):
+        # Mirrors the real combined write+read: the add raises on fail_on_add,
+        # so the fail-closed path stays exercised.
+        await self.add_annotation(workspace_id, chart_id, symbol, timeframe, annotation)
+        return await self.list_annotations(workspace_id, chart_id)
+
     async def remove_annotations(self, workspace_id, chart_id, ids):
         bucket = self.instances.get((workspace_id, chart_id), {})
         removed = 0
@@ -94,7 +102,10 @@ class FakeChartDB:
 def _patch_db(db: FakeChartDB):
     """Patch the DB functions the tool module imported with the fake's methods."""
     return (
-        patch("src.tools.chart_annotation.tools.add_annotation", db.add_annotation),
+        patch(
+            "src.tools.chart_annotation.tools.add_and_list_annotations",
+            db.add_and_list_annotations,
+        ),
         patch("src.tools.chart_annotation.tools.list_annotations", db.list_annotations),
         patch("src.tools.chart_annotation.tools.remove_annotations", db.remove_annotations),
         patch("src.tools.chart_annotation.tools.clear_chart", db.clear_chart),

--- a/tests/unit/tools/test_chart_annotation.py
+++ b/tests/unit/tools/test_chart_annotation.py
@@ -1,0 +1,816 @@
+"""Unit tests for chart annotation tools and schemas."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from src.tools.chart_annotation.schemas import (
+    DrawChartAnnotationArgs,
+    FibRetracementAnnotation,
+    ManageChartAnnotationsArgs,
+    MarkerAnnotation,
+    PriceLineAnnotation,
+    RectangleAnnotation,
+    TextAnnotation,
+    TrendlineAnnotation,
+    VerticalLineAnnotation,
+)
+from src.tools.chart_annotation.tools import (
+    draw_chart_annotation,
+    manage_chart_annotations,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _tool_call(name: str, args: dict, call_id: str = "call_test") -> dict:
+    return {"name": name, "args": args, "id": call_id, "type": "tool_call"}
+
+
+def _drawn(result) -> dict:
+    """The single annotation just drawn, read from the inline-card artifact.
+
+    ``draw_chart_annotation`` returns a ``chart_annotation`` wrapper artifact
+    whose ``annotations`` list holds the chart instance's full current set. The
+    happy-path tests draw exactly one into a fresh instance, so [0] is it.
+    """
+    return result.artifact["annotations"][0]
+
+
+def _config(workspace_id: str | None = "ws_abc") -> dict:
+    configurable: dict = {"user_id": "user_xyz"}
+    if workspace_id is not None:
+        configurable["workspace_id"] = workspace_id
+    return {"configurable": configurable}
+
+
+class FakeChartDB:
+    """In-memory stand-in for ``src.server.database.chart_annotation``.
+
+    Mirrors the real instance semantics: rows keyed by
+    ``(workspace_id, chart_id, annotation_id)``, insertion order preserved per
+    instance, upsert on a duplicate annotation_id.
+    """
+
+    def __init__(self, fail_on_add: bool = False):
+        # (workspace_id, chart_id) -> {annotation_id: payload}
+        self.instances: dict[tuple[str, str], dict[str, dict]] = {}
+        self.fail_on_add = fail_on_add
+
+    async def add_annotation(self, workspace_id, chart_id, symbol, timeframe, annotation):
+        if self.fail_on_add:
+            raise RuntimeError("simulated db failure")
+        bucket = self.instances.setdefault((workspace_id, chart_id), {})
+        bucket[annotation["annotation_id"]] = dict(annotation)
+
+    async def list_annotations(self, workspace_id, chart_id):
+        return list(self.instances.get((workspace_id, chart_id), {}).values())
+
+    async def remove_annotations(self, workspace_id, chart_id, ids):
+        bucket = self.instances.get((workspace_id, chart_id), {})
+        removed = 0
+        for ann_id in ids:
+            if ann_id in bucket:
+                del bucket[ann_id]
+                removed += 1
+        return removed
+
+    async def clear_chart(self, workspace_id, chart_id):
+        bucket = self.instances.pop((workspace_id, chart_id), {})
+        return len(bucket)
+
+    def bucket(self, workspace_id, chart_id) -> dict[str, dict]:
+        return self.instances.get((workspace_id, chart_id), {})
+
+
+def _patch_db(db: FakeChartDB):
+    """Patch the DB functions the tool module imported with the fake's methods."""
+    return (
+        patch("src.tools.chart_annotation.tools.add_annotation", db.add_annotation),
+        patch("src.tools.chart_annotation.tools.list_annotations", db.list_annotations),
+        patch("src.tools.chart_annotation.tools.remove_annotations", db.remove_annotations),
+        patch("src.tools.chart_annotation.tools.clear_chart", db.clear_chart),
+    )
+
+
+@pytest.fixture
+def fake_db():
+    db = FakeChartDB()
+    patchers = _patch_db(db)
+    for p in patchers:
+        p.start()
+    try:
+        yield db
+    finally:
+        for p in patchers:
+            p.stop()
+
+
+@pytest.fixture
+def failing_db():
+    """Fake DB whose add_annotation always raises (fail-closed path)."""
+    db = FakeChartDB(fail_on_add=True)
+    patchers = _patch_db(db)
+    for p in patchers:
+        p.start()
+    try:
+        yield db
+    finally:
+        for p in patchers:
+            p.stop()
+
+
+# --------------------------------------------------------------------------- #
+# Schema validation
+# --------------------------------------------------------------------------- #
+
+
+class TestAnnotationSchemas:
+    def test_price_line_variant_roundtrip(self):
+        args = DrawChartAnnotationArgs(
+            symbol="NVDA",
+            annotation={"type": "price_line", "price": 205.0, "label": "Resistance"},
+        )
+        assert isinstance(args.annotation, PriceLineAnnotation)
+        assert args.annotation.price == 205.0
+        assert args.annotation.style == "solid"  # default
+
+    def test_trendline_variant_roundtrip(self):
+        args = DrawChartAnnotationArgs(
+            symbol="AAPL",
+            annotation={
+                "type": "trendline",
+                "point1": {"time": "2024-10-16T00:00:00Z", "price": 145.2},
+                "point2": {"time": "2024-12-20T00:00:00Z", "price": 138.7},
+            },
+        )
+        assert isinstance(args.annotation, TrendlineAnnotation)
+        assert args.annotation.point1.price == 145.2
+
+    def test_marker_variant_roundtrip(self):
+        args = DrawChartAnnotationArgs(
+            symbol="TSLA",
+            annotation={
+                "type": "marker",
+                "time": "2024-11-14T00:00:00Z",
+                "shape": "arrowUp",
+            },
+        )
+        assert isinstance(args.annotation, MarkerAnnotation)
+        assert args.annotation.position == "aboveBar"  # default
+
+    def test_vertical_line_variant_roundtrip(self):
+        args = DrawChartAnnotationArgs(
+            symbol="NVDA",
+            annotation={
+                "type": "vertical_line",
+                "time": "2024-11-14T00:00:00Z",
+                "label": "Earnings",
+            },
+        )
+        assert isinstance(args.annotation, VerticalLineAnnotation)
+        assert args.annotation.style == "dashed"  # default
+
+    def test_rectangle_variant_roundtrip(self):
+        args = DrawChartAnnotationArgs(
+            symbol="NVDA",
+            annotation={
+                "type": "rectangle",
+                "point1": {"time": "2024-10-16T00:00:00Z", "price": 145.2},
+                "point2": {"time": "2024-12-20T00:00:00Z", "price": 138.7},
+                "label": "Demand zone",
+            },
+        )
+        assert isinstance(args.annotation, RectangleAnnotation)
+        assert args.annotation.point1.price == 145.2
+        assert args.annotation.point2.time == "2024-12-20T00:00:00Z"
+
+    def test_text_variant_roundtrip(self):
+        args = DrawChartAnnotationArgs(
+            symbol="NVDA",
+            annotation={
+                "type": "text",
+                "time": "2024-11-14T00:00:00Z",
+                "price": 200.0,
+                "text": "Breakout",
+            },
+        )
+        assert isinstance(args.annotation, TextAnnotation)
+        assert args.annotation.text == "Breakout"
+
+    def test_text_requires_text_field(self):
+        with pytest.raises(ValidationError):
+            DrawChartAnnotationArgs(
+                symbol="NVDA",
+                annotation={
+                    "type": "text",
+                    "time": "2024-11-14T00:00:00Z",
+                    "price": 200.0,
+                },
+            )
+
+    def test_fib_retracement_variant_roundtrip(self):
+        args = DrawChartAnnotationArgs(
+            symbol="NVDA",
+            annotation={
+                "type": "fib_retracement",
+                "point1": {"time": "2024-10-16T00:00:00Z", "price": 100.0},
+                "point2": {"time": "2024-12-20T00:00:00Z", "price": 200.0},
+            },
+        )
+        assert isinstance(args.annotation, FibRetracementAnnotation)
+        assert args.annotation.point2.price == 200.0
+
+    def test_invalid_discriminator_rejected(self):
+        with pytest.raises(ValidationError):
+            DrawChartAnnotationArgs(
+                symbol="NVDA",
+                annotation={"type": "bogus", "price": 1.0},
+            )
+
+    def test_trendline_missing_point2_rejected(self):
+        with pytest.raises(ValidationError):
+            DrawChartAnnotationArgs(
+                symbol="NVDA",
+                annotation={
+                    "type": "trendline",
+                    "point1": {"time": "2024-10-16T00:00:00Z", "price": 145.0},
+                },
+            )
+
+    def test_timeframe_defaults_to_1day(self):
+        args = DrawChartAnnotationArgs(
+            symbol="NVDA",
+            annotation={"type": "price_line", "price": 1.0},
+        )
+        assert args.timeframe == "1day"
+
+    def test_timeframe_accepts_valid_interval(self):
+        args = DrawChartAnnotationArgs(
+            symbol="NVDA",
+            timeframe="1hour",
+            annotation={"type": "price_line", "price": 1.0},
+        )
+        assert args.timeframe == "1hour"
+
+    def test_timeframe_rejects_unknown_interval(self):
+        with pytest.raises(ValidationError):
+            DrawChartAnnotationArgs(
+                symbol="NVDA",
+                timeframe="2hour",
+                annotation={"type": "price_line", "price": 1.0},
+            )
+
+    def test_schema_emits_oneof_with_all_variants(self):
+        """The LLM sees a discriminated oneOf with exactly our variants."""
+        schema = DrawChartAnnotationArgs.model_json_schema()
+        ann = schema["properties"]["annotation"]
+        assert "oneOf" in ann
+        assert ann["discriminator"]["propertyName"] == "type"
+        mapping = ann["discriminator"]["mapping"]
+        assert set(mapping.keys()) == {
+            "price_line",
+            "trendline",
+            "marker",
+            "vertical_line",
+            "rectangle",
+            "text",
+            "fib_retracement",
+        }
+
+    def test_manage_args_validates_action(self):
+        # valid
+        ManageChartAnnotationsArgs(symbol="NVDA", action="list")
+        ManageChartAnnotationsArgs(symbol="NVDA", action="remove", ids=["a"])
+        # invalid action
+        with pytest.raises(ValidationError):
+            ManageChartAnnotationsArgs(symbol="NVDA", action="flush")
+
+
+# --------------------------------------------------------------------------- #
+# draw_chart_annotation tool
+# --------------------------------------------------------------------------- #
+
+
+class TestDrawChartAnnotation:
+    @pytest.mark.asyncio
+    async def test_price_line_happy_path(self, fake_db):
+        writer = MagicMock()
+        with patch("langgraph.config.get_stream_writer", return_value=writer):
+            result = await draw_chart_annotation.ainvoke(
+                _tool_call(
+                    "draw_chart_annotation",
+                    {
+                        "symbol": "nvda",
+                        "annotation": {
+                            "type": "price_line",
+                            "price": 205.0,
+                            "label": "Resistance",
+                        },
+                    },
+                ),
+                config=_config(),
+            )
+
+        # content mentions price and symbol upper-cased
+        assert "205" in result.content
+        assert "NVDA" in result.content
+
+        # artifact is the chart_annotation wrapper carrying the full set + identity
+        assert result.artifact["type"] == "chart_annotation"
+        assert result.artifact["op"] == "add"
+        assert result.artifact["symbol"] == "NVDA"
+        assert result.artifact["timeframe"] == "1day"
+        assert result.artifact["chart_id"] == "NVDA:1day"
+        assert result.artifact["workspace_id"] == "ws_abc"
+        annotation_id = result.artifact["annotation_id"]
+        assert annotation_id.startswith("ann_")
+        assert _drawn(result)["type"] == "price_line"
+
+        # DB got the write under the (workspace, chart_id) instance
+        bucket = fake_db.bucket("ws_abc", "NVDA:1day")
+        assert annotation_id in bucket
+        assert bucket[annotation_id]["price"] == 205.0
+        assert bucket[annotation_id]["label"] == "Resistance"
+
+        # Stream writer emitted the artifact event with op=add + identity
+        writer.assert_called_once()
+        payload = writer.call_args[0][0]
+        assert payload["artifact_type"] == "chart_annotation"
+        assert payload["payload"]["op"] == "add"
+        assert payload["payload"]["symbol"] == "NVDA"
+        assert payload["payload"]["timeframe"] == "1day"
+        assert payload["payload"]["chart_id"] == "NVDA:1day"
+        assert payload["payload"]["workspace_id"] == "ws_abc"
+        assert payload["payload"]["annotation_id"] == annotation_id
+
+    @pytest.mark.asyncio
+    async def test_trendline_happy_path(self, fake_db):
+        writer = MagicMock()
+        with patch("langgraph.config.get_stream_writer", return_value=writer):
+            result = await draw_chart_annotation.ainvoke(
+                _tool_call(
+                    "draw_chart_annotation",
+                    {
+                        "symbol": "NVDA",
+                        "annotation": {
+                            "type": "trendline",
+                            "point1": {"time": "2024-10-16T00:00:00Z", "price": 145.2},
+                            "point2": {"time": "2024-12-20T00:00:00Z", "price": 138.7},
+                            "label": "Channel top",
+                        },
+                    },
+                ),
+                config=_config(),
+            )
+
+        assert _drawn(result)["type"] == "trendline"
+        assert _drawn(result)["point1"]["price"] == 145.2
+        writer.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_marker_happy_path(self, fake_db):
+        writer = MagicMock()
+        with patch("langgraph.config.get_stream_writer", return_value=writer):
+            result = await draw_chart_annotation.ainvoke(
+                _tool_call(
+                    "draw_chart_annotation",
+                    {
+                        "symbol": "NVDA",
+                        "annotation": {
+                            "type": "marker",
+                            "time": "2024-11-14T00:00:00Z",
+                            "shape": "arrowUp",
+                            "text": "Earnings beat",
+                        },
+                    },
+                ),
+                config=_config(),
+            )
+
+        assert _drawn(result)["type"] == "marker"
+        assert _drawn(result)["shape"] == "arrowUp"
+        writer.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_vertical_line_happy_path(self, fake_db):
+        writer = MagicMock()
+        with patch("langgraph.config.get_stream_writer", return_value=writer):
+            result = await draw_chart_annotation.ainvoke(
+                _tool_call(
+                    "draw_chart_annotation",
+                    {
+                        "symbol": "NVDA",
+                        "annotation": {
+                            "type": "vertical_line",
+                            "time": "2024-11-14T00:00:00Z",
+                            "label": "Earnings",
+                        },
+                    },
+                ),
+                config=_config(),
+            )
+
+        assert _drawn(result)["type"] == "vertical_line"
+        assert _drawn(result)["style"] == "dashed"  # default persisted
+        writer.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_rectangle_happy_path(self, fake_db):
+        writer = MagicMock()
+        with patch("langgraph.config.get_stream_writer", return_value=writer):
+            result = await draw_chart_annotation.ainvoke(
+                _tool_call(
+                    "draw_chart_annotation",
+                    {
+                        "symbol": "NVDA",
+                        "annotation": {
+                            "type": "rectangle",
+                            "point1": {"time": "2024-10-16T00:00:00Z", "price": 145.2},
+                            "point2": {"time": "2024-12-20T00:00:00Z", "price": 138.7},
+                            "label": "Demand zone",
+                        },
+                    },
+                ),
+                config=_config(),
+            )
+
+        assert _drawn(result)["type"] == "rectangle"
+        assert _drawn(result)["point1"]["price"] == 145.2
+        writer.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_text_happy_path(self, fake_db):
+        writer = MagicMock()
+        with patch("langgraph.config.get_stream_writer", return_value=writer):
+            result = await draw_chart_annotation.ainvoke(
+                _tool_call(
+                    "draw_chart_annotation",
+                    {
+                        "symbol": "NVDA",
+                        "annotation": {
+                            "type": "text",
+                            "time": "2024-11-14T00:00:00Z",
+                            "price": 200.0,
+                            "text": "Breakout",
+                        },
+                    },
+                ),
+                config=_config(),
+            )
+
+        assert _drawn(result)["type"] == "text"
+        assert _drawn(result)["text"] == "Breakout"
+        writer.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_fib_retracement_happy_path(self, fake_db):
+        writer = MagicMock()
+        with patch("langgraph.config.get_stream_writer", return_value=writer):
+            result = await draw_chart_annotation.ainvoke(
+                _tool_call(
+                    "draw_chart_annotation",
+                    {
+                        "symbol": "NVDA",
+                        "annotation": {
+                            "type": "fib_retracement",
+                            "point1": {"time": "2024-10-16T00:00:00Z", "price": 100.0},
+                            "point2": {"time": "2024-12-20T00:00:00Z", "price": 200.0},
+                        },
+                    },
+                ),
+                config=_config(),
+            )
+
+        assert _drawn(result)["type"] == "fib_retracement"
+        assert _drawn(result)["point2"]["price"] == 200.0
+        writer.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_result_artifact_carries_full_cumulative_set(self, fake_db):
+        """Each draw's inline-card artifact holds the instance's full set."""
+        writer = MagicMock()
+        with patch("langgraph.config.get_stream_writer", return_value=writer):
+            await draw_chart_annotation.ainvoke(
+                _tool_call(
+                    "draw_chart_annotation",
+                    {"symbol": "NVDA", "annotation": {"type": "price_line", "price": 200.0}},
+                ),
+                config=_config(),
+            )
+            second = await draw_chart_annotation.ainvoke(
+                _tool_call(
+                    "draw_chart_annotation",
+                    {"symbol": "NVDA", "annotation": {"type": "price_line", "price": 210.0}},
+                ),
+                config=_config(),
+            )
+
+        assert second.artifact["type"] == "chart_annotation"
+        prices = sorted(a["price"] for a in second.artifact["annotations"])
+        assert prices == [200.0, 210.0]
+
+    @pytest.mark.asyncio
+    async def test_timeframe_creates_distinct_instance(self, fake_db):
+        """Same ticker, different timeframe = a separate chart instance."""
+        writer = MagicMock()
+        with patch("langgraph.config.get_stream_writer", return_value=writer):
+            daily = await draw_chart_annotation.ainvoke(
+                _tool_call(
+                    "draw_chart_annotation",
+                    {"symbol": "NVDA", "annotation": {"type": "price_line", "price": 200.0}},
+                ),
+                config=_config(),
+            )
+            hourly = await draw_chart_annotation.ainvoke(
+                _tool_call(
+                    "draw_chart_annotation",
+                    {
+                        "symbol": "NVDA",
+                        "timeframe": "1hour",
+                        "annotation": {"type": "price_line", "price": 210.0},
+                    },
+                ),
+                config=_config(),
+            )
+
+        assert daily.artifact["chart_id"] == "NVDA:1day"
+        assert hourly.artifact["chart_id"] == "NVDA:1hour"
+        # Two separate instances, each with exactly its own annotation.
+        assert len(daily.artifact["annotations"]) == 1
+        assert len(hourly.artifact["annotations"]) == 1
+        assert len(fake_db.bucket("ws_abc", "NVDA:1day")) == 1
+        assert len(fake_db.bucket("ws_abc", "NVDA:1hour")) == 1
+
+    @pytest.mark.asyncio
+    async def test_missing_workspace_returns_error_no_write(self, fake_db):
+        writer = MagicMock()
+        with patch("langgraph.config.get_stream_writer", return_value=writer):
+            result = await draw_chart_annotation.ainvoke(
+                _tool_call(
+                    "draw_chart_annotation",
+                    {
+                        "symbol": "NVDA",
+                        "annotation": {"type": "price_line", "price": 1.0},
+                    },
+                ),
+                config=_config(workspace_id=None),
+            )
+
+        assert "workspace_id" in result.content.lower()
+        assert result.artifact == {}
+        writer.assert_not_called()
+        assert fake_db.instances == {}
+
+    @pytest.mark.asyncio
+    async def test_db_failure_is_fail_closed(self, failing_db):
+        """When the DB write fails we must NOT emit an SSE event (no ghost draw)."""
+        writer = MagicMock()
+        with patch("langgraph.config.get_stream_writer", return_value=writer):
+            result = await draw_chart_annotation.ainvoke(
+                _tool_call(
+                    "draw_chart_annotation",
+                    {
+                        "symbol": "NVDA",
+                        "annotation": {"type": "price_line", "price": 205.0},
+                    },
+                ),
+                config=_config(),
+            )
+
+        assert "persistence" in result.content.lower() or "could not save" in result.content.lower()
+        assert result.artifact == {}
+        writer.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# manage_chart_annotations tool
+# --------------------------------------------------------------------------- #
+
+
+class TestManageChartAnnotations:
+    @pytest.mark.asyncio
+    async def test_list_returns_stored_annotations(self, fake_db):
+        writer = MagicMock()
+        with patch("langgraph.config.get_stream_writer", return_value=writer):
+            # seed one
+            await draw_chart_annotation.ainvoke(
+                _tool_call(
+                    "draw_chart_annotation",
+                    {
+                        "symbol": "NVDA",
+                        "annotation": {"type": "price_line", "price": 205.0},
+                    },
+                ),
+                config=_config(),
+            )
+
+            result = await manage_chart_annotations.ainvoke(
+                _tool_call(
+                    "manage_chart_annotations",
+                    {"symbol": "NVDA", "action": "list"},
+                ),
+                config=_config(),
+            )
+
+        assert result.artifact["symbol"] == "NVDA"
+        assert result.artifact["chart_id"] == "NVDA:1day"
+        assert result.artifact["timeframe"] == "1day"
+        assert len(result.artifact["annotations"]) == 1
+        assert result.artifact["annotations"][0]["price"] == 205.0
+
+    @pytest.mark.asyncio
+    async def test_list_scoped_to_timeframe(self, fake_db):
+        """list returns only the requested instance, not other timeframes."""
+        writer = MagicMock()
+        with patch("langgraph.config.get_stream_writer", return_value=writer):
+            await draw_chart_annotation.ainvoke(
+                _tool_call(
+                    "draw_chart_annotation",
+                    {"symbol": "NVDA", "annotation": {"type": "price_line", "price": 200.0}},
+                ),
+                config=_config(),
+            )
+            await draw_chart_annotation.ainvoke(
+                _tool_call(
+                    "draw_chart_annotation",
+                    {
+                        "symbol": "NVDA",
+                        "timeframe": "1hour",
+                        "annotation": {"type": "price_line", "price": 210.0},
+                    },
+                ),
+                config=_config(),
+            )
+
+            hourly = await manage_chart_annotations.ainvoke(
+                _tool_call(
+                    "manage_chart_annotations",
+                    {"symbol": "NVDA", "timeframe": "1hour", "action": "list"},
+                ),
+                config=_config(),
+            )
+
+        assert hourly.artifact["chart_id"] == "NVDA:1hour"
+        assert len(hourly.artifact["annotations"]) == 1
+        assert hourly.artifact["annotations"][0]["price"] == 210.0
+
+    @pytest.mark.asyncio
+    async def test_list_does_not_accept_ids(self, fake_db):
+        result = await manage_chart_annotations.ainvoke(
+            _tool_call(
+                "manage_chart_annotations",
+                {"symbol": "NVDA", "action": "list", "ids": ["ann_1"]},
+            ),
+            config=_config(),
+        )
+        assert "does not accept" in result.content.lower()
+        assert result.artifact == {}
+
+    @pytest.mark.asyncio
+    async def test_remove_deletes_specific_ids(self, fake_db):
+        writer = MagicMock()
+        with patch("langgraph.config.get_stream_writer", return_value=writer):
+            draw_result = await draw_chart_annotation.ainvoke(
+                _tool_call(
+                    "draw_chart_annotation",
+                    {
+                        "symbol": "NVDA",
+                        "annotation": {"type": "price_line", "price": 205.0},
+                    },
+                ),
+                config=_config(),
+            )
+            ann_id = draw_result.artifact["annotation_id"]
+            writer.reset_mock()
+
+            result = await manage_chart_annotations.ainvoke(
+                _tool_call(
+                    "manage_chart_annotations",
+                    {"symbol": "NVDA", "action": "remove", "ids": [ann_id]},
+                ),
+                config=_config(),
+            )
+
+        assert result.artifact["removed"] == 1
+        assert result.artifact["chart_id"] == "NVDA:1day"
+        assert ann_id not in fake_db.bucket("ws_abc", "NVDA:1day")
+        # SSE remove event emitted with identity
+        writer.assert_called_once()
+        payload = writer.call_args[0][0]["payload"]
+        assert payload["op"] == "remove"
+        assert payload["chart_id"] == "NVDA:1day"
+        assert payload["workspace_id"] == "ws_abc"
+        assert payload["ids"] == [ann_id]
+
+    @pytest.mark.asyncio
+    async def test_remove_requires_non_empty_ids(self, fake_db):
+        result = await manage_chart_annotations.ainvoke(
+            _tool_call(
+                "manage_chart_annotations",
+                {"symbol": "NVDA", "action": "remove"},
+            ),
+            config=_config(),
+        )
+        assert "requires" in result.content.lower()
+        assert result.artifact == {}
+
+    @pytest.mark.asyncio
+    async def test_clear_all_removes_everything(self, fake_db):
+        writer = MagicMock()
+        with patch("langgraph.config.get_stream_writer", return_value=writer):
+            for price in (200.0, 210.0, 220.0):
+                await draw_chart_annotation.ainvoke(
+                    _tool_call(
+                        "draw_chart_annotation",
+                        {
+                            "symbol": "NVDA",
+                            "annotation": {"type": "price_line", "price": price},
+                        },
+                    ),
+                    config=_config(),
+                )
+            writer.reset_mock()
+
+            result = await manage_chart_annotations.ainvoke(
+                _tool_call(
+                    "manage_chart_annotations",
+                    {"symbol": "NVDA", "action": "clear_all"},
+                ),
+                config=_config(),
+            )
+
+        assert result.artifact["cleared"] == 3
+        assert result.artifact["chart_id"] == "NVDA:1day"
+        assert fake_db.bucket("ws_abc", "NVDA:1day") == {}
+        writer.assert_called_once()
+        payload = writer.call_args[0][0]["payload"]
+        assert payload["op"] == "clear"
+        assert payload["chart_id"] == "NVDA:1day"
+        assert payload["workspace_id"] == "ws_abc"
+
+    @pytest.mark.asyncio
+    async def test_clear_all_rejects_ids(self, fake_db):
+        result = await manage_chart_annotations.ainvoke(
+            _tool_call(
+                "manage_chart_annotations",
+                {"symbol": "NVDA", "action": "clear_all", "ids": ["ann_1"]},
+            ),
+            config=_config(),
+        )
+        assert "does not accept" in result.content.lower()
+        assert result.artifact == {}
+
+
+# --------------------------------------------------------------------------- #
+# Registry visibility
+# --------------------------------------------------------------------------- #
+
+
+class TestSkillRegistryVisibility:
+    def test_chart_annotation_registered_for_both_modes(self):
+        from src.ptc_agent.agent.middleware.skills.registry import SKILL_REGISTRY
+
+        skill = SKILL_REGISTRY["chart-annotation"]
+        # Discoverable in both modes so the agent can self-load it on demand
+        # (including from the standalone chat page, where it renders a card).
+        assert skill.exposure == "both"
+        tool_names = skill.get_tool_names()
+        assert set(tool_names) == {"draw_chart_annotation", "manage_chart_annotations"}
+
+    def test_appears_in_default_listing(self):
+        """chart-annotation must be in the manifest the LLM sees in every mode.
+
+        ``list_skills`` drives what gets injected into the system prompt via
+        SkillsMiddleware. The agent can only choose to load a skill it can see,
+        so a discoverable skill must appear here.
+        """
+        from src.ptc_agent.agent.middleware.skills.registry import list_skills
+
+        for mode in ("ptc", "flash", None):
+            listed = {s["name"] for s in list_skills(mode=mode)}
+            assert "chart-annotation" in listed, (
+                f"chart-annotation missing from listing for mode={mode}"
+            )
+
+    def test_synced_to_sandbox(self):
+        """exposure=both ⇒ SKILL.md is uploaded so PTC can self-load by reading it."""
+        from src.ptc_agent.agent.middleware.skills.registry import (
+            get_sandbox_skill_names,
+        )
+
+        assert "chart-annotation" in get_sandbox_skill_names()
+
+    def test_reachable_by_name_in_every_mode(self):
+        from src.ptc_agent.agent.middleware.skills.registry import get_skill
+
+        for mode in ("ptc", "flash", None):
+            skill = get_skill("chart-annotation", mode=mode)
+            assert skill is not None, f"get_skill returned None for mode={mode}"
+            assert skill.name == "chart-annotation"

--- a/tests/unit/tools/test_chart_annotation.py
+++ b/tests/unit/tools/test_chart_annotation.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 
 from src.tools.chart_annotation.schemas import (
     DrawChartAnnotationArgs,
+    EventAnnotation,
     FibRetracementAnnotation,
     ManageChartAnnotationsArgs,
     MarkerAnnotation,
@@ -215,6 +216,33 @@ class TestAnnotationSchemas:
                 },
             )
 
+    def test_event_variant_roundtrip(self):
+        args = DrawChartAnnotationArgs(
+            symbol="NVDA",
+            annotation={
+                "type": "event",
+                "time": "2024-11-14T00:00:00Z",
+                "price": 205.0,
+                "title": "Q3 earnings beat",
+                "detail": "Beat EPS by $0.15 and raised full-year guidance ~5%.",
+            },
+        )
+        assert isinstance(args.annotation, EventAnnotation)
+        assert args.annotation.title == "Q3 earnings beat"
+        assert args.annotation.color is None  # default
+
+    def test_event_requires_title_and_detail(self):
+        with pytest.raises(ValidationError):
+            DrawChartAnnotationArgs(
+                symbol="NVDA",
+                annotation={
+                    "type": "event",
+                    "time": "2024-11-14T00:00:00Z",
+                    "price": 205.0,
+                    "title": "Earnings",  # missing detail
+                },
+            )
+
     def test_fib_retracement_variant_roundtrip(self):
         args = DrawChartAnnotationArgs(
             symbol="NVDA",
@@ -281,6 +309,7 @@ class TestAnnotationSchemas:
             "vertical_line",
             "rectangle",
             "text",
+            "event",
             "fib_retracement",
         }
 
@@ -467,6 +496,34 @@ class TestDrawChartAnnotation:
 
         assert _drawn(result)["type"] == "text"
         assert _drawn(result)["text"] == "Breakout"
+        writer.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_event_happy_path(self, fake_db):
+        writer = MagicMock()
+        with patch("langgraph.config.get_stream_writer", return_value=writer):
+            result = await draw_chart_annotation.ainvoke(
+                _tool_call(
+                    "draw_chart_annotation",
+                    {
+                        "symbol": "NVDA",
+                        "annotation": {
+                            "type": "event",
+                            "time": "2024-11-14T00:00:00Z",
+                            "price": 205.0,
+                            "title": "Q3 earnings beat",
+                            "detail": "Beat EPS and raised guidance.",
+                        },
+                    },
+                ),
+                config=_config(),
+            )
+
+        assert "Q3 earnings beat" in result.content
+        drawn = _drawn(result)
+        assert drawn["type"] == "event"
+        assert drawn["title"] == "Q3 earnings beat"
+        assert drawn["detail"] == "Beat EPS and raised guidance."
         writer.assert_called_once()
 
     @pytest.mark.asyncio

--- a/tests/unit/tools/test_chart_annotation_schema_parity.py
+++ b/tests/unit/tools/test_chart_annotation_schema_parity.py
@@ -1,0 +1,227 @@
+"""Backend↔frontend type-parity guard for chart annotations.
+
+The chart-annotation data shape is defined TWICE, by hand:
+
+- Backend (source of truth): the pydantic discriminated union in
+  ``src/tools/chart_annotation/schemas.py`` (``Annotation`` = union of
+  PriceLineAnnotation, TrendlineAnnotation, MarkerAnnotation,
+  VerticalLineAnnotation, RectangleAnnotation, TextAnnotation,
+  EventAnnotation, FibRetracementAnnotation; discriminator ``type``).
+- Frontend (hand-mirrored): the ``StoredAnnotation`` / ``ChartInstance``
+  types in
+  ``web/src/pages/MarketView/stores/chartAnnotationStore.ts``.
+
+These drift independently — a backend field change won't fail any test
+until something breaks at runtime in the browser. This test pins an
+explicit, committed expectation of the backend contract (the exact set of
+discriminator ``type`` values, and per-variant the field names, which are
+required, and their JSON types). Any backend annotation-shape change makes
+this fail loudly, forcing a conscious update.
+
+WHEN THIS TEST FAILS: you changed the pydantic annotation schema. Update
+``EXPECTED_ANNOTATION_CONTRACT`` below to match AND update the hand-mirrored
+TypeScript types in
+``web/src/pages/MarketView/stores/chartAnnotationStore.ts`` in lockstep
+(the ``StoredAnnotation`` union and its member interfaces), or the frontend
+will silently disagree with the wire format the agent emits.
+
+The expectation is encoded against the JSON schema (the actual wire shape),
+so ``float`` reads as ``number``, ``str | None`` as ``string|null``,
+``Literal[...]`` enums as ``string``, and nested models (``TimePricePoint``)
+as ``object`` — matching how the frontend declares the same fields.
+"""
+
+from typing import get_args
+
+from pydantic import TypeAdapter
+
+from src.tools.chart_annotation.schemas import Annotation
+
+# ---------------------------------------------------------------------------
+# Committed expectation of the backend contract.
+#
+# Shape: { discriminator_type: { field_name: (json_type, required) } }
+#   json_type ∈ {"string", "number", "string|null", "object"}
+#   required  ∈ {True, False}
+#
+# `object` denotes a nested TimePricePoint anchor ({time: string, price:
+# number}); its inner shape is asserted separately in
+# EXPECTED_TIME_PRICE_POINT below.
+# ---------------------------------------------------------------------------
+EXPECTED_ANNOTATION_CONTRACT: dict[str, dict[str, tuple[str, bool]]] = {
+    "price_line": {
+        "type": ("string", True),
+        "price": ("number", True),
+        "label": ("string|null", False),
+        "color": ("string|null", False),
+        "style": ("string", False),
+    },
+    "trendline": {
+        "type": ("string", True),
+        "point1": ("object", True),
+        "point2": ("object", True),
+        "label": ("string|null", False),
+        "color": ("string|null", False),
+    },
+    "marker": {
+        "type": ("string", True),
+        "time": ("string", True),
+        "shape": ("string", True),
+        "position": ("string", False),
+        "text": ("string|null", False),
+        "color": ("string|null", False),
+    },
+    "vertical_line": {
+        "type": ("string", True),
+        "time": ("string", True),
+        "label": ("string|null", False),
+        "color": ("string|null", False),
+        "style": ("string", False),
+    },
+    "rectangle": {
+        "type": ("string", True),
+        "point1": ("object", True),
+        "point2": ("object", True),
+        "label": ("string|null", False),
+        "color": ("string|null", False),
+    },
+    "text": {
+        "type": ("string", True),
+        "time": ("string", True),
+        "price": ("number", True),
+        "text": ("string", True),
+        "color": ("string|null", False),
+    },
+    "event": {
+        "type": ("string", True),
+        "time": ("string", True),
+        "price": ("number", True),
+        "title": ("string", True),
+        "detail": ("string", True),
+        "color": ("string|null", False),
+    },
+    "fib_retracement": {
+        "type": ("string", True),
+        "point1": ("object", True),
+        "point2": ("object", True),
+        "label": ("string|null", False),
+        "color": ("string|null", False),
+    },
+}
+
+# Inner shape of the (time, price) anchor shared by trendline / rectangle /
+# fib_retracement. Mirrors the frontend `TimePricePoint` interface.
+EXPECTED_TIME_PRICE_POINT: dict[str, tuple[str, bool]] = {
+    "time": ("string", True),
+    "price": ("number", True),
+}
+
+
+def _json_type_token(field_schema: dict) -> str:
+    """Collapse one JSON-schema property into a parity token.
+
+    Maps the actual wire shape (not the python annotation) so the
+    expectation reads the way the frontend declares the same field:
+      - ``{"type": "string"}`` (incl. const/enum strings) → ``"string"``
+      - ``{"type": "number"}`` → ``"number"``
+      - ``{"anyOf": [{"type": "string"}, {"type": "null"}]}`` → ``"string|null"``
+      - ``{"$ref": ".../TimePricePoint"}`` (nested model) → ``"object"``
+    """
+    if "$ref" in field_schema:
+        return "object"
+
+    if "anyOf" in field_schema:
+        inner = {
+            opt.get("type")
+            for opt in field_schema["anyOf"]
+        }
+        if inner == {"string", "null"}:
+            return "string|null"
+        if inner == {"number", "null"}:
+            return "number|null"
+        # Surface any unexpected optional combination explicitly so it can't
+        # silently pass as a known token.
+        return "anyOf:" + "|".join(sorted(t or "?" for t in inner))
+
+    # const (single-value Literal) and enum (multi-value Literal) both carry
+    # an explicit "type" — for annotations that is always "string".
+    return field_schema.get("type", "unknown")
+
+
+def _variant_schemas() -> dict[str, dict]:
+    """Resolve each union member's full JSON schema, keyed by discriminator.
+
+    Walks the discriminated-union JSON schema: the ``discriminator.mapping``
+    maps each ``type`` value to a ``$ref`` into ``$defs``.
+    """
+    schema = TypeAdapter(Annotation).json_schema()
+    defs = schema["$defs"]
+    mapping = schema["discriminator"]["mapping"]
+    resolved: dict[str, dict] = {}
+    for type_value, ref in mapping.items():
+        def_name = ref.split("/")[-1]
+        resolved[type_value] = defs[def_name]
+    return resolved
+
+
+def _contract_from_schema(variant_schema: dict) -> dict[str, tuple[str, bool]]:
+    """Reduce one variant's JSON schema to {field: (json_type, required)}."""
+    required = set(variant_schema.get("required", []))
+    props = variant_schema["properties"]
+    return {
+        name: (_json_type_token(prop), name in required)
+        for name, prop in props.items()
+    }
+
+
+def test_discriminator_type_values_match_expectation():
+    """The exact set of `type` discriminator values is pinned."""
+    schema = TypeAdapter(Annotation).json_schema()
+    assert schema["discriminator"]["propertyName"] == "type"
+    live_types = set(schema["discriminator"]["mapping"])
+    assert live_types == set(EXPECTED_ANNOTATION_CONTRACT), (
+        "Annotation discriminator `type` values drifted. Update "
+        "EXPECTED_ANNOTATION_CONTRACT and the frontend StoredAnnotation "
+        "union (chartAnnotationStore.ts) in lockstep."
+    )
+
+
+def test_union_member_count_matches_discriminator():
+    """No union member can be added without a discriminator entry."""
+    union, _field = get_args(Annotation)
+    members = get_args(union)
+    assert len(members) == len(EXPECTED_ANNOTATION_CONTRACT)
+
+
+def test_each_variant_field_contract_matches_expectation():
+    """Per-variant: field names, required flags, and JSON types are pinned.
+
+    This is the core drift guard — any added/removed/renamed field, any
+    required↔optional flip, or any type change on the backend fails here.
+    """
+    variant_schemas = _variant_schemas()
+    for type_value, expected_fields in EXPECTED_ANNOTATION_CONTRACT.items():
+        live = _contract_from_schema(variant_schemas[type_value])
+        assert live == expected_fields, (
+            f"Annotation variant '{type_value}' drifted from the committed "
+            f"contract. Update EXPECTED_ANNOTATION_CONTRACT and the matching "
+            f"frontend interface in chartAnnotationStore.ts.\n"
+            f"  expected: {expected_fields}\n"
+            f"  actual:   {live}"
+        )
+
+
+def test_time_price_point_shape_matches_expectation():
+    """The shared (time, price) anchor shape is pinned.
+
+    `object`-typed fields (point1/point2) reference this nested model; pin it
+    explicitly so a change to the anchor shape can't slip past the `object`
+    token.
+    """
+    schema = TypeAdapter(Annotation).json_schema()
+    tpp = schema["$defs"]["TimePricePoint"]
+    assert _contract_from_schema(tpp) == EXPECTED_TIME_PRICE_POINT, (
+        "TimePricePoint anchor shape drifted. Update "
+        "EXPECTED_TIME_PRICE_POINT and the frontend TimePricePoint "
+        "interface in chartAnnotationStore.ts."
+    )

--- a/web/src/contexts/AuthContext.tsx
+++ b/web/src/contexts/AuthContext.tsx
@@ -4,6 +4,7 @@ import { supabase } from '../lib/supabase';
 import { setTokenGetter } from '../api/client';
 import { queryKeys } from '../lib/queryKeys';
 import { OAUTH_BROADCAST_CHANNEL, OAUTH_POPUP_WINDOW_NAME, OAUTH_POPUP_FEATURES } from '../lib/oauthPopup';
+import { clearFlashWorkspaceCache } from '@/pages/MarketView/utils/flashWorkspace';
 
 import type { AuthResponse, OAuthResponse, Provider, Session } from '@supabase/supabase-js';
 
@@ -140,6 +141,7 @@ function SupabaseAuthProvider({ children }: { children: React.ReactNode }) {
       } else {
         // Logged out — wipe all cached data
         queryClient.clear();
+        clearFlashWorkspaceCache();
         setTokenGetter(() => Promise.resolve(null));
       }
     });

--- a/web/src/lib/queryKeys.ts
+++ b/web/src/lib/queryKeys.ts
@@ -62,4 +62,8 @@ export const queryKeys = {
     // Effective per-workspace server list (builtins + workspace servers).
     workspace: (wsId: string) => [...queryKeys.mcp.all, 'workspace', wsId],
   },
+  marketData: {
+    all:  ['marketData'],
+    bars: (symbol: string, interval: string) => [...queryKeys.marketData.all, 'bars', symbol, interval],
+  },
 };

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -1172,6 +1172,7 @@
       "sector-overviewDesc": "Industry landscape report: market size, competitive dynamics, company profiles, valuation context",
       "competitive-analysisDesc": "Competitive landscape analysis: positioning, scorecards, moat assessment, market share trends",
       "initiating-coverageDesc": "Full equity research initiation: company research, financial model, valuation, charts, 30-50 page report",
+      "chart-annotationDesc": "Annotate a price chart: price lines, trendlines, zones, and event markers, live on MarketView or as a clickable preview card",
       "report-issueDesc": "Report issues and propose fixes to improve agent capabilities"
     },
     "compactedNotification": "Context compacted · {{from}} messages → summary",
@@ -1253,6 +1254,26 @@
     "a11y": {
       "toolCallCompleted": "completed",
       "toolCallFailed": "failed"
+    },
+    "chartAnnotationCard": {
+      "openAnnotatedChart": "Open annotated chart",
+      "openInMarketView": "Open in MarketView",
+      "loadingChart": "Loading chart…",
+      "previewUnavailable": "Preview unavailable",
+      "close": "Close",
+      "cardAria_one": "{{symbol}} {{timeframe}}, {{count}} annotation. Open annotated chart.",
+      "cardAria_other": "{{symbol}} {{timeframe}}, {{count}} annotations. Open annotated chart.",
+      "dialogTitle_one": "{{symbol}} {{timeframe}} — {{count}} annotation",
+      "dialogTitle_other": "{{symbol}} {{timeframe}} — {{count}} annotations",
+      "chipJumpTitle": "Switch the chart to {{symbol}} · {{timeframe}} to show these annotations",
+      "chipShowTitle": "Show these annotations on the chart",
+      "chipShownTitle": "Shown on the chart",
+      "chipViewCount_one": "View {{count}} annotation on chart",
+      "chipViewCount_other": "View {{count}} annotations on chart",
+      "chipShowCount_one": "Show {{count}} annotation on chart",
+      "chipShowCount_other": "Show {{count}} annotations on chart",
+      "chipShownCount_one": "{{count}} annotation on chart",
+      "chipShownCount_other": "{{count}} annotations on chart"
     }
   },
   "context": {
@@ -2090,7 +2111,13 @@
       "noWorkspacePrompt": "No workspace selected. Pick one in the chat input.",
       "startConversation": "Start a conversation by typing a message below",
       "defaultPlaceholder": "What would you like to know?",
-      "returnToChat": "Return to Chat"
+      "returnToChat": "Return to Chat",
+      "openInChat": "Open in Chat"
+    },
+    "chart": {
+      "clearAnnotations": "Clear",
+      "clearAnnotationsTitle": "Clear annotations from the chart (kept in chat — click the artifact to restore)",
+      "newsEventAria": "News event: {{title}}"
     }
   },
   "onboarding": {

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -1183,6 +1183,7 @@
     "offloadedNotification": "Context offloaded · {{args}} tool args, {{reads}} reads",
     "compactionError": "Context compaction failed",
     "compactBusy": "Can only compact when the current turn has finished streaming.",
+    "offloadBusy": "Can only offload when the current turn has finished streaming.",
     "modelSelector": {
       "manageModels": "Manage models",
       "moreModels": "More models",

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -1776,6 +1776,8 @@
       "automations": "Automations",
       "createAutomation": "Create Automation",
       "manageAutomation": "Manage Automation",
+      "annotateChart": "Annotate Chart",
+      "manageAnnotations": "Manage Annotations",
       "skill": "Skill",
       "memory": "Memory",
       "workspaceMemory": "Workspace Memory",
@@ -1856,6 +1858,8 @@
       "creatingAutomation": "creating automation...",
       "actionAutomation": "{{action}} automation...",
       "managingAutomation": "managing automation...",
+      "annotatingChart": "annotating chart...",
+      "updatingAnnotations": "updating annotations...",
       "processing": "processing..."
     },
     "preparing": {

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -2089,7 +2089,8 @@
       "ptcDisabledReason": "Create a workspace in /chat to use PTC mode",
       "noWorkspacePrompt": "No workspace selected. Pick one in the chat input.",
       "startConversation": "Start a conversation by typing a message below",
-      "defaultPlaceholder": "What would you like to know?"
+      "defaultPlaceholder": "What would you like to know?",
+      "returnToChat": "Return to Chat"
     }
   },
   "onboarding": {

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -1765,6 +1765,8 @@
       "automations": "自动化",
       "createAutomation": "创建自动化",
       "manageAutomation": "管理自动化",
+      "annotateChart": "标注图表",
+      "manageAnnotations": "管理标注",
       "skill": "技能",
       "memory": "记忆",
       "workspaceMemory": "工作区记忆",
@@ -1845,6 +1847,8 @@
       "creatingAutomation": "创建自动化...",
       "actionAutomation": "{{action}} 自动化...",
       "managingAutomation": "管理自动化...",
+      "annotatingChart": "正在标注图表...",
+      "updatingAnnotations": "正在更新标注...",
       "processing": "处理中..."
     },
     "preparing": {

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -1172,6 +1172,7 @@
       "sector-overviewDesc": "行业全景报告：市场规模、竞争格局、公司概览、估值背景",
       "competitive-analysisDesc": "竞争格局分析：市场定位、评分卡、护城河评估、份额趋势",
       "initiating-coverageDesc": "全面研究启动：公司研究、财务模型、估值、图表、30-50 页报告",
+      "chart-annotationDesc": "标注价格图表：价格线、趋势线、区间和事件标记，实时显示在 MarketView 或作为可点击的预览卡片",
       "report-issueDesc": "报告问题并提出改进建议以提升 Agent 能力"
     },
     "compactedNotification": "上下文已压缩 · {{from}} 条消息 → 摘要",
@@ -1253,6 +1254,26 @@
     "a11y": {
       "toolCallCompleted": "已完成",
       "toolCallFailed": "已失败"
+    },
+    "chartAnnotationCard": {
+      "openAnnotatedChart": "打开标注图表",
+      "openInMarketView": "在行情中心打开",
+      "loadingChart": "正在加载图表…",
+      "previewUnavailable": "预览不可用",
+      "close": "关闭",
+      "cardAria_one": "{{symbol}} {{timeframe}}，{{count}} 个标注。打开标注图表。",
+      "cardAria_other": "{{symbol}} {{timeframe}}，{{count}} 个标注。打开标注图表。",
+      "dialogTitle_one": "{{symbol}} {{timeframe}} · {{count}} 个标注",
+      "dialogTitle_other": "{{symbol}} {{timeframe}} · {{count}} 个标注",
+      "chipJumpTitle": "将图表切换到 {{symbol}} · {{timeframe}} 以显示这些标注",
+      "chipShowTitle": "在图表上显示这些标注",
+      "chipShownTitle": "已显示在图表上",
+      "chipViewCount_one": "在图表上查看 {{count}} 个标注",
+      "chipViewCount_other": "在图表上查看 {{count}} 个标注",
+      "chipShowCount_one": "在图表上显示 {{count}} 个标注",
+      "chipShowCount_other": "在图表上显示 {{count}} 个标注",
+      "chipShownCount_one": "图表上有 {{count}} 个标注",
+      "chipShownCount_other": "图表上有 {{count}} 个标注"
     }
   },
   "context": {
@@ -2070,7 +2091,13 @@
       "noWorkspacePrompt": "未选择工作区。请在输入框中选择一个。",
       "startConversation": "在下方输入消息开始对话",
       "defaultPlaceholder": "你想了解什么？",
-      "returnToChat": "返回对话"
+      "returnToChat": "返回对话",
+      "openInChat": "在对话中打开"
+    },
+    "chart": {
+      "clearAnnotations": "清除",
+      "clearAnnotationsTitle": "从图表中清除标注（已保留在对话中，点击该结果可恢复）",
+      "newsEventAria": "新闻事件：{{title}}"
     }
   },
   "onboarding": {

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -1183,6 +1183,7 @@
     "offloadedNotification": "上下文已转存 · {{args}} 个工具参数, {{reads}} 个读取",
     "compactionError": "上下文压缩失败",
     "compactBusy": "当前轮次还在流式输出中，请等结束后再压缩。",
+    "offloadBusy": "当前轮次还在流式输出中，请等结束后再转存。",
     "modelSelector": {
       "manageModels": "管理模型",
       "moreModels": "更多模型",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -2069,7 +2069,8 @@
       "ptcDisabledReason": "在 /chat 中创建工作区以使用 PTC 模式",
       "noWorkspacePrompt": "未选择工作区。请在输入框中选择一个。",
       "startConversation": "在下方输入消息开始对话",
-      "defaultPlaceholder": "你想了解什么？"
+      "defaultPlaceholder": "你想了解什么？",
+      "returnToChat": "返回对话"
     }
   },
   "onboarding": {

--- a/web/src/pages/ChatAgent/components/ActivityBlock.tsx
+++ b/web/src/pages/ChatAgent/components/ActivityBlock.tsx
@@ -104,6 +104,9 @@ interface ActivityItem {
   isFailed?: boolean;
   _recentlyCompleted?: boolean;
   _liveState?: LiveState;
+  /** Intermediate chart-annotation draw — render as an ordinary row, never a
+   *  card (the latest draw per chart owns the card; set in MessageList). */
+  _annotationStep?: boolean;
   content?: string;
   reasoningTitle?: string;
   [key: string]: unknown;
@@ -156,7 +159,8 @@ const ActivityBlock = memo(function ActivityBlock({ items, preparingToolCall, is
         if (
           item.type === 'tool_call' &&
           INLINE_ARTIFACT_TOOLS.has(item.toolName || '') &&
-          item.toolCallResult?.artifact
+          item.toolCallResult?.artifact &&
+          !item._annotationStep
         ) {
           inlineCharts.push(item);
         } else {

--- a/web/src/pages/ChatAgent/components/ActivityBlock.tsx
+++ b/web/src/pages/ChatAgent/components/ActivityBlock.tsx
@@ -29,6 +29,7 @@ import {
 } from './charts/InlineArtifactCards';
 import { InlineAutomationCard } from './charts/InlineAutomationCards';
 import { InlinePreviewCard } from './charts/InlinePreviewCard';
+import { InlineChartAnnotationCard } from './charts/InlineChartAnnotationCard';
 import { useTranslation } from 'react-i18next';
 import './ActivityBlock.css';
 
@@ -66,6 +67,7 @@ const INLINE_ARTIFACT_MAP: Record<string, React.ComponentType<{ artifact: Record
   automations: InlineAutomationCard,
   preview_url: InlinePreviewCard,
   web_search: InlineWebSearchCard,
+  chart_annotation: InlineChartAnnotationCard,
 };
 
 /** Spring config matching radix-accordion feel */

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -95,6 +95,12 @@ interface LocationState {
    * the bus state powers the visual chips and any follow-up the user types.
    */
   widgetSnapshots?: WidgetContextSnapshot[];
+  /**
+   * Skill names to preload as hidden skills (chart-annotation forwarding from
+   * MarketView). Merged into `additionalContext` as `{type:'skills',name}` on
+   * the auto-fire send so hidden skills stay active on the PTC side.
+   */
+  skills?: string[];
   [key: string]: unknown;
 }
 
@@ -1818,30 +1824,50 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
 
     // Handle regular message flow
     if (location.state?.initialMessage && !initialMessageSentRef.current) {
+      // Merge state.skills (names) into additionalContext as skill entries,
+      // so hidden skills preloaded upstream (e.g. chart-annotation from
+      // MarketView) stay active on the PTC side.
+      const mergeSkills = (
+        context: Record<string, unknown>[] | null | undefined,
+        skills: unknown,
+      ): Record<string, unknown>[] | null => {
+        const base = Array.isArray(context) ? [...context] : [];
+        if (Array.isArray(skills)) {
+          for (const name of skills) {
+            if (typeof name !== 'string' || !name) continue;
+            if (base.some((c) => c?.type === 'skills' && c?.name === name)) continue;
+            base.push({ type: 'skills', name });
+          }
+        }
+        return base.length > 0 ? base : null;
+      };
+
       // For new threads (__default__), send immediately without waiting for history
       // For existing threads, wait for history to finish loading
       if (threadId === '__default__') {
         // New thread - send immediately
         initialMessageSentRef.current = true;
         // Capture state values before clearing (navigate may update location ref)
-        const { initialMessage, planMode, additionalContext, attachmentMeta, model, reasoningEffort, widgetSnapshots } = location.state;
+        const { initialMessage, planMode, additionalContext, attachmentMeta, model, reasoningEffort, widgetSnapshots, skills } = location.state;
+        const mergedContext = mergeSkills(additionalContext, skills);
         // Clear navigation state to prevent re-sending on re-renders
         navigate(location.pathname, { replace: true, state: {} });
         // Small delay to ensure component is fully mounted
         setTimeout(() => {
-          handleSendMessage(initialMessage, planMode || false, additionalContext || null, attachmentMeta || null, { model, reasoningEffort, widgetSnapshots });
+          handleSendMessage(initialMessage, planMode || false, mergedContext, attachmentMeta || null, { model, reasoningEffort, widgetSnapshots });
         }, 100);
       } else if (!isLoadingHistory && !isLoading) {
         // Existing thread - wait for history to load, then send
         // This ensures we don't send duplicate messages
         initialMessageSentRef.current = true;
         // Capture state values before clearing (navigate may update location ref)
-        const { initialMessage, planMode, additionalContext, attachmentMeta, model, reasoningEffort, widgetSnapshots } = location.state;
+        const { initialMessage, planMode, additionalContext, attachmentMeta, model, reasoningEffort, widgetSnapshots, skills } = location.state;
+        const mergedContext = mergeSkills(additionalContext, skills);
         // Clear navigation state to prevent re-sending on re-renders
         navigate(location.pathname, { replace: true, state: {} });
         // Small delay to ensure component is fully mounted
         setTimeout(() => {
-          handleSendMessage(initialMessage, planMode || false, additionalContext || null, attachmentMeta || null, { model, reasoningEffort, widgetSnapshots });
+          handleSendMessage(initialMessage, planMode || false, mergedContext, attachmentMeta || null, { model, reasoningEffort, widgetSnapshots });
         }, 100);
       }
     }

--- a/web/src/pages/ChatAgent/components/MessageList.tsx
+++ b/web/src/pages/ChatAgent/components/MessageList.tsx
@@ -24,6 +24,7 @@ import {
 import { InlineAutomationCard } from './charts/InlineAutomationCards';
 import { InlinePreviewCard } from './charts/InlinePreviewCard';
 import { InlineChartAnnotationCard } from './charts/InlineChartAnnotationCard';
+import { chartInstanceKey, planChartAnnotationCards } from './chartAnnotationGrouping';
 import { extractFilePaths, FileMentionCards } from './FileCard';
 import { normalizeFileRefs } from '../utils/normalizeFileRefs';
 import { useUser } from '@/hooks/useUser';
@@ -1216,6 +1217,11 @@ const MessageContentSegments = memo(function MessageContentSegments({ segments, 
         return false;
       });
 
+      // One card per chart instance, pinned at the first draw and fed the
+      // latest cumulative artifact (so it grows in place); every other draw
+      // folds into the timeline as an ordinary row.
+      const chartCardPlan = planChartAnnotationCards(filtered, toolCallProcesses);
+
       const blocks: RenderBlock[] = [];
       let pendingItems: Array<Record<string, unknown>> = [];
       let activityCounter = 0;
@@ -1318,13 +1324,45 @@ const MessageContentSegments = memo(function MessageContentSegments({ segments, 
               }
             }
           } else if (isArtifactReady) {
-            flushActivity();
-            blocks.push({
-              type: 'compact_artifact',
-              key: `compact-${seg.toolCallId}`,
-              toolCallId: seg.toolCallId!,
-              proc,
-            });
+            const isChartAnnotation = (artifactResult as Record<string, unknown>).type === 'chart_annotation';
+            const plan = isChartAnnotation
+              ? chartCardPlan.get(chartInstanceKey(artifactResult as Record<string, unknown>))
+              : undefined;
+            if (isChartAnnotation && plan && plan.anchorCallId !== seg.toolCallId) {
+              // A later draw on a chart whose card is already pinned at its first
+              // draw: render as an ordinary completed row (its content shows in
+              // the pinned card above). `_annotationStep` stops ActivityBlock
+              // (see its partition guard) from re-promoting it into a card.
+              pendingItems.push({
+                type: 'tool_call',
+                id: seg.toolCallId,
+                toolCallId: seg.toolCallId,
+                ...proc,
+                _liveState: 'completed',
+                _annotationStep: true,
+              });
+            } else if (isChartAnnotation && plan) {
+              // The anchor (first) draw: pin the card here but feed it the LATEST
+              // cumulative artifact so it grows in place. Key is the chart
+              // instance, not the tool-call id, so the element persists across
+              // draws (no remount) and its legend can animate the new annotations.
+              const latestProc = (toolCallProcesses[plan.latestCallId] as typeof proc) ?? proc;
+              flushActivity();
+              blocks.push({
+                type: 'compact_artifact',
+                key: `chart-${chartInstanceKey(artifactResult as Record<string, unknown>)}`,
+                toolCallId: plan.latestCallId,
+                proc: latestProc,
+              });
+            } else {
+              flushActivity();
+              blocks.push({
+                type: 'compact_artifact',
+                key: `compact-${seg.toolCallId}`,
+                toolCallId: seg.toolCallId!,
+                proc,
+              });
+            }
           } else if (!streamEnded && age < MIN_LIVE_EXPOSURE_MS && !INLINE_ARTIFACT_TOOLS.has(proc.toolName as string)) {
             pendingItems.push({
               type: 'tool_call',
@@ -1386,39 +1424,12 @@ const MessageContentSegments = memo(function MessageContentSegments({ segments, 
       // Flush trailing activity items
       flushActivity();
 
-      // Collapse chart-annotation previews to one card per chart instance.
-      // Every draw_chart_annotation call returns the FULL cumulative annotation
-      // set for its (workspace, chart_id) instance — chart_id = SYMBOL:timeframe
-      // — so each card is a complete snapshot and earlier cards are strict
-      // subsets of the last. Rendering all of them stacks near-duplicate charts
-      // (one per tool call); keep only the latest card per instance. Distinct
-      // timeframes (e.g. AAPL:1day vs AAPL:1hour) are separate charts and each
-      // keeps its own latest card.
-      const chartKeyOf = (b: RenderBlock): string | null => {
-        if (b.type !== 'compact_artifact') return null;
-        const artifact = ((b as CompactArtifactRenderBlock).proc.toolCallResult as Record<string, unknown> | undefined)
-          ?.artifact as Record<string, unknown> | undefined;
-        if (artifact?.type !== 'chart_annotation') return null;
-        const ws = (artifact.workspace_id as string) ?? '';
-        const chartId =
-          (artifact.chart_id as string) ??
-          `${String(artifact.symbol ?? '').toUpperCase()}:${(artifact.timeframe as string) ?? '1day'}`;
-        return `${ws}|${chartId}`;
-      };
-      const lastChartIdxByKey = new Map<string, number>();
-      blocks.forEach((b, i) => {
-        const key = chartKeyOf(b);
-        if (key !== null) lastChartIdxByKey.set(key, i);
-      });
-      const dedupedBlocks =
-        lastChartIdxByKey.size === 0
-          ? blocks
-          : blocks.filter((b, i) => {
-              const key = chartKeyOf(b);
-              return key === null || lastChartIdxByKey.get(key) === i;
-            });
-
-      return { blocks: dedupedBlocks, nextExpiry: computedNextExpiry };
+      // Per chart instance, only the anchor (first) draw became a
+      // `compact_artifact` block — fed the latest cumulative proc via
+      // `chartCardPlan` (see `planChartAnnotationCards` above); every later draw
+      // was forced to an ordinary `_annotationStep` row, so no post-pass dedup
+      // is needed.
+      return { blocks, nextExpiry: computedNextExpiry };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- tick is a semantic dep: forces recomputation when timer fires for live→completed transitions
     }, [groupedSegments, tick, reasoningProcesses, toolCallProcesses, isStreaming, isSubagentView, textOnly]);
 

--- a/web/src/pages/ChatAgent/components/MessageList.tsx
+++ b/web/src/pages/ChatAgent/components/MessageList.tsx
@@ -23,6 +23,7 @@ import {
 } from './charts/InlineArtifactCards';
 import { InlineAutomationCard } from './charts/InlineAutomationCards';
 import { InlinePreviewCard } from './charts/InlinePreviewCard';
+import { InlineChartAnnotationCard } from './charts/InlineChartAnnotationCard';
 import { extractFilePaths, FileMentionCards } from './FileCard';
 import { normalizeFileRefs } from '../utils/normalizeFileRefs';
 import { useUser } from '@/hooks/useUser';
@@ -143,6 +144,7 @@ const INLINE_ARTIFACT_MAP: Record<string, React.ComponentType<{ artifact: Record
   automations: InlineAutomationCard,
   preview_url: InlinePreviewCard,
   web_search: InlineWebSearchCard,
+  chart_annotation: InlineChartAnnotationCard,
 };
 
 /* --- Attachment helpers --- */
@@ -1384,7 +1386,39 @@ const MessageContentSegments = memo(function MessageContentSegments({ segments, 
       // Flush trailing activity items
       flushActivity();
 
-      return { blocks, nextExpiry: computedNextExpiry };
+      // Collapse chart-annotation previews to one card per chart instance.
+      // Every draw_chart_annotation call returns the FULL cumulative annotation
+      // set for its (workspace, chart_id) instance — chart_id = SYMBOL:timeframe
+      // — so each card is a complete snapshot and earlier cards are strict
+      // subsets of the last. Rendering all of them stacks near-duplicate charts
+      // (one per tool call); keep only the latest card per instance. Distinct
+      // timeframes (e.g. AAPL:1day vs AAPL:1hour) are separate charts and each
+      // keeps its own latest card.
+      const chartKeyOf = (b: RenderBlock): string | null => {
+        if (b.type !== 'compact_artifact') return null;
+        const artifact = ((b as CompactArtifactRenderBlock).proc.toolCallResult as Record<string, unknown> | undefined)
+          ?.artifact as Record<string, unknown> | undefined;
+        if (artifact?.type !== 'chart_annotation') return null;
+        const ws = (artifact.workspace_id as string) ?? '';
+        const chartId =
+          (artifact.chart_id as string) ??
+          `${String(artifact.symbol ?? '').toUpperCase()}:${(artifact.timeframe as string) ?? '1day'}`;
+        return `${ws}|${chartId}`;
+      };
+      const lastChartIdxByKey = new Map<string, number>();
+      blocks.forEach((b, i) => {
+        const key = chartKeyOf(b);
+        if (key !== null) lastChartIdxByKey.set(key, i);
+      });
+      const dedupedBlocks =
+        lastChartIdxByKey.size === 0
+          ? blocks
+          : blocks.filter((b, i) => {
+              const key = chartKeyOf(b);
+              return key === null || lastChartIdxByKey.get(key) === i;
+            });
+
+      return { blocks: dedupedBlocks, nextExpiry: computedNextExpiry };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- tick is a semantic dep: forces recomputation when timer fires for live→completed transitions
     }, [groupedSegments, tick, reasoningProcesses, toolCallProcesses, isStreaming, isSubagentView, textOnly]);
 

--- a/web/src/pages/ChatAgent/components/__tests__/MessageList.chartAnnotation.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/MessageList.chartAnnotation.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * The agent draws a chart in several `draw_chart_annotation` calls. Only the
+ * LATEST draw per chart instance renders the rich preview card; earlier draws
+ * fold into the activity timeline as ordinary tool-call rows so the user can
+ * watch the chart get built up step by step.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MessageContentSegments } from '../MessageList';
+
+vi.mock('framer-motion', async () => {
+  const ReactActual = await vi.importActual<typeof import('react')>('react');
+  const FRAMER_ONLY_PROPS = new Set([
+    'initial', 'animate', 'exit', 'transition', 'variants',
+    'whileHover', 'whileTap', 'whileInView', 'layout', 'layoutId',
+    'onAnimationComplete', 'onAnimationStart',
+  ]);
+  const createEl = ReactActual.createElement as (type: unknown, props?: unknown, ...children: unknown[]) => React.ReactElement;
+  const make = (Comp: React.ElementType | string) =>
+    function MotionStub({ children, ...props }: { children?: React.ReactNode } & Record<string, unknown>) {
+      const domProps: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(props)) {
+        if (!FRAMER_ONLY_PROPS.has(k)) domProps[k] = v;
+      }
+      return createEl(Comp, domProps, children);
+    };
+  return {
+    motion: new Proxy({} as Record<string, unknown>, {
+      get: (_t, key: string) => (key === 'create' ? make : make(key)),
+    }),
+    AnimatePresence: ({ children }: { children?: React.ReactNode }) =>
+      ReactActual.createElement(ReactActual.Fragment, null, children),
+    animate: () => ({ stop: () => {} }),
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (opts && typeof opts === 'object') {
+        let out = key;
+        for (const [k, v] of Object.entries(opts)) {
+          out = out.replace(new RegExp(`{{\\s*${k}\\s*}}`, 'g'), String(v));
+        }
+        return out;
+      }
+      return key;
+    },
+  }),
+}));
+
+vi.mock('../Markdown', () => ({
+  default: ({ content }: { content: string }) => <div data-testid="markdown-content">{content}</div>,
+}));
+
+// draw_chart_annotation must be a recognized inline-artifact tool for the
+// latest-vs-intermediate split to engage.
+vi.mock('../charts/InlineArtifactCards', () => ({
+  INLINE_ARTIFACT_TOOLS: new Set<string>(['draw_chart_annotation']),
+  InlineStockPriceCard: () => null,
+  InlineCompanyOverviewCard: () => null,
+  InlineMarketIndicesCard: () => null,
+  InlineSectorPerformanceCard: () => null,
+  InlineSecFilingCard: () => null,
+  InlineStockScreenerCard: () => null,
+  InlineWebSearchCard: () => null,
+}));
+
+vi.mock('../charts/InlineAutomationCards', () => ({ InlineAutomationCard: () => null }));
+vi.mock('../charts/InlinePreviewCard', () => ({ InlinePreviewCard: () => null }));
+vi.mock('../charts/InlineChartAnnotationCard', () => ({
+  // Surface the annotation count so the test can confirm the pinned card is fed
+  // the LATEST cumulative artifact, not the first draw's.
+  InlineChartAnnotationCard: ({ artifact }: { artifact: Record<string, unknown> }) => (
+    <div
+      data-testid="annotation-card"
+      data-count={(artifact?.annotations as unknown[] | undefined)?.length ?? 0}
+    />
+  ),
+}));
+
+type SegmentsProps = React.ComponentProps<typeof MessageContentSegments>;
+
+const baseProps = {
+  reasoningProcesses: {},
+  toolCallProcesses: {},
+  todoListProcesses: {},
+  subagentTasks: {},
+  hasError: false,
+  isAssistant: true,
+  textOnly: true,
+} satisfies Partial<SegmentsProps>;
+
+// `cumulative` is the full annotation set returned by that draw — each draw is a
+// superset of the previous, mirroring the backend's cumulative artifact.
+// `symbol` selects the chart instance (chart_id = SYMBOL:1day) so a test can
+// drive draws against more than one chart in a single turn.
+function drawProc(
+  annotationType: string,
+  cumulative: number,
+  symbol = 'NVDA',
+): Record<string, unknown> {
+  return {
+    toolName: 'draw_chart_annotation',
+    toolCall: { args: { symbol, annotation: { type: annotationType } } },
+    isInProgress: false,
+    isComplete: true,
+    isFailed: false,
+    _createdAt: Date.now(),
+    toolCallResult: {
+      artifact: {
+        type: 'chart_annotation',
+        workspace_id: 'ws1',
+        chart_id: `${symbol}:1day`,
+        symbol,
+        timeframe: '1day',
+        annotations: Array.from({ length: cumulative }, (_, i) => ({ annotation_id: `${symbol}-a${i}` })),
+      },
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] });
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('MessageContentSegments — chart-annotation draws', () => {
+  it('pins one card (fed the latest cumulative artifact); later draws fold into the accordion', () => {
+    const props: SegmentsProps = {
+      ...baseProps,
+      segments: [
+        { type: 'tool_call', order: 0, toolCallId: 'd1' },
+        { type: 'tool_call', order: 1, toolCallId: 'd2' },
+      ],
+      toolCallProcesses: {
+        d1: drawProc('trendline', 1),
+        d2: drawProc('price_line', 2),
+      },
+      isStreaming: false,
+    };
+
+    render(<MessageContentSegments {...props} />);
+
+    // Exactly one card, and it shows the LATEST cumulative set (2), not the
+    // first draw's (1) — i.e. pinned at the first draw but fed the newest data.
+    const cards = screen.getAllByTestId('annotation-card');
+    expect(cards).toHaveLength(1);
+    expect(cards[0]).toHaveAttribute('data-count', '2');
+    // The later draw (d2) is an ordinary completed row in the steps accordion.
+    const accordion = screen.getByRole('button', { name: /toolArtifact/i });
+    expect(accordion).toBeInTheDocument();
+    // Pin-to-FIRST: the card sits at the anchor (first) draw, so it renders
+    // BEFORE the accordion holding the later draw. If the card were pinned at the
+    // latest draw instead, it would follow the accordion — guard against that swap.
+    expect(
+      cards[0].compareDocumentPosition(accordion) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it('pins one card per distinct chart instance, each fed its own latest set', () => {
+    const props: SegmentsProps = {
+      ...baseProps,
+      segments: [
+        { type: 'tool_call', order: 0, toolCallId: 'n1' },
+        { type: 'tool_call', order: 1, toolCallId: 'a1' },
+      ],
+      toolCallProcesses: {
+        n1: drawProc('trendline', 1, 'NVDA'),
+        a1: drawProc('price_line', 3, 'AAPL'),
+      },
+      isStreaming: false,
+    };
+
+    render(<MessageContentSegments {...props} />);
+
+    // Two distinct charts (NVDA, AAPL) → two cards, each with its own count.
+    const counts = screen
+      .getAllByTestId('annotation-card')
+      .map((el) => el.getAttribute('data-count'))
+      .sort();
+    expect(counts).toEqual(['1', '3']);
+    // Both are anchors (one draw each) → no intermediate rows, no accordion.
+    expect(screen.queryByRole('button', { name: /toolArtifact/i })).toBeNull();
+  });
+
+  it('renders a single draw as a card with no accordion', () => {
+    const props: SegmentsProps = {
+      ...baseProps,
+      segments: [{ type: 'tool_call', order: 0, toolCallId: 'd1' }],
+      toolCallProcesses: { d1: drawProc('trendline', 1) },
+      isStreaming: false,
+    };
+
+    render(<MessageContentSegments {...props} />);
+
+    const cards = screen.getAllByTestId('annotation-card');
+    expect(cards).toHaveLength(1);
+    expect(cards[0]).toHaveAttribute('data-count', '1');
+    expect(screen.queryByRole('button', { name: /toolArtifact/i })).toBeNull();
+  });
+});

--- a/web/src/pages/ChatAgent/components/__tests__/chartAnnotationGrouping.test.ts
+++ b/web/src/pages/ChatAgent/components/__tests__/chartAnnotationGrouping.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+
+import { chartInstanceKey, planChartAnnotationCards } from '../chartAnnotationGrouping';
+
+const drawProc = (artifact: Record<string, unknown> | undefined) => ({
+  toolName: 'draw_chart_annotation',
+  toolCallResult: artifact ? { artifact } : undefined,
+});
+
+const chartAnnotation = (over: Record<string, unknown> = {}) => ({
+  type: 'chart_annotation',
+  workspace_id: 'ws1',
+  chart_id: 'NVDA:1day',
+  ...over,
+});
+
+describe('chartInstanceKey', () => {
+  it('uses workspace_id + chart_id when present', () => {
+    expect(chartInstanceKey(chartAnnotation())).toBe('ws1|NVDA:1day');
+  });
+
+  it('derives SYMBOL:timeframe when chart_id is absent, defaulting timeframe to 1day', () => {
+    expect(chartInstanceKey({ workspace_id: 'ws1', symbol: 'nvda' })).toBe('ws1|NVDA:1day');
+    expect(chartInstanceKey({ workspace_id: 'ws1', symbol: 'nvda', timeframe: '1hour' })).toBe(
+      'ws1|NVDA:1hour',
+    );
+  });
+
+  it('uses an empty workspace segment when workspace_id is missing', () => {
+    expect(chartInstanceKey({ chart_id: 'NVDA:1day' })).toBe('|NVDA:1day');
+  });
+
+  it('falls through empty-string chart_id/timeframe instead of collapsing charts onto one key', () => {
+    // `||` (not `??`): an empty chart_id must derive SYMBOL:timeframe, otherwise
+    // two different charts would both key to `ws1|` and share a single card.
+    expect(chartInstanceKey({ workspace_id: 'ws1', chart_id: '', symbol: 'nvda' })).toBe(
+      'ws1|NVDA:1day',
+    );
+    expect(
+      chartInstanceKey({ workspace_id: 'ws1', symbol: 'nvda', timeframe: '' }),
+    ).toBe('ws1|NVDA:1day');
+  });
+});
+
+describe('planChartAnnotationCards', () => {
+  it('anchors the card at the first draw and tracks the latest per chart instance', () => {
+    const segments = [
+      { type: 'tool_call', toolCallId: 'a' },
+      { type: 'tool_call', toolCallId: 'b' },
+      { type: 'tool_call', toolCallId: 'c' },
+    ];
+    const procs = {
+      a: drawProc(chartAnnotation()),
+      b: drawProc(chartAnnotation()),
+      c: drawProc(chartAnnotation()),
+    };
+    const plan = planChartAnnotationCards(segments, procs);
+    expect(plan.get('ws1|NVDA:1day')).toEqual({ anchorCallId: 'a', latestCallId: 'c' });
+  });
+
+  it('plans one card per distinct chart (symbol/timeframe)', () => {
+    const segments = [
+      { type: 'tool_call', toolCallId: 'a' },
+      { type: 'tool_call', toolCallId: 'b' },
+      { type: 'tool_call', toolCallId: 'c' },
+    ];
+    const procs = {
+      a: drawProc(chartAnnotation({ chart_id: 'NVDA:1day' })),
+      b: drawProc(chartAnnotation({ chart_id: 'NVDA:1hour' })),
+      c: drawProc(chartAnnotation({ chart_id: 'NVDA:1day' })),
+    };
+    const plan = planChartAnnotationCards(segments, procs);
+    expect(plan.get('ws1|NVDA:1day')).toEqual({ anchorCallId: 'a', latestCallId: 'c' });
+    expect(plan.get('ws1|NVDA:1hour')).toEqual({ anchorCallId: 'b', latestCallId: 'b' });
+  });
+
+  it('ignores in-progress draws with no artifact yet (latest stays the newest completed)', () => {
+    const segments = [
+      { type: 'tool_call', toolCallId: 'a' },
+      { type: 'tool_call', toolCallId: 'b' }, // still streaming, no artifact
+    ];
+    const procs = {
+      a: drawProc(chartAnnotation()),
+      b: drawProc(undefined),
+    };
+    const plan = planChartAnnotationCards(segments, procs);
+    expect(plan.get('ws1|NVDA:1day')).toEqual({ anchorCallId: 'a', latestCallId: 'a' });
+  });
+
+  it('ignores non-chart_annotation artifacts and non-tool_call segments', () => {
+    const segments = [
+      { type: 'reasoning', toolCallId: undefined },
+      { type: 'tool_call', toolCallId: 'a' },
+      { type: 'tool_call', toolCallId: 'b' },
+    ];
+    const procs = {
+      a: drawProc({ type: 'stock_prices' }),
+      b: drawProc(chartAnnotation()),
+    };
+    const plan = planChartAnnotationCards(segments, procs);
+    expect(plan.size).toBe(1);
+    expect(plan.get('ws1|NVDA:1day')).toEqual({ anchorCallId: 'b', latestCallId: 'b' });
+  });
+});

--- a/web/src/pages/ChatAgent/components/__tests__/toolDisplayConfig.test.ts
+++ b/web/src/pages/ChatAgent/components/__tests__/toolDisplayConfig.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect } from 'vitest';
 import {
   categorizeTool,
   getCompletedRowTitle,
+  getCompletedSummary,
   getInProgressText,
   getToolIcon,
 } from '../toolDisplayConfig';
@@ -134,6 +135,49 @@ describe('getToolIcon — memo write/edit icon variant', () => {
     const editIcon = getToolIcon('Edit', { file_path: '.agents/user/memo/x.md' });
     const writeIcon = getToolIcon('Write', { file_path: '.agents/user/memo/x.md' });
     expect(editIcon).toBe(writeIcon);
+  });
+});
+
+describe('chart annotation — symbol + interval headline', () => {
+  it('summarizes a draw as "SYMBOL · <interval label>"', () => {
+    const summary = getCompletedSummary(
+      'draw_chart_annotation',
+      { args: { symbol: 'nvda', timeframe: '1hour', annotation: { type: 'trendline' } } },
+    );
+    expect(summary).toBe('NVDA · 1H');
+  });
+
+  it('defaults a missing timeframe to 1D (the server-side default)', () => {
+    const summary = getCompletedSummary('draw_chart_annotation', { args: { symbol: 'AAPL' } });
+    expect(summary).toBe('AAPL · 1D');
+  });
+
+  it('summarizes manage_chart_annotations the same way', () => {
+    const summary = getCompletedSummary(
+      'manage_chart_annotations',
+      { args: { symbol: 'TSLA', timeframe: '1day', action: 'clear' } },
+    );
+    expect(summary).toBe('TSLA · 1D');
+  });
+
+  it('falls back to the raw timeframe for an unmapped interval', () => {
+    const summary = getCompletedSummary('draw_chart_annotation', { args: { symbol: 'MSFT', timeframe: '1week' } });
+    expect(summary).toBe('MSFT · 1week');
+  });
+
+  it('returns null when the draw has no symbol (falls through to generic summary)', () => {
+    // No symbol → no chart instance to name; must not emit "undefined · 1D".
+    expect(getCompletedSummary('draw_chart_annotation', { args: {} })).toBeNull();
+    expect(getCompletedSummary('manage_chart_annotations', { args: { timeframe: '1hour' } })).toBeNull();
+  });
+
+  it('labels the row "Annotate Chart" / "Manage Annotations"', () => {
+    expect(getCompletedRowTitle('draw_chart_annotation', { args: { symbol: 'NVDA' } }, tIdentity)).toBe(
+      'toolArtifact.tool.annotateChart',
+    );
+    expect(getCompletedRowTitle('manage_chart_annotations', { args: { symbol: 'NVDA' } }, tIdentity)).toBe(
+      'toolArtifact.tool.manageAnnotations',
+    );
   });
 });
 

--- a/web/src/pages/ChatAgent/components/chartAnnotationGrouping.ts
+++ b/web/src/pages/ChatAgent/components/chartAnnotationGrouping.ts
@@ -1,0 +1,73 @@
+/**
+ * Helpers for deciding which `chart_annotation` tool call renders the rich
+ * preview card/pill and which fold into the activity timeline as ordinary rows.
+ *
+ * The agent typically draws a chart in several `draw_chart_annotation` calls,
+ * each returning the FULL cumulative annotation set for its
+ * `(workspace_id, chart_id)` instance (chart_id = `SYMBOL:timeframe`). Only the
+ * LATEST draw per instance is worth a card — it is a strict superset of the
+ * earlier ones. The earlier draws still render, but as normal tool-call rows so
+ * the user can watch the chart get built up step by step.
+ */
+
+interface ToolCallProcessLike {
+  toolCallResult?: { artifact?: Record<string, unknown> } | Record<string, unknown>;
+}
+
+interface SegmentLike {
+  type: string;
+  toolCallId?: string;
+}
+
+/** Stable per-chart-instance key: `workspace_id|SYMBOL:timeframe`. Uses `||` so
+ *  an empty-string `chart_id`/`timeframe` falls through to the derived form
+ *  rather than collapsing distinct charts onto one key. */
+export function chartInstanceKey(artifact: Record<string, unknown>): string {
+  const ws = (artifact.workspace_id as string) ?? '';
+  const chartId =
+    (artifact.chart_id as string) ||
+    `${String(artifact.symbol ?? '').toUpperCase()}:${(artifact.timeframe as string) || '1day'}`;
+  return `${ws}|${chartId}`;
+}
+
+function artifactOf(proc: ToolCallProcessLike | undefined): Record<string, unknown> | undefined {
+  return (proc?.toolCallResult as Record<string, unknown> | undefined)?.artifact as
+    | Record<string, unknown>
+    | undefined;
+}
+
+export interface ChartCardPlan {
+  /** First artifact-ready draw — where the single card is pinned in the
+   *  transcript, so it stays put while later draws land below it. */
+  anchorCallId: string;
+  /** Last artifact-ready draw — whose cumulative artifact the pinned card
+   *  renders, so the card grows in place to the full picture. */
+  latestCallId: string;
+}
+
+/**
+ * Walk the segments in order and, per chart instance, record the first
+ * artifact-ready `chart_annotation` draw (the card's anchor position) and the
+ * latest (the cumulative artifact to show). In-progress draws (no artifact yet)
+ * are ignored, so the card reflects the most recent COMPLETED draw while a newer
+ * one is still streaming.
+ */
+export function planChartAnnotationCards(
+  segments: ReadonlyArray<SegmentLike>,
+  toolCallProcesses: Record<string, ToolCallProcessLike | undefined>,
+): Map<string, ChartCardPlan> {
+  const plan = new Map<string, ChartCardPlan>();
+  for (const seg of segments) {
+    if (seg.type !== 'tool_call' || !seg.toolCallId) continue;
+    const artifact = artifactOf(toolCallProcesses[seg.toolCallId]);
+    if (artifact?.type !== 'chart_annotation') continue;
+    const key = chartInstanceKey(artifact);
+    const existing = plan.get(key);
+    if (existing) {
+      existing.latestCallId = seg.toolCallId;
+    } else {
+      plan.set(key, { anchorCallId: seg.toolCallId, latestCallId: seg.toolCallId });
+    }
+  }
+  return plan;
+}

--- a/web/src/pages/ChatAgent/components/charts/AnnotationPreviewChart.tsx
+++ b/web/src/pages/ChatAgent/components/charts/AnnotationPreviewChart.tsx
@@ -1,0 +1,116 @@
+/**
+ * A compact area/line preview of a stock's price — the resting state of the
+ * chat annotation card. Built as a plain SVG from fetched OHLC bars (no
+ * lightweight-charts), so it's cheap to render inline in the transcript.
+ * Theme-aware via CSS variables.
+ */
+
+import React, { useId, useMemo } from 'react';
+
+import type { ChartDataPoint } from '@/types/market';
+
+const PAD_L = 6;
+const PAD_R = 6;
+const PAD_T = 8;
+const PAD_B = 6;
+const VB_W = 600;
+const VB_H = 200;
+
+interface AnnotationPreviewChartProps {
+  bars: ChartDataPoint[];
+  /** Area / line color (price up vs down over the window). */
+  trendColor: string;
+  /** Pulse a dot at the latest close. Parent must be ``position: relative``. */
+  showLastPrice?: boolean;
+}
+
+export function AnnotationPreviewChart({
+  bars,
+  trendColor,
+  showLastPrice = false,
+}: AnnotationPreviewChartProps): React.ReactElement | null {
+  const gradId = useId();
+
+  const model = useMemo(() => {
+    if (bars.length < 2) return null;
+
+    let pmin = Infinity;
+    let pmax = -Infinity;
+    for (const b of bars) {
+      if (b.low < pmin) pmin = b.low;
+      if (b.high > pmax) pmax = b.high;
+    }
+    if (!Number.isFinite(pmin) || !Number.isFinite(pmax)) return null;
+
+    const span = pmax - pmin || 1;
+    pmin -= span * 0.06;
+    pmax += span * 0.06;
+
+    const innerW = VB_W - PAD_L - PAD_R;
+    const innerH = VB_H - PAD_T - PAD_B;
+    const n = bars.length;
+    const x = (i: number) => PAD_L + (n > 1 ? i / (n - 1) : 0.5) * innerW;
+    const y = (p: number) => PAD_T + innerH - ((p - pmin) / (pmax - pmin)) * innerH;
+
+    const linePts = bars.map((b, i) => `${x(i).toFixed(1)},${y(b.close).toFixed(1)}`).join(' ');
+    const areaPath = `M${PAD_L},${(PAD_T + innerH).toFixed(1)} L${linePts} L${(PAD_L + innerW).toFixed(1)},${(PAD_T + innerH).toFixed(1)} Z`;
+    // Latest close, as a % of the viewBox, for the (non-distorting) HTML dot overlay.
+    const lastXPct = (x(n - 1) / VB_W) * 100;
+    const lastYPct = (y(bars[n - 1].close) / VB_H) * 100;
+    return { linePts, areaPath, lastXPct, lastYPct };
+  }, [bars]);
+
+  if (!model) return null;
+
+  return (
+    <>
+      <svg viewBox={`0 0 ${VB_W} ${VB_H}`} preserveAspectRatio="none" style={{ width: '100%', height: '100%', display: 'block' }} aria-hidden="true">
+        <defs>
+          <linearGradient id={gradId} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0" stopColor={trendColor} stopOpacity={0.2} />
+            <stop offset="1" stopColor={trendColor} stopOpacity={0} />
+          </linearGradient>
+        </defs>
+        <path d={model.areaPath} fill={`url(#${gradId})`} />
+        <polyline
+          points={model.linePts}
+          fill="none"
+          stroke={trendColor}
+          strokeWidth={2}
+          strokeLinejoin="round"
+          vectorEffect="non-scaling-stroke"
+        />
+      </svg>
+      {showLastPrice && (
+        <span
+          aria-hidden="true"
+          style={{
+            position: 'absolute',
+            left: `${model.lastXPct}%`,
+            top: `${model.lastYPct}%`,
+            width: 8,
+            height: 8,
+            transform: 'translate(-50%, -50%)',
+            pointerEvents: 'none',
+          }}
+        >
+          <span
+            className="animate-ping motion-reduce:animate-none"
+            style={{ position: 'absolute', inset: 0, borderRadius: 9999, backgroundColor: trendColor, opacity: 0.55 }}
+          />
+          <span
+            style={{
+              position: 'absolute',
+              inset: 0,
+              borderRadius: 9999,
+              backgroundColor: trendColor,
+              boxShadow: `0 0 6px ${trendColor}`,
+            }}
+          />
+        </span>
+      )}
+    </>
+  );
+}
+
+export default AnnotationPreviewChart;

--- a/web/src/pages/ChatAgent/components/charts/InlineArtifactCards.tsx
+++ b/web/src/pages/ChatAgent/components/charts/InlineArtifactCards.tsx
@@ -26,6 +26,7 @@ export const INLINE_ARTIFACT_TOOLS = new Set([
   'create_automation',
   'GetPreviewUrl',
   'WebSearch',
+  'draw_chart_annotation',
 ]);
 
 // ─── Helpers ────────────────────────────────────────────────────────

--- a/web/src/pages/ChatAgent/components/charts/InlineChartAnnotationCard.tsx
+++ b/web/src/pages/ChatAgent/components/charts/InlineChartAnnotationCard.tsx
@@ -473,7 +473,7 @@ export function InlineChartAnnotationCard({
                     }}
                   >
                     <span
-                      style={{ width: 8, height: 8, borderRadius: 2.5, background: v.color, flexShrink: 0 }}
+                      style={{ width: 8, height: 8, borderRadius: 2.5, backgroundColor: v.color, flexShrink: 0 }}
                     />
                     <span
                       style={{

--- a/web/src/pages/ChatAgent/components/charts/InlineChartAnnotationCard.tsx
+++ b/web/src/pages/ChatAgent/components/charts/InlineChartAnnotationCard.tsx
@@ -18,6 +18,7 @@ import React, { Suspense, lazy, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import { LineChart, ExternalLink, Check, ArrowRight, X } from 'lucide-react';
 
 import {
@@ -35,7 +36,7 @@ import {
   useDisplayCleared,
 } from '@/pages/MarketView/stores/chartAnnotationStore';
 import { useStockBars } from '@/pages/MarketView/hooks/useStockBars';
-import { AUTO_FIT_BARS } from '@/pages/MarketView/utils/chartConstants';
+import { AUTO_FIT_BARS, INTERVAL_LABEL } from '@/pages/MarketView/utils/chartConstants';
 import { describeAnnotationVisual } from '@/pages/MarketView/utils/annotationGeometry';
 
 import { useWorkspaceId } from '../../contexts/WorkspaceContext';
@@ -65,17 +66,6 @@ const CENTERED: React.CSSProperties = {
   justifyContent: 'center',
 };
 
-// Short label for the timeframe pill (falls back to the raw value). Keys mirror
-// the agent's `Timeframe` enum — the only timeframes a chart instance can have.
-const TF_LABEL: Record<string, string> = {
-  '1min': '1m',
-  '5min': '5m',
-  '15min': '15m',
-  '30min': '30m',
-  '1hour': '1H',
-  '4hour': '4H',
-  '1day': '1D',
-};
 
 // Translucent chrome that floats over the chart (theme-aware via color-mix).
 const GLASS_BG = 'color-mix(in srgb, var(--color-bg-tool-card) 62%, transparent)';
@@ -103,6 +93,7 @@ export function InlineChartAnnotationCard({
   const ctxWorkspaceId = useWorkspaceId();
   const { chartPresent, activeSymbol, activeTimeframe, onJumpToChart } = useChartSurface();
   const isMobile = useIsMobile();
+  const reduceMotion = useReducedMotion();
 
   const symbol = ((artifact?.symbol as string) || '').toUpperCase();
   const timeframe = (artifact?.timeframe as string) || '1day';
@@ -175,7 +166,10 @@ export function InlineChartAnnotationCard({
     };
 
     const title = canJump
-      ? t('chat.chartAnnotationCard.chipJumpTitle', { symbol, timeframe })
+      ? t('chat.chartAnnotationCard.chipJumpTitle', {
+          symbol,
+          timeframe: INTERVAL_LABEL[timeframe] ?? timeframe,
+        })
       : displayCleared
         ? t('chat.chartAnnotationCard.chipShowTitle')
         : t('chat.chartAnnotationCard.chipShownTitle');
@@ -208,7 +202,7 @@ export function InlineChartAnnotationCard({
           : <Check size={14} style={{ color: 'var(--color-profit)', flexShrink: 0 }} />}
         <span>
           <span style={{ color: 'var(--color-text-primary)', fontWeight: 600 }}>{symbol}</span>
-          <span style={{ color: TEXT_COLOR }}>{` · ${timeframe}`}</span>
+          <span style={{ color: TEXT_COLOR }}>{` · ${INTERVAL_LABEL[timeframe] ?? timeframe}`}</span>
           {' · '}
           {canJump
             ? t('chat.chartAnnotationCard.chipViewCount', { count })
@@ -440,7 +434,7 @@ export function InlineChartAnnotationCard({
               borderRadius: 7,
             }}
           >
-            {TF_LABEL[timeframe] ?? timeframe}
+            {INTERVAL_LABEL[timeframe] ?? timeframe}
           </span>
 
           {/* Bottom-left — annotation legend (the real annotations). */}
@@ -457,33 +451,43 @@ export function InlineChartAnnotationCard({
                 maxWidth: '62%',
               }}
             >
-              {shownVisuals.map((v, i) => (
-                <span
-                  key={i}
-                  style={{
-                    display: 'inline-flex',
-                    alignItems: 'center',
-                    gap: 6,
-                    fontSize: 11.5,
-                    fontWeight: 600,
-                    color: 'var(--color-text-secondary)',
-                  }}
-                >
-                  <span
-                    style={{ width: 8, height: 8, borderRadius: 2.5, background: v.color, flexShrink: 0 }}
-                  />
-                  <span
+              {/* `initial={false}` keeps the first paint (and history replay)
+                  instant; only annotations that arrive while the pinned card is
+                  already mounted animate in, so the legend grows smoothly as the
+                  agent draws. */}
+              <AnimatePresence initial={false}>
+                {shownVisuals.map((v, i) => (
+                  <motion.span
+                    key={annotations[i]?.annotation_id || `legend-${i}`}
+                    initial={reduceMotion ? false : { opacity: 0, y: 3, scale: 0.96 }}
+                    animate={{ opacity: 1, y: 0, scale: 1 }}
+                    exit={reduceMotion ? { opacity: 0 } : { opacity: 0, y: -3, scale: 0.96 }}
+                    transition={{ duration: reduceMotion ? 0 : 0.2, ease: 'easeOut' }}
                     style={{
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                      whiteSpace: 'nowrap',
-                      maxWidth: 130,
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: 6,
+                      fontSize: 11.5,
+                      fontWeight: 600,
+                      color: 'var(--color-text-secondary)',
                     }}
                   >
-                    {v.label}
-                  </span>
-                </span>
-              ))}
+                    <span
+                      style={{ width: 8, height: 8, borderRadius: 2.5, background: v.color, flexShrink: 0 }}
+                    />
+                    <span
+                      style={{
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                        maxWidth: 130,
+                      }}
+                    >
+                      {v.label}
+                    </span>
+                  </motion.span>
+                ))}
+              </AnimatePresence>
               {extraCount > 0 && (
                 <span style={{ fontSize: 11.5, fontWeight: 600, color: TEXT_COLOR }}>+{extraCount}</span>
               )}
@@ -536,7 +540,11 @@ export function InlineChartAnnotationCard({
             }}
           >
             <DialogTitle className="sr-only">
-              {t('chat.chartAnnotationCard.dialogTitle', { symbol, timeframe, count })}
+              {t('chat.chartAnnotationCard.dialogTitle', {
+                symbol,
+                timeframe: INTERVAL_LABEL[timeframe] ?? timeframe,
+                count,
+              })}
             </DialogTitle>
 
             {/* Slim modal chrome — keeps the close + "Open in MarketView"

--- a/web/src/pages/ChatAgent/components/charts/InlineChartAnnotationCard.tsx
+++ b/web/src/pages/ChatAgent/components/charts/InlineChartAnnotationCard.tsx
@@ -2,91 +2,107 @@
  * Inline preview for an agent ``chart_annotation`` artifact in the chat
  * transcript.
  *
- * On the standalone ChatAgent page there is no chart, so this renders a live
- * lightweight-charts mini candlestick with the annotations drawn on it; the
- * card expands into MarketView (carrying symbol + thread + workspace so the
- * conversation continues there). Inside the MarketView desktop panel the real
- * chart already shows the drawing live, so the card collapses to a one-line
- * confirmation chip (see ChartSurfaceContext).
+ * Two-stage on the standalone ChatAgent page (no live chart present):
+ *   1. a full-bleed "spotlight" card — the symbol's real (clean) price chart;
+ *      ticker, latest price, window change and an annotation legend float over
+ *      soft scrims, all from the same bars (annotations are listed, not drawn);
+ *   2. clicking opens a roomy modal with the full interactive chart (candles,
+ *      MA, volume, RSI, the annotations) plus a button to open it in MarketView.
+ *
+ * Inside the MarketView desktop panel the real chart already shows the drawing
+ * live, so the card collapses to a one-line confirmation chip (see
+ * ChartSurfaceContext).
  */
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { Suspense, lazy, useCallback, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
-import { createChart, ColorType, CrosshairMode, LineStyle } from 'lightweight-charts';
-import type { IChartApi, ISeriesApi, Time } from 'lightweight-charts';
-import { LineChart, ExternalLink, Check } from 'lucide-react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { LineChart, ExternalLink, Check, ArrowRight, X } from 'lucide-react';
 
-import type { ChartDataPoint } from '@/types/market';
-import { fetchStockData } from '@/pages/MarketView/utils/api';
+import {
+  Dialog,
+  DialogOverlay,
+  DialogPortal,
+  DialogClose,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useIsMobile } from '@/hooks/useIsMobile';
 import type { StoredAnnotation } from '@/pages/MarketView/stores/chartAnnotationStore';
 import {
   chartAnnotationStore,
   makeChartId,
   useDisplayCleared,
 } from '@/pages/MarketView/stores/chartAnnotationStore';
-import { AgentAnnotationsPrimitive } from '@/pages/MarketView/utils/agentAnnotationsPrimitive';
-import {
-  DEFAULT_LINE_COLOR,
-  DEFAULT_TRENDLINE_COLOR,
-  buildMarkers,
-  buildPrimitiveData,
-  isPriceLine,
-  isTrendline,
-  resolveTrendlineData,
-  styleToLwc,
-  toUnixSeconds,
-} from '@/pages/MarketView/utils/annotationGeometry';
+import { useStockBars } from '@/pages/MarketView/hooks/useStockBars';
+import { AUTO_FIT_BARS } from '@/pages/MarketView/utils/chartConstants';
+import { describeAnnotationVisual } from '@/pages/MarketView/utils/annotationGeometry';
 
 import { useWorkspaceId } from '../../contexts/WorkspaceContext';
 import { useChartSurface } from '../../contexts/ChartSurfaceContext';
+import { AnnotationPreviewChart } from './AnnotationPreviewChart';
+
+// Lazy: the surface pulls in the whole MarketView chart stack (lightweight-charts,
+// html2canvas, TradingView). Keep it out of the chat bundle until a chart opens.
+const MarketChartSurface = lazy(() =>
+  import('@/pages/MarketView/components/MarketChartSurface').then((m) => ({
+    default: m.MarketChartSurface,
+  })),
+);
 
 const CARD_BG = 'var(--color-bg-tool-card)';
 const CARD_BORDER = 'var(--color-border-muted)';
 const TEXT_COLOR = 'var(--color-text-tertiary)';
 const ACCENT = 'var(--color-accent-primary)';
-const CHART_HEIGHT = 184;
+const ACCENT_SOFT = 'var(--color-accent-soft)';
+
+// Centered overlay for the chart's loading / empty states.
+const CENTERED: React.CSSProperties = {
+  position: 'absolute',
+  inset: 0,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+};
+
+// Short label for the timeframe pill (falls back to the raw value). Keys mirror
+// the agent's `Timeframe` enum — the only timeframes a chart instance can have.
+const TF_LABEL: Record<string, string> = {
+  '1min': '1m',
+  '5min': '5m',
+  '15min': '15m',
+  '30min': '30m',
+  '1hour': '1H',
+  '4hour': '4H',
+  '1day': '1D',
+};
+
+// Translucent chrome that floats over the chart (theme-aware via color-mix).
+const GLASS_BG = 'color-mix(in srgb, var(--color-bg-tool-card) 62%, transparent)';
+const GLASS_BORDER = 'color-mix(in srgb, var(--color-text-primary) 16%, transparent)';
+const SCRIM_TOP =
+  'linear-gradient(to bottom, color-mix(in srgb, var(--color-bg-tool-card) 92%, transparent), transparent)';
+const SCRIM_BOTTOM =
+  'linear-gradient(to top, color-mix(in srgb, var(--color-bg-tool-card) 94%, transparent), transparent)';
+
+// How many annotation chips to show in the floating legend before "+N".
+const MAX_LEGEND = 3;
 
 interface InlineChartAnnotationCardProps {
   artifact: Record<string, unknown> | null | undefined;
   onClick?: () => void;
 }
 
-/** Gather every ISO time referenced by an annotation set (for chart range). */
-function collectTimes(annotations: StoredAnnotation[]): number[] {
-  const out: number[] = [];
-  for (const a of annotations) {
-    if ('time' in a && typeof a.time === 'string') {
-      const t = toUnixSeconds(a.time);
-      if (t != null) out.push(t);
-    }
-    if ('point1' in a && 'point2' in a) {
-      const t1 = toUnixSeconds(a.point1.time);
-      const t2 = toUnixSeconds(a.point2.time);
-      if (t1 != null) out.push(t1);
-      if (t2 != null) out.push(t2);
-    }
-  }
-  return out;
-}
-
-function fmtDate(unixSeconds: number): string {
-  return new Date(unixSeconds * 1000).toISOString().slice(0, 10);
-}
-
-/** Resolve a chart color from a CSS variable on the element, with fallback. */
-function cssVar(el: HTMLElement, name: string, fallback: string): string {
-  const v = getComputedStyle(el).getPropertyValue(name).trim();
-  return v || fallback;
-}
-
 export function InlineChartAnnotationCard({
   artifact,
 }: InlineChartAnnotationCardProps): React.ReactElement | null {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
   const params = useParams();
   const ctxWorkspaceId = useWorkspaceId();
-  const { chartPresent } = useChartSurface();
+  const { chartPresent, activeSymbol, activeTimeframe, onJumpToChart } = useChartSurface();
+  const isMobile = useIsMobile();
 
   const symbol = ((artifact?.symbol as string) || '').toUpperCase();
   const timeframe = (artifact?.timeframe as string) || '1day';
@@ -100,15 +116,16 @@ export function InlineChartAnnotationCard({
   // Whether this instance is currently cleared from the chart (MarketView only).
   const displayCleared = useDisplayCleared(workspaceId, symbol, timeframe);
 
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const chartRef = useRef<IChartApi | null>(null);
-  const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+  // Stage-2 modal open state (standalone ChatAgent page only).
+  const [open, setOpen] = useState(false);
+  // Card hover drives the CTA fill (glass → accent).
+  const [hover, setHover] = useState(false);
 
-  // Stable dependency key so the chart only rebuilds when the set changes.
-  const annKey = useMemo(
-    () => annotations.map((a) => a.annotation_id).join(','),
-    [annotations],
-  );
+  // Resting-card price preview: cached bars for this symbol/timeframe. Skipped
+  // inside MarketView (chartPresent) where the card collapses to a chip.
+  const { bars, isLoading: barsLoading } = useStockBars(symbol, timeframe, {
+    enabled: !chartPresent,
+  });
 
   // Re-apply a cleared drawing to the adjacent MarketView chart.
   const handleRestore = useCallback(() => {
@@ -116,7 +133,7 @@ export function InlineChartAnnotationCard({
     chartAnnotationStore.restoreDisplay(workspaceId, makeChartId(symbol, timeframe));
   }, [workspaceId, symbol, timeframe]);
 
-  const handleExpand = useCallback(() => {
+  const handleOpenInMarketView = useCallback(() => {
     if (!symbol) return;
     const sp = new URLSearchParams();
     sp.set('symbol', symbol);
@@ -128,161 +145,53 @@ export function InlineChartAnnotationCard({
     navigate(`/market?${sp.toString()}`);
   }, [symbol, timeframe, workspaceId, threadId, location, navigate]);
 
-  // Fetch data + build the mini chart. Skipped entirely when a real chart is
-  // present (MarketView) — the chip variant renders instead.
-  useEffect(() => {
-    if (chartPresent || !symbol) return;
-    let cancelled = false;
-    const controller = new AbortController();
-    setStatus('loading');
-
-    (async () => {
-      // Range: span the annotation times (padded), else backend default.
-      const times = collectTimes(annotations);
-      let fromDate: string | undefined;
-      let toDate: string | undefined;
-      if (times.length > 0) {
-        const min = Math.min(...times);
-        const max = Math.max(...times);
-        const span = Math.max(max - min, 30 * 86400);
-        const pad = Math.round(span * 0.2);
-        fromDate = fmtDate(min - pad);
-        toDate = fmtDate(max + pad + 5 * 86400);
-      }
-
-      const result = await fetchStockData(symbol, timeframe, fromDate, toDate, {
-        signal: controller.signal,
-      });
-      if (cancelled) return;
-
-      const data = result.data as ChartDataPoint[];
-      const container = containerRef.current;
-      if (result.error || !data?.length || !container) {
-        setStatus('error');
-        return;
-      }
-
-      // Tear down a prior chart (set changed / re-render).
-      if (chartRef.current) {
-        chartRef.current.remove();
-        chartRef.current = null;
-      }
-
-      let chart: IChartApi;
-      try {
-        chart = createChart(container, {
-          layout: {
-            background: { type: ColorType.Solid, color: cssVar(container, '--color-bg-tool-card', '#0e0f12') },
-            textColor: cssVar(container, '--color-text-tertiary', '#8b8f98'),
-          },
-          autoSize: true,
-          grid: {
-            vertLines: { color: cssVar(container, '--color-border-muted', '#23262e') },
-            horzLines: { color: cssVar(container, '--color-border-muted', '#23262e') },
-          },
-          crosshair: { mode: CrosshairMode.Hidden },
-          handleScroll: false,
-          handleScale: false,
-          rightPriceScale: { borderColor: cssVar(container, '--color-border-muted', '#23262e') },
-          timeScale: {
-            borderColor: cssVar(container, '--color-border-muted', '#23262e'),
-            timeVisible: false,
-          },
-        });
-      } catch {
-        setStatus('error');
-        return;
-      }
-      chartRef.current = chart;
-
-      const upColor = cssVar(container, '--color-profit', '#0FEDBE');
-      const downColor = cssVar(container, '--color-loss', '#FF383C');
-      const series: ISeriesApi<'Candlestick'> = chart.addCandlestickSeries({
-        upColor,
-        downColor,
-        borderVisible: false,
-        wickUpColor: upColor,
-        wickDownColor: downColor,
-      });
-      series.setData(
-        data.map((d) => ({ time: d.time as Time, open: d.open, high: d.high, low: d.low, close: d.close })),
-      );
-
-      // Native annotations: price lines + trendlines.
-      for (const ann of annotations) {
-        if (isPriceLine(ann)) {
-          series.createPriceLine({
-            price: ann.price,
-            title: ann.label ?? '',
-            color: ann.color ?? DEFAULT_LINE_COLOR,
-            lineWidth: 1,
-            lineStyle: styleToLwc(ann.style),
-            axisLabelVisible: true,
-            lineVisible: true,
-          });
-        } else if (isTrendline(ann)) {
-          const lineData = resolveTrendlineData(ann, data);
-          if (!lineData) continue;
-          const ls = chart.addLineSeries({
-            color: ann.color ?? DEFAULT_TRENDLINE_COLOR,
-            lineWidth: 2,
-            lineStyle: LineStyle.Dashed,
-            lastValueVisible: false,
-            priceLineVisible: false,
-            crosshairMarkerVisible: false,
-            // Label drawn as a chip at the line end (buildPrimitiveData).
-          });
-          ls.setData(lineData);
-        }
-      }
-
-      // Markers + canvas-primitive shapes (rect / vline / text / fib).
-      const markers = buildMarkers(annotations, data);
-      if (markers.length) series.setMarkers(markers);
-      const prim = new AgentAnnotationsPrimitive();
-      series.attachPrimitive(prim);
-      prim.setTheme(
-        document.documentElement.getAttribute('data-theme') === 'light' ? 'light' : 'dark',
-      );
-      // The inline card has no interactive overlay, so event titles render as
-      // canvas chips here (the detail is only reachable on the live chart).
-      prim.setData(buildPrimitiveData(annotations, data, { eventsAsText: true }));
-
-      chart.timeScale().fitContent();
-      setStatus('ready');
-    })();
-
-    return () => {
-      cancelled = true;
-      controller.abort();
-      if (chartRef.current) {
-        chartRef.current.remove();
-        chartRef.current = null;
-      }
-    };
-  }, [chartPresent, symbol, timeframe, annKey, annotations]);
-
   if (!artifact || !symbol) return null;
 
   const count = annotations.length;
-  const countLabel = `${count} annotation${count === 1 ? '' : 's'}`;
 
   // Inside MarketView: the real chart shows the drawing — collapse to a chip.
-  // The chip is clickable: when the user has cleared the drawing from the chart,
-  // clicking re-applies it; otherwise it's a confirmation that it's on the chart.
+  // The chip is clickable. Three states:
+  //  - different instance than what's on screen → jump the chart to it;
+  //  - this instance but cleared from the chart → re-apply it;
+  //  - this instance and showing → a passive confirmation.
   if (chartPresent) {
+    const isActiveInstance =
+      (activeSymbol ?? '').toUpperCase() === symbol &&
+      (!activeTimeframe || activeTimeframe === timeframe);
+    const canJump = !!onJumpToChart && !isActiveInstance;
+    // Accent border invites a click whenever one would change the chart.
+    const accented = canJump || displayCleared;
+
+    const handleChipClick = (): void => {
+      if (canJump) {
+        onJumpToChart?.(symbol, timeframe);
+        // Un-clear so the drawing shows once the chart switches to it.
+        if (workspaceId) {
+          chartAnnotationStore.restoreDisplay(workspaceId, makeChartId(symbol, timeframe));
+        }
+      } else {
+        handleRestore();
+      }
+    };
+
+    const title = canJump
+      ? t('chat.chartAnnotationCard.chipJumpTitle', { symbol, timeframe })
+      : displayCleared
+        ? t('chat.chartAnnotationCard.chipShowTitle')
+        : t('chat.chartAnnotationCard.chipShownTitle');
+
     return (
       <button
         type="button"
-        onClick={handleRestore}
-        title={displayCleared ? 'Show these annotations on the chart' : 'Shown on the chart'}
+        onClick={handleChipClick}
+        title={title}
         style={{
           display: 'inline-flex',
           alignItems: 'center',
           gap: 8,
           background: CARD_BG,
-          border: `1px solid ${displayCleared ? ACCENT : CARD_BORDER}`,
-          borderRadius: 8,
+          border: `1px solid ${accented ? ACCENT : CARD_BORDER}`,
+          borderRadius: 999,
           padding: '6px 12px',
           fontSize: 12,
           color: TEXT_COLOR,
@@ -291,95 +200,432 @@ export function InlineChartAnnotationCard({
         }}
         onMouseEnter={(e) => (e.currentTarget.style.borderColor = ACCENT)}
         onMouseLeave={(e) =>
-          (e.currentTarget.style.borderColor = displayCleared ? ACCENT : CARD_BORDER)
+          (e.currentTarget.style.borderColor = accented ? ACCENT : CARD_BORDER)
         }
       >
-        {displayCleared
+        {accented
           ? <LineChart size={14} style={{ color: ACCENT, flexShrink: 0 }} />
           : <Check size={14} style={{ color: 'var(--color-profit)', flexShrink: 0 }} />}
         <span>
           <span style={{ color: 'var(--color-text-primary)', fontWeight: 600 }}>{symbol}</span>
           <span style={{ color: TEXT_COLOR }}>{` · ${timeframe}`}</span>
           {' · '}
-          {displayCleared ? `Show ${countLabel} on chart` : `${countLabel} on chart`}
+          {canJump
+            ? t('chat.chartAnnotationCard.chipViewCount', { count })
+            : displayCleared
+              ? t('chat.chartAnnotationCard.chipShowCount', { count })
+              : t('chat.chartAnnotationCard.chipShownCount', { count })}
         </span>
+        {canJump && <ArrowRight size={13} style={{ color: ACCENT, flexShrink: 0 }} />}
       </button>
     );
   }
 
-  return (
-    <div
-      role="button"
-      tabIndex={0}
-      onClick={handleExpand}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          handleExpand();
-        }
-      }}
-      style={{
-        background: CARD_BG,
-        border: `1px solid ${CARD_BORDER}`,
-        borderRadius: 8,
-        padding: 10,
-        cursor: 'pointer',
-        transition: 'border-color 0.15s',
-        outline: 'none',
-        userSelect: 'none',
-      }}
-      onMouseEnter={(e) => (e.currentTarget.style.borderColor = ACCENT)}
-      onMouseLeave={(e) => (e.currentTarget.style.borderColor = CARD_BORDER)}
-    >
-      {/* Header */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
-        <LineChart size={15} style={{ color: ACCENT, flexShrink: 0 }} />
-        <span style={{ fontWeight: 700, color: 'var(--color-text-primary)', fontSize: 14 }}>{symbol}</span>
-        <span style={{ fontSize: 11, color: TEXT_COLOR }}>{timeframe}</span>
-        <span style={{ fontSize: 11, color: TEXT_COLOR }}>·</span>
-        <span style={{ fontSize: 11, color: TEXT_COLOR }}>{countLabel}</span>
-        <span
-          style={{
-            marginLeft: 'auto',
-            display: 'inline-flex',
-            alignItems: 'center',
-            gap: 4,
-            fontSize: 11,
-            fontWeight: 600,
-            color: ACCENT,
-          }}
-        >
-          Open in MarketView
-          <ExternalLink size={12} />
-        </span>
-      </div>
+  // Render the same recent window the live chart auto-fits to (not the whole
+  // fetched history), so the header %-change and curve match what opens.
+  const fitBars = AUTO_FIT_BARS[timeframe] ?? 180;
+  const viewBars = bars.length > fitBars ? bars.slice(-fitBars) : bars;
 
-      {/* Chart / fallback */}
-      {status === 'error' ? (
-        <div style={{ fontSize: 12, color: TEXT_COLOR, padding: '12px 2px' }}>
-          Chart preview unavailable — open in MarketView to view the {countLabel}.
-        </div>
-      ) : (
-        <div style={{ position: 'relative', width: '100%', height: CHART_HEIGHT }}>
-          <div ref={containerRef} className="[&_*]:outline-none" style={{ width: '100%', height: CHART_HEIGHT }} />
-          {status === 'loading' && (
+  // Price + window change from those same bars, so the header never disagrees
+  // with the curve underneath it.
+  const lastClose = viewBars.length ? viewBars[viewBars.length - 1].close : null;
+  const firstClose = viewBars.length ? viewBars[0].close : null;
+  const pct =
+    lastClose != null && firstClose ? ((lastClose - firstClose) / firstClose) * 100 : null;
+  const up = pct == null || pct >= 0;
+  const trendColor = up ? 'var(--color-profit)' : 'var(--color-loss)';
+  const hasChart = !barsLoading && viewBars.length >= 2;
+  const plotHeight = isMobile ? 200 : 248;
+
+  // The floating legend names the real annotations (they're listed here, not
+  // drawn over the preview curve — the full set shows when the chart opens).
+  const visuals = annotations.map(describeAnnotationVisual);
+  const shownVisuals = visuals.slice(0, MAX_LEGEND);
+  const extraCount = visuals.length - shownVisuals.length;
+
+  // Stage 1 — the "spotlight" card: a clean full-bleed price chart; ticker /
+  // price float over soft scrims, an annotation legend sits bottom-left, and the
+  // CTA opens the full interactive chart (where the annotations are drawn).
+  return (
+    <>
+      <div
+        role="button"
+        tabIndex={0}
+        aria-label={t('chat.chartAnnotationCard.cardAria', { symbol, timeframe, count })}
+        onClick={() => setOpen(true)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            setOpen(true);
+          }
+        }}
+        onMouseEnter={(e) => {
+          setHover(true);
+          e.currentTarget.style.borderColor = ACCENT;
+          e.currentTarget.style.transform = 'translateY(-2px)';
+          e.currentTarget.style.boxShadow =
+            '0 2px 6px rgba(0,0,0,0.06), 0 26px 50px -20px rgba(0,0,0,0.6)';
+        }}
+        onMouseLeave={(e) => {
+          setHover(false);
+          e.currentTarget.style.borderColor = CARD_BORDER;
+          e.currentTarget.style.transform = 'none';
+          e.currentTarget.style.boxShadow =
+            '0 1px 2px rgba(0,0,0,0.05), 0 16px 36px -18px rgba(0,0,0,0.5)';
+        }}
+        // Keyboard focus needs a visible ring (outline is suppressed for the
+        // rounded card). Gate on :focus-visible so a mouse click stays clean.
+        onFocus={(e) => {
+          if (!e.currentTarget.matches(':focus-visible')) return;
+          setHover(true);
+          e.currentTarget.style.borderColor = ACCENT;
+          e.currentTarget.style.transform = 'translateY(-2px)';
+          e.currentTarget.style.boxShadow =
+            `0 0 0 2px ${ACCENT}, 0 2px 6px rgba(0,0,0,0.06), 0 26px 50px -20px rgba(0,0,0,0.6)`;
+        }}
+        onBlur={(e) => {
+          setHover(false);
+          e.currentTarget.style.borderColor = CARD_BORDER;
+          e.currentTarget.style.transform = 'none';
+          e.currentTarget.style.boxShadow =
+            '0 1px 2px rgba(0,0,0,0.05), 0 16px 36px -18px rgba(0,0,0,0.5)';
+        }}
+        style={{
+          position: 'relative',
+          background: CARD_BG,
+          border: `1px solid ${CARD_BORDER}`,
+          borderRadius: 20,
+          overflow: 'hidden',
+          cursor: 'pointer',
+          outline: 'none',
+          userSelect: 'none',
+          boxShadow: '0 1px 2px rgba(0,0,0,0.05), 0 16px 36px -18px rgba(0,0,0,0.5)',
+          transition: 'border-color 0.16s, box-shadow 0.16s, transform 0.16s',
+        }}
+      >
+        {/* Full-bleed plot — the real chart, or a loading / empty fallback. */}
+        <div style={{ position: 'relative', height: plotHeight }}>
+          {barsLoading ? (
+            <div style={CENTERED}>
+              <span style={{ fontSize: 12, color: TEXT_COLOR }}>
+                {t('chat.chartAnnotationCard.loadingChart')}
+              </span>
+            </div>
+          ) : hasChart ? (
+            // Clean price line only — the legend below conveys the annotations.
+            <AnnotationPreviewChart
+              bars={viewBars}
+              trendColor={trendColor}
+              showLastPrice
+            />
+          ) : (
+            <div style={CENTERED}>
+              <span
+                style={{
+                  display: 'inline-flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  gap: 6,
+                  color: TEXT_COLOR,
+                }}
+              >
+                <LineChart size={26} style={{ opacity: 0.5 }} />
+                <span style={{ fontSize: 12 }}>
+                  {t('chat.chartAnnotationCard.previewUnavailable')}
+                </span>
+              </span>
+            </div>
+          )}
+
+          {/* Scrims keep the floating chrome legible over the chart. */}
+          {hasChart && (
+            <>
+              <div
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  height: 78,
+                  background: SCRIM_TOP,
+                  pointerEvents: 'none',
+                }}
+              />
+              <div
+                style={{
+                  position: 'absolute',
+                  bottom: 0,
+                  left: 0,
+                  right: 0,
+                  height: 92,
+                  background: SCRIM_BOTTOM,
+                  pointerEvents: 'none',
+                }}
+              />
+            </>
+          )}
+
+          {/* Top-left — ticker, latest price, window change. */}
+          <div
+            style={{
+              position: 'absolute',
+              top: 15,
+              left: 17,
+              display: 'flex',
+              alignItems: 'baseline',
+              gap: 9,
+              minWidth: 0,
+            }}
+          >
+            <span
+              style={{
+                fontSize: 21,
+                fontWeight: 700,
+                color: 'var(--color-text-primary)',
+                letterSpacing: '-0.01em',
+              }}
+            >
+              {symbol}
+            </span>
+            {lastClose != null && (
+              <span style={{ fontSize: 16, fontWeight: 700, color: 'var(--color-text-primary)' }}>
+                ${lastClose.toLocaleString('en-US', {
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 2,
+                })}
+              </span>
+            )}
+            {pct != null && (
+              <span
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 3,
+                  fontSize: 13,
+                  fontWeight: 600,
+                  color: trendColor,
+                }}
+              >
+                <span
+                  style={{
+                    width: 0,
+                    height: 0,
+                    borderLeft: '3.5px solid transparent',
+                    borderRight: '3.5px solid transparent',
+                    ...(up
+                      ? { borderBottom: `5px solid ${trendColor}` }
+                      : { borderTop: `5px solid ${trendColor}` }),
+                  }}
+                />
+                {pct >= 0 ? '+' : ''}
+                {pct.toFixed(2)}%
+              </span>
+            )}
+          </div>
+
+          {/* Top-right — timeframe pill. */}
+          <span
+            style={{
+              position: 'absolute',
+              top: 16,
+              right: 16,
+              fontSize: 11,
+              fontWeight: 700,
+              letterSpacing: '0.03em',
+              color: TEXT_COLOR,
+              background: GLASS_BG,
+              border: `1px solid ${GLASS_BORDER}`,
+              backdropFilter: 'blur(8px)',
+              padding: '4px 9px',
+              borderRadius: 7,
+            }}
+          >
+            {TF_LABEL[timeframe] ?? timeframe}
+          </span>
+
+          {/* Bottom-left — annotation legend (the real annotations). */}
+          {hasChart && shownVisuals.length > 0 && (
             <div
               style={{
                 position: 'absolute',
-                inset: 0,
+                bottom: 15,
+                left: 17,
                 display: 'flex',
+                flexWrap: 'wrap',
                 alignItems: 'center',
-                justifyContent: 'center',
-                fontSize: 12,
-                color: TEXT_COLOR,
+                gap: 14,
+                maxWidth: '62%',
               }}
             >
-              Loading chart…
+              {shownVisuals.map((v, i) => (
+                <span
+                  key={i}
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 6,
+                    fontSize: 11.5,
+                    fontWeight: 600,
+                    color: 'var(--color-text-secondary)',
+                  }}
+                >
+                  <span
+                    style={{ width: 8, height: 8, borderRadius: 2.5, background: v.color, flexShrink: 0 }}
+                  />
+                  <span
+                    style={{
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                      maxWidth: 130,
+                    }}
+                  >
+                    {v.label}
+                  </span>
+                </span>
+              ))}
+              {extraCount > 0 && (
+                <span style={{ fontSize: 11.5, fontWeight: 600, color: TEXT_COLOR }}>+{extraCount}</span>
+              )}
             </div>
           )}
+
+          {/* Bottom-right — CTA (glass → accent on hover). */}
+          <span
+            style={{
+              position: 'absolute',
+              bottom: 14,
+              right: 14,
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 7,
+              fontSize: 13,
+              fontWeight: 600,
+              padding: '9px 15px',
+              borderRadius: 11,
+              backdropFilter: 'blur(8px)',
+              background: hover ? ACCENT : GLASS_BG,
+              border: `1px solid ${hover ? 'transparent' : GLASS_BORDER}`,
+              color: hover ? '#fff' : 'var(--color-text-primary)',
+              transition: 'background 0.16s, color 0.16s, border-color 0.16s',
+            }}
+          >
+            {t('chat.chartAnnotationCard.openAnnotatedChart')}
+            <ArrowRight
+              size={14}
+              style={{ transform: hover ? 'translateX(3px)' : 'none', transition: 'transform 0.16s' }}
+            />
+          </span>
         </div>
-      )}
-    </div>
+      </div>
+
+      {/* Stage 2 — the modal: a ~3/4-viewport, self-contained replica of the
+          MarketView chart surface (same header, toolbar, candles, MA, volume,
+          RSI and the agent's annotations). */}
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogPortal>
+          <DialogOverlay />
+          <DialogPrimitive.Content
+            aria-describedby={undefined}
+            className="fixed left-1/2 top-1/2 z-[1030] flex flex-col -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-xl border bg-background shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
+            style={{
+              width: isMobile ? '96vw' : '75vw',
+              height: isMobile ? '88vh' : '80vh',
+              maxWidth: 'none',
+              maxHeight: '94vh',
+            }}
+          >
+            <DialogTitle className="sr-only">
+              {t('chat.chartAnnotationCard.dialogTitle', { symbol, timeframe, count })}
+            </DialogTitle>
+
+            {/* Slim modal chrome — keeps the close + "Open in MarketView"
+                buttons off the chart's own header (which has the price). */}
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'flex-end',
+                gap: 8,
+                padding: '8px 10px',
+                borderBottom: `1px solid ${CARD_BORDER}`,
+                flexShrink: 0,
+              }}
+            >
+              <button
+                type="button"
+                onClick={handleOpenInMarketView}
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 6,
+                  padding: '6px 12px',
+                  borderRadius: 8,
+                  border: `1px solid ${CARD_BORDER}`,
+                  background: ACCENT_SOFT,
+                  color: ACCENT,
+                  fontSize: 12,
+                  fontWeight: 600,
+                  cursor: 'pointer',
+                  whiteSpace: 'nowrap',
+                  transition: 'border-color 0.15s',
+                }}
+                onMouseEnter={(e) => (e.currentTarget.style.borderColor = ACCENT)}
+                onMouseLeave={(e) => (e.currentTarget.style.borderColor = CARD_BORDER)}
+              >
+                {t('chat.chartAnnotationCard.openInMarketView')}
+                <ExternalLink size={13} />
+              </button>
+              <DialogClose
+                aria-label={t('chat.chartAnnotationCard.close')}
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  width: 30,
+                  height: 30,
+                  borderRadius: 8,
+                  border: `1px solid ${CARD_BORDER}`,
+                  background: 'transparent',
+                  color: TEXT_COLOR,
+                  cursor: 'pointer',
+                }}
+              >
+                <X size={16} />
+              </DialogClose>
+            </div>
+
+            {/* The chart surface fills the rest — mounted only while open. */}
+            <div style={{ flex: 1, minHeight: 0 }}>
+              {open && (
+                <Suspense
+                  fallback={
+                    <div
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        height: '100%',
+                        fontSize: 13,
+                        color: TEXT_COLOR,
+                      }}
+                    >
+                      {t('chat.chartAnnotationCard.loadingChart')}
+                    </div>
+                  }
+                >
+                  <MarketChartSurface
+                    symbol={symbol}
+                    timeframe={timeframe}
+                    workspaceId={workspaceId ?? null}
+                  />
+                </Suspense>
+              )}
+            </div>
+          </DialogPrimitive.Content>
+        </DialogPortal>
+      </Dialog>
+    </>
   );
 }
 

--- a/web/src/pages/ChatAgent/components/charts/InlineChartAnnotationCard.tsx
+++ b/web/src/pages/ChatAgent/components/charts/InlineChartAnnotationCard.tsx
@@ -1,0 +1,384 @@
+/**
+ * Inline preview for an agent ``chart_annotation`` artifact in the chat
+ * transcript.
+ *
+ * On the standalone ChatAgent page there is no chart, so this renders a live
+ * lightweight-charts mini candlestick with the annotations drawn on it; the
+ * card expands into MarketView (carrying symbol + thread + workspace so the
+ * conversation continues there). Inside the MarketView desktop panel the real
+ * chart already shows the drawing live, so the card collapses to a one-line
+ * confirmation chip (see ChartSurfaceContext).
+ */
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { createChart, ColorType, CrosshairMode, LineStyle } from 'lightweight-charts';
+import type { IChartApi, ISeriesApi, Time } from 'lightweight-charts';
+import { LineChart, ExternalLink, Check } from 'lucide-react';
+
+import type { ChartDataPoint } from '@/types/market';
+import { fetchStockData } from '@/pages/MarketView/utils/api';
+import type { StoredAnnotation } from '@/pages/MarketView/stores/chartAnnotationStore';
+import {
+  chartAnnotationStore,
+  makeChartId,
+  useDisplayCleared,
+} from '@/pages/MarketView/stores/chartAnnotationStore';
+import { AgentAnnotationsPrimitive } from '@/pages/MarketView/utils/agentAnnotationsPrimitive';
+import {
+  DEFAULT_LINE_COLOR,
+  DEFAULT_TRENDLINE_COLOR,
+  buildMarkers,
+  buildPrimitiveData,
+  isPriceLine,
+  isTrendline,
+  resolveTrendlineData,
+  styleToLwc,
+  toUnixSeconds,
+} from '@/pages/MarketView/utils/annotationGeometry';
+
+import { useWorkspaceId } from '../../contexts/WorkspaceContext';
+import { useChartSurface } from '../../contexts/ChartSurfaceContext';
+
+const CARD_BG = 'var(--color-bg-tool-card)';
+const CARD_BORDER = 'var(--color-border-muted)';
+const TEXT_COLOR = 'var(--color-text-tertiary)';
+const ACCENT = 'var(--color-accent-primary)';
+const CHART_HEIGHT = 184;
+
+interface InlineChartAnnotationCardProps {
+  artifact: Record<string, unknown> | null | undefined;
+  onClick?: () => void;
+}
+
+/** Gather every ISO time referenced by an annotation set (for chart range). */
+function collectTimes(annotations: StoredAnnotation[]): number[] {
+  const out: number[] = [];
+  for (const a of annotations) {
+    if ('time' in a && typeof a.time === 'string') {
+      const t = toUnixSeconds(a.time);
+      if (t != null) out.push(t);
+    }
+    if ('point1' in a && 'point2' in a) {
+      const t1 = toUnixSeconds(a.point1.time);
+      const t2 = toUnixSeconds(a.point2.time);
+      if (t1 != null) out.push(t1);
+      if (t2 != null) out.push(t2);
+    }
+  }
+  return out;
+}
+
+function fmtDate(unixSeconds: number): string {
+  return new Date(unixSeconds * 1000).toISOString().slice(0, 10);
+}
+
+/** Resolve a chart color from a CSS variable on the element, with fallback. */
+function cssVar(el: HTMLElement, name: string, fallback: string): string {
+  const v = getComputedStyle(el).getPropertyValue(name).trim();
+  return v || fallback;
+}
+
+export function InlineChartAnnotationCard({
+  artifact,
+}: InlineChartAnnotationCardProps): React.ReactElement | null {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const params = useParams();
+  const ctxWorkspaceId = useWorkspaceId();
+  const { chartPresent } = useChartSurface();
+
+  const symbol = ((artifact?.symbol as string) || '').toUpperCase();
+  const timeframe = (artifact?.timeframe as string) || '1day';
+  const annotations = useMemo(
+    () => (artifact?.annotations as StoredAnnotation[] | undefined) ?? [],
+    [artifact],
+  );
+  const workspaceId = (artifact?.workspace_id as string | undefined) || ctxWorkspaceId || undefined;
+  const threadId = params.threadId as string | undefined;
+
+  // Whether this instance is currently cleared from the chart (MarketView only).
+  const displayCleared = useDisplayCleared(workspaceId, symbol, timeframe);
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const chartRef = useRef<IChartApi | null>(null);
+  const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+
+  // Stable dependency key so the chart only rebuilds when the set changes.
+  const annKey = useMemo(
+    () => annotations.map((a) => a.annotation_id).join(','),
+    [annotations],
+  );
+
+  // Re-apply a cleared drawing to the adjacent MarketView chart.
+  const handleRestore = useCallback(() => {
+    if (!workspaceId || !symbol) return;
+    chartAnnotationStore.restoreDisplay(workspaceId, makeChartId(symbol, timeframe));
+  }, [workspaceId, symbol, timeframe]);
+
+  const handleExpand = useCallback(() => {
+    if (!symbol) return;
+    const sp = new URLSearchParams();
+    sp.set('symbol', symbol);
+    sp.set('tf', timeframe);
+    sp.set('mode', 'ptc');
+    if (workspaceId) sp.set('ws', workspaceId);
+    if (threadId && threadId !== '__default__') sp.set('thread', threadId);
+    sp.set('returnTo', location.pathname + location.search);
+    navigate(`/market?${sp.toString()}`);
+  }, [symbol, timeframe, workspaceId, threadId, location, navigate]);
+
+  // Fetch data + build the mini chart. Skipped entirely when a real chart is
+  // present (MarketView) — the chip variant renders instead.
+  useEffect(() => {
+    if (chartPresent || !symbol) return;
+    let cancelled = false;
+    const controller = new AbortController();
+    setStatus('loading');
+
+    (async () => {
+      // Range: span the annotation times (padded), else backend default.
+      const times = collectTimes(annotations);
+      let fromDate: string | undefined;
+      let toDate: string | undefined;
+      if (times.length > 0) {
+        const min = Math.min(...times);
+        const max = Math.max(...times);
+        const span = Math.max(max - min, 30 * 86400);
+        const pad = Math.round(span * 0.2);
+        fromDate = fmtDate(min - pad);
+        toDate = fmtDate(max + pad + 5 * 86400);
+      }
+
+      const result = await fetchStockData(symbol, timeframe, fromDate, toDate, {
+        signal: controller.signal,
+      });
+      if (cancelled) return;
+
+      const data = result.data as ChartDataPoint[];
+      const container = containerRef.current;
+      if (result.error || !data?.length || !container) {
+        setStatus('error');
+        return;
+      }
+
+      // Tear down a prior chart (set changed / re-render).
+      if (chartRef.current) {
+        chartRef.current.remove();
+        chartRef.current = null;
+      }
+
+      let chart: IChartApi;
+      try {
+        chart = createChart(container, {
+          layout: {
+            background: { type: ColorType.Solid, color: cssVar(container, '--color-bg-tool-card', '#0e0f12') },
+            textColor: cssVar(container, '--color-text-tertiary', '#8b8f98'),
+          },
+          autoSize: true,
+          grid: {
+            vertLines: { color: cssVar(container, '--color-border-muted', '#23262e') },
+            horzLines: { color: cssVar(container, '--color-border-muted', '#23262e') },
+          },
+          crosshair: { mode: CrosshairMode.Hidden },
+          handleScroll: false,
+          handleScale: false,
+          rightPriceScale: { borderColor: cssVar(container, '--color-border-muted', '#23262e') },
+          timeScale: {
+            borderColor: cssVar(container, '--color-border-muted', '#23262e'),
+            timeVisible: false,
+          },
+        });
+      } catch {
+        setStatus('error');
+        return;
+      }
+      chartRef.current = chart;
+
+      const upColor = cssVar(container, '--color-profit', '#0FEDBE');
+      const downColor = cssVar(container, '--color-loss', '#FF383C');
+      const series: ISeriesApi<'Candlestick'> = chart.addCandlestickSeries({
+        upColor,
+        downColor,
+        borderVisible: false,
+        wickUpColor: upColor,
+        wickDownColor: downColor,
+      });
+      series.setData(
+        data.map((d) => ({ time: d.time as Time, open: d.open, high: d.high, low: d.low, close: d.close })),
+      );
+
+      // Native annotations: price lines + trendlines.
+      for (const ann of annotations) {
+        if (isPriceLine(ann)) {
+          series.createPriceLine({
+            price: ann.price,
+            title: ann.label ?? '',
+            color: ann.color ?? DEFAULT_LINE_COLOR,
+            lineWidth: 1,
+            lineStyle: styleToLwc(ann.style),
+            axisLabelVisible: true,
+            lineVisible: true,
+          });
+        } else if (isTrendline(ann)) {
+          const lineData = resolveTrendlineData(ann, data);
+          if (!lineData) continue;
+          const ls = chart.addLineSeries({
+            color: ann.color ?? DEFAULT_TRENDLINE_COLOR,
+            lineWidth: 2,
+            lineStyle: LineStyle.Dashed,
+            lastValueVisible: false,
+            priceLineVisible: false,
+            crosshairMarkerVisible: false,
+            // Label drawn as a chip at the line end (buildPrimitiveData).
+          });
+          ls.setData(lineData);
+        }
+      }
+
+      // Markers + canvas-primitive shapes (rect / vline / text / fib).
+      const markers = buildMarkers(annotations, data);
+      if (markers.length) series.setMarkers(markers);
+      const prim = new AgentAnnotationsPrimitive();
+      series.attachPrimitive(prim);
+      prim.setTheme(
+        document.documentElement.getAttribute('data-theme') === 'light' ? 'light' : 'dark',
+      );
+      prim.setData(buildPrimitiveData(annotations, data));
+
+      chart.timeScale().fitContent();
+      setStatus('ready');
+    })();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+      if (chartRef.current) {
+        chartRef.current.remove();
+        chartRef.current = null;
+      }
+    };
+  }, [chartPresent, symbol, timeframe, annKey, annotations]);
+
+  if (!artifact || !symbol) return null;
+
+  const count = annotations.length;
+  const countLabel = `${count} annotation${count === 1 ? '' : 's'}`;
+
+  // Inside MarketView: the real chart shows the drawing — collapse to a chip.
+  // The chip is clickable: when the user has cleared the drawing from the chart,
+  // clicking re-applies it; otherwise it's a confirmation that it's on the chart.
+  if (chartPresent) {
+    return (
+      <button
+        type="button"
+        onClick={handleRestore}
+        title={displayCleared ? 'Show these annotations on the chart' : 'Shown on the chart'}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 8,
+          background: CARD_BG,
+          border: `1px solid ${displayCleared ? ACCENT : CARD_BORDER}`,
+          borderRadius: 8,
+          padding: '6px 12px',
+          fontSize: 12,
+          color: TEXT_COLOR,
+          cursor: 'pointer',
+          transition: 'border-color 0.15s',
+        }}
+        onMouseEnter={(e) => (e.currentTarget.style.borderColor = ACCENT)}
+        onMouseLeave={(e) =>
+          (e.currentTarget.style.borderColor = displayCleared ? ACCENT : CARD_BORDER)
+        }
+      >
+        {displayCleared
+          ? <LineChart size={14} style={{ color: ACCENT, flexShrink: 0 }} />
+          : <Check size={14} style={{ color: 'var(--color-profit)', flexShrink: 0 }} />}
+        <span>
+          <span style={{ color: 'var(--color-text-primary)', fontWeight: 600 }}>{symbol}</span>
+          <span style={{ color: TEXT_COLOR }}>{` · ${timeframe}`}</span>
+          {' · '}
+          {displayCleared ? `Show ${countLabel} on chart` : `${countLabel} on chart`}
+        </span>
+      </button>
+    );
+  }
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={handleExpand}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          handleExpand();
+        }
+      }}
+      style={{
+        background: CARD_BG,
+        border: `1px solid ${CARD_BORDER}`,
+        borderRadius: 8,
+        padding: 10,
+        cursor: 'pointer',
+        transition: 'border-color 0.15s',
+        outline: 'none',
+        userSelect: 'none',
+      }}
+      onMouseEnter={(e) => (e.currentTarget.style.borderColor = ACCENT)}
+      onMouseLeave={(e) => (e.currentTarget.style.borderColor = CARD_BORDER)}
+    >
+      {/* Header */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+        <LineChart size={15} style={{ color: ACCENT, flexShrink: 0 }} />
+        <span style={{ fontWeight: 700, color: 'var(--color-text-primary)', fontSize: 14 }}>{symbol}</span>
+        <span style={{ fontSize: 11, color: TEXT_COLOR }}>{timeframe}</span>
+        <span style={{ fontSize: 11, color: TEXT_COLOR }}>·</span>
+        <span style={{ fontSize: 11, color: TEXT_COLOR }}>{countLabel}</span>
+        <span
+          style={{
+            marginLeft: 'auto',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 4,
+            fontSize: 11,
+            fontWeight: 600,
+            color: ACCENT,
+          }}
+        >
+          Open in MarketView
+          <ExternalLink size={12} />
+        </span>
+      </div>
+
+      {/* Chart / fallback */}
+      {status === 'error' ? (
+        <div style={{ fontSize: 12, color: TEXT_COLOR, padding: '12px 2px' }}>
+          Chart preview unavailable — open in MarketView to view the {countLabel}.
+        </div>
+      ) : (
+        <div style={{ position: 'relative', width: '100%', height: CHART_HEIGHT }}>
+          <div ref={containerRef} className="[&_*]:outline-none" style={{ width: '100%', height: CHART_HEIGHT }} />
+          {status === 'loading' && (
+            <div
+              style={{
+                position: 'absolute',
+                inset: 0,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: 12,
+                color: TEXT_COLOR,
+              }}
+            >
+              Loading chart…
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default InlineChartAnnotationCard;

--- a/web/src/pages/ChatAgent/components/charts/InlineChartAnnotationCard.tsx
+++ b/web/src/pages/ChatAgent/components/charts/InlineChartAnnotationCard.tsx
@@ -244,7 +244,9 @@ export function InlineChartAnnotationCard({
       prim.setTheme(
         document.documentElement.getAttribute('data-theme') === 'light' ? 'light' : 'dark',
       );
-      prim.setData(buildPrimitiveData(annotations, data));
+      // The inline card has no interactive overlay, so event titles render as
+      // canvas chips here (the detail is only reachable on the live chart).
+      prim.setData(buildPrimitiveData(annotations, data, { eventsAsText: true }));
 
       chart.timeScale().fitContent();
       setStatus('ready');

--- a/web/src/pages/ChatAgent/components/charts/__tests__/AnnotationPreviewChart.test.tsx
+++ b/web/src/pages/ChatAgent/components/charts/__tests__/AnnotationPreviewChart.test.tsx
@@ -1,0 +1,43 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import type { ChartDataPoint } from '@/types/market';
+import { AnnotationPreviewChart } from '../AnnotationPreviewChart';
+
+// Five ascending daily bars (time is unix SECONDS, matching ChartDataPoint).
+const DAY = 86_400;
+const T0 = 1_700_000_000;
+const BARS: ChartDataPoint[] = Array.from({ length: 5 }, (_, i) => ({
+  time: T0 + i * DAY,
+  open: 100 + i,
+  high: 104 + i,
+  low: 98 + i,
+  close: 101 + i,
+  volume: 1_000 + i,
+}));
+
+describe('AnnotationPreviewChart', () => {
+  it('renders the price area + line from the bars', () => {
+    const { container } = render(
+      <AnnotationPreviewChart bars={BARS} trendColor="var(--color-profit)" />,
+    );
+    expect(container.querySelector('svg')).toBeInTheDocument();
+    // The price series: a filled area path + the close polyline.
+    expect(container.querySelector('path')).toBeInTheDocument();
+    expect(container.querySelector('polyline')).toBeInTheDocument();
+  });
+
+  it('pulses a current-price dot when showLastPrice is set', () => {
+    const { container } = render(
+      <AnnotationPreviewChart bars={BARS} trendColor="var(--color-profit)" showLastPrice />,
+    );
+    expect(container.querySelector('.animate-ping')).toBeInTheDocument();
+  });
+
+  it('renders nothing without enough bars to draw a line', () => {
+    const { container } = render(
+      <AnnotationPreviewChart bars={BARS.slice(0, 1)} trendColor="var(--color-profit)" />,
+    );
+    expect(container.querySelector('svg')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/pages/ChatAgent/components/charts/__tests__/InlineChartAnnotationCard.test.tsx
+++ b/web/src/pages/ChatAgent/components/charts/__tests__/InlineChartAnnotationCard.test.tsx
@@ -1,40 +1,33 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-// --- Mock lightweight-charts (canvas can't render in jsdom) ---------------
-const fakeSeries = {
-  setData: vi.fn(),
-  createPriceLine: vi.fn(),
-  setMarkers: vi.fn(),
-  attachPrimitive: vi.fn(),
-};
-const fakeLineSeries = { setData: vi.fn() };
-const fakeChart = {
-  addCandlestickSeries: vi.fn(() => fakeSeries),
-  addLineSeries: vi.fn(() => fakeLineSeries),
-  timeScale: vi.fn(() => ({ fitContent: vi.fn() })),
-  remove: vi.fn(),
-};
-vi.mock('lightweight-charts', () => ({
-  createChart: vi.fn(() => fakeChart),
-  ColorType: { Solid: 'solid' },
-  CrosshairMode: { Normal: 1, Magnet: 0, Hidden: 2 },
-  LineStyle: { Solid: 0, Dotted: 1, Dashed: 2 },
+// Stub the heavy chart surface — it owns websockets, React Query and the real
+// lightweight-charts canvas, all tested in MarketView. Here we only care that
+// the card mounts it with the right props once the modal opens.
+vi.mock('@/pages/MarketView/components/MarketChartSurface', () => ({
+  MarketChartSurface: (props: { symbol: string; timeframe?: string; workspaceId?: string | null }) => (
+    <div data-testid="surface">{`${props.symbol}:${props.timeframe}:${props.workspaceId ?? ''}`}</div>
+  ),
 }));
 
-// --- Mock the market-data fetch -------------------------------------------
-import { fetchStockData } from '@/pages/MarketView/utils/api';
-vi.mock('@/pages/MarketView/utils/api', () => ({
-  fetchStockData: vi.fn(),
+// Stub the OHLC fetch hook so the resting card's preview chart has bars without
+// hitting React Query / the network. Two ascending bars → an "up" green trend.
+vi.mock('@/pages/MarketView/hooks/useStockBars', () => ({
+  useStockBars: () => ({
+    bars: [
+      { time: 1_700_000_000, open: 100, high: 102, low: 99, close: 101 },
+      { time: 1_700_086_400, open: 101, high: 110, low: 100, close: 108 },
+    ],
+    isLoading: false,
+    isError: false,
+  }),
 }));
 
 import { WorkspaceProvider } from '../../../contexts/WorkspaceContext';
-import { ChartSurfaceContext } from '../../../contexts/ChartSurfaceContext';
+import { ChartSurfaceContext, type ChartSurface } from '../../../contexts/ChartSurfaceContext';
 import { chartAnnotationStore } from '@/pages/MarketView/stores/chartAnnotationStore';
 import { InlineChartAnnotationCard } from '../InlineChartAnnotationCard';
-
-const mockedFetch = vi.mocked(fetchStockData);
 
 const ARTIFACT = {
   type: 'chart_annotation',
@@ -61,12 +54,13 @@ function LocationDisplay(): React.ReactElement {
 
 function renderCard(
   artifact: Record<string, unknown>,
-  { chartPresent = false }: { chartPresent?: boolean } = {},
+  surface: Partial<ChartSurface> = {},
 ) {
+  const value: ChartSurface = { chartPresent: false, ...surface };
   return render(
     <MemoryRouter initialEntries={['/chat/t/thread-123']}>
       <WorkspaceProvider workspaceId="ws-ctx" downloadFile={null}>
-        <ChartSurfaceContext.Provider value={{ chartPresent }}>
+        <ChartSurfaceContext.Provider value={value}>
           <Routes>
             <Route
               path="/chat/t/:threadId"
@@ -81,36 +75,48 @@ function renderCard(
 }
 
 describe('InlineChartAnnotationCard', () => {
-  beforeEach(() => {
-    mockedFetch.mockResolvedValue({
-      data: [
-        { time: Math.floor(Date.parse('2024-10-16T00:00:00Z') / 1000), open: 100, high: 105, low: 99, close: 104, volume: 1 },
-        { time: Math.floor(Date.parse('2024-11-20T00:00:00Z') / 1000), open: 140, high: 152, low: 139, close: 150, volume: 1 },
-      ],
-    } as never);
-  });
-
   afterEach(() => {
     vi.clearAllMocks();
     chartAnnotationStore._resetForTesting();
   });
 
-  it('renders a mini-chart card and applies annotations after fetch', async () => {
+  it('renders the spotlight preview card, with the heavy surface deferred until opened', () => {
     renderCard(ARTIFACT);
 
     expect(screen.getByText('NVDA')).toBeInTheDocument();
-    expect(screen.getByText('2 annotations')).toBeInTheDocument();
-    expect(screen.getByText('Open in MarketView')).toBeInTheDocument();
-
-    await waitFor(() => expect(mockedFetch).toHaveBeenCalledWith('NVDA', '1day', expect.any(String), expect.any(String), expect.any(Object)));
-    // native price line + primitive applied
-    await waitFor(() => expect(fakeSeries.createPriceLine).toHaveBeenCalled());
-    expect(fakeSeries.attachPrimitive).toHaveBeenCalled();
+    // The annotation count rides the card's accessible name; the floating legend
+    // names the real annotations (labelled price line + the rectangle's "Zone").
+    expect(screen.getByRole('button', { name: /2 annotations/ })).toBeInTheDocument();
+    expect(screen.getByText('Resistance')).toBeInTheDocument();
+    expect(screen.getByText('Open annotated chart')).toBeInTheDocument();
+    // The resting preview is a lightweight inline SVG of the price + overlays;
+    // the full lightweight-charts surface only mounts after the modal opens.
+    expect(screen.queryByTestId('surface')).not.toBeInTheDocument();
   });
 
-  it('expands into MarketView carrying symbol, ptc mode, workspace, thread, returnTo', async () => {
+  it('opens the modal with the chart surface, scoped to symbol/timeframe/workspace', async () => {
     renderCard(ARTIFACT);
-    fireEvent.click(screen.getByText('NVDA'));
+    fireEvent.click(screen.getByRole('button'));
+
+    // Surface is lazy-loaded, so it resolves a tick after the modal opens.
+    expect(await screen.findByTestId('surface')).toHaveTextContent('NVDA:1day:ws-art');
+  });
+
+  // The spotlight card is a role="button" — it must be keyboard-operable, not
+  // just mouse-clickable. Enter and Space both open the modal.
+  it.each(['Enter', ' '])('opens the modal via the %s key (keyboard a11y)', async (key) => {
+    renderCard(ARTIFACT);
+    const card = screen.getByRole('button');
+    expect(card).toHaveAttribute('tabindex', '0');
+
+    fireEvent.keyDown(card, { key });
+    expect(await screen.findByTestId('surface')).toHaveTextContent('NVDA:1day:ws-art');
+  });
+
+  it('opens MarketView from the modal carrying symbol, ptc mode, workspace, thread, returnTo', async () => {
+    renderCard(ARTIFACT);
+    fireEvent.click(screen.getByRole('button')); // stage 1 -> modal
+    fireEvent.click(await screen.findByText('Open in MarketView'));
 
     const loc = await screen.findByTestId('loc');
     const url = loc.textContent || '';
@@ -123,42 +129,34 @@ describe('InlineChartAnnotationCard', () => {
     expect(params.get('returnTo')).toBe('/chat/t/thread-123');
   });
 
-  it('uses the artifact timeframe for the header, fetch, and expand URL', async () => {
+  it('uses the artifact timeframe for the bubble, the surface, and the MarketView URL', async () => {
     const hourly = { ...ARTIFACT, timeframe: '1hour' };
     renderCard(hourly);
 
-    // Header shows the timeframe.
-    expect(screen.getByText('1hour')).toBeInTheDocument();
-    // Fetch uses the timeframe, not the daily default.
-    await waitFor(() =>
-      expect(mockedFetch).toHaveBeenCalledWith(
-        'NVDA',
-        '1hour',
-        expect.any(String),
-        expect.any(String),
-        expect.any(Object),
-      ),
-    );
+    // The pill shows the short label; the full timeframe rides the accessible name.
+    expect(screen.getByText('1H')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /1hour/ })).toBeInTheDocument();
 
-    // Expanding carries the timeframe so MarketView lands on the right view.
-    fireEvent.click(screen.getByText('NVDA'));
+    fireEvent.click(screen.getByRole('button')); // open modal
+    expect(await screen.findByTestId('surface')).toHaveTextContent('NVDA:1hour:ws-art');
+
+    // Opening MarketView carries the timeframe so it lands on the right view.
+    fireEvent.click(await screen.findByText('Open in MarketView'));
     const loc = await screen.findByTestId('loc');
     const url = loc.textContent || '';
     const params = new URLSearchParams(url.slice(url.indexOf('?')));
     expect(params.get('tf')).toBe('1hour');
   });
 
-  it('collapses to a chip (no chart, no navigation) when a chart is present', async () => {
-    const { createChart } = await import('lightweight-charts');
+  it('collapses to a chip (no chart, no modal) when a chart is present', () => {
     renderCard(ARTIFACT, { chartPresent: true });
 
     expect(screen.getByText(/on chart/i)).toBeInTheDocument();
     expect(screen.queryByText('Open in MarketView')).not.toBeInTheDocument();
-    expect(vi.mocked(createChart)).not.toHaveBeenCalled();
-    expect(mockedFetch).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('surface')).not.toBeInTheDocument();
   });
 
-  it('chip restores a cleared drawing to the chart when clicked', async () => {
+  it('chip restores a cleared drawing to the chart when clicked', () => {
     // The drawing was cleared from the chart elsewhere (the Clear button).
     chartAnnotationStore.clearDisplay('ws-art', 'NVDA:1day');
     renderCard(ARTIFACT, { chartPresent: true });
@@ -171,10 +169,36 @@ describe('InlineChartAnnotationCard', () => {
     expect(chartAnnotationStore.isDisplayCleared('ws-art', 'NVDA:1day')).toBe(false);
   });
 
-  it('falls back to a text summary when the data fetch fails', async () => {
-    mockedFetch.mockResolvedValue({ data: [], error: 'No data available' } as never);
-    renderCard(ARTIFACT);
+  it('chip jumps the chart to a different ticker than the one on screen', () => {
+    const onJumpToChart = vi.fn();
+    // Drawing is on NVDA but the live chart shows AAPL → the chip offers a jump.
+    chartAnnotationStore.clearDisplay('ws-art', 'NVDA:1day');
+    renderCard(ARTIFACT, {
+      chartPresent: true,
+      activeSymbol: 'AAPL',
+      activeTimeframe: '1day',
+      onJumpToChart,
+    });
 
-    expect(await screen.findByText(/Chart preview unavailable/i)).toBeInTheDocument();
+    expect(screen.getByText(/view .* on chart/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(onJumpToChart).toHaveBeenCalledWith('NVDA', '1day');
+    // Jumping also un-clears the instance so it shows once the chart switches.
+    expect(chartAnnotationStore.isDisplayCleared('ws-art', 'NVDA:1day')).toBe(false);
+  });
+
+  it('chip confirms (no jump) when it already describes the on-screen instance', () => {
+    const onJumpToChart = vi.fn();
+    renderCard(ARTIFACT, {
+      chartPresent: true,
+      activeSymbol: 'NVDA',
+      activeTimeframe: '1day',
+      onJumpToChart,
+    });
+
+    expect(screen.getByText(/on chart/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button'));
+    expect(onJumpToChart).not.toHaveBeenCalled();
   });
 });

--- a/web/src/pages/ChatAgent/components/charts/__tests__/InlineChartAnnotationCard.test.tsx
+++ b/web/src/pages/ChatAgent/components/charts/__tests__/InlineChartAnnotationCard.test.tsx
@@ -1,0 +1,180 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mock lightweight-charts (canvas can't render in jsdom) ---------------
+const fakeSeries = {
+  setData: vi.fn(),
+  createPriceLine: vi.fn(),
+  setMarkers: vi.fn(),
+  attachPrimitive: vi.fn(),
+};
+const fakeLineSeries = { setData: vi.fn() };
+const fakeChart = {
+  addCandlestickSeries: vi.fn(() => fakeSeries),
+  addLineSeries: vi.fn(() => fakeLineSeries),
+  timeScale: vi.fn(() => ({ fitContent: vi.fn() })),
+  remove: vi.fn(),
+};
+vi.mock('lightweight-charts', () => ({
+  createChart: vi.fn(() => fakeChart),
+  ColorType: { Solid: 'solid' },
+  CrosshairMode: { Normal: 1, Magnet: 0, Hidden: 2 },
+  LineStyle: { Solid: 0, Dotted: 1, Dashed: 2 },
+}));
+
+// --- Mock the market-data fetch -------------------------------------------
+import { fetchStockData } from '@/pages/MarketView/utils/api';
+vi.mock('@/pages/MarketView/utils/api', () => ({
+  fetchStockData: vi.fn(),
+}));
+
+import { WorkspaceProvider } from '../../../contexts/WorkspaceContext';
+import { ChartSurfaceContext } from '../../../contexts/ChartSurfaceContext';
+import { chartAnnotationStore } from '@/pages/MarketView/stores/chartAnnotationStore';
+import { InlineChartAnnotationCard } from '../InlineChartAnnotationCard';
+
+const mockedFetch = vi.mocked(fetchStockData);
+
+const ARTIFACT = {
+  type: 'chart_annotation',
+  op: 'add',
+  symbol: 'NVDA',
+  workspace_id: 'ws-art',
+  annotation_id: 'ann_1',
+  annotations: [
+    { annotation_id: 'ann_1', symbol: 'NVDA', type: 'price_line', price: 205, label: 'Resistance' },
+    {
+      annotation_id: 'ann_2',
+      symbol: 'NVDA',
+      type: 'rectangle',
+      point1: { time: '2024-10-16T00:00:00Z', price: 150 },
+      point2: { time: '2024-11-20T00:00:00Z', price: 140 },
+    },
+  ],
+};
+
+function LocationDisplay(): React.ReactElement {
+  const loc = useLocation();
+  return <div data-testid="loc">{loc.pathname + loc.search}</div>;
+}
+
+function renderCard(
+  artifact: Record<string, unknown>,
+  { chartPresent = false }: { chartPresent?: boolean } = {},
+) {
+  return render(
+    <MemoryRouter initialEntries={['/chat/t/thread-123']}>
+      <WorkspaceProvider workspaceId="ws-ctx" downloadFile={null}>
+        <ChartSurfaceContext.Provider value={{ chartPresent }}>
+          <Routes>
+            <Route
+              path="/chat/t/:threadId"
+              element={<InlineChartAnnotationCard artifact={artifact} />}
+            />
+            <Route path="/market" element={<LocationDisplay />} />
+          </Routes>
+        </ChartSurfaceContext.Provider>
+      </WorkspaceProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('InlineChartAnnotationCard', () => {
+  beforeEach(() => {
+    mockedFetch.mockResolvedValue({
+      data: [
+        { time: Math.floor(Date.parse('2024-10-16T00:00:00Z') / 1000), open: 100, high: 105, low: 99, close: 104, volume: 1 },
+        { time: Math.floor(Date.parse('2024-11-20T00:00:00Z') / 1000), open: 140, high: 152, low: 139, close: 150, volume: 1 },
+      ],
+    } as never);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    chartAnnotationStore._resetForTesting();
+  });
+
+  it('renders a mini-chart card and applies annotations after fetch', async () => {
+    renderCard(ARTIFACT);
+
+    expect(screen.getByText('NVDA')).toBeInTheDocument();
+    expect(screen.getByText('2 annotations')).toBeInTheDocument();
+    expect(screen.getByText('Open in MarketView')).toBeInTheDocument();
+
+    await waitFor(() => expect(mockedFetch).toHaveBeenCalledWith('NVDA', '1day', expect.any(String), expect.any(String), expect.any(Object)));
+    // native price line + primitive applied
+    await waitFor(() => expect(fakeSeries.createPriceLine).toHaveBeenCalled());
+    expect(fakeSeries.attachPrimitive).toHaveBeenCalled();
+  });
+
+  it('expands into MarketView carrying symbol, ptc mode, workspace, thread, returnTo', async () => {
+    renderCard(ARTIFACT);
+    fireEvent.click(screen.getByText('NVDA'));
+
+    const loc = await screen.findByTestId('loc');
+    const url = loc.textContent || '';
+    expect(url.startsWith('/market?')).toBe(true);
+    const params = new URLSearchParams(url.slice(url.indexOf('?')));
+    expect(params.get('symbol')).toBe('NVDA');
+    expect(params.get('mode')).toBe('ptc');
+    expect(params.get('ws')).toBe('ws-art');
+    expect(params.get('thread')).toBe('thread-123');
+    expect(params.get('returnTo')).toBe('/chat/t/thread-123');
+  });
+
+  it('uses the artifact timeframe for the header, fetch, and expand URL', async () => {
+    const hourly = { ...ARTIFACT, timeframe: '1hour' };
+    renderCard(hourly);
+
+    // Header shows the timeframe.
+    expect(screen.getByText('1hour')).toBeInTheDocument();
+    // Fetch uses the timeframe, not the daily default.
+    await waitFor(() =>
+      expect(mockedFetch).toHaveBeenCalledWith(
+        'NVDA',
+        '1hour',
+        expect.any(String),
+        expect.any(String),
+        expect.any(Object),
+      ),
+    );
+
+    // Expanding carries the timeframe so MarketView lands on the right view.
+    fireEvent.click(screen.getByText('NVDA'));
+    const loc = await screen.findByTestId('loc');
+    const url = loc.textContent || '';
+    const params = new URLSearchParams(url.slice(url.indexOf('?')));
+    expect(params.get('tf')).toBe('1hour');
+  });
+
+  it('collapses to a chip (no chart, no navigation) when a chart is present', async () => {
+    const { createChart } = await import('lightweight-charts');
+    renderCard(ARTIFACT, { chartPresent: true });
+
+    expect(screen.getByText(/on chart/i)).toBeInTheDocument();
+    expect(screen.queryByText('Open in MarketView')).not.toBeInTheDocument();
+    expect(vi.mocked(createChart)).not.toHaveBeenCalled();
+    expect(mockedFetch).not.toHaveBeenCalled();
+  });
+
+  it('chip restores a cleared drawing to the chart when clicked', async () => {
+    // The drawing was cleared from the chart elsewhere (the Clear button).
+    chartAnnotationStore.clearDisplay('ws-art', 'NVDA:1day');
+    renderCard(ARTIFACT, { chartPresent: true });
+
+    // Chip reflects the cleared state and invites re-showing.
+    expect(screen.getByText(/show .* on chart/i)).toBeInTheDocument();
+    expect(chartAnnotationStore.isDisplayCleared('ws-art', 'NVDA:1day')).toBe(true);
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(chartAnnotationStore.isDisplayCleared('ws-art', 'NVDA:1day')).toBe(false);
+  });
+
+  it('falls back to a text summary when the data fetch fails', async () => {
+    mockedFetch.mockResolvedValue({ data: [], error: 'No data available' } as never);
+    renderCard(ARTIFACT);
+
+    expect(await screen.findByText(/Chart preview unavailable/i)).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/ChatAgent/components/toolDisplayConfig.ts
+++ b/web/src/pages/ChatAgent/components/toolDisplayConfig.ts
@@ -3,9 +3,10 @@ import {
   TrendingUp, Building2, BarChart3, PieChart, Search, Globe,
   FilePlus, FileText, FilePen, FolderSearch, SquareChevronRight, Wrench,
   Newspaper, Brain, User, FileBarChart, Clock, ClipboardList, Zap, Settings, Terminal,
-  Sparkles, BookText, BookMarked, BookPlus,
+  Sparkles, BookText, BookMarked, BookPlus, PenLine,
 } from 'lucide-react';
 import { classifyAgentPath, topicFromMemoryKey, type AgentPathInfo } from '../utils/agentPaths';
+import { INTERVAL_LABEL } from '@/pages/MarketView/utils/chartConstants';
 
 /** Translation function signature compatible with i18next's t() */
 type TFn = (key: string, opts?: Record<string, unknown>) => string;
@@ -89,6 +90,9 @@ export const TOOL_DISPLAY_CONFIG: Record<string, ToolDisplayEntry> = {
   check_automations:        { displayName: 'Automations',          i18nKey: 'automations',         icon: Clock },
   create_automation:        { displayName: 'Create Automation',    i18nKey: 'createAutomation',    icon: Zap },
   manage_automation:        { displayName: 'Manage Automation',    i18nKey: 'manageAutomation',    icon: Settings },
+  // Chart annotation
+  draw_chart_annotation:    { displayName: 'Annotate Chart',       i18nKey: 'annotateChart',       icon: PenLine },
+  manage_chart_annotations: { displayName: 'Manage Annotations',   i18nKey: 'manageAnnotations',   icon: Settings },
 };
 
 // Single source of truth for "what tool name indicates a file
@@ -316,6 +320,10 @@ export function getInProgressText(rawToolName: string, toolCall: ToolCall | unde
       return args?.action
         ? (tr?.('actionAutomation', { action: args.action }) ?? `${args.action} automation...`)
         : (tr?.('managingAutomation') ?? 'managing automation...');
+    case 'draw_chart_annotation':
+      return tr?.('annotatingChart') ?? 'annotating chart...';
+    case 'manage_chart_annotations':
+      return tr?.('updatingAnnotations') ?? 'updating annotations...';
     default:
       return tr?.('processing') ?? 'processing...';
   }
@@ -350,6 +358,14 @@ export function getCompletedSummary(toolName: string, toolCall: ToolCall | undef
       // extra pill needed (would duplicate the entity name).
       return null;
     }
+  }
+  // Annotation steps: headline reads "NVDA · 1D" — the chart instance the draw
+  // targets. `timeframe` defaults to 1day server-side, so a missing arg means 1D.
+  // INTERVAL_LABEL is the shared chart interval→label map (chartConstants).
+  if (toolName === 'draw_chart_annotation' || toolName === 'manage_chart_annotations') {
+    if (!args.symbol) return null;
+    const tf = (args.timeframe as string) || '1day';
+    return `${String(args.symbol).toUpperCase()} · ${INTERVAL_LABEL[tf] ?? tf}`;
   }
   if (args.description) return args.description;
   if (args.symbol) return args.symbol;

--- a/web/src/pages/ChatAgent/contexts/ChartSurfaceContext.ts
+++ b/web/src/pages/ChatAgent/contexts/ChartSurfaceContext.ts
@@ -11,9 +11,20 @@ import { createContext, useContext } from 'react';
  *   the user can click to expand into MarketView.
  * - MarketView (`chartPresent: true`): the real chart already shows the
  *   drawing live, so the card collapses to a one-line confirmation chip.
+ *
+ * MarketView also supplies the instance currently on screen (`activeSymbol` /
+ * `activeTimeframe`) and an `onJumpToChart` callback, so a chip describing a
+ * different ticker/timeframe than what's displayed can switch the live chart
+ * to it on click.
  */
 export interface ChartSurface {
   chartPresent: boolean;
+  /** Symbol currently shown on the adjacent live chart (MarketView only). */
+  activeSymbol?: string;
+  /** Normalized timeframe currently shown on the adjacent live chart. */
+  activeTimeframe?: string;
+  /** Switch the adjacent live chart to a symbol+timeframe (MarketView only). */
+  onJumpToChart?: (symbol: string, timeframe: string) => void;
 }
 
 export const ChartSurfaceContext = createContext<ChartSurface>({ chartPresent: false });

--- a/web/src/pages/ChatAgent/contexts/ChartSurfaceContext.ts
+++ b/web/src/pages/ChatAgent/contexts/ChartSurfaceContext.ts
@@ -21,7 +21,11 @@ export interface ChartSurface {
   chartPresent: boolean;
   /** Symbol currently shown on the adjacent live chart (MarketView only). */
   activeSymbol?: string;
-  /** Normalized timeframe currently shown on the adjacent live chart. */
+  /**
+   * Raw interval currently shown on the adjacent live chart (NOT normalized) —
+   * so a view-only interval like `1s` doesn't read as "active" for a `1day`
+   * annotation.
+   */
   activeTimeframe?: string;
   /** Switch the adjacent live chart to a symbol+timeframe (MarketView only). */
   onJumpToChart?: (symbol: string, timeframe: string) => void;

--- a/web/src/pages/ChatAgent/contexts/ChartSurfaceContext.ts
+++ b/web/src/pages/ChatAgent/contexts/ChartSurfaceContext.ts
@@ -1,0 +1,23 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * Signals whether the chat transcript is rendered next to a live chart.
+ *
+ * The chat engine (`useChatMessages`) and its `MessageList` are shared by the
+ * standalone ChatAgent page AND the MarketView desktop chat panel. When the
+ * agent draws a chart annotation, the inline preview card behaves differently
+ * by surface:
+ * - ChatAgent (`chartPresent: false`, the default): render a live mini chart
+ *   the user can click to expand into MarketView.
+ * - MarketView (`chartPresent: true`): the real chart already shows the
+ *   drawing live, so the card collapses to a one-line confirmation chip.
+ */
+export interface ChartSurface {
+  chartPresent: boolean;
+}
+
+export const ChartSurfaceContext = createContext<ChartSurface>({ chartPresent: false });
+
+export function useChartSurface(): ChartSurface {
+  return useContext(ChartSurfaceContext);
+}

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -1084,6 +1084,14 @@ export function useChatMessages(
 
         // Handle artifact events (e.g., todo_update)
         // In history replay, artifacts DO have turn_index, so we can use it directly
+        //
+        // NOTE: `chart_annotation` artifacts are intentionally NOT replayed here
+        // (only the live stream applies them to the annotation store). On reload,
+        // MarketView's `useChartAnnotationSync` REST fetch is the authoritative
+        // source that repopulates the store from Postgres, and the inline card
+        // renders from the replayed `tool_call_result.artifact`. If a live chart
+        // surface is ever added to the standalone chat page, add a
+        // `chart_annotation` branch here so reloads stay consistent.
         if (eventType === 'artifact') {
           const artifactType = event.artifact_type;
           if (artifactType === 'todo_update') {

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -59,7 +59,7 @@ import {
 // shared MarketView store so the desktop MarketView chat panel (which uses
 // this engine for both flash and PTC) renders them live. Harmless on the
 // standalone /chat page — the store simply has no chart consumer there.
-import { applyAnnotationArtifact } from '../../MarketView/stores/chartAnnotationStore';
+import { applyAnnotationArtifact } from '@/pages/MarketView/stores/chartAnnotationStore';
 
 // --- Internal types for useChatMessages ---
 

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -55,6 +55,11 @@ import {
   handleHistorySteeringDelivered,
   isSubagentHistoryEvent,
 } from './utils/historyEventHandlers';
+// Chart-annotation live bridge: writes agent-drawn annotations into the
+// shared MarketView store so the desktop MarketView chat panel (which uses
+// this engine for both flash and PTC) renders them live. Harmless on the
+// standalone /chat page — the store simply has no chart consumer there.
+import { applyAnnotationArtifact } from '../../MarketView/stores/chartAnnotationStore';
 
 // --- Internal types for useChatMessages ---
 
@@ -3374,6 +3379,8 @@ export function useChatMessages(
             setMessages: setMessagesForHandlers,
             eventId: event._eventId as number,
           });
+        } else if (artifactType === 'chart_annotation') {
+          applyAnnotationArtifact(artifactType, (event.payload || {}) as Record<string, unknown>);
         } else if (artifactType === 'file_operation' && onFileArtifact) {
           onFileArtifact(event);
         } else if (artifactType === 'preview_url' && onPreviewUrl) {

--- a/web/src/pages/MarketView/MarketView.tsx
+++ b/web/src/pages/MarketView/MarketView.tsx
@@ -9,7 +9,7 @@ import type { MarketChartHandle } from './components/MarketChart';
 import ChatInput from '../../components/ui/chat-input';
 import MarketChatPanel from './components/MarketChatPanel';
 import MarketSidebarPanel from './components/MarketSidebarPanel';
-import { supports1sInterval } from './utils/chartConstants';
+import { INTERVALS, supports1sInterval } from './utils/chartConstants';
 import { useMarketChat } from './hooks/useMarketChat';
 import { getWorkspaces } from '../ChatAgent/utils/api';
 import { attachmentsToContexts } from '../ChatAgent/utils/fileUpload';
@@ -261,8 +261,10 @@ function MarketViewInner() {
       }
     }
     // Land on the timeframe the expanded card was drawn for, so its annotations
-    // (keyed by symbol:timeframe) show immediately.
-    if (tfParam) {
+    // (keyed by symbol:timeframe) show immediately. Validate against the chart's
+    // own interval allowlist so a stale/hand-crafted ?tf= can't strand the chart
+    // on an unknown interval (empty data + annotations keyed to a dead chart_id).
+    if (tfParam && INTERVALS.some((i) => i.key === tfParam)) {
       setSelectedInterval(tfParam);
     }
     // Apply workspace before mode so MarketChatPanel resolves the right

--- a/web/src/pages/MarketView/MarketView.tsx
+++ b/web/src/pages/MarketView/MarketView.tsx
@@ -194,11 +194,27 @@ function MarketViewInner() {
   const [flashWorkspaceId, setFlashWorkspaceId] = useState<string | null>(null);
   useEffect(() => {
     let cancelled = false;
-    getOrFetchFlashWorkspaceId().then((id) => {
-      if (!cancelled) setFlashWorkspaceId(id);
-    });
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    // A transient null (e.g. a failed first fetch) would otherwise leave
+    // Fast-mode annotations unscoped for the whole session, so retry a few
+    // times. getOrFetchFlashWorkspaceId clears its cache on failure, so each
+    // call re-attempts the request.
+    const attempt = (remaining: number) => {
+      getOrFetchFlashWorkspaceId().then((id) => {
+        if (cancelled) return;
+        if (id) {
+          setFlashWorkspaceId(id);
+          return;
+        }
+        if (remaining > 0) {
+          timer = setTimeout(() => attempt(remaining - 1), 1500);
+        }
+      });
+    };
+    attempt(3);
     return () => {
       cancelled = true;
+      if (timer) clearTimeout(timer);
     };
   }, []);
 

--- a/web/src/pages/MarketView/MarketView.tsx
+++ b/web/src/pages/MarketView/MarketView.tsx
@@ -23,11 +23,10 @@ import { loadPref, savePref } from './utils/prefs';
 import { useIsMobile } from '@/hooks/useIsMobile';
 
 import { useStockData } from './hooks/useStockData';
-import {
-  useChartAnnotationSync,
-  getOrFetchFlashWorkspaceId,
-} from './hooks/useChartAnnotationSync';
-import { normalizeTimeframe } from './stores/chartAnnotationStore';
+import { useChartAnnotationSync } from './hooks/useChartAnnotationSync';
+import { getOrFetchFlashWorkspaceId } from './utils/flashWorkspace';
+import { marketViewAnnotationContext } from './constants/annotationPrompt';
+import { normalizeTimeframe, subscribeLiveAnnotationAdd } from './stores/chartAnnotationStore';
 
 interface SearchResult {
   name?: string;
@@ -210,6 +209,36 @@ function MarketViewInner() {
   const activeWorkspaceId = mode === 'fast' ? flashWorkspaceId : selectedWorkspaceId;
   useChartAnnotationSync(activeWorkspaceId, selectedStock);
 
+  // Switch the chart to a given instance — used by the live-add auto-focus
+  // below and by an annotation chip that jumps to a different ticker.
+  const handleJumpToChart = useCallback((symbol: string, timeframe?: string | null) => {
+    const sym = (symbol || '').trim().toUpperCase();
+    if (!sym) return;
+    if (sym !== selectedStock) {
+      setSelectedStock(sym);
+      setSelectedStockDisplay(null);
+      setChartMeta(null);
+      setShowOverview(false);
+    }
+    if (timeframe) {
+      const tf = normalizeTimeframe(timeframe);
+      setSelectedInterval((cur) => (cur === tf ? cur : tf));
+    }
+  }, [selectedStock]);
+
+  // Auto-apply: when the agent draws an annotation from the chat panel on a
+  // different instance than what's on screen (e.g. the user asks to mark GOOGL
+  // while viewing AAPL), bring the chart to that symbol+timeframe so the new
+  // drawing is actually visible instead of silently landing off-screen. Scoped
+  // to the active workspace's live draws (the store's live-add channel only
+  // fires for fresh SSE adds, not server re-sync).
+  useEffect(() => {
+    return subscribeLiveAnnotationAdd((add) => {
+      if (!activeWorkspaceId || add.workspaceId !== activeWorkspaceId) return;
+      handleJumpToChart(add.symbol, add.timeframe);
+    });
+  }, [activeWorkspaceId, handleJumpToChart]);
+
   // Chat return path — captured from URL when navigating from chat DetailPanel
   const [chatReturnPath, setChatReturnPath] = useState<string | null>(null);
 
@@ -383,9 +412,7 @@ function MarketViewInner() {
       {
         type: 'skills',
         name: 'chart-annotation',
-        instruction: sym
-          ? `The user is viewing the ${sym} chart on the ${tf} timeframe in MarketView. When they ask to annotate or draw on "the chart", pass symbol="${sym}" and timeframe="${tf}" unless they name another ticker or interval.`
-          : undefined,
+        instruction: sym ? marketViewAnnotationContext(sym, tf) : undefined,
       },
     ];
     if (chartImage) {
@@ -715,6 +742,7 @@ function MarketViewInner() {
                   onNavigateSubagent={(tid, taskId) => navigate(`/chat/t/${tid}/${taskId}`)}
                   placeholder="What would you like to know?"
                   onReturnToChat={chatReturnPath ? () => navigate(chatReturnPath) : undefined}
+                  onJumpToChart={handleJumpToChart}
                 />
               </div>
             </div>

--- a/web/src/pages/MarketView/MarketView.tsx
+++ b/web/src/pages/MarketView/MarketView.tsx
@@ -14,7 +14,6 @@ import { useMarketChat } from './hooks/useMarketChat';
 import { getWorkspaces } from '../ChatAgent/utils/api';
 import { attachmentsToContexts } from '../ChatAgent/utils/fileUpload';
 import { motion, AnimatePresence } from 'framer-motion';
-import { ArrowLeft } from 'lucide-react';
 import CompanyOverviewPanel from './components/CompanyOverviewPanel';
 import { MobileBottomSheet } from '../../components/ui/mobile-bottom-sheet';
 import { MobileFabChat } from '../../components/ui/mobile-fab-chat';
@@ -24,6 +23,11 @@ import { loadPref, savePref } from './utils/prefs';
 import { useIsMobile } from '@/hooks/useIsMobile';
 
 import { useStockData } from './hooks/useStockData';
+import {
+  useChartAnnotationSync,
+  getOrFetchFlashWorkspaceId,
+} from './hooks/useChartAnnotationSync';
+import { normalizeTimeframe } from './stores/chartAnnotationStore';
 
 interface SearchResult {
   name?: string;
@@ -186,14 +190,39 @@ function MarketViewInner() {
   // chat lives in MarketChatPanel which drives its own useChatMessages.
   const { isLoading, handleSendMessage: handleFastModeSend } = useMarketChat();
 
+  // Resolve the user's flash workspace id once so we can scope chart
+  // annotations to the workspace the chat is actually running in.
+  const [flashWorkspaceId, setFlashWorkspaceId] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    getOrFetchFlashWorkspaceId().then((id) => {
+      if (!cancelled) setFlashWorkspaceId(id);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // The chart shows the agent-drawn instance for whichever workspace the chat
+  // panel is using — flash workspace in Fast mode, the selected one in PTC.
+  // Annotations are keyed by (workspace_id, chart_id), so this single id scopes
+  // both the persistence sync and the live chart selection.
+  const activeWorkspaceId = mode === 'fast' ? flashWorkspaceId : selectedWorkspaceId;
+  useChartAnnotationSync(activeWorkspaceId, selectedStock);
+
   // Chat return path — captured from URL when navigating from chat DetailPanel
   const [chatReturnPath, setChatReturnPath] = useState<string | null>(null);
 
-  // Handle URL parameters (symbol + returnTo from chat context). Preserve `?thread`
-  // so MarketChatPanel can pick it up to resume the right conversation.
+  // Handle URL parameters (symbol + returnTo from chat context, and ws + mode
+  // when expanding a chart-annotation preview from ChatAgent). Preserve
+  // `?thread` so MarketChatPanel can pick it up to resume the right
+  // conversation in the same workspace.
   useEffect(() => {
     const symbolParam = searchParams.get('symbol');
     const returnToParam = searchParams.get('returnTo');
+    const wsParam = searchParams.get('ws');
+    const modeParam = searchParams.get('mode');
+    const tfParam = searchParams.get('tf');
     if (symbolParam) {
       const symbol = symbolParam.trim().toUpperCase();
       if (symbol && symbol !== selectedStock) {
@@ -202,14 +231,30 @@ function MarketViewInner() {
         setChartMeta(null);
       }
     }
+    // Land on the timeframe the expanded card was drawn for, so its annotations
+    // (keyed by symbol:timeframe) show immediately.
+    if (tfParam) {
+      setSelectedInterval(tfParam);
+    }
+    // Apply workspace before mode so MarketChatPanel resolves the right
+    // (ptc) workspace when it mounts the forwarded thread.
+    if (wsParam) {
+      setSelectedWorkspaceId(wsParam);
+    }
+    if (modeParam === 'ptc' || modeParam === 'fast') {
+      setMode(modeParam);
+    }
     if (returnToParam) {
       setChatReturnPath(returnToParam);
     }
-    if (symbolParam || returnToParam) {
+    if (symbolParam || returnToParam || wsParam || modeParam || tfParam) {
       setSearchParams((prev) => {
         const next = new URLSearchParams(prev);
         next.delete('symbol');
         next.delete('returnTo');
+        next.delete('ws');
+        next.delete('mode');
+        next.delete('tf');
         return next;
       }, { replace: true });
     }
@@ -326,8 +371,23 @@ function MarketViewInner() {
   }, [selectedStock, selectedInterval, stockInfo, selectedStockDisplay, overviewData, displayPrice]);
 
   const handleSendMessage = useCallback(async (message: string, planMode: boolean, attachments: AttachmentItem[] = [], _slashCommands: string[] = [], { model, reasoningEffort }: { model?: string; reasoningEffort?: string } = {}) => {
-    // Build additional_context from chart image + file attachments
-    const contexts = [];
+    // Build additional_context from chart image + file attachments.
+    // Always preload the chart-annotation skill so the drawing tools are
+    // available from turn 1 (the agent can also self-load it elsewhere, but
+    // injecting here guarantees turn-1 availability on the chart surface).
+    // Tell it which ticker + timeframe "the chart" is so it edits the instance
+    // the user is actually viewing (chart_id = SYMBOL:timeframe).
+    const sym = (selectedStock || '').toUpperCase();
+    const tf = normalizeTimeframe(selectedInterval);
+    const contexts: unknown[] = [
+      {
+        type: 'skills',
+        name: 'chart-annotation',
+        instruction: sym
+          ? `The user is viewing the ${sym} chart on the ${tf} timeframe in MarketView. When they ask to annotate or draw on "the chart", pass symbol="${sym}" and timeframe="${tf}" unless they name another ticker or interval.`
+          : undefined,
+      },
+    ];
     if (chartImage) {
       contexts.push({ type: 'image', data: chartImage, description: chartImageDesc || undefined });
     }
@@ -381,6 +441,9 @@ function MarketViewInner() {
             initialMessage: message,
             planMode: planMode || false,
             additionalContext: imageContext,
+            // PTC side needs the same skill activated so the chart tools
+            // are available without the LLM having to call LoadSkill.
+            skills: ['chart-annotation'],
             ...(attachmentMeta ? { attachmentMeta } : {}),
             ...(model ? { model } : {}),
             ...(reasoningEffort ? { reasoningEffort } : {}),
@@ -397,7 +460,7 @@ function MarketViewInner() {
     }
     setChartImage(null);
     setChartImageDesc(null);
-  }, [handleFastModeSend, navigate, toast, chartImage, chartImageDesc, mode, selectedWorkspaceId]);
+  }, [handleFastModeSend, navigate, toast, chartImage, chartImageDesc, mode, selectedWorkspaceId, selectedStock, selectedInterval]);
 
   const handleSidebarSymbolClick = useCallback((symbol: string) => {
     setSelectedStock(symbol);
@@ -478,6 +541,7 @@ function MarketViewInner() {
               ref={chartRef}
               symbol={selectedStock}
               interval={selectedInterval}
+              workspaceId={activeWorkspaceId}
               onIntervalChange={handleIntervalChange}
               onCapture={handleCaptureChart}
               onStockMeta={handleStockMeta as any}
@@ -606,6 +670,7 @@ function MarketViewInner() {
                   ref={chartRef}
                   symbol={selectedStock}
                   interval={selectedInterval}
+                  workspaceId={activeWorkspaceId}
                   onIntervalChange={handleIntervalChange}
                   onCapture={handleCaptureChart}
                   onStockMeta={handleStockMeta as any}
@@ -632,6 +697,7 @@ function MarketViewInner() {
               <div className="market-right-panel-inner">
                 <MarketChatPanel
                   symbol={selectedStock}
+                  interval={selectedInterval}
                   mode={mode}
                   onModeChange={setMode}
                   workspaces={workspaces}
@@ -648,47 +714,11 @@ function MarketViewInner() {
                   onShuffleQueries={handleShuffleQueries}
                   onNavigateSubagent={(tid, taskId) => navigate(`/chat/t/${tid}/${taskId}`)}
                   placeholder="What would you like to know?"
+                  onReturnToChat={chatReturnPath ? () => navigate(chatReturnPath) : undefined}
                 />
               </div>
             </div>
           </div>
-          {/* Floating "Return to Chat" card — shown when navigated from chat context */}
-          {chatReturnPath && (
-            <button
-              onClick={() => navigate(chatReturnPath)}
-              style={{
-                position: 'fixed',
-                bottom: 24,
-                right: 416,
-                display: 'flex',
-                alignItems: 'center',
-                gap: 8,
-                padding: '10px 16px',
-                background: 'var(--color-accent-soft)',
-                border: '1px solid var(--color-accent-overlay)',
-                borderRadius: 10,
-                color: 'var(--color-accent-light)',
-                fontSize: 13,
-                fontWeight: 500,
-                cursor: 'pointer',
-                backdropFilter: 'blur(12px)',
-                boxShadow: '0 4px 20px rgba(0,0,0,0.3)',
-                transition: 'background 0.15s, border-color 0.15s',
-                zIndex: 50,
-              }}
-              onMouseEnter={(e: React.MouseEvent<HTMLButtonElement>) => {
-                e.currentTarget.style.background = 'var(--color-accent-overlay)';
-                e.currentTarget.style.borderColor = 'var(--color-accent-primary)';
-              }}
-              onMouseLeave={(e: React.MouseEvent<HTMLButtonElement>) => {
-                e.currentTarget.style.background = 'var(--color-accent-soft)';
-                e.currentTarget.style.borderColor = 'var(--color-accent-overlay)';
-              }}
-            >
-              <ArrowLeft style={{ width: 14, height: 14 }} />
-              Return to Chat
-            </button>
-          )}
         </>
       )}
     </div>

--- a/web/src/pages/MarketView/components/AgentEventOverlay.css
+++ b/web/src/pages/MarketView/components/AgentEventOverlay.css
@@ -16,7 +16,7 @@
   height: 7px;
   border-radius: 50%;
   transform: translate(-50%, -50%);
-  box-shadow: 0 0 0 2px var(--color-bg-base, rgba(0, 0, 0, 0.6));
+  box-shadow: 0 0 0 2px var(--color-bg-card);
   pointer-events: none;
 }
 
@@ -48,6 +48,7 @@
 }
 
 .agent-event-badge:hover,
+.agent-event-badge--open,
 .agent-event-badge[data-state='open'] {
   border-color: var(--color-accent-primary);
 }
@@ -80,6 +81,25 @@
   border-top: 1px solid var(--color-border-muted);
 }
 
+/* Coarse pointers (touch): the visible badge chrome is ~22px tall and can be
+   narrow for short titles — below the 44x44px recommended touch target. Expand
+   an invisible, centered hit overlay to >=44px in both axes so taps land
+   reliably, without growing the visible badge on any device. */
+@media (pointer: coarse) {
+  .agent-event-badge::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 100%;
+    min-width: 44px;
+    height: 44px;
+    transform: translate(-50%, -50%);
+    /* Behind the badge's own content but still part of the button's hit area. */
+    z-index: -1;
+  }
+}
+
 .agent-event-badge-dot {
   flex-shrink: 0;
   width: 7px;
@@ -94,6 +114,9 @@
 
 /* Detail popover (portaled to body, inherits the theme tokens). */
 .agent-event-pop.agent-event-pop {
+  /* Sit above the inline annotation card's modal (z-1030); the overlay can be
+     mounted inside that dialog, and a popover behind its own trigger is unusable. */
+  z-index: 1040;
   width: 280px;
   max-width: calc(100vw - 24px);
   padding: 12px 14px;

--- a/web/src/pages/MarketView/components/AgentEventOverlay.css
+++ b/web/src/pages/MarketView/components/AgentEventOverlay.css
@@ -1,0 +1,127 @@
+/* Interactive news-event badges layered over the live chart.
+   The overlay itself is click-through; only the badges capture pointer events,
+   so chart pan/zoom keeps working everywhere between them. */
+
+.agent-event-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 16; /* above the candle canvas, below the crosshair tooltip (20) */
+}
+
+/* Small dot pinned to the exact (time, price) anchor. */
+.agent-event-anchor {
+  position: absolute;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  box-shadow: 0 0 0 2px var(--color-bg-base, rgba(0, 0, 0, 0.6));
+  pointer-events: none;
+}
+
+/* The always-visible title badge. Floats above its anchor by default. */
+.agent-event-badge {
+  position: absolute;
+  transform: translate(-50%, calc(-100% - 9px));
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 200px;
+  padding: 3px 9px;
+  border-radius: 6px;
+  border: 1px solid var(--color-border-muted);
+  background: var(--color-bg-elevated);
+  box-shadow: var(--shadow-card);
+  color: var(--color-text-primary);
+  font: 600 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  line-height: 1.3;
+  white-space: nowrap;
+  cursor: pointer;
+  pointer-events: auto;
+  transition: border-color 0.12s ease, transform 0.12s ease;
+}
+
+/* When there's no room above, flip the badge below the anchor. */
+.agent-event-badge--below {
+  transform: translate(-50%, 9px);
+}
+
+.agent-event-badge:hover,
+.agent-event-badge[data-state='open'] {
+  border-color: var(--color-accent-primary);
+}
+
+.agent-event-badge:focus-visible {
+  outline: 2px solid var(--color-accent-primary);
+  outline-offset: 1px;
+}
+
+/* Downward caret pointing at the anchor (upward when flipped below). */
+.agent-event-badge::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  bottom: -4px;
+  width: 7px;
+  height: 7px;
+  background: var(--color-bg-elevated);
+  border-right: 1px solid var(--color-border-muted);
+  border-bottom: 1px solid var(--color-border-muted);
+  transform: translateX(-50%) rotate(45deg);
+}
+
+.agent-event-badge--below::after {
+  bottom: auto;
+  top: -4px;
+  border-right: none;
+  border-bottom: none;
+  border-left: 1px solid var(--color-border-muted);
+  border-top: 1px solid var(--color-border-muted);
+}
+
+.agent-event-badge-dot {
+  flex-shrink: 0;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+}
+
+.agent-event-badge-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Detail popover (portaled to body, inherits the theme tokens). */
+.agent-event-pop.agent-event-pop {
+  width: 280px;
+  max-width: calc(100vw - 24px);
+  padding: 12px 14px;
+}
+
+.agent-event-pop-head {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-bottom: 7px;
+}
+
+.agent-event-pop-dot {
+  flex-shrink: 0;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.agent-event-pop-title {
+  font: 700 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  color: var(--color-text-primary);
+}
+
+.agent-event-pop-detail {
+  margin: 0;
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--color-text-secondary);
+  white-space: pre-wrap;
+}

--- a/web/src/pages/MarketView/components/AgentEventOverlay.tsx
+++ b/web/src/pages/MarketView/components/AgentEventOverlay.tsx
@@ -130,7 +130,7 @@ function EventBadge({ ev, hoverCapable }: EventBadgeProps): React.ReactElement {
           aria-label={t('marketView.chart.newsEventAria', { title: ev.title })}
           {...hoverProps}
         >
-          <span className="agent-event-badge-dot" style={{ background: ev.color }} />
+          <span className="agent-event-badge-dot" style={{ backgroundColor: ev.color }} />
           <span className="agent-event-badge-title">{ev.title}</span>
         </button>
       </Mount>
@@ -147,7 +147,7 @@ function EventBadge({ ev, hoverCapable }: EventBadgeProps): React.ReactElement {
         {...contentHover}
       >
         <div className="agent-event-pop-head">
-          <span className="agent-event-pop-dot" style={{ background: ev.color }} />
+          <span className="agent-event-pop-dot" style={{ backgroundColor: ev.color }} />
           <span className="agent-event-pop-title">{ev.title}</span>
         </div>
         <p className="agent-event-pop-detail">{ev.detail}</p>
@@ -281,7 +281,7 @@ export function AgentEventOverlay({
         <React.Fragment key={ev.id}>
           <span
             className="agent-event-anchor"
-            style={{ left: `${ev.x}px`, top: `${ev.y}px`, background: ev.color }}
+            style={{ left: `${ev.x}px`, top: `${ev.y}px`, backgroundColor: ev.color }}
           />
           <EventBadge ev={ev} hoverCapable={hoverCapable} />
         </React.Fragment>

--- a/web/src/pages/MarketView/components/AgentEventOverlay.tsx
+++ b/web/src/pages/MarketView/components/AgentEventOverlay.tsx
@@ -23,9 +23,15 @@ import React, {
   useState,
   type RefObject,
 } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { IChartApi, ISeriesApi, Time } from 'lightweight-charts';
 
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
 import type { ChartDataPoint } from '@/types/market';
 
 import { useAnnotationsForView } from '../stores/chartAnnotationStore';
@@ -70,6 +76,7 @@ interface EventBadgeProps {
 
 /** One news badge + its hover/tap detail popover. */
 function EventBadge({ ev, hoverCapable }: EventBadgeProps): React.ReactElement {
+  const { t } = useTranslation();
   const [open, setOpen] = useState(false);
   const closeTimer = useRef<number | null>(null);
 
@@ -79,21 +86,26 @@ function EventBadge({ ev, hoverCapable }: EventBadgeProps): React.ReactElement {
       closeTimer.current = null;
     }
   }, []);
+  const openNow = useCallback(() => {
+    clearClose();
+    setOpen(true);
+  }, [clearClose]);
   const scheduleClose = useCallback(() => {
     clearClose();
     closeTimer.current = window.setTimeout(() => setOpen(false), HOVER_CLOSE_MS);
   }, [clearClose]);
   useEffect(() => clearClose, [clearClose]);
 
-  // Hover handlers only on hover-capable devices; touch falls back to the
-  // trigger's native click toggle (Radix calls onOpenChange on tap).
-  const triggerHover = hoverCapable
+  // Hover-capable devices: open on hover/focus and anchor the popover (no
+  // click trigger, so a click can't toggle it shut right after pointerenter
+  // opened it). Touch devices: a Trigger so a tap toggles the detail.
+  const Mount = hoverCapable ? PopoverAnchor : PopoverTrigger;
+  const hoverProps = hoverCapable
     ? {
-        onPointerEnter: () => {
-          clearClose();
-          setOpen(true);
-        },
+        onPointerEnter: openNow,
         onPointerLeave: scheduleClose,
+        onFocus: openNow,
+        onBlur: scheduleClose,
       }
     : {};
   const contentHover = hoverCapable
@@ -110,18 +122,18 @@ function EventBadge({ ev, hoverCapable }: EventBadgeProps): React.ReactElement {
         setOpen(o);
       }}
     >
-      <PopoverTrigger asChild>
+      <Mount asChild>
         <button
           type="button"
-          className={`agent-event-badge${ev.below ? ' agent-event-badge--below' : ''}`}
+          className={`agent-event-badge${ev.below ? ' agent-event-badge--below' : ''}${open ? ' agent-event-badge--open' : ''}`}
           style={{ left: `${ev.x}px`, top: `${ev.y}px` }}
-          aria-label={`News event: ${ev.title}`}
-          {...triggerHover}
+          aria-label={t('marketView.chart.newsEventAria', { title: ev.title })}
+          {...hoverProps}
         >
           <span className="agent-event-badge-dot" style={{ background: ev.color }} />
           <span className="agent-event-badge-title">{ev.title}</span>
         </button>
-      </PopoverTrigger>
+      </Mount>
       <PopoverContent
         side={side}
         align="center"
@@ -223,7 +235,20 @@ export function AgentEventOverlay({
     } catch {
       return;
     }
-    const onRange = () => recompute();
+    // Coalesce pan/zoom + resize repositioning into one reposition per frame.
+    // lightweight-charts fires the range-change handler many times per drag; a
+    // synchronous setPlaced() on each tick thrashes React (re-rendering every
+    // badge + its Radix popover). Batch them through a single rAF instead.
+    let scheduled = 0;
+    const schedule = () => {
+      if (scheduled) return;
+      scheduled = requestAnimationFrame(() => {
+        scheduled = 0;
+        recompute();
+      });
+    };
+
+    const onRange = () => schedule();
     try {
       timeScale.subscribeVisibleLogicalRangeChange(onRange);
     } catch {
@@ -233,7 +258,7 @@ export function AgentEventOverlay({
     let ro: ResizeObserver | null = null;
     const host = hostRef.current;
     if (host && typeof ResizeObserver !== 'undefined') {
-      ro = new ResizeObserver(() => recompute());
+      ro = new ResizeObserver(() => schedule());
       ro.observe(host);
     }
     const raf = requestAnimationFrame(() => recompute());
@@ -246,6 +271,7 @@ export function AgentEventOverlay({
       }
       ro?.disconnect();
       cancelAnimationFrame(raf);
+      if (scheduled) cancelAnimationFrame(scheduled);
     };
   }, [recompute, symbol, theme, visible, events, chartData, chartRef]);
 

--- a/web/src/pages/MarketView/components/AgentEventOverlay.tsx
+++ b/web/src/pages/MarketView/components/AgentEventOverlay.tsx
@@ -273,7 +273,7 @@ export function AgentEventOverlay({
       cancelAnimationFrame(raf);
       if (scheduled) cancelAnimationFrame(scheduled);
     };
-  }, [recompute, symbol, theme, visible, events, chartData, chartRef]);
+  }, [recompute, symbol, theme, visible, chartData, chartRef]);
 
   return (
     <div ref={hostRef} className="agent-event-overlay" aria-hidden={placed.length === 0}>

--- a/web/src/pages/MarketView/components/AgentEventOverlay.tsx
+++ b/web/src/pages/MarketView/components/AgentEventOverlay.tsx
@@ -1,0 +1,267 @@
+/**
+ * Interactive DOM overlay for ``event`` (news-event) annotations on the live
+ * MarketView chart.
+ *
+ * Canvas chips (drawn by ``AgentAnnotationsPrimitive``) can't receive
+ * hover/click, so news events render as DOM badges layered over the chart:
+ * each badge is anchored at its ``(time, price)`` point via the chart's
+ * coordinate API and repositioned on pan/zoom/resize. The always-visible badge
+ * shows the event title; the few-sentence ``detail`` is revealed on hover
+ * (hover-capable devices) or tap/click (touch) via a Radix Popover.
+ *
+ * Mounts inside ``chart-wrapper`` (alongside the crosshair tooltip) and only in
+ * the custom/Light chart mode — the TradingView iframe has no surface to
+ * overlay. Styling rides the theme-aware CSS tokens, so it follows light/dark
+ * without per-instance work.
+ */
+
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type RefObject,
+} from 'react';
+import type { IChartApi, ISeriesApi, Time } from 'lightweight-charts';
+
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import type { ChartDataPoint } from '@/types/market';
+
+import { useAnnotationsForView } from '../stores/chartAnnotationStore';
+import { buildEvents, type EventItem } from '../utils/annotationGeometry';
+import './AgentEventOverlay.css';
+
+// Keep a badge's center this far from the pane edges so it stays readable.
+const EDGE_X = 30;
+// Below this anchor-y the badge flips under the point (no room above it).
+const FLIP_Y = 44;
+// Grace period before a hover-opened popover closes, so the pointer can travel
+// from the badge into the detail card without it vanishing.
+const HOVER_CLOSE_MS = 120;
+
+const hoverMql =
+  typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+    ? window.matchMedia('(hover: hover)')
+    : null;
+
+/** True on pointer devices that can hover (desktop), false on touch. */
+function useHoverCapable(): boolean {
+  const [hoverable, setHoverable] = useState(() => hoverMql?.matches ?? false);
+  useEffect(() => {
+    if (!hoverMql) return;
+    const onChange = () => setHoverable(hoverMql.matches);
+    hoverMql.addEventListener('change', onChange);
+    return () => hoverMql.removeEventListener('change', onChange);
+  }, []);
+  return hoverable;
+}
+
+interface PlacedEvent extends EventItem {
+  x: number;
+  y: number;
+  below: boolean;
+}
+
+interface EventBadgeProps {
+  ev: PlacedEvent;
+  hoverCapable: boolean;
+}
+
+/** One news badge + its hover/tap detail popover. */
+function EventBadge({ ev, hoverCapable }: EventBadgeProps): React.ReactElement {
+  const [open, setOpen] = useState(false);
+  const closeTimer = useRef<number | null>(null);
+
+  const clearClose = useCallback(() => {
+    if (closeTimer.current != null) {
+      clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+  }, []);
+  const scheduleClose = useCallback(() => {
+    clearClose();
+    closeTimer.current = window.setTimeout(() => setOpen(false), HOVER_CLOSE_MS);
+  }, [clearClose]);
+  useEffect(() => clearClose, [clearClose]);
+
+  // Hover handlers only on hover-capable devices; touch falls back to the
+  // trigger's native click toggle (Radix calls onOpenChange on tap).
+  const triggerHover = hoverCapable
+    ? {
+        onPointerEnter: () => {
+          clearClose();
+          setOpen(true);
+        },
+        onPointerLeave: scheduleClose,
+      }
+    : {};
+  const contentHover = hoverCapable
+    ? { onPointerEnter: clearClose, onPointerLeave: scheduleClose }
+    : {};
+
+  const side = ev.below ? 'bottom' : 'top';
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(o) => {
+        clearClose();
+        setOpen(o);
+      }}
+    >
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className={`agent-event-badge${ev.below ? ' agent-event-badge--below' : ''}`}
+          style={{ left: `${ev.x}px`, top: `${ev.y}px` }}
+          aria-label={`News event: ${ev.title}`}
+          {...triggerHover}
+        >
+          <span className="agent-event-badge-dot" style={{ background: ev.color }} />
+          <span className="agent-event-badge-title">{ev.title}</span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        side={side}
+        align="center"
+        sideOffset={10}
+        collisionPadding={12}
+        className="agent-event-pop"
+        onOpenAutoFocus={(e) => {
+          // Don't yank focus on hover-open; let click-open focus normally.
+          if (hoverCapable) e.preventDefault();
+        }}
+        {...contentHover}
+      >
+        <div className="agent-event-pop-head">
+          <span className="agent-event-pop-dot" style={{ background: ev.color }} />
+          <span className="agent-event-pop-title">{ev.title}</span>
+        </div>
+        <p className="agent-event-pop-detail">{ev.detail}</p>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+interface AgentEventOverlayProps {
+  chartRef: RefObject<IChartApi | null>;
+  seriesRef: RefObject<ISeriesApi<'Candlestick'> | null>;
+  chartData: ChartDataPoint[] | null;
+  /** Light/dark — drives re-placement on toggle (styling rides CSS tokens). */
+  theme: 'light' | 'dark';
+  /** False when the user cleared the drawing; keeps the store intact. */
+  visible: boolean;
+  workspaceId: string | null | undefined;
+  symbol: string | null | undefined;
+  timeframe: string | null | undefined;
+}
+
+export function AgentEventOverlay({
+  chartRef,
+  seriesRef,
+  chartData,
+  theme,
+  visible,
+  workspaceId,
+  symbol,
+  timeframe,
+}: AgentEventOverlayProps): React.ReactElement {
+  const hoverCapable = useHoverCapable();
+  const annotations = useAnnotationsForView(workspaceId ?? null, symbol ?? null, timeframe ?? null);
+  const events = useMemo(() => buildEvents(annotations, chartData), [annotations, chartData]);
+
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const [placed, setPlaced] = useState<PlacedEvent[]>([]);
+
+  // Latest events read inside recompute without re-subscribing every change.
+  const eventsRef = useRef<EventItem[]>(events);
+  eventsRef.current = visible ? events : [];
+
+  const recompute = useCallback(() => {
+    const chart = chartRef.current;
+    const series = seriesRef.current;
+    const evs = eventsRef.current;
+    if (!chart || !series || evs.length === 0) {
+      setPlaced((prev) => (prev.length ? [] : prev));
+      return;
+    }
+    let timeScale: ReturnType<IChartApi['timeScale']>;
+    try {
+      timeScale = chart.timeScale();
+    } catch {
+      return;
+    }
+    const host = hostRef.current;
+    const w = host?.clientWidth ?? 0;
+    const next: PlacedEvent[] = [];
+    for (const ev of evs) {
+      let x: number | null;
+      let y: number | null;
+      try {
+        x = timeScale.timeToCoordinate(ev.time as unknown as Time);
+        y = series.priceToCoordinate(ev.price);
+      } catch {
+        continue;
+      }
+      if (x == null || y == null) continue;
+      const cx = w > 0 ? Math.max(EDGE_X, Math.min(x, w - EDGE_X)) : x;
+      next.push({ ...ev, x: cx, y, below: y < FLIP_Y });
+    }
+    setPlaced(next);
+  }, [chartRef, seriesRef]);
+
+  // Reposition on pan/zoom (logical range), resize (ResizeObserver), and chart
+  // rebuilds (symbol/theme/data deps re-grab the current chart instance). The
+  // initial placement waits a frame so the chart has laid out.
+  useEffect(() => {
+    const chart = chartRef.current;
+    if (!chart) return;
+    let timeScale: ReturnType<IChartApi['timeScale']>;
+    try {
+      timeScale = chart.timeScale();
+    } catch {
+      return;
+    }
+    const onRange = () => recompute();
+    try {
+      timeScale.subscribeVisibleLogicalRangeChange(onRange);
+    } catch {
+      /* chart disposed */
+    }
+
+    let ro: ResizeObserver | null = null;
+    const host = hostRef.current;
+    if (host && typeof ResizeObserver !== 'undefined') {
+      ro = new ResizeObserver(() => recompute());
+      ro.observe(host);
+    }
+    const raf = requestAnimationFrame(() => recompute());
+
+    return () => {
+      try {
+        timeScale.unsubscribeVisibleLogicalRangeChange(onRange);
+      } catch {
+        /* already disposed */
+      }
+      ro?.disconnect();
+      cancelAnimationFrame(raf);
+    };
+  }, [recompute, symbol, theme, visible, events, chartData, chartRef]);
+
+  return (
+    <div ref={hostRef} className="agent-event-overlay" aria-hidden={placed.length === 0}>
+      {placed.map((ev) => (
+        <React.Fragment key={ev.id}>
+          <span
+            className="agent-event-anchor"
+            style={{ left: `${ev.x}px`, top: `${ev.y}px`, background: ev.color }}
+          />
+          <EventBadge ev={ev} hoverCapable={hoverCapable} />
+        </React.Fragment>
+      ))}
+    </div>
+  );
+}
+
+export default AgentEventOverlay;

--- a/web/src/pages/MarketView/components/MarketChart.css
+++ b/web/src/pages/MarketView/components/MarketChart.css
@@ -197,6 +197,12 @@
   border-color: var(--color-accent-primary);
 }
 
+/* "Clear annotations" toolbar button — a chart-tool-btn that carries an icon
+   plus a label, shown in the tools row only while agent annotations are drawn. */
+.chart-tool-btn.chart-clear-annotations-btn {
+  gap: 4px;
+}
+
 /* Light chart visible in Light mode: fills parent flex column */
 .light-chart-visible {
   flex: 1;

--- a/web/src/pages/MarketView/components/MarketChart.tsx
+++ b/web/src/pages/MarketView/components/MarketChart.tsx
@@ -36,7 +36,7 @@ import { useChartAnnotations } from '../hooks/useChartAnnotations';
 import { useChartOverlays } from '../hooks/useChartOverlays';
 import { useAgentAnnotations } from '../hooks/useAgentAnnotations';
 import { AgentEventOverlay } from './AgentEventOverlay';
-import { chartAnnotationStore, makeChartId, useAnnotationsForView, useDisplayCleared } from '../stores/chartAnnotationStore';
+import { chartAnnotationStore, makeChartId, normalizeTimeframe, useAnnotationsForView, useDisplayCleared } from '../stores/chartAnnotationStore';
 import { SlidersHorizontal, Settings2, Maximize2, Minimize2, ChevronDown, Plus, Minus, RotateCcw, Menu, X } from 'lucide-react';
 
 import { loadPref, savePref } from '../utils/prefs';
@@ -265,9 +265,14 @@ const MarketChart = React.memo(forwardRef<MarketChartHandle, MarketChartProps>((
   // Subscribe to the store directly too: `hasAgentAnnotations` drives the
   // first-class Clear button, and `agentAnnotationsCleared` suppresses the
   // drawing (data stays in the store) until the user re-opens the artifact.
-  const agentAnnotations = useAnnotationsForView(workspaceId ?? null, symbol, interval);
+  //
+  // The agent can only draw on VALID_TIMEFRAMES, so it stores under the
+  // normalized timeframe (e.g. '1s' -> '1day'). Look annotations up under the
+  // same normalized key, or they are invisible on non-agent-writable intervals.
+  const annotationInterval = normalizeTimeframe(interval);
+  const agentAnnotations = useAnnotationsForView(workspaceId ?? null, symbol, annotationInterval);
   const hasAgentAnnotations = agentAnnotations.length > 0;
-  const agentAnnotationsCleared = useDisplayCleared(workspaceId ?? null, symbol, interval);
+  const agentAnnotationsCleared = useDisplayCleared(workspaceId ?? null, symbol, annotationInterval);
   const agentMarkers = useAgentAnnotations(
     chartRef,
     candlestickSeriesRef,
@@ -275,7 +280,7 @@ const MarketChart = React.memo(forwardRef<MarketChartHandle, MarketChartProps>((
     chartMode,
     chartDataForHooks as any,
     workspaceId ?? null,
-    interval,
+    annotationInterval,
     !agentAnnotationsCleared,
     theme,
   );
@@ -1569,8 +1574,8 @@ const MarketChart = React.memo(forwardRef<MarketChartHandle, MarketChartProps>((
 
   const handleClearAgentAnnotations = useCallback(() => {
     if (!workspaceId || !symbol) return;
-    chartAnnotationStore.clearDisplay(workspaceId, makeChartId(symbol, interval));
-  }, [workspaceId, symbol, interval]);
+    chartAnnotationStore.clearDisplay(workspaceId, makeChartId(symbol, annotationInterval));
+  }, [workspaceId, symbol, annotationInterval]);
 
   const handleToggleOverlay = useCallback((key: string) => {
     setOverlayVisibility((prev) => ({ ...prev, [key]: !prev[key] }));
@@ -1923,7 +1928,7 @@ const MarketChart = React.memo(forwardRef<MarketChartHandle, MarketChartProps>((
                   visible={!agentAnnotationsCleared}
                   workspaceId={workspaceId ?? null}
                   symbol={symbol}
-                  timeframe={interval}
+                  timeframe={annotationInterval}
                 />
               )}
               {scrollLoading && (

--- a/web/src/pages/MarketView/components/MarketChart.tsx
+++ b/web/src/pages/MarketView/components/MarketChart.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState, useImperativeHandle, forwardRef, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import { createChart, ColorType, CrosshairMode, PriceScaleMode, LineType, LineStyle } from 'lightweight-charts';
 import type { IChartApi, LogicalRange, MouseEventParams } from 'lightweight-charts';
 import html2canvas from 'html2canvas';
@@ -120,6 +121,7 @@ const MarketChart = React.memo(forwardRef<MarketChartHandle, MarketChartProps>((
   marketStatus,
   snapshot,
 }, ref) => {
+  const { t } = useTranslation();
   const { theme } = useTheme();
   const ct = getChartTheme(theme as 'dark' | 'light');
   const providers = Array.isArray(marketStatus?.providers) ? marketStatus.providers as string[] : [];
@@ -1799,10 +1801,10 @@ const MarketChart = React.memo(forwardRef<MarketChartHandle, MarketChartProps>((
                   type="button"
                   className="chart-tool-btn chart-clear-annotations-btn"
                   onClick={handleClearAgentAnnotations}
-                  title="Clear annotations from the chart (kept in chat — click the artifact to restore)"
+                  title={t('marketView.chart.clearAnnotationsTitle')}
                 >
                   <X size={14} />
-                  Clear
+                  {t('marketView.chart.clearAnnotations')}
                 </button>
               )}
               {/* Tools dropdown — wide only */}

--- a/web/src/pages/MarketView/components/MarketChart.tsx
+++ b/web/src/pages/MarketView/components/MarketChart.tsx
@@ -34,6 +34,7 @@ import { TradingViewAttribution } from '@/pages/Dashboard/widgets/framework/Trad
 import { useChartAnnotations } from '../hooks/useChartAnnotations';
 import { useChartOverlays } from '../hooks/useChartOverlays';
 import { useAgentAnnotations } from '../hooks/useAgentAnnotations';
+import { AgentEventOverlay } from './AgentEventOverlay';
 import { chartAnnotationStore, makeChartId, useAnnotationsForView, useDisplayCleared } from '../stores/chartAnnotationStore';
 import { SlidersHorizontal, Settings2, Maximize2, Minimize2, ChevronDown, Plus, Minus, RotateCcw, Menu, X } from 'lucide-react';
 
@@ -1911,6 +1912,18 @@ const MarketChart = React.memo(forwardRef<MarketChartHandle, MarketChartProps>((
                 containerWidth={chartContainerRef.current?.clientWidth}
                 containerHeight={chartContainerRef.current?.clientHeight}
               />
+              {chartMode === 'custom' && (
+                <AgentEventOverlay
+                  chartRef={chartRef}
+                  seriesRef={candlestickSeriesRef}
+                  chartData={chartDataForHooks as any}
+                  theme={theme as 'light' | 'dark'}
+                  visible={!agentAnnotationsCleared}
+                  workspaceId={workspaceId ?? null}
+                  symbol={symbol}
+                  timeframe={interval}
+                />
+              )}
               {scrollLoading && (
                 <div className="chart-scroll-loading">
                   <div className="chart-scroll-loading-spinner" />

--- a/web/src/pages/MarketView/components/MarketChart.tsx
+++ b/web/src/pages/MarketView/components/MarketChart.tsx
@@ -33,7 +33,9 @@ import TradingViewWidget from './TradingViewWidget';
 import { TradingViewAttribution } from '@/pages/Dashboard/widgets/framework/TradingViewAttribution';
 import { useChartAnnotations } from '../hooks/useChartAnnotations';
 import { useChartOverlays } from '../hooks/useChartOverlays';
-import { SlidersHorizontal, Settings2, Maximize2, Minimize2, ChevronDown, Plus, Minus, RotateCcw, Menu } from 'lucide-react';
+import { useAgentAnnotations } from '../hooks/useAgentAnnotations';
+import { chartAnnotationStore, makeChartId, useAnnotationsForView, useDisplayCleared } from '../stores/chartAnnotationStore';
+import { SlidersHorizontal, Settings2, Maximize2, Minimize2, ChevronDown, Plus, Minus, RotateCcw, Menu, X } from 'lucide-react';
 
 import { loadPref, savePref } from '../utils/prefs';
 import type { SnapshotData } from '@/types/market';
@@ -75,6 +77,8 @@ interface OverlayVisibility {
 interface MarketChartProps {
   symbol: string;
   interval?: string;
+  /** Active workspace — scopes which agent-drawn chart instance is shown. */
+  workspaceId?: string | null;
   onIntervalChange?: (interval: string) => void;
   onCapture?: () => void;
   onStockMeta?: (meta: unknown) => void;
@@ -100,6 +104,7 @@ export interface MarketChartHandle {
 const MarketChart = React.memo(forwardRef<MarketChartHandle, MarketChartProps>(({
   symbol,
   interval = '1day',
+  workspaceId,
   onIntervalChange,
   onCapture: _onCapture,
   onStockMeta,
@@ -253,8 +258,27 @@ const MarketChart = React.memo(forwardRef<MarketChartHandle, MarketChartProps>((
   const priceTargetsForAnnotations = overlayVisibility.priceTargets ? (overlayData?.priceTargets as any) : null;
   useChartAnnotations(candlestickSeriesRef, stockMeta, quoteData, priceTargetsForAnnotations, annotationsVisible, symbol);
 
-  // --- Series markers via hook ---
-  useChartOverlays(candlestickSeriesRef, chartDataForHooks as any, earningsData as any, overlayData as any, overlayVisibility as any, symbol);
+  // --- Agent-sourced annotations: price_line, trendline, marker (derived) ---
+  // Subscribe to the store directly too: `hasAgentAnnotations` drives the
+  // first-class Clear button, and `agentAnnotationsCleared` suppresses the
+  // drawing (data stays in the store) until the user re-opens the artifact.
+  const agentAnnotations = useAnnotationsForView(workspaceId ?? null, symbol, interval);
+  const hasAgentAnnotations = agentAnnotations.length > 0;
+  const agentAnnotationsCleared = useDisplayCleared(workspaceId ?? null, symbol, interval);
+  const agentMarkers = useAgentAnnotations(
+    chartRef,
+    candlestickSeriesRef,
+    symbol,
+    chartMode,
+    chartDataForHooks as any,
+    workspaceId ?? null,
+    interval,
+    !agentAnnotationsCleared,
+    theme,
+  );
+
+  // --- Series markers via hook (earnings + grades + agent markers) ---
+  useChartOverlays(candlestickSeriesRef, chartDataForHooks as any, earningsData as any, overlayData as any, overlayVisibility as any, symbol, agentMarkers);
 
   // --- Live tick updates from WS (1s and 1min intervals, custom/Light mode only) ---
   useEffect(() => {
@@ -1540,6 +1564,11 @@ const MarketChart = React.memo(forwardRef<MarketChartHandle, MarketChartProps>((
     setAnnotationsVisible((prev) => !prev);
   }, []);
 
+  const handleClearAgentAnnotations = useCallback(() => {
+    if (!workspaceId || !symbol) return;
+    chartAnnotationStore.clearDisplay(workspaceId, makeChartId(symbol, interval));
+  }, [workspaceId, symbol, interval]);
+
   const handleToggleOverlay = useCallback((key: string) => {
     setOverlayVisibility((prev) => ({ ...prev, [key]: !prev[key] }));
   }, []);
@@ -1761,6 +1790,20 @@ const MarketChart = React.memo(forwardRef<MarketChartHandle, MarketChartProps>((
         <div className="chart-tools-right">
           {!isTV && (
             <>
+              {/* Clear annotations — first-class, shown only while agent
+                  annotations are drawn. Clears them from the chart (data stays
+                  in the store; re-open the chat artifact to restore). */}
+              {hasAgentAnnotations && !agentAnnotationsCleared && (
+                <button
+                  type="button"
+                  className="chart-tool-btn chart-clear-annotations-btn"
+                  onClick={handleClearAgentAnnotations}
+                  title="Clear annotations from the chart (kept in chat — click the artifact to restore)"
+                >
+                  <X size={14} />
+                  Clear
+                </button>
+              )}
               {/* Tools dropdown — wide only */}
               <div className="toolbar-dropdown toolbar--wide-only" ref={toolsDropdownRef}>
                 <button

--- a/web/src/pages/MarketView/components/MarketChartSurface.tsx
+++ b/web/src/pages/MarketView/components/MarketChartSurface.tsx
@@ -1,0 +1,167 @@
+/**
+ * A self-contained replica of the MarketView chart surface — the stock header
+ * plus the candlestick / MA / volume / RSI chart — wired with its own
+ * market-data websocket, REST data and annotation sync.
+ *
+ * Drop it anywhere outside the MarketView page (e.g. the chat transcript's
+ * chart-annotation modal) to show the *same* chart the user sees on MarketView,
+ * including the agent's drawn annotations. It mirrors the data wiring of
+ * ``MarketView``'s desktop left panel; it's read-only (no chat capture, no
+ * watchlist), but interval switching and the company-overview panel work in
+ * place. Provide its own ``MarketDataWSProvider`` so it can live on any page.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+
+import StockHeader from './StockHeader';
+import MarketChart from './MarketChart';
+import CompanyOverviewPanel from './CompanyOverviewPanel';
+import { MarketDataWSProvider, useMarketDataWSContext } from '../contexts/MarketDataWSContext';
+import { useStockData } from '../hooks/useStockData';
+import { useChartAnnotationSync } from '../hooks/useChartAnnotationSync';
+import { supports1sInterval } from '../utils/chartConstants';
+
+interface OverviewData {
+  quote?: Record<string, unknown>;
+  earningsSurprises?: unknown;
+  [key: string]: unknown;
+}
+
+interface MarketChartSurfaceProps {
+  symbol: string;
+  /** Initial chart interval (e.g. '1day'); switchable in place via the toolbar. */
+  timeframe?: string;
+  /** Workspace whose agent-drawn annotations to show. */
+  workspaceId?: string | null;
+}
+
+function MarketChartSurfaceInner({
+  symbol,
+  timeframe = '1day',
+  workspaceId,
+}: MarketChartSurfaceProps): React.ReactElement {
+  const {
+    prices: wsPrices,
+    connectionStatus: wsStatus,
+    dataLevel: wsDataLevel,
+    ginlixDataEnabled,
+    subscribe: wsSubscribe,
+    unsubscribe: wsUnsubscribe,
+    setPreviousClose,
+    setDayOpen,
+  } = useMarketDataWSContext();
+
+  const [selectedInterval, setSelectedInterval] = useState<string>(timeframe);
+  const [chartMeta, setChartMeta] = useState<Record<string, unknown> | null>(null);
+  const [showOverview, setShowOverview] = useState(false);
+
+  const {
+    stockInfo,
+    realTimePrice,
+    snapshotData,
+    overviewData,
+    overviewLoading,
+    overlayData,
+    marketStatus,
+    handleLatestBar,
+  } = useStockData({ selectedStock: symbol, wsStatus, setPreviousClose, setDayOpen });
+
+  // Load this symbol's persisted annotations (all timeframes) into the store so
+  // MarketChart renders them — exactly as the live MarketView page does.
+  useChartAnnotationSync(workspaceId ?? null, symbol);
+
+  // Subscribe to the live feed for this symbol.
+  useEffect(() => {
+    if (!symbol) return;
+    wsSubscribe([symbol]);
+    return () => wsUnsubscribe([symbol]);
+  }, [symbol, wsSubscribe, wsUnsubscribe]);
+
+  // Auto-downgrade 1s → 1m when the symbol doesn't support 1s.
+  useEffect(() => {
+    if (selectedInterval === '1s' && !supports1sInterval(symbol)) {
+      setSelectedInterval('1min');
+    }
+  }, [symbol, selectedInterval]);
+
+  const handleIntervalChange = useCallback((interval: string) => {
+    setSelectedInterval(interval);
+  }, []);
+
+  const handleStockMeta = useCallback((meta: unknown) => {
+    setChartMeta(meta as Record<string, unknown> | null);
+  }, []);
+
+  // Prefer the live WS price; fall back to REST (guard against a stale
+  // cross-symbol value when switching tickers).
+  const realTimePriceMatch = realTimePrice?.symbol === symbol ? realTimePrice : null;
+  const displayPrice = wsPrices.get(symbol) || realTimePriceMatch;
+  const quote = (overviewData as OverviewData | null)?.quote || null;
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        minHeight: 0,
+        background: 'var(--color-bg-card)',
+        overflow: 'hidden',
+      }}
+    >
+      <StockHeader
+        symbol={symbol}
+        stockInfo={stockInfo}
+        realTimePrice={displayPrice}
+        chartMeta={chartMeta}
+        displayOverride={null}
+        onToggleOverview={() => setShowOverview((v) => !v)}
+        wsStatus={wsStatus}
+        wsHasData={!!wsPrices.get(symbol)}
+        wsDataLevel={wsDataLevel}
+        ginlixDataEnabled={ginlixDataEnabled}
+        quoteData={quote}
+        marketStatus={marketStatus}
+        snapshot={snapshotData}
+      />
+      <div style={{ position: 'relative', flex: 1, minHeight: 0, display: 'flex' }}>
+        {showOverview && (
+          <CompanyOverviewPanel
+            symbol={symbol}
+            visible={showOverview}
+            onClose={() => setShowOverview(false)}
+            data={overviewData as OverviewData | null}
+            loading={overviewLoading}
+          />
+        )}
+        <MarketChart
+          symbol={symbol}
+          interval={selectedInterval}
+          workspaceId={workspaceId ?? null}
+          onIntervalChange={handleIntervalChange}
+          onStockMeta={handleStockMeta}
+          onLatestBar={handleLatestBar}
+          quoteData={quote}
+          earningsData={(overviewData as OverviewData | null)?.earningsSurprises || null}
+          overlayData={overlayData as Record<string, unknown> | null}
+          stockMeta={chartMeta}
+          snapshot={snapshotData}
+          liveTick={wsPrices.get(symbol)?.barData || null}
+          wsStatus={wsStatus}
+          ginlixDataEnabled={ginlixDataEnabled}
+          marketStatus={marketStatus}
+        />
+      </div>
+    </div>
+  );
+}
+
+export function MarketChartSurface(props: MarketChartSurfaceProps): React.ReactElement {
+  return (
+    <MarketDataWSProvider>
+      <MarketChartSurfaceInner {...props} />
+    </MarketDataWSProvider>
+  );
+}
+
+export default MarketChartSurface;

--- a/web/src/pages/MarketView/components/MarketChatPanel.tsx
+++ b/web/src/pages/MarketView/components/MarketChatPanel.tsx
@@ -509,12 +509,12 @@ function ChatBody(props: ChatBodyProps): React.ReactElement {
   const handleAction = useCallback((cmd: ActionCommandLike) => {
     if (!threadId || threadId === '__default__') return;
 
-    const surfaceActionError = (err: unknown, fallbackKey: string) => {
+    const surfaceActionError = (err: unknown, fallbackKey: string, busyKey = 'chat.compactBusy') => {
       const resp = (err as { response?: { status?: number; data?: unknown } } | undefined)?.response;
       const detail = ((resp?.data ?? undefined) as { detail?: unknown } | undefined)?.detail;
       if (detail && typeof detail === 'object' && !Array.isArray(detail)) {
         const obj = detail as { code?: string; message?: string };
-        if (obj.code === 'workflow_active') { insertNotification(t('chat.compactBusy'), 'warning'); return; }
+        if (obj.code === 'workflow_active') { insertNotification(t(busyKey), 'warning'); return; }
         if (typeof obj.message === 'string' && obj.message.length > 0) { insertNotification(obj.message, 'warning'); return; }
         insertNotification(t(fallbackKey), 'warning');
         return;
@@ -542,7 +542,7 @@ function ChatBody(props: ChatBodyProps): React.ReactElement {
             reads: (data.offloaded_reads as number) || 0,
           }));
         })
-        .catch((err: unknown) => { surfaceActionError(err, 'chat.compactionError'); setIsCompacting?.(false); });
+        .catch((err: unknown) => { surfaceActionError(err, 'chat.compactionError', 'chat.offloadBusy'); setIsCompacting?.(false); });
     }
   }, [threadId, setIsCompacting, insertNotification, t]);
 

--- a/web/src/pages/MarketView/components/MarketChatPanel.tsx
+++ b/web/src/pages/MarketView/components/MarketChatPanel.tsx
@@ -294,7 +294,11 @@ function ChatBody(props: ChatBodyProps): React.ReactElement {
     () => ({
       chartPresent: true,
       activeSymbol: symbol ? symbol.toUpperCase() : undefined,
-      activeTimeframe: normalizeTimeframe(interval),
+      // Raw interval, not normalized: the chip compares this against an
+      // annotation's timeframe to decide "shown vs jump". A view-only interval
+      // like 1s (which collapses to 1day) must NOT read as active for a 1day
+      // annotation that the 1s chart can't actually display.
+      activeTimeframe: interval,
       onJumpToChart,
     }),
     [symbol, interval, onJumpToChart],

--- a/web/src/pages/MarketView/components/MarketChatPanel.tsx
+++ b/web/src/pages/MarketView/components/MarketChatPanel.tsx
@@ -1,19 +1,19 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { ArrowLeft, RefreshCw } from 'lucide-react';
+import { ArrowLeft, RefreshCw, MessageSquare, Loader2, ScrollText } from 'lucide-react';
 import { queryKeys } from '@/lib/queryKeys';
 import { ErrorBanner } from '@/components/ui/error-banner';
 import LogoLoading from '@/components/ui/logo-loading';
-import ChatInput from '@/components/ui/chat-input';
+import ChatInput, { type ChatInputHandle } from '@/components/ui/chat-input';
 import { useNarrowContainer } from '@/hooks/useNarrowContainer';
 import MessageList from '../../ChatAgent/components/MessageList';
 import { SubagentTelemetryContext } from '../../ChatAgent/components/SubagentTelemetryContext';
-import { ChartSurfaceContext } from '../../ChatAgent/contexts/ChartSurfaceContext';
+import { ChartSurfaceContext, type ChartSurface } from '../../ChatAgent/contexts/ChartSurfaceContext';
 import { WorkspaceProvider } from '../../ChatAgent/contexts/WorkspaceContext';
 import { useChatMessages } from '../../ChatAgent/hooks/useChatMessages';
-import { getFlashWorkspace } from '../../ChatAgent/utils/api';
+import { getFlashWorkspace, getPreviewUrl, summarizeThread, offloadThread } from '../../ChatAgent/utils/api';
 import { attachmentsToContexts } from '../../ChatAgent/utils/fileUpload';
 import {
   resolveSubagentTelemetry as resolveSubagentTelemetryPure,
@@ -25,11 +25,50 @@ import MarketChatHistoryButton from './MarketChatHistoryButton';
 import MarketDetailDialog, { type DialogPayload } from './MarketDetailDialog';
 import { getMarketThreadId, setMarketThreadId, clearMarketThreadId } from '../utils/threadPersistence';
 import { normalizeTimeframe } from '../stores/chartAnnotationStore';
+import { marketViewAnnotationContext } from '../constants/annotationPrompt';
 import './MarketPanel.css';
 
-// MarketView always has the live chart beside the chat, so inline
-// chart-annotation previews collapse to a confirmation chip here.
-const CHART_PRESENT = { chartPresent: true } as const;
+/** Compact status banner shown above the input (interrupt, compaction, etc.). */
+function bannerStyle(background: string): React.CSSProperties {
+  return {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    padding: '6px 10px',
+    borderRadius: 6,
+    background,
+    color: 'var(--color-text-tertiary)',
+    fontSize: 12,
+  };
+}
+
+/** Append a URL path suffix (e.g. "/report.html") to a resolved signed URL. */
+function appendPathSuffix(baseUrl: string, path?: string): string {
+  if (!path) return baseUrl;
+  try {
+    const parsed = new URL(baseUrl);
+    parsed.pathname = parsed.pathname.replace(/\/+$/, '') + path;
+    return parsed.toString();
+  } catch {
+    return baseUrl;
+  }
+}
+
+/** Slash-command shapes emitted by ChatInput (skill/subagent pills, action verbs). */
+interface SlashCommandLike {
+  type: string;
+  name: string;
+  skillName?: string;
+}
+interface ActionCommandLike {
+  name: string;
+  type?: string;
+}
+interface ModelOptionsLike {
+  model?: string | null;
+  reasoningEffort?: string | null;
+  fastMode?: boolean | null;
+}
 
 interface Workspace {
   workspace_id: string;
@@ -67,6 +106,8 @@ interface MarketChatPanelProps {
   placeholder?: string;
   /** When set (navigated from chat context), shows a "Return to Chat" chip in the header. */
   onReturnToChat?: () => void;
+  /** Switch the live chart to a symbol+timeframe (so a chip can jump to it). */
+  onJumpToChart?: (symbol: string, timeframe: string) => void;
 }
 
 /**
@@ -215,6 +256,7 @@ function ChatBody(props: ChatBodyProps): React.ReactElement {
     onNavigateSubagent,
     placeholder,
     onReturnToChat,
+    onJumpToChart,
     activeWorkspaceId,
     initialThreadId,
     onSelectThread,
@@ -222,9 +264,17 @@ function ChatBody(props: ChatBodyProps): React.ReactElement {
   } = props;
 
   const { t } = useTranslation();
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [, setSearchParams] = useSearchParams();
   const [dialogPayload, setDialogPayload] = useState<DialogPayload | null>(null);
+  // Port of the preview currently shown — guards against a late URL resolution
+  // reopening a dialog the user already closed (or switched away from).
+  const previewPortRef = useRef<number | null>(null);
+  // ChatInput handle — lets edit/regenerate/retry read the current model picker.
+  const chatInputRef = useRef<ChatInputHandle>(null);
+  // Set when the user stops a running turn, so the input placeholder reflects it.
+  const [wasStopped, setWasStopped] = useState(false);
 
   const messagesContainerRef = useRef<HTMLDivElement | null>(null);
   const isNarrowChat = useNarrowContainer(messagesContainerRef, 640);
@@ -236,8 +286,47 @@ function ChatBody(props: ChatBodyProps): React.ReactElement {
 
   const agentMode = mode === 'fast' ? 'flash' : 'ptc';
 
+  // MarketView always has the live chart beside the chat, so inline
+  // chart-annotation previews collapse to a confirmation chip. Tell the chip
+  // which instance is on screen + how to switch the chart, so a chip for a
+  // different ticker/timeframe can jump the chart to it.
+  const chartSurface = useMemo<ChartSurface>(
+    () => ({
+      chartPresent: true,
+      activeSymbol: symbol ? symbol.toUpperCase() : undefined,
+      activeTimeframe: normalizeTimeframe(interval),
+      onJumpToChart,
+    }),
+    [symbol, interval, onJumpToChart],
+  );
+
+  // Open the served-HTML preview. The SSE artifact carries only a port, so —
+  // like ChatView — open immediately in a loading state, then resolve the
+  // authenticated signed URL and swap it in (otherwise the viewer is blank).
   const handlePreview = useCallback((preview: PreviewData) => {
-    setDialogPayload({ type: 'preview', preview });
+    previewPortRef.current = preview.port;
+    setDialogPayload({ type: 'preview', preview: { ...preview, loading: true } });
+
+    if (preview.url || !activeWorkspaceId) return;
+
+    getPreviewUrl(activeWorkspaceId, preview.port, preview.command)
+      .then((result: { url: string }) => {
+        if (previewPortRef.current !== preview.port) return; // closed / superseded
+        const url = appendPathSuffix(result.url, preview.path);
+        setDialogPayload({ type: 'preview', preview: { ...preview, url, loading: false } });
+      })
+      .catch(() => {
+        if (previewPortRef.current !== preview.port) return;
+        setDialogPayload({
+          type: 'preview',
+          preview: { ...preview, url: '', loading: false, error: true },
+        });
+      });
+  }, [activeWorkspaceId]);
+
+  const handleCloseDialog = useCallback(() => {
+    previewPortRef.current = null;
+    setDialogPayload(null);
   }, []);
 
   // Origin tag — symbol uppercased so AAPL/aapl collapse. Validated server-side
@@ -273,7 +362,40 @@ function ChatBody(props: ChatBodyProps): React.ReactElement {
     threadModels,
     lastThreadModel,
     handleSendMessage,
+    stopWorkflow,
     getSubagentHistory,
+    // HITL handlers — plan approval, ask-user questions, workspace/PTC/secretary
+    // proposals. Without these wired into MessageList the cards render but their
+    // Accept/Decline buttons are dead.
+    handleApproveInterrupt,
+    handleRejectInterrupt,
+    handleAnswerQuestion,
+    handleSkipQuestion,
+    handleApproveCreateWorkspace,
+    handleRejectCreateWorkspace,
+    handleApproveStartQuestion,
+    handleRejectStartQuestion,
+    handleApprovePTCAgent,
+    handleRejectPTCAgent,
+    handleApproveSecretaryAction,
+    handleRejectSecretaryAction,
+    // Turn/context state — drives the stop button, input gating, and the
+    // interrupted / plan-feedback / compaction status banners.
+    pendingInterrupt,
+    pendingRejection,
+    hasActiveSubagents,
+    workspaceStarting,
+    isCompacting,
+    setIsCompacting,
+    tokenUsage,
+    insertNotification,
+    // Message-level actions — edit, regenerate, retry, and feedback thumbs.
+    handleEditMessage,
+    handleRegenerate,
+    handleRetry,
+    handleThumbUp,
+    handleThumbDown,
+    getFeedbackForMessage,
   } = chat;
 
   // Subagent telemetry resolver — feeds ActivityBlock's live token counts.
@@ -304,8 +426,8 @@ function ChatBody(props: ChatBodyProps): React.ReactElement {
       message: string,
       planMode: boolean,
       attachments: AttachmentItem[] = [],
-      _slashCommands: unknown[] = [],
-      modelOptions: { model?: string | null; reasoningEffort?: string | null; fastMode?: boolean | null } = {},
+      slashCommands: SlashCommandLike[] = [],
+      modelOptions: ModelOptionsLike = {},
     ) => {
       // Always activate the chart-annotation skill so the agent can draw on
       // the live chart from turn 1, and tell it which ticker + timeframe "the
@@ -317,11 +439,20 @@ function ChatBody(props: ChatBodyProps): React.ReactElement {
         {
           type: 'skills',
           name: 'chart-annotation',
-          instruction: sym
-            ? `The user is viewing the ${sym} chart on the ${tf} timeframe in MarketView. When they ask to annotate or draw on "the chart", pass symbol="${sym}" and timeframe="${tf}" unless they name another ticker or interval.`
-            : undefined,
+          instruction: sym ? marketViewAnnotationContext(sym, tf) : undefined,
         },
       ];
+
+      // Skill contexts from typed slash commands (mirrors ChatView). Skip a
+      // second chart-annotation context — it's always injected above.
+      for (const cmd of slashCommands) {
+        if (cmd.type === 'skill' && cmd.skillName && cmd.skillName !== 'chart-annotation') {
+          contexts.push({ type: 'skills', name: cmd.skillName });
+        } else if (cmd.type === 'subagent') {
+          contexts.push({ type: 'directive', content: 'User wishes you to complete this task using subagents.' });
+        }
+      }
+
       const metaItems: Record<string, unknown>[] = [];
 
       if (chartImage) {
@@ -355,6 +486,61 @@ function ChatBody(props: ChatBodyProps): React.ReactElement {
     },
     [symbol, interval, chartImage, chartImageDesc, handleSendMessage, onClearChartImage],
   );
+
+  // Stop the running turn (the input's Stop button). Mirrors ChatView: the hook's
+  // stopWorkflow aborts the stream reader, finalizes the open message with a
+  // "Stopped" chip, and hard-cancels the backend run; we flip the stopped marker.
+  const handleStop = useCallback(() => {
+    setWasStopped(true);
+    void stopWorkflow();
+  }, [stopWorkflow]);
+
+  // Clear the stopped marker once a new turn starts.
+  useEffect(() => {
+    if (isLoading) setWasStopped(false);
+  }, [isLoading]);
+
+  // Action slash commands (/compact, /offload). Mirrors ChatView's handler so
+  // the input's action verbs do the same thing here.
+  const handleAction = useCallback((cmd: ActionCommandLike) => {
+    if (!threadId || threadId === '__default__') return;
+
+    const surfaceActionError = (err: unknown, fallbackKey: string) => {
+      const resp = (err as { response?: { status?: number; data?: unknown } } | undefined)?.response;
+      const detail = ((resp?.data ?? undefined) as { detail?: unknown } | undefined)?.detail;
+      if (detail && typeof detail === 'object' && !Array.isArray(detail)) {
+        const obj = detail as { code?: string; message?: string };
+        if (obj.code === 'workflow_active') { insertNotification(t('chat.compactBusy'), 'warning'); return; }
+        if (typeof obj.message === 'string' && obj.message.length > 0) { insertNotification(obj.message, 'warning'); return; }
+        insertNotification(t(fallbackKey), 'warning');
+        return;
+      }
+      if (typeof detail === 'string' && detail.length > 0) { insertNotification(detail, 'warning'); return; }
+      insertNotification(t(fallbackKey), 'warning');
+    };
+
+    if (cmd.name === 'compact') {
+      setIsCompacting?.('summarize');
+      summarizeThread(threadId)
+        .then((data: Record<string, unknown>) => {
+          setIsCompacting?.(false);
+          const detail = (data.summary_text as string | undefined) || undefined;
+          insertNotification(t('chat.compactedNotification', { from: data.original_message_count }), 'info', detail);
+        })
+        .catch((err: unknown) => { surfaceActionError(err, 'chat.compactionError'); setIsCompacting?.(false); });
+    } else if (cmd.name === 'offload') {
+      setIsCompacting?.('offload');
+      offloadThread(threadId)
+        .then((data: Record<string, unknown>) => {
+          setIsCompacting?.(false);
+          insertNotification(t('chat.offloadedNotification', {
+            args: (data.offloaded_args as number) || 0,
+            reads: (data.offloaded_reads as number) || 0,
+          }));
+        })
+        .catch((err: unknown) => { surfaceActionError(err, 'chat.compactionError'); setIsCompacting?.(false); });
+    }
+  }, [threadId, setIsCompacting, insertNotification, t]);
 
   // Track whether the user is currently parked near the bottom of the
   // message list. Auto-scroll only fires while this is true, so a user
@@ -396,7 +582,47 @@ function ChatBody(props: ChatBodyProps): React.ReactElement {
 
   const initialModel = lastThreadModel ?? null;
 
+  // In fast mode, carry the source thread/workspace into a PTC-agent proposal so
+  // its "open in chat" deep-link lands back here. Null in PTC mode.
+  const flashContext = agentMode === 'flash' && threadId && threadId !== '__default__'
+    ? { threadId, workspaceId: activeWorkspaceId }
+    : null;
+
   const showQuickQueries = messages.length === 0 && !isLoading && !isLoadingHistory;
+
+  // Continue the current conversation in the full ChatView page. `/chat/t/:id`
+  // resolves the thread's workspace on its own; we also pass it via state to
+  // skip the lookup. Available once a real thread exists.
+  const canOpenInChat = !!threadId && threadId !== '__default__';
+  const handleOpenInChat = useCallback(() => {
+    if (!threadId || threadId === '__default__') return;
+    navigate(`/chat/t/${threadId}`, { state: { workspaceId: activeWorkspaceId } });
+  }, [navigate, threadId, activeWorkspaceId]);
+
+  // Shared styling for the header's right-hand action chip.
+  const headerBtnStyle: React.CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 5,
+    flexShrink: 0,
+    padding: '4px 10px',
+    background: 'var(--color-accent-soft)',
+    border: '1px solid var(--color-accent-overlay)',
+    borderRadius: 8,
+    color: 'var(--color-accent-light)',
+    fontSize: 12,
+    fontWeight: 500,
+    cursor: 'pointer',
+    transition: 'background 0.15s, border-color 0.15s',
+  };
+  const headerBtnHover = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.currentTarget.style.background = 'var(--color-accent-overlay)';
+    e.currentTarget.style.borderColor = 'var(--color-accent-primary)';
+  };
+  const headerBtnLeave = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.currentTarget.style.background = 'var(--color-accent-soft)';
+    e.currentTarget.style.borderColor = 'var(--color-accent-overlay)';
+  };
 
   // Session title: first user message text (truncated) or fallback to "New chat".
   const newChatLabel = t('marketView.chatHistory.newChat');
@@ -434,38 +660,30 @@ function ChatBody(props: ChatBodyProps): React.ReactElement {
           onSelectThread={onSelectThread}
           onStartNewChat={onStartNewChat}
         />
-        {onReturnToChat && (
+        {canOpenInChat ? (
+          <button
+            type="button"
+            onClick={handleOpenInChat}
+            title={t('marketView.chatPanel.openInChat')}
+            style={headerBtnStyle}
+            onMouseEnter={headerBtnHover}
+            onMouseLeave={headerBtnLeave}
+          >
+            <MessageSquare style={{ width: 13, height: 13 }} />
+            {t('marketView.chatPanel.openInChat')}
+          </button>
+        ) : onReturnToChat ? (
           <button
             type="button"
             onClick={onReturnToChat}
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 5,
-              flexShrink: 0,
-              padding: '4px 10px',
-              background: 'var(--color-accent-soft)',
-              border: '1px solid var(--color-accent-overlay)',
-              borderRadius: 8,
-              color: 'var(--color-accent-light)',
-              fontSize: 12,
-              fontWeight: 500,
-              cursor: 'pointer',
-              transition: 'background 0.15s, border-color 0.15s',
-            }}
-            onMouseEnter={(e: React.MouseEvent<HTMLButtonElement>) => {
-              e.currentTarget.style.background = 'var(--color-accent-overlay)';
-              e.currentTarget.style.borderColor = 'var(--color-accent-primary)';
-            }}
-            onMouseLeave={(e: React.MouseEvent<HTMLButtonElement>) => {
-              e.currentTarget.style.background = 'var(--color-accent-soft)';
-              e.currentTarget.style.borderColor = 'var(--color-accent-overlay)';
-            }}
+            style={headerBtnStyle}
+            onMouseEnter={headerBtnHover}
+            onMouseLeave={headerBtnLeave}
           >
             <ArrowLeft style={{ width: 13, height: 13 }} />
             {t('marketView.chatPanel.returnToChat')}
           </button>
-        )}
+        ) : null}
       </div>
 
       {/* Messages */}
@@ -487,7 +705,7 @@ function ChatBody(props: ChatBodyProps): React.ReactElement {
           </div>
         ) : (
           <div style={{ padding: '16px 24px', maxWidth: '100%' }}>
-            <ChartSurfaceContext.Provider value={CHART_PRESENT}>
+            <ChartSurfaceContext.Provider value={chartSurface}>
               <SubagentTelemetryContext.Provider value={resolveSubagentTelemetry}>
                 <MessageList
                   messages={messages as never[]}
@@ -496,6 +714,29 @@ function ChatBody(props: ChatBodyProps): React.ReactElement {
                   hideAvatar={isNarrowChat}
                   onOpenSubagentTask={handleOpenSubagentTask}
                   onToolCallDetailClick={handleToolCallDetailClick}
+                  onApprovePlan={handleApproveInterrupt}
+                  onRejectPlan={handleRejectInterrupt}
+                  onAnswerQuestion={handleAnswerQuestion}
+                  onSkipQuestion={handleSkipQuestion}
+                  onApproveCreateWorkspace={handleApproveCreateWorkspace}
+                  onRejectCreateWorkspace={handleRejectCreateWorkspace}
+                  onApproveStartQuestion={handleApproveStartQuestion}
+                  onRejectStartQuestion={handleRejectStartQuestion}
+                  onApprovePTCAgent={handleApprovePTCAgent}
+                  onRejectPTCAgent={handleRejectPTCAgent}
+                  onApproveSecretaryAction={handleApproveSecretaryAction}
+                  onRejectSecretaryAction={handleRejectSecretaryAction}
+                  onEditMessage={(id: string, content: string) =>
+                    handleEditMessage(id, content, chatInputRef.current?.getModelOptions?.())}
+                  onRegenerate={(id: string) =>
+                    handleRegenerate(id, chatInputRef.current?.getModelOptions?.())}
+                  onRetry={() => handleRetry(chatInputRef.current?.getModelOptions?.())}
+                  onThumbUp={handleThumbUp}
+                  onThumbDown={handleThumbDown}
+                  getFeedbackForMessage={getFeedbackForMessage}
+                  onReportWithAgent={(instruction: string) =>
+                    handleSendMessage(`/self-improve ${instruction}`, false, null, null, {})}
+                  flashContext={flashContext}
                   onWidgetSendPrompt={(text: string) => handleSendMessage(text, false, null, null, {})}
                 />
               </SubagentTelemetryContext.Provider>
@@ -527,9 +768,51 @@ function ChatBody(props: ChatBodyProps): React.ReactElement {
         </div>
       )}
 
+      {/* Status banners — feedback for plan-rejection, interrupt, background
+          subagents, workspace warming, and context compaction. Mirrors the
+          indicators ChatView shows above its input. */}
+      {(pendingRejection
+        || (hasActiveSubagents && !isLoading)
+        || workspaceStarting
+        || isCompacting) && (
+        <div style={{ padding: '0 12px', display: 'flex', flexDirection: 'column', gap: 6 }}>
+          {pendingRejection && (
+            <div style={bannerStyle('var(--color-accent-soft)')}>
+              <ScrollText style={{ width: 14, height: 14, flexShrink: 0, color: 'var(--color-accent-primary)' }} />
+              <span>{t('chat.planFeedbackHint')}</span>
+            </div>
+          )}
+          {hasActiveSubagents && !isLoading && (
+            <div style={bannerStyle('transparent')}>
+              <span style={{ position: 'relative', display: 'flex', height: 8, width: 8 }}>
+                <span style={{ position: 'absolute', display: 'inline-flex', height: '100%', width: '100%', borderRadius: '9999px', background: 'var(--color-accent-primary)', opacity: 0.6 }} className="animate-ping motion-reduce:animate-none" />
+                <span style={{ position: 'relative', display: 'inline-flex', borderRadius: '9999px', height: 8, width: 8, background: 'var(--color-accent-primary)' }} />
+              </span>
+              <span>{t('chat.backgroundTasksRunning')}</span>
+            </div>
+          )}
+          {workspaceStarting && (
+            <div style={bannerStyle('transparent')}>
+              <Loader2 style={{ width: 14, height: 14, flexShrink: 0, color: 'var(--color-accent-primary)' }} className="animate-spin" />
+              <span>{t(workspaceStarting === 'archived' ? 'chat.workspaceRestoring' : 'chat.workspaceStarting')}</span>
+            </div>
+          )}
+          {isCompacting && (
+            <div style={bannerStyle('transparent')}>
+              <Loader2 style={{ width: 14, height: 14, flexShrink: 0, color: 'var(--color-accent-primary)' }} className="animate-spin" />
+              <span>{t(isCompacting === 'offload' ? 'chat.offloading' : 'chat.compacting')}</span>
+            </div>
+          )}
+        </div>
+      )}
+
       {/* Input */}
       <ChatInput
+        ref={chatInputRef}
         onSend={handleSend as never}
+        disabled={isLoadingHistory || !!pendingInterrupt}
+        onStop={handleStop}
+        onAction={handleAction}
         isLoading={isLoading}
         mode={mode}
         onModeChange={onModeChange}
@@ -542,12 +825,17 @@ function ChatBody(props: ChatBodyProps): React.ReactElement {
         onRemoveChartImage={onClearChartImage}
         prefillMessage={prefillMessage}
         onClearPrefill={onClearPrefill}
-        placeholder={placeholder ?? t('marketView.chatPanel.defaultPlaceholder')}
+        placeholder={
+          wasStopped && !isLoading && !pendingInterrupt && !pendingRejection
+            ? t('chat.placeholderStopped')
+            : (placeholder ?? t('marketView.chatPanel.defaultPlaceholder'))
+        }
         initialModel={initialModel}
         threadModels={threadModels}
+        tokenUsage={tokenUsage}
       />
 
-      <MarketDetailDialog payload={dialogPayload} onClose={() => setDialogPayload(null)} />
+      <MarketDetailDialog payload={dialogPayload} onClose={handleCloseDialog} />
     </div>
   );
 }

--- a/web/src/pages/MarketView/components/MarketChatPanel.tsx
+++ b/web/src/pages/MarketView/components/MarketChatPanel.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useSearchParams } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { RefreshCw } from 'lucide-react';
+import { ArrowLeft, RefreshCw } from 'lucide-react';
 import { queryKeys } from '@/lib/queryKeys';
 import { ErrorBanner } from '@/components/ui/error-banner';
 import LogoLoading from '@/components/ui/logo-loading';
@@ -10,6 +10,7 @@ import ChatInput from '@/components/ui/chat-input';
 import { useNarrowContainer } from '@/hooks/useNarrowContainer';
 import MessageList from '../../ChatAgent/components/MessageList';
 import { SubagentTelemetryContext } from '../../ChatAgent/components/SubagentTelemetryContext';
+import { ChartSurfaceContext } from '../../ChatAgent/contexts/ChartSurfaceContext';
 import { WorkspaceProvider } from '../../ChatAgent/contexts/WorkspaceContext';
 import { useChatMessages } from '../../ChatAgent/hooks/useChatMessages';
 import { getFlashWorkspace } from '../../ChatAgent/utils/api';
@@ -23,7 +24,12 @@ import type { PreviewData } from '../../ChatAgent/hooks/utils/types';
 import MarketChatHistoryButton from './MarketChatHistoryButton';
 import MarketDetailDialog, { type DialogPayload } from './MarketDetailDialog';
 import { getMarketThreadId, setMarketThreadId, clearMarketThreadId } from '../utils/threadPersistence';
+import { normalizeTimeframe } from '../stores/chartAnnotationStore';
 import './MarketPanel.css';
+
+// MarketView always has the live chart beside the chat, so inline
+// chart-annotation previews collapse to a confirmation chip here.
+const CHART_PRESENT = { chartPresent: true } as const;
 
 interface Workspace {
   workspace_id: string;
@@ -41,6 +47,8 @@ interface AttachmentItem {
 
 interface MarketChatPanelProps {
   symbol: string;
+  /** Current chart interval — tells the agent which timeframe to annotate. */
+  interval: string;
   mode: 'fast' | 'ptc';
   onModeChange: (mode: 'fast' | 'ptc') => void;
   workspaces: Workspace[];
@@ -57,6 +65,8 @@ interface MarketChatPanelProps {
   onShuffleQueries: () => void;
   onNavigateSubagent?: (threadId: string, taskId: string) => void;
   placeholder?: string;
+  /** When set (navigated from chat context), shows a "Return to Chat" chip in the header. */
+  onReturnToChat?: () => void;
 }
 
 /**
@@ -187,6 +197,7 @@ interface ChatBodyProps extends MarketChatPanelProps {
 function ChatBody(props: ChatBodyProps): React.ReactElement {
   const {
     symbol,
+    interval,
     mode,
     onModeChange,
     ptcWorkspaces,
@@ -203,6 +214,7 @@ function ChatBody(props: ChatBodyProps): React.ReactElement {
     onShuffleQueries,
     onNavigateSubagent,
     placeholder,
+    onReturnToChat,
     activeWorkspaceId,
     initialThreadId,
     onSelectThread,
@@ -295,7 +307,21 @@ function ChatBody(props: ChatBodyProps): React.ReactElement {
       _slashCommands: unknown[] = [],
       modelOptions: { model?: string | null; reasoningEffort?: string | null; fastMode?: boolean | null } = {},
     ) => {
-      const contexts: Record<string, unknown>[] = [];
+      // Always activate the chart-annotation skill so the agent can draw on
+      // the live chart from turn 1, and tell it which ticker + timeframe "the
+      // chart" is (chart_id = SYMBOL:timeframe — drawing on the wrong timeframe
+      // won't show on the view the user is looking at).
+      const sym = symbol ? symbol.toUpperCase() : '';
+      const tf = normalizeTimeframe(interval);
+      const contexts: Record<string, unknown>[] = [
+        {
+          type: 'skills',
+          name: 'chart-annotation',
+          instruction: sym
+            ? `The user is viewing the ${sym} chart on the ${tf} timeframe in MarketView. When they ask to annotate or draw on "the chart", pass symbol="${sym}" and timeframe="${tf}" unless they name another ticker or interval.`
+            : undefined,
+        },
+      ];
       const metaItems: Record<string, unknown>[] = [];
 
       if (chartImage) {
@@ -327,7 +353,7 @@ function ChatBody(props: ChatBodyProps): React.ReactElement {
       handleSendMessage(message, planMode, additionalContext, attachmentMeta, modelOptions);
       onClearChartImage();
     },
-    [chartImage, chartImageDesc, handleSendMessage, onClearChartImage],
+    [symbol, interval, chartImage, chartImageDesc, handleSendMessage, onClearChartImage],
   );
 
   // Track whether the user is currently parked near the bottom of the
@@ -387,12 +413,15 @@ function ChatBody(props: ChatBodyProps): React.ReactElement {
 
   return (
     <div className="market-panel">
-      {/* Header — session title (left) doubles as history dropdown trigger */}
+      {/* Header — session title (left) doubles as history dropdown trigger.
+          When navigated from chat, a compact "Return to Chat" chip sits at the
+          right so it never overlaps the message input. */}
       <div
         style={{
           display: 'flex',
           alignItems: 'center',
-          justifyContent: 'flex-start',
+          justifyContent: 'space-between',
+          gap: 8,
           padding: '6px 12px',
           borderBottom: '1px solid var(--color-border-muted)',
           flexShrink: 0,
@@ -405,6 +434,38 @@ function ChatBody(props: ChatBodyProps): React.ReactElement {
           onSelectThread={onSelectThread}
           onStartNewChat={onStartNewChat}
         />
+        {onReturnToChat && (
+          <button
+            type="button"
+            onClick={onReturnToChat}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 5,
+              flexShrink: 0,
+              padding: '4px 10px',
+              background: 'var(--color-accent-soft)',
+              border: '1px solid var(--color-accent-overlay)',
+              borderRadius: 8,
+              color: 'var(--color-accent-light)',
+              fontSize: 12,
+              fontWeight: 500,
+              cursor: 'pointer',
+              transition: 'background 0.15s, border-color 0.15s',
+            }}
+            onMouseEnter={(e: React.MouseEvent<HTMLButtonElement>) => {
+              e.currentTarget.style.background = 'var(--color-accent-overlay)';
+              e.currentTarget.style.borderColor = 'var(--color-accent-primary)';
+            }}
+            onMouseLeave={(e: React.MouseEvent<HTMLButtonElement>) => {
+              e.currentTarget.style.background = 'var(--color-accent-soft)';
+              e.currentTarget.style.borderColor = 'var(--color-accent-overlay)';
+            }}
+          >
+            <ArrowLeft style={{ width: 13, height: 13 }} />
+            {t('marketView.chatPanel.returnToChat')}
+          </button>
+        )}
       </div>
 
       {/* Messages */}
@@ -426,17 +487,19 @@ function ChatBody(props: ChatBodyProps): React.ReactElement {
           </div>
         ) : (
           <div style={{ padding: '16px 24px', maxWidth: '100%' }}>
-            <SubagentTelemetryContext.Provider value={resolveSubagentTelemetry}>
-              <MessageList
-                messages={messages as never[]}
-                isLoading={isLoading}
-                isLoadingHistory={isLoadingHistory}
-                hideAvatar={isNarrowChat}
-                onOpenSubagentTask={handleOpenSubagentTask}
-                onToolCallDetailClick={handleToolCallDetailClick}
-                onWidgetSendPrompt={(text: string) => handleSendMessage(text, false, null, null, {})}
-              />
-            </SubagentTelemetryContext.Provider>
+            <ChartSurfaceContext.Provider value={CHART_PRESENT}>
+              <SubagentTelemetryContext.Provider value={resolveSubagentTelemetry}>
+                <MessageList
+                  messages={messages as never[]}
+                  isLoading={isLoading}
+                  isLoadingHistory={isLoadingHistory}
+                  hideAvatar={isNarrowChat}
+                  onOpenSubagentTask={handleOpenSubagentTask}
+                  onToolCallDetailClick={handleToolCallDetailClick}
+                  onWidgetSendPrompt={(text: string) => handleSendMessage(text, false, null, null, {})}
+                />
+              </SubagentTelemetryContext.Provider>
+            </ChartSurfaceContext.Provider>
             {messageError && (
               <div style={{ margin: '8px 0' }}>
                 <ErrorBanner error={messageError} />

--- a/web/src/pages/MarketView/components/__tests__/AgentEventOverlay.test.tsx
+++ b/web/src/pages/MarketView/components/__tests__/AgentEventOverlay.test.tsx
@@ -130,4 +130,26 @@ describe('AgentEventOverlay', () => {
     await flushFrame();
     expect(screen.queryByText('Q3 earnings beat')).not.toBeInTheDocument();
   });
+
+  it('applies a valid agent color but rejects a url() value (no CSS exfil channel)', async () => {
+    // A real color is applied to the badge dot via the backgroundColor longhand.
+    chartAnnotationStore.setAll('ws', 'NVDA:1day', [{ ...EVENT, color: '#22c55e' }]);
+    const okRender = renderOverlay();
+    await flushFrame();
+    const okDot = okRender.container.querySelector('.agent-event-badge-dot') as HTMLElement;
+    expect(okDot.style.backgroundColor).not.toBe('');
+    okRender.unmount();
+
+    // A url() value would have triggered a network fetch through the `background`
+    // shorthand. The backgroundColor longhand rejects it, so nothing is applied.
+    chartAnnotationStore._resetForTesting();
+    chartAnnotationStore.setAll('ws', 'NVDA:1day', [
+      { ...EVENT, color: 'url(//evil.example/beacon.gif)' },
+    ]);
+    const evilRender = renderOverlay();
+    await flushFrame();
+    const evilDot = evilRender.container.querySelector('.agent-event-badge-dot') as HTMLElement;
+    expect(evilDot.style.backgroundColor).toBe('');
+    expect(evilDot.getAttribute('style') ?? '').not.toContain('url(');
+  });
 });

--- a/web/src/pages/MarketView/components/__tests__/AgentEventOverlay.test.tsx
+++ b/web/src/pages/MarketView/components/__tests__/AgentEventOverlay.test.tsx
@@ -85,6 +85,16 @@ describe('AgentEventOverlay', () => {
     expect(screen.queryByText(/Beat EPS by/)).not.toBeInTheDocument();
   });
 
+  it('exposes the .agent-event-badge hook the coarse-pointer hit-area CSS targets', async () => {
+    // The >=44px touch target is implemented as a `@media (pointer: coarse)`
+    // `::before` overlay on `.agent-event-badge` (jsdom can't evaluate media
+    // queries or pseudo-elements, so we pin the class hook the CSS relies on).
+    renderOverlay();
+    await flushFrame();
+    const badge = screen.getByText('Q3 earnings beat').closest('button');
+    expect(badge).toHaveClass('agent-event-badge');
+  });
+
   it('reveals the detail on click (tap path)', async () => {
     renderOverlay();
     await flushFrame();
@@ -108,10 +118,10 @@ describe('AgentEventOverlay', () => {
     expect(screen.getByText('Q3 earnings beat')).toBeInTheDocument();
     timeScale.timeToCoordinate.mockReturnValue(null as unknown as number);
     // Force a reposition by invoking the visible-range subscription callback.
+    // Repositioning is coalesced into a single rAF, so flush a frame after.
     const cb = timeScale.subscribeVisibleLogicalRangeChange.mock.calls[0]?.[0];
-    await act(async () => {
-      cb?.();
-    });
+    cb?.();
+    await flushFrame();
     expect(screen.queryByText('Q3 earnings beat')).not.toBeInTheDocument();
   });
 

--- a/web/src/pages/MarketView/components/__tests__/AgentEventOverlay.test.tsx
+++ b/web/src/pages/MarketView/components/__tests__/AgentEventOverlay.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRef } from 'react';
+import type { IChartApi, ISeriesApi } from 'lightweight-charts';
+
+import { chartAnnotationStore } from '../../stores/chartAnnotationStore';
+import type { StoredAnnotation } from '../../stores/chartAnnotationStore';
+import type { ChartDataPoint } from '@/types/market';
+import { AgentEventOverlay } from '../AgentEventOverlay';
+
+const T = (iso: string): number => Math.floor(Date.parse(iso) / 1000);
+
+/** Flush the overlay's requestAnimationFrame placement inside act(). */
+const flushFrame = (): Promise<void> =>
+  act(async () => {
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+  });
+
+const CHART: ChartDataPoint[] = [
+  { time: T('2024-11-14T00:00:00Z'), open: 110, high: 115, low: 108, close: 112, volume: 1 },
+];
+
+const EVENT: StoredAnnotation = {
+  annotation_id: 'e1',
+  symbol: 'NVDA',
+  type: 'event',
+  time: '2024-11-14T00:00:00Z',
+  price: 112,
+  title: 'Q3 earnings beat',
+  detail: 'Beat EPS by $0.15 and raised full-year guidance ~5%.',
+};
+
+/** A chart/series stub whose coordinate calls return fixed pixels. */
+function makeRefs() {
+  const timeScale = {
+    timeToCoordinate: vi.fn(() => 120),
+    subscribeVisibleLogicalRangeChange: vi.fn(),
+    unsubscribeVisibleLogicalRangeChange: vi.fn(),
+  };
+  const chart = { timeScale: vi.fn(() => timeScale) } as unknown as IChartApi;
+  const series = { priceToCoordinate: vi.fn(() => 90) } as unknown as ISeriesApi<'Candlestick'>;
+  const chartRef = createRef<IChartApi | null>() as { current: IChartApi | null };
+  const seriesRef = createRef<ISeriesApi<'Candlestick'> | null>() as {
+    current: ISeriesApi<'Candlestick'> | null;
+  };
+  chartRef.current = chart;
+  seriesRef.current = series;
+  return { chartRef, seriesRef, timeScale };
+}
+
+function renderOverlay(over: Partial<Parameters<typeof AgentEventOverlay>[0]> = {}) {
+  const { chartRef, seriesRef, timeScale } = makeRefs();
+  const utils = render(
+    <AgentEventOverlay
+      chartRef={chartRef}
+      seriesRef={seriesRef}
+      chartData={CHART}
+      theme="dark"
+      visible
+      workspaceId="ws"
+      symbol="NVDA"
+      timeframe="1day"
+      {...over}
+    />,
+  );
+  return { ...utils, timeScale };
+}
+
+describe('AgentEventOverlay', () => {
+  beforeEach(() => {
+    chartAnnotationStore._resetForTesting();
+    chartAnnotationStore.setAll('ws', 'NVDA:1day', [EVENT]);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    chartAnnotationStore._resetForTesting();
+  });
+
+  it('renders a badge with the event title once positioned', async () => {
+    renderOverlay();
+    await flushFrame();
+    expect(screen.getByText('Q3 earnings beat')).toBeInTheDocument();
+    // Detail is hidden until the badge is opened.
+    expect(screen.queryByText(/Beat EPS by/)).not.toBeInTheDocument();
+  });
+
+  it('reveals the detail on click (tap path)', async () => {
+    renderOverlay();
+    await flushFrame();
+    fireEvent.click(screen.getByText('Q3 earnings beat'));
+    expect(await screen.findByText(/Beat EPS by \$0\.15/)).toBeInTheDocument();
+  });
+
+  it('renders nothing when there are no event annotations', async () => {
+    chartAnnotationStore._resetForTesting();
+    chartAnnotationStore.setAll('ws', 'NVDA:1day', [
+      { annotation_id: 'p1', symbol: 'NVDA', type: 'price_line', price: 200 },
+    ]);
+    renderOverlay();
+    await flushFrame();
+    expect(screen.queryByText('Q3 earnings beat')).not.toBeInTheDocument();
+  });
+
+  it('does not render the badge when an off-screen coordinate is returned', async () => {
+    const { timeScale } = renderOverlay();
+    await flushFrame();
+    expect(screen.getByText('Q3 earnings beat')).toBeInTheDocument();
+    timeScale.timeToCoordinate.mockReturnValue(null as unknown as number);
+    // Force a reposition by invoking the visible-range subscription callback.
+    const cb = timeScale.subscribeVisibleLogicalRangeChange.mock.calls[0]?.[0];
+    await act(async () => {
+      cb?.();
+    });
+    expect(screen.queryByText('Q3 earnings beat')).not.toBeInTheDocument();
+  });
+
+  it('hides everything when visible=false', async () => {
+    renderOverlay({ visible: false });
+    await flushFrame();
+    expect(screen.queryByText('Q3 earnings beat')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/pages/MarketView/components/__tests__/MarketChartSurface.test.tsx
+++ b/web/src/pages/MarketView/components/__tests__/MarketChartSurface.test.tsx
@@ -1,0 +1,261 @@
+/**
+ * Render + wiring tests for ``MarketChartSurface`` — the self-contained replica
+ * of the MarketView chart panel. The heavy children (lightweight-charts
+ * MarketChart, StockHeader, CompanyOverviewPanel) and the market-data
+ * websocket / REST hooks are mocked so we assert the surface's own behaviour:
+ * prop wiring to children, the interval-switch state, the overview toggle, the
+ * WS-over-REST price preference, the subscribe/unsubscribe lifecycle, and the
+ * 1s → 1min auto-downgrade for non-US symbols.
+ */
+
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+
+// --- Hoisted mock surface -------------------------------------------------
+
+// Controllable WS context value; mutated per-test.
+const ws = vi.hoisted(() => ({
+  prices: new Map<string, unknown>(),
+  connectionStatus: 'connected',
+  dataLevel: 'realtime',
+  ginlixDataEnabled: true,
+  subscribe: vi.fn(),
+  unsubscribe: vi.fn(),
+  setPreviousClose: vi.fn(),
+  setDayOpen: vi.fn(),
+}));
+
+// Controllable useStockData return; mutated per-test.
+const sd = vi.hoisted(() => ({
+  stockInfo: { name: 'Apple Inc.' } as Record<string, unknown> | null,
+  realTimePrice: null as Record<string, unknown> | null,
+  snapshotData: { symbol: 'AAPL' } as Record<string, unknown> | null,
+  overviewData: null as Record<string, unknown> | null,
+  overviewLoading: false,
+  overlayData: null as Record<string, unknown> | null,
+  marketStatus: 'open' as unknown,
+  handleLatestBar: vi.fn(),
+}));
+
+// Captured props handed to each mocked child.
+const header = vi.hoisted(() => ({ props: null as Record<string, unknown> | null }));
+const chart = vi.hoisted(() => ({ props: null as Record<string, unknown> | null }));
+const overview = vi.hoisted(() => ({ props: null as Record<string, unknown> | null }));
+
+// Spy for the annotation-sync side effect (args we want to assert on).
+const syncSpy = vi.hoisted(() => vi.fn());
+
+vi.mock('../../contexts/MarketDataWSContext', () => ({
+  // Provider is a transparent pass-through here — the surface only needs the
+  // hook value, which we control directly.
+  MarketDataWSProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useMarketDataWSContext: () => ws,
+}));
+
+vi.mock('../../hooks/useStockData', () => ({
+  useStockData: (...args: unknown[]) => {
+    // Record the call so we can assert the surface forwards selectedStock etc.
+    (sd as Record<string, unknown>).__lastArgs = args;
+    return sd;
+  },
+}));
+
+vi.mock('../../hooks/useChartAnnotationSync', () => ({
+  useChartAnnotationSync: (...args: unknown[]) => syncSpy(...args),
+}));
+
+vi.mock('../StockHeader', () => ({
+  default: (props: Record<string, unknown>) => {
+    header.props = props;
+    return (
+      <button data-testid="stock-header" onClick={props.onToggleOverview as () => void}>
+        header
+      </button>
+    );
+  },
+}));
+
+vi.mock('../MarketChart', () => ({
+  default: (props: Record<string, unknown>) => {
+    chart.props = props;
+    return (
+      <button
+        data-testid="market-chart"
+        onClick={() => (props.onIntervalChange as (i: string) => void)('5min')}
+      >
+        chart
+      </button>
+    );
+  },
+}));
+
+vi.mock('../CompanyOverviewPanel', () => ({
+  default: (props: Record<string, unknown>) => {
+    overview.props = props;
+    return (
+      <button data-testid="overview-panel" onClick={props.onClose as () => void}>
+        overview
+      </button>
+    );
+  },
+}));
+
+import { MarketChartSurface } from '../MarketChartSurface';
+
+beforeEach(() => {
+  ws.prices = new Map();
+  ws.connectionStatus = 'connected';
+  ws.dataLevel = 'realtime';
+  ws.ginlixDataEnabled = true;
+  sd.stockInfo = { name: 'Apple Inc.' };
+  sd.realTimePrice = null;
+  sd.snapshotData = { symbol: 'AAPL' };
+  sd.overviewData = null;
+  sd.overviewLoading = false;
+  sd.overlayData = null;
+  sd.marketStatus = 'open';
+  header.props = null;
+  chart.props = null;
+  overview.props = null;
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe('MarketChartSurface', () => {
+  it('renders the header + chart and forwards the symbol to both', () => {
+    render(<MarketChartSurface symbol="AAPL" />);
+
+    expect(screen.getByTestId('stock-header')).toBeInTheDocument();
+    expect(screen.getByTestId('market-chart')).toBeInTheDocument();
+    expect(header.props!.symbol).toBe('AAPL');
+    expect(chart.props!.symbol).toBe('AAPL');
+  });
+
+  it('defaults the chart interval to 1day when no timeframe is given', () => {
+    render(<MarketChartSurface symbol="AAPL" />);
+    expect(chart.props!.interval).toBe('1day');
+  });
+
+  it('uses the provided timeframe as the initial interval', () => {
+    render(<MarketChartSurface symbol="AAPL" timeframe="1hour" />);
+    expect(chart.props!.interval).toBe('1hour');
+  });
+
+  it('updates the chart interval when the chart reports a switch', () => {
+    render(<MarketChartSurface symbol="AAPL" timeframe="1day" />);
+    expect(chart.props!.interval).toBe('1day');
+
+    act(() => fireEvent.click(screen.getByTestId('market-chart'))); // → '5min'
+    expect(chart.props!.interval).toBe('5min');
+  });
+
+  it('hides the overview panel until toggled, then shows + closes it', () => {
+    render(<MarketChartSurface symbol="AAPL" />);
+    expect(screen.queryByTestId('overview-panel')).not.toBeInTheDocument();
+
+    act(() => fireEvent.click(screen.getByTestId('stock-header'))); // onToggleOverview
+    expect(screen.getByTestId('overview-panel')).toBeInTheDocument();
+
+    act(() => fireEvent.click(screen.getByTestId('overview-panel'))); // onClose
+    expect(screen.queryByTestId('overview-panel')).not.toBeInTheDocument();
+  });
+
+  it('subscribes to the symbol feed on mount and unsubscribes on unmount', () => {
+    const { unmount } = render(<MarketChartSurface symbol="AAPL" />);
+    expect(ws.subscribe).toHaveBeenCalledWith(['AAPL']);
+
+    unmount();
+    expect(ws.unsubscribe).toHaveBeenCalledWith(['AAPL']);
+  });
+
+  it('loads this symbol\'s annotations via useChartAnnotationSync(workspaceId, symbol)', () => {
+    render(<MarketChartSurface symbol="AAPL" workspaceId="ws-7" />);
+    expect(syncSpy).toHaveBeenCalledWith('ws-7', 'AAPL');
+    // workspaceId is forwarded to the chart too.
+    expect(chart.props!.workspaceId).toBe('ws-7');
+  });
+
+  it('passes a null workspaceId to sync + chart when none is provided', () => {
+    render(<MarketChartSurface symbol="AAPL" />);
+    expect(syncSpy).toHaveBeenCalledWith(null, 'AAPL');
+    expect(chart.props!.workspaceId).toBeNull();
+  });
+
+  it('prefers the live WS price over the REST realTimePrice for the header', () => {
+    const wsPrice = { symbol: 'AAPL', price: 200, barData: { close: 200 } };
+    ws.prices = new Map([['AAPL', wsPrice]]);
+    sd.realTimePrice = { symbol: 'AAPL', price: 111 };
+
+    render(<MarketChartSurface symbol="AAPL" />);
+    expect(header.props!.realTimePrice).toBe(wsPrice);
+    expect(header.props!.wsHasData).toBe(true);
+    // liveTick is sourced from the WS bar payload.
+    expect(chart.props!.liveTick).toEqual(wsPrice.barData);
+  });
+
+  it('falls back to REST price only when it matches the current symbol', () => {
+    // No WS price; REST price is for a DIFFERENT symbol → guarded to null.
+    sd.realTimePrice = { symbol: 'MSFT', price: 99 };
+    render(<MarketChartSurface symbol="AAPL" />);
+    expect(header.props!.realTimePrice).toBeNull();
+    expect(header.props!.wsHasData).toBe(false);
+  });
+
+  it('uses the REST price when it matches and there is no WS price', () => {
+    const rest = { symbol: 'AAPL', price: 123 };
+    sd.realTimePrice = rest;
+    render(<MarketChartSurface symbol="AAPL" />);
+    expect(header.props!.realTimePrice).toBe(rest);
+  });
+
+  it('threads quote + overlay + earnings overview data into the chart', () => {
+    sd.overviewData = {
+      quote: { last: 150 },
+      earningsSurprises: [{ q: 1 }],
+    };
+    sd.overlayData = { grades: [] };
+
+    render(<MarketChartSurface symbol="AAPL" />);
+    expect(chart.props!.quoteData).toEqual({ last: 150 });
+    expect(chart.props!.earningsData).toEqual([{ q: 1 }]);
+    expect(chart.props!.overlayData).toEqual({ grades: [] });
+    // Header gets the same quote.
+    expect(header.props!.quoteData).toEqual({ last: 150 });
+  });
+
+  it('forwards overview loading + data to the panel when open', () => {
+    sd.overviewData = { quote: { last: 1 } };
+    sd.overviewLoading = true;
+    render(<MarketChartSurface symbol="AAPL" />);
+
+    act(() => fireEvent.click(screen.getByTestId('stock-header')));
+    expect(overview.props!.loading).toBe(true);
+    expect(overview.props!.data).toEqual({ quote: { last: 1 } });
+    expect(overview.props!.symbol).toBe('AAPL');
+  });
+
+  it('auto-downgrades a 1s timeframe to 1min for a non-US symbol', () => {
+    // A foreign-exchange suffix (.HK) does not support 1s.
+    render(<MarketChartSurface symbol="0700.HK" timeframe="1s" />);
+    expect(chart.props!.interval).toBe('1min');
+  });
+
+  it('keeps a 1s timeframe for a US equity', () => {
+    render(<MarketChartSurface symbol="AAPL" timeframe="1s" />);
+    expect(chart.props!.interval).toBe('1s');
+  });
+
+  it('forwards WS connection state + ginlix flag to header and chart', () => {
+    ws.connectionStatus = 'connecting';
+    ws.dataLevel = 'delayed';
+    ws.ginlixDataEnabled = false;
+
+    render(<MarketChartSurface symbol="AAPL" />);
+    expect(header.props!.wsStatus).toBe('connecting');
+    expect(header.props!.wsDataLevel).toBe('delayed');
+    expect(header.props!.ginlixDataEnabled).toBe(false);
+    expect(chart.props!.wsStatus).toBe('connecting');
+    expect(chart.props!.ginlixDataEnabled).toBe(false);
+  });
+});

--- a/web/src/pages/MarketView/components/__tests__/MarketChatPanel.test.tsx
+++ b/web/src/pages/MarketView/components/__tests__/MarketChatPanel.test.tsx
@@ -1,0 +1,286 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Hoisted fixtures referenced inside vi.mock factories ---
+
+// One spy per chat-engine handler so we can assert the panel forwards the SAME
+// function the hook returns. The original bug was that the HITL handlers weren't
+// forwarded at all (dead Accept/Decline buttons); the parity pass also wires the
+// message-action + stop + action-command handlers.
+const h = vi.hoisted(() => ({
+  handleSendMessage: vi.fn(),
+  handleApproveInterrupt: vi.fn(),
+  handleRejectInterrupt: vi.fn(),
+  handleAnswerQuestion: vi.fn(),
+  handleSkipQuestion: vi.fn(),
+  handleApproveCreateWorkspace: vi.fn(),
+  handleRejectCreateWorkspace: vi.fn(),
+  handleApproveStartQuestion: vi.fn(),
+  handleRejectStartQuestion: vi.fn(),
+  handleApprovePTCAgent: vi.fn(),
+  handleRejectPTCAgent: vi.fn(),
+  handleApproveSecretaryAction: vi.fn(),
+  handleRejectSecretaryAction: vi.fn(),
+  handleEditMessage: vi.fn(),
+  handleRegenerate: vi.fn(),
+  handleRetry: vi.fn(),
+  handleThumbUp: vi.fn(),
+  handleThumbDown: vi.fn(),
+  getFeedbackForMessage: vi.fn(),
+  insertNotification: vi.fn(),
+  setIsCompacting: vi.fn(),
+  stopWorkflow: vi.fn(),
+  threadId: 'thread-xyz', // mutated per-test to exercise the new-chat case
+  pendingInterrupt: null as unknown, // mutated per-test to exercise input gating
+}));
+
+// API spies — compaction calls straight into the ChatAgent api module. (Stop is
+// owned by the hook's stopWorkflow, mocked via `h`, since #273 retired the
+// soft-interrupt endpoint in favor of a client-side hard cancel.)
+const api = vi.hoisted(() => ({
+  summarizeThread: vi.fn().mockResolvedValue({ original_message_count: 3 }),
+  offloadThread: vi.fn().mockResolvedValue({ offloaded_args: 1, offloaded_reads: 2 }),
+}));
+
+// Capture the props MarketChatPanel hands to MessageList + ChatInput.
+const ml = vi.hoisted(() => ({ props: null as Record<string, unknown> | null }));
+const ci = vi.hoisted(() => ({ props: null as Record<string, unknown> | null }));
+
+vi.mock('@/pages/ChatAgent/hooks/useChatMessages', () => ({
+  useChatMessages: () => ({
+    messages: [{ id: 'm1', role: 'assistant' }], // non-empty → MessageList renders
+    isLoading: false,
+    isLoadingHistory: false,
+    messageError: null,
+    threadId: h.threadId,
+    threadModels: {},
+    lastThreadModel: null,
+    handleSendMessage: h.handleSendMessage,
+    stopWorkflow: h.stopWorkflow,
+    getSubagentHistory: vi.fn(),
+    handleApproveInterrupt: h.handleApproveInterrupt,
+    handleRejectInterrupt: h.handleRejectInterrupt,
+    handleAnswerQuestion: h.handleAnswerQuestion,
+    handleSkipQuestion: h.handleSkipQuestion,
+    handleApproveCreateWorkspace: h.handleApproveCreateWorkspace,
+    handleRejectCreateWorkspace: h.handleRejectCreateWorkspace,
+    handleApproveStartQuestion: h.handleApproveStartQuestion,
+    handleRejectStartQuestion: h.handleRejectStartQuestion,
+    handleApprovePTCAgent: h.handleApprovePTCAgent,
+    handleRejectPTCAgent: h.handleRejectPTCAgent,
+    handleApproveSecretaryAction: h.handleApproveSecretaryAction,
+    handleRejectSecretaryAction: h.handleRejectSecretaryAction,
+    pendingInterrupt: h.pendingInterrupt,
+    pendingRejection: null,
+    hasActiveSubagents: false,
+    workspaceStarting: false,
+    isCompacting: false,
+    setIsCompacting: h.setIsCompacting,
+    tokenUsage: null,
+    insertNotification: h.insertNotification,
+    handleEditMessage: h.handleEditMessage,
+    handleRegenerate: h.handleRegenerate,
+    handleRetry: h.handleRetry,
+    handleThumbUp: h.handleThumbUp,
+    handleThumbDown: h.handleThumbDown,
+    getFeedbackForMessage: h.getFeedbackForMessage,
+  }),
+}));
+
+vi.mock('@/pages/ChatAgent/components/MessageList', () => ({
+  default: (props: Record<string, unknown>) => {
+    ml.props = props;
+    return <div data-testid="message-list" />;
+  },
+}));
+
+vi.mock('@/components/ui/chat-input', () => ({
+  default: (props: Record<string, unknown>) => {
+    ci.props = props;
+    return <div data-testid="chat-input" />;
+  },
+}));
+
+vi.mock('@/pages/MarketView/components/MarketChatHistoryButton', () => ({
+  default: () => <div data-testid="history-btn" />,
+}));
+
+vi.mock('@/pages/ChatAgent/utils/api', async (importActual) => ({
+  ...(await importActual<Record<string, unknown>>()),
+  getFlashWorkspace: vi.fn().mockResolvedValue({ workspace_id: 'flash-ws' }),
+  getPreviewUrl: vi.fn().mockResolvedValue({ url: 'https://signed.example/' }),
+  summarizeThread: api.summarizeThread,
+  offloadThread: api.offloadThread,
+}));
+
+import MarketChatPanel from '../MarketChatPanel';
+
+type PanelProps = React.ComponentProps<typeof MarketChatPanel>;
+
+const baseProps: PanelProps = {
+  symbol: 'AAPL',
+  interval: '1day',
+  mode: 'ptc',
+  onModeChange: vi.fn(),
+  workspaces: [{ workspace_id: 'ws-1' }],
+  selectedWorkspaceId: 'ws-1',
+  onWorkspaceChange: vi.fn(),
+  chartImage: null,
+  chartImageDesc: null,
+  onCaptureChart: vi.fn(),
+  onClearChartImage: vi.fn(),
+  prefillMessage: '',
+  onClearPrefill: vi.fn(),
+  quickQueries: [],
+  onQuickQuery: vi.fn(),
+  onShuffleQueries: vi.fn(),
+};
+
+function renderPanel(override: Partial<PanelProps> = {}) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/market']}>
+        <Routes>
+          <Route path="/market" element={<MarketChatPanel {...baseProps} {...override} />} />
+          <Route path="/chat/t/:threadId" element={<div data-testid="chat-page" />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('MarketChatPanel', () => {
+  beforeEach(() => {
+    h.threadId = 'thread-xyz';
+    h.pendingInterrupt = null;
+    ml.props = null;
+    ci.props = null;
+    localStorage.clear();
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it('forwards every HITL handler to MessageList so plan/question cards work', () => {
+    renderPanel();
+    const p = ml.props!;
+    expect(p.onApprovePlan).toBe(h.handleApproveInterrupt);
+    expect(p.onRejectPlan).toBe(h.handleRejectInterrupt);
+    expect(p.onAnswerQuestion).toBe(h.handleAnswerQuestion);
+    expect(p.onSkipQuestion).toBe(h.handleSkipQuestion);
+    expect(p.onApproveCreateWorkspace).toBe(h.handleApproveCreateWorkspace);
+    expect(p.onRejectCreateWorkspace).toBe(h.handleRejectCreateWorkspace);
+    expect(p.onApproveStartQuestion).toBe(h.handleApproveStartQuestion);
+    expect(p.onRejectStartQuestion).toBe(h.handleRejectStartQuestion);
+    expect(p.onApprovePTCAgent).toBe(h.handleApprovePTCAgent);
+    expect(p.onRejectPTCAgent).toBe(h.handleRejectPTCAgent);
+    expect(p.onApproveSecretaryAction).toBe(h.handleApproveSecretaryAction);
+    expect(p.onRejectSecretaryAction).toBe(h.handleRejectSecretaryAction);
+  });
+
+  it('forwards message-action + feedback handlers to MessageList', () => {
+    renderPanel();
+    const p = ml.props!;
+    // Thumbs + feedback lookup are passed straight through.
+    expect(p.onThumbUp).toBe(h.handleThumbUp);
+    expect(p.onThumbDown).toBe(h.handleThumbDown);
+    expect(p.getFeedbackForMessage).toBe(h.getFeedbackForMessage);
+    // Edit/regenerate/retry are thin wrappers (they thread the model picker), so
+    // assert they're wired and delegate to the hook.
+    expect(typeof p.onEditMessage).toBe('function');
+    (p.onEditMessage as (id: string, c: string) => void)('m1', 'edited');
+    expect(h.handleEditMessage).toHaveBeenCalledWith('m1', 'edited', undefined);
+    (p.onRegenerate as (id: string) => void)('m1');
+    expect(h.handleRegenerate).toHaveBeenCalledWith('m1', undefined);
+    (p.onRetry as () => void)();
+    expect(h.handleRetry).toHaveBeenCalled();
+    // PTC mode → no flash deep-link context.
+    expect(p.flashContext).toBeNull();
+  });
+
+  it('wires the stop button to the hook hard-cancel (stopWorkflow)', async () => {
+    renderPanel();
+    expect(typeof ci.props!.onStop).toBe('function');
+    // onStop flips `wasStopped` synchronously then fires stopWorkflow — wrap in act.
+    await act(async () => { (ci.props!.onStop as () => void)(); });
+    expect(h.stopWorkflow).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the input while a plan approval is pending', () => {
+    renderPanel();
+    expect(ci.props!.disabled).toBe(false);
+
+    h.pendingInterrupt = { interruptId: 'i1' };
+    ci.props = null;
+    renderPanel();
+    expect(ci.props!.disabled).toBe(true);
+  });
+
+  it('routes /compact and /offload action commands to the thread', () => {
+    renderPanel();
+    const onAction = ci.props!.onAction as (cmd: { name: string }) => void;
+    onAction({ name: 'compact' });
+    expect(api.summarizeThread).toHaveBeenCalledWith('thread-xyz');
+    onAction({ name: 'offload' });
+    expect(api.offloadThread).toHaveBeenCalledWith('thread-xyz');
+  });
+
+  it('forwards typed slash commands as skill + subagent contexts on send', () => {
+    renderPanel();
+    const onSend = ci.props!.onSend as (
+      m: string, plan: boolean, att: unknown[], cmds: unknown[], opts: unknown,
+    ) => void;
+    onSend('draw a trend line', false, [], [
+      { type: 'skill', name: 'deep-research', skillName: 'deep-research' },
+      { type: 'subagent', name: 'subagent' },
+    ], {});
+
+    expect(h.handleSendMessage).toHaveBeenCalledTimes(1);
+    const contexts = h.handleSendMessage.mock.calls[0][2] as Array<Record<string, unknown>>;
+    // Chart-annotation skill is always injected; the typed skill rides alongside.
+    expect(contexts).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: 'skills', name: 'chart-annotation' }),
+      expect.objectContaining({ type: 'skills', name: 'deep-research' }),
+      expect.objectContaining({ type: 'directive' }),
+    ]));
+  });
+
+  it('does not double-inject chart-annotation when typed explicitly', () => {
+    renderPanel();
+    const onSend = ci.props!.onSend as (
+      m: string, plan: boolean, att: unknown[], cmds: unknown[], opts: unknown,
+    ) => void;
+    onSend('annotate', false, [], [
+      { type: 'skill', name: 'chart-annotation', skillName: 'chart-annotation' },
+    ], {});
+
+    const contexts = h.handleSendMessage.mock.calls[0][2] as Array<Record<string, unknown>>;
+    const chartCtx = contexts.filter((c) => c.name === 'chart-annotation');
+    expect(chartCtx).toHaveLength(1);
+  });
+
+  it('shows "Open in Chat" for an active thread and deep-links to /chat/t/{id}', () => {
+    renderPanel();
+    const btn = screen.getByText('Open in Chat');
+    fireEvent.click(btn);
+    expect(screen.getByTestId('chat-page')).toBeInTheDocument();
+  });
+
+  it('falls back to "Return to Chat" before a thread exists, when arrived from chat', () => {
+    h.threadId = '__default__';
+    const onReturnToChat = vi.fn();
+    renderPanel({ onReturnToChat });
+
+    expect(screen.queryByText('Open in Chat')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText('Return to Chat'));
+    expect(onReturnToChat).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows no continue button on a fresh chat with no return path', () => {
+    h.threadId = '__default__';
+    renderPanel();
+    expect(screen.queryByText('Open in Chat')).not.toBeInTheDocument();
+    expect(screen.queryByText('Return to Chat')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/pages/MarketView/constants/annotationPrompt.ts
+++ b/web/src/pages/MarketView/constants/annotationPrompt.ts
@@ -1,0 +1,11 @@
+/**
+ * Skill-injection context shared by MarketView's two chat surfaces (the desktop
+ * `MarketChatPanel` and the mobile FAB path in `MarketView`). Tells the
+ * chart-annotation skill which ticker + timeframe "the chart" is, so the agent
+ * edits the instance the user is actually viewing (chart_id = SYMBOL:timeframe)
+ * instead of guessing. `sym` is the uppercased ticker; `tf` is a normalized
+ * timeframe.
+ */
+export function marketViewAnnotationContext(sym: string, tf: string): string {
+  return `The user is viewing the ${sym} chart on the ${tf} timeframe in MarketView. When they ask to annotate or draw on "the chart", pass symbol="${sym}" and timeframe="${tf}" unless they name another ticker or interval.`;
+}

--- a/web/src/pages/MarketView/hooks/__tests__/useAgentAnnotations.test.tsx
+++ b/web/src/pages/MarketView/hooks/__tests__/useAgentAnnotations.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * Regression tests for the grid-signature memoization in
+ * ``useAgentAnnotations``. A live price-only tick churns the ``chartData``
+ * array reference but does not change bar count or first/last bar time, and the
+ * annotation geometry only snaps anchors to bar TIMES — so it must NOT trigger
+ * a rebuild of the canvas-primitive payload or the returned marker array.
+ * Appending a bar (length + last time change) MUST recompute both.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { createRef } from 'react';
+import type { IChartApi, ISeriesApi } from 'lightweight-charts';
+
+import type { ChartDataPoint } from '@/types/market';
+import {
+  chartAnnotationStore,
+  makeChartId,
+  type StoredAnnotation,
+} from '../../stores/chartAnnotationStore';
+
+// Capture the live primitive instance + its setData calls. The primitive does
+// real canvas work in production; here we only care that `setData` is (or is
+// not) invoked, so a class stub with vi.fn() methods is enough.
+const setDataSpy = vi.fn();
+const setThemeSpy = vi.fn();
+vi.mock('../../utils/agentAnnotationsPrimitive', () => {
+  class AgentAnnotationsPrimitive {
+    setData = setDataSpy;
+    setTheme = setThemeSpy;
+  }
+  return { AgentAnnotationsPrimitive };
+});
+
+// Import after the mock is registered so the hook picks up the stub primitive.
+import { useAgentAnnotations } from '../useAgentAnnotations';
+
+const WORKSPACE = 'ws-1';
+const SYMBOL = 'NVDA';
+const TIMEFRAME = '1day';
+
+const T = (iso: string): number => Math.floor(Date.parse(iso) / 1000);
+
+/** A two-bar grid; later mutated to a price-only tick or a bar-append. */
+function makeChart(lastClose: number, bars = 2): ChartDataPoint[] {
+  const base = [
+    { time: T('2024-11-12T00:00:00Z'), open: 100, high: 105, low: 99, close: 102, volume: 1 },
+    { time: T('2024-11-13T00:00:00Z'), open: 102, high: 108, low: 101, close: lastClose, volume: 1 },
+  ];
+  if (bars > 2) {
+    base.push({
+      time: T('2024-11-14T00:00:00Z'),
+      open: lastClose,
+      high: lastClose + 5,
+      low: lastClose - 2,
+      close: lastClose + 3,
+      volume: 1,
+    });
+  }
+  return base;
+}
+
+/** Annotations exercising both the primitive payload and the marker array. */
+function seedAnnotations(): void {
+  const chartId = makeChartId(SYMBOL, TIMEFRAME);
+  const rect: StoredAnnotation = {
+    annotation_id: 'r1',
+    symbol: SYMBOL,
+    type: 'rectangle',
+    point1: { time: '2024-11-12T00:00:00Z', price: 100 },
+    point2: { time: '2024-11-13T00:00:00Z', price: 108 },
+    label: 'Zone',
+  };
+  const marker: StoredAnnotation = {
+    annotation_id: 'm1',
+    symbol: SYMBOL,
+    type: 'marker',
+    time: '2024-11-13T00:00:00Z',
+    shape: 'arrowUp',
+    text: 'Buy',
+  };
+  chartAnnotationStore.add(WORKSPACE, chartId, rect);
+  chartAnnotationStore.add(WORKSPACE, chartId, marker);
+}
+
+/** Stub chart/series refs the primitive + native-line effects need. */
+function makeRefs() {
+  const series = {
+    attachPrimitive: vi.fn(),
+    detachPrimitive: vi.fn(),
+    createPriceLine: vi.fn(),
+    removePriceLine: vi.fn(),
+    setData: vi.fn(),
+  } as unknown as ISeriesApi<'Candlestick'>;
+  const chart = {
+    addLineSeries: vi.fn(() => ({ setData: vi.fn() })),
+    removeSeries: vi.fn(),
+  } as unknown as IChartApi;
+  const chartRef = createRef<IChartApi | null>() as { current: IChartApi | null };
+  const seriesRef = createRef<ISeriesApi<'Candlestick'> | null>() as {
+    current: ISeriesApi<'Candlestick'> | null;
+  };
+  chartRef.current = chart;
+  seriesRef.current = series;
+  return { chartRef, seriesRef };
+}
+
+function renderAnnotations(chartData: ChartDataPoint[]) {
+  const { chartRef, seriesRef } = makeRefs();
+  return renderHook(
+    ({ data }: { data: ChartDataPoint[] }) =>
+      useAgentAnnotations(
+        chartRef,
+        seriesRef,
+        SYMBOL,
+        'custom',
+        data,
+        WORKSPACE,
+        TIMEFRAME,
+        true,
+        'dark',
+      ),
+    { initialProps: { data: chartData } },
+  );
+}
+
+describe('useAgentAnnotations grid-signature memoization', () => {
+  beforeEach(() => {
+    chartAnnotationStore._resetForTesting();
+    setDataSpy.mockClear();
+    setThemeSpy.mockClear();
+    seedAnnotations();
+  });
+  afterEach(() => {
+    chartAnnotationStore._resetForTesting();
+  });
+
+  it('does NOT rebuild on a price-only tick (same length + first/last time)', () => {
+    const { result, rerender } = renderAnnotations(makeChart(106));
+
+    const setDataAfterMount = setDataSpy.mock.calls.length;
+    const markersAfterMount = result.current;
+    expect(setDataAfterMount).toBeGreaterThan(0); // built once on mount
+
+    // Price-only tick: brand-new array reference, same 2 bars, same first/last
+    // time, only the last close moved. gridSig is unchanged → no recompute.
+    act(() => rerender({ data: makeChart(107) }));
+
+    expect(setDataSpy.mock.calls.length).toBe(setDataAfterMount);
+    expect(result.current).toBe(markersAfterMount); // same array identity
+  });
+
+  it('DOES recompute when a bar is appended (length + last time change)', () => {
+    const { result, rerender } = renderAnnotations(makeChart(106));
+
+    const setDataAfterMount = setDataSpy.mock.calls.length;
+    const markersAfterMount = result.current;
+
+    // Append a third bar: length 2 → 3 and last bar time advances → gridSig
+    // changes → both the primitive payload and the marker array recompute.
+    act(() => rerender({ data: makeChart(106, 3) }));
+
+    expect(setDataSpy.mock.calls.length).toBeGreaterThan(setDataAfterMount);
+    expect(result.current).not.toBe(markersAfterMount);
+  });
+});

--- a/web/src/pages/MarketView/hooks/__tests__/useChartAnnotationSync.test.ts
+++ b/web/src/pages/MarketView/hooks/__tests__/useChartAnnotationSync.test.ts
@@ -1,0 +1,172 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Mock } from 'vitest';
+
+vi.mock('@/api/client', () => ({
+  api: {
+    get: vi.fn().mockResolvedValue({ data: { charts: [] } }),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+    patch: vi.fn(),
+  },
+}));
+
+vi.mock('../../stores/chartAnnotationStore', () => ({
+  chartAnnotationStore: {
+    getMutationSeq: vi.fn(() => 0),
+    setChartsForSymbol: vi.fn(),
+  },
+}));
+
+import { api } from '@/api/client';
+
+import { chartAnnotationStore } from '../../stores/chartAnnotationStore';
+import { useChartAnnotationSync } from '../useChartAnnotationSync';
+
+const mockGet = api.get as Mock;
+const mockGetSeq = chartAnnotationStore.getMutationSeq as Mock;
+const mockSetCharts = chartAnnotationStore.setChartsForSymbol as Mock;
+
+const WS = '11111111-1111-1111-1111-111111111111';
+
+beforeEach(() => {
+  mockGet.mockReset().mockResolvedValue({ data: { charts: [] } });
+  mockGetSeq.mockReset().mockReturnValue(0);
+  mockSetCharts.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useChartAnnotationSync', () => {
+  it('does nothing when workspaceId or symbol is missing', () => {
+    renderHook(() => useChartAnnotationSync(null, 'NVDA'));
+    renderHook(() => useChartAnnotationSync(WS, null));
+    renderHook(() => useChartAnnotationSync(undefined, undefined));
+
+    expect(mockGet).not.toHaveBeenCalled();
+    expect(mockSetCharts).not.toHaveBeenCalled();
+  });
+
+  it('fetches the chart-annotations endpoint with the symbol param on mount', async () => {
+    renderHook(() => useChartAnnotationSync(WS, 'NVDA'));
+
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(1));
+    expect(mockGet).toHaveBeenCalledWith(
+      `/api/v1/workspaces/${WS}/chart-annotations`,
+      expect.objectContaining({
+        params: { symbol: 'NVDA' },
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it('reconciles fetched charts into the store with the captured race-guard seq', async () => {
+    // Capture the seq BEFORE the fetch — bump the source value afterward to
+    // prove the hook passes the pre-fetch value, not a later one.
+    mockGetSeq.mockReturnValue(7);
+    const charts = [
+      { chart_id: 'NVDA:1day', symbol: 'NVDA', timeframe: '1day', annotations: [] },
+    ];
+    mockGet.mockResolvedValueOnce({ data: { charts } });
+
+    renderHook(() => useChartAnnotationSync(WS, 'NVDA'));
+
+    await waitFor(() => expect(mockSetCharts).toHaveBeenCalledTimes(1));
+    expect(mockSetCharts).toHaveBeenCalledWith(WS, 'NVDA', charts, 7);
+    // The seq is read once, before the (awaited) fetch resolves.
+    expect(mockGetSeq).toHaveBeenCalledTimes(1);
+  });
+
+  it('captures the mutation seq before issuing the fetch (race-guard ordering)', () => {
+    const order: string[] = [];
+    mockGetSeq.mockImplementation(() => {
+      order.push('seq');
+      return 0;
+    });
+    mockGet.mockImplementation(() => {
+      order.push('get');
+      return Promise.resolve({ data: { charts: [] } });
+    });
+
+    renderHook(() => useChartAnnotationSync(WS, 'NVDA'));
+
+    expect(order).toEqual(['seq', 'get']);
+  });
+
+  it('passes an empty array to the store when the response has no charts', async () => {
+    mockGet.mockResolvedValueOnce({ data: {} });
+
+    renderHook(() => useChartAnnotationSync(WS, 'NVDA'));
+
+    await waitFor(() => expect(mockSetCharts).toHaveBeenCalledTimes(1));
+    expect(mockSetCharts).toHaveBeenCalledWith(WS, 'NVDA', [], 0);
+  });
+
+  it('aborts the in-flight request on unmount', () => {
+    let capturedSignal: AbortSignal | undefined;
+    mockGet.mockImplementation((_url: string, config: { signal?: AbortSignal }) => {
+      capturedSignal = config?.signal;
+      return new Promise(() => {}); // never resolves
+    });
+
+    const { unmount } = renderHook(() => useChartAnnotationSync(WS, 'NVDA'));
+    expect(capturedSignal?.aborted).toBe(false);
+
+    unmount();
+    expect(capturedSignal?.aborted).toBe(true);
+  });
+
+  it('aborts and re-fetches when a dependency changes', async () => {
+    const signals: AbortSignal[] = [];
+    mockGet.mockImplementation((_url: string, config: { signal?: AbortSignal }) => {
+      if (config?.signal) signals.push(config.signal);
+      return new Promise(() => {});
+    });
+
+    const { rerender } = renderHook(
+      ({ sym }: { sym: string }) => useChartAnnotationSync(WS, sym),
+      { initialProps: { sym: 'NVDA' } },
+    );
+    expect(mockGet).toHaveBeenCalledTimes(1);
+
+    rerender({ sym: 'AAPL' });
+    expect(mockGet).toHaveBeenCalledTimes(2);
+    // The first request's signal was aborted by the cleanup; the second is live.
+    expect(signals[0].aborted).toBe(true);
+    expect(signals[1].aborted).toBe(false);
+  });
+
+  it('does not write to the store after the effect is cancelled mid-fetch', async () => {
+    let resolveGet: (value: { data: { charts: unknown[] } }) => void = () => {};
+    mockGet.mockImplementation(
+      () => new Promise((res) => { resolveGet = res; }),
+    );
+
+    const { unmount } = renderHook(() => useChartAnnotationSync(WS, 'NVDA'));
+    // Unmount before the request resolves — the `cancelled` guard must hold.
+    unmount();
+    resolveGet({ data: { charts: [] } });
+
+    // Give the awaited continuation a tick to run.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockSetCharts).not.toHaveBeenCalled();
+  });
+
+  it('does not write to the store when the request is aborted (CanceledError)', async () => {
+    mockGet.mockRejectedValueOnce(
+      Object.assign(new Error('canceled'), { name: 'CanceledError' }),
+    );
+
+    renderHook(() => useChartAnnotationSync(WS, 'NVDA'));
+
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(1));
+    // Flush the rejected-promise continuation.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockSetCharts).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/pages/MarketView/hooks/__tests__/useStockBars.test.ts
+++ b/web/src/pages/MarketView/hooks/__tests__/useStockBars.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Contract tests for ``useStockBars`` — the React Query wrapper around
+ * ``fetchStockData`` used by lightweight bar consumers (e.g. the chat
+ * annotation preview). We mock ``fetchStockData`` so we exercise the hook's
+ * own behaviour: query-key derivation (symbol upper-casing), the enabled gate,
+ * the soft-error → throw translation, and the loading/error projection.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+import type { ChartDataPoint } from '@/types/market';
+import { queryKeys } from '@/lib/queryKeys';
+
+// Mock the data dependency. Each test sets the resolved/rejected value.
+const fetchStockData = vi.fn();
+vi.mock('../../utils/api', () => ({
+  fetchStockData: (...args: unknown[]) => fetchStockData(...args),
+}));
+
+import { useStockBars } from '../useStockBars';
+
+const DAY = 86_400;
+const T0 = 1_700_000_000;
+const BARS: ChartDataPoint[] = Array.from({ length: 3 }, (_, i) => ({
+  time: T0 + i * DAY,
+  open: 100 + i,
+  high: 104 + i,
+  low: 98 + i,
+  close: 101 + i,
+  volume: 1_000 + i,
+}));
+
+let qc: QueryClient;
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return React.createElement(QueryClientProvider, { client: qc }, children);
+}
+
+function renderBars(
+  symbol: string | null | undefined,
+  interval: string,
+  opts?: { enabled?: boolean },
+) {
+  return renderHook(() => useStockBars(symbol, interval, opts), { wrapper });
+}
+
+describe('useStockBars', () => {
+  beforeEach(() => {
+    // The hook hardcodes ``retry: 1`` per-query (overriding any client default),
+    // so ``retryDelay: 0`` keeps the one retry instant + deterministic instead
+    // of waiting out the default exponential backoff.
+    qc = new QueryClient({
+      defaultOptions: { queries: { retryDelay: 0, gcTime: 0 } },
+    });
+    fetchStockData.mockReset();
+  });
+  afterEach(() => {
+    qc.clear();
+    vi.clearAllMocks();
+  });
+
+  it('fetches and returns the bars on success', async () => {
+    fetchStockData.mockResolvedValue({ data: BARS });
+    const { result } = renderBars('AAPL', '1day');
+
+    // Starts loading, no bars yet.
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.bars).toEqual([]);
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.bars).toEqual(BARS);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('upper-cases the symbol for both the fetch and the query key', async () => {
+    fetchStockData.mockResolvedValue({ data: BARS });
+    renderBars('aapl', '1day');
+
+    await waitFor(() => expect(fetchStockData).toHaveBeenCalledTimes(1));
+    // First positional arg to fetchStockData is the symbol.
+    expect(fetchStockData.mock.calls[0][0]).toBe('AAPL');
+    expect(fetchStockData.mock.calls[0][1]).toBe('1day');
+    // The cache entry is keyed by the upper-cased symbol.
+    const cached = qc.getQueryData(queryKeys.marketData.bars('AAPL', '1day'));
+    expect(cached).toEqual(BARS);
+  });
+
+  it('passes an AbortSignal through to fetchStockData', async () => {
+    fetchStockData.mockResolvedValue({ data: BARS });
+    renderBars('AAPL', '1day');
+
+    await waitFor(() => expect(fetchStockData).toHaveBeenCalled());
+    const optsArg = fetchStockData.mock.calls[0][4] as { signal?: AbortSignal };
+    expect(optsArg.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('passes a from/to window for ranged intervals (e.g. 1min)', async () => {
+    fetchStockData.mockResolvedValue({ data: BARS });
+    renderBars('AAPL', '1min');
+
+    await waitFor(() => expect(fetchStockData).toHaveBeenCalled());
+    const [, , from, to] = fetchStockData.mock.calls[0] as [string, string, string, string];
+    // INITIAL_LOAD_DAYS['1min'] = 7 (> 0) → ranged → YYYY-MM-DD strings, from < to.
+    expect(from).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(to).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(from <= to).toBe(true);
+  });
+
+  it('omits the from/to window for full-history intervals (e.g. 1day → 0 days)', async () => {
+    fetchStockData.mockResolvedValue({ data: BARS });
+    renderBars('AAPL', '1day');
+
+    await waitFor(() => expect(fetchStockData).toHaveBeenCalled());
+    const [, , from, to] = fetchStockData.mock.calls[0] as [string, string, string?, string?];
+    // INITIAL_LOAD_DAYS['1day'] = 0 → previewRange returns {} → undefined bounds.
+    expect(from).toBeUndefined();
+    expect(to).toBeUndefined();
+  });
+
+  it('does not fetch when disabled', () => {
+    fetchStockData.mockResolvedValue({ data: BARS });
+    const { result } = renderBars('AAPL', '1day', { enabled: false });
+
+    expect(fetchStockData).not.toHaveBeenCalled();
+    // Gated query is idle, not loading; consumers see empty bars.
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.bars).toEqual([]);
+  });
+
+  it('does not fetch when the symbol is empty/nullish', () => {
+    fetchStockData.mockResolvedValue({ data: BARS });
+    const { result } = renderBars(null, '1day');
+
+    expect(fetchStockData).not.toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.bars).toEqual([]);
+  });
+
+  it('surfaces a soft error (no data + error) as a query error', async () => {
+    fetchStockData.mockResolvedValue({ data: [], error: 'No data available' });
+    const { result } = renderBars('AAPL', '1day');
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.bars).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('does NOT error when data is present even if an error string is set', async () => {
+    // Soft error is only promoted when there is no data; a partial result with
+    // bars wins and is cached.
+    fetchStockData.mockResolvedValue({ data: BARS, error: 'stale' });
+    const { result } = renderBars('AAPL', '1day');
+
+    await waitFor(() => expect(result.current.bars).toEqual(BARS));
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('marks isError when fetchStockData rejects', async () => {
+    fetchStockData.mockRejectedValue(new Error('network down'));
+    const { result } = renderBars('AAPL', '1day');
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.bars).toEqual([]);
+  });
+
+  it('dedupes repeated mounts for the same symbol/interval to one request', async () => {
+    fetchStockData.mockResolvedValue({ data: BARS });
+    const { result: a } = renderBars('AAPL', '1day');
+    const { result: b } = renderBars('AAPL', '1day');
+
+    await waitFor(() => expect(a.current.bars).toEqual(BARS));
+    await waitFor(() => expect(b.current.bars).toEqual(BARS));
+    // Shared cache key → a single network call backs both consumers.
+    expect(fetchStockData).toHaveBeenCalledTimes(1);
+  });
+
+  it('keys separately by interval (different intervals → separate fetches)', async () => {
+    fetchStockData.mockResolvedValue({ data: BARS });
+    renderBars('AAPL', '1day');
+    renderBars('AAPL', '1min');
+
+    await waitFor(() => expect(fetchStockData).toHaveBeenCalledTimes(2));
+    const intervals = fetchStockData.mock.calls.map((c) => c[1]);
+    expect(intervals).toEqual(expect.arrayContaining(['1day', '1min']));
+  });
+});

--- a/web/src/pages/MarketView/hooks/useAgentAnnotations.ts
+++ b/web/src/pages/MarketView/hooks/useAgentAnnotations.ts
@@ -85,6 +85,19 @@ export function useAgentAnnotations(
   const primitiveRef = useRef<AgentAnnotationsPrimitive | null>(null);
   const primitiveSeriesRef = useRef<ISeriesApi<'Candlestick'> | null>(null);
 
+  // Cheap grid signature: bar count + first/last bar time. The geometry
+  // functions only read `chartData` to snap anchor TIMES to bar times — never
+  // the live price — so a price-only tick (same length + first/last time, new
+  // last close) yields identical output. Memoizing on this signature instead of
+  // the raw `chartData` reference skips the full rebuild on every price tick,
+  // while still recomputing when a bar is appended/backfilled or the
+  // symbol/timeframe changes (any of which moves length or first/last time).
+  const gridSig = useMemo(() => {
+    const n = chartData?.length ?? 0;
+    if (!n) return '0';
+    return `${n}:${chartData![0].time}:${chartData![n - 1].time}`;
+  }, [chartData]);
+
   useEffect(() => {
     const series = candlestickSeriesRef.current;
     const chart = chartRef.current;
@@ -180,9 +193,17 @@ export function useAgentAnnotations(
         trendlines.delete(id);
       }
     }
-  }, [annotations, applyable, symbol, chartRef, candlestickSeriesRef, chartData]);
+    // `chartData` is read inside (resolveTrendlineData) but `gridSig` is the
+    // intentional dependency — see the gridSig comment above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [annotations, applyable, symbol, chartRef, candlestickSeriesRef, gridSig]);
 
   // Canvas-primitive shapes: rectangle, vertical_line, text, fib_retracement.
+  // Memoized on `gridSig` (not the raw `chartData` ref) so a price-only tick
+  // reuses the same payload and the effect below doesn't fire `setData`.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const primitiveData = useMemo(() => buildPrimitiveData(annotations, chartData), [annotations, gridSig]);
+
   useEffect(() => {
     const series = candlestickSeriesRef.current;
     if (!series) return;
@@ -211,8 +232,8 @@ export function useAgentAnnotations(
     prim.setTheme(theme);
     // Not in Light mode → draw nothing, but keep the primitive attached so
     // toggling back re-populates from the store.
-    prim.setData(applyable ? buildPrimitiveData(annotations, chartData) : EMPTY_PRIMITIVE_DATA);
-  }, [annotations, applyable, symbol, chartRef, candlestickSeriesRef, chartData, theme]);
+    prim.setData(applyable ? primitiveData : EMPTY_PRIMITIVE_DATA);
+  }, [primitiveData, applyable, symbol, chartRef, candlestickSeriesRef, theme]);
 
   // Detach the primitive on unmount (chart teardown disposes it otherwise,
   // but a bare hook unmount should clean up after itself too).
@@ -233,8 +254,12 @@ export function useAgentAnnotations(
   }, []);
 
   // Derive marker payloads for the caller to merge with overlay markers.
+  // Memoized on `gridSig` (not the raw `chartData` ref) — markers snap to bar
+  // times only, so a price-only tick reuses the same array identity.
   return useMemo<SeriesMarker<Time>[]>(
     () => (applyable ? buildMarkers(annotations, chartData) : []),
-    [annotations, applyable, chartData],
+    // gridSig is the intentional dependency in place of the raw chartData ref.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [annotations, applyable, gridSig],
   );
 }

--- a/web/src/pages/MarketView/hooks/useAgentAnnotations.ts
+++ b/web/src/pages/MarketView/hooks/useAgentAnnotations.ts
@@ -1,0 +1,240 @@
+/**
+ * Apply agent-sourced annotations (from ``chartAnnotationStore``) to the
+ * lightweight-charts instance.
+ *
+ * Responsibilities:
+ * - Create and remove ``priceLine`` primitives on the candlestick series.
+ * - Create and remove two-point ``lineSeries`` primitives for trendlines
+ *   via ``chart.addLineSeries()``.
+ * - Drive one ``AgentAnnotationsPrimitive`` for the canvas shapes
+ *   (rectangle, vertical_line, text, fib_retracement).
+ * - Derive a list of ``SeriesMarker`` objects for ``marker`` annotations
+ *   — the caller passes this list to ``useChartOverlays`` so they merge
+ *   with earnings/grade markers (``series.setMarkers()`` replaces, so
+ *   everything must be set in one call).
+ *
+ * The pure annotation→drawable translation lives in
+ * ``utils/annotationGeometry`` so it can be shared with the inline mini
+ * chart rendered in the chat transcript.
+ *
+ * Chart-mode guard: when ``chartMode !== 'custom'`` (Advanced/TradingView
+ * iframe is active) we skip all chart mutations but leave the store
+ * intact — the effect re-runs when the user toggles back to Light.
+ */
+
+import { useEffect, useMemo, useRef, type RefObject } from 'react';
+import {
+  LineStyle,
+  type IChartApi,
+  type IPriceLine,
+  type ISeriesApi,
+  type SeriesMarker,
+  type Time,
+} from 'lightweight-charts';
+
+import type { ChartDataPoint } from '@/types/market';
+
+import { useAnnotationsForView } from '../stores/chartAnnotationStore';
+import { AgentAnnotationsPrimitive } from '../utils/agentAnnotationsPrimitive';
+import {
+  DEFAULT_LINE_COLOR,
+  DEFAULT_TRENDLINE_COLOR,
+  buildMarkers,
+  buildPrimitiveData,
+  isPriceLine,
+  isTrendline,
+  resolveTrendlineData,
+  styleToLwc,
+} from '../utils/annotationGeometry';
+
+const EMPTY_PRIMITIVE_DATA = { rects: [], vlines: [], texts: [], fibs: [] };
+
+/**
+ * Apply agent annotations from the store to the chart.
+ *
+ * Returns derived marker definitions for the current symbol. The caller
+ * should hand them to ``useChartOverlays`` so one ``setMarkers`` call
+ * owns the full marker set.
+ */
+export function useAgentAnnotations(
+  chartRef: RefObject<IChartApi | null>,
+  candlestickSeriesRef: RefObject<ISeriesApi<'Candlestick'> | null>,
+  symbol: string | null | undefined,
+  chartMode: string,
+  chartData: ChartDataPoint[] | null,
+  workspaceId: string | null | undefined,
+  timeframe: string | null | undefined,
+  visible: boolean = true,
+  theme: 'light' | 'dark' = 'dark',
+): SeriesMarker<Time>[] {
+  const annotations = useAnnotationsForView(workspaceId, symbol, timeframe);
+
+  // Apply annotations only in the Light (custom) chart mode, and only when the
+  // user hasn't hidden them. `visible === false` keeps the store intact but
+  // removes every live primitive (same teardown path as a non-applyable mode),
+  // so toggling back re-creates them.
+  const applyable = chartMode === 'custom' && visible;
+
+  // Track LWC objects by annotation_id so we can remove them cleanly.
+  const priceLineRefs = useRef<Map<string, IPriceLine>>(new Map());
+  const trendlineSeriesRefs = useRef<Map<string, ISeriesApi<'Line'>>>(new Map());
+
+  // One canvas primitive owns rectangles, vertical lines, text, and fib
+  // levels (shapes LWC has no native API for). We track which series it is
+  // attached to so we can re-attach after a chart/series rebuild.
+  const primitiveRef = useRef<AgentAnnotationsPrimitive | null>(null);
+  const primitiveSeriesRef = useRef<ISeriesApi<'Candlestick'> | null>(null);
+
+  useEffect(() => {
+    const series = candlestickSeriesRef.current;
+    const chart = chartRef.current;
+    if (!series || !chart) return;
+
+    // When the chart is not in Light mode, or the symbol changed, remove
+    // every live primitive. The store still holds the data so toggling
+    // back re-creates them.
+    const priceLines = priceLineRefs.current;
+    const trendlines = trendlineSeriesRefs.current;
+
+    const alivePriceLineIds = new Set<string>();
+    const aliveTrendlineIds = new Set<string>();
+
+    if (applyable) {
+      for (const ann of annotations) {
+        if (isPriceLine(ann)) {
+          alivePriceLineIds.add(ann.annotation_id);
+          if (priceLines.has(ann.annotation_id)) continue;
+          try {
+            const line = series.createPriceLine({
+              price: ann.price,
+              title: ann.label ?? '',
+              color: ann.color ?? DEFAULT_LINE_COLOR,
+              lineWidth: 1,
+              lineStyle: styleToLwc(ann.style),
+              axisLabelVisible: true,
+              lineVisible: true,
+            });
+            priceLines.set(ann.annotation_id, line);
+          } catch (err) {
+            if (import.meta.env.DEV) {
+              console.warn('[useAgentAnnotations] createPriceLine failed', err);
+            }
+          }
+        } else if (isTrendline(ann)) {
+          aliveTrendlineIds.add(ann.annotation_id);
+
+          const lineData = resolveTrendlineData(ann, chartData);
+          if (!lineData) continue; // degenerate / unparseable times — skip
+
+          let lineSeries = trendlines.get(ann.annotation_id);
+          if (!lineSeries) {
+            try {
+              lineSeries = chart.addLineSeries({
+                color: ann.color ?? DEFAULT_TRENDLINE_COLOR,
+                lineWidth: 2,
+                lineStyle: LineStyle.Dashed,
+                lastValueVisible: false,
+                priceLineVisible: false,
+                crosshairMarkerVisible: false,
+                // Label is drawn as a chip at the line's end (see
+                // buildPrimitiveData) — the native `title` strands it on the
+                // price axis, detached from the line.
+              });
+              trendlines.set(ann.annotation_id, lineSeries);
+            } catch (err) {
+              console.warn('[useAgentAnnotations] addLineSeries failed', err);
+              continue;
+            }
+          }
+          // Always re-apply data: if chartData was empty on the first pass
+          // and populated later, we re-snap to real bar times on the next
+          // effect run instead of keeping stale raw timestamps.
+          try {
+            lineSeries.setData(lineData);
+          } catch (err) {
+            console.warn('[useAgentAnnotations] trendline setData failed', err);
+          }
+        }
+      }
+    }
+
+    // Remove stale entries: anything currently in refs but no longer in
+    // the store (or we went into a non-applyable mode).
+    for (const [id, line] of priceLines) {
+      if (!applyable || !alivePriceLineIds.has(id)) {
+        try {
+          series.removePriceLine(line);
+        } catch {
+          /* series may have been disposed */
+        }
+        priceLines.delete(id);
+      }
+    }
+    for (const [id, lineSeries] of trendlines) {
+      if (!applyable || !aliveTrendlineIds.has(id)) {
+        try {
+          chart.removeSeries(lineSeries);
+        } catch {
+          /* already removed */
+        }
+        trendlines.delete(id);
+      }
+    }
+  }, [annotations, applyable, symbol, chartRef, candlestickSeriesRef, chartData]);
+
+  // Canvas-primitive shapes: rectangle, vertical_line, text, fib_retracement.
+  useEffect(() => {
+    const series = candlestickSeriesRef.current;
+    if (!series) return;
+
+    // Attach a primitive to the current series. If the series was rebuilt
+    // (theme/symbol change recreates the chart), the old primitive went away
+    // with its disposed series — attach a fresh one to the new series.
+    if (!primitiveRef.current || primitiveSeriesRef.current !== series) {
+      const prim = new AgentAnnotationsPrimitive();
+      try {
+        series.attachPrimitive(prim);
+        primitiveRef.current = prim;
+        primitiveSeriesRef.current = series;
+      } catch (err) {
+        if (import.meta.env.DEV) {
+          console.warn('[useAgentAnnotations] attachPrimitive failed', err);
+        }
+        return;
+      }
+    }
+
+    const prim = primitiveRef.current;
+    if (!prim) return;
+
+    // Keep the chip palette in sync with the active light/dark theme.
+    prim.setTheme(theme);
+    // Not in Light mode → draw nothing, but keep the primitive attached so
+    // toggling back re-populates from the store.
+    prim.setData(applyable ? buildPrimitiveData(annotations, chartData) : EMPTY_PRIMITIVE_DATA);
+  }, [annotations, applyable, symbol, chartRef, candlestickSeriesRef, chartData, theme]);
+
+  // Detach the primitive on unmount (chart teardown disposes it otherwise,
+  // but a bare hook unmount should clean up after itself too).
+  useEffect(() => {
+    return () => {
+      const prim = primitiveRef.current;
+      const series = primitiveSeriesRef.current;
+      if (prim && series) {
+        try {
+          series.detachPrimitive(prim);
+        } catch {
+          /* series already disposed */
+        }
+      }
+      primitiveRef.current = null;
+      primitiveSeriesRef.current = null;
+    };
+  }, []);
+
+  // Derive marker payloads for the caller to merge with overlay markers.
+  return useMemo<SeriesMarker<Time>[]>(
+    () => (applyable ? buildMarkers(annotations, chartData) : []),
+    [annotations, applyable, chartData],
+  );
+}

--- a/web/src/pages/MarketView/hooks/useChartAnnotationSync.ts
+++ b/web/src/pages/MarketView/hooks/useChartAnnotationSync.ts
@@ -38,6 +38,9 @@ export function useChartAnnotationSync(
 
     const controller = new AbortController();
     let cancelled = false;
+    // Capture the live-mutation seq before the fetch so a stale response can't
+    // overwrite an instance a concurrent SSE add/remove/clear changed meanwhile.
+    const seqAtStart = chartAnnotationStore.getMutationSeq();
 
     (async () => {
       try {
@@ -50,6 +53,7 @@ export function useChartAnnotationSync(
           workspaceId,
           symbol,
           data?.charts ?? [],
+          seqAtStart,
         );
       } catch (err: unknown) {
         const error = err as { name?: string };
@@ -69,37 +73,4 @@ export function useChartAnnotationSync(
       controller.abort();
     };
   }, [workspaceId, symbol]);
-}
-
-/**
- * Ensure the user's Flash workspace exists and return its id. Cached in
- * module scope so a successful call happens once per session. A failed
- * call clears the cache so the next caller retries instead of the
- * session being permanently stuck on a null id.
- */
-let flashWorkspaceIdPromise: Promise<string | null> | null = null;
-
-export function getOrFetchFlashWorkspaceId(): Promise<string | null> {
-  if (flashWorkspaceIdPromise) return flashWorkspaceIdPromise;
-  const pending = (async () => {
-    try {
-      const { data } = await api.post<{ workspace_id: string }>(
-        '/api/v1/workspaces/flash',
-      );
-      const id = data?.workspace_id ?? null;
-      if (!id) {
-        // Empty response — treat as failure so we retry next time.
-        flashWorkspaceIdPromise = null;
-      }
-      return id;
-    } catch (err) {
-      if (import.meta.env.DEV) {
-        console.warn('[chart-annotation] flash workspace lookup failed', err);
-      }
-      flashWorkspaceIdPromise = null;
-      return null;
-    }
-  })();
-  flashWorkspaceIdPromise = pending;
-  return pending;
 }

--- a/web/src/pages/MarketView/hooks/useChartAnnotationSync.ts
+++ b/web/src/pages/MarketView/hooks/useChartAnnotationSync.ts
@@ -1,0 +1,105 @@
+/**
+ * Persistence sync for chart annotations.
+ *
+ * On mount and whenever ``workspaceId`` or ``symbol`` changes, fetch
+ * ``GET /api/v1/workspaces/{workspace_id}/chart-annotations?symbol=X`` for the
+ * active workspace and reconcile every chart instance (all timeframes) for that
+ * symbol into ``chartAnnotationStore``. The store keys by
+ * ``(workspace_id, chart_id)``, so we fetch all timeframes up front and the
+ * chart selects the one matching the current interval — switching the interval
+ * needs no refetch.
+ */
+
+import { useEffect } from 'react';
+
+import { api } from '@/api/client';
+
+import {
+  chartAnnotationStore,
+  type ChartInstance,
+} from '../stores/chartAnnotationStore';
+
+interface ChartsResponse {
+  workspace_id: string;
+  charts: ChartInstance[];
+}
+
+/**
+ * Fetch and reconcile annotations for the active workspace + symbol. Replaces
+ * every locally-held instance for that `(workspace, symbol)` so a reload mirrors
+ * server state, including instances cleared elsewhere.
+ */
+export function useChartAnnotationSync(
+  workspaceId: string | null | undefined,
+  symbol: string | null | undefined,
+): void {
+  useEffect(() => {
+    if (!workspaceId || !symbol) return;
+
+    const controller = new AbortController();
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const { data } = await api.get<ChartsResponse>(
+          `/api/v1/workspaces/${encodeURIComponent(workspaceId)}/chart-annotations`,
+          { params: { symbol }, signal: controller.signal },
+        );
+        if (cancelled) return;
+        chartAnnotationStore.setChartsForSymbol(
+          workspaceId,
+          symbol,
+          data?.charts ?? [],
+        );
+      } catch (err: unknown) {
+        const error = err as { name?: string };
+        if (error?.name === 'CanceledError' || error?.name === 'AbortError') {
+          return;
+        }
+        // Missing workspace / 403 / 500 — leave the store as-is; the user may
+        // not own the selected workspace in some stale-selection edge cases.
+        if (import.meta.env.DEV) {
+          console.warn('[useChartAnnotationSync] sync failed', workspaceId, err);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [workspaceId, symbol]);
+}
+
+/**
+ * Ensure the user's Flash workspace exists and return its id. Cached in
+ * module scope so a successful call happens once per session. A failed
+ * call clears the cache so the next caller retries instead of the
+ * session being permanently stuck on a null id.
+ */
+let flashWorkspaceIdPromise: Promise<string | null> | null = null;
+
+export function getOrFetchFlashWorkspaceId(): Promise<string | null> {
+  if (flashWorkspaceIdPromise) return flashWorkspaceIdPromise;
+  const pending = (async () => {
+    try {
+      const { data } = await api.post<{ workspace_id: string }>(
+        '/api/v1/workspaces/flash',
+      );
+      const id = data?.workspace_id ?? null;
+      if (!id) {
+        // Empty response — treat as failure so we retry next time.
+        flashWorkspaceIdPromise = null;
+      }
+      return id;
+    } catch (err) {
+      if (import.meta.env.DEV) {
+        console.warn('[chart-annotation] flash workspace lookup failed', err);
+      }
+      flashWorkspaceIdPromise = null;
+      return null;
+    }
+  })();
+  flashWorkspaceIdPromise = pending;
+  return pending;
+}

--- a/web/src/pages/MarketView/hooks/useChartOverlays.ts
+++ b/web/src/pages/MarketView/hooks/useChartOverlays.ts
@@ -65,6 +65,13 @@ type OverlayMarker = {
   text?: string;
 };
 
+const VALID_MARKER_SHAPES: ReadonlySet<string> = new Set([
+  'arrowUp',
+  'arrowDown',
+  'circle',
+  'square',
+]);
+
 /**
  * Manages series markers on the candlestick series.
  * Combines earnings surprises, analyst grade changes, and caller-supplied
@@ -137,11 +144,18 @@ export function useChartOverlays(
       markers.push(...extraMarkers);
     }
 
+    // Drop any marker without a valid shape/time. setMarkers replaces the whole
+    // list and throws on a malformed entry, so one bad agent marker would
+    // otherwise blank every marker here — earnings and grades included.
+    const safeMarkers = markers.filter(
+      (m) => VALID_MARKER_SHAPES.has(m.shape) && Number.isFinite(m.time as number),
+    );
+
     // Sort markers by time (required by lightweight-charts)
-    markers.sort((a, b) => (a.time as number) - (b.time as number));
+    safeMarkers.sort((a, b) => (a.time as number) - (b.time as number));
 
     try {
-      series.setMarkers(markers);
+      series.setMarkers(safeMarkers);
     } catch (_) {
       /* series may be disposed */
     }

--- a/web/src/pages/MarketView/hooks/useChartOverlays.ts
+++ b/web/src/pages/MarketView/hooks/useChartOverlays.ts
@@ -57,9 +57,19 @@ function snapToNearestBar(chartData: ChartDataPoint[], dateStr: string): number 
   return chartData[lo].time;
 }
 
+type OverlayMarker = {
+  time: Time;
+  position: 'aboveBar' | 'belowBar' | 'inBar';
+  shape: 'arrowUp' | 'arrowDown' | 'circle' | 'square';
+  color: string;
+  text?: string;
+};
+
 /**
  * Manages series markers on the candlestick series.
- * Combines earnings surprises and analyst grade changes into markers.
+ * Combines earnings surprises, analyst grade changes, and caller-supplied
+ * agent markers into a single ``setMarkers`` call (LWC replaces the full
+ * list each call, so all sources must merge here).
  */
 export function useChartOverlays(
   candlestickSeriesRef: RefObject<ISeriesApi<'Candlestick'> | null>,
@@ -67,7 +77,8 @@ export function useChartOverlays(
   earningsData: EarningsEntry[] | null,
   overlayData: OverlayData | null,
   overlayVisibility: OverlayVisibility | null,
-  symbol: string | null
+  symbol: string | null,
+  extraMarkers: OverlayMarker[] = []
 ): void {
   useEffect(() => {
     const series = candlestickSeriesRef.current;
@@ -78,7 +89,7 @@ export function useChartOverlays(
       return;
     }
 
-    const markers: Array<{ time: Time; position: 'aboveBar' | 'belowBar'; shape: 'arrowUp' | 'arrowDown'; color: string; text: string }> = [];
+    const markers: OverlayMarker[] = [];
 
     // Earnings markers
     if (overlayVisibility?.earnings && earningsData && Array.isArray(earningsData)) {
@@ -121,6 +132,11 @@ export function useChartOverlays(
       });
     }
 
+    // Merge caller-supplied agent markers
+    if (extraMarkers && extraMarkers.length > 0) {
+      markers.push(...extraMarkers);
+    }
+
     // Sort markers by time (required by lightweight-charts)
     markers.sort((a, b) => (a.time as number) - (b.time as number));
 
@@ -135,5 +151,5 @@ export function useChartOverlays(
         try { series.setMarkers([]); } catch (_) { /* already cleaned */ }
       }
     };
-  }, [candlestickSeriesRef, chartData, earningsData, overlayData, overlayVisibility, symbol]);
+  }, [candlestickSeriesRef, chartData, earningsData, overlayData, overlayVisibility, symbol, extraMarkers]);
 }

--- a/web/src/pages/MarketView/hooks/useMarketChat.ts
+++ b/web/src/pages/MarketView/hooks/useMarketChat.ts
@@ -12,6 +12,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { buildRateLimitError, type StructuredError } from '@/utils/rateLimitError';
 import { sendFlashChatMessage } from '../utils/api';
+import { applyAnnotationArtifact } from '../stores/chartAnnotationStore';
 
 // --- Local message types (simplified subset of ChatAgent types) ---
 
@@ -474,6 +475,12 @@ export function useMarketChat(): UseMarketChatReturn {
               assistantMessageId,
               toolCalls,
             });
+          } else if (eventType === 'artifact') {
+            // Chart annotation artifact: update the shared store.
+            applyAnnotationArtifact(
+              event.artifact_type as string | undefined,
+              (event.payload as Record<string, unknown>) || {},
+            );
           } else if (eventType === 'tool_call_result') {
             const toolCallId = event.tool_call_id as string;
             if (toolCallId) {

--- a/web/src/pages/MarketView/hooks/useStockBars.ts
+++ b/web/src/pages/MarketView/hooks/useStockBars.ts
@@ -1,0 +1,77 @@
+/**
+ * React Query wrapper around ``fetchStockData`` for read-only OHLC bars.
+ *
+ * The live MarketView chart loads bars imperatively; this hook exists for
+ * lightweight consumers (e.g. the chat transcript's annotation preview) that
+ * just want a cached array of bars for a ``(symbol, interval)`` without the
+ * websocket / quote / overview machinery. Cached and deduped by query key so
+ * repeated cards for the same symbol share one request.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+
+import { queryKeys } from '@/lib/queryKeys';
+import type { ChartDataPoint } from '@/types/market';
+
+import { fetchStockData } from '../utils/api';
+import { INITIAL_LOAD_DAYS } from '../utils/chartConstants';
+
+const FIVE_MIN = 5 * 60 * 1000;
+const THIRTY_MIN = 30 * 60 * 1000;
+
+/**
+ * The same initial history window the live chart loads for this interval, so the
+ * preview agrees with what opens. ``0`` days (e.g. daily) means full history.
+ */
+function previewRange(interval: string): { from?: string; to?: string } {
+  const days = INITIAL_LOAD_DAYS[interval] ?? 90;
+  if (days <= 0) return {};
+  const fmt = (d: Date) => d.toLocaleDateString('en-CA', { timeZone: 'America/New_York' });
+  const to = new Date();
+  const from = new Date();
+  from.setDate(from.getDate() - days);
+  return { from: fmt(from), to: fmt(to) };
+}
+
+interface UseStockBarsOptions {
+  /** Gate the fetch (e.g. only when the card is the resting preview). */
+  enabled?: boolean;
+}
+
+interface UseStockBarsResult {
+  bars: ChartDataPoint[];
+  isLoading: boolean;
+  isError: boolean;
+}
+
+/** Fetch cached OHLC bars for a symbol + interval. */
+export function useStockBars(
+  symbol: string | null | undefined,
+  interval: string,
+  { enabled = true }: UseStockBarsOptions = {},
+): UseStockBarsResult {
+  const sym = (symbol || '').toUpperCase();
+  const active = enabled && !!sym;
+
+  const query = useQuery({
+    queryKey: queryKeys.marketData.bars(sym, interval),
+    queryFn: async ({ signal }) => {
+      const { from, to } = previewRange(interval);
+      const result = await fetchStockData(sym, interval, from, to, { signal });
+      // fetchStockData reports soft errors in-band; surface a real failure so
+      // React Query marks the query errored instead of caching an empty array.
+      if (!result.data?.length && result.error) throw new Error(result.error);
+      return result.data;
+    },
+    enabled: active,
+    staleTime: FIVE_MIN,
+    gcTime: THIRTY_MIN,
+    retry: 1,
+  });
+
+  return {
+    bars: query.data ?? [],
+    isLoading: active && query.isLoading,
+    isError: query.isError,
+  };
+}

--- a/web/src/pages/MarketView/hooks/useStockBars.ts
+++ b/web/src/pages/MarketView/hooks/useStockBars.ts
@@ -50,7 +50,7 @@ export function useStockBars(
   interval: string,
   { enabled = true }: UseStockBarsOptions = {},
 ): UseStockBarsResult {
-  const sym = (symbol || '').toUpperCase();
+  const sym = (symbol || '').trim().toUpperCase();
   const active = enabled && !!sym;
 
   const query = useQuery({

--- a/web/src/pages/MarketView/stores/__tests__/chartAnnotationStore.test.ts
+++ b/web/src/pages/MarketView/stores/__tests__/chartAnnotationStore.test.ts
@@ -7,11 +7,13 @@ import {
   DEFAULT_TIMEFRAME,
   makeChartId,
   normalizeTimeframe,
+  subscribeLiveAnnotationAdd,
   useAnnotationsForView,
   useDisplayCleared,
   VALID_TIMEFRAMES,
   type ChartInstance,
   type FibRetracementAnnotation,
+  type LiveAnnotationAdd,
   type PriceLineAnnotation,
   type RectangleAnnotation,
   type StoredAnnotation,
@@ -215,6 +217,55 @@ describe('chartAnnotationStore', () => {
     expect(chartAnnotationStore.getState().byChart[storeKey(WS, 'NVDA:1day')]).toBeUndefined();
   });
 
+  it('setChartsForSymbol(sinceSeq) does not resurrect an instance cleared mid-fetch', () => {
+    // A sync starts and captures the seq it will pass.
+    chartAnnotationStore.add(WS, 'NVDA:1day', makePriceLine('ann_d', 'NVDA', 200));
+    const seqAtStart = chartAnnotationStore.getMutationSeq();
+
+    // A live clear lands while the (now stale) list request is in flight.
+    chartAnnotationStore.clear(WS, 'NVDA:1day');
+    expect(chartAnnotationStore.getState().byChart[storeKey(WS, 'NVDA:1day')]).toBeUndefined();
+
+    // The stale response still carries the instance — but it must NOT come back.
+    chartAnnotationStore.setChartsForSymbol(
+      WS,
+      'NVDA',
+      [
+        {
+          chart_id: 'NVDA:1day',
+          symbol: 'NVDA',
+          timeframe: '1day',
+          annotations: [makePriceLine('ann_d', 'NVDA', 200)],
+        },
+      ],
+      seqAtStart,
+    );
+    expect(chartAnnotationStore.getState().byChart[storeKey(WS, 'NVDA:1day')]).toBeUndefined();
+  });
+
+  it('setChartsForSymbol(sinceSeq) keeps an instance added mid-fetch over a stale snapshot', () => {
+    const seqAtStart = chartAnnotationStore.getMutationSeq();
+    // Live add during the in-flight list (a timeframe the server hasn't returned).
+    chartAnnotationStore.add(WS, 'NVDA:1hour', makePriceLine('ann_live', 'NVDA', 210, '1hour'));
+
+    chartAnnotationStore.setChartsForSymbol(
+      WS,
+      'NVDA',
+      [
+        {
+          chart_id: 'NVDA:1day',
+          symbol: 'NVDA',
+          timeframe: '1day',
+          annotations: [makePriceLine('ann_d', 'NVDA', 200)],
+        },
+      ],
+      seqAtStart,
+    );
+    // Server's 1day installed AND the live 1hour preserved (not dropped).
+    expect(Object.keys(chartAnnotationStore.getState().byChart[storeKey(WS, 'NVDA:1day')]!)).toEqual(['ann_d']);
+    expect(Object.keys(chartAnnotationStore.getState().byChart[storeKey(WS, 'NVDA:1hour')]!)).toEqual(['ann_live']);
+  });
+
   it('clearDisplay() / restoreDisplay() flag display only, leaving data intact', () => {
     chartAnnotationStore.add(WS, 'NVDA:1day', makePriceLine('ann_1', 'NVDA', 200));
     expect(chartAnnotationStore.isDisplayCleared(WS, 'NVDA:1day')).toBe(false);
@@ -235,6 +286,19 @@ describe('chartAnnotationStore', () => {
     expect(chartAnnotationStore.isDisplayCleared(WS, 'NVDA:1day')).toBe(true);
     expect(chartAnnotationStore.isDisplayCleared(WS, 'NVDA:1hour')).toBe(false);
     expect(chartAnnotationStore.isDisplayCleared(WS2, 'NVDA:1day')).toBe(false);
+  });
+
+  it('clearDisplay() caps the cleared set, evicting the oldest entry', () => {
+    // Clear far more distinct instances than the cap (200) so a long session
+    // can't grow the set without bound.
+    for (let i = 0; i < 250; i += 1) {
+      chartAnnotationStore.clearDisplay(WS, `SYM${i}:1day`);
+    }
+    // The 50 oldest were evicted (re-show, data untouched); the newest remain.
+    expect(chartAnnotationStore.isDisplayCleared(WS, 'SYM0:1day')).toBe(false);
+    expect(chartAnnotationStore.isDisplayCleared(WS, 'SYM49:1day')).toBe(false);
+    expect(chartAnnotationStore.isDisplayCleared(WS, 'SYM50:1day')).toBe(true);
+    expect(chartAnnotationStore.isDisplayCleared(WS, 'SYM249:1day')).toBe(true);
   });
 });
 
@@ -354,6 +418,134 @@ describe('applyAnnotationArtifact', () => {
       chart_id: 'NVDA:1day',
     });
     expect(chartAnnotationStore.getState().byChart[storeKey(WS, 'NVDA:1day')]).toBeUndefined();
+  });
+
+  it('rejects a marker with no valid shape (would blank the shared marker layer)', () => {
+    // A marker with no shape makes lightweight-charts' setMarkers throw, which
+    // would wipe earnings + grade markers too — reject it at the store boundary.
+    applyAnnotationArtifact('chart_annotation', {
+      op: 'add',
+      workspace_id: WS,
+      chart_id: 'NVDA:1day',
+      annotation: {
+        annotation_id: 'm_bad',
+        symbol: 'NVDA',
+        type: 'marker',
+        time: '2024-11-14T00:00:00Z',
+      },
+    });
+    expect(chartAnnotationStore.getState().byChart[storeKey(WS, 'NVDA:1day')]).toBeUndefined();
+
+    // A marker with a valid shape is accepted.
+    applyAnnotationArtifact('chart_annotation', {
+      op: 'add',
+      workspace_id: WS,
+      chart_id: 'NVDA:1day',
+      annotation: {
+        annotation_id: 'm_ok',
+        symbol: 'NVDA',
+        type: 'marker',
+        time: '2024-11-14T00:00:00Z',
+        shape: 'circle',
+      },
+    });
+    expect(
+      Object.keys(chartAnnotationStore.getState().byChart[storeKey(WS, 'NVDA:1day')]!),
+    ).toEqual(['m_ok']);
+  });
+});
+
+describe('subscribeLiveAnnotationAdd', () => {
+  afterEach(() => {
+    chartAnnotationStore._resetForTesting();
+  });
+
+  it('fires on a fresh add op with the resolved instance identity', () => {
+    const seen: LiveAnnotationAdd[] = [];
+    const unsub = subscribeLiveAnnotationAdd((a) => seen.push(a));
+
+    applyAnnotationArtifact('chart_annotation', {
+      op: 'add',
+      workspace_id: WS,
+      chart_id: 'NVDA:1day',
+      annotation: { annotation_id: 'ann_1', symbol: 'NVDA', type: 'price_line', price: 205 },
+    });
+
+    expect(seen).toEqual([
+      { workspaceId: WS, chartId: 'NVDA:1day', symbol: 'NVDA', timeframe: '1day' },
+    ]);
+    unsub();
+  });
+
+  it('derives symbol + timeframe from a chart_id assembled from symbol+timeframe', () => {
+    const seen: LiveAnnotationAdd[] = [];
+    subscribeLiveAnnotationAdd((a) => seen.push(a));
+
+    applyAnnotationArtifact('chart_annotation', {
+      op: 'add',
+      workspace_id: WS,
+      symbol: 'AAPL',
+      timeframe: '1hour',
+      annotation: { annotation_id: 'ann_1', symbol: 'AAPL', type: 'price_line', price: 1 },
+    });
+
+    expect(seen).toEqual([
+      { workspaceId: WS, chartId: 'AAPL:1hour', symbol: 'AAPL', timeframe: '1hour' },
+    ]);
+  });
+
+  it('does not fire on remove / clear ops or rejected annotations', () => {
+    chartAnnotationStore.add(WS, 'NVDA:1day', makePriceLine('ann_1', 'NVDA', 200));
+    const seen: LiveAnnotationAdd[] = [];
+    subscribeLiveAnnotationAdd((a) => seen.push(a));
+
+    applyAnnotationArtifact('chart_annotation', {
+      op: 'remove',
+      workspace_id: WS,
+      chart_id: 'NVDA:1day',
+      ids: ['ann_1'],
+    });
+    applyAnnotationArtifact('chart_annotation', {
+      op: 'clear',
+      workspace_id: WS,
+      chart_id: 'NVDA:1day',
+    });
+    // Malformed annotation is rejected before any emit.
+    applyAnnotationArtifact('chart_annotation', {
+      op: 'add',
+      workspace_id: WS,
+      chart_id: 'NVDA:1day',
+      annotation: { annotation_id: 'ann_x', symbol: 'NVDA', type: 'bogus' },
+    });
+
+    expect(seen).toEqual([]);
+  });
+
+  it('does not fire on bare store writes (only live SSE adds)', () => {
+    const seen: LiveAnnotationAdd[] = [];
+    subscribeLiveAnnotationAdd((a) => seen.push(a));
+
+    chartAnnotationStore.add(WS, 'NVDA:1day', makePriceLine('ann_1', 'NVDA', 200));
+    chartAnnotationStore.setChartsForSymbol(WS, 'NVDA', [
+      { chart_id: 'NVDA:1day', symbol: 'NVDA', timeframe: '1day', annotations: [] },
+    ]);
+
+    expect(seen).toEqual([]);
+  });
+
+  it('stops delivering after unsubscribe', () => {
+    const seen: LiveAnnotationAdd[] = [];
+    const unsub = subscribeLiveAnnotationAdd((a) => seen.push(a));
+    unsub();
+
+    applyAnnotationArtifact('chart_annotation', {
+      op: 'add',
+      workspace_id: WS,
+      chart_id: 'NVDA:1day',
+      annotation: { annotation_id: 'ann_1', symbol: 'NVDA', type: 'price_line', price: 1 },
+    });
+
+    expect(seen).toEqual([]);
   });
 });
 

--- a/web/src/pages/MarketView/stores/__tests__/chartAnnotationStore.test.ts
+++ b/web/src/pages/MarketView/stores/__tests__/chartAnnotationStore.test.ts
@@ -1,0 +1,451 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  applyAnnotationArtifact,
+  chartAnnotationStore,
+  DEFAULT_TIMEFRAME,
+  makeChartId,
+  normalizeTimeframe,
+  useAnnotationsForView,
+  useDisplayCleared,
+  VALID_TIMEFRAMES,
+  type ChartInstance,
+  type FibRetracementAnnotation,
+  type PriceLineAnnotation,
+  type RectangleAnnotation,
+  type StoredAnnotation,
+  type TextAnnotation,
+  type TrendlineAnnotation,
+  type VerticalLineAnnotation,
+} from '../chartAnnotationStore';
+
+const WS = '11111111-1111-1111-1111-111111111111';
+const WS2 = '22222222-2222-2222-2222-222222222222';
+
+const storeKey = (ws: string, chartId: string): string => `${ws}||${chartId}`;
+
+function makePriceLine(
+  id: string,
+  symbol: string,
+  price: number,
+  timeframe = '1day',
+): PriceLineAnnotation {
+  return {
+    annotation_id: id,
+    symbol: symbol.toUpperCase(),
+    timeframe,
+    chart_id: makeChartId(symbol, timeframe),
+    type: 'price_line',
+    price,
+  };
+}
+
+function makeTrendline(id: string, symbol: string): TrendlineAnnotation {
+  return {
+    annotation_id: id,
+    symbol: symbol.toUpperCase(),
+    type: 'trendline',
+    point1: { time: '2024-10-01T00:00:00Z', price: 100 },
+    point2: { time: '2024-12-01T00:00:00Z', price: 120 },
+  };
+}
+
+describe('makeChartId / normalizeTimeframe', () => {
+  it('makeChartId uppercases the ticker and joins with the timeframe', () => {
+    expect(makeChartId('nvda', '1day')).toBe('NVDA:1day');
+    expect(makeChartId(' aapl ', '1hour')).toBe('AAPL:1hour');
+  });
+
+  it('normalizeTimeframe passes valid intervals through', () => {
+    for (const tf of VALID_TIMEFRAMES) {
+      expect(normalizeTimeframe(tf)).toBe(tf);
+    }
+  });
+
+  it('normalizeTimeframe falls back to the default for unknown intervals', () => {
+    expect(normalizeTimeframe('1s')).toBe(DEFAULT_TIMEFRAME);
+    expect(normalizeTimeframe('2hour')).toBe(DEFAULT_TIMEFRAME);
+    expect(normalizeTimeframe('')).toBe(DEFAULT_TIMEFRAME);
+    expect(normalizeTimeframe(null)).toBe(DEFAULT_TIMEFRAME);
+    expect(normalizeTimeframe(undefined)).toBe(DEFAULT_TIMEFRAME);
+  });
+});
+
+describe('chartAnnotationStore', () => {
+  afterEach(() => {
+    chartAnnotationStore._resetForTesting();
+  });
+
+  it('add() upserts by annotation_id within one instance (idempotent)', () => {
+    const a = makePriceLine('ann_1', 'NVDA', 200);
+    chartAnnotationStore.add(WS, 'NVDA:1day', a);
+    chartAnnotationStore.add(WS, 'NVDA:1day', { ...a, price: 205 }); // same id → upsert
+
+    const bucket = chartAnnotationStore.getState().byChart[storeKey(WS, 'NVDA:1day')];
+    expect(bucket).toBeDefined();
+    expect(Object.keys(bucket!)).toHaveLength(1);
+    expect((bucket!.ann_1 as PriceLineAnnotation).price).toBe(205);
+  });
+
+  it('scopes by timeframe — same ticker, different timeframe is a separate instance', () => {
+    chartAnnotationStore.add(WS, 'NVDA:1day', makePriceLine('ann_d', 'NVDA', 200, '1day'));
+    chartAnnotationStore.add(WS, 'NVDA:1hour', makePriceLine('ann_h', 'NVDA', 210, '1hour'));
+
+    const state = chartAnnotationStore.getState();
+    expect(Object.keys(state.byChart[storeKey(WS, 'NVDA:1day')]!)).toEqual(['ann_d']);
+    expect(Object.keys(state.byChart[storeKey(WS, 'NVDA:1hour')]!)).toEqual(['ann_h']);
+  });
+
+  it('scopes by workspace — same chart_id in another workspace is a separate instance', () => {
+    chartAnnotationStore.add(WS, 'NVDA:1day', makePriceLine('ann_a', 'NVDA', 200));
+    chartAnnotationStore.add(WS2, 'NVDA:1day', makePriceLine('ann_b', 'NVDA', 300));
+
+    const state = chartAnnotationStore.getState();
+    expect(Object.keys(state.byChart[storeKey(WS, 'NVDA:1day')]!)).toEqual(['ann_a']);
+    expect(Object.keys(state.byChart[storeKey(WS2, 'NVDA:1day')]!)).toEqual(['ann_b']);
+  });
+
+  it('remove() deletes specific ids only', () => {
+    chartAnnotationStore.add(WS, 'NVDA:1day', makePriceLine('ann_1', 'NVDA', 200));
+    chartAnnotationStore.add(WS, 'NVDA:1day', makeTrendline('ann_2', 'NVDA'));
+    chartAnnotationStore.remove(WS, 'NVDA:1day', ['ann_1']);
+
+    const bucket = chartAnnotationStore.getState().byChart[storeKey(WS, 'NVDA:1day')];
+    expect(bucket).toBeDefined();
+    expect(Object.keys(bucket!)).toEqual(['ann_2']);
+  });
+
+  it('clear() drops one instance but leaves others alone', () => {
+    chartAnnotationStore.add(WS, 'NVDA:1day', makePriceLine('ann_nvda', 'NVDA', 200));
+    chartAnnotationStore.add(WS, 'AAPL:1day', makePriceLine('ann_aapl', 'AAPL', 180));
+
+    chartAnnotationStore.clear(WS, 'NVDA:1day');
+
+    const state = chartAnnotationStore.getState();
+    expect(state.byChart[storeKey(WS, 'NVDA:1day')]).toBeUndefined();
+    expect(state.byChart[storeKey(WS, 'AAPL:1day')]).toBeDefined();
+    expect(Object.keys(state.byChart[storeKey(WS, 'AAPL:1day')]!)).toEqual(['ann_aapl']);
+  });
+
+  it('stores and retrieves every annotation variant by id', () => {
+    const vline: VerticalLineAnnotation = {
+      annotation_id: 'ann_v',
+      symbol: 'NVDA',
+      type: 'vertical_line',
+      time: '2024-11-14T00:00:00Z',
+      label: 'Earnings',
+      style: 'dashed',
+    };
+    const rect: RectangleAnnotation = {
+      annotation_id: 'ann_r',
+      symbol: 'NVDA',
+      type: 'rectangle',
+      point1: { time: '2024-10-16T00:00:00Z', price: 150 },
+      point2: { time: '2024-11-20T00:00:00Z', price: 140 },
+    };
+    const text: TextAnnotation = {
+      annotation_id: 'ann_t',
+      symbol: 'NVDA',
+      type: 'text',
+      time: '2024-11-14T00:00:00Z',
+      price: 205,
+      text: 'Breakout',
+    };
+    const fib: FibRetracementAnnotation = {
+      annotation_id: 'ann_f',
+      symbol: 'NVDA',
+      type: 'fib_retracement',
+      point1: { time: '2024-10-16T00:00:00Z', price: 100 },
+      point2: { time: '2024-12-20T00:00:00Z', price: 200 },
+    };
+    for (const a of [vline, rect, text, fib] as StoredAnnotation[]) {
+      chartAnnotationStore.add(WS, 'NVDA:1day', a);
+    }
+
+    const bucket = chartAnnotationStore.getState().byChart[storeKey(WS, 'NVDA:1day')];
+    expect(bucket).toBeDefined();
+    expect(Object.keys(bucket!).sort()).toEqual(['ann_f', 'ann_r', 'ann_t', 'ann_v']);
+    expect((bucket!.ann_t as TextAnnotation).text).toBe('Breakout');
+    expect((bucket!.ann_r as RectangleAnnotation).point2.price).toBe(140);
+  });
+
+  it('setAll() replaces only the requested instance', () => {
+    chartAnnotationStore.add(WS, 'NVDA:1day', makePriceLine('ann_nvda_1', 'NVDA', 200));
+    chartAnnotationStore.add(WS, 'AAPL:1day', makePriceLine('ann_aapl_1', 'AAPL', 180));
+
+    chartAnnotationStore.setAll(WS, 'NVDA:1day', [makePriceLine('ann_nvda_new', 'NVDA', 210)]);
+
+    const state = chartAnnotationStore.getState();
+    expect(Object.keys(state.byChart[storeKey(WS, 'NVDA:1day')]!)).toEqual(['ann_nvda_new']);
+    // AAPL must be untouched
+    expect(Object.keys(state.byChart[storeKey(WS, 'AAPL:1day')]!)).toEqual(['ann_aapl_1']);
+  });
+
+  it('setChartsForSymbol() reconciles all timeframes and drops removed instances', () => {
+    // Seed two NVDA instances + one AAPL + one in another workspace.
+    chartAnnotationStore.add(WS, 'NVDA:1day', makePriceLine('ann_d', 'NVDA', 200, '1day'));
+    chartAnnotationStore.add(WS, 'NVDA:1hour', makePriceLine('ann_h', 'NVDA', 210, '1hour'));
+    chartAnnotationStore.add(WS, 'AAPL:1day', makePriceLine('ann_aapl', 'AAPL', 180));
+    chartAnnotationStore.add(WS2, 'NVDA:1day', makePriceLine('ann_other', 'NVDA', 999));
+
+    // Server now reports only NVDA:1day (with a fresh annotation). The 1hour
+    // instance was cleared elsewhere and must disappear locally.
+    const charts: ChartInstance[] = [
+      {
+        chart_id: 'NVDA:1day',
+        symbol: 'NVDA',
+        timeframe: '1day',
+        annotations: [makePriceLine('ann_d_new', 'NVDA', 201, '1day')],
+      },
+    ];
+    chartAnnotationStore.setChartsForSymbol(WS, 'NVDA', charts);
+
+    const state = chartAnnotationStore.getState();
+    expect(Object.keys(state.byChart[storeKey(WS, 'NVDA:1day')]!)).toEqual(['ann_d_new']);
+    expect(state.byChart[storeKey(WS, 'NVDA:1hour')]).toBeUndefined(); // dropped
+    // Other symbol + other workspace untouched.
+    expect(Object.keys(state.byChart[storeKey(WS, 'AAPL:1day')]!)).toEqual(['ann_aapl']);
+    expect(Object.keys(state.byChart[storeKey(WS2, 'NVDA:1day')]!)).toEqual(['ann_other']);
+  });
+
+  it('setChartsForSymbol() with an empty list clears that symbol locally', () => {
+    chartAnnotationStore.add(WS, 'NVDA:1day', makePriceLine('ann_d', 'NVDA', 200));
+    chartAnnotationStore.setChartsForSymbol(WS, 'NVDA', []);
+    expect(chartAnnotationStore.getState().byChart[storeKey(WS, 'NVDA:1day')]).toBeUndefined();
+  });
+
+  it('clearDisplay() / restoreDisplay() flag display only, leaving data intact', () => {
+    chartAnnotationStore.add(WS, 'NVDA:1day', makePriceLine('ann_1', 'NVDA', 200));
+    expect(chartAnnotationStore.isDisplayCleared(WS, 'NVDA:1day')).toBe(false);
+
+    chartAnnotationStore.clearDisplay(WS, 'NVDA:1day');
+    expect(chartAnnotationStore.isDisplayCleared(WS, 'NVDA:1day')).toBe(true);
+    // Data must survive a display clear.
+    expect(
+      Object.keys(chartAnnotationStore.getState().byChart[storeKey(WS, 'NVDA:1day')]!),
+    ).toEqual(['ann_1']);
+
+    chartAnnotationStore.restoreDisplay(WS, 'NVDA:1day');
+    expect(chartAnnotationStore.isDisplayCleared(WS, 'NVDA:1day')).toBe(false);
+  });
+
+  it('clearDisplay() is scoped to one instance', () => {
+    chartAnnotationStore.clearDisplay(WS, 'NVDA:1day');
+    expect(chartAnnotationStore.isDisplayCleared(WS, 'NVDA:1day')).toBe(true);
+    expect(chartAnnotationStore.isDisplayCleared(WS, 'NVDA:1hour')).toBe(false);
+    expect(chartAnnotationStore.isDisplayCleared(WS2, 'NVDA:1day')).toBe(false);
+  });
+});
+
+describe('applyAnnotationArtifact', () => {
+  afterEach(() => {
+    chartAnnotationStore._resetForTesting();
+  });
+
+  it('add op upserts a valid annotation under (workspace, chart_id)', () => {
+    applyAnnotationArtifact('chart_annotation', {
+      op: 'add',
+      workspace_id: WS,
+      chart_id: 'NVDA:1day',
+      annotation: {
+        annotation_id: 'ann_1',
+        symbol: 'NVDA',
+        type: 'price_line',
+        price: 205,
+      },
+    });
+    const bucket = chartAnnotationStore.getState().byChart[storeKey(WS, 'NVDA:1day')];
+    expect(bucket).toBeDefined();
+    expect((bucket!.ann_1 as PriceLineAnnotation).price).toBe(205);
+  });
+
+  it('derives chart_id from symbol + timeframe when chart_id is absent', () => {
+    applyAnnotationArtifact('chart_annotation', {
+      op: 'add',
+      workspace_id: WS,
+      symbol: 'NVDA',
+      timeframe: '1hour',
+      annotation: {
+        annotation_id: 'ann_1',
+        symbol: 'NVDA',
+        type: 'price_line',
+        price: 205,
+      },
+    });
+    expect(
+      chartAnnotationStore.getState().byChart[storeKey(WS, 'NVDA:1hour')],
+    ).toBeDefined();
+  });
+
+  it('skips when workspace_id is missing (cannot key the instance)', () => {
+    applyAnnotationArtifact('chart_annotation', {
+      op: 'add',
+      chart_id: 'NVDA:1day',
+      annotation: { annotation_id: 'ann_1', symbol: 'NVDA', type: 'price_line', price: 1 },
+    });
+    expect(chartAnnotationStore.getState().byChart).toEqual({});
+  });
+
+  it('rejects a malformed annotation (unknown type / missing id)', () => {
+    applyAnnotationArtifact('chart_annotation', {
+      op: 'add',
+      workspace_id: WS,
+      chart_id: 'NVDA:1day',
+      annotation: { annotation_id: 'ann_x', symbol: 'NVDA', type: 'bogus' },
+    });
+    applyAnnotationArtifact('chart_annotation', {
+      op: 'add',
+      workspace_id: WS,
+      chart_id: 'NVDA:1day',
+      annotation: { symbol: 'NVDA', type: 'price_line', price: 1 }, // no id
+    });
+    expect(chartAnnotationStore.getState().byChart[storeKey(WS, 'NVDA:1day')]).toBeUndefined();
+  });
+
+  it('ignores non chart_annotation artifact types', () => {
+    applyAnnotationArtifact('html_widget', {
+      op: 'add',
+      workspace_id: WS,
+      chart_id: 'NVDA:1day',
+      annotation: { annotation_id: 'a', symbol: 'NVDA', type: 'price_line', price: 1 },
+    });
+    expect(chartAnnotationStore.getState().byChart).toEqual({});
+  });
+
+  it('add op restores a cleared display so a fresh draw is visible again', () => {
+    chartAnnotationStore.clearDisplay(WS, 'NVDA:1day');
+    expect(chartAnnotationStore.isDisplayCleared(WS, 'NVDA:1day')).toBe(true);
+
+    applyAnnotationArtifact('chart_annotation', {
+      op: 'add',
+      workspace_id: WS,
+      chart_id: 'NVDA:1day',
+      annotation: { annotation_id: 'ann_new', symbol: 'NVDA', type: 'price_line', price: 207 },
+    });
+
+    expect(chartAnnotationStore.isDisplayCleared(WS, 'NVDA:1day')).toBe(false);
+  });
+
+  it('remove op deletes ids; clear op drops the instance', () => {
+    const add = (id: string, price: number) =>
+      applyAnnotationArtifact('chart_annotation', {
+        op: 'add',
+        workspace_id: WS,
+        chart_id: 'NVDA:1day',
+        annotation: { annotation_id: id, symbol: 'NVDA', type: 'price_line', price },
+      });
+    add('ann_1', 205);
+    add('ann_2', 210);
+
+    applyAnnotationArtifact('chart_annotation', {
+      op: 'remove',
+      workspace_id: WS,
+      chart_id: 'NVDA:1day',
+      ids: ['ann_1'],
+    });
+    expect(
+      Object.keys(chartAnnotationStore.getState().byChart[storeKey(WS, 'NVDA:1day')]!),
+    ).toEqual(['ann_2']);
+
+    applyAnnotationArtifact('chart_annotation', {
+      op: 'clear',
+      workspace_id: WS,
+      chart_id: 'NVDA:1day',
+    });
+    expect(chartAnnotationStore.getState().byChart[storeKey(WS, 'NVDA:1day')]).toBeUndefined();
+  });
+});
+
+describe('useAnnotationsForView', () => {
+  afterEach(() => {
+    act(() => {
+      chartAnnotationStore._resetForTesting();
+    });
+  });
+
+  it('returns only annotations for the requested instance', () => {
+    act(() => {
+      chartAnnotationStore.add(WS, 'NVDA:1day', makePriceLine('ann_d', 'NVDA', 200, '1day'));
+      chartAnnotationStore.add(WS, 'NVDA:1hour', makePriceLine('ann_h', 'NVDA', 210, '1hour'));
+    });
+
+    const { result } = renderHook(() => useAnnotationsForView(WS, 'NVDA', '1day'));
+    expect(result.current.map((a) => a.annotation_id)).toEqual(['ann_d']);
+  });
+
+  it('re-renders when the matching instance mutates', () => {
+    const { result } = renderHook(() => useAnnotationsForView(WS, 'NVDA', '1day'));
+    expect(result.current).toHaveLength(0);
+
+    act(() => {
+      chartAnnotationStore.add(WS, 'NVDA:1day', makePriceLine('ann_1', 'NVDA', 200));
+    });
+    expect(result.current).toHaveLength(1);
+
+    act(() => {
+      chartAnnotationStore.remove(WS, 'NVDA:1day', ['ann_1']);
+    });
+    expect(result.current).toHaveLength(0);
+  });
+
+  it('does not re-render when an unrelated instance mutates', () => {
+    let renderCount = 0;
+    const { result } = renderHook(() => {
+      renderCount += 1;
+      return useAnnotationsForView(WS, 'NVDA', '1day');
+    });
+
+    const initialRenders = renderCount;
+
+    act(() => {
+      // Different timeframe, different workspace — both unrelated.
+      chartAnnotationStore.add(WS, 'NVDA:1hour', makePriceLine('ann_h', 'NVDA', 210, '1hour'));
+      chartAnnotationStore.add(WS2, 'NVDA:1day', makePriceLine('ann_o', 'NVDA', 999));
+    });
+
+    expect(renderCount).toBe(initialRenders);
+    expect(result.current).toHaveLength(0);
+  });
+
+  it('returns an empty array when workspace / symbol / timeframe is missing', () => {
+    const { result: noWs } = renderHook(() => useAnnotationsForView(null, 'NVDA', '1day'));
+    const { result: noSym } = renderHook(() => useAnnotationsForView(WS, null, '1day'));
+    const { result: noTf } = renderHook(() => useAnnotationsForView(WS, 'NVDA', null));
+    expect(noWs.current).toEqual([]);
+    expect(noSym.current).toEqual([]);
+    expect(noTf.current).toEqual([]);
+  });
+});
+
+describe('useDisplayCleared', () => {
+  afterEach(() => {
+    act(() => {
+      chartAnnotationStore._resetForTesting();
+    });
+  });
+
+  it('tracks the cleared/restored state for one instance', () => {
+    const { result } = renderHook(() => useDisplayCleared(WS, 'NVDA', '1day'));
+    expect(result.current).toBe(false);
+
+    act(() => {
+      chartAnnotationStore.clearDisplay(WS, 'NVDA:1day');
+    });
+    expect(result.current).toBe(true);
+
+    act(() => {
+      chartAnnotationStore.restoreDisplay(WS, 'NVDA:1day');
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('is false when workspace / symbol / timeframe is missing', () => {
+    const { result: noWs } = renderHook(() => useDisplayCleared(null, 'NVDA', '1day'));
+    const { result: noSym } = renderHook(() => useDisplayCleared(WS, null, '1day'));
+    const { result: noTf } = renderHook(() => useDisplayCleared(WS, 'NVDA', null));
+    expect(noWs.current).toBe(false);
+    expect(noSym.current).toBe(false);
+    expect(noTf.current).toBe(false);
+  });
+});

--- a/web/src/pages/MarketView/stores/chartAnnotationStore.ts
+++ b/web/src/pages/MarketView/stores/chartAnnotationStore.ts
@@ -178,12 +178,74 @@ let state: State = { byChart: {} };
 // reload re-syncs from the server and shows everything again.
 let clearedKeys: ReadonlySet<string> = new Set();
 
+// Safety valve: a long session that clears many distinct charts must not grow
+// this set without bound. Well above any realistic count of charts a user
+// hides in one session; the oldest entry is evicted past the cap (that chart
+// simply re-shows — harmless, the data is untouched).
+const MAX_CLEARED_KEYS = 200;
+
+// Monotonic counter bumped on every data mutation (add/remove/clear), plus the
+// seq of each instance's last mutation. The persistence sync captures the seq
+// before its fetch and passes it to `setChartsForSymbol`, so a stale server
+// snapshot can't clobber an instance a concurrent live add/remove/clear just
+// changed — e.g. `clear_all` racing an in-flight list must not resurrect the
+// cleared instance.
+let mutationSeq = 0;
+const keyMutatedAt = new Map<string, number>();
+
+function bumpMutation(key: string): void {
+  mutationSeq += 1;
+  keyMutatedAt.set(key, mutationSeq);
+}
+
 const listeners = new Set<() => void>();
 
 function emit(): void {
   for (const listener of listeners) {
     listener();
   }
+}
+
+/**
+ * One freshly-drawn annotation instance, broadcast on the live-add channel.
+ * Carries the resolved instance identity so a surface with a live chart can
+ * focus the drawing the agent just made.
+ */
+export interface LiveAnnotationAdd {
+  workspaceId: string;
+  chartId: string;
+  symbol: string;
+  timeframe: string;
+}
+
+// Live-add channel. Fired ONLY for a fresh SSE `add` artifact (see
+// `applyAnnotationArtifact`) — never on server re-sync (`setChartsForSymbol`)
+// or bare `add()` calls. MarketView subscribes so it can auto-focus the chart
+// on the instance the agent just drew, even when that's a different ticker /
+// timeframe than the one currently on screen.
+const liveAddListeners = new Set<(add: LiveAnnotationAdd) => void>();
+
+function emitLiveAdd(add: LiveAnnotationAdd): void {
+  for (const listener of liveAddListeners) {
+    listener(add);
+  }
+}
+
+/** Subscribe to fresh annotation draws. Returns an unsubscribe function. */
+export function subscribeLiveAnnotationAdd(
+  listener: (add: LiveAnnotationAdd) => void,
+): () => void {
+  liveAddListeners.add(listener);
+  return () => {
+    liveAddListeners.delete(listener);
+  };
+}
+
+/** Split a `{SYMBOL}:{timeframe}` chart id into its parts. */
+function parseChartId(chartId: string): { symbol: string; timeframe: string } {
+  const idx = chartId.indexOf(':');
+  if (idx < 0) return { symbol: chartId, timeframe: DEFAULT_TIMEFRAME };
+  return { symbol: chartId.slice(0, idx), timeframe: chartId.slice(idx + 1) };
 }
 
 function toUpper(symbol: string): string {
@@ -205,6 +267,11 @@ export const chartAnnotationStore = {
     return state;
   },
 
+  /** Current live-mutation sequence — capture before a sync fetch (see `setChartsForSymbol`). */
+  getMutationSeq(): number {
+    return mutationSeq;
+  },
+
   subscribe(listener: () => void): () => void {
     listeners.add(listener);
     return () => {
@@ -222,6 +289,7 @@ export const chartAnnotationStore = {
       [annotation.annotation_id]: annotation,
     };
     state = { byChart: { ...state.byChart, [key]: nextBucket } };
+    bumpMutation(key);
     emit();
   },
 
@@ -241,6 +309,7 @@ export const chartAnnotationStore = {
     }
     if (!changed) return;
     state = { byChart: { ...state.byChart, [key]: next } };
+    bumpMutation(key);
     emit();
   },
 
@@ -264,6 +333,11 @@ export const chartAnnotationStore = {
     if (clearedKeys.has(key)) return;
     const next = new Set(clearedKeys);
     next.add(key);
+    // Evict the oldest entry once past the cap (insertion-ordered Set).
+    if (next.size > MAX_CLEARED_KEYS) {
+      const oldest = next.values().next().value;
+      if (oldest !== undefined) next.delete(oldest);
+    }
     clearedKeys = next;
     emit();
   },
@@ -287,6 +361,7 @@ export const chartAnnotationStore = {
     const nextByChart = { ...state.byChart };
     delete nextByChart[key];
     state = { byChart: nextByChart };
+    bumpMutation(key);
     emit();
   },
 
@@ -315,27 +390,39 @@ export const chartAnnotationStore = {
    * dropping any local instance the server no longer has. Used by the
    * persistence sync so a reload is the source of truth for that symbol
    * without nuking other workspaces' or symbols' instances.
+   *
+   * `sinceSeq` (optional): the mutation seq captured before the sync's fetch.
+   * Any instance whose last live mutation happened *after* that seq is left as
+   * its current local state — never overwritten or resurrected — so a stale
+   * server snapshot can't undo a concurrent live add/remove/clear.
    */
   setChartsForSymbol(
     workspaceId: string,
     symbol: string,
     charts: ChartInstance[],
+    sinceSeq?: number,
   ): void {
     if (!workspaceId) return;
     const sym = toUpper(symbol);
     const prefix = `${workspaceId}${SEP}${sym}:`;
+    const isFresher = (key: string): boolean =>
+      sinceSeq != null && (keyMutatedAt.get(key) ?? 0) > sinceSeq;
     const nextByChart: Record<string, Bucket> = {};
-    // Keep everything that isn't this (workspace, symbol).
+    // Keep everything that isn't this (workspace, symbol), plus any instance of
+    // this (workspace, symbol) that a concurrent live mutation owns now.
     for (const [k, v] of Object.entries(state.byChart)) {
-      if (!k.startsWith(prefix)) nextByChart[k] = v;
+      if (!k.startsWith(prefix) || isFresher(k)) nextByChart[k] = v;
     }
-    // Install the server's instances for this (workspace, symbol).
+    // Install the server's instances for this (workspace, symbol), skipping any
+    // a concurrent live mutation changed mid-fetch (stale snapshot must not win).
     for (const chart of charts) {
+      const key = storeKey(workspaceId, chart.chart_id);
+      if (isFresher(key)) continue;
       const bucket: Bucket = {};
       for (const ann of chart.annotations ?? []) {
         bucket[ann.annotation_id] = ann;
       }
-      nextByChart[storeKey(workspaceId, chart.chart_id)] = bucket;
+      nextByChart[key] = bucket;
     }
     state = { byChart: nextByChart };
     emit();
@@ -345,6 +432,8 @@ export const chartAnnotationStore = {
   _resetForTesting(): void {
     state = { byChart: {} };
     clearedKeys = new Set();
+    mutationSeq = 0;
+    keyMutatedAt.clear();
     emit();
   },
 };
@@ -358,6 +447,16 @@ const KNOWN_ANNOTATION_TYPES: ReadonlySet<string> = new Set<AnnotationType>([
   'text',
   'event',
   'fib_retracement',
+]);
+
+// A marker with no valid shape makes lightweight-charts' setMarkers() throw,
+// which would blank the whole (shared) marker layer — earnings + grades too.
+// Reject it at the store boundary so one bad agent marker can't take them down.
+const VALID_MARKER_SHAPES: ReadonlySet<string> = new Set([
+  'arrowUp',
+  'arrowDown',
+  'circle',
+  'square',
 ]);
 
 /** Resolve the chart_id from a payload, deriving it if only symbol+tf given. */
@@ -398,11 +497,17 @@ export function applyAnnotationArtifact(
       typeof raw.annotation_id === 'string' &&
       typeof raw.symbol === 'string' &&
       typeof raw.type === 'string' &&
-      KNOWN_ANNOTATION_TYPES.has(raw.type)
+      KNOWN_ANNOTATION_TYPES.has(raw.type) &&
+      (raw.type !== 'marker' ||
+        (typeof raw.shape === 'string' && VALID_MARKER_SHAPES.has(raw.shape)))
     ) {
       chartAnnotationStore.add(workspaceId, chartId, raw as unknown as StoredAnnotation);
       // A fresh draw un-clears the instance so the new annotation is visible.
       chartAnnotationStore.restoreDisplay(workspaceId, chartId);
+      // Notify live-add subscribers so a live chart can auto-focus the
+      // instance just drawn (a different ticker/timeframe than what's shown).
+      const { symbol, timeframe } = parseChartId(chartId);
+      emitLiveAdd({ workspaceId, chartId, symbol, timeframe });
     }
   } else if (op === 'remove') {
     const ids = payload.ids as string[] | undefined;

--- a/web/src/pages/MarketView/stores/chartAnnotationStore.ts
+++ b/web/src/pages/MarketView/stores/chartAnnotationStore.ts
@@ -434,6 +434,7 @@ export const chartAnnotationStore = {
     clearedKeys = new Set();
     mutationSeq = 0;
     keyMutatedAt.clear();
+    liveAddListeners.clear();
     emit();
   },
 };
@@ -461,10 +462,10 @@ const VALID_MARKER_SHAPES: ReadonlySet<string> = new Set([
 
 /** Resolve the chart_id from a payload, deriving it if only symbol+tf given. */
 function resolveChartId(payload: Record<string, unknown>): string | null {
-  const chartId = payload.chart_id as string | undefined;
-  if (chartId) return chartId;
-  const symbol = payload.symbol as string | undefined;
-  if (!symbol) return null;
+  const chartId = payload.chart_id;
+  if (typeof chartId === 'string' && chartId) return chartId;
+  const symbol = payload.symbol;
+  if (typeof symbol !== 'string' || !symbol) return null;
   return makeChartId(symbol, normalizeTimeframe(payload.timeframe as string | undefined));
 }
 

--- a/web/src/pages/MarketView/stores/chartAnnotationStore.ts
+++ b/web/src/pages/MarketView/stores/chartAnnotationStore.ts
@@ -32,6 +32,7 @@ export type AnnotationType =
   | 'vertical_line'
   | 'rectangle'
   | 'text'
+  | 'event'
   | 'fib_retracement';
 
 export interface TimePricePoint {
@@ -106,6 +107,19 @@ export interface FibRetracementAnnotation extends BaseAnnotation {
   color?: string | null;
 }
 
+export interface EventAnnotation extends BaseAnnotation {
+  type: 'event';
+  /** ISO8601 datetime anchoring the badge horizontally. */
+  time: string;
+  /** Price (y-axis value) anchoring the badge vertically. */
+  price: number;
+  /** Short headline shown on the always-visible badge. */
+  title: string;
+  /** A few sentences revealed on hover/click. */
+  detail: string;
+  color?: string | null;
+}
+
 export type StoredAnnotation =
   | PriceLineAnnotation
   | TrendlineAnnotation
@@ -113,6 +127,7 @@ export type StoredAnnotation =
   | VerticalLineAnnotation
   | RectangleAnnotation
   | TextAnnotation
+  | EventAnnotation
   | FibRetracementAnnotation;
 
 /** One server-side chart instance, as returned by the list endpoint. */
@@ -341,6 +356,7 @@ const KNOWN_ANNOTATION_TYPES: ReadonlySet<string> = new Set<AnnotationType>([
   'vertical_line',
   'rectangle',
   'text',
+  'event',
   'fib_retracement',
 ]);
 

--- a/web/src/pages/MarketView/stores/chartAnnotationStore.ts
+++ b/web/src/pages/MarketView/stores/chartAnnotationStore.ts
@@ -1,0 +1,445 @@
+/**
+ * Chart annotation store — module-level store keyed by chart instance.
+ *
+ * A chart instance is ``(workspace_id, chart_id)`` where
+ * ``chart_id = "{SYMBOL}:{timeframe}"`` — the same identity the backend and
+ * the agent use. A line drawn on ``NVDA:1day`` does not appear on
+ * ``NVDA:1hour``; a different workspace has its own charts.
+ *
+ * Annotations flow into the store from two sources:
+ * 1. SSE `artifact` events with `artifact_type === 'chart_annotation'` —
+ *    these arrive live during a chat turn and carry `workspace_id` +
+ *    `chart_id` in the payload.
+ * 2. The persistence fetcher (`useChartAnnotationSync`) that pulls
+ *    `GET /api/v1/workspaces/{workspace_id}/chart-annotations?symbol=X`
+ *    on mount and symbol change.
+ *
+ * Consumers subscribe via `useAnnotationsForView(workspaceId, symbol,
+ * timeframe)` and the chart rendering hook (`useAgentAnnotations`) translates
+ * the store shape into LWC primitives.
+ *
+ * Implementation: a singleton store built on `useSyncExternalStore`. Snapshots
+ * for a given chart instance are referentially stable between unrelated writes
+ * so consumers don't re-render when another instance's bucket mutates.
+ */
+
+import { useMemo, useSyncExternalStore } from 'react';
+
+export type AnnotationType =
+  | 'price_line'
+  | 'trendline'
+  | 'marker'
+  | 'vertical_line'
+  | 'rectangle'
+  | 'text'
+  | 'fib_retracement';
+
+export interface TimePricePoint {
+  time: string;
+  price: number;
+}
+
+export interface BaseAnnotation {
+  annotation_id: string;
+  symbol: string;
+  /** Chart interval this annotation belongs to (e.g. '1day'). */
+  timeframe?: string;
+  /** Disclosed instance key, `{SYMBOL}:{timeframe}`. */
+  chart_id?: string;
+  type: AnnotationType;
+}
+
+export interface PriceLineAnnotation extends BaseAnnotation {
+  type: 'price_line';
+  price: number;
+  label?: string | null;
+  color?: string | null;
+  style?: 'solid' | 'dashed' | 'dotted';
+}
+
+export interface TrendlineAnnotation extends BaseAnnotation {
+  type: 'trendline';
+  point1: TimePricePoint;
+  point2: TimePricePoint;
+  label?: string | null;
+  color?: string | null;
+}
+
+export interface MarkerAnnotation extends BaseAnnotation {
+  type: 'marker';
+  time: string;
+  shape: 'arrowUp' | 'arrowDown' | 'circle' | 'square';
+  position?: 'aboveBar' | 'belowBar' | 'inBar';
+  text?: string | null;
+  color?: string | null;
+}
+
+export interface VerticalLineAnnotation extends BaseAnnotation {
+  type: 'vertical_line';
+  time: string;
+  label?: string | null;
+  color?: string | null;
+  style?: 'solid' | 'dashed' | 'dotted';
+}
+
+export interface RectangleAnnotation extends BaseAnnotation {
+  type: 'rectangle';
+  point1: TimePricePoint;
+  point2: TimePricePoint;
+  label?: string | null;
+  color?: string | null;
+}
+
+export interface TextAnnotation extends BaseAnnotation {
+  type: 'text';
+  time: string;
+  price: number;
+  text: string;
+  color?: string | null;
+}
+
+export interface FibRetracementAnnotation extends BaseAnnotation {
+  type: 'fib_retracement';
+  point1: TimePricePoint;
+  point2: TimePricePoint;
+  label?: string | null;
+  color?: string | null;
+}
+
+export type StoredAnnotation =
+  | PriceLineAnnotation
+  | TrendlineAnnotation
+  | MarkerAnnotation
+  | VerticalLineAnnotation
+  | RectangleAnnotation
+  | TextAnnotation
+  | FibRetracementAnnotation;
+
+/** One server-side chart instance, as returned by the list endpoint. */
+export interface ChartInstance {
+  chart_id: string;
+  symbol: string;
+  timeframe: string;
+  annotations: StoredAnnotation[];
+}
+
+// Timeframes the agent can draw on (mirrors the backend `Timeframe` enum).
+// The chart's `interval` may be a superset (e.g. '1s'); intervals outside this
+// set simply never match an agent-drawn chart instance.
+export const VALID_TIMEFRAMES: ReadonlySet<string> = new Set([
+  '1min',
+  '5min',
+  '15min',
+  '30min',
+  '1hour',
+  '4hour',
+  '1day',
+]);
+
+export const DEFAULT_TIMEFRAME = '1day';
+
+/** Coerce a chart interval to a timeframe the agent understands. */
+export function normalizeTimeframe(interval: string | null | undefined): string {
+  const tf = (interval ?? '').trim();
+  return VALID_TIMEFRAMES.has(tf) ? tf : DEFAULT_TIMEFRAME;
+}
+
+/** Disclosed instance key: `{SYMBOL}:{timeframe}` (uppercased ticker). */
+export function makeChartId(symbol: string, timeframe: string): string {
+  return `${symbol.trim().toUpperCase()}:${timeframe.trim()}`;
+}
+
+type Bucket = Record<string, StoredAnnotation>;
+type State = { byChart: Record<string, Bucket> };
+
+const EMPTY_BUCKET: Bucket = Object.freeze({}) as Bucket;
+const SEP = '||';
+
+let state: State = { byChart: {} };
+
+// Display-cleared chart instances. The "Clear" affordance removes a drawing from
+// the chart while keeping its data in `byChart` — re-opening the annotation
+// artifact in chat (or a new live draw) restores it. Ephemeral by design: a
+// reload re-syncs from the server and shows everything again.
+let clearedKeys: ReadonlySet<string> = new Set();
+
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+function toUpper(symbol: string): string {
+  return symbol.trim().toUpperCase();
+}
+
+/** Composite key for one chart instance bucket. */
+function storeKey(workspaceId: string, chartId: string): string {
+  return `${workspaceId}${SEP}${chartId}`;
+}
+
+/**
+ * Module-level store API. Safe to call from anywhere — SSE handlers,
+ * effect hooks, event handlers. Every mutator is scoped to one chart
+ * instance `(workspaceId, chartId)`.
+ */
+export const chartAnnotationStore = {
+  getState(): State {
+    return state;
+  },
+
+  subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  },
+
+  /** Upsert a single annotation by its id into a chart instance. Idempotent. */
+  add(workspaceId: string, chartId: string, annotation: StoredAnnotation): void {
+    if (!workspaceId || !chartId) return;
+    const key = storeKey(workspaceId, chartId);
+    const prevBucket = state.byChart[key] ?? {};
+    const nextBucket: Bucket = {
+      ...prevBucket,
+      [annotation.annotation_id]: annotation,
+    };
+    state = { byChart: { ...state.byChart, [key]: nextBucket } };
+    emit();
+  },
+
+  /** Remove specific ids from a chart instance's bucket. */
+  remove(workspaceId: string, chartId: string, ids: string[]): void {
+    if (!workspaceId || !chartId || !ids?.length) return;
+    const key = storeKey(workspaceId, chartId);
+    const prev = state.byChart[key];
+    if (!prev) return;
+    const next: Bucket = { ...prev };
+    let changed = false;
+    for (const id of ids) {
+      if (id in next) {
+        delete next[id];
+        changed = true;
+      }
+    }
+    if (!changed) return;
+    state = { byChart: { ...state.byChart, [key]: next } };
+    emit();
+  },
+
+  /** True when the user cleared this instance from the chart display. */
+  isDisplayCleared(
+    workspaceId: string | null | undefined,
+    chartId: string | null | undefined,
+  ): boolean {
+    if (!workspaceId || !chartId) return false;
+    return clearedKeys.has(storeKey(workspaceId, chartId));
+  },
+
+  /**
+   * Remove a chart instance from the display without deleting its data. The
+   * data stays in `byChart`; `restoreDisplay` (or a new live add) brings it
+   * back.
+   */
+  clearDisplay(workspaceId: string, chartId: string): void {
+    if (!workspaceId || !chartId) return;
+    const key = storeKey(workspaceId, chartId);
+    if (clearedKeys.has(key)) return;
+    const next = new Set(clearedKeys);
+    next.add(key);
+    clearedKeys = next;
+    emit();
+  },
+
+  /** Re-show a previously cleared chart instance. No-op if not cleared. */
+  restoreDisplay(workspaceId: string, chartId: string): void {
+    if (!workspaceId || !chartId) return;
+    const key = storeKey(workspaceId, chartId);
+    if (!clearedKeys.has(key)) return;
+    const next = new Set(clearedKeys);
+    next.delete(key);
+    clearedKeys = next;
+    emit();
+  },
+
+  /** Drop every annotation in a chart instance. */
+  clear(workspaceId: string, chartId: string): void {
+    if (!workspaceId || !chartId) return;
+    const key = storeKey(workspaceId, chartId);
+    if (!(key in state.byChart)) return;
+    const nextByChart = { ...state.byChart };
+    delete nextByChart[key];
+    state = { byChart: nextByChart };
+    emit();
+  },
+
+  /**
+   * Replace one chart instance's bucket with exactly these annotations.
+   * Leaves other instances untouched.
+   */
+  setAll(
+    workspaceId: string,
+    chartId: string,
+    annotations: StoredAnnotation[],
+  ): void {
+    if (!workspaceId || !chartId) return;
+    const key = storeKey(workspaceId, chartId);
+    const bucket: Bucket = {};
+    for (const ann of annotations) {
+      bucket[ann.annotation_id] = ann;
+    }
+    state = { byChart: { ...state.byChart, [key]: bucket } };
+    emit();
+  },
+
+  /**
+   * Reconcile every chart instance for a `(workspace, symbol)` against the
+   * server's view: replace all timeframes for that symbol with `charts`,
+   * dropping any local instance the server no longer has. Used by the
+   * persistence sync so a reload is the source of truth for that symbol
+   * without nuking other workspaces' or symbols' instances.
+   */
+  setChartsForSymbol(
+    workspaceId: string,
+    symbol: string,
+    charts: ChartInstance[],
+  ): void {
+    if (!workspaceId) return;
+    const sym = toUpper(symbol);
+    const prefix = `${workspaceId}${SEP}${sym}:`;
+    const nextByChart: Record<string, Bucket> = {};
+    // Keep everything that isn't this (workspace, symbol).
+    for (const [k, v] of Object.entries(state.byChart)) {
+      if (!k.startsWith(prefix)) nextByChart[k] = v;
+    }
+    // Install the server's instances for this (workspace, symbol).
+    for (const chart of charts) {
+      const bucket: Bucket = {};
+      for (const ann of chart.annotations ?? []) {
+        bucket[ann.annotation_id] = ann;
+      }
+      nextByChart[storeKey(workspaceId, chart.chart_id)] = bucket;
+    }
+    state = { byChart: nextByChart };
+    emit();
+  },
+
+  /** Test-only: wipe every chart instance. */
+  _resetForTesting(): void {
+    state = { byChart: {} };
+    clearedKeys = new Set();
+    emit();
+  },
+};
+
+const KNOWN_ANNOTATION_TYPES: ReadonlySet<string> = new Set<AnnotationType>([
+  'price_line',
+  'trendline',
+  'marker',
+  'vertical_line',
+  'rectangle',
+  'text',
+  'fib_retracement',
+]);
+
+/** Resolve the chart_id from a payload, deriving it if only symbol+tf given. */
+function resolveChartId(payload: Record<string, unknown>): string | null {
+  const chartId = payload.chart_id as string | undefined;
+  if (chartId) return chartId;
+  const symbol = payload.symbol as string | undefined;
+  if (!symbol) return null;
+  return makeChartId(symbol, normalizeTimeframe(payload.timeframe as string | undefined));
+}
+
+/**
+ * Apply one SSE ``chart_annotation`` artifact event to the store.
+ *
+ * Shared by both chat engines (MarketView's flash ``useMarketChat`` and
+ * ChatAgent's ``useChatMessages``) so the live add/remove/clear logic + shape
+ * validation lives in one place. The payload carries ``workspace_id`` +
+ * ``chart_id`` (or ``symbol`` + ``timeframe`` to derive it). The store's
+ * consumers (LWC primitives) throw on a malformed ``type`` / ``annotation_id``,
+ * so we validate before writing. No-op for any other artifact type, a missing
+ * payload, or a payload without a workspace to key on.
+ */
+export function applyAnnotationArtifact(
+  artifactType: string | undefined,
+  payload: Record<string, unknown> | undefined,
+): void {
+  if (artifactType !== 'chart_annotation' || !payload) return;
+  const workspaceId = payload.workspace_id as string | undefined;
+  const chartId = resolveChartId(payload);
+  if (!workspaceId) return;
+  if (!chartId) return;
+
+  const op = payload.op as string | undefined;
+  if (op === 'add') {
+    const raw = payload.annotation as Record<string, unknown> | undefined;
+    if (
+      raw &&
+      typeof raw.annotation_id === 'string' &&
+      typeof raw.symbol === 'string' &&
+      typeof raw.type === 'string' &&
+      KNOWN_ANNOTATION_TYPES.has(raw.type)
+    ) {
+      chartAnnotationStore.add(workspaceId, chartId, raw as unknown as StoredAnnotation);
+      // A fresh draw un-clears the instance so the new annotation is visible.
+      chartAnnotationStore.restoreDisplay(workspaceId, chartId);
+    }
+  } else if (op === 'remove') {
+    const ids = payload.ids as string[] | undefined;
+    if (Array.isArray(ids) && ids.length > 0) {
+      chartAnnotationStore.remove(workspaceId, chartId, ids);
+    }
+  } else if (op === 'clear') {
+    chartAnnotationStore.clear(workspaceId, chartId);
+  }
+}
+
+function getBucket(
+  workspaceId: string | null | undefined,
+  chartId: string | null | undefined,
+): Bucket {
+  if (!workspaceId || !chartId) return EMPTY_BUCKET;
+  return state.byChart[storeKey(workspaceId, chartId)] ?? EMPTY_BUCKET;
+}
+
+/**
+ * Subscribe to annotations for one chart instance — the active workspace's
+ * `symbol:timeframe`. Returns a referentially stable array so React consumers
+ * only re-render when that instance's bucket actually changes.
+ */
+export function useAnnotationsForView(
+  workspaceId: string | null | undefined,
+  symbol: string | null | undefined,
+  timeframe: string | null | undefined,
+): StoredAnnotation[] {
+  const chartId =
+    symbol && timeframe ? makeChartId(symbol, timeframe) : null;
+  const bucket = useSyncExternalStore(
+    chartAnnotationStore.subscribe,
+    () => getBucket(workspaceId, chartId),
+    () => EMPTY_BUCKET, // SSR: nothing
+  );
+  return useMemo(() => Object.values(bucket), [bucket]);
+}
+
+/**
+ * Subscribe to whether one chart instance is currently cleared from the
+ * display. `true` means the data is still in the store but the user dismissed
+ * it from the chart.
+ */
+export function useDisplayCleared(
+  workspaceId: string | null | undefined,
+  symbol: string | null | undefined,
+  timeframe: string | null | undefined,
+): boolean {
+  const chartId = symbol && timeframe ? makeChartId(symbol, timeframe) : null;
+  return useSyncExternalStore(
+    chartAnnotationStore.subscribe,
+    () => chartAnnotationStore.isDisplayCleared(workspaceId, chartId),
+    () => false, // SSR: nothing cleared
+  );
+}

--- a/web/src/pages/MarketView/utils/__tests__/agentAnnotationsPrimitive.test.ts
+++ b/web/src/pages/MarketView/utils/__tests__/agentAnnotationsPrimitive.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  __testing,
+  shouldSkipOffscreenSpan,
+  type VisibleTimeRange,
+} from '../agentAnnotationsPrimitive';
+
+const { chipWidth, withAlpha, textWidthCache, resetColorResolver, namedColorCache } = __testing;
+
+// Minimal CanvasRenderingContext2D stub: only the members chipWidth touches.
+function makeCtx(measure: (text: string) => number): {
+  ctx: CanvasRenderingContext2D;
+  measureText: ReturnType<typeof vi.fn>;
+} {
+  const measureText = vi.fn((text: string) => ({ width: measure(text) }));
+  const ctx = { font: '', measureText } as unknown as CanvasRenderingContext2D;
+  return { ctx, measureText };
+}
+
+describe('withAlpha', () => {
+  beforeEach(() => {
+    namedColorCache.clear();
+    resetColorResolver();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('expands #rgb shorthand and applies alpha', () => {
+    expect(withAlpha('#f00', 0.1)).toBe('rgba(255,0,0,0.1)');
+  });
+
+  it('parses #rrggbb and applies alpha', () => {
+    expect(withAlpha('#22c55e', 0.7)).toBe('rgba(34,197,94,0.7)');
+  });
+
+  it('parses #rrggbbaa (drops embedded alpha, uses requested)', () => {
+    expect(withAlpha('#22c55eff', 0.5)).toBe('rgba(34,197,94,0.5)');
+  });
+
+  it('rewrites rgb() with the requested alpha', () => {
+    expect(withAlpha('rgb(10, 20, 30)', 0.4)).toBe('rgba(10,20,30,0.4)');
+  });
+
+  it('rewrites rgba() with the requested alpha (replacing existing)', () => {
+    expect(withAlpha('rgba(10,20,30,0.9)', 0.2)).toBe('rgba(10,20,30,0.2)');
+  });
+
+  it('honors alpha for named CSS colors when a canvas resolver is available', () => {
+    // jsdom has no canvas backend, so simulate a browser canvas that normalizes
+    // a named color to #rrggbb the way real browsers do.
+    const fakeCtx = { _fill: '' } as unknown as CanvasRenderingContext2D;
+    Object.defineProperty(fakeCtx, 'fillStyle', {
+      get() {
+        return (this as { _fill: string })._fill;
+      },
+      set(v: string) {
+        // Only "tomato" is recognized; anything else (the sentinel) sticks.
+        if (v === 'tomato') (this as { _fill: string })._fill = '#ff6347';
+        else (this as { _fill: string })._fill = v;
+      },
+    });
+    vi.spyOn(document, 'createElement').mockReturnValue({
+      getContext: () => fakeCtx,
+    } as unknown as HTMLCanvasElement);
+
+    expect(withAlpha('tomato', 0.1)).toBe('rgba(255,99,71,0.1)');
+  });
+
+  it('falls back to the original color for unknown strings with no resolution', () => {
+    // Resolver present but rejects the value: fillStyle stays at the sentinel.
+    const fakeCtx = { _fill: '' } as unknown as CanvasRenderingContext2D;
+    Object.defineProperty(fakeCtx, 'fillStyle', {
+      get() {
+        return (this as { _fill: string })._fill;
+      },
+      set(v: string) {
+        (this as { _fill: string })._fill = v; // never normalizes → sentinel sticks
+      },
+    });
+    vi.spyOn(document, 'createElement').mockReturnValue({
+      getContext: () => fakeCtx,
+    } as unknown as HTMLCanvasElement);
+
+    expect(withAlpha('definitely-not-a-color', 0.3)).toBe('definitely-not-a-color');
+  });
+
+  it('falls back unchanged for named colors when no canvas is available (jsdom)', () => {
+    // Real jsdom env: getContext('2d') returns null → guarded fallback, no throw.
+    expect(withAlpha('red', 0.1)).toBe('red');
+  });
+});
+
+describe('chipWidth measureText cache', () => {
+  beforeEach(() => {
+    textWidthCache.clear();
+  });
+
+  it('measures a given text once and reuses the cached width', () => {
+    const { ctx, measureText } = makeCtx((t) => t.length * 10);
+    const first = chipWidth(ctx, 'Earnings');
+    const second = chipWidth(ctx, 'Earnings');
+    expect(first).toBe(second);
+    expect(measureText).toHaveBeenCalledTimes(1);
+  });
+
+  it('measures distinct texts independently', () => {
+    const { ctx, measureText } = makeCtx((t) => t.length * 10);
+    chipWidth(ctx, 'A');
+    chipWidth(ctx, 'BB');
+    chipWidth(ctx, 'A'); // cached
+    expect(measureText).toHaveBeenCalledTimes(2);
+    expect(measureText).toHaveBeenNthCalledWith(1, 'A');
+    expect(measureText).toHaveBeenNthCalledWith(2, 'BB');
+  });
+
+  it('includes padding/dot geometry in the returned width', () => {
+    const { ctx } = makeCtx(() => 100);
+    // CHIP_PAD_X*2 (14) + DOT_R*2 (6) + DOT_GAP (6) + measured (100) = 126
+    expect(chipWidth(ctx, 'x')).toBe(126);
+  });
+});
+
+describe('shouldSkipOffscreenSpan', () => {
+  const range: VisibleTimeRange = { from: 1000, to: 2000 };
+
+  it('does not skip when at least one anchor is on-screen', () => {
+    // coordA non-null = on-screen, even if the other is off-screen.
+    expect(shouldSkipOffscreenSpan(range, 50, 1500, null, 3000)).toBe(false);
+    expect(shouldSkipOffscreenSpan(range, null, 500, 80, 1500)).toBe(false);
+  });
+
+  it('skips when both anchors are off-screen on the left (phantom)', () => {
+    expect(shouldSkipOffscreenSpan(range, null, 200, null, 500)).toBe(true);
+  });
+
+  it('skips when both anchors are off-screen on the right (phantom)', () => {
+    expect(shouldSkipOffscreenSpan(range, null, 2500, null, 3000)).toBe(true);
+  });
+
+  it('does NOT skip an opposite-side straddle (shape genuinely spans the pane)', () => {
+    expect(shouldSkipOffscreenSpan(range, null, 200, null, 3000)).toBe(false);
+  });
+
+  it('does not skip when both anchors are inside the range but un-coordinated', () => {
+    // Defensive: both null yet times inside the viewport → classify as inside,
+    // not a same-side phantom, so we draw rather than drop a valid shape.
+    expect(shouldSkipOffscreenSpan(range, null, 1200, null, 1800)).toBe(false);
+  });
+});

--- a/web/src/pages/MarketView/utils/__tests__/annotationGeometry.test.ts
+++ b/web/src/pages/MarketView/utils/__tests__/annotationGeometry.test.ts
@@ -75,8 +75,8 @@ describe('buildMarkers', () => {
     // sorted by time ascending
     expect(markers[0].time).toBe(T('2024-11-14T00:00:00Z'));
     expect(markers[0].shape).toBe('arrowUp');
-    // square collapses to circle (LWC has no square marker)
-    expect(markers[1].shape).toBe('circle');
+    // square is a native LWC SeriesMarkerShape — passed through, not downgraded.
+    expect(markers[1].shape).toBe('square');
   });
 
   it('ignores non-marker annotations', () => {

--- a/web/src/pages/MarketView/utils/__tests__/annotationGeometry.test.ts
+++ b/web/src/pages/MarketView/utils/__tests__/annotationGeometry.test.ts
@@ -141,6 +141,46 @@ describe('buildPrimitiveData', () => {
     expect(byRatio[0.5]).toBe(150);
   });
 
+  it('orders rect and fib x-anchors by time even when points arrive reversed', () => {
+    // point1 is LATER than point2 for both shapes. The off-screen clamp in the
+    // primitive assumes time1 is the earlier (left) edge, so buildPrimitiveData
+    // must reorder the span — otherwise a corner outside the loaded range paints
+    // a phantom shape spanning the whole chart.
+    const anns: StoredAnnotation[] = [
+      {
+        annotation_id: 'r-rev',
+        symbol: 'NVDA',
+        type: 'rectangle',
+        point1: { time: '2024-12-20T00:00:00Z', price: 140 },
+        point2: { time: '2024-10-16T00:00:00Z', price: 150 },
+      },
+      {
+        annotation_id: 'f-rev',
+        symbol: 'NVDA',
+        type: 'fib_retracement',
+        point1: { time: '2024-12-20T00:00:00Z', price: 200 },
+        point2: { time: '2024-10-16T00:00:00Z', price: 100 },
+      },
+    ];
+
+    const data = buildPrimitiveData(anns, CHART);
+
+    const rect = data.rects[0];
+    expect(rect.time1).toBeLessThanOrEqual(rect.time2);
+    expect(rect.time1).toBe(T('2024-10-16T00:00:00Z'));
+    expect(rect.time2).toBe(T('2024-12-20T00:00:00Z'));
+
+    const fib = data.fibs[0];
+    expect(fib.time1).toBeLessThanOrEqual(fib.time2);
+    expect(fib.time1).toBe(T('2024-10-16T00:00:00Z'));
+    expect(fib.time2).toBe(T('2024-12-20T00:00:00Z'));
+    // Direction is preserved: level prices stay tied to point identity, NOT the
+    // reordered time span. point1.price=200 -> ratio 1.0, point2.price=100 -> 0.0.
+    const byRatio = Object.fromEntries(fib.levels.map((l) => [l.ratio, l.price]));
+    expect(byRatio[1]).toBe(200);
+    expect(byRatio[0]).toBe(100);
+  });
+
   it('renders a trendline label as a chip anchored at the later endpoint', () => {
     const anns: StoredAnnotation[] = [
       {

--- a/web/src/pages/MarketView/utils/__tests__/annotationGeometry.test.ts
+++ b/web/src/pages/MarketView/utils/__tests__/annotationGeometry.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ChartDataPoint } from '@/types/market';
+
+import type { StoredAnnotation } from '../../stores/chartAnnotationStore';
+import {
+  FIB_RATIOS,
+  buildMarkers,
+  buildPrimitiveData,
+  dashForStyle,
+  resolveBarTime,
+  resolveTrendlineData,
+  snapToNearestBar,
+  toUnixSeconds,
+} from '../annotationGeometry';
+
+const T = (iso: string): number => Math.floor(Date.parse(iso) / 1000);
+
+// Four daily bars the annotations below reference.
+const CHART: ChartDataPoint[] = [
+  { time: T('2024-10-16T00:00:00Z'), open: 100, high: 105, low: 99, close: 104, volume: 1 },
+  { time: T('2024-11-14T00:00:00Z'), open: 110, high: 115, low: 108, close: 112, volume: 1 },
+  { time: T('2024-11-20T00:00:00Z'), open: 120, high: 125, low: 118, close: 122, volume: 1 },
+  { time: T('2024-12-20T00:00:00Z'), open: 200, high: 205, low: 198, close: 202, volume: 1 },
+];
+
+describe('time helpers', () => {
+  it('toUnixSeconds parses ISO and rejects garbage', () => {
+    expect(toUnixSeconds('2024-10-16T00:00:00Z')).toBe(T('2024-10-16T00:00:00Z'));
+    expect(toUnixSeconds('not-a-date')).toBeNull();
+  });
+
+  it('snapToNearestBar returns the closest bar time', () => {
+    // 2024-11-13 is closest to the 11-14 bar
+    expect(snapToNearestBar(CHART, T('2024-11-13T06:00:00Z'))).toBe(T('2024-11-14T00:00:00Z'));
+    expect(snapToNearestBar([], 123)).toBeNull();
+  });
+
+  it('resolveBarTime falls back to raw seconds without chart data', () => {
+    expect(resolveBarTime(null, '2024-10-16T00:00:00Z')).toBe(T('2024-10-16T00:00:00Z'));
+  });
+
+  it('dashForStyle maps styles to canvas dash patterns', () => {
+    expect(dashForStyle('solid')).toEqual([]);
+    expect(dashForStyle('dotted')).toEqual([1, 3]);
+    expect(dashForStyle('dashed')).toEqual([4, 4]);
+    expect(dashForStyle(undefined)).toEqual([4, 4]);
+  });
+});
+
+describe('buildMarkers', () => {
+  it('builds sorted markers and maps square/circle shapes', () => {
+    const anns: StoredAnnotation[] = [
+      {
+        annotation_id: 'm2',
+        symbol: 'NVDA',
+        type: 'marker',
+        time: '2024-12-20T00:00:00Z',
+        shape: 'square',
+      },
+      {
+        annotation_id: 'm1',
+        symbol: 'NVDA',
+        type: 'marker',
+        time: '2024-11-14T00:00:00Z',
+        shape: 'arrowUp',
+        text: 'Earnings',
+      },
+    ];
+    const markers = buildMarkers(anns, CHART);
+    expect(markers).toHaveLength(2);
+    // sorted by time ascending
+    expect(markers[0].time).toBe(T('2024-11-14T00:00:00Z'));
+    expect(markers[0].shape).toBe('arrowUp');
+    // square collapses to circle (LWC has no square marker)
+    expect(markers[1].shape).toBe('circle');
+  });
+
+  it('ignores non-marker annotations', () => {
+    const anns: StoredAnnotation[] = [
+      { annotation_id: 'p1', symbol: 'NVDA', type: 'price_line', price: 200 },
+    ];
+    expect(buildMarkers(anns, CHART)).toEqual([]);
+  });
+});
+
+describe('buildPrimitiveData', () => {
+  it('routes each variant to the right bucket and computes fib levels', () => {
+    const anns: StoredAnnotation[] = [
+      {
+        annotation_id: 'r1',
+        symbol: 'NVDA',
+        type: 'rectangle',
+        point1: { time: '2024-10-16T00:00:00Z', price: 150 },
+        point2: { time: '2024-11-20T00:00:00Z', price: 140 },
+      },
+      {
+        annotation_id: 'v1',
+        symbol: 'NVDA',
+        type: 'vertical_line',
+        time: '2024-11-14T00:00:00Z',
+        style: 'dotted',
+      },
+      {
+        annotation_id: 't1',
+        symbol: 'NVDA',
+        type: 'text',
+        time: '2024-11-14T00:00:00Z',
+        price: 205,
+        text: 'Breakout',
+      },
+      {
+        annotation_id: 'f1',
+        symbol: 'NVDA',
+        type: 'fib_retracement',
+        point1: { time: '2024-10-16T00:00:00Z', price: 100 },
+        point2: { time: '2024-12-20T00:00:00Z', price: 200 },
+      },
+      // price lines / trendlines are NOT primitive shapes — must be ignored
+      { annotation_id: 'p1', symbol: 'NVDA', type: 'price_line', price: 200 },
+    ];
+
+    const data = buildPrimitiveData(anns, CHART);
+    expect(data.rects).toHaveLength(1);
+    expect(data.vlines).toHaveLength(1);
+    expect(data.vlines[0].dash).toEqual([1, 3]); // dotted
+    expect(data.texts).toHaveLength(1);
+    expect(data.texts[0].text).toBe('Breakout');
+    expect(data.fibs).toHaveLength(1);
+
+    const fib = data.fibs[0];
+    expect(fib.levels).toHaveLength(FIB_RATIOS.length);
+    // price = p2 + (p1 - p2) * ratio; with p1=100, p2=200:
+    // ratio 0 -> 200, ratio 1 -> 100, ratio 0.5 -> 150
+    const byRatio = Object.fromEntries(fib.levels.map((l) => [l.ratio, l.price]));
+    expect(byRatio[0]).toBe(200);
+    expect(byRatio[1]).toBe(100);
+    expect(byRatio[0.5]).toBe(150);
+  });
+
+  it('renders a trendline label as a chip anchored at the later endpoint', () => {
+    const anns: StoredAnnotation[] = [
+      {
+        annotation_id: 'tl1',
+        symbol: 'NVDA',
+        type: 'trendline',
+        label: 'Uptrend Support',
+        color: '#22c55e',
+        point1: { time: '2024-10-16T00:00:00Z', price: 100 },
+        point2: { time: '2024-11-20T00:00:00Z', price: 140 },
+      },
+    ];
+    const data = buildPrimitiveData(anns, CHART);
+    // The line is drawn natively; only its label becomes a primitive chip.
+    expect(data.texts).toHaveLength(1);
+    expect(data.texts[0].text).toBe('Uptrend Support');
+    expect(data.texts[0].price).toBe(140); // later point (2024-11-20)
+    expect(data.texts[0].color).toBe('#22c55e');
+  });
+
+  it('omits the trendline chip when the line has no label', () => {
+    const anns: StoredAnnotation[] = [
+      {
+        annotation_id: 'tl2',
+        symbol: 'NVDA',
+        type: 'trendline',
+        point1: { time: '2024-10-16T00:00:00Z', price: 100 },
+        point2: { time: '2024-11-20T00:00:00Z', price: 140 },
+      },
+    ];
+    expect(buildPrimitiveData(anns, CHART).texts).toHaveLength(0);
+  });
+});
+
+describe('resolveTrendlineData', () => {
+  it('returns two points sorted by time', () => {
+    const line = resolveTrendlineData(
+      {
+        annotation_id: 'tl',
+        symbol: 'NVDA',
+        type: 'trendline',
+        point1: { time: '2024-12-20T00:00:00Z', price: 200 },
+        point2: { time: '2024-10-16T00:00:00Z', price: 100 },
+      },
+      CHART,
+    );
+    expect(line).not.toBeNull();
+    expect(line!).toHaveLength(2);
+    // earlier bar first, carrying its own price (100)
+    expect(line![0].time).toBe(T('2024-10-16T00:00:00Z'));
+    expect(line![0].value).toBe(100);
+    expect(line![1].value).toBe(200);
+  });
+
+  it('returns null for a degenerate same-time line', () => {
+    const line = resolveTrendlineData(
+      {
+        annotation_id: 'tl',
+        symbol: 'NVDA',
+        type: 'trendline',
+        point1: { time: '2024-10-16T00:00:00Z', price: 100 },
+        point2: { time: '2024-10-16T00:00:00Z', price: 120 },
+      },
+      null,
+    );
+    expect(line).toBeNull();
+  });
+});

--- a/web/src/pages/MarketView/utils/__tests__/annotationGeometry.test.ts
+++ b/web/src/pages/MarketView/utils/__tests__/annotationGeometry.test.ts
@@ -4,10 +4,13 @@ import type { ChartDataPoint } from '@/types/market';
 
 import type { StoredAnnotation } from '../../stores/chartAnnotationStore';
 import {
+  DEFAULT_EVENT_COLOR,
   FIB_RATIOS,
+  buildEvents,
   buildMarkers,
   buildPrimitiveData,
   dashForStyle,
+  isEvent,
   resolveBarTime,
   resolveTrendlineData,
   snapToNearestBar,
@@ -158,6 +161,40 @@ describe('buildPrimitiveData', () => {
     expect(data.texts[0].color).toBe('#22c55e');
   });
 
+  it('omits event annotations from primitive data by default (DOM overlay owns them)', () => {
+    const anns: StoredAnnotation[] = [
+      {
+        annotation_id: 'e1',
+        symbol: 'NVDA',
+        type: 'event',
+        time: '2024-11-14T00:00:00Z',
+        price: 205,
+        title: 'Earnings',
+        detail: 'Beat and raised.',
+      },
+    ];
+    expect(buildPrimitiveData(anns, CHART).texts).toHaveLength(0);
+  });
+
+  it('renders the event title as a canvas chip when eventsAsText is set (inline card)', () => {
+    const anns: StoredAnnotation[] = [
+      {
+        annotation_id: 'e1',
+        symbol: 'NVDA',
+        type: 'event',
+        time: '2024-11-14T00:00:00Z',
+        price: 205,
+        title: 'Earnings',
+        detail: 'Beat and raised.',
+        color: '#abcdef',
+      },
+    ];
+    const data = buildPrimitiveData(anns, CHART, { eventsAsText: true });
+    expect(data.texts).toHaveLength(1);
+    expect(data.texts[0].text).toBe('Earnings'); // title, not detail
+    expect(data.texts[0].color).toBe('#abcdef');
+  });
+
   it('omits the trendline chip when the line has no label', () => {
     const anns: StoredAnnotation[] = [
       {
@@ -169,6 +206,77 @@ describe('buildPrimitiveData', () => {
       },
     ];
     expect(buildPrimitiveData(anns, CHART).texts).toHaveLength(0);
+  });
+});
+
+describe('buildEvents', () => {
+  it('resolves events to snapped bar times, sorted, with default color', () => {
+    const anns: StoredAnnotation[] = [
+      {
+        annotation_id: 'e2',
+        symbol: 'NVDA',
+        type: 'event',
+        time: '2024-12-20T00:00:00Z',
+        price: 202,
+        title: 'Later',
+        detail: 'd2',
+      },
+      {
+        annotation_id: 'e1',
+        symbol: 'NVDA',
+        type: 'event',
+        time: '2024-11-13T06:00:00Z', // snaps to the 11-14 bar
+        price: 112,
+        title: 'Earlier',
+        detail: 'd1',
+        color: '#123456',
+      },
+      // non-event annotations are ignored
+      { annotation_id: 'p1', symbol: 'NVDA', type: 'price_line', price: 200 },
+    ];
+    const events = buildEvents(anns, CHART);
+    expect(events).toHaveLength(2);
+    // sorted ascending by resolved time
+    expect(events[0].title).toBe('Earlier');
+    expect(events[0].time).toBe(T('2024-11-14T00:00:00Z'));
+    expect(events[0].color).toBe('#123456');
+    // default color applied when omitted
+    expect(events[1].title).toBe('Later');
+    expect(events[1].color).toBe(DEFAULT_EVENT_COLOR);
+  });
+
+  it('skips events whose time cannot be parsed', () => {
+    const anns: StoredAnnotation[] = [
+      {
+        annotation_id: 'e1',
+        symbol: 'NVDA',
+        type: 'event',
+        time: 'not-a-date',
+        price: 100,
+        title: 'Bad',
+        detail: 'd',
+      },
+    ];
+    // resolveBarTime returns null only when toUnixSeconds fails AND no chart
+    // data; with chart data a bad ISO yields null seconds → skipped.
+    expect(buildEvents(anns, null)).toHaveLength(0);
+  });
+
+  it('isEvent narrows the event type', () => {
+    expect(
+      isEvent({
+        annotation_id: 'e1',
+        symbol: 'NVDA',
+        type: 'event',
+        time: '2024-11-14T00:00:00Z',
+        price: 1,
+        title: 't',
+        detail: 'd',
+      }),
+    ).toBe(true);
+    expect(isEvent({ annotation_id: 'p1', symbol: 'NVDA', type: 'price_line', price: 1 })).toBe(
+      false,
+    );
   });
 });
 

--- a/web/src/pages/MarketView/utils/agentAnnotationsPrimitive.ts
+++ b/web/src/pages/MarketView/utils/agentAnnotationsPrimitive.ts
@@ -561,6 +561,7 @@ function rectToBox(
 // and there's no usable canvas (non-DOM / jsdom without a canvas backend), so
 // we stop trying and fall back to returning named colors unchanged.
 let colorResolverCtx: CanvasRenderingContext2D | null | undefined;
+const NAMED_COLOR_CACHE_MAX = 512;
 const namedColorCache = new Map<string, string | null>();
 
 function getColorResolverCtx(): CanvasRenderingContext2D | null {
@@ -590,6 +591,7 @@ function resetColorResolver(): void {
 function resolveNamedColor(color: string): string | null {
   const cached = namedColorCache.get(color);
   if (cached !== undefined) return cached;
+  if (namedColorCache.size >= NAMED_COLOR_CACHE_MAX) namedColorCache.clear();
   const ctx = getColorResolverCtx();
   if (!ctx) {
     namedColorCache.set(color, null);

--- a/web/src/pages/MarketView/utils/agentAnnotationsPrimitive.ts
+++ b/web/src/pages/MarketView/utils/agentAnnotationsPrimitive.ts
@@ -161,9 +161,27 @@ function roundRectPath(
   ctx.closePath();
 }
 
-function chipWidth(ctx: CanvasRenderingContext2D, text: string): number {
+// CHIP_FONT is a module constant, so a given text always measures to the same
+// width. Cache measured text widths so we don't re-run measureText for every
+// label on every paint (every tick/pan/zoom). Capped to bound memory across
+// many distinct labels; on overflow we clear wholesale (cheaper than LRU and
+// the cost is one re-measure pass, which is what we were paying every frame
+// before this cache existed).
+const TEXT_WIDTH_CACHE_MAX = 512;
+const textWidthCache = new Map<string, number>();
+
+function measureTextWidth(ctx: CanvasRenderingContext2D, text: string): number {
+  const cached = textWidthCache.get(text);
+  if (cached !== undefined) return cached;
   ctx.font = CHIP_FONT;
-  return CHIP_PAD_X * 2 + DOT_R * 2 + DOT_GAP + ctx.measureText(text).width;
+  const width = ctx.measureText(text).width;
+  if (textWidthCache.size >= TEXT_WIDTH_CACHE_MAX) textWidthCache.clear();
+  textWidthCache.set(text, width);
+  return width;
+}
+
+function chipWidth(ctx: CanvasRenderingContext2D, text: string): number {
+  return CHIP_PAD_X * 2 + DOT_R * 2 + DOT_GAP + measureTextWidth(ctx, text);
 }
 
 /**
@@ -324,8 +342,9 @@ export class AgentAnnotationsPrimitive {
 
     target.useMediaCoordinateSpace(({ context: ctx, mediaSize }) => {
       const timeScale = chart.timeScale();
+      const range = getVisibleSecondsRange(chart);
       for (const r of rects) {
-        const box = rectToBox(timeScale, series, r, mediaSize.width);
+        const box = rectToBox(timeScale, series, r, mediaSize.width, range);
         if (!box) continue;
         ctx.fillStyle = withAlpha(r.color, 0.1);
         ctx.fillRect(box.left, box.top, box.width, box.height);
@@ -344,13 +363,14 @@ export class AgentAnnotationsPrimitive {
 
     target.useMediaCoordinateSpace(({ context: ctx, mediaSize }) => {
       const timeScale = chart.timeScale();
+      const range = getVisibleSecondsRange(chart);
       // All labels are collected, then placed + drawn last, so chips sit above
       // every stroke and a single declutter pass keeps them from colliding.
       const labels: LabelReq[] = [];
 
       // Rectangle borders (fills are drawn in the bottom pane view).
       for (const r of rects) {
-        const box = rectToBox(timeScale, series, r, mediaSize.width);
+        const box = rectToBox(timeScale, series, r, mediaSize.width, range);
         if (!box) continue;
         ctx.save();
         ctx.strokeStyle = withAlpha(r.color, 0.7);
@@ -394,8 +414,12 @@ export class AgentAnnotationsPrimitive {
 
       // Fibonacci retracement levels.
       for (const f of fibs) {
+        if (!range) continue;
         const x1 = timeScale.timeToCoordinate(f.time1 as unknown as Time);
         const x2 = timeScale.timeToCoordinate(f.time2 as unknown as Time);
+        // Both anchors off-screen on the same side would clamp to a phantom
+        // full-pane line; skip those (opposite-side straddles still span below).
+        if (shouldSkipOffscreenSpan(range, x1, f.time1, x2, f.time2)) continue;
         const left = Math.min(x1 ?? 0, x2 ?? mediaSize.width);
         const right = Math.max(x1 ?? 0, x2 ?? mediaSize.width);
         for (const lvl of f.levels) {
@@ -452,15 +476,72 @@ interface TimeScaleLike {
   timeToCoordinate(time: Time): number | null;
 }
 
+/** Visible time range as unix-second numbers (matches stored item times). */
+export interface VisibleTimeRange {
+  from: number;
+  to: number;
+}
+
+/**
+ * Read the chart's visible time range as unix-second numbers, or null if the
+ * chart has no data. Times in this primitive are stored as unix seconds and the
+ * chart uses UTCTimestamp (numeric) times, so `from`/`to` come back numeric —
+ * mirroring how `ExtendedHoursBgPrimitive` compares them.
+ */
+function getVisibleSecondsRange(chart: IChartApiBase<Time>): VisibleTimeRange | null {
+  const range = chart.timeScale().getVisibleRange();
+  if (!range) return null;
+  const from = range.from as unknown as number;
+  const to = range.to as unknown as number;
+  if (typeof from !== 'number' || typeof to !== 'number') return null;
+  return { from, to };
+}
+
+/**
+ * Decide whether a two-anchor shape (rect / fib) should be skipped because both
+ * of its anchors lie off-screen on the SAME side of the viewport — in which case
+ * clamping each null coordinate to 0/width would paint a phantom full-pane shape.
+ *
+ * Returns true (skip) only when both anchors are off-screen AND on the same side.
+ * When the anchors straddle the viewport (one off-left, one off-right) the shape
+ * genuinely spans the pane, so we return false and let the caller draw full-width.
+ * On-screen anchors (non-null coordinate) never trigger a skip.
+ */
+export function shouldSkipOffscreenSpan(
+  range: VisibleTimeRange,
+  coordA: number | null,
+  timeA: number,
+  coordB: number | null,
+  timeB: number,
+): boolean {
+  if (coordA != null || coordB != null) return false; // at least one on-screen
+  const sideA = classifyOffscreenSide(range, timeA);
+  const sideB = classifyOffscreenSide(range, timeB);
+  // Both off-screen on the same, known side → phantom; skip.
+  return sideA !== 0 && sideA === sideB;
+}
+
+/** -1 = off-left (before `from`), +1 = off-right (after `to`), 0 = inside/unknown. */
+function classifyOffscreenSide(range: VisibleTimeRange, time: number): -1 | 0 | 1 {
+  if (time < range.from) return -1;
+  if (time > range.to) return 1;
+  return 0;
+}
+
 /** Convert a rect item to viewport-clipped pixel box, or null if undrawable. */
 function rectToBox(
   timeScale: TimeScaleLike,
   series: SeriesLike,
   r: RectItem,
   width: number,
+  range: VisibleTimeRange | null,
 ): Box | null {
+  if (!range) return null;
   const xa = timeScale.timeToCoordinate(r.time1 as unknown as Time);
   const xb = timeScale.timeToCoordinate(r.time2 as unknown as Time);
+  // Both corners off-screen on the same side would clamp to a phantom full-pane
+  // box; skip those (opposite-side straddles still draw full-width below).
+  if (shouldSkipOffscreenSpan(range, xa, r.time1, xb, r.time2)) return null;
   // Clip horizontally to the viewport when a corner is off-screen.
   const x1 = xa ?? 0;
   const x2 = xb ?? width;
@@ -475,12 +556,70 @@ function rectToBox(
   return { left, top, width: right - left, height: bottom - top };
 }
 
+// Lazily-created 2d context used only to normalize named CSS colors (e.g.
+// "tomato" → "#ff6347"). Resolution results are cached. `null` means we tried
+// and there's no usable canvas (non-DOM / jsdom without a canvas backend), so
+// we stop trying and fall back to returning named colors unchanged.
+let colorResolverCtx: CanvasRenderingContext2D | null | undefined;
+const namedColorCache = new Map<string, string | null>();
+
+function getColorResolverCtx(): CanvasRenderingContext2D | null {
+  if (colorResolverCtx !== undefined) return colorResolverCtx;
+  try {
+    if (typeof document === 'undefined') {
+      colorResolverCtx = null;
+      return null;
+    }
+    colorResolverCtx = document.createElement('canvas').getContext('2d');
+  } catch {
+    colorResolverCtx = null;
+  }
+  return colorResolverCtx;
+}
+
+/** Drop the lazily-created resolver context so it is re-acquired on next use. */
+function resetColorResolver(): void {
+  colorResolverCtx = undefined;
+}
+
 /**
- * Apply an alpha to a CSS color. Handles #rgb/#rrggbb/#rrggbbaa and
- * rgb()/rgba(); for anything else returns the color unchanged (so named
- * colors still render, just without the requested transparency).
+ * Resolve a named/unknown CSS color to a normalized form the hex/rgb fast paths
+ * can re-parse (browsers return `#rrggbb` or `rgb(...)`). Returns null when no
+ * canvas is available or the value isn't a recognized color. Cached per input.
+ */
+function resolveNamedColor(color: string): string | null {
+  const cached = namedColorCache.get(color);
+  if (cached !== undefined) return cached;
+  const ctx = getColorResolverCtx();
+  if (!ctx) {
+    namedColorCache.set(color, null);
+    return null;
+  }
+  // Setting fillStyle to an unparseable value is a no-op, so seed with a sentinel
+  // and detect rejection by the value not changing away from it.
+  const SENTINEL = '#010203';
+  ctx.fillStyle = SENTINEL;
+  ctx.fillStyle = color;
+  const normalized = ctx.fillStyle;
+  const resolved =
+    typeof normalized === 'string' && normalized.toLowerCase() !== SENTINEL
+      ? normalized
+      : null;
+  namedColorCache.set(color, resolved);
+  return resolved;
+}
+
+/**
+ * Apply an alpha to a CSS color. Handles #rgb/#rrggbb/#rrggbbaa, rgb()/rgba(),
+ * and named CSS colors (resolved via a canvas context when one is available).
+ * Falls back to returning the color unchanged only when it can't be parsed and
+ * no canvas is available to normalize it.
  */
 function withAlpha(color: string, alpha: number): string {
+  return withAlphaInner(color, alpha, true);
+}
+
+function withAlphaInner(color: string, alpha: number, allowNamed: boolean): string {
   const c = color.trim();
   if (c.startsWith('#')) {
     const hex = c.slice(1);
@@ -508,5 +647,26 @@ function withAlpha(color: string, alpha: number): string {
       return `rgba(${parts[0]},${parts[1]},${parts[2]},${alpha})`;
     }
   }
+  // Named/unknown color: normalize via canvas, then re-run the fast paths on the
+  // normalized hex/rgb. `allowNamed` guards against infinite recursion if a
+  // resolver ever returns another unparseable string.
+  if (allowNamed) {
+    const resolved = resolveNamedColor(c);
+    if (resolved && resolved !== c) {
+      return withAlphaInner(resolved, alpha, false);
+    }
+  }
   return color;
 }
+
+/**
+ * Internal helpers exposed only for unit tests. Not part of the public API —
+ * do not import from application code.
+ */
+export const __testing = {
+  chipWidth,
+  withAlpha,
+  textWidthCache,
+  namedColorCache,
+  resetColorResolver,
+};

--- a/web/src/pages/MarketView/utils/agentAnnotationsPrimitive.ts
+++ b/web/src/pages/MarketView/utils/agentAnnotationsPrimitive.ts
@@ -1,0 +1,512 @@
+/**
+ * Lightweight-charts v4 series primitive that draws the agent annotation
+ * shapes LWC has no native API for: rectangles (zones), vertical lines,
+ * free-floating text, and Fibonacci retracement levels.
+ *
+ * Price lines, trendlines, and markers are handled elsewhere via native
+ * LWC APIs (createPriceLine / addLineSeries / setMarkers); this primitive
+ * only owns the canvas-drawn geometry.
+ *
+ * The hook (`useAgentAnnotations`) converts store annotations into the
+ * coordinate-free item arrays below (times as unix seconds, prices as
+ * y-values) and calls `setData`. This primitive does the per-frame
+ * coordinate conversion and drawing — mirroring `ExtendedHoursBgPrimitive`.
+ *
+ * Labels render as theme-aware frosted chips (light/dark) with a soft shadow
+ * and an accent dot keyed to the annotation color; a declutter pass keeps them
+ * from overlapping each other or spilling past the pane edges.
+ *
+ * Usage:
+ *   const prim = new AgentAnnotationsPrimitive();
+ *   candlestickSeries.attachPrimitive(prim);
+ *   prim.setTheme('light');                 // or 'dark' (default)
+ *   prim.setData({ rects, vlines, texts, fibs });
+ */
+
+import type {
+  ISeriesPrimitivePaneView,
+  ISeriesPrimitivePaneRenderer,
+  SeriesPrimitivePaneViewZOrder,
+  Time,
+  IChartApiBase,
+} from 'lightweight-charts';
+import type { CanvasRenderingTarget2D } from 'fancy-canvas';
+
+export interface RectItem {
+  time1: number;
+  time2: number;
+  price1: number;
+  price2: number;
+  color: string;
+  label?: string;
+}
+
+export interface VLineItem {
+  time: number;
+  color: string;
+  /** Canvas dash pattern; [] means solid. */
+  dash: number[];
+  label?: string;
+}
+
+export interface TextItem {
+  time: number;
+  price: number;
+  text: string;
+  color: string;
+}
+
+export interface FibLevel {
+  ratio: number;
+  price: number;
+}
+
+export interface FibItem {
+  time1: number;
+  time2: number;
+  levels: FibLevel[];
+  color: string;
+}
+
+export interface AgentAnnotationsData {
+  rects: RectItem[];
+  vlines: VLineItem[];
+  texts: TextItem[];
+  fibs: FibItem[];
+}
+
+interface SeriesLike {
+  priceToCoordinate(price: number): number | null;
+}
+
+interface SeriesAttachedParams {
+  chart: IChartApiBase<Time>;
+  series: SeriesLike;
+  requestUpdate: () => void;
+}
+
+const EMPTY: AgentAnnotationsData = { rects: [], vlines: [], texts: [], fibs: [] };
+
+export type AnnotationTheme = 'light' | 'dark';
+
+const CHIP_FONT =
+  '600 11px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+
+interface ChipPalette {
+  bg: string;
+  border: string;
+  ink: string;
+  shadow: string;
+}
+
+// Frosted chip surfaces tuned to the two chart backgrounds (#000 dark /
+// #FFFCF9 light). The annotation's own color is demoted to a small accent dot
+// so the label text stays high-contrast ink on whatever palette the agent picks
+// — the single biggest legibility win over stamping raw color on a dark box.
+const CHIP_PALETTE: Record<AnnotationTheme, ChipPalette> = {
+  dark: {
+    bg: 'rgba(20, 22, 27, 0.88)',
+    border: 'rgba(255, 255, 255, 0.16)',
+    ink: '#F4F4F5',
+    shadow: 'rgba(0, 0, 0, 0.55)',
+  },
+  light: {
+    bg: 'rgba(255, 252, 249, 0.94)',
+    border: 'rgba(45, 43, 40, 0.16)',
+    ink: '#2D2B28',
+    shadow: 'rgba(45, 43, 40, 0.22)',
+  },
+};
+
+const CHIP_H = 19; // fixed chip height → consistent vertical rhythm
+const CHIP_PAD_X = 7;
+const CHIP_RADIUS = 4;
+const DOT_R = 3;
+const DOT_GAP = 6;
+const CHIP_GAP = 4; // min vertical gap between decluttered chips
+const EDGE = 4; // keep chips off the pane edges
+
+type ChipAlign = 'left' | 'center' | 'right';
+
+interface LabelReq {
+  text: string;
+  accent: string;
+  anchorX: number;
+  anchorY: number;
+  align: ChipAlign;
+}
+
+interface PlacedChip extends LabelReq {
+  left: number;
+  top: number;
+  width: number;
+}
+
+/** Trace a rounded-rectangle path (caller fills/strokes). */
+function roundRectPath(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  r: number,
+): void {
+  const rad = Math.min(r, w / 2, h / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + rad, y);
+  ctx.arcTo(x + w, y, x + w, y + h, rad);
+  ctx.arcTo(x + w, y + h, x, y + h, rad);
+  ctx.arcTo(x, y + h, x, y, rad);
+  ctx.arcTo(x, y, x + w, y, rad);
+  ctx.closePath();
+}
+
+function chipWidth(ctx: CanvasRenderingContext2D, text: string): number {
+  ctx.font = CHIP_FONT;
+  return CHIP_PAD_X * 2 + DOT_R * 2 + DOT_GAP + ctx.measureText(text).width;
+}
+
+/**
+ * Resolve each label anchor → clamped chip box, then nudge overlapping chips
+ * downward so no two collide and none spill past the pane edges. Chips stay
+ * pinned to their anchor's x (the meaningful axis); only y is decluttered.
+ */
+function layoutChips(
+  ctx: CanvasRenderingContext2D,
+  reqs: LabelReq[],
+  paneW: number,
+  paneH: number,
+): PlacedChip[] {
+  const chips: PlacedChip[] = reqs.map((r) => {
+    const width = chipWidth(ctx, r.text);
+    let left =
+      r.align === 'center'
+        ? r.anchorX - width / 2
+        : r.align === 'right'
+          ? r.anchorX - width
+          : r.anchorX;
+    left = Math.max(EDGE, Math.min(left, paneW - width - EDGE));
+    let top = r.anchorY - CHIP_H / 2;
+    top = Math.max(EDGE, Math.min(top, paneH - CHIP_H - EDGE));
+    return { ...r, left, top, width };
+  });
+
+  // Greedy top-down declutter: each chip drops below every earlier chip it
+  // would overlap horizontally. Earlier = smaller resolved top, so the chips
+  // we compare against are already final.
+  chips.sort((a, b) => a.top - b.top || a.left - b.left);
+  for (let i = 0; i < chips.length; i++) {
+    const cur = chips[i];
+    let top = cur.top;
+    for (let j = 0; j < i; j++) {
+      const prev = chips[j];
+      const xOverlap =
+        cur.left < prev.left + prev.width + CHIP_GAP &&
+        prev.left < cur.left + cur.width + CHIP_GAP;
+      if (xOverlap) top = Math.max(top, prev.top + CHIP_H + CHIP_GAP);
+    }
+    if (top + CHIP_H > paneH - EDGE) top = Math.max(EDGE, paneH - EDGE - CHIP_H);
+    cur.top = top;
+  }
+  return chips;
+}
+
+function drawChip(
+  ctx: CanvasRenderingContext2D,
+  chip: PlacedChip,
+  pal: ChipPalette,
+): void {
+  const { left, top, width } = chip;
+  const cy = top + CHIP_H / 2;
+
+  // Frosted background with a soft drop shadow for separation from candles.
+  ctx.save();
+  ctx.shadowColor = pal.shadow;
+  ctx.shadowBlur = 7;
+  ctx.shadowOffsetY = 1.5;
+  roundRectPath(ctx, left, top, width, CHIP_H, CHIP_RADIUS);
+  ctx.fillStyle = pal.bg;
+  ctx.fill();
+  ctx.restore();
+
+  // Hairline border.
+  roundRectPath(ctx, left + 0.5, top + 0.5, width - 1, CHIP_H - 1, CHIP_RADIUS);
+  ctx.strokeStyle = pal.border;
+  ctx.lineWidth = 1;
+  ctx.stroke();
+
+  // Accent dot keyed to the annotation color (forced opaque for a crisp dot).
+  const dotX = left + CHIP_PAD_X + DOT_R;
+  ctx.beginPath();
+  ctx.arc(dotX, cy, DOT_R, 0, Math.PI * 2);
+  ctx.fillStyle = withAlpha(chip.accent, 1);
+  ctx.fill();
+
+  // Label text in high-contrast ink.
+  ctx.font = CHIP_FONT;
+  ctx.textAlign = 'left';
+  ctx.textBaseline = 'middle';
+  ctx.fillStyle = pal.ink;
+  ctx.fillText(chip.text, dotX + DOT_R + DOT_GAP, cy + 0.5);
+}
+
+export class AgentAnnotationsPrimitive {
+  private _data: AgentAnnotationsData = EMPTY;
+  private _theme: AnnotationTheme = 'dark';
+  private _chart: IChartApiBase<Time> | null = null;
+  private _series: SeriesLike | null = null;
+  private _requestUpdate: (() => void) | null = null;
+
+  attached({ chart, series, requestUpdate }: SeriesAttachedParams): void {
+    this._chart = chart;
+    this._series = series;
+    this._requestUpdate = requestUpdate;
+  }
+
+  detached(): void {
+    this._chart = null;
+    this._series = null;
+    this._requestUpdate = null;
+  }
+
+  setData(data: AgentAnnotationsData): void {
+    this._data = data;
+    this._requestUpdate?.();
+  }
+
+  /** Switch the chip palette between light/dark; redraws if it changed. */
+  setTheme(theme: AnnotationTheme): void {
+    if (this._theme === theme) return;
+    this._theme = theme;
+    this._requestUpdate?.();
+  }
+
+  updateAllViews(): void {}
+
+  paneViews(): ISeriesPrimitivePaneView[] {
+    const source = this;
+    // Two views: rectangle fills sit below the candles; everything else
+    // (borders, lines, text, fib levels) draws on top.
+    return [
+      {
+        zOrder(): SeriesPrimitivePaneViewZOrder {
+          return 'bottom';
+        },
+        renderer(): ISeriesPrimitivePaneRenderer {
+          return {
+            draw(target: CanvasRenderingTarget2D): void {
+              source._drawFills(target);
+            },
+          };
+        },
+      },
+      {
+        zOrder(): SeriesPrimitivePaneViewZOrder {
+          return 'top';
+        },
+        renderer(): ISeriesPrimitivePaneRenderer {
+          return {
+            draw(target: CanvasRenderingTarget2D): void {
+              source._drawForeground(target);
+            },
+          };
+        },
+      },
+    ];
+  }
+
+  private _drawFills(target: CanvasRenderingTarget2D): void {
+    const chart = this._chart;
+    const series = this._series;
+    if (!chart || !series) return;
+    const { rects } = this._data;
+    if (rects.length === 0) return;
+
+    target.useMediaCoordinateSpace(({ context: ctx, mediaSize }) => {
+      const timeScale = chart.timeScale();
+      for (const r of rects) {
+        const box = rectToBox(timeScale, series, r, mediaSize.width);
+        if (!box) continue;
+        ctx.fillStyle = withAlpha(r.color, 0.1);
+        ctx.fillRect(box.left, box.top, box.width, box.height);
+      }
+    });
+  }
+
+  private _drawForeground(target: CanvasRenderingTarget2D): void {
+    const chart = this._chart;
+    const series = this._series;
+    if (!chart || !series) return;
+    const { rects, vlines, texts, fibs } = this._data;
+    if (!rects.length && !vlines.length && !texts.length && !fibs.length) return;
+
+    const pal = CHIP_PALETTE[this._theme];
+
+    target.useMediaCoordinateSpace(({ context: ctx, mediaSize }) => {
+      const timeScale = chart.timeScale();
+      // All labels are collected, then placed + drawn last, so chips sit above
+      // every stroke and a single declutter pass keeps them from colliding.
+      const labels: LabelReq[] = [];
+
+      // Rectangle borders (fills are drawn in the bottom pane view).
+      for (const r of rects) {
+        const box = rectToBox(timeScale, series, r, mediaSize.width);
+        if (!box) continue;
+        ctx.save();
+        ctx.strokeStyle = withAlpha(r.color, 0.7);
+        ctx.lineWidth = 1;
+        ctx.strokeRect(box.left, box.top, box.width, box.height);
+        ctx.restore();
+        if (r.label) {
+          labels.push({
+            text: r.label,
+            accent: r.color,
+            anchorX: box.left + 2,
+            anchorY: box.top + CHIP_H / 2 + 2,
+            align: 'left',
+          });
+        }
+      }
+
+      // Vertical lines.
+      for (const v of vlines) {
+        const x = timeScale.timeToCoordinate(v.time as unknown as Time);
+        if (x == null) continue;
+        ctx.save();
+        ctx.strokeStyle = withAlpha(v.color, 0.8);
+        ctx.lineWidth = 1;
+        ctx.setLineDash(v.dash);
+        ctx.beginPath();
+        ctx.moveTo(x, 0);
+        ctx.lineTo(x, mediaSize.height);
+        ctx.stroke();
+        ctx.restore();
+        if (v.label) {
+          labels.push({
+            text: v.label,
+            accent: v.color,
+            anchorX: x,
+            anchorY: EDGE + CHIP_H / 2,
+            align: 'center',
+          });
+        }
+      }
+
+      // Fibonacci retracement levels.
+      for (const f of fibs) {
+        const x1 = timeScale.timeToCoordinate(f.time1 as unknown as Time);
+        const x2 = timeScale.timeToCoordinate(f.time2 as unknown as Time);
+        const left = Math.min(x1 ?? 0, x2 ?? mediaSize.width);
+        const right = Math.max(x1 ?? 0, x2 ?? mediaSize.width);
+        for (const lvl of f.levels) {
+          const y = series.priceToCoordinate(lvl.price);
+          if (y == null) continue;
+          ctx.save();
+          ctx.strokeStyle = withAlpha(f.color, 0.55);
+          ctx.lineWidth = 1;
+          ctx.setLineDash([2, 3]);
+          ctx.beginPath();
+          ctx.moveTo(left, y);
+          ctx.lineTo(right, y);
+          ctx.stroke();
+          ctx.restore();
+          labels.push({
+            text: `${lvl.ratio} · ${lvl.price.toFixed(2)}`,
+            accent: f.color,
+            anchorX: right,
+            anchorY: y,
+            align: 'right',
+          });
+        }
+      }
+
+      // Free-floating text.
+      for (const t of texts) {
+        if (!t.text) continue;
+        const x = timeScale.timeToCoordinate(t.time as unknown as Time);
+        const y = series.priceToCoordinate(t.price);
+        if (x == null || y == null) continue;
+        labels.push({
+          text: t.text,
+          accent: t.color,
+          anchorX: x,
+          anchorY: y,
+          align: 'center',
+        });
+      }
+
+      const chips = layoutChips(ctx, labels, mediaSize.width, mediaSize.height);
+      for (const chip of chips) drawChip(ctx, chip, pal);
+    });
+  }
+}
+
+interface Box {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+interface TimeScaleLike {
+  timeToCoordinate(time: Time): number | null;
+}
+
+/** Convert a rect item to viewport-clipped pixel box, or null if undrawable. */
+function rectToBox(
+  timeScale: TimeScaleLike,
+  series: SeriesLike,
+  r: RectItem,
+  width: number,
+): Box | null {
+  const xa = timeScale.timeToCoordinate(r.time1 as unknown as Time);
+  const xb = timeScale.timeToCoordinate(r.time2 as unknown as Time);
+  // Clip horizontally to the viewport when a corner is off-screen.
+  const x1 = xa ?? 0;
+  const x2 = xb ?? width;
+  const left = Math.max(0, Math.min(x1, x2));
+  const right = Math.min(width, Math.max(x1, x2));
+  const ya = series.priceToCoordinate(r.price1);
+  const yb = series.priceToCoordinate(r.price2);
+  if (ya == null || yb == null) return null;
+  const top = Math.min(ya, yb);
+  const bottom = Math.max(ya, yb);
+  if (right <= left || bottom <= top) return null;
+  return { left, top, width: right - left, height: bottom - top };
+}
+
+/**
+ * Apply an alpha to a CSS color. Handles #rgb/#rrggbb/#rrggbbaa and
+ * rgb()/rgba(); for anything else returns the color unchanged (so named
+ * colors still render, just without the requested transparency).
+ */
+function withAlpha(color: string, alpha: number): string {
+  const c = color.trim();
+  if (c.startsWith('#')) {
+    const hex = c.slice(1);
+    let r: number;
+    let g: number;
+    let b: number;
+    if (hex.length === 3) {
+      r = parseInt(hex[0] + hex[0], 16);
+      g = parseInt(hex[1] + hex[1], 16);
+      b = parseInt(hex[2] + hex[2], 16);
+    } else if (hex.length === 6 || hex.length === 8) {
+      r = parseInt(hex.slice(0, 2), 16);
+      g = parseInt(hex.slice(2, 4), 16);
+      b = parseInt(hex.slice(4, 6), 16);
+    } else {
+      return color;
+    }
+    if ([r, g, b].some((n) => Number.isNaN(n))) return color;
+    return `rgba(${r},${g},${b},${alpha})`;
+  }
+  const rgbMatch = c.match(/^rgba?\(([^)]+)\)$/i);
+  if (rgbMatch) {
+    const parts = rgbMatch[1].split(',').map((p) => p.trim());
+    if (parts.length >= 3) {
+      return `rgba(${parts[0]},${parts[1]},${parts[2]},${alpha})`;
+    }
+  }
+  return color;
+}

--- a/web/src/pages/MarketView/utils/annotationGeometry.ts
+++ b/web/src/pages/MarketView/utils/annotationGeometry.ts
@@ -235,9 +235,14 @@ export function buildPrimitiveData(
       const t1 = resolveBarTime(chartData, ann.point1.time);
       const t2 = resolveBarTime(chartData, ann.point2.time);
       if (t1 == null || t2 == null) continue;
+      // Order corners so time1 <= time2. The box is symmetric in its two
+      // corners, but the off-screen clamp in the primitive assumes time1 is the
+      // earlier (left) edge — reversed anchors would otherwise paint a phantom
+      // span when one corner falls outside the loaded range.
+      const rectEarlierFirst = t1 <= t2;
       rects.push({
-        time1: t1,
-        time2: t2,
+        time1: rectEarlierFirst ? t1 : t2,
+        time2: rectEarlierFirst ? t2 : t1,
         price1: ann.point1.price,
         price2: ann.point2.price,
         color: ann.color ?? DEFAULT_RECT_COLOR,
@@ -268,13 +273,16 @@ export function buildPrimitiveData(
       if (t1 == null || t2 == null) continue;
       const p1 = ann.point1.price;
       const p2 = ann.point2.price;
+      // Level prices are tied to point identity (point1 = 1.0, point2 = 0.0),
+      // so do NOT reorder them by time. Only the rendered x-span needs time1 <=
+      // time2 for the primitive's off-screen clamp to be correct.
       const levels = FIB_RATIOS.map((ratio) => ({
         ratio,
         price: p2 + (p1 - p2) * ratio,
       }));
       fibs.push({
-        time1: t1,
-        time2: t2,
+        time1: Math.min(t1, t2),
+        time2: Math.max(t1, t2),
         levels,
         color: ann.color ?? DEFAULT_FIB_COLOR,
       });

--- a/web/src/pages/MarketView/utils/annotationGeometry.ts
+++ b/web/src/pages/MarketView/utils/annotationGeometry.ts
@@ -123,6 +123,49 @@ export function isEvent(a: StoredAnnotation): a is EventAnnotation {
   return a.type === 'event';
 }
 
+// --- Compact visual summary -----------------------------------------------
+
+export interface AnnotationVisual {
+  /** Display label — the agent's label/text/title, or a per-type fallback. */
+  label: string;
+  /** Accent color — the agent's color, or the per-type default. */
+  color: string;
+  /** Human-readable kind ("Price line", "Trendline", …). */
+  kind: string;
+  /** Optional value detail ("$317.40"); empty when not applicable. */
+  detail: string;
+}
+
+function formatPrice(n: number): string {
+  if (!Number.isFinite(n)) return '';
+  return `$${n.toLocaleString('en-US', { maximumFractionDigits: 2 })}`;
+}
+
+/**
+ * Resolve one annotation to label / color / kind / detail for compact UIs —
+ * the chat card's legend, swatches and schematic thumbnail. Pure; mirrors the
+ * per-type default colors used when the agent omits one.
+ */
+export function describeAnnotationVisual(a: StoredAnnotation): AnnotationVisual {
+  if (isPriceLine(a))
+    return { label: a.label || 'Price line', color: a.color || DEFAULT_LINE_COLOR, kind: 'Price line', detail: formatPrice(a.price) };
+  if (isTrendline(a))
+    return { label: a.label || 'Trendline', color: a.color || DEFAULT_TRENDLINE_COLOR, kind: 'Trendline', detail: '' };
+  if (isMarker(a))
+    return { label: a.text || 'Marker', color: a.color || DEFAULT_MARKER_COLOR, kind: 'Marker', detail: '' };
+  if (isVerticalLine(a))
+    return { label: a.label || 'Time marker', color: a.color || DEFAULT_VLINE_COLOR, kind: 'Vertical line', detail: '' };
+  if (isRectangle(a))
+    return { label: a.label || 'Zone', color: a.color || DEFAULT_RECT_COLOR, kind: 'Zone', detail: '' };
+  if (isText(a))
+    return { label: a.text || 'Note', color: a.color || DEFAULT_TEXT_COLOR, kind: 'Note', detail: '' };
+  if (isEvent(a))
+    return { label: a.title || 'Event', color: a.color || DEFAULT_EVENT_COLOR, kind: 'Event', detail: '' };
+  if (isFib(a))
+    return { label: a.label || 'Fib retracement', color: a.color || DEFAULT_FIB_COLOR, kind: 'Fib retracement', detail: '' };
+  return { label: 'Annotation', color: DEFAULT_LINE_COLOR, kind: 'Annotation', detail: '' };
+}
+
 /**
  * Two-point line data for a trendline, snapped to bars when possible.
  *
@@ -134,6 +177,9 @@ export function resolveTrendlineData(
   ann: TrendlineAnnotation,
   chartData: ChartDataPoint[] | null,
 ): { time: Time; value: number }[] | null {
+  // Defensive: stored payloads come from agent-generated JSONB; a row missing
+  // its anchor points would otherwise throw on the .time deref below.
+  if (!ann.point1 || !ann.point2) return null;
   const t1 = toUnixSeconds(ann.point1.time);
   const t2 = toUnixSeconds(ann.point2.time);
   if (t1 == null || t2 == null) return null;
@@ -185,6 +231,7 @@ export function buildPrimitiveData(
 
   for (const ann of annotations) {
     if (isRectangle(ann)) {
+      if (!ann.point1 || !ann.point2) continue;
       const t1 = resolveBarTime(chartData, ann.point1.time);
       const t2 = resolveBarTime(chartData, ann.point2.time);
       if (t1 == null || t2 == null) continue;
@@ -215,6 +262,7 @@ export function buildPrimitiveData(
         color: ann.color ?? DEFAULT_TEXT_COLOR,
       });
     } else if (isFib(ann)) {
+      if (!ann.point1 || !ann.point2) continue;
       const t1 = resolveBarTime(chartData, ann.point1.time);
       const t2 = resolveBarTime(chartData, ann.point2.time);
       if (t1 == null || t2 == null) continue;
@@ -242,6 +290,7 @@ export function buildPrimitiveData(
         color: ann.color ?? DEFAULT_EVENT_COLOR,
       });
     } else if (isTrendline(ann) && ann.label) {
+      if (!ann.point1 || !ann.point2) continue;
       // The line itself is drawn natively (addLineSeries); only its label
       // becomes a chip, anchored at the chronologically-later endpoint so it
       // sits at the end of the drawn line instead of stranded on the price
@@ -315,7 +364,7 @@ export function buildMarkers(
     markers.push({
       time: snapped as Time,
       position: ann.position ?? 'aboveBar',
-      shape: ann.shape === 'circle' || ann.shape === 'square' ? 'circle' : ann.shape,
+      shape: ann.shape,
       color: ann.color ?? DEFAULT_MARKER_COLOR,
       text: ann.text ?? '',
     });

--- a/web/src/pages/MarketView/utils/annotationGeometry.ts
+++ b/web/src/pages/MarketView/utils/annotationGeometry.ts
@@ -20,6 +20,7 @@ import type {
   AgentAnnotationsData,
 } from './agentAnnotationsPrimitive';
 import type {
+  EventAnnotation,
   FibRetracementAnnotation,
   MarkerAnnotation,
   PriceLineAnnotation,
@@ -40,6 +41,9 @@ export const DEFAULT_RECT_COLOR = '#4F8AD6';
 export const DEFAULT_VLINE_COLOR = '#4F8AD6';
 export const DEFAULT_TEXT_COLOR = '#4F8AD6';
 export const DEFAULT_FIB_COLOR = '#C99A4E';
+// News/event badges read as editorial callouts — a warm amber that stands
+// apart from the slate-blue technical accents on both chart backgrounds.
+export const DEFAULT_EVENT_COLOR = '#D8893B';
 
 /** Standard Fibonacci retracement ratios. */
 export const FIB_RATIOS = [0, 0.236, 0.382, 0.5, 0.618, 0.786, 1] as const;
@@ -115,6 +119,9 @@ export function isText(a: StoredAnnotation): a is TextAnnotation {
 export function isFib(a: StoredAnnotation): a is FibRetracementAnnotation {
   return a.type === 'fib_retracement';
 }
+export function isEvent(a: StoredAnnotation): a is EventAnnotation {
+  return a.type === 'event';
+}
 
 /**
  * Two-point line data for a trendline, snapped to bars when possible.
@@ -160,10 +167,16 @@ export function resolveTrendlineData(
  * Build the canvas-primitive data (rectangles, vertical lines, text, fib
  * levels) for a set of annotations. Items whose times can't be resolved are
  * skipped.
+ *
+ * ``event`` annotations are interactive DOM badges on the live chart
+ * (``AgentEventOverlay``), so they're omitted here by default. The inline chat
+ * mini-chart has no DOM overlay, so it passes ``eventsAsText: true`` to render
+ * the event title as a non-interactive canvas chip instead.
  */
 export function buildPrimitiveData(
   annotations: StoredAnnotation[],
   chartData: ChartDataPoint[] | null,
+  opts?: { eventsAsText?: boolean },
 ): AgentAnnotationsData {
   const rects: RectItem[] = [];
   const vlines: VLineItem[] = [];
@@ -217,6 +230,17 @@ export function buildPrimitiveData(
         levels,
         color: ann.color ?? DEFAULT_FIB_COLOR,
       });
+    } else if (isEvent(ann) && opts?.eventsAsText) {
+      // Inline chat card only: no DOM overlay there, so surface the event
+      // title as a canvas chip. The live chart renders an interactive badge.
+      const t = resolveBarTime(chartData, ann.time);
+      if (t == null) continue;
+      texts.push({
+        time: t,
+        price: ann.price,
+        text: ann.title,
+        color: ann.color ?? DEFAULT_EVENT_COLOR,
+      });
     } else if (isTrendline(ann) && ann.label) {
       // The line itself is drawn natively (addLineSeries); only its label
       // becomes a chip, anchored at the chronologically-later endpoint so it
@@ -238,6 +262,43 @@ export function buildPrimitiveData(
   }
 
   return { rects, vlines, texts, fibs };
+}
+
+/** A news/event annotation resolved to a drawable bar time (unix seconds). */
+export interface EventItem {
+  id: string;
+  time: number;
+  price: number;
+  title: string;
+  detail: string;
+  color: string;
+}
+
+/**
+ * Resolve ``event`` annotations to (bar-time, price) anchors for the
+ * interactive DOM overlay. Items whose time can't be resolved are skipped.
+ * Sorted by time so overlapping badges stack deterministically.
+ */
+export function buildEvents(
+  annotations: StoredAnnotation[],
+  chartData: ChartDataPoint[] | null,
+): EventItem[] {
+  const out: EventItem[] = [];
+  for (const ann of annotations) {
+    if (!isEvent(ann)) continue;
+    const t = resolveBarTime(chartData, ann.time);
+    if (t == null) continue;
+    out.push({
+      id: ann.annotation_id,
+      time: t,
+      price: ann.price,
+      title: ann.title,
+      detail: ann.detail,
+      color: ann.color ?? DEFAULT_EVENT_COLOR,
+    });
+  }
+  out.sort((a, b) => a.time - b.time);
+  return out;
 }
 
 /** Build LWC series markers for marker annotations, sorted by time. */

--- a/web/src/pages/MarketView/utils/annotationGeometry.ts
+++ b/web/src/pages/MarketView/utils/annotationGeometry.ts
@@ -1,0 +1,265 @@
+/**
+ * Pure helpers that translate stored annotations into lightweight-charts
+ * drawable data (time-snapping, primitive items, markers, trendline points).
+ *
+ * Kept free of React so they can be shared by ``useAgentAnnotations`` (the
+ * live MarketView chart) and ``InlineChartAnnotationCard`` (the one-shot
+ * mini chart rendered in the chat transcript). Times are unix seconds,
+ * prices are raw y-values — the primitive / series do pixel conversion.
+ */
+
+import { LineStyle, type SeriesMarker, type Time } from 'lightweight-charts';
+
+import type { ChartDataPoint } from '@/types/market';
+
+import type {
+  FibItem,
+  RectItem,
+  TextItem,
+  VLineItem,
+  AgentAnnotationsData,
+} from './agentAnnotationsPrimitive';
+import type {
+  FibRetracementAnnotation,
+  MarkerAnnotation,
+  PriceLineAnnotation,
+  RectangleAnnotation,
+  StoredAnnotation,
+  TextAnnotation,
+  TrendlineAnnotation,
+  VerticalLineAnnotation,
+} from '../stores/chartAnnotationStore';
+
+// Default colors — used only when the agent omits a color. A calm, cohesive
+// accent set (slate blue + muted gold for fibs) that reads cleanly on both the
+// black dark-mode and cream light-mode chart backgrounds.
+export const DEFAULT_LINE_COLOR = '#4F8AD6';
+export const DEFAULT_TRENDLINE_COLOR = 'rgba(79,138,214,0.7)';
+export const DEFAULT_MARKER_COLOR = '#4F8AD6';
+export const DEFAULT_RECT_COLOR = '#4F8AD6';
+export const DEFAULT_VLINE_COLOR = '#4F8AD6';
+export const DEFAULT_TEXT_COLOR = '#4F8AD6';
+export const DEFAULT_FIB_COLOR = '#C99A4E';
+
+/** Standard Fibonacci retracement ratios. */
+export const FIB_RATIOS = [0, 0.236, 0.382, 0.5, 0.618, 0.786, 1] as const;
+
+export function dashForStyle(style?: 'solid' | 'dashed' | 'dotted'): number[] {
+  if (style === 'dotted') return [1, 3];
+  if (style === 'solid') return [];
+  return [4, 4]; // dashed (default for vertical lines)
+}
+
+export function styleToLwc(style: PriceLineAnnotation['style']): LineStyle {
+  if (style === 'dashed') return LineStyle.Dashed;
+  if (style === 'dotted') return LineStyle.Dotted;
+  return LineStyle.Solid;
+}
+
+export function toUnixSeconds(iso: string): number | null {
+  const ms = Date.parse(iso);
+  if (!Number.isFinite(ms)) return null;
+  return Math.floor(ms / 1000);
+}
+
+export function snapToNearestBar(
+  chartData: ChartDataPoint[] | null,
+  target: number,
+): number | null {
+  if (!chartData || chartData.length === 0) return null;
+  let lo = 0;
+  let hi = chartData.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (chartData[mid].time < target) lo = mid + 1;
+    else hi = mid;
+  }
+  if (lo > 0) {
+    const diffLo = Math.abs(chartData[lo].time - target);
+    const diffPrev = Math.abs(chartData[lo - 1].time - target);
+    if (diffPrev < diffLo) lo -= 1;
+  }
+  return chartData[lo].time;
+}
+
+/** ISO → unix seconds, snapped to the nearest bar when chart data exists. */
+export function resolveBarTime(
+  chartData: ChartDataPoint[] | null,
+  iso: string,
+): number | null {
+  const secs = toUnixSeconds(iso);
+  if (secs == null) return null;
+  return snapToNearestBar(chartData, secs) ?? secs;
+}
+
+// --- Type guards ----------------------------------------------------------
+
+export function isPriceLine(a: StoredAnnotation): a is PriceLineAnnotation {
+  return a.type === 'price_line';
+}
+export function isTrendline(a: StoredAnnotation): a is TrendlineAnnotation {
+  return a.type === 'trendline';
+}
+export function isMarker(a: StoredAnnotation): a is MarkerAnnotation {
+  return a.type === 'marker';
+}
+export function isVerticalLine(a: StoredAnnotation): a is VerticalLineAnnotation {
+  return a.type === 'vertical_line';
+}
+export function isRectangle(a: StoredAnnotation): a is RectangleAnnotation {
+  return a.type === 'rectangle';
+}
+export function isText(a: StoredAnnotation): a is TextAnnotation {
+  return a.type === 'text';
+}
+export function isFib(a: StoredAnnotation): a is FibRetracementAnnotation {
+  return a.type === 'fib_retracement';
+}
+
+/**
+ * Two-point line data for a trendline, snapped to bars when possible.
+ *
+ * Falls back to raw timestamps if both points snap to the same bar (LWC
+ * rejects duplicate/unsorted times). Returns null for a degenerate line
+ * (both anchors at the same time).
+ */
+export function resolveTrendlineData(
+  ann: TrendlineAnnotation,
+  chartData: ChartDataPoint[] | null,
+): { time: Time; value: number }[] | null {
+  const t1 = toUnixSeconds(ann.point1.time);
+  const t2 = toUnixSeconds(ann.point2.time);
+  if (t1 == null || t2 == null) return null;
+
+  const snap1 = snapToNearestBar(chartData, t1);
+  const snap2 = snapToNearestBar(chartData, t2);
+  let lineT1: number;
+  let lineT2: number;
+  let priceA: number;
+  let priceB: number;
+  if (snap1 != null && snap2 != null && snap1 !== snap2) {
+    [lineT1, lineT2, priceA, priceB] =
+      snap1 < snap2
+        ? [snap1, snap2, ann.point1.price, ann.point2.price]
+        : [snap2, snap1, ann.point2.price, ann.point1.price];
+  } else if (t1 !== t2) {
+    [lineT1, lineT2, priceA, priceB] =
+      t1 < t2
+        ? [t1, t2, ann.point1.price, ann.point2.price]
+        : [t2, t1, ann.point2.price, ann.point1.price];
+  } else {
+    return null;
+  }
+  return [
+    { time: lineT1 as Time, value: priceA },
+    { time: lineT2 as Time, value: priceB },
+  ];
+}
+
+/**
+ * Build the canvas-primitive data (rectangles, vertical lines, text, fib
+ * levels) for a set of annotations. Items whose times can't be resolved are
+ * skipped.
+ */
+export function buildPrimitiveData(
+  annotations: StoredAnnotation[],
+  chartData: ChartDataPoint[] | null,
+): AgentAnnotationsData {
+  const rects: RectItem[] = [];
+  const vlines: VLineItem[] = [];
+  const texts: TextItem[] = [];
+  const fibs: FibItem[] = [];
+
+  for (const ann of annotations) {
+    if (isRectangle(ann)) {
+      const t1 = resolveBarTime(chartData, ann.point1.time);
+      const t2 = resolveBarTime(chartData, ann.point2.time);
+      if (t1 == null || t2 == null) continue;
+      rects.push({
+        time1: t1,
+        time2: t2,
+        price1: ann.point1.price,
+        price2: ann.point2.price,
+        color: ann.color ?? DEFAULT_RECT_COLOR,
+        label: ann.label ?? undefined,
+      });
+    } else if (isVerticalLine(ann)) {
+      const t = resolveBarTime(chartData, ann.time);
+      if (t == null) continue;
+      vlines.push({
+        time: t,
+        color: ann.color ?? DEFAULT_VLINE_COLOR,
+        dash: dashForStyle(ann.style),
+        label: ann.label ?? undefined,
+      });
+    } else if (isText(ann)) {
+      const t = resolveBarTime(chartData, ann.time);
+      if (t == null) continue;
+      texts.push({
+        time: t,
+        price: ann.price,
+        text: ann.text,
+        color: ann.color ?? DEFAULT_TEXT_COLOR,
+      });
+    } else if (isFib(ann)) {
+      const t1 = resolveBarTime(chartData, ann.point1.time);
+      const t2 = resolveBarTime(chartData, ann.point2.time);
+      if (t1 == null || t2 == null) continue;
+      const p1 = ann.point1.price;
+      const p2 = ann.point2.price;
+      const levels = FIB_RATIOS.map((ratio) => ({
+        ratio,
+        price: p2 + (p1 - p2) * ratio,
+      }));
+      fibs.push({
+        time1: t1,
+        time2: t2,
+        levels,
+        color: ann.color ?? DEFAULT_FIB_COLOR,
+      });
+    } else if (isTrendline(ann) && ann.label) {
+      // The line itself is drawn natively (addLineSeries); only its label
+      // becomes a chip, anchored at the chronologically-later endpoint so it
+      // sits at the end of the drawn line instead of stranded on the price
+      // axis (LWC's native series `title` floats it to the right gutter).
+      const s1 = toUnixSeconds(ann.point1.time);
+      const s2 = toUnixSeconds(ann.point2.time);
+      if (s1 == null || s2 == null) continue;
+      const last = s2 >= s1 ? ann.point2 : ann.point1;
+      const t = resolveBarTime(chartData, last.time);
+      if (t == null) continue;
+      texts.push({
+        time: t,
+        price: last.price,
+        text: ann.label,
+        color: ann.color ?? DEFAULT_TRENDLINE_COLOR,
+      });
+    }
+  }
+
+  return { rects, vlines, texts, fibs };
+}
+
+/** Build LWC series markers for marker annotations, sorted by time. */
+export function buildMarkers(
+  annotations: StoredAnnotation[],
+  chartData: ChartDataPoint[] | null,
+): SeriesMarker<Time>[] {
+  const markers: SeriesMarker<Time>[] = [];
+  for (const ann of annotations) {
+    if (!isMarker(ann)) continue;
+    const secs = toUnixSeconds(ann.time);
+    if (secs == null) continue;
+    const snapped = snapToNearestBar(chartData, secs) ?? secs;
+    markers.push({
+      time: snapped as Time,
+      position: ann.position ?? 'aboveBar',
+      shape: ann.shape === 'circle' || ann.shape === 'square' ? 'circle' : ann.shape,
+      color: ann.color ?? DEFAULT_MARKER_COLOR,
+      text: ann.text ?? '',
+    });
+  }
+  // LWC requires markers sorted by time.
+  markers.sort((a, b) => (a.time as number) - (b.time as number));
+  return markers;
+}

--- a/web/src/pages/MarketView/utils/chartConstants.ts
+++ b/web/src/pages/MarketView/utils/chartConstants.ts
@@ -100,6 +100,13 @@ export const INTERVALS: IntervalConfig[] = [
   { key: '1day',  label: '1D'  },
 ];
 
+// Interval key → short display label, derived from INTERVALS. Single source for
+// any surface that shows a timeframe badge (chart picker, annotation cards/rows).
+// Look up as `INTERVAL_LABEL[key] ?? key` so unknown keys degrade to the raw value.
+export const INTERVAL_LABEL: Record<string, string> = Object.fromEntries(
+  INTERVALS.map((i) => [i.key, i.label]),
+);
+
 // Intervals shown as direct buttons in the toolbar
 export const PRIMARY_INTERVAL_KEYS = new Set(['1s', '1min', '1day']);
 

--- a/web/src/pages/MarketView/utils/flashWorkspace.ts
+++ b/web/src/pages/MarketView/utils/flashWorkspace.ts
@@ -4,7 +4,9 @@ import { api } from '@/api/client';
  * Ensure the user's Flash workspace exists and return its id. Cached in
  * module scope so a successful call happens once per session. A failed
  * call clears the cache so the next caller retries instead of the
- * session being permanently stuck on a null id.
+ * session being permanently stuck on a null id. Invalidated on logout via
+ * {@link clearFlashWorkspaceCache} so a different user in the same tab does
+ * not inherit the previous user's workspace id.
  */
 let flashWorkspaceIdPromise: Promise<string | null> | null = null;
 
@@ -31,4 +33,10 @@ export function getOrFetchFlashWorkspaceId(): Promise<string | null> {
   })();
   flashWorkspaceIdPromise = pending;
   return pending;
+}
+
+/** Drop the cached Flash workspace id. Call on logout so the next user in the
+ * same tab re-resolves their own workspace instead of inheriting this one. */
+export function clearFlashWorkspaceCache(): void {
+  flashWorkspaceIdPromise = null;
 }

--- a/web/src/pages/MarketView/utils/flashWorkspace.ts
+++ b/web/src/pages/MarketView/utils/flashWorkspace.ts
@@ -1,0 +1,34 @@
+import { api } from '@/api/client';
+
+/**
+ * Ensure the user's Flash workspace exists and return its id. Cached in
+ * module scope so a successful call happens once per session. A failed
+ * call clears the cache so the next caller retries instead of the
+ * session being permanently stuck on a null id.
+ */
+let flashWorkspaceIdPromise: Promise<string | null> | null = null;
+
+export function getOrFetchFlashWorkspaceId(): Promise<string | null> {
+  if (flashWorkspaceIdPromise) return flashWorkspaceIdPromise;
+  const pending = (async () => {
+    try {
+      const { data } = await api.post<{ workspace_id: string }>(
+        '/api/v1/workspaces/flash',
+      );
+      const id = data?.workspace_id ?? null;
+      if (!id) {
+        // Empty response — treat as failure so we retry next time.
+        flashWorkspaceIdPromise = null;
+      }
+      return id;
+    } catch (err) {
+      if (import.meta.env.DEV) {
+        console.warn('[chart-annotation] flash workspace lookup failed', err);
+      }
+      flashWorkspaceIdPromise = null;
+      return null;
+    }
+  })();
+  flashWorkspaceIdPromise = pending;
+  return pending;
+}


### PR DESCRIPTION
## Summary

Adds an end-to-end **chart-annotation** capability. The agent can draw on the MarketView price chart — trendlines, horizontal price lines, and price-anchored event markers — and persist them per chart instance. Annotations sync live onto the chart and stream into the chat transcript as inline annotation cards.

MarketView is our **TradingView-style chart**, rendered with TradingView's open-source [Lightweight Charts](https://github.com/tradingview/lightweight-charts) library; annotations are drawn as overlays/primitives on top of that same surface, so the agent's drawings sit natively on the price chart a broader audience already recognizes.

## Annotation types shipped

Eight annotation types (`draw_chart_annotation`), each validated by its own schema:

| Type | What it draws |
|---|---|
| `price_line` | Horizontal line at a price level (support/resistance), styleable solid / dashed / dotted |
| `trendline` | Diagonal line connecting two `(time, price)` points |
| `marker` | Bar marker — `arrowUp` / `arrowDown` / `circle` / `square`, positioned above / below / in bar |
| `vertical_line` | Vertical line at a timestamp (mark an event/time boundary) |
| `rectangle` | Rectangular zone over a time × price region (e.g. consolidation / supply-demand zone) |
| `text` | Free text label anchored at a point |
| `event` | Price-anchored event marker with hover/tap detail (used for news events) |
| `fib_retracement` | Fibonacci retracement levels between two anchor points |

Lifecycle is managed by `manage_chart_annotations` with `list` / `remove` / `clear_all` actions.

## Chart instances & multi-step iteration

A **chart instance is keyed by `workspace_id | TICKER:interval`** — annotations are scoped to a specific symbol *and* interval, on a **per-workspace basis**. This is the unit the agent operates on:

- The agent can **iterate on a single chart across multiple steps** — drawing, refining, and adding annotations over several `draw_chart_annotation` calls — and every draw targets the same instance.
- Each draw result carries the **full cumulative** annotation set (a superset of the prior draw), so state is reconstructable from any single draw without diffing.
- Switching ticker or interval is a different instance with its own annotations; instances persist per workspace and survive reloads.

## What's included

**Backend (tools + storage + API)**
- `draw_chart_annotation` and `manage_chart_annotations` tools (`src/tools/chart_annotation/`) with validated schemas — bounded payloads, `Timeframe` enum, and LLM payload validation.
- `chart_annotations` table via migration `014_add_chart_annotations.py`, with a raw-psycopg data layer (`src/server/database/chart_annotation.py`).
- Server endpoint (`src/server/app/chart_annotations.py`) wired into `setup.py`.
- A `chart-annotation` agent skill (`skills/chart-annotation/SKILL.md`) registered in the skills registry.

**MarketView (TradingView-style live chart)**
- Built on TradingView's OSS Lightweight Charts; agent-driven annotation rendering and chart sync via `useAgentAnnotations`, `useChartAnnotationSync`, `useChartOverlays`, and the `chartAnnotationStore`.
- Geometry + primitive helpers (`annotationGeometry.ts`, `agentAnnotationsPrimitive.ts`) place annotations against price/time coordinates as chart primitives.
- Price-anchored **news event annotations** with hover/tap detail (`AgentEventOverlay`).
- A `MarketChartSurface` extraction so the chat panel and MarketView share one chart surface.

**Chat (inline annotation cards)**
- `InlineChartAnnotationCard` renders a draw as a spotlight preview, with the heavy chart surface deferred until the card is opened.
- Because the agent iterates on one chart across several draws, the card **pins at the first (anchor) draw's position** but is fed the **latest cumulative** set; each later draw folds into the activity timeline as an ordinary tool-call row rather than being deduped away. One card per distinct chart instance.
- Tool headline reads `TICKER · <interval>` (e.g. `NVDA · 1D`); a subtle framer-motion legend fade-in honors `prefers-reduced-motion`.
- The three duplicated timeframe→label maps are consolidated into a single `INTERVAL_LABEL` derived from `chartConstants.INTERVALS`.

## Notable design decisions

- **Instance = `workspace | ticker:interval`.** Scoping to symbol + interval per workspace lets the agent build one chart up over many steps while keeping annotations from bleeding across tickers, intervals, or workspaces.
- **One card per chart, pinned to the first draw.** Keeps the transcript stable as the chart is built step by step — the user sees intermediate draws as rows in order, while the rich card always reflects the final state. Avoids remounting/refetching the chart surface on every draw.
- **Cumulative artifacts.** Each draw carries the full annotation set, so the pinned card renders the latest state without reconciling deltas.
- **Shared interval label map.** Single source (`INTERVAL_LABEL`) for every timeframe badge, with `INTERVAL_LABEL[key] ?? key` fallback so unknown keys degrade to the raw value.

## Testing

- Frontend: typecheck (`tsc --noEmit`) and ESLint clean (no new warnings); Vitest coverage for the pin-to-first card position, multi-chart rendering, interval headline, `chartInstanceKey` edge cases, geometry, store, sync, and the inline card.
- Backend: schema parity/bounds tests and endpoint tests (`tests/unit/tools/test_chart_annotation*.py`, `tests/unit/server/app/test_chart_annotations.py`).

## Notes

- i18n: en-US and zh-CN strings added for the new tool rows.
- Large first PR because the branch is published for the first time — it carries the full feature across backend, MarketView, and chat.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “chart-annotation” skill with tools to draw and manage workspace-scoped annotations, including persisted event/news overlays.
  * Introduced backend endpoints to list chart annotations by symbol/timeframe and bulk-clear annotations.
  * Updated chat and MarketView with inline preview cards, modal rendering, multi-draw grouping, workspace-scoped syncing, and a “Clear annotations” chart control.
* **Documentation**
  * Added skill documentation covering supported annotation types, draw payloads, and management actions.
* **Localization**
  * Added English/Chinese UI strings and updated annotation-related statuses and tool labels.
* **Tests**
  * Added API, schema-parity, and chat/MarketView rendering tests for chart-annotation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->