### PR TITLE
perf(skills): inject a skill's SKILL.md body once via middleware

### DIFF
--- a/src/ptc_agent/agent/middleware/skills/__init__.py
+++ b/src/ptc_agent/agent/middleware/skills/__init__.py
@@ -9,7 +9,13 @@ This module provides:
 - Helper functions for skill management
 """
 
-from ptc_agent.agent.middleware.skills.content import load_skill_content
+from ptc_agent.agent.middleware.skills.content import (
+    SkillPrefixResult,
+    SkillRequest,
+    build_skill_content,
+    compute_already_loaded,
+    load_skill_content,
+)
 from ptc_agent.agent.middleware.skills.discovery import SkillMetadata
 from ptc_agent.agent.middleware.skills.lock import (
     SkillLockEntry,
@@ -38,7 +44,11 @@ __all__ = [
     "SkillMode",
     "SkillsLockFile",
     "SKILL_REGISTRY",
+    "SkillPrefixResult",
+    "SkillRequest",
     "SkillsMiddleware",
+    "build_skill_content",
+    "compute_already_loaded",
     "get_command_to_skill_map",
     "get_skill",
     "get_skill_registry",

--- a/src/ptc_agent/agent/middleware/skills/content.py
+++ b/src/ptc_agent/agent/middleware/skills/content.py
@@ -1,17 +1,48 @@
-"""Skill content loading — reads SKILL.md from local filesystem.
+"""Skill content loading + inline-injection helpers.
 
-Moved here from ``src.server.utils.skill_context`` to avoid a circular import
-(middleware → server → middleware).  This module only depends on the skills
-registry, not on the server layer.
+Reads SKILL.md from the local filesystem and builds the ``<loaded-skill>`` blocks
+appended to the user message when a skill is activated. Lives in ``ptc_agent``
+(not the server) so ``SkillsMiddleware`` can own body injection without importing
+``src.server`` — keeping the layering one-directional (middleware → skills only).
 """
 
 import logging
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from ptc_agent.agent.middleware.skills.registry import SkillMode, get_skill
 
 logger = logging.getLogger(__name__)
+
+
+def loaded_skill_marker(name: str) -> str:
+    """Opening tag marking a skill's injected SKILL.md body in the message history.
+
+    Single source of truth shared by the writer (``build_skill_content``) and the
+    scanner (``compute_already_loaded``) so the marker format can't drift between them.
+    """
+    return f'<loaded-skill name="{name}">'
+
+
+@dataclass(frozen=True)
+class SkillRequest:
+    """A skill the client asked to activate this turn.
+
+    Lightweight stand-in for the server's ``SkillContext`` so this module stays
+    free of any ``src.server`` dependency; only ``name``/``instruction`` are used.
+    """
+
+    name: str
+    instruction: Optional[str] = None
+
+
+@dataclass
+class SkillPrefixResult:
+    """Result of building skill content for inline injection."""
+
+    content: str  # Formatted skill text wrapped in <loaded-skill> tags
+    loaded_skill_names: list[str] = field(default_factory=list)  # Skills injected fresh this turn (excludes already-loaded)
 
 
 def load_skill_content(
@@ -69,3 +100,183 @@ def load_skill_content(
         )
 
     return content
+
+
+def build_tool_descriptions(
+    skill_name: str, mode: SkillMode | None = None
+) -> Optional[str]:
+    """Build formatted tool descriptions for a skill.
+
+    Mirrors the format from ``SkillsMiddleware._build_skill_result``.
+
+    Args:
+        skill_name: Name of the skill
+        mode: Optional agent mode filter
+
+    Returns:
+        Formatted tool description string, or None if skill has no tools
+    """
+    skill = get_skill(skill_name, mode=mode)
+    if not skill or not skill.tools:
+        return None
+
+    return skill.format_tool_descriptions()
+
+
+def build_skill_content(
+    skills: list[SkillRequest],
+    skill_dirs: Optional[list[str]] = None,
+    mode: SkillMode | None = None,
+    already_loaded: Optional[set[str]] = None,
+) -> Optional[SkillPrefixResult]:
+    """Build skill content for inline injection into the user message.
+
+    Creates formatted skill content wrapped in ``<loaded-skill>`` XML tags,
+    suitable for appending inline to the last user message. Also returns the
+    list of freshly loaded skill names so the caller can set ``loaded_skills``
+    in graph state for immediate tool availability.
+
+    Skills whose name is in ``already_loaded`` are active in the thread already —
+    their tools persist via ``loaded_skills`` state — so the (large) SKILL.md body
+    is skipped and only their per-turn instruction is re-emitted (e.g. MarketView
+    re-sends chart-annotation every turn with a fresh symbol/timeframe).
+
+    Args:
+        skills: Skills to load (anything exposing ``.name``/``.instruction``).
+        skill_dirs: Optional list of local skill directories to search.
+        mode: Optional agent mode filter. Skills whose exposure doesn't match the
+              mode are skipped.
+        already_loaded: Skill names already active in the thread; their bodies are
+              skipped (instruction still refreshed).
+
+    Returns:
+        SkillPrefixResult with content string and freshly loaded skill names, or
+        None if there is nothing to inject.
+    """
+    if not skills:
+        return None
+
+    already_loaded = already_loaded or set()
+    newly_loaded: list[str] = []
+    skill_blocks: list[str] = []
+    instructions: list[tuple[str, str]] = []
+
+    for skill_ctx in skills:
+        # Already active this thread AND still exposed in this mode: tools persist
+        # in state, so skip the body and only refresh the instruction (cheap, may
+        # carry per-turn context). The mode re-check keeps this branch consistent
+        # with the fresh path below — a stale loaded_skills entry for a skill not
+        # exposed in the current mode falls through and is skipped, not injected.
+        if skill_ctx.name in already_loaded and get_skill(skill_ctx.name, mode=mode):
+            if skill_ctx.instruction:
+                instructions.append((skill_ctx.name, skill_ctx.instruction))
+            continue
+
+        content = load_skill_content(skill_ctx.name, skill_dirs, mode=mode)
+        if not content:
+            logger.warning(f"Skipping skill '{skill_ctx.name}': SKILL.md not found")
+            continue
+
+        newly_loaded.append(skill_ctx.name)
+
+        # Build per-skill block with tool descriptions
+        block_parts = [content]
+        tool_desc = build_tool_descriptions(skill_ctx.name, mode=mode)
+        if tool_desc:
+            block_parts.append(f"\n**Available tools:**\n{tool_desc}")
+            block_parts.append(
+                "You can call these tools directly without needing to call LoadSkill."
+            )
+
+        block_content = "\n".join(block_parts)
+        skill_blocks.append(
+            f"{loaded_skill_marker(skill_ctx.name)}\n{block_content}\n</loaded-skill>"
+        )
+
+        if skill_ctx.instruction:
+            instructions.append((skill_ctx.name, skill_ctx.instruction))
+
+    # Nothing to inject: no fresh bodies and no instructions to refresh.
+    if not skill_blocks and not instructions:
+        return None
+
+    # Combine all skill blocks
+    parts = list(skill_blocks)
+
+    # Add instructions. Use the bare single-instruction form only when exactly
+    # one skill is represented in the whole message; otherwise name each one so
+    # the owning skill is unambiguous (a fresh body block plus a separate
+    # already-loaded skill's instruction would otherwise read as orphaned).
+    if instructions:
+        represented = set(newly_loaded) | {name for name, _ in instructions}
+        if len(instructions) == 1 and len(represented) == 1:
+            parts.append(f"\n[Instruction: {instructions[0][1]}]")
+        else:
+            parts.append("\n[Instructions]")
+            parts.extend(f"- {name}: {text}" for name, text in instructions)
+
+    combined_content = "\n\n".join(parts)
+
+    logger.debug(
+        f"Built skill content: fresh={newly_loaded}, instructions={len(instructions)}"
+    )
+
+    return SkillPrefixResult(
+        content=combined_content,
+        loaded_skill_names=newly_loaded,
+    )
+
+
+def _message_text(message: Any) -> str:
+    """Best-effort plain text of a checkpoint message (str or multimodal list)."""
+    content = getattr(message, "content", None)
+    if content is None and isinstance(message, dict):
+        content = message.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for part in content:
+            if isinstance(part, dict):
+                parts.append(part.get("text", "") or "")
+            elif isinstance(part, str):
+                parts.append(part)
+        return " ".join(parts)
+    return ""
+
+
+def compute_already_loaded(
+    loaded: Any, messages: Any, summarization_event: Any
+) -> set[str]:
+    """Skills whose SKILL.md body is still live in the effective message window.
+
+    A skill's tools persist via ``loaded_skills`` state, so later turns can skip
+    re-pasting the full SKILL.md body. Two caveats this handles:
+
+    - **No compaction**: the full history is in the model's view, so every
+      injected body still survives — trust ``loaded`` as-is.
+    - **Compaction**: the body lives only in the message history, which compaction
+      summarizes. Reuse ``get_effective_messages`` so this view can't drift from
+      what the model actually sees, then drop the lossy summary at index 0 — a body
+      that survives only inside the summary is gone verbatim and must be re-injected
+      (its tools stay available via state regardless).
+
+    Non-string skill names are filtered out; any unexpected shape degrades to an
+    empty set so the caller re-injects in full.
+    """
+    loaded_set = {name for name in (loaded or []) if isinstance(name, str)}
+    if not loaded_set:
+        return set()
+
+    event = summarization_event
+    if not isinstance(event, dict) or not event.get("cutoff_index"):
+        return loaded_set
+
+    from ptc_agent.agent.middleware.compaction import get_effective_messages
+
+    effective = get_effective_messages(messages or [], event)[1:]
+    return {
+        name
+        for name in loaded_set
+        if any(loaded_skill_marker(name) in _message_text(m) for m in effective)
+    }

--- a/src/ptc_agent/agent/middleware/skills/content.py
+++ b/src/ptc_agent/agent/middleware/skills/content.py
@@ -16,12 +16,20 @@ from ptc_agent.agent.middleware.skills.registry import SkillMode, get_skill
 logger = logging.getLogger(__name__)
 
 
-def loaded_skill_marker(name: str) -> str:
+def loaded_skill_marker(name: str, message_id: str | None = None) -> str:
     """Opening tag marking a skill's injected SKILL.md body in the message history.
 
     Single source of truth shared by the writer (``build_skill_content``) and the
     scanner (``compute_already_loaded``) so the marker format can't drift between them.
+
+    The optional ``mid`` attribute binds the marker to the framework-assigned id of
+    the message the body is written into. The scanner only treats a marker as live
+    when its ``mid`` equals the id of the message it is found in, so neither user-typed
+    text nor a SKILL.md that documents this format can forge a "body still loaded"
+    match — the id is assigned by the framework, not by content anyone can author.
     """
+    if message_id:
+        return f'<loaded-skill name="{name}" mid="{message_id}">'
     return f'<loaded-skill name="{name}">'
 
 
@@ -128,6 +136,7 @@ def build_skill_content(
     skill_dirs: Optional[list[str]] = None,
     mode: SkillMode | None = None,
     already_loaded: Optional[set[str]] = None,
+    message_id: Optional[str] = None,
 ) -> Optional[SkillPrefixResult]:
     """Build skill content for inline injection into the user message.
 
@@ -148,6 +157,9 @@ def build_skill_content(
               mode are skipped.
         already_loaded: Skill names already active in the thread; their bodies are
               skipped (instruction still refreshed).
+        message_id: Framework id of the message this content is appended to. Embedded
+              in each block's marker so the dedup scanner can verify the marker really
+              belongs to that message (see ``loaded_skill_marker``).
 
     Returns:
         SkillPrefixResult with content string and freshly loaded skill names, or
@@ -190,7 +202,8 @@ def build_skill_content(
 
         block_content = "\n".join(block_parts)
         skill_blocks.append(
-            f"{loaded_skill_marker(skill_ctx.name)}\n{block_content}\n</loaded-skill>"
+            f"{loaded_skill_marker(skill_ctx.name, message_id)}\n"
+            f"{block_content}\n</loaded-skill>"
         )
 
         if skill_ctx.instruction:
@@ -227,6 +240,14 @@ def build_skill_content(
     )
 
 
+def _message_id(message: Any) -> Optional[str]:
+    """Framework-assigned id of a checkpoint message (object ``.id`` or dict ``id``)."""
+    mid = getattr(message, "id", None)
+    if mid is None and isinstance(message, dict):
+        mid = message.get("id")
+    return mid
+
+
 def _message_text(message: Any) -> str:
     """Best-effort plain text of a checkpoint message (str or multimodal list)."""
     content = getattr(message, "content", None)
@@ -261,6 +282,12 @@ def compute_already_loaded(
       that survives only inside the summary is gone verbatim and must be re-injected
       (its tools stay available via state regardless).
 
+    The marker scan is identity-bound: a skill counts as live only when its marker,
+    carrying ``mid`` equal to the scanned message's own framework id, is present in
+    that message. Content alone can't forge a match (a user-typed marker, or a
+    SKILL.md documenting the format, carries a ``mid`` that won't equal the id of the
+    message it sits in), so a spurious "still loaded" can't suppress a real body.
+
     Non-string skill names are filtered out; any unexpected shape degrades to an
     empty set so the caller re-injects in full.
     """
@@ -275,8 +302,13 @@ def compute_already_loaded(
     from ptc_agent.agent.middleware.compaction import get_effective_messages
 
     effective = get_effective_messages(messages or [], event)[1:]
-    return {
-        name
-        for name in loaded_set
-        if any(loaded_skill_marker(name) in _message_text(m) for m in effective)
-    }
+    live: set[str] = set()
+    for m in effective:
+        mid = _message_id(m)
+        if not mid:
+            continue
+        text = _message_text(m)
+        for name in loaded_set:
+            if name not in live and loaded_skill_marker(name, mid) in text:
+                live.add(name)
+    return live

--- a/src/ptc_agent/agent/middleware/skills/content.py
+++ b/src/ptc_agent/agent/middleware/skills/content.py
@@ -172,8 +172,17 @@ def build_skill_content(
     newly_loaded: list[str] = []
     skill_blocks: list[str] = []
     instructions: list[tuple[str, str]] = []
+    seen_names: set[str] = set()
 
     for skill_ctx in skills:
+        # Same skill named twice in one request: emit it once. ``already_loaded``
+        # only guards prior turns; this guards intra-turn duplication (e.g.
+        # duplicate additional_context entries) so a body/instruction can't be
+        # pasted twice in the same message.
+        if skill_ctx.name in seen_names:
+            continue
+        seen_names.add(skill_ctx.name)
+
         # Already active this thread AND still exposed in this mode: tools persist
         # in state, so skip the body and only refresh the instruction (cheap, may
         # carry per-turn context). The mode re-check keeps this branch consistent

--- a/src/ptc_agent/agent/middleware/skills/middleware.py
+++ b/src/ptc_agent/agent/middleware/skills/middleware.py
@@ -29,7 +29,6 @@ Usage:
 """
 
 import asyncio
-import operator
 from collections.abc import Awaitable, Callable
 from typing import Annotated, Any
 
@@ -40,13 +39,19 @@ from langchain.agents.middleware.types import (
     ModelResponse,
     PrivateStateAttr,
 )
-from langchain_core.messages import ToolMessage
+from langchain_core.messages import BaseMessage, ToolMessage
+from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 from langgraph.types import Command
 from typing_extensions import NotRequired
 
 from ptc_agent.agent.middleware._utils import append_to_system_message
-from ptc_agent.agent.middleware.skills.content import load_skill_content
+from ptc_agent.agent.middleware.skills.content import (
+    SkillRequest,
+    build_skill_content,
+    compute_already_loaded,
+    load_skill_content,
+)
 from ptc_agent.agent.middleware.skills.discovery import (
     SkillMetadata,
     adiscover_skills,
@@ -65,10 +70,68 @@ logger = structlog.get_logger(__name__)
 LOADED_SKILLS_KEY = "loaded_skills"
 
 
+def _union_loaded_skills(left: list[str], right: list[str]) -> list[str]:
+    """Reducer for ``loaded_skills``: order-preserving set union.
+
+    ``loaded_skills`` is semantically a set — every consumer reads it via
+    ``set(...)``. Plain ``operator.add`` lets the same name accumulate (a turn
+    re-seeding an already-loaded skill, or the agent re-reading a skill file),
+    bloating the persisted state on long threads. Deduping here keeps the
+    channel bounded while staying append-compatible.
+    """
+    merged = list(left or [])
+    seen = set(merged)
+    for name in right or []:
+        if name not in seen:
+            merged.append(name)
+            seen.add(name)
+    return merged
+
+
+def _is_human_message(message: Any) -> bool:
+    """True if ``message`` is a user/human turn (LangChain object or raw dict)."""
+    if isinstance(message, dict):
+        return message.get("role") == "user" or message.get("type") == "human"
+    return getattr(message, "type", None) == "human"
+
+
+def _append_body_to_last_human(messages: list, text: str) -> BaseMessage | dict | None:
+    """Return a copy of the last user message with ``text`` appended to its content.
+
+    Preserves the message ``id`` so ``add_messages`` replaces it in place rather
+    than appending a new turn. Returns None when the last message isn't a user
+    turn — skill_contexts is only set on normal turns where it is, so that path is
+    just defense (tools still load via ``loaded_skills``; only the body is skipped).
+    """
+    if not messages:
+        return None
+    last = messages[-1]
+    if not _is_human_message(last):
+        return None
+
+    if isinstance(last, dict):
+        content = last.get("content")
+        new = dict(last)
+        if isinstance(content, list):
+            new["content"] = content + [{"type": "text", "text": text}]
+        else:
+            new["content"] = (content if isinstance(content, str) else "") + text
+        return new
+
+    content = getattr(last, "content", "")
+    if isinstance(content, list):
+        new_content = content + [{"type": "text", "text": text}]
+    elif isinstance(content, str):
+        new_content = content + text
+    else:
+        new_content = (str(content) if content else "") + text
+    return last.model_copy(update={"content": new_content})
+
+
 class LoadedSkillsState(AgentState):
     """State schema for tracking loaded skills."""
 
-    loaded_skills: NotRequired[Annotated[list[str], operator.add]]
+    loaded_skills: NotRequired[Annotated[list[str], _union_loaded_skills]]
     discovered_skills: NotRequired[Annotated[list[SkillMetadata], PrivateStateAttr]]
 
 
@@ -183,32 +246,108 @@ class SkillsMiddleware(AgentMiddleware):
 
         return load_skill
 
-    async def abefore_agent(self, state: Any, runtime: Any) -> dict | None:
-        """Scan filesystem for user-installed skills (async, PTC mode only).
+    async def abefore_agent(
+        self, state: Any, runtime: Any, *, config: RunnableConfig | None = None
+    ) -> dict | None:
+        """Turn-entry hook: discover filesystem skills AND inject requested bodies.
 
-        Uses optimized discovery: skills already present in ``_known_skills``
-        (from the upload manifest) are returned without re-downloading.
-        Only truly new skills trigger a download.
+        Two responsibilities, both run once per turn before the first model call:
 
-        Runs on every user message so newly deployed skills are picked up
-        mid-thread. The known_skills cache keeps re-scans cheap (~100ms
-        with 0 downloads when all skills are already known).
+        1. **Discover** user-installed skills from the sandbox filesystem (PTC mode,
+           when ``backend``/``sources`` are configured). Skills already in
+           ``_known_skills`` (upload manifest) are returned without re-downloading,
+           so re-scans stay cheap (~100ms, 0 downloads when all are known).
+        2. **Inject** SKILL.md bodies for skills the client requested this turn
+           (``config["configurable"]["skill_contexts"]``). A skill whose body is
+           still live in the thread is skipped — only its per-turn instruction is
+           refreshed — so a re-sent skill (e.g. MarketView's chart-annotation)
+           isn't pasted into history every turn. The returned ``loaded_skills``
+           persists via reducer, exposing the skill's tools the same turn.
         """
-        if not self._backend or not self._sources:
-            return {"discovered_skills": []}
+        update: dict[str, Any] = {"discovered_skills": []}
 
-        all_skills: dict[str, SkillMetadata] = {}
-        for source_path in self._sources:
-            for skill in await adiscover_skills(
-                self._backend, source_path, self._known_skills
-            ):
-                all_skills[skill["name"]] = skill
+        if self._backend and self._sources:
+            all_skills: dict[str, SkillMetadata] = {}
+            for source_path in self._sources:
+                for skill in await adiscover_skills(
+                    self._backend, source_path, self._known_skills
+                ):
+                    all_skills[skill["name"]] = skill
 
-        # Filter out registry skills — registry is source of truth for those
-        unregistered = [
-            s for name, s in all_skills.items() if name not in self.skill_registry
+            # Filter out registry skills — registry is source of truth for those
+            update["discovered_skills"] = [
+                s for name, s in all_skills.items() if name not in self.skill_registry
+            ]
+
+        skill_update = self._inject_requested_skills(state, config)
+        if skill_update:
+            update.update(skill_update)
+
+        return update
+
+    def _inject_requested_skills(
+        self, state: Any, config: RunnableConfig | None
+    ) -> dict | None:
+        """Inject SKILL.md bodies for skills requested via config this turn.
+
+        Reads ``skill_contexts`` (+ optional ``skill_dirs``) from
+        ``config["configurable"]``, dedups against bodies already live in the
+        thread, appends fresh bodies to the last user message, and returns the
+        ``messages``/``loaded_skills`` state update (or None when there's nothing
+        to inject — e.g. HITL/replay turns where the server omits skill_contexts).
+        """
+        if not config:
+            return None
+        configurable = config.get("configurable") or {}
+        raw_contexts = configurable.get("skill_contexts")
+        if not raw_contexts:
+            return None
+
+        skills = [
+            SkillRequest(
+                name=(c.get("name") if isinstance(c, dict) else getattr(c, "name", ""))
+                or "",
+                instruction=(
+                    c.get("instruction")
+                    if isinstance(c, dict)
+                    else getattr(c, "instruction", None)
+                ),
+            )
+            for c in raw_contexts
         ]
-        return {"discovered_skills": unregistered}
+        skills = [s for s in skills if s.name]
+        if not skills:
+            return None
+
+        messages = state.get("messages") if hasattr(state, "get") else None
+        messages = messages or []
+        loaded = state.get("loaded_skills") if hasattr(state, "get") else None
+        event = state.get("_summarization_event") if hasattr(state, "get") else None
+        already_loaded = compute_already_loaded(loaded, messages, event)
+
+        result = build_skill_content(
+            skills,
+            skill_dirs=configurable.get("skill_dirs"),
+            mode=self._mode,
+            already_loaded=already_loaded,
+        )
+        if not result:
+            return None
+
+        update: dict[str, Any] = {}
+        updated_msg = _append_body_to_last_human(messages, result.content)
+        if updated_msg is not None:
+            update["messages"] = [updated_msg]
+        if result.loaded_skill_names:
+            update["loaded_skills"] = result.loaded_skill_names
+
+        if update:
+            logger.info(
+                "Skill bodies injected via middleware",
+                mode=self._mode,
+                fresh=result.loaded_skill_names,
+            )
+        return update or None
 
     def _build_combined_manifest(self, state: Any) -> str | None:
         """Build a combined skill manifest for the system message.

--- a/src/ptc_agent/agent/middleware/skills/middleware.py
+++ b/src/ptc_agent/agent/middleware/skills/middleware.py
@@ -97,13 +97,23 @@ def _is_human_message(message: Any) -> bool:
     return getattr(message, "type", None) == "human"
 
 
+def _join_body(base: str, text: str) -> str:
+    """Join an appended skill body onto string message content with a blank-line
+    separator — the wire format the server's old inline injection used. List
+    content separates via its own appended block, so this is the string path only.
+    """
+    return f"{base}\n\n{text}" if base else text
+
+
 def _append_body_to_last_human(messages: list, text: str) -> BaseMessage | dict | None:
     """Return a copy of the last user message with ``text`` appended to its content.
 
     Preserves the message ``id`` so ``add_messages`` replaces it in place rather
-    than appending a new turn. Returns None when the last message isn't a user
-    turn — skill_contexts is only set on normal turns where it is, so that path is
-    just defense (tools still load via ``loaded_skills``; only the body is skipped).
+    than appending a new turn. String content is joined with a blank-line separator
+    (``_join_body``); list content gets ``text`` as a fresh block, which is already
+    separated. Returns None when the last message isn't a user turn — skill_contexts
+    is only set on normal turns where it is, so that path is just defense (tools still
+    load via ``loaded_skills``; only the body is skipped).
     """
     if not messages:
         return None
@@ -117,16 +127,16 @@ def _append_body_to_last_human(messages: list, text: str) -> BaseMessage | dict 
         if isinstance(content, list):
             new["content"] = content + [{"type": "text", "text": text}]
         else:
-            new["content"] = (content if isinstance(content, str) else "") + text
+            new["content"] = _join_body(content if isinstance(content, str) else "", text)
         return new
 
     content = getattr(last, "content", "")
     if isinstance(content, list):
         new_content = content + [{"type": "text", "text": text}]
     elif isinstance(content, str):
-        new_content = content + text
+        new_content = _join_body(content, text)
     else:
-        new_content = (str(content) if content else "") + text
+        new_content = _join_body(str(content) if content else "", text)
     return last.model_copy(update={"content": new_content})
 
 

--- a/src/ptc_agent/agent/middleware/skills/middleware.py
+++ b/src/ptc_agent/agent/middleware/skills/middleware.py
@@ -48,6 +48,7 @@ from typing_extensions import NotRequired
 from ptc_agent.agent.middleware._utils import append_to_system_message
 from ptc_agent.agent.middleware.skills.content import (
     SkillRequest,
+    _message_id,
     build_skill_content,
     compute_already_loaded,
     load_skill_content,
@@ -325,11 +326,19 @@ class SkillsMiddleware(AgentMiddleware):
         event = state.get("_summarization_event") if hasattr(state, "get") else None
         already_loaded = compute_already_loaded(loaded, messages, event)
 
+        # Bind the injected marker to the message the body lands on (the last user
+        # turn) so the dedup scanner can later verify it, not just pattern-match text.
+        last = messages[-1] if messages else None
+        target_id = (
+            _message_id(last) if last is not None and _is_human_message(last) else None
+        )
+
         result = build_skill_content(
             skills,
             skill_dirs=configurable.get("skill_dirs"),
             mode=self._mode,
             already_loaded=already_loaded,
+            message_id=target_id,
         )
         if not result:
             return None

--- a/src/ptc_agent/agent/middleware/skills/middleware.py
+++ b/src/ptc_agent/agent/middleware/skills/middleware.py
@@ -77,12 +77,13 @@ def _union_loaded_skills(left: list[str], right: list[str]) -> list[str]:
     ``loaded_skills`` is semantically a set — every consumer reads it via
     ``set(...)``. Plain ``operator.add`` lets the same name accumulate (a turn
     re-seeding an already-loaded skill, or the agent re-reading a skill file),
-    bloating the persisted state on long threads. Deduping here keeps the
-    channel bounded while staying append-compatible.
+    bloating the persisted state on long threads. Normalizing both operands keeps
+    the channel bounded and also re-bounds threads that already carried duplicate
+    names from the old ``operator.add`` reducer (which would otherwise persist).
     """
-    merged = list(left or [])
-    seen = set(merged)
-    for name in right or []:
+    merged: list[str] = []
+    seen: set[str] = set()
+    for name in (*(left or []), *(right or [])):
         if name not in seen:
             merged.append(name)
             seen.add(name)
@@ -280,13 +281,13 @@ class SkillsMiddleware(AgentMiddleware):
                 s for name, s in all_skills.items() if name not in self.skill_registry
             ]
 
-        skill_update = self._inject_requested_skills(state, config)
+        skill_update = await self._inject_requested_skills(state, config)
         if skill_update:
             update.update(skill_update)
 
         return update
 
-    def _inject_requested_skills(
+    async def _inject_requested_skills(
         self, state: Any, config: RunnableConfig | None
     ) -> dict | None:
         """Inject SKILL.md bodies for skills requested via config this turn.
@@ -296,6 +297,9 @@ class SkillsMiddleware(AgentMiddleware):
         thread, appends fresh bodies to the last user message, and returns the
         ``messages``/``loaded_skills`` state update (or None when there's nothing
         to inject — e.g. HITL/replay turns where the server omits skill_contexts).
+
+        The SKILL.md disk reads run in a worker thread so this turn-entry hook
+        doesn't block the event loop before the first model call.
         """
         if not config:
             return None
@@ -333,7 +337,8 @@ class SkillsMiddleware(AgentMiddleware):
             _message_id(last) if last is not None and _is_human_message(last) else None
         )
 
-        result = build_skill_content(
+        result = await asyncio.to_thread(
+            build_skill_content,
             skills,
             skill_dirs=configurable.get("skill_dirs"),
             mode=self._mode,

--- a/src/server/handlers/chat/_common.py
+++ b/src/server/handlers/chat/_common.py
@@ -34,7 +34,6 @@ from src.server.services.persistence.conversation import (
 )
 from src.server.services.workflow_tracker import WorkflowTracker
 from src.server.utils.skill_context import (
-    build_skill_content,
     detect_slash_commands,
     parse_skill_contexts,
 )
@@ -524,20 +523,20 @@ async def persist_or_skip_replay(
         )
 
 
-def inject_skills(
+def prepare_skill_contexts(
     messages: list[dict],
     request: ChatRequest,
-    config,
     mode: str,
-) -> list[str]:
-    """Detect and inject skill content into the last user message.
+) -> list[dict]:
+    """Resolve which skills this turn activates, for the agent to inject.
 
-    Handles slash-command detection as a fallback when ``additional_context``
-    does not contain ``skill_contexts``.
-
-    Returns the list of loaded skill names.
+    Parses ``additional_context`` skill items and, as a fallback when none are
+    present, detects a leading ``/command`` in the last user message (stripping
+    the prefix in place). Returns plain ``{"name", "instruction"}`` dicts to thread
+    through ``config["configurable"]["skill_contexts"]`` — ``SkillsMiddleware`` then
+    loads the SKILL.md body once and dedups against bodies already live in the
+    thread. No body loading or checkpoint reads happen here.
     """
-    loaded_skill_names: list[str] = []
     skill_contexts = parse_skill_contexts(request.additional_context)
 
     # Detect slash commands from message text (fallback for missing additional_context)
@@ -552,19 +551,13 @@ def inject_skills(
                     last_msg["content"] = cleaned_text
 
     if skill_contexts:
-        skill_dirs = [
-            local_dir
-            for local_dir, _ in config.skills.local_skill_dirs_with_sandbox()
-        ]
-        skill_result = build_skill_content(
-            skill_contexts, skill_dirs=skill_dirs, mode=mode
+        logger.info(
+            f"[{mode.upper()}_CHAT] Skills requested: {[s.name for s in skill_contexts]}"
         )
-        if skill_result:
-            _append_to_last_user_message(messages, "\n\n" + skill_result.content)
-            loaded_skill_names = skill_result.loaded_skill_names
-            logger.info(f"[{mode.upper()}_CHAT] Skills injected: {loaded_skill_names}")
 
-    return loaded_skill_names
+    return [
+        {"name": s.name, "instruction": s.instruction} for s in skill_contexts
+    ]
 
 
 def build_graph_config(
@@ -580,11 +573,15 @@ def build_graph_config(
     recursion_limit: int,
     plan_mode: bool | None = None,
     extra_configurable: dict | None = None,
+    skill_contexts: list[dict] | None = None,
+    skill_dirs: list[str] | None = None,
 ) -> dict:
     """Build the LangGraph ``config`` dict shared by flash and PTC handlers.
 
     ``mode`` should be ``"flash"`` or ``"ptc"``.
     ``extra_configurable`` is an optional dict merged into ``configurable``.
+    ``skill_contexts`` (+ ``skill_dirs``) are passed to ``SkillsMiddleware`` so it
+    injects each requested skill's SKILL.md body once; omit on HITL/replay turns.
     """
     workflow_type = "flash_agent" if mode == "flash" else "ptc_agent"
 
@@ -616,6 +613,10 @@ def build_graph_config(
     }
     if extra_configurable:
         configurable.update(extra_configurable)
+    if skill_contexts:
+        configurable["skill_contexts"] = skill_contexts
+        if skill_dirs:
+            configurable["skill_dirs"] = skill_dirs
 
     graph_config: dict = {
         "configurable": configurable,

--- a/src/server/handlers/chat/_common.py
+++ b/src/server/handlers/chat/_common.py
@@ -13,7 +13,7 @@ import json
 import logging
 import time
 from collections.abc import AsyncGenerator
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import psycopg
 from fastapi import HTTPException
@@ -523,6 +523,28 @@ async def persist_or_skip_replay(
         )
 
 
+def _slash_text_target(content: Any) -> tuple[str, dict | None]:
+    """Locate the leading-slash text for command detection in a user message.
+
+    Returns ``(text, block)`` where ``block`` is the content-list element to
+    rewrite when stripping the prefix (``None`` for plain-string content). User
+    content is a block list when a supported attachment rewrites it
+    (``inject_multimodal_context``) or the client sends a multi-part message;
+    without scanning it, slash commands on those turns would be invisible. Only a
+    block whose text starts with ``/`` is considered, so attachment-label blocks
+    never false-match.
+    """
+    if isinstance(content, str):
+        return content, None
+    if isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                text = block.get("text", "") or ""
+                if text.startswith("/"):
+                    return text, block
+    return "", None
+
+
 def prepare_skill_contexts(
     messages: list[dict],
     request: ChatRequest,
@@ -539,16 +561,21 @@ def prepare_skill_contexts(
     """
     skill_contexts = parse_skill_contexts(request.additional_context)
 
-    # Detect slash commands from message text (fallback for missing additional_context)
+    # Detect slash commands from message text (fallback for missing additional_context).
+    # Handles both plain-string content and the content-block list a supported
+    # attachment leaves behind, so `/cmd` + an image/PDF still activates the skill.
     if not skill_contexts and not request.hitl_response and messages:
         last_msg = messages[-1]
-        msg_text = last_msg.get("content", "") if isinstance(last_msg.get("content"), str) else ""
+        msg_text, text_block = _slash_text_target(last_msg.get("content"))
         if msg_text:
             cleaned_text, detected = detect_slash_commands(msg_text, mode=mode)
             if detected:
                 skill_contexts = detected
                 if cleaned_text != msg_text:
-                    last_msg["content"] = cleaned_text
+                    if text_block is None:
+                        last_msg["content"] = cleaned_text
+                    else:
+                        text_block["text"] = cleaned_text
 
     if skill_contexts:
         logger.info(

--- a/src/server/handlers/chat/flash_workflow.py
+++ b/src/server/handlers/chat/flash_workflow.py
@@ -64,10 +64,10 @@ from ._common import (
     handle_workflow_error,
     init_tracking,
     inject_inline_reminders,
-    inject_skills,
     logger,
     normalize_request_messages,
     persist_or_skip_replay,
+    prepare_skill_contexts,
     process_hitl_response,
     serialize_context_metadata,
     setup_steering_tracking,
@@ -341,8 +341,18 @@ async def astream_flash_workflow(
                     f"noted for {effective_model}"
                 )
 
-        # Skill Context Injection (Flash mode)
-        loaded_skill_names = inject_skills(messages, request, config, mode="flash")
+        # Skill Context Resolution (Flash) — body injection happens in
+        # SkillsMiddleware, which dedups bodies already live in the thread. Only
+        # set on normal turns; HITL/replay carry no new user message to attach to.
+        if not request.hitl_response and not is_checkpoint_replay:
+            skill_contexts = prepare_skill_contexts(messages, request, mode="flash")
+        else:
+            skill_contexts = []
+        skill_dirs = (
+            [local_dir for local_dir, _ in config.skills.local_skill_dirs_with_sandbox()]
+            if skill_contexts
+            else None
+        )
 
         # Inline context injection (directive + widget + chart selection) --
         # Flash-specific. Skip on HITL resumes and checkpoint replay because
@@ -376,8 +386,7 @@ async def astream_flash_workflow(
             )
         else:
             input_state = {"messages": messages}
-            if loaded_skill_names:
-                input_state["loaded_skills"] = loaded_skill_names
+            # Skill tools auto-load via SkillsMiddleware (sets loaded_skills in state).
 
         graph_config = build_graph_config(
             thread_id=thread_id,
@@ -390,6 +399,8 @@ async def astream_flash_workflow(
             effective_model=effective_model,
             is_byok=is_byok,
             recursion_limit=get_flash_recursion_limit(),
+            skill_contexts=skill_contexts,
+            skill_dirs=skill_dirs,
         )
         graph_config["run_id"] = run_id
 

--- a/src/server/handlers/chat/flash_workflow.py
+++ b/src/server/handlers/chat/flash_workflow.py
@@ -347,7 +347,7 @@ async def astream_flash_workflow(
         if not request.hitl_response and not is_checkpoint_replay:
             skill_contexts = prepare_skill_contexts(messages, request, mode="flash")
         else:
-            skill_contexts = []
+            skill_contexts = None
         skill_dirs = (
             [local_dir for local_dir, _ in config.skills.local_skill_dirs_with_sandbox()]
             if skill_contexts

--- a/src/server/handlers/chat/ptc_workflow.py
+++ b/src/server/handlers/chat/ptc_workflow.py
@@ -74,10 +74,10 @@ from ._common import (
     handle_workflow_error,
     init_tracking,
     inject_inline_reminders,
-    inject_skills,
     logger,
     normalize_request_messages,
     persist_or_skip_replay,
+    prepare_skill_contexts,
     process_hitl_response,
     serialize_context_metadata,
     setup_steering_tracking,
@@ -565,21 +565,24 @@ async def astream_ptc_workflow(
         messages = normalize_request_messages(request)
 
         # =====================================================================
-        # Skill Context Injection (inline with last user message)
+        # Skill Context Resolution (body injection happens in SkillsMiddleware)
         # =====================================================================
-        # When skills are requested via additional_context, load SKILL.md content
-        # and append inline to the last user message using <loaded-skill> tags.
-        # The original user_input is preserved for database persistence.
+        # Resolve which skills this turn activates — from additional_context or a
+        # leading /<command> in the message (stripped in place). The SKILL.md body
+        # is injected by SkillsMiddleware at turn entry, which dedups against bodies
+        # already live in the thread so a re-sent skill isn't pasted every turn.
         #
-        # Server-side slash command detection: also scan the last user message
-        # for /<command> prefixes as a fallback when additional_context is missing.
-        #
-        # PTC guards skill injection with `not request.hitl_response` because the
-        # helper does not guard the build_skill_content call itself.
-        if not request.hitl_response:
-            loaded_skill_names = inject_skills(messages, request, config, mode="ptc")
+        # Only set on normal turns: HITL resumes and checkpoint replays carry no new
+        # user message, so the middleware must not inject (mirrors the prior guard).
+        if not request.hitl_response and not is_checkpoint_replay:
+            skill_contexts = prepare_skill_contexts(messages, request, mode="ptc")
         else:
-            loaded_skill_names = []
+            skill_contexts = []
+        skill_dirs = (
+            [local_dir for local_dir, _ in config.skills.local_skill_dirs_with_sandbox()]
+            if skill_contexts
+            else None
+        )
 
         # Multimodal Context Injection
         # All attachments are uploaded to sandbox (when available) so the
@@ -682,9 +685,7 @@ async def astream_ptc_workflow(
                 "messages": messages,
                 "current_agent": "ptc",  # For FileOperationMiddleware SSE events
             }
-            # Auto-load skill tools when skills were injected via additional_context
-            if loaded_skill_names:
-                input_state["loaded_skills"] = loaded_skill_names
+            # Skill tools auto-load via SkillsMiddleware (sets loaded_skills in state).
 
         # =====================================================================
         # Plan Mode Injection
@@ -765,6 +766,8 @@ async def astream_ptc_workflow(
             is_byok=is_byok,
             recursion_limit=get_ptc_recursion_limit(),
             plan_mode=effective_plan_mode,
+            skill_contexts=skill_contexts,
+            skill_dirs=skill_dirs,
         )
         # Propagate run_id to LangGraph via the top-level config key; it
         # lands on ExecutionInfo.run_id and CheckpointMetadata.run_id so

--- a/src/server/handlers/chat/ptc_workflow.py
+++ b/src/server/handlers/chat/ptc_workflow.py
@@ -577,7 +577,7 @@ async def astream_ptc_workflow(
         if not request.hitl_response and not is_checkpoint_replay:
             skill_contexts = prepare_skill_contexts(messages, request, mode="ptc")
         else:
-            skill_contexts = []
+            skill_contexts = None
         skill_dirs = (
             [local_dir for local_dir, _ in config.skills.local_skill_dirs_with_sandbox()]
             if skill_contexts

--- a/src/server/utils/skill_context.py
+++ b/src/server/utils/skill_context.py
@@ -1,50 +1,20 @@
 """
-Skill context utilities for chat endpoint.
+Skill context utilities for the chat endpoint.
 
-This module provides functions to parse skill contexts from requests,
-load SKILL.md content from the skill registry, and build skill prefix
-messages for the LLM.
+Pure request-parsing helpers: extract ``SkillContext`` items from a request's
+``additional_context`` and detect ``/command`` prefixes in the message text.
+Body loading + inline injection live in ``ptc_agent`` (``SkillsMiddleware``);
+the server only resolves *which* skills the turn requested.
 """
 
 import logging
 import re
-from dataclasses import dataclass, field
 from typing import Any, List, Optional
 
 from src.server.models.additional_context import SkillContext
-from ptc_agent.agent.middleware.skills import get_command_to_skill_map, get_skill, SkillMode
-from ptc_agent.agent.middleware.skills.content import (
-    load_skill_content,  # noqa: F401 — re-exported for backwards compatibility
-)
+from ptc_agent.agent.middleware.skills import SkillMode, get_command_to_skill_map
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass
-class SkillPrefixResult:
-    """Result of building skill content for inline injection."""
-
-    content: str  # Formatted skill text wrapped in <loaded-skill> tags
-    loaded_skill_names: list[str] = field(default_factory=list)  # Skills that successfully loaded
-
-
-def build_tool_descriptions(skill_name: str, mode: SkillMode | None = None) -> Optional[str]:
-    """Build formatted tool descriptions for a skill.
-
-    Mirrors the format from SkillsMiddleware._build_skill_result.
-
-    Args:
-        skill_name: Name of the skill
-        mode: Optional agent mode filter
-
-    Returns:
-        Formatted tool description string, or None if skill has no tools
-    """
-    skill = get_skill(skill_name, mode=mode)
-    if not skill or not skill.tools:
-        return None
-
-    return skill.format_tool_descriptions()
 
 
 def parse_skill_contexts(
@@ -100,94 +70,6 @@ def parse_skill_contexts(
         )
 
     return skill_contexts
-
-
-def build_skill_content(
-    skills: List[SkillContext],
-    skill_dirs: Optional[List[str]] = None,
-    mode: SkillMode | None = None,
-) -> Optional[SkillPrefixResult]:
-    """Build skill content for inline injection into user messages.
-
-    Creates formatted skill content wrapped in <loaded-skill> XML tags,
-    suitable for appending inline to the last user message. Also returns
-    the list of successfully loaded skill names so callers can set
-    loaded_skills in the graph state for immediate tool availability.
-
-    Args:
-        skills: List of SkillContext objects to load
-        skill_dirs: Optional list of local skill directories to search
-        mode: Optional agent mode filter. Skills whose exposure doesn't match
-              the mode will be skipped.
-
-    Returns:
-        SkillPrefixResult with content string and loaded skill names, or None if no skills loaded
-
-    Example:
-        >>> skills = [SkillContext(type="skills", name="user-profile", instruction="Help onboard")]
-        >>> result = build_skill_content(skills)
-        >>> '<loaded-skill' in result.content
-        True
-        >>> result.loaded_skill_names
-        ['user-profile']
-    """
-    if not skills:
-        return None
-
-    loaded_skills = []
-    skill_blocks = []
-    instructions = []
-
-    for skill_ctx in skills:
-        content = load_skill_content(skill_ctx.name, skill_dirs, mode=mode)
-
-        if content:
-            loaded_skills.append(skill_ctx.name)
-
-            # Build per-skill block with tool descriptions
-            block_parts = [content]
-            tool_desc = build_tool_descriptions(skill_ctx.name, mode=mode)
-            if tool_desc:
-                block_parts.append(f"\n**Available tools:**\n{tool_desc}")
-                block_parts.append("You can call these tools directly without needing to call LoadSkill.")
-
-            block_content = "\n".join(block_parts)
-            skill_blocks.append(
-                f'<loaded-skill name="{skill_ctx.name}">\n{block_content}\n</loaded-skill>'
-            )
-
-            if skill_ctx.instruction:
-                instructions.append(f"- {skill_ctx.name}: {skill_ctx.instruction}")
-        else:
-            logger.warning(
-                f"Skipping skill '{skill_ctx.name}': SKILL.md not found"
-            )
-
-    if not loaded_skills:
-        return None
-
-    # Combine all skill blocks
-    parts = skill_blocks
-
-    # Add instructions if any
-    if instructions:
-        if len(instructions) == 1 and len(skills) == 1:
-            parts.append(f"\n[Instruction: {skills[0].instruction}]")
-        else:
-            parts.append("\n[Instructions]")
-            parts.extend(instructions)
-
-    combined_content = "\n\n".join(parts)
-
-    logger.debug(
-        f"Built skill content with {len(loaded_skills)} skills: "
-        f"{loaded_skills}"
-    )
-
-    return SkillPrefixResult(
-        content=combined_content,
-        loaded_skill_names=loaded_skills,
-    )
 
 
 def detect_slash_commands(

--- a/tests/unit/middleware/skills/test_loaded_skills_reducer.py
+++ b/tests/unit/middleware/skills/test_loaded_skills_reducer.py
@@ -1,0 +1,31 @@
+"""Tests for the ``loaded_skills`` state reducer.
+
+The channel is semantically a set (every consumer reads it via ``set(...)``),
+so the reducer must dedup-union rather than accumulate — otherwise a turn that
+re-seeds an already-loaded skill grows the persisted list unboundedly.
+"""
+
+from src.ptc_agent.agent.middleware.skills.middleware import _union_loaded_skills
+
+
+def test_union_appends_new_names():
+    assert _union_loaded_skills(["a"], ["b"]) == ["a", "b"]
+
+
+def test_union_dedupes_repeated_name():
+    # The bug operator.add had: re-seeding "a" must not duplicate it.
+    assert _union_loaded_skills(["a"], ["a"]) == ["a"]
+
+
+def test_union_preserves_left_order_and_appends_only_fresh():
+    assert _union_loaded_skills(["a", "b"], ["b", "c", "a", "d"]) == ["a", "b", "c", "d"]
+
+
+def test_union_handles_none_operands():
+    assert _union_loaded_skills(None, ["a"]) == ["a"]
+    assert _union_loaded_skills(["a"], None) == ["a"]
+    assert _union_loaded_skills(None, None) == []
+
+
+def test_union_dedupes_within_right():
+    assert _union_loaded_skills([], ["x", "x", "y"]) == ["x", "y"]

--- a/tests/unit/middleware/skills/test_loaded_skills_reducer.py
+++ b/tests/unit/middleware/skills/test_loaded_skills_reducer.py
@@ -29,3 +29,10 @@ def test_union_handles_none_operands():
 
 def test_union_dedupes_within_right():
     assert _union_loaded_skills([], ["x", "x", "y"]) == ["x", "y"]
+
+
+def test_union_dedupes_within_left():
+    # Threads persisted under the old operator.add reducer can carry left-side
+    # duplicates; the reducer must re-bound them, not pass them through forever.
+    assert _union_loaded_skills(["a", "a", "b"], []) == ["a", "b"]
+    assert _union_loaded_skills(["a", "b", "a"], ["b", "c"]) == ["a", "b", "c"]

--- a/tests/unit/middleware/skills/test_skill_content.py
+++ b/tests/unit/middleware/skills/test_skill_content.py
@@ -1,0 +1,259 @@
+"""Tests for the skill content layer (``ptc_agent`` skills middleware).
+
+Covers two pure functions that the SkillsMiddleware composes:
+
+- ``build_skill_content`` — the already-loaded dedup that keeps a re-sent skill's
+  SKILL.md body from being re-injected every turn while still refreshing its
+  (per-turn) instruction.
+- ``compute_already_loaded`` — which skills' bodies are still live in the
+  effective (post-compaction) message window, so the body can be skipped.
+
+Import + patch targets use the ``src.`` prefix consistently: ``src.ptc_agent.X``
+and ``ptc_agent.X`` are distinct module objects, so the patch namespace must match
+the import namespace or ``patch`` hits the wrong module.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.ptc_agent.agent.middleware.skills.content import (
+    SkillRequest,
+    build_skill_content,
+    compute_already_loaded,
+)
+
+MOD = "src.ptc_agent.agent.middleware.skills.content"
+
+
+def _ctx(name: str, instruction: str | None = None) -> SkillRequest:
+    return SkillRequest(name=name, instruction=instruction)
+
+
+@pytest.fixture(autouse=True)
+def _skill_exposed_in_mode():
+    """The already-loaded branch calls ``get_skill(name, mode)`` to confirm the
+    skill is still exposed in the current mode. Default it truthy so the dedup
+    tests exercise the skip path; the mode-mismatch test overrides it to None.
+    """
+    with patch(f"{MOD}.get_skill", return_value=MagicMock()):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# build_skill_content
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_skill_injects_full_body_and_instruction():
+    with (
+        patch(f"{MOD}.load_skill_content", return_value="SKILL BODY"),
+        patch(f"{MOD}.build_tool_descriptions", return_value=None),
+    ):
+        result = build_skill_content([_ctx("chart-annotation", "draw on AAPL:1day")])
+
+    assert result is not None
+    assert result.loaded_skill_names == ["chart-annotation"]
+    assert '<loaded-skill name="chart-annotation">' in result.content
+    assert "SKILL BODY" in result.content
+    assert "[Instruction: draw on AAPL:1day]" in result.content
+
+
+def test_already_loaded_skill_skips_body_keeps_instruction():
+    with (
+        patch(f"{MOD}.load_skill_content", return_value="SKILL BODY") as load,
+        patch(f"{MOD}.build_tool_descriptions", return_value=None),
+    ):
+        result = build_skill_content(
+            [_ctx("chart-annotation", "draw on NVDA:1hour")],
+            already_loaded={"chart-annotation"},
+        )
+
+    # Body is not re-pasted and the skill is not re-counted as freshly loaded...
+    assert result is not None
+    assert result.loaded_skill_names == []
+    assert "<loaded-skill" not in result.content
+    assert "SKILL BODY" not in result.content
+    load.assert_not_called()
+    # ...but the fresh instruction (current symbol/timeframe) still rides.
+    assert "[Instruction: draw on NVDA:1hour]" in result.content
+
+
+def test_already_loaded_skill_without_instruction_returns_none():
+    with (
+        patch(f"{MOD}.load_skill_content", return_value="SKILL BODY"),
+        patch(f"{MOD}.build_tool_descriptions", return_value=None),
+    ):
+        result = build_skill_content(
+            [_ctx("chart-annotation")],
+            already_loaded={"chart-annotation"},
+        )
+
+    # Nothing to inject: body skipped, no instruction to refresh.
+    assert result is None
+
+
+def test_mixed_fresh_and_already_loaded():
+    def fake_load(name, skill_dirs=None, mode=None):
+        return f"BODY:{name}"
+
+    with (
+        patch(f"{MOD}.load_skill_content", side_effect=fake_load),
+        patch(f"{MOD}.build_tool_descriptions", return_value=None),
+    ):
+        result = build_skill_content(
+            [
+                _ctx("chart-annotation", "draw on AAPL:1day"),
+                _ctx("research", "find news"),
+            ],
+            already_loaded={"chart-annotation"},
+        )
+
+    assert result is not None
+    # Only the not-yet-loaded skill gets a body and a fresh-name entry.
+    assert result.loaded_skill_names == ["research"]
+    assert "BODY:research" in result.content
+    assert "BODY:chart-annotation" not in result.content
+    assert '<loaded-skill name="research">' in result.content
+    # Both instructions are listed (multi-instruction format).
+    assert "[Instructions]" in result.content
+    assert "- chart-annotation: draw on AAPL:1day" in result.content
+    assert "- research: find news" in result.content
+
+
+def test_single_instruction_across_multiple_skills_uses_named_format():
+    """A fresh skill body plus a *different* already-loaded skill's instruction
+    means two skills are represented, so the lone instruction must be named —
+    the bare ``[Instruction: ...]`` form would read as belonging to the fresh
+    skill's body block instead of its real owner.
+    """
+    with (
+        patch(f"{MOD}.load_skill_content", return_value="SKILL BODY"),
+        patch(f"{MOD}.build_tool_descriptions", return_value=None),
+    ):
+        result = build_skill_content(
+            [
+                _ctx("research"),  # fresh, no instruction -> body block only
+                _ctx("chart-annotation", "draw on NVDA:1day"),  # already loaded -> instruction only
+            ],
+            already_loaded={"chart-annotation"},
+        )
+
+    assert result is not None
+    assert result.loaded_skill_names == ["research"]
+    assert '<loaded-skill name="research">' in result.content
+    # Two skills represented -> named list, never the bare shorthand.
+    assert "[Instructions]" in result.content
+    assert "- chart-annotation: draw on NVDA:1day" in result.content
+    assert "[Instruction: draw on NVDA:1day]" not in result.content
+
+
+def test_already_loaded_but_mode_mismatch_drops_instruction():
+    """A stale loaded_skills entry for a skill no longer exposed in the current
+    mode must NOT short-circuit to an instruction-only inject — the mode re-check
+    fails, the skill falls through to the fresh path, and load_skill_content
+    (which also mode-gates) rejects it. Net: nothing is injected, so a caller
+    can't smuggle an instruction past the mode gate via a stale loaded set.
+    """
+    with (
+        patch(f"{MOD}.get_skill", return_value=None),  # not exposed in this mode
+        patch(f"{MOD}.load_skill_content", return_value=None),  # fresh path also rejects
+        patch(f"{MOD}.build_tool_descriptions", return_value=None),
+    ):
+        result = build_skill_content(
+            [_ctx("chart-annotation", "draw on NVDA:1day")],
+            already_loaded={"chart-annotation"},
+            mode="flash",
+        )
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# compute_already_loaded
+# ---------------------------------------------------------------------------
+
+
+def test_compute_filters_non_str_names():
+    """Only string skill names survive."""
+    result = compute_already_loaded(
+        ["chart-annotation", None, 7, "research"], [], None
+    )
+    assert result == {"chart-annotation", "research"}
+
+
+def test_compute_empty_loaded_returns_empty():
+    assert compute_already_loaded([], [{"content": "hi"}], None) == set()
+    assert compute_already_loaded(None, None, None) == set()
+
+
+def test_compute_no_compaction_trusts_loaded_set():
+    """Without a compaction event the full history is in the model's view, so
+    every loaded skill's body still survives — no marker scan needed."""
+    result = compute_already_loaded(
+        ["chart-annotation"],
+        [{"content": "hi"}],  # marker not present, but no compaction
+        None,
+    )
+    assert result == {"chart-annotation"}
+
+
+def test_compute_event_without_cutoff_trusts_loaded_set():
+    """A summarization event with no/zero cutoff_index means nothing was actually
+    summarized away, so trust the loaded set as-is."""
+    assert compute_already_loaded(
+        ["chart-annotation"], [{"content": "hi"}], {"cutoff_index": 0}
+    ) == {"chart-annotation"}
+
+
+def test_compute_compaction_drops_body_before_cutoff():
+    """After compaction, a skill whose injected body now sits *before* the
+    cutoff is dropped so the body gets re-injected."""
+    result = compute_already_loaded(
+        ["chart-annotation"],
+        [
+            {"content": '<loaded-skill name="chart-annotation">body</loaded-skill>'},
+            {"content": "assistant reply"},
+            {"content": "later user turn"},  # messages[2:] — no marker
+        ],
+        {"cutoff_index": 2, "summary_message": {"content": "compacted summary"}},
+    )
+    assert result == set()
+
+
+def test_compute_compaction_keeps_body_after_cutoff():
+    """A skill whose body marker still appears in the surviving tail
+    (messages[cutoff:]) stays in the dedup set — no need to re-inject."""
+    result = compute_already_loaded(
+        ["chart-annotation", "research"],
+        [
+            {"content": "pre-cutoff summarized turn"},
+            {"content": '<loaded-skill name="chart-annotation">body</loaded-skill>'},
+            {"content": "another turn"},
+        ],
+        {"cutoff_index": 1, "summary_message": {"content": "compacted summary"}},
+    )
+    # Only chart-annotation's marker survives the cutoff; research's body is gone.
+    assert result == {"chart-annotation"}
+
+
+def test_compute_compaction_ignores_marker_inside_summary():
+    """A body that survives only inside the (lossy) summary message is gone
+    verbatim — get_effective_messages prepends the summary at index 0 and we
+    scan from index 1, so such a skill is dropped and re-injected."""
+    result = compute_already_loaded(
+        ["chart-annotation"],
+        [
+            {"content": '<loaded-skill name="chart-annotation">body</loaded-skill>'},
+            {"content": "assistant reply"},
+            {"content": "later user turn"},  # surviving tail — no marker
+        ],
+        {
+            "cutoff_index": 2,
+            # Marker present in the summary, but the summary is lossy prose.
+            "summary_message": {
+                "content": 'mentions <loaded-skill name="chart-annotation"> once'
+            },
+        },
+    )
+    assert result == set()

--- a/tests/unit/middleware/skills/test_skill_content.py
+++ b/tests/unit/middleware/skills/test_skill_content.py
@@ -91,6 +91,41 @@ def test_fresh_skill_marker_carries_message_id():
     assert '<loaded-skill name="chart-annotation" mid="msg-7">' in result.content
 
 
+def test_same_skill_twice_in_one_request_emits_body_once():
+    """Intra-request dedup: a duplicate name (e.g. duplicate additional_context
+    entries) must not paste the body or count the skill as loaded twice."""
+    with (
+        patch(f"{MOD}.load_skill_content", return_value="SKILL BODY") as load,
+        patch(f"{MOD}.build_tool_descriptions", return_value=None),
+    ):
+        result = build_skill_content(
+            [_ctx("chart-annotation", "AAPL:1d"), _ctx("chart-annotation", "TSLA:4h")],
+            message_id="m1",
+        )
+
+    assert result is not None
+    assert result.loaded_skill_names == ["chart-annotation"]
+    assert result.content.count('<loaded-skill name="chart-annotation"') == 1
+    load.assert_called_once()  # the second occurrence is skipped before disk I/O
+
+
+def test_same_already_loaded_skill_twice_refreshes_instruction_once():
+    """A duplicate name on the already-loaded path must not double the instruction."""
+    with (
+        patch(f"{MOD}.load_skill_content", return_value="SKILL BODY"),
+        patch(f"{MOD}.build_tool_descriptions", return_value=None),
+    ):
+        result = build_skill_content(
+            [_ctx("chart-annotation", "AAPL:1d"), _ctx("chart-annotation", "TSLA:4h")],
+            already_loaded={"chart-annotation"},
+        )
+
+    assert result is not None
+    # First occurrence wins; the duplicate is dropped before it can re-emit.
+    assert result.content.count("AAPL:1d") == 1
+    assert "TSLA:4h" not in result.content
+
+
 def test_already_loaded_skill_skips_body_keeps_instruction():
     with (
         patch(f"{MOD}.load_skill_content", return_value="SKILL BODY") as load,

--- a/tests/unit/middleware/skills/test_skill_content.py
+++ b/tests/unit/middleware/skills/test_skill_content.py
@@ -59,6 +59,25 @@ def test_fresh_skill_injects_full_body_and_instruction():
     assert "[Instruction: draw on AAPL:1day]" in result.content
 
 
+def test_fresh_skill_appends_tool_descriptions_block():
+    """When a skill has tools, the body block carries an **Available tools:**
+    section plus the 'call directly' note — the text the model uses to invoke
+    the skill's tools without a separate LoadSkill round-trip."""
+    with (
+        patch(f"{MOD}.load_skill_content", return_value="SKILL BODY"),
+        patch(
+            f"{MOD}.build_tool_descriptions",
+            return_value="- draw_chart_annotation: draw on the chart",
+        ),
+    ):
+        result = build_skill_content([_ctx("chart-annotation")])
+
+    assert result is not None
+    assert "**Available tools:**" in result.content
+    assert "- draw_chart_annotation: draw on the chart" in result.content
+    assert "without needing to call LoadSkill" in result.content
+
+
 def test_already_loaded_skill_skips_body_keeps_instruction():
     with (
         patch(f"{MOD}.load_skill_content", return_value="SKILL BODY") as load,
@@ -257,3 +276,26 @@ def test_compute_compaction_ignores_marker_inside_summary():
         },
     )
     assert result == set()
+
+
+def test_compute_compaction_scans_multimodal_list_content():
+    """Attachments produce list-content user turns, and the body is appended as a
+    ``{"type": "text"}`` part — so the marker scan must read list content, not
+    just plain strings, or a multimodal turn would falsely re-inject every time."""
+    result = compute_already_loaded(
+        ["chart-annotation"],
+        [
+            {"content": "pre-cutoff summarized turn"},
+            {
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "data:..."}},
+                    {
+                        "type": "text",
+                        "text": '<loaded-skill name="chart-annotation">body</loaded-skill>',
+                    },
+                ]
+            },
+        ],
+        {"cutoff_index": 1, "summary_message": {"content": "compacted summary"}},
+    )
+    assert result == {"chart-annotation"}

--- a/tests/unit/middleware/skills/test_skill_content.py
+++ b/tests/unit/middleware/skills/test_skill_content.py
@@ -78,6 +78,19 @@ def test_fresh_skill_appends_tool_descriptions_block():
     assert "without needing to call LoadSkill" in result.content
 
 
+def test_fresh_skill_marker_carries_message_id():
+    """The emitted marker binds to the target message's id so the dedup scanner
+    can verify it later (defeats content-forged 'already loaded' matches)."""
+    with (
+        patch(f"{MOD}.load_skill_content", return_value="SKILL BODY"),
+        patch(f"{MOD}.build_tool_descriptions", return_value=None),
+    ):
+        result = build_skill_content([_ctx("chart-annotation")], message_id="msg-7")
+
+    assert result is not None
+    assert '<loaded-skill name="chart-annotation" mid="msg-7">' in result.content
+
+
 def test_already_loaded_skill_skips_body_keeps_instruction():
     with (
         patch(f"{MOD}.load_skill_content", return_value="SKILL BODY") as load,
@@ -231,9 +244,12 @@ def test_compute_compaction_drops_body_before_cutoff():
     result = compute_already_loaded(
         ["chart-annotation"],
         [
-            {"content": '<loaded-skill name="chart-annotation">body</loaded-skill>'},
-            {"content": "assistant reply"},
-            {"content": "later user turn"},  # messages[2:] — no marker
+            {
+                "content": '<loaded-skill name="chart-annotation" mid="m0">body</loaded-skill>',
+                "id": "m0",
+            },
+            {"content": "assistant reply", "id": "m1"},
+            {"content": "later user turn", "id": "m2"},  # messages[2:] — no marker
         ],
         {"cutoff_index": 2, "summary_message": {"content": "compacted summary"}},
     )
@@ -242,13 +258,17 @@ def test_compute_compaction_drops_body_before_cutoff():
 
 def test_compute_compaction_keeps_body_after_cutoff():
     """A skill whose body marker still appears in the surviving tail
-    (messages[cutoff:]) stays in the dedup set — no need to re-inject."""
+    (messages[cutoff:]) — with ``mid`` matching that message's own id —
+    stays in the dedup set; no need to re-inject."""
     result = compute_already_loaded(
         ["chart-annotation", "research"],
         [
-            {"content": "pre-cutoff summarized turn"},
-            {"content": '<loaded-skill name="chart-annotation">body</loaded-skill>'},
-            {"content": "another turn"},
+            {"content": "pre-cutoff summarized turn", "id": "m0"},
+            {
+                "content": '<loaded-skill name="chart-annotation" mid="m1">body</loaded-skill>',
+                "id": "m1",
+            },
+            {"content": "another turn", "id": "m2"},
         ],
         {"cutoff_index": 1, "summary_message": {"content": "compacted summary"}},
     )
@@ -263,9 +283,12 @@ def test_compute_compaction_ignores_marker_inside_summary():
     result = compute_already_loaded(
         ["chart-annotation"],
         [
-            {"content": '<loaded-skill name="chart-annotation">body</loaded-skill>'},
-            {"content": "assistant reply"},
-            {"content": "later user turn"},  # surviving tail — no marker
+            {
+                "content": '<loaded-skill name="chart-annotation" mid="m0">body</loaded-skill>',
+                "id": "m0",
+            },
+            {"content": "assistant reply", "id": "m1"},
+            {"content": "later user turn", "id": "m2"},  # surviving tail — no marker
         ],
         {
             "cutoff_index": 2,
@@ -285,17 +308,79 @@ def test_compute_compaction_scans_multimodal_list_content():
     result = compute_already_loaded(
         ["chart-annotation"],
         [
-            {"content": "pre-cutoff summarized turn"},
+            {"content": "pre-cutoff summarized turn", "id": "m0"},
             {
+                "id": "m1",
                 "content": [
                     {"type": "image_url", "image_url": {"url": "data:..."}},
                     {
                         "type": "text",
-                        "text": '<loaded-skill name="chart-annotation">body</loaded-skill>',
+                        "text": '<loaded-skill name="chart-annotation" mid="m1">body</loaded-skill>',
                     },
-                ]
+                ],
             },
         ],
         {"cutoff_index": 1, "summary_message": {"content": "compacted summary"}},
     )
     assert result == {"chart-annotation"}
+
+
+def test_compute_compaction_ignores_foreign_mid():
+    """Identity binding: a marker whose ``mid`` is some *other* message's id (e.g.
+    a user copied a real marker from earlier in the thread into a new turn) does
+    NOT count — the mid must equal the scanned message's own id."""
+    result = compute_already_loaded(
+        ["chart-annotation"],
+        [
+            {"content": "pre-cutoff summarized turn", "id": "m0"},
+            {
+                # mid points at a different message than the one it lives in.
+                "content": '<loaded-skill name="chart-annotation" mid="m0">body</loaded-skill>',
+                "id": "m_self",
+            },
+        ],
+        {"cutoff_index": 1, "summary_message": {"content": "compacted summary"}},
+    )
+    assert result == set()
+
+
+def test_compute_compaction_ignores_documented_block_in_other_skill_body():
+    """Finding #2: a SKILL.md body that *documents* the format with a full
+    ``<loaded-skill name="research" ...>...</loaded-skill>`` example must not make
+    ``research`` look loaded — the documented mid won't equal the host message id."""
+    result = compute_already_loaded(
+        ["research"],
+        [
+            {"content": "pre-cutoff summarized turn", "id": "m0"},
+            {
+                # chart-annotation's own body, which happens to document the format.
+                "content": (
+                    '<loaded-skill name="chart-annotation" mid="a1">\n'
+                    'To load a skill the server emits '
+                    '<loaded-skill name="research" mid="example">...</loaded-skill>\n'
+                    "</loaded-skill>"
+                ),
+                "id": "a1",
+            },
+        ],
+        {"cutoff_index": 1, "summary_message": {"content": "compacted summary"}},
+    )
+    assert result == set()
+
+
+def test_compute_compaction_ignores_bare_legacy_marker():
+    """A bare ``<loaded-skill name="X">`` with no ``mid`` (legacy injection or a
+    user typing the old format) no longer matches — the scanner requires the
+    mid-bound form, so such a turn re-injects rather than falsely deduping."""
+    result = compute_already_loaded(
+        ["chart-annotation"],
+        [
+            {"content": "pre-cutoff summarized turn", "id": "m0"},
+            {
+                "content": '<loaded-skill name="chart-annotation">body</loaded-skill>',
+                "id": "m1",
+            },
+        ],
+        {"cutoff_index": 1, "summary_message": {"content": "compacted summary"}},
+    )
+    assert result == set()

--- a/tests/unit/middleware/skills/test_skill_injection_middleware.py
+++ b/tests/unit/middleware/skills/test_skill_injection_middleware.py
@@ -1,0 +1,175 @@
+"""Tests for ``SkillsMiddleware.abefore_agent`` skill-body injection.
+
+The middleware reads ``skill_contexts`` from ``config["configurable"]``, dedups
+against bodies already live in the thread (``compute_already_loaded``), appends
+fresh bodies to the last user message in place (preserving its id), and returns
+the ``messages``/``loaded_skills`` state update.
+
+These tests drive the hook with fake state/config and patch the content layer at
+the middleware namespace, so they verify the *wiring* (what gets read from state,
+what gets returned) independently of build_skill_content's own logic.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+from src.ptc_agent.agent.middleware.skills.content import SkillPrefixResult
+from src.ptc_agent.agent.middleware.skills.middleware import SkillsMiddleware
+
+MW = "src.ptc_agent.agent.middleware.skills.middleware"
+
+
+def _config(skill_contexts=None, skill_dirs=None):
+    configurable: dict = {}
+    if skill_contexts is not None:
+        configurable["skill_contexts"] = skill_contexts
+    if skill_dirs is not None:
+        configurable["skill_dirs"] = skill_dirs
+    return {"configurable": configurable}
+
+
+@pytest.mark.asyncio
+async def test_fresh_skill_returns_body_and_loaded_skills():
+    mw = SkillsMiddleware(mode="flash")
+    hm = HumanMessage(content="annotate the chart", id="u1")
+    state = {"messages": [hm], "loaded_skills": []}
+    config = _config(
+        skill_contexts=[{"name": "chart-annotation", "instruction": "AAPL:1d"}],
+        skill_dirs=["/skills"],
+    )
+    result_obj = SkillPrefixResult(
+        content="\n\nBODY-AND-INSTRUCTION", loaded_skill_names=["chart-annotation"]
+    )
+
+    with (
+        patch(f"{MW}.compute_already_loaded", return_value=set()) as cal,
+        patch(f"{MW}.build_skill_content", return_value=result_obj) as bsc,
+    ):
+        out = await mw.abefore_agent(state, MagicMock(), config=config)
+
+    # Filesystem discovery still runs (empty for flash) alongside injection.
+    assert out["discovered_skills"] == []
+    assert out["loaded_skills"] == ["chart-annotation"]
+
+    # Body appended to the SAME user message (id preserved -> add_messages replaces).
+    assert len(out["messages"]) == 1
+    injected = out["messages"][0]
+    assert injected.id == "u1"
+    assert "annotate the chart" in injected.content
+    assert injected.content.endswith("BODY-AND-INSTRUCTION")
+
+    # already_loaded came from compute_already_loaded(state channels).
+    ca_args = cal.call_args.args
+    assert ca_args[0] == []  # loaded_skills
+    assert ca_args[1] == [hm]  # messages
+
+    # build_skill_content received the coerced SkillRequests + config skill_dirs.
+    skills_arg = bsc.call_args.args[0]
+    assert [s.name for s in skills_arg] == ["chart-annotation"]
+    assert skills_arg[0].instruction == "AAPL:1d"
+    assert bsc.call_args.kwargs["skill_dirs"] == ["/skills"]
+    assert bsc.call_args.kwargs["mode"] == "flash"
+    assert bsc.call_args.kwargs["already_loaded"] == set()
+
+
+@pytest.mark.asyncio
+async def test_already_loaded_skips_loaded_skills_keeps_instruction():
+    """When the body is deduped (no fresh names), the instruction still rides on
+    the message but ``loaded_skills`` is not returned (tools already persist)."""
+    mw = SkillsMiddleware(mode="flash")
+    hm = HumanMessage(content="annotate", id="u1")
+    state = {"messages": [hm], "loaded_skills": ["chart-annotation"]}
+    config = _config(
+        skill_contexts=[{"name": "chart-annotation", "instruction": "NVDA:1h"}]
+    )
+    result_obj = SkillPrefixResult(
+        content="\n\n[Instruction: NVDA:1h]", loaded_skill_names=[]
+    )
+
+    with (
+        patch(f"{MW}.compute_already_loaded", return_value={"chart-annotation"}),
+        patch(f"{MW}.build_skill_content", return_value=result_obj),
+    ):
+        out = await mw.abefore_agent(state, MagicMock(), config=config)
+
+    assert "loaded_skills" not in out
+    assert out["messages"][0].content.endswith("[Instruction: NVDA:1h]")
+    assert out["messages"][0].id == "u1"
+
+
+@pytest.mark.asyncio
+async def test_no_skill_contexts_is_noop_injection():
+    mw = SkillsMiddleware(mode="flash")
+    state = {"messages": [HumanMessage(content="hi", id="u1")]}
+
+    with patch(f"{MW}.build_skill_content") as bsc:
+        out = await mw.abefore_agent(state, MagicMock(), config=_config())
+
+    bsc.assert_not_called()
+    assert out == {"discovered_skills": []}
+
+
+@pytest.mark.asyncio
+async def test_config_none_is_noop_injection():
+    mw = SkillsMiddleware(mode="flash")
+    state = {"messages": [HumanMessage(content="hi", id="u1")]}
+
+    with patch(f"{MW}.build_skill_content") as bsc:
+        out = await mw.abefore_agent(state, MagicMock(), config=None)
+
+    bsc.assert_not_called()
+    assert out == {"discovered_skills": []}
+
+
+@pytest.mark.asyncio
+async def test_build_returns_none_injects_nothing():
+    mw = SkillsMiddleware(mode="flash")
+    state = {"messages": [HumanMessage(content="hi", id="u1")], "loaded_skills": []}
+    config = _config(skill_contexts=[{"name": "chart-annotation"}])
+
+    with (
+        patch(f"{MW}.compute_already_loaded", return_value=set()),
+        patch(f"{MW}.build_skill_content", return_value=None),
+    ):
+        out = await mw.abefore_agent(state, MagicMock(), config=config)
+
+    assert out == {"discovered_skills": []}
+
+
+@pytest.mark.asyncio
+async def test_last_message_not_human_still_returns_loaded_skills():
+    """Defense path: if the last message isn't a user turn, the body can't attach
+    but the skill's tools must still load via ``loaded_skills``."""
+    mw = SkillsMiddleware(mode="flash")
+    state = {"messages": [AIMessage(content="assistant", id="a1")], "loaded_skills": []}
+    config = _config(skill_contexts=[{"name": "chart-annotation"}])
+    result_obj = SkillPrefixResult(content="BODY", loaded_skill_names=["chart-annotation"])
+
+    with (
+        patch(f"{MW}.compute_already_loaded", return_value=set()),
+        patch(f"{MW}.build_skill_content", return_value=result_obj),
+    ):
+        out = await mw.abefore_agent(state, MagicMock(), config=config)
+
+    assert out["loaded_skills"] == ["chart-annotation"]
+    assert "messages" not in out
+
+
+@pytest.mark.asyncio
+async def test_blank_skill_names_are_dropped():
+    """A skill_contexts entry with no name doesn't reach build_skill_content."""
+    mw = SkillsMiddleware(mode="flash")
+    state = {"messages": [HumanMessage(content="hi", id="u1")], "loaded_skills": []}
+    config = _config(skill_contexts=[{"name": "", "instruction": "x"}])
+
+    with (
+        patch(f"{MW}.compute_already_loaded", return_value=set()) as cal,
+        patch(f"{MW}.build_skill_content") as bsc,
+    ):
+        out = await mw.abefore_agent(state, MagicMock(), config=config)
+
+    bsc.assert_not_called()
+    cal.assert_not_called()
+    assert out == {"discovered_skills": []}

--- a/tests/unit/middleware/skills/test_skill_injection_middleware.py
+++ b/tests/unit/middleware/skills/test_skill_injection_middleware.py
@@ -19,7 +19,10 @@ from src.ptc_agent.agent.middleware.skills.content import (
     SkillPrefixResult,
     loaded_skill_marker,
 )
-from src.ptc_agent.agent.middleware.skills.middleware import SkillsMiddleware
+from src.ptc_agent.agent.middleware.skills.middleware import (
+    SkillsMiddleware,
+    _append_body_to_last_human,
+)
 
 MW = "src.ptc_agent.agent.middleware.skills.middleware"
 
@@ -42,8 +45,11 @@ async def test_fresh_skill_returns_body_and_loaded_skills():
         skill_contexts=[{"name": "chart-annotation", "instruction": "AAPL:1d"}],
         skill_dirs=["/skills"],
     )
+    # build_skill_content returns a clean self-contained block — NO leading "\n\n".
+    # The blank-line separator is the append's job (_join_body), so the mock must
+    # reflect the real contract or the separator regression slips through again.
     result_obj = SkillPrefixResult(
-        content="\n\nBODY-AND-INSTRUCTION", loaded_skill_names=["chart-annotation"]
+        content="BODY-AND-INSTRUCTION", loaded_skill_names=["chart-annotation"]
     )
 
     with (
@@ -56,12 +62,12 @@ async def test_fresh_skill_returns_body_and_loaded_skills():
     assert out["discovered_skills"] == []
     assert out["loaded_skills"] == ["chart-annotation"]
 
-    # Body appended to the SAME user message (id preserved -> add_messages replaces).
+    # Body appended to the SAME user message (id preserved -> add_messages replaces),
+    # with a blank-line separator between the user text and the skill body.
     assert len(out["messages"]) == 1
     injected = out["messages"][0]
     assert injected.id == "u1"
-    assert "annotate the chart" in injected.content
-    assert injected.content.endswith("BODY-AND-INSTRUCTION")
+    assert injected.content == "annotate the chart\n\nBODY-AND-INSTRUCTION"
 
     # already_loaded came from compute_already_loaded(state channels).
     ca_args = cal.call_args.args
@@ -90,7 +96,7 @@ async def test_already_loaded_skips_loaded_skills_keeps_instruction():
         skill_contexts=[{"name": "chart-annotation", "instruction": "NVDA:1h"}]
     )
     result_obj = SkillPrefixResult(
-        content="\n\n[Instruction: NVDA:1h]", loaded_skill_names=[]
+        content="[Instruction: NVDA:1h]", loaded_skill_names=[]
     )
 
     with (
@@ -100,7 +106,7 @@ async def test_already_loaded_skips_loaded_skills_keeps_instruction():
         out = await mw.abefore_agent(state, MagicMock(), config=config)
 
     assert "loaded_skills" not in out
-    assert out["messages"][0].content.endswith("[Instruction: NVDA:1h]")
+    assert out["messages"][0].content == "annotate\n\n[Instruction: NVDA:1h]"
     assert out["messages"][0].id == "u1"
 
 
@@ -208,7 +214,7 @@ async def test_injected_body_survives_patch_tool_calls_rewrite():
     def _fake_build(skills, *, skill_dirs, mode, already_loaded, message_id):
         block = f"{loaded_skill_marker('chart-annotation', message_id)}\nBODY\n</loaded-skill>"
         return SkillPrefixResult(
-            content=f"\n\n{block}\n\n[Instruction: AAPL:1d]",
+            content=f"{block}\n\n[Instruction: AAPL:1d]",
             loaded_skill_names=["chart-annotation"],
         )
 
@@ -238,6 +244,50 @@ async def test_injected_body_survives_patch_tool_calls_rewrite():
     assert len(humans) == 1
     assert humans[0].id == "h1"
     assert '<loaded-skill name="chart-annotation" mid="h1">' in humans[0].content
+
+
+class TestAppendBodyToLastHuman:
+    """The append join itself — exercised without mocking build_skill_content, so a
+    missing blank-line separator (the old wire format) can't slip past again.
+    """
+
+    BODY = '<loaded-skill name="chart-annotation" mid="u1">\nBODY\n</loaded-skill>'
+
+    def test_str_content_gets_blank_line_separator(self):
+        out = _append_body_to_last_human(
+            [HumanMessage(content="annotate the chart", id="u1")], self.BODY
+        )
+        # A blank line separates the user's text from the injected body — the exact
+        # wire format the server's old inline injection produced ("\n\n" + body).
+        assert out.content == f"annotate the chart\n\n{self.BODY}"
+        assert out.id == "u1"
+
+    def test_empty_str_content_has_no_leading_separator(self):
+        # Nothing precedes the body, so no dangling blank line.
+        out = _append_body_to_last_human([HumanMessage(content="", id="u1")], self.BODY)
+        assert out.content == self.BODY
+
+    def test_list_content_appends_a_fresh_block(self):
+        # Multimodal content: the body rides as its own text block — inherently
+        # separated, so no "\n\n" is woven into the prior block.
+        image = {"type": "image_url", "image_url": {"url": "data:..."}}
+        text = {"type": "text", "text": "annotate the chart"}
+        out = _append_body_to_last_human(
+            [HumanMessage(content=[image, text], id="u1")], self.BODY
+        )
+        assert out.content == [image, text, {"type": "text", "text": self.BODY}]
+
+    def test_dict_message_str_content_gets_separator(self):
+        out = _append_body_to_last_human(
+            [{"role": "user", "content": "hello", "id": "u1"}], self.BODY
+        )
+        assert out["content"] == f"hello\n\n{self.BODY}"
+
+    def test_non_human_last_message_returns_none(self):
+        assert (
+            _append_body_to_last_human([AIMessage(content="assistant", id="a1")], self.BODY)
+            is None
+        )
 
 
 def test_runnable_callable_injects_config_into_abefore_agent():

--- a/tests/unit/middleware/skills/test_skill_injection_middleware.py
+++ b/tests/unit/middleware/skills/test_skill_injection_middleware.py
@@ -173,3 +173,18 @@ async def test_blank_skill_names_are_dropped():
     bsc.assert_not_called()
     cal.assert_not_called()
     assert out == {"discovered_skills": []}
+
+
+def test_runnable_callable_injects_config_into_abefore_agent():
+    """The whole feature hinges on LangGraph injecting per-request ``config`` into
+    ``abefore_agent`` (that's how skill_contexts reach the hook). RunnableCallable
+    only injects ``config`` when it can read the parameter's annotation — adding
+    ``from __future__ import annotations`` to the module would stringify it and
+    silently drop the injection, turning skill injection into a no-op in prod with
+    every direct-call unit test still green. This guards that regression.
+    """
+    from langgraph._internal._runnable import RunnableCallable
+
+    mw = SkillsMiddleware(mode="flash")
+    rc = RunnableCallable(None, mw.abefore_agent)
+    assert "config" in rc.func_accepts

--- a/tests/unit/middleware/skills/test_skill_injection_middleware.py
+++ b/tests/unit/middleware/skills/test_skill_injection_middleware.py
@@ -72,6 +72,8 @@ async def test_fresh_skill_returns_body_and_loaded_skills():
     assert bsc.call_args.kwargs["skill_dirs"] == ["/skills"]
     assert bsc.call_args.kwargs["mode"] == "flash"
     assert bsc.call_args.kwargs["already_loaded"] == set()
+    # The last human message's id is threaded through so the marker can bind to it.
+    assert bsc.call_args.kwargs["message_id"] == "u1"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/middleware/skills/test_skill_injection_middleware.py
+++ b/tests/unit/middleware/skills/test_skill_injection_middleware.py
@@ -15,7 +15,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage
 
-from src.ptc_agent.agent.middleware.skills.content import SkillPrefixResult
+from src.ptc_agent.agent.middleware.skills.content import (
+    SkillPrefixResult,
+    loaded_skill_marker,
+)
 from src.ptc_agent.agent.middleware.skills.middleware import SkillsMiddleware
 
 MW = "src.ptc_agent.agent.middleware.skills.middleware"
@@ -175,6 +178,66 @@ async def test_blank_skill_names_are_dropped():
     bsc.assert_not_called()
     cal.assert_not_called()
     assert out == {"discovered_skills": []}
+
+
+@pytest.mark.asyncio
+async def test_injected_body_survives_patch_tool_calls_rewrite():
+    """Cross-middleware ordering invariant: the injected body survives PatchToolCalls.
+
+    ``SkillsMiddleware.abefore_agent`` appends a skill body (+ ``mid``-bound marker) to
+    the last human message in place. deepagents' ``PatchToolCallsMiddleware.before_agent``
+    is the one other ``before_agent`` hook in both the PTC and Flash stacks; it runs
+    AFTER Skills and rewrites the whole ``messages`` list to patch dangling tool calls.
+    This pins that the rewrite preserves the augmented human message verbatim — same id,
+    body + marker intact — so injection is never dropped or mis-targeted. If a future
+    deepagents version (or a reordered stack) re-ids/truncates that message, this fails.
+    """
+    from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
+
+    mw = SkillsMiddleware(mode="flash")
+    hm = HumanMessage(content="annotate the chart", id="h1")
+    state = {"messages": [hm], "loaded_skills": []}
+    config = _config(
+        skill_contexts=[{"name": "chart-annotation", "instruction": "AAPL:1d"}],
+        skill_dirs=["/skills"],
+    )
+
+    # Exercise the real append path. The fake body carries the real mid-bound marker
+    # for whatever message_id Skills threads through (the last human's id), so this also
+    # proves _inject_requested_skills binds the marker to h1 — not a hardcoded constant.
+    def _fake_build(skills, *, skill_dirs, mode, already_loaded, message_id):
+        block = f"{loaded_skill_marker('chart-annotation', message_id)}\nBODY\n</loaded-skill>"
+        return SkillPrefixResult(
+            content=f"\n\n{block}\n\n[Instruction: AAPL:1d]",
+            loaded_skill_names=["chart-annotation"],
+        )
+
+    with patch(f"{MW}.build_skill_content", side_effect=_fake_build):
+        out = await mw.abefore_agent(state, MagicMock(), config=config)
+
+    augmented = out["messages"][0]
+    assert augmented.id == "h1"
+    assert '<loaded-skill name="chart-annotation" mid="h1">' in augmented.content
+
+    # PatchToolCalls runs next, with a DANGLING tool call present so its rewrite branch
+    # actually fires (it no-ops when every tool call is answered).
+    dangling = AIMessage(
+        content="",
+        id="a1",
+        tool_calls=[{"name": "do_thing", "args": {}, "id": "call_1"}],
+    )
+    patched = PatchToolCallsMiddleware().before_agent(
+        {"messages": [augmented, dangling]}, MagicMock()
+    )
+
+    # The rewrite fired (not a no-op) AND preserved the body-augmented human message.
+    assert patched is not None
+    msgs = patched["messages"]
+    assert any(getattr(m, "type", None) == "tool" for m in msgs)  # synthetic patch added
+    humans = [m for m in msgs if getattr(m, "type", None) == "human"]
+    assert len(humans) == 1
+    assert humans[0].id == "h1"
+    assert '<loaded-skill name="chart-annotation" mid="h1">' in humans[0].content
 
 
 def test_runnable_callable_injects_config_into_abefore_agent():

--- a/tests/unit/server/handlers/test_chat_common.py
+++ b/tests/unit/server/handlers/test_chat_common.py
@@ -21,6 +21,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import psycopg
 import pytest
 
+from src.server.models.additional_context import SkillContext
 
 COMMON = "src.server.handlers.chat._common"
 
@@ -993,95 +994,75 @@ class TestSetupSteeringTracking:
 
 
 # ---------------------------------------------------------------------------
-# inject_skills
+# prepare_skill_contexts
 # ---------------------------------------------------------------------------
 
 
-class TestInjectSkills:
+class TestPrepareSkillContexts:
     def test_no_skills_returns_empty(self):
-        from src.server.handlers.chat._common import inject_skills
+        from src.server.handlers.chat._common import prepare_skill_contexts
 
         request = MagicMock()
         request.additional_context = None
         request.hitl_response = None
         messages = [{"role": "user", "content": "hello"}]
-        config = MagicMock()
 
         with patch(f"{COMMON}.parse_skill_contexts", return_value=[]):
-            result = inject_skills(messages, request, config, mode="flash")
+            result = prepare_skill_contexts(messages, request, mode="flash")
 
         assert result == []
 
     def test_skill_from_additional_context(self):
-        from src.server.handlers.chat._common import inject_skills
+        from src.server.handlers.chat._common import prepare_skill_contexts
 
         request = MagicMock()
         request.additional_context = [MagicMock(type="skills")]
         request.hitl_response = None
         messages = [{"role": "user", "content": "hello"}]
-        config = MagicMock()
-        config.skills.local_skill_dirs_with_sandbox.return_value = [
-            ("/skills/dir", "/sandbox/dir")
-        ]
 
-        skill_result = MagicMock()
-        skill_result.content = "skill content"
-        skill_result.loaded_skill_names = ["research"]
+        ctx = SkillContext(type="skills", name="research", instruction="find news")
+        with patch(f"{COMMON}.parse_skill_contexts", return_value=[ctx]):
+            result = prepare_skill_contexts(messages, request, mode="flash")
 
-        with (
-            patch(f"{COMMON}.parse_skill_contexts", return_value=["skill_ctx"]),
-            patch(f"{COMMON}.build_skill_content", return_value=skill_result),
-        ):
-            result = inject_skills(messages, request, config, mode="flash")
+        # Returns plain dicts to thread through config; no body injected here.
+        assert result == [{"name": "research", "instruction": "find news"}]
+        assert messages[0]["content"] == "hello"
 
-        assert result == ["research"]
-        assert "skill content" in messages[0]["content"]
-
-    def test_slash_command_detection_fallback(self):
-        from src.server.handlers.chat._common import inject_skills
+    def test_slash_command_detection_fallback_strips_prefix(self):
+        from src.server.handlers.chat._common import prepare_skill_contexts
 
         request = MagicMock()
         request.additional_context = None
         request.hitl_response = None
         messages = [{"role": "user", "content": "/research market analysis"}]
-        config = MagicMock()
-        config.skills.local_skill_dirs_with_sandbox.return_value = []
 
-        detected_skill = MagicMock()
-        skill_result = MagicMock()
-        skill_result.content = "research skill loaded"
-        skill_result.loaded_skill_names = ["research"]
-
+        ctx = SkillContext(type="skills", name="research")
         with (
             patch(f"{COMMON}.parse_skill_contexts", return_value=[]),
             patch(
                 f"{COMMON}.detect_slash_commands",
-                return_value=("market analysis", [detected_skill]),
+                return_value=("market analysis", [ctx]),
             ),
-            patch(f"{COMMON}.build_skill_content", return_value=skill_result),
         ):
-            result = inject_skills(messages, request, config, mode="flash")
+            result = prepare_skill_contexts(messages, request, mode="flash")
 
-        assert result == ["research"]
-        # The message text should be cleaned (slash command stripped) then
-        # skill content appended
-        assert messages[0]["content"].startswith("market analysis")
-        assert "research skill loaded" in messages[0]["content"]
+        assert result == [{"name": "research", "instruction": None}]
+        # The /command prefix is stripped in place; no skill body appended.
+        assert messages[0]["content"] == "market analysis"
 
     def test_hitl_response_skips_slash_detection(self):
-        from src.server.handlers.chat._common import inject_skills
+        from src.server.handlers.chat._common import prepare_skill_contexts
 
         request = MagicMock()
         request.additional_context = None
         request.hitl_response = {"int-1": {}}
         messages = [{"role": "user", "content": "/research something"}]
-        config = MagicMock()
 
         with (
             patch(f"{COMMON}.parse_skill_contexts", return_value=[]),
             patch(f"{COMMON}.detect_slash_commands") as mock_detect,
         ):
-            result = inject_skills(messages, request, config, mode="flash")
+            result = prepare_skill_contexts(messages, request, mode="flash")
 
         mock_detect.assert_not_called()
         assert result == []

--- a/tests/unit/server/handlers/test_chat_common.py
+++ b/tests/unit/server/handlers/test_chat_common.py
@@ -775,6 +775,34 @@ class TestBuildGraphConfig:
         config = self._build(timezone_str="UTC")
         assert config["configurable"]["timezone"] == "UTC"
 
+    def test_skill_contexts_and_dirs_threaded_to_configurable(self):
+        """The server→middleware handoff: both skill_contexts and skill_dirs must
+        land in ``configurable`` so SkillsMiddleware can inject + locate bodies."""
+        config = self._build(
+            skill_contexts=[{"name": "chart-annotation", "instruction": "AAPL:1d"}],
+            skill_dirs=["/skills"],
+        )
+        assert config["configurable"]["skill_contexts"] == [
+            {"name": "chart-annotation", "instruction": "AAPL:1d"}
+        ]
+        assert config["configurable"]["skill_dirs"] == ["/skills"]
+
+    def test_skill_contexts_without_dirs_omits_dirs(self):
+        """skill_dirs is nested under the skill_contexts gate; contexts may be
+        present while dirs default (middleware falls back to project_root/skills)."""
+        config = self._build(
+            skill_contexts=[{"name": "research"}], skill_dirs=None
+        )
+        assert config["configurable"]["skill_contexts"] == [{"name": "research"}]
+        assert "skill_dirs" not in config["configurable"]
+
+    def test_skill_dirs_without_contexts_is_dropped(self):
+        """No skills requested → neither key is set, even if skill_dirs is passed
+        (the ``if skill_contexts`` gate guards the whole block)."""
+        config = self._build(skill_contexts=None, skill_dirs=["/skills"])
+        assert "skill_contexts" not in config["configurable"]
+        assert "skill_dirs" not in config["configurable"]
+
 
 # ---------------------------------------------------------------------------
 # wait_or_steer

--- a/tests/unit/server/handlers/test_chat_common.py
+++ b/tests/unit/server/handlers/test_chat_common.py
@@ -1095,6 +1095,61 @@ class TestPrepareSkillContexts:
         mock_detect.assert_not_called()
         assert result == []
 
+    def test_slash_detection_on_multimodal_list_content(self):
+        """A supported attachment rewrites content into a block list; the slash
+        command must still activate, be stripped in its own text block, and leave
+        the attachment blocks intact."""
+        from src.server.handlers.chat._common import prepare_skill_contexts
+
+        request = MagicMock()
+        request.additional_context = None
+        request.hitl_response = None
+        image_block = {"type": "image_url", "image_url": {"url": "data:image/png;x"}}
+        text_block = {"type": "text", "text": "/research market analysis"}
+        messages = [{"role": "user", "content": [image_block, text_block]}]
+
+        ctx = SkillContext(type="skills", name="research")
+        with (
+            patch(f"{COMMON}.parse_skill_contexts", return_value=[]),
+            patch(
+                f"{COMMON}.detect_slash_commands",
+                return_value=("market analysis", [ctx]),
+            ),
+        ):
+            result = prepare_skill_contexts(messages, request, mode="flash")
+
+        assert result == [{"name": "research", "instruction": None}]
+        # Prefix stripped in the text block; the image block survives untouched.
+        assert messages[0]["content"][0] is image_block
+        assert messages[0]["content"][1]["text"] == "market analysis"
+
+    def test_list_content_without_slash_block_skips_detection(self):
+        """List content whose text blocks don't lead with `/` activates nothing."""
+        from src.server.handlers.chat._common import prepare_skill_contexts
+
+        request = MagicMock()
+        request.additional_context = None
+        request.hitl_response = None
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "[Attached image: chart.png]"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;x"}},
+                    {"type": "text", "text": "what do you see"},
+                ],
+            }
+        ]
+
+        with (
+            patch(f"{COMMON}.parse_skill_contexts", return_value=[]),
+            patch(f"{COMMON}.detect_slash_commands") as mock_detect,
+        ):
+            result = prepare_skill_contexts(messages, request, mode="flash")
+
+        mock_detect.assert_not_called()
+        assert result == []
+
 
 # ---------------------------------------------------------------------------
 # _resolve_timezone

--- a/tests/unit/server/handlers/test_chat_package_imports.py
+++ b/tests/unit/server/handlers/test_chat_package_imports.py
@@ -74,7 +74,7 @@ class TestSubmoduleImports:
         assert hasattr(mod, "apply_fetch_override")
         assert hasattr(mod, "ensure_thread")
         assert hasattr(mod, "persist_or_skip_replay")
-        assert hasattr(mod, "inject_skills")
+        assert hasattr(mod, "prepare_skill_contexts")
         assert hasattr(mod, "build_graph_config")
         assert hasattr(mod, "wait_or_steer")
         assert hasattr(mod, "handle_workflow_error")

--- a/tests/unit/server/utils/test_skill_context.py
+++ b/tests/unit/server/utils/test_skill_context.py
@@ -1,0 +1,85 @@
+"""Tests for the server's skill request-parsing helpers.
+
+Body loading + inline injection moved into ``ptc_agent`` (SkillsMiddleware); this
+module now only resolves *which* skills a request activated:
+``parse_skill_contexts`` (from ``additional_context``) and ``detect_slash_commands``
+(leading ``/command`` fallback).
+"""
+
+from unittest.mock import patch
+
+from src.server.models.additional_context import SkillContext
+from src.server.utils.skill_context import (
+    detect_slash_commands,
+    parse_skill_contexts,
+)
+
+MOD = "src.server.utils.skill_context"
+
+
+# ---------------------------------------------------------------------------
+# parse_skill_contexts
+# ---------------------------------------------------------------------------
+
+
+def test_parse_none_and_empty_returns_empty():
+    assert parse_skill_contexts(None) == []
+    assert parse_skill_contexts([]) == []
+
+
+def test_parse_dict_skill_item():
+    result = parse_skill_contexts(
+        [{"type": "skills", "name": "chart-annotation", "instruction": "AAPL:1d"}]
+    )
+    assert len(result) == 1
+    assert result[0].name == "chart-annotation"
+    assert result[0].instruction == "AAPL:1d"
+
+
+def test_parse_passes_through_skillcontext_instances():
+    ctx = SkillContext(type="skills", name="research", instruction="news")
+    assert parse_skill_contexts([ctx]) == [ctx]
+
+
+def test_parse_filters_non_skill_items():
+    result = parse_skill_contexts(
+        [
+            {"type": "directive", "content": "be terse"},
+            {"type": "skills", "name": "research"},
+        ]
+    )
+    assert [s.name for s in result] == ["research"]
+
+
+# ---------------------------------------------------------------------------
+# detect_slash_commands
+# ---------------------------------------------------------------------------
+
+
+def test_detect_non_slash_text_is_unchanged():
+    text, detected = detect_slash_commands("hello world")
+    assert text == "hello world"
+    assert detected == []
+
+
+def test_detect_matched_command_strips_prefix():
+    with patch(f"{MOD}.get_command_to_skill_map", return_value={"research": "research"}):
+        text, detected = detect_slash_commands("/research market analysis")
+    assert text == "market analysis"
+    assert [s.name for s in detected] == ["research"]
+
+
+def test_detect_command_only_keeps_original_text():
+    """A bare ``/command`` with no body keeps the original text so the agent at
+    least knows what was asked."""
+    with patch(f"{MOD}.get_command_to_skill_map", return_value={"research": "research"}):
+        text, detected = detect_slash_commands("/research")
+    assert text == "/research"
+    assert [s.name for s in detected] == ["research"]
+
+
+def test_detect_unregistered_command_is_unchanged():
+    with patch(f"{MOD}.get_command_to_skill_map", return_value={"research": "research"}):
+        text, detected = detect_slash_commands("/unknown do thing")
+    assert text == "/unknown do thing"
+    assert detected == []


### PR DESCRIPTION
## Summary

A thread's SKILL.md body now injects **once** instead of every turn. Frontends like
MarketView re-send the active skill in `additional_context` on every turn; previously
the server re-decided dedup by calling `graph.aget_state(...)` per skill-turn — a full
checkpoint deserialization (all messages) just to read a small `loaded_skills` list,
which the executor then loads *again* when the run starts.

This moves the dedup + body injection into `SkillsMiddleware.abefore_agent`, where the
executor has already materialized `loaded_skills`, `messages`, and `_summarization_event`
in state for free. Net effect: **zero extra checkpoint reads per skill-turn**, the dedup
lives in the middleware that already owns `loaded_skills`, and the server handler shrinks
to pure request parsing. Fork/regenerate consistency becomes automatic (the hook sees the
resumed state, so no `checkpoint_id` threading).

## Overview

| Category               | Files |   +LOC | −LOC |
|------------------------|------:|-------:|-----:|
| Modified (prod)        |     7 |    499 |  201 |
| New (prod)             |     0 |      0 |    0 |
| Tests (excluded)       |     6 |    808 |   42 |
| **Net (excl. tests)**  |       | **+298** |    |

### `src/ptc_agent/agent/middleware/skills/` — the core (net +401)
- `content.py` (+248/−5) — hosts `build_skill_content` + `SkillPrefixResult` (moved here
  from the server so `ptc_agent` no longer imports `src.server`); adds pure
  `compute_already_loaded(loaded, messages, event)`, the single-source `loaded_skill_marker`,
  and `_message_id` / `_message_text` helpers.
- `middleware.py` (+176/−28) — `abefore_agent` now also injects skill bodies: dedup against
  what's live, append the fresh body to the last human message in place (id preserved → the
  reducer replaces, not appends), and return `loaded_skills` so tools are exposed the same turn.
- `__init__.py` (+11/−1) — re-exports.

### `src/server/handlers/chat/` — slim down (net +15)
- `_common.py` (+23/−22) — `build_graph_config` threads `skill_contexts` / `skill_dirs` into
  `configurable`; `prepare_skill_contexts` shrinks to parse + slash-detect (no state read).
- `flash_workflow.py` (+16/−5), `ptc_workflow.py` (+19/−16) — call the slimmed parser and
  drop the `input_state["loaded_skills"] = …` seeding (the middleware sets it now).

### `src/server/utils/` (net −118)
- `skill_context.py` (+6/−124) — removes `build_skill_content` / `SkillPrefixResult` (now in
  `ptc_agent`); keeps `parse_skill_contexts` + `detect_slash_commands`.

**What this introduces:** the skill-body dedup decision moves from a per-turn server-side
`aget_state` read into the middleware that already has the state, eliminating a redundant
full-checkpoint deserialization on every skill-bearing turn while preserving identical
inject-once behavior.

## How it works

1. Server parses `additional_context` → `skill_contexts` and puts it in
   `config["configurable"]` **only on normal turns** (not HITL/replay), so the middleware
   no-ops on resume exactly like the old `not request.hitl_response` guard.
2. `abefore_agent` reads `skill_contexts` from config, computes `already_loaded` from
   in-memory state (reusing `get_effective_messages` so the view can't drift from what the
   model sees), builds the content, and returns `{messages(+body), loaded_skills}` — merged
   via reducers and checkpointed, so the body lands in history once.
3. Returning `loaded_skills` before the first model call means `_filter_tools` exposes the
   skill's tools the same turn.

Compatible with the new DeltaChannel messages reducer (#283): both do id-preserving
replace-by-id, so appending the body to the last human message in place still replaces
rather than duplicates.

## Commits
- `4fc31e9c` perf(skills): inject a skill's SKILL.md body once via middleware
- `f452ab5f` test(skills): cover skill_contexts plumbing, tool block, multimodal scan
- `197a7637` fix(skills): bind loaded-skill marker to its message id
- `4461c3b3` test(skills): pin injected body surviving PatchToolCalls rewrite

## Test coverage
- `uv run ruff check src/` — clean.
- Targeted (`tests/unit/middleware/skills/ + test_chat_common.py + test_skill_context.py`) —
  **166 passed**. Full unit suite green.
- New tests cover: server→middleware `skill_contexts`/`skill_dirs` plumbing; the
  `RunnableCallable` config-injection invariant (a future `from __future__ import annotations`
  would silently no-op the feature — guarded); multimodal-list marker scan; the tool-descriptions
  block; the full `mid`-bound dedup matrix (fresh carries `mid`, foreign `mid` ignored, a SKILL.md
  documenting the format ignored, bare legacy marker ignored); and the cross-middleware ordering
  invariant (body survives `PatchToolCallsMiddleware`'s rewrite, same id + marker).

## E2E (real container: flash, OSS, live Redis + Postgres + LLM)
Drove a 2-turn flash conversation with `chart-annotation` re-sent each turn, then
materialized the DeltaChannel checkpoint via a throwaway `StateGraph(DeltaAgentState)`
on the same checkpointer:
- Turn 1 logged `fresh=['chart-annotation']`; the body landed on the human message and its
  marker carries `mid` **equal to that message's real framework id** (verified MATCH) — proves
  the marker binds to the runtime id and round-trips DeltaChannel storage intact.
- Re-send logged `fresh=[]`; the second human message carries only `[Instruction: …]`, no body.
- **Exactly 1** `<loaded-skill>` body block across the full 53-message history.
- Skill tools executed both turns (price lines / arrows / Fibonacci on AAPL + TSLA).

## Robustness (resolved in this PR)
- **Marker forge (review findings #1/#2).** A bare-substring marker scan could be fooled into
  *skipping* a real body — by a user typing the marker, or a SKILL.md documenting the
  `<loaded-skill>` format. Not a security issue (single-thread, self-inflicted, worst case is a
  recoverable missing body — tools gate on the user-unwritable `loaded_skills`), but a real edge.
  `197a7637` closes both by binding the marker to the framework-assigned message id (`mid="…"`)
  and only counting a marker as live when its `mid` equals the id of the message it sits in —
  content can't forge an id it doesn't control. No new persisted state.
- **Hook ordering.** `SkillsMiddleware.abefore_agent` is the only `before_agent` hook that
  *edits* the last human message. One other `before_agent` hook — deepagents'
  `PatchToolCallsMiddleware` — runs after Skills (both stacks) and rewrites the message list, but
  only inserts dangling-tool-call placeholders while preserving every existing message object
  (id + content), so it can't drop or mis-target the injected body. `4461c3b3` pins this with a
  test (body + `mid` survive the rewrite, same id), so a deepagents upgrade or stack reorder that
  re-ids/truncates the human turn fails the suite.

## Non-blocking follow-up
- **One-time re-inject on deploy:** in-flight threads holding an old bare-marker body (no `mid=`)
  re-inject once after this ships, then dedup normally. Harmless — perf optimization, not correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resolve skill contexts per turn and inject requested `SKILL.md` guidance/tools via middleware so it surfaces when needed.
  * Enhanced slash-command skill selection with reliable detection inside multimodal message content.
  * Flash/PTC workflows now pass skill contexts and directories through to skill-loading middleware; HITL/replay turns skip body injection.

* **Bug Fixes**
  * Prevent repeated skill state growth with order-preserving de-duplication.
  * More robust “already loaded” detection across message-history compaction, avoiding stale or unintended re-injection.

* **Tests**
  * Added extensive unit coverage for skill content generation, marker-based tracking, and middleware/request parsing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->