### PR TITLE
feat(checkpointer): opt LangGraph messages channel into DeltaChannel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,15 @@ dependencies = [
     "langchain-anthropic>=1.0.0",
     "langchain_google_genai>=2.0.0",
     "langchain-deepseek>=0.1.4",
-    # LangGraph
-    "langgraph>=0.3.5",
-    "langgraph-checkpoint-postgres>=2.0.0",
+    # LangGraph — floor pinned at the beta DeltaChannel on-disk format (messages
+    # checkpoints are _DeltaSnapshot/sentinel blobs). langgraph<1.2 cannot read
+    # them; downgrading after delta blobs exist strands threads on resume.
+    # >=1.2.2 brings upstream id-stamping for DeltaChannel writes (ensure_message_ids
+    # in pregel/_messages.py), which stamps id-less BaseMessage/dict/list writes
+    # before persistence — the mechanism that keeps reconstruction deterministic
+    # paired with the non-minting reducer in ptc_agent.agent.state.
+    "langgraph>=1.2.2,<2",
+    "langgraph-checkpoint-postgres>=3.1",
     # Other dependencies
     "python-dotenv>=1.0.1",
     # Pinned: we import from scrapling.engines._browsers._controllers /
@@ -64,7 +70,12 @@ dependencies = [
     "edgartools>=5.7.2",
     "langsmith-fetch>=0.3.1",
     "structlog",
-    "deepagents>=0.5.3",
+    # Floor at 0.6.11: that release made the messages delta reducer non-minting
+    # (our vendored copy in ptc_agent.agent.state matches it — see the parity test)
+    # and switched PatchToolCallsMiddleware off the id-less `Overwrite` write, so
+    # langgraph's ensure_message_ids covers every id-less messages write and no
+    # app-side id-stamping shim is needed.
+    "deepagents>=0.6.11",
     "daytona-sdk>=0.130.0",
     "boto3>=1.42.28",
     "tavily-python>=0.7.18",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,9 @@ dependencies = [
     # before persistence — the mechanism that keeps reconstruction deterministic
     # paired with the non-minting reducer in ptc_agent.agent.state.
     "langgraph>=1.2.2,<2",
-    "langgraph-checkpoint-postgres>=3.1",
+    # ceiling mirrors langgraph<2 — the postgres saver serializes the same delta
+    # blobs and moves in lockstep with core, so it can't cross a major on its own.
+    "langgraph-checkpoint-postgres>=3.1,<4",
     # Other dependencies
     "python-dotenv>=1.0.1",
     # Pinned: we import from scrapling.engines._browsers._controllers /

--- a/scripts/ops/scrub_nul_checkpoint.py
+++ b/scripts/ops/scrub_nul_checkpoint.py
@@ -67,7 +67,15 @@ def _strip_nul(value: Any) -> tuple[Any, int]:
         return out_list, n
     if isinstance(value, tuple):
         cleaned = [_strip_nul(item) for item in value]
-        return tuple(c for c, _ in cleaned), sum(n for _, n in cleaned)
+        fields = [c for c, _ in cleaned]
+        total = sum(n for _, n in cleaned)
+        # NamedTuple (e.g. langgraph's `_DeltaSnapshot`): reconstruct with the
+        # SAME type so the serializer still emits its dedicated ext code.
+        # Flattening to a plain tuple would make `DeltaChannel.from_checkpoint`
+        # stop recognizing the snapshot, corrupting the channel on resume.
+        if hasattr(value, "_fields"):
+            return type(value)(*fields), total
+        return tuple(fields), total
     # Pydantic/LangChain message objects: walk attributes that look textual.
     # `content` is the dominant carrier. Other str attributes get same treatment.
     if hasattr(value, "__dict__"):

--- a/src/ptc_agent/agent/agent.py
+++ b/src/ptc_agent/agent/agent.py
@@ -21,6 +21,7 @@ from ptc_agent.agent.backends import (
     StoreBackend,
 )
 from ptc_agent.agent.middleware import SubAgentMiddleware
+from ptc_agent.agent.state import DeltaAgentState
 from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
 from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
 
@@ -750,6 +751,7 @@ class PTCAgent:
             middleware=deepagent_middleware,
             checkpointer=checkpointer,
             store=store,
+            state_schema=DeltaAgentState,
         ).with_config({"recursion_limit": 2000})
 
         return BackgroundSubagentOrchestrator(

--- a/src/ptc_agent/agent/flash/agent.py
+++ b/src/ptc_agent/agent/flash/agent.py
@@ -25,6 +25,7 @@ from ptc_agent.agent.middleware import (
     ProvenanceMiddleware,
 )
 from ptc_agent.agent.middleware.runtime_context import RuntimeContextMiddleware
+from ptc_agent.agent.state import DeltaAgentState
 from ptc_agent.agent.prompts import format_current_time, get_loader
 from ptc_agent.config import AgentConfig
 
@@ -334,6 +335,7 @@ class FlashAgent:
             middleware=middleware,
             checkpointer=checkpointer,
             store=store,
+            state_schema=DeltaAgentState,
         )
         if response_format is not None:
             create_kwargs["response_format"] = response_format

--- a/src/ptc_agent/agent/middleware/background_subagent/subagent.py
+++ b/src/ptc_agent/agent/middleware/background_subagent/subagent.py
@@ -26,6 +26,7 @@ from ptc_agent.agent.middleware.background_subagent.middleware import (
 )
 from ptc_agent.agent.middleware.background_subagent.registry import BackgroundTaskRegistry
 from ptc_agent.agent.middleware._utils import append_to_system_message
+from ptc_agent.agent.state import DeltaAgentState
 from src.llms.content_utils import extract_reasoning_summary_index
 from src.llms.llm import narrow_prompt_cache_key
 from src.server.utils.content_normalizer import normalize_text_content
@@ -454,6 +455,7 @@ def _get_subagents(
             middleware=general_purpose_middleware,
             name="general-purpose",
             checkpointer=checkpointer,
+            state_schema=DeltaAgentState,
         )
         agents["general-purpose"] = general_purpose_subagent
         subagent_descriptions.append(
@@ -488,6 +490,7 @@ def _get_subagents(
             middleware=_middleware,
             name=agent_["name"],
             checkpointer=checkpointer,
+            state_schema=DeltaAgentState,
         )
     return agents, subagent_descriptions
 

--- a/src/ptc_agent/agent/state.py
+++ b/src/ptc_agent/agent/state.py
@@ -1,0 +1,116 @@
+"""DeltaChannel state schema for the messages key.
+
+Vendors deepagents' batch reducer as a public `messages_delta_reducer` and
+defines `DeltaAgentState` (an `AgentState` whose `messages` uses `DeltaChannel`
+for O(1)-per-step checkpoint storage instead of re-serializing the full list).
+`DeltaAgentState` is structurally identical to deepagents 0.6.11's
+`DeepAgentState` (`AgentState` + `DeltaChannel(reducer, snapshot_frequency=50)`);
+we vendor the reducer rather than import the private `deepagents._messages_reducer`
+symbol so on-disk reconstruction stays frozen to our release. The parity test
+`test_messages_delta_reducer.py::test_vendored_reducer_matches_deepagents` fails
+CI if our copy drifts.
+
+One-way data format: once a thread is checkpointed under `DeltaChannel` its head
+blob is a sentinel or `_DeltaSnapshot`, which reverting to `add_messages` (or
+downgrading langgraph below 1.2) cannot read — so keep the `langgraph`/
+`langgraph-checkpoint*` floors pinned at >=1.2 in pyproject.toml.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, cast
+
+from langchain.agents import AgentState
+from langchain_core.messages import (
+    AnyMessage,
+    BaseMessage,
+    RemoveMessage,
+    convert_to_messages,
+)
+from langgraph.channels import DeltaChannel
+from langgraph.graph.message import REMOVE_ALL_MESSAGES
+from typing_extensions import Required
+
+# A full snapshot blob is written every N updates, bounding delta replay depth
+# (matches deepagents' tested default). Single source of truth for the
+# `DeltaChannel` snapshot frequency, consumed by `DeltaAgentState` below.
+MESSAGES_SNAPSHOT_FREQUENCY = 50
+
+
+def messages_delta_reducer(  # noqa: C901, PLR0912
+    state: list[AnyMessage], writes: list[list[AnyMessage]]
+) -> list[AnyMessage]:
+    """Batch reducer for `DeltaChannel` on the messages key.
+
+    Dedups by id, tombstones via `RemoveMessage`, resets on
+    `REMOVE_ALL_MESSAGES`, and coerces raw dict/str/tuple input via
+    `convert_to_messages`. IDs are NOT assigned here: langgraph's
+    `ensure_message_ids` (>=1.2.2) stamps id-less writes before they are
+    persisted, so by replay time messages already carry stable ids; minting in
+    the reducer would re-roll a different uuid on every replay. id-less messages
+    are appended as-is (deterministic). Matches deepagents 0.6.11's batch
+    `_messages_delta_reducer` (the vendoring source), NOT `add_messages` (an
+    unknown-id `RemoveMessage` is silently ignored; chunks are not converted).
+    """
+    # Each write is either a list of message-likes or a single message-like
+    # (BaseMessage / dict / str / tuple). Only lists flatten; everything
+    # else is one message.
+    flat: list[Any] = []
+    for w in writes:
+        if isinstance(w, list):
+            flat.extend(w)
+        else:
+            flat.append(w)
+    # Steady state: the reducer's own output is already typed BaseMessages,
+    # so skip convert_to_messages on the fast path. Only raw input (initial
+    # dicts, deserialized blobs) hits the slow path. `state` is None on
+    # `DeltaChannel.replay_writes` for threads whose earliest checkpoint did not
+    # seed `messages: []`; `state or []` keeps that off the convert_to_messages
+    # crash path.
+    state_msgs = state if state and isinstance(state[0], BaseMessage) else cast("list[AnyMessage]", convert_to_messages(state or []))
+    msgs = cast("list[AnyMessage]", convert_to_messages(flat))
+
+    # REMOVE_ALL_MESSAGES resets everything; find the last sentinel and
+    # discard all state plus all writes before it.
+    remove_all_idx = None
+    for idx, m in enumerate(msgs):
+        if isinstance(m, RemoveMessage) and m.id == REMOVE_ALL_MESSAGES:
+            remove_all_idx = idx
+    if remove_all_idx is not None:
+        state_msgs = []
+        msgs = msgs[remove_all_idx + 1 :]
+
+    result: list[AnyMessage | None] = []
+    index: dict[str, int] = {}
+    for m in state_msgs:
+        if m.id is not None:
+            index[m.id] = len(result)
+        result.append(m)
+    for msg in msgs:
+        mid = msg.id
+        if mid is None:
+            result.append(msg)
+        elif isinstance(msg, RemoveMessage):
+            if mid in index:
+                result[index[mid]] = None
+                del index[mid]
+        elif mid in index:
+            result[index[mid]] = msg
+        else:
+            index[mid] = len(result)
+            result.append(msg)
+    return [m for m in result if m is not None]
+
+
+class DeltaAgentState(AgentState):
+    """`AgentState` with a `DeltaChannel`-backed `messages` key."""
+
+    messages: Required[
+        Annotated[
+            list[AnyMessage],
+            DeltaChannel(
+                messages_delta_reducer,
+                snapshot_frequency=MESSAGES_SNAPSHOT_FREQUENCY,
+            ),
+        ]
+    ]

--- a/src/server/handlers/workflow_handler.py
+++ b/src/server/handlers/workflow_handler.py
@@ -179,7 +179,6 @@ async def get_workflow_status(thread_id: str) -> dict:
                 checkpoint_info = {
                     "has_plan": False,  # PTC doesn't use plans
                     "has_final_report": bool(state_values.get("final_report")),
-                    "message_count": len(state_values.get("messages", [])),
                     "completed": len(pending_sends) == 0,
                     "checkpoint_id": checkpoint_tuple.config.get(
                         "configurable", {}

--- a/src/server/models/chat.py
+++ b/src/server/models/chat.py
@@ -8,9 +8,32 @@ that use the ptc-agent library for code execution in Daytona sandboxes.
 import copy
 from typing import Any, Dict, List, Literal, Mapping, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from src.server.models.additional_context import AdditionalContext
+
+# Roles the chat path can VALIDLY persist into the ``messages`` channel. The
+# chat path writes ``{"role", "content"}`` dicts straight in; under DeltaChannel
+# that raw write is stored BEFORE the reducer runs, so a role must clear TWO bars:
+#
+#   1. ``convert_to_messages`` must rebuild it from ``{"role", "content"}`` alone
+#      — it is replayed on every reconstruction. ``tool``/``function`` fail here:
+#      they map to ToolMessage/FunctionMessage and need ``tool_call_id``/``name``
+#      ``ChatMessage`` can't supply, so they raise on every resume and brick the
+#      thread.
+#   2. langgraph's ``ensure_message_ids`` must STAMP it at ``put_writes`` (role in
+#      langgraph's ``_MESSAGE_ROLES``). An accepted-but-unstamped role persists
+#      id-less; the hard-stop checkpoint flush / offload write the full list back
+#      via ``aupdate_state`` (which does NOT re-run ``ensure_message_ids``), and the
+#      non-minting reducer can't dedup an id-less message, so it DUPLICATES.
+#
+# ``developer`` clears bar 1 (``convert_to_messages`` maps it to SystemMessage) but
+# FAILS bar 2 (not in langgraph's ``_MESSAGE_ROLES``), so it is excluded — clients
+# wanting developer semantics send ``system``, which maps identically and stamps.
+# ``role`` is client-controlled; reject the rest with a clean 422 before persisting.
+_VALID_MESSAGE_ROLES = frozenset(
+    {"user", "assistant", "system", "human", "ai"}
+)
 
 
 # =============================================================================
@@ -168,6 +191,22 @@ class ChatMessage(BaseModel):
         ...,
         description="The content of the message, either a string or a list of content items",
     )
+
+    @field_validator("role")
+    @classmethod
+    def _validate_role(cls, v: str) -> str:
+        """Reject roles unsafe under delta replay — see ``_VALID_MESSAGE_ROLES``.
+
+        An unsupported role either raises in ``convert_to_messages`` on every
+        reconstruction (a bricked thread) or persists id-less and duplicates on
+        the hard-stop flush; both are rejected with a 422 before anything persists.
+        """
+        if v not in _VALID_MESSAGE_ROLES:
+            allowed = ", ".join(sorted(_VALID_MESSAGE_ROLES))
+            raise ValueError(
+                f"Unsupported message role {v!r}. Must be one of: {allowed}."
+            )
+        return v
 
 
 # =============================================================================

--- a/src/server/utils/checkpointer.py
+++ b/src/server/utils/checkpointer.py
@@ -19,6 +19,12 @@ from src.config.settings import get_checkpointer_pool_max
 
 logger = logging.getLogger(__name__)
 
+# Message ids under DeltaChannel are stamped upstream by langgraph's
+# ``ensure_message_ids`` (>=1.2.2) at ``put_writes`` time, before the checkpointer
+# persists the raw delta write; the vendored reducer in ``ptc_agent.agent.state``
+# never mints. So id-less ``messages`` writes already carry stable ids by the time
+# they reach the savers below — no id-stamping shim is needed here.
+
 # Module-level connection pool cache to reuse connections across graph compilations
 _postgres_pool_cache: dict[str, AsyncConnectionPool] = {}
 

--- a/tests/unit/ptc_agent/agent/test_delta_channel_determinism.py
+++ b/tests/unit/ptc_agent/agent/test_delta_channel_determinism.py
@@ -1,0 +1,231 @@
+"""Determinism guard for `DeltaChannel`-backed `messages` — THE P1 regression test.
+
+Under `DeltaChannel`, non-snapshot steps persist the *raw* write (a sentinel in
+`channel_values`, the messages stored as a checkpoint write) BEFORE the reducer
+runs. A message that entered the channel *without an id* would be persisted
+id-less; if the reducer minted a fresh `uuid4()` for it on every reconstruction,
+two reads of the same checkpoint would disagree on ids and a full-list write-back
+(the hard-stop checkpoint flush in `background_task_manager._flush_checkpoint`, or
+a post-`/offload` write) would freeze one id into history while the original
+id-less write kept re-minting → duplicate messages.
+
+The clean pattern that prevents this (matching deepagents 0.6.11) has two parts,
+and NO app-side id-stamping shim:
+
+* **Upstream stamp.** langgraph's `ensure_message_ids` (>=1.2.2) stamps id-less
+  `BaseMessage`/dict/list writes inside `PregelLoop.put_writes` — BEFORE the
+  checkpointer persists the raw delta write — so every message lands on disk with
+  a stable id, for any saver (plain `InMemorySaver` included).
+* **Non-minting reducer.** The vendored `ptc_agent.agent.state.messages_delta_reducer`
+  appends an id-less message as-is and never re-rolls its id, so even a message
+  that somehow slipped past the upstream stamp reconstructs deterministically (id
+  stays None) rather than duplicating.
+
+langalpha emits no id-less `Overwrite` writes — the one deepagents path that did
+(`PatchToolCallsMiddleware`'s dangling-tool repair) was changed in 0.6.11 to write
+a plain list that `ensure_message_ids` covers — so the earlier id-stamping
+checkpointer shim is no longer needed. These tests pin the property on a plain
+saver and the >=1.2.2 floor in pyproject.toml: if a langgraph bump regresses the
+upstream stamp, they fail.
+"""
+
+from __future__ import annotations
+
+import pytest
+from langchain_core.messages import (
+    AIMessage,
+    AnyMessage,
+    HumanMessage,
+    RemoveMessage,
+)
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import END, START, StateGraph
+
+from ptc_agent.agent.state import DeltaAgentState
+
+# --- repro harness ---------------------------------------------------------
+
+# Each superstep writes >1 id-less message; this reliably exercises any
+# id-stamping-order non-determinism (a single id-less write per step only trips
+# it ~10% of the time, which would be a flaky demonstration).
+_NODE_MESSAGES_PER_STEP = 2
+_TURNS = 6
+# 1 HumanMessage input + N node messages per turn.
+_EXPECTED_COUNT = _TURNS * (1 + _NODE_MESSAGES_PER_STEP)
+
+
+def _build_graph(saver):
+    """A real ``StateGraph`` whose ``messages`` field is the ``DeltaChannel``.
+
+    The single node returns id-less ``AIMessage``s, mirroring the many id-less
+    app messages langalpha writes (orchestrator/steering/subagent-return/etc.).
+    """
+    builder = StateGraph(DeltaAgentState)
+
+    def node(_state: DeltaAgentState) -> dict[str, list[AnyMessage]]:
+        return {
+            "messages": [
+                AIMessage(f"from-node-{k}") for k in range(_NODE_MESSAGES_PER_STEP)
+            ]
+        }
+
+    builder.add_node("respond", node)
+    builder.add_edge(START, "respond")
+    builder.add_edge("respond", END)
+    return builder.compile(checkpointer=saver)
+
+
+def _drive_turns(graph, config) -> None:
+    """Drive `_TURNS` turns of id-less ``HumanMessage`` input through the graph."""
+    for i in range(_TURNS):
+        graph.invoke({"messages": [HumanMessage(f"turn {i}")]}, config)
+
+
+def _drive_turns_dicts(graph, config) -> None:
+    """Drive turns with dict-form user input — the REAL chat path.
+
+    ``normalize_request_messages`` feeds ``{"role", "content"}`` dicts into the
+    graph, not ``BaseMessage`` objects. langgraph's ``ensure_message_ids`` stamps
+    the dict's ``id`` in place (a separate branch from the BaseMessage one), so
+    this exercises the dict half of the upstream stamp.
+    """
+    for i in range(_TURNS):
+        graph.invoke({"messages": [{"role": "user", "content": f"turn {i}"}]}, config)
+
+
+def _reconstruct_ids(graph, config) -> list[str]:
+    """Reconstruct the thread's messages and return their ids."""
+    return [m.id for m in graph.get_state(config).values["messages"]]
+
+
+def _simulate_hard_stop_flush(graph, config) -> None:
+    """Replicate ``background_task_manager._flush_checkpoint`` exactly.
+
+    The app does ``aget_state`` then ``aupdate_state(config, snapshot.values)`` —
+    a full-list write-back of the reconstructed state. We use the sync
+    equivalents here.
+    """
+    values = graph.get_state(config).values
+    graph.update_state(config, values)
+
+
+# --- precondition: the delta step that makes the property meaningful --------
+
+
+def test_head_checkpoint_omits_messages_on_non_snapshot_step():
+    """Head ``channel_values`` omits ``messages`` (sentinel / non-snapshot step).
+
+    With ``snapshot_frequency=50`` (DeltaAgentState's default) a thread of
+    ~18 messages never hits a snapshot step, so the latest checkpoint blob is a
+    sentinel and the raw ``channel_values`` dict has no ``messages`` key. This is
+    the precondition that makes the determinism property meaningful — without it,
+    the full list would be stored every step (the ``add_messages`` behaviour) and
+    there would be nothing to re-mint.
+    """
+    saver = InMemorySaver()
+    graph = _build_graph(saver)
+    config = {"configurable": {"thread_id": "head-sentinel"}}
+    _drive_turns(graph, config)
+
+    tup = saver.get_tuple(config)
+    channel_values = tup.checkpoint["channel_values"]
+    assert "messages" not in channel_values, (
+        "expected a non-snapshot delta step (sentinel), but the head checkpoint "
+        f"stored messages directly: {list(channel_values)}"
+    )
+
+
+# --- the P1 guard: deterministic reconstruction, flush is a no-op -----------
+
+
+def test_reconstruction_is_deterministic_and_flush_noop():
+    """Two reconstructions agree on ids and the hard-stop flush does not duplicate.
+
+    Covers both the ``BaseMessage`` path and the dict chat path (the REAL path —
+    ``normalize_request_messages`` feeds ``{"role","content"}`` dicts). On a plain
+    saver with NO shim, ``ensure_message_ids`` stamps every id-less write before
+    persistence, so reconstruction is deterministic and the full-list write-back
+    is a no-op. A mismatch means the langgraph >=1.2.2 upstream stamp regressed.
+    """
+    for label, drive in (("basemsg", _drive_turns), ("dict", _drive_turns_dicts)):
+        saver = InMemorySaver()  # plain saver — upstream stamp is the only mechanism
+        graph = _build_graph(saver)
+        config = {"configurable": {"thread_id": f"determinism-{label}"}}
+        drive(graph, config)
+
+        ids_a = _reconstruct_ids(graph, config)
+        ids_b = _reconstruct_ids(graph, config)
+        assert len(ids_a) == _EXPECTED_COUNT
+        assert None not in ids_a, f"every {label} write must be stamped upstream"
+        assert ids_a == ids_b, (
+            f"{label} reconstruction must be deterministic; a mismatch means the "
+            "langgraph >=1.2.2 id-stamp regressed"
+        )
+        before = len(graph.get_state(config).values["messages"])
+        _simulate_hard_stop_flush(graph, config)
+        after = len(graph.get_state(config).values["messages"])
+        assert after == before == _EXPECTED_COUNT, (
+            f"{label} hard-stop flush must be a no-op, got {before} -> {after}"
+        )
+
+
+def test_remove_message_by_id_still_removes_across_reconstruction():
+    """Stable ids let ``RemoveMessage(id=...)`` reliably target a message.
+
+    Stable ids are the precondition that lets compaction/offload remove messages
+    by id across turns. With upstream stamping every message has a stable id, so
+    the removal write hits across reconstruction.
+    """
+    saver = InMemorySaver()
+    graph = _build_graph(saver)
+    config = {"configurable": {"thread_id": "remove-by-id"}}
+    _drive_turns(graph, config)
+
+    messages = graph.get_state(config).values["messages"]
+    target_id = messages[0].id
+    assert target_id is not None
+
+    graph.update_state(config, {"messages": [RemoveMessage(id=target_id)]})
+
+    after = graph.get_state(config).values["messages"]
+    after_ids = [m.id for m in after]
+    assert len(after) == _EXPECTED_COUNT - 1
+    assert target_id not in after_ids, (
+        "RemoveMessage-by-id must remove the targeted message; a miss means ids "
+        "were not stable across reconstruction"
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_path_is_deterministic_and_flush_noop():
+    """The PRODUCTION path is async (``aput_writes``); pin it independently.
+
+    Every sync test drives ``put_writes``; the prod Postgres saver and the
+    in-memory dev path under the ASGI server checkpoint via ``aput_writes`` — a
+    separate method body that could regress independently. Drive the delta graph
+    with ``ainvoke`` (dict chat input, the worst case): reconstruction must be
+    deterministic and the hard-stop flush a no-op.
+    """
+    saver = InMemorySaver()
+    graph = _build_graph(saver)
+    config = {"configurable": {"thread_id": "async-determinism"}}
+    for i in range(_TURNS):
+        await graph.ainvoke(
+            {"messages": [{"role": "user", "content": f"turn {i}"}]}, config
+        )
+
+    ids_a = [m.id for m in (await graph.aget_state(config)).values["messages"]]
+    ids_b = [m.id for m in (await graph.aget_state(config)).values["messages"]]
+    assert len(ids_a) == _EXPECTED_COUNT
+    assert None not in ids_a, "async path must stamp every write upstream"
+    assert ids_a == ids_b, (
+        "async (aput_writes) reconstruction must be deterministic"
+    )
+
+    snap = await graph.aget_state(config)
+    before = len(snap.values["messages"])
+    await graph.aupdate_state(config, snap.values)
+    after = len((await graph.aget_state(config)).values["messages"])
+    assert after == before == _EXPECTED_COUNT, (
+        f"async hard-stop flush must be a no-op, got {before} -> {after}"
+    )

--- a/tests/unit/ptc_agent/agent/test_delta_channel_ordering.py
+++ b/tests/unit/ptc_agent/agent/test_delta_channel_ordering.py
@@ -1,0 +1,167 @@
+"""Same-superstep replay ordering for `DeltaChannel`-backed `messages` (P2).
+
+ACCEPTED RESIDUAL RISK (documented, not a blocker). When two or more parallel
+tasks write to the ``messages`` channel in the *same* superstep, the order they
+reconstruct from a non-snapshot delta checkpoint may differ from the order they
+ran live. Live ``apply_writes`` orders same-superstep task writes by ``task_path``
+(`langgraph/pregel/_algo.py`); the **Postgres** saver's delta stage-2 replay
+(`aget_delta_channel_history`) orders by ``(task_id, idx)`` and ignores the stored
+``task_path`` — so the two can disagree. This is library-level (beta); there is
+no app-side fix, and the plan accepts it because the UI renders from persisted
+SSE events in emission order, never from the reconstructed checkpoint list.
+
+What this test does:
+
+1. Builds a genuine FAN-OUT — one seed node fans out to two sibling nodes that
+   each write one ``messages`` update in the SAME superstep (NOT a single node
+   returning a 2-element list, which is one write and would never reorder).
+2. Asserts the LIVE order is deterministic and is the expected ``apply_writes`` /
+   ``task_path`` order. This guards the path the sequential orchestrator and the
+   model's live context actually depend on, and it is rock-solid (measured stable
+   across 50 runs).
+3. Best-effort: compares the reconstructed order against the live order.
+
+KNOWN LIMITATION — why the reconstruction comparison is `xfail`:
+
+The real, documented divergence (`task_id,idx` vs `task_path`) lives specifically
+in the POSTGRES saver's two-stage SQL replay. The in-memory saver has its OWN
+``get_delta_channel_history`` implementation that does NOT reproduce that
+particular ordering rule. What it DOES show is that same-superstep reconstruction
+order is *non-deterministic* in-memory (measured: live order is always
+``[seed, A, B]`` but reconstruction is ``[seed, A, B]`` or ``[seed, B, A]`` ~50/50
+across runs). That is a flaky, different-mechanism reorder, so we cannot make a
+stable in-memory assertion that reconstruction == live. We therefore mark the
+reconstruction-order comparison ``xfail(strict=False)``: it passes when the run
+happens to preserve order and "x-fails" when it doesn't, and the reason documents
+that exercising the *real* Postgres divergence requires a Postgres saver. This is
+exactly the residual the plan says to document, not block on.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.graph import END, START, StateGraph
+
+from langgraph.checkpoint.memory import InMemorySaver
+
+from ptc_agent.agent.state import DeltaAgentState
+
+# Stable ids so we compare by id/content, independent of stamping behaviour.
+_SEED_ID = "seed"
+_LEFT_ID = "left"
+_RIGHT_ID = "right"
+
+# Live (apply_writes / task_path) order, measured stable across 50 runs.
+_EXPECTED_LIVE_ORDER = [_SEED_ID, _LEFT_ID, _RIGHT_ID]
+
+
+def _build_fan_out_graph(saver):
+    """seed -> {left, right} in parallel -> END; left+right write in one superstep."""
+    builder = StateGraph(DeltaAgentState)
+
+    builder.add_node("seed", lambda _s: {"messages": [HumanMessage("seed", id=_SEED_ID)]})
+    builder.add_node("left", lambda _s: {"messages": [AIMessage("left", id=_LEFT_ID)]})
+    builder.add_node("right", lambda _s: {"messages": [AIMessage("right", id=_RIGHT_ID)]})
+
+    builder.add_edge(START, "seed")
+    # Fan-out: two outgoing edges from one node -> both run in the same superstep.
+    builder.add_edge("seed", "left")
+    builder.add_edge("seed", "right")
+    builder.add_edge("left", END)
+    builder.add_edge("right", END)
+    return builder.compile(checkpointer=saver)
+
+
+def test_fan_out_live_order_is_deterministic():
+    """LIVE same-superstep order is the deterministic apply_writes / task_path order.
+
+    This is the rock-solid guard: the sequential orchestrator path and the model's
+    live context depend on this ordering, and it must stay stable. If a future
+    langgraph/langchain change perturbs live fan-out ordering this fails loudly.
+    """
+    graph = _build_fan_out_graph(InMemorySaver())
+    config = {"configurable": {"thread_id": "fanout-live"}}
+    result = graph.invoke({"messages": []}, config)
+
+    live_ids = [m.id for m in result["messages"]]
+    assert live_ids == _EXPECTED_LIVE_ORDER, (
+        "live same-superstep fan-out order changed; the orchestrator and model "
+        f"context rely on a stable order. got {live_ids}"
+    )
+
+
+def test_fan_out_head_checkpoint_is_non_snapshot():
+    """The head checkpoint is a sentinel, so reconstruction exercises delta replay."""
+    saver = InMemorySaver()
+    graph = _build_fan_out_graph(saver)
+    config = {"configurable": {"thread_id": "fanout-sentinel"}}
+    graph.invoke({"messages": []}, config)
+
+    channel_values = saver.get_tuple(config).checkpoint["channel_values"]
+    assert "messages" not in channel_values, (
+        "expected a non-snapshot delta step so reconstruction replays writes; "
+        f"head stored messages directly: {list(channel_values)}"
+    )
+
+
+def test_fan_out_reconstruction_preserves_all_messages():
+    """Integrity guard (reliable, NOT xfail): reconstruction loses/dups no message.
+
+    Multiset-equality is the part that IS reliable — a dropped or duplicated
+    message on delta replay is a real corruption regression and must fail loudly.
+    Only the *order* is the accepted non-deterministic residual, asserted separately
+    in the xfail test below; keeping integrity out of the xfail umbrella means a
+    genuine message-loss bug can no longer hide as an expected failure.
+    """
+    graph = _build_fan_out_graph(InMemorySaver())
+    config = {"configurable": {"thread_id": "fanout-recon-set"}}
+    result = graph.invoke({"messages": []}, config)
+    live_ids = [m.id for m in result["messages"]]
+
+    recon_ids = [m.id for m in graph.get_state(config).values["messages"]]
+
+    # Counter, not set: a DUPLICATED id must fail here too, and set() collapses
+    # duplicates (so a [seed, A, A] reconstruction would pass against {seed, A}).
+    # Duplication is exactly the corruption this guard exists to catch; order is
+    # the separate xfail concern, so compare as a multiset, not a sequence.
+    assert Counter(recon_ids) == Counter(live_ids), (
+        f"reconstruction lost or duplicated a message: recon {sorted(recon_ids)} "
+        f"!= live {sorted(live_ids)}"
+    )
+
+
+@pytest.mark.xfail(
+    strict=False,
+    reason=(
+        "In-memory delta reconstruction of same-superstep fan-out writes is "
+        "non-deterministic (~50/50 order across runs) and does NOT reproduce the "
+        "specific documented Postgres divergence (task_id,idx vs task_path). The "
+        "real divergence lives in AsyncPostgresSaver.aget_delta_channel_history and "
+        "requires a Postgres saver to exercise; this is an accepted residual risk "
+        "with no app-side fix. See module docstring."
+    ),
+)
+def test_fan_out_reconstruction_preserves_live_order():
+    """Best-effort (xfail): reconstructed ORDER matches live order.
+
+    Passes when the in-memory replay happens to preserve order; x-fails when it
+    reorders. Message integrity (nothing lost/duplicated) is asserted reliably and
+    separately in ``test_fan_out_reconstruction_preserves_all_messages`` — only the
+    order is the accepted P2 residual absorbed here. Exercising the real Postgres
+    divergence is left to integration tests against a Postgres saver.
+    """
+    graph = _build_fan_out_graph(InMemorySaver())
+    config = {"configurable": {"thread_id": "fanout-recon"}}
+    result = graph.invoke({"messages": []}, config)
+    live_ids = [m.id for m in result["messages"]]
+
+    recon_ids = [m.id for m in graph.get_state(config).values["messages"]]
+
+    # Order is the residual: assert it; xfail absorbs the in-memory non-determinism.
+    assert recon_ids == live_ids, (
+        f"reconstructed order {recon_ids} != live order {live_ids} "
+        "(accepted P2 residual under in-memory replay)"
+    )

--- a/tests/unit/ptc_agent/agent/test_delta_channel_resolution.py
+++ b/tests/unit/ptc_agent/agent/test_delta_channel_resolution.py
@@ -1,0 +1,108 @@
+"""Channel-resolution proof for the DeltaChannel adoption linchpin.
+
+Passing ``state_schema=DeltaAgentState`` to ``langchain.agents.create_agent``
+must make the compiled graph's ``messages`` channel a ``DeltaChannel`` — winning
+the schema merge against the ``add_messages`` (``BinaryOperatorAggregate``)
+annotation declared by the base ``AgentState`` and by middleware state schemas.
+
+These tests build a real agent through the same factory the production
+agent/flash/subagent factories use, with a representative subset of the real
+middleware stack (the full PTC/Flash stack needs sandbox/MCP/network infra that
+a unit test can't construct). One middleware in the subset *explicitly*
+re-declares ``messages: add_messages`` so the override genuinely wins a conflict,
+not just a no-op.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from langchain.agents import AgentState, create_agent
+from langchain.agents.middleware import AgentMiddleware, TodoListMiddleware
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langgraph.channels import DeltaChannel
+from langgraph.channels.binop import BinaryOperatorAggregate
+from langgraph.graph.message import add_messages
+
+from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
+from ptc_agent.agent.state import DeltaAgentState
+
+
+class _ConflictState(AgentState):
+    """State schema that re-declares ``messages`` with ``add_messages``.
+
+    Stands in for the ~25 middleware state subclasses that declare
+    ``messages: add_messages`` in the real stack, so the merge has a genuine
+    conflict for ``DeltaAgentState`` to win.
+    """
+
+    messages: Annotated[list, add_messages]
+
+
+class _ConflictMiddleware(AgentMiddleware):
+    state_schema = _ConflictState
+
+
+def _fake_model() -> GenericFakeChatModel:
+    """Stub chat model so the build never touches the network."""
+    return GenericFakeChatModel(messages=iter([]))
+
+
+def _representative_middleware() -> list[AgentMiddleware]:
+    """A real-middleware subset that includes a ``messages: add_messages`` conflict.
+
+    ``TodoListMiddleware`` and ``PatchToolCallsMiddleware`` are both present in
+    the real PTC middleware stack and construct without infra. The conflict
+    middleware forces the schema merge the linchpin must win.
+    """
+    return [_ConflictMiddleware(), TodoListMiddleware(), PatchToolCallsMiddleware()]
+
+
+def test_messages_channel_is_delta_channel_with_state_schema():
+    """WITH ``state_schema=DeltaAgentState`` the messages channel is a DeltaChannel."""
+    agent = create_agent(
+        _fake_model(),
+        tools=[],
+        middleware=_representative_middleware(),
+        state_schema=DeltaAgentState,
+    )
+
+    channel = agent.channels["messages"]
+    assert isinstance(channel, DeltaChannel), (
+        f"expected DeltaChannel, got {type(channel).__name__} — the "
+        "state_schema override lost the messages schema merge"
+    )
+    assert not isinstance(channel, BinaryOperatorAggregate)
+
+
+def test_messages_channel_is_binop_without_state_schema():
+    """WITHOUT ``state_schema`` the SAME build falls back to BinaryOperatorAggregate.
+
+    Proves the assertion above is meaningful: the DeltaChannel result is caused
+    by the override, not by the middleware subset or the fake model.
+    """
+    agent = create_agent(
+        _fake_model(),
+        tools=[],
+        middleware=_representative_middleware(),
+    )
+
+    channel = agent.channels["messages"]
+    assert isinstance(channel, BinaryOperatorAggregate)
+    assert not isinstance(channel, DeltaChannel)
+
+
+def test_delta_channel_uses_vendored_reducer():
+    """The resolved DeltaChannel carries our vendored ``messages_delta_reducer``."""
+    from ptc_agent.agent.state import messages_delta_reducer
+
+    agent = create_agent(
+        _fake_model(),
+        tools=[],
+        middleware=_representative_middleware(),
+        state_schema=DeltaAgentState,
+    )
+
+    channel = agent.channels["messages"]
+    assert isinstance(channel, DeltaChannel)
+    assert channel.reducer is messages_delta_reducer

--- a/tests/unit/ptc_agent/agent/test_messages_delta_reducer.py
+++ b/tests/unit/ptc_agent/agent/test_messages_delta_reducer.py
@@ -1,0 +1,426 @@
+"""Parity between the vendored `messages_delta_reducer` and langgraph's `add_messages`.
+
+The vendored reducer is the linchpin of DeltaChannel correctness: replaying
+writes through it must reconstruct exactly what `add_messages` would have built,
+for type / content / dedup / tombstone / ordering. `add_messages` is a
+single-write reducer `(left, right)`; `messages_delta_reducer` is a batch reducer
+`(state, [writes...])`. We drive them equivalently — apply writes one-by-one
+through `add_messages` to build the expected, the same batch through the vendored
+reducer — so the structural comparison is fair.
+
+The reducers diverge on ONE axis by design: `add_messages` mints a `uuid4()` for
+id-less messages, while `messages_delta_reducer` is non-minting (id-less messages
+keep id=None). Under DeltaChannel, langgraph's `ensure_message_ids` stamps ids
+upstream before persistence, so minting in the reducer would re-roll a different
+id on every replay. We therefore compare structure / content / count, not id
+presence or UUID value.
+"""
+
+import copy
+
+import pytest
+from langchain_core.messages import (
+    AIMessage,
+    HumanMessage,
+    RemoveMessage,
+    ToolMessage,
+)
+from langgraph.graph.message import REMOVE_ALL_MESSAGES, add_messages
+
+from ptc_agent.agent.state import messages_delta_reducer
+
+
+def _apply_add_messages(writes):
+    """Sequentially fold writes through the single-write `add_messages` reducer."""
+    state = []
+    for w in writes:
+        state = add_messages(state, w)
+    return state
+
+
+def _assert_structural_parity(expected, actual):
+    """Compare two message lists by type + content + count (not id / UUID value).
+
+    The reducers diverge on id-minting by design (see module docstring): id-less
+    raw input gets a minted id under `add_messages` but stays id=None under the
+    non-minting `messages_delta_reducer`. Tests that care about explicit ids assert
+    the id sequence directly.
+    """
+    assert len(expected) == len(actual)
+    for exp, act in zip(expected, actual, strict=True):
+        assert type(exp) is type(act)
+        assert exp.content == act.content
+
+
+def test_append_new_messages():
+    state = [HumanMessage(content="hi", id="h1"), AIMessage(content="hello", id="a1")]
+    writes = [[HumanMessage(content="how are you", id="h2")]]
+
+    expected = _apply_add_messages([state, *writes])
+    actual = messages_delta_reducer(state, writes)
+
+    _assert_structural_parity(expected, actual)
+    assert [m.content for m in actual] == ["hi", "hello", "how are you"]
+    assert [m.id for m in actual] == ["h1", "a1", "h2"]
+
+
+def test_dedup_by_id_replaces_in_place():
+    state = [
+        HumanMessage(content="hi", id="h1"),
+        AIMessage(content="draft", id="a1"),
+        HumanMessage(content="next", id="h2"),
+    ]
+    writes = [[AIMessage(content="final", id="a1")]]
+
+    expected = _apply_add_messages([state, *writes])
+    actual = messages_delta_reducer(state, writes)
+
+    _assert_structural_parity(expected, actual)
+    # same id -> replaced, position preserved (not moved to end)
+    assert [m.content for m in actual] == ["hi", "final", "next"]
+    assert [m.id for m in actual] == ["h1", "a1", "h2"]
+
+
+def test_remove_message_by_id():
+    state = [
+        HumanMessage(content="hi", id="h1"),
+        AIMessage(content="bye", id="a1"),
+        HumanMessage(content="again", id="h2"),
+    ]
+    writes = [[RemoveMessage(id="a1")]]
+
+    expected = _apply_add_messages([state, *writes])
+    actual = messages_delta_reducer(state, writes)
+
+    _assert_structural_parity(expected, actual)
+    assert [m.id for m in actual] == ["h1", "h2"]
+    assert [m.content for m in actual] == ["hi", "again"]
+
+
+def test_remove_all_messages_mid_batch_resets_then_appends():
+    state = [HumanMessage(content="old1", id="h1"), AIMessage(content="old2", id="a1")]
+    # one write carrying the reset sentinel followed by a fresh message
+    writes = [
+        [
+            RemoveMessage(id=REMOVE_ALL_MESSAGES),
+            HumanMessage(content="fresh", id="h2"),
+        ]
+    ]
+
+    expected = _apply_add_messages([state, *writes])
+    actual = messages_delta_reducer(state, writes)
+
+    _assert_structural_parity(expected, actual)
+    assert [m.id for m in actual] == ["h2"]
+    assert [m.content for m in actual] == ["fresh"]
+
+
+def test_remove_all_across_separate_writes():
+    """REMOVE_ALL in one write, appends in a later write within the same batch."""
+    state = [HumanMessage(content="old", id="h1")]
+    writes = [
+        [RemoveMessage(id=REMOVE_ALL_MESSAGES)],
+        [AIMessage(content="a", id="a1"), HumanMessage(content="b", id="h2")],
+    ]
+
+    expected = _apply_add_messages([state, *writes])
+    actual = messages_delta_reducer(state, writes)
+
+    _assert_structural_parity(expected, actual)
+    assert [m.id for m in actual] == ["a1", "h2"]
+    assert [m.content for m in actual] == ["a", "b"]
+
+
+def test_idless_messages_are_not_minted():
+    """Non-minting contract: id-less messages reconstruct with id=None.
+
+    Minting in the reducer would re-roll a different id on every replay under
+    DeltaChannel; langgraph's `ensure_message_ids` stamps ids upstream instead, so
+    by replay time messages already carry stable ids. (add_messages, by contrast,
+    mints — the one intended divergence; we do NOT compare against it here because
+    folding through add_messages would mutate these shared objects' ids in place.)
+    """
+    writes = [[HumanMessage(content="hi")], [AIMessage(content="hello")]]
+    actual = messages_delta_reducer([], writes)
+
+    assert [m.content for m in actual] == ["hi", "hello"]
+    assert all(m.id is None for m in actual), "reducer must not mint ids"
+
+
+def test_raw_dict_input_is_coerced():
+    state = []
+    writes = [[{"role": "user", "content": "hi"}]]
+
+    expected = _apply_add_messages([state, *writes])
+    actual = messages_delta_reducer(state, writes)
+
+    _assert_structural_parity(expected, actual)
+    assert len(actual) == 1
+    assert isinstance(actual[0], HumanMessage)
+    assert actual[0].content == "hi"
+    # Non-minting: the reducer coerces the dict but does NOT assign an id
+    # (ensure_message_ids stamps upstream); add_messages would have minted one.
+    assert actual[0].id is None
+
+
+def test_raw_str_and_tuple_input_coerced():
+    """Raw string and ``(role, content)`` tuple writes coerce like add_messages.
+
+    Coercion (type + content) matches add_messages; id assignment does NOT — the
+    reducer is non-minting, so an id-less raw write stays id=None here while
+    add_messages would mint a uuid.
+    """
+    for raw in ["hi there", ("user", "howdy")]:
+        expected = _apply_add_messages([[], [raw]])
+        actual = messages_delta_reducer([], [[raw]])
+
+        _assert_structural_parity(expected, actual)
+        assert len(actual) == 1
+        assert isinstance(actual[0], HumanMessage)
+        assert actual[0].id is None
+
+
+def test_remove_unknown_id_is_silently_ignored_diverging_from_add_messages():
+    """Intentional divergence: an unknown-id ``RemoveMessage`` is a no-op here.
+
+    ``add_messages`` raises ``ValueError`` for a RemoveMessage targeting an id
+    not present; the batch reducer ``DeltaChannel`` requires silently ignores it
+    (batching-invariance — a RemoveMessage may legitimately re-run after its
+    target is already gone). This pins that contract so a future refactor doesn't
+    accidentally "fix" it back to raising and break delta replay.
+    """
+    state = [HumanMessage(content="hi", id="h1")]
+
+    # add_messages raises on the phantom remove ...
+    with pytest.raises(ValueError):
+        add_messages(state, [RemoveMessage(id="absent")])
+
+    # ... the vendored reducer silently no-ops, leaving state intact.
+    actual = messages_delta_reducer(list(state), [[RemoveMessage(id="absent")]])
+    assert [m.id for m in actual] == ["h1"]
+    assert [m.content for m in actual] == ["hi"]
+
+
+def test_offload_remove_all_then_full_relist_parity():
+    """The REAL `/offload` + `/compact` write shape: REMOVE_ALL then a full
+    re-list of the (already id'd) prior state.
+
+    ``compact.py`` emits ``[RemoveMessage(REMOVE_ALL_MESSAGES), *messages]`` in one
+    ``aupdate_state``. The existing REMOVE_ALL tests reset then append a *single
+    fresh* message; this pins the reset-then-rebuild that must reconstruct
+    identically to ``add_messages`` (including preserving the original ids, since
+    after the reset they are fresh appends to an empty list).
+    """
+    state = [
+        HumanMessage(content="q", id="k1"),
+        AIMessage(content="draft", id="k2"),
+        ToolMessage(content="tool", tool_call_id="tc1", id="k3"),
+    ]
+    # offload truncates args but keeps the same message objects/ids; simulate by
+    # re-listing the same ids with one content edited.
+    relisted = [
+        HumanMessage(content="q", id="k1"),
+        AIMessage(content="draft", id="k2"),
+        ToolMessage(content="[offloaded]", tool_call_id="tc1", id="k3"),
+    ]
+    writes = [[RemoveMessage(id=REMOVE_ALL_MESSAGES), *relisted]]
+
+    expected = _apply_add_messages([state, *writes])
+    actual = messages_delta_reducer(state, writes)
+
+    _assert_structural_parity(expected, actual)
+    assert [m.id for m in actual] == ["k1", "k2", "k3"]
+    assert [m.content for m in actual] == ["q", "draft", "[offloaded]"]
+
+
+def test_last_remove_all_wins_among_multiple():
+    """Two REMOVE_ALL sentinels in one batch → only writes after the LAST one
+    survive ("last sentinel wins").
+
+    Load-bearing for replay-invariance: a re-run/stacked compaction can put two
+    resets in a single delta batch, and the reducer must discard everything
+    (state + writes) before the final sentinel. Asserted directly (add_messages
+    handles repeated REMOVE_ALL differently, so parity is not the contract here).
+    """
+    state = [HumanMessage(content="old", id="o1")]
+    writes = [
+        [
+            RemoveMessage(id=REMOVE_ALL_MESSAGES),
+            AIMessage(content="dropped", id="d1"),
+            RemoveMessage(id=REMOVE_ALL_MESSAGES),
+            AIMessage(content="kept", id="k1"),
+        ]
+    ]
+
+    actual = messages_delta_reducer(state, writes)
+
+    assert [m.id for m in actual] == ["k1"]
+    assert [m.content for m in actual] == ["kept"]
+
+
+def test_state_with_raw_dicts_is_coerced():
+    """Slow-path: a non-empty ``state`` of raw dicts (deserialized-blob / initial
+    dict state) is coerced via ``convert_to_messages``.
+
+    The fast-path guard only skips coercion when ``state[0]`` is a BaseMessage;
+    the raw-dict-state branch (the reason the guard exists) is otherwise
+    unexercised, so a regression dropping coercion would pass silently.
+    """
+    state = [{"role": "user", "content": "hi", "id": "h1"}]
+    writes = [[AIMessage(content="x", id="a1")]]
+
+    expected = _apply_add_messages([state, *writes])
+    actual = messages_delta_reducer(state, writes)
+
+    _assert_structural_parity(expected, actual)
+    assert isinstance(actual[0], HumanMessage)
+    assert [m.id for m in actual] == ["h1", "a1"]
+    assert [m.content for m in actual] == ["hi", "x"]
+
+
+def test_mixed_batch_parity():
+    """A realistic multi-write batch: append, tool result, dedup, remove."""
+    state = [
+        HumanMessage(content="question", id="h1"),
+        AIMessage(content="thinking", id="a1"),
+    ]
+    writes = [
+        [ToolMessage(content="tool out", tool_call_id="tc1", id="t1")],
+        [AIMessage(content="answer", id="a1")],  # dedup replace in place
+        [HumanMessage(content="followup", id="h2")],
+        [RemoveMessage(id="t1")],  # remove the tool message
+    ]
+
+    expected = _apply_add_messages([state, *writes])
+    actual = messages_delta_reducer(state, writes)
+
+    _assert_structural_parity(expected, actual)
+    assert [m.id for m in actual] == [m.id for m in expected]
+    assert [m.content for m in actual] == ["question", "answer", "followup"]
+
+
+# --- drift guard: the vendored reducer must match deepagents' upstream copy ----
+#
+# `messages_delta_reducer` is a near-verbatim copy of deepagents'
+# `_messages_delta_reducer` (see src/ptc_agent/agent/state.py). Because it is
+# reconstruction logic for persisted delta blobs, we vendor it — freezing its
+# semantics to our release — rather than importing the private symbol at runtime
+# (a deepagents bump could otherwise silently change how existing threads read
+# back). This guard imports deepagents' reducer in the TEST ONLY and asserts
+# behavioural parity across the reconstruction-defining cases, so drift surfaces
+# as a red CI light we consciously reconcile, not a silent divergence.
+
+# (state, writes, ids_deterministic) — ids_deterministic flags cases where every
+# input carries an explicit id. Both reducers are non-minting (id-less inputs are
+# appended as-is with id=None), so structure / content / id-presence always match;
+# the explicit-id cases additionally pin that the surviving id *sequence* matches.
+_DEEPAGENTS_PARITY_CASES = [
+    pytest.param([], [[HumanMessage("a", id="h1")]], True, id="append"),
+    pytest.param(
+        [AIMessage("x", id="a1")], [[AIMessage("y", id="a1")]], True, id="dedup-in-place"
+    ),
+    pytest.param(
+        [AIMessage("x", id="a1")], [[RemoveMessage(id="a1")]], True, id="tombstone"
+    ),
+    pytest.param(
+        [AIMessage("x", id="a1")],
+        [[RemoveMessage(id=REMOVE_ALL_MESSAGES), HumanMessage("fresh", id="h2")]],
+        True,
+        id="remove-all-mid-batch",
+    ),
+    pytest.param(
+        [HumanMessage("old", id="h1")],
+        [[RemoveMessage(id=REMOVE_ALL_MESSAGES)], [AIMessage("a", id="a1")]],
+        True,
+        id="remove-all-across-writes",
+    ),
+    pytest.param(
+        [HumanMessage("hi", id="h1")],
+        [[RemoveMessage(id="absent")]],
+        True,
+        id="unknown-id-remove-noop",
+    ),
+    pytest.param(
+        [HumanMessage("old", id="o1")],
+        [
+            [
+                RemoveMessage(id=REMOVE_ALL_MESSAGES),
+                AIMessage("d", id="d1"),
+                RemoveMessage(id=REMOVE_ALL_MESSAGES),
+                AIMessage("k", id="k1"),
+            ]
+        ],
+        True,
+        id="last-remove-all-wins",
+    ),
+    pytest.param(
+        [HumanMessage("q", id="k1"), AIMessage("draft", id="k2")],
+        [
+            [
+                RemoveMessage(id=REMOVE_ALL_MESSAGES),
+                HumanMessage("q", id="k1"),
+                AIMessage("draft", id="k2"),
+            ]
+        ],
+        True,
+        id="offload-relist",
+    ),
+    pytest.param(
+        [{"role": "user", "content": "hi", "id": "h1"}],
+        [[AIMessage("x", id="a1")]],
+        True,
+        id="raw-dict-state",
+    ),
+    pytest.param(
+        [HumanMessage("q", id="h1"), AIMessage("thinking", id="a1")],
+        [
+            [ToolMessage("tool out", tool_call_id="tc1", id="t1")],
+            [AIMessage("answer", id="a1")],
+            [HumanMessage("followup", id="h2")],
+            [RemoveMessage(id="t1")],
+        ],
+        True,
+        id="mixed-batch",
+    ),
+    pytest.param([], [[HumanMessage("hi")], [AIMessage("hello")]], False, id="idless-passthrough"),
+    pytest.param([], [[{"role": "user", "content": "d"}]], False, id="dict-input"),
+    pytest.param([], [["just a string"]], False, id="str-input"),
+    pytest.param([], [[("user", "howdy")]], False, id="tuple-input"),
+]
+
+
+def _struct(msgs):
+    """Reducer output as (type, content, id-present) — id presence, not value, so
+    explicit-id and id-less (None) cases are both comparable across reducers."""
+    return [(type(m).__name__, m.content, m.id is not None) for m in msgs]
+
+
+@pytest.mark.parametrize("state, writes, ids_deterministic", _DEEPAGENTS_PARITY_CASES)
+def test_vendored_reducer_matches_deepagents(state, writes, ids_deterministic):
+    """The vendored reducer must behave identically to deepagents' upstream copy.
+
+    A red here means deepagents changed `_messages_delta_reducer`: reconcile
+    `src/ptc_agent/agent/state.py` and confirm the change is safe for already-
+    persisted delta blobs before following it.
+    """
+    try:
+        from deepagents._messages_reducer import _messages_delta_reducer as upstream
+    except ImportError as exc:  # private module/symbol — a rename is itself drift
+        pytest.fail(
+            "deepagents._messages_reducer._messages_delta_reducer is gone "
+            f"({exc}); the vendored messages_delta_reducer can no longer be drift-"
+            "checked against upstream — reconcile state.py with deepagents."
+        )
+
+    # deepcopy per call: both reducers build their result from the input objects
+    # in place, so shared inputs would let the first call pollute the second.
+    ours = messages_delta_reducer(copy.deepcopy(state), copy.deepcopy(writes))
+    theirs = upstream(copy.deepcopy(state), copy.deepcopy(writes))
+
+    assert _struct(ours) == _struct(theirs), (
+        "vendored reducer diverged from deepagents' _messages_delta_reducer"
+    )
+    if ids_deterministic:
+        assert [m.id for m in ours] == [m.id for m in theirs], (
+            "explicit-id reconstruction order/ids diverged from deepagents'"
+        )

--- a/tests/unit/scripts/ops/test_scrub_nul_checkpoint.py
+++ b/tests/unit/scripts/ops/test_scrub_nul_checkpoint.py
@@ -1,0 +1,118 @@
+"""Unit tests for the NUL-scrub ops script's delta-awareness.
+
+`scrub_nul_checkpoint._strip_nul` walks deserialized checkpoint structures and
+strips NUL bytes. A `_DeltaSnapshot` is a `NamedTuple`; the generic tuple branch
+must reconstruct it with the SAME type, not flatten it to a plain tuple —
+otherwise `DeltaChannel.from_checkpoint` stops recognizing the snapshot and the
+`messages` channel corrupts on resume.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+from langgraph.checkpoint.serde.types import _DeltaSnapshot
+
+from scripts.ops.scrub_nul_checkpoint import _strip_nul
+
+
+def test_strip_nul_preserves_delta_snapshot_type():
+    """A `_DeltaSnapshot` containing a NUL stays a `_DeltaSnapshot` and is cleaned."""
+    snap = _DeltaSnapshot(value="msg\x00one")
+
+    cleaned, count = _strip_nul(snap)
+
+    # (a) Same NamedTuple type, not flattened to a plain tuple.
+    assert isinstance(cleaned, _DeltaSnapshot)
+    assert type(cleaned).__name__ == "_DeltaSnapshot"
+    assert type(cleaned) is _DeltaSnapshot
+    # (b) NUL removed from the field; the field is still accessible by name.
+    assert cleaned.value == "msgone"
+    assert "\x00" not in cleaned.value
+    assert count == 1
+
+
+def test_strip_nul_delta_snapshot_with_nested_structure():
+    """NUL inside a list/dict carried by the snapshot is scrubbed, type preserved."""
+    snap = _DeltaSnapshot(value=["a\x00b", {"k": "v\x00al"}])
+
+    cleaned, count = _strip_nul(snap)
+
+    assert isinstance(cleaned, _DeltaSnapshot)
+    assert cleaned.value == ["ab", {"k": "val"}]
+    assert count == 2
+
+
+def test_strip_nul_delta_snapshot_survives_serde_roundtrip():
+    """The cleaned snapshot must re-serialize via the same serde the script uses
+    and rehydrate as a `_DeltaSnapshot` — the property the script relies on."""
+    serde = JsonPlusSerializer()
+    snap = _DeltaSnapshot(value="poison\x00ed")
+
+    cleaned, _ = _strip_nul(snap)
+    type_str, blob = serde.dumps_typed(cleaned)
+    rehydrated = serde.loads_typed((type_str, blob))
+
+    assert isinstance(rehydrated, _DeltaSnapshot)
+    assert rehydrated.value == "poisoned"
+
+
+def test_strip_nul_preserves_generic_namedtuple():
+    """Any NamedTuple (not just `_DeltaSnapshot`) keeps its type after scrubbing."""
+
+    class _Pair(NamedTuple):
+        left: str
+        right: str
+
+    cleaned, count = _strip_nul(_Pair(left="x\x00y", right="z"))
+
+    assert isinstance(cleaned, _Pair)
+    assert cleaned._fields == ("left", "right")
+    assert cleaned.left == "xy"
+    assert cleaned.right == "z"
+    assert count == 1
+
+
+def test_strip_nul_snapshot_with_message_object_scrubs_content():
+    """The ACTUAL production shape: a `_DeltaSnapshot` whose value is a list of
+    LangChain message objects, with a NUL in `ToolMessage.content`.
+
+    The module docstring names message content as the dominant NUL carrier, but
+    the existing snapshot tests only carry str / list-of-str/dict. This drives the
+    message-object branch (`hasattr(value, "__dict__")`) nested inside the
+    NamedTuple reconstruction: the NUL is stripped from `content`, the object stays
+    a `ToolMessage`, and the wrapper stays a `_DeltaSnapshot`."""
+    from langchain_core.messages import ToolMessage
+
+    snap = _DeltaSnapshot(
+        value=[ToolMessage(content="bad\x00data", tool_call_id="c1", id="t1")]
+    )
+
+    cleaned, count = _strip_nul(snap)
+
+    assert isinstance(cleaned, _DeltaSnapshot)
+    assert type(cleaned.value[0]) is ToolMessage
+    assert cleaned.value[0].content == "baddata"
+    assert cleaned.value[0].id == "t1"
+    assert count == 1
+
+
+def test_strip_nul_plain_tuple_stays_plain_tuple():
+    """A plain tuple (no `_fields`) is still scrubbed and returned as a plain tuple."""
+    cleaned, count = _strip_nul(("a\x00", "b"))
+
+    assert type(cleaned) is tuple
+    assert cleaned == ("a", "b")
+    assert count == 1
+
+
+def test_strip_nul_no_nul_is_noop():
+    """No NUL anywhere → value unchanged, count 0, type preserved."""
+    snap = _DeltaSnapshot(value=["clean", {"k": "v"}])
+
+    cleaned, count = _strip_nul(snap)
+
+    assert isinstance(cleaned, _DeltaSnapshot)
+    assert cleaned.value == ["clean", {"k": "v"}]
+    assert count == 0

--- a/tests/unit/server/models/test_chat_models.py
+++ b/tests/unit/server/models/test_chat_models.py
@@ -11,7 +11,6 @@ from src.server.models.chat import (
     ChatMessage,
     ChatRequest,
     ContentItem,
-    GeneratePodcastRequest,
     HITLDecision,
     HITLResponse,
     SubagentMessageRequest,
@@ -170,6 +169,69 @@ class TestChatMessage:
         items = [ContentItem(type="text", text="hello")]
         msg = ChatMessage(role="assistant", content=items)
         assert isinstance(msg.content, list)
+
+    def test_valid_roles_accepted(self):
+        # Roles that both convert_to_messages can build AND langgraph stamps.
+        for role in ("user", "assistant", "system", "human", "ai"):
+            assert ChatMessage(role=role, content="x").role == role
+
+    def test_developer_role_rejected(self):
+        """``developer`` converts fine (convert_to_messages -> SystemMessage) but is
+        NOT in langgraph's ``_MESSAGE_ROLES``, so ``ensure_message_ids`` never stamps
+        it. It would persist id-less and duplicate on the hard-stop checkpoint flush
+        (a full-list ``aupdate_state`` write-back the non-minting reducer can't
+        dedup). Reject at the boundary; clients send ``system`` for the same effect."""
+        with pytest.raises(ValidationError, match="Unsupported message role"):
+            ChatMessage(role="developer", content="x")
+
+    def test_every_valid_role_is_stamped_by_langgraph(self):
+        """The invariant behind the set: every accepted role MUST be in langgraph's
+        ``_MESSAGE_ROLES`` (the set ``ensure_message_ids`` stamps at put_writes).
+        An accepted-but-unstamped role persists id-less and duplicates on the
+        hard-stop flush. Ties the validator to langgraph's actual stamping contract:
+        re-adding an unstamped role (e.g. ``developer``) or a langgraph bump that
+        narrows ``_MESSAGE_ROLES`` fails here instead of corrupting threads in prod."""
+        from langgraph.pregel._messages import _MESSAGE_ROLES
+
+        from src.server.models.chat import _VALID_MESSAGE_ROLES
+
+        unstamped = _VALID_MESSAGE_ROLES - _MESSAGE_ROLES
+        assert not unstamped, (
+            f"roles accepted but NOT stamped by langgraph: {sorted(unstamped)} — "
+            "each persists id-less and duplicates on the hard-stop flush"
+        )
+
+    def test_tool_and_function_roles_rejected(self):
+        """``tool``/``function`` are accepted by convert_to_messages but map to
+        ToolMessage/FunctionMessage, which require tool_call_id/name that
+        ChatMessage cannot supply. A client POST of {"role":"tool"} would pass
+        the model, then raise KeyError('tool_call_id') in the reducer — and under
+        DeltaChannel the raw write is persisted before the reducer, so it
+        re-raises on every reconstruction and bricks the thread. Reject at the
+        boundary."""
+        for role in ("tool", "function"):
+            with pytest.raises(ValidationError, match="Unsupported message role"):
+                ChatMessage(role=role, content="x")
+
+    def test_unknown_role_rejected(self):
+        """A client-controlled unknown role is rejected at the request boundary
+        (422), so it is never persisted to the delta channel where it would
+        re-raise in convert_to_messages on every reconstruction and brick the
+        thread."""
+        with pytest.raises(ValidationError, match="Unsupported message role"):
+            ChatMessage(role="banana", content="hi")
+
+    def test_role_is_case_sensitive(self):
+        # langchain matches roles case-sensitively (msg dict 'role' used as-is),
+        # so "User" would raise downstream — reject it cleanly here too.
+        with pytest.raises(ValidationError):
+            ChatMessage(role="User", content="hi")
+
+    def test_chatrequest_with_bad_role_rejected(self):
+        """End-to-end: the bad role is caught when the request body is parsed,
+        before any handler / graph / checkpoint runs."""
+        with pytest.raises(ValidationError):
+            ChatRequest(messages=[{"role": "banana", "content": "hi"}])
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -976,7 +976,7 @@ wheels = [
 
 [[package]]
 name = "deepagents"
-version = "0.6.3"
+version = "0.6.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain" },
@@ -986,9 +986,9 @@ dependencies = [
     { name = "langsmith" },
     { name = "wcmatch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2d/e4/f0db12de9a63ace505a81a3bd1bff2012fa94d57698bcc4edb6cc44daf3a/deepagents-0.6.3.tar.gz", hash = "sha256:ce2bc1d91a29b8355e43bdf89da553705e103cd1f2b3ff7b999b69be8eac1237", size = 180551, upload_time = "2026-05-20T21:16:38.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/61/c8aff4d0c3649d02b0090f304917892e7ce7b840b92f86f95751151c1e9c/deepagents-0.6.11.tar.gz", hash = "sha256:c5cb0bc2964ef81d2d81cd26855d7cd3a1dd0b8170c5d451c01a0860f997cae0", size = 205926, upload_time = "2026-06-18T21:05:38.247Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/e9/35a5668b4226afe8ec83a71c38e53a677b207ed9a10bd806b1be6cbf6277/deepagents-0.6.3-py3-none-any.whl", hash = "sha256:5c9a3ab30cd24eae0a5afe654fe5030ead4f8a86154c77757dd6350342ad50ac", size = 205652, upload_time = "2026-05-20T21:16:36.999Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/aa/395b0d439f026629b22a5de5cda7b8de25ca456a33abdf3235687cc77c6f/deepagents-0.6.11-py3-none-any.whl", hash = "sha256:b470feaadd7c1519fc2079114e3738c10780417843dd2447141e28046236ac5a", size = 230548, upload_time = "2026-06-18T21:05:36.85Z" },
 ]
 
 [[package]]
@@ -2073,7 +2073,7 @@ requires-dist = [
     { name = "charset-normalizer", specifier = ">=3.4.0" },
     { name = "croniter", specifier = ">=2.0.0" },
     { name = "daytona-sdk", specifier = ">=0.130.0" },
-    { name = "deepagents", specifier = ">=0.5.3" },
+    { name = "deepagents", specifier = ">=0.6.11" },
     { name = "edgartools", specifier = ">=5.7.2" },
     { name = "fastapi", specifier = ">=0.110.0" },
     { name = "html-to-markdown", specifier = ">=3.5.0" },
@@ -2088,8 +2088,8 @@ requires-dist = [
     { name = "langchain-google-genai", specifier = ">=2.0.0" },
     { name = "langchain-openai", specifier = ">=1.0.0" },
     { name = "langchain-qwq", specifier = ">=0.3.0" },
-    { name = "langgraph", specifier = ">=0.3.5" },
-    { name = "langgraph-checkpoint-postgres", specifier = ">=2.0.0" },
+    { name = "langgraph", specifier = ">=1.2.2,<2" },
+    { name = "langgraph-checkpoint-postgres", specifier = ">=3.1" },
     { name = "langgraph-cli", extras = ["inmem"], marker = "extra == 'dev'", specifier = ">=0.2.10" },
     { name = "langsmith-fetch", specifier = ">=0.3.1" },
     { name = "matplotlib" },
@@ -2146,35 +2146,35 @@ dev = [
 
 [[package]]
 name = "langchain"
-version = "1.3.1"
+version = "1.3.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/11/e5/6350e77a9e2764eaafcb2d581cbf0b800f53c6bc98fdf5ebc85f3a931ded/langchain-1.3.1.tar.gz", hash = "sha256:bc283c220233230f48b8e50ab1fbf1b688bcb206d933fa448d40a9b143177f62", size = 581329, upload_time = "2026-05-15T18:14:55.368Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/a2/91a7197c604a3ce1b774b3c10dd114c3c745c6186a304fc2573b3f94d400/langchain-1.3.11.tar.gz", hash = "sha256:f3cf9cd4d2329b1a03eb8fd92b9d73e4e58a4d52570d67725fc77fbe0f104b32", size = 633374, upload_time = "2026-06-22T23:00:33.44Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/11/3d7ed10b535413a07ed5e15682abcb77f3c4204ac49586977a495f9b24e6/langchain-1.3.1-py3-none-any.whl", hash = "sha256:154e9c30c90b391eba4315296f6bf6b6fac6b058ddea4cc771a10470968fe36f", size = 114345, upload_time = "2026-05-15T18:14:53.984Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a4/3a181967294f8876362cc4ba36840d50b8286fa23bb3f5e602b69eb3cb1e/langchain-1.3.11-py3-none-any.whl", hash = "sha256:7ae011f95a09b22feea1e8ae4e43f0b6164aebf4c61b8ad845b45f72ff3a90a2", size = 133639, upload_time = "2026-06-22T23:00:31.619Z" },
 ]
 
 [[package]]
 name = "langchain-anthropic"
-version = "1.4.3"
+version = "1.4.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anthropic" },
     { name = "langchain-core" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fa/e3/d2f9dec95602524b1cfb4be2747ba5bc38d32501b2a56cb4bcb76e80bb45/langchain_anthropic-1.4.3.tar.gz", hash = "sha256:f8a2442463c0629b1b3110eaeaa56fdbdc87df2a802f8c7f5ecf611eb4874ec8", size = 685219, upload_time = "2026-05-03T17:33:27.118Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/d0/5b117541b9e13619a387b3c829b97ef8d54f848716c0cb574df35a326dea/langchain_anthropic-1.4.7.tar.gz", hash = "sha256:34a7eb0db6bb7c92ff89b3f985de6417d5ef7a148d4595f4498fd3ca4f14aa77", size = 706692, upload_time = "2026-06-22T22:56:05.749Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/55/482a1968c95275e8be6d8c1e53b54f0f7be0b8b155ce1608c947a95cf543/langchain_anthropic-1.4.3-py3-none-any.whl", hash = "sha256:65466e0f2f95909a009708f2958e917dfdbfab79c612b4484a30866a85e1f291", size = 50389, upload_time = "2026-05-03T17:33:25.671Z" },
+    { url = "https://files.pythonhosted.org/packages/94/bf/78c71bdd7b9ec6fcd6ca45114d5910bfbad2fba21e5223523e793a17520d/langchain_anthropic-1.4.7-py3-none-any.whl", hash = "sha256:2e9d9dd4cb66de19394d7a9d552e1dbf2cd3c1da9f799a0c372b5fc84e298d8f", size = 51978, upload_time = "2026-06-22T22:56:04.349Z" },
 ]
 
 [[package]]
 name = "langchain-core"
-version = "1.4.0"
+version = "1.4.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -2187,9 +2187,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/de/679a53472c25860837e32c0442c962fa86e95317a36460e2c9d5c91b17c2/langchain_core-1.4.0.tar.gz", hash = "sha256:1dc341eed802ed9c117c0df3923c991e5e9e226571e5725c194eeb5bd93d1a7f", size = 920260, upload_time = "2026-05-11T18:42:35.919Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/e3/bea6d0080acf183332f24dcd74c208aee5857cf8f783c3fb0bd86027d8fb/langchain_core-1.4.8.tar.gz", hash = "sha256:5bf1f8411077c904182ad8f975943d36adcbf579c4e017b3a118b719229ebf9a", size = 957974, upload_time = "2026-06-18T19:39:23.636Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/1a/86c38c27b81913a1c6c12448cab55defb5a1097c7dc9a4cea83f55477a2d/langchain_core-1.4.0-py3-none-any.whl", hash = "sha256:23cbbdb46e38ddd1dd5247e6167e96013eae74bea4c5949c550809970a9e565c", size = 548120, upload_time = "2026-05-11T18:42:33.992Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d6/bdf6f0481cc57ef300d6b1eb48cf1400c0409be715d6eb3cabadd1142a09/langchain_core-1.4.8-py3-none-any.whl", hash = "sha256:d84c28b05e3ba8d4271d0827aad5b592ccdaaf986e76768c23503f0a2045e8aa", size = 557416, upload_time = "2026-06-18T19:39:21.902Z" },
 ]
 
 [[package]]
@@ -2207,7 +2207,7 @@ wheels = [
 
 [[package]]
 name = "langchain-google-genai"
-version = "4.2.3"
+version = "4.2.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filetype" },
@@ -2215,9 +2215,9 @@ dependencies = [
     { name = "langchain-core" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/85/20/76e3b367d31ee8b8beda715ffdd6a5db12d99700a12936123bd9adaaa00f/langchain_google_genai-4.2.3.tar.gz", hash = "sha256:b36bf2201c7b1f1b5d3e13a122af2f8f829151a15183985dcf24e2bc0fcfe69c", size = 269998, upload_time = "2026-05-21T22:11:34.291Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/4b/a1acdba3a86f861d379cb654f234d334c04a4c93178c8c7b0182ddeb9966/langchain_google_genai-4.2.5.tar.gz", hash = "sha256:2abab4be22699a9cc29948b2bf012946f51a0bbf10ab3a4a9a129047234829f8", size = 271850, upload_time = "2026-06-10T01:48:57.06Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/0f/61f0c667d31bfc80fff5af0985d8d7925a75592283a3d2f4b0abf63614e6/langchain_google_genai-4.2.3-py3-none-any.whl", hash = "sha256:2b1be55443c0f409f52799a95f86011e8fa4d15d50b2ee8db2416096828b7042", size = 68569, upload_time = "2026-05-21T22:11:32.749Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/82/3d4d3dc181ea1756f323dad4d5936239c2f404ea0acb5102316224280634/langchain_google_genai-4.2.5-py3-none-any.whl", hash = "sha256:289699ddb8e1076a76144f83e25e0086e4ce629b196fc103251f2a629e0756e5", size = 69404, upload_time = "2026-06-10T01:48:56.09Z" },
 ]
 
 [[package]]
@@ -2236,14 +2236,14 @@ wheels = [
 
 [[package]]
 name = "langchain-protocol"
-version = "0.0.15"
+version = "0.0.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/24/9777489d6fbbee64af0c8f96d4f840239c408cf694f3394672807dafc490/langchain_protocol-0.0.15.tar.gz", hash = "sha256:9ab2d11ee73944754f10e037e717098d3a6796f0e58afa9cadda6154e7655ade", size = 5862, upload_time = "2026-05-01T22:30:04.748Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/59/b5959aea96faa9146e2e49a7a22882b3528c62efafe9a6a95beab30c2305/langchain_protocol-0.0.18.tar.gz", hash = "sha256:ec3e11782f1ed0c9db38e5a9ed01b0e7a0d3fba406faa8aef6594b73c56a63e6", size = 6150, upload_time = "2026-06-18T17:08:26.959Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/7a/9c97a7b9cbe4c5dc6a44cdb1545450c28f0c8ce89b9c1f0ee7fbad896263/langchain_protocol-0.0.15-py3-none-any.whl", hash = "sha256:461eb794358f83d5e42635a5797799ffec7b4702314e34edf73ac21e75d3ef79", size = 6982, upload_time = "2026-05-01T22:30:03.877Z" },
+    { url = "https://files.pythonhosted.org/packages/99/2e/d82db9eec13ad0f72e7aaad5c4bc730ab111934fdc83c85523206eb9b0a0/langchain_protocol-0.0.18-py3-none-any.whl", hash = "sha256:70b53a86fbf9cedc863555effe44da192ab02d556ddbf2cf95b8873adcf41b5a", size = 7221, upload_time = "2026-06-18T17:08:25.996Z" },
 ]
 
 [[package]]
@@ -2270,7 +2270,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.1"
+version = "1.2.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -2280,9 +2280,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/8e/34a57e338a319e3b32c1bd183c2a9a04f7f35d683d3f3d8f597f6eacbc4e/langgraph-1.2.1.tar.gz", hash = "sha256:28314f844678d9d307cbd63e7b48b0145bf17177d84b40ee2921061e07b6f966", size = 693750, upload_time = "2026-05-21T18:33:07.478Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/7a/ea09b05bb0cbddfa43bd34fc581357e87fc3f21a751cc0d419688c3106da/langgraph-1.2.6.tar.gz", hash = "sha256:f9b45a34f13930c94d96cdb76277447ad2cc70ec2d18cd2764d7fdadb36cdc1b", size = 714400, upload_time = "2026-06-18T20:58:21.514Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/8c/313912e26866893bd15be9b4ea3442dc86f69270b0ad01a4961d1eba7118/langgraph-1.2.1-py3-none-any.whl", hash = "sha256:5cc4020de8f1e2a048d773f6e9128646a2af8c68a8067ab9cab177a2fcc8d221", size = 235317, upload_time = "2026-05-21T18:33:05.687Z" },
+    { url = "https://files.pythonhosted.org/packages/89/32/772db1b00a9fe42f50320d1aa20caefb76e621eff1f7218b9918093d631d/langgraph-1.2.6-py3-none-any.whl", hash = "sha256:1cf94d3ca124f84f77ce408fa1b06c3dee680a8aafffe364a8fd5d7d03eb8695", size = 246132, upload_time = "2026-06-18T20:58:20.335Z" },
 ]
 
 [[package]]
@@ -2409,35 +2409,43 @@ wheels = [
 
 [[package]]
 name = "langgraph-sdk"
-version = "0.3.15"
+version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
+    { name = "langchain-core" },
+    { name = "langchain-protocol" },
     { name = "orjson" },
+    { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/af/cdd4d6f3c05b3c1112ed3f12ef830faf15951b21d22cbc622a4becbbe25c/langgraph_sdk-0.3.15.tar.gz", hash = "sha256:29e805003d2c6e296823dd71992610976fd0428cefaa8b3304fd91f2247037de", size = 201924, upload_time = "2026-05-22T16:54:27.678Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/2b/bd8ac26d4e97f6df88ef05ce5b6a38945a3903e1025d926f4752aa88aa97/langgraph_sdk-0.4.2.tar.gz", hash = "sha256:b88f0f5f6328ac0680d6790614a905b2bcfa257f2276dba4e38f0e86db0aa738", size = 348327, upload_time = "2026-06-01T17:51:19.856Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/a5/0196d9c05749c25bc198e4909d68c998bc3120297e14944921baf2f4c384/langgraph_sdk-0.3.15-py3-none-any.whl", hash = "sha256:3838773acf7456d158165385d49f48f1e856f28b56ccd99ea139a8f27004815d", size = 98166, upload_time = "2026-05-22T16:54:26.013Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/05/aac507337cceae773c2cc9ab91eb6301963af7aeeb55b4217a00e15aff17/langgraph_sdk-0.4.2-py3-none-any.whl", hash = "sha256:75fa5096c1177ce39c847096a8fe3745ffd480ddb412995f836e9f5f884c43dd", size = 160521, upload_time = "2026-06-01T17:51:18.849Z" },
 ]
 
 [[package]]
 name = "langsmith"
-version = "0.8.5"
+version = "0.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
     { name = "httpx" },
     { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
     { name = "packaging" },
     { name = "pydantic" },
     { name = "requests" },
     { name = "requests-toolbelt" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
     { name = "uuid-utils" },
+    { name = "websockets" },
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/17/eb/8883d1158c743d0aac350f09df7880714d27283497e8c80bb9fe3480f165/langsmith-0.8.5.tar.gz", hash = "sha256:3615243d99c12f4047f13042bdc05a373dce232d106a6511b3ca7b48c5af1c2c", size = 4462348, upload_time = "2026-05-15T21:31:41.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/26/b72987d947278f63ec1e85f01ce85ca7ab2621c7efc0845d4a3a8e5d5dfb/langsmith-0.9.1.tar.gz", hash = "sha256:e5eb905224d156bcece4985285c55b51fffcb06c9353b2c4adb42e1c48b0d05d", size = 4557557, upload_time = "2026-06-23T17:04:23.233Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/85/968c88a63e32a59b3e5c68afd2fe114ce0708a125db0be1a85efc25fb2ea/langsmith-0.8.5-py3-none-any.whl", hash = "sha256:efc779f9d450dcaf9d97bc8894f4926276509d6e730e05289af9a64debce06ae", size = 399564, upload_time = "2026-05-15T21:31:39.046Z" },
+    { url = "https://files.pythonhosted.org/packages/63/42/13c67eb24cddb368df2c8af13e319c86b1d270c90f5b8c9e8baed3593e04/langsmith-0.9.1-py3-none-any.whl", hash = "sha256:1160bf667af63d9bc081821f1df351cb84f7875740858f2a97ffef62b21800a9", size = 578856, upload_time = "2026-06-23T17:04:21.47Z" },
 ]
 
 [package.optional-dependencies]
@@ -5452,47 +5460,33 @@ wheels = [
 
 [[package]]
 name = "websockets"
-version = "16.0"
+version = "15.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload_time = "2026-01-10T09:23:47.181Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload_time = "2025-03-05T20:03:41.606Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload_time = "2026-01-10T09:22:46.787Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload_time = "2026-01-10T09:22:47.999Z" },
-    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload_time = "2026-01-10T09:22:49.809Z" },
-    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload_time = "2026-01-10T09:22:51.071Z" },
-    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload_time = "2026-01-10T09:22:52.224Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload_time = "2026-01-10T09:22:53.443Z" },
-    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload_time = "2026-01-10T09:22:55.033Z" },
-    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload_time = "2026-01-10T09:22:56.251Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload_time = "2026-01-10T09:22:57.478Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload_time = "2026-01-10T09:22:59.333Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload_time = "2026-01-10T09:23:01.171Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload_time = "2026-01-10T09:23:02.341Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload_time = "2026-01-10T09:23:03.756Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload_time = "2026-01-10T09:23:05.01Z" },
-    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload_time = "2026-01-10T09:23:06.301Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload_time = "2026-01-10T09:23:07.492Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload_time = "2026-01-10T09:23:09.245Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload_time = "2026-01-10T09:23:10.483Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload_time = "2026-01-10T09:23:12.178Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload_time = "2026-01-10T09:23:13.511Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload_time = "2026-01-10T09:23:14.727Z" },
-    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload_time = "2026-01-10T09:23:15.939Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload_time = "2026-01-10T09:23:17.148Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload_time = "2026-01-10T09:23:18.372Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload_time = "2026-01-10T09:23:19.652Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload_time = "2026-01-10T09:23:21.458Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload_time = "2026-01-10T09:23:22.715Z" },
-    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload_time = "2026-01-10T09:23:24.523Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload_time = "2026-01-10T09:23:25.781Z" },
-    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload_time = "2026-01-10T09:23:27.033Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload_time = "2026-01-10T09:23:28.259Z" },
-    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload_time = "2026-01-10T09:23:29.449Z" },
-    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload_time = "2026-01-10T09:23:31.368Z" },
-    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload_time = "2026-01-10T09:23:32.627Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload_time = "2026-01-10T09:23:33.816Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload_time = "2026-01-10T09:23:35.016Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload_time = "2026-01-10T09:23:45.395Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6b/4545a0d843594f5d0771e86463606a3988b5a09ca5123136f8a76580dd63/websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3", size = 175437, upload_time = "2025-03-05T20:02:16.706Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/71/809a0f5f6a06522af902e0f2ea2757f71ead94610010cf570ab5c98e99ed/websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665", size = 173096, upload_time = "2025-03-05T20:02:18.832Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/69/1a681dd6f02180916f116894181eab8b2e25b31e484c5d0eae637ec01f7c/websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2", size = 173332, upload_time = "2025-03-05T20:02:20.187Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/02/0073b3952f5bce97eafbb35757f8d0d54812b6174ed8dd952aa08429bcc3/websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215", size = 183152, upload_time = "2025-03-05T20:02:22.286Z" },
+    { url = "https://files.pythonhosted.org/packages/74/45/c205c8480eafd114b428284840da0b1be9ffd0e4f87338dc95dc6ff961a1/websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5", size = 182096, upload_time = "2025-03-05T20:02:24.368Z" },
+    { url = "https://files.pythonhosted.org/packages/14/8f/aa61f528fba38578ec553c145857a181384c72b98156f858ca5c8e82d9d3/websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65", size = 182523, upload_time = "2025-03-05T20:02:25.669Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/6d/0267396610add5bc0d0d3e77f546d4cd287200804fe02323797de77dbce9/websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe", size = 182790, upload_time = "2025-03-05T20:02:26.99Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/c68c5adbf679cf610ae2f74a9b871ae84564462955d991178f95a1ddb7dd/websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4", size = 182165, upload_time = "2025-03-05T20:02:30.291Z" },
+    { url = "https://files.pythonhosted.org/packages/29/93/bb672df7b2f5faac89761cb5fa34f5cec45a4026c383a4b5761c6cea5c16/websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597", size = 182160, upload_time = "2025-03-05T20:02:31.634Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/83/de1f7709376dc3ca9b7eeb4b9a07b4526b14876b6d372a4dc62312bebee0/websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9", size = 176395, upload_time = "2025-03-05T20:02:33.017Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/71/abf2ebc3bbfa40f391ce1428c7168fb20582d0ff57019b69ea20fa698043/websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7", size = 176841, upload_time = "2025-03-05T20:02:34.498Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9f/51f0cf64471a9d2b4d0fc6c534f323b664e7095640c34562f5182e5a7195/websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931", size = 175440, upload_time = "2025-03-05T20:02:36.695Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/05/aa116ec9943c718905997412c5989f7ed671bc0188ee2ba89520e8765d7b/websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675", size = 173098, upload_time = "2025-03-05T20:02:37.985Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0b/33cef55ff24f2d92924923c99926dcce78e7bd922d649467f0eda8368923/websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151", size = 173329, upload_time = "2025-03-05T20:02:39.298Z" },
+    { url = "https://files.pythonhosted.org/packages/31/1d/063b25dcc01faa8fada1469bdf769de3768b7044eac9d41f734fd7b6ad6d/websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22", size = 183111, upload_time = "2025-03-05T20:02:40.595Z" },
+    { url = "https://files.pythonhosted.org/packages/93/53/9a87ee494a51bf63e4ec9241c1ccc4f7c2f45fff85d5bde2ff74fcb68b9e/websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f", size = 182054, upload_time = "2025-03-05T20:02:41.926Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b2/83a6ddf56cdcbad4e3d841fcc55d6ba7d19aeb89c50f24dd7e859ec0805f/websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8", size = 182496, upload_time = "2025-03-05T20:02:43.304Z" },
+    { url = "https://files.pythonhosted.org/packages/98/41/e7038944ed0abf34c45aa4635ba28136f06052e08fc2168520bb8b25149f/websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375", size = 182829, upload_time = "2025-03-05T20:02:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/17/de15b6158680c7623c6ef0db361da965ab25d813ae54fcfeae2e5b9ef910/websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d", size = 182217, upload_time = "2025-03-05T20:02:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195, upload_time = "2025-03-05T20:02:51.561Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload_time = "2025-03-05T20:02:53.814Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload_time = "2025-03-05T20:02:55.237Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload_time = "2025-03-05T20:03:39.41Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2089,7 +2089,7 @@ requires-dist = [
     { name = "langchain-openai", specifier = ">=1.0.0" },
     { name = "langchain-qwq", specifier = ">=0.3.0" },
     { name = "langgraph", specifier = ">=1.2.2,<2" },
-    { name = "langgraph-checkpoint-postgres", specifier = ">=3.1" },
+    { name = "langgraph-checkpoint-postgres", specifier = ">=3.1,<4" },
     { name = "langgraph-cli", extras = ["inmem"], marker = "extra == 'dev'", specifier = ">=0.2.10" },
     { name = "langsmith-fetch", specifier = ">=0.3.1" },
     { name = "matplotlib" },


### PR DESCRIPTION
## Summary

Opts the LangGraph `messages` channel into **`DeltaChannel`** (beta) so long
research threads store O(1)-per-step delta writes with a full snapshot every 50
updates, instead of re-serializing the entire message list every superstep
(O(N²) per thread over its life). Wired into the PTC, Flash, and subagent agent
factories via `state_schema=DeltaAgentState`.

This adopts **deepagents 0.6.11's clean DeltaChannel pattern verbatim**: a
**non-minting** messages reducer plus langgraph's upstream `ensure_message_ids`
(>=1.2.2), which stamps a stable id onto every id-less `messages` write *before*
it is persisted. No app-side id-stamping is needed — the reducer never re-mints on
replay, so reconstruction is deterministic by construction.

- **Performance** — `DeltaAgentState` + a vendored copy of deepagents 0.6.11's
  batch reducer (`state.py`); `state_schema` wired into all four `create_agent`
  call sites.
- **Determinism** — id stamping is langgraph's `ensure_message_ids`; the vendored
  reducer is non-minting (an id-less message is appended as-is, never re-rolled),
  so the hard-stop checkpoint flush / `/offload` write-back is a no-op and
  `RemoveMessage`-by-id stays stable across reconstruction.
- **Ops** — `scrub_nul_checkpoint.py` made `_DeltaSnapshot`-aware (preserves the
  NamedTuple on reserialize so the NUL-scrub maintenance script round-trips delta
  heads).
- **Guardrail** — `chat.py` role validator rejects roles unsafe under delta
  replay: those `convert_to_messages` can't rebuild (`tool`/`function`) AND those
  langgraph's `ensure_message_ids` doesn't stamp (`developer`) — an unstamped role
  persists id-less and would duplicate on the hard-stop flush.

**No data migration ships** — legacy `add_messages` threads reconstruct faithfully
under `DeltaChannel` with no backfill; see *Legacy-thread migration* below for the
investigation behind that.

## Overview

| Category               | Files | +LOC | −LOC |
|------------------------|------:|-----:|-----:|
| Modified (prod)        |     8 |   77 |    7 |
| New (prod)             |     1 |  116 |    0 |
| **Net (excl. tests + lock)** | **9** | **193** | **7** |
| Lock (uv.lock)         |     1 |   65 |   71 |
| Tests                  |     6 | 1113 |    1 |
| **Total**              | **16** | **1371** | **79** |

**By module**

- **Agent core** (`src/ptc_agent/`, net +123)
  - `agent/state.py` *(new, +116)* — `DeltaAgentState` + vendored **non-minting**
    `messages_delta_reducer` (dedup-by-id, `RemoveMessage` tombstones,
    `REMOVE_ALL_MESSAGES` reset, dict/str/tuple coercion, `None`-state replay
    guard); `MESSAGES_SNAPSHOT_FREQUENCY = 50`. Structurally identical to
    deepagents' `DeepAgentState`.
  - `agent/agent.py`, `agent/flash/agent.py`, `middleware/background_subagent/subagent.py`
    *(+2/+2/+3)* — pass `state_schema=DeltaAgentState` to the four `create_agent` calls.
- **Server** (`src/server/`, net +46/−2)
  - `utils/checkpointer.py` *(+6/−0)* — `get_checkpointer` returns plain
    `MemorySaver`/`AsyncPostgresSaver`; a comment records that langgraph's
    `ensure_message_ids` does the stamping, so no id-stamping shim is needed.
  - `handlers/workflow_handler.py` *(+0/−1)* — drops the vestigial
    `message_count` field from the `/status` response (see *Status field removed*).
  - `models/chat.py` *(+40/−1)* — `ChatMessage.role` validator: rejects roles
    unsafe under delta replay — `tool`/`function` (can't rebuild) and `developer`
    (converts but isn't stamped by langgraph, so it'd dup on the hard-stop flush).
- **Ops scripts** (`scripts/ops/`, net +9/−1)
  - `scrub_nul_checkpoint.py` *(+9/−1)* — preserve `_DeltaSnapshot` NamedTuple on reserialize.
- **Dependencies** — `pyproject.toml` *(+15/−4)* deepagents `>=0.6.11`, langgraph
  `>=1.2.2,<2`; `uv.lock` regen (langchain-core / langgraph cascade, plus a
  transitive `websockets` 16.0→15.0.1 downgrade pulled by langgraph-sdk/langsmith
  — within our `>=12.0` floor; `shared_ws_manager` uses a stable subset, so no
  code impact).
- **Tests** (`tests/unit/`, +1113) — see Test Coverage.

**Status field removed.** `GET /threads/{id}/status` previously returned a
`message_count` (`len(messages)` since the repo's initial-release squash). Verified
across all four services + frontend + integration gateway + CLI + docs: **no
consumer reads it** — the frontend's status type doesn't even declare it, and the
handler returns a plain untyped `dict` (it was never a typed contract). Under
DeltaChannel a non-snapshot step would need a ≤4-query delta-history walk to
reconstruct that count on ~98% of status polls, purely to populate a dead field.
Rather than carry that cost (the reviewers' P2), the field and its reconstruction
helper are removed outright — net effect on `workflow_handler.py` is a single
deleted line.

**What this introduces:** O(1)-per-step checkpoint storage for the messages
channel on long threads, made deterministic the same way deepagents does it
(non-minting reducer + langgraph's upstream id-stamp), plus a delta-aware NUL
scrub. Pre-existing threads need no migration — langgraph reconstructs their
legacy heads directly.

## Diff Size
- Total: 16 files changed, 1371 insertions(+), 79 deletions(−)
- Net (excl. tests + lock): 9 files changed, 193 insertions(+), 7 deletions(−)

## Test Coverage
Core behavior fully covered by unit tests; the legacy-thread reconstruction path
was additionally validated read-only against real production-shape checkpointer
data (see *Legacy-thread migration*).

Tests (6 files, all green — 4664 passed / 1 xpassed suite-wide; the lone
xfail/xpass is `test_fan_out_reconstruction_preserves_live_order`, a ~50/50
in-memory fan-out reordering documented as an accepted residual — both states green):
- `test_delta_channel_determinism.py` — **P1 regression guard** on a *plain*
  saver: id-less writes (BaseMessage + dict chat path) reconstruct to stable ids
  via `ensure_message_ids`; hard-stop flush is a no-op; `RemoveMessage`-by-id
  still removes; the async (`aput_writes`) path is covered.
- `test_messages_delta_reducer.py` — reducer parity vs deepagents 0.6.11's
  `_messages_delta_reducer` (drift guard) + semantic cases incl. the non-minting
  contract (id-less input stays id=None).
- `test_delta_channel_ordering.py` — same-superstep parallel ToolMessages: a
  reliable integrity guard (`test_fan_out_reconstruction_preserves_all_messages`,
  no message lost/duplicated) split out from the order comparison, which stays
  `xfail` as the accepted in-memory P2 residual.
- `test_delta_channel_resolution.py` — compiled graph's `messages` channel is
  `DeltaChannel` with `state_schema`, `BinaryOperatorAggregate` without.
- `test_scrub_nul_checkpoint.py` — `_DeltaSnapshot` survives NUL-scrub roundtrip.
- `test_chat_models.py` — role validator: `developer` rejected (converts but
  unstamped → would dup on flush) + `test_every_valid_role_is_stamped_by_langgraph`
  ties the accepted set to langgraph's `_MESSAGE_ROLES` so a re-add or langgraph
  bump fails loudly.

## Conformance with deepagents

Adopts deepagents 0.6.11's DeltaChannel pattern as-is — no divergence, no extra
machinery.

**Same as deepagents (parity-tested):**
- **Reducer** — `messages_delta_reducer` (`state.py`) is a vendored copy of
  deepagents 0.6.11's `_messages_delta_reducer`: dedup-by-id, `RemoveMessage`
  tombstones, `REMOVE_ALL_MESSAGES` reset, dict/str/tuple coercion, and
  **non-minting** (id-less messages appended as-is; ids come from langgraph's
  `ensure_message_ids`). `test_vendored_reducer_matches_deepagents` fails CI if our
  copy drifts from the installed symbol — including byte-for-byte details like the
  `state_msgs` coercion line, which we keep identical to upstream.
- **Schema** — `DeltaAgentState` equals deepagents' `DeepAgentState`: same
  `AgentState` base, same `Required[Annotated[list[AnyMessage], DeltaChannel(reducer,
  snapshot_frequency=50)]]` field.

**Only difference — vendored, not imported.** We keep our own reducer copy rather
than importing the private `deepagents._messages_reducer` symbol, so on-disk
reconstruction stays frozen to our release (a beta API can move without a semver
bump); the parity test bridges the two. We also wire delta via `create_agent` +
`state_schema=` rather than `create_deep_agent`, keeping our own middleware stack
and backend filesystem — same delta wiring on `messages`.

**No id-stamping shim.** An earlier revision of this branch carried a checkpointer
shim to stamp id-less `Overwrite`-wrapped writes (the one path `ensure_message_ids`
misses). It's gone: deepagents 0.6.11 changed the only middleware that emitted that
shape — `PatchToolCallsMiddleware`, repairing a dangling tool call after a mid-tool
cancel — to write a plain list that `ensure_message_ids` covers, and langalpha
emits no id-less `Overwrite` writes of its own. With a non-minting reducer, even a
hypothetical miss reconstructs deterministically (id stays None) rather than
duplicating, so the shim and its tests earned removal.

## Legacy-thread migration: investigated, not needed

An earlier revision of this branch shipped a one-shot backfill script on the
assumption that threads checkpointed under the old `add_messages` reducer would
reconstruct incorrectly once `messages` became a `DeltaChannel` — losing message
ids, reordering, or duplicating on the first post-deploy read. **That assumption
was wrong; the backfill (and its tests) have been removed.** Recording the analysis
so the decision is auditable and reviewers know why no migration ships:

- **The wrong direction.** The "threads diverge" conclusion came from exercising the
  low-level delta replay method (`aget_delta_channel_history(..., seed=False)`)
  *directly*. That method does walk raw ancestor `checkpoint_writes` and, for writes
  persisted before langgraph's `ensure_message_ids` stamped them, will drop ids /
  skip dedup / reorder. But that is **not the path production uses** to load a
  thread.

- **The correction.** `DeltaChannel.from_checkpoint` has an explicit migration
  branch: when a stored `messages` blob is a plain list (a legacy
  `BinaryOperatorAggregate` value) rather than a `_DeltaSnapshot` or sentinel, the
  channel **uses that list directly** — the reducer is never invoked and no ancestor
  writes are replayed. A legacy `add_messages` thread materializes the full list in
  *every* checkpoint, including its head, so loading it under `DeltaChannel` reads
  that head verbatim. Confirmed read-only via the production `graph.aget_state` path
  against real legacy threads — including large, deeply-checkpointed,
  multi-hundred-message histories — and corroborated by runtime instrumentation
  showing every legacy head took the plain-value branch with **zero** threads on the
  replay path and **zero** id-less messages in any real head.

- **Why the backfill was not just unnecessary but harmful.** It re-snapshotted each
  legacy head via `aupdate_state`. In langgraph, `update_state` / `bulk_update_state`
  call `create_checkpoint(...)` **without** `channels_to_snapshot` (only the runtime
  superstep path supplies it), so a `DeltaChannel` value is *omitted* from the new
  head — a sentinel, **not** a `_DeltaSnapshot`. That **forces** the very
  ancestor-replay path the migration was meant to avoid, turning a faithful legacy
  head into a divergent reconstruction (id loss + duplication). Reproduced on a real
  `AsyncPostgresSaver`.

- **Subagents.** Background-subagent lineages (`task:<id>` checkpoint namespaces) are
  the same: legacy heads reconstruct directly and faithfully. They were never
  addressable by a standalone re-snapshot graph anyway (a non-root `checkpoint_ns`
  is reset to root on a standalone `aupdate_state`), so nothing here needed — or
  could — backfill them.

**Net:** the DeltaChannel opt-in is self-migrating by langgraph's design. No data
migration and no deploy-ordering constraint for existing threads.

## Rollout notes
1. **No data migration / no deploy ordering** (see *Legacy-thread migration*) —
   existing threads reconstruct faithfully on first load.
2. **One-way data format.** Once a thread takes a step under `DeltaChannel`, its head
   becomes a sentinel or `_DeltaSnapshot` that reverting to `add_messages` (or
   downgrading langgraph below 1.2) cannot read — keep the `langgraph` /
   `langgraph-checkpoint*` floors pinned at `>=1.2`. Validate on staging first.
3. **deepagents floor raised to >=0.6.11.** The non-minting reducer parity and the
   no-shim assumption both require it; the bump pulls a minor langchain-core
   (1.4.0→1.4.8) / langgraph (1.2.4→1.2.6) cascade. Full unit suite green on it.

## Test plan
- [x] `uv run pytest tests/unit/` — 4664 passed, 1 xpassed
- [x] Verified read-only that real legacy `add_messages` threads reconstruct
      faithfully under `DeltaChannel` via the production `graph.aget_state` path
      (same length / ids / order / contents; zero threads on the replay path) — so
      no migration is required
- [x] Live E2E (running backend, real Postgres): hard-stop checkpoint flush →
      reconstruct ×2 → no dup, ids stable; resume turn appends cleanly;
      `role:"developer"` → 422
- [x] `uv run ruff check` on changed files — clean
- [ ] Staging: resume a pre-change thread, hard-stop flush, `/offload`,
      multi-tool-call turn; verify `checkpoint_blobs` are sentinels on non-snapshot
      steps, full `_DeltaSnapshot` every ~50 updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added delta-based message checkpointing support for agent state, improving consistency when messages are saved and restored.
  * Added stricter validation for chat message roles, rejecting unsupported or misspelled roles earlier.

* **Bug Fixes**
  * Preserved message types and ordering during checkpoint cleanup and reconstruction.
  * Improved handling of message IDs so removals and replay behave more reliably.
  * Removed an outdated checkpoint message count from workflow status details.

* **Tests**
  * Added broad regression coverage for message reconstruction, ordering, cleanup, and role validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->