### PR TITLE
feat(provenance): capture bash-run MCP calls + store full per-access result bodies

### DIFF
--- a/migrations/versions/015_add_provenance_result_bodies.py
+++ b/migrations/versions/015_add_provenance_result_bodies.py
@@ -1,0 +1,64 @@
+"""Add provenance_result_bodies: a global content-addressed store of raw result bodies.
+
+The 500-char ``result_snippet`` renders the Sources panel but is too truncated
+to verify a response against — the figures a verifier must check (revenue, EPS)
+live in the full result body (e.g. a 126 KB 10-Q), not its metadata head. This
+table stores the raw per-access result body keyed by ``result_sha256`` so a
+post-hoc verifier can read the exact bytes the agent reasoned over. The store is
+global: a static 10-Q fetched by many users across months is stored once. Small
+bodies live inline in ``body_inline``; bodies over the cap keep a head inline and
+spill the full body to object storage (``object_key``). ``byte_len`` is the TRUE
+full length, so ``truncated = byte_len > length(body_inline)``.
+
+No FK from ``provenance_records`` — bodies are shared across rows and GC'd
+independently; ``result_sha256`` is the logical link. Bodies are immutable, so
+writes are ``ON CONFLICT DO NOTHING`` (a dedup hit is a pure no-op). The GC
+mark-sweep deletes rows that no provenance record references and that are older
+than a grace window keyed on ``created_at`` (a body written mid-turn is younger
+than the grace, so it is never reaped before its provenance row commits — no
+per-access ``last_seen_at`` bump is needed). ``idx_provenance_records_sha`` serves
+the NOT EXISTS orphan check + verifier joins; ``idx_provenance_result_bodies_created_at``
+lets the sweep seek old rows without scanning the whole table.
+
+Revision ID: 015
+Revises: 014
+"""
+
+from alembic import op
+
+
+revision = "015"
+down_revision = "014"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS provenance_result_bodies (
+            result_sha256 TEXT PRIMARY KEY,
+            body_inline TEXT NOT NULL,
+            object_key TEXT,
+            byte_len BIGINT NOT NULL,
+            content_type TEXT,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+    """)
+
+    # Serves the GC mark-sweep NOT EXISTS against provenance_records + verifier joins.
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS idx_provenance_records_sha
+        ON provenance_records(result_sha256)
+    """)
+
+    # Lets the GC sweep seek bodies past the created_at grace window cheaply.
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS idx_provenance_result_bodies_created_at
+        ON provenance_result_bodies(created_at)
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_provenance_result_bodies_created_at")
+    op.execute("DROP INDEX IF EXISTS idx_provenance_records_sha")
+    op.execute("DROP TABLE IF EXISTS provenance_result_bodies")

--- a/src/ptc_agent/agent/middleware/provenance/middleware.py
+++ b/src/ptc_agent/agent/middleware/provenance/middleware.py
@@ -115,6 +115,15 @@ _MAX_TRACE_ENTRIES = 200
 # event unclamped (the DB writer already coerces a bad value to NULL).
 _TIMESTAMP_MAX_CHARS = 64
 
+# Sanity ceiling for the agent-claimed true result size (the one trace field that
+# otherwise rode through to the SSE event and the BIGINT column unvalidated). It's
+# the TRUE byte length of an MCP result, so it can legitimately exceed the 64 KiB
+# body cap (a truncated body); this only rejects a non-numeric, negative, or absurd
+# value a poisoned trace could forge. Generous — no honest single result approaches
+# it (real maxima are low single-digit MB), but it keeps a fabricated exabyte size
+# out of the record/event.
+_RESULT_SIZE_MAX_BYTES = 256 * 1024 * 1024
+
 # Max concurrent in-flight background body-store writes per middleware instance.
 # A backpressure valve: once this many flushes are outstanding, awrap_tool_call
 # waits for one to finish before scheduling the next, so a burst of source-bearing
@@ -213,6 +222,23 @@ def _clamp_body_bytes(value: Any, limit: int) -> str | None:
     if len(encoded) <= limit:
         return value
     return encoded[:limit].decode("utf-8", errors="ignore")
+
+
+def _coerce_result_size(value: Any) -> int | None:
+    """Trust the agent-authored ``result_size`` only as a bounded non-negative int.
+
+    Every other trace field is clamped on the way in; ``result_size`` rode through
+    raw onto the SSE event and the BIGINT column. On a verified body
+    ``_verify_source_sha`` overwrites it with the real length, so this guards the
+    unverified path (a truncated body, or a forged trace): a non-numeric, negative,
+    or absurd size becomes None rather than being emitted/persisted. ``bool`` is
+    excluded since it is an ``int`` subclass.
+    """
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    if value < 0 or value > _RESULT_SIZE_MAX_BYTES:
+        return None
+    return value
 
 
 def _is_error_result(result: Any) -> bool:
@@ -778,7 +804,7 @@ class ProvenanceMiddleware(AgentMiddleware):
                 args_fingerprint=hash_args(entry.get("args")),
                 args=redact_args(entry.get("args")),
                 result_sha256=_truncate(entry.get("result_sha256"), _SHA_MAX_CHARS),
-                result_size=entry.get("result_size"),
+                result_size=_coerce_result_size(entry.get("result_size")),
                 result_snippet=_truncate(
                     entry.get("result_snippet"), SNIPPET_MAX_CHARS
                 ),

--- a/src/ptc_agent/agent/middleware/provenance/middleware.py
+++ b/src/ptc_agent/agent/middleware/provenance/middleware.py
@@ -14,6 +14,7 @@ from the LangGraph namespace.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import uuid
 from collections.abc import Awaitable, Callable, Iterable, Iterator
@@ -30,6 +31,10 @@ from ptc_agent.agent.provenance import (
     fingerprint_result,
     hash_args,
     redact_args,
+)
+from ptc_agent.agent.provenance.types import (
+    RESULT_BODY_MAX_BYTES,
+    _canonicalize,
 )
 
 logger = logging.getLogger(__name__)
@@ -113,6 +118,16 @@ _MAX_TRACE_ENTRIES = 200
 _ERROR_CONTENT_PREFIXES = ("[error]", "error:", "failed to ", "exception:", "exception ")
 
 
+def _canonical_body(value: Any) -> str:
+    """Full canonical string of a fingerprinted value — the raw per-access body.
+
+    Must equal the exact string ``fingerprint_result`` hashes for ``value`` so
+    the stored body is hash-consistent with ``result_sha256`` (it is the full
+    body, NOT the snippet-truncated form).
+    """
+    return _canonicalize(value)
+
+
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -158,8 +173,16 @@ def _is_agent_infra_path(path: str) -> bool:
     )
 
 
+# Tools whose artifact carries an in-sandbox ``mcp_trace``. All run agent code
+# in the sandbox: ExecuteCode directly, Bash when it runs a script importing the
+# MCP wrappers, and BashOutput which surfaces a backgrounded script's trace when
+# the command finishes. They share the trace extractor, the error-result
+# exemption, and the mcp_trace strip.
+_MCP_TRACE_TOOLS = ("ExecuteCode", "Bash", "BashOutput")
+
+
 def _strip_mcp_trace(result: Any) -> None:
-    """Drop the provenance-only mcp_trace key from an ExecuteCode artifact.
+    """Drop the provenance-only mcp_trace key from an ExecuteCode/Bash artifact.
 
     Mutates the ToolMessage artifact in place so the raw in-sandbox trace never
     propagates outward onto tool_call_result or into persisted sse_events.
@@ -172,6 +195,21 @@ def _strip_mcp_trace(result: Any) -> None:
 def _truncate(value: Any, limit: int) -> Any:
     """Clamp a string field to ``limit`` chars; pass non-strings through."""
     return value[:limit] if isinstance(value, str) else value
+
+
+def _clamp_body_bytes(value: Any, limit: int) -> str | None:
+    """Byte-clamp an untrusted trace body; pass None / non-strings to None.
+
+    Re-clamps the agent-authored ``result_body`` host-side (the sandbox already
+    byte-caps it) on a byte boundary with ``errors="ignore"`` so a multibyte
+    split is dropped, mirroring the sandbox's decode.
+    """
+    if not isinstance(value, str):
+        return None
+    encoded = value.encode("utf-8")
+    if len(encoded) <= limit:
+        return value
+    return encoded[:limit].decode("utf-8", errors="ignore")
 
 
 def _is_error_result(result: Any) -> bool:
@@ -226,6 +264,12 @@ class ProvenanceMiddleware(AgentMiddleware):
             # consumed) and Grep (content matched) are.
             "Grep": self._extract_file_read,
             "ExecuteCode": self._extract_execute_code,
+            # Bash shares the trace extractor: a script it runs (e.g. `python
+            # analysis.py`) writes the same mcp_trace, surfaced on the artifact.
+            "Bash": self._extract_execute_code,
+            # BashOutput surfaces a backgrounded script's mcp_trace on the status
+            # read that observes completion — same artifact contract as Bash.
+            "BashOutput": self._extract_execute_code,
             **dict.fromkeys(_MARKET_DATA_TOOLS, self._extract_market_data),
         }
 
@@ -244,10 +288,11 @@ class ProvenanceMiddleware(AgentMiddleware):
             if extractor is None:
                 return result
 
-            # Don't attest a source the tool never actually returned. ExecuteCode
-            # is exempt: its code may "error" while individual in-sandbox MCP
-            # calls succeeded, and those trace entries are guarded per-entry.
-            if tool_name != "ExecuteCode" and _is_error_result(result):
+            # Don't attest a source the tool never actually returned. The
+            # MCP-trace tools (ExecuteCode/Bash) are exempt: the code/command may
+            # "error" while individual in-sandbox MCP calls succeeded, and those
+            # trace entries are guarded per-entry.
+            if tool_name not in _MCP_TRACE_TOOLS and _is_error_result(result):
                 return result
 
             try:
@@ -259,7 +304,7 @@ class ProvenanceMiddleware(AgentMiddleware):
                 # lands in persisted sse_events. In a finally so it runs even if
                 # the extractor raises — the raw-args-never-persisted property must
                 # not depend on extraction succeeding.
-                if tool_name == "ExecuteCode":
+                if tool_name in _MCP_TRACE_TOOLS:
                     _strip_mcp_trace(result)
 
             if not sources:
@@ -269,7 +314,9 @@ class ProvenanceMiddleware(AgentMiddleware):
             if writer is None:
                 return result
 
+            body_batch: list[tuple] = []
             for source in sources:
+                self._verify_source_sha(source)
                 source.result_snippet = self._redact_snippet(source.result_snippet)
                 try:
                     writer(build_provenance_event(source))
@@ -279,6 +326,19 @@ class ProvenanceMiddleware(AgentMiddleware):
                         tool_name,
                         exc_info=True,
                     )
+                item = self._body_item(source)
+                if item is not None:
+                    body_batch.append(item)
+            # One batched write per TOOL CALL, after this call's emits (best-effort,
+            # never on the SSE event): collapses this call's per-source fan-out —
+            # web_search's N URLs, the market fan-out's duplicate shas,
+            # execute_code's N mcp_trace entries — into a single chunked upsert, so
+            # a slow or failed body write can't delay or break the provenance
+            # events. Per call, not per turn: awrap_tool_call wraps one tool call,
+            # so a turn with many source-bearing calls does one flush each. A
+            # turn-level sink would batch further but needs cross-call buffering in
+            # shared middleware state (concurrency-sensitive) — deferred.
+            await self._flush_bodies(body_batch)
         except Exception:
             # WARNING, not DEBUG: a broken extractor silently degrades the
             # feature to "no provenance"; surface it so it's observable.
@@ -298,6 +358,99 @@ class ProvenanceMiddleware(AgentMiddleware):
         except Exception:
             logger.debug("[PROVENANCE] snippet redaction failed; dropping snippet")
             return None
+
+    def _redact_body(self, body: str | None) -> str | None:
+        """Scrub secrets from a FULL body — pure redaction, NO truncation.
+
+        Uses the same deterministic ``self._redactor`` as ``_redact_snippet``
+        (which only redacts; the snippet is truncated upstream at fingerprint
+        time), so the body is redacted over its full length while staying
+        deterministic for the shared content-addressed store's dedup. Returns
+        None if redaction itself fails (don't store an unredacted body).
+        """
+        if body is None:
+            return None
+        if self._redactor is None:
+            return body
+        try:
+            return self._redactor(body)
+        except Exception:
+            logger.debug("[PROVENANCE] body redaction failed; dropping body")
+            return None
+
+    def _verify_source_sha(self, source: ProvenanceSource) -> None:
+        """Drop an agent-authored content-address the captured body doesn't hash to.
+
+        For ``mcp_tool`` sources both ``result_sha256`` and ``result_body`` come from
+        the in-sandbox trace, which the agent's own ``execute_code`` can forge (it
+        shares ``MCP_TRACE_FILE``). The body store is GLOBAL + content-addressed, so a
+        trusted sha is the only thing standing between one tenant and another's body:
+        a forged ``(sha, body)`` pair would either poison the sha for every later
+        fetch of the real content, or — paired with a fabricated record — read a body
+        by an attacker-chosen address (IDOR-by-content-address).
+
+        We trust the agent's sha only if the bytes we hold reproduce it. On a miss we
+        null BOTH the sha and the body, so neither the body write nor the provenance
+        record (built from this source's sha) trusts an address we can't verify. A
+        self-consistent forgery still passes, but it can only claim its own hash —
+        colliding with real content would require breaking SHA-256. Host-computed
+        shas (web/sec/market) are produced by trusted code and left untouched.
+
+        A legitimately truncated MCP body (>64 KiB) hashes to the head, not the full
+        result, so it fails here and loses its body — honest, since we never hold the
+        full bytes to verify or serve anyway.
+        """
+        if source.source_type != "mcp_tool":
+            return
+        body, sha = source.result_body, source.result_sha256
+        if body and sha and hashlib.sha256(body.encode("utf-8")).hexdigest() == sha:
+            # The head we hold IS the full verified body; size it honestly.
+            source.result_size = len(body.encode("utf-8"))
+            return
+        source.result_sha256 = None
+        source.result_body = None
+
+    def _body_item(self, source: ProvenanceSource) -> tuple | None:
+        """Build a ``(sha, redacted_body, byte_len, content_type)`` store tuple.
+
+        Returns None unless the source carries both a body and the
+        ``result_sha256`` it hashes to, or if redaction itself fails (we never
+        store an unredacted body). Pure — no DB; the batch is flushed once per turn.
+        """
+        if not source.result_body or not source.result_sha256:
+            return None
+        redacted = self._redact_body(source.result_body)
+        if redacted is None:
+            return None
+        size = source.result_size
+        if not isinstance(size, int) or size < 0:
+            size = len(redacted.encode("utf-8"))
+        return (
+            source.result_sha256,
+            redacted,
+            size,
+            "text/plain; charset=utf-8",
+        )
+
+    async def _flush_bodies(self, items: list[tuple]) -> None:
+        """Batch-write a turn's redacted bodies to the store (best-effort).
+
+        Never raises (mirrors ``WorkspaceContextMiddleware._sync_front_matter_to_db``):
+        a lost body must not break the turn. ``store_result_bodies`` dedupes by sha
+        and upserts in one connection.
+        """
+        if not items:
+            return
+        try:
+            from src.server.database.provenance_bodies import store_result_bodies
+
+            await store_result_bodies(items)
+        except Exception as e:
+            logger.warning(
+                "[PROVENANCE] store_result_bodies failed (%d items): %s",
+                len(items),
+                e,
+            )
 
     # ----- per-tool extractors ------------------------------------------
 
@@ -329,6 +482,8 @@ class ProvenanceMiddleware(AgentMiddleware):
                 result_sha256=sha256,
                 result_size=size,
                 result_snippet=snippet,
+                # Body = the same per-item value that produced result_sha256.
+                result_body=_canonical_body(item),
             )
 
     def _extract_web_fetch(
@@ -350,6 +505,7 @@ class ProvenanceMiddleware(AgentMiddleware):
             result_sha256=sha256,
             result_size=size,
             result_snippet=snippet,
+            result_body=_canonical_body(content),
         )
 
     def _extract_sec_filing(
@@ -384,6 +540,7 @@ class ProvenanceMiddleware(AgentMiddleware):
                     result_sha256=sha256,
                     result_size=size,
                     result_snippet=snippet,
+                    result_body=_canonical_body(filing),
                 )
             return
 
@@ -403,6 +560,7 @@ class ProvenanceMiddleware(AgentMiddleware):
             result_sha256=sha256,
             result_size=size,
             result_snippet=snippet,
+            result_body=_canonical_body(artifact),
         )
 
     def _extract_market_data(
@@ -445,6 +603,7 @@ class ProvenanceMiddleware(AgentMiddleware):
             artifact if artifact is not None else getattr(result, "content", result)
         )
         sha256, size, snippet = fingerprint_result(fingerprint_target)
+        body = _canonical_body(fingerprint_target)
         for identifier in identifiers:
             yield ProvenanceSource(
                 record_id=_new_id(),
@@ -458,6 +617,7 @@ class ProvenanceMiddleware(AgentMiddleware):
                 result_sha256=sha256,
                 result_size=size,
                 result_snippet=snippet,
+                result_body=body,
             )
 
     def _extract_file_read(
@@ -494,9 +654,11 @@ class ProvenanceMiddleware(AgentMiddleware):
     ) -> Iterator[ProvenanceSource]:
         """One mcp_tool source per entry in the result artifact's ``mcp_trace``.
 
-        Contract (Phase B2): artifact is a dict with key ``mcp_trace``, a list
-        of ``{server, tool, args, result_sha256, result_size, result_snippet,
-        timestamp}``. Yields nothing when the artifact/trace is absent.
+        Shared by ExecuteCode and Bash — both surface an ``mcp_trace`` artifact
+        for the MCP calls their in-sandbox code made. Contract (Phase B2):
+        artifact is a dict with key ``mcp_trace``, a list of ``{server, tool,
+        args, result_sha256, result_size, result_snippet, timestamp}``. Yields
+        nothing when the artifact/trace is absent.
         """
         artifact = getattr(result, "artifact", None)
         trace = artifact.get("mcp_trace") if isinstance(artifact, dict) else []
@@ -530,5 +692,12 @@ class ProvenanceMiddleware(AgentMiddleware):
                 result_size=entry.get("result_size"),
                 result_snippet=_truncate(
                     entry.get("result_snippet"), SNIPPET_MAX_CHARS
+                ),
+                # The per-call body the sandbox captured for THIS MCP call (the
+                # root fix: NOT the aggregate ExecuteCode stdout). Re-clamped
+                # host-side as the trace is agent-authored. May be absent once
+                # the sandbox's per-execution body budget is exhausted.
+                result_body=_clamp_body_bytes(
+                    entry.get("result_body"), RESULT_BODY_MAX_BYTES
                 ),
             )

--- a/src/ptc_agent/agent/middleware/provenance/middleware.py
+++ b/src/ptc_agent/agent/middleware/provenance/middleware.py
@@ -416,19 +416,23 @@ class ProvenanceMiddleware(AgentMiddleware):
         Returns None unless the source carries both a body and the
         ``result_sha256`` it hashes to, or if redaction itself fails (we never
         store an unredacted body). Pure — no DB; the batch is flushed once per turn.
+
+        ``byte_len`` is the length of the body we actually store (post-redaction),
+        NOT the raw pre-redaction ``result_size``. The read side derives truncation
+        as ``byte_len > len(inline)``, so a body that redaction shrank below the
+        inline cap is stored whole and reads back complete — the flag tracks what we
+        hold, not the original size (which the provenance record keeps as
+        ``result_size``).
         """
         if not source.result_body or not source.result_sha256:
             return None
         redacted = self._redact_body(source.result_body)
         if redacted is None:
             return None
-        size = source.result_size
-        if not isinstance(size, int) or size < 0:
-            size = len(redacted.encode("utf-8"))
         return (
             source.result_sha256,
             redacted,
-            size,
+            len(redacted.encode("utf-8")),
             "text/plain; charset=utf-8",
         )
 

--- a/src/ptc_agent/agent/middleware/provenance/middleware.py
+++ b/src/ptc_agent/agent/middleware/provenance/middleware.py
@@ -108,6 +108,11 @@ _MARKET_DATA_TOOLS = (
 _SHA_MAX_CHARS = 128
 _IDENT_PART_MAX_CHARS = 256
 _MAX_TRACE_ENTRIES = 200
+# Cap on the agent-controlled trace timestamp. A well-formed ISO-8601 value is
+# ~25-35 chars; anything longer (or non-string) is a poisoned/buggy trace, so it
+# falls back to now(). Bounds the one trace field that otherwise rode the SSE
+# event unclamped (the DB writer already coerces a bad value to NULL).
+_TIMESTAMP_MAX_CHARS = 64
 
 # A tool result whose content begins with one of these is treated as failed, so
 # we don't record a "source accessed" for data the tool never actually returned.
@@ -681,11 +686,19 @@ class ProvenanceMiddleware(AgentMiddleware):
             # poisoned trace can't bloat the identifier/snippet/sha columns.
             server = str(server)[:_IDENT_PART_MAX_CHARS]
             tool = str(tool)[:_IDENT_PART_MAX_CHARS]
+            # Clamp the agent-controlled timestamp like the other trace fields:
+            # a non-string or oversized value would otherwise ride the SSE event.
+            raw_ts = entry.get("timestamp")
+            timestamp = (
+                raw_ts[:_TIMESTAMP_MAX_CHARS]
+                if isinstance(raw_ts, str) and raw_ts
+                else _now_iso()
+            )
             yield ProvenanceSource(
                 record_id=_new_id(),
                 source_type="mcp_tool",
                 identifier=f"{server}:{tool}",
-                timestamp=entry.get("timestamp") or _now_iso(),
+                timestamp=timestamp,
                 provider=f"mcp:{server}",
                 tool_call_id=tool_call_id,
                 # Keep the readable redacted args alongside the legacy hash; the

--- a/src/ptc_agent/agent/middleware/provenance/middleware.py
+++ b/src/ptc_agent/agent/middleware/provenance/middleware.py
@@ -14,6 +14,7 @@ from the LangGraph namespace.
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import logging
 import uuid
@@ -29,12 +30,12 @@ from ptc_agent.agent.provenance import (
     ProvenanceSource,
     build_provenance_event,
     fingerprint_result,
+    fingerprint_result_with_body,
     hash_args,
     redact_args,
 )
 from ptc_agent.agent.provenance.types import (
     RESULT_BODY_MAX_BYTES,
-    _canonicalize,
 )
 
 logger = logging.getLogger(__name__)
@@ -114,6 +115,13 @@ _MAX_TRACE_ENTRIES = 200
 # event unclamped (the DB writer already coerces a bad value to NULL).
 _TIMESTAMP_MAX_CHARS = 64
 
+# Max concurrent in-flight background body-store writes per middleware instance.
+# A backpressure valve: once this many flushes are outstanding, awrap_tool_call
+# waits for one to finish before scheduling the next, so a burst of source-bearing
+# tool calls can't spawn unbounded tasks or exhaust the DB pool. Keep it below the
+# pool's comfortable concurrency.
+_BODY_FLUSH_TASK_LIMIT = 16
+
 # A tool result whose content begins with one of these is treated as failed, so
 # we don't record a "source accessed" for data the tool never actually returned.
 # Each prefix is qualified (not a bare verb) so legit content isn't misread as an
@@ -121,16 +129,6 @@ _TIMESTAMP_MAX_CHARS = 64
 # and "failed to " not "failed" ("Failed Q4 earnings beat ..."). The real string
 # errors that reach here are web_fetch's "Failed to fetch/process ...".
 _ERROR_CONTENT_PREFIXES = ("[error]", "error:", "failed to ", "exception:", "exception ")
-
-
-def _canonical_body(value: Any) -> str:
-    """Full canonical string of a fingerprinted value — the raw per-access body.
-
-    Must equal the exact string ``fingerprint_result`` hashes for ``value`` so
-    the stored body is hash-consistent with ``result_sha256`` (it is the full
-    body, NOT the snippet-truncated form).
-    """
-    return _canonicalize(value)
 
 
 def _now_iso() -> str:
@@ -256,6 +254,10 @@ class ProvenanceMiddleware(AgentMiddleware):
     ) -> None:
         super().__init__()
         self._redactor = redactor
+        # Background body-store writes in flight (strong refs so they aren't GC'd
+        # mid-flush). Drained best-effort at agent end; see _schedule_body_flush.
+        self._body_flush_tasks: set[asyncio.Task[None]] = set()
+        self._max_body_flush_tasks = _BODY_FLUSH_TASK_LIMIT
         # tool name -> extractor(request, result) -> Iterable[ProvenanceSource]
         self._extractors: dict[
             str, Callable[[Any, Any], Iterable[ProvenanceSource]]
@@ -337,13 +339,11 @@ class ProvenanceMiddleware(AgentMiddleware):
             # One batched write per TOOL CALL, after this call's emits (best-effort,
             # never on the SSE event): collapses this call's per-source fan-out —
             # web_search's N URLs, the market fan-out's duplicate shas,
-            # execute_code's N mcp_trace entries — into a single chunked upsert, so
-            # a slow or failed body write can't delay or break the provenance
-            # events. Per call, not per turn: awrap_tool_call wraps one tool call,
-            # so a turn with many source-bearing calls does one flush each. A
-            # turn-level sink would batch further but needs cross-call buffering in
-            # shared middleware state (concurrency-sensitive) — deferred.
-            await self._flush_bodies(body_batch)
+            # execute_code's N mcp_trace entries — into a single chunked upsert.
+            # Scheduled OFF the tool-call critical path (background task, drained at
+            # agent end) so a DB/object-store write never delays the tool result or
+            # the next LLM step; the provenance events above already went out.
+            await self._schedule_body_flush(body_batch)
         except Exception:
             # WARNING, not DEBUG: a broken extractor silently degrades the
             # feature to "no provenance"; surface it so it's observable.
@@ -420,7 +420,8 @@ class ProvenanceMiddleware(AgentMiddleware):
 
         Returns None unless the source carries both a body and the
         ``result_sha256`` it hashes to, or if redaction itself fails (we never
-        store an unredacted body). Pure — no DB; the batch is flushed once per turn.
+        store an unredacted body). Pure — no DB; the batch is flushed by a
+        background task scheduled once per tool call.
 
         ``byte_len`` is the length of the body we actually store (post-redaction),
         NOT the raw pre-redaction ``result_size``. The read side derives truncation
@@ -461,6 +462,78 @@ class ProvenanceMiddleware(AgentMiddleware):
                 e,
             )
 
+    async def _schedule_body_flush(self, items: list[tuple]) -> None:
+        """Run one tool call's body flush OFF the tool-call critical path.
+
+        Schedules ``_flush_bodies`` as a tracked background task instead of
+        awaiting it inline, so the tool result returns without waiting on the DB /
+        object-store write. Bounded by ``_max_body_flush_tasks``: when saturated we
+        wait for one to drain before scheduling, which is the only inline wait on
+        the common path. The set is per-instance task ownership, NOT a per-run body
+        buffer, so concurrent subagents on this shared instance can't mix data.
+        """
+        if not items:
+            return
+        self._reap_body_flush_tasks()
+        while len(self._body_flush_tasks) >= self._max_body_flush_tasks:
+            done, _ = await asyncio.wait(
+                self._body_flush_tasks, return_when=asyncio.FIRST_COMPLETED
+            )
+            for task in done:
+                self._body_flush_tasks.discard(task)
+                self._consume_body_flush_task(task)
+        task = asyncio.create_task(
+            self._flush_bodies(items), name="provenance_body_flush"
+        )
+        self._body_flush_tasks.add(task)
+        task.add_done_callback(self._on_body_flush_done)
+
+    def _on_body_flush_done(self, task: asyncio.Task[None]) -> None:
+        self._body_flush_tasks.discard(task)
+        self._consume_body_flush_task(task)
+
+    def _consume_body_flush_task(self, task: asyncio.Task[None]) -> None:
+        """Retrieve a finished flush's result so its exception is never orphaned."""
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            logger.debug("[PROVENANCE] background body flush cancelled")
+        except Exception:
+            # _flush_bodies already swallows; this is belt-and-suspenders so a
+            # background task can't surface as an "exception never retrieved" warning.
+            logger.warning("[PROVENANCE] background body flush failed", exc_info=True)
+
+    def _reap_body_flush_tasks(self) -> None:
+        for task in tuple(self._body_flush_tasks):
+            if task.done():
+                self._body_flush_tasks.discard(task)
+                self._consume_body_flush_task(task)
+
+    async def _drain_body_flushes(self) -> None:
+        """Await body flushes already scheduled at entry (idempotent best-effort).
+
+        Snapshots the currently-tracked tasks and awaits them; writes a still-running
+        subagent schedules afterward stay tracked for the next drain. ``shield`` keeps
+        an in-flight DB write from being cancelled if this drain is itself cancelled
+        (e.g. a hard turn stop) mid-transaction.
+        """
+        self._reap_body_flush_tasks()
+        pending = tuple(self._body_flush_tasks)
+        if not pending:
+            return
+        try:
+            await asyncio.gather(
+                *(asyncio.shield(task) for task in pending),
+                return_exceptions=True,
+            )
+        finally:
+            self._reap_body_flush_tasks()
+
+    async def aafter_agent(self, state: Any, runtime: Any) -> dict | None:
+        """Drain background body writes at agent end (best-effort quiescence)."""
+        await self._drain_body_flushes()
+        return None
+
     # ----- per-tool extractors ------------------------------------------
 
     def _extract_web_search(
@@ -478,7 +551,7 @@ class ProvenanceMiddleware(AgentMiddleware):
             url = item.get("url")
             if not url:
                 continue
-            sha256, size, snippet = fingerprint_result(item)
+            sha256, size, snippet, body = fingerprint_result_with_body(item)
             yield ProvenanceSource(
                 record_id=_new_id(),
                 source_type="web_search",
@@ -492,7 +565,7 @@ class ProvenanceMiddleware(AgentMiddleware):
                 result_size=size,
                 result_snippet=snippet,
                 # Body = the same per-item value that produced result_sha256.
-                result_body=_canonical_body(item),
+                result_body=body,
             )
 
     def _extract_web_fetch(
@@ -503,7 +576,7 @@ class ProvenanceMiddleware(AgentMiddleware):
         if not url:
             return
         content = getattr(result, "content", result)
-        sha256, size, snippet = fingerprint_result(content)
+        sha256, size, snippet, body = fingerprint_result_with_body(content)
         yield ProvenanceSource(
             record_id=_new_id(),
             source_type="web_fetch",
@@ -514,7 +587,7 @@ class ProvenanceMiddleware(AgentMiddleware):
             result_sha256=sha256,
             result_size=size,
             result_snippet=snippet,
-            result_body=_canonical_body(content),
+            result_body=body,
         )
 
     def _extract_sec_filing(
@@ -536,7 +609,7 @@ class ProvenanceMiddleware(AgentMiddleware):
                 url = filing.get("source_url")
                 if not url:
                     continue
-                sha256, size, snippet = fingerprint_result(filing)
+                sha256, size, snippet, body = fingerprint_result_with_body(filing)
                 yield ProvenanceSource(
                     record_id=_new_id(),
                     source_type="sec_filing",
@@ -549,14 +622,14 @@ class ProvenanceMiddleware(AgentMiddleware):
                     result_sha256=sha256,
                     result_size=size,
                     result_snippet=snippet,
-                    result_body=_canonical_body(filing),
+                    result_body=body,
                 )
             return
 
         source_url = artifact.get("source_url")
         if not source_url:
             return
-        sha256, size, snippet = fingerprint_result(artifact)
+        sha256, size, snippet, body = fingerprint_result_with_body(artifact)
         yield ProvenanceSource(
             record_id=_new_id(),
             source_type="sec_filing",
@@ -569,7 +642,7 @@ class ProvenanceMiddleware(AgentMiddleware):
             result_sha256=sha256,
             result_size=size,
             result_snippet=snippet,
-            result_body=_canonical_body(artifact),
+            result_body=body,
         )
 
     def _extract_market_data(
@@ -611,8 +684,7 @@ class ProvenanceMiddleware(AgentMiddleware):
         fingerprint_target = (
             artifact if artifact is not None else getattr(result, "content", result)
         )
-        sha256, size, snippet = fingerprint_result(fingerprint_target)
-        body = _canonical_body(fingerprint_target)
+        sha256, size, snippet, body = fingerprint_result_with_body(fingerprint_target)
         for identifier in identifiers:
             yield ProvenanceSource(
                 record_id=_new_id(),

--- a/src/ptc_agent/agent/provenance/__init__.py
+++ b/src/ptc_agent/agent/provenance/__init__.py
@@ -7,6 +7,7 @@ from ptc_agent.agent.provenance.types import (
     ProvenanceSource,
     build_provenance_event,
     fingerprint_result,
+    fingerprint_result_with_body,
     hash_args,
     redact_args,
 )
@@ -16,6 +17,7 @@ __all__ = [
     "ProvenanceSource",
     "build_provenance_event",
     "fingerprint_result",
+    "fingerprint_result_with_body",
     "hash_args",
     "redact_args",
 ]

--- a/src/ptc_agent/agent/provenance/types.py
+++ b/src/ptc_agent/agent/provenance/types.py
@@ -21,6 +21,12 @@ from datetime import datetime, timezone
 # required for cross-surface dedup.
 SNIPPET_MAX_CHARS = 500
 
+# Canonical per-body cap (bytes). Doubles as the in-sandbox transport cap on the
+# untrusted mcp_tool trace channel. The server-side body store re-declares the
+# same value locally (to stay out of the agent import graph); both copies MUST
+# hold this number.
+RESULT_BODY_MAX_BYTES = 64 * 1024
+
 
 @dataclass
 class ProvenanceSource:
@@ -49,6 +55,11 @@ class ProvenanceSource:
     result_sha256: str | None = None
     result_size: int | None = None
     result_snippet: str | None = None
+    # Transient: the full (redacted) per-access body whose hash is
+    # ``result_sha256``. Consumed live by ProvenanceMiddleware to write the
+    # content-addressed body store; intentionally NOT carried by
+    # ``build_provenance_event`` so it never rides the SSE event.
+    result_body: str | None = None
     agent: str | None = None
 
 

--- a/src/ptc_agent/agent/provenance/types.py
+++ b/src/ptc_agent/agent/provenance/types.py
@@ -83,6 +83,15 @@ def _canonicalize(value: object) -> str:
             return ""
 
 
+def _fingerprint_canonical(canonical: str) -> tuple[str, int, str]:
+    """Fingerprint an already-canonical string as ``(sha256_hex, byte_size, snippet)``."""
+    encoded = canonical.encode("utf-8")
+    sha256_hex = hashlib.sha256(encoded).hexdigest()
+    size = len(encoded)
+    snippet = canonical[:SNIPPET_MAX_CHARS]
+    return sha256_hex, size, snippet
+
+
 def fingerprint_result(value: object) -> tuple[str, int, str]:
     """Fingerprint a tool result as ``(sha256_hex, utf8_byte_size, snippet)``.
 
@@ -91,12 +100,20 @@ def fingerprint_result(value: object) -> tuple[str, int, str]:
     characters of the canonical string, truncated on a char boundary; it may
     contain NUL — downstream Postgres sanitization strips that, not this.
     """
+    return _fingerprint_canonical(_canonicalize(value))
+
+
+def fingerprint_result_with_body(value: object) -> tuple[str, int, str, str]:
+    """Like :func:`fingerprint_result`, plus the canonical string itself.
+
+    Canonicalizes ``value`` once and returns ``(sha256_hex, size, snippet,
+    canonical)``, so a caller storing the full body reuses the exact string that
+    produced ``sha256_hex`` — byte-identity with ``result_sha256`` is structural,
+    and a large dict/list is serialized once instead of twice.
+    """
     canonical = _canonicalize(value)
-    encoded = canonical.encode("utf-8")
-    sha256_hex = hashlib.sha256(encoded).hexdigest()
-    size = len(encoded)
-    snippet = canonical[:SNIPPET_MAX_CHARS]
-    return sha256_hex, size, snippet
+    sha256_hex, size, snippet = _fingerprint_canonical(canonical)
+    return sha256_hex, size, snippet, canonical
 
 
 def hash_args(args: object) -> dict | None:

--- a/src/ptc_agent/agent/tools/bash.py
+++ b/src/ptc_agent/agent/tools/bash.py
@@ -1,5 +1,7 @@
 """Execute bash commands in the sandbox."""
 
+from typing import Any
+
 import structlog
 from langchain_core.tools import BaseTool, tool
 
@@ -45,14 +47,14 @@ def create_execute_bash_tool(backend: SandboxBackend, thread_id: str = "") -> Ba
     # Resolve the default working directory from sandbox config at tool creation time
     _default_working_dir = backend.filesystem_config.working_directory
 
-    @tool
+    @tool("Bash", response_format="content_and_artifact")
     async def Bash(
         command: str,
         description: str | None = None,
         timeout: int | None = 120000,
         run_in_background: bool | None = False,
         working_dir: str | None = _default_working_dir,
-    ) -> str:
+    ) -> tuple[str, dict[str, Any]]:
         """Execute bash commands in a persistent shell session.
 
         Use for: git, npm, docker, system commands, directory operations,
@@ -67,7 +69,9 @@ def create_execute_bash_tool(backend: SandboxBackend, thread_id: str = "") -> Ba
             working_dir: Working directory (default: /home/workspace)
 
         Returns:
-            Command output (stdout/stderr), or ERROR message
+            Command output (stdout/stderr), or ERROR message. The artifact carries
+            ``mcp_trace`` (provenance for MCP calls made by scripts run here) and
+            never enters the LLM context.
 
         Paths: Quote paths with spaces. Use /home/workspace/ for workspace files.
         """
@@ -77,7 +81,7 @@ def create_execute_bash_tool(backend: SandboxBackend, thread_id: str = "") -> Ba
                 "Blocked bash command touching memory path",
                 command=command[:100],
             )
-            return _MEMORY_ROUTE_ERROR
+            return _MEMORY_ROUTE_ERROR, {"mcp_trace": []}
 
         try:
             logger.debug(
@@ -101,6 +105,11 @@ def create_execute_bash_tool(backend: SandboxBackend, thread_id: str = "") -> Ba
                 thread_id=thread_id or None,
             )
 
+            # Provenance for any MCP calls a script run here made (foreground
+            # only; absent/empty for plain shell commands). Stripped from the
+            # artifact by the provenance middleware before it leaves the host.
+            artifact = {"mcp_trace": list(result.get("mcp_trace") or [])}
+
             if result["success"]:
                 stdout = result.get("stdout", "")
                 stderr = result.get("stderr", "")
@@ -116,13 +125,13 @@ def create_execute_bash_tool(backend: SandboxBackend, thread_id: str = "") -> Ba
                         command=command[:50],
                         output_length=len(output),
                     )
-                    return output
+                    return output, artifact
                 # Command succeeded but no output (e.g., mkdir)
                 logger.debug(
                     "Bash command executed successfully (no output)",
                     command=command[:50],
                 )
-                return "Command completed successfully"
+                return "Command completed successfully", artifact
 
             # Command failed — Daytona returns combined stdout+stderr in "stdout"
             stdout = result.get("stdout", "")
@@ -137,7 +146,10 @@ def create_execute_bash_tool(backend: SandboxBackend, thread_id: str = "") -> Ba
                 output_length=len(error_output),
             )
 
-            return f"ERROR: Command failed (exit code {exit_code})\n{error_output}"
+            return (
+                f"ERROR: Command failed (exit code {exit_code})\n{error_output}",
+                artifact,
+            )
 
         except Exception as e:
             error_msg = f"Failed to execute bash command: {e!s}"
@@ -147,7 +159,7 @@ def create_execute_bash_tool(backend: SandboxBackend, thread_id: str = "") -> Ba
                 error=str(e),
                 exc_info=True,
             )
-            return f"ERROR: {error_msg}"
+            return f"ERROR: {error_msg}", {"mcp_trace": []}
 
     # Patch the LLM-visible description with the actual configured working directory
     if _default_working_dir != "/home/workspace":

--- a/src/ptc_agent/agent/tools/bash_output.py
+++ b/src/ptc_agent/agent/tools/bash_output.py
@@ -1,6 +1,6 @@
 """Get output and status of background bash commands."""
 
-from typing import Literal
+from typing import Any, Literal
 
 import structlog
 from langchain_core.tools import BaseTool, tool
@@ -20,8 +20,10 @@ def create_bash_output_tool(backend: SandboxBackend) -> BaseTool:
         Configured BashOutput tool function
     """
 
-    @tool
-    async def BashOutput(command_id: str, action: Literal["status", "stop"] = "status") -> str:
+    @tool("BashOutput", response_format="content_and_artifact")
+    async def BashOutput(
+        command_id: str, action: Literal["status", "stop"] = "status"
+    ) -> tuple[str, dict[str, Any]]:
         """Get the output/status of a background command, or stop it.
 
         Use this to check on commands started with run_in_background=True.
@@ -31,14 +33,19 @@ def create_bash_output_tool(backend: SandboxBackend) -> BaseTool:
             action: "status" (default) to check output, or "stop" to terminate the command
 
         Returns:
-            Status and output of the background command, or confirmation of stop
+            Status and output of the background command, or confirmation of stop.
+            The artifact carries ``mcp_trace`` (provenance for MCP calls a
+            backgrounded script made, surfaced once when the command finishes)
+            and never enters the LLM context.
         """
         try:
             if action == "stop":
                 stopped = await backend.astop_background_command(command_id)
                 if stopped:
-                    return f"Background command {command_id} stopped."
-                return f"No running background command found with id {command_id}."
+                    msg = f"Background command {command_id} stopped."
+                else:
+                    msg = f"No running background command found with id {command_id}."
+                return msg, {"mcp_trace": []}
 
             result = await backend.aget_background_command_status(command_id)
 
@@ -46,6 +53,10 @@ def create_bash_output_tool(backend: SandboxBackend) -> BaseTool:
             exit_code = result["exit_code"]
             stdout = result.get("stdout", "")
             stderr = result.get("stderr", "")
+            # MCP provenance for a backgrounded script's calls — present only on
+            # the status read that observes completion. Stripped from the
+            # artifact by the provenance middleware before it leaves the host.
+            artifact = {"mcp_trace": list(result.get("mcp_trace") or [])}
 
             # Format status line
             if is_running:
@@ -61,11 +72,11 @@ def create_bash_output_tool(backend: SandboxBackend) -> BaseTool:
             if stderr:
                 parts.append(f"Errors:\n{stderr}")
 
-            return "\n".join(parts)
+            return "\n".join(parts), artifact
 
         except Exception as e:
             error_msg = f"Failed to get background command output: {e!s}"
             logger.error(error_msg, command_id=command_id, exc_info=True)
-            return f"ERROR: {error_msg}"
+            return f"ERROR: {error_msg}", {"mcp_trace": []}
 
     return BashOutput

--- a/src/ptc_agent/core/sandbox/ptc_sandbox.py
+++ b/src/ptc_agent/core/sandbox/ptc_sandbox.py
@@ -3267,9 +3267,20 @@ except OSError as e:
                 # Can't check status (e.g. sandbox restarted) — treat as
                 # finished to avoid zombie entries that permanently block the cap.
                 finished.append(cmd_id)
-        # Delete finished sessions
+        # Delete finished sessions. A finished command's MCP trace is normally
+        # harvested by the BashOutput that observes completion (provenance is
+        # attributed to that observation). A command that finished but was never
+        # observed before the cap forced eviction has no tool-call surface to
+        # attribute its trace to, so it's dropped — log it so the rare provenance
+        # gap is observable, not silent. (Faithful harvest-on-evict would need a
+        # deferred-trace channel keyed to the original launch; out of scope here.)
         for cmd_id in finished:
-            self._bg_trace_paths.pop(cmd_id, None)
+            dropped_trace = self._bg_trace_paths.pop(cmd_id, None)
+            if dropped_trace:
+                logger.info(
+                    "Evicting finished bg session with unharvested MCP trace",
+                    cmd_id=cmd_id,
+                )
             sid = self._bg_sessions.pop(cmd_id, None)
             if sid:
                 try:

--- a/src/ptc_agent/core/sandbox/ptc_sandbox.py
+++ b/src/ptc_agent/core/sandbox/ptc_sandbox.py
@@ -2711,6 +2711,12 @@ except OSError as e:
                 retry_policy=RetryPolicy.SAFE,
             )
             trace_bytes = int((getattr(size_res, "stdout", "") or "").strip() or 0)
+            if trace_bytes == 0:
+                # No trace written — the common case for a bash command that
+                # imported no MCP wrappers (git/npm/ls/...). The file was never
+                # created, so skip BOTH the read and the rm below (nothing to
+                # delete): saves two sandbox round-trips on every non-MCP bash run.
+                return records
             if trace_bytes > _MCP_TRACE_READ_MAX_BYTES:
                 logger.warning(
                     "MCP trace file over read cap; skipping",
@@ -3281,6 +3287,17 @@ except OSError as e:
                     "Evicting finished bg session with unharvested MCP trace",
                     cmd_id=cmd_id,
                 )
+                # The pop above drops the last host-side reference to this trace,
+                # so delete the JSONL now — otherwise it leaks on the sandbox
+                # until teardown (no later path knows the filename to reap it).
+                try:
+                    await self._runtime_call(
+                        self.runtime.exec,
+                        f"rm -f {shlex.quote(dropped_trace)}",
+                        retry_policy=RetryPolicy.SAFE,
+                    )
+                except Exception:
+                    logger.debug("Evict bg trace cleanup failed", path=dropped_trace)
             sid = self._bg_sessions.pop(cmd_id, None)
             if sid:
                 try:
@@ -3768,8 +3785,10 @@ except OSError as e:
         foreground and background bash paths so the two can't drift in how they
         build PYTHONPATH or quote the trace path.
         """
-        assert self.runtime is not None
-        sandbox_root = await self.runtime.fetch_working_dir()
+        # Use the cached working dir (set on create/reconnect via
+        # fetch_working_dir, and used by normalize_path on this same bash path) so
+        # wrapping a command doesn't add a Daytona round-trip per bash invocation.
+        sandbox_root = self._work_dir
         internal_dir = f"{sandbox_root}/_internal"
         pythonpath = f"{sandbox_root}:{internal_dir}/src:{internal_dir}"
         trace_path = f"{sandbox_root}/.system/trace/{bash_id}_{uuid.uuid4().hex}.jsonl"

--- a/src/ptc_agent/core/sandbox/ptc_sandbox.py
+++ b/src/ptc_agent/core/sandbox/ptc_sandbox.py
@@ -172,6 +172,11 @@ class PTCSandbox:
 
         # Per-command sessions for background Bash commands (cmd_id → session_id)
         self._bg_sessions: dict[str, str] = {}
+        # Per-command MCP provenance trace paths for background Bash (cmd_id →
+        # trace_path). Harvested when get_background_command_status observes the
+        # command finished, so a backgrounded script's MCP calls are recorded
+        # too (the foreground/ExecuteCode path harvests inline).
+        self._bg_trace_paths: dict[str, str] = {}
         # Per-port sessions for preview servers (port → (session_id, cmd_id))
         self._preview_sessions: dict[int, tuple[str, str]] = {}
         # Per-port locks to serialize start_and_get_preview_url (avoids races)
@@ -644,6 +649,7 @@ class PTCSandbox:
 
         # Clear stale state — sessions and preview links don't survive stop/start
         self._bg_sessions.clear()
+        self._bg_trace_paths.clear()
         self._preview_sessions.clear()
         self._preview_link_cache.clear()
 
@@ -2687,9 +2693,33 @@ except OSError as e:
         partial write (e.g. after a crash) never breaks result assembly. Never
         raises — tracing is provenance-only and must not affect execution.
         """
+        # Host-memory bound on the read. The generated client's per-execution
+        # body budget caps what IT emits, but MCP_TRACE_FILE is visible to
+        # agent-authored sandbox code, which can append to the JSONL directly —
+        # so the budget is not a host-side safety bound. Size the file first and
+        # skip a file far past any legit trace rather than pulling it (possibly
+        # GBs) into memory. ~4x the body budget (RESULT_BODY_TRACE_BUDGET_BYTES)
+        # leaves slack for snippets/args/metadata; the extractor clamps anyway.
+        _MCP_TRACE_READ_MAX_BYTES = 16 * 1024 * 1024
+
         records: list[dict] = []
+        content: str | None = None
         try:
-            content = await self.aread_file_text(trace_path)
+            size_res = await self._runtime_call(
+                self.runtime.exec,
+                f"wc -c < {shlex.quote(trace_path)} 2>/dev/null",
+                retry_policy=RetryPolicy.SAFE,
+            )
+            trace_bytes = int((getattr(size_res, "stdout", "") or "").strip() or 0)
+            if trace_bytes > _MCP_TRACE_READ_MAX_BYTES:
+                logger.warning(
+                    "MCP trace file over read cap; skipping",
+                    path=trace_path,
+                    bytes=trace_bytes,
+                    cap=_MCP_TRACE_READ_MAX_BYTES,
+                )
+            else:
+                content = await self.aread_file_text(trace_path)
         except Exception as e:
             logger.debug("Failed to read MCP trace file", path=trace_path, error=str(e))
             content = None
@@ -3239,6 +3269,7 @@ except OSError as e:
                 finished.append(cmd_id)
         # Delete finished sessions
         for cmd_id in finished:
+            self._bg_trace_paths.pop(cmd_id, None)
             sid = self._bg_sessions.pop(cmd_id, None)
             if sid:
                 try:
@@ -3313,6 +3344,7 @@ except OSError as e:
                 "stdout": "",
                 "stderr": "No background session found for this command",
                 "cmd_id": cmd_id,
+                "mcp_trace": [],
             }
 
         result: SessionCommandResult = await self._runtime_call(
@@ -3323,9 +3355,18 @@ except OSError as e:
         )
         is_running = result.exit_code is None
 
+        # Harvest the backgrounded command's MCP provenance trace exactly once,
+        # when it finishes. This rides the same status path that returns the
+        # command's output to the agent, so there's no result-bearing path that
+        # skips provenance (the stop action returns no output). Best-effort.
+        mcp_trace: list[dict] = []
+
         # Auto-clean: if the command finished (e.g. killed via pkill), tear
         # down the orphaned session so it doesn't leak on the Daytona side.
         if not is_running:
+            trace_path = self._bg_trace_paths.pop(cmd_id, None)
+            if trace_path:
+                mcp_trace = await self._collect_mcp_trace(trace_path)
             sid = self._bg_sessions.pop(cmd_id, None)
             if sid:
                 try:
@@ -3343,6 +3384,7 @@ except OSError as e:
             "stdout": result.stdout,
             "stderr": result.stderr,
             "cmd_id": cmd_id,
+            "mcp_trace": mcp_trace,
         }
 
     async def stop_background_command(self, cmd_id: str) -> bool:
@@ -3355,6 +3397,9 @@ except OSError as e:
             return False
         await self._wait_ready()
         assert self.runtime is not None
+        # Drop the trace mapping (the ephemeral sandbox FS owns the file itself).
+        # A stopped command yields no output, so there's nothing to attest.
+        self._bg_trace_paths.pop(cmd_id, None)
         try:
             await self._runtime_call(
                 self.runtime.delete_session,
@@ -3460,6 +3505,12 @@ except OSError as e:
         await self._wait_ready()
         start_time = time.time()
 
+        # Per-execution MCP provenance trace file (foreground only; set just
+        # before exec). Initialized here so the finally can clean it up on a
+        # cancel that skips the except below.
+        trace_path: str | None = None
+        trace_collected = False
+
         try:
             # Generate bash execution ID for tracking
             self.bash_execution_count += 1
@@ -3525,6 +3576,14 @@ except OSError as e:
             if background:
                 session_id = await self._create_bg_session(bash_id)
                 assert self.runtime is not None
+                # Inject the same MCP provenance trace env the foreground path
+                # uses so a backgrounded `python script.py` that imports the MCP
+                # wrappers records its mcp_trace too — harvested on completion in
+                # get_background_command_status. The audit .sh stays clean; only
+                # the executed command carries the exports.
+                bg_trace_path, bg_command = await self._build_trace_env_command(
+                    bash_id, full_command
+                )
                 # Track immediately so cleanup() can find it if execute fails
                 sentinel_key = f"_pending:{session_id}"
                 self._bg_sessions[sentinel_key] = session_id
@@ -3532,7 +3591,7 @@ except OSError as e:
                     result = await self._runtime_call(
                         self.runtime.session_execute,
                         session_id,
-                        full_command,
+                        bg_command,
                         run_async=True,
                         retry_policy=RetryPolicy.UNSAFE,
                         total_timeout=30,
@@ -3552,6 +3611,7 @@ except OSError as e:
                 # Replace sentinel with real cmd_id key
                 self._bg_sessions.pop(sentinel_key, None)
                 self._bg_sessions[result.cmd_id] = session_id
+                self._bg_trace_paths[result.cmd_id] = bg_trace_path
                 logger.debug(
                     "Background command started",
                     bash_id=bash_id,
@@ -3570,11 +3630,20 @@ except OSError as e:
                     "command_hash": command_hash,
                 }
 
-            # Execute directly via process.exec — no file upload dependency
+            # Execute directly via process.exec — no file upload dependency.
+            # Inject a per-execution MCP provenance trace file + the wrapper
+            # import path so a python script run here (e.g. `python analysis.py`
+            # importing `tools.{server}`) records the same mcp_trace ExecuteCode
+            # does — closing the bash provenance bypass. PYTHONPATH is prepended
+            # (preserving any existing value). The audit .sh above stays clean;
+            # only the executed command carries the exports.
             assert self.runtime is not None
+            trace_path, exec_command = await self._build_trace_env_command(
+                bash_id, full_command
+            )
             exec_result = await self._runtime_call(
                 self.runtime.exec,
-                full_command,
+                exec_command,
                 timeout=timeout,
                 retry_policy=RetryPolicy.UNSAFE,
                 total_timeout=timeout + 30,
@@ -3588,6 +3657,11 @@ except OSError as e:
                 {"success": "true" if exit_code == 0 else "false", "kind": "bash"},
             )
 
+            # Harvest the in-sandbox MCP trace (best-effort; reads + deletes the
+            # file). No MCP call → file absent → empty list, no behavior change.
+            mcp_trace = await self._collect_mcp_trace(trace_path)
+            trace_collected = True
+
             if exit_code == 0:
                 return {
                     "success": True,
@@ -3596,6 +3670,7 @@ except OSError as e:
                     "exit_code": 0,
                     "bash_id": bash_id,
                     "command_hash": command_hash,
+                    "mcp_trace": mcp_trace,
                 }
 
             return {
@@ -3605,6 +3680,7 @@ except OSError as e:
                 "exit_code": exit_code,
                 "bash_id": bash_id,
                 "command_hash": command_hash,
+                "mcp_trace": mcp_trace,
             }
 
         except Exception as e:
@@ -3628,6 +3704,11 @@ except OSError as e:
                 exc_info=True,
                 extra={"is_timeout": is_timeout},
             )
+            # Recover any MCP trace flushed before the failure (best-effort).
+            recovered_trace: list[dict] = []
+            if trace_path is not None:
+                recovered_trace = await self._collect_mcp_trace(trace_path)
+                trace_collected = True
             return {
                 "success": False,
                 "stdout": "",
@@ -3635,7 +3716,59 @@ except OSError as e:
                 "exit_code": -1,
                 "bash_id": locals().get("bash_id"),
                 "command_hash": None,
+                "mcp_trace": recovered_trace,
             }
+        finally:
+            # asyncio.CancelledError (BaseException) skips the except above, so a
+            # cancel after MCP_TRACE_FILE was set would leave the JSONL behind.
+            # Delete it here when neither path collected. shield() so the rm still
+            # runs even though this await is itself unwinding a cancel.
+            if (
+                trace_path is not None
+                and not trace_collected
+                and self.runtime is not None
+            ):
+                try:
+                    await asyncio.shield(
+                        self._runtime_call(
+                            self.runtime.exec,
+                            f"rm -f {shlex.quote(trace_path)}",
+                            retry_policy=RetryPolicy.SAFE,
+                        )
+                    )
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    logger.debug(
+                        "Failed to clean up bash MCP trace file on cancel",
+                        path=trace_path,
+                        error=str(e),
+                    )
+
+    async def _build_trace_env_command(
+        self, bash_id: str, full_command: str
+    ) -> tuple[str, str]:
+        """Wrap a bash command with the MCP-provenance trace env.
+
+        Returns ``(trace_path, command)``. ``command`` exports ``MCP_TRACE_FILE``
+        plus the wrapper ``PYTHONPATH`` (prepended, preserving any existing value)
+        before running ``full_command``, so a ``python script.py`` that imports the
+        MCP wrappers records the same ``mcp_trace`` ExecuteCode does. Shared by the
+        foreground and background bash paths so the two can't drift in how they
+        build PYTHONPATH or quote the trace path.
+        """
+        assert self.runtime is not None
+        sandbox_root = await self.runtime.fetch_working_dir()
+        internal_dir = f"{sandbox_root}/_internal"
+        pythonpath = f"{sandbox_root}:{internal_dir}/src:{internal_dir}"
+        trace_path = f"{sandbox_root}/.system/trace/{bash_id}_{uuid.uuid4().hex}.jsonl"
+        command = (
+            f"export MCP_TRACE_FILE={shlex.quote(trace_path)} && "
+            f"export PYTHONPATH={shlex.quote(pythonpath)}"
+            f"${{PYTHONPATH:+:$PYTHONPATH}} && "
+            f"{full_command}"
+        )
+        return trace_path, command
 
     async def _list_result_files(self) -> list[str]:
         """List files in the results directory.
@@ -4297,6 +4430,7 @@ except OSError as e:
                         logger.debug("Failed to delete session", session_id=sid)
                 self._preview_sessions.clear()
                 self._bg_sessions.clear()
+                self._bg_trace_paths.clear()
 
                 try:
                     await self._runtime_call(

--- a/src/ptc_agent/core/sandbox/ptc_sandbox.py
+++ b/src/ptc_agent/core/sandbox/ptc_sandbox.py
@@ -3609,7 +3609,7 @@ except OSError as e:
                 # wrappers records its mcp_trace too — harvested on completion in
                 # get_background_command_status. The audit .sh stays clean; only
                 # the executed command carries the exports.
-                bg_trace_path, bg_command = await self._build_trace_env_command(
+                bg_trace_path, bg_command = self._build_trace_env_command(
                     bash_id, full_command
                 )
                 # Track immediately so cleanup() can find it if execute fails
@@ -3666,7 +3666,7 @@ except OSError as e:
             # (preserving any existing value). The audit .sh above stays clean;
             # only the executed command carries the exports.
             assert self.runtime is not None
-            trace_path, exec_command = await self._build_trace_env_command(
+            trace_path, exec_command = self._build_trace_env_command(
                 bash_id, full_command
             )
             exec_result = await self._runtime_call(
@@ -3773,7 +3773,7 @@ except OSError as e:
                         error=str(e),
                     )
 
-    async def _build_trace_env_command(
+    def _build_trace_env_command(
         self, bash_id: str, full_command: str
     ) -> tuple[str, str]:
         """Wrap a bash command with the MCP-provenance trace env.

--- a/src/ptc_agent/core/tool_generator.py
+++ b/src/ptc_agent/core/tool_generator.py
@@ -6,6 +6,7 @@ from typing import Any
 import structlog
 
 from ptc_agent.agent.provenance import SNIPPET_MAX_CHARS
+from ptc_agent.agent.provenance.types import RESULT_BODY_MAX_BYTES
 from ptc_agent.config.core import MCPServerConfig
 
 from .mcp_registry import MCPToolInfo
@@ -28,7 +29,16 @@ logger = structlog.get_logger(__name__)
 # re-uploaded to a reused sandbox. Folding this constant into the tool_modules
 # version makes a bump force the regenerated client onto every workspace on its
 # next sync. See ptc_sandbox._compute_sandbox_manifest.
-MCP_CLIENT_CODEGEN_VERSION = "1"
+MCP_CLIENT_CODEGEN_VERSION = "2"
+
+# Aggregate per-execution ceiling on result_body bytes emitted BY THE GENERATED
+# CLIENT, interpolated into it. This keeps a cooperative run's trace small (per
+# call still capped at RESULT_BODY_MAX_BYTES; this bounds their sum to ~4 MiB).
+# It is NOT a host-memory security bound: MCP_TRACE_FILE is visible to agent
+# code, which can append to the JSONL directly and bypass this counter. The hard
+# host-side bound on what _collect_mcp_trace reads lives in ptc_sandbox (it sizes
+# the file and skips one far past any legit trace).
+RESULT_BODY_TRACE_BUDGET_BYTES = 4 * 1024 * 1024
 
 
 def _safe_func_name(name: str) -> str:
@@ -972,6 +982,19 @@ _sse_sessions: dict[str, bool] = {{}}  # server_name -> initialized
 # MCP server configurations
 _SERVER_CONFIGS = {servers_dict}
 {vault_block}
+# Per-execution running sum of emitted result_body bytes. The generated client
+# module is imported once per sandbox process, so this module-global accumulates
+# across every MCP call in one execute_code run. Caps interpolated at codegen
+# time from agent/provenance/types.py (RESULT_BODY_MAX_BYTES = per-call body cap;
+# the budget is the aggregate ceiling): once the running sum crosses the budget
+# we stop emitting result_body (snippet/sha/size still recorded) to keep a
+# cooperative run's trace small. This is a courtesy bound only — agent code can
+# write MCP_TRACE_FILE directly; the hard host-memory bound is in
+# ptc_sandbox._collect_mcp_trace, which sizes the file before reading it.
+_RESULT_BODY_MAX_BYTES = {RESULT_BODY_MAX_BYTES}
+_RESULT_BODY_TRACE_BUDGET_BYTES = {RESULT_BODY_TRACE_BUDGET_BYTES}
+_result_body_emitted_bytes = 0
+
 
 def _trace_mcp_call(server: str, tool: str, args: Any, result: Any) -> None:
     """Append one JSONL provenance line for an MCP call (best-effort, never raises).
@@ -980,6 +1003,7 @@ def _trace_mcp_call(server: str, tool: str, args: Any, result: Any) -> None:
     computed in-sandbox and must reproduce the host-side fingerprint_result
     contract byte-for-byte.
     """
+    global _result_body_emitted_bytes
     try:
         trace_file = os.environ.get("MCP_TRACE_FILE")
         if not trace_file:
@@ -1002,6 +1026,8 @@ def _trace_mcp_call(server: str, tool: str, args: Any, result: Any) -> None:
             "tool": tool,
             "args": args if isinstance(args, dict) else {{}},
             "result_sha256": hashlib.sha256(encoded).hexdigest(),
+            # TRUE full byte length — independent of the body cap below, so the
+            # host can derive truncation as byte_len > len(stored body).
             "result_size": len(encoded),
             # Cap interpolated from the canonical SNIPPET_MAX_CHARS in
             # agent/provenance/types.py at codegen time, so host + sandbox
@@ -1009,6 +1035,15 @@ def _trace_mcp_call(server: str, tool: str, args: Any, result: Any) -> None:
             "result_snippet": canonical[:{SNIPPET_MAX_CHARS}],
             "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
         }}
+        # Per-call body = first RESULT_BODY_MAX_BYTES *bytes* of the canonical
+        # result (decode with errors="ignore" so a multibyte char split at the
+        # cap is dropped, not mojibake). Hash-consistent: the body is a prefix of
+        # the exact bytes that produced result_sha256. Skip once the aggregate
+        # per-execution budget is exhausted — snippet/sha/size always survive.
+        if _result_body_emitted_bytes < _RESULT_BODY_TRACE_BUDGET_BYTES:
+            body = encoded[:_RESULT_BODY_MAX_BYTES].decode("utf-8", errors="ignore")
+            entry["result_body"] = body
+            _result_body_emitted_bytes += len(body.encode("utf-8"))
         os.makedirs(os.path.dirname(trace_file), exist_ok=True)
         with open(trace_file, "a", encoding="utf-8") as fh:
             fh.write(json.dumps(entry, default=str, ensure_ascii=False) + "\\n")

--- a/src/ptc_agent/core/tool_generator.py
+++ b/src/ptc_agent/core/tool_generator.py
@@ -982,9 +982,12 @@ _sse_sessions: dict[str, bool] = {{}}  # server_name -> initialized
 # MCP server configurations
 _SERVER_CONFIGS = {servers_dict}
 {vault_block}
-# Per-execution running sum of emitted result_body bytes. The generated client
-# module is imported once per sandbox process, so this module-global accumulates
-# across every MCP call in one execute_code run. Caps interpolated at codegen
+# Per-execution running sum of emitted result_body bytes. Each execute_code runs
+# in a FRESH interpreter process — both the Daytona and Docker providers spawn a
+# new `python` per code_run (a one-shot run, NOT a persistent kernel/session), so
+# this module is re-imported and the counter resets to 0 every run. It therefore
+# accumulates only across the MCP calls within ONE execute_code, never session-
+# wide. Caps interpolated at codegen
 # time from agent/provenance/types.py (RESULT_BODY_MAX_BYTES = per-call body cap;
 # the budget is the aggregate ceiling): once the running sum crosses the budget
 # we stop emitting result_body (snippet/sha/size still recorded) to keep a

--- a/src/server/app/setup.py
+++ b/src/server/app/setup.py
@@ -402,7 +402,7 @@ async def lifespan(app: FastAPI):
     # Shutdown
     logger.info("Application shutdown started...")
 
-    # 0. Shutdown ProvenanceGCService
+    # 0.1. Shutdown ProvenanceGCService
     try:
         from src.server.services.provenance_gc import ProvenanceGCService
 
@@ -410,7 +410,7 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.warning(f"Error shutting down ProvenanceGCService: {e}")
 
-    # 0. Shutdown NewsRefreshService
+    # 0.2. Shutdown NewsRefreshService
     try:
         from src.server.services.news_refresh_service import NewsRefreshService
 
@@ -418,7 +418,7 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.warning(f"Error shutting down NewsRefreshService: {e}")
 
-    # 0. Shutdown MarketInsightService
+    # 0.3. Shutdown MarketInsightService
     try:
         from src.server.services.insight_service import InsightService
 

--- a/src/server/app/setup.py
+++ b/src/server/app/setup.py
@@ -387,10 +387,28 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.warning(f"Failed to start NewsRefreshService: {e}")
 
+    # Start ProvenanceGCService (daily mark-sweep of orphaned result bodies)
+    try:
+        from src.server.services.provenance_gc import ProvenanceGCService
+
+        provenance_gc = ProvenanceGCService.get_instance()
+        await provenance_gc.start()
+        logger.info("ProvenanceGCService started")
+    except Exception as e:
+        logger.warning(f"Failed to start ProvenanceGCService: {e}")
+
     yield  # Server is running
 
     # Shutdown
     logger.info("Application shutdown started...")
+
+    # 0. Shutdown ProvenanceGCService
+    try:
+        from src.server.services.provenance_gc import ProvenanceGCService
+
+        await ProvenanceGCService.get_instance().stop()
+    except Exception as e:
+        logger.warning(f"Error shutting down ProvenanceGCService: {e}")
 
     # 0. Shutdown NewsRefreshService
     try:

--- a/src/server/app/threads.py
+++ b/src/server/app/threads.py
@@ -1409,10 +1409,7 @@ async def get_provenance_bodies(
         rows = await get_provenance_for_thread(thread_id)
 
         from src.server.database.conversation import get_db_connection
-        from src.server.database.provenance_bodies import (
-            RESULT_BODY_MAX_BYTES,
-            fetch_result_bodies,
-        )
+        from src.server.database.provenance_bodies import fetch_result_bodies
 
         eligible = [row for row in rows if row.get("result_sha256")]
         capped = len(eligible) > limit
@@ -1429,10 +1426,12 @@ async def get_provenance_bodies(
                 continue
             body_inline = body["body_inline"] or ""
             byte_len = body["byte_len"]
-            # Incomplete iff the body spilled to an object or its true length
-            # exceeded the inline cap — NOT a raw-vs-inline length compare, which
-            # mislabels a redaction-shortened (but complete) body as truncated.
-            truncated = body["object_key"] is not None or byte_len > RESULT_BODY_MAX_BYTES
+            # byte_len is the length of the STORED (post-redaction) body, so the
+            # inline head is incomplete exactly when the full stored body is longer
+            # than what's inline — i.e. it spilled to an object, or a head was kept
+            # with no bucket to spill to. A body redaction shrank below the cap is
+            # stored whole (byte_len == len(inline)) and reads back complete.
+            truncated = byte_len > len(body_inline.encode("utf-8"))
             records.append(
                 {
                     "provenance_record_id": str(row["provenance_record_id"]),
@@ -1489,8 +1488,6 @@ async def get_provenance_record_body(
 
         from src.server.database.conversation import get_db_connection
         from src.server.database.provenance_bodies import (
-            FULL_BODY_READ_MAX_BYTES,
-            RESULT_BODY_MAX_BYTES,
             fetch_full_body,
             fetch_result_bodies,
         )
@@ -1504,21 +1501,19 @@ async def get_provenance_record_body(
             )
 
         byte_len = meta["byte_len"]
-        object_key = meta["object_key"]
         if full:
             body = await fetch_full_body(sha) or ""
-            # A full read is incomplete only if the spilled object exceeded the
-            # read cap, or the body was over the inline cap but never spilled (no
-            # bucket) so there was nothing more to read back. Keyed off byte_len +
-            # object_key, not a raw-vs-redacted length compare.
-            truncated = byte_len > FULL_BODY_READ_MAX_BYTES or (
-                object_key is None and byte_len > RESULT_BODY_MAX_BYTES
-            )
+            # byte_len is the full stored-body length; the read is incomplete
+            # exactly when we returned fewer bytes than that — the spilled object
+            # exceeded the read cap, or a head was kept with no bucket to spill to.
+            truncated = byte_len > len(body.encode("utf-8"))
         else:
             body = meta["body_inline"] or ""
-            # The inline head is incomplete iff the body spilled or exceeded the
-            # cap but couldn't spill — independent of redaction shortening it.
-            truncated = object_key is not None or byte_len > RESULT_BODY_MAX_BYTES
+            # The inline head is incomplete exactly when the full stored body is
+            # longer than the inline slice (spilled, or head kept with no bucket).
+            # byte_len tracks the stored (post-redaction) length, so a redaction-
+            # shrunk body that fits inline reads back complete.
+            truncated = byte_len > len(body.encode("utf-8"))
 
         return {
             "provenance_record_id": str(row["provenance_record_id"]),

--- a/src/server/app/threads.py
+++ b/src/server/app/threads.py
@@ -52,6 +52,7 @@ from src.server.database.conversation import (
     get_replay_thread_data,
 )
 from src.server.database.provenance import (
+    get_provenance_body_refs,
     get_provenance_for_thread,
     get_provenance_record,
 )
@@ -1406,16 +1407,18 @@ async def get_provenance_bodies(
     """
     try:
         await require_thread_owner(thread_id, x_user_id)
-        rows = await get_provenance_for_thread(thread_id)
 
         from src.server.database.conversation import get_db_connection
         from src.server.database.provenance_bodies import fetch_result_bodies
 
-        eligible = [row for row in rows if row.get("result_sha256")]
-        capped = len(eligible) > limit
-        eligible = eligible[:limit]
-        shas = [row["result_sha256"] for row in eligible]
+        # Eligible refs are filtered + capped in SQL (LIMIT limit+1) and the body
+        # fetch shares the same connection, so a long thread doesn't transfer every
+        # record (and its args JSON) just to discard all but `limit`.
         async with get_db_connection() as conn:
+            eligible = await get_provenance_body_refs(conn, thread_id, limit)
+            capped = len(eligible) > limit
+            eligible = eligible[:limit]
+            shas = [row["result_sha256"] for row in eligible]
             bodies = await fetch_result_bodies(conn, shas)
 
         records = []

--- a/src/server/app/threads.py
+++ b/src/server/app/threads.py
@@ -1502,7 +1502,10 @@ async def get_provenance_record_body(
 
         byte_len = meta["byte_len"]
         if full:
-            body = await fetch_full_body(sha) or ""
+            # meta already carries body_inline + object_key from the fetch above,
+            # so pass it through — fetch_full_body skips a second connection and
+            # only does the spilled-object read when there's an object_key.
+            body = await fetch_full_body(sha, row=meta) or ""
             # byte_len is the full stored-body length; the read is incomplete
             # exactly when we returned fewer bytes than that — the spilled object
             # exceeded the read cap, or a head was kept with no bucket to spill to.

--- a/src/server/app/threads.py
+++ b/src/server/app/threads.py
@@ -4,6 +4,7 @@ Unified Thread Router — all thread-related endpoints under /api/v1/threads.
 Route definitions are thin; business logic lives in handlers/.
 """
 
+import hashlib
 import json
 import logging
 import secrets
@@ -50,7 +51,10 @@ from src.server.database.conversation import (
     delete_feedback,
     get_replay_thread_data,
 )
-from src.server.database.provenance import get_provenance_for_thread
+from src.server.database.provenance import (
+    get_provenance_for_thread,
+    get_provenance_record,
+)
 from psycopg_pool import PoolTimeout
 from src.server.dependencies.usage_limits import ChatRateLimited
 
@@ -1363,3 +1367,173 @@ async def get_provenance(thread_id: str, x_user_id: CurrentUserId):
     except Exception as e:
         logger.exception(f"Error getting provenance for thread {thread_id}: {e}")
         raise HTTPException(status_code=500, detail="Failed to get provenance")
+
+
+def _body_hashes_to(body: str, sha256: str | None) -> bool:
+    """True iff ``body`` reproduces the content-address ``sha256``.
+
+    The verifier's integrity check: a present body that hashes to its advertised
+    sha is the exact content the agent reasoned over. A mismatch means the body was
+    redacted (a secret was stripped) or is otherwise not the hashed bytes — the
+    caller distinguishes the two via the ``truncated`` flag.
+    """
+    if not body or not sha256:
+        return False
+    return hashlib.sha256(body.encode("utf-8")).hexdigest() == sha256
+
+
+@router.get("/{thread_id}/provenance/bodies")
+async def get_provenance_bodies(
+    thread_id: str,
+    x_user_id: CurrentUserId,
+    limit: int = Query(
+        100,
+        ge=1,
+        le=200,
+        description="Max bodies returned; a long thread is capped (see `capped`).",
+    ),
+):
+    """Return stored result bodies (inline head only) for a thread's provenance records.
+
+    Sibling to ``/provenance`` (which stays snippet-only): joins each record's
+    ``result_sha256`` to the content-addressed body store and returns the inline
+    head plus ``truncated`` and ``verified`` flags. Spilled objects are never
+    fetched here — use the per-record ``/body?full=true`` endpoint for the full body.
+
+    The response is bounded: each inline head is up to 64 KiB, so a long thread is
+    capped at ``limit`` bodies (``capped: true`` when more were available) to keep
+    one request from materializing tens of MB.
+    """
+    try:
+        await require_thread_owner(thread_id, x_user_id)
+        rows = await get_provenance_for_thread(thread_id)
+
+        from src.server.database.conversation import get_db_connection
+        from src.server.database.provenance_bodies import (
+            RESULT_BODY_MAX_BYTES,
+            fetch_result_bodies,
+        )
+
+        eligible = [row for row in rows if row.get("result_sha256")]
+        capped = len(eligible) > limit
+        eligible = eligible[:limit]
+        shas = [row["result_sha256"] for row in eligible]
+        async with get_db_connection() as conn:
+            bodies = await fetch_result_bodies(conn, shas)
+
+        records = []
+        for row in eligible:
+            sha = row["result_sha256"]
+            body = bodies.get(sha)
+            if body is None:
+                continue
+            body_inline = body["body_inline"] or ""
+            byte_len = body["byte_len"]
+            # Incomplete iff the body spilled to an object or its true length
+            # exceeded the inline cap — NOT a raw-vs-inline length compare, which
+            # mislabels a redaction-shortened (but complete) body as truncated.
+            truncated = body["object_key"] is not None or byte_len > RESULT_BODY_MAX_BYTES
+            records.append(
+                {
+                    "provenance_record_id": str(row["provenance_record_id"]),
+                    "result_sha256": sha,
+                    "body_inline": body_inline,
+                    "byte_len": byte_len,
+                    "truncated": truncated,
+                    # The stored body hashes to result_sha256 (untruncated + not
+                    # redacted). False on a truncated head or a redaction-modified
+                    # body — the signal that "these bytes != the advertised hash."
+                    "verified": (not truncated) and _body_hashes_to(body_inline, sha),
+                }
+            )
+
+        return {"thread_id": thread_id, "records": records, "capped": capped}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception(
+            f"Error getting provenance bodies for thread {thread_id}: {e}"
+        )
+        raise HTTPException(status_code=500, detail="Failed to get provenance bodies")
+
+
+@router.get("/{thread_id}/provenance/{provenance_record_id}/body")
+async def get_provenance_record_body(
+    thread_id: str,
+    provenance_record_id: str,
+    x_user_id: CurrentUserId,
+    full: bool = Query(
+        False,
+        description="When true, read the full body (pulls the spilled object if any).",
+    ),
+):
+    """Return the body for a single provenance record.
+
+    With ``full=true`` the full body is read via ``fetch_full_body`` (pulling the
+    spilled object when present, capped at ``FULL_BODY_READ_MAX_BYTES`` so one
+    request can't serialize a ~10 MiB object — an over-cap body returns truncated);
+    otherwise only the inline head is returned. The record must belong to the
+    caller's thread.
+    """
+    try:
+        await require_thread_owner(thread_id, x_user_id)
+        row = await get_provenance_record(thread_id, provenance_record_id)
+        if row is None:
+            raise HTTPException(status_code=404, detail="Provenance record not found")
+
+        sha = row.get("result_sha256")
+        if not sha:
+            raise HTTPException(
+                status_code=404, detail="Provenance record has no stored body"
+            )
+
+        from src.server.database.conversation import get_db_connection
+        from src.server.database.provenance_bodies import (
+            FULL_BODY_READ_MAX_BYTES,
+            RESULT_BODY_MAX_BYTES,
+            fetch_full_body,
+            fetch_result_bodies,
+        )
+
+        async with get_db_connection() as conn:
+            bodies = await fetch_result_bodies(conn, [sha])
+        meta = bodies.get(sha)
+        if meta is None:
+            raise HTTPException(
+                status_code=404, detail="Provenance record has no stored body"
+            )
+
+        byte_len = meta["byte_len"]
+        object_key = meta["object_key"]
+        if full:
+            body = await fetch_full_body(sha) or ""
+            # A full read is incomplete only if the spilled object exceeded the
+            # read cap, or the body was over the inline cap but never spilled (no
+            # bucket) so there was nothing more to read back. Keyed off byte_len +
+            # object_key, not a raw-vs-redacted length compare.
+            truncated = byte_len > FULL_BODY_READ_MAX_BYTES or (
+                object_key is None and byte_len > RESULT_BODY_MAX_BYTES
+            )
+        else:
+            body = meta["body_inline"] or ""
+            # The inline head is incomplete iff the body spilled or exceeded the
+            # cap but couldn't spill — independent of redaction shortening it.
+            truncated = object_key is not None or byte_len > RESULT_BODY_MAX_BYTES
+
+        return {
+            "provenance_record_id": str(row["provenance_record_id"]),
+            "result_sha256": sha,
+            "body": body,
+            "byte_len": byte_len,
+            "truncated": truncated,
+            # With full=true and no truncation, a true value attests the body is the
+            # exact bytes behind result_sha256; false means redacted or head-only.
+            "verified": (not truncated) and _body_hashes_to(body, sha),
+        }
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception(
+            f"Error getting provenance body for record {provenance_record_id}: {e}"
+        )
+        raise HTTPException(status_code=500, detail="Failed to get provenance body")

--- a/src/server/database/provenance.py
+++ b/src/server/database/provenance.py
@@ -336,6 +336,37 @@ async def get_provenance_for_thread(
             return [dict(row) for row in rows]
 
 
+async def get_provenance_body_refs(
+    conn,
+    conversation_thread_id: str,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """(record_id, sha) refs for the body-list endpoint, capped in SQL.
+
+    Only the records that carry a ``result_sha256``, in the same turn order as
+    ``get_provenance_for_thread`` but filtered + ``LIMIT``-ed in SQL so a long
+    thread doesn't transfer every row (and its ``args`` JSON) just to discard all
+    but ``limit``. Fetches ``limit + 1`` so the caller can detect "more were
+    available" for its ``capped`` flag. Runs on the caller's connection so the
+    body fetch reuses it.
+    """
+    async with conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute(
+            """
+            SELECT provenance_record_id, result_sha256
+            FROM provenance_records
+            WHERE conversation_thread_id = %s
+              AND result_sha256 IS NOT NULL
+            ORDER BY turn_index ASC,
+                     source_timestamp ASC NULLS LAST, created_at ASC
+            LIMIT %s
+            """,
+            (conversation_thread_id, limit + 1),
+        )
+        rows = await cur.fetchall()
+        return [dict(row) for row in rows]
+
+
 async def get_provenance_record(
     conversation_thread_id: str,
     provenance_record_id: str,

--- a/src/server/database/provenance.py
+++ b/src/server/database/provenance.py
@@ -334,3 +334,34 @@ async def get_provenance_for_thread(
             )
             rows = await cur.fetchall()
             return [dict(row) for row in rows]
+
+
+async def get_provenance_record(
+    conversation_thread_id: str,
+    provenance_record_id: str,
+) -> dict[str, Any] | None:
+    """Return one provenance row by (thread, record_id), or None.
+
+    Targeted lookup for the single-record body endpoint so it fetches just the one
+    row instead of loading the whole thread's provenance and scanning in Python.
+    Compares the id as text, so a malformed id simply finds no row (404) rather
+    than raising on a uuid cast.
+    """
+    async with get_db_connection() as conn:
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(
+                """
+                SELECT
+                    provenance_record_id, conversation_response_id,
+                    conversation_thread_id, turn_index, tool_call_id,
+                    source_type, identifier, title, detail, args_fingerprint,
+                    args, result_sha256, result_size, result_snippet, agent,
+                    provider, source_timestamp, created_at
+                FROM provenance_records
+                WHERE conversation_thread_id = %s
+                  AND provenance_record_id::text = %s
+                """,
+                (conversation_thread_id, provenance_record_id),
+            )
+            row = await cur.fetchone()
+            return dict(row) if row else None

--- a/src/server/database/provenance_bodies.py
+++ b/src/server/database/provenance_bodies.py
@@ -50,7 +50,7 @@ _GC_LOCK_KEY = "provenance_gc_sweep"
 # it. Single source of truth: both sweep_orphan_bodies and ProvenanceGCService
 # resolve their grace from this, and the reuse-touch window below derives from it
 # so the two can't drift.
-_GC_GRACE_DAYS = 7
+GC_GRACE_DAYS = 7
 
 # Reuse-touch window (days). A dedup write refreshes an existing body's created_at
 # ONLY when it's older than this — re-arming the grace window for a body being
@@ -68,7 +68,7 @@ _GC_GRACE_DAYS = 7
 # DELETE on the same rows (a deadlock surface, on exactly the hottest rows). The
 # age-gated touch keeps the common path lock-free and only locks the rare row
 # that is actually near GC-eligibility.
-_REUSE_TOUCH_AFTER_DAYS = _GC_GRACE_DAYS - 1
+_REUSE_TOUCH_AFTER_DAYS = GC_GRACE_DAYS - 1
 
 # A real SHA-256 hexdigest. Object keys are derived from the sha, so anything that
 # isn't a clean digest (e.g. a path-traversal payload from a future untrusted
@@ -320,7 +320,7 @@ async def fetch_full_body(
         return None
 
 
-async def sweep_orphan_bodies(grace_days: int = _GC_GRACE_DAYS) -> int:
+async def sweep_orphan_bodies(grace_days: int = GC_GRACE_DAYS) -> int:
     """Delete body rows unreferenced by any provenance record past the grace window.
 
     Mark-sweep GC: removes rows whose ``result_sha256`` no longer appears in

--- a/src/server/database/provenance_bodies.py
+++ b/src/server/database/provenance_bodies.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+from collections.abc import Iterable
 
 from psycopg.rows import dict_row
 
@@ -116,7 +117,9 @@ def _build_body_row(
     )
 
 
-async def store_result_bodies(items) -> None:
+async def store_result_bodies(
+    items: Iterable[tuple[str, str, int, str | None]],
+) -> None:
     """Batch-persist content-addressed result bodies (best-effort, never raises).
 
     ``items`` is an iterable of ``(sha256, body, true_byte_len, content_type)``.
@@ -152,12 +155,23 @@ async def store_result_bodies(items) -> None:
             # event loop — pure encode + NUL-scan, no I/O — so we don't pay a
             # thread-pool hop per row. Only an oversize body reaches boto3 (the
             # spill branch in _build_body_row); offload just that off the loop.
-            if len(body.encode("utf-8")) > RESULT_BODY_MAX_BYTES:
-                row = await asyncio.to_thread(
-                    _build_body_row, sha256, body, true_byte_len, content_type
+            try:
+                if len(body.encode("utf-8")) > RESULT_BODY_MAX_BYTES:
+                    row = await asyncio.to_thread(
+                        _build_body_row, sha256, body, true_byte_len, content_type
+                    )
+                else:
+                    row = _build_body_row(sha256, body, true_byte_len, content_type)
+            except Exception as e:
+                # Isolate per-item build failures so one bad body can't drop the
+                # rest of the turn's. _build_body_row is already defensive
+                # (upload_bytes returns False, never raises), so this is
+                # belt-and-suspenders for the module's "best-effort" contract.
+                logger.warning(
+                    "[provenance] skipped one result body (build failed)",
+                    extra={"result_sha256": sha256, "error": str(e)},
                 )
-            else:
-                row = _build_body_row(sha256, body, true_byte_len, content_type)
+                continue
             if row is not None:
                 rows.append(row)
                 if row[2]:
@@ -351,6 +365,12 @@ async def sweep_orphan_bodies(grace_days: int = _GC_GRACE_DAYS) -> int:
             # gone; a concurrent reuse may have re-inserted one with the same
             # content-addressed object key, and deleting that object would strand
             # the live row's body. Only the survivors get their objects reclaimed.
+            # Residual (accepted): a reuse that uploaded provenance/{sha} but hasn't
+            # committed its insert when this recheck runs is still seen as absent,
+            # so its object can be deleted out from under the about-to-commit row.
+            # That row then degrades to head-only on full=true (inline head still
+            # served) and self-heals on the next reuse, which re-uploads
+            # unconditionally — so it's a transient degrade, never data loss.
             spilled = [(sha, key) for sha, key in rows if key]
             if spilled:
                 async with conn.cursor() as check_cur:

--- a/src/server/database/provenance_bodies.py
+++ b/src/server/database/provenance_bodies.py
@@ -1,0 +1,378 @@
+"""Global content-addressed store for raw per-access tool result bodies.
+
+Bodies are keyed by ``result_sha256`` and shared across users/turns: a static
+filing fetched many times is stored once. Bodies up to
+``RESULT_BODY_MAX_BYTES`` live inline in Postgres; larger bodies keep a
+byte-safe head inline and spill the full bytes to object storage under
+``provenance/{sha256}``. Every write is best-effort and never raises — losing a
+body must not break the turn that produced it. GC is an independent mark-sweep
+against ``provenance_records`` (no FK; ``result_sha256`` is the logical link).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+
+from psycopg.rows import dict_row
+
+from src.server.database.conversation import get_db_connection
+from src.server.utils.pg_sanitize import strip_pg_nul_str
+from src.utils.storage import (
+    delete_object as _storage_delete_object,
+    get_bytes as _storage_get_bytes,
+    is_storage_enabled,
+    upload_bytes as _storage_upload_bytes,
+)
+
+logger = logging.getLogger(__name__)
+
+# Inline/spill cap. Canonical home is ``ptc_agent.agent.provenance.types``;
+# re-declared here (not imported) to keep this server-side module free of the
+# agent package's import graph and unaffected by the sibling edit adding it
+# there. Both copies MUST hold the same value.
+RESULT_BODY_MAX_BYTES = 64 * 1024
+
+# Rows per multi-row INSERT. Bounds the statement size (each body_inline is up to
+# RESULT_BODY_MAX_BYTES), so a turn with hundreds of MCP calls upserts in a few
+# chunks rather than one giant statement.
+_BATCH_CHUNK = 50
+
+# Advisory-lock key for the GC sweep. The sweep runs from every app instance's
+# lifespan; this lets only one instance sweep per cycle (others skip) if langalpha
+# is ever scaled past a single process.
+_GC_LOCK_KEY = "provenance_gc_sweep"
+
+# GC grace window (days): an orphan body younger than this is presumed mid-turn
+# — its provenance record may not have committed yet — so the sweep never reaps
+# it. Single source of truth: both sweep_orphan_bodies and ProvenanceGCService
+# resolve their grace from this, and the reuse-touch window below derives from it
+# so the two can't drift.
+_GC_GRACE_DAYS = 7
+
+# Reuse-touch window (days). A dedup write refreshes an existing body's created_at
+# ONLY when it's older than this — re-arming the grace window for a body being
+# resurrected from near GC-eligibility, so the sweep can't reap it mid-reuse
+# before the new turn's provenance record commits. One day inside the grace edge
+# so a reused body is always refreshed before it can be swept. Recent rows (the
+# overwhelming majority of dedup hits) fail the predicate, so the UPDATE matches
+# nothing — no row lock, no rewrite — preserving the no-churn DO NOTHING path.
+#
+# Why a conditional touch and NOT the obvious `ON CONFLICT DO UPDATE SET
+# last_seen_at = NOW()`: this store is global + content-addressed, so a popular
+# body (a hot 10-Q fetched by many users) is ONE row that many concurrent turns
+# dedup against. DO UPDATE on every hit takes a row write-lock on that hot row
+# each time, serializing those turns against each other AND against the GC's
+# DELETE on the same rows (a deadlock surface, on exactly the hottest rows). The
+# age-gated touch keeps the common path lock-free and only locks the rare row
+# that is actually near GC-eligibility.
+_REUSE_TOUCH_AFTER_DAYS = _GC_GRACE_DAYS - 1
+
+# A real SHA-256 hexdigest. Object keys are derived from the sha, so anything that
+# isn't a clean digest (e.g. a path-traversal payload from a future untrusted
+# caller) must never reach the object store as ``provenance/{sha}``.
+_SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
+
+# Ceiling on a single ``full=true`` body read. Spilled objects are already bounded
+# by the storage upload cap (default 10 MiB), but that whole body would otherwise
+# be decoded into one string and serialized into one JSON response on every
+# request. Cap the read so a verifier pull can't materialize ~10 MiB per call;
+# bodies past the cap come back truncated (true byte_len preserved, verified=false).
+FULL_BODY_READ_MAX_BYTES = 4 * 1024 * 1024
+
+
+def _build_body_row(
+    sha256: str, body: str, true_byte_len: int, content_type: str | None
+) -> tuple | None:
+    """Resolve one (sha, body) into an inline-head row, spilling oversize bytes.
+
+    Returns the row tuple to insert, or None when there is nothing to store.
+    Object-storage upload (for bodies over the cap) happens here, off the DB txn.
+    """
+    if not sha256 or not body:
+        return None
+    encoded = body.encode("utf-8")
+    object_key: str | None = None
+    if len(encoded) <= RESULT_BODY_MAX_BYTES:
+        body_inline = body
+    else:
+        # Slice on a byte boundary then decode with errors="ignore" so a
+        # multibyte char split at the cap is dropped, not mojibake.
+        body_inline = encoded[:RESULT_BODY_MAX_BYTES].decode("utf-8", errors="ignore")
+        # Only spill under a well-formed digest key; a malformed sha keeps the
+        # inline head and skips object storage rather than writing a junk key.
+        if is_storage_enabled() and _SHA256_RE.match(sha256):
+            key = f"provenance/{sha256}"
+            uploaded = _storage_upload_bytes(key, encoded, content_type)
+            if uploaded:
+                object_key = key
+    return (
+        strip_pg_nul_str(sha256),
+        strip_pg_nul_str(body_inline),
+        strip_pg_nul_str(object_key),
+        true_byte_len,
+        strip_pg_nul_str(content_type),
+    )
+
+
+async def store_result_bodies(items) -> None:
+    """Batch-persist content-addressed result bodies (best-effort, never raises).
+
+    ``items`` is an iterable of ``(sha256, body, true_byte_len, content_type)``.
+    Dedupes by sha in-memory (a single turn's market fan-out repeats the same body
+    across symbols), spills oversize bodies to object storage, then upserts the
+    rows in chunked multi-row statements on ONE connection. Bodies are immutable +
+    content-addressed, so the write is ``ON CONFLICT DO NOTHING`` — a dedup hit is a
+    pure no-op (no row rewrite, no WAL, no autovacuum churn on hot rows).
+
+    First-writer-wins on the body is benign: a collision means byte-identical
+    *unredacted* content (same sha), and secret-bearing output is execution-
+    specific (unique sha), so the shared body is never another tenant's secret;
+    differing redaction across tenants only affects which redacted-but-equivalent
+    bytes are served, flagged by ``verified=false`` downstream.
+    """
+    prepared: dict[str, tuple] = {}
+    for sha256, body, true_byte_len, content_type in items:
+        if not sha256 or not body or sha256 in prepared:
+            continue
+        prepared[sha256] = (body, true_byte_len, content_type)
+    if not prepared:
+        return
+    # Object keys uploaded this call (only oversize spills set one). Tracked so a
+    # DB failure can reclaim uploads whose row never committed — the upload in
+    # _build_body_row precedes the insert, and GC only learns objects from
+    # deleted rows, so an uncommitted upload would otherwise be invisible to it.
+    uploaded: list[tuple[str, str]] = []
+    committed: set[str] = set()
+    try:
+        rows = []
+        for sha256, (body, true_byte_len, content_type) in prepared.items():
+            # Build small inline bodies (the common case) synchronously on the
+            # event loop — pure encode + NUL-scan, no I/O — so we don't pay a
+            # thread-pool hop per row. Only an oversize body reaches boto3 (the
+            # spill branch in _build_body_row); offload just that off the loop.
+            if len(body.encode("utf-8")) > RESULT_BODY_MAX_BYTES:
+                row = await asyncio.to_thread(
+                    _build_body_row, sha256, body, true_byte_len, content_type
+                )
+            else:
+                row = _build_body_row(sha256, body, true_byte_len, content_type)
+            if row is not None:
+                rows.append(row)
+                if row[2]:
+                    uploaded.append((row[0], row[2]))
+        if not rows:
+            return
+        shas = [row[0] for row in rows]
+        async with get_db_connection() as conn:
+            # One transaction for the whole turn's bodies: the reuse-touch UPDATE
+            # and every INSERT chunk commit together in a single fsync, instead of
+            # one commit per chunk on the autocommit pool. On a raise the block
+            # rolls back as a unit, so `committed` stays empty and every spilled
+            # upload is reclaimed in the except below.
+            async with conn.cursor() as cur, conn.transaction():
+                # Reuse touch (D′): re-arm the GC grace window for any EXISTING
+                # body being reused here that has aged near eligibility, so the
+                # sweep can't delete it mid-reuse before this turn's provenance
+                # record commits. Conditional on age, so recent rows (most dedup
+                # hits) and not-yet-inserted shas match nothing — no lock, no
+                # rewrite. Runs before the insert; brand-new shas are then created
+                # fresh by the DO NOTHING insert below. See sweep_orphan_bodies.
+                await cur.execute(
+                    """
+                    UPDATE provenance_result_bodies
+                       SET created_at = NOW()
+                     WHERE result_sha256 = ANY(%s)
+                       AND created_at < NOW() - make_interval(days => %s)
+                    """,
+                    (shas, _REUSE_TOUCH_AFTER_DAYS),
+                )
+                for start in range(0, len(rows), _BATCH_CHUNK):
+                    chunk = rows[start : start + _BATCH_CHUNK]
+                    values = ", ".join(["(%s, %s, %s, %s, %s)"] * len(chunk))
+                    params = [v for row in chunk for v in row]
+                    await cur.execute(
+                        f"""
+                        INSERT INTO provenance_result_bodies
+                            (result_sha256, body_inline, object_key, byte_len, content_type)
+                        VALUES {values}
+                        ON CONFLICT (result_sha256) DO NOTHING
+                        """,
+                        params,
+                    )
+            # Transaction committed here: every chunk is now durable, so all
+            # spilled uploads have a row. (A raise skips this — `committed` stays
+            # empty and the except reclaims the uploads.)
+            committed.update(shas)
+    except Exception as e:
+        logger.warning(f"[provenance] store_result_bodies failed ({len(prepared)} items): {e}")
+        # Reclaim spilled objects whose row never committed (best-effort). A
+        # later store of the same content re-uploads + inserts, so a missed one
+        # self-heals; this just bounds orphan accumulation on a hard DB failure.
+        for sha256, object_key in uploaded:
+            if sha256 in committed:
+                continue
+            try:
+                await asyncio.to_thread(_storage_delete_object, object_key)
+            except Exception:
+                logger.debug(
+                    "[provenance] orphan upload cleanup failed (harmless)",
+                    extra={"object_key": object_key},
+                )
+
+
+async def store_result_body(
+    sha256: str,
+    body: str,
+    true_byte_len: int,
+    content_type: str | None = None,
+) -> None:
+    """Single-body convenience wrapper over :func:`store_result_bodies`."""
+    await store_result_bodies([(sha256, body, true_byte_len, content_type)])
+
+
+async def fetch_result_bodies(conn, shas: list[str]) -> dict[str, dict]:
+    """Fetch body rows for ``shas`` keyed by sha (inline/metadata only).
+
+    Does NOT fetch spilled objects — the caller decides whether to read the full
+    body via ``fetch_full_body``. Empty input returns an empty dict.
+    """
+    if not shas:
+        return {}
+    async with conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute(
+            """
+            SELECT result_sha256, body_inline, object_key, byte_len, content_type
+            FROM provenance_result_bodies
+            WHERE result_sha256 = ANY(%s)
+            """,
+            (list(shas),),
+        )
+        rows = await cur.fetchall()
+    return {
+        row["result_sha256"]: {
+            "body_inline": row["body_inline"],
+            "object_key": row["object_key"],
+            "byte_len": row["byte_len"],
+            "content_type": row["content_type"],
+        }
+        for row in rows
+    }
+
+
+async def fetch_full_body(
+    sha256: str, max_bytes: int = FULL_BODY_READ_MAX_BYTES
+) -> str | None:
+    """Return the full body for one sha, reading the spilled object if present.
+
+    Capped at ``max_bytes`` (byte-sliced before decode, so the caller's response
+    stays bounded even for a ~10 MiB spilled object); an over-cap body comes back
+    head-only and the caller's ``truncated`` check flips on the true ``byte_len``.
+    Best-effort: returns None on any failure or when the sha is unknown.
+    """
+    if not sha256:
+        return None
+    try:
+        async with get_db_connection() as conn:
+            async with conn.cursor(row_factory=dict_row) as cur:
+                await cur.execute(
+                    """
+                    SELECT body_inline, object_key
+                    FROM provenance_result_bodies
+                    WHERE result_sha256 = %s
+                    """,
+                    (sha256,),
+                )
+                row = await cur.fetchone()
+        if row is None:
+            return None
+        object_key = row["object_key"]
+        if object_key and is_storage_enabled():
+            data = await asyncio.to_thread(_storage_get_bytes, object_key)
+            if data is not None:
+                return data[:max_bytes].decode("utf-8", errors="ignore")
+        return row["body_inline"]
+    except Exception as e:
+        logger.warning(f"[provenance] fetch_full_body failed for sha={sha256}: {e}")
+        return None
+
+
+async def sweep_orphan_bodies(grace_days: int = _GC_GRACE_DAYS) -> int:
+    """Delete body rows unreferenced by any provenance record past the grace window.
+
+    Mark-sweep GC: removes rows whose ``result_sha256`` no longer appears in
+    ``provenance_records`` and whose ``created_at`` is older than ``grace_days``.
+    Grace on ``created_at`` covers the body-write → record-commit gap; a body
+    reused from near-eligibility has its ``created_at`` refreshed by the reuse
+    touch in :func:`store_result_bodies` (D′), so it can't be reaped mid-reuse.
+    A non-blocking advisory lock keeps concurrent instances from running
+    duplicate sweeps.
+
+    Spilled objects are reclaimed AFTER the row delete commits, and only for shas
+    a concurrent reuse hasn't re-inserted in the meantime: the object key is
+    content-addressed (``provenance/{sha}``), so deleting it out from under a
+    freshly re-inserted row would strand that live row's spilled body. Returns
+    rows deleted.
+    """
+    try:
+        rows: list = []
+        to_delete: list[str] = []
+        async with get_db_connection() as conn:
+            # Explicit txn so the xact-scoped advisory lock spans the DELETE on the
+            # autocommit pool; non-blocking try-lock means a second instance skips
+            # this cycle rather than waiting and then re-running an empty DELETE.
+            async with conn.cursor() as cur, conn.transaction():
+                await cur.execute(
+                    "SELECT pg_try_advisory_xact_lock(hashtextextended(%s, 0))",
+                    (_GC_LOCK_KEY,),
+                )
+                locked = await cur.fetchone()
+                if not (locked and locked[0]):
+                    logger.debug("[provenance] sweep skipped — GC lock held elsewhere")
+                    return 0
+                # make_interval(days => %s) binds cleanly; a bare INTERVAL '%s days'
+                # literal can't be parameterized by psycopg3.
+                await cur.execute(
+                    """
+                    DELETE FROM provenance_result_bodies b
+                    WHERE NOT EXISTS (
+                        SELECT 1 FROM provenance_records p
+                        WHERE p.result_sha256 = b.result_sha256
+                    )
+                      AND b.created_at < NOW() - make_interval(days => %s)
+                    RETURNING result_sha256, object_key
+                    """,
+                    (grace_days,),
+                )
+                rows = await cur.fetchall()
+
+            # Re-check (post-commit, on the same conn) which spilled shas are truly
+            # gone; a concurrent reuse may have re-inserted one with the same
+            # content-addressed object key, and deleting that object would strand
+            # the live row's body. Only the survivors get their objects reclaimed.
+            spilled = [(sha, key) for sha, key in rows if key]
+            if spilled:
+                async with conn.cursor() as check_cur:
+                    await check_cur.execute(
+                        "SELECT result_sha256 FROM provenance_result_bodies "
+                        "WHERE result_sha256 = ANY(%s)",
+                        ([sha for sha, _ in spilled],),
+                    )
+                    present = {r[0] for r in await check_cur.fetchall()}
+                to_delete = [key for sha, key in spilled if sha not in present]
+
+        deleted = len(rows)
+        # Slow object deletes run after the connection is released to the pool.
+        for object_key in to_delete:
+            try:
+                await asyncio.to_thread(_storage_delete_object, object_key)
+            except Exception:
+                logger.warning(
+                    "[provenance] orphan object delete failed (harmless)",
+                    extra={"object_key": object_key},
+                )
+        return deleted
+    except Exception as e:
+        logger.warning(f"[provenance] sweep_orphan_bodies failed: {e}")
+        return 0

--- a/src/server/database/provenance_bodies.py
+++ b/src/server/database/provenance_bodies.py
@@ -276,7 +276,10 @@ async def fetch_result_bodies(conn, shas: list[str]) -> dict[str, dict]:
 
 
 async def fetch_full_body(
-    sha256: str, max_bytes: int = FULL_BODY_READ_MAX_BYTES
+    sha256: str,
+    max_bytes: int = FULL_BODY_READ_MAX_BYTES,
+    *,
+    row: dict | None = None,
 ) -> str | None:
     """Return the full body for one sha, reading the spilled object if present.
 
@@ -284,23 +287,28 @@ async def fetch_full_body(
     stays bounded even for a ~10 MiB spilled object); an over-cap body comes back
     head-only and the caller's ``truncated`` check flips on the true ``byte_len``.
     Best-effort: returns None on any failure or when the sha is unknown.
+
+    Pass ``row`` (a dict carrying ``body_inline`` + ``object_key``, e.g. from
+    :func:`fetch_result_bodies`) to skip the row lookup — the caller already holds
+    those columns, so the only work left is the optional spilled-object read.
     """
     if not sha256:
         return None
     try:
-        async with get_db_connection() as conn:
-            async with conn.cursor(row_factory=dict_row) as cur:
-                await cur.execute(
-                    """
-                    SELECT body_inline, object_key
-                    FROM provenance_result_bodies
-                    WHERE result_sha256 = %s
-                    """,
-                    (sha256,),
-                )
-                row = await cur.fetchone()
         if row is None:
-            return None
+            async with get_db_connection() as conn:
+                async with conn.cursor(row_factory=dict_row) as cur:
+                    await cur.execute(
+                        """
+                        SELECT body_inline, object_key
+                        FROM provenance_result_bodies
+                        WHERE result_sha256 = %s
+                        """,
+                        (sha256,),
+                    )
+                    row = await cur.fetchone()
+            if row is None:
+                return None
         object_key = row["object_key"]
         if object_key and is_storage_enabled():
             data = await asyncio.to_thread(_storage_get_bytes, object_key)

--- a/src/server/services/provenance_gc.py
+++ b/src/server/services/provenance_gc.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import asyncio
 import logging
 
-from src.server.database.provenance_bodies import _GC_GRACE_DAYS, sweep_orphan_bodies
+from src.server.database.provenance_bodies import GC_GRACE_DAYS, sweep_orphan_bodies
 
 logger = logging.getLogger(__name__)
 
@@ -21,8 +21,8 @@ logger = logging.getLogger(__name__)
 _DEFAULT_INTERVAL_SECONDS = 86400
 # Grace window before an unreferenced body is reaped, so a body written mid-turn
 # isn't swept before its provenance row commits. Sourced from provenance_bodies
-# so the sweep grace and the reuse-touch window stay coupled (see _GC_GRACE_DAYS).
-_DEFAULT_GRACE_DAYS = _GC_GRACE_DAYS
+# so the sweep grace and the reuse-touch window stay coupled (see GC_GRACE_DAYS).
+_DEFAULT_GRACE_DAYS = GC_GRACE_DAYS
 
 
 class ProvenanceGCService:

--- a/src/server/services/provenance_gc.py
+++ b/src/server/services/provenance_gc.py
@@ -1,0 +1,95 @@
+"""Periodic GC for the content-addressed provenance body store.
+
+Runs a daily mark-and-sweep that deletes ``provenance_result_bodies`` rows whose
+``result_sha256`` is no longer referenced by any ``provenance_records`` row and
+that are past the grace window, plus their spilled objects. The DELETE + object
+cleanup lives in ``sweep_orphan_bodies``; this service just schedules it on an
+interval and survives per-cycle failures.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from src.server.database.provenance_bodies import _GC_GRACE_DAYS, sweep_orphan_bodies
+
+logger = logging.getLogger(__name__)
+
+# Once per day. The sweep is cheap (indexed NOT EXISTS) and bodies churn slowly,
+# so a tighter cadence buys nothing.
+_DEFAULT_INTERVAL_SECONDS = 86400
+# Grace window before an unreferenced body is reaped, so a body written mid-turn
+# isn't swept before its provenance row commits. Sourced from provenance_bodies
+# so the sweep grace and the reuse-touch window stay coupled (see _GC_GRACE_DAYS).
+_DEFAULT_GRACE_DAYS = _GC_GRACE_DAYS
+
+
+class ProvenanceGCService:
+    """Singleton background sweeper for orphaned provenance result bodies."""
+
+    _instance: ProvenanceGCService | None = None
+
+    @classmethod
+    def get_instance(cls) -> ProvenanceGCService:
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    def __init__(
+        self,
+        interval_seconds: int = _DEFAULT_INTERVAL_SECONDS,
+        grace_days: int = _DEFAULT_GRACE_DAYS,
+    ) -> None:
+        self._interval = interval_seconds
+        self._grace_days = grace_days
+        self._shutdown_event = asyncio.Event()
+        self._task: asyncio.Task | None = None
+
+    async def start(self) -> None:
+        """Launch the sweep loop (no-op if already running)."""
+        if self._task and not self._task.done():
+            return
+        self._shutdown_event.clear()
+        self._task = asyncio.create_task(self._loop(), name="provenance_gc_sweep")
+        logger.info(
+            "[ProvenanceGC] started — sweep every %ds, grace=%dd",
+            self._interval,
+            self._grace_days,
+        )
+
+    async def stop(self) -> None:
+        """Signal shutdown and cancel the sweep loop."""
+        self._shutdown_event.set()
+        if self._task and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        logger.info("[ProvenanceGC] stopped")
+
+    async def _loop(self) -> None:
+        """Sweep on start, then every interval — one failed cycle never kills the loop.
+
+        Sweeping first (rather than after a full interval) means a process that
+        restarts more often than ``_interval`` — frequent deploys, ``--reload`` —
+        still runs a sweep each start instead of never reaching the first one. The
+        grace window in ``sweep_orphan_bodies`` keeps a startup sweep from reaping
+        bodies written just before this boot.
+        """
+        while not self._shutdown_event.is_set():
+            try:
+                deleted = await sweep_orphan_bodies(grace_days=self._grace_days)
+                if deleted:
+                    logger.info("[ProvenanceGC] swept %d orphan body row(s)", deleted)
+            except Exception:
+                logger.error("[ProvenanceGC] sweep cycle failed", exc_info=True)
+
+            try:
+                await asyncio.wait_for(
+                    self._shutdown_event.wait(), timeout=self._interval
+                )
+                return  # shutdown requested during the sleep
+            except asyncio.TimeoutError:
+                pass

--- a/tests/unit/core/sandbox/test_ptc_sandbox_delegation.py
+++ b/tests/unit/core/sandbox/test_ptc_sandbox_delegation.py
@@ -98,6 +98,35 @@ class TestPTCSandboxDelegation:
 
     @patch("ptc_agent.core.sandbox.ptc_sandbox.create_provider")
     @pytest.mark.asyncio
+    async def test_execute_bash_injects_mcp_trace_env_and_harvests(
+        self, mock_create_provider, mock_provider, mock_runtime
+    ):
+        # A python script run via Bash must record the same MCP provenance
+        # ExecuteCode does: the foreground command carries an MCP_TRACE_FILE env +
+        # the wrapper PYTHONPATH, and the harvested trace is returned for the
+        # provenance middleware. (Closes the bash provenance bypass.)
+        from ptc_agent.core.sandbox.ptc_sandbox import PTCSandbox
+
+        mock_create_provider.return_value = mock_provider
+        mock_runtime.fetch_working_dir = AsyncMock(return_value="/home/workspace")
+        sandbox = PTCSandbox(config=_make_config())
+        sandbox.runtime = mock_runtime
+
+        trace = [{"server": "marketdata", "tool": "quote", "result_sha256": "a" * 64}]
+        with patch.object(
+            sandbox, "_collect_mcp_trace", AsyncMock(return_value=trace)
+        ) as collect:
+            result = await sandbox.execute_bash_command("python analysis.py")
+
+        exec_cmds = [c.args[0] for c in mock_runtime.exec.call_args_list if c.args]
+        main_cmd = next(c for c in exec_cmds if "python analysis.py" in c)
+        assert "export MCP_TRACE_FILE=" in main_cmd
+        assert "export PYTHONPATH=" in main_cmd
+        collect.assert_awaited_once()
+        assert result["mcp_trace"] == trace
+
+    @patch("ptc_agent.core.sandbox.ptc_sandbox.create_provider")
+    @pytest.mark.asyncio
     async def test_aupload_file_bytes_routes_to_runtime(
         self, mock_create_provider, mock_provider, mock_runtime
     ):
@@ -179,3 +208,122 @@ class TestPTCSandboxDelegation:
 
         await sandbox.close()
         mock_provider.close.assert_called()
+
+
+class TestBackgroundBashTrace:
+    """The background-bash provenance bypass closure (BashOutput is the only
+    result-bearing path for a backgrounded command, so the MCP trace must be
+    injected at launch and harvested on the status read that sees completion)."""
+
+    def _sandbox(self, mock_create_provider, mock_provider, mock_runtime):
+        from ptc_agent.core.sandbox.ptc_sandbox import PTCSandbox
+
+        mock_create_provider.return_value = mock_provider
+        sandbox = PTCSandbox(config=_make_config())
+        sandbox.runtime = mock_runtime
+        return sandbox
+
+    @patch("ptc_agent.core.sandbox.ptc_sandbox.create_provider")
+    @pytest.mark.asyncio
+    async def test_launch_injects_trace_env_and_records_path(
+        self, mock_create_provider, mock_provider, mock_runtime
+    ):
+        from ptc_agent.core.sandbox.runtime import SessionCommandResult
+
+        sandbox = self._sandbox(mock_create_provider, mock_provider, mock_runtime)
+        mock_runtime.fetch_working_dir = AsyncMock(return_value="/home/workspace")
+        mock_runtime.create_session = AsyncMock()
+        mock_runtime.session_execute = AsyncMock(
+            return_value=SessionCommandResult(
+                cmd_id="cmd-xyz", exit_code=None, stdout="", stderr=""
+            )
+        )
+
+        result = await sandbox.execute_bash_command(
+            "python long_job.py", background=True
+        )
+
+        # The executed bg command carries the MCP trace env (so a backgrounded
+        # python script importing the wrappers records its calls) ...
+        bg_cmd = mock_runtime.session_execute.call_args.args[1]
+        assert "export MCP_TRACE_FILE=" in bg_cmd
+        assert "export PYTHONPATH=" in bg_cmd
+        assert "python long_job.py" in bg_cmd
+        # ... and the trace path is tracked under the returned cmd_id for harvest.
+        assert "cmd-xyz" in result["stdout"]
+        assert sandbox._bg_trace_paths.get("cmd-xyz", "").endswith(".jsonl")
+
+    @patch("ptc_agent.core.sandbox.ptc_sandbox.create_provider")
+    @pytest.mark.asyncio
+    async def test_status_harvests_trace_once_on_completion(
+        self, mock_create_provider, mock_provider, mock_runtime
+    ):
+        from ptc_agent.core.sandbox.runtime import SessionCommandResult
+
+        sandbox = self._sandbox(mock_create_provider, mock_provider, mock_runtime)
+        sandbox._bg_sessions["cmd-1"] = "bg-bash_0001"
+        sandbox._bg_trace_paths["cmd-1"] = "/home/workspace/.system/trace/t.jsonl"
+        mock_runtime.session_command_logs = AsyncMock(
+            return_value=SessionCommandResult(
+                cmd_id="cmd-1", exit_code=0, stdout="done", stderr=""
+            )
+        )
+        trace = [{"server": "marketdata", "tool": "quote", "result_sha256": "a" * 64}]
+        with patch.object(
+            sandbox, "_collect_mcp_trace", AsyncMock(return_value=trace)
+        ) as collect:
+            result = await sandbox.get_background_command_status("cmd-1")
+
+        collect.assert_awaited_once()
+        assert result["mcp_trace"] == trace
+        # Trace path is consumed so a second status read can't re-emit it.
+        assert "cmd-1" not in sandbox._bg_trace_paths
+
+    @patch("ptc_agent.core.sandbox.ptc_sandbox.create_provider")
+    @pytest.mark.asyncio
+    async def test_status_while_running_does_not_harvest(
+        self, mock_create_provider, mock_provider, mock_runtime
+    ):
+        from ptc_agent.core.sandbox.runtime import SessionCommandResult
+
+        sandbox = self._sandbox(mock_create_provider, mock_provider, mock_runtime)
+        sandbox._bg_sessions["cmd-1"] = "bg-bash_0001"
+        sandbox._bg_trace_paths["cmd-1"] = "/home/workspace/.system/trace/t.jsonl"
+        mock_runtime.session_command_logs = AsyncMock(
+            return_value=SessionCommandResult(
+                cmd_id="cmd-1", exit_code=None, stdout="...", stderr=""
+            )
+        )
+        with patch.object(
+            sandbox, "_collect_mcp_trace", AsyncMock(return_value=[])
+        ) as collect:
+            result = await sandbox.get_background_command_status("cmd-1")
+
+        collect.assert_not_awaited()
+        assert result["mcp_trace"] == []
+        # Still running → trace path retained for the eventual completion read.
+        assert "cmd-1" in sandbox._bg_trace_paths
+
+    @patch("ptc_agent.core.sandbox.ptc_sandbox.create_provider")
+    @pytest.mark.asyncio
+    async def test_status_unknown_cmd_returns_empty_trace(
+        self, mock_create_provider, mock_provider, mock_runtime
+    ):
+        sandbox = self._sandbox(mock_create_provider, mock_provider, mock_runtime)
+        result = await sandbox.get_background_command_status("nope")
+        assert result["mcp_trace"] == []
+
+    @patch("ptc_agent.core.sandbox.ptc_sandbox.create_provider")
+    @pytest.mark.asyncio
+    async def test_stop_drops_trace_mapping(
+        self, mock_create_provider, mock_provider, mock_runtime
+    ):
+        sandbox = self._sandbox(mock_create_provider, mock_provider, mock_runtime)
+        sandbox._bg_sessions["cmd-1"] = "bg-bash_0001"
+        sandbox._bg_trace_paths["cmd-1"] = "/home/workspace/.system/trace/t.jsonl"
+        mock_runtime.delete_session = AsyncMock()
+
+        stopped = await sandbox.stop_background_command("cmd-1")
+        assert stopped is True
+        # A stopped command yields no output, so nothing to attest — drop the map.
+        assert "cmd-1" not in sandbox._bg_trace_paths

--- a/tests/unit/ptc_agent/agent/middleware/provenance/test_middleware.py
+++ b/tests/unit/ptc_agent/agent/middleware/provenance/test_middleware.py
@@ -706,6 +706,93 @@ async def test_bash_strips_mcp_trace_from_artifact(middleware):
     assert result.artifact["other"] == "kept"
 
 
+# ----- BashOutput shares the same pipeline (the completion-poll entry point) --
+
+
+@pytest.mark.asyncio
+async def test_bash_output_extracts_mcp_trace_like_execute_code(middleware):
+    # A backgrounded script's MCP calls are harvested on the BashOutput that
+    # observes completion, so BashOutput surfaces the same mcp_trace artifact and
+    # must produce identical mcp_tool provenance, attributed to the BashOutput call.
+    artifact = {
+        "mcp_trace": [
+            {
+                "server": "marketdata",
+                "tool": "quote",
+                "args": {"symbol": "TST"},
+                "result_sha256": "a" * 64,
+                "result_size": 12,
+                "result_snippet": "snip",
+                "timestamp": "2026-01-01T00:00:00+00:00",
+            }
+        ]
+    }
+    emitted = []
+    await _run(
+        middleware,
+        _make_request("BashOutput", {"command_id": "cmd-1"}, tool_call_id="bashout-1"),
+        _result(content="done", artifact=artifact),
+        emitted,
+    )
+    assert len(emitted) == 1
+    assert emitted[0]["identifier"] == "marketdata:quote"
+    assert emitted[0]["source_type"] == "mcp_tool"
+    assert emitted[0]["tool_call_id"] == "bashout-1"
+
+
+@pytest.mark.asyncio
+async def test_bash_output_records_despite_error_content(middleware):
+    # BashOutput is exempt from the error-result skip like Bash/ExecuteCode: the
+    # polled command may have exited non-zero after an MCP call already succeeded.
+    artifact = {
+        "mcp_trace": [
+            {
+                "server": "finance",
+                "tool": "get_prices",
+                "args": {"symbol": "TST"},
+                "result_sha256": "abc",
+                "result_size": 10,
+                "result_snippet": "ok",
+            }
+        ]
+    }
+    emitted = []
+    await _run(
+        middleware,
+        _make_request("BashOutput", {"command_id": "cmd-1"}, tool_call_id="bashout-1"),
+        _result(content="ERROR: Command failed (exit code 1)", artifact=artifact),
+        emitted,
+    )
+    assert len(emitted) == 1
+    assert emitted[0]["source_type"] == "mcp_tool"
+
+
+@pytest.mark.asyncio
+async def test_bash_output_strips_mcp_trace_from_artifact(middleware):
+    """mcp_trace must not survive on the BashOutput artifact either."""
+    artifact = {
+        "mcp_trace": [
+            {
+                "server": "marketdata",
+                "tool": "quote",
+                "args": {"symbol": "TST"},
+                "result_sha256": "a" * 64,
+                "result_size": 12,
+                "result_snippet": "snip",
+            }
+        ],
+        "other": "kept",
+    }
+    result = await _run(
+        middleware,
+        _make_request("BashOutput", {"command_id": "cmd-1"}, tool_call_id="bashout-1"),
+        _result(content="done", artifact=artifact),
+        [],
+    )
+    assert "mcp_trace" not in result.artifact
+    assert result.artifact["other"] == "kept"
+
+
 # ----- host-side caps on the untrusted in-sandbox trace ----------------------
 
 

--- a/tests/unit/ptc_agent/agent/middleware/provenance/test_middleware.py
+++ b/tests/unit/ptc_agent/agent/middleware/provenance/test_middleware.py
@@ -412,6 +412,40 @@ async def test_execute_code_one_mcp_tool_event_per_trace_entry(middleware):
 
 
 @pytest.mark.asyncio
+async def test_execute_code_coerces_malformed_result_size(middleware):
+    """Agent-authored result_size is validated like the other trace fields.
+
+    It rode through raw onto the SSE event + BIGINT column; a non-numeric,
+    negative, or absurd value is now coerced to None. A valid size on an
+    unverified entry survives — it's the only signal that a large (truncated)
+    result existed.
+    """
+    base = {
+        "server": "s",
+        "args": {},
+        "result_snippet": "x",
+        "timestamp": "2026-01-01T00:00:00+00:00",
+    }
+    artifact = {
+        "mcp_trace": [
+            {**base, "tool": "bad_str", "result_sha256": "a" * 64, "result_size": "12"},
+            {**base, "tool": "negative", "result_sha256": "b" * 64, "result_size": -5},
+            {**base, "tool": "absurd", "result_sha256": "c" * 64, "result_size": 10**18},
+            {**base, "tool": "ok", "result_sha256": "d" * 64, "result_size": 4096},
+        ]
+    }
+    emitted = []
+    await _run(
+        middleware,
+        _make_request("ExecuteCode", {"code": "..."}, tool_call_id="ec-1"),
+        _result(content="SUCCESS", artifact=artifact),
+        emitted,
+    )
+
+    assert [e["result_size"] for e in emitted] == [None, None, None, 4096]
+
+
+@pytest.mark.asyncio
 async def test_execute_code_strips_mcp_trace_from_artifact(middleware):
     """mcp_trace must not survive on the artifact (it would ride tool_call_result)."""
     artifact = {

--- a/tests/unit/ptc_agent/agent/middleware/provenance/test_middleware.py
+++ b/tests/unit/ptc_agent/agent/middleware/provenance/test_middleware.py
@@ -399,7 +399,11 @@ async def test_execute_code_one_mcp_tool_event_per_trace_entry(middleware):
     # Args are hashed, never stored raw (may carry secrets/PII).
     assert emitted[0]["args_fingerprint"] == hash_args({"symbol": "TST"})
     assert set(emitted[0]["args_fingerprint"]) == {"sha256"}
-    assert emitted[0]["result_sha256"] == "a" * 64
+    # These entries carry no result_body, so the integrity gate can't reproduce
+    # their (agent-authored) sha and nulls it rather than let a provenance record
+    # advertise an unverifiable content-address (closes poisoning + IDOR-by-
+    # content-address). Structure/identifiers still flow through.
+    assert emitted[0]["result_sha256"] is None
     assert emitted[0]["timestamp"] == "2026-01-01T00:00:00+00:00"
 
 
@@ -613,6 +617,93 @@ async def test_execute_code_records_despite_error_content(middleware):
     )
     assert len(emitted) == 1
     assert emitted[0]["source_type"] == "mcp_tool"
+
+
+# ----- Bash shares the mcp_trace pipeline (closes the bash provenance bypass) -
+
+
+@pytest.mark.asyncio
+async def test_bash_extracts_mcp_trace_like_execute_code(middleware):
+    # A script run via Bash (`python analysis.py`) surfaces the same mcp_trace
+    # artifact ExecuteCode does; it must produce identical mcp_tool provenance,
+    # attributed to the Bash tool call.
+    artifact = {
+        "mcp_trace": [
+            {
+                "server": "marketdata",
+                "tool": "quote",
+                "args": {"symbol": "TST"},
+                "result_sha256": "a" * 64,
+                "result_size": 12,
+                "result_snippet": "snip",
+                "timestamp": "2026-01-01T00:00:00+00:00",
+            }
+        ]
+    }
+    emitted = []
+    await _run(
+        middleware,
+        _make_request("Bash", {"command": "python analysis.py"}, tool_call_id="bash-1"),
+        _result(content="done", artifact=artifact),
+        emitted,
+    )
+    assert len(emitted) == 1
+    assert emitted[0]["identifier"] == "marketdata:quote"
+    assert emitted[0]["source_type"] == "mcp_tool"
+    assert emitted[0]["tool_call_id"] == "bash-1"
+
+
+@pytest.mark.asyncio
+async def test_bash_records_despite_error_content(middleware):
+    # Bash is exempt from the error-result skip like ExecuteCode: the command may
+    # exit non-zero (ERROR content) after an in-sandbox MCP call already succeeded.
+    artifact = {
+        "mcp_trace": [
+            {
+                "server": "finance",
+                "tool": "get_prices",
+                "args": {"symbol": "TST"},
+                "result_sha256": "abc",
+                "result_size": 10,
+                "result_snippet": "ok",
+            }
+        ]
+    }
+    emitted = []
+    await _run(
+        middleware,
+        _make_request("Bash", {"command": "python analysis.py"}, tool_call_id="bash-1"),
+        _result(content="ERROR: Command failed (exit code 1)", artifact=artifact),
+        emitted,
+    )
+    assert len(emitted) == 1
+    assert emitted[0]["source_type"] == "mcp_tool"
+
+
+@pytest.mark.asyncio
+async def test_bash_strips_mcp_trace_from_artifact(middleware):
+    """mcp_trace must not survive on the Bash artifact (it would ride tool_call_result)."""
+    artifact = {
+        "mcp_trace": [
+            {
+                "server": "marketdata",
+                "tool": "quote",
+                "args": {"symbol": "TST"},
+                "result_sha256": "a" * 64,
+                "result_size": 12,
+                "result_snippet": "snip",
+            }
+        ],
+        "other": "kept",
+    }
+    result = await _run(
+        middleware,
+        _make_request("Bash", {"command": "python analysis.py"}, tool_call_id="bash-1"),
+        _result(content="done", artifact=artifact),
+        [],
+    )
+    assert "mcp_trace" not in result.artifact
+    assert result.artifact["other"] == "kept"
 
 
 # ----- host-side caps on the untrusted in-sandbox trace ----------------------

--- a/tests/unit/ptc_agent/agent/middleware/provenance/test_middleware.py
+++ b/tests/unit/ptc_agent/agent/middleware/provenance/test_middleware.py
@@ -33,7 +33,11 @@ async def _run(middleware, request, result, emitted):
         return result
 
     with patch(_WRITER_PATH, return_value=emitted.append):
-        return await middleware.awrap_tool_call(request, handler)
+        out = await middleware.awrap_tool_call(request, handler)
+        # Body flush is now scheduled in the background; drain it so emission
+        # assertions see a settled state (mirrors the runtime's aafter_agent).
+        await middleware._drain_body_flushes()
+        return out
 
 
 @pytest.fixture
@@ -514,6 +518,9 @@ async def test_emit_failure_does_not_break_tool_call(middleware):
         result = await middleware.awrap_tool_call(
             _make_request("WebSearch", {"query": "q"}), handler
         )
+    # A flush was scheduled despite the writer failure; drain it so no task is
+    # left pending at loop close (best-effort store swallows its own errors).
+    await middleware._drain_body_flushes()
 
     assert result is sentinel
 

--- a/tests/unit/ptc_agent/agent/middleware/provenance/test_middleware_result_body.py
+++ b/tests/unit/ptc_agent/agent/middleware/provenance/test_middleware_result_body.py
@@ -620,3 +620,14 @@ async def test_fanout_bodies_flushed_in_one_batch():
     stored_shas = {item[0] for item in items}
     assert stored_shas == {e["result_sha256"] for e in emitted}
     assert len(stored_shas) == 2
+
+
+def test_result_body_cap_matches_across_layers():
+    """The body cap is re-declared (not imported) in the server store to keep that
+    module off the agent import graph, so the two copies can drift silently. Pin
+    them equal here: drift would split MCP-body verification from truncation."""
+    from src.server.database.provenance_bodies import (
+        RESULT_BODY_MAX_BYTES as SERVER_CAP,
+    )
+
+    assert RESULT_BODY_MAX_BYTES == SERVER_CAP

--- a/tests/unit/ptc_agent/agent/middleware/provenance/test_middleware_result_body.py
+++ b/tests/unit/ptc_agent/agent/middleware/provenance/test_middleware_result_body.py
@@ -551,10 +551,11 @@ async def test_host_path_sha_trusted_even_when_body_diverges():
     assert emitted[0]["result_sha256"] and items[0][0] == emitted[0]["result_sha256"]
 
 
-def test_body_item_coerces_nonint_result_size(middleware):
-    """A non-int result_size (only reachable on a malformed source) falls back to
-    the body's byte length rather than poisoning the BIGINT bind and aborting the
-    whole batch chunk."""
+def test_body_item_byte_len_ignores_result_size(middleware):
+    """byte_len is derived purely from the stored body's length; ``result_size``
+    is never read, so even a garbage value can't poison the BIGINT bind. The read
+    side keys truncation off ``byte_len > len(inline)``, which requires byte_len to
+    measure what we actually store — not the (possibly absent/malformed) raw size."""
     body = "hello body"
     src = SimpleNamespace(
         result_body=body,
@@ -564,6 +565,31 @@ def test_body_item_coerces_nonint_result_size(middleware):
     item = middleware._body_item(src)
     assert item is not None
     assert item[2] == len(body.encode("utf-8"))
+
+
+def test_body_item_byte_len_tracks_redacted_length():
+    """When redaction SHRINKS the body, byte_len records the post-redaction length
+    actually stored, not the larger raw result_size. This is the invariant behind
+    the read-side truncation flag: a body that was big pre-redaction but redacted
+    below the inline cap must read back as complete (byte_len <= len(inline)), not
+    be mislabeled a partial head."""
+    secret = "X" * 5000
+    body = f"head {secret} tail"
+    mw = ProvenanceMiddleware(
+        redactor=lambda s: s.replace(secret, "[REDACTED]") if s else s
+    )
+    src = SimpleNamespace(
+        result_body=body,
+        result_sha256=hashlib.sha256(body.encode()).hexdigest(),
+        result_size=len(body.encode("utf-8")),
+    )
+    item = mw._body_item(src)
+    assert item is not None
+    redacted = item[1]
+    assert secret not in redacted and "[REDACTED]" in redacted
+    # byte_len measures the stored (redacted) body, strictly less than the raw size.
+    assert item[2] == len(redacted.encode("utf-8"))
+    assert item[2] < len(body.encode("utf-8"))
 
 
 @pytest.mark.asyncio

--- a/tests/unit/ptc_agent/agent/middleware/provenance/test_middleware_result_body.py
+++ b/tests/unit/ptc_agent/agent/middleware/provenance/test_middleware_result_body.py
@@ -64,7 +64,11 @@ async def _run(middleware, request, result, emitted, *, store=None):
     with patch(_WRITER_PATH, return_value=emitted.append), patch(
         _STORE_PATH, store
     ):
-        return await middleware.awrap_tool_call(request, handler)
+        out = await middleware.awrap_tool_call(request, handler)
+        # The flush is scheduled in the background; drain inside the patch so the
+        # task's lazy store_result_bodies import resolves to the mock above.
+        await middleware._drain_body_flushes()
+        return out
 
 
 def _stored_items(store):
@@ -631,3 +635,52 @@ def test_result_body_cap_matches_across_layers():
     )
 
     assert RESULT_BODY_MAX_BYTES == SERVER_CAP
+
+
+# ---------------------------------------------------------------------------
+# Body store runs OFF the tool-call critical path: scheduled in the background
+# during awrap_tool_call, settled at agent end (aafter_agent / _drain).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_body_flush_is_deferred_then_drained(middleware):
+    """awrap_tool_call returns WITHOUT awaiting the store write; the write lands
+    once the background task is drained. This is the latency win: the tool result
+    (and the next LLM step) no longer waits on the DB/object-store write."""
+    request = _make_request("WebFetch", {"url": "https://x.test/doc"})
+    result = _result(content="external document body")
+    emitted: list = []
+    store = AsyncMock()
+
+    async def handler(_req):
+        return result
+
+    with patch(_WRITER_PATH, return_value=emitted.append), patch(_STORE_PATH, store):
+        out = await middleware.awrap_tool_call(request, handler)
+        # Scheduled, not yet executed — the tool result already returned.
+        store.assert_not_awaited()
+        await middleware._drain_body_flushes()
+        store.assert_awaited_once()
+
+    assert out is result
+    # The drain is idempotent and leaves no dangling tasks.
+    assert middleware._body_flush_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_aafter_agent_drains_pending_flush(middleware):
+    """The runtime drain point (aafter_agent) awaits in-flight body writes."""
+    request = _make_request("WebFetch", {"url": "https://x.test/doc"})
+    result = _result(content="external document body")
+    store = AsyncMock()
+
+    async def handler(_req):
+        return result
+
+    with patch(_WRITER_PATH, return_value=[].append), patch(_STORE_PATH, store):
+        await middleware.awrap_tool_call(request, handler)
+        store.assert_not_awaited()
+        await middleware.aafter_agent(state=None, runtime=None)
+        store.assert_awaited_once()
+    assert middleware._body_flush_tasks == set()

--- a/tests/unit/ptc_agent/agent/middleware/provenance/test_middleware_result_body.py
+++ b/tests/unit/ptc_agent/agent/middleware/provenance/test_middleware_result_body.py
@@ -1,0 +1,596 @@
+"""Tests for ProvenanceMiddleware's per-access ``result_body`` capture + store.
+
+Each ``_extract_*`` sets ``source.result_body`` from the SAME value that
+produced ``result_sha256`` (per-item for fan-out tools). In ``awrap_tool_call``
+the body is redacted in full and live-written to the content-addressed store
+best-effort AFTER the SSE emit — the ``provenance`` event itself never carries
+the body. Neutral placeholder data throughout.
+
+The regression that started this work: ``_extract_execute_code`` must stamp each
+mcp_tool source with ITS OWN per-call trace body, never the aggregate ExecuteCode
+stdout. That is the most important test here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from ptc_agent.agent.middleware.provenance import ProvenanceMiddleware
+from ptc_agent.agent.provenance.types import RESULT_BODY_MAX_BYTES
+
+_WRITER_PATH = (
+    "ptc_agent.agent.middleware.provenance.middleware.get_stream_writer"
+)
+# store_result_bodies is imported lazily inside _flush_bodies via
+# `from src.server.database.provenance_bodies import store_result_bodies`, so the
+# patch target is the attribute on the source module. The middleware batches a
+# turn's bodies into ONE call whose sole positional arg is a list of
+# (sha, body, byte_len, content_type) tuples.
+_STORE_PATH = "src.server.database.provenance_bodies.store_result_bodies"
+
+
+def _make_request(name, args, tool_call_id="call-1"):
+    return SimpleNamespace(
+        tool_call={"name": name, "args": args, "id": tool_call_id}
+    )
+
+
+def _result(content="", artifact=None):
+    return SimpleNamespace(content=content, artifact=artifact)
+
+
+def _canonical(value) -> str:
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, sort_keys=True, default=str, ensure_ascii=False)
+    return str(value)
+
+
+async def _run(middleware, request, result, emitted, *, store=None):
+    """Run awrap_tool_call with a patched stream writer + body store.
+
+    Returns the tool result. ``store`` (if given) is patched in as
+    store_result_bodies so callers can assert on what got persisted.
+    """
+    async def handler(_req):
+        return result
+
+    if store is None:
+        store = AsyncMock()
+    with patch(_WRITER_PATH, return_value=emitted.append), patch(
+        _STORE_PATH, store
+    ):
+        return await middleware.awrap_tool_call(request, handler)
+
+
+def _stored_items(store):
+    """Flatten every (sha, body, byte_len, content_type) tuple across all batched
+    store_result_bodies calls (the middleware flushes one list per turn)."""
+    return [
+        item
+        for call in store.await_args_list
+        for item in (call.args[0] if call.args else [])
+    ]
+
+
+@pytest.fixture
+def middleware():
+    return ProvenanceMiddleware()
+
+
+# ---------------------------------------------------------------------------
+# REGRESSION (the bug that started this): each mcp_tool source carries ITS OWN
+# per-call trace body — never the aggregate ExecuteCode stdout.
+# ---------------------------------------------------------------------------
+
+
+def test_execute_code_body_is_per_call_not_aggregate(middleware):
+    """Construct a trace with multiple entries, each a distinct result_body, and
+    assert every yielded source carries its own entry's body — not the others'
+    and not the aggregate ExecuteCode stdout."""
+    body_a = json.dumps({"price": 101.5, "symbol": "AAA"})
+    body_b = json.dumps({"price": 202.5, "symbol": "BBB"})
+    body_c = json.dumps({"shares": 333, "symbol": "CCC"})
+    aggregate_stdout = "AGGREGATE CODE STDOUT: printed 3 quotes, done."
+
+    artifact = {
+        "mcp_trace": [
+            {
+                "server": "marketdata",
+                "tool": "quote",
+                "args": {"symbol": "AAA"},
+                "result_sha256": hashlib.sha256(body_a.encode()).hexdigest(),
+                "result_size": len(body_a.encode()),
+                "result_snippet": body_a[:50],
+                "result_body": body_a,
+            },
+            {
+                "server": "marketdata",
+                "tool": "quote",
+                "args": {"symbol": "BBB"},
+                "result_sha256": hashlib.sha256(body_b.encode()).hexdigest(),
+                "result_size": len(body_b.encode()),
+                "result_snippet": body_b[:50],
+                "result_body": body_b,
+            },
+            {
+                "server": "positions",
+                "tool": "holdings",
+                "args": {"symbol": "CCC"},
+                "result_sha256": hashlib.sha256(body_c.encode()).hexdigest(),
+                "result_size": len(body_c.encode()),
+                "result_snippet": body_c[:50],
+                "result_body": body_c,
+            },
+        ]
+    }
+    request = _make_request("ExecuteCode", {"code": "..."}, tool_call_id="ec-1")
+    result = _result(content=aggregate_stdout, artifact=artifact)
+
+    sources = list(middleware._extract_execute_code(request, result))
+
+    assert len(sources) == 3
+    bodies = [s.result_body for s in sources]
+    # Each source carries its OWN per-call body.
+    assert bodies == [body_a, body_b, body_c]
+    # No source carries the aggregate ExecuteCode stdout (the old bug).
+    assert all(aggregate_stdout not in (b or "") for b in bodies)
+    # Bodies are all distinct (no cross-contamination between calls).
+    assert len(set(bodies)) == 3
+    # Each body hashes to its own row's result_sha256 (verifier ground truth).
+    for src in sources:
+        assert (
+            hashlib.sha256(src.result_body.encode()).hexdigest()
+            == src.result_sha256
+        )
+
+
+def test_execute_code_body_absent_when_entry_omits_it(middleware):
+    """A trace entry past the sandbox's per-execution budget has no result_body;
+    the source's body is None but sha/snippet/size still flow through."""
+    body = json.dumps({"ok": True})
+    artifact = {
+        "mcp_trace": [
+            {
+                "server": "marketdata",
+                "tool": "quote",
+                "args": {"symbol": "AAA"},
+                "result_sha256": hashlib.sha256(body.encode()).hexdigest(),
+                "result_size": len(body.encode()),
+                "result_snippet": body[:50],
+                # result_body intentionally absent (budget exhausted in-sandbox).
+            }
+        ]
+    }
+    request = _make_request("ExecuteCode", {"code": "..."}, tool_call_id="ec-1")
+    sources = list(
+        middleware._extract_execute_code(request, _result(artifact=artifact))
+    )
+    assert len(sources) == 1
+    assert sources[0].result_body is None
+    assert sources[0].result_sha256  # sha still present
+    assert sources[0].result_snippet == body[:50]
+
+
+def test_execute_code_host_reclamps_oversized_trace_body(middleware):
+    """The trace is agent-authored; a body exceeding the cap is re-clamped
+    host-side to <= RESULT_BODY_MAX_BYTES (defense in depth)."""
+    oversized = "q" * (RESULT_BODY_MAX_BYTES + 4096)
+    artifact = {
+        "mcp_trace": [
+            {
+                "server": "marketdata",
+                "tool": "quote",
+                "args": {},
+                "result_sha256": "a" * 64,
+                "result_size": len(oversized.encode()),
+                "result_snippet": "snip",
+                "result_body": oversized,
+            }
+        ]
+    }
+    request = _make_request("ExecuteCode", {"code": "..."}, tool_call_id="ec-1")
+    sources = list(
+        middleware._extract_execute_code(request, _result(artifact=artifact))
+    )
+    assert len(sources) == 1
+    assert (
+        len(sources[0].result_body.encode("utf-8")) <= RESULT_BODY_MAX_BYTES
+    )
+    assert sources[0].result_body == oversized[:RESULT_BODY_MAX_BYTES]
+
+
+# ---------------------------------------------------------------------------
+# Per-item fan-out: web_search per item + sec_filing per filing set result_body
+# per item, hash-consistent with that item's result_sha256.
+# ---------------------------------------------------------------------------
+
+
+def test_web_search_body_is_per_item_hash_consistent(middleware):
+    item_a = {"url": "https://example.com/a", "title": "Alpha", "snippet": "aaa"}
+    item_b = {"url": "https://example.com/b", "title": "Beta", "snippet": "bbb"}
+    artifact = {"results": [item_a, item_b]}
+    request = _make_request("WebSearch", {"query": "q"}, tool_call_id="ws-1")
+
+    sources = list(middleware._extract_web_search(request, _result(artifact=artifact)))
+
+    assert len(sources) == 2
+    # Each source's body is its OWN item's canonical form.
+    assert sources[0].result_body == _canonical(item_a)
+    assert sources[1].result_body == _canonical(item_b)
+    assert sources[0].result_body != sources[1].result_body
+    # Hash-consistent: each body hashes to that item's result_sha256.
+    for src in sources:
+        assert (
+            hashlib.sha256(src.result_body.encode("utf-8")).hexdigest()
+            == src.result_sha256
+        )
+
+
+def test_sec_filing_body_is_per_filing_hash_consistent(middleware):
+    filing_a = {"filing_date": "2026-01-01", "source_url": "https://sec.test/1"}
+    filing_b = {"filing_date": "2026-02-01", "source_url": "https://sec.test/2"}
+    artifact = {
+        "type": "sec_filing",
+        "symbol": "TESTCO",
+        "filings": [filing_a, filing_b],
+    }
+    request = _make_request("get_sec_filing", {"symbol": "TESTCO"})
+
+    sources = list(
+        middleware._extract_sec_filing(
+            request, _result(content="x", artifact=artifact)
+        )
+    )
+
+    assert len(sources) == 2
+    assert sources[0].result_body == _canonical(filing_a)
+    assert sources[1].result_body == _canonical(filing_b)
+    assert sources[0].result_body != sources[1].result_body
+    for src in sources:
+        assert (
+            hashlib.sha256(src.result_body.encode("utf-8")).hexdigest()
+            == src.result_sha256
+        )
+
+
+def test_sec_single_filing_body_is_artifact_hash_consistent(middleware):
+    """The single-filing branch (10-K/10-Q) hashes the whole artifact; the body
+    must be that same artifact value."""
+    artifact = {
+        "type": "sec_filing",
+        "symbol": "TESTCO",
+        "source_url": "https://sec.test/10k",
+        "text": "filing body text",
+    }
+    request = _make_request("get_sec_filing", {"symbol": "TESTCO"})
+    sources = list(
+        middleware._extract_sec_filing(
+            request, _result(content="x", artifact=artifact)
+        )
+    )
+    assert len(sources) == 1
+    assert sources[0].result_body == _canonical(artifact)
+    assert (
+        hashlib.sha256(sources[0].result_body.encode("utf-8")).hexdigest()
+        == sources[0].result_sha256
+    )
+
+
+def test_web_fetch_body_is_content_hash_consistent(middleware):
+    content = "fetched markdown body, the agent reasoned over this"
+    request = _make_request("WebFetch", {"url": "https://docs.test/page"})
+    sources = list(
+        middleware._extract_web_fetch(request, _result(content=content))
+    )
+    assert len(sources) == 1
+    assert sources[0].result_body == _canonical(content)
+    assert (
+        hashlib.sha256(sources[0].result_body.encode("utf-8")).hexdigest()
+        == sources[0].result_sha256
+    )
+
+
+def test_market_data_body_shared_across_symbols(middleware):
+    """One market call may yield several symbol rows; each carries the same
+    fingerprinted body (the single result they all came from)."""
+    artifact = {"indices": ["^AAA", "^BBB"], "data": [1, 2, 3]}
+    request = _make_request("get_market_indices", {"indices": ["^AAA", "^BBB"]})
+    sources = list(
+        middleware._extract_market_data(request, _result(artifact=artifact))
+    )
+    assert len(sources) == 2
+    assert sources[0].result_body == _canonical(artifact)
+    assert sources[0].result_body == sources[1].result_body
+    for src in sources:
+        assert (
+            hashlib.sha256(src.result_body.encode("utf-8")).hexdigest()
+            == src.result_sha256
+        )
+
+
+# ---------------------------------------------------------------------------
+# result_body NEVER rides the SSE event (sse_events gains 0 bytes).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_result_body_not_on_emitted_event(middleware):
+    artifact = {
+        "results": [
+            {"url": "https://x.test/a", "title": "A", "snippet": "long body a"},
+        ]
+    }
+    emitted = []
+    await _run(
+        middleware,
+        _make_request("WebSearch", {"query": "q"}),
+        _result(artifact=artifact),
+        emitted,
+    )
+    assert len(emitted) == 1
+    event = emitted[0]
+    # The body is intentionally absent from the emitted event...
+    assert "result_body" not in event
+    # ...and the event key set is exactly the pre-body shape (no new keys).
+    assert set(event.keys()) == {
+        "type",
+        "record_id",
+        "source_type",
+        "identifier",
+        "title",
+        "detail",
+        "provider",
+        "tool_call_id",
+        "args_fingerprint",
+        "args",
+        "result_sha256",
+        "result_size",
+        "result_snippet",
+        "timestamp",
+        "agent",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Redaction before store: the body handed to store_result_body is redacted, and
+# the SSE emit still fires. Store is best-effort — a raising store can't break
+# the turn.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_body_redacted_before_store_and_emit_unaffected():
+    """A known secret in the full body is redacted before store_result_body, and
+    the provenance event still emits unchanged."""
+    secret = "Bearer super-secret-token-value"
+    mw = ProvenanceMiddleware(
+        redactor=lambda s: s.replace(secret, "[REDACTED]") if s else s
+    )
+    content = f"prefix {secret} suffix with more body the agent read"
+    store = AsyncMock()
+    emitted = []
+
+    result = await _run(
+        mw,
+        _make_request("WebFetch", {"url": "https://docs.test/x"}),
+        _result(content=content),
+        emitted,
+        store=store,
+    )
+
+    # The SSE emit fired (unchanged path).
+    assert len(emitted) == 1
+    assert emitted[0]["identifier"] == "https://docs.test/x"
+    # The tool result is returned unchanged.
+    assert result.content == content
+
+    # The batched store call carried a REDACTED body (secret scrubbed).
+    store.assert_awaited_once()
+    items = _stored_items(store)
+    assert len(items) == 1
+    stored_sha, stored_body = items[0][0], items[0][1]
+    assert stored_sha == emitted[0]["result_sha256"]
+    assert secret not in stored_body
+    assert "[REDACTED]" in stored_body
+
+
+@pytest.mark.asyncio
+async def test_store_failure_does_not_break_turn():
+    """store_result_body raising must not break the tool call or the SSE emit
+    (best-effort live write, like WorkspaceContextMiddleware front-matter sync)."""
+    mw = ProvenanceMiddleware()
+    store = AsyncMock(side_effect=RuntimeError("db down"))
+    emitted = []
+
+    result = await _run(
+        mw,
+        _make_request("WebFetch", {"url": "https://docs.test/y"}),
+        _result(content="some body the agent read"),
+        emitted,
+        store=store,
+    )
+
+    # The event still emitted and the result still returned despite the raise.
+    assert len(emitted) == 1
+    assert emitted[0]["identifier"] == "https://docs.test/y"
+    assert result.content == "some body the agent read"
+    store.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_store_skipped_when_no_body(middleware):
+    """file_read sets no result_body, so store_result_body is never called even
+    though a provenance event is emitted."""
+    store = AsyncMock()
+    emitted = []
+    await _run(
+        middleware,
+        _make_request("Read", {"file_path": "work/out.csv"}),
+        _result(content="real file data"),
+        emitted,
+        store=store,
+    )
+    assert len(emitted) == 1  # event still emitted
+    store.assert_not_awaited()  # but no body to store
+
+
+# ---------------------------------------------------------------------------
+# Integrity gate: an agent-authored (mcp_tool) sha is trusted only if the body
+# we hold reproduces it. A forged or unverifiable pair is dropped AND its sha is
+# nulled on the record, closing cross-tenant poisoning + IDOR-by-content-address.
+# ---------------------------------------------------------------------------
+
+
+def _mcp_artifact(body, sha, *, size=None):
+    return {
+        "mcp_trace": [
+            {
+                "server": "marketdata",
+                "tool": "quote",
+                "args": {"symbol": "AAA"},
+                "result_sha256": sha,
+                "result_size": size if size is not None else len(body.encode()),
+                "result_snippet": body[:50],
+                "result_body": body,
+            }
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_mcp_body_with_matching_sha_is_stored_and_sha_kept():
+    mw = ProvenanceMiddleware()
+    body = json.dumps({"price": 101.5, "symbol": "AAA"})
+    real_sha = hashlib.sha256(body.encode()).hexdigest()
+    store = AsyncMock()
+    emitted = []
+    await _run(
+        mw,
+        _make_request("ExecuteCode", {"code": "..."}, tool_call_id="ec-1"),
+        _result(content="agg", artifact=_mcp_artifact(body, real_sha)),
+        emitted,
+        store=store,
+    )
+    items = _stored_items(store)
+    assert len(items) == 1
+    assert items[0][0] == real_sha and items[0][1] == body
+    # The verified sha survives on the record.
+    assert emitted[0]["result_sha256"] == real_sha
+
+
+@pytest.mark.asyncio
+async def test_mcp_body_with_forged_sha_is_dropped_and_record_sha_nulled():
+    mw = ProvenanceMiddleware()
+    body = json.dumps({"price": 101.5, "symbol": "AAA"})
+    forged_sha = "f" * 64  # body does NOT hash to this
+    store = AsyncMock()
+    emitted = []
+    await _run(
+        mw,
+        _make_request("ExecuteCode", {"code": "..."}, tool_call_id="ec-1"),
+        _result(content="agg", artifact=_mcp_artifact(body, forged_sha)),
+        emitted,
+        store=store,
+    )
+    # No body persisted under a sha we can't reproduce.
+    assert _stored_items(store) == []
+    # And the record carries no content-address, so it can't fetch a global
+    # body by an attacker-chosen sha.
+    assert emitted[0].get("result_sha256") is None
+
+
+@pytest.mark.asyncio
+async def test_mcp_truncated_body_cannot_verify_and_is_dropped():
+    """A >64 KiB MCP result: the host holds only the 64 KiB head, which can't
+    reproduce the full-result sha, so the body is dropped and the sha nulled —
+    honest, since the full bytes were never recoverable on the MCP path anyway."""
+    mw = ProvenanceMiddleware()
+    full = "z" * (RESULT_BODY_MAX_BYTES + 5000)
+    full_sha = hashlib.sha256(full.encode()).hexdigest()  # over the FULL result
+    store = AsyncMock()
+    emitted = []
+    await _run(
+        mw,
+        _make_request("ExecuteCode", {"code": "..."}, tool_call_id="ec-1"),
+        _result(artifact=_mcp_artifact(full, full_sha, size=len(full.encode()))),
+        emitted,
+        store=store,
+    )
+    assert _stored_items(store) == []
+    assert emitted[0].get("result_sha256") is None
+
+
+@pytest.mark.asyncio
+async def test_host_path_sha_trusted_even_when_body_diverges():
+    """Host-computed shas (web/sec/market) are NOT subject to the gate: a redacted
+    web_fetch body diverges from its sha by design, yet it is still stored and the
+    record keeps its (trusted) sha."""
+    secret = "Bearer host-secret-token"
+    mw = ProvenanceMiddleware(
+        redactor=lambda s: s.replace(secret, "[REDACTED]") if s else s
+    )
+    content = f"prefix {secret} suffix body"
+    store = AsyncMock()
+    emitted = []
+    await _run(
+        mw,
+        _make_request("WebFetch", {"url": "https://docs.test/x"}),
+        _result(content=content),
+        emitted,
+        store=store,
+    )
+    items = _stored_items(store)
+    assert len(items) == 1
+    assert secret not in items[0][1] and "[REDACTED]" in items[0][1]
+    # Host sha is trusted and survives even though the stored body was redacted.
+    assert emitted[0]["result_sha256"] and items[0][0] == emitted[0]["result_sha256"]
+
+
+def test_body_item_coerces_nonint_result_size(middleware):
+    """A non-int result_size (only reachable on a malformed source) falls back to
+    the body's byte length rather than poisoning the BIGINT bind and aborting the
+    whole batch chunk."""
+    body = "hello body"
+    src = SimpleNamespace(
+        result_body=body,
+        result_sha256=hashlib.sha256(body.encode()).hexdigest(),
+        result_size="not-an-int",
+    )
+    item = middleware._body_item(src)
+    assert item is not None
+    assert item[2] == len(body.encode("utf-8"))
+
+
+@pytest.mark.asyncio
+async def test_fanout_bodies_flushed_in_one_batch():
+    """A multi-result web_search emits per item but flushes ONE batched store call
+    carrying a body per item (each its own sha) — N round-trips collapsed to 1."""
+    mw = ProvenanceMiddleware()
+    artifact = {
+        "results": [
+            {"url": "https://x.test/a", "title": "A", "snippet": "body a"},
+            {"url": "https://x.test/b", "title": "B", "snippet": "body b"},
+        ]
+    }
+    store = AsyncMock()
+    emitted = []
+    await _run(
+        mw,
+        _make_request("WebSearch", {"query": "q"}),
+        _result(artifact=artifact),
+        emitted,
+        store=store,
+    )
+    assert len(emitted) == 2
+    # Exactly one batched write for the whole turn.
+    store.assert_awaited_once()
+    items = _stored_items(store)
+    # One item per source, distinct shas matching the emitted events.
+    stored_shas = {item[0] for item in items}
+    assert stored_shas == {e["result_sha256"] for e in emitted}
+    assert len(stored_shas) == 2

--- a/tests/unit/ptc_agent/agent/middleware/provenance/test_provenance_body_hash_stability.py
+++ b/tests/unit/ptc_agent/agent/middleware/provenance/test_provenance_body_hash_stability.py
@@ -38,13 +38,14 @@ _WRITER_PATH = (
 # (sha, body, byte_len, content_type) tuples.
 _STORE_PATH = "src.server.database.provenance_bodies.store_result_bodies"
 
-# An armed redactor, exactly like production: real secret VALUES configured.
-# None of these strings appears in the clean SEC / market payloads below, so a
-# correct redactor must leave those bodies byte-identical to their canonical form.
+# An armed redactor, exactly like production: secret VALUES configured. These are
+# deliberately obvious non-secrets (just long enough to clear the redactor's >=8
+# char gate) so they don't trip secret scanners; none appears in the clean SEC /
+# market payloads below, so a correct redactor leaves those bodies byte-identical.
 _VAULT_SECRETS = {
-    "FMP_API_KEY": "fmpk_live_9a8b7c6d5e4f3g2h1i0j",
-    "OPENAI_API_KEY": "sk-proj-AAAABBBBCCCCDDDDEEEE",
-    "GITHUB_TOKEN": "ghp_ZZZZ1111YYYY2222XXXX3333",
+    "FMP_API_KEY": "fake-fmp-key-for-tests-only",
+    "OPENAI_API_KEY": "fake-openai-key-for-tests-only",
+    "GITHUB_TOKEN": "fake-github-token-for-tests-only",
 }
 
 

--- a/tests/unit/ptc_agent/agent/middleware/provenance/test_provenance_body_hash_stability.py
+++ b/tests/unit/ptc_agent/agent/middleware/provenance/test_provenance_body_hash_stability.py
@@ -1,8 +1,8 @@
 """Hash-stability of the content-addressed body store on the SAFE FREQUENT PATH.
 
-The body handed to ``store_result_body`` is ``_canonical_body(value)`` — the exact
-string ``fingerprint_result(value)`` hashes into ``result_sha256`` — after passing
-through ``_redact_body``. So for content carrying NO secret value and NO
+The body handed to ``store_result_body`` is the ``canonical`` string from
+``fingerprint_result_with_body(value)`` — the exact string hashed into
+``result_sha256`` — after passing through ``_redact_body``. So for content carrying NO secret value and NO
 ``gxsa_/gxsr_`` sandbox token (SEC filings, market-data snapshots, static docs —
 the very content the GLOBAL dedup store exists to share across users/threads),
 redaction is the identity and ``sha256(stored_body) == result_sha256`` exactly.
@@ -83,6 +83,9 @@ async def _run(middleware, request, result):
         _STORE_PATH, store
     ):
         await middleware.awrap_tool_call(request, handler)
+        # Drain the background flush inside the patch so the task's lazy
+        # store_result_bodies import resolves to the mock.
+        await middleware._drain_body_flushes()
     return emitted, store
 
 

--- a/tests/unit/ptc_agent/agent/middleware/provenance/test_provenance_body_hash_stability.py
+++ b/tests/unit/ptc_agent/agent/middleware/provenance/test_provenance_body_hash_stability.py
@@ -1,0 +1,264 @@
+"""Hash-stability of the content-addressed body store on the SAFE FREQUENT PATH.
+
+The body handed to ``store_result_body`` is ``_canonical_body(value)`` — the exact
+string ``fingerprint_result(value)`` hashes into ``result_sha256`` — after passing
+through ``_redact_body``. So for content carrying NO secret value and NO
+``gxsa_/gxsr_`` sandbox token (SEC filings, market-data snapshots, static docs —
+the very content the GLOBAL dedup store exists to share across users/threads),
+redaction is the identity and ``sha256(stored_body) == result_sha256`` exactly.
+
+That equality is what both (a) a post-hoc verifier and (b) the content-addressed
+dedup key rest on, so it is pinned here against a LIVE, ARMED
+``LeakDetectionMiddleware`` (real secret values configured, just absent from the
+content) to prove the redactor does not false-positive-corrupt clean content.
+
+The intentional exclusion — a genuine leak (sandbox token / configured secret)
+present in the body IS redacted, so the stored body no longer hashes to the
+raw-content sha — is documented by the negative-control tests at the bottom.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from ptc_agent.agent.middleware.provenance import ProvenanceMiddleware
+from ptc_agent.agent.middleware.tool.leak_detection import LeakDetectionMiddleware
+from ptc_agent.agent.provenance.types import RESULT_BODY_MAX_BYTES
+
+_WRITER_PATH = (
+    "ptc_agent.agent.middleware.provenance.middleware.get_stream_writer"
+)
+# store_result_bodies is imported lazily inside _flush_bodies; the middleware
+# batches a turn's bodies into ONE call whose sole arg is a list of
+# (sha, body, byte_len, content_type) tuples.
+_STORE_PATH = "src.server.database.provenance_bodies.store_result_bodies"
+
+# An armed redactor, exactly like production: real secret VALUES configured.
+# None of these strings appears in the clean SEC / market payloads below, so a
+# correct redactor must leave those bodies byte-identical to their canonical form.
+_VAULT_SECRETS = {
+    "FMP_API_KEY": "fmpk_live_9a8b7c6d5e4f3g2h1i0j",
+    "OPENAI_API_KEY": "sk-proj-AAAABBBBCCCCDDDDEEEE",
+    "GITHUB_TOKEN": "ghp_ZZZZ1111YYYY2222XXXX3333",
+}
+
+
+def _armed_middleware() -> ProvenanceMiddleware:
+    redactor = LeakDetectionMiddleware(vault_secrets=dict(_VAULT_SECRETS)).redact
+    return ProvenanceMiddleware(redactor=redactor)
+
+
+def _canonical(value) -> str:
+    """Mirror of types._canonicalize for assertions."""
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, sort_keys=True, default=str, ensure_ascii=False)
+    return str(value)
+
+
+def _make_request(name, args, tool_call_id="call-1"):
+    return SimpleNamespace(
+        tool_call={"name": name, "args": args, "id": tool_call_id}
+    )
+
+
+def _result(content="", artifact=None):
+    return SimpleNamespace(content=content, artifact=artifact)
+
+
+async def _run(middleware, request, result):
+    """Run awrap_tool_call with patched writer + store; return (emitted, store)."""
+    emitted: list = []
+    store = AsyncMock()
+
+    async def handler(_req):
+        return result
+
+    with patch(_WRITER_PATH, return_value=emitted.append), patch(
+        _STORE_PATH, store
+    ):
+        await middleware.awrap_tool_call(request, handler)
+    return emitted, store
+
+
+def _stored(store):
+    """[(sha, body, size, content_type), ...] handed to the batched store call."""
+    return [
+        item
+        for c in store.await_args_list
+        for item in (c.args[0] if c.args else [])
+    ]
+
+
+# --- realistic, secret-free payloads (the frequent dedup path) -------------
+
+_SEC_TEXT = (
+    "Apple Inc. CONDENSED CONSOLIDATED STATEMENTS OF OPERATIONS (Unaudited). "
+    "Net sales: Products $61,564; Services $24,213; Total net sales $85,777. "
+    "Cost of sales $46,099. Gross margin $39,678. Operating income $25,352. "
+    "Net income $21,448. Diluted EPS $1.40."
+)
+
+
+def _sec_artifact(text: str) -> dict:
+    return {
+        "symbol": "AAPL",
+        "filings": [
+            {
+                "source_url": (
+                    "https://www.sec.gov/Archives/edgar/data/320193/"
+                    "000032019324000081/aapl-20240629.htm"
+                ),
+                "form_type": "10-Q",
+                "filed_at": "2024-08-02",
+                "accession_no": "0000320193-24-000081",
+                "text": text,
+            }
+        ],
+    }
+
+
+_MARKET_SNAPSHOT = {
+    "symbol": "AAPL",
+    "as_of": "2024-08-02T20:00:00Z",
+    "open": 219.15,
+    "high": 225.60,
+    "low": 217.71,
+    "close": 219.86,
+    "volume": 105568400,
+    "change_pct": -4.82,
+}
+
+
+# ---------------------------------------------------------------------------
+# Safe frequent path: stored body hashes EXACTLY to result_sha256.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sec_filing_body_hashes_to_sha():
+    """A small 10-Q filing (no secrets): the body persisted under `sha` hashes to `sha`."""
+    req = _make_request("get_sec_filing", {"symbol": "AAPL"})
+    _, store = await _run(_armed_middleware(), req, _result(artifact=_sec_artifact(_SEC_TEXT)))
+
+    calls = _stored(store)
+    assert len(calls) == 1
+    sha, body, size, content_type = calls[0]
+    assert hashlib.sha256(body.encode("utf-8")).hexdigest() == sha
+    assert size == len(body.encode("utf-8"))
+    assert content_type == "text/plain; charset=utf-8"
+    assert "[REDACTED" not in body  # armed redactor left clean content untouched
+
+
+@pytest.mark.asyncio
+async def test_market_snapshot_body_hashes_to_sha():
+    """A market-data snapshot (no secrets): stored body is the canonical artifact and hashes to `sha`."""
+    req = _make_request("get_stock_daily_prices", {"symbol": "AAPL"})
+    _, store = await _run(_armed_middleware(), req, _result(artifact=_MARKET_SNAPSHOT))
+
+    sha, body, size, _ = _stored(store)[0]
+    assert body == _canonical(_MARKET_SNAPSHOT)
+    assert hashlib.sha256(body.encode("utf-8")).hexdigest() == sha
+    assert "[REDACTED" not in body
+
+
+@pytest.mark.asyncio
+async def test_large_sec_filing_full_body_hashes_to_sha():
+    """A >64 KiB filing: the middleware hands the FULL canonical body to the store
+    (the head/spill split happens INSIDE store_result_body), so the persisted body
+    still hashes to `sha`. The spilled full body is the verifier's ground truth."""
+    big_text = "MD&A. " + ("Quarterly revenue grew across all segments. " * 4000)
+    art = _sec_artifact(big_text)
+    assert len(_canonical(art["filings"][0]).encode("utf-8")) > RESULT_BODY_MAX_BYTES
+
+    req = _make_request("get_sec_filing", {"symbol": "AAPL"})
+    _, store = await _run(_armed_middleware(), req, _result(artifact=art))
+
+    sha, body, size, _ = _stored(store)[0]
+    # Full body handed off (not a 64 KiB head) and still hash-consistent.
+    assert len(body.encode("utf-8")) > RESULT_BODY_MAX_BYTES
+    assert hashlib.sha256(body.encode("utf-8")).hexdigest() == sha
+    assert size == len(body.encode("utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Dedup-key stability: identical content -> identical sha -> one body row.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_same_static_doc_dedups_to_one_sha_across_turns():
+    """The same static filing fetched in two separate turns yields the same sha, so
+    ON CONFLICT collapses it to a single stored body (the whole point of the store)."""
+    req1 = _make_request("get_sec_filing", {"symbol": "AAPL"}, tool_call_id="turn-1")
+    req2 = _make_request("get_sec_filing", {"symbol": "AAPL"}, tool_call_id="turn-2")
+
+    _, s1 = await _run(_armed_middleware(), req1, _result(artifact=_sec_artifact(_SEC_TEXT)))
+    # Independently-constructed identical content (fresh dict, different turn).
+    _, s2 = await _run(_armed_middleware(), req2, _result(artifact=_sec_artifact(_SEC_TEXT)))
+
+    sha1, body1, _, _ = _stored(s1)[0]
+    sha2, body2, _, _ = _stored(s2)[0]
+    assert sha1 == sha2
+    assert body1 == body2
+
+
+@pytest.mark.asyncio
+async def test_different_content_gets_different_sha():
+    """Content that differs by one sentence must NOT collide on the dedup key."""
+    art_a = _sec_artifact(_SEC_TEXT)
+    art_b = _sec_artifact(_SEC_TEXT + " Subsequent event: a cash dividend was declared.")
+    req = _make_request("get_sec_filing", {"symbol": "AAPL"})
+
+    _, sa = await _run(_armed_middleware(), req, _result(artifact=art_a))
+    _, sb = await _run(_armed_middleware(), req, _result(artifact=art_b))
+    assert _stored(sa)[0][0] != _stored(sb)[0][0]
+
+
+@pytest.mark.asyncio
+async def test_dict_key_order_does_not_change_sha():
+    """Canonicalization sorts keys, so the same snapshot with shuffled key order
+    dedups to the same body — a real risk since upstream JSON ordering is unstable."""
+    shuffled = dict(reversed(list(_MARKET_SNAPSHOT.items())))
+    req = _make_request("get_stock_daily_prices", {"symbol": "AAPL"})
+
+    _, s1 = await _run(_armed_middleware(), req, _result(artifact=_MARKET_SNAPSHOT))
+    _, s2 = await _run(_armed_middleware(), req, _result(artifact=shuffled))
+    assert _stored(s1)[0][0] == _stored(s2)[0][0]
+
+
+# ---------------------------------------------------------------------------
+# Negative controls: a genuine leak IS redacted, so the body diverges from the
+# raw-content sha. This is the ONLY case the safe-path invariant excludes — and
+# clean content under the SAME armed redactor stays untouched (proven above).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sandbox_token_in_body_is_redacted_and_diverges():
+    art = _sec_artifact(_SEC_TEXT + " internal token=gxsa_abc123DEF456ghi789")
+    req = _make_request("get_sec_filing", {"symbol": "AAPL"})
+    _, store = await _run(_armed_middleware(), req, _result(artifact=art))
+
+    sha, body, _, _ = _stored(store)[0]
+    assert "gxsa_abc123DEF456ghi789" not in body
+    assert "[REDACTED:SANDBOX_TOKEN]" in body
+    # By design: sha is over the RAW content (with the token); body is redacted.
+    assert hashlib.sha256(body.encode("utf-8")).hexdigest() != sha
+
+
+@pytest.mark.asyncio
+async def test_configured_secret_value_in_body_is_redacted_and_diverges():
+    secret = _VAULT_SECRETS["FMP_API_KEY"]
+    art = _sec_artifact(_SEC_TEXT + f" debug apikey={secret} end")
+    req = _make_request("get_sec_filing", {"symbol": "AAPL"})
+    _, store = await _run(_armed_middleware(), req, _result(artifact=art))
+
+    sha, body, _, _ = _stored(store)[0]
+    assert secret not in body
+    assert "[REDACTED:FMP_API_KEY]" in body
+    assert hashlib.sha256(body.encode("utf-8")).hexdigest() != sha

--- a/tests/unit/ptc_agent/agent/provenance/test_types.py
+++ b/tests/unit/ptc_agent/agent/provenance/test_types.py
@@ -171,6 +171,51 @@ def test_build_event_has_full_key_set():
     assert set(event.keys()) == expected_keys
 
 
+def test_build_event_never_carries_result_body():
+    """The transient ``result_body`` is consumed live by the middleware and must
+    NEVER ride the SSE event — that keeps ``sse_events`` gaining 0 bytes. The
+    event key set stays exactly the pre-body shape even when the source carries
+    a large body."""
+    source = ProvenanceSource(
+        record_id="rec-1",
+        source_type="web_fetch",
+        identifier="https://example.test/a",
+        timestamp="2026-01-01T00:00:00+00:00",
+        result_sha256="deadbeef",
+        result_size=99999,
+        result_snippet="snip",
+        result_body="x" * 50000,  # a substantial full body
+    )
+
+    event = build_provenance_event(source)
+
+    assert "result_body" not in event
+    # No value in the event equals the body (it isn't smuggled under another key).
+    assert source.result_body not in event.values()
+    # The key set is unchanged vs. the documented pre-body shape.
+    assert set(event.keys()) == {
+        "type",
+        "record_id",
+        "source_type",
+        "identifier",
+        "title",
+        "detail",
+        "provider",
+        "tool_call_id",
+        "args_fingerprint",
+        "args",
+        "result_sha256",
+        "result_size",
+        "result_snippet",
+        "timestamp",
+        "agent",
+    }
+    # build_provenance_event takes no result_body kwarg (a TypeError guards the
+    # contract that the body can't be injected through the builder either).
+    with pytest.raises(TypeError):
+        build_provenance_event(result_body="leak")  # type: ignore[call-arg]
+
+
 # ----- redact_args: security-critical deny-list -----------------------------
 
 _REDACTED = "[redacted]"

--- a/tests/unit/ptc_agent/agent/provenance/test_types.py
+++ b/tests/unit/ptc_agent/agent/provenance/test_types.py
@@ -11,6 +11,7 @@ from ptc_agent.agent.provenance import (
     ProvenanceSource,
     build_provenance_event,
     fingerprint_result,
+    fingerprint_result_with_body,
     hash_args,
     redact_args,
 )
@@ -79,6 +80,25 @@ def test_fingerprint_handles_odd_inputs_without_raising():
         assert isinstance(sha, str) and len(sha) == 64
         assert isinstance(size, int) and size >= 0
         assert isinstance(snippet, str)
+
+
+def test_fingerprint_with_body_matches_fingerprint_and_is_hash_consistent():
+    # The 4-tuple's sha/size/snippet must equal fingerprint_result's, and the
+    # returned body must be byte-identical to the string that produced the sha —
+    # that identity is the whole point (a verifier hashes the stored body).
+    for value in (
+        {"gamma": {"y": 2, "x": 1}, "alpha": 1},
+        [1, {"k": "v"}, None],
+        "plain string result",
+        "x" * 5000,
+        None,
+    ):
+        sha, size, snippet = fingerprint_result(value)
+        sha_b, size_b, snippet_b, body = fingerprint_result_with_body(value)
+        assert (sha_b, size_b, snippet_b) == (sha, size, snippet)
+        assert hashlib.sha256(body.encode("utf-8")).hexdigest() == sha
+        assert len(body.encode("utf-8")) == size
+        assert body[:500] == snippet  # snippet is the canonical body's head
 
 
 def test_build_event_generates_record_id_and_timestamp_when_omitted():

--- a/tests/unit/ptc_agent/agent/tools/test_bash_output_tool.py
+++ b/tests/unit/ptc_agent/agent/tools/test_bash_output_tool.py
@@ -1,0 +1,110 @@
+"""Tests for the BashOutput tool's mcp_trace artifact (closes the bash bypass).
+
+A backgrounded command's only result-bearing path is BashOutput, so it returns
+``(content, {"mcp_trace": [...]})`` and surfaces the trace the backgrounded
+script recorded — present once the command completes, empty on stop / no trace /
+error. The artifact never enters the LLM context; the provenance middleware
+consumes it. Neutral placeholder data only.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ptc_agent.agent.tools.bash_output import create_bash_output_tool
+
+
+def _make_backend(*, status: dict | None = None, stopped: bool = True) -> Any:
+    backend = SimpleNamespace()
+    backend.aget_background_command_status = AsyncMock(return_value=status or {})
+    backend.astop_background_command = AsyncMock(return_value=stopped)
+    return backend
+
+
+def _tool_call(command_id: str, action: str = "status") -> dict:
+    # A ToolCall (not a bare args dict) makes a content_and_artifact tool return a
+    # ToolMessage carrying .artifact, so we can assert on the trace.
+    return {
+        "type": "tool_call",
+        "name": "BashOutput",
+        "args": {"command_id": command_id, "action": action},
+        "id": "bo-1",
+    }
+
+
+class TestBashOutputMcpTraceArtifact:
+    @pytest.mark.asyncio
+    async def test_completed_command_surfaces_trace(self):
+        trace = [{"server": "marketdata", "tool": "quote", "result_sha256": "a" * 64}]
+        tool = create_bash_output_tool(
+            _make_backend(
+                status={
+                    "is_running": False,
+                    "exit_code": 0,
+                    "stdout": "done",
+                    "stderr": "",
+                    "mcp_trace": trace,
+                }
+            )
+        )
+        msg = await tool.ainvoke(_tool_call("cmd-1"))
+        assert msg.artifact == {"mcp_trace": trace}
+        assert "COMPLETED (success)" in msg.content
+        assert "done" in msg.content
+
+    @pytest.mark.asyncio
+    async def test_running_command_has_empty_trace(self):
+        tool = create_bash_output_tool(
+            _make_backend(
+                status={
+                    "is_running": True,
+                    "exit_code": None,
+                    "stdout": "",
+                    "stderr": "",
+                    "mcp_trace": [],
+                }
+            )
+        )
+        msg = await tool.ainvoke(_tool_call("cmd-1"))
+        assert msg.artifact == {"mcp_trace": []}
+        assert "RUNNING" in msg.content
+
+    @pytest.mark.asyncio
+    async def test_stop_action_returns_empty_trace(self):
+        # A stopped command yields no output, so there's nothing to attest.
+        tool = create_bash_output_tool(_make_backend(stopped=True))
+        msg = await tool.ainvoke(_tool_call("cmd-1", action="stop"))
+        assert msg.artifact == {"mcp_trace": []}
+        assert "stopped" in msg.content
+
+    @pytest.mark.asyncio
+    async def test_missing_trace_key_defaults_to_empty(self):
+        # A status dict without mcp_trace (e.g. legacy/unknown cmd) is tolerated.
+        tool = create_bash_output_tool(
+            _make_backend(
+                status={
+                    "is_running": False,
+                    "exit_code": 1,
+                    "stdout": "",
+                    "stderr": "boom",
+                }
+            )
+        )
+        msg = await tool.ainvoke(_tool_call("cmd-1"))
+        assert msg.artifact == {"mcp_trace": []}
+        assert "exit code 1" in msg.content
+
+    @pytest.mark.asyncio
+    async def test_backend_error_returns_empty_trace(self):
+        backend = _make_backend()
+        backend.aget_background_command_status = AsyncMock(
+            side_effect=RuntimeError("sandbox gone")
+        )
+        tool = create_bash_output_tool(backend)
+        msg = await tool.ainvoke(_tool_call("cmd-1"))
+        assert msg.artifact == {"mcp_trace": []}
+        assert msg.content.startswith("ERROR")

--- a/tests/unit/ptc_agent/agent/tools/test_bash_tool.py
+++ b/tests/unit/ptc_agent/agent/tools/test_bash_tool.py
@@ -1,0 +1,93 @@
+"""Tests for the Bash tool's mcp_trace artifact (closes the bash provenance bypass).
+
+The Bash tool returns ``(content, {"mcp_trace": [...]})`` so a script it runs that
+calls MCP wrappers records the same provenance ExecuteCode does. These pin the
+artifact wiring: trace passed through on success and failure, empty on a plain
+command or a blocked memory path. Neutral placeholder data only.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ptc_agent.agent.tools.bash import create_execute_bash_tool
+
+
+def _make_backend(result: dict) -> Any:
+    backend = SimpleNamespace()
+    backend.filesystem_config = SimpleNamespace(working_directory="/home/workspace")
+    backend.aexecute_bash = AsyncMock(return_value=result)
+    return backend
+
+
+def _tool_call(command: str) -> dict:
+    # Invoking with a ToolCall (not a bare args dict) makes a content_and_artifact
+    # tool return a ToolMessage carrying .artifact, so we can assert on it.
+    return {
+        "type": "tool_call",
+        "name": "Bash",
+        "args": {"command": command},
+        "id": "bash-1",
+    }
+
+
+class TestBashMcpTraceArtifact:
+    @pytest.mark.asyncio
+    async def test_success_surfaces_mcp_trace_on_artifact(self):
+        trace = [{"server": "marketdata", "tool": "quote", "result_sha256": "a" * 64}]
+        tool = create_execute_bash_tool(
+            _make_backend(
+                {
+                    "success": True,
+                    "stdout": "ok",
+                    "stderr": "",
+                    "exit_code": 0,
+                    "mcp_trace": trace,
+                }
+            )
+        )
+        msg = await tool.ainvoke(_tool_call("python analysis.py"))
+        assert msg.artifact == {"mcp_trace": trace}
+        assert "ok" in msg.content
+
+    @pytest.mark.asyncio
+    async def test_failure_still_carries_mcp_trace(self):
+        # A non-zero exit after a successful in-sandbox MCP call must keep the trace.
+        trace = [{"server": "finance", "tool": "get_prices", "result_sha256": "b" * 64}]
+        tool = create_execute_bash_tool(
+            _make_backend(
+                {
+                    "success": False,
+                    "stdout": "boom",
+                    "stderr": "",
+                    "exit_code": 1,
+                    "mcp_trace": trace,
+                }
+            )
+        )
+        msg = await tool.ainvoke(_tool_call("python analysis.py"))
+        assert msg.artifact == {"mcp_trace": trace}
+        assert msg.content.startswith("ERROR")
+
+    @pytest.mark.asyncio
+    async def test_plain_command_has_empty_trace(self):
+        tool = create_execute_bash_tool(
+            _make_backend(
+                {"success": True, "stdout": "", "stderr": "", "exit_code": 0}
+            )
+        )
+        msg = await tool.ainvoke(_tool_call("mkdir foo"))
+        assert msg.artifact == {"mcp_trace": []}
+
+    @pytest.mark.asyncio
+    async def test_memory_path_block_returns_empty_trace_and_skips_backend(self):
+        backend = _make_backend({"success": True, "stdout": "", "exit_code": 0})
+        tool = create_execute_bash_tool(backend)
+        msg = await tool.ainvoke(_tool_call("cat .agents/user/memory/secret.md"))
+        assert msg.artifact == {"mcp_trace": []}
+        assert "ERROR" in msg.content
+        backend.aexecute_bash.assert_not_called()

--- a/tests/unit/ptc_agent/core/sandbox/test_execute_mcp_trace.py
+++ b/tests/unit/ptc_agent/core/sandbox/test_execute_mcp_trace.py
@@ -89,12 +89,24 @@ def _make_sandbox(mock_runtime):
     return sandbox
 
 
+def _exec_side_effect(command, *args, **kwargs):
+    """Default exec mock: ``wc -c`` sizes the trace before the read.
+
+    A populated trace reports a real non-zero byte count in production (an
+    absent/empty file reports 0, which short-circuits the read). Other exec
+    calls (rm, mkdir) return empty.
+    """
+    if str(command).lstrip().startswith("wc -c"):
+        return ExecResult("4096", "", 0)
+    return ExecResult("", "", 0)
+
+
 @pytest.fixture
 def mock_runtime():
     runtime = AsyncMock(spec=SandboxRuntime)
     runtime.working_dir = WORK_DIR
     runtime.fetch_working_dir = AsyncMock(return_value=WORK_DIR)
-    runtime.exec = AsyncMock(return_value=ExecResult("", "", 0))
+    runtime.exec = AsyncMock(side_effect=_exec_side_effect)
     runtime.upload_file = AsyncMock()
     runtime.code_run = AsyncMock(return_value=CodeRunResult("out", "", 0, []))
     return runtime
@@ -207,3 +219,23 @@ async def test_mcp_trace_skipped_when_file_over_read_cap(
 
     assert trace == []
     sandbox.aread_file_text.assert_not_awaited()
+
+
+@patch("ptc_agent.core.sandbox.ptc_sandbox.create_provider")
+@pytest.mark.asyncio
+async def test_mcp_trace_skips_read_when_file_absent(
+    mock_create_provider, mock_provider, mock_runtime
+):
+    # A bash/exec run that imported no MCP wrappers never creates the trace file,
+    # so `wc -c` reports 0 bytes and the read (and the rm) are skipped entirely —
+    # no wasted round-trip on the common non-MCP path.
+    mock_create_provider.return_value = mock_provider
+    sandbox = _make_sandbox(mock_runtime)
+    mock_runtime.exec = AsyncMock(return_value=ExecResult("", "", 0))
+
+    trace = await sandbox._collect_mcp_trace(f"{WORK_DIR}/.system/trace/t.jsonl")
+
+    assert trace == []
+    sandbox.aread_file_text.assert_not_awaited()
+    # Only the `wc -c` sizing ran — no read, no rm (both skipped).
+    assert mock_runtime.exec.await_count == 1

--- a/tests/unit/ptc_agent/core/sandbox/test_execute_mcp_trace.py
+++ b/tests/unit/ptc_agent/core/sandbox/test_execute_mcp_trace.py
@@ -188,3 +188,22 @@ async def test_mcp_trace_empty_when_no_file(
 
     assert result.success is True
     assert result.mcp_trace == []
+
+
+@patch("ptc_agent.core.sandbox.ptc_sandbox.create_provider")
+@pytest.mark.asyncio
+async def test_mcp_trace_skipped_when_file_over_read_cap(
+    mock_create_provider, mock_provider, mock_runtime
+):
+    # MCP_TRACE_FILE is writable by agent-authored sandbox code, so the host
+    # sizes it (wc -c) before reading. A file past the 16 MiB read cap is skipped
+    # entirely — never pulled into host memory — and yields no trace.
+    mock_create_provider.return_value = mock_provider
+    sandbox = _make_sandbox(mock_runtime)
+    over_cap = 16 * 1024 * 1024 + 1
+    mock_runtime.exec = AsyncMock(return_value=ExecResult(str(over_cap), "", 0))
+
+    trace = await sandbox._collect_mcp_trace(f"{WORK_DIR}/.system/trace/t.jsonl")
+
+    assert trace == []
+    sandbox.aread_file_text.assert_not_awaited()

--- a/tests/unit/ptc_agent/core/test_mcp_trace_result_body.py
+++ b/tests/unit/ptc_agent/core/test_mcp_trace_result_body.py
@@ -1,0 +1,216 @@
+"""Tests for the per-call ``result_body`` channel in the generated MCP client.
+
+The generated ``mcp_client.py`` ``_trace_mcp_call`` emits a byte-capped
+``result_body`` (the raw bytes that produced ``result_sha256``) into each trace
+entry, while ``result_size`` still records the TRUE full byte length. A
+per-execution aggregate guard (``_RESULT_BODY_TRACE_BUDGET_BYTES``) stops
+emitting ``result_body`` once the running sum crosses the budget — but snippet,
+sha and size always survive — so agent-authored sandbox code can't stream
+unbounded bytes into host memory.
+
+These exec the generated module (same approach as test_mcp_trace_generation.py)
+so the assertions exercise the real interpolated client code, not a transcript.
+"""
+
+from __future__ import annotations
+
+import json
+
+from ptc_agent.agent.provenance.types import (
+    RESULT_BODY_MAX_BYTES,
+    fingerprint_result,
+)
+from ptc_agent.config.core import MCPServerConfig
+from ptc_agent.core.tool_generator import (
+    RESULT_BODY_TRACE_BUDGET_BYTES,
+    ToolFunctionGenerator,
+)
+
+
+def _builtin_config() -> MCPServerConfig:
+    return MCPServerConfig(
+        name="market_data",
+        transport="stdio",
+        command="python",
+        args=["-m", "server"],
+        env={"API_KEY": "from-os-environ"},
+    )
+
+
+def _render() -> str:
+    return ToolFunctionGenerator().generate_mcp_client_code(
+        [_builtin_config()], working_dir="/home/workspace"
+    )
+
+
+def _exec_module(code: str) -> dict:
+    """Exec the generated client; each call yields a FRESH module-global counter.
+
+    The aggregate guard counter (``_result_body_emitted_bytes``) is a
+    module-global accumulating across calls within ONE module instance, so a
+    per-test fresh exec isolates the budget state between tests.
+    """
+    namespace: dict = {}
+    exec(compile(code, "mcp_client.py", "exec"), namespace)  # noqa: S102
+    return namespace
+
+
+# ---------------------------------------------------------------------------
+# Per-call byte cap: body <= RESULT_BODY_MAX_BYTES, result_size = TRUE length.
+# ---------------------------------------------------------------------------
+
+
+def test_result_body_capped_to_max_bytes_while_size_is_true_length(
+    tmp_path, monkeypatch
+) -> None:
+    trace_file = tmp_path / "trace.jsonl"
+    monkeypatch.setenv("MCP_TRACE_FILE", str(trace_file))
+
+    ns = _exec_module(_render())
+    # A single-byte ASCII char per position so byte length == char length, and
+    # the result is comfortably larger than the per-call cap.
+    big = "x" * (RESULT_BODY_MAX_BYTES + 5000)
+    ns["_trace_mcp_call"]("s", "t", {}, big)
+
+    entry = json.loads(trace_file.read_text(encoding="utf-8").splitlines()[0])
+
+    # The body is capped at the byte ceiling...
+    assert len(entry["result_body"].encode("utf-8")) <= RESULT_BODY_MAX_BYTES
+    assert entry["result_body"] == big[:RESULT_BODY_MAX_BYTES]
+    # ...but result_size carries the TRUE full byte length, not the cap.
+    assert entry["result_size"] == len(big.encode("utf-8"))
+    assert entry["result_size"] > RESULT_BODY_MAX_BYTES
+    # The cap is a strict prefix of the exact bytes that produced the sha, so the
+    # body stays hash-consistent with result_sha256 (verifier can trust it).
+    sha, _size, _snippet = fingerprint_result(big)
+    assert entry["result_sha256"] == sha
+    assert big.encode("utf-8").startswith(
+        entry["result_body"].encode("utf-8")
+    )
+
+
+def test_result_body_uncapped_when_under_max_bytes(tmp_path, monkeypatch) -> None:
+    """A small result is carried whole as the body (no truncation)."""
+    trace_file = tmp_path / "trace.jsonl"
+    monkeypatch.setenv("MCP_TRACE_FILE", str(trace_file))
+
+    ns = _exec_module(_render())
+    small = {"rows": [1, 2, 3], "note": "tiny"}
+    ns["_trace_mcp_call"]("s", "t", {}, small)
+
+    entry = json.loads(trace_file.read_text(encoding="utf-8").splitlines()[0])
+    canonical = json.dumps(
+        small, sort_keys=True, default=str, ensure_ascii=False
+    )
+    assert entry["result_body"] == canonical
+    assert entry["result_size"] == len(canonical.encode("utf-8"))
+
+
+def test_result_body_byte_cap_drops_split_multibyte_char(
+    tmp_path, monkeypatch
+) -> None:
+    """The cap slices on a byte boundary then decodes errors='ignore', so a
+    multibyte char straddling the cap is dropped (not mojibake), and the body
+    never exceeds the byte ceiling."""
+    trace_file = tmp_path / "trace.jsonl"
+    monkeypatch.setenv("MCP_TRACE_FILE", str(trace_file))
+
+    ns = _exec_module(_render())
+    # Land a 3-byte char (€ = 0xE2 0x82 0xAC) straddling the cap boundary: pad
+    # with (cap - 1) ASCII bytes so the euro starts at byte (cap - 1).
+    payload = "a" * (RESULT_BODY_MAX_BYTES - 1) + "€" + "tail"
+    ns["_trace_mcp_call"]("s", "t", {}, payload)
+
+    entry = json.loads(trace_file.read_text(encoding="utf-8").splitlines()[0])
+    body_bytes = entry["result_body"].encode("utf-8")
+    assert len(body_bytes) <= RESULT_BODY_MAX_BYTES
+    # The straddling euro is dropped entirely, leaving only the ASCII prefix.
+    assert entry["result_body"] == "a" * (RESULT_BODY_MAX_BYTES - 1)
+    # The true size still counts the whole payload including the euro + tail.
+    assert entry["result_size"] == len(payload.encode("utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Aggregate per-execution guard: once the cumulative emitted body bytes cross
+# the budget, subsequent calls stop emitting result_body but STILL emit
+# snippet + sha256 + size.
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_guard_stops_emitting_body_but_keeps_sha_snippet_size(
+    tmp_path, monkeypatch
+) -> None:
+    trace_file = tmp_path / "trace.jsonl"
+    monkeypatch.setenv("MCP_TRACE_FILE", str(trace_file))
+
+    ns = _exec_module(_render())
+    trace = ns["_trace_mcp_call"]
+
+    # Each call emits a full per-call cap worth of body. The number of calls to
+    # exhaust the aggregate budget is budget / per-call-cap; do a couple extra so
+    # at least one trailing call lands past the budget.
+    per_call = RESULT_BODY_MAX_BYTES
+    calls_to_exhaust = RESULT_BODY_TRACE_BUDGET_BYTES // per_call
+    total_calls = calls_to_exhaust + 3
+    big = "y" * per_call
+    for i in range(total_calls):
+        trace("s", f"tool_{i}", {}, big)
+
+    entries = [
+        json.loads(line)
+        for line in trace_file.read_text(encoding="utf-8").splitlines()
+    ]
+    assert len(entries) == total_calls
+
+    with_body = [e for e in entries if "result_body" in e]
+    without_body = [e for e in entries if "result_body" not in e]
+
+    # The guard kicked in: at least the trailing calls lost their body...
+    assert without_body, "expected the aggregate guard to suppress some bodies"
+    # ...but it stopped emitting bodies only AFTER the budget was crossed, so the
+    # early calls kept theirs (the guard is not all-or-nothing).
+    assert with_body, "early calls should still carry a body under budget"
+
+    # Snippet + sha + size survive on EVERY entry, including the guarded ones.
+    for e in entries:
+        assert e["result_sha256"]
+        assert e["result_snippet"]
+        assert e["result_size"] == len(big.encode("utf-8"))
+
+    # The first entry (well under budget) carries a body; the very last entry
+    # (well past budget) does not — pins the ordering of the guard.
+    assert "result_body" in entries[0]
+    assert "result_body" not in entries[-1]
+
+
+def test_aggregate_guard_counter_is_per_module_instance(
+    tmp_path, monkeypatch
+) -> None:
+    """A fresh module exec resets the budget — the counter is a module-global,
+    so each execute_code run (one module import) starts from zero. This is the
+    invariant the host relies on for the per-execution (not per-process) bound."""
+    monkeypatch.setenv("MCP_TRACE_FILE", str(tmp_path / "a.jsonl"))
+    ns1 = _exec_module(_render())
+    assert ns1["_result_body_emitted_bytes"] == 0
+    ns1["_trace_mcp_call"]("s", "t", {}, "z" * 100)
+    assert ns1["_result_body_emitted_bytes"] > 0
+
+    # A second module instance is independent (fresh counter at zero).
+    ns2 = _exec_module(_render())
+    assert ns2["_result_body_emitted_bytes"] == 0
+
+
+def test_generated_client_interpolates_budget_and_counter() -> None:
+    """The aggregate guard logic + caps are interpolated from the canonical
+    constants — guards against a codegen regression that drops the budget."""
+    code = _render()
+    assert f"_RESULT_BODY_MAX_BYTES = {RESULT_BODY_MAX_BYTES}" in code
+    assert (
+        f"_RESULT_BODY_TRACE_BUDGET_BYTES = {RESULT_BODY_TRACE_BUDGET_BYTES}"
+        in code
+    )
+    assert "_result_body_emitted_bytes = 0" in code
+    # The guard reads the running sum against the budget before emitting a body.
+    assert (
+        "_result_body_emitted_bytes < _RESULT_BODY_TRACE_BUDGET_BYTES" in code
+    )

--- a/tests/unit/ptc_agent/core/test_mcp_trace_result_body.py
+++ b/tests/unit/ptc_agent/core/test_mcp_trace_result_body.py
@@ -187,8 +187,11 @@ def test_aggregate_guard_counter_is_per_module_instance(
     tmp_path, monkeypatch
 ) -> None:
     """A fresh module exec resets the budget — the counter is a module-global,
-    so each execute_code run (one module import) starts from zero. This is the
-    invariant the host relies on for the per-execution (not per-process) bound."""
+    so each execute_code run starts from zero. This holds in production because
+    every execute_code spawns a fresh interpreter (both providers run code_run as
+    a one-shot `python`, not a persistent kernel), so the module is re-imported
+    per run and the counter never accumulates session-wide — the per-execution
+    bound the host relies on."""
     monkeypatch.setenv("MCP_TRACE_FILE", str(tmp_path / "a.jsonl"))
     ns1 = _exec_module(_render())
     assert ns1["_result_body_emitted_bytes"] == 0

--- a/tests/unit/server/app/test_threads_provenance.py
+++ b/tests/unit/server/app/test_threads_provenance.py
@@ -151,19 +151,19 @@ class TestGetProvenanceBodies:
 
     @pytest.mark.asyncio
     async def test_redacted_inline_body_is_not_truncated(self, threads_client):
-        # Sibling to the test above, but redaction CHANGED the body's length:
-        # `byte_len` tracks the RAW pre-redaction size, while `body_inline` holds
-        # the (shorter) redacted bytes, and there is no spilled object. The complete
-        # redacted body is present and under the cap, so `truncated` is False — it
-        # keys off object_key + the cap, NOT a raw-vs-redacted length compare (which
-        # would mislabel a shortened-but-complete body as a partial head). The
-        # authoritative "not the raw bytes" signal is `verified=false`.
+        # A body that redaction shrank stays COMPLETE. `byte_len` tracks the stored
+        # (post-redaction) length, `body_inline` holds the whole redacted body, and
+        # there's no spilled object — so `truncated` is False even when the original
+        # was larger (this is the case that mislabeled when byte_len was the raw
+        # pre-redaction size: a body redacted from over the inline cap down to under
+        # it is whole, not a head). The "not the raw bytes" signal is `verified=false`.
         raw_body = b"api_key=sk-supersecretvalue-0123456789abcdef"
         raw_sha = hashlib.sha256(raw_body).hexdigest()
         redacted = "api_key=[REDACTED:API_KEY]"
         assert len(redacted.encode()) < len(raw_body)  # redaction shortened it
         rows = [_row(0, RESPONSE_0, "web_fetch", "https://x.test/a", raw_sha)]
-        bodies = {raw_sha: _body_meta(redacted, byte_len=len(raw_body))}
+        # byte_len = stored (redacted) length, as _body_item records it post-redaction.
+        bodies = {raw_sha: _body_meta(redacted)}
         with _patch_body_store(OWNER_ID, rows, bodies):
             resp = await threads_client.get(
                 f"/api/v1/threads/{THREAD_ID}/provenance/bodies"
@@ -171,6 +171,23 @@ class TestGetProvenanceBodies:
         rec = resp.json()["records"][0]
         assert rec["body_inline"] == redacted  # complete redacted body, not a head
         assert rec["truncated"] is False
+        assert rec["verified"] is False
+
+    @pytest.mark.asyncio
+    async def test_no_bucket_head_is_truncated(self, threads_client):
+        # Over-cap body with no object store configured → only the inline head was
+        # kept (object_key None). The stored byte_len exceeds the inline slice, so
+        # truncated flips True without a spilled object — the head is incomplete.
+        head = "h" * 200
+        sha = "b" * 64
+        rows = [_row(0, RESPONSE_0, "web_fetch", "https://x.test/a", sha)]
+        bodies = {sha: _body_meta(head, byte_len=500_000, object_key=None)}
+        with _patch_body_store(OWNER_ID, rows, bodies):
+            resp = await threads_client.get(
+                f"/api/v1/threads/{THREAD_ID}/provenance/bodies"
+            )
+        rec = resp.json()["records"][0]
+        assert rec["truncated"] is True
         assert rec["verified"] is False
 
     @pytest.mark.asyncio

--- a/tests/unit/server/app/test_threads_provenance.py
+++ b/tests/unit/server/app/test_threads_provenance.py
@@ -73,9 +73,10 @@ async def _fake_db_conn():
 def _patch_body_store(owner, rows, bodies, *, full_body=None):
     """Patch owner + record lookups + the body-store reads the verifier endpoints use.
 
-    Patches both the list read (``get_provenance_for_thread``, used by ``/bodies``)
-    and the targeted single-record read (``get_provenance_record``, used by
-    ``/{id}/body``); the latter matches ``rows`` by record id so unknown ids 404.
+    Patches both the list read (``get_provenance_body_refs``, used by ``/bodies``,
+    which the endpoint filters + caps in SQL) and the targeted single-record read
+    (``get_provenance_record``, used by ``/{id}/body``); the latter matches ``rows``
+    by record id so unknown ids 404.
     """
 
     async def _get_record(thread_id, record_id):
@@ -84,14 +85,19 @@ def _patch_body_store(owner, rows, bodies, *, full_body=None):
             None,
         )
 
+    async def _get_body_refs(conn, thread_id, limit):
+        # Mirror the SQL: eligible rows in order, capped at limit + 1.
+        eligible = [r for r in rows if r.get("result_sha256")]
+        return eligible[: limit + 1]
+
     patches = [
         patch(
             "src.server.database.conversation.get_thread_owner_id",
             new=AsyncMock(return_value=owner),
         ),
         patch(
-            "src.server.app.threads.get_provenance_for_thread",
-            new=AsyncMock(return_value=rows),
+            "src.server.app.threads.get_provenance_body_refs",
+            new=AsyncMock(side_effect=_get_body_refs),
         ),
         patch(
             "src.server.app.threads.get_provenance_record",

--- a/tests/unit/server/app/test_threads_provenance.py
+++ b/tests/unit/server/app/test_threads_provenance.py
@@ -5,6 +5,8 @@ by_source_type summary shape. Mirrors the dependency-override + AsyncClient
 pattern used by the other threads route tests. Neutral placeholder data only.
 """
 
+import hashlib
+from contextlib import ExitStack, asynccontextmanager, contextmanager
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
 
@@ -51,6 +53,189 @@ def _row(turn_index, response_id, source_type, identifier, sha):
         "provider": "tavily",
         "created_at": datetime.now(timezone.utc),
     }
+
+
+def _body_meta(body_inline, *, byte_len=None, object_key=None):
+    return {
+        "body_inline": body_inline,
+        "object_key": object_key,
+        "byte_len": byte_len if byte_len is not None else len(body_inline.encode()),
+        "content_type": "text/plain; charset=utf-8",
+    }
+
+
+@asynccontextmanager
+async def _fake_db_conn():
+    yield AsyncMock()
+
+
+@contextmanager
+def _patch_body_store(owner, rows, bodies, *, full_body=None):
+    """Patch owner + record lookups + the body-store reads the verifier endpoints use.
+
+    Patches both the list read (``get_provenance_for_thread``, used by ``/bodies``)
+    and the targeted single-record read (``get_provenance_record``, used by
+    ``/{id}/body``); the latter matches ``rows`` by record id so unknown ids 404.
+    """
+
+    async def _get_record(thread_id, record_id):
+        return next(
+            (r for r in rows if str(r["provenance_record_id"]) == str(record_id)),
+            None,
+        )
+
+    patches = [
+        patch(
+            "src.server.database.conversation.get_thread_owner_id",
+            new=AsyncMock(return_value=owner),
+        ),
+        patch(
+            "src.server.app.threads.get_provenance_for_thread",
+            new=AsyncMock(return_value=rows),
+        ),
+        patch(
+            "src.server.app.threads.get_provenance_record",
+            new=AsyncMock(side_effect=_get_record),
+        ),
+        patch(
+            "src.server.database.conversation.get_db_connection",
+            new=_fake_db_conn,
+        ),
+        patch(
+            "src.server.database.provenance_bodies.fetch_result_bodies",
+            new=AsyncMock(return_value=bodies),
+        ),
+        patch(
+            "src.server.database.provenance_bodies.fetch_full_body",
+            new=AsyncMock(return_value=full_body),
+        ),
+    ]
+    with ExitStack() as stack:
+        for p in patches:
+            stack.enter_context(p)
+        yield
+
+
+class TestGetProvenanceBodies:
+    @pytest.mark.asyncio
+    async def test_verified_true_when_body_hashes_to_sha(self, threads_client):
+        body = "the exact bytes the agent reasoned over"
+        sha = hashlib.sha256(body.encode()).hexdigest()
+        rows = [_row(0, RESPONSE_0, "web_fetch", "https://x.test/a", sha)]
+        bodies = {sha: _body_meta(body)}
+        with _patch_body_store(OWNER_ID, rows, bodies):
+            resp = await threads_client.get(
+                f"/api/v1/threads/{THREAD_ID}/provenance/bodies"
+            )
+        assert resp.status_code == 200
+        rec = resp.json()["records"][0]
+        assert rec["result_sha256"] == sha
+        assert rec["truncated"] is False
+        assert rec["verified"] is True
+
+    @pytest.mark.asyncio
+    async def test_verified_false_when_body_redacted(self, threads_client):
+        # Stored body was redacted, so it no longer hashes to the raw-content sha:
+        # present + not truncated + verified=False is the redaction signal.
+        raw_sha = hashlib.sha256(b"raw body with a secret").hexdigest()
+        redacted = "raw body with [REDACTED]"
+        rows = [_row(0, RESPONSE_0, "web_fetch", "https://x.test/a", raw_sha)]
+        bodies = {raw_sha: _body_meta(redacted)}
+        with _patch_body_store(OWNER_ID, rows, bodies):
+            resp = await threads_client.get(
+                f"/api/v1/threads/{THREAD_ID}/provenance/bodies"
+            )
+        rec = resp.json()["records"][0]
+        assert rec["truncated"] is False
+        assert rec["verified"] is False
+
+    @pytest.mark.asyncio
+    async def test_redacted_inline_body_is_not_truncated(self, threads_client):
+        # Sibling to the test above, but redaction CHANGED the body's length:
+        # `byte_len` tracks the RAW pre-redaction size, while `body_inline` holds
+        # the (shorter) redacted bytes, and there is no spilled object. The complete
+        # redacted body is present and under the cap, so `truncated` is False — it
+        # keys off object_key + the cap, NOT a raw-vs-redacted length compare (which
+        # would mislabel a shortened-but-complete body as a partial head). The
+        # authoritative "not the raw bytes" signal is `verified=false`.
+        raw_body = b"api_key=sk-supersecretvalue-0123456789abcdef"
+        raw_sha = hashlib.sha256(raw_body).hexdigest()
+        redacted = "api_key=[REDACTED:API_KEY]"
+        assert len(redacted.encode()) < len(raw_body)  # redaction shortened it
+        rows = [_row(0, RESPONSE_0, "web_fetch", "https://x.test/a", raw_sha)]
+        bodies = {raw_sha: _body_meta(redacted, byte_len=len(raw_body))}
+        with _patch_body_store(OWNER_ID, rows, bodies):
+            resp = await threads_client.get(
+                f"/api/v1/threads/{THREAD_ID}/provenance/bodies"
+            )
+        rec = resp.json()["records"][0]
+        assert rec["body_inline"] == redacted  # complete redacted body, not a head
+        assert rec["truncated"] is False
+        assert rec["verified"] is False
+
+    @pytest.mark.asyncio
+    async def test_truncated_head_is_not_verified(self, threads_client):
+        head = "h" * 100
+        sha = "a" * 64
+        rows = [_row(0, RESPONSE_0, "web_fetch", "https://x.test/a", sha)]
+        # byte_len far exceeds the inline head → truncated, can't verify the head.
+        bodies = {sha: _body_meta(head, byte_len=500_000, object_key="provenance/x")}
+        with _patch_body_store(OWNER_ID, rows, bodies):
+            resp = await threads_client.get(
+                f"/api/v1/threads/{THREAD_ID}/provenance/bodies"
+            )
+        rec = resp.json()["records"][0]
+        assert rec["truncated"] is True
+        assert rec["verified"] is False
+
+    @pytest.mark.asyncio
+    async def test_capped_when_more_than_limit(self, threads_client):
+        rows = [
+            _row(0, RESPONSE_0, "web_fetch", f"https://x.test/{i}", f"{i:064d}")
+            for i in range(3)
+        ]
+        bodies = {f"{i:064d}": _body_meta(f"body {i}") for i in range(3)}
+        with _patch_body_store(OWNER_ID, rows, bodies):
+            resp = await threads_client.get(
+                f"/api/v1/threads/{THREAD_ID}/provenance/bodies?limit=1"
+            )
+        body = resp.json()
+        assert body["capped"] is True
+        assert len(body["records"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_non_owner_returns_403(self, threads_client):
+        with _patch_body_store("someone-else", [], {}):
+            resp = await threads_client.get(
+                f"/api/v1/threads/{THREAD_ID}/provenance/bodies"
+            )
+        assert resp.status_code == 403
+
+
+class TestGetProvenanceRecordBody:
+    @pytest.mark.asyncio
+    async def test_full_body_verified(self, threads_client):
+        body = "full body content the agent saw"
+        sha = hashlib.sha256(body.encode()).hexdigest()
+        rows = [_row(0, RESPONSE_0, "web_fetch", "doc", sha)]
+        bodies = {sha: _body_meta(body)}
+        with _patch_body_store(OWNER_ID, rows, bodies, full_body=body):
+            resp = await threads_client.get(
+                f"/api/v1/threads/{THREAD_ID}/provenance/rec-doc/body?full=true"
+            )
+        assert resp.status_code == 200
+        out = resp.json()
+        assert out["body"] == body
+        assert out["verified"] is True
+
+    @pytest.mark.asyncio
+    async def test_unknown_record_returns_404(self, threads_client):
+        rows = [_row(0, RESPONSE_0, "web_fetch", "doc", "a" * 64)]
+        with _patch_body_store(OWNER_ID, rows, {}):
+            resp = await threads_client.get(
+                f"/api/v1/threads/{THREAD_ID}/provenance/rec-MISSING/body"
+            )
+        assert resp.status_code == 404
 
 
 class TestGetProvenanceAuth:

--- a/tests/unit/server/database/test_provenance_bodies.py
+++ b/tests/unit/server/database/test_provenance_bodies.py
@@ -1,0 +1,710 @@
+"""Content-addressed result-body store (``provenance_bodies``).
+
+Mirrors the mock-connection approach of ``test_provenance_insert.py`` /
+``test_market_insight_db.py``: ``store_result_body`` / ``sweep_orphan_bodies``
+open their OWN pooled connection via ``get_db_connection``, so we patch that at
+the module's import path rather than passing a conn in. The object-storage layer
+(``upload_bytes`` / ``get_bytes`` / ``delete_object`` / ``is_storage_enabled``)
+is mocked where ``provenance_bodies`` imported it. Asserts:
+
+* small body → inline, no spill, no upload, byte_len == true length,
+* body > 64 KiB + storage → byte-safe head inline + full bytes uploaded to
+  ``provenance/{sha}`` + object_key set + byte_len is the TRUE full length,
+* body > 64 KiB without a bucket → inline head only, no upload (graceful),
+* ``ON CONFLICT (result_sha256) DO NOTHING`` dedups without rewriting the
+  immutable body (a hit is a pure no-op — no last_seen bump),
+* ``store_result_bodies`` batches a turn's writes: dedups by sha, chunks the
+  multi-row upsert into one connection,
+* truncation is recoverable from ``byte_len`` vs the inline length,
+* best-effort: empty inputs no-op, a raising storage/DB layer never propagates,
+* GC deletes only unreferenced + past-grace rows and ``delete_object``s the
+  swept spills, surviving a raising delete.
+"""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.server.database.provenance_bodies import (
+    FULL_BODY_READ_MAX_BYTES,
+    RESULT_BODY_MAX_BYTES,
+    fetch_full_body,
+    fetch_result_bodies,
+    store_result_bodies,
+    store_result_body,
+    sweep_orphan_bodies,
+)
+
+MOD = "src.server.database.provenance_bodies"
+SHA = "a" * 64
+
+
+@pytest.fixture
+def mock_cursor():
+    """AsyncMock cursor; fetchall defaults to no swept rows, fetchone to a
+    granted advisory lock ``(True,)`` (the sweep's first fetchone is the lock probe)."""
+    cursor = AsyncMock()
+    cursor.execute = AsyncMock()
+    cursor.fetchall = AsyncMock(return_value=[])
+    cursor.fetchone = AsyncMock(return_value=(True,))
+    return cursor
+
+
+@pytest.fixture
+def mock_connection(mock_cursor):
+    conn = AsyncMock()
+
+    @asynccontextmanager
+    async def _cursor_cm(*args, **kwargs):
+        yield mock_cursor
+
+    @asynccontextmanager
+    async def _txn_cm(*args, **kwargs):
+        yield None
+
+    conn.cursor = _cursor_cm
+    conn.transaction = _txn_cm
+    return conn
+
+
+@pytest.fixture
+def patched_db(mock_connection):
+    """Patch get_db_connection at the provenance_bodies import path."""
+
+    @asynccontextmanager
+    async def _fake():
+        yield mock_connection
+
+    with patch(f"{MOD}.get_db_connection", new=_fake):
+        yield mock_connection
+
+
+def _insert_params(mock_cursor):
+    """Params of the INSERT INTO provenance_result_bodies execute call."""
+    call = next(
+        c
+        for c in mock_cursor.execute.call_args_list
+        if "INSERT INTO provenance_result_bodies" in c.args[0]
+    )
+    return call.args[1]
+
+
+def _insert_field(mock_cursor, name):
+    """Bind value by column name (INSERT column order is fixed in the module)."""
+    cols = ["result_sha256", "body_inline", "object_key", "byte_len", "content_type"]
+    return _insert_params(mock_cursor)[cols.index(name)]
+
+
+class TestStoreResultBodyInline:
+    @pytest.mark.asyncio
+    async def test_small_body_stored_inline_no_spill(self, patched_db, mock_cursor):
+        body = "small result body"
+        with (
+            patch(f"{MOD}.is_storage_enabled", return_value=True),
+            patch(f"{MOD}._storage_upload_bytes") as upload,
+        ):
+            await store_result_body(SHA, body, true_byte_len=len(body.encode()))
+
+        # Inline body is the body verbatim; no spill, no upload.
+        assert _insert_field(mock_cursor, "body_inline") == body
+        assert _insert_field(mock_cursor, "object_key") is None
+        upload.assert_not_called()
+        # byte_len carries the TRUE full length the caller passed.
+        assert _insert_field(mock_cursor, "byte_len") == len(body.encode())
+
+    @pytest.mark.asyncio
+    async def test_exactly_at_cap_stays_inline(self, patched_db, mock_cursor):
+        # Boundary: a body whose encoded length == cap must NOT spill.
+        body = "x" * RESULT_BODY_MAX_BYTES
+        with (
+            patch(f"{MOD}.is_storage_enabled", return_value=True),
+            patch(f"{MOD}._storage_upload_bytes") as upload,
+        ):
+            await store_result_body(SHA, body, true_byte_len=len(body.encode()))
+        assert _insert_field(mock_cursor, "body_inline") == body
+        assert _insert_field(mock_cursor, "object_key") is None
+        upload.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_content_type_threaded_through(self, patched_db, mock_cursor):
+        body = "ok"
+        with (
+            patch(f"{MOD}.is_storage_enabled", return_value=True),
+            patch(f"{MOD}._storage_upload_bytes"),
+        ):
+            await store_result_body(
+                SHA, body, true_byte_len=2, content_type="application/json"
+            )
+        assert _insert_field(mock_cursor, "content_type") == "application/json"
+
+
+class TestStoreResultBodySpill:
+    @pytest.mark.asyncio
+    async def test_large_body_spills_head_inline_full_to_object(
+        self, patched_db, mock_cursor
+    ):
+        # 100 KiB > 64 KiB cap → byte-safe head inline, full bytes to storage.
+        full = "y" * (100 * 1024)
+        full_bytes = full.encode()
+        with (
+            patch(f"{MOD}.is_storage_enabled", return_value=True),
+            patch(f"{MOD}._storage_upload_bytes", return_value=True) as upload,
+        ):
+            await store_result_body(
+                SHA, full, true_byte_len=len(full_bytes), content_type="text/plain"
+            )
+
+        inline = _insert_field(mock_cursor, "body_inline")
+        # Head is the first 64 KiB, byte-safe (single-byte chars here so == cap).
+        assert inline == full[:RESULT_BODY_MAX_BYTES]
+        assert len(inline.encode()) <= RESULT_BODY_MAX_BYTES
+        # Full bytes uploaded to the content-addressed key, with content_type.
+        upload.assert_called_once_with(f"provenance/{SHA}", full_bytes, "text/plain")
+        # object_key set only because upload reported success.
+        assert _insert_field(mock_cursor, "object_key") == f"provenance/{SHA}"
+        # byte_len is the TRUE full length, not the inline head length.
+        assert _insert_field(mock_cursor, "byte_len") == len(full_bytes)
+        assert _insert_field(mock_cursor, "byte_len") > len(inline.encode())
+
+    @pytest.mark.asyncio
+    async def test_head_is_byte_safe_for_multibyte_chars(
+        self, patched_db, mock_cursor
+    ):
+        # A multibyte char straddling the cap must be dropped, not mojibake.
+        # "€" is 3 bytes; fill so the boundary lands mid-char.
+        body = "a" * (RESULT_BODY_MAX_BYTES - 1) + "€" + "b" * 1000
+        with (
+            patch(f"{MOD}.is_storage_enabled", return_value=True),
+            patch(f"{MOD}._storage_upload_bytes", return_value=True),
+        ):
+            await store_result_body(SHA, body, true_byte_len=len(body.encode()))
+        inline = _insert_field(mock_cursor, "body_inline")
+        # No replacement chars / partial bytes — clean decode under the cap.
+        assert len(inline.encode()) <= RESULT_BODY_MAX_BYTES
+        assert "�" not in inline
+        assert inline == "a" * (RESULT_BODY_MAX_BYTES - 1)
+
+    @pytest.mark.asyncio
+    async def test_malformed_sha_skips_spill_no_object_key(
+        self, patched_db, mock_cursor
+    ):
+        # An oversize body keyed by a non-hex sha (e.g. a traversal payload from a
+        # future untrusted caller) keeps the inline head and never builds an object
+        # key like provenance/../foo.
+        full = "y" * (100 * 1024)
+        with (
+            patch(f"{MOD}.is_storage_enabled", return_value=True),
+            patch(f"{MOD}._storage_upload_bytes", return_value=True) as upload,
+        ):
+            await store_result_body(
+                "../evil", full, true_byte_len=len(full.encode())
+            )
+        upload.assert_not_called()
+        assert _insert_field(mock_cursor, "object_key") is None
+
+    @pytest.mark.asyncio
+    async def test_upload_failure_leaves_object_key_none(
+        self, patched_db, mock_cursor
+    ):
+        # Storage enabled but upload returns falsey → inline head only, no key.
+        full = "z" * (80 * 1024)
+        with (
+            patch(f"{MOD}.is_storage_enabled", return_value=True),
+            patch(f"{MOD}._storage_upload_bytes", return_value=False),
+        ):
+            await store_result_body(SHA, full, true_byte_len=len(full.encode()))
+        assert _insert_field(mock_cursor, "object_key") is None
+        # byte_len still reflects the true length (truncation still inferable).
+        assert _insert_field(mock_cursor, "byte_len") == len(full.encode())
+
+
+class TestStoreResultBodyNoBucket:
+    @pytest.mark.asyncio
+    async def test_large_body_no_bucket_degrades_to_inline_head(
+        self, patched_db, mock_cursor
+    ):
+        # No storage configured → inline head only, object_key NULL, no upload.
+        full = "w" * (200 * 1024)
+        with (
+            patch(f"{MOD}.is_storage_enabled", return_value=False),
+            patch(f"{MOD}._storage_upload_bytes") as upload,
+        ):
+            await store_result_body(SHA, full, true_byte_len=len(full.encode()))
+        upload.assert_not_called()
+        assert _insert_field(mock_cursor, "object_key") is None
+        inline = _insert_field(mock_cursor, "body_inline")
+        assert len(inline.encode()) <= RESULT_BODY_MAX_BYTES
+        # Truncation remains recoverable from byte_len > inline length.
+        assert _insert_field(mock_cursor, "byte_len") > len(inline.encode())
+
+
+class TestStoreResultBodyConflict:
+    @pytest.mark.asyncio
+    async def test_insert_uses_on_conflict_do_nothing(
+        self, patched_db, mock_cursor
+    ):
+        # Bodies are immutable + content-addressed, so a dedup hit must be a pure
+        # no-op: ON CONFLICT DO NOTHING (no row rewrite, no last_seen bump, no WAL).
+        with patch(f"{MOD}.is_storage_enabled", return_value=False):
+            await store_result_body(SHA, "body", true_byte_len=4)
+        sql = next(
+            c.args[0]
+            for c in mock_cursor.execute.call_args_list
+            if "INSERT INTO provenance_result_bodies" in c.args[0]
+        )
+        assert "ON CONFLICT (result_sha256) DO NOTHING" in sql
+        # The conflict clause must NOT rewrite any stored column.
+        conflict = sql.split("ON CONFLICT", 1)[1]
+        assert "DO UPDATE" not in conflict
+        assert "body_inline" not in conflict
+        assert "object_key" not in conflict
+
+    @pytest.mark.asyncio
+    async def test_reuse_touch_precedes_insert_and_is_age_conditional(
+        self, patched_db, mock_cursor
+    ):
+        # D′: a conditional created_at bump runs BEFORE the DO NOTHING insert, so a
+        # reused old body's grace window is re-armed and the sweep can't reap it
+        # mid-reuse. Conditional on age → recent rows match nothing (no churn).
+        from src.server.database.provenance_bodies import _REUSE_TOUCH_AFTER_DAYS
+
+        with patch(f"{MOD}.is_storage_enabled", return_value=False):
+            await store_result_body(SHA, "body", true_byte_len=4)
+        calls = mock_cursor.execute.call_args_list
+        update_idx = next(
+            i for i, c in enumerate(calls)
+            if "UPDATE provenance_result_bodies" in c.args[0]
+        )
+        insert_idx = next(
+            i for i, c in enumerate(calls)
+            if "INSERT INTO provenance_result_bodies" in c.args[0]
+        )
+        assert update_idx < insert_idx  # touch first, then insert
+        update_sql = calls[update_idx].args[0]
+        assert "SET created_at = NOW()" in update_sql
+        assert "created_at < NOW() - make_interval(days =>" in update_sql
+        # shas bound as an array, age threshold bound (never interpolated).
+        assert calls[update_idx].args[1] == ([SHA], _REUSE_TOUCH_AFTER_DAYS)
+
+    @pytest.mark.asyncio
+    async def test_storing_same_sha_twice_is_single_insert_each(
+        self, patched_db, mock_cursor
+    ):
+        # Two stores → two INSERT executes that both rely on ON CONFLICT to keep
+        # exactly one row (the DB enforces single-row; we assert the same key +
+        # same body are written, so a re-store can't change the stored body).
+        with patch(f"{MOD}.is_storage_enabled", return_value=False):
+            await store_result_body(SHA, "body-A", true_byte_len=6)
+            await store_result_body(SHA, "body-A", true_byte_len=6)
+        inserts = [
+            c
+            for c in mock_cursor.execute.call_args_list
+            if "INSERT INTO provenance_result_bodies" in c.args[0]
+        ]
+        assert len(inserts) == 2
+        # Same sha bound both times; body unchanged across the re-store.
+        assert inserts[0].args[1][0] == inserts[1].args[1][0] == SHA
+        assert inserts[0].args[1][1] == inserts[1].args[1][1] == "body-A"
+
+
+class TestStoreResultBodiesBatch:
+    """The batch writer: dedup by sha, chunked multi-row upserts, one connection."""
+
+    @pytest.mark.asyncio
+    async def test_dedups_repeated_sha_to_one_row(self, patched_db, mock_cursor):
+        # Market fan-out repeats the same (sha, body) across symbols; the batch
+        # must collapse them to a single row rather than re-upserting N times.
+        items = [(SHA, "body", 4, None)] * 5
+        with patch(f"{MOD}.is_storage_enabled", return_value=False):
+            await store_result_bodies(items)
+        inserts = [
+            c
+            for c in mock_cursor.execute.call_args_list
+            if "INSERT INTO provenance_result_bodies" in c.args[0]
+        ]
+        assert len(inserts) == 1
+        # One row → exactly one 5-column group bound.
+        assert len(inserts[0].args[1]) == 5
+        assert inserts[0].args[1][0] == SHA
+
+    @pytest.mark.asyncio
+    async def test_distinct_shas_one_multirow_statement(
+        self, patched_db, mock_cursor
+    ):
+        items = [(f"{i:064d}", f"body-{i}", 6, None) for i in range(3)]
+        with patch(f"{MOD}.is_storage_enabled", return_value=False):
+            await store_result_bodies(items)
+        inserts = [
+            c
+            for c in mock_cursor.execute.call_args_list
+            if "INSERT INTO provenance_result_bodies" in c.args[0]
+        ]
+        assert len(inserts) == 1
+        sql = inserts[0].args[0]
+        # Three VALUES groups in one statement, DO NOTHING, 15 flat params.
+        assert sql.count("(%s, %s, %s, %s, %s)") == 3
+        assert "ON CONFLICT (result_sha256) DO NOTHING" in sql
+        assert len(inserts[0].args[1]) == 15
+
+    @pytest.mark.asyncio
+    async def test_large_batch_is_chunked(self, patched_db, mock_cursor):
+        import math
+
+        from src.server.database.provenance_bodies import _BATCH_CHUNK
+
+        n = _BATCH_CHUNK * 2 + 10
+        items = [(f"{i:064d}", "b", 1, None) for i in range(n)]
+        with patch(f"{MOD}.is_storage_enabled", return_value=False):
+            await store_result_bodies(items)
+        inserts = [
+            c
+            for c in mock_cursor.execute.call_args_list
+            if "INSERT INTO provenance_result_bodies" in c.args[0]
+        ]
+        assert len(inserts) == math.ceil(n / _BATCH_CHUNK)
+
+    @pytest.mark.asyncio
+    async def test_all_empty_items_no_execute(self, patched_db, mock_cursor):
+        await store_result_bodies([("", "b", 1, None), (SHA, "", 0, None)])
+        mock_cursor.execute.assert_not_called()
+
+
+class TestStoreResultBodyBestEffort:
+    @pytest.mark.asyncio
+    async def test_empty_sha_is_noop(self, patched_db, mock_cursor):
+        await store_result_body("", "body", true_byte_len=4)
+        mock_cursor.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_body_is_noop(self, patched_db, mock_cursor):
+        await store_result_body(SHA, "", true_byte_len=0)
+        mock_cursor.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_raising_db_layer_does_not_propagate(self, mock_connection):
+        # A DB failure mid-store must be swallowed (the turn must not break).
+        @asynccontextmanager
+        async def _boom():
+            raise RuntimeError("db down")
+            yield  # pragma: no cover
+
+        with (
+            patch(f"{MOD}.get_db_connection", new=_boom),
+            patch(f"{MOD}.is_storage_enabled", return_value=False),
+        ):
+            await store_result_body(SHA, "body", true_byte_len=4)  # no raise
+
+    @pytest.mark.asyncio
+    async def test_raising_storage_layer_does_not_propagate(
+        self, patched_db, mock_cursor
+    ):
+        full = "q" * (70 * 1024)
+        with (
+            patch(f"{MOD}.is_storage_enabled", return_value=True),
+            patch(
+                f"{MOD}._storage_upload_bytes",
+                side_effect=RuntimeError("s3 down"),
+            ),
+        ):
+            await store_result_body(SHA, full, true_byte_len=len(full.encode()))
+        # Upload raised before the INSERT, so no row is written, but no raise.
+        assert not any(
+            "INSERT INTO provenance_result_bodies" in c.args[0]
+            for c in mock_cursor.execute.call_args_list
+        )
+
+
+class TestFetchResultBodies:
+    @pytest.mark.asyncio
+    async def test_empty_shas_short_circuits(self, mock_connection, mock_cursor):
+        out = await fetch_result_bodies(mock_connection, [])
+        assert out == {}
+        mock_cursor.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_round_trip_truncation_semantics(
+        self, mock_connection, mock_cursor
+    ):
+        # The verifier reads byte_len + inline; truncation is byte_len > inline
+        # length. Inline row: byte_len == len(inline) → NOT truncated. Spilled
+        # row: byte_len > len(inline) → truncated.
+        inline_body = "short inline body"
+        head = "h" * RESULT_BODY_MAX_BYTES
+        mock_cursor.fetchall.return_value = [
+            {
+                "result_sha256": "sha-inline",
+                "body_inline": inline_body,
+                "object_key": None,
+                "byte_len": len(inline_body.encode()),
+                "content_type": None,
+            },
+            {
+                "result_sha256": "sha-spill",
+                "body_inline": head,
+                "object_key": "provenance/sha-spill",
+                "byte_len": 100 * 1024,
+                "content_type": "text/plain",
+            },
+        ]
+        out = await fetch_result_bodies(
+            mock_connection, ["sha-inline", "sha-spill"]
+        )
+        assert set(out) == {"sha-inline", "sha-spill"}
+
+        inline = out["sha-inline"]
+        assert inline["object_key"] is None
+        # NOT truncated: byte_len equals the inline byte length.
+        assert inline["byte_len"] == len(inline["body_inline"].encode())
+
+        spill = out["sha-spill"]
+        assert spill["object_key"] == "provenance/sha-spill"
+        # Truncated: true byte_len exceeds the stored 64 KiB head.
+        assert spill["byte_len"] > len(spill["body_inline"].encode())
+
+    @pytest.mark.asyncio
+    async def test_uses_any_array_bind(self, mock_connection, mock_cursor):
+        await fetch_result_bodies(mock_connection, ["s1", "s2"])
+        call = mock_cursor.execute.call_args
+        assert "= ANY(%s)" in call.args[0]
+        # Shas are bound as a list (psycopg3 array), not interpolated.
+        assert call.args[1] == (["s1", "s2"],)
+
+
+class TestFetchFullBody:
+    @pytest.mark.asyncio
+    async def test_unknown_sha_returns_none(self, patched_db, mock_cursor):
+        mock_cursor.fetchone.return_value = None
+        assert await fetch_full_body(SHA) is None
+
+    @pytest.mark.asyncio
+    async def test_empty_sha_returns_none(self, patched_db, mock_cursor):
+        assert await fetch_full_body("") is None
+        mock_cursor.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_inline_row_returns_inline_no_storage_read(
+        self, patched_db, mock_cursor
+    ):
+        mock_cursor.fetchone.return_value = {
+            "body_inline": "the full small body",
+            "object_key": None,
+        }
+        with patch(f"{MOD}._storage_get_bytes") as get_bytes:
+            out = await fetch_full_body(SHA)
+        assert out == "the full small body"
+        get_bytes.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_spilled_row_reads_full_object(self, patched_db, mock_cursor):
+        mock_cursor.fetchone.return_value = {
+            "body_inline": "h" * RESULT_BODY_MAX_BYTES,  # only the head
+            "object_key": "provenance/sha-spill",
+        }
+        full = "full body " * 100000
+        with (
+            patch(f"{MOD}.is_storage_enabled", return_value=True),
+            patch(
+                f"{MOD}._storage_get_bytes", return_value=full.encode()
+            ) as get_bytes,
+        ):
+            out = await fetch_full_body(SHA)
+        # The reassembled body is the full object, not the truncated head.
+        assert out == full
+        get_bytes.assert_called_once_with("provenance/sha-spill")
+
+    @pytest.mark.asyncio
+    async def test_object_read_failure_falls_back_to_head(
+        self, patched_db, mock_cursor
+    ):
+        # If the object is gone/unreadable, return the inline head, never raise.
+        mock_cursor.fetchone.return_value = {
+            "body_inline": "head only",
+            "object_key": "provenance/missing",
+        }
+        with (
+            patch(f"{MOD}.is_storage_enabled", return_value=True),
+            patch(f"{MOD}._storage_get_bytes", return_value=None),
+        ):
+            assert await fetch_full_body(SHA) == "head only"
+
+    @pytest.mark.asyncio
+    async def test_spilled_object_capped_at_max_bytes(self, patched_db, mock_cursor):
+        # The read is byte-sliced at max_bytes so one request can't decode a whole
+        # ~10 MiB object; errors="ignore" drops a multibyte char split at the cut.
+        mock_cursor.fetchone.return_value = {
+            "body_inline": "head",
+            "object_key": "provenance/big",
+        }
+        full = "é" * 10  # 'é' is 2 bytes in UTF-8 → 20 bytes total
+        with (
+            patch(f"{MOD}.is_storage_enabled", return_value=True),
+            patch(f"{MOD}._storage_get_bytes", return_value=full.encode()),
+        ):
+            out = await fetch_full_body(SHA, max_bytes=5)
+        # 5-byte cut lands mid-char; the dangling half-'é' is dropped → 2 chars.
+        assert out == "éé"
+        assert len(out.encode()) <= 5
+
+    @pytest.mark.asyncio
+    async def test_default_cap_bounds_oversized_object(self, patched_db, mock_cursor):
+        # Default cap is FULL_BODY_READ_MAX_BYTES — an object past it comes back
+        # truncated to the cap (the caller's truncated flag flips on byte_len).
+        mock_cursor.fetchone.return_value = {
+            "body_inline": "head",
+            "object_key": "provenance/huge",
+        }
+        oversized = b"x" * (FULL_BODY_READ_MAX_BYTES + 4096)
+        with (
+            patch(f"{MOD}.is_storage_enabled", return_value=True),
+            patch(f"{MOD}._storage_get_bytes", return_value=oversized),
+        ):
+            out = await fetch_full_body(SHA)
+        assert len(out.encode()) == FULL_BODY_READ_MAX_BYTES
+
+
+class TestSweepOrphanBodies:
+    @pytest.mark.asyncio
+    async def test_delete_sql_shape_and_grace_bind(self, patched_db, mock_cursor):
+        await sweep_orphan_bodies(grace_days=7)
+        delete_call = next(
+            c
+            for c in mock_cursor.execute.call_args_list
+            if "DELETE FROM provenance_result_bodies" in c.args[0]
+        )
+        sql = delete_call.args[0]
+        # Mark-sweep: unreferenced (NOT EXISTS against provenance_records) AND
+        # past the grace window, returning object_key for spill cleanup.
+        assert "NOT EXISTS" in sql
+        assert "provenance_records" in sql
+        assert "created_at" in sql
+        assert "make_interval(days =>" in sql
+        # Returns the sha too, so the post-commit re-check can tell which spilled
+        # objects are safe to reclaim.
+        assert "RETURNING result_sha256, object_key" in sql
+        # grace_days is a bound parameter, never string-interpolated.
+        assert delete_call.args[1] == (7,)
+
+    @pytest.mark.asyncio
+    async def test_acquires_advisory_lock_before_delete(self, patched_db, mock_cursor):
+        # Leader election: the non-blocking try-lock probe runs first, the DELETE
+        # second, so the xact-scoped lock is held across the sweep.
+        await sweep_orphan_bodies()
+        calls = mock_cursor.execute.call_args_list
+        assert "pg_try_advisory_xact_lock" in calls[0].args[0]
+        assert "DELETE FROM provenance_result_bodies" in calls[1].args[0]
+
+    @pytest.mark.asyncio
+    async def test_skips_when_lock_not_acquired(self, patched_db, mock_cursor):
+        # Another instance holds the GC lock → probe returns (False,); this sweep
+        # issues no DELETE and reaps nothing.
+        mock_cursor.fetchone.return_value = (False,)
+        with patch(f"{MOD}._storage_delete_object") as delete:
+            assert await sweep_orphan_bodies() == 0
+        assert not any(
+            "DELETE FROM provenance_result_bodies" in c.args[0]
+            for c in mock_cursor.execute.call_args_list
+        )
+        delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_returns_deleted_count(self, patched_db, mock_cursor):
+        # Rows are (result_sha256, object_key); the one spilled row triggers a
+        # re-check (2nd fetchall) — [] means none re-inserted, so it's reclaimed.
+        mock_cursor.fetchall.side_effect = [
+            [("s1", None), ("s2", None), ("s3", "provenance/x")],
+            [],
+        ]
+        with patch(f"{MOD}._storage_delete_object"):
+            assert await sweep_orphan_bodies() == 3
+
+    @pytest.mark.asyncio
+    async def test_deletes_objects_only_for_spilled_rows(
+        self, patched_db, mock_cursor
+    ):
+        # Two swept rows spilled (have object_key), one was inline-only (None). The
+        # re-check (2nd fetchall) finds none re-inserted, so both objects reclaim.
+        mock_cursor.fetchall.side_effect = [
+            [("s1", "provenance/sha1"), ("s2", None), ("s3", "provenance/sha2")],
+            [],
+        ]
+        with patch(f"{MOD}._storage_delete_object") as delete:
+            deleted = await sweep_orphan_bodies()
+        assert deleted == 3
+        called_keys = {c.args[0] for c in delete.call_args_list}
+        assert called_keys == {"provenance/sha1", "provenance/sha2"}
+
+    @pytest.mark.asyncio
+    async def test_recheck_keeps_object_when_sha_reinserted(
+        self, patched_db, mock_cursor
+    ):
+        # A concurrent reuse re-inserted the swept sha (re-check finds it present),
+        # so its content-addressed object must NOT be deleted — it backs the live
+        # re-inserted row. Count still reflects the rows the DELETE removed.
+        mock_cursor.fetchall.side_effect = [
+            [("s1", "provenance/sha1")],  # DELETE removed it
+            [("s1",)],  # re-check: reused, back in the table
+        ]
+        with patch(f"{MOD}._storage_delete_object") as delete:
+            assert await sweep_orphan_bodies() == 1
+        delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_object_delete_failure_does_not_raise(
+        self, patched_db, mock_cursor
+    ):
+        # A failing object delete is harmless — sweep still returns the count.
+        mock_cursor.fetchall.side_effect = [[("s1", "provenance/sha1")], []]
+        with patch(
+            f"{MOD}._storage_delete_object",
+            side_effect=RuntimeError("delete failed"),
+        ):
+            assert await sweep_orphan_bodies() == 1
+
+    @pytest.mark.asyncio
+    async def test_db_failure_returns_zero_not_raise(self):
+        @asynccontextmanager
+        async def _boom():
+            raise RuntimeError("db down")
+            yield  # pragma: no cover
+
+        with patch(f"{MOD}.get_db_connection", new=_boom):
+            assert await sweep_orphan_bodies() == 0
+
+    @pytest.mark.asyncio
+    async def test_no_orphans_no_object_deletes(self, patched_db, mock_cursor):
+        # Default fetchall is [] → nothing swept, delete_object never called.
+        with patch(f"{MOD}._storage_delete_object") as delete:
+            assert await sweep_orphan_bodies() == 0
+        delete.assert_not_called()
+
+
+class TestLeanIndexWriterHasNoResultFull:
+    def test_insert_columns_has_no_result_full(self):
+        # The index writer was reverted to the lean 16-column shape — no
+        # result_full join column (the regression that started the rewrite).
+        from src.server.database.provenance import _INSERT_COLUMNS
+
+        assert "result_full" not in _INSERT_COLUMNS
+        assert len(_INSERT_COLUMNS) == 16
+
+    def test_no_result_full_helpers_on_module(self):
+        # The join helpers/const that populated result_full are gone too.
+        import src.server.database.provenance as prov
+
+        assert not hasattr(prov, "_RESULT_FULL_MAX_CHARS")
+        assert not hasattr(prov, "_content_text")
+        assert not hasattr(prov, "_tool_result_contents")
+
+
+class TestBodyCapStaysInSyncWithAgentSide:
+    def test_max_bytes_matches_canonical_agent_constant(self):
+        # RESULT_BODY_MAX_BYTES is re-declared in this module (not imported) to
+        # keep the server side out of the agent import graph; both copies MUST
+        # hold the same value — the inline/spill boundary IS the in-sandbox
+        # transport cap. Pin the invariant so editing one can't silently desync.
+        from ptc_agent.agent.provenance.types import (
+            RESULT_BODY_MAX_BYTES as AGENT_MAX_BYTES,
+        )
+
+        assert RESULT_BODY_MAX_BYTES == AGENT_MAX_BYTES

--- a/tests/unit/server/database/test_provenance_bodies.py
+++ b/tests/unit/server/database/test_provenance_bodies.py
@@ -562,6 +562,34 @@ class TestFetchFullBody:
             out = await fetch_full_body(SHA)
         assert len(out.encode()) == FULL_BODY_READ_MAX_BYTES
 
+    @pytest.mark.asyncio
+    async def test_preloaded_row_inline_skips_db_query(self, patched_db, mock_cursor):
+        # A caller that already holds the row (e.g. from fetch_result_bodies)
+        # passes it via row= — fetch_full_body must not open a second connection.
+        row = {"body_inline": "the full small body", "object_key": None}
+        with patch(f"{MOD}._storage_get_bytes") as get_bytes:
+            out = await fetch_full_body(SHA, row=row)
+        assert out == "the full small body"
+        mock_cursor.execute.assert_not_called()
+        get_bytes.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_preloaded_row_still_reads_spilled_object(
+        self, patched_db, mock_cursor
+    ):
+        # With a preloaded row the DB query is skipped, but a spilled object_key
+        # still triggers the object read (the only work left for full=true).
+        row = {"body_inline": "h" * RESULT_BODY_MAX_BYTES, "object_key": "provenance/x"}
+        full = "full body " * 100000
+        with (
+            patch(f"{MOD}.is_storage_enabled", return_value=True),
+            patch(f"{MOD}._storage_get_bytes", return_value=full.encode()) as get_bytes,
+        ):
+            out = await fetch_full_body(SHA, row=row)
+        assert out == full
+        mock_cursor.execute.assert_not_called()
+        get_bytes.assert_called_once_with("provenance/x")
+
 
 class TestSweepOrphanBodies:
     @pytest.mark.asyncio

--- a/tests/unit/server/services/test_provenance_gc.py
+++ b/tests/unit/server/services/test_provenance_gc.py
@@ -1,0 +1,172 @@
+"""``ProvenanceGCService`` — the periodic orphan-body sweeper.
+
+The loop sweeps on start, then sleeps an interval (via ``wait_for`` on a shutdown
+event) before the next sweep; the service is a process-global singleton. Tests
+reset ``ProvenanceGCService._instance`` around each case to avoid singleton bleed,
+use a tiny interval so the loop cycles fast (no multi-second waits), and patch
+``sweep_orphan_bodies`` at the service module's import path. Asserts:
+
+* ``get_instance`` returns the same cached object,
+* ``start`` schedules a task and ``stop`` cancels it cleanly,
+* ``stop`` is idempotent (safe when never started, called twice),
+* the loop invokes ``sweep_orphan_bodies`` with the configured grace,
+* the first sweep fires on start, NOT after a full interval (so a process that
+  restarts faster than the interval still sweeps),
+* a sweep raising inside one cycle never kills the service.
+"""
+
+import asyncio
+
+import pytest
+
+from src.server.services.provenance_gc import ProvenanceGCService
+
+MOD = "src.server.services.provenance_gc"
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    """Clear the process-global instance before and after each test."""
+    ProvenanceGCService._instance = None
+    yield
+    ProvenanceGCService._instance = None
+
+
+class TestSingleton:
+    def test_get_instance_caches(self):
+        a = ProvenanceGCService.get_instance()
+        b = ProvenanceGCService.get_instance()
+        assert a is b
+
+    def test_constructor_params_injectable(self):
+        svc = ProvenanceGCService(interval_seconds=5, grace_days=3)
+        assert svc._interval == 5
+        assert svc._grace_days == 3
+
+
+class TestStartStop:
+    @pytest.mark.asyncio
+    async def test_start_schedules_task(self):
+        svc = ProvenanceGCService(interval_seconds=3600)
+        try:
+            await svc.start()
+            assert svc._task is not None
+            assert not svc._task.done()
+        finally:
+            await svc.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_is_idempotent(self):
+        svc = ProvenanceGCService(interval_seconds=3600)
+        try:
+            await svc.start()
+            first = svc._task
+            await svc.start()  # already running → no new task
+            assert svc._task is first
+        finally:
+            await svc.stop()
+
+    @pytest.mark.asyncio
+    async def test_stop_cancels_task(self):
+        svc = ProvenanceGCService(interval_seconds=3600)
+        await svc.start()
+        task = svc._task
+        await svc.stop()
+        assert task.done()
+
+    @pytest.mark.asyncio
+    async def test_stop_when_never_started_is_noop(self):
+        svc = ProvenanceGCService(interval_seconds=3600)
+        await svc.stop()  # no task → must not raise
+        assert svc._task is None
+
+    @pytest.mark.asyncio
+    async def test_stop_is_idempotent(self):
+        svc = ProvenanceGCService(interval_seconds=3600)
+        await svc.start()
+        await svc.stop()
+        await svc.stop()  # second stop on a done task → must not raise
+
+
+class TestLoopSweeps:
+    @pytest.mark.asyncio
+    async def test_loop_invokes_sweep_with_grace(self, monkeypatch):
+        # Tiny interval so the first wait_for times out almost immediately and
+        # the loop reaches the sweep without a real multi-second sleep.
+        called = asyncio.Event()
+        seen_grace = []
+
+        async def fake_sweep(grace_days):
+            seen_grace.append(grace_days)
+            called.set()
+            return 0
+
+        monkeypatch.setattr(f"{MOD}.sweep_orphan_bodies", fake_sweep)
+        svc = ProvenanceGCService(interval_seconds=0.01, grace_days=11)
+        try:
+            await svc.start()
+            await asyncio.wait_for(called.wait(), timeout=2.0)
+        finally:
+            await svc.stop()
+        assert seen_grace and seen_grace[0] == 11
+
+    @pytest.mark.asyncio
+    async def test_loop_survives_a_failing_sweep_cycle(self, monkeypatch):
+        # One raising cycle must not kill the loop — it sweeps again next tick.
+        calls = []
+        twice = asyncio.Event()
+
+        async def flaky_sweep(grace_days):
+            calls.append(1)
+            if len(calls) == 1:
+                raise RuntimeError("sweep boom")
+            twice.set()
+            return 0
+
+        monkeypatch.setattr(f"{MOD}.sweep_orphan_bodies", flaky_sweep)
+        svc = ProvenanceGCService(interval_seconds=0.01)
+        try:
+            await svc.start()
+            # If the loop died on the first raise, this wait times out.
+            await asyncio.wait_for(twice.wait(), timeout=2.0)
+        finally:
+            await svc.stop()
+        assert len(calls) >= 2
+
+    @pytest.mark.asyncio
+    async def test_sweeps_on_start_not_after_a_full_interval(self, monkeypatch):
+        # Regression: the loop must sweep on start, not wait a full interval first
+        # — else a process restarting faster than the interval never sweeps. A huge
+        # interval means this would time out if the sweep waited for it.
+        swept = asyncio.Event()
+
+        async def fake_sweep(grace_days):
+            swept.set()
+            return 0
+
+        monkeypatch.setattr(f"{MOD}.sweep_orphan_bodies", fake_sweep)
+        svc = ProvenanceGCService(interval_seconds=3600)
+        try:
+            await svc.start()
+            await asyncio.wait_for(swept.wait(), timeout=2.0)
+        finally:
+            await svc.stop()
+
+    @pytest.mark.asyncio
+    async def test_stop_during_sleep_exits_without_further_sweeping(self, monkeypatch):
+        # Sweep runs once on start, then the loop parks in the long interval sleep;
+        # stop() must exit that sleep without triggering a second sweep.
+        swept = []
+        first = asyncio.Event()
+
+        async def fake_sweep(grace_days):
+            swept.append(1)
+            first.set()
+            return 0
+
+        monkeypatch.setattr(f"{MOD}.sweep_orphan_bodies", fake_sweep)
+        svc = ProvenanceGCService(interval_seconds=3600)
+        await svc.start()
+        await asyncio.wait_for(first.wait(), timeout=2.0)  # startup sweep done
+        await svc.stop()
+        assert swept == [1]  # exactly the startup sweep, no second one

--- a/web/src/pages/ChatAgent/components/__tests__/SourcesPanel.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/SourcesPanel.test.tsx
@@ -113,6 +113,45 @@ describe('SourcesPanel', () => {
     expect(screen.getByText('Checksum')).toBeInTheDocument();
   });
 
+  it('keeps two same-ticker, same-kind market_data snapshots with different content as distinct cards', () => {
+    // The native-tool analogue of the mcp_tool fix. Same ticker AND same
+    // data-kind, but the result changed between calls — live market data is
+    // time-varying, so an identical query seconds apart is a distinct snapshot.
+    // Each native call carries its own tool_call_id so both survive storage; the
+    // entity deck must then split them by result_sha256 (NOT by the shared kind
+    // label) on expand, or the earlier snapshot is silently dropped.
+    const records = asMap([
+      rec({ record_id: 'r1', source_type: 'market_data', identifier: 'AAPL', detail: 'daily_prices', result_sha256: 'a'.repeat(20), result_size: 512, provider: 'market_data_proxy' }),
+      rec({ record_id: 'r2', source_type: 'market_data', identifier: 'AAPL', detail: 'daily_prices', result_sha256: 'b'.repeat(20), result_size: 512, provider: 'market_data_proxy' }),
+    ]);
+    render(<SourcesPanel provenanceRecords={records} />);
+
+    // Grouped into one ticker row (visual stacking is fine)...
+    expect(screen.getByTestId('group-count-market_data')).toHaveTextContent('1');
+    // ...but the deck holds both snapshots, not one collapsed card.
+    expect(screen.getByText('2 sources')).toBeInTheDocument();
+
+    // On expand, each snapshot is its own card — two cards of the same kind.
+    fireEvent.click(screen.getByRole('button', { name: /AAPL — Expand/ }));
+    expect(screen.getAllByRole('button', { name: /Daily prices — View details/ })).toHaveLength(2);
+  });
+
+  it('collapses two same-ticker, same-kind market_data accesses with identical content to one card', () => {
+    // The inverse: a true re-fetch returning byte-identical bytes (same sha) is
+    // one access, not a phantom duplicate. The entity deck dedups by content
+    // hash, so it renders a single flat card rather than a 2-card deck.
+    const records = asMap([
+      rec({ record_id: 'r1', source_type: 'market_data', identifier: 'AAPL', detail: 'daily_prices', result_sha256: 'same'.repeat(5), provider: 'market_data_proxy' }),
+      rec({ record_id: 'r2', source_type: 'market_data', identifier: 'AAPL', detail: 'daily_prices', result_sha256: 'same'.repeat(5), provider: 'market_data_proxy' }),
+    ]);
+    render(<SourcesPanel provenanceRecords={records} />);
+
+    expect(screen.getByTestId('group-count-market_data')).toHaveTextContent('1');
+    expect(screen.queryByTestId('source-stack')).not.toBeInTheDocument();
+    expect(screen.queryByText(/sources$/)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /AAPL — View details/ })).toBeInTheDocument();
+  });
+
   it('dedups display by (source_type, identifier)', () => {
     const records = asMap([
       rec({ record_id: 'r1', source_type: 'web_fetch', identifier: 'https://example.com/page', title: 'Page' }),

--- a/web/src/pages/ChatAgent/hooks/utils/streamEventHandlers.ts
+++ b/web/src/pages/ChatAgent/hooks/utils/streamEventHandlers.ts
@@ -7,6 +7,7 @@ import { normalizeAction } from './eventUtils';
 import type { MessageRecord, SetMessages, ToolCallRecord, ToolCallResultRecord, TodoPayload, HtmlWidgetData } from './types';
 import type { ProvenanceEvent } from '@/types/sse';
 import type { ProvenanceRecord } from '@/types/chat';
+import { provenanceMcpKey } from '@/types/chat';
 
 /**
  * Builds the immutable `provenanceRecords` key for a provenance record.
@@ -14,14 +15,25 @@ import type { ProvenanceRecord } from '@/types/chat';
  * web_search emits multiple records that share one `tool_call_id` (one per
  * result URL), so the key prefixes the tool_call_id with `source_type` +
  * `identifier` to keep every distinct source — grouping by tool_call_id while
- * never dropping a sibling URL.
+ * never dropping a sibling URL. For `mcp_tool` the identifier is `"server:tool"`
+ * (shared across calls), so the per-access discriminator (args fingerprint +
+ * result hash, see {@link provenanceMcpKey}) is appended too — otherwise two
+ * calls to one tool with different args (get_stock_data for AAPL vs NVDA), or
+ * even the same args returning different data (live market data), collide and
+ * the last silently overwrites the first.
  */
 export function provenanceRecordKey(record: {
   tool_call_id?: string;
   source_type: string;
   identifier: string;
+  args_fingerprint?: Record<string, unknown> | null;
+  result_sha256?: string | null;
 }): string {
-  return `${record.tool_call_id || ''}:${record.source_type}:${record.identifier}`;
+  const base = `${record.tool_call_id || ''}:${record.source_type}:${record.identifier}`;
+  const mcp = provenanceMcpKey(
+    record as Pick<ProvenanceRecord, 'source_type' | 'args_fingerprint' | 'result_sha256'>,
+  );
+  return mcp ? `${base}:${mcp}` : base;
 }
 
 /**

--- a/web/src/types/__tests__/provenance.test.ts
+++ b/web/src/types/__tests__/provenance.test.ts
@@ -2,18 +2,82 @@
  * Shared provenance dedup helpers: provenanceDisplayKey and
  * countDedupedSources are the single source of truth used by both the Sources
  * pill (MessageList) and the Sources panel so their counts cannot diverge.
+ * provenanceRecordKey is the storage key for the live/replay accumulator.
  */
 import { describe, it, expect } from 'vitest';
-import { provenanceDisplayKey, countDedupedSources, type ProvenanceRecord } from '../chat';
+import {
+  provenanceMcpKey,
+  provenanceDisplayKey,
+  countDedupedSources,
+  type ProvenanceRecord,
+} from '../chat';
+import { provenanceRecordKey } from '@/pages/ChatAgent/hooks/utils/streamEventHandlers';
 
-function rec(source_type: string, identifier: string): ProvenanceRecord {
+function rec(
+  source_type: string,
+  identifier: string,
+  args_fingerprint?: Record<string, unknown>,
+  result_sha256?: string,
+): ProvenanceRecord {
   return {
-    record_id: `${source_type}:${identifier}`,
+    record_id: `${source_type}:${identifier}:${JSON.stringify(args_fingerprint ?? null)}:${result_sha256 ?? ''}`,
     timestamp: '2026-01-01T00:00:00Z',
     source_type: source_type as ProvenanceRecord['source_type'],
     identifier,
+    args_fingerprint,
+    result_sha256,
   };
 }
+
+describe('provenanceMcpKey', () => {
+  it('is empty for non-mcp_tool sources even with a fingerprint and sha', () => {
+    expect(provenanceMcpKey(rec('web_search', 'https://x/a', { sha256: 'h' }, 'r'))).toBe('');
+  });
+
+  it('is empty for an mcp_tool call with neither args nor a result hash', () => {
+    expect(provenanceMcpKey(rec('mcp_tool', 'srv:list_tools'))).toBe('');
+  });
+
+  it('includes the args fingerprint', () => {
+    expect(provenanceMcpKey(rec('mcp_tool', 'srv:get_prices', { sha256: 'abc' }))).toBe(
+      '{"sha256":"abc"}#',
+    );
+  });
+
+  it('includes the result hash, so same-args calls returning different data differ', () => {
+    // Live market data: identical query seconds apart returns a different
+    // snapshot. The result hash must keep them distinct.
+    const a = provenanceMcpKey(
+      rec('mcp_tool', 'price_data:get_stock_data', { sha256: 'aapl' }, 'r1'),
+    );
+    const b = provenanceMcpKey(
+      rec('mcp_tool', 'price_data:get_stock_data', { sha256: 'aapl' }, 'r2'),
+    );
+    expect(a).not.toBe(b);
+  });
+
+  it('falls back to the args fingerprint when the result hash is nulled (oversized body)', () => {
+    // Bodies over the inline cap have result_sha256 nulled server-side, so the
+    // key can only lean on args. Same args still collapse; different args stay
+    // distinct — truncation must not merge unrelated oversized calls.
+    const same = provenanceMcpKey(rec('mcp_tool', 'srv:dump', { sha256: 'q' }, undefined));
+    const sameAgain = provenanceMcpKey(rec('mcp_tool', 'srv:dump', { sha256: 'q' }, undefined));
+    const other = provenanceMcpKey(rec('mcp_tool', 'srv:dump', { sha256: 'z' }, undefined));
+    expect(same).toBe('{"sha256":"q"}#');
+    expect(same).toBe(sameAgain);
+    expect(same).not.toBe(other);
+  });
+
+  it('keys a no-arg tool purely by its result hash', () => {
+    // A tool called with no arguments (e.g. a list/status call) has an empty
+    // fingerprint, so the result hash is the only discriminator: same bytes
+    // collapse, different bytes stay apart.
+    const r1 = provenanceMcpKey(rec('mcp_tool', 'srv:list_holdings', undefined, 'r1'));
+    const r2 = provenanceMcpKey(rec('mcp_tool', 'srv:list_holdings', undefined, 'r2'));
+    expect(r1).toBe('#r1');
+    expect(r1).not.toBe(r2);
+  });
+});
 
 describe('provenanceDisplayKey', () => {
   it('keys on (source_type, identifier)', () => {
@@ -25,6 +89,18 @@ describe('provenanceDisplayKey', () => {
   it('tolerates missing fields without throwing', () => {
     expect(provenanceDisplayKey({} as ProvenanceRecord)).toBe(' ');
   });
+
+  it('separates two calls to one mcp_tool by args (the AAPL-vs-NVDA bug)', () => {
+    // Both share identifier "price_data:get_stock_data" — only args differ. The
+    // key must distinguish them or the second call overwrites the first.
+    const aapl = provenanceDisplayKey(
+      rec('mcp_tool', 'price_data:get_stock_data', { sha256: 'aapl' }),
+    );
+    const nvda = provenanceDisplayKey(
+      rec('mcp_tool', 'price_data:get_stock_data', { sha256: 'nvda' }),
+    );
+    expect(aapl).not.toBe(nvda);
+  });
 });
 
 describe('countDedupedSources', () => {
@@ -33,14 +109,15 @@ describe('countDedupedSources', () => {
     expect(countDedupedSources(null)).toBe(0);
   });
 
-  it('collapses same (source_type, identifier) to one — ignoring distinct shas', () => {
+  it('collapses same web URL to one — ignoring distinct shas (collapse-by-URL)', () => {
     const records = {
       a: { ...rec('web_fetch', 'https://example.com/p'), result_sha256: 'sha-1' },
       b: { ...rec('web_fetch', 'https://example.com/p'), result_sha256: 'sha-2' },
       c: rec('mcp_tool', 'srv:get_prices'),
     };
     // Two distinct display keys: the duplicated URL collapses despite differing
-    // shas (live UI omits sha from the key, unlike the DB endpoint).
+    // shas (web sources intentionally omit sha from the key). mcp_tool keeps sha
+    // (see below), but here srv:get_prices has no args/sha so it's its own row.
     expect(countDedupedSources(records)).toBe(2);
   });
 
@@ -50,5 +127,151 @@ describe('countDedupedSources', () => {
       b: rec('web_search', 'https://example.com/b'),
     };
     expect(countDedupedSources(records)).toBe(2);
+  });
+
+  it('counts two same-tool mcp calls with different args as two sources', () => {
+    // Regression: get_stock_data(AAPL) and get_stock_data(NVDA) in one
+    // execute_code/bash block share source_type + identifier; only the args
+    // fingerprint differs. Both must be counted.
+    const records = {
+      a: rec('mcp_tool', 'price_data:get_stock_data', { sha256: 'aapl' }),
+      b: rec('mcp_tool', 'price_data:get_stock_data', { sha256: 'nvda' }),
+    };
+    expect(countDedupedSources(records)).toBe(2);
+  });
+
+  it('counts same-tool SAME-ticker calls with different args as two sources', () => {
+    // Same tool AND same ticker, but different args (e.g. a different date
+    // range or interval) → distinct args_fingerprint → distinct sources. The
+    // fingerprint is over the WHOLE arg set, not just the symbol.
+    const records = {
+      jun: rec('mcp_tool', 'price_data:get_stock_data', { sha256: 'aapl-jun-1day' }),
+      jan: rec('mcp_tool', 'price_data:get_stock_data', { sha256: 'aapl-jan-1day' }),
+    };
+    expect(countDedupedSources(records)).toBe(2);
+  });
+
+  it('counts same-args mcp calls that returned different data as two snapshots', () => {
+    // Time-varying market data: identical args, different result. The earlier
+    // snapshot must not be silently overwritten by the later one.
+    const records = {
+      morning: rec('mcp_tool', 'price_data:get_stock_data', { sha256: 'aapl' }, 'open-quote'),
+      close: rec('mcp_tool', 'price_data:get_stock_data', { sha256: 'aapl' }, 'close-quote'),
+    };
+    expect(countDedupedSources(records)).toBe(2);
+  });
+
+  it('collapses a true duplicate (same args AND same result) to one source', () => {
+    // A re-delivered/replayed event for the same access — identical args AND
+    // identical result hash — is one source, not two.
+    const records = {
+      a: rec('mcp_tool', 'price_data:get_stock_data', { sha256: 'aapl' }, 'same-bytes'),
+      b: rec('mcp_tool', 'price_data:get_stock_data', { sha256: 'aapl' }, 'same-bytes'),
+    };
+    expect(countDedupedSources(records)).toBe(1);
+  });
+
+  it('shows one card for the same data product fetched in two code blocks', () => {
+    // The live storage key includes tool_call_id (so both events are retained),
+    // but the display key omits it — identical identifier+args+result collapse to
+    // one card. The same statement read in two execute_code blocks shows once.
+    const records = {
+      a: rec('mcp_tool', 'fundamentals:get_financial_statements', { sha256: 'inc' }, 'bytes'),
+      b: rec('mcp_tool', 'fundamentals:get_financial_statements', { sha256: 'inc' }, 'bytes'),
+    };
+    expect(countDedupedSources(records)).toBe(1);
+  });
+
+  it('counts a no-arg mcp tool by its result hash', () => {
+    const distinct = {
+      a: rec('mcp_tool', 'srv:list_holdings', undefined, 'r1'),
+      b: rec('mcp_tool', 'srv:list_holdings', undefined, 'r2'),
+    };
+    const same = {
+      a: rec('mcp_tool', 'srv:list_holdings', undefined, 'r1'),
+      b: rec('mcp_tool', 'srv:list_holdings', undefined, 'r1'),
+    };
+    expect(countDedupedSources(distinct)).toBe(2);
+    expect(countDedupedSources(same)).toBe(1);
+  });
+});
+
+describe('provenanceRecordKey', () => {
+  it('is unchanged for non-mcp_tool sources (no discriminator suffix)', () => {
+    expect(
+      provenanceRecordKey({
+        tool_call_id: 'call-1',
+        source_type: 'web_search',
+        identifier: 'https://example.com/a',
+        args_fingerprint: { sha256: 'h' },
+        result_sha256: 'r',
+      }),
+    ).toBe('call-1:web_search:https://example.com/a');
+  });
+
+  it('keeps two same-tool mcp calls distinct despite a shared tool_call_id', () => {
+    // The root-cause case: both in-sandbox MCP calls inherit the outer
+    // execute_code/bash tool_call_id AND the same "server:tool" identifier, so
+    // the discriminator is the only thing keeping them from colliding.
+    const aapl = provenanceRecordKey({
+      tool_call_id: 'bash-1',
+      source_type: 'mcp_tool',
+      identifier: 'price_data:get_stock_data',
+      args_fingerprint: { sha256: 'aapl' },
+    });
+    const nvda = provenanceRecordKey({
+      tool_call_id: 'bash-1',
+      source_type: 'mcp_tool',
+      identifier: 'price_data:get_stock_data',
+      args_fingerprint: { sha256: 'nvda' },
+    });
+    expect(aapl).not.toBe(nvda);
+  });
+
+  it('keeps same-args calls distinct when the result differs (time-varying data)', () => {
+    const morning = provenanceRecordKey({
+      tool_call_id: 'bash-1',
+      source_type: 'mcp_tool',
+      identifier: 'price_data:get_stock_data',
+      args_fingerprint: { sha256: 'aapl' },
+      result_sha256: 'open-quote',
+    });
+    const close = provenanceRecordKey({
+      tool_call_id: 'bash-1',
+      source_type: 'mcp_tool',
+      identifier: 'price_data:get_stock_data',
+      args_fingerprint: { sha256: 'aapl' },
+      result_sha256: 'close-quote',
+    });
+    expect(morning).not.toBe(close);
+  });
+
+  it('collapses a byte-identical duplicate within one code block to one storage key', () => {
+    // Same tool_call_id, identifier, args AND result (a re-emitted access, or
+    // the agent calling an identical historical query twice in one block): the
+    // accumulator stores it once rather than as two look-alike cards.
+    const call = {
+      tool_call_id: 'bash-1',
+      source_type: 'mcp_tool',
+      identifier: 'price_data:get_stock_data',
+      args_fingerprint: { sha256: 'aapl' },
+      result_sha256: 'bytes',
+    };
+    expect(provenanceRecordKey(call)).toBe(provenanceRecordKey({ ...call }));
+  });
+
+  it('keeps the same access in two different code blocks under separate keys', () => {
+    // Distinct execute_code blocks carry distinct tool_call_ids, which the
+    // storage key includes — so both live events survive (the display key later
+    // collapses them; see countDedupedSources). This divergence is intentional.
+    const common = {
+      source_type: 'mcp_tool' as const,
+      identifier: 'price_data:get_stock_data',
+      args_fingerprint: { sha256: 'aapl' },
+      result_sha256: 'bytes',
+    };
+    expect(provenanceRecordKey({ ...common, tool_call_id: 'bash-1' })).not.toBe(
+      provenanceRecordKey({ ...common, tool_call_id: 'bash-2' }),
+    );
   });
 });

--- a/web/src/types/chat.ts
+++ b/web/src/types/chat.ts
@@ -159,21 +159,58 @@ export interface ProvenanceRecord {
 }
 
 /**
- * Live-UI dedup key for a provenance record: `(source_type, identifier)`.
+ * Per-access discriminator appended to a provenance dedup key — `mcp_tool` only.
  *
- * NOTE: the DB provenance endpoint dedups on `(source_type, identifier,
- * result_sha256)`. The live UI intentionally omits `result_sha256` because not
- * every record path carries a sha during streaming — so the same identifier
- * collapses to one row here even when the DB would keep distinct shas. This
- * divergence is intentional; do not try to make them identical.
+ * Web/SEC/file sources have a per-access-unique `identifier` (a URL or path), so
+ * the identifier alone separates two accesses. `market_data` repeats its ticker
+ * identifier across calls, but each native tool call carries its own
+ * `tool_call_id`, so the storage key stays distinct and the panel deck splits the
+ * row by `result_sha256` on expand. An `mcp_tool` source has neither safeguard:
+ * its identifier is `"server:tool"` (shared by every call to that tool) AND all
+ * in-sandbox calls in one execute_code/bash block share that block's outer
+ * `tool_call_id` — so two parts are added here to discriminate:
+ *  1. `args_fingerprint` — separates calls with different inputs: get_stock_data
+ *     for AAPL vs NVDA, or the same ticker over a different date range/interval.
+ *  2. `result_sha256` — separates calls with IDENTICAL inputs that returned
+ *     DIFFERENT data. Market data is time-varying, so the same query seconds
+ *     apart is a distinct snapshot the agent reasoned over and earns its own
+ *     card; collapsing on args alone would silently drop the earlier snapshot.
+ *
+ * This mirrors the backend persist dedup, which already keys on `result_sha256`.
+ * Returns '' for non-mcp_tool (web sources keep their collapse-by-URL behavior).
+ * When an mcp_tool body is too large to hash (sha nulled), it falls back to args.
+ */
+export function provenanceMcpKey(
+  record: Pick<ProvenanceRecord, 'source_type' | 'args_fingerprint' | 'result_sha256'>,
+): string {
+  if (record.source_type !== 'mcp_tool') return '';
+  const args = record.args_fingerprint ? JSON.stringify(record.args_fingerprint) : '';
+  const sha = record.result_sha256 ?? '';
+  return args || sha ? `${args}#${sha}` : '';
+}
+
+/**
+ * Live-UI dedup key for a provenance record: `(source_type, identifier)`, plus
+ * the per-access mcp_tool discriminator (args fingerprint + result hash; see
+ * {@link provenanceMcpKey}), since an mcp_tool identifier is shared across calls.
+ *
+ * NOTE: web sources intentionally omit `result_sha256` here — the same URL
+ * collapses to one row even when the DB keeps distinct shas. `mcp_tool` does
+ * NOT omit it, because identical args can still return different data (live
+ * market data). This per-source-type divergence is intentional.
  */
 export function provenanceDisplayKey(
-  record: Pick<ProvenanceRecord, 'source_type' | 'identifier'> & {
+  record: Pick<
+    ProvenanceRecord,
+    'source_type' | 'identifier' | 'args_fingerprint' | 'result_sha256'
+  > & {
     source_type?: ProvenanceRecord['source_type'];
     identifier?: string;
   },
 ): string {
-  return `${record.source_type ?? ''} ${record.identifier ?? ''}`;
+  const base = `${record.source_type ?? ''} ${record.identifier ?? ''}`;
+  const mcp = provenanceMcpKey(record);
+  return mcp ? `${base} ${mcp}` : base;
 }
 
 /**
@@ -182,7 +219,10 @@ export function provenanceDisplayKey(
  * the displayed count and grouped rows can never silently diverge.
  */
 export function countDedupedSources(
-  records?: Record<string, Pick<ProvenanceRecord, 'source_type' | 'identifier'>> | null,
+  records?: Record<
+    string,
+    Pick<ProvenanceRecord, 'source_type' | 'identifier' | 'args_fingerprint' | 'result_sha256'>
+  > | null,
 ): number {
   if (!records) return 0;
   const seen = new Set<string>();


### PR DESCRIPTION
## Overview

Two changes to the provenance pipeline, relative to `main`:

1. **New capture surface — MCP calls from bash-run scripts.** Provenance now
   traces MCP tool calls made by a Python script run via `Bash` (foreground) and
   by a backgrounded script surfaced through `BashOutput`; previously only direct
   `execute_code` calls were traced, so MCP access from `python analysis.py`-style
   runs was invisible to the Sources panel and to a verifier. Closing this needed
   sandbox-side wiring: the bash command now exports `MCP_TRACE_FILE` and prepends
   the wrapper path to `PYTHONPATH`, so a plain `python script.py` resolves the
   generated MCP client and writes the same trace `execute_code` does.
2. **Full result bodies.** Provenance kept only a redacted snippet +
   `result_sha256` per access, so a verifier couldn't read the bytes the agent
   reasoned over. This adds a global, content-addressed **body store**: the raw
   per-access result captured at the access site, deduplicated by content hash,
   redacted before storage, spilled to object storage above 64 KiB, with read
   endpoints that hand back the exact, hash-consistent body.

| Category            | Files | +LOC | −LOC |
|---------------------|------:|-----:|-----:|
| Modified (prod)     |    11 |  700 |   43 |
| New (prod)          |     3 |  537 |    0 |
| Tests (excluded)    |    14 | 2,960 |    6 |
| **Net (excl. tests)** | **14** | **1,237** | **43** |

### migrations  (net +64)
- `015_add_provenance_result_bodies.py` (+64) — new `provenance_result_bodies`
  table (`result_sha256` PK, `body_inline`, `object_key`, true `byte_len`,
  `content_type`, `created_at`/`last_seen_at`) + `idx_provenance_records_sha`
  serving the GC mark-sweep and verifier joins. No FK — bodies are shared and
  GC'd independently of records.

### agent — capture & trace  (net +387)
- `core/sandbox/ptc_sandbox.py` (+150/−5) — closes the bash provenance bypass: a
  shared `_build_trace_env_command` injects `MCP_TRACE_FILE` + a `PYTHONPATH`
  prepend into both foreground and background bash execution so a `python
  script.py` resolves the MCP wrappers and writes a trace; the foreground path
  collects that trace (with recovery on exception and `asyncio.shield` cleanup on
  cancel), and backgrounded traces are tracked per command and harvested on the
  `BashOutput` that observes completion (dropped + logged if the session is
  evicted unobserved). `_collect_mcp_trace` enforces a **16 MiB host-side read
  cap** — the hard memory bound against agent code appending to the trace file
  directly (the codegen budget below is only cooperative). `_bg_trace_paths` is
  cleared on `stop()`/`cleanup()` and dropped on `stop_background_command`.
- `agent/middleware/provenance/middleware.py` (+182/−9) — registers `Bash` and
  `BashOutput` as provenance sources alongside `ExecuteCode` (shared
  `_extract_execute_code`, `mcp_trace` strip, error-exemption via
  `_MCP_TRACE_TOOLS`); each `_extract_*` stamps `result_body` via `_canonical_body`
  from the **same** value it hashes (per-item for fan-out; `execute_code` pulls
  each mcp_tool call's own trace body via `_clamp_body_bytes`, never the aggregate
  stdout); `_verify_source_sha` trust-gates agent-authored `mcp_tool` shas —
  nulling both sha and body on mismatch (so the emitted SSE event also carries a
  null sha) and re-sizing `result_size` from the verified bytes on match;
  `_body_item`/`_redact_body`/`_flush_bodies` batch one redacted store-write **per
  tool call** (collapsing that call's fan-out). The SSE event shape is unchanged —
  no body bytes ride it.
- `core/tool_generator.py` (+36/−1) — generated MCP client emits a byte-capped
  `result_body` per call plus an aggregate per-execution budget (~4 MiB,
  cooperative) after which it stops emitting bodies (sha/snippet/size still
  recorded). Codegen version bumped to force the new client onto reused sandboxes.
- `agent/tools/bash.py` (+20/−8), `agent/tools/bash_output.py` (+19/−8) — return
  `(content, {"mcp_trace": [...]})` so the trace reaches the middleware; the
  middleware strips it before the artifact leaves the host (never enters the LLM
  context).
- `agent/provenance/types.py` (+11) — `result_body` field on `ProvenanceSource`
  + canonical `RESULT_BODY_MAX_BYTES = 64 KiB`.

### server — store, serve, GC  (net +691)
- `database/provenance_bodies.py` (+378, new) — `store_result_bodies` (batched,
  inline / spill / no-bucket-degrade, `ON CONFLICT` dedup + recency touch),
  `fetch_result_bodies`, `fetch_full_body` (byte-sliced object read), and
  `sweep_orphan_bodies` (GC).
- `services/provenance_gc.py` (+95, new) — daily singleton mark-sweep with a
  grace window and a non-blocking advisory lock; registered in the app lifespan.
- `app/threads.py` (+170/−1) — two read endpoints: list bodies for a thread and
  fetch one record's full body (`?full=true`), each returning `byte_len` +
  `truncated` + a `verified` flag.
- `database/provenance.py` (+31) — `get_provenance_record` targeted single-row
  lookup for the body endpoint (no whole-thread scan).
- `app/setup.py` (+18) — start/stop the GC service in `lifespan`.

### frontend  (net +52)
- `types/chat.ts` (+49/−9), `pages/ChatAgent/hooks/utils/streamEventHandlers.ts`
  (+14/−2) — a shared `provenanceMcpKey` now discriminates `mcp_tool` sources by
  `(args_fingerprint, result_sha256)` in both the live storage key
  (`provenanceRecordKey`) and the UI dedup key (`provenanceDisplayKey` +
  `countDedupedSources`), so the visible source count reflects it. Formalized
  per-source-type policy: web/SEC/file sources still collapse by URL, but
  `mcp_tool` keeps the sha — identical args returning different data (e.g. live
  market quotes) now render as separate sources instead of collapsing into one.

**What this introduces:** every external data access the agent makes — via
`execute_code` or a script run through `Bash`/`BashOutput` — is now traced, and a
verifier can read the *exact*, hash-consistent bytes the agent saw, stored once
globally, spilled to object storage when large, redacted at rest, without bloating
the SSE stream or the `conversation_responses.sse_events` blob.

## Truncation & verification contract

- `byte_len` is the length of the **stored (post-redaction)** body; a read is
  incomplete exactly when fewer bytes come back than `byte_len`
  (`truncated = byte_len > len(returned)`). A body that redaction shrank below the
  inline cap is stored whole and reads back complete — no false "partial head".
- `mcp_tool` shas/bodies come from the in-sandbox trace, which agent code can
  forge (`MCP_TRACE_FILE` is sandbox-visible), so they're trusted only when the
  held bytes reproduce the claimed hash; on a miss the sha is nulled everywhere
  (SSE event, record, body store). Host-computed shas (web/sec/market) are
  trusted. The 16 MiB host-side trace read cap is the hard bound against an
  oversized agent-authored trace; the codegen body budget is only cooperative.

## Known limitations / follow-ups (not in this PR)

- A backgrounded script's MCP trace is attributed to the `BashOutput` that
  observes completion; if the session is evicted (cap pressure) before any
  `BashOutput` reads it, the trace is dropped — logged, not recovered.
- Empty-args + oversized `mcp_tool` bodies can still collapse in keying.
- `?full=true` reads the whole spilled object into host memory before slicing to
  the 4 MiB read cap.
- Lifting the in-sandbox transport cap (direct sandbox→object-storage upload) is
  deferred.

## Test plan

- `uv run pytest tests/unit/ptc_agent/... tests/unit/server/...` — body store
  (inline/spill/degrade/dedup), per-access capture incl. the bash/bash_output
  trace path and the per-call-not-aggregate `mcp_tool` regression, sha trust gate,
  GC sweep, truncation labelling, threads read endpoints.
- `pnpm vitest run` — Sources keying (storage + display dedup).
- `ruff check` clean on all changed files.
- Migration round-trips `upgrade → downgrade → upgrade`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added provenance result body retrieval APIs (list plus inline/full body) with `truncated` and integrity `verified` indicators.
  * Persist full provenance result bodies content-addressed for later access.
  * Enhanced Bash/BashOutput to surface MCP execution trace details via tool artifacts.
  * Improved MCP provenance dedup/keying to distinguish arguments and time-varying results.
* **Bug Fixes**
  * Added stronger provenance body integrity verification (including redaction/truncation handling).
  * Improved MCP trace harvesting consistency for foreground and background executions.
  * Added periodic garbage collection for orphaned provenance bodies to prevent buildup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->