### PR TITLE
fix(docker): add docker sandbox rootless local setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,10 @@ DAYTONA_API_KEY=
 # Explicit values: "daytona" (hosted sandbox) or "docker" (local containers).
 SANDBOX_PROVIDER=
 
+# Docker socket exposed to the backend when SANDBOX_PROVIDER=docker.
+# If your Docker context is rootless, set this to /run/user/<uid>/docker.sock.
+DOCKER_HOST_SOCKET=/var/run/docker.sock
+
 # Financial Modeling Prep — high-quality financial data for tools and MCP servers
 # Free tier available at https://site.financialmodelingprep.com/
 # Without this key, enable Yahoo Finance MCP servers in agent_config.yaml for free data.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,9 +68,12 @@ services:
       - ./src:/app/src
       - ./server.py:/app/server.py
       - ./agent_config.yaml:/app/agent_config.yaml
+      # Required when SANDBOX_PROVIDER=docker and the backend auto-builds
+      # langalpha-sandbox:latest on first workspace creation.
+      - ./Dockerfile.sandbox:/app/Dockerfile.sandbox:ro
       # Docker socket — only needed when SANDBOX_PROVIDER=docker (DooD pattern).
       # Safe to remove if using only the Daytona provider.
-      - /var/run/docker.sock:/var/run/docker.sock
+      - ${DOCKER_HOST_SOCKET:-/var/run/docker.sock}:/var/run/docker.sock
       - ./config.yaml:/app/config.yaml
       - ./mcp_servers:/app/mcp_servers
       - ./skills:/app/skills

--- a/src/ptc_agent/core/sandbox/providers/docker.py
+++ b/src/ptc_agent/core/sandbox/providers/docker.py
@@ -877,7 +877,7 @@ class DockerProvider(SandboxProvider):
                 f"Build the image manually or place {dockerfile_name} in the repo root."
             )
 
-        build_context = os.path.dirname(dockerfile_path)
+        dockerfile_basename = os.path.basename(dockerfile_path)
         image_tag = self._config.image
 
         logger.info(
@@ -886,18 +886,17 @@ class DockerProvider(SandboxProvider):
             tag=image_tag,
         )
 
-        # Use aiodocker to build. aiodocker 0.26 does not accept the Docker SDK's
-        # ``path=``/``dockerfile=`` kwargs; it expects a tar stream plus
-        # ``path_dockerfile``.
+        # Use aiodocker to build. It expects a tar stream via ``fileobj`` and
+        # the Dockerfile path via ``path_dockerfile``.
         try:
             build_tar = io.BytesIO()
             with tarfile.open(fileobj=build_tar, mode="w") as tar:
-                tar.add(build_context, arcname=".")
+                tar.add(dockerfile_path, arcname=dockerfile_basename)
             build_tar.seek(0)
 
             async for log_line in client.images.build(
                 fileobj=build_tar,
-                path_dockerfile=os.path.basename(dockerfile_path),
+                path_dockerfile=dockerfile_basename,
                 tag=image_tag,
                 rm=True,
                 stream=True,

--- a/src/ptc_agent/core/sandbox/providers/docker.py
+++ b/src/ptc_agent/core/sandbox/providers/docker.py
@@ -886,14 +886,21 @@ class DockerProvider(SandboxProvider):
             tag=image_tag,
         )
 
-        # Use aiodocker to build
+        # Use aiodocker to build. aiodocker 0.26 does not accept the Docker SDK's
+        # ``path=``/``dockerfile=`` kwargs; it expects a tar stream plus
+        # ``path_dockerfile``.
         try:
-            # aiodocker build expects a tar context or path
+            build_tar = io.BytesIO()
+            with tarfile.open(fileobj=build_tar, mode="w") as tar:
+                tar.add(build_context, arcname=".")
+            build_tar.seek(0)
+
             async for log_line in client.images.build(
-                path=build_context,
-                dockerfile=os.path.basename(dockerfile_path),
+                fileobj=build_tar,
+                path_dockerfile=os.path.basename(dockerfile_path),
                 tag=image_tag,
                 rm=True,
+                stream=True,
             ):
                 if isinstance(log_line, dict) and "stream" in log_line:
                     line = log_line["stream"].strip()

--- a/src/ptc_agent/core/sandbox/providers/docker.py
+++ b/src/ptc_agent/core/sandbox/providers/docker.py
@@ -900,6 +900,7 @@ class DockerProvider(SandboxProvider):
                 tag=image_tag,
                 rm=True,
                 stream=True,
+                encoding="identity",
             ):
                 if isinstance(log_line, dict) and "stream" in log_line:
                     line = log_line["stream"].strip()

--- a/tests/unit/core/sandbox/test_docker_provider.py
+++ b/tests/unit/core/sandbox/test_docker_provider.py
@@ -538,6 +538,7 @@ class TestDockerProvider:
         """aiodocker build expects fileobj/path_dockerfile, not Docker SDK path kwargs."""
         monkeypatch.chdir(tmp_path)
         (tmp_path / "Dockerfile.sandbox").write_text("FROM scratch\n")
+        (tmp_path / "unrelated.txt").write_text("not part of the build context\n")
         mock_client.images.inspect = AsyncMock(side_effect=Exception("missing image"))
         build_kwargs = {}
 
@@ -550,6 +551,8 @@ class TestDockerProvider:
         await provider._ensure_image(mock_client)
 
         assert "fileobj" in build_kwargs
+        with tarfile.open(fileobj=build_kwargs["fileobj"], mode="r") as tar:
+            assert tar.getnames() == ["Dockerfile.sandbox"]
         assert build_kwargs["path_dockerfile"] == "Dockerfile.sandbox"
         assert build_kwargs["tag"] == "test-sandbox:latest"
         assert build_kwargs["stream"] is True

--- a/tests/unit/core/sandbox/test_docker_provider.py
+++ b/tests/unit/core/sandbox/test_docker_provider.py
@@ -532,9 +532,34 @@ class TestDockerProvider:
         mock_client.containers.create.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_ensure_image_builds_with_aiodocker_tar_stream(
+        self, provider, mock_client, tmp_path, monkeypatch
+    ):
+        """aiodocker build expects fileobj/path_dockerfile, not Docker SDK path kwargs."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "Dockerfile.sandbox").write_text("FROM scratch\n")
+        mock_client.images.inspect = AsyncMock(side_effect=Exception("missing image"))
+        build_kwargs = {}
+
+        async def build_iter(**kwargs):
+            build_kwargs.update(kwargs)
+            yield {"stream": "ok"}
+
+        mock_client.images.build = build_iter
+
+        await provider._ensure_image(mock_client)
+
+        assert "fileobj" in build_kwargs
+        assert build_kwargs["path_dockerfile"] == "Dockerfile.sandbox"
+        assert build_kwargs["tag"] == "test-sandbox:latest"
+        assert build_kwargs["stream"] is True
+        assert "path" not in build_kwargs
+        assert "dockerfile" not in build_kwargs
+
+    @pytest.mark.asyncio
     async def test_create_starts_container(self, provider, mock_client):
         """create() should call container.start() after creation."""
-        runtime = await provider.create()
+        await provider.create()
         mock_container = mock_client.containers.create.return_value
         mock_container.start.assert_called_once()
 
@@ -895,7 +920,7 @@ class TestDockerRuntimePreviewUrl:
         DockerRuntime._server_side_host = None
         mock_loop = AsyncMock()
         mock_loop.getaddrinfo = AsyncMock(side_effect=OSError)
-        with patch("asyncio.get_running_loop", return_value=mock_loop) as mock_get_loop:
+        with patch("asyncio.get_running_loop", return_value=mock_loop):
             await DockerRuntime._resolve_server_side_host()
             await DockerRuntime._resolve_server_side_host()
             assert mock_loop.getaddrinfo.call_count == 1

--- a/tests/unit/core/sandbox/test_docker_provider.py
+++ b/tests/unit/core/sandbox/test_docker_provider.py
@@ -556,6 +556,7 @@ class TestDockerProvider:
         assert build_kwargs["path_dockerfile"] == "Dockerfile.sandbox"
         assert build_kwargs["tag"] == "test-sandbox:latest"
         assert build_kwargs["stream"] is True
+        assert build_kwargs["encoding"] == "identity"
         assert "path" not in build_kwargs
         assert "dockerfile" not in build_kwargs
 


### PR DESCRIPTION
## Summary

This isolates the local Docker sandbox fixes needed for rootless Docker environments.

- expose `DOCKER_HOST_SOCKET` in `.env.example` so rootless Docker users can mount `/run/user/<uid>/docker.sock` into the backend
- mount `Dockerfile.sandbox` into the backend container so the Docker provider can auto-build `langalpha-sandbox:latest`
- build missing sandbox images through `aiodocker` with a tar stream (`fileobj` + `path_dockerfile`) instead of Docker SDK-style `path` / `dockerfile` kwargs
- add unit coverage for the `aiodocker` image build call shape

## Why

When `SANDBOX_PROVIDER=docker` runs inside the compose backend, sandbox creation can fail before a container is created if the backend cannot see the correct Docker socket or cannot find `Dockerfile.sandbox` at `/app/Dockerfile.sandbox`. With rootless Docker, the host socket commonly lives under `/run/user/<uid>/docker.sock`, so the compose mount needs to be configurable.

The image auto-build path also needs to match `aiodocker 0.26`, which expects a tar stream and `path_dockerfile`; passing Docker SDK kwargs fails during sandbox image creation.

## Validation

- `uv run --extra dev ruff check src/ptc_agent/core/sandbox/providers/docker.py tests/unit/core/sandbox/test_docker_provider.py`
- `uv run pytest tests/unit/core/sandbox/test_docker_provider.py -q` (`111 passed`)
- `docker compose config -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `DOCKER_HOST_SOCKET` configuration option (including rootless Docker guidance) and updated the development container to use it for the Docker host socket.
* **Bug Fixes**
  * Improved Docker image auto-build behavior by correctly building from an in-memory Dockerfile archive, improving reliability when the target image is missing.
* **Tests**
  * Expanded unit test coverage for the Docker image build fallback path and refined related assertions for container startup and host resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->