### PR TITLE
feat(checkpointer): opt LangGraph messages channel into DeltaChannel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,14 @@ dependencies = [
     "langchain-anthropic>=1.0.0",
     "langchain_google_genai>=2.0.0",
     "langchain-deepseek>=0.1.4",
-    # LangGraph
-    "langgraph>=0.3.5",
-    "langgraph-checkpoint-postgres>=2.0.0",
+    # LangGraph — floor pinned at the beta DeltaChannel on-disk format (messages
+    # checkpoints are _DeltaSnapshot/sentinel blobs). langgraph<1.2 cannot read
+    # them; downgrading after delta blobs exist strands threads on resume.
+    # >=1.2.2 brings upstream id-stamping for DeltaChannel writes (ensure_message_ids
+    # in pregel/_loop.py), which covers id-less BaseMessage/dict writes; our
+    # checkpointer shim still covers the Overwrite-wrapped case it does not.
+    "langgraph>=1.2.2,<2",
+    "langgraph-checkpoint-postgres>=3.1",
     # Other dependencies
     "python-dotenv>=1.0.1",
     # Pinned: we import from scrapling.engines._browsers._controllers /

--- a/scripts/ops/backfill_delta.py
+++ b/scripts/ops/backfill_delta.py
@@ -1,0 +1,343 @@
+"""One-off legacy-to-DeltaChannel checkpoint backfill (run once during rollout).
+
+Legacy threads were checkpointed with ``add_messages`` (full list per step); under
+``DeltaChannel`` the first turn on such a thread co-locates its input write with
+the legacy head, which delta reconstruction excludes — silently dropping that one
+message from the model's context for that turn. The transcript UI is unaffected
+(it replays from persisted SSE events), but the agent itself does not see the
+dropped message, so this must run before the first post-migration turn on each
+legacy thread — deploying the code alone does NOT fix existing threads. It
+re-snapshots each legacy root-namespace lineage via ``aupdate_state`` to insert a
+clean delta boundary, then records a store marker so a later ``--apply`` run skips
+the rescan.
+
+Idempotent across sequential re-runs (a re-snapshotted head is no longer a plain
+list, so re-runs skip it); the marker is written only when zero lineages failed.
+Root namespace only: subagent ``task:<id>`` namespaces can't be addressed by
+``aupdate_state`` from a standalone graph, so they are counted and skipped — each
+such lineage takes the one-turn drop on its own first post-migration turn (accepted,
+bounded loss). A per-thread guard (skip active threads + re-read the head before
+writing) makes ``--apply`` safe against live traffic; run it drained or
+single-instance, as concurrent workers can both pass the sub-ms guard window.
+
+Usage:
+    uv run python scripts/ops/backfill_delta.py            # dry-run (report only)
+    uv run python scripts/ops/backfill_delta.py --apply    # re-snapshot + mark
+
+Connects via the same DB_* env vars the app uses (src/server/app/setup.py).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+# Add project root to path so we can import from src/
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("backfill_delta")
+
+# Marker namespace/key in the LangGraph store. The 2-tuple is prefix-safe: no
+# shorter ("system",) namespace is used elsewhere (memory uses (user_id, ...)).
+MIGRATION_NAMESPACE = ("system", "migrations")
+MIGRATION_MARKER_KEY = "delta_channel_v1"
+
+# Bound concurrent re-snapshots so the backfill doesn't saturate the checkpointer pool.
+_MAX_CONCURRENCY = 4
+# Re-snapshot in fixed-size batches so a large thread corpus doesn't materialize
+# one coroutine per lineage up front (the semaphore caps concurrency, not the
+# number of pending coroutines); warn past _LARGE_SWEEP_WARN lineages.
+_BATCH_SIZE = 500
+_LARGE_SWEEP_WARN = 10_000
+# Per-thread op timeouts (mirror workflow_handler's 10s state-update guard, with
+# headroom for the read).
+_READ_TIMEOUT_S = 15.0
+_RESNAPSHOT_TIMEOUT_S = 30.0
+
+
+def _build_resnapshot_graph(checkpointer: Any) -> Any:
+    """Minimal ``DeltaAgentState`` graph used only for ``aupdate_state`` re-snapshots.
+
+    aupdate_state carries forward channels this graph doesn't declare (verified:
+    they persist in ``channel_versions``), so one fixed schema is safe for every
+    thread regardless of which middleware channels it accumulated.
+    """
+    from langgraph.graph import END, START, StateGraph
+
+    from src.ptc_agent.agent.state import DeltaAgentState
+
+    builder = StateGraph(DeltaAgentState)
+    builder.add_node("noop", lambda _state: {})
+    builder.add_edge(START, "noop")
+    builder.add_edge("noop", END)
+    return builder.compile(checkpointer=checkpointer)
+
+
+async def _migrate_lineage(
+    graph: Any,
+    checkpointer: Any,
+    thread_id: str,
+    sem: asyncio.Semaphore,
+    *,
+    apply: bool,
+) -> str:
+    """Re-snapshot one root-namespace lineage if still legacy. Returns a status:
+    ``migrated`` (or, in dry-run, *would* migrate) / ``delta`` (already migrated) /
+    ``pending`` (interrupted) / ``active`` (a live turn is writing the lineage) /
+    ``missing`` / ``failed``. Dry-run only classifies; it never writes."""
+    config = {"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}}
+    async with sem:
+        try:
+            tup = await asyncio.wait_for(
+                checkpointer.aget_tuple(config), timeout=_READ_TIMEOUT_S
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                "delta-backfill: read failed for thread %s: %s", thread_id, e
+            )
+            return "failed"
+
+        if tup is None:
+            return "missing"
+        channel_values = tup.checkpoint.get("channel_values", {})
+        messages = channel_values.get("messages")
+        # A plain list means legacy add_messages storage; a sentinel/snapshot (or
+        # an absent key) means already delta -> nothing to do.
+        if not isinstance(messages, list):
+            return "delta"
+        # Interrupted / mid-turn: re-snapshotting could disturb pending state.
+        # Leave it; its next turn takes the natural (bounded, self-correcting) path.
+        if tup.pending_writes:
+            return "pending"
+        # Dry run: classification is enough — report it would migrate, write
+        # nothing, and skip the (write-only) race guard below.
+        if not apply:
+            return "migrated"
+        # A live turn co-writing this lineage could fork the head we're about to
+        # re-snapshot. pending_writes misses a turn paused between superstep
+        # boundaries, so also consult the live-task registry, then re-read the
+        # head immediately before the write and bail if it moved. A residual
+        # sub-ms TOCTOU window remains (no lock); running drained avoids it.
+        try:
+            from src.server.services.background_task_manager import (
+                BackgroundTaskManager,
+            )
+
+            if await BackgroundTaskManager.get_instance().has_active_task_for_thread(
+                thread_id
+            ):
+                return "active"
+        except Exception:  # noqa: BLE001
+            pass  # registry unavailable -> rely on the checkpoint_id re-check below
+        head_id = tup.config.get("configurable", {}).get("checkpoint_id")
+        try:
+            fresh = await asyncio.wait_for(
+                checkpointer.aget_tuple(config), timeout=_READ_TIMEOUT_S
+            )
+        except Exception:  # noqa: BLE001
+            fresh = None
+        fresh_id = (
+            fresh.config.get("configurable", {}).get("checkpoint_id") if fresh else None
+        )
+        # Bail if the head advanced (new checkpoint) OR gained pending writes on
+        # the SAME checkpoint id since our first read — a turn attaches its input
+        # write via put_writes before cutting the next checkpoint, so checkpoint_id
+        # alone misses it. pending_writes are DB-persisted, so this also catches a
+        # turn live in another process (has_active_task above is process-local).
+        if fresh is None or fresh_id != head_id or fresh.pending_writes:
+            return "active"
+
+        try:
+            await asyncio.wait_for(
+                graph.aupdate_state(config, {"messages": messages}),
+                timeout=_RESNAPSHOT_TIMEOUT_S,
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                "delta-backfill: re-snapshot failed for thread %s: %s", thread_id, e
+            )
+            return "failed"
+        return "migrated"
+
+
+async def run_delta_backfill_sweep(
+    checkpointer: Any, store: Any, *, apply: bool = False
+) -> Optional[dict[str, int]]:
+    """Re-snapshot legacy root lineages, guarded by a store marker.
+
+    Returns ``None`` when there is no Postgres checkpointer, or (in ``apply``
+    mode) when the completion marker is already set. ``apply=False`` (default) is
+    a dry run: it scans and reports what *would* migrate without writing anything
+    or consulting the marker. ``apply=True`` re-snapshots and, when nothing
+    failed, records the marker so a later run skips the rescan.
+    """
+    if checkpointer is None or not hasattr(checkpointer, "conn"):
+        logger.info("delta-backfill: no Postgres checkpointer; nothing to do")
+        return None
+
+    # The completion marker (store) lets a later apply run skip the rescan; it is
+    # only consulted/written when applying. A dry run always scans and reports.
+    if apply and store is not None:
+        try:
+            marker = await store.aget(MIGRATION_NAMESPACE, MIGRATION_MARKER_KEY)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                "delta-backfill: marker read failed (%s); proceeding (idempotent)", e
+            )
+            marker = None
+        if marker is not None:
+            logger.info("delta-backfill: already complete (marker present); skipping")
+            return None
+
+    pool = checkpointer.conn
+    try:
+        async with pool.connection() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "SELECT DISTINCT thread_id FROM checkpoints "
+                    "WHERE checkpoint_ns = %s",
+                    ("",),
+                )
+                thread_ids = [row[0] for row in await cur.fetchall()]
+                await cur.execute(
+                    "SELECT COUNT(*) FROM ("
+                    "SELECT DISTINCT thread_id, checkpoint_ns FROM checkpoints "
+                    "WHERE checkpoint_ns <> %s) sub",
+                    ("",),
+                )
+                subagent_lineages = (await cur.fetchone())[0]
+    except Exception as e:  # noqa: BLE001
+        logger.warning("delta-backfill: enumeration failed (%s); aborting", e)
+        return None
+
+    logger.info(
+        "delta-backfill: scanning %d root lineage(s) (%d subagent lineage(s) skipped)%s",
+        len(thread_ids),
+        subagent_lineages,
+        "" if apply else " [dry run]",
+    )
+    if len(thread_ids) > _LARGE_SWEEP_WARN:
+        logger.warning(
+            "delta-backfill: %d lineages exceeds %d; processing in batches of %d",
+            len(thread_ids),
+            _LARGE_SWEEP_WARN,
+            _BATCH_SIZE,
+        )
+
+    graph = _build_resnapshot_graph(checkpointer)
+    sem = asyncio.Semaphore(_MAX_CONCURRENCY)
+    results: list[str] = []
+    for start in range(0, len(thread_ids), _BATCH_SIZE):
+        batch = thread_ids[start : start + _BATCH_SIZE]
+        results.extend(
+            await asyncio.gather(
+                *(
+                    _migrate_lineage(graph, checkpointer, tid, sem, apply=apply)
+                    for tid in batch
+                )
+            )
+        )
+    counts: dict[str, int] = {
+        "scanned": len(thread_ids),
+        "migrated": results.count("migrated"),
+        "already_delta": results.count("delta"),
+        "skipped_pending": results.count("pending"),
+        "skipped_active": results.count("active"),
+        "missing": results.count("missing"),
+        "failed": results.count("failed"),
+        "subagent_lineages_skipped": int(subagent_lineages),
+    }
+    logger.info("delta-backfill: complete — %s", counts)
+
+    # Persist the marker only on a successful apply, so a later run skips the
+    # rescan. Failures (rare) keep it unset -> re-run to retry them; already-
+    # migrated threads skip cheaply, so the retry isn't a full re-run.
+    # Interrupted/active/subagent skips are expected and do NOT block the marker
+    # (they'd otherwise rescan forever); those lineages self-heal on their next
+    # turn (bounded one-turn effect).
+    if not apply:
+        logger.info(
+            "delta-backfill: dry run — no changes written. Re-run with --apply."
+        )
+    elif counts["failed"]:
+        logger.warning(
+            "delta-backfill: %d lineage(s) failed; marker NOT written, re-run to retry",
+            counts["failed"],
+        )
+    elif store is None:
+        logger.warning(
+            "delta-backfill: no store; completion marker not recorded (re-runs rescan)"
+        )
+    else:
+        marker_value = {
+            "completed_at": datetime.now(timezone.utc).isoformat(),
+            **counts,
+        }
+        try:
+            await store.aput(MIGRATION_NAMESPACE, MIGRATION_MARKER_KEY, marker_value)
+            logger.info("delta-backfill: completion marker written; re-runs will skip")
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                "delta-backfill: marker write failed (%s); re-runs will rescan", e
+            )
+    return counts
+
+
+async def main(apply: bool) -> int:
+    from src.server.utils.checkpointer import (
+        close_checkpointer_pool,
+        get_checkpointer,
+        get_store,
+        open_checkpointer_pool,
+    )
+
+    # Mirror src/server/app/setup.py exactly: the app reads DB_* (not the
+    # MEMORY_DB_* defaults get_checkpointer falls back to), so build the
+    # checkpointer the same way to hit the same database.
+    checkpointer = get_checkpointer(
+        memory_type=os.getenv("MEMORY_DB_TYPE", "postgres"),
+        db_host=os.getenv("DB_HOST", "localhost"),
+        db_port=os.getenv("DB_PORT", "5432"),
+        db_name=os.getenv("DB_NAME", "postgres"),
+        db_user=os.getenv("DB_USER", "postgres"),
+        db_password=os.getenv("DB_PASSWORD", "postgres"),
+    )
+    await open_checkpointer_pool(checkpointer)
+    try:
+        store = get_store(checkpointer)
+        if store is None:
+            logger.warning(
+                "No LangGraph store available; marker won't persist (re-runs rescan)"
+            )
+        counts = await run_delta_backfill_sweep(checkpointer, store, apply=apply)
+    finally:
+        await close_checkpointer_pool(checkpointer)
+
+    if counts is None:
+        logger.info("Nothing to do (no Postgres checkpointer or already complete).")
+        return 0
+    mode = "applied" if apply else "dry-run"
+    logger.info("Backfill %s — %s", mode, counts)
+    if not apply:
+        logger.info("Re-run with --apply to perform the re-snapshot.")
+    return 1 if counts.get("failed") else 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually re-snapshot legacy lineages and write the marker. "
+        "Default is dry-run (report only).",
+    )
+    args = parser.parse_args()
+    sys.exit(asyncio.run(main(args.apply)))

--- a/scripts/ops/scrub_nul_checkpoint.py
+++ b/scripts/ops/scrub_nul_checkpoint.py
@@ -67,7 +67,15 @@ def _strip_nul(value: Any) -> tuple[Any, int]:
         return out_list, n
     if isinstance(value, tuple):
         cleaned = [_strip_nul(item) for item in value]
-        return tuple(c for c, _ in cleaned), sum(n for _, n in cleaned)
+        fields = [c for c, _ in cleaned]
+        total = sum(n for _, n in cleaned)
+        # NamedTuple (e.g. langgraph's `_DeltaSnapshot`): reconstruct with the
+        # SAME type so the serializer still emits its dedicated ext code.
+        # Flattening to a plain tuple would make `DeltaChannel.from_checkpoint`
+        # stop recognizing the snapshot, corrupting the channel on resume.
+        if hasattr(value, "_fields"):
+            return type(value)(*fields), total
+        return tuple(fields), total
     # Pydantic/LangChain message objects: walk attributes that look textual.
     # `content` is the dominant carrier. Other str attributes get same treatment.
     if hasattr(value, "__dict__"):

--- a/src/ptc_agent/agent/agent.py
+++ b/src/ptc_agent/agent/agent.py
@@ -21,6 +21,7 @@ from ptc_agent.agent.backends import (
     StoreBackend,
 )
 from ptc_agent.agent.middleware import SubAgentMiddleware
+from ptc_agent.agent.state import DeltaAgentState
 from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
 from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
 
@@ -750,6 +751,7 @@ class PTCAgent:
             middleware=deepagent_middleware,
             checkpointer=checkpointer,
             store=store,
+            state_schema=DeltaAgentState,
         ).with_config({"recursion_limit": 2000})
 
         return BackgroundSubagentOrchestrator(

--- a/src/ptc_agent/agent/flash/agent.py
+++ b/src/ptc_agent/agent/flash/agent.py
@@ -25,6 +25,7 @@ from ptc_agent.agent.middleware import (
     ProvenanceMiddleware,
 )
 from ptc_agent.agent.middleware.runtime_context import RuntimeContextMiddleware
+from ptc_agent.agent.state import DeltaAgentState
 from ptc_agent.agent.prompts import format_current_time, get_loader
 from ptc_agent.config import AgentConfig
 
@@ -334,6 +335,7 @@ class FlashAgent:
             middleware=middleware,
             checkpointer=checkpointer,
             store=store,
+            state_schema=DeltaAgentState,
         )
         if response_format is not None:
             create_kwargs["response_format"] = response_format

--- a/src/ptc_agent/agent/middleware/background_subagent/subagent.py
+++ b/src/ptc_agent/agent/middleware/background_subagent/subagent.py
@@ -26,6 +26,7 @@ from ptc_agent.agent.middleware.background_subagent.middleware import (
 )
 from ptc_agent.agent.middleware.background_subagent.registry import BackgroundTaskRegistry
 from ptc_agent.agent.middleware._utils import append_to_system_message
+from ptc_agent.agent.state import DeltaAgentState
 from src.llms.content_utils import extract_reasoning_summary_index
 from src.llms.llm import narrow_prompt_cache_key
 from src.server.utils.content_normalizer import normalize_text_content
@@ -454,6 +455,7 @@ def _get_subagents(
             middleware=general_purpose_middleware,
             name="general-purpose",
             checkpointer=checkpointer,
+            state_schema=DeltaAgentState,
         )
         agents["general-purpose"] = general_purpose_subagent
         subagent_descriptions.append(
@@ -488,6 +490,7 @@ def _get_subagents(
             middleware=_middleware,
             name=agent_["name"],
             checkpointer=checkpointer,
+            state_schema=DeltaAgentState,
         )
     return agents, subagent_descriptions
 

--- a/src/ptc_agent/agent/state.py
+++ b/src/ptc_agent/agent/state.py
@@ -1,0 +1,109 @@
+"""DeltaChannel state schema for the messages key.
+
+Vendors deepagents' batch reducer as a public `messages_delta_reducer` and
+defines `DeltaAgentState` (an `AgentState` whose `messages` uses `DeltaChannel`
+for O(1)-per-step checkpoint storage instead of re-serializing the full list).
+
+One-way data format: once a thread is checkpointed under `DeltaChannel` its head
+blob is a sentinel or `_DeltaSnapshot`, which reverting to `add_messages` (or
+downgrading langgraph below 1.2) cannot read — so keep the `langgraph`/
+`langgraph-checkpoint*` floors pinned at >=1.2 in pyproject.toml.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Annotated, Any, cast
+
+from langchain.agents import AgentState
+from langchain_core.messages import (
+    AnyMessage,
+    BaseMessage,
+    RemoveMessage,
+    convert_to_messages,
+)
+from langgraph.channels import DeltaChannel
+from langgraph.graph.message import REMOVE_ALL_MESSAGES
+from typing_extensions import Required
+
+# A full snapshot blob is written every N updates, bounding delta replay depth
+# (matches deepagents' tested default). The count reconstruction in
+# `workflow_handler` MUST use this same value, so it lives here as the single
+# source of truth — keep it in sync with both call sites.
+MESSAGES_SNAPSHOT_FREQUENCY = 50
+
+
+def messages_delta_reducer(  # noqa: C901, PLR0912
+    state: list[AnyMessage], writes: list[list[AnyMessage]]
+) -> list[AnyMessage]:
+    """Batch reducer for `DeltaChannel` on the messages key.
+
+    Dedups by id, tombstones via `RemoveMessage`, resets on
+    `REMOVE_ALL_MESSAGES`, mints a UUID for id-less messages, and coerces raw
+    dict/str/tuple input via `convert_to_messages`. Matches deepagents' batch
+    `_messages_delta_reducer` (the vendoring source), NOT `add_messages` (an
+    unknown-id `RemoveMessage` is silently ignored; chunks are not converted).
+    """
+    # Each write is either a list of message-likes or a single message-like
+    # (BaseMessage / dict / str / tuple). Only lists flatten; everything
+    # else is one message.
+    flat: list[Any] = []
+    for w in writes:
+        if isinstance(w, list):
+            flat.extend(w)
+        else:
+            flat.append(w)
+    # Steady state: the reducer's own output is already typed BaseMessages,
+    # so skip convert_to_messages on the fast path. Only raw input (initial
+    # dicts, deserialized blobs) hits the slow path.
+    state_msgs = state if state and isinstance(state[0], BaseMessage) else cast("list[AnyMessage]", convert_to_messages(state))
+    msgs = cast("list[AnyMessage]", convert_to_messages(flat))
+
+    # REMOVE_ALL_MESSAGES resets everything; find the last sentinel and
+    # discard all state plus all writes before it.
+    remove_all_idx = None
+    for idx, m in enumerate(msgs):
+        if isinstance(m, RemoveMessage) and m.id == REMOVE_ALL_MESSAGES:
+            remove_all_idx = idx
+    if remove_all_idx is not None:
+        state_msgs = []
+        msgs = msgs[remove_all_idx + 1 :]
+
+    result: list[AnyMessage | None] = []
+    index: dict[str, int] = {}
+    for m in state_msgs:
+        if m.id is None:
+            m.id = str(uuid.uuid4())
+        index[m.id] = len(result)
+        result.append(m)
+    for msg in msgs:
+        mid = msg.id
+        if mid is None:
+            msg.id = str(uuid.uuid4())
+            mid = msg.id
+            index[mid] = len(result)
+            result.append(msg)
+        elif isinstance(msg, RemoveMessage):
+            if mid in index:
+                result[index[mid]] = None
+                del index[mid]
+        elif mid in index:
+            result[index[mid]] = msg
+        else:
+            index[mid] = len(result)
+            result.append(msg)
+    return [m for m in result if m is not None]
+
+
+class DeltaAgentState(AgentState):
+    """`AgentState` with a `DeltaChannel`-backed `messages` key."""
+
+    messages: Required[
+        Annotated[
+            list[AnyMessage],
+            DeltaChannel(
+                messages_delta_reducer,
+                snapshot_frequency=MESSAGES_SNAPSHOT_FREQUENCY,
+            ),
+        ]
+    ]

--- a/src/server/handlers/workflow_handler.py
+++ b/src/server/handlers/workflow_handler.py
@@ -58,6 +58,75 @@ def extract_state_values(checkpoint_tuple) -> dict:
     return channel_values
 
 
+async def _delta_safe_message_count(checkpoint_tuple) -> Optional[int]:
+    """Count ``messages`` from a raw checkpoint tuple, DeltaChannel-aware.
+
+    Handles the three shapes ``messages`` takes under delta (a legacy/seed list,
+    a ``_DeltaSnapshot`` blob, or absent on a non-snapshot step), then folds in
+    the head's pending writes (which sit after the checkpoint row). Returns
+    ``None`` on error — falling back to the raw list length when we have one; the
+    count is purely informational, so a missing value is safe. (Per-branch detail
+    in the inline comments below.)
+    """
+    if not checkpoint_tuple or not checkpoint_tuple.checkpoint:
+        return None
+
+    channel_values = checkpoint_tuple.checkpoint.get("channel_values", {})
+    messages_value = channel_values.get("messages")
+
+    try:
+        from langgraph.channels import DeltaChannel
+        from langgraph.errors import EmptyChannelError
+        from langgraph.types import MISSING
+
+        from ptc_agent.agent.state import (
+            MESSAGES_SNAPSHOT_FREQUENCY,
+            messages_delta_reducer,
+        )
+
+        channel = DeltaChannel(
+            messages_delta_reducer, snapshot_frequency=MESSAGES_SNAPSHOT_FREQUENCY
+        )
+        if messages_value is not None:
+            # Complete value on this checkpoint: either a legacy ``add_messages``
+            # plain list or a `_DeltaSnapshot` blob (snapshot step). Both seed via
+            # from_checkpoint — no DB round trip — then head writes fold in below.
+            channel = channel.from_checkpoint(messages_value)
+        else:
+            # Non-snapshot step: `messages` is a sentinel (absent). Seed from the
+            # delta history and replay ancestor writes. Use the tuple's own config
+            # — it carries the resolved checkpoint_id the history walk anchors on
+            # (a bare thread_id config yields nothing).
+            checkpointer = get_checkpointer()
+            history = await checkpointer.aget_delta_channel_history(
+                config=checkpoint_tuple.config, channels=["messages"]
+            )
+            entry = history.get("messages", {})
+            channel = channel.from_checkpoint(entry.get("seed", MISSING))
+            channel.replay_writes(entry.get("writes", []))
+
+        head_writes = [
+            w for w in (checkpoint_tuple.pending_writes or []) if w[1] == "messages"
+        ]
+        if head_writes:
+            channel.replay_writes(head_writes)
+
+        try:
+            return len(channel.get())
+        except EmptyChannelError:
+            return 0
+    except Exception as e:
+        # Never regress a legacy plain-list thread to None on a reconstruction
+        # error — its raw length is a correct (if pre-head-write) fallback.
+        if isinstance(messages_value, list):
+            logger.debug(f"delta message_count fold failed; raw list len: {e}")
+            return len(messages_value)
+        logger.debug(
+            f"Could not reconstruct delta message_count (reporting None): {e}"
+        )
+        return None
+
+
 async def cancel_workflow(thread_id: str, run_id: Optional[str] = None) -> dict:
     """
     Explicitly cancel a workflow execution (user stop).
@@ -179,7 +248,11 @@ async def get_workflow_status(thread_id: str) -> dict:
                 checkpoint_info = {
                     "has_plan": False,  # PTC doesn't use plans
                     "has_final_report": bool(state_values.get("final_report")),
-                    "message_count": len(state_values.get("messages", [])),
+                    # DeltaChannel-safe: messages may be absent from raw
+                    # channel_values on non-snapshot steps; reconstruct cheaply.
+                    "message_count": await _delta_safe_message_count(
+                        checkpoint_tuple
+                    ),
                     "completed": len(pending_sends) == 0,
                     "checkpoint_id": checkpoint_tuple.config.get(
                         "configurable", {}

--- a/src/server/models/chat.py
+++ b/src/server/models/chat.py
@@ -8,9 +8,27 @@ that use the ptc-agent library for code execution in Daytona sandboxes.
 import copy
 from typing import Any, Dict, List, Literal, Mapping, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from src.server.models.additional_context import AdditionalContext
+
+# Roles the chat path can VALIDLY turn into a message. It persists
+# ``{"role", "content"}`` dicts straight into the ``messages`` channel; under
+# DeltaChannel that raw write is stored BEFORE the reducer runs and REPLAYED
+# through ``convert_to_messages`` on every reconstruction, so any role that
+# ``convert_to_messages`` cannot build from ``{"role", "content"}`` alone raises
+# on every resume and bricks the thread (``role`` is client-controlled). Reject
+# those at the request boundary instead — a clean 422 before anything persists.
+#
+# This is ``convert_to_messages``'s accepted set MINUS ``tool``/``function``:
+# those map to ToolMessage/FunctionMessage, which REQUIRE ``tool_call_id`` /
+# ``name`` — fields ``ChatMessage`` cannot supply, so they ALWAYS raise in
+# ``convert_to_messages`` (e.g. ``KeyError: 'tool_call_id'``) and would brick the
+# thread under delta replay. The chat API only ever produces
+# user/assistant/system/developer/human/ai messages.
+_VALID_MESSAGE_ROLES = frozenset(
+    {"user", "assistant", "system", "developer", "human", "ai"}
+)
 
 
 # =============================================================================
@@ -168,6 +186,22 @@ class ChatMessage(BaseModel):
         ...,
         description="The content of the message, either a string or a list of content items",
     )
+
+    @field_validator("role")
+    @classmethod
+    def _validate_role(cls, v: str) -> str:
+        """Reject roles that would later raise in ``convert_to_messages``.
+
+        Without this, an unknown role is persisted to the delta channel and
+        re-raises on every reconstruction (a bricked thread); see
+        ``_VALID_MESSAGE_ROLES``.
+        """
+        if v not in _VALID_MESSAGE_ROLES:
+            allowed = ", ".join(sorted(_VALID_MESSAGE_ROLES))
+            raise ValueError(
+                f"Unsupported message role {v!r}. Must be one of: {allowed}."
+            )
+        return v
 
 
 # =============================================================================

--- a/src/server/utils/checkpointer.py
+++ b/src/server/utils/checkpointer.py
@@ -8,16 +8,96 @@ This module is standalone and does not depend on deep_research.
 import asyncio
 import logging
 import os
-from typing import Any, Optional
+import uuid
+from typing import Any, Optional, Sequence
 
+from langchain_core.messages import BaseMessage
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
 from langgraph.store.postgres import AsyncPostgresStore
+from langgraph.types import Overwrite
 from psycopg_pool import AsyncConnectionPool
 
 from src.config.settings import get_checkpointer_pool_max
 
 logger = logging.getLogger(__name__)
+
+
+def _stamp_message_ids(
+    writes: Sequence[tuple[str, Any]],
+) -> Sequence[tuple[str, Any]]:
+    """Stamp ids on id-less ``messages``-channel writes, in place.
+
+    Covers ``BaseMessage`` objects and raw ``{"role","content"}`` dicts (the chat
+    path), including either wrapped in an ``Overwrite`` (unwrapped, wrapper kept).
+    Needed under DeltaChannel, which persists the raw write via ``put_writes``
+    BEFORE the reducer runs — without a stable id the reducer re-mints a new uuid
+    on every replay (non-deterministic ids → duplication on the hard-stop flush).
+    langgraph >=1.2.2 stamps bare ``BaseMessage``/dict writes upstream
+    (``ensure_message_ids`` in ``pregel/_loop.py``) but NOT the ``Overwrite``
+    wrapper. In deepagents' default stack the only id-less Overwrite write is
+    ``PatchToolCallsMiddleware`` repairing a dangling tool call after a mid-tool
+    cancel (the hard-stop path); eviction keeps the original id and summarization's
+    id-less writes are plain lists, so both are already upstream-covered. The
+    Overwrite unwrap here is the load-bearing cover at >=1.2.2.
+    A no-op under plain ``add_messages``; leaves ``RemoveMessage`` untouched so
+    ``REMOVE_ALL_MESSAGES`` reset still works.
+    """
+    for ch, val in writes:
+        if ch != "messages":
+            continue
+        # Unwrap Overwrite(value=[...]) so id-less messages inside it are stamped
+        # too; the wrapper itself is left in place, preserving reset semantics.
+        inner = val.value if isinstance(val, Overwrite) else val
+        msgs = inner if isinstance(inner, (list, tuple)) else [inner]
+        for m in msgs:
+            if isinstance(m, BaseMessage):
+                if m.id is None:
+                    m.id = str(uuid.uuid4())
+            elif isinstance(m, dict) and not m.get("id"):
+                # The chat path feeds dict messages, not BaseMessage; they re-mint
+                # on every delta replay unless stamped here. convert_to_messages
+                # honors the dict "id", so this gives a stable, deterministic id.
+                m["id"] = str(uuid.uuid4())
+    return writes
+
+
+class IdStampingCheckpointerMixin:
+    """Saver mixin that id-stamps id-less ``messages`` writes before persisting.
+
+    Overrides ``put_writes``/``aput_writes`` to run :func:`_stamp_message_ids`
+    on the writes, then delegates to ``super()`` unchanged. Mix into a concrete
+    saver (e.g. ``AsyncPostgresSaver``, ``InMemorySaver``) ahead of it in the
+    MRO so the stamp happens before serialization.
+    """
+
+    def put_writes(
+        self,
+        config,
+        writes: Sequence[tuple[str, Any]],
+        task_id: str,
+        task_path: str = "",
+    ) -> None:
+        writes = _stamp_message_ids(writes)
+        return super().put_writes(config, writes, task_id, task_path)
+
+    async def aput_writes(
+        self,
+        config,
+        writes: Sequence[tuple[str, Any]],
+        task_id: str,
+        task_path: str = "",
+    ) -> None:
+        writes = _stamp_message_ids(writes)
+        return await super().aput_writes(config, writes, task_id, task_path)
+
+
+class IdStampingMemorySaver(IdStampingCheckpointerMixin, MemorySaver):
+    """In-memory saver (dev) with id-stamping of id-less ``messages`` writes."""
+
+
+class IdStampingAsyncPostgresSaver(IdStampingCheckpointerMixin, AsyncPostgresSaver):
+    """Postgres saver (prod) with id-stamping of id-less ``messages`` writes."""
 
 # Module-level connection pool cache to reuse connections across graph compilations
 _postgres_pool_cache: dict[str, AsyncConnectionPool] = {}
@@ -70,7 +150,7 @@ def get_checkpointer(memory_type: str = "memory", **kwargs) -> Optional[Any]:
     """
     if memory_type == "memory":
         logger.info("Using in-memory checkpointer")
-        return MemorySaver()
+        return IdStampingMemorySaver()
 
     elif memory_type == "postgres":
         # Get database connection info from kwargs or environment variables
@@ -113,7 +193,7 @@ def get_checkpointer(memory_type: str = "memory", **kwargs) -> Optional[Any]:
             )
 
         pool = _postgres_pool_cache[db_uri]
-        return AsyncPostgresSaver(pool)
+        return IdStampingAsyncPostgresSaver(pool)
 
     else:
         raise ValueError(f"Unsupported storage type: {memory_type}")

--- a/tests/unit/ptc_agent/agent/test_delta_channel_determinism.py
+++ b/tests/unit/ptc_agent/agent/test_delta_channel_determinism.py
@@ -1,0 +1,491 @@
+"""Determinism guard for `DeltaChannel`-backed `messages` — THE P1 regression test.
+
+Under `DeltaChannel`, non-snapshot steps persist the *raw* write (a sentinel in
+`channel_values`, the actual messages stored as a checkpoint write) BEFORE the
+reducer runs. Any message that enters the channel *without an id* is therefore
+persisted id-less, and the reducer re-mints a fresh `uuid4()` for it on *every*
+reconstruction — so two reconstructions of the same checkpoint disagree on ids,
+and a full-list write-back (the hard-stop checkpoint flush in
+`background_task_manager._flush_checkpoint`, or a post-`/offload` write) freezes
+one id into history while the original id-less write keeps re-minting → duplicate
+messages.
+
+Two layers stamp ids before persistence; this test pins what each covers on the
+pinned langgraph (>=1.2.2):
+
+* **Upstream (langgraph >=1.2.2)** stamps id-less `BaseMessage`/dict writes inside
+  `PregelLoop.put_writes` (`ensure_message_ids`, keyed on `DeltaChannel`), BEFORE
+  the checkpointer sees them — so a plain `InMemorySaver` is already deterministic
+  for the `HumanMessage`/dict chat path. `test_upstream_stamps_plain_id_less_writes`
+  guards that, and the >=1.2.2 floor in pyproject.toml: if a bump regresses the
+  upstream stamp, it fails.
+* **Our `IdStampingCheckpointerMixin`** (`src.server.utils.checkpointer`) is the
+  *residual* cover for the case upstream misses: `ensure_message_ids` handles only
+  `BaseMessage`/dict/list, NOT the `Overwrite` wrapper. In deepagents' default
+  stack the one middleware that writes an *id-less* message inside `Overwrite([...])`
+  is `PatchToolCallsMiddleware`, repairing a dangling tool call after a mid-tool
+  cancel (exactly the hard-stop path this branch touches). `filesystem` eviction
+  keeps the original id and `summarization`'s id-less writes are plain lists, so
+  both are already covered by the upstream stamp.
+  An id-less message inside an `Overwrite` survives upstream un-stamped and
+  re-mints once a later turn folds it into reducer `state`. The mixin unwraps the
+  `Overwrite` and stamps it. `test_overwrite_id_less_without_shim_*` reproduces the
+  gap on a plain saver; `test_shim_fixes_overwrite_id_less_path` proves the mixin
+  closes it, keeping reconstruction deterministic and the flush a no-op.
+"""
+
+from __future__ import annotations
+
+import pytest
+from langchain_core.messages import (
+    AIMessage,
+    AnyMessage,
+    HumanMessage,
+    RemoveMessage,
+    ToolMessage,
+)
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import END, START, StateGraph
+from langgraph.types import Overwrite
+
+from ptc_agent.agent.state import DeltaAgentState
+from src.server.utils.checkpointer import IdStampingCheckpointerMixin
+
+
+class ShimmedSaver(IdStampingCheckpointerMixin, InMemorySaver):
+    """In-memory saver WITH the P1 id-stamping fix (mixin first in MRO)."""
+
+
+# A plain ``InMemorySaver`` is the "no shim" control that reproduces the bug.
+
+
+# --- repro harness ---------------------------------------------------------
+
+# Each superstep writes >1 id-less message; this reliably exercises the
+# id-minting-order non-determinism (a single id-less write per step only trips
+# it ~10% of the time, which would be a flaky bug demonstration).
+_NODE_MESSAGES_PER_STEP = 2
+_TURNS = 6
+# 1 HumanMessage input + N node messages per turn.
+_EXPECTED_COUNT = _TURNS * (1 + _NODE_MESSAGES_PER_STEP)
+
+
+def _build_graph(saver):
+    """A real ``StateGraph`` whose ``messages`` field is the ``DeltaChannel``.
+
+    The single node returns id-less ``AIMessage``s, mirroring the many id-less
+    app messages langalpha writes (orchestrator/steering/subagent-return/etc.).
+    """
+    builder = StateGraph(DeltaAgentState)
+
+    def node(_state: DeltaAgentState) -> dict[str, list[AnyMessage]]:
+        return {
+            "messages": [
+                AIMessage(f"from-node-{k}") for k in range(_NODE_MESSAGES_PER_STEP)
+            ]
+        }
+
+    builder.add_node("respond", node)
+    builder.add_edge(START, "respond")
+    builder.add_edge("respond", END)
+    return builder.compile(checkpointer=saver)
+
+
+def _drive_turns(graph, config) -> None:
+    """Drive `_TURNS` turns of id-less ``HumanMessage`` input through the graph."""
+    for i in range(_TURNS):
+        graph.invoke({"messages": [HumanMessage(f"turn {i}")]}, config)
+
+
+def _drive_turns_dicts(graph, config) -> None:
+    """Drive turns with dict-form user input — the REAL chat path.
+
+    ``normalize_request_messages`` feeds ``{"role", "content"}`` dicts into the
+    graph, not ``BaseMessage`` objects. Dicts skipped the BaseMessage id-stamp
+    (the P1 hole Codex found), so this is the path the shim must cover.
+    """
+    for i in range(_TURNS):
+        graph.invoke({"messages": [{"role": "user", "content": f"turn {i}"}]}, config)
+
+
+def _reconstruct_ids(graph, config) -> list[str]:
+    """Reconstruct the thread's messages and return their ids."""
+    return [m.id for m in graph.get_state(config).values["messages"]]
+
+
+def _simulate_hard_stop_flush(graph, config) -> None:
+    """Replicate ``background_task_manager._flush_checkpoint`` exactly.
+
+    The app does ``aget_state`` then ``aupdate_state(config, snapshot.values)`` —
+    a full-list write-back of the reconstructed state. We use the sync
+    equivalents here.
+    """
+    values = graph.get_state(config).values
+    graph.update_state(config, values)
+
+
+# --- precondition + upstream-fix guard -------------------------------------
+
+
+def test_head_checkpoint_omits_messages_on_non_snapshot_step():
+    """Head ``channel_values`` omits ``messages`` (sentinel / non-snapshot step).
+
+    With ``snapshot_frequency=50`` (DeltaAgentState's default) a thread of
+    ~18 messages never hits a snapshot step, so the latest checkpoint blob is a
+    sentinel and the raw ``channel_values`` dict has no ``messages`` key. This is
+    the precondition that makes the determinism property meaningful — without it,
+    the full list would be stored every step (the ``add_messages`` behaviour) and
+    there would be nothing to re-mint.
+    """
+    saver = InMemorySaver()
+    graph = _build_graph(saver)
+    config = {"configurable": {"thread_id": "head-sentinel"}}
+    _drive_turns(graph, config)
+
+    tup = saver.get_tuple(config)
+    channel_values = tup.checkpoint["channel_values"]
+    assert "messages" not in channel_values, (
+        "expected a non-snapshot delta step (sentinel), but the head checkpoint "
+        f"stored messages directly: {list(channel_values)}"
+    )
+
+
+def test_upstream_stamps_plain_id_less_writes():
+    """Upstream (langgraph >=1.2.2) makes a PLAIN saver deterministic for the
+    common id-less write path — so the mixin is redundant *there*.
+
+    `ensure_message_ids` runs in `PregelLoop.put_writes` before the checkpointer,
+    stamping id-less `BaseMessage` and dict writes for any saver. A plain
+    `InMemorySaver` with NO shim therefore reconstructs deterministically and its
+    hard-stop flush is a no-op, for both the `HumanMessage` and dict chat paths.
+    This pins that behaviour and the >=1.2.2 floor in pyproject.toml: if a langgraph
+    bump drops the upstream stamp this fails — and the Overwrite tests below show
+    the mixin is still load-bearing for the case upstream never covered.
+    """
+    for label, drive in (("basemsg", _drive_turns), ("dict", _drive_turns_dicts)):
+        saver = InMemorySaver()  # NO shim — upstream is the only thing stamping
+        graph = _build_graph(saver)
+        config = {"configurable": {"thread_id": f"upstream-{label}"}}
+        drive(graph, config)
+
+        ids_a = _reconstruct_ids(graph, config)
+        ids_b = _reconstruct_ids(graph, config)
+        assert len(ids_a) == _EXPECTED_COUNT
+        assert None not in ids_a, f"upstream must stamp every {label} write"
+        assert ids_a == ids_b, (
+            f"langgraph >=1.2.2 must reconstruct the {label} path deterministically "
+            "without the shim; a mismatch means the upstream id-stamp regressed"
+        )
+        before = len(graph.get_state(config).values["messages"])
+        _simulate_hard_stop_flush(graph, config)
+        after = len(graph.get_state(config).values["messages"])
+        assert after == before == _EXPECTED_COUNT, (
+            f"upstream-stamped {label} flush must be a no-op, got {before} -> {after}"
+        )
+
+
+# --- residual gap: Overwrite-wrapped id-less messages (upstream misses these) --
+#
+# `ensure_message_ids` only handles BaseMessage/dict/list, never the `Overwrite`
+# wrapper. In deepagents' default stack the only id-less Overwrite write to
+# `messages` is patch_tool_calls' dangling-tool repair after a mid-tool cancel
+# (filesystem eviction keeps the id; summarization's id-less writes are plain
+# lists, both upstream-covered). An id-less message inside an Overwrite is
+# persisted un-stamped and re-mints once a later turn folds it into reducer
+# `state` — the live bug-vs-fix discriminator that justifies keeping the mixin.
+
+
+def _drive_overwrite_then_turn(graph, config) -> None:
+    """`_TURNS` normal turns, an `Overwrite([id-kept, id-less ToolMessage])` repair
+    (the `patch_tool_calls` shape), then one more turn so the reducer folds the
+    id-less message into `state`."""
+    _drive_turns(graph, config)
+    graph.update_state(
+        config,
+        {
+            "messages": Overwrite(
+                [
+                    AIMessage("base", id="keep"),
+                    ToolMessage(content="cancelled", tool_call_id="c1"),
+                ]
+            )
+        },
+    )
+    graph.invoke({"messages": [HumanMessage("after-repair")]}, config)
+
+
+def test_overwrite_id_less_without_shim_is_nondeterministic_and_dups():
+    """Control: upstream alone does NOT cover the Overwrite path → P1 is live.
+
+    On a plain saver the single id-less ToolMessage inside the Overwrite re-mints a
+    different uuid on every reconstruction (so the mismatch is reliable, not
+    probabilistic), and the hard-stop flush write-back duplicates it. Proves the
+    fix-half below is meaningful — if this ever goes stable, upstream started
+    covering Overwrite and the mixin's unwrap may have become redundant.
+    """
+    saver = InMemorySaver()  # upstream-only, no mixin
+    graph = _build_graph(saver)
+    config = {"configurable": {"thread_id": "overwrite-bug"}}
+    _drive_overwrite_then_turn(graph, config)
+
+    ids_a = _reconstruct_ids(graph, config)
+    ids_b = _reconstruct_ids(graph, config)
+    assert ids_a != ids_b, (
+        "Overwrite-wrapped id-less message must re-mint without the shim (P1)"
+    )
+    before = len(graph.get_state(config).values["messages"])
+    _simulate_hard_stop_flush(graph, config)
+    after = len(graph.get_state(config).values["messages"])
+    assert after > before, (
+        f"hard-stop flush must duplicate the re-minted message, got {before} -> {after}"
+    )
+
+
+def test_shim_fixes_overwrite_id_less_path():
+    """With the mixin: the Overwrite-wrapped id-less message is stamped before
+    persistence, so reconstruction is deterministic and the flush is a no-op."""
+    graph = _build_graph(ShimmedSaver())
+    config = {"configurable": {"thread_id": "overwrite-fix"}}
+    _drive_overwrite_then_turn(graph, config)
+
+    ids_a = _reconstruct_ids(graph, config)
+    ids_b = _reconstruct_ids(graph, config)
+    assert None not in ids_a, "the mixin must stamp the Overwrite-injected message"
+    assert ids_a == ids_b, "mixin must stabilise Overwrite-injected ids"
+    before = len(graph.get_state(config).values["messages"])
+    _simulate_hard_stop_flush(graph, config)
+    after = len(graph.get_state(config).values["messages"])
+    assert after == before, (
+        f"Overwrite flush must be a no-op under the shim, got {before} -> {after}"
+    )
+
+
+# --- fix half: ShimmedSaver (IdStampingCheckpointerMixin + InMemorySaver) ----
+
+
+def test_shim_reconstruction_is_deterministic():
+    """With the shim: two reconstructions of the same checkpoint give same ids."""
+    graph = _build_graph(ShimmedSaver())
+    config = {"configurable": {"thread_id": "fix-determinism"}}
+    _drive_turns(graph, config)
+
+    ids_a = _reconstruct_ids(graph, config)
+    ids_b = _reconstruct_ids(graph, config)
+    assert len(ids_a) == _EXPECTED_COUNT
+    assert ids_a == ids_b, "id-stamping shim must make reconstruction deterministic"
+
+
+def test_shim_hard_stop_flush_is_noop_on_count():
+    """With the shim: the hard-stop flush write-back does not duplicate messages."""
+    graph = _build_graph(ShimmedSaver())
+    config = {"configurable": {"thread_id": "fix-flush"}}
+    _drive_turns(graph, config)
+
+    before = len(graph.get_state(config).values["messages"])
+    assert before == _EXPECTED_COUNT
+    _simulate_hard_stop_flush(graph, config)
+    after = len(graph.get_state(config).values["messages"])
+    assert after == before, (
+        f"hard-stop flush must be a no-op under the shim, got {before} -> {after}"
+    )
+
+
+def test_shim_remove_message_by_id_still_removes_across_reconstruction():
+    """With the shim: ids are stable, so `RemoveMessage(id=...)` reliably hits.
+
+    This is a positive correctness guard for the shim, not a bug-vs-fix
+    discriminator: stable ids are the precondition that lets compaction/offload
+    target messages by id across turns. (Measured: in-memory this particular
+    assertion happens to also pass without the shim, because the removal write
+    and its replay land in the same reconstruction pass; the discriminating
+    P1 symptoms are the determinism + flush-no-op tests above. The genuine
+    by-id-miss surfaces when a previously-frozen id is targeted on the Postgres
+    replay path.)
+    """
+    graph = _build_graph(ShimmedSaver())
+    config = {"configurable": {"thread_id": "fix-remove"}}
+    _drive_turns(graph, config)
+
+    messages = graph.get_state(config).values["messages"]
+    target_id = messages[0].id
+    assert target_id is not None
+
+    graph.update_state(config, {"messages": [RemoveMessage(id=target_id)]})
+
+    after = graph.get_state(config).values["messages"]
+    after_ids = [m.id for m in after]
+    assert len(after) == _EXPECTED_COUNT - 1
+    assert target_id not in after_ids, (
+        "RemoveMessage-by-id must remove the targeted message; a miss means ids "
+        "were not stable across reconstruction"
+    )
+
+
+# --- the dict-input chat path (not just BaseMessage) -------------------------
+#
+# The harness above drives ``HumanMessage`` objects; the REAL chat path feeds
+# ``{"role", "content"}`` dicts (``normalize_request_messages``). On langgraph
+# >=1.2.2 upstream stamps these too (asserted by the plain-saver path in
+# `test_upstream_stamps_plain_id_less_writes`), and the shim stamps them
+# redundantly. These pin that the shim's dict coverage keeps the chat path
+# deterministic — belt-and-suspenders if the upstream stamp ever regresses.
+
+
+def test_shim_dict_input_reconstruction_is_deterministic():
+    """With the shim: the dict chat path reconstructs deterministically.
+
+    Regression for the P1 hole — the shim originally stamped only BaseMessage
+    writes, but the chat path feeds dicts. The dict-aware shim gives them a
+    stable id so two reconstructions of the same checkpoint agree.
+    """
+    graph = _build_graph(ShimmedSaver())
+    config = {"configurable": {"thread_id": "fix-dict-determinism"}}
+    _drive_turns_dicts(graph, config)
+
+    ids_a = _reconstruct_ids(graph, config)
+    ids_b = _reconstruct_ids(graph, config)
+    assert len(ids_a) == _EXPECTED_COUNT
+    assert ids_a == ids_b, (
+        "dict-input reconstruction must be deterministic under the shim"
+    )
+
+
+def test_shim_dict_input_hard_stop_flush_is_noop():
+    """With the shim: the hard-stop flush on a dict-input thread is a no-op."""
+    graph = _build_graph(ShimmedSaver())
+    config = {"configurable": {"thread_id": "fix-dict-flush"}}
+    _drive_turns_dicts(graph, config)
+
+    before = len(graph.get_state(config).values["messages"])
+    assert before == _EXPECTED_COUNT
+    _simulate_hard_stop_flush(graph, config)
+    after = len(graph.get_state(config).values["messages"])
+    assert after == before, (
+        f"hard-stop flush on the dict chat path must not duplicate, got "
+        f"{before} -> {after}"
+    )
+
+
+def test_stamp_message_ids_covers_dicts_and_basemessages():
+    """Direct unit test of the shim's stamping rules.
+
+    id-less ``BaseMessage``s and id-less dict messages get stamped; already-id'd
+    messages, ``RemoveMessage``, and non-``messages`` channels are left alone.
+    """
+    from src.server.utils.checkpointer import _stamp_message_ids
+
+    bare = AIMessage(content="bare")          # id-less BaseMessage
+    keep = AIMessage(content="x", id="keep")  # already has an id
+    rm = RemoveMessage(id="r")                # must stay untouched
+    dict_msg = {"role": "user", "content": "hi"}  # id-less dict (chat path)
+    single = AIMessage(content="solo")        # single (non-list) write value
+    other = AIMessage(content="b")            # non-messages channel
+
+    writes = [
+        ("messages", [bare, keep, rm, dict_msg]),
+        ("messages", single),
+        ("other", [other]),
+    ]
+    _stamp_message_ids(writes)
+
+    assert bare.id is not None
+    assert keep.id == "keep"
+    assert rm.id == "r"
+    assert dict_msg.get("id")          # dict stamped (the P1 fix)
+    assert single.id is not None       # single non-list value stamped
+    assert other.id is None            # non-messages channel untouched
+
+
+@pytest.mark.asyncio
+async def test_shim_async_path_is_deterministic_and_flush_noop():
+    """The PRODUCTION path is async (``aput_writes``); every test above drives the
+    SYNC graph, so only ``put_writes`` runs.
+
+    ``IdStampingAsyncPostgresSaver`` (prod) and the in-memory dev path under the
+    ASGI server both checkpoint via ``aput_writes`` — a SEPARATE method body that
+    could regress independently of ``put_writes``. This drives the delta graph
+    with ``ainvoke`` (dict chat input, the worst case) so the async stamp override
+    is exercised end-to-end: reconstruction must be deterministic and the
+    hard-stop flush a no-op.
+    """
+    graph = _build_graph(ShimmedSaver())
+    config = {"configurable": {"thread_id": "fix-async"}}
+    for i in range(_TURNS):
+        await graph.ainvoke(
+            {"messages": [{"role": "user", "content": f"turn {i}"}]}, config
+        )
+
+    ids_a = [m.id for m in (await graph.aget_state(config)).values["messages"]]
+    ids_b = [m.id for m in (await graph.aget_state(config)).values["messages"]]
+    assert len(ids_a) == _EXPECTED_COUNT
+    assert ids_a == ids_b, (
+        "async (aput_writes) reconstruction must be deterministic under the shim"
+    )
+
+    snap = await graph.aget_state(config)
+    before = len(snap.values["messages"])
+    await graph.aupdate_state(config, snap.values)
+    after = len((await graph.aget_state(config)).values["messages"])
+    assert after == before == _EXPECTED_COUNT, (
+        f"async hard-stop flush must be a no-op under the shim, got {before} -> {after}"
+    )
+
+
+def test_stamp_message_ids_overwrite_single_and_empty():
+    """``Overwrite`` wrapping a SINGLE (non-list) message, and an empty
+    ``Overwrite([])`` reset.
+
+    The covered unwrap test always wraps a *list*; a regression that only handled
+    ``Overwrite(list)`` would pass it. ``Overwrite`` can in principle wrap a single
+    value too, so pin both defensively: the single value inside the wrapper gets
+    stamped, and an empty reset stays an untouched, preserved ``Overwrite``.
+    """
+    from langgraph.types import Overwrite
+
+    from src.server.utils.checkpointer import _stamp_message_ids
+
+    single_msg = AIMessage(content="solo")            # id-less single BaseMessage
+    single_dict = {"role": "user", "content": "x"}    # id-less single dict
+    r1 = _stamp_message_ids(
+        [("messages", Overwrite(single_msg)), ("messages", Overwrite(single_dict))]
+    )
+    assert single_msg.id is not None
+    assert single_dict.get("id")
+    assert isinstance(r1[0][1], Overwrite)
+    assert isinstance(r1[1][1], Overwrite)
+
+    # Empty Overwrite([]) (a reset to no messages) is a structural no-op: nothing
+    # to stamp, and the wrapper must survive so DeltaChannel still resets.
+    r2 = _stamp_message_ids([("messages", Overwrite([]))])
+    assert isinstance(r2[0][1], Overwrite)
+    assert r2[0][1].value == []
+
+
+def test_stamp_message_ids_unwraps_overwrite():
+    """The shim must stamp id-less messages wrapped in ``Overwrite``.
+
+    deepagents' ``PatchToolCallsMiddleware`` (default stack) repairs a dangling
+    tool call on resume-after-cancel by writing ``{"messages": Overwrite([...
+    id-less ToolMessage ...])}``. Before the unwrap, the wrapper was neither list
+    nor tuple, so the shim skipped it and the filler persisted id-less → re-minted
+    on every delta replay (non-deterministic ids on the hard-stop resume path).
+    This pins the unwrap so the message is stamped while the ``Overwrite`` wrapper
+    (reset semantics) is preserved.
+    """
+    from langchain_core.messages import ToolMessage
+    from langgraph.types import Overwrite
+
+    from src.server.utils.checkpointer import _stamp_message_ids
+
+    patched = ToolMessage(content="cancelled", tool_call_id="call_1")  # id-less
+    keep = AIMessage(content="x", id="keep")
+    dict_msg = {"role": "user", "content": "hi"}  # id-less dict inside Overwrite
+    writes = [("messages", Overwrite([patched, keep, dict_msg]))]
+
+    result = _stamp_message_ids(writes)
+
+    assert patched.id is not None      # id-less BaseMessage inside Overwrite stamped
+    assert keep.id == "keep"           # already-id'd left alone
+    assert dict_msg.get("id")          # id-less dict inside Overwrite stamped
+    # wrapper preserved so DeltaChannel still treats it as a reset/base
+    assert isinstance(result[0][1], Overwrite)

--- a/tests/unit/ptc_agent/agent/test_delta_channel_ordering.py
+++ b/tests/unit/ptc_agent/agent/test_delta_channel_ordering.py
@@ -1,0 +1,145 @@
+"""Same-superstep replay ordering for `DeltaChannel`-backed `messages` (P2).
+
+ACCEPTED RESIDUAL RISK (documented, not a blocker). When two or more parallel
+tasks write to the ``messages`` channel in the *same* superstep, the order they
+reconstruct from a non-snapshot delta checkpoint may differ from the order they
+ran live. Live ``apply_writes`` orders same-superstep task writes by ``task_path``
+(`langgraph/pregel/_algo.py`); the **Postgres** saver's delta stage-2 replay
+(`aget_delta_channel_history`) orders by ``(task_id, idx)`` and ignores the stored
+``task_path`` — so the two can disagree. This is library-level (beta); there is
+no app-side fix, and the plan accepts it because the UI renders from persisted
+SSE events in emission order, never from the reconstructed checkpoint list.
+
+What this test does:
+
+1. Builds a genuine FAN-OUT — one seed node fans out to two sibling nodes that
+   each write one ``messages`` update in the SAME superstep (NOT a single node
+   returning a 2-element list, which is one write and would never reorder).
+2. Asserts the LIVE order is deterministic and is the expected ``apply_writes`` /
+   ``task_path`` order. This guards the path the sequential orchestrator and the
+   model's live context actually depend on, and it is rock-solid (measured stable
+   across 50 runs).
+3. Best-effort: compares the reconstructed order against the live order.
+
+KNOWN LIMITATION — why the reconstruction comparison is `xfail`:
+
+The real, documented divergence (`task_id,idx` vs `task_path`) lives specifically
+in the POSTGRES saver's two-stage SQL replay. The in-memory saver has its OWN
+``get_delta_channel_history`` implementation that does NOT reproduce that
+particular ordering rule. What it DOES show is that same-superstep reconstruction
+order is *non-deterministic* in-memory (measured: live order is always
+``[seed, A, B]`` but reconstruction is ``[seed, A, B]`` or ``[seed, B, A]`` ~50/50
+across runs). That is a flaky, different-mechanism reorder, so we cannot make a
+stable in-memory assertion that reconstruction == live. We therefore mark the
+reconstruction-order comparison ``xfail(strict=False)``: it passes when the run
+happens to preserve order and "x-fails" when it doesn't, and the reason documents
+that exercising the *real* Postgres divergence requires a Postgres saver. This is
+exactly the residual the plan says to document, not block on.
+"""
+
+from __future__ import annotations
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.graph import END, START, StateGraph
+
+from ptc_agent.agent.state import DeltaAgentState
+from src.server.utils.checkpointer import IdStampingCheckpointerMixin
+from langgraph.checkpoint.memory import InMemorySaver
+
+
+class ShimmedSaver(IdStampingCheckpointerMixin, InMemorySaver):
+    """In-memory saver with the P1 id-stamping fix; ids are stable for this test."""
+
+
+# Stable ids so we compare by id/content, independent of the P1 minting behaviour.
+_SEED_ID = "seed"
+_LEFT_ID = "left"
+_RIGHT_ID = "right"
+
+# Live (apply_writes / task_path) order, measured stable across 50 runs.
+_EXPECTED_LIVE_ORDER = [_SEED_ID, _LEFT_ID, _RIGHT_ID]
+
+
+def _build_fan_out_graph(saver):
+    """seed -> {left, right} in parallel -> END; left+right write in one superstep."""
+    builder = StateGraph(DeltaAgentState)
+
+    builder.add_node("seed", lambda _s: {"messages": [HumanMessage("seed", id=_SEED_ID)]})
+    builder.add_node("left", lambda _s: {"messages": [AIMessage("left", id=_LEFT_ID)]})
+    builder.add_node("right", lambda _s: {"messages": [AIMessage("right", id=_RIGHT_ID)]})
+
+    builder.add_edge(START, "seed")
+    # Fan-out: two outgoing edges from one node -> both run in the same superstep.
+    builder.add_edge("seed", "left")
+    builder.add_edge("seed", "right")
+    builder.add_edge("left", END)
+    builder.add_edge("right", END)
+    return builder.compile(checkpointer=saver)
+
+
+def test_fan_out_live_order_is_deterministic():
+    """LIVE same-superstep order is the deterministic apply_writes / task_path order.
+
+    This is the rock-solid guard: the sequential orchestrator path and the model's
+    live context depend on this ordering, and it must stay stable. If a future
+    langgraph/langchain change perturbs live fan-out ordering this fails loudly.
+    """
+    graph = _build_fan_out_graph(ShimmedSaver())
+    config = {"configurable": {"thread_id": "fanout-live"}}
+    result = graph.invoke({"messages": []}, config)
+
+    live_ids = [m.id for m in result["messages"]]
+    assert live_ids == _EXPECTED_LIVE_ORDER, (
+        "live same-superstep fan-out order changed; the orchestrator and model "
+        f"context rely on a stable order. got {live_ids}"
+    )
+
+
+def test_fan_out_head_checkpoint_is_non_snapshot():
+    """The head checkpoint is a sentinel, so reconstruction exercises delta replay."""
+    saver = ShimmedSaver()
+    graph = _build_fan_out_graph(saver)
+    config = {"configurable": {"thread_id": "fanout-sentinel"}}
+    graph.invoke({"messages": []}, config)
+
+    channel_values = saver.get_tuple(config).checkpoint["channel_values"]
+    assert "messages" not in channel_values, (
+        "expected a non-snapshot delta step so reconstruction replays writes; "
+        f"head stored messages directly: {list(channel_values)}"
+    )
+
+
+@pytest.mark.xfail(
+    strict=False,
+    reason=(
+        "In-memory delta reconstruction of same-superstep fan-out writes is "
+        "non-deterministic (~50/50 order across runs) and does NOT reproduce the "
+        "specific documented Postgres divergence (task_id,idx vs task_path). The "
+        "real divergence lives in AsyncPostgresSaver.aget_delta_channel_history and "
+        "requires a Postgres saver to exercise; this is an accepted residual risk "
+        "with no app-side fix. See module docstring."
+    ),
+)
+def test_fan_out_reconstruction_preserves_live_order():
+    """Best-effort: reconstructed order matches live order.
+
+    Passes when the in-memory replay happens to preserve order; x-fails when it
+    reorders. Either way it documents and guards the accepted P2 residual without
+    introducing a flaky hard assertion. Exercising the real Postgres divergence
+    is left to integration tests against a Postgres saver.
+    """
+    graph = _build_fan_out_graph(ShimmedSaver())
+    config = {"configurable": {"thread_id": "fanout-recon"}}
+    result = graph.invoke({"messages": []}, config)
+    live_ids = [m.id for m in result["messages"]]
+
+    recon_ids = [m.id for m in graph.get_state(config).values["messages"]]
+
+    # Same set always (no message lost/dup) — that part IS reliable.
+    assert set(recon_ids) == set(live_ids)
+    # Order is the residual: assert it; xfail absorbs the in-memory non-determinism.
+    assert recon_ids == live_ids, (
+        f"reconstructed order {recon_ids} != live order {live_ids} "
+        "(accepted P2 residual under in-memory replay)"
+    )

--- a/tests/unit/ptc_agent/agent/test_delta_channel_resolution.py
+++ b/tests/unit/ptc_agent/agent/test_delta_channel_resolution.py
@@ -1,0 +1,108 @@
+"""Channel-resolution proof for the DeltaChannel adoption linchpin.
+
+Passing ``state_schema=DeltaAgentState`` to ``langchain.agents.create_agent``
+must make the compiled graph's ``messages`` channel a ``DeltaChannel`` — winning
+the schema merge against the ``add_messages`` (``BinaryOperatorAggregate``)
+annotation declared by the base ``AgentState`` and by middleware state schemas.
+
+These tests build a real agent through the same factory the production
+agent/flash/subagent factories use, with a representative subset of the real
+middleware stack (the full PTC/Flash stack needs sandbox/MCP/network infra that
+a unit test can't construct). One middleware in the subset *explicitly*
+re-declares ``messages: add_messages`` so the override genuinely wins a conflict,
+not just a no-op.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from langchain.agents import AgentState, create_agent
+from langchain.agents.middleware import AgentMiddleware, TodoListMiddleware
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langgraph.channels import DeltaChannel
+from langgraph.channels.binop import BinaryOperatorAggregate
+from langgraph.graph.message import add_messages
+
+from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
+from ptc_agent.agent.state import DeltaAgentState
+
+
+class _ConflictState(AgentState):
+    """State schema that re-declares ``messages`` with ``add_messages``.
+
+    Stands in for the ~25 middleware state subclasses that declare
+    ``messages: add_messages`` in the real stack, so the merge has a genuine
+    conflict for ``DeltaAgentState`` to win.
+    """
+
+    messages: Annotated[list, add_messages]
+
+
+class _ConflictMiddleware(AgentMiddleware):
+    state_schema = _ConflictState
+
+
+def _fake_model() -> GenericFakeChatModel:
+    """Stub chat model so the build never touches the network."""
+    return GenericFakeChatModel(messages=iter([]))
+
+
+def _representative_middleware() -> list[AgentMiddleware]:
+    """A real-middleware subset that includes a ``messages: add_messages`` conflict.
+
+    ``TodoListMiddleware`` and ``PatchToolCallsMiddleware`` are both present in
+    the real PTC middleware stack and construct without infra. The conflict
+    middleware forces the schema merge the linchpin must win.
+    """
+    return [_ConflictMiddleware(), TodoListMiddleware(), PatchToolCallsMiddleware()]
+
+
+def test_messages_channel_is_delta_channel_with_state_schema():
+    """WITH ``state_schema=DeltaAgentState`` the messages channel is a DeltaChannel."""
+    agent = create_agent(
+        _fake_model(),
+        tools=[],
+        middleware=_representative_middleware(),
+        state_schema=DeltaAgentState,
+    )
+
+    channel = agent.channels["messages"]
+    assert isinstance(channel, DeltaChannel), (
+        f"expected DeltaChannel, got {type(channel).__name__} — the "
+        "state_schema override lost the messages schema merge"
+    )
+    assert not isinstance(channel, BinaryOperatorAggregate)
+
+
+def test_messages_channel_is_binop_without_state_schema():
+    """WITHOUT ``state_schema`` the SAME build falls back to BinaryOperatorAggregate.
+
+    Proves the assertion above is meaningful: the DeltaChannel result is caused
+    by the override, not by the middleware subset or the fake model.
+    """
+    agent = create_agent(
+        _fake_model(),
+        tools=[],
+        middleware=_representative_middleware(),
+    )
+
+    channel = agent.channels["messages"]
+    assert isinstance(channel, BinaryOperatorAggregate)
+    assert not isinstance(channel, DeltaChannel)
+
+
+def test_delta_channel_uses_vendored_reducer():
+    """The resolved DeltaChannel carries our vendored ``messages_delta_reducer``."""
+    from ptc_agent.agent.state import messages_delta_reducer
+
+    agent = create_agent(
+        _fake_model(),
+        tools=[],
+        middleware=_representative_middleware(),
+        state_schema=DeltaAgentState,
+    )
+
+    channel = agent.channels["messages"]
+    assert isinstance(channel, DeltaChannel)
+    assert channel.reducer is messages_delta_reducer

--- a/tests/unit/ptc_agent/agent/test_messages_delta_reducer.py
+++ b/tests/unit/ptc_agent/agent/test_messages_delta_reducer.py
@@ -1,0 +1,409 @@
+"""Parity between the vendored `messages_delta_reducer` and langgraph's `add_messages`.
+
+The vendored reducer is the linchpin of DeltaChannel correctness: replaying
+writes through it must reconstruct exactly what `add_messages` would have built.
+`add_messages` is a single-write reducer `(left, right)`; `messages_delta_reducer`
+is a batch reducer `(state, [writes...])`. We drive them equivalently — apply
+writes one-by-one through `add_messages` to build the expected, the same batch
+through the vendored reducer — so the structural comparison is fair.
+
+IDs minted for id-less messages differ between the two functions (both call
+`uuid4()`), so we compare structure/content/count, not the UUID values.
+"""
+
+import copy
+
+import pytest
+from langchain_core.messages import (
+    AIMessage,
+    HumanMessage,
+    RemoveMessage,
+    ToolMessage,
+)
+from langgraph.graph.message import REMOVE_ALL_MESSAGES, add_messages
+
+from ptc_agent.agent.state import messages_delta_reducer
+
+
+def _apply_add_messages(writes):
+    """Sequentially fold writes through the single-write `add_messages` reducer."""
+    state = []
+    for w in writes:
+        state = add_messages(state, w)
+    return state
+
+
+def _assert_structural_parity(expected, actual):
+    """Compare two message lists by type + content + id-presence, not UUID value."""
+    assert len(expected) == len(actual)
+    for exp, act in zip(expected, actual, strict=True):
+        assert type(exp) is type(act)
+        assert exp.content == act.content
+        # ids must both be present (assigned) or both absent
+        assert (exp.id is None) == (act.id is None)
+
+
+def test_append_new_messages():
+    state = [HumanMessage(content="hi", id="h1"), AIMessage(content="hello", id="a1")]
+    writes = [[HumanMessage(content="how are you", id="h2")]]
+
+    expected = _apply_add_messages([state, *writes])
+    actual = messages_delta_reducer(state, writes)
+
+    _assert_structural_parity(expected, actual)
+    assert [m.content for m in actual] == ["hi", "hello", "how are you"]
+    assert [m.id for m in actual] == ["h1", "a1", "h2"]
+
+
+def test_dedup_by_id_replaces_in_place():
+    state = [
+        HumanMessage(content="hi", id="h1"),
+        AIMessage(content="draft", id="a1"),
+        HumanMessage(content="next", id="h2"),
+    ]
+    writes = [[AIMessage(content="final", id="a1")]]
+
+    expected = _apply_add_messages([state, *writes])
+    actual = messages_delta_reducer(state, writes)
+
+    _assert_structural_parity(expected, actual)
+    # same id -> replaced, position preserved (not moved to end)
+    assert [m.content for m in actual] == ["hi", "final", "next"]
+    assert [m.id for m in actual] == ["h1", "a1", "h2"]
+
+
+def test_remove_message_by_id():
+    state = [
+        HumanMessage(content="hi", id="h1"),
+        AIMessage(content="bye", id="a1"),
+        HumanMessage(content="again", id="h2"),
+    ]
+    writes = [[RemoveMessage(id="a1")]]
+
+    expected = _apply_add_messages([state, *writes])
+    actual = messages_delta_reducer(state, writes)
+
+    _assert_structural_parity(expected, actual)
+    assert [m.id for m in actual] == ["h1", "h2"]
+    assert [m.content for m in actual] == ["hi", "again"]
+
+
+def test_remove_all_messages_mid_batch_resets_then_appends():
+    state = [HumanMessage(content="old1", id="h1"), AIMessage(content="old2", id="a1")]
+    # one write carrying the reset sentinel followed by a fresh message
+    writes = [
+        [
+            RemoveMessage(id=REMOVE_ALL_MESSAGES),
+            HumanMessage(content="fresh", id="h2"),
+        ]
+    ]
+
+    expected = _apply_add_messages([state, *writes])
+    actual = messages_delta_reducer(state, writes)
+
+    _assert_structural_parity(expected, actual)
+    assert [m.id for m in actual] == ["h2"]
+    assert [m.content for m in actual] == ["fresh"]
+
+
+def test_remove_all_across_separate_writes():
+    """REMOVE_ALL in one write, appends in a later write within the same batch."""
+    state = [HumanMessage(content="old", id="h1")]
+    writes = [
+        [RemoveMessage(id=REMOVE_ALL_MESSAGES)],
+        [AIMessage(content="a", id="a1"), HumanMessage(content="b", id="h2")],
+    ]
+
+    expected = _apply_add_messages([state, *writes])
+    actual = messages_delta_reducer(state, writes)
+
+    _assert_structural_parity(expected, actual)
+    assert [m.id for m in actual] == ["a1", "h2"]
+    assert [m.content for m in actual] == ["a", "b"]
+
+
+def test_idless_messages_get_ids_assigned():
+    state = []
+    writes = [[HumanMessage(content="hi")], [AIMessage(content="hello")]]
+
+    expected = _apply_add_messages([state, *writes])
+    actual = messages_delta_reducer(state, writes)
+
+    _assert_structural_parity(expected, actual)
+    # ids minted (not None); values differ between the two functions, so only
+    # assert presence + uniqueness, not equality.
+    assert all(m.id is not None for m in actual)
+    assert len({m.id for m in actual}) == len(actual)
+    assert [m.content for m in actual] == ["hi", "hello"]
+
+
+def test_raw_dict_input_is_coerced():
+    state = []
+    writes = [[{"role": "user", "content": "hi"}]]
+
+    expected = _apply_add_messages([state, *writes])
+    actual = messages_delta_reducer(state, writes)
+
+    _assert_structural_parity(expected, actual)
+    assert len(actual) == 1
+    assert isinstance(actual[0], HumanMessage)
+    assert actual[0].content == "hi"
+    assert actual[0].id is not None
+
+
+def test_raw_str_and_tuple_input_coerced():
+    """Raw string and ``(role, content)`` tuple writes coerce like add_messages."""
+    for raw in ["hi there", ("user", "howdy")]:
+        expected = _apply_add_messages([[], [raw]])
+        actual = messages_delta_reducer([], [[raw]])
+
+        _assert_structural_parity(expected, actual)
+        assert len(actual) == 1
+        assert isinstance(actual[0], HumanMessage)
+        assert actual[0].id is not None
+
+
+def test_remove_unknown_id_is_silently_ignored_diverging_from_add_messages():
+    """Intentional divergence: an unknown-id ``RemoveMessage`` is a no-op here.
+
+    ``add_messages`` raises ``ValueError`` for a RemoveMessage targeting an id
+    not present; the batch reducer ``DeltaChannel`` requires silently ignores it
+    (batching-invariance — a RemoveMessage may legitimately re-run after its
+    target is already gone). This pins that contract so a future refactor doesn't
+    accidentally "fix" it back to raising and break delta replay.
+    """
+    state = [HumanMessage(content="hi", id="h1")]
+
+    # add_messages raises on the phantom remove ...
+    with pytest.raises(ValueError):
+        add_messages(state, [RemoveMessage(id="absent")])
+
+    # ... the vendored reducer silently no-ops, leaving state intact.
+    actual = messages_delta_reducer(list(state), [[RemoveMessage(id="absent")]])
+    assert [m.id for m in actual] == ["h1"]
+    assert [m.content for m in actual] == ["hi"]
+
+
+def test_offload_remove_all_then_full_relist_parity():
+    """The REAL `/offload` + `/compact` write shape: REMOVE_ALL then a full
+    re-list of the (already id'd) prior state.
+
+    ``compact.py`` emits ``[RemoveMessage(REMOVE_ALL_MESSAGES), *messages]`` in one
+    ``aupdate_state``. The existing REMOVE_ALL tests reset then append a *single
+    fresh* message; this pins the reset-then-rebuild that must reconstruct
+    identically to ``add_messages`` (including preserving the original ids, since
+    after the reset they are fresh appends to an empty list).
+    """
+    state = [
+        HumanMessage(content="q", id="k1"),
+        AIMessage(content="draft", id="k2"),
+        ToolMessage(content="tool", tool_call_id="tc1", id="k3"),
+    ]
+    # offload truncates args but keeps the same message objects/ids; simulate by
+    # re-listing the same ids with one content edited.
+    relisted = [
+        HumanMessage(content="q", id="k1"),
+        AIMessage(content="draft", id="k2"),
+        ToolMessage(content="[offloaded]", tool_call_id="tc1", id="k3"),
+    ]
+    writes = [[RemoveMessage(id=REMOVE_ALL_MESSAGES), *relisted]]
+
+    expected = _apply_add_messages([state, *writes])
+    actual = messages_delta_reducer(state, writes)
+
+    _assert_structural_parity(expected, actual)
+    assert [m.id for m in actual] == ["k1", "k2", "k3"]
+    assert [m.content for m in actual] == ["q", "draft", "[offloaded]"]
+
+
+def test_last_remove_all_wins_among_multiple():
+    """Two REMOVE_ALL sentinels in one batch → only writes after the LAST one
+    survive ("last sentinel wins").
+
+    Load-bearing for replay-invariance: a re-run/stacked compaction can put two
+    resets in a single delta batch, and the reducer must discard everything
+    (state + writes) before the final sentinel. Asserted directly (add_messages
+    handles repeated REMOVE_ALL differently, so parity is not the contract here).
+    """
+    state = [HumanMessage(content="old", id="o1")]
+    writes = [
+        [
+            RemoveMessage(id=REMOVE_ALL_MESSAGES),
+            AIMessage(content="dropped", id="d1"),
+            RemoveMessage(id=REMOVE_ALL_MESSAGES),
+            AIMessage(content="kept", id="k1"),
+        ]
+    ]
+
+    actual = messages_delta_reducer(state, writes)
+
+    assert [m.id for m in actual] == ["k1"]
+    assert [m.content for m in actual] == ["kept"]
+
+
+def test_state_with_raw_dicts_is_coerced():
+    """Slow-path: a non-empty ``state`` of raw dicts (deserialized-blob / initial
+    dict state) is coerced via ``convert_to_messages``.
+
+    The fast-path guard only skips coercion when ``state[0]`` is a BaseMessage;
+    the raw-dict-state branch (the reason the guard exists) is otherwise
+    unexercised, so a regression dropping coercion would pass silently.
+    """
+    state = [{"role": "user", "content": "hi", "id": "h1"}]
+    writes = [[AIMessage(content="x", id="a1")]]
+
+    expected = _apply_add_messages([state, *writes])
+    actual = messages_delta_reducer(state, writes)
+
+    _assert_structural_parity(expected, actual)
+    assert isinstance(actual[0], HumanMessage)
+    assert [m.id for m in actual] == ["h1", "a1"]
+    assert [m.content for m in actual] == ["hi", "x"]
+
+
+def test_mixed_batch_parity():
+    """A realistic multi-write batch: append, tool result, dedup, remove."""
+    state = [
+        HumanMessage(content="question", id="h1"),
+        AIMessage(content="thinking", id="a1"),
+    ]
+    writes = [
+        [ToolMessage(content="tool out", tool_call_id="tc1", id="t1")],
+        [AIMessage(content="answer", id="a1")],  # dedup replace in place
+        [HumanMessage(content="followup", id="h2")],
+        [RemoveMessage(id="t1")],  # remove the tool message
+    ]
+
+    expected = _apply_add_messages([state, *writes])
+    actual = messages_delta_reducer(state, writes)
+
+    _assert_structural_parity(expected, actual)
+    assert [m.id for m in actual] == [m.id for m in expected]
+    assert [m.content for m in actual] == ["question", "answer", "followup"]
+
+
+# --- drift guard: the vendored reducer must match deepagents' upstream copy ----
+#
+# `messages_delta_reducer` is a near-verbatim copy of deepagents'
+# `_messages_delta_reducer` (see src/ptc_agent/agent/state.py). Because it is
+# reconstruction logic for persisted delta blobs, we vendor it — freezing its
+# semantics to our release — rather than importing the private symbol at runtime
+# (a deepagents bump could otherwise silently change how existing threads read
+# back). This guard imports deepagents' reducer in the TEST ONLY and asserts
+# behavioural parity across the reconstruction-defining cases, so drift surfaces
+# as a red CI light we consciously reconcile, not a silent divergence.
+
+# (state, writes, ids_deterministic) — ids_deterministic is True when every input
+# message carries an explicit id, so the two reducers' output id sequences must
+# match exactly; False when id-less inputs are minted (both call uuid4(), so only
+# structure / content / id-presence is comparable).
+_DEEPAGENTS_PARITY_CASES = [
+    pytest.param([], [[HumanMessage("a", id="h1")]], True, id="append"),
+    pytest.param(
+        [AIMessage("x", id="a1")], [[AIMessage("y", id="a1")]], True, id="dedup-in-place"
+    ),
+    pytest.param(
+        [AIMessage("x", id="a1")], [[RemoveMessage(id="a1")]], True, id="tombstone"
+    ),
+    pytest.param(
+        [AIMessage("x", id="a1")],
+        [[RemoveMessage(id=REMOVE_ALL_MESSAGES), HumanMessage("fresh", id="h2")]],
+        True,
+        id="remove-all-mid-batch",
+    ),
+    pytest.param(
+        [HumanMessage("old", id="h1")],
+        [[RemoveMessage(id=REMOVE_ALL_MESSAGES)], [AIMessage("a", id="a1")]],
+        True,
+        id="remove-all-across-writes",
+    ),
+    pytest.param(
+        [HumanMessage("hi", id="h1")],
+        [[RemoveMessage(id="absent")]],
+        True,
+        id="unknown-id-remove-noop",
+    ),
+    pytest.param(
+        [HumanMessage("old", id="o1")],
+        [
+            [
+                RemoveMessage(id=REMOVE_ALL_MESSAGES),
+                AIMessage("d", id="d1"),
+                RemoveMessage(id=REMOVE_ALL_MESSAGES),
+                AIMessage("k", id="k1"),
+            ]
+        ],
+        True,
+        id="last-remove-all-wins",
+    ),
+    pytest.param(
+        [HumanMessage("q", id="k1"), AIMessage("draft", id="k2")],
+        [
+            [
+                RemoveMessage(id=REMOVE_ALL_MESSAGES),
+                HumanMessage("q", id="k1"),
+                AIMessage("draft", id="k2"),
+            ]
+        ],
+        True,
+        id="offload-relist",
+    ),
+    pytest.param(
+        [{"role": "user", "content": "hi", "id": "h1"}],
+        [[AIMessage("x", id="a1")]],
+        True,
+        id="raw-dict-state",
+    ),
+    pytest.param(
+        [HumanMessage("q", id="h1"), AIMessage("thinking", id="a1")],
+        [
+            [ToolMessage("tool out", tool_call_id="tc1", id="t1")],
+            [AIMessage("answer", id="a1")],
+            [HumanMessage("followup", id="h2")],
+            [RemoveMessage(id="t1")],
+        ],
+        True,
+        id="mixed-batch",
+    ),
+    pytest.param([], [[HumanMessage("hi")], [AIMessage("hello")]], False, id="idless-mint"),
+    pytest.param([], [[{"role": "user", "content": "d"}]], False, id="dict-input"),
+    pytest.param([], [["just a string"]], False, id="str-input"),
+    pytest.param([], [[("user", "howdy")]], False, id="tuple-input"),
+]
+
+
+def _struct(msgs):
+    """Reducer output as (type, content, id-present) — minted UUID values are
+    random, so compared only for presence, not equality."""
+    return [(type(m).__name__, m.content, m.id is not None) for m in msgs]
+
+
+@pytest.mark.parametrize("state, writes, ids_deterministic", _DEEPAGENTS_PARITY_CASES)
+def test_vendored_reducer_matches_deepagents(state, writes, ids_deterministic):
+    """The vendored reducer must behave identically to deepagents' upstream copy.
+
+    A red here means deepagents changed `_messages_delta_reducer`: reconcile
+    `src/ptc_agent/agent/state.py` and confirm the change is safe for already-
+    persisted delta blobs before following it.
+    """
+    try:
+        from deepagents._messages_reducer import _messages_delta_reducer as upstream
+    except ImportError as exc:  # private module/symbol — a rename is itself drift
+        pytest.fail(
+            "deepagents._messages_reducer._messages_delta_reducer is gone "
+            f"({exc}); the vendored messages_delta_reducer can no longer be drift-"
+            "checked against upstream — reconcile state.py with deepagents."
+        )
+
+    # deepcopy per call: both reducers mint ids in place, so shared inputs would
+    # let the first call pollute the second.
+    ours = messages_delta_reducer(copy.deepcopy(state), copy.deepcopy(writes))
+    theirs = upstream(copy.deepcopy(state), copy.deepcopy(writes))
+
+    assert _struct(ours) == _struct(theirs), (
+        "vendored reducer diverged from deepagents' _messages_delta_reducer"
+    )
+    if ids_deterministic:
+        assert [m.id for m in ours] == [m.id for m in theirs], (
+            "explicit-id reconstruction order/ids diverged from deepagents'"
+        )

--- a/tests/unit/scripts/ops/test_delta_migration.py
+++ b/tests/unit/scripts/ops/test_delta_migration.py
@@ -1,0 +1,144 @@
+"""Tests for the one-off DeltaChannel backfill (scripts/ops/backfill_delta.py).
+
+The core regression: a legacy ``add_messages`` thread, after ``messages`` is
+opted into ``DeltaChannel``, drops its first post-delta message unless the lineage
+is re-snapshotted first (Finding B). These tests pin that ``apply=True`` prevents
+the loss, preserves other state channels, and is idempotent; that ``apply=False``
+(dry-run) classifies without writing; plus the store-marker guard short-circuits.
+"""
+
+import asyncio
+
+import pytest
+from langchain.agents import AgentState
+from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import END, START, StateGraph
+
+from scripts.ops.backfill_delta import (
+    _build_resnapshot_graph,
+    _migrate_lineage,
+    run_delta_backfill_sweep,
+)
+from src.server.utils.checkpointer import IdStampingCheckpointerMixin
+
+
+class _ShimmedMemorySaver(IdStampingCheckpointerMixin, InMemorySaver):
+    """In-memory saver with the prod id-stamping shim (matches the real saver)."""
+
+
+class _LegacyRichState(AgentState):
+    # An extra non-messages channel, to prove the re-snapshot preserves channels
+    # the re-snapshot graph never declares.
+    note: str
+
+
+def _legacy_graph(saver):
+    """A plain add_messages graph — simulates a pre-delta thread."""
+    builder = StateGraph(_LegacyRichState)
+    builder.add_node(
+        "respond", lambda _s: {"messages": [AIMessage("a1")], "note": "keep"}
+    )
+    builder.add_edge(START, "respond")
+    builder.add_edge("respond", END)
+    return builder.compile(checkpointer=saver)
+
+
+@pytest.mark.asyncio
+async def test_resnapshot_migrates_legacy_lineage_without_loss():
+    saver = _ShimmedMemorySaver()
+    cfg = {"configurable": {"thread_id": "t-legacy", "checkpoint_ns": ""}}
+    await _legacy_graph(saver).ainvoke(
+        {"messages": [HumanMessage("q1")], "note": "keep"}, cfg
+    )
+
+    # Head is legacy: messages stored as a plain list (q1 + a1).
+    head = (await saver.aget_tuple(cfg)).checkpoint["channel_values"]
+    assert isinstance(head["messages"], list)
+    before = len(head["messages"])
+    assert before == 2
+
+    graph = _build_resnapshot_graph(saver)
+    sem = asyncio.Semaphore(1)
+    assert (
+        await _migrate_lineage(graph, saver, "t-legacy", sem, apply=True) == "migrated"
+    )
+
+    # Head is now a delta checkpoint (messages no longer a plain list), and the
+    # unrelated "note" channel survived the re-snapshot.
+    after = (await saver.aget_tuple(cfg)).checkpoint
+    assert not isinstance(after["channel_values"].get("messages"), list)
+    assert "note" in after["channel_versions"]
+
+    # A real post-migration turn (user + assistant): both survive -> count +2.
+    await graph.aupdate_state(cfg, {"messages": [HumanMessage("q2"), AIMessage("a2")]})
+    contents = [m.content for m in (await graph.aget_state(cfg)).values["messages"]]
+    assert contents == ["q1", "a1", "q2", "a2"]
+    assert len(contents) == before + 2
+
+    # Idempotent: a re-run skips the already-migrated lineage.
+    assert await _migrate_lineage(graph, saver, "t-legacy", sem, apply=True) == "delta"
+
+
+@pytest.mark.asyncio
+async def test_without_resnapshot_first_post_delta_message_is_lost():
+    """Control: proves the sweep is meaningful — writing straight onto the legacy
+    head (no re-snapshot) loses the first post-delta message (Finding B)."""
+    saver = _ShimmedMemorySaver()
+    cfg = {"configurable": {"thread_id": "t-nofix", "checkpoint_ns": ""}}
+    await _legacy_graph(saver).ainvoke(
+        {"messages": [HumanMessage("q1")], "note": "keep"}, cfg
+    )
+
+    graph = _build_resnapshot_graph(saver)
+    await graph.aupdate_state(cfg, {"messages": [HumanMessage("q2")]})
+    contents = [m.content for m in (await graph.aget_state(cfg)).values["messages"]]
+    assert "q2" not in contents
+
+
+@pytest.mark.asyncio
+async def test_dry_run_reports_without_writing():
+    """apply=False classifies a legacy lineage as would-migrate but writes nothing."""
+    saver = _ShimmedMemorySaver()
+    cfg = {"configurable": {"thread_id": "t-dry", "checkpoint_ns": ""}}
+    await _legacy_graph(saver).ainvoke(
+        {"messages": [HumanMessage("q1")], "note": "keep"}, cfg
+    )
+
+    graph = _build_resnapshot_graph(saver)
+    sem = asyncio.Semaphore(1)
+    # Reports it would migrate...
+    assert (
+        await _migrate_lineage(graph, saver, "t-dry", sem, apply=False) == "migrated"
+    )
+    # ...but the head is untouched: messages still a plain legacy list.
+    head = (await saver.aget_tuple(cfg)).checkpoint["channel_values"]
+    assert isinstance(head["messages"], list)
+
+
+@pytest.mark.asyncio
+async def test_sweep_no_store_is_noop():
+    """In-memory mode (no Postgres store) -> nothing durable to migrate."""
+    assert await run_delta_backfill_sweep(_ShimmedMemorySaver(), None) is None
+
+
+@pytest.mark.asyncio
+async def test_sweep_skips_when_marker_present():
+    """Once the marker is set, the sweep skips the rescan and writes nothing."""
+
+    class _FakeStore:
+        def __init__(self):
+            self.put_calls = []
+
+        async def aget(self, ns, key):
+            return {"completed_at": "earlier"}
+
+        async def aput(self, ns, key, value):
+            self.put_calls.append(value)
+
+    class _FakeCkpt:
+        conn = object()  # satisfies the Postgres-checkpointer guard
+
+    store = _FakeStore()
+    assert await run_delta_backfill_sweep(_FakeCkpt(), store, apply=True) is None
+    assert store.put_calls == []

--- a/tests/unit/scripts/ops/test_scrub_nul_checkpoint.py
+++ b/tests/unit/scripts/ops/test_scrub_nul_checkpoint.py
@@ -1,0 +1,118 @@
+"""Unit tests for the NUL-scrub ops script's delta-awareness.
+
+`scrub_nul_checkpoint._strip_nul` walks deserialized checkpoint structures and
+strips NUL bytes. A `_DeltaSnapshot` is a `NamedTuple`; the generic tuple branch
+must reconstruct it with the SAME type, not flatten it to a plain tuple —
+otherwise `DeltaChannel.from_checkpoint` stops recognizing the snapshot and the
+`messages` channel corrupts on resume.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+from langgraph.checkpoint.serde.types import _DeltaSnapshot
+
+from scripts.ops.scrub_nul_checkpoint import _strip_nul
+
+
+def test_strip_nul_preserves_delta_snapshot_type():
+    """A `_DeltaSnapshot` containing a NUL stays a `_DeltaSnapshot` and is cleaned."""
+    snap = _DeltaSnapshot(value="msg\x00one")
+
+    cleaned, count = _strip_nul(snap)
+
+    # (a) Same NamedTuple type, not flattened to a plain tuple.
+    assert isinstance(cleaned, _DeltaSnapshot)
+    assert type(cleaned).__name__ == "_DeltaSnapshot"
+    assert type(cleaned) is _DeltaSnapshot
+    # (b) NUL removed from the field; the field is still accessible by name.
+    assert cleaned.value == "msgone"
+    assert "\x00" not in cleaned.value
+    assert count == 1
+
+
+def test_strip_nul_delta_snapshot_with_nested_structure():
+    """NUL inside a list/dict carried by the snapshot is scrubbed, type preserved."""
+    snap = _DeltaSnapshot(value=["a\x00b", {"k": "v\x00al"}])
+
+    cleaned, count = _strip_nul(snap)
+
+    assert isinstance(cleaned, _DeltaSnapshot)
+    assert cleaned.value == ["ab", {"k": "val"}]
+    assert count == 2
+
+
+def test_strip_nul_delta_snapshot_survives_serde_roundtrip():
+    """The cleaned snapshot must re-serialize via the same serde the script uses
+    and rehydrate as a `_DeltaSnapshot` — the property the script relies on."""
+    serde = JsonPlusSerializer()
+    snap = _DeltaSnapshot(value="poison\x00ed")
+
+    cleaned, _ = _strip_nul(snap)
+    type_str, blob = serde.dumps_typed(cleaned)
+    rehydrated = serde.loads_typed((type_str, blob))
+
+    assert isinstance(rehydrated, _DeltaSnapshot)
+    assert rehydrated.value == "poisoned"
+
+
+def test_strip_nul_preserves_generic_namedtuple():
+    """Any NamedTuple (not just `_DeltaSnapshot`) keeps its type after scrubbing."""
+
+    class _Pair(NamedTuple):
+        left: str
+        right: str
+
+    cleaned, count = _strip_nul(_Pair(left="x\x00y", right="z"))
+
+    assert isinstance(cleaned, _Pair)
+    assert cleaned._fields == ("left", "right")
+    assert cleaned.left == "xy"
+    assert cleaned.right == "z"
+    assert count == 1
+
+
+def test_strip_nul_snapshot_with_message_object_scrubs_content():
+    """The ACTUAL production shape: a `_DeltaSnapshot` whose value is a list of
+    LangChain message objects, with a NUL in `ToolMessage.content`.
+
+    The module docstring names message content as the dominant NUL carrier, but
+    the existing snapshot tests only carry str / list-of-str/dict. This drives the
+    message-object branch (`hasattr(value, "__dict__")`) nested inside the
+    NamedTuple reconstruction: the NUL is stripped from `content`, the object stays
+    a `ToolMessage`, and the wrapper stays a `_DeltaSnapshot`."""
+    from langchain_core.messages import ToolMessage
+
+    snap = _DeltaSnapshot(
+        value=[ToolMessage(content="bad\x00data", tool_call_id="c1", id="t1")]
+    )
+
+    cleaned, count = _strip_nul(snap)
+
+    assert isinstance(cleaned, _DeltaSnapshot)
+    assert type(cleaned.value[0]) is ToolMessage
+    assert cleaned.value[0].content == "baddata"
+    assert cleaned.value[0].id == "t1"
+    assert count == 1
+
+
+def test_strip_nul_plain_tuple_stays_plain_tuple():
+    """A plain tuple (no `_fields`) is still scrubbed and returned as a plain tuple."""
+    cleaned, count = _strip_nul(("a\x00", "b"))
+
+    assert type(cleaned) is tuple
+    assert cleaned == ("a", "b")
+    assert count == 1
+
+
+def test_strip_nul_no_nul_is_noop():
+    """No NUL anywhere → value unchanged, count 0, type preserved."""
+    snap = _DeltaSnapshot(value=["clean", {"k": "v"}])
+
+    cleaned, count = _strip_nul(snap)
+
+    assert isinstance(cleaned, _DeltaSnapshot)
+    assert cleaned.value == ["clean", {"k": "v"}]
+    assert count == 0

--- a/tests/unit/server/handlers/test_workflow_handler_message_count.py
+++ b/tests/unit/server/handlers/test_workflow_handler_message_count.py
@@ -1,0 +1,358 @@
+"""Tests for DeltaChannel-safe message_count in workflow_handler.
+
+Under DeltaChannel, the latest checkpoint is usually a NON-snapshot step:
+``messages`` is absent from raw ``channel_values`` (a sentinel), so the old
+``len(channel_values["messages"])`` would report 0. ``_delta_safe_message_count``
+reconstructs the true count cheaply via the checkpointer (no graph, no sandbox),
+folding in the head checkpoint's own pending writes (which the delta history
+excludes — Codex P3).
+
+The scenario is built with an in-memory ``StateGraph`` whose ``messages`` field
+uses ``DeltaChannel`` + the vendored reducer, so ``InMemorySaver`` exercises the
+real ``aget_delta_channel_history`` path.
+"""
+
+from typing import Annotated
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.messages import (
+    AIMessage,
+    AnyMessage,
+    HumanMessage,
+    RemoveMessage,
+)
+from langgraph.channels import DeltaChannel
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import END, START, StateGraph
+from langgraph.graph.message import REMOVE_ALL_MESSAGES
+from typing_extensions import TypedDict
+
+from ptc_agent.agent.state import messages_delta_reducer
+
+
+class _DeltaState(TypedDict):
+    messages: Annotated[
+        list[AnyMessage],
+        DeltaChannel(messages_delta_reducer, snapshot_frequency=50),
+    ]
+
+
+def _node(state):
+    # Append an id-less AI message (id-less is the worst case for delta replay).
+    return {"messages": [AIMessage(content="reply")]}
+
+
+def _build_delta_graph():
+    g = StateGraph(_DeltaState)
+    g.add_node("n", _node)
+    g.add_edge(START, "n")
+    g.add_edge("n", END)
+    saver = InMemorySaver()
+    return g.compile(checkpointer=saver), saver
+
+
+class _Snap1State(TypedDict):
+    # snapshot_frequency=1 → every step is a snapshot, so the head checkpoint
+    # stores a real `_DeltaSnapshot` blob in channel_values (not a sentinel).
+    messages: Annotated[
+        list[AnyMessage],
+        DeltaChannel(messages_delta_reducer, snapshot_frequency=1),
+    ]
+
+
+def _build_snapshot_graph():
+    g = StateGraph(_Snap1State)
+    g.add_node("n", _node)
+    g.add_edge(START, "n")
+    g.add_edge("n", END)
+    saver = InMemorySaver()
+    return g.compile(checkpointer=saver), saver
+
+
+async def _run_turns(graph, cfg, n):
+    for i in range(n):
+        await graph.ainvoke({"messages": [HumanMessage(content=f"q{i}")]}, cfg)
+
+
+@pytest.mark.asyncio
+async def test_delta_count_nonsnapshot_step_reconstructs_true_count():
+    """Latest step is a non-snapshot delta step (messages absent from
+    channel_values) → the helper reconstructs the TRUE count, not 0."""
+    from src.server.handlers.workflow_handler import _delta_safe_message_count
+
+    graph, saver = _build_delta_graph()
+    cfg = {"configurable": {"thread_id": "t1"}}
+    await _run_turns(graph, cfg, 3)  # 3 Human + 3 AI = 6 messages
+
+    tup = await saver.aget_tuple(cfg)
+    # Precondition: this is genuinely a non-snapshot step.
+    assert "messages" not in tup.checkpoint.get("channel_values", {})
+
+    true_count = len(graph.get_state(cfg).values["messages"])
+    assert true_count == 6
+
+    with patch(
+        "src.server.handlers.workflow_handler.get_checkpointer",
+        return_value=saver,
+    ):
+        count = await _delta_safe_message_count(tup)
+
+    assert count == true_count == 6
+
+
+@pytest.mark.asyncio
+async def test_delta_count_includes_head_pending_writes():
+    """Codex P3: a write stored ON the head checkpoint is excluded from the
+    delta history, so the helper must fold in ``pending_writes`` or undercount."""
+    from src.server.handlers.workflow_handler import _delta_safe_message_count
+
+    graph, saver = _build_delta_graph()
+    cfg = {"configurable": {"thread_id": "t1"}}
+    await _run_turns(graph, cfg, 3)  # 6 messages so far
+
+    head = await saver.aget_tuple(cfg)
+    # Attach a pending message write directly ON the head checkpoint, mirroring
+    # how aupdate_state records the write after the checkpoint row.
+    await saver.aput_writes(
+        head.config,
+        [("messages", [HumanMessage(content="head-extra")])],
+        task_id="task-x",
+    )
+    head2 = await saver.aget_tuple(head.config)
+    # Precondition: the head genuinely carries a pending messages write.
+    assert any(w[1] == "messages" for w in (head2.pending_writes or []))
+
+    with patch(
+        "src.server.handlers.workflow_handler.get_checkpointer",
+        return_value=saver,
+    ):
+        count = await _delta_safe_message_count(head2)
+
+    # 6 base + 1 head-pending = 7. Without the P3 fold-in this would be 6.
+    assert count == 7
+
+
+@pytest.mark.asyncio
+async def test_delta_count_after_remove_all_head_write_reports_reset_count():
+    """After ``/offload`` or ``/compact``, the head checkpoint carries a
+    ``messages`` pending write that STARTS with ``RemoveMessage(REMOVE_ALL)``.
+
+    The fold-in replays that head write through the reducer on top of the
+    delta-history seed, so the reset must be honored — the count is the
+    post-compaction size, not seed + relist. Without honoring the reset this
+    would report 7 (6 base + 1) instead of 1."""
+    from langchain_core.messages import RemoveMessage
+    from langgraph.graph.message import REMOVE_ALL_MESSAGES
+
+    from src.server.handlers.workflow_handler import _delta_safe_message_count
+
+    graph, saver = _build_delta_graph()
+    cfg = {"configurable": {"thread_id": "reset"}}
+    await _run_turns(graph, cfg, 3)  # 6 messages so far
+
+    head = await saver.aget_tuple(cfg)
+    # Mirror compact.py:326 — REMOVE_ALL then a fresh re-list (here, one kept msg).
+    await saver.aput_writes(
+        head.config,
+        [
+            (
+                "messages",
+                [
+                    RemoveMessage(id=REMOVE_ALL_MESSAGES),
+                    HumanMessage(content="kept", id="k1"),
+                ],
+            )
+        ],
+        task_id="reset-x",
+    )
+    head2 = await saver.aget_tuple(head.config)
+
+    with patch(
+        "src.server.handlers.workflow_handler.get_checkpointer",
+        return_value=saver,
+    ):
+        count = await _delta_safe_message_count(head2)
+
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_real_snapshot_step_counts_deltasnapshot_not_field_count():
+    """Codex P2: on a REAL snapshot step, ``channel_values['messages']`` is a
+    ``_DeltaSnapshot`` NamedTuple, not a plain list. The naive
+    ``len(channel_values['messages'])`` returns 1 (the NamedTuple field count);
+    the helper must rehydrate the blob and report the true message count."""
+    from src.server.handlers.workflow_handler import _delta_safe_message_count
+
+    graph, saver = _build_snapshot_graph()  # snapshot every step
+    cfg = {"configurable": {"thread_id": "snap"}}
+    await _run_turns(graph, cfg, 1)  # 1 Human + 1 AI = 2 messages
+
+    tup = await saver.aget_tuple(cfg)
+    mv = tup.checkpoint.get("channel_values", {}).get("messages")
+    # Precondition: a real snapshot stores a _DeltaSnapshot, and naive len() is 1.
+    assert mv is not None and not isinstance(mv, list)
+    assert len(mv) == 1  # the bug the fix must avoid
+
+    true_count = len(graph.get_state(cfg).values["messages"])
+    assert true_count == 2
+
+    with patch(
+        "src.server.handlers.workflow_handler.get_checkpointer",
+        return_value=saver,
+    ):
+        count = await _delta_safe_message_count(tup)
+
+    assert count == true_count == 2
+
+
+@pytest.mark.asyncio
+async def test_legacy_plain_list_path_uses_direct_len():
+    """When ``messages`` is a plain list in channel_values (legacy add_messages
+    thread) with no head pending writes, the helper seeds from the list and never
+    consults the (beta) delta history."""
+    from src.server.handlers.workflow_handler import _delta_safe_message_count
+
+    msgs = [HumanMessage(content="a"), AIMessage(content="b"), HumanMessage(content="c")]
+    tup = MagicMock()
+    tup.checkpoint = {"channel_values": {"messages": msgs}}
+    tup.pending_writes = []
+
+    checkpointer = MagicMock()
+    checkpointer.aget_delta_channel_history = AsyncMock()
+
+    with patch(
+        "src.server.handlers.workflow_handler.get_checkpointer",
+        return_value=checkpointer,
+    ):
+        count = await _delta_safe_message_count(tup)
+
+    assert count == 3
+    # Complete-value path must not consult the (beta) delta history.
+    checkpointer.aget_delta_channel_history.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_legacy_plain_list_folds_head_pending_writes():
+    """Codex finding: the legacy plain-list branch must also fold in head pending
+    writes, like the delta/snapshot branches. A legacy thread mid-``/offload``
+    carries a ``RemoveMessage(REMOVE_ALL_MESSAGES)`` head write; the naive
+    ``len(messages_value)`` would report the pre-reset count instead of the
+    post-reset one."""
+    from src.server.handlers.workflow_handler import _delta_safe_message_count
+
+    # Legacy seed of 3 messages...
+    msgs = [
+        HumanMessage(content="a", id="1"),
+        AIMessage(content="b", id="2"),
+        HumanMessage(content="c", id="3"),
+    ]
+    tup = MagicMock()
+    tup.checkpoint = {"channel_values": {"messages": msgs}}
+    # ...with an offload-shape head write: reset all, keep one.
+    tup.pending_writes = [
+        (
+            "task1",
+            "messages",
+            [RemoveMessage(id=REMOVE_ALL_MESSAGES), HumanMessage(content="kept", id="k")],
+        )
+    ]
+
+    checkpointer = MagicMock()
+    checkpointer.aget_delta_channel_history = AsyncMock()
+
+    with patch(
+        "src.server.handlers.workflow_handler.get_checkpointer",
+        return_value=checkpointer,
+    ):
+        count = await _delta_safe_message_count(tup)
+
+    # Reset + 1 kept = 1. Without the fold-in this would be the stale 3.
+    assert count == 1
+    checkpointer.aget_delta_channel_history.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delta_count_returns_none_on_error():
+    """Any failure in the delta-reconstruction branch falls back to None so the
+    status endpoint can never break on beta-internal churn. message_count is
+    purely informational (no consumer branches on it)."""
+    from src.server.handlers.workflow_handler import _delta_safe_message_count
+
+    # messages absent → delta branch; checkpointer raises.
+    tup = MagicMock()
+    tup.checkpoint = {"channel_values": {}}
+    tup.config = {"configurable": {"thread_id": "t1", "checkpoint_id": "x"}}
+    tup.pending_writes = []
+
+    checkpointer = MagicMock()
+    checkpointer.aget_delta_channel_history = AsyncMock(side_effect=RuntimeError("boom"))
+
+    with patch(
+        "src.server.handlers.workflow_handler.get_checkpointer",
+        return_value=checkpointer,
+    ):
+        count = await _delta_safe_message_count(tup)
+
+    assert count is None
+
+
+@pytest.mark.asyncio
+async def test_empty_tuple_returns_none():
+    """No checkpoint tuple → None (no crash)."""
+    from src.server.handlers.workflow_handler import _delta_safe_message_count
+
+    assert await _delta_safe_message_count(None) is None
+    empty = MagicMock()
+    empty.checkpoint = None
+    assert await _delta_safe_message_count(empty) is None
+
+
+@pytest.mark.asyncio
+async def test_get_workflow_status_reports_true_count_on_delta_step():
+    """End-to-end: get_workflow_status surfaces the reconstructed count (not 0)
+    in progress.message_count for a non-snapshot delta thread."""
+    from src.server.handlers import workflow_handler
+
+    graph, saver = _build_delta_graph()
+    cfg = {"configurable": {"thread_id": "t1"}}
+    await _run_turns(graph, cfg, 3)  # 6 messages
+    tup = await saver.aget_tuple(cfg)
+    assert "messages" not in tup.checkpoint.get("channel_values", {})
+
+    tracker = MagicMock()
+    tracker.get_status = AsyncMock(return_value=None)
+    tracker.mark_completed = AsyncMock()
+
+    manager = MagicMock()
+    manager.get_workflow_status = AsyncMock(return_value={"status": "not_found"})
+
+    patches = [
+        patch.object(
+            workflow_handler, "get_checkpoint_tuple", AsyncMock(return_value=tup)
+        ),
+        patch.object(workflow_handler, "get_checkpointer", return_value=saver),
+        patch(
+            "src.server.services.workflow_tracker.WorkflowTracker.get_instance",
+            return_value=tracker,
+        ),
+        patch(
+            "src.server.services.background_task_manager.BackgroundTaskManager.get_instance",
+            return_value=manager,
+        ),
+        patch(
+            "src.server.database.conversation.get_thread_by_id",
+            new=AsyncMock(return_value=None),
+        ),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        result = await workflow_handler.get_workflow_status("t1")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert result["progress"] is not None
+    assert result["progress"]["message_count"] == 6

--- a/tests/unit/server/models/test_chat_models.py
+++ b/tests/unit/server/models/test_chat_models.py
@@ -171,6 +171,43 @@ class TestChatMessage:
         msg = ChatMessage(role="assistant", content=items)
         assert isinstance(msg.content, list)
 
+    def test_valid_roles_accepted(self):
+        # Roles the chat path can validly turn into a message all pass.
+        for role in ("user", "assistant", "system", "developer", "human", "ai"):
+            assert ChatMessage(role=role, content="x").role == role
+
+    def test_tool_and_function_roles_rejected(self):
+        """``tool``/``function`` are accepted by convert_to_messages but map to
+        ToolMessage/FunctionMessage, which require tool_call_id/name that
+        ChatMessage cannot supply. A client POST of {"role":"tool"} would pass
+        the model, then raise KeyError('tool_call_id') in the reducer — and under
+        DeltaChannel the raw write is persisted before the reducer, so it
+        re-raises on every reconstruction and bricks the thread. Reject at the
+        boundary."""
+        for role in ("tool", "function"):
+            with pytest.raises(ValidationError, match="Unsupported message role"):
+                ChatMessage(role=role, content="x")
+
+    def test_unknown_role_rejected(self):
+        """A client-controlled unknown role is rejected at the request boundary
+        (422), so it is never persisted to the delta channel where it would
+        re-raise in convert_to_messages on every reconstruction and brick the
+        thread."""
+        with pytest.raises(ValidationError, match="Unsupported message role"):
+            ChatMessage(role="banana", content="hi")
+
+    def test_role_is_case_sensitive(self):
+        # langchain matches roles case-sensitively (msg dict 'role' used as-is),
+        # so "User" would raise downstream — reject it cleanly here too.
+        with pytest.raises(ValidationError):
+            ChatMessage(role="User", content="hi")
+
+    def test_chatrequest_with_bad_role_rejected(self):
+        """End-to-end: the bad role is caught when the request body is parsed,
+        before any handler / graph / checkpoint runs."""
+        with pytest.raises(ValidationError):
+            ChatRequest(messages=[{"role": "banana", "content": "hi"}])
+
 
 # ---------------------------------------------------------------------------
 # ChatRequest

--- a/uv.lock
+++ b/uv.lock
@@ -2088,8 +2088,8 @@ requires-dist = [
     { name = "langchain-google-genai", specifier = ">=2.0.0" },
     { name = "langchain-openai", specifier = ">=1.0.0" },
     { name = "langchain-qwq", specifier = ">=0.3.0" },
-    { name = "langgraph", specifier = ">=0.3.5" },
-    { name = "langgraph-checkpoint-postgres", specifier = ">=2.0.0" },
+    { name = "langgraph", specifier = ">=1.2.2,<2" },
+    { name = "langgraph-checkpoint-postgres", specifier = ">=3.1" },
     { name = "langgraph-cli", extras = ["inmem"], marker = "extra == 'dev'", specifier = ">=0.2.10" },
     { name = "langsmith-fetch", specifier = ">=0.3.1" },
     { name = "matplotlib" },
@@ -2270,7 +2270,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.1"
+version = "1.2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -2280,9 +2280,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/8e/34a57e338a319e3b32c1bd183c2a9a04f7f35d683d3f3d8f597f6eacbc4e/langgraph-1.2.1.tar.gz", hash = "sha256:28314f844678d9d307cbd63e7b48b0145bf17177d84b40ee2921061e07b6f966", size = 693750, upload_time = "2026-05-21T18:33:07.478Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/43/dac5a2621c1e57f8eb7f0703f6f6fe34a5caf62f8f0fb4d2bb395bb454ea/langgraph-1.2.4.tar.gz", hash = "sha256:5df076973a2d23efb13eceb279d1e5b46feebcbbeded0a86a2ef669abd9e4399", size = 720374, upload_time = "2026-06-02T17:07:37.347Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/8c/313912e26866893bd15be9b4ea3442dc86f69270b0ad01a4961d1eba7118/langgraph-1.2.1-py3-none-any.whl", hash = "sha256:5cc4020de8f1e2a048d773f6e9128646a2af8c68a8067ab9cab177a2fcc8d221", size = 235317, upload_time = "2026-05-21T18:33:05.687Z" },
+    { url = "https://files.pythonhosted.org/packages/48/9e/31ca236104966d7bb14ea9e93cfd73350aea8c41008ddf057b65794ed10d/langgraph-1.2.4-py3-none-any.whl", hash = "sha256:ffe3e1e31dce28907640f82525858470f293506d2b272d07ea3b3ce97974b067", size = 245402, upload_time = "2026-06-02T17:07:35.977Z" },
 ]
 
 [[package]]
@@ -2409,15 +2409,18 @@ wheels = [
 
 [[package]]
 name = "langgraph-sdk"
-version = "0.3.15"
+version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
+    { name = "langchain-core" },
+    { name = "langchain-protocol" },
     { name = "orjson" },
+    { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/af/cdd4d6f3c05b3c1112ed3f12ef830faf15951b21d22cbc622a4becbbe25c/langgraph_sdk-0.3.15.tar.gz", hash = "sha256:29e805003d2c6e296823dd71992610976fd0428cefaa8b3304fd91f2247037de", size = 201924, upload_time = "2026-05-22T16:54:27.678Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/2b/bd8ac26d4e97f6df88ef05ce5b6a38945a3903e1025d926f4752aa88aa97/langgraph_sdk-0.4.2.tar.gz", hash = "sha256:b88f0f5f6328ac0680d6790614a905b2bcfa257f2276dba4e38f0e86db0aa738", size = 348327, upload_time = "2026-06-01T17:51:19.856Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/a5/0196d9c05749c25bc198e4909d68c998bc3120297e14944921baf2f4c384/langgraph_sdk-0.3.15-py3-none-any.whl", hash = "sha256:3838773acf7456d158165385d49f48f1e856f28b56ccd99ea139a8f27004815d", size = 98166, upload_time = "2026-05-22T16:54:26.013Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/05/aac507337cceae773c2cc9ab91eb6301963af7aeeb55b4217a00e15aff17/langgraph_sdk-0.4.2-py3-none-any.whl", hash = "sha256:75fa5096c1177ce39c847096a8fe3745ffd480ddb412995f836e9f5f884c43dd", size = 160521, upload_time = "2026-06-01T17:51:18.849Z" },
 ]
 
 [[package]]
@@ -5452,47 +5455,33 @@ wheels = [
 
 [[package]]
 name = "websockets"
-version = "16.0"
+version = "15.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload_time = "2026-01-10T09:23:47.181Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload_time = "2025-03-05T20:03:41.606Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload_time = "2026-01-10T09:22:46.787Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload_time = "2026-01-10T09:22:47.999Z" },
-    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload_time = "2026-01-10T09:22:49.809Z" },
-    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload_time = "2026-01-10T09:22:51.071Z" },
-    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload_time = "2026-01-10T09:22:52.224Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload_time = "2026-01-10T09:22:53.443Z" },
-    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload_time = "2026-01-10T09:22:55.033Z" },
-    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload_time = "2026-01-10T09:22:56.251Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload_time = "2026-01-10T09:22:57.478Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload_time = "2026-01-10T09:22:59.333Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload_time = "2026-01-10T09:23:01.171Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload_time = "2026-01-10T09:23:02.341Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload_time = "2026-01-10T09:23:03.756Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload_time = "2026-01-10T09:23:05.01Z" },
-    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload_time = "2026-01-10T09:23:06.301Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload_time = "2026-01-10T09:23:07.492Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload_time = "2026-01-10T09:23:09.245Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload_time = "2026-01-10T09:23:10.483Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload_time = "2026-01-10T09:23:12.178Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload_time = "2026-01-10T09:23:13.511Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload_time = "2026-01-10T09:23:14.727Z" },
-    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload_time = "2026-01-10T09:23:15.939Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload_time = "2026-01-10T09:23:17.148Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload_time = "2026-01-10T09:23:18.372Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload_time = "2026-01-10T09:23:19.652Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload_time = "2026-01-10T09:23:21.458Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload_time = "2026-01-10T09:23:22.715Z" },
-    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload_time = "2026-01-10T09:23:24.523Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload_time = "2026-01-10T09:23:25.781Z" },
-    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload_time = "2026-01-10T09:23:27.033Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload_time = "2026-01-10T09:23:28.259Z" },
-    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload_time = "2026-01-10T09:23:29.449Z" },
-    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload_time = "2026-01-10T09:23:31.368Z" },
-    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload_time = "2026-01-10T09:23:32.627Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload_time = "2026-01-10T09:23:33.816Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload_time = "2026-01-10T09:23:35.016Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload_time = "2026-01-10T09:23:45.395Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6b/4545a0d843594f5d0771e86463606a3988b5a09ca5123136f8a76580dd63/websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3", size = 175437, upload_time = "2025-03-05T20:02:16.706Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/71/809a0f5f6a06522af902e0f2ea2757f71ead94610010cf570ab5c98e99ed/websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665", size = 173096, upload_time = "2025-03-05T20:02:18.832Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/69/1a681dd6f02180916f116894181eab8b2e25b31e484c5d0eae637ec01f7c/websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2", size = 173332, upload_time = "2025-03-05T20:02:20.187Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/02/0073b3952f5bce97eafbb35757f8d0d54812b6174ed8dd952aa08429bcc3/websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215", size = 183152, upload_time = "2025-03-05T20:02:22.286Z" },
+    { url = "https://files.pythonhosted.org/packages/74/45/c205c8480eafd114b428284840da0b1be9ffd0e4f87338dc95dc6ff961a1/websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5", size = 182096, upload_time = "2025-03-05T20:02:24.368Z" },
+    { url = "https://files.pythonhosted.org/packages/14/8f/aa61f528fba38578ec553c145857a181384c72b98156f858ca5c8e82d9d3/websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65", size = 182523, upload_time = "2025-03-05T20:02:25.669Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/6d/0267396610add5bc0d0d3e77f546d4cd287200804fe02323797de77dbce9/websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe", size = 182790, upload_time = "2025-03-05T20:02:26.99Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/c68c5adbf679cf610ae2f74a9b871ae84564462955d991178f95a1ddb7dd/websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4", size = 182165, upload_time = "2025-03-05T20:02:30.291Z" },
+    { url = "https://files.pythonhosted.org/packages/29/93/bb672df7b2f5faac89761cb5fa34f5cec45a4026c383a4b5761c6cea5c16/websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597", size = 182160, upload_time = "2025-03-05T20:02:31.634Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/83/de1f7709376dc3ca9b7eeb4b9a07b4526b14876b6d372a4dc62312bebee0/websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9", size = 176395, upload_time = "2025-03-05T20:02:33.017Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/71/abf2ebc3bbfa40f391ce1428c7168fb20582d0ff57019b69ea20fa698043/websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7", size = 176841, upload_time = "2025-03-05T20:02:34.498Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9f/51f0cf64471a9d2b4d0fc6c534f323b664e7095640c34562f5182e5a7195/websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931", size = 175440, upload_time = "2025-03-05T20:02:36.695Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/05/aa116ec9943c718905997412c5989f7ed671bc0188ee2ba89520e8765d7b/websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675", size = 173098, upload_time = "2025-03-05T20:02:37.985Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0b/33cef55ff24f2d92924923c99926dcce78e7bd922d649467f0eda8368923/websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151", size = 173329, upload_time = "2025-03-05T20:02:39.298Z" },
+    { url = "https://files.pythonhosted.org/packages/31/1d/063b25dcc01faa8fada1469bdf769de3768b7044eac9d41f734fd7b6ad6d/websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22", size = 183111, upload_time = "2025-03-05T20:02:40.595Z" },
+    { url = "https://files.pythonhosted.org/packages/93/53/9a87ee494a51bf63e4ec9241c1ccc4f7c2f45fff85d5bde2ff74fcb68b9e/websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f", size = 182054, upload_time = "2025-03-05T20:02:41.926Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b2/83a6ddf56cdcbad4e3d841fcc55d6ba7d19aeb89c50f24dd7e859ec0805f/websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8", size = 182496, upload_time = "2025-03-05T20:02:43.304Z" },
+    { url = "https://files.pythonhosted.org/packages/98/41/e7038944ed0abf34c45aa4635ba28136f06052e08fc2168520bb8b25149f/websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375", size = 182829, upload_time = "2025-03-05T20:02:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/17/de15b6158680c7623c6ef0db361da965ab25d813ae54fcfeae2e5b9ef910/websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d", size = 182217, upload_time = "2025-03-05T20:02:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195, upload_time = "2025-03-05T20:02:51.561Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload_time = "2025-03-05T20:02:53.814Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload_time = "2025-03-05T20:02:55.237Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload_time = "2025-03-05T20:03:39.41Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Opts the LangGraph `messages` channel into **`DeltaChannel`** (beta) so long
research threads store O(1)-per-step delta writes with a full snapshot every 50
updates, instead of re-serializing the entire message list every superstep
(O(N²) per thread over its life). Wired into the PTC, Flash, and subagent agent
factories.

The core risk of the beta channel — **non-deterministic message ids on replay** —
is fixed by an id-stamping checkpointer shim, with the supporting machinery and a
full regression suite around it:

- **Performance** — `DeltaAgentState` + a vendored batch reducer (`state.py`);
  `state_schema` wired into all four `create_agent` call sites.
- **Correctness (P1 fix)** — `_stamp_message_ids` `put_writes`/`aput_writes` shim
  stamps a stable UUID on id-less `messages` writes *before* persistence. Without
  it, `DeltaChannel` persists the raw id-less write and the reducer re-mints a
  different id on every replay → duplication on the hard-stop flush / `/offload`,
  and broken `RemoveMessage`-by-id. Covers `BaseMessage`, raw `{role,content}`
  dicts, and the `Overwrite` wrapper (the case upstream `ensure_message_ids` at
  langgraph ≥1.2.2 does not handle).
- **Telemetry** — delta-safe `message_count` in `workflow_handler` (reconstructs
  via the delta history + head pending writes on non-snapshot steps).
- **Ops** — `backfill_delta.py` re-snapshots legacy `add_messages` lineages to a
  clean delta boundary; `scrub_nul_checkpoint.py` made `_DeltaSnapshot`-aware.
- **Guardrail** — `chat.py` role validator rejects roles `convert_to_messages`
  can't rebuild on replay.

## Overview

| Category               | Files | +LOC | −LOC |
|------------------------|------:|-----:|-----:|
| Modified (prod)        |     8 |  213 |    9 |
| New (prod)             |     2 |  452 |    0 |
| **Net (excl. tests + lock)** | **10** | **665** | **9** |
| Lock (uv.lock)         |     1 |   38 |   49 |
| Tests                  |     8 | 1809 |    0 |
| **Total**              | **19** | **2512** | **58** |

**By module**

- **Agent core** (`src/ptc_agent/`, net +116)
  - `agent/state.py` *(new, +109)* — `DeltaAgentState` + vendored
    `messages_delta_reducer` (dedup-by-id, `RemoveMessage` tombstones,
    `REMOVE_ALL_MESSAGES` reset, id-minting); `MESSAGES_SNAPSHOT_FREQUENCY = 50`.
  - `agent/agent.py`, `agent/flash/agent.py`, `middleware/background_subagent/subagent.py`
    *(+2/+2/+3)* — pass `state_schema=DeltaAgentState` to the four `create_agent` calls.
- **Server** (`src/server/`, net +189/−5)
  - `utils/checkpointer.py` *(+80/−3)* — `_stamp_message_ids` + `IdStampingCheckpointerMixin`,
    applied to the memory + Postgres savers `get_checkpointer` returns.
  - `handlers/workflow_handler.py` *(+74/−1)* — `_delta_safe_message_count`
    (snapshot / seed+replay / head-pending-writes paths).
  - `models/chat.py` *(+35/−1)* — `ChatMessage.role` validator.
- **Ops scripts** (`scripts/ops/`, net +352/−1)
  - `backfill_delta.py` *(new, +343)* — legacy→delta seed-boundary backfill
    (dry-run default, store-marker idempotency, active-thread guard).
  - `scrub_nul_checkpoint.py` *(+9/−1)* — preserve `_DeltaSnapshot` NamedTuple on reserialize.
- **Dependencies** — `pyproject.toml` *(+8/−3)* langgraph `>=1.2.2,<2` floor; `uv.lock` regen.
- **Tests** (`tests/unit/`, +1809) — see Test Coverage.

**What this introduces:** O(1)-per-step checkpoint storage for the messages
channel on long threads, made safe under the beta format by deterministic message
ids (id-stamping shim + vendored reducer), a delta-aware status count and NUL
scrub, and a one-shot migration for pre-existing threads.

## Diff Size
- Total: 19 files changed, 2512 insertions(+), 58 deletions(−)
- Net (excl. tests + lock): 10 files changed, 665 insertions(+), 9 deletions(−)

## Test Coverage
`COVERAGE: 47/64 paths (73%)`. Core behavior fully covered; gaps are in
`backfill_delta.py` error/guard branches and two informational `message_count`
fallbacks (low blast radius — count is non-functional telemetry).

Tests (8 files, all green — 4684 passed / 1 xfailed suite-wide):
- `test_delta_channel_determinism.py` — **P1 regression guard**: id-less message
  reconstructs to stable ids across two reads; hard-stop flush is a 6→6 no-op (not
  6→9); `RemoveMessage`-by-id still removes; plus a no-shim control proving the dup.
- `test_messages_delta_reducer.py` — reducer parity vs deepagents'
  `_messages_delta_reducer` (drift guard) + 13 semantic cases.
- `test_delta_channel_ordering.py` — same-superstep parallel ToolMessages
  reconstruct in live order (P2).
- `test_delta_channel_resolution.py` — compiled graph's `messages` channel is
  `DeltaChannel` with `state_schema`, `BinaryOperatorAggregate` without.
- `test_workflow_handler_message_count.py` — non-snapshot reconstruct, head
  pending writes, `REMOVE_ALL`, legacy list, error→None.
- `test_delta_migration.py` — proves the seed-boundary one-message drop without
  re-snapshot, and the backfill fix.
- `test_scrub_nul_checkpoint.py` — `_DeltaSnapshot` survives NUL-scrub roundtrip.
- `test_chat_models.py` — role validator.

## Conformance with deepagents

This adopts the same DeltaChannel approach deepagents ships, with one deliberate
addition deepagents lacks.

**Same as deepagents (parity-tested):**
- **Reducer behavior** — `messages_delta_reducer` (`state.py`) is a vendored copy
  of deepagents 0.6.3's `_messages_delta_reducer`: dedup-by-id, `RemoveMessage`
  tombstones, `REMOVE_ALL_MESSAGES` reset, id-minting for id-less messages,
  dict/str/tuple coercion, no chunk coercion. `test_vendored_reducer_matches_deepagents`
  fails CI if our copy drifts from the installed deepagents symbol.
- **Schema** — `DeltaAgentState` equals deepagents' `_DeepAgentState`: same
  `AgentState` base, same `Required[Annotated[list[AnyMessage], DeltaChannel(reducer,
  snapshot_frequency=50)]]` field, same `snapshot_frequency=50`.

**Different from deepagents:**
- **Vendored, not imported.** We keep our own reducer copy rather than importing
  the private `deepagents._messages_reducer` symbol — a beta API that can move
  without a semver bump, while our on-disk reconstruction must stay stable. The
  parity test bridges the two.
- **`create_agent` + `state_schema=`, not `create_deep_agent`.** Same delta wiring
  on `messages`; we keep our own middleware stack and backend filesystem.
- **Id-stamping checkpointer shim (deepagents has none).** deepagents' minting
  reducer is latently non-deterministic under DeltaChannel — langgraph's
  `put_writes` persists the id-less write *before* the reducer mints, so replay
  re-mints a fresh UUID → flush duplication, broken `RemoveMessage`-by-id. Their
  own default `PatchToolCallsMiddleware` trips it: it repairs a dangling tool call
  after a mid-tool cancel by writing an id-less `ToolMessage` inside `Overwrite`
  (the exact hard-stop path), and upstream `ensure_message_ids` skips the
  `Overwrite` wrapper. So stock `create_deep_agent` + DeltaChannel inherits the bug;
  `_stamp_message_ids` stamps a stable id before persistence and closes it.

## ⚠️ Rollout risk — read before deploy

1. **Migration ordering (P1).** Deploying the code does **not** fix existing
   threads. Until `uv run python scripts/ops/backfill_delta.py --apply` runs, each
   legacy `add_messages` thread silently drops its **first** post-migration user
   message from *model context* for one turn (transcript UI is unaffected — it
   replays from SSE events). Subagent `task:<id>` lineages are not backfilled and
   take that one-turn drop once. **Run `--apply` before/with the deploy, or accept
   the bounded one-turn loss.** The format is one-way once written (no downgrade
   below langgraph 1.2) — validate on staging first.
2. **Latent shim gap (P1, not currently live).** `_stamp_message_ids` doesn't
   cover bare tuple/string message writes (`("user","hi")`). No current caller
   emits those; a future one would reintroduce the re-mint bug. Tracked as a
   follow-up.
3. **Status-endpoint cost (P2).** `message_count` now issues a delta history query
   per poll on non-snapshot steps for an informational value — review if that
   endpoint is polled hot.

## Test plan
- [x] `uv run pytest tests/unit/` — 4684 passed, 1 xfailed
- [x] `uv run ruff check` on changed files — clean
- [ ] Staging: resume a pre-change thread, hard-stop flush, `/offload`,
      multi-tool-call turn; run `backfill_delta.py --apply`; verify `checkpoint_blobs`
      are sentinels on non-snapshot steps, full `_DeltaSnapshot` every ~50 updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved checkpoint handling for conversation state, including more reliable message reconstruction and recovery across restarts.
  * Added support for preserving message history during one-time migration of older conversations.
* **Bug Fixes**
  * Fixed message counting in workflow status for cases where state is reconstructed from checkpoints.
  * Improved message persistence so missing message IDs are handled consistently.
  * Strengthened validation for chat message roles to reject unsupported values.
* **Documentation**
  * Expanded guidance around checkpoint compatibility and safe downgrade behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->