### PR TITLE
fix(report-back): reliable, live-streaming flash↔PTC report-back

### DIFF
--- a/src/server/app/threads.py
+++ b/src/server/app/threads.py
@@ -90,7 +90,11 @@ def _track_task(task: asyncio.Task) -> None:
 
 
 async def _consume_background_gen(
-    gen, label: str, thread_id: str, run_id: str
+    gen,
+    label: str,
+    thread_id: str,
+    run_id: str,
+    report_back_ptc_thread_id: str | None = None,
 ) -> bool:
     """Drain an async generator in the background, cleaning up Redis on failure."""
     _ok = True
@@ -113,14 +117,22 @@ async def _consume_background_gen(
 
             cache = get_cache_client()
             if cache.enabled and cache.client:
-                # Only the PTC generator crashing reaches this with a real
-                # ptc_origin: a flash-dispatch crash looks up
-                # ptc_origin:{flash_thread_id} (wrong key) -> no-op, so the
-                # report-back keys survive for reload recovery.
-                origin = await cache.get(f"ptc_origin:{thread_id}")
+                # Resolve the PTC thread whose report-back watch this crash should
+                # tear down. The origin is keyed by the *PTC* thread id:
+                #   - PTC_DISPATCH crash: thread_id IS the ptc thread -> direct hit,
+                #     clear (the watched run just died).
+                #   - report-back run crash: report_back_ptc_thread_id names the
+                #     completed PTC -> clear, else a never-finishing report-back
+                #     leaves /status reporting a stale pending run until TTL.
+                #   - ordinary flash-dispatch crash: no report_back id and thread_id
+                #     is the flash thread -> ptc_origin:{flash_tid} misses -> no-op,
+                #     so a still-running dispatched PTC's keys survive for reload
+                #     recovery.
+                ptc_thread_id = report_back_ptc_thread_id or thread_id
+                origin = await cache.get(f"ptc_origin:{ptc_thread_id}")
                 if origin:
                     flash_tid = origin.get("flash_thread_id")
-                    await clear_flash_report_back(cache, thread_id, flash_tid)
+                    await clear_flash_report_back(cache, ptc_thread_id, flash_tid)
                     if flash_tid:
                         await cache.client.publish(
                             f"thread:wake:{flash_tid}",
@@ -637,7 +649,13 @@ async def _handle_send_message(
                 await manager.pre_register(thread_id, run_id)
             _track_task(asyncio.create_task(
                 observe_background_chat_turn(
-                    _consume_background_gen(flash_gen, "FLASH_DISPATCH", thread_id, run_id),
+                    _consume_background_gen(
+                        flash_gen,
+                        "FLASH_DISPATCH",
+                        thread_id,
+                        run_id,
+                        report_back_ptc_thread_id=request.report_back_ptc_thread_id,
+                    ),
                     mode="flash",
                     model=_model,
                     user_id=user_id,

--- a/src/server/app/threads.py
+++ b/src/server/app/threads.py
@@ -107,19 +107,21 @@ async def _consume_background_gen(
         )
         try:
             from src.utils.cache.redis_cache import get_cache_client
+            from src.server.handlers.chat.ptc_workflow import (
+                clear_flash_report_back,
+            )
 
             cache = get_cache_client()
             if cache.enabled and cache.client:
+                # Only the PTC generator crashing reaches this with a real
+                # ptc_origin: a flash-dispatch crash looks up
+                # ptc_origin:{flash_thread_id} (wrong key) -> no-op, so the
+                # report-back keys survive for reload recovery.
                 origin = await cache.get(f"ptc_origin:{thread_id}")
                 if origin:
                     flash_tid = origin.get("flash_thread_id")
-                    await cache.delete(f"ptc_origin:{thread_id}")
+                    await clear_flash_report_back(cache, thread_id, flash_tid)
                     if flash_tid:
-                        watch_key = f"flash_watch:{flash_tid}"
-                        await cache.client.srem(watch_key, thread_id)
-                        remaining = await cache.client.scard(watch_key)
-                        if remaining == 0:
-                            await cache.client.delete(watch_key)
                         await cache.client.publish(
                             f"thread:wake:{flash_tid}",
                             '{"error": "background_workflow_failed"}',
@@ -560,9 +562,16 @@ async def _handle_send_message(
         _svc_token = _get_service_token()
         is_internal = bool(_svc_token and _req_token and hmac.compare_digest(_req_token, _svc_token))
 
-        # Strip query_type from non-internal requests (prevent spoofing system messages)
-        if not is_internal and request.query_type:
-            request = request.model_copy(update={"query_type": None})
+        # Strip internal-only fields from non-internal requests (prevent
+        # spoofing system messages / forging report-back watch cleanup).
+        if not is_internal:
+            internal_overrides = {}
+            if request.query_type:
+                internal_overrides["query_type"] = None
+            if request.report_back_ptc_thread_id:
+                internal_overrides["report_back_ptc_thread_id"] = None
+            if internal_overrides:
+                request = request.model_copy(update=internal_overrides)
     except BaseException:
         await release_burst_slot(user_id)
         raise

--- a/src/server/handlers/chat/flash_workflow.py
+++ b/src/server/handlers/chat/flash_workflow.py
@@ -86,6 +86,33 @@ from .stream_from_log import stream_from_log
 
 
 # ---------------------------------------------------------------------------
+# Report-back watch cleanup
+# ---------------------------------------------------------------------------
+
+
+async def _maybe_clear_report_back(request: ChatRequest, flash_thread_id: str) -> None:
+    """Clear the durable flash report-back watch if this run consumed one.
+
+    A flash run dispatched as a PTC report-back carries
+    ``report_back_ptc_thread_id``. This is invoked from the success-only
+    completion hook, so by now the summary is persisted — clearing the watch is
+    safe (any reload surfaces the summary via history). A failed/crashed
+    report-back run never reaches the hook, so its keys survive for recovery.
+    """
+    ptc_thread_id = getattr(request, "report_back_ptc_thread_id", None)
+    if not ptc_thread_id:
+        return
+
+    from src.utils.cache.redis_cache import get_cache_client
+    from src.server.handlers.chat.ptc_workflow import clear_flash_report_back
+
+    cache = get_cache_client()
+    if not (cache.enabled and cache.client):
+        return
+    await clear_flash_report_back(cache, ptc_thread_id, flash_thread_id)
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -476,6 +503,18 @@ async def astream_flash_workflow(
                         thread_id, handler.injected_steerings
                     )
 
+                # If this flash run consumed a PTC report-back, the summary is
+                # now persisted — clear the durable watch so a client reload no
+                # longer surfaces it as pending. This success-only hook is the
+                # consumption point; a failed run leaves the keys for recovery.
+                try:
+                    await _maybe_clear_report_back(request, thread_id)
+                except Exception as e:
+                    logger.warning(
+                        f"[FLASH_COMPLETE] report-back watch cleanup failed for "
+                        f"{thread_id}: {e}"
+                    )
+
                 logger.info(
                     f"[FLASH_COMPLETE] Background completion persisted: "
                     f"thread_id={thread_id} duration={execution_time:.2f}s"
@@ -507,6 +546,12 @@ async def astream_flash_workflow(
                     "handler": handler,
                     "token_callback": token_callback,
                     "persistence_service": persistence_service,
+                    # Lets the BTM terminal handlers clear the report-back watch
+                    # if this run fails or is cancelled (the success path clears
+                    # it from the completion hook above).
+                    "report_back_ptc_thread_id": getattr(
+                        request, "report_back_ptc_thread_id", None
+                    ),
                 },
                 completion_callback=on_flash_workflow_complete,
                 graph=flash_graph,

--- a/src/server/handlers/chat/ptc_workflow.py
+++ b/src/server/handlers/chat/ptc_workflow.py
@@ -111,12 +111,60 @@ def _fire_and_forget(coro: Coroutine, *, name: str = "") -> None:
     _background_tasks.add(t)
 
 
+# Bounded retry schedule for the report-back POST: 3 attempts total, with
+# ~0.5s then ~2s backoff between them. Retry on transient failures (network
+# error, 5xx, or 409 from a momentarily-busy flash thread); give up
+# immediately on any other 4xx.
+_REPORT_BACK_BACKOFFS = (0.5, 2.0)
+
+# TTL for the report-back run pointer; matches the watch SET's TTL.
+_FLASH_RB_RUN_TTL = 86400
+
+
+def flash_rb_run_key(flash_thread_id: str) -> str:
+    """Redis key holding the latest report-back flash run_id for a flash thread."""
+    return f"flash_rb_run:{flash_thread_id}"
+
+
+async def clear_flash_report_back(
+    cache, ptc_thread_id: str, flash_thread_id: str | None
+) -> None:
+    """Clear durable flash report-back watch state for one PTC thread.
+
+    Deletes ``ptc_origin:{ptc_thread_id}`` and removes ``ptc_thread_id`` from
+    the ``flash_watch:{flash_thread_id}`` SET, deleting the SET (and the
+    report-back run pointer) once it empties. Does not swallow Redis errors —
+    callers wrap it in their own try/except so each call site keeps its existing
+    failure semantics.
+    """
+    await cache.delete(f"ptc_origin:{ptc_thread_id}")
+    if flash_thread_id and cache.client:
+        watch_key = f"flash_watch:{flash_thread_id}"
+        await cache.client.srem(watch_key, ptc_thread_id)
+        remaining = await cache.client.scard(watch_key)
+        if remaining == 0:
+            await cache.client.delete(watch_key)
+            await cache.delete(flash_rb_run_key(flash_thread_id))
+
+
 async def _flash_report_back(ptc_thread_id: str, workspace_id: str | None) -> None:
-    """Send a message to the originating flash thread when PTC completes.
+    """Notify the originating flash thread when its dispatched PTC run completes.
 
     Checks Redis for origin metadata stored by the ptc_agent secretary tool.
     If ``report_back`` is enabled, POSTs a synthetic user message to the flash
-    thread, triggering flash to call ``agent_output`` and summarize results.
+    thread (with a bounded retry), triggering flash to call ``agent_output``
+    and summarize results, then publishes a wake notification.
+
+    The wake payload and a durable ``flash_rb_run`` pointer both carry the
+    report-back run_id so a client attaches to the exact run instead of
+    inferring it: an in-session client uses the wake's run_id directly, a
+    reloading client reads the pointer via ``/status``.
+
+    This does NOT clear ``ptc_origin`` / ``flash_watch`` — the durable watch is
+    cleared only when the report-back flash run reaches a terminal state (its
+    summary is persisted on success), so a client that missed the live wake
+    still sees the pending report-back on reload. On exhausted failure it
+    neither wakes nor clears; the keys' TTL is the only GC.
     """
     import os
 
@@ -146,59 +194,106 @@ async def _flash_report_back(ptc_thread_id: str, workspace_id: str | None) -> No
         f"summarize the results for the user.\n"
         "</system>"
     )
+    payload = {
+        "messages": [{"role": "user", "content": message}],
+        "agent_mode": "flash",
+        "workspace_id": flash_workspace_id,
+        "query_type": "system",
+        # Lets the report-back flash run identify which watch member to clear
+        # on its own completion.
+        "report_back_ptc_thread_id": ptc_thread_id,
+    }
+    headers = {
+        "X-Service-Token": service_token,
+        "X-User-Id": user_id,
+        "X-Dispatch": "background",
+    }
+    url = f"{self_base_url}/api/v1/threads/{flash_thread_id}/messages"
 
-    try:
-        async with aiohttp.ClientSession() as session:
-            async with session.post(
-                f"{self_base_url}/api/v1/threads/{flash_thread_id}/messages",
-                json={
-                    "messages": [{"role": "user", "content": message}],
-                    "agent_mode": "flash",
-                    "workspace_id": flash_workspace_id,
-                    "query_type": "system",
-                },
-                headers={
-                    "X-Service-Token": service_token,
-                    "X-User-Id": user_id,
-                    "X-Dispatch": "background",
-                },
-                timeout=aiohttp.ClientTimeout(connect=10, sock_read=30),
-            ) as resp:
-                if resp.status >= 400:
+    dispatched = False
+    rb_run_id = None
+    for attempt in range(len(_REPORT_BACK_BACKOFFS) + 1):
+        retryable = False
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    url,
+                    json=payload,
+                    headers=headers,
+                    timeout=aiohttp.ClientTimeout(connect=10, sock_read=30),
+                ) as resp:
+                    if resp.status < 400:
+                        dispatched = True
+                        try:
+                            rb_run_id = (await resp.json()).get("run_id")
+                        except Exception:
+                            rb_run_id = None
+                        logger.info(
+                            f"[FLASH_REPORT_BACK] Sent completion to flash thread "
+                            f"{flash_thread_id} for PTC thread {ptc_thread_id} "
+                            f"(attempt {attempt + 1})"
+                        )
+                        break
                     body = await resp.text()
-                    logger.warning(
-                        f"[FLASH_REPORT_BACK] Failed to POST to flash thread "
-                        f"{flash_thread_id}: {resp.status} {body[:200]}"
-                    )
-                else:
-                    logger.info(
-                        f"[FLASH_REPORT_BACK] Sent completion to flash thread "
-                        f"{flash_thread_id} for PTC thread {ptc_thread_id}"
-                    )
+                    if resp.status == 409 or resp.status >= 500:
+                        retryable = True
+                        logger.warning(
+                            f"[FLASH_REPORT_BACK] Retryable {resp.status} POSTing to "
+                            f"flash thread {flash_thread_id} (attempt {attempt + 1}): "
+                            f"{body[:200]}"
+                        )
+                    else:
+                        # Any other 4xx is a permanent rejection — give up
+                        # immediately without waking or clearing.
+                        logger.warning(
+                            f"[FLASH_REPORT_BACK] Non-retryable {resp.status} POSTing "
+                            f"to flash thread {flash_thread_id}: {body[:200]}; "
+                            f"giving up"
+                        )
+                        return
+        except Exception as e:
+            # Network error / timeout — retryable.
+            retryable = True
+            logger.warning(
+                f"[FLASH_REPORT_BACK] HTTP error POSTing to flash thread "
+                f"{flash_thread_id} (attempt {attempt + 1}): {e}"
+            )
 
-                # Clean up Redis state before publishing the wake notification.
-                # This ordering ensures the frontend sees consistent state
-                # (flash_watch cleared) when it reacts to the wake event.
-                try:
-                    await cache.delete(f"ptc_origin:{ptc_thread_id}")
-                    if flash_thread_id:
-                        watch_key = f"flash_watch:{flash_thread_id}"
-                        await cache.client.srem(watch_key, ptc_thread_id)
-                        remaining = await cache.client.scard(watch_key)
-                        if remaining == 0:
-                            await cache.client.delete(watch_key)
-                except Exception:
-                    pass
+        if retryable and attempt < len(_REPORT_BACK_BACKOFFS):
+            await asyncio.sleep(_REPORT_BACK_BACKOFFS[attempt])
 
-                try:
-                    await cache.client.publish(
-                        f"thread:wake:{flash_thread_id}",
-                        json.dumps({"thread_id": flash_thread_id}),
-                    )
-                except Exception:
-                    pass  # Best-effort; frontend will fall back to reconnect on page load
-    except Exception as e:
-        logger.warning(f"[FLASH_REPORT_BACK] HTTP error: {e}")
+    if not dispatched:
+        logger.warning(
+            f"[FLASH_REPORT_BACK] Exhausted retries POSTing to flash thread "
+            f"{flash_thread_id} for PTC thread {ptc_thread_id}; leaving watch "
+            f"state intact for reload recovery"
+        )
+        return
+
+    # Persist the report-back run pointer so a reloading client can read it from
+    # /status and attach to the exact run. Best-effort: if it fails, the client
+    # falls back to history replay on reload.
+    if rb_run_id:
+        try:
+            await cache.set(
+                flash_rb_run_key(flash_thread_id),
+                {"run_id": rb_run_id},
+                ttl=_FLASH_RB_RUN_TTL,
+            )
+        except Exception:
+            pass
+
+    # Publish the wake on success only, carrying the run_id so an in-session
+    # client attaches directly without a /status round-trip. Do NOT clear
+    # ptc_origin / flash_watch here — the watch is consumed (cleared) when the
+    # report-back flash run reaches a terminal state.
+    try:
+        await cache.client.publish(
+            f"thread:wake:{flash_thread_id}",
+            json.dumps({"thread_id": flash_thread_id, "run_id": rb_run_id}),
+        )
+    except Exception:
+        pass  # Best-effort; frontend will fall back to reconnect on page load
 
 
 async def astream_ptc_workflow(
@@ -285,9 +380,12 @@ async def astream_ptc_workflow(
         needs_startup = not workspace_manager.has_ready_session(workspace_id)
         # When the workspace was evicted/restarted, any in-BTM TaskInfo for
         # this thread holds a stale sandbox reference — cancel it first so
-        # admission/steering routes against live state only.
+        # admission/steering routes against live state only. Exclude our own
+        # run_id: on the dispatched path threads.py already pre-registered
+        # (thread_id, run_id) as a QUEUED placeholder, and without this the
+        # cold-start cleanup cancels the very run it is about to start.
         if needs_startup:
-            await manager.cancel_stale_workflow(thread_id)
+            await manager.cancel_stale_workflow(thread_id, exclude_run_id=run_id)
         # Dispatched flow owns the BTM placeholder ``threads.py`` already
         # reserved for it under the same ``(thread_id, run_id)`` key.
         # We still must guarantee at most one in-flight LangGraph ``astream``

--- a/src/server/handlers/workflow_handler.py
+++ b/src/server/handlers/workflow_handler.py
@@ -287,9 +287,14 @@ async def get_workflow_status(thread_id: str) -> dict:
             logger.debug(f"Could not fetch share status for {thread_id}: {e}")
 
         # Check if this flash thread has pending PTC report-backs
-        # (flash_watch is a Redis SET of dispatched ptc_thread_ids)
+        # (flash_watch is a Redis SET of dispatched ptc_thread_ids). When
+        # pending, surface the report-back run_id the backend recorded so the
+        # client attaches to the exact run instead of inferring it from run_id
+        # changes.
         pending_report_back = False
+        report_back_run_id = None
         try:
+            from src.server.handlers.chat.ptc_workflow import flash_rb_run_key
             from src.utils.cache.redis_cache import get_cache_client
 
             cache = get_cache_client()
@@ -297,6 +302,9 @@ async def get_workflow_status(thread_id: str) -> dict:
                 count = await cache.client.scard(f"flash_watch:{thread_id}")
                 if count and count > 0:
                     pending_report_back = True
+                    rb = await cache.get(flash_rb_run_key(thread_id))
+                    if isinstance(rb, dict):
+                        report_back_run_id = rb.get("run_id")
         except Exception:
             pass
 
@@ -312,6 +320,7 @@ async def get_workflow_status(thread_id: str) -> dict:
             "active_tasks": active_tasks,
             "is_shared": is_shared,
             "pending_report_back": pending_report_back,
+            "report_back_run_id": report_back_run_id,
         }
 
         logger.debug(f"Status check for {thread_id}: {status}")

--- a/src/server/models/chat.py
+++ b/src/server/models/chat.py
@@ -302,6 +302,15 @@ class ChatRequest(BaseModel):
         description="Override query_type for this request. Internal use only.",
     )
 
+    # Internal: PTC thread id whose report-back this flash run consumes. When a
+    # flash report-back run (dispatched after PTC completion) finishes, its
+    # completion hook clears the durable flash_watch entry for this PTC thread.
+    report_back_ptc_thread_id: Optional[str] = Field(
+        default=None,
+        description="PTC thread id this flash report-back run consumes. "
+        "Internal use only.",
+    )
+
     # External thread identity (for channel integrations like Telegram, Slack)
     external_thread_id: Optional[str] = Field(
         default=None,

--- a/src/server/services/background_task_manager.py
+++ b/src/server/services/background_task_manager.py
@@ -1599,6 +1599,30 @@ class BackgroundTaskManager:
             )
             return False
 
+    async def _clear_report_back_watch(self, thread_id: str, metadata: dict) -> None:
+        """Best-effort clear of the flash report-back watch on a terminal run.
+
+        A report-back flash run carries ``report_back_ptc_thread_id`` in its
+        metadata; when it fails or is cancelled the watch is never consumed by
+        the success-only completion hook, so clear it here to stop ``/status``
+        reporting the report-back as pending until the keys' 24h TTL.
+        """
+        ptc_thread_id = (metadata or {}).get("report_back_ptc_thread_id")
+        if not ptc_thread_id:
+            return
+        try:
+            from src.server.handlers.chat.ptc_workflow import clear_flash_report_back
+            from src.utils.cache.redis_cache import get_cache_client
+
+            cache = get_cache_client()
+            if cache.enabled and cache.client:
+                await clear_flash_report_back(cache, ptc_thread_id, thread_id)
+        except Exception as e:
+            logger.warning(
+                f"[BackgroundTaskManager] report-back watch clear failed for "
+                f"{thread_id}: {e}"
+            )
+
     async def _mark_failed(
         self,
         thread_id: str,
@@ -1683,6 +1707,8 @@ class BackgroundTaskManager:
             logger.warning(
                 f"[BackgroundTaskManager] tracker.mark_failed failed for {key}: {tracker_err}"
             )
+
+        await self._clear_report_back_watch(thread_id, metadata)
 
         task_info.persistence_complete.set()
         async with self.task_lock:
@@ -1941,6 +1967,8 @@ class BackgroundTaskManager:
                 f"[BackgroundTaskManager] tracker.mark_cancelled failed for {key}: {tracker_err}"
             )
 
+        await self._clear_report_back_watch(thread_id, metadata)
+
         task_info.persistence_complete.set()
         async with self.task_lock:
             self._release_terminal_refs(thread_id, run_id)
@@ -2083,11 +2111,21 @@ class BackgroundTaskManager:
             return True
 
     async def cancel_stale_workflow(
-        self, thread_id: str, timeout: float = 10.0
+        self,
+        thread_id: str,
+        timeout: float = 10.0,
+        exclude_run_id: Optional[str] = None,
     ) -> bool:
-        """Cancel a stale workflow on the given thread."""
+        """Cancel a stale workflow on the given thread.
+
+        ``exclude_run_id`` skips that run when locating the stale task, so a
+        dispatched flow can pass its own pre-registered placeholder's run_id and
+        not cancel the very run it is about to start.
+        """
         async with self.task_lock:
-            task_info = self._find_active_for_thread(thread_id)
+            task_info = self._find_active_for_thread(
+                thread_id, exclude_run_id=exclude_run_id
+            )
             if not task_info:
                 return False
 

--- a/src/tools/secretary/tools.py
+++ b/src/tools/secretary/tools.py
@@ -379,6 +379,18 @@ async def ptc_agent(
     # Resolve workspace_id from existing thread or create/verify workspace
     if is_continuation:
         from src.server.database.conversation import get_thread_by_id
+        from src.server.utils.pg_sanitize import normalize_uuid
+
+        # Normalize once so the owner check and the fetch bind the same canonical
+        # UUID. get_thread_owner_id normalizes internally; get_thread_by_id binds
+        # raw, so a non-canonical id (e.g. urn:uuid:...) would pass the owner
+        # check yet 22P02 on the fetch. None means not a UUID -> not found.
+        normalized_id = normalize_uuid(thread_id)
+        if normalized_id is None:
+            return _error_command(
+                "thread not found or not owned by user", tool_call_id
+            )
+        thread_id = normalized_id
 
         # Ownership lives on workspaces.user_id (conversation_threads has no
         # user_id column), so verify via the JOIN helper rather than reading

--- a/src/tools/secretary/tools.py
+++ b/src/tools/secretary/tools.py
@@ -380,9 +380,12 @@ async def ptc_agent(
     if is_continuation:
         from src.server.database.conversation import get_thread_by_id
 
+        # Ownership lives on workspaces.user_id (conversation_threads has no
+        # user_id column), so verify via the JOIN helper rather than reading
+        # a user_id off the thread row, which is always None.
+        if err := await _verify_thread_owner(thread_id, user_id, tool_call_id):
+            return err
         thread = await get_thread_by_id(thread_id)
-        if not thread or str(thread.get("user_id")) != user_id:
-            return _error_command("thread not found", tool_call_id)
         workspace_id = str(thread["workspace_id"])
         workspace_name = None
     else:

--- a/tests/unit/server/app/test_consume_background_gen.py
+++ b/tests/unit/server/app/test_consume_background_gen.py
@@ -1,0 +1,98 @@
+"""Crash-path cleanup for `_consume_background_gen`.
+
+When a dispatched background generator raises, the except branch tears down the
+report-back watch keyed by the *PTC* thread id. Regression: the FLASH_DISPATCH
+site (a report-back run) used the flash thread id as the origin key, so a
+report-back run that crashed before its terminal handler fired left the durable
+watch/pointer alive until TTL and `/status` kept reporting a stale pending run.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.server.app.threads import _consume_background_gen
+
+
+async def _crashing_gen():
+    raise RuntimeError("kaboom")
+    yield  # unreachable — marks this as an async generator
+
+
+class _FakeClient:
+    def __init__(self):
+        self.publish = AsyncMock()
+        self.xadd = AsyncMock()
+
+
+class _FakeCache:
+    def __init__(self, origin_map):
+        self.enabled = True
+        self.client = _FakeClient()
+        self._origin = origin_map
+
+    async def get(self, key):
+        return self._origin.get(key)
+
+
+def _patched(cache, clear):
+    return (
+        patch(
+            "src.utils.cache.redis_cache.get_cache_client", return_value=cache
+        ),
+        patch(
+            "src.server.handlers.chat.ptc_workflow.clear_flash_report_back", clear
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_report_back_crash_clears_watch_via_ptc_thread_id():
+    # report-back run: thread_id is the flash thread, but the origin lives under
+    # the completed PTC thread named by report_back_ptc_thread_id.
+    cache = _FakeCache({"ptc_origin:ptc-1": {"flash_thread_id": "flash-1"}})
+    clear = AsyncMock()
+    p1, p2 = _patched(cache, clear)
+    with p1, p2:
+        ok = await _consume_background_gen(
+            _crashing_gen(),
+            "FLASH_DISPATCH",
+            "flash-1",
+            "run-1",
+            report_back_ptc_thread_id="ptc-1",
+        )
+    assert ok is False
+    clear.assert_awaited_once_with(cache, "ptc-1", "flash-1")
+    cache.client.publish.assert_awaited_once()
+    assert cache.client.publish.call_args[0][0] == "thread:wake:flash-1"
+
+
+@pytest.mark.asyncio
+async def test_ordinary_flash_dispatch_crash_preserves_watch():
+    # No report_back id: the origin lookup uses the flash thread id, misses, and
+    # leaves a still-running dispatched PTC's keys intact for reload recovery.
+    cache = _FakeCache({})  # ptc_origin:flash-1 absent
+    clear = AsyncMock()
+    p1, p2 = _patched(cache, clear)
+    with p1, p2:
+        ok = await _consume_background_gen(
+            _crashing_gen(), "FLASH_DISPATCH", "flash-1", "run-1"
+        )
+    assert ok is False
+    clear.assert_not_awaited()
+    cache.client.publish.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ptc_dispatch_crash_clears_via_thread_id():
+    # PTC_DISPATCH: thread_id IS the ptc thread, so the default origin key hits.
+    cache = _FakeCache({"ptc_origin:ptc-9": {"flash_thread_id": "flash-9"}})
+    clear = AsyncMock()
+    p1, p2 = _patched(cache, clear)
+    with p1, p2:
+        ok = await _consume_background_gen(
+            _crashing_gen(), "PTC_DISPATCH", "ptc-9", "run-9"
+        )
+    assert ok is False
+    clear.assert_awaited_once_with(cache, "ptc-9", "flash-9")
+    assert cache.client.publish.call_args[0][0] == "thread:wake:flash-9"

--- a/tests/unit/server/handlers/chat/test_flash_report_back.py
+++ b/tests/unit/server/handlers/chat/test_flash_report_back.py
@@ -1,0 +1,338 @@
+"""Tests for the flash report-back notification path.
+
+Pins the durability contract introduced to fix the unreliable flash->PTC
+report-back wake:
+
+- ``_flash_report_back`` publishes the wake on a successful POST but no longer
+  clears ``ptc_origin`` / ``flash_watch`` — the watch is cleared only when the
+  report-back flash run completes and persists its summary.
+- The POST is bounded-retried (network error / 5xx / 409 retry; other 4xx give
+  up immediately). On exhausted failure it neither wakes nor clears.
+- ``clear_flash_report_back`` is the shared cleanup helper.
+- The flash completion hook clears only when ``report_back_ptc_thread_id`` is set.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.server.handlers.chat import flash_workflow, ptc_workflow
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+def _make_cache(origin, *, scard=0):
+    """Build a MagicMock cache client with async ops wired for the report-back path."""
+    cache = MagicMock()
+    cache.enabled = True
+    cache.get = AsyncMock(return_value=origin)
+    cache.set = AsyncMock(return_value=True)
+    cache.delete = AsyncMock(return_value=True)
+
+    client = MagicMock()
+    client.publish = AsyncMock()
+    client.srem = AsyncMock()
+    client.scard = AsyncMock(return_value=scard)
+    client.delete = AsyncMock(return_value=1)
+    cache.client = client
+    return cache
+
+
+def _origin(**overrides):
+    base = {
+        "origin": "flash",
+        "report_back": True,
+        "flash_thread_id": "flash-1",
+        "flash_workspace_id": "fws-1",
+        "ptc_thread_id": "ptc-1",
+        "user_id": "u-1",
+    }
+    base.update(overrides)
+    return base
+
+
+class _FakeResp:
+    def __init__(self, status: int, body: str = "", json_body: dict | None = None):
+        self.status = status
+        self._body = body
+        self._json = {} if json_body is None else json_body
+
+    async def text(self) -> str:
+        return self._body
+
+    async def json(self) -> dict:
+        return self._json
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeReqCtx:
+    """Async CM returned by ``session.post(...)`` — raises or yields a response."""
+
+    def __init__(self, outcome):
+        self._outcome = outcome
+
+    async def __aenter__(self):
+        if isinstance(self._outcome, Exception):
+            raise self._outcome
+        return self._outcome
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeSession:
+    """Async CM that records ``post`` calls and replays queued outcomes."""
+
+    def __init__(self, outcomes):
+        self._outcomes = list(outcomes)
+        self.post_calls: list[dict] = []
+
+    def post(self, url, **kwargs):
+        self.post_calls.append({"url": url, **kwargs})
+        return _FakeReqCtx(self._outcomes.pop(0))
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _run_report_back(cache, session, ptc_thread_id="ptc-1", workspace_id="ws-1"):
+    """Invoke ``_flash_report_back`` with mocked aiohttp + cache + zero backoff."""
+    return patch.multiple(
+        "src.server.handlers.chat.ptc_workflow",
+        _REPORT_BACK_BACKOFFS=(0, 0),  # instant retries
+    ), patch("aiohttp.ClientSession", MagicMock(return_value=session)), patch(
+        "src.utils.cache.redis_cache.get_cache_client", return_value=cache
+    )
+
+
+# ---------------------------------------------------------------------------
+# _flash_report_back — success publishes, does not clear
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_2xx_publishes_wake_with_run_id_records_pointer_and_does_not_clear():
+    cache = _make_cache(_origin())
+    session = _FakeSession(
+        [_FakeResp(200, json_body={"status": "dispatched", "run_id": "rb-1"})]
+    )
+
+    cm_backoff, cm_session, cm_cache = _run_report_back(cache, session)
+    with cm_backoff, cm_session, cm_cache:
+        await ptc_workflow._flash_report_back("ptc-1", "ws-1")
+
+    # Wake published exactly once on the flash thread channel, carrying the run_id
+    # so an in-session client attaches to that exact run.
+    cache.client.publish.assert_awaited_once()
+    channel, payload = cache.client.publish.await_args.args
+    assert channel == "thread:wake:flash-1"
+    wake = json.loads(payload)
+    assert wake["thread_id"] == "flash-1"
+    assert wake["run_id"] == "rb-1"
+
+    # Durable run pointer recorded (for the reload path) with the watch TTL.
+    cache.set.assert_awaited_once()
+    set_args = cache.set.await_args
+    assert set_args.args[0] == "flash_rb_run:flash-1"
+    assert set_args.args[1] == {"run_id": "rb-1"}
+    assert set_args.kwargs["ttl"] == ptc_workflow._FLASH_RB_RUN_TTL
+
+    # Durable watch state survives — NOT cleared here.
+    cache.delete.assert_not_called()
+    cache.client.srem.assert_not_called()
+    cache.client.delete.assert_not_called()
+
+    # POST body carries the carry field + system query_type.
+    assert len(session.post_calls) == 1
+    body = session.post_calls[0]["json"]
+    assert body["report_back_ptc_thread_id"] == "ptc-1"
+    assert body["query_type"] == "system"
+    assert body["agent_mode"] == "flash"
+
+
+@pytest.mark.asyncio
+async def test_no_origin_returns_early():
+    cache = _make_cache(None)
+    session = _FakeSession([])
+
+    cm_backoff, cm_session, cm_cache = _run_report_back(cache, session)
+    with cm_backoff, cm_session, cm_cache:
+        await ptc_workflow._flash_report_back("ptc-1", "ws-1")
+
+    assert session.post_calls == []
+    cache.client.publish.assert_not_called()
+    cache.delete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_report_back_disabled_returns_early():
+    cache = _make_cache(_origin(report_back=False))
+    session = _FakeSession([])
+
+    cm_backoff, cm_session, cm_cache = _run_report_back(cache, session)
+    with cm_backoff, cm_session, cm_cache:
+        await ptc_workflow._flash_report_back("ptc-1", "ws-1")
+
+    assert session.post_calls == []
+    cache.client.publish.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _flash_report_back — retry behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retries_on_5xx_then_succeeds():
+    cache = _make_cache(_origin())
+    session = _FakeSession([_FakeResp(503), _FakeResp(200)])
+
+    cm_backoff, cm_session, cm_cache = _run_report_back(cache, session)
+    with cm_backoff, cm_session, cm_cache:
+        await ptc_workflow._flash_report_back("ptc-1", "ws-1")
+
+    assert len(session.post_calls) == 2  # retried once, then dispatched
+    cache.client.publish.assert_awaited_once()
+    cache.delete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_retries_on_network_error_then_succeeds():
+    cache = _make_cache(_origin())
+    session = _FakeSession([ConnectionError("network down"), _FakeResp(200)])
+
+    cm_backoff, cm_session, cm_cache = _run_report_back(cache, session)
+    with cm_backoff, cm_session, cm_cache:
+        await ptc_workflow._flash_report_back("ptc-1", "ws-1")
+
+    assert len(session.post_calls) == 2
+    cache.client.publish.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_exhausts_on_409_5xx_network_no_wake_no_clear():
+    # 409 (busy) -> 500 -> network error: all retryable, three attempts, exhaust.
+    cache = _make_cache(_origin())
+    session = _FakeSession(
+        [_FakeResp(409), _FakeResp(500), ConnectionError("boom")]
+    )
+
+    cm_backoff, cm_session, cm_cache = _run_report_back(cache, session)
+    with cm_backoff, cm_session, cm_cache:
+        await ptc_workflow._flash_report_back("ptc-1", "ws-1")
+
+    assert len(session.post_calls) == 3  # all three attempts used
+    # Exhausted: neither wakes nor clears -> keys survive for reload recovery.
+    cache.client.publish.assert_not_called()
+    cache.delete.assert_not_called()
+    cache.client.srem.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_gives_up_immediately_on_other_4xx():
+    cache = _make_cache(_origin())
+    session = _FakeSession([_FakeResp(400), _FakeResp(200)])
+
+    cm_backoff, cm_session, cm_cache = _run_report_back(cache, session)
+    with cm_backoff, cm_session, cm_cache:
+        await ptc_workflow._flash_report_back("ptc-1", "ws-1")
+
+    assert len(session.post_calls) == 1  # no retry after a non-retryable 4xx
+    cache.client.publish.assert_not_called()
+    cache.delete.assert_not_called()
+    cache.client.srem.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# clear_flash_report_back — shared helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_clear_deletes_origin_srems_and_drops_empty_set():
+    cache = _make_cache(None, scard=0)
+
+    await ptc_workflow.clear_flash_report_back(cache, "ptc-1", "flash-1")
+
+    cache.client.srem.assert_awaited_once_with("flash_watch:flash-1", "ptc-1")
+    cache.client.scard.assert_awaited_once_with("flash_watch:flash-1")
+    # SET emptied -> deleted, along with the report-back run pointer.
+    cache.client.delete.assert_awaited_once_with("flash_watch:flash-1")
+    deleted = [c.args[0] for c in cache.delete.await_args_list]
+    assert "ptc_origin:ptc-1" in deleted
+    assert "flash_rb_run:flash-1" in deleted
+
+
+@pytest.mark.asyncio
+async def test_clear_keeps_set_when_other_members_remain():
+    cache = _make_cache(None, scard=2)
+
+    await ptc_workflow.clear_flash_report_back(cache, "ptc-1", "flash-1")
+
+    cache.delete.assert_awaited_once_with("ptc_origin:ptc-1")
+    cache.client.srem.assert_awaited_once_with("flash_watch:flash-1", "ptc-1")
+    # SET still has members -> NOT deleted.
+    cache.client.delete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_clear_without_flash_thread_id_only_deletes_origin():
+    cache = _make_cache(None)
+
+    await ptc_workflow.clear_flash_report_back(cache, "ptc-1", None)
+
+    cache.delete.assert_awaited_once_with("ptc_origin:ptc-1")
+    cache.client.srem.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Flash completion hook -> clear gated on report_back_ptc_thread_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_completion_clears_when_report_back_id_set():
+    cache = _make_cache(None)
+    request = SimpleNamespace(report_back_ptc_thread_id="ptc-1")
+
+    with patch(
+        "src.utils.cache.redis_cache.get_cache_client", return_value=cache
+    ), patch(
+        "src.server.handlers.chat.ptc_workflow.clear_flash_report_back",
+        new=AsyncMock(),
+    ) as mock_clear:
+        await flash_workflow._maybe_clear_report_back(request, "flash-1")
+
+    mock_clear.assert_awaited_once_with(cache, "ptc-1", "flash-1")
+
+
+@pytest.mark.asyncio
+async def test_completion_skips_clear_when_report_back_id_none():
+    request = SimpleNamespace(report_back_ptc_thread_id=None)
+
+    with patch(
+        "src.server.handlers.chat.ptc_workflow.clear_flash_report_back",
+        new=AsyncMock(),
+    ) as mock_clear, patch(
+        "src.utils.cache.redis_cache.get_cache_client"
+    ) as mock_get_cache:
+        await flash_workflow._maybe_clear_report_back(request, "flash-1")
+
+    mock_clear.assert_not_called()
+    # Short-circuits before touching the cache at all.
+    mock_get_cache.assert_not_called()

--- a/tests/unit/server/services/test_background_task_manager.py
+++ b/tests/unit/server/services/test_background_task_manager.py
@@ -252,6 +252,53 @@ class TestCancelStaleWorkflowTimeout:
 
 
 # ---------------------------------------------------------------------------
+# cancel_stale_workflow — excludes the caller's own pre-registered placeholder
+# ---------------------------------------------------------------------------
+
+class TestCancelStaleWorkflowExcludesOwnRun:
+    """Regression: a dispatched cold-start must not cancel its own placeholder.
+
+    On the dispatched path threads.py pre-registers (thread_id, run_id) as a
+    QUEUED placeholder before astream_ptc_workflow runs. When the sandbox is
+    cold, astream calls cancel_stale_workflow to clear a stale prior run — and
+    without exclude_run_id it found and cancelled its OWN placeholder, so
+    start_workflow later settled it "cancelled before start" and the run
+    silently never executed.
+    """
+
+    @pytest.mark.asyncio
+    async def test_excluded_own_placeholder_not_cancelled(self):
+        """With exclude_run_id naming the only (placeholder) run, nothing is cancelled."""
+        btm = _make_btm()
+        placeholder = _make_task_info(
+            status=TaskStatus.QUEUED, run_id="run-self", task=None, inner_task=None
+        )
+        btm.tasks[("thread-1", "run-self")] = placeholder
+
+        result = await btm.cancel_stale_workflow("thread-1", exclude_run_id="run-self")
+
+        assert result is False
+        assert not placeholder.cancel_event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_other_stale_run_still_cancelled_when_excluding_own(self):
+        """A genuinely stale OTHER run is still cancelled despite the exclusion."""
+        btm = _make_btm()
+        stale = _make_task_info(status=TaskStatus.RUNNING, run_id="run-stale")
+        own = _make_task_info(
+            status=TaskStatus.QUEUED, run_id="run-self", task=None, inner_task=None
+        )
+        btm.tasks[("thread-1", "run-stale")] = stale
+        btm.tasks[("thread-1", "run-self")] = own
+
+        result = await btm.cancel_stale_workflow("thread-1", exclude_run_id="run-self")
+
+        assert result is True
+        assert stale.cancel_event.is_set()
+        assert not own.cancel_event.is_set()
+
+
+# ---------------------------------------------------------------------------
 # consume_workflow uses closure-captured events
 # ---------------------------------------------------------------------------
 
@@ -1226,3 +1273,65 @@ class TestCancelCompaction:
         task.cancel()
         with suppress(asyncio.CancelledError):
             await task
+
+
+# ---------------------------------------------------------------------------
+# _clear_report_back_watch — terminal runs clear the flash report-back watch
+# ---------------------------------------------------------------------------
+
+class TestClearReportBackWatch:
+    """A report-back flash run that fails/cancels must clear the watch, since the
+    success-only completion hook never runs on a terminal failure (else /status
+    reports the report-back pending until its 24h TTL)."""
+
+    @pytest.mark.asyncio
+    async def test_clears_when_metadata_has_ptc_thread_id(self):
+        btm = _make_btm()
+        cache = MagicMock()
+        cache.enabled = True
+        cache.client = MagicMock()
+        mock_clear = AsyncMock()
+
+        with patch(
+            "src.utils.cache.redis_cache.get_cache_client", return_value=cache
+        ), patch(
+            "src.server.handlers.chat.ptc_workflow.clear_flash_report_back", mock_clear
+        ):
+            await btm._clear_report_back_watch(
+                "flash-1", {"report_back_ptc_thread_id": "ptc-1"}
+            )
+
+        mock_clear.assert_awaited_once_with(cache, "ptc-1", "flash-1")
+
+    @pytest.mark.asyncio
+    async def test_noop_without_ptc_thread_id(self):
+        btm = _make_btm()
+        mock_clear = AsyncMock()
+
+        with patch(
+            "src.utils.cache.redis_cache.get_cache_client"
+        ) as mock_get_cache, patch(
+            "src.server.handlers.chat.ptc_workflow.clear_flash_report_back", mock_clear
+        ):
+            await btm._clear_report_back_watch("flash-1", {"user_id": "u-1"})
+
+        mock_clear.assert_not_called()
+        mock_get_cache.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_swallows_clear_errors(self):
+        btm = _make_btm()
+        cache = MagicMock()
+        cache.enabled = True
+        cache.client = MagicMock()
+
+        with patch(
+            "src.utils.cache.redis_cache.get_cache_client", return_value=cache
+        ), patch(
+            "src.server.handlers.chat.ptc_workflow.clear_flash_report_back",
+            AsyncMock(side_effect=RuntimeError("redis down")),
+        ):
+            # Must not raise — terminal handlers call this best-effort.
+            await btm._clear_report_back_watch(
+                "flash-1", {"report_back_ptc_thread_id": "ptc-1"}
+            )

--- a/tests/unit/tools/secretary/test_ptc_agent_continuation.py
+++ b/tests/unit/tools/secretary/test_ptc_agent_continuation.py
@@ -1,0 +1,135 @@
+"""Regression coverage for ``ptc_agent`` continuation ownership check.
+
+The continuation branch (``thread_id`` provided) used to verify ownership by
+reading ``thread.get("user_id")`` off ``get_thread_by_id``. But that helper
+never selects ``user_id`` (and ``conversation_threads`` has no such column —
+ownership lives on ``workspaces.user_id`` via the FK), so the value was always
+``None`` and every continuation errored with "thread not found" before any
+dispatch could happen.
+
+The fix reuses ``_verify_thread_owner`` (which JOINs ``workspaces``). These
+tests pin that a legitimate owner reaches dispatch and a non-owner is rejected.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.tools.secretary.tools import ptc_agent
+
+USER_ID = "user-1"
+PTC_THREAD_ID = "11111111-1111-1111-1111-111111111111"
+WORKSPACE_ID = "22222222-2222-2222-2222-222222222222"
+
+
+def _tool_call(args: dict, call_id: str = "call_test") -> dict:
+    """Build a ToolCall-shaped dict so ``ainvoke`` injects ``tool_call_id``."""
+    return {"name": "ptc_agent", "args": args, "id": call_id, "type": "tool_call"}
+
+
+def _config(user_id: str | None = USER_ID) -> dict:
+    # Deliberately omit ``thread_id`` so the report_back Redis branch is a
+    # no-op (flash_thread_id is None) and we don't have to mock the cache.
+    return {"configurable": {"user_id": user_id}}
+
+
+def _payload(result) -> dict:
+    """Decode the JSON body of the ToolMessage carried by the Command."""
+    message = result.update["messages"][0]
+    return json.loads(message.content)
+
+
+class _FakeResp:
+    def __init__(self, status: int = 200, body: dict | None = None) -> None:
+        self.status = status
+        self._body = body if body is not None else {"status": "dispatched"}
+
+    async def __aenter__(self) -> "_FakeResp":
+        return self
+
+    async def __aexit__(self, *_exc) -> bool:
+        return False
+
+    async def json(self) -> dict:
+        return self._body
+
+
+class _FakeSession:
+    def __init__(self, resp: _FakeResp) -> None:
+        self._resp = resp
+
+    async def __aenter__(self) -> "_FakeSession":
+        return self
+
+    async def __aexit__(self, *_exc) -> bool:
+        return False
+
+    def post(self, *_args, **_kwargs) -> _FakeResp:
+        return self._resp
+
+
+@pytest.mark.asyncio
+async def test_continuation_owner_match_reaches_dispatch():
+    """A thread the user owns proceeds past the ownership check to dispatch."""
+    owner = AsyncMock(return_value=USER_ID)
+    by_id = AsyncMock(return_value={
+        "conversation_thread_id": PTC_THREAD_ID,
+        "workspace_id": WORKSPACE_ID,
+    })
+
+    with patch(
+        "src.server.database.conversation.get_thread_owner_id", owner
+    ), patch(
+        "src.server.database.conversation.get_thread_by_id", by_id
+    ), patch(
+        "src.tools.secretary.tools._hitl_confirm", return_value=(True, {})
+    ), patch(
+        "aiohttp.ClientSession", return_value=_FakeSession(_FakeResp())
+    ):
+        result = await ptc_agent.ainvoke(
+            _tool_call({"question": "follow up please", "thread_id": PTC_THREAD_ID}),
+            config=_config(),
+        )
+
+    payload = _payload(result)
+    assert payload.get("success") is True, payload
+    assert payload.get("status") == "dispatched", payload
+    # Continuation preserves the existing thread and resolves its workspace.
+    assert payload.get("thread_id") == PTC_THREAD_ID
+    assert payload.get("workspace_id") == WORKSPACE_ID
+    owner.assert_awaited_once_with(PTC_THREAD_ID)
+
+
+@pytest.mark.asyncio
+async def test_continuation_owner_mismatch_returns_thread_not_found():
+    """A thread owned by someone else is rejected before dispatch."""
+    owner = AsyncMock(return_value="someone-else")
+    by_id = AsyncMock(return_value={
+        "conversation_thread_id": PTC_THREAD_ID,
+        "workspace_id": WORKSPACE_ID,
+    })
+    # If ownership were (wrongly) accepted, this would blow up — proving the
+    # guard returned before any dispatch attempt.
+    dispatch = MagicMock(side_effect=AssertionError("dispatch must not run"))
+
+    with patch(
+        "src.server.database.conversation.get_thread_owner_id", owner
+    ), patch(
+        "src.server.database.conversation.get_thread_by_id", by_id
+    ), patch(
+        "src.tools.secretary.tools._hitl_confirm", return_value=(True, {})
+    ), patch(
+        "aiohttp.ClientSession", dispatch
+    ):
+        result = await ptc_agent.ainvoke(
+            _tool_call({"question": "follow up please", "thread_id": PTC_THREAD_ID}),
+            config=_config(),
+        )
+
+    payload = _payload(result)
+    assert payload.get("success") is False, payload
+    assert "thread not found" in payload.get("error", ""), payload
+    dispatch.assert_not_called()

--- a/tests/unit/tools/secretary/test_ptc_agent_continuation.py
+++ b/tests/unit/tools/secretary/test_ptc_agent_continuation.py
@@ -133,3 +133,62 @@ async def test_continuation_owner_mismatch_returns_thread_not_found():
     assert payload.get("success") is False, payload
     assert "thread not found" in payload.get("error", ""), payload
     dispatch.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_continuation_normalizes_noncanonical_thread_id():
+    """A non-canonical id (urn:uuid:) is normalized once so the owner check and
+    the fetch bind the same canonical form — the fetch can't 22P02 after the
+    owner check (which normalizes internally) has already passed."""
+    raw = f"urn:uuid:{PTC_THREAD_ID}"
+    owner = AsyncMock(return_value=USER_ID)
+    by_id = AsyncMock(return_value={
+        "conversation_thread_id": PTC_THREAD_ID,
+        "workspace_id": WORKSPACE_ID,
+    })
+
+    with patch(
+        "src.server.database.conversation.get_thread_owner_id", owner
+    ), patch(
+        "src.server.database.conversation.get_thread_by_id", by_id
+    ), patch(
+        "src.tools.secretary.tools._hitl_confirm", return_value=(True, {})
+    ), patch(
+        "aiohttp.ClientSession", return_value=_FakeSession(_FakeResp())
+    ):
+        result = await ptc_agent.ainvoke(
+            _tool_call({"question": "follow up please", "thread_id": raw}),
+            config=_config(),
+        )
+
+    payload = _payload(result)
+    assert payload.get("success") is True, payload
+    # Both lookups receive the canonical form, not the urn:uuid: input.
+    owner.assert_awaited_once_with(PTC_THREAD_ID)
+    by_id.assert_awaited_once_with(PTC_THREAD_ID)
+
+
+@pytest.mark.asyncio
+async def test_continuation_non_uuid_thread_id_short_circuits():
+    """A non-UUID id (e.g. an agent file/dir name) is rejected before any DB
+    lookup, so it can't reach get_thread_by_id and raise."""
+    owner = AsyncMock(return_value=USER_ID)
+    by_id = AsyncMock(return_value={})
+
+    with patch(
+        "src.server.database.conversation.get_thread_owner_id", owner
+    ), patch(
+        "src.server.database.conversation.get_thread_by_id", by_id
+    ), patch(
+        "src.tools.secretary.tools._hitl_confirm", return_value=(True, {})
+    ):
+        result = await ptc_agent.ainvoke(
+            _tool_call({"question": "follow up please", "thread_id": "results"}),
+            config=_config(),
+        )
+
+    payload = _payload(result)
+    assert payload.get("success") is False, payload
+    assert "thread not found" in payload.get("error", ""), payload
+    owner.assert_not_awaited()
+    by_id.assert_not_awaited()

--- a/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.reconnectNav.test.ts
+++ b/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.reconnectNav.test.ts
@@ -128,4 +128,56 @@ describe('useChatMessages — cross-thread navigation reconnect', () => {
     await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
     expect(mockReconnect).toHaveBeenCalledTimes(2);
   });
+
+  it("a superseded reconnect unwinding does not clear the new thread's spinner", async () => {
+    // Two reconnects that both HANG, so we can read isReconnecting across the
+    // supersede. Thread A streams; navigating to B supersedes A and starts B's
+    // own (still-pending) reconnect. When A's superseded reconnect finally
+    // unwinds, its `finally` must NOT clear isReconnecting — that spinner now
+    // belongs to B. Pre-fix the clear was unconditional and hid B's spinner.
+    let resolveA: (() => void) | undefined;
+    let resolveB: (() => void) | undefined;
+    mockReconnect
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ disconnected: boolean; aborted: boolean }>((res) => {
+            resolveA = () => res({ disconnected: false, aborted: false });
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ disconnected: boolean; aborted: boolean }>((res) => {
+            resolveB = () => res({ disconnected: false, aborted: false });
+          }),
+      );
+    mockStatus.mockResolvedValue({ can_reconnect: true, status: 'running', run_id: 'run-A', active_tasks: [] });
+
+    let tid = 'th-A';
+    const { result, rerender } = renderHookWithProviders(() => useChatMessages('ws', tid));
+
+    await waitFor(() => expect(mockReconnect).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(result.current.isReconnecting).toBe(true));
+
+    // Navigate to B while A still streams → supersede A, start B's reconnect.
+    mockStatus.mockResolvedValue({ can_reconnect: true, status: 'running', run_id: 'run-B', active_tasks: [] });
+    tid = 'th-B';
+    await act(async () => {
+      rerender();
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    await waitFor(() => expect(mockReconnect).toHaveBeenCalledTimes(2));
+    // B is reconnecting now (it set the spinner after the supersede cleared it).
+    expect(result.current.isReconnecting).toBe(true);
+
+    // A's superseded reconnect unwinds. Its finally is guarded by stillActive
+    // (false post-supersede), so it must leave B's spinner on.
+    await act(async () => {
+      resolveA?.();
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    expect(result.current.isReconnecting).toBe(true);
+
+    resolveB?.();
+    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+  });
 });

--- a/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.reconnectNav.test.ts
+++ b/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.reconnectNav.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Regression: cross-thread navigation must reconnect to the LANDED thread's
+ * active run, not the prior thread's stale run.
+ *
+ * Within one SPA session the `useChatMessages` instance is reused as the user
+ * navigates threads (e.g. clicking a dispatched-PTC card in a flash thread to
+ * jump into the running PTC thread). `currentRunIdRef` keeps the last stream's
+ * run_id, and `lastEventIdRef` keeps its per-stream-key cursor. On the new
+ * thread's load, the reconnect path must repoint at that thread's CURRENT run
+ * (from `/status`) and rewind the cursor — otherwise it attaches to a dead key
+ * `workflow:stream:{newThread}:{priorRun}`, receives zero live events, and the
+ * turn only appears on a later refetch (the live-render bug this guards).
+ *
+ * We use the REAL hook internals and mock only the api module — the thread-load
+ * reconnect path touches getWorkflowStatus / replayThreadHistory /
+ * fetchThreadTurns / reconnectToWorkflowStream, none of which need real network.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+import { act, waitFor } from '@testing-library/react';
+import { renderHookWithProviders } from '@/test/utils';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+vi.mock('@/lib/supabase', () => ({ supabase: null }));
+
+vi.mock('../utils/threadStorage', () => ({
+  getStoredThreadId: vi.fn().mockReturnValue(null),
+  setStoredThreadId: vi.fn(),
+  removeStoredThreadId: vi.fn(),
+}));
+
+vi.mock('../../utils/api', () => ({
+  sendChatMessageStream: vi.fn(),
+  sendHitlResponse: vi.fn(),
+  cancelWorkflow: vi.fn().mockResolvedValue({ success: true }),
+  replayThreadHistory: vi.fn().mockResolvedValue(undefined),
+  getWorkflowStatus: vi.fn().mockResolvedValue({ can_reconnect: false, status: 'completed' }),
+  reconnectToWorkflowStream: vi.fn().mockResolvedValue({ disconnected: false, aborted: false }),
+  streamSubagentTaskEvents: vi.fn(),
+  fetchThreadTurns: vi.fn().mockResolvedValue({ turns: [], retry_checkpoint_id: null }),
+  submitFeedback: vi.fn(),
+  removeFeedback: vi.fn(),
+  getThreadFeedback: vi.fn().mockResolvedValue([]),
+  watchThread: vi.fn(() => ({ abort: new AbortController() })),
+}));
+
+import { getWorkflowStatus, reconnectToWorkflowStream } from '../../utils/api';
+import { useChatMessages } from '../useChatMessages';
+
+const mockStatus = getWorkflowStatus as Mock;
+const mockReconnect = reconnectToWorkflowStream as Mock;
+
+describe('useChatMessages — cross-thread navigation reconnect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reconnect targets the landed thread's run, not the prior thread's stale run", async () => {
+    // Thread A is live with run-A.
+    mockStatus.mockResolvedValue({ can_reconnect: true, status: 'running', run_id: 'run-A', active_tasks: [] });
+
+    let tid = 'th-A';
+    const { rerender } = renderHookWithProviders(() => useChatMessages('ws', tid));
+
+    // Thread A load reconnects to its own run, seeding currentRunIdRef with run-A.
+    await waitFor(() => expect(mockReconnect).toHaveBeenCalledTimes(1));
+    expect(mockReconnect.mock.calls[0][0]).toBe('th-A');
+    expect(mockReconnect.mock.calls[0][1]).toBe('run-A');
+    // Let the thread-A reconnect's finally (cleanupAfterStreamEnd) reset
+    // isStreamingRef so the thread-B load effect isn't blocked.
+    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+
+    // Navigate to thread B — a DIFFERENT running dispatched run.
+    mockStatus.mockResolvedValue({ can_reconnect: true, status: 'running', run_id: 'run-B', active_tasks: [] });
+    tid = 'th-B';
+    await act(async () => {
+      rerender();
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    await waitFor(() => expect(mockReconnect).toHaveBeenCalledTimes(2));
+    expect(mockReconnect.mock.calls[1][0]).toBe('th-B');
+    expect(mockReconnect.mock.calls[1][1]).toBe('run-B'); // NOT the stale 'run-A'
+    expect(mockReconnect.mock.calls[1][2]).toBeNull(); // fresh per-stream-key cursor
+  });
+
+  it('supersedes an in-flight stream on the prior thread so the navigated-to thread still loads', async () => {
+    // Thread A's reconnect HANGS — it keeps streaming (isStreamingRef stays true).
+    // This mimics a flash report-back streaming on the flash thread when the user
+    // clicks the dispatch card to jump into the running PTC thread. Before the
+    // fix, the thread-load effect's isStreamingRef guard would skip thread B's
+    // load and it would appear blank.
+    let resolveA: (() => void) | undefined;
+    mockReconnect.mockImplementationOnce(
+      () =>
+        new Promise<{ disconnected: boolean; aborted: boolean }>((res) => {
+          resolveA = () => res({ disconnected: false, aborted: false });
+        }),
+    );
+    mockStatus.mockResolvedValue({ can_reconnect: true, status: 'running', run_id: 'run-A', active_tasks: [] });
+
+    let tid = 'th-A';
+    const { rerender } = renderHookWithProviders(() => useChatMessages('ws', tid));
+
+    await waitFor(() => expect(mockReconnect).toHaveBeenCalledTimes(1));
+    expect(mockReconnect.mock.calls[0][1]).toBe('run-A');
+
+    // Thread A is STILL streaming (its reconnect promise never resolved). Navigate
+    // to thread B — its load must supersede A's stream and reconnect to run-B.
+    mockReconnect.mockResolvedValue({ disconnected: false, aborted: false });
+    mockStatus.mockResolvedValue({ can_reconnect: true, status: 'running', run_id: 'run-B', active_tasks: [] });
+    tid = 'th-B';
+    await act(async () => {
+      rerender();
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    await waitFor(() => expect(mockReconnect).toHaveBeenCalledTimes(2));
+    expect(mockReconnect.mock.calls[1][0]).toBe('th-B');
+    expect(mockReconnect.mock.calls[1][1]).toBe('run-B');
+
+    // Let the superseded stream unwind; its cleanup must be a no-op (it is no
+    // longer the active stream), so thread B's state is left intact.
+    resolveA?.();
+    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+    expect(mockReconnect).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.reportBack.test.ts
+++ b/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.reportBack.test.ts
@@ -1,0 +1,502 @@
+/**
+ * Regression: report-back watch re-arm on load (PTC → flash report-back).
+ *
+ * After a PTC dispatch, the backend fires a follow-up flash "report-back"
+ * workflow once the PTC analysis completes. If the user navigated away and
+ * came back, `/status` returns `pending_report_back=true` (and, because the
+ * PTC turn itself is done, `can_reconnect=false`). On load the hook must:
+ *  (a) ARM the lightweight watch (`startReportBackWatch` → `watchThread`), and
+ *  (b) attach to the report-back run the BACKEND NAMES — either the run_id the
+ *      wake carries (in-session fast path) or `/status.report_back_run_id` (after
+ *      a reload). It must NOT attach to the stale dispatch/resume run held in
+ *      currentRunIdRef: reconnecting there hits a drained stream key and yields
+ *      zero events, so the report-back turn would only show on a later refetch
+ *      (the live-render bug this guards against).
+ *
+ * Inverse: with `pending_report_back=false` the watch is NOT armed; and when no
+ * report-back run is ever named (the PTC dispatch failed) it does NOT attach.
+ *
+ * We use the REAL hook internals (no streamEventHandlers stubs, mirroring the
+ * sibling stop suite) but mock the api module — the report-back path only
+ * touches getWorkflowStatus / watchThread / replayThreadHistory /
+ * reconnectToWorkflowStream, none of which need real network.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+import { act, waitFor } from '@testing-library/react';
+import { renderHookWithProviders } from '@/test/utils';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+vi.mock('@/lib/supabase', () => ({ supabase: null }));
+
+vi.mock('../utils/threadStorage', () => ({
+  getStoredThreadId: vi.fn().mockReturnValue(null),
+  setStoredThreadId: vi.fn(),
+  removeStoredThreadId: vi.fn(),
+}));
+
+vi.mock('../../utils/api', () => ({
+  sendChatMessageStream: vi.fn(),
+  sendHitlResponse: vi.fn(),
+  cancelWorkflow: vi.fn().mockResolvedValue({ success: true }),
+  replayThreadHistory: vi.fn().mockResolvedValue(undefined),
+  getWorkflowStatus: vi.fn().mockResolvedValue({ can_reconnect: false, status: 'completed' }),
+  reconnectToWorkflowStream: vi.fn().mockResolvedValue({ disconnected: false, aborted: false }),
+  streamSubagentTaskEvents: vi.fn(),
+  fetchThreadTurns: vi.fn().mockResolvedValue({ turns: [], retry_checkpoint_id: null }),
+  submitFeedback: vi.fn(),
+  removeFeedback: vi.fn(),
+  getThreadFeedback: vi.fn().mockResolvedValue([]),
+  watchThread: vi.fn(),
+}));
+
+import { getWorkflowStatus, replayThreadHistory, reconnectToWorkflowStream, watchThread, sendChatMessageStream } from '../../utils/api';
+import { useChatMessages } from '../useChatMessages';
+
+const mockStatus = getWorkflowStatus as Mock;
+const mockReplay = replayThreadHistory as Mock;
+const mockReconnect = reconnectToWorkflowStream as Mock;
+const mockWatch = watchThread as Mock;
+const mockSend = sendChatMessageStream as Mock;
+
+/**
+ * Flush the mount effect's status-fetch → history-load → branch decision.
+ * Every awaited call in that chain (getWorkflowStatus, replayThreadHistory) is
+ * a resolved mock, and the report-back arm decision is synchronous right after
+ * — so flushing micro + macro tasks settles it deterministically.
+ */
+async function settleMountEffect() {
+  for (let i = 0; i < 2; i++) {
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+  }
+}
+
+describe('useChatMessages — report-back watch (PTC → flash report-back)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('arms the report-back watch on load and the wake payload drives a direct reconnect', async () => {
+    // PTC turn is done (can_reconnect:false) but a report-back is still pending.
+    mockStatus.mockResolvedValue({
+      can_reconnect: false,
+      status: 'completed',
+      pending_report_back: true,
+      active_tasks: [],
+    });
+
+    const watchCalls: Array<{ tid: string; cb: (p?: { run_id?: string | null }) => void | Promise<void> }> = [];
+    mockWatch.mockImplementation((tid: string, cb: (p?: { run_id?: string | null }) => void | Promise<void>) => {
+      watchCalls.push({ tid, cb });
+      return { abort: new AbortController() };
+    });
+
+    renderHookWithProviders(() => useChatMessages('ws-rb', 'th-rb'));
+
+    // (a) Armed: a watch was opened for this thread with a callback, and no
+    // reconnect has fired yet (the PTC turn was already complete).
+    await waitFor(() => expect(mockWatch).toHaveBeenCalledTimes(1));
+    expect(mockWatch).toHaveBeenCalledWith('th-rb', expect.any(Function));
+    expect(mockReconnect).not.toHaveBeenCalled();
+
+    // (b) The wake names the report-back run directly → the callback attaches to
+    // that exact run (not a stale one) and reads its stream from the start
+    // (lastEventId=null), with no /status round-trip.
+    await act(async () => {
+      await watchCalls[0].cb({ run_id: 'rb-run-1' });
+    });
+
+    expect(mockReconnect).toHaveBeenCalledTimes(1);
+    // Signature: reconnectToWorkflowStream(threadId, runId, lastEventId, onEvent, signal)
+    expect(mockReconnect.mock.calls[0][0]).toBe('th-rb');
+    expect(mockReconnect.mock.calls[0][1]).toBe('rb-run-1'); // run named by the wake, not stale
+    expect(mockReconnect.mock.calls[0][2]).toBeNull(); // fresh per-stream-key cursor
+  });
+
+  it('attaches via /status.report_back_run_id when the wake was missed (reload / payload-less wake)', async () => {
+    // On load the report-back is still pending → arm the watch.
+    mockStatus.mockResolvedValue({
+      can_reconnect: false,
+      status: 'completed',
+      run_id: 'dispatch-run',
+      pending_report_back: true,
+      active_tasks: [],
+    });
+
+    const watchCalls: Array<{ tid: string; cb: (p?: { run_id?: string | null }) => void | Promise<void> }> = [];
+    mockWatch.mockImplementation((tid: string, cb: (p?: { run_id?: string | null }) => void | Promise<void>) => {
+      watchCalls.push({ tid, cb });
+      return { abort: new AbortController() };
+    });
+
+    renderHookWithProviders(() => useChatMessages('ws-rb', 'th-rb'));
+
+    await waitFor(() => expect(mockWatch).toHaveBeenCalledTimes(1));
+
+    // The callback fires WITHOUT a run_id (payload-less wake, or a reload poll) →
+    // it falls back to /status, which now NAMES the report-back run via
+    // report_back_run_id. Its events are still buffered on the per-run stream, so
+    // the watch must ATTACH and replay them (streaming the summary in) rather than
+    // reload history (which duplicates the dispatch card) or sit idle.
+    mockStatus.mockResolvedValue({
+      can_reconnect: false,
+      status: 'completed',
+      run_id: 'rb-run-done',
+      pending_report_back: false,
+      report_back_run_id: 'rb-run-done',
+      active_tasks: [],
+    });
+
+    await act(async () => {
+      await watchCalls[0].cb();
+    });
+
+    expect(mockReconnect).toHaveBeenCalledTimes(1);
+    expect(mockReconnect.mock.calls[0][0]).toBe('th-rb');
+    expect(mockReconnect.mock.calls[0][1]).toBe('rb-run-done'); // the run /status named, replayed
+    expect(mockReconnect.mock.calls[0][2]).toBeNull(); // fresh per-stream-key cursor
+  });
+
+  it('does NOT attach when no report-back run is ever named (PTC dispatch failed)', async () => {
+    // Report-back pending on load → arm the watch.
+    mockStatus.mockResolvedValue({
+      can_reconnect: false,
+      status: 'completed',
+      run_id: 'dispatch-run',
+      pending_report_back: true,
+      active_tasks: [],
+    });
+
+    const watchCalls: Array<{ tid: string; cb: (p?: { run_id?: string | null }) => void | Promise<void> }> = [];
+    mockWatch.mockImplementation((tid: string, cb: (p?: { run_id?: string | null }) => void | Promise<void>) => {
+      watchCalls.push({ tid, cb });
+      return { abort: new AbortController() };
+    });
+
+    renderHookWithProviders(() => useChatMessages('ws-rb', 'th-rb'));
+    await waitFor(() => expect(mockWatch).toHaveBeenCalledTimes(1));
+
+    // PTC dispatch failed: no report-back run is ever created, so /status never
+    // populates report_back_run_id (and eventually stops reporting it pending).
+    // Attaching to anything here would re-stream "Dispatched." — so the watch
+    // must NOT attach.
+    mockStatus.mockResolvedValue({
+      can_reconnect: false,
+      status: 'completed',
+      run_id: 'dispatch-run',
+      pending_report_back: false,
+      report_back_run_id: null, // never named
+      active_tasks: [],
+    });
+
+    await act(async () => {
+      await watchCalls[0].cb();
+    });
+
+    expect(mockReconnect).not.toHaveBeenCalled();
+  });
+
+  it('does NOT attach a stale wake after the user navigated to another thread', async () => {
+    // Regression: the wake fast-path attaches immediately. If the user dispatched
+    // PTC on the flash thread and then jumped into the PTC thread, a flash wake
+    // firing LATE must not attach the report-back onto the PTC thread — that would
+    // race the PTC reconnect for the stream and the PTC turn would stop streaming.
+    mockStatus.mockResolvedValue({
+      can_reconnect: false,
+      status: 'completed',
+      pending_report_back: true,
+      active_tasks: [],
+    });
+
+    const watchCalls: Array<{ tid: string; cb: (p?: { run_id?: string | null }) => void | Promise<void> }> = [];
+    mockWatch.mockImplementation((tid: string, cb: (p?: { run_id?: string | null }) => void | Promise<void>) => {
+      watchCalls.push({ tid, cb });
+      return { abort: new AbortController() };
+    });
+
+    let tid = 'th-rb';
+    const { rerender } = renderHookWithProviders(() => useChatMessages('ws-rb', tid));
+    await waitFor(() => expect(mockWatch).toHaveBeenCalledTimes(1));
+    expect(watchCalls[0].tid).toBe('th-rb');
+
+    // Navigate to a different thread with nothing pending (no new watch armed).
+    mockStatus.mockResolvedValue({
+      can_reconnect: false,
+      status: 'completed',
+      pending_report_back: false,
+      active_tasks: [],
+    });
+    tid = 'th-other';
+    await act(async () => {
+      rerender();
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // The th-rb wake fires now, naming its run — but we're on th-other. Must bail.
+    await act(async () => {
+      await watchCalls[0].cb({ run_id: 'rb-late' });
+    });
+
+    expect(mockReconnect).not.toHaveBeenCalled();
+  });
+
+  it('supersedes a streaming report-back when the user jumps into the live PTC thread', async () => {
+    // The live race that keeps breaking PTC: on the flash thread a report-back
+    // attaches (fast path) and is STILL streaming when the user clicks the
+    // dispatch card to jump into the running PTC thread. The flash report-back
+    // owns isStreamingRef/streamingThreadIdRef; navigation must SUPERSEDE it so
+    // the PTC thread loads and reconnects to its own live run.
+    mockStatus.mockResolvedValue({
+      can_reconnect: false,
+      status: 'completed',
+      pending_report_back: true,
+      active_tasks: [],
+    });
+
+    const watchCalls: Array<{ tid: string; cb: (p?: { run_id?: string | null }) => void | Promise<void> }> = [];
+    mockWatch.mockImplementation((tid: string, cb: (p?: { run_id?: string | null }) => void | Promise<void>) => {
+      watchCalls.push({ tid, cb });
+      return { abort: new AbortController() };
+    });
+
+    // Flash report-back reconnect HOLDS the stream open (never resolves) so it
+    // keeps ownership when navigation happens. PTC reconnect resolves normally.
+    mockReconnect.mockImplementation((threadId: string) => {
+      if (threadId === 'th-flash') return new Promise(() => {}); // hold forever
+      return Promise.resolve({ disconnected: false, aborted: false });
+    });
+
+    let tid = 'th-flash';
+    const { rerender } = renderHookWithProviders(() => useChatMessages('ws-rb', tid));
+    await waitFor(() => expect(mockWatch).toHaveBeenCalledTimes(1));
+
+    // Wake names the run → report-back attaches on the flash thread (fast path).
+    // Don't await the callback to completion — its reconnect promise never
+    // resolves; just let the synchronous attach + ownership claim run.
+    await act(async () => {
+      void watchCalls[0].cb({ run_id: 'rb-run' });
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    expect(mockReconnect.mock.calls.some((c) => c[0] === 'th-flash')).toBe(true);
+
+    // PTC thread is live (can_reconnect:true). User jumps into it.
+    mockStatus.mockResolvedValue({
+      can_reconnect: true,
+      status: 'running',
+      run_id: 'ptc-run',
+      active_tasks: [],
+      pending_report_back: false,
+    });
+    tid = 'th-ptc';
+    await act(async () => {
+      rerender();
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // PTC must reconnect to its own run. If supersede fails, this is never called.
+    const ptcCall = mockReconnect.mock.calls.find((c) => c[0] === 'th-ptc');
+    expect(ptcCall).toBeTruthy();
+    expect(ptcCall![1]).toBe('ptc-run');
+  });
+
+  it('supersedes the in-flight flash dispatch SEND when the user jumps into the live PTC thread', async () => {
+    // The other half of the live flow: the user clicks "jump to thread" while the
+    // flash DISPATCH TURN ITSELF is still streaming (a send, not a reconnect).
+    // A send sets isStreamingRef=true; if it does NOT also claim stream ownership,
+    // streamingThreadIdRef stays null, supersede can't fire, and the load guard
+    // (isStreamingRef) blocks the PTC thread from ever loading → PTC never streams.
+    // This is the regression that kept breaking PTC live while unit tests passed.
+    mockStatus.mockResolvedValue({
+      can_reconnect: false,
+      status: 'completed',
+      pending_report_back: false,
+      active_tasks: [],
+    });
+    mockWatch.mockImplementation(() => ({ abort: new AbortController() }));
+
+    // The flash send HOLDS (never resolves) so it stays in-progress across the
+    // navigation. The PTC reconnect resolves normally.
+    mockSend.mockImplementation(() => new Promise(() => {}));
+    mockReconnect.mockImplementation((threadId: string) =>
+      threadId === 'th-ptc'
+        ? Promise.resolve({ disconnected: false, aborted: false })
+        : new Promise(() => {}),
+    );
+
+    let tid = 'th-flash';
+    const { result, rerender } = renderHookWithProviders(() => useChatMessages('ws-flash', tid));
+    await settleMountEffect();
+
+    // Start a send on the flash thread; it holds → isStreamingRef stays true.
+    await act(async () => {
+      void result.current.handleSendMessage('dispatch a ptc analysis');
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // PTC thread is live; user jumps into it.
+    mockStatus.mockResolvedValue({
+      can_reconnect: true,
+      status: 'running',
+      run_id: 'ptc-run',
+      active_tasks: [],
+      pending_report_back: false,
+    });
+    tid = 'th-ptc';
+    await act(async () => {
+      rerender();
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    const ptcCall = mockReconnect.mock.calls.find((c) => c[0] === 'th-ptc');
+    expect(ptcCall).toBeTruthy();
+    expect(ptcCall![1]).toBe('ptc-run');
+  });
+
+  it('arms the report-back watch on refresh even when the flash thread reconnects to an active run', async () => {
+    // Refresh on the flash thread right as the report-back becomes due: /status
+    // reports the thread ACTIVE (can_reconnect:true) AND a report-back pending.
+    // The load takes the reconnect branch — but it must ALSO arm the watch, so if
+    // that one reconnect doesn't land on the report-back run (stale/drained run,
+    // or a short summary that finishes before attach), the watch still catches it
+    // via /status.report_back_run_id. Without this the report-back only surfaces
+    // on a LATER history-replay refresh (static, not live) — the reported bug.
+    mockStatus.mockResolvedValue({
+      can_reconnect: true,
+      status: 'active',
+      run_id: 'active-run',
+      pending_report_back: true,
+      report_back_run_id: 'rb-run',
+      active_tasks: [],
+    });
+    mockReconnect.mockResolvedValue({ disconnected: false, aborted: false });
+
+    const watchCalls: Array<{ tid: string }> = [];
+    mockWatch.mockImplementation((tid: string) => {
+      watchCalls.push({ tid });
+      return { abort: new AbortController() };
+    });
+
+    renderHookWithProviders(() => useChatMessages('ws-rb', 'th-flash'));
+
+    // The active run is reconnected to...
+    await waitFor(() => expect(mockReconnect.mock.calls.some((c) => c[0] === 'th-flash')).toBe(true));
+    // ...AND the report-back watch is armed as the reliable catch.
+    await waitFor(() => expect(mockWatch).toHaveBeenCalledWith('th-flash', expect.any(Function)));
+  });
+
+  it('keeps the pending flash report-back alive across a jump into the live PTC thread, then streams it on return', async () => {
+    // THE simultaneity contract every prior fix oscillated on. A flash
+    // report-back is PENDING (its PTC run still live, the report-back not yet
+    // started) when the user jumps flash → PTC. Both must hold at once:
+    //   • PTC streams live on the jumped-into thread, and
+    //   • the keyed flash watch SURVIVES the navigation (not torn down), so the
+    //     report-back still streams when the user returns.
+    // The old code tore the watch down on navigation (supersede + thread-change
+    // cleanup), so the report-back was lost — this test fails against that code.
+    mockStatus.mockResolvedValue({
+      can_reconnect: false,
+      status: 'completed',
+      pending_report_back: true,
+      active_tasks: [],
+    });
+    mockReconnect.mockResolvedValue({ disconnected: false, aborted: false });
+
+    const watchCalls: Array<{ tid: string; cb: (p?: { run_id?: string | null }) => void | Promise<void>; controller: AbortController }> = [];
+    mockWatch.mockImplementation((tid: string, cb: (p?: { run_id?: string | null }) => void | Promise<void>) => {
+      const controller = new AbortController();
+      watchCalls.push({ tid, cb, controller });
+      return { abort: controller };
+    });
+
+    let tid = 'th-flash';
+    const { rerender } = renderHookWithProviders(() => useChatMessages('ws-rb', tid));
+
+    // Armed once for the flash thread; nothing streaming yet (PTC turn is done).
+    await waitFor(() => expect(mockWatch).toHaveBeenCalledTimes(1));
+    expect(watchCalls[0].tid).toBe('th-flash');
+    expect(mockReconnect).not.toHaveBeenCalled();
+
+    // User jumps into the live PTC thread.
+    mockStatus.mockResolvedValue({
+      can_reconnect: true,
+      status: 'running',
+      run_id: 'ptc-run',
+      pending_report_back: false,
+      active_tasks: [],
+    });
+    tid = 'th-ptc';
+    await act(async () => {
+      rerender();
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // PTC streams live...
+    const ptcCall = mockReconnect.mock.calls.find((c) => c[0] === 'th-ptc');
+    expect(ptcCall).toBeTruthy();
+    expect(ptcCall![1]).toBe('ptc-run');
+    // ...AND the flash watch SURVIVED the jump: not re-armed, not aborted.
+    expect(mockWatch).toHaveBeenCalledTimes(1);
+    expect(watchCalls[0].controller.signal.aborted).toBe(false);
+
+    // The report-back STARTS while the user is on the PTC thread: the flash wake
+    // fires naming its run. The keyed watch captures the run id but must NOT
+    // attach onto th-ptc (its render gate keeps it off the visible PTC thread).
+    await act(async () => {
+      await watchCalls[0].cb({ run_id: 'rb-run' });
+    });
+    expect(mockReconnect.mock.calls.some((c) => c[0] === 'th-flash')).toBe(false);
+
+    // User returns to the flash thread (still pending → idempotent re-arm no-op,
+    // so the same persistent watch keeps the run id it captured while away).
+    mockStatus.mockResolvedValue({
+      can_reconnect: false,
+      status: 'completed',
+      pending_report_back: true,
+      report_back_run_id: 'rb-run',
+      active_tasks: [],
+    });
+    tid = 'th-flash';
+    await act(async () => {
+      rerender();
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // The persistent watch is on its flash thread again; its next reconcile (a
+    // poll tick, simulated here with a payload-less callback) streams the run id
+    // it REMEMBERED — no fresh run_id needed — live into a new bubble.
+    await act(async () => {
+      await watchCalls[0].cb();
+    });
+
+    const rbCall = mockReconnect.mock.calls.find((c) => c[0] === 'th-flash');
+    expect(rbCall).toBeTruthy();
+    expect(rbCall![1]).toBe('rb-run');
+    expect(rbCall![2]).toBeNull(); // fresh per-stream-key cursor
+    // Only ever ONE watch — keyed and persistent, never re-armed per navigation.
+    expect(mockWatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT arm the watch when pending_report_back is false', async () => {
+    mockStatus.mockResolvedValue({
+      can_reconnect: false,
+      status: 'completed',
+      pending_report_back: false,
+      active_tasks: [],
+    });
+    mockWatch.mockImplementation(() => ({ abort: new AbortController() }));
+
+    renderHookWithProviders(() => useChatMessages('ws-rb', 'th-rb'));
+
+    // Let the load + status check fully settle.
+    await waitFor(() => expect(mockReplay).toHaveBeenCalled());
+    await settleMountEffect();
+
+    expect(mockWatch).not.toHaveBeenCalled();
+    expect(mockReconnect).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -97,6 +97,13 @@ const PROPOSAL_DATA_KEY_MAP: Record<string, string> = {
 /** Secretary action interrupt types (for type guard in handlers). */
 const SECRETARY_ACTION_TYPES = new Set(['delete_workspace', 'stop_workspace', 'delete_thread']);
 
+/**
+ * Stop polling `/status` for a PTC report-back after this many ~3s ticks (~3min)
+ * so a report-back that never arrives (e.g. PTC dispatch failed, flash_watch
+ * never cleared) doesn't poll forever.
+ */
+const REPORT_BACK_MAX_POLLS = 60;
+
 /** Pending HITL interrupt state. */
 interface PendingInterrupt {
   type?: string;
@@ -169,6 +176,8 @@ interface WorkflowStatusResponse {
   active_tasks?: string[];
   is_shared?: boolean;
   pending_report_back?: boolean;
+  report_back_run_id?: string | null;
+  run_id?: string | null;
   [key: string]: unknown;
 }
 
@@ -589,6 +598,13 @@ export function useChatMessages(
   // the client-side reader stops immediately (instant stop) — the matching POST
   // /cancel tears down the backend run. Null when no main stream is in flight.
   const mainStreamAbortRef = useRef<AbortController | null>(null);
+  // The thread a reconnect stream is attached to (set when reconnectToStream
+  // marks isStreamingRef). Lets the thread-load effect tell "this thread is
+  // streaming" (skip the load) from "a DIFFERENT thread is streaming" (e.g. a
+  // flash report-back) — in the latter case it supersedes that stream so the
+  // navigated-to thread can still load and reconnect. Null when no reconnect
+  // stream is in flight.
+  const streamingThreadIdRef = useRef<string | null>(null);
   // Guards finalizeStreamingMessage / stopWorkflow so a double-click stop (or
   // handler re-entry) doesn't append duplicate synthetic close events. Cleared
   // on the next send.
@@ -622,6 +638,19 @@ export function useChatMessages(
   // Track if streaming is in progress to prevent history loading during streaming
   const isStreamingRef = useRef(false);
 
+  // (isStreamingRef, streamingThreadIdRef) are one invariant: a reconnect stream
+  // is owned by exactly one thread, or none. Mutate them only through these so
+  // the flag and the owner can never drift out of sync (the supersede logic and
+  // the thread-load guard both depend on them agreeing).
+  const acquireStreamOwnership = (tid: string | null) => {
+    isStreamingRef.current = true;
+    streamingThreadIdRef.current = tid;
+  };
+  const releaseStreamOwnership = () => {
+    isStreamingRef.current = false;
+    streamingThreadIdRef.current = null;
+  };
+
   // Feedback state: { [turnIndex]: { rating, ... } }
   const feedbackMapRef = useRef<Record<number, { rating: string | null; [key: string]: unknown }>>({});
 
@@ -644,6 +673,24 @@ export function useChatMessages(
   // Report-back watch: after PTC dispatch, watch for the flash report-back workflow via SSE
   const awaitingReportBackRef = useRef(false);
   const reportBackWatchAbortRef = useRef<AbortController | null>(null);
+  const reportBackPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // The flash thread the active report-back watch belongs to. The watch is keyed
+  // to this thread, NOT the visible thread, so it survives navigation into the
+  // dispatched PTC thread and only renders when this flash thread is back on
+  // screen. This is what lets the flash report-back and a live PTC stream coexist
+  // instead of fighting over the single visible-thread slot. Null when no watch.
+  const reportBackWatchThreadIdRef = useRef<string | null>(null);
+  // The report-back run id once the backend names it (wake payload or /status).
+  // Captured even while the user is away on the PTC thread, so the report-back
+  // still streams when they return to the flash thread. Cleared on attach/stop.
+  const reportBackRunIdRef = useRef<string | null>(null);
+  // Generation token for the report-back watch. Bumped whenever a watch is torn
+  // down (consume, hard-stop, re-arm for a DIFFERENT flash thread, unmount). An
+  // in-flight wake/poll callback captures its generation and bails if it no
+  // longer matches. (Can't key off threadIdRef: it has two writers — the
+  // prop-sync effect and the stream metadata handler — that disagree transiently
+  // on a fresh thread, which would bail even the in-session case.)
+  const reportBackWatchEpochRef = useRef(0);
 
   // Track the last received SSE event ID for reconnection
   const lastEventIdRef = useRef<number | string | null>(null);
@@ -2037,8 +2084,17 @@ export function useChatMessages(
    * Reconnects to an in-progress workflow stream after page refresh.
    * Creates an assistant message placeholder and processes live SSE events.
    */
-  const reconnectToStream = async ({ activeTasks = [] }: { activeTasks?: string[] } = {}) => {
+  const reconnectToStream = async ({ activeTasks = [], runId, resetCursor = false }: { activeTasks?: string[]; runId?: string | null; resetCursor?: boolean } = {}) => {
     if (!threadId || threadId === '__default__') return;
+
+    // Callers that (re)attach to the thread's CURRENT active run — thread-load,
+    // cross-thread navigation, post-HITL resume, report-back — pass that run's
+    // id and rewind the cursor. Without this, currentRunIdRef/lastEventIdRef
+    // still point at the PRIOR thread's stream, so we attach to a dead key
+    // (zero live events → content only appears on a later refetch). The
+    // mid-stream disconnect path omits both and keeps its in-progress cursor.
+    if (runId !== undefined) currentRunIdRef.current = runId;
+    if (resetCursor) lastEventIdRef.current = null;
 
     console.log('[Reconnect] Starting reconnection for thread:', threadId);
 
@@ -2050,7 +2106,7 @@ export function useChatMessages(
 
     setIsLoading(true);
     setIsReconnecting(true);
-    isStreamingRef.current = true;
+    acquireStreamOwnership(threadId);
     // Fresh stream: clear any stale stop flag from a PRIOR turn (e.g. user
     // hard-stopped thread A, then switched to live thread B). Without this the
     // stop-during-reconnect guards below (result.aborted || wasStoppedRef) would
@@ -2275,13 +2331,19 @@ export function useChatMessages(
         return prev;
       });
 
-      // Skip cleanup on a user stop — stopWorkflow already cleared isLoading /
+      // Only finalize if this reconnect is still the active stream. Navigation
+      // can supersede it (the thread-load effect aborts a report-back stream on
+      // the prior thread and starts a fresh stream for the new thread); running
+      // cleanup here would then reset isStreamingRef / re-arm watches and clobber
+      // the new thread's stream. The owner that superseded us manages that state.
+      const stillActive = mainStreamAbortRef.current === abortController;
+      // Skip cleanup on a user stop too — stopWorkflow already cleared isLoading /
       // hasActiveSubagents and ran finalize; re-running it here would re-toggle
       // loading and re-open the report-back watch after the stop.
-      if (!wasInterruptedRef.current && !wasStoppedRef.current) {
+      if (stillActive && !wasInterruptedRef.current && !wasStoppedRef.current) {
         cleanupAfterStreamEnd(assistantMessageId);
       }
-      if (mainStreamAbortRef.current === abortController) {
+      if (stillActive) {
         mainStreamAbortRef.current = null;
       }
     }
@@ -2334,50 +2396,173 @@ export function useChatMessages(
   // that receives a push notification (via Redis pub/sub) when this happens.
 
   const stopReportBackWatch = () => {
+    // Invalidate the current watch generation so any in-flight wake/poll callback
+    // bails instead of attaching after teardown.
+    reportBackWatchEpochRef.current += 1;
+    reportBackWatchThreadIdRef.current = null;
+    reportBackRunIdRef.current = null;
     if (reportBackWatchAbortRef.current) {
       reportBackWatchAbortRef.current.abort();
       reportBackWatchAbortRef.current = null;
     }
+    if (reportBackPollRef.current) {
+      clearInterval(reportBackPollRef.current);
+      reportBackPollRef.current = null;
+    }
   };
 
-  const startReportBackWatch = () => {
-    stopReportBackWatch();
-
-    const tid = threadIdRef.current;
+  // Drive the flash thread to the PTC report-back turn once the PTC completes.
+  //
+  // The watch is KEYED to the flash thread (`flashThreadId`), not the visible
+  // thread, and persists across navigation. When the user jumps into the
+  // dispatched PTC thread, the watch keeps running but does NOT render — it only
+  // attaches when its flash thread is the one on screen and idle. That is how the
+  // flash report-back and a live PTC stream coexist: the watch holds the named
+  // run id (captured from a wake even while away) and streams it the moment the
+  // user returns to the flash thread.
+  //
+  // The backend names the report-back run explicitly — no inference from run_id
+  // changes. It signals readiness via a fire-and-forget Redis pub/sub wake
+  // (`thread:wake:{tid}`) carrying the run_id, and durably records that run_id so
+  // it's also readable from `/status` (`report_back_run_id`). An in-session
+  // client attaches straight from the wake's run_id; a client that missed the
+  // wake (slow connect or a full reload) discovers the run via a `/status` poll.
+  const startReportBackWatch = (flashThreadId?: string | null) => {
+    const tid = flashThreadId ?? threadIdRef.current;
     if (!tid || tid === '__default__') return;
 
-    if (import.meta.env.DEV) console.log('[ReportBack] Opening watch connection for thread:', tid);
+    // Idempotent: a watch for this flash thread is already running. It survives
+    // navigation, so re-arming on return (loadAndMaybeReconnect / stream-end)
+    // must NOT tear it down — that would drop the run id it has already captured.
+    if (reportBackWatchAbortRef.current && reportBackWatchThreadIdRef.current === tid) return;
 
-    const { abort } = watchThread(tid, async () => {
-      reportBackWatchAbortRef.current = null;
+    stopReportBackWatch();
+    reportBackWatchThreadIdRef.current = tid;
+
+    // This watch generation. If a teardown bumps the epoch (consume, hard-stop,
+    // re-arm for a different flash thread, unmount), a wake/poll callback captured
+    // here is stale and must not attach.
+    const epoch = reportBackWatchEpochRef.current;
+
+    let consumed = false;
+    let inFlight = false;
+    let polls = 0;
+
+    // Attach to the named report-back run's per-run stream — which still replays
+    // its buffered events even after completion — so the summary streams into a
+    // fresh bubble naturally, with no jarring full-history reload (a reload also
+    // duplicates the live dispatch card, since history replay re-adds it next to
+    // the surviving live bubble). Skip if the named run is the one already on
+    // screen (the dispatch turn, or a report-back run we already attached to).
+    const attach = async (runId: string | null, activeTasks: string[]) => {
+      if (!runId || runId === currentRunIdRef.current) return false;
+      consumed = true;
       awaitingReportBackRef.current = false;
+      reportBackRunIdRef.current = null;
+      stopReportBackWatch();
+      await reconnectToStream({ activeTasks, runId, resetCursor: true });
+      return true;
+    };
 
-      // If flash is currently streaming, the report-back system message was
-      // steered into the active turn — no separate reconnect needed.
-      if (isStreamingRef.current) {
-        if (import.meta.env.DEV) console.log('[ReportBack] Steered into active stream, skipping reconnect');
+    const reconcile = async (source: string, wakeRunId?: string | null) => {
+      // Stale generation (re-armed for another thread / hard-stopped / unmounted).
+      if (reportBackWatchEpochRef.current !== epoch) return;
+      if (consumed) return;
+
+      // Remember the named run as soon as we learn it — even if the flash thread
+      // is NOT the one on screen right now. A wake fires once, when the PTC run
+      // finishes; if the user is away on the PTC thread at that instant we still
+      // capture the id so the report-back streams on return.
+      if (wakeRunId) reportBackRunIdRef.current = wakeRunId;
+
+      // Render gate: only attach when this flash thread is the visible thread and
+      // no other stream owns the slot. Off-thread (e.g. the user jumped into the
+      // PTC thread) we just hold the run id and leave the PTC stream untouched.
+      if (threadIdRef.current !== tid || isStreamingRef.current || inFlight) return;
+
+      // On the flash thread and idle. Attach a known run id immediately (no
+      // /status round-trip needed — the wake or a prior poll already named it).
+      if (reportBackRunIdRef.current) {
+        await attach(reportBackRunIdRef.current, []);
         return;
       }
 
-      if (import.meta.env.DEV) console.log('[ReportBack] Report-back workflow detected, reconnecting');
-
-      // Small delay to let the workflow buffer initial events
-      await new Promise((r) => setTimeout(r, 500));
-
+      inFlight = true;
+      let status: WorkflowStatusResponse;
       try {
-        const status = await getWorkflowStatus(tid);
-        if (status.can_reconnect) {
-          await reconnectToStream({ activeTasks: status.active_tasks || [] });
-        }
-      } catch (err) {
-        if (import.meta.env.DEV) console.log('[ReportBack] Reconnect after watch failed:', (err as Error).message);
+        status = await getWorkflowStatus(tid);
+      } catch {
+        inFlight = false;
+        return;
       }
+      inFlight = false;
+      // Re-check generation/visibility after the await: the watch may have been
+      // torn down, or the user may have navigated away, while /status was in flight.
+      if (consumed || reportBackWatchEpochRef.current !== epoch) return;
+      if (threadIdRef.current !== tid || isStreamingRef.current) return;
+
+      if (status.report_back_run_id) reportBackRunIdRef.current = status.report_back_run_id;
+      if (await attach(reportBackRunIdRef.current, status.active_tasks || [])) return;
+
+      // No report-back run named yet (still pending) or none is coming (the PTC
+      // dispatch failed). Keep polling, but give up after a bounded window so a
+      // never-arriving report-back doesn't poll forever.
+      if (source === 'poll' && ++polls >= REPORT_BACK_MAX_POLLS) {
+        consumed = true;
+        awaitingReportBackRef.current = false;
+        stopReportBackWatch();
+      }
+    };
+
+    const { abort } = watchThread(tid, async (payload) => {
+      const wakeRunId = payload?.run_id ?? null;
+      if (wakeRunId) {
+        await reconcile('wake', wakeRunId);
+        return;
+      }
+      // Payload-less wake (older backend / malformed): fall back to a /status
+      // reconcile. A short delay lets the report-back run register so
+      // report_back_run_id is populated.
+      await new Promise((r) => setTimeout(r, 500));
+      await reconcile('wake');
     });
     reportBackWatchAbortRef.current = abort;
+    reportBackPollRef.current = setInterval(() => reconcile('poll'), 3000);
   };
 
   // Load history when workspace or threadId changes, then check for reconnection
   useEffect(() => {
+    // A reconnect stream is live on a DIFFERENT thread than the one we're now
+    // loading — e.g. a flash report-back is streaming on the flash thread and the
+    // user clicked the dispatch card to jump into the running PTC thread. Without
+    // this, the isStreamingRef guard below would skip the PTC load and it would
+    // appear blank (the report-back stream "holds" the global streaming flag).
+    // Supersede that stream: abort it (it continues server-side and replays on
+    // return) so THIS thread can load and reconnect. The aborted stream's finally
+    // is a no-op now (its `stillActive` check fails — see reconnectToStream).
+    //
+    // We do NOT stop the report-back watch here. Superseding the visible flash
+    // reader (so the PTC thread can take the slot) must not erase the independent
+    // pending report-back: the keyed watch persists, holds its run id, and renders
+    // again when the user returns to the flash thread. Its render gate
+    // (threadIdRef === its flash thread) keeps it off the PTC thread meanwhile.
+    const supersedeOtherThreadStream =
+      isStreamingRef.current &&
+      streamingThreadIdRef.current !== null &&
+      // A '__default__' owner is a new-conversation send whose id hasn't resolved
+      // yet; its prop transitions '__default__' → realTid, which must NOT supersede
+      // its own in-flight stream. The isStreamingRef guard below skips the
+      // redundant load instead.
+      streamingThreadIdRef.current !== '__default__' &&
+      streamingThreadIdRef.current !== threadId &&
+      !!threadId &&
+      threadId !== '__default__';
+    if (supersedeOtherThreadStream) {
+      mainStreamAbortRef.current?.abort();
+      mainStreamAbortRef.current = null;
+      releaseStreamOwnership();
+    }
+
     // Guard: Only load if we have a workspaceId and a valid threadId (not '__default__')
     // Also skip if streaming is in progress (prevents race condition when thread ID changes during streaming)
     if (!workspaceId || !threadId || threadId === '__default__' || historyLoadingRef.current || isStreamingRef.current) {
@@ -2428,11 +2613,30 @@ export function useChatMessages(
         historyLoadedKeyRef.current = loadKey;
       }
 
+      // A pending PTC report-back is caught by the watch — the reliable mechanism
+      // that attaches to the run /status names (report_back_run_id) or a wake
+      // carries. Arm it here, BEFORE the reconnect branch below, so it runs
+      // regardless of whether this load also reconnects to an active run. On a
+      // refresh right as the report-back becomes due, /status can report
+      // can_reconnect=true AND pending_report_back=true; reconnecting to
+      // status.run_id alone can miss the report-back run (stale/drained run, or a
+      // short summary that finishes before attach), and without the watch it would
+      // only surface on a later history-replay refresh. The watch stays dormant
+      // while a reconnect stream is live (its reconcile bails on isStreamingRef),
+      // and attach() skips the run already on screen — so this never double-streams.
+      if (status.pending_report_back) {
+        if (import.meta.env.DEV) console.log('[ReportBack] Pending report-back detected on load, opening watch');
+        awaitingReportBackRef.current = true;
+        // Key the watch to THIS thread (the flash thread — pending_report_back is
+        // a flash-thread property). Idempotent if a watch for it already persists.
+        startReportBackWatch(threadId);
+      }
+
       if (historyHasUnresolvedInterruptRef.current && status.can_reconnect) {
         // Workflow is active → interrupt was answered, reconnect will deliver resolution
         console.log('[Reconnect] Unresolved interrupt from history, reconnecting to get resolution events');
         historyHasUnresolvedInterruptRef.current = false;
-        await reconnectToStream({ activeTasks: status.active_tasks || [] });
+        await reconnectToStream({ activeTasks: status.active_tasks || [], runId: status.run_id ?? null, resetCursor: true });
         unresolvedHistoryInterruptRef.current = [];
       } else if (historyHasUnresolvedInterruptRef.current && !status.can_reconnect) {
         // Workflow genuinely paused → make interrupt(s) interactive
@@ -2499,7 +2703,7 @@ export function useChatMessages(
         historyHasUnresolvedInterruptRef.current = false;
       } else if (status.can_reconnect) {
         console.log('[Reconnect] Workflow status:', status.status, 'can_reconnect:', status.can_reconnect, 'active_tasks:', status.active_tasks);
-        await reconnectToStream({ activeTasks: status.active_tasks || [] });
+        await reconnectToStream({ activeTasks: status.active_tasks || [], runId: status.run_id ?? null, resetCursor: true });
       } else if (status.active_tasks && status.active_tasks.length > 0) {
         // Main workflow completed but subagent tasks still running.
         // Reopen per-task SSE streams so cards stay live after refresh.
@@ -2550,30 +2754,36 @@ export function useChatMessages(
         if (finalizePendingTodos) finalizePendingTodos();
         // Also patch inline todoListProcesses in messages
         setMessages((prev) => finalizeTodoListProcessesInMessages(prev));
-
-        // Re-open watch if a PTC report-back is still pending (e.g., user navigated away and back)
-        if (status.pending_report_back) {
-          if (import.meta.env.DEV) console.log('[ReportBack] Pending report-back detected on load, opening watch');
-          awaitingReportBackRef.current = true;
-          startReportBackWatch();
-        }
+        // (Report-back watch is armed earlier, before the reconnect branch, so it
+        // covers the active-reconnect case too — see that block above.)
       }
     };
 
     loadAndMaybeReconnect();
 
-    // Cleanup: Cancel loading if workspace or thread changes or component unmounts
+    // Cleanup: Cancel loading if workspace or thread changes or component unmounts.
+    // The report-back watch is deliberately NOT torn down here — it is keyed to its
+    // flash thread and must survive navigation into the dispatched PTC thread (a
+    // dedicated unmount-only effect stops it when the component truly goes away).
     return () => {
       cancelled = true;
       historyLoadingRef.current = false;
       closeAllSubagentStreams();
       subagentStateRefsRef.current = {};
-      stopReportBackWatch();
-      awaitingReportBackRef.current = false;
     };
     // Note: loadConversationHistory is not in deps because it uses workspaceId and threadId from closure
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [workspaceId, threadId, reloadTrigger]);
+
+  // The report-back watch survives thread navigation (so a flash report-back and a
+  // live PTC stream coexist), so the thread-load effect above can't own its
+  // teardown. Stop it only when the chat hook itself unmounts.
+  useEffect(() => {
+    return () => {
+      stopReportBackWatch();
+      awaitingReportBackRef.current = false;
+    };
+  }, []);
 
   /**
    * Marks all subagentTasks in messages as 'completed'.
@@ -2691,7 +2901,7 @@ export function useChatMessages(
     setWorkspaceStarting(false);
     setIsCompacting(false);
     currentMessageRef.current = null;
-    isStreamingRef.current = false;
+    releaseStreamOwnership();
 
     const hasOpenStreams = subagentStreamsRef.current.size > 0;
     if (!hasOpenStreams) {
@@ -2705,9 +2915,16 @@ export function useChatMessages(
     if (finalizePendingTodos) finalizePendingTodos();
     setMessages((prev) => finalizeTodoListProcessesInMessages(prev, assistantMessageId));
 
-    // Open watch connection for report-back if a PTC agent was dispatched with report_back enabled
+    // Open watch connection for report-back if a PTC agent was dispatched with
+    // report_back enabled. The watch attaches to the run the backend names (wake
+    // payload or /status's report_back_run_id), skipping the run currently on
+    // screen (this just-finished "Dispatched." turn). Key it to the flash thread
+    // that dispatched: an already-running watch names it (re-arm is then a no-op);
+    // otherwise this is the initial in-session arm, where the visible thread IS
+    // the flash thread. Without the key, a stream-end while the user is on the
+    // dispatched PTC thread would wrongly re-point the watch at the PTC thread.
     if (awaitingReportBackRef.current) {
-      startReportBackWatch();
+      startReportBackWatch(reportBackWatchThreadIdRef.current ?? threadIdRef.current);
     }
   };
 
@@ -2881,7 +3098,7 @@ export function useChatMessages(
     // effect. dropQueuedSend clears the ref synchronously (before the effect runs
     // post-render) and removes its optimistic shimmer bubble.
     dropQueuedSend();
-    isStreamingRef.current = false;
+    releaseStreamOwnership();
     currentMessageRef.current = null;
 
     // (c) Abort per-task subagent streams + the report-back watch so no
@@ -3932,7 +4149,7 @@ export function useChatMessages(
         }
 
         setIsLoading(false);
-        isStreamingRef.current = false;
+        releaseStreamOwnership();
         currentMessageRef.current = null;
         if (wasInterruptedRef) wasInterruptedRef.current = true;
       }
@@ -4008,7 +4225,7 @@ export function useChatMessages(
       const assistantMessage = createAssistantMessage(newAssistantId);
       setMessages((prev) => appendMessage(prev, assistantMessage));
       currentMessageRef.current = newAssistantId;
-      isStreamingRef.current = true;
+      acquireStreamOwnership(threadId);
       setIsLoading(true);
       // This demoted POST is now the active main turn; clear the stopped guard
       // and register its controller so stopWorkflow can abort it.
@@ -4128,7 +4345,7 @@ export function useChatMessages(
           }))
         );
         setMessageError((err as Error).message || 'Failed to send message');
-        isStreamingRef.current = false;
+        releaseStreamOwnership();
         setIsLoading(false);
         return;
       }
@@ -4260,8 +4477,11 @@ export function useChatMessages(
     completedTaskIdsRef.current.clear();
     // Clear the stopped guard so a fresh send can finalize again on stop.
     wasStoppedRef.current = false;
-    // Mark streaming as in progress to prevent history loading during streaming
-    isStreamingRef.current = true;
+    // Mark streaming as in progress (prevents history loading during streaming)
+    // AND claim ownership for this thread, so navigating to another thread mid-send
+    // supersedes this stream rather than leaving it orphaned (the load guard would
+    // otherwise block the new thread because isStreamingRef is still set).
+    acquireStreamOwnership(threadId);
 
     // Create assistant message placeholder
     const assistantMessageId = `assistant-${Date.now()}`;
@@ -4504,7 +4724,7 @@ export function useChatMessages(
     setIsLoading(true);
     setMessageError(null);
     wasStoppedRef.current = false;
-    isStreamingRef.current = true;
+    acquireStreamOwnership(threadId);
     // Fresh AbortController so stopWorkflow can abort this resumed stream.
     const abortController = new AbortController();
     mainStreamAbortRef.current = abortController;
@@ -4840,7 +5060,7 @@ export function useChatMessages(
     setHasActiveSubagents(false);
     completedTaskIdsRef.current.clear();
     wasStoppedRef.current = false;
-    isStreamingRef.current = true;
+    acquireStreamOwnership(threadId);
 
     // Truncate messages and add new user message (if editing) + assistant placeholder
     const assistantMessageId = `assistant-${Date.now()}`;

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -598,6 +598,11 @@ export function useChatMessages(
   // the client-side reader stops immediately (instant stop) — the matching POST
   // /cancel tears down the backend run. Null when no main stream is in flight.
   const mainStreamAbortRef = useRef<AbortController | null>(null);
+  // The reconnect that currently owns the "Reconnecting…" spinner. Its finally
+  // clears the spinner only if it's still the owner — a newer reconnect takes
+  // ownership and manages its own spinner, so a stale/superseded reconnect can
+  // neither clobber the new one's spinner nor strand its own.
+  const isReconnectingOwnerRef = useRef<AbortController | null>(null);
   // The thread a reconnect stream is attached to (set when reconnectToStream
   // marks isStreamingRef). Lets the thread-load effect tell "this thread is
   // streaming" (skip the load) from "a DIFFERENT thread is streaming" (e.g. a
@@ -2237,6 +2242,8 @@ export function useChatMessages(
     // stop already tore everything down.
     const abortController = new AbortController();
     mainStreamAbortRef.current = abortController;
+    // This reconnect now owns the spinner set above (setIsReconnecting(true)).
+    isReconnectingOwnerRef.current = abortController;
 
     try {
       // Replay buffered events first — this processes artifact{task,spawned} events
@@ -2316,8 +2323,6 @@ export function useChatMessages(
         setMessageError((err as Error).message || 'Failed to reconnect to stream');
       }
     } finally {
-      setIsReconnecting(false);
-
       // Clean up empty reconnect messages (no content segments = nothing was
       // streamed). Skip on a user stop: finalizeStreamingMessage just stamped
       // this bubble `stopped: true` (with the "⏹ Stopped" chip) but left it
@@ -2342,6 +2347,15 @@ export function useChatMessages(
       // loading and re-open the report-back watch after the stop.
       if (stillActive && !wasInterruptedRef.current && !wasStoppedRef.current) {
         cleanupAfterStreamEnd(assistantMessageId);
+      }
+      // Clear the spinner only if THIS reconnect still owns it. A newer reconnect
+      // (cross-thread nav) took ownership and manages its own spinner — clobbering
+      // it would hide the new thread's reconnect. Any other teardown that swapped
+      // the stream out from under us (user stop, steering demoted to a new turn)
+      // leaves ownership with us, so we still clear and never strand the spinner.
+      if (isReconnectingOwnerRef.current === abortController) {
+        setIsReconnecting(false);
+        isReconnectingOwnerRef.current = null;
       }
       if (stillActive) {
         mainStreamAbortRef.current = null;
@@ -3091,6 +3105,8 @@ export function useChatMessages(
     // Stopping mid-bringup or mid-compaction must clear these too — otherwise a
     // stuck "starting sandbox" / "compacting" indicator outlives the stop.
     // cleanupAfterStreamEnd resets them, but the stop path skips that cleanup.
+    // (isReconnecting is handled by the reconnect finally's ownership check: the
+    // abort above unwinds the reader, whose finally still owns and clears it.)
     setWorkspaceStarting(false);
     setIsCompacting(false);
     // Drop any message queued during compaction: the user just cancelled, so it

--- a/web/src/pages/ChatAgent/utils/__tests__/api.test.ts
+++ b/web/src/pages/ChatAgent/utils/__tests__/api.test.ts
@@ -33,6 +33,7 @@ import {
   deleteThread,
   sendHitlResponse,
   streamWorkspaceEvents,
+  watchThread,
 } from '../api';
 
 const mockGet = api.get as Mock;
@@ -383,6 +384,85 @@ describe('ChatAgent API utilities', () => {
         'event: status\ndata: {"status":"running"}\n\n',
       ]);
       await streamWorkspaceEvents('ws-1', vi.fn(), ctrl());
+      expect(reader.cancel).toHaveBeenCalled();
+    });
+  });
+
+  describe('watchThread', () => {
+    let originalFetch: typeof global.fetch;
+
+    beforeEach(() => {
+      originalFetch = global.fetch;
+    });
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    /** Build a fetch mock whose /watch body streams the given SSE text chunks. */
+    function mockWatchResponse(chunks: string[], { ok = true } = {}) {
+      const encoder = new TextEncoder();
+      const queue = [...chunks];
+      const reader = {
+        read: vi.fn(async () => {
+          if (queue.length === 0) return { done: true, value: undefined };
+          return { done: false, value: encoder.encode(queue.shift()!) };
+        }),
+        cancel: vi.fn(async () => {}),
+      };
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok,
+        status: ok ? 200 : 503,
+        body: ok ? { getReader: () => reader } : null,
+      });
+      global.fetch = fetchMock as unknown as typeof fetch;
+      return { fetchMock, reader };
+    }
+
+    /** Run watchThread and resolve with the payload it reports (one-shot). */
+    function runWatch(): Promise<{ run_id?: string | null } | undefined> {
+      return new Promise((resolve) => {
+        watchThread('flash-1', resolve);
+      });
+    }
+
+    it('parses the run_id from a wake delivered as a single frame', async () => {
+      mockWatchResponse([
+        'event: workflow_started\ndata: {"thread_id":"flash-1","run_id":"rb-1"}\n\n',
+      ]);
+      expect(await runWatch()).toEqual({ run_id: 'rb-1' });
+    });
+
+    it('parses the run_id when the data line arrives in a later read() chunk', async () => {
+      // Regression: the wake frame is split mid-`data:` across reads. Reacting on
+      // first sight of the event name parsed partial JSON and lost the run_id,
+      // forcing a /status fallback that a fast report-back has already torn down.
+      mockWatchResponse([
+        'event: workflow_started\ndata: {"thread_id":"flash-1","ru',
+        'n_id":"rb-1"}\n\n',
+      ]);
+      expect(await runWatch()).toEqual({ run_id: 'rb-1' });
+    });
+
+    it('skips keepalive pings before reporting the wake run_id', async () => {
+      mockWatchResponse([
+        ': ping\n\n',
+        ': ping\n\n',
+        'event: workflow_started\ndata: {"run_id":"rb-9"}\n\n',
+      ]);
+      expect(await runWatch()).toEqual({ run_id: 'rb-9' });
+    });
+
+    it('reports a null run_id for a malformed wake (caller falls back to /status)', async () => {
+      mockWatchResponse(['event: workflow_started\ndata: {not json}\n\n']);
+      expect(await runWatch()).toEqual({ run_id: null });
+    });
+
+    it('cancels the reader once the wake is consumed', async () => {
+      const { reader } = mockWatchResponse([
+        'event: workflow_started\ndata: {"run_id":"rb-1"}\n\n',
+      ]);
+      await runWatch();
       expect(reader.cancel).toHaveBeenCalled();
     });
   });

--- a/web/src/pages/ChatAgent/utils/__tests__/api.test.ts
+++ b/web/src/pages/ChatAgent/utils/__tests__/api.test.ts
@@ -458,6 +458,16 @@ describe('ChatAgent API utilities', () => {
       expect(await runWatch()).toEqual({ run_id: null });
     });
 
+    it('joins multiple data: lines per the SSE spec before parsing', async () => {
+      // A wake whose JSON spans multiple data: lines must concatenate with a
+      // newline (SSE spec). The old single-line regex captured only the first
+      // line, truncating the JSON and forcing a /status fallback.
+      mockWatchResponse([
+        'event: workflow_started\ndata: {"thread_id":"flash-1",\ndata: "run_id":"rb-7"}\n\n',
+      ]);
+      expect(await runWatch()).toEqual({ run_id: 'rb-7' });
+    });
+
     it('cancels the reader once the wake is consumed', async () => {
       const { reader } = mockWatchResponse([
         'event: workflow_started\ndata: {"run_id":"rb-1"}\n\n',

--- a/web/src/pages/ChatAgent/utils/api.ts
+++ b/web/src/pages/ChatAgent/utils/api.ts
@@ -557,14 +557,16 @@ export async function getWorkflowStatus(threadId: string) {
 /**
  * Watch a thread for new workflow activity via SSE (Redis pub/sub backed).
  * Returns an AbortController so the caller can close the connection.
- * Calls onWorkflowStarted() when the backend signals a new workflow.
+ * Calls onWorkflowStarted(payload) when the backend signals a new workflow;
+ * the payload carries the started run_id (e.g. a flash report-back run) so the
+ * caller can attach to that exact run directly.
  * @param {string} threadId - The thread ID to watch
  * @param {Function} onWorkflowStarted - Callback when new workflow is detected
  * @returns {{ abort: AbortController }} - Call abort.abort() to stop watching
  */
 export function watchThread(
   threadId: string,
-  onWorkflowStarted: () => void,
+  onWorkflowStarted: (payload?: { run_id?: string | null }) => void,
 ): { abort: AbortController } {
   const abort = new AbortController();
   const MAX_RETRIES = 2;
@@ -590,16 +592,33 @@ export function watchThread(
           const { done, value } = await reader.read();
           if (done) break;
           buffer += decoder.decode(value, { stream: true });
-          // Check for workflow_started event
-          if (buffer.includes('event: workflow_started')) {
+          // Process only COMPLETE SSE frames (terminated by a blank line). A
+          // single frame can arrive split across reads, so reacting on the first
+          // sight of the event name would race a half-buffered `data:` line and
+          // parse partial JSON — losing the run_id and forcing the caller down a
+          // /status fallback that, for a fast report-back, has already been torn
+          // down. Splitting on the frame terminator guarantees the data line is
+          // whole before we read the run_id.
+          let sep: number;
+          while ((sep = buffer.indexOf('\n\n')) >= 0) {
+            const frame = buffer.slice(0, sep);
+            buffer = buffer.slice(sep + 2);
+            // Skip keepalive pings / timeout frames — only the wake carries a run_id.
+            if (!frame.includes('event: workflow_started')) continue;
             reader.cancel();
-            onWorkflowStarted();
+            // Pull the run_id out of the event's data line so the caller can
+            // attach to that exact run without a /status round-trip.
+            let payload: { run_id?: string | null } = {};
+            const m = frame.match(/data: (.*)/);
+            if (m) {
+              try {
+                payload = JSON.parse(m[1].trim());
+              } catch {
+                /* payload-less / malformed wake — caller falls back to /status */
+              }
+            }
+            onWorkflowStarted({ run_id: payload.run_id ?? null });
             return;
-          }
-          // Discard processed keepalive lines to prevent buffer growth
-          const lastNewline = buffer.lastIndexOf('\n\n');
-          if (lastNewline >= 0) {
-            buffer = buffer.slice(lastNewline + 2);
           }
         }
         return; // Stream ended cleanly without event — no retry

--- a/web/src/pages/ChatAgent/utils/api.ts
+++ b/web/src/pages/ChatAgent/utils/api.ts
@@ -607,12 +607,19 @@ export function watchThread(
             if (!frame.includes('event: workflow_started')) continue;
             reader.cancel();
             // Pull the run_id out of the event's data line so the caller can
-            // attach to that exact run without a /status round-trip.
+            // attach to that exact run without a /status round-trip. Per the SSE
+            // spec, multiple data: lines join with a newline — collect them all
+            // (mirroring streamFetch above) so a multi-line payload stays
+            // parseable instead of truncating to the first line and corrupting
+            // the JSON. The backend wake is single-line today; this is resilience.
             let payload: { run_id?: string | null } = {};
-            const m = frame.match(/data: (.*)/);
-            if (m) {
+            const dataLines: string[] = [];
+            for (const raw of frame.split('\n')) {
+              if (raw.startsWith('data:')) dataLines.push(raw.slice(5).trim());
+            }
+            if (dataLines.length) {
               try {
-                payload = JSON.parse(m[1].trim());
+                payload = JSON.parse(dataLines.join('\n'));
               } catch {
                 /* payload-less / malformed wake — caller falls back to /status */
               }

--- a/web/src/pages/ChatAgent/utils/api.ts
+++ b/web/src/pages/ChatAgent/utils/api.ts
@@ -566,7 +566,7 @@ export async function getWorkflowStatus(threadId: string) {
  */
 export function watchThread(
   threadId: string,
-  onWorkflowStarted: (payload?: { run_id?: string | null }) => void,
+  onWorkflowStarted: (payload?: { run_id?: string | null }) => void | Promise<void>,
 ): { abort: AbortController } {
   const abort = new AbortController();
   const MAX_RETRIES = 2;
@@ -624,7 +624,7 @@ export function watchThread(
                 /* payload-less / malformed wake — caller falls back to /status */
               }
             }
-            onWorkflowStarted({ run_id: payload.run_id ?? null });
+            await onWorkflowStarted({ run_id: payload.run_id ?? null });
             return;
           }
         }


### PR DESCRIPTION
## Summary

Makes the flash→PTC **report-back** path work end-to-end for the single-job case.
When a flash turn dispatches a background PTC research job via the secretary
`ptc_agent` tool, the job's summary should stream back into the flash thread live
on completion. Three defects broke that:

**Dispatch fix** (`52b03d9c`) — `ptc_agent` continuation always failed with "thread
not found". The `is_continuation` branch compared `thread.get("user_id")`, but
`conversation_threads` has no `user_id` column (ownership lives on
`workspaces.user_id`), so the value was always `None`. Now reuses
`_verify_thread_owner`, which JOINs `workspaces` to resolve the real owner.

**Report-back fix** (`af35a6c2`) — the flash thread was not reliably notified when
the PTC job finished. `_flash_report_back` cleared the Redis watch state before
publishing the wake (and even on a failed POST), so a client that missed the live
pub/sub never reopened the watch on reload. The watch (`flash_watch` + `ptc_origin`)
now clears only when the report-back flash run reaches a terminal state: success via
the completion hook, fail/cancel via `BackgroundTaskManager`. The wake payload and a
durable `flash_rb_run` pointer both carry the `run_id`, and `/status` returns
`report_back_run_id`, so clients attach to the exact run instead of inferring it.
`report_back_ptc_thread_id` is stripped for non-internal callers (anti-spoof).

**Streaming fix** (`998ab08d`) — in-session the summary rendered as an empty spinner
and only appeared after a refresh. `watchThread` reacted on a partial SSE buffer and
regex-parsed possibly-split JSON, losing the `run_id` so the one-shot watch closed
with nothing to attach. Now splits the buffer on complete frames, attaches to the
named run from the wake, and keys the watch to the flash thread so it survives a jump
into the live PTC thread and replays on return. Stream ownership is tracked via an
`acquire/releaseStreamOwnership` invariant so the flash report-back and a live PTC
stream no longer fight over the single visible slot.

## Overview

| Category | Files | +LOC | -LOC |
|---|---:|---:|---:|
| Modified (production) | 9 | 579 | 129 |
| New (production) | 0 | 0 | 0 |
| Tests (4 new + 2 modified, excluded from net) | 6 | 1295 | 0 |
| **Net (excl. tests)** | **9** | **579** | **129** |

**By module**

- **Backend / server** (`src/server/`, modified)
  - `handlers/chat/ptc_workflow.py` (+152/-54) — durable `flash_rb_run` pointer,
    bounded report-back retry, terminal-state clear, run_id in the wake.
  - `services/background_task_manager.py` (+41/-3) — `_clear_report_back_watch` wired
    into `_mark_failed` / `_mark_cancelled` so failed/cancelled runs clear the watch.
  - `handlers/chat/flash_workflow.py` (+45) — clear-on-success hook; threads
    `report_back_ptc_thread_id` into task metadata.
  - `app/threads.py` (+18/-9) — PTC-crash-path clear; strip `report_back_ptc_thread_id`
    for non-internal callers.
  - `handlers/workflow_handler.py` (+10/-1) — `/status` returns `report_back_run_id`.
  - `models/chat.py` (+9) — `report_back_ptc_thread_id` field on `ChatRequest`.
- **Backend / tools** (`src/tools/secretary/tools.py`, +5/-2, modified) — continuation
  uses `_verify_thread_owner` instead of the always-`None` `thread.get("user_id")`.
- **Frontend / ChatAgent** (`web/src/pages/ChatAgent/`, modified)
  - `hooks/useChatMessages.ts` (+270/-50) — keyed nav-surviving report-back watch,
    stream-ownership invariant, epoch guard, bounded missed-wake poll.
  - `utils/api.ts` (+29/-10) — `watchThread` frame-splitting; `reconnectToStream`
    attaches to a named run with cursor reset.

**What this introduces:** a single background PTC job dispatched from a flash thread
now reports its result back and streams live into that flash thread, surviving
navigation to the PTC thread and surviving a reload, instead of erroring on dispatch,
silently dropping the notification, or rendering only after a manual refresh.

## Diff Size
- Total: 15 files changed, 1874 insertions(+), 129 deletions(-)
- Net (excl. tests): 9 files changed, 579 insertions(+), 129 deletions(-)

## Test Coverage

New/extended unit coverage:
- `tests/unit/tools/secretary/test_ptc_agent_continuation.py` (new) — continuation
  owner-verification path.
- `tests/unit/server/handlers/chat/test_flash_report_back.py` (new) — report-back
  retry/clear lifecycle, terminal-state clear, run_id in wake/pointer.
- `tests/unit/server/services/test_background_task_manager.py` — `_clear_report_back_watch`
  via terminal handlers.
- `web/.../__tests__/useChatMessages.reportBack.test.ts` (new) — live attach,
  missed-wake reload via `/status`, nav supersede + replay, no-run no-attach.
- `web/.../__tests__/useChatMessages.reconnectNav.test.ts` (new) — reconnect/navigation
  ownership.
- `web/.../utils/__tests__/api.test.ts` — `watchThread` frame-splitting.

**Known gaps (deferred, none blocking):** a direct assertion that
`report_back_ptc_thread_id` is stripped for non-internal callers (security control),
the `_mark_failed`/`_mark_cancelled` → clear wiring as an isolated case, and the
`REPORT_BACK_MAX_POLLS` give-up branch (needs fake timers).

## Pre-Landing Review

Reviewed via `/review` (no hard blockers). One auto-fix applied: `run_id?: string`
→ `string | null` in `useChatMessages.ts` (backend returns `null`). Deferred nits
(non-blocking): per-attempt `aiohttp.ClientSession` in `_flash_report_back`, a
defense-in-depth origin match in `clear_flash_report_back`, and a duplicate
`_FLASH_RB_RUN_TTL` constant. No SQL/data-safety or trust-boundary issues; the
anti-spoof strip is correct (POST host fixed to `GINLIXFLOW_BASE_URL`, only a
server-generated UUID interpolated, no SSRF).

## Scope

Single-job report-back only. The **concurrent multi-dispatch** case (2+ background
jobs from one flash thread finishing close together) is a known follow-up, designed
but not built. It touches the same files and stacks on this change.

## Test plan
- [x] Backend unit, broad (`tests/unit/server` + `tests/unit/tools`) — 2600 passed
- [x] Backend unit, targeted (secretary + chat handlers + BTM) — 139 passed
- [x] Frontend unit, targeted (ChatAgent hooks + api) — 157 passed
- [x] `ruff check src/` clean; `pnpm lint` 0 errors
- [x] E2E (`/e2e-chat`, live worktree container, oss-mode) — dispatch, report-back,
      and live-stream paths exercised against the running backend; report-back
      dispatched and streamed live (incremental chunks, no refresh)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for reporting a specific report-back run identifier in workflow status to enable more accurate reconnection.
* **Bug Fixes**
  * Improved chat report-back reconnect behavior so users resume the correct stream when navigating between threads.
  * Enhanced flash/PTC report-back cleanup on completion, cancellation, and failure to reduce stale “pending” states.
  * Strengthened chat continuation by denying continuation attempts for threads that aren’t owned, returning clearer “thread not found” style errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->