### PR TITLE
feat(chat): reliable scroll-to-latest + shared nav-panel folder state

### DIFF
--- a/web/src/contexts/AuthContext.tsx
+++ b/web/src/contexts/AuthContext.tsx
@@ -5,6 +5,8 @@ import { setTokenGetter } from '../api/client';
 import { queryKeys } from '../lib/queryKeys';
 import { OAUTH_BROADCAST_CHANNEL, OAUTH_POPUP_WINDOW_NAME, OAUTH_POPUP_FEATURES } from '../lib/oauthPopup';
 import { clearFlashWorkspaceCache } from '@/pages/MarketView/utils/flashWorkspace';
+import { resetNavPanelExpansion } from '@/pages/ChatAgent/components/navExpansionStore';
+import { resetStableNavOrder, resetSharedWorkspaceThreads } from '@/pages/ChatAgent/hooks/useNavigationData';
 
 import type { AuthResponse, OAuthResponse, Provider, Session } from '@supabase/supabase-js';
 
@@ -142,6 +144,12 @@ function SupabaseAuthProvider({ children }: { children: React.ReactNode }) {
         // Logged out — wipe all cached data
         queryClient.clear();
         clearFlashWorkspaceCache();
+        // Module-level nav stores live on globalThis (no page reload on logout),
+        // so they'd otherwise leak one user's folders/thread lists into the next
+        // user's session on a shared tab. Reset them on every sign-out.
+        resetNavPanelExpansion();
+        resetStableNavOrder();
+        resetSharedWorkspaceThreads();
         setTokenGetter(() => Promise.resolve(null));
       }
     });

--- a/web/src/contexts/__tests__/AuthContext.test.tsx
+++ b/web/src/contexts/__tests__/AuthContext.test.tsx
@@ -31,6 +31,19 @@ vi.mock('../../api/client', () => ({
   setTokenGetter: vi.fn(),
 }));
 
+// Spy on the module-level nav stores so we can assert sign-out resets them.
+const mockResetNavPanelExpansion = vi.fn();
+const mockResetStableNavOrder = vi.fn();
+const mockResetSharedWorkspaceThreads = vi.fn();
+
+vi.mock('@/pages/ChatAgent/components/navExpansionStore', () => ({
+  resetNavPanelExpansion: () => mockResetNavPanelExpansion(),
+}));
+vi.mock('@/pages/ChatAgent/hooks/useNavigationData', () => ({
+  resetStableNavOrder: () => mockResetStableNavOrder(),
+  resetSharedWorkspaceThreads: () => mockResetSharedWorkspaceThreads(),
+}));
+
 // Dynamic import so mocks and env stubs are applied first
 const { AuthProvider, useAuth } = await import('../AuthContext');
 
@@ -144,6 +157,29 @@ describe('AuthContext', () => {
         expect(screen.getByTestId('isInitialized').textContent).toBe('true')
       );
       expect(mockOnAuthStateChange).toHaveBeenCalled();
+    });
+
+    // Regression: the module-level nav stores live on globalThis and survive
+    // logout (no page reload), so they must be reset on sign-out or one user's
+    // folders/thread lists leak into the next user's session on a shared tab.
+    it('resets the module-level nav stores on sign-out', async () => {
+      renderWithQueryClient(
+        <AuthProvider>
+          <TestConsumer />
+        </AuthProvider>
+      );
+
+      await waitFor(() => expect(mockOnAuthStateChange).toHaveBeenCalled());
+
+      const handler = mockOnAuthStateChange.mock.calls[0][0] as (
+        event: string,
+        session: unknown,
+      ) => void;
+      handler('SIGNED_OUT', null);
+
+      expect(mockResetNavPanelExpansion).toHaveBeenCalledTimes(1);
+      expect(mockResetStableNavOrder).toHaveBeenCalledTimes(1);
+      expect(mockResetSharedWorkspaceThreads).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/web/src/contexts/__tests__/AuthContext.test.tsx
+++ b/web/src/contexts/__tests__/AuthContext.test.tsx
@@ -1,6 +1,6 @@
 import React, { type ReactElement } from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 // Enable platform auth code path (AuthProvider checks VITE_HOST_MODE)
@@ -175,7 +175,11 @@ describe('AuthContext', () => {
         event: string,
         session: unknown,
       ) => void;
-      handler('SIGNED_OUT', null);
+      // Wrap in act(): the handler drives AuthProvider state updates, which
+      // React 19 warns about if flushed outside an act() boundary.
+      await act(async () => {
+        handler('SIGNED_OUT', null);
+      });
 
       expect(mockResetNavPanelExpansion).toHaveBeenCalledTimes(1);
       expect(mockResetStableNavOrder).toHaveBeenCalledTimes(1);

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -871,8 +871,15 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
   const armSettleTimers = useCallback(() => {
     if (settleQuietTimerRef.current) clearTimeout(settleQuietTimerRef.current);
     settleQuietTimerRef.current = setTimeout(() => {
+      // Quiet window elapsed — the settle session is over. Tear down BOTH timers
+      // so the next pin session arms a fresh hard cap; otherwise it inherits this
+      // session's stale (shortened or already-elapsed) one and gives up early.
       pinTargetRef.current = null;
       settleQuietTimerRef.current = null;
+      if (settleHardCapRef.current) {
+        clearTimeout(settleHardCapRef.current);
+        settleHardCapRef.current = null;
+      }
     }, SETTLE_QUIET_MS);
     if (!settleHardCapRef.current) {
       settleHardCapRef.current = setTimeout(() => {

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -17,6 +17,7 @@ import { toast } from '@/components/ui/use-toast';
 import { mergeWarmingDisplay } from '../utils/warmWorkspace';
 import { useChatMessages } from '../hooks/useChatMessages';
 import { saveChatSession, getChatSession, clearChatSession } from '../hooks/utils/chatSessionRestore';
+import { isNearBottom } from '../utils/scrollHelpers';
 import type { PreviewData } from '../hooks/utils/types';
 import type { ProvenanceRecord } from '@/types/chat';
 import { clampPanelWidth as clampPanelWidthUtil } from '@/lib/panelUtils';
@@ -48,6 +49,7 @@ import Markdown from './Markdown';
 import NavigationPanel from './NavigationPanel';
 import NavDisplayOptions from './NavDisplayOptions';
 import ChatMinimap from './ChatMinimap';
+import JumpToLatestPill from './JumpToLatestPill';
 import { useNavigationData } from '../hooks/useNavigationData';
 import ShareButton from './ShareButton';
 import { WorkspaceProvider } from '../contexts/WorkspaceContext';
@@ -534,7 +536,15 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
       const ref = activeAgentId === 'main' ? scrollAreaRef : subagentScrollAreaRef;
       const container = getScrollContainer(ref);
       if (container) {
+        // Mark as programmatic so the main-tab scroll listener doesn't treat
+        // this restore as a user scroll (which would cancel the pin / save).
+        programmaticScrollRef.current = true;
         container.scrollTop = savedPosition;
+        requestAnimationFrame(() =>
+          requestAnimationFrame(() => {
+            programmaticScrollRef.current = false;
+          }),
+        );
       }
     });
   }, [activeAgentId, getScrollContainer]);
@@ -751,6 +761,145 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
   currentThreadIdRef.current = currentThreadId;
   // Keep resolvedThreadIdRef in sync with the resolved thread ID from useChatMessages
   resolvedThreadIdRef.current = currentThreadId || threadId;
+
+  // ==========================================================================
+  // Chat transcript scroll controller
+  // Reliable land-at-bottom that survives async content (charts/code/images)
+  // expanding after the initial scroll, plus a jump-to-latest affordance.
+  // See utils/scrollHelpers.
+  // ==========================================================================
+
+  // "Near bottom" trackers (used by streaming follow + the pin controller).
+  const isNearBottomRef = useRef(true);
+  const isSubagentNearBottomRef = useRef(true);
+
+  // Pin controller state.
+  type PinTarget = { mode: 'bottom' };
+  const pinTargetRef = useRef<PinTarget | null>(null);
+  const programmaticScrollRef = useRef(false);
+  const settleQuietTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const settleHardCapRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reapplyRafRef = useRef<number | null>(null);
+  const restoredForThreadRef = useRef<string | null>(null);
+
+  // Jump-to-latest pill.
+  const messagesLenRef = useRef(0);
+  messagesLenRef.current = messages.length;
+  const pillBaselineLenRef = useRef(0);
+  const [jumpPill, setJumpPill] = useState<{ visible: boolean; hasNew: boolean; newCount: number }>({
+    visible: false,
+    hasNew: false,
+    newCount: 0,
+  });
+  const setPillState = useCallback((next: { visible: boolean; hasNew: boolean; newCount: number }) => {
+    setJumpPill((prev) =>
+      prev.visible === next.visible && prev.hasNew === next.hasNew && prev.newCount === next.newCount
+        ? prev
+        : next,
+    );
+  }, []);
+  const userMsgCount = useMemo(
+    () => (messages as Array<{ role?: string }>).filter((m) => m?.role === 'user').length,
+    [messages],
+  );
+
+  // Wrap a programmatic scroll so the scroll listener doesn't mistake it for a
+  // user scroll (which cancels the pin). Smooth scrolls clear on `scrollend`
+  // (600ms fallback for engines without it); instant clears after the scroll
+  // event flushes (double rAF).
+  const withProgrammaticScroll = useCallback(
+    (fn: () => void, behavior: 'auto' | 'smooth' = 'auto') => {
+      programmaticScrollRef.current = true;
+      fn();
+      if (behavior === 'smooth') {
+        const c = getScrollContainer(scrollAreaRef);
+        let cleared = false;
+        const clear = () => {
+          if (cleared) return;
+          cleared = true;
+          c?.removeEventListener('scrollend', clear);
+          programmaticScrollRef.current = false;
+        };
+        c?.addEventListener('scrollend', clear, { once: true });
+        setTimeout(clear, 600);
+      } else {
+        requestAnimationFrame(() =>
+          requestAnimationFrame(() => {
+            programmaticScrollRef.current = false;
+          }),
+        );
+      }
+    },
+    [getScrollContainer],
+  );
+
+  // The growing content node inside the fixed-height Radix viewport. The viewport
+  // height is fixed (h-full); only its content grows as async media expands, so
+  // that is what the ResizeObserver must watch.
+  const getScrollContent = useCallback(
+    (c: HTMLElement): HTMLElement =>
+      c.querySelector<HTMLElement>('.max-w-3xl') ?? (c.firstElementChild as HTMLElement) ?? c,
+    [],
+  );
+
+  const clearSettleTimers = useCallback(() => {
+    if (settleQuietTimerRef.current) {
+      clearTimeout(settleQuietTimerRef.current);
+      settleQuietTimerRef.current = null;
+    }
+    if (settleHardCapRef.current) {
+      clearTimeout(settleHardCapRef.current);
+      settleHardCapRef.current = null;
+    }
+  }, []);
+
+  // Arm the settle window: re-pin while content keeps growing, give up after a
+  // 1.5s quiet window (reset on each settle resize) or an 8s hard cap.
+  const armSettleTimers = useCallback(() => {
+    if (settleQuietTimerRef.current) clearTimeout(settleQuietTimerRef.current);
+    settleQuietTimerRef.current = setTimeout(() => {
+      pinTargetRef.current = null;
+      settleQuietTimerRef.current = null;
+    }, 1500);
+    if (!settleHardCapRef.current) {
+      settleHardCapRef.current = setTimeout(() => {
+        pinTargetRef.current = null;
+        settleHardCapRef.current = null;
+        if (settleQuietTimerRef.current) {
+          clearTimeout(settleQuietTimerRef.current);
+          settleQuietTimerRef.current = null;
+        }
+      }, 8000);
+    }
+  }, []);
+
+  const pinToBottom = useCallback(
+    (behavior: 'auto' | 'smooth' = 'auto') => {
+      const c = getScrollContainer(scrollAreaRef);
+      if (!c) return;
+      pinTargetRef.current = { mode: 'bottom' };
+      isNearBottomRef.current = true;
+      pillBaselineLenRef.current = messagesLenRef.current;
+      setPillState({ visible: false, hasNew: false, newCount: 0 });
+      withProgrammaticScroll(() => c.scrollTo({ top: c.scrollHeight, behavior }), behavior);
+      armSettleTimers();
+    },
+    [getScrollContainer, withProgrammaticScroll, armSettleTimers, setPillState],
+  );
+
+  // Re-apply the bottom pin (rAF-coalesced); called by the ResizeObserver each
+  // time content settles, so async media finishing layout can't strand the user
+  // mid-thread.
+  const reapplyPin = useCallback(() => {
+    if (reapplyRafRef.current != null) return;
+    reapplyRafRef.current = requestAnimationFrame(() => {
+      reapplyRafRef.current = null;
+      const c = getScrollContainer(scrollAreaRef);
+      if (!pinTargetRef.current || !c) return;
+      withProgrammaticScroll(() => c.scrollTo({ top: c.scrollHeight }), 'auto');
+      armSettleTimers();
+    });
+  }, [getScrollContainer, withProgrammaticScroll, armSettleTimers]);
 
   // Copy-a-link to an HTML report opens a consent chooser; the actual copy runs
   // in one of the two handlers below depending on the user's pick.
@@ -1678,8 +1827,8 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     if ((e.target as HTMLElement).closest('button, a')) return;
     const ref = activeAgentId === 'main' ? scrollAreaRef : subagentScrollAreaRef;
     const container = getScrollContainer(ref);
-    container?.scrollTo({ top: 0, behavior: 'smooth' });
-  }, [isMobile, activeAgentId, getScrollContainer]);
+    if (container) withProgrammaticScroll(() => container.scrollTo({ top: 0, behavior: 'smooth' }), 'smooth');
+  }, [isMobile, activeAgentId, getScrollContainer, withProgrammaticScroll]);
 
   // Pin toggle: pin docks the panel open (persisted); unpin returns to hover mode.
   const handleTogglePin = useCallback(() => {
@@ -1973,50 +2122,100 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     navigate(location.pathname, { replace: true, state: { ...navState, widgetSnapshots: undefined } });
   }, [location.state, location.pathname, navigate]);
 
-  // Smart auto-scroll: only scroll to bottom when user is already near the bottom
-  const isNearBottomRef = useRef(true);
-  const isSubagentNearBottomRef = useRef(true);
-
-  // Attach scroll listener to detect user scroll position
-  // Re-attaches when activeAgentId changes (ScrollArea remounts on tab switch)
+  // Scroll listener + settle-aware ResizeObserver.
+  // Re-attaches when activeAgentId changes (ScrollArea remounts on tab switch).
   useEffect(() => {
     const isMain = activeAgentId === 'main';
     const ref = isMain ? scrollAreaRef : subagentScrollAreaRef;
     const nearBottomRef = isMain ? isNearBottomRef : isSubagentNearBottomRef;
-
-    if (!ref.current) return;
-    const scrollContainer = ref.current.querySelector('[data-radix-scroll-area-viewport]') ||
-                           ref.current.querySelector('.overflow-auto') ||
-                           ref.current;
-    if (!scrollContainer) return;
+    const c = getScrollContainer(ref);
+    if (!c) return;
 
     // Reset to near-bottom when switching tabs
     nearBottomRef.current = true;
 
     const handleScroll = () => {
-      const threshold = 120;
-      const { scrollTop, scrollHeight, clientHeight } = scrollContainer;
-      nearBottomRef.current = scrollHeight - scrollTop - clientHeight < threshold;
+      nearBottomRef.current = isNearBottom(
+        { scrollTop: c.scrollTop, scrollHeight: c.scrollHeight, clientHeight: c.clientHeight },
+        120,
+      );
+      if (!isMain) return;
+      if (programmaticScrollRef.current) return; // ignore our own scrolls
+      // A genuine user scroll takes control away from the pin controller.
+      pinTargetRef.current = null;
+      clearSettleTimers();
+      // Update jump-to-latest pill.
+      const atBottom = nearBottomRef.current;
+      setJumpPill((prev) => {
+        if (atBottom) {
+          return prev.visible || prev.hasNew ? { visible: false, hasNew: false, newCount: 0 } : prev;
+        }
+        if (prev.visible) return prev; // keep hasNew/newCount once shown
+        pillBaselineLenRef.current = messagesLenRef.current;
+        return { visible: true, hasNew: false, newCount: 0 };
+      });
     };
+    c.addEventListener('scroll', handleScroll, { passive: true });
 
-    scrollContainer.addEventListener('scroll', handleScroll, { passive: true });
-    return () => scrollContainer.removeEventListener('scroll', handleScroll);
-  }, [activeAgentId]);
-
-  // Auto-scroll main chat to bottom when messages change, but only if user is near the bottom
-  useEffect(() => {
-    if (!isNearBottomRef.current) return;
-    if (!scrollAreaRef.current) return;
-
-    const scrollContainer = scrollAreaRef.current.querySelector('[data-radix-scroll-area-viewport]') ||
-                           scrollAreaRef.current.querySelector('.overflow-auto') ||
-                           scrollAreaRef.current;
-    if (scrollContainer) {
-      setTimeout(() => {
-        scrollContainer.scrollTo({ top: scrollContainer.scrollHeight, behavior: 'smooth' });
-      }, 0);
+    // While a pin target is set, re-apply it whenever the transcript grows
+    // (charts/code/images finishing layout) — the fix for landing mid-thread.
+    let ro: ResizeObserver | null = null;
+    if (isMain) {
+      ro = new ResizeObserver(() => {
+        if (pinTargetRef.current) reapplyPin();
+      });
+      ro.observe(getScrollContent(c));
     }
-  }, [messages]);
+    return () => {
+      c.removeEventListener('scroll', handleScroll);
+      ro?.disconnect();
+      if (reapplyRafRef.current != null) {
+        cancelAnimationFrame(reapplyRafRef.current);
+        reapplyRafRef.current = null;
+      }
+    };
+  }, [activeAgentId, getScrollContainer, getScrollContent, reapplyPin, clearSettleTimers]);
+
+  // Auto-scroll main chat to bottom when messages change, but only if the user is
+  // near the bottom and the pin controller isn't currently owning the scroll.
+  useEffect(() => {
+    if (pinTargetRef.current) return; // pin controller owns scroll during settle
+    if (!isNearBottomRef.current) {
+      // User is reading earlier turns — surface "N new" instead of yanking them down.
+      const delta = messagesLenRef.current - pillBaselineLenRef.current;
+      if (delta > 0) {
+        setJumpPill((prev) => (prev.visible ? { visible: true, hasNew: true, newCount: delta } : prev));
+      }
+      return;
+    }
+    const c = getScrollContainer(scrollAreaRef);
+    if (!c) return;
+    setTimeout(() => {
+      c.scrollTo({ top: c.scrollHeight, behavior: 'smooth' });
+    }, 0);
+  }, [messages, getScrollContainer]);
+
+  // Thread-entry restore — the core fix. Fires on the real "history is present"
+  // signal (isLoadingHistory flips false), not on an empty/partial list, then
+  // pins to bottom through the async settle window.
+  useEffect(() => {
+    if (!isActive) return;
+    const tid = currentThreadId || threadId;
+    if (!tid || tid === '__default__') return;
+    if (isLoadingHistory) return;
+    if (restoredForThreadRef.current === tid) return;
+    restoredForThreadRef.current = tid;
+    requestAnimationFrame(() => pinToBottom('auto'));
+  }, [isActive, isLoadingHistory, currentThreadId, threadId, pinToBottom]);
+
+  // Cleanup pending scroll timers/rAF on unmount.
+  useEffect(() => {
+    return () => {
+      if (settleQuietTimerRef.current) clearTimeout(settleQuietTimerRef.current);
+      if (settleHardCapRef.current) clearTimeout(settleHardCapRef.current);
+      if (reapplyRafRef.current != null) cancelAnimationFrame(reapplyRafRef.current);
+    };
+  }, []);
 
   // Drain the announcement queue one item at a time. Each announcement is
   // displayed for 1500ms, followed by ~80ms of silence before the next so
@@ -2131,16 +2330,19 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
       // Skip slide-in animation if inheriting open state
       if (wantNavVisible) skipNavAnimRef.current = true;
 
+      const tidNow = currentThreadId || threadId;
       requestAnimationFrame(() => {
         if (wantNavVisible) skipNavAnimRef.current = false;
-        const container = getScrollContainer(scrollAreaRef);
-        if (container) {
-          container.scrollTo({ top: container.scrollHeight });
+        // First-mount restore is owned by the entry-restore effect. Here we only
+        // catch up a cached re-entry to the bottom if the user left it at bottom;
+        // otherwise the DOM scroll position preserved under display:none stands.
+        if (restoredForThreadRef.current === tidNow && isNearBottomRef.current) {
+          pinToBottom('auto');
         }
       });
     }
     prevIsActiveRef.current = isActive;
-  }, [isActive, getScrollContainer]);
+  }, [isActive, getScrollContainer, currentThreadId, threadId, pinToBottom]);
 
   // Early return if workspaceId or threadId is missing
   if (!workspaceId || !threadId) {
@@ -2561,6 +2763,17 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
                 <ChatMinimap
                   messages={messages as unknown as MessageRecord[]}
                   scrollAreaRef={scrollAreaRef}
+                />
+              )}
+              {/* Jump-to-latest pill — shown only when the minimap isn't (mobile,
+                  right panel open, or <2 user messages); the minimap's Bottom
+                  button covers the desktop case so exactly one affordance shows. */}
+              {activeAgentId === 'main' && (isMobile || !!rightPanelType || userMsgCount < 2) && (
+                <JumpToLatestPill
+                  visible={jumpPill.visible}
+                  hasNew={jumpPill.hasNew}
+                  newCount={jumpPill.newCount}
+                  onJump={() => pinToBottom('smooth')}
                 />
               )}
             </div>

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -328,6 +328,14 @@ function SubagentStatusIndicator({ status, currentTool, toolCalls = 0, messages 
   );
 }
 
+// Scroll/pin tuning. Distance from the bottom (px) still counted as "at bottom";
+// settle window the pin re-applies through as async media expands; fallback for
+// engines without a `scrollend` event.
+const NEAR_BOTTOM_PX = 120;
+const SETTLE_QUIET_MS = 1500;
+const SETTLE_HARD_CAP_MS = 8000;
+const SCROLLEND_FALLBACK_MS = 600;
+
 function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName: initialWorkspaceName, isActive = true, onThreadResolved, warmingState = false }: ChatViewProps): React.ReactElement | null {
   const { t } = useTranslation();
   const isMobile = useIsMobile();
@@ -781,6 +789,11 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
   const settleHardCapRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reapplyRafRef = useRef<number | null>(null);
   const restoredForThreadRef = useRef<string | null>(null);
+  // Streaming auto-follow's deferred scroll, and the entry-restore frame —
+  // tracked so a thread switch / unmount cancels a pending scroll instead of
+  // yanking a now-stale view.
+  const streamFollowTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const entryRestoreRafRef = useRef<number | null>(null);
 
   // Jump-to-latest pill.
   const messagesLenRef = useRef(0);
@@ -821,7 +834,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
           programmaticScrollRef.current = false;
         };
         c?.addEventListener('scrollend', clear, { once: true });
-        setTimeout(clear, 600);
+        setTimeout(clear, SCROLLEND_FALLBACK_MS);
       } else {
         requestAnimationFrame(() =>
           requestAnimationFrame(() => {
@@ -860,7 +873,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     settleQuietTimerRef.current = setTimeout(() => {
       pinTargetRef.current = null;
       settleQuietTimerRef.current = null;
-    }, 1500);
+    }, SETTLE_QUIET_MS);
     if (!settleHardCapRef.current) {
       settleHardCapRef.current = setTimeout(() => {
         pinTargetRef.current = null;
@@ -869,7 +882,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
           clearTimeout(settleQuietTimerRef.current);
           settleQuietTimerRef.current = null;
         }
-      }, 8000);
+      }, SETTLE_HARD_CAP_MS);
     }
   }, []);
 
@@ -2137,7 +2150,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     const handleScroll = () => {
       nearBottomRef.current = isNearBottom(
         { scrollTop: c.scrollTop, scrollHeight: c.scrollHeight, clientHeight: c.clientHeight },
-        120,
+        NEAR_BOTTOM_PX,
       );
       if (!isMain) return;
       if (programmaticScrollRef.current) return; // ignore our own scrolls
@@ -2157,6 +2170,18 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     };
     c.addEventListener('scroll', handleScroll, { passive: true });
 
+    // A real user gesture (wheel / touch) reclaims scroll control even mid
+    // programmatic smooth-scroll. Without this, those scroll events are flagged
+    // programmatic and ignored above, so the pin keeps yanking against the user.
+    const handleUserIntent = () => {
+      if (!isMain) return;
+      programmaticScrollRef.current = false;
+      pinTargetRef.current = null;
+      clearSettleTimers();
+    };
+    c.addEventListener('wheel', handleUserIntent, { passive: true });
+    c.addEventListener('touchstart', handleUserIntent, { passive: true });
+
     // While a pin target is set, re-apply it whenever the transcript grows
     // (charts/code/images finishing layout) — the fix for landing mid-thread.
     let ro: ResizeObserver | null = null;
@@ -2168,6 +2193,8 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     }
     return () => {
       c.removeEventListener('scroll', handleScroll);
+      c.removeEventListener('wheel', handleUserIntent);
+      c.removeEventListener('touchstart', handleUserIntent);
       ro?.disconnect();
       if (reapplyRafRef.current != null) {
         cancelAnimationFrame(reapplyRafRef.current);
@@ -2190,10 +2217,24 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     }
     const c = getScrollContainer(scrollAreaRef);
     if (!c) return;
-    setTimeout(() => {
-      c.scrollTo({ top: c.scrollHeight, behavior: 'smooth' });
+    if (streamFollowTimerRef.current) clearTimeout(streamFollowTimerRef.current);
+    streamFollowTimerRef.current = setTimeout(() => {
+      streamFollowTimerRef.current = null;
+      // Re-check at fire time: if a pin took over or the user scrolled up
+      // between scheduling and firing, do not yank them to the bottom. Wrap as
+      // programmatic so this scroll isn't misread as the user scrolling away.
+      if (pinTargetRef.current || !isNearBottomRef.current) return;
+      const el = getScrollContainer(scrollAreaRef);
+      if (!el) return;
+      withProgrammaticScroll(() => el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' }), 'smooth');
     }, 0);
-  }, [messages, getScrollContainer]);
+    return () => {
+      if (streamFollowTimerRef.current) {
+        clearTimeout(streamFollowTimerRef.current);
+        streamFollowTimerRef.current = null;
+      }
+    };
+  }, [messages, getScrollContainer, withProgrammaticScroll]);
 
   // Thread-entry restore — the core fix. Fires on the real "history is present"
   // signal (isLoadingHistory flips false), not on an empty/partial list, then
@@ -2205,7 +2246,18 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     if (isLoadingHistory) return;
     if (restoredForThreadRef.current === tid) return;
     restoredForThreadRef.current = tid;
-    requestAnimationFrame(() => pinToBottom('auto'));
+    entryRestoreRafRef.current = requestAnimationFrame(() => {
+      entryRestoreRafRef.current = null;
+      // The instance may have gone inactive (cached/hidden) before this frame.
+      if (!isActiveRef.current) return;
+      pinToBottom('auto');
+    });
+    return () => {
+      if (entryRestoreRafRef.current != null) {
+        cancelAnimationFrame(entryRestoreRafRef.current);
+        entryRestoreRafRef.current = null;
+      }
+    };
   }, [isActive, isLoadingHistory, currentThreadId, threadId, pinToBottom]);
 
   // Cleanup pending scroll timers/rAF on unmount.
@@ -2214,6 +2266,8 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
       if (settleQuietTimerRef.current) clearTimeout(settleQuietTimerRef.current);
       if (settleHardCapRef.current) clearTimeout(settleHardCapRef.current);
       if (reapplyRafRef.current != null) cancelAnimationFrame(reapplyRafRef.current);
+      if (streamFollowTimerRef.current) clearTimeout(streamFollowTimerRef.current);
+      if (entryRestoreRafRef.current != null) cancelAnimationFrame(entryRestoreRafRef.current);
     };
   }, []);
 
@@ -2590,6 +2644,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
                         </button>
                       </>
                     }
+                    isActive={isActive}
                     workspaces={navWorkspaces}
                     workspaceThreads={navWorkspaceThreads}
                     currentWorkspaceId={workspaceId}

--- a/web/src/pages/ChatAgent/components/JumpToLatestPill.css
+++ b/web/src/pages/ChatAgent/components/JumpToLatestPill.css
@@ -1,0 +1,58 @@
+.jump-to-latest-pill {
+  position: absolute;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 20;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  background: var(--color-bg-card, #ffffff);
+  border: 1px solid var(--color-border-elevated, rgba(20, 20, 23, 0.14));
+  border-radius: 999px;
+  font-size: 12px;
+  color: var(--color-text-primary, #1a1a1c);
+  cursor: pointer;
+  box-shadow:
+    0 16px 32px -10px rgba(20, 20, 23, 0.16),
+    0 4px 8px -4px rgba(20, 20, 23, 0.08);
+  transition:
+    transform 180ms cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow 180ms cubic-bezier(0.16, 1, 0.3, 1),
+    border-color 180ms ease;
+  animation: jumpPillIn 220ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.jump-to-latest-pill:hover {
+  transform: translateX(-50%) translateY(-1px);
+  border-color: var(--color-accent-primary, #b88a2c);
+  box-shadow:
+    0 22px 40px -10px rgba(20, 20, 23, 0.18),
+    0 6px 12px -4px rgba(20, 20, 23, 0.10);
+}
+
+.jump-to-latest-pill:focus-visible {
+  outline: 2px solid var(--color-accent-primary, #b88a2c);
+  outline-offset: 2px;
+}
+
+.jump-to-latest-pill__count {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--color-accent-primary, #b88a2c);
+}
+
+@keyframes jumpPillIn {
+  from { opacity: 0; transform: translateX(-50%) translateY(8px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .jump-to-latest-pill {
+    animation: none;
+    transition: none;
+  }
+  .jump-to-latest-pill:hover {
+    transform: translateX(-50%);
+  }
+}

--- a/web/src/pages/ChatAgent/components/JumpToLatestPill.css
+++ b/web/src/pages/ChatAgent/components/JumpToLatestPill.css
@@ -6,41 +6,42 @@
   z-index: 20;
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 6px;
-  padding: 6px 14px;
-  background: var(--color-bg-card, #ffffff);
-  border: 1px solid var(--color-border-elevated, rgba(20, 20, 23, 0.14));
+  /* 44px tall = a comfortable touch target (WCAG 2.5.5). */
+  min-height: 44px;
+  padding: 0 18px;
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border-elevated);
   border-radius: 999px;
-  font-size: 12px;
-  color: var(--color-text-primary, #1a1a1c);
+  font-size: 13px;
+  color: var(--color-text-primary);
   cursor: pointer;
-  box-shadow:
-    0 16px 32px -10px rgba(20, 20, 23, 0.16),
-    0 4px 8px -4px rgba(20, 20, 23, 0.08);
+  /* Theme-aware token (strong on the dark default, soft on light) — a hardcoded
+     near-black shadow was invisible against the dark theme's near-black bg. */
+  box-shadow: var(--shadow-card);
   transition:
     transform 180ms cubic-bezier(0.16, 1, 0.3, 1),
-    box-shadow 180ms cubic-bezier(0.16, 1, 0.3, 1),
     border-color 180ms ease;
   animation: jumpPillIn 220ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .jump-to-latest-pill:hover {
   transform: translateX(-50%) translateY(-1px);
-  border-color: var(--color-accent-primary, #b88a2c);
-  box-shadow:
-    0 22px 40px -10px rgba(20, 20, 23, 0.18),
-    0 6px 12px -4px rgba(20, 20, 23, 0.10);
+  border-color: var(--color-accent-primary);
 }
 
 .jump-to-latest-pill:focus-visible {
-  outline: 2px solid var(--color-accent-primary, #b88a2c);
+  outline: 2px solid var(--color-accent-primary);
   outline-offset: 2px;
 }
 
 .jump-to-latest-pill__count {
-  font-weight: 600;
+  /* Text-primary (not accent): the blue accent fails AA contrast on the dark
+     near-black pill; bold tabular text-primary is legible in both themes. */
+  font-weight: 700;
   font-variant-numeric: tabular-nums;
-  color: var(--color-accent-primary, #b88a2c);
+  color: var(--color-text-primary);
 }
 
 @keyframes jumpPillIn {

--- a/web/src/pages/ChatAgent/components/JumpToLatestPill.tsx
+++ b/web/src/pages/ChatAgent/components/JumpToLatestPill.tsx
@@ -1,0 +1,42 @@
+import { useTranslation } from 'react-i18next';
+import { ArrowDown } from 'lucide-react';
+import './JumpToLatestPill.css';
+
+interface JumpToLatestPillProps {
+  /** Whether the user is scrolled up far enough to warrant the affordance. */
+  visible: boolean;
+  /** New messages arrived below the fold while scrolled up. */
+  hasNew: boolean;
+  /** Count of new messages since the user last scrolled up (only shown when hasNew). */
+  newCount?: number;
+  onJump: () => void;
+}
+
+/**
+ * Floating "jump to latest" affordance shown when the user has scrolled up.
+ * Switches to a "N new" style when messages arrive below the fold. Purely
+ * presentational — all scroll logic lives in ChatView.
+ */
+export default function JumpToLatestPill({ visible, hasNew, newCount = 0, onJump }: JumpToLatestPillProps) {
+  const { t } = useTranslation();
+  if (!visible) return null;
+
+  const showCount = hasNew && newCount > 0;
+
+  return (
+    <button
+      type="button"
+      className="jump-to-latest-pill"
+      onClick={onJump}
+      aria-label={t('chat.jumpToLatest.aria', { defaultValue: 'Scroll to latest message' })}
+    >
+      {showCount && <span className="jump-to-latest-pill__count">{newCount}</span>}
+      <span>
+        {showCount
+          ? t('chat.jumpToLatest.newSuffix', { defaultValue: 'new' })
+          : t('chat.jumpToLatest.label', { defaultValue: 'Jump to latest' })}
+      </span>
+      <ArrowDown className="h-3.5 w-3.5" />
+    </button>
+  );
+}

--- a/web/src/pages/ChatAgent/components/NavigationPanel.tsx
+++ b/web/src/pages/ChatAgent/components/NavigationPanel.tsx
@@ -226,11 +226,14 @@ function NavigationPanel({
   }, [isActive, currentWorkspaceId, currentThreadId, workspaces, workspaceThreads, onLoadMoreThreads]);
 
   const toggleWorkspace = useCallback((wsId: string) => {
+    // Capture pre-toggle state: only an *expand* should lazy-load threads.
+    const wasExpanded = expandedWorkspaces.has(wsId);
     // Routed through the store so every collapse is traceable in one place.
     toggleWorkspaceExpansion(wsId);
-    // Lazy-load threads when expanding -- expandWorkspace is a no-op when data is
-    // already cached, so calling unconditionally is safe.
-    expandWorkspace(wsId);
+    // Lazy-load threads only when opening. expandWorkspace is a no-op when data
+    // is already cached, but the shared store is capped and can evict a list, so
+    // calling it on a collapse would fire a needless re-fetch.
+    if (!wasExpanded) expandWorkspace(wsId);
   }, [expandWorkspace]);
 
   const toggleThread = useCallback((threadId: string) => {

--- a/web/src/pages/ChatAgent/components/NavigationPanel.tsx
+++ b/web/src/pages/ChatAgent/components/NavigationPanel.tsx
@@ -19,6 +19,7 @@ import {
   subscribeNavExpansion,
   getNavExpansionVersion,
   toggleWorkspaceExpansion,
+  toggleThreadExpansion,
 } from './navExpansionStore';
 import './NavigationPanel.css';
 
@@ -237,12 +238,7 @@ function NavigationPanel({
   }, [expandWorkspace]);
 
   const toggleThread = useCallback((threadId: string) => {
-    if (expandedThreads.has(threadId)) {
-      expandedThreads.delete(threadId);
-    } else {
-      expandedThreads.add(threadId);
-    }
-    notifyNavExpansion();
+    toggleThreadExpansion(threadId);
   }, []);
 
   // Inline workspace rename — the name span becomes a text input while editing.

--- a/web/src/pages/ChatAgent/components/NavigationPanel.tsx
+++ b/web/src/pages/ChatAgent/components/NavigationPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useRef } from 'react';
+import React, { useState, useCallback, useRef, useSyncExternalStore } from 'react';
 import { useTranslation } from 'react-i18next';
 import { motion, AnimatePresence } from 'framer-motion';
 import { DndContext, DragOverlay, closestCenter, PointerSensor, MeasuringStrategy, useSensor, useSensors } from '@dnd-kit/core';
@@ -12,6 +12,14 @@ import {
 import { ScrollArea } from '../../../components/ui/scroll-area';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '../../../components/ui/dropdown-menu';
 import { useIsMobile } from '@/hooks/useIsMobile';
+import {
+  expandedWorkspaces,
+  expandedThreads,
+  notifyNavExpansion,
+  subscribeNavExpansion,
+  getNavExpansionVersion,
+  toggleWorkspaceExpansion,
+} from './navExpansionStore';
 import './NavigationPanel.css';
 
 interface WorkspaceEntry {
@@ -108,30 +116,24 @@ function SortableWorkspace({ wsId, disabled, children }: {
   );
 }
 
+// Cap on how many extra thread pages the active-thread auto-reveal will fetch
+// before giving up: covers a genuinely deep thread while bounding a stale or
+// deleted id that would otherwise page through the whole workspace.
+const MAX_REVEAL_PAGES = 20;
+
 /**
  * NavigationPanel -- hover-triggered overlay sidebar showing
  * Workspace -> Thread -> Agent hierarchy.
  *
  * Follows the collapsible tree pattern from FilePanel's DirectoryNode:
  * ChevronRight/Down toggles, indented rows, Lucide icons throughout.
+ *
+ * Expansion state lives in ./navExpansionStore (a globalThis-anchored module)
+ * so it's shared across every cached panel instance and survives HMR. Keeping
+ * it out of this file lets NavigationPanel export only its component, so Fast
+ * Refresh hot-swaps cleanly instead of forcing full reloads that could split
+ * the module state and make folders appear to auto-collapse on thread switch.
  */
-// Expansion state shared across panel instances (one mounts per cached
-// ChatView), so user-opened folders survive thread switches within a session.
-const _expandedWorkspaces = new Set<string>();
-const _expandedThreads = new Set<string>();
-
-export function resetNavPanelExpansion() {
-  _expandedWorkspaces.clear();
-  _expandedThreads.clear();
-}
-
-// Forget a deleted workspace so the mount-effect doesn't re-expand it (and fire
-// a spurious threads 404) on the next panel remount. Only deletion is a safe
-// prune signal — `workspaces` is a paged/limited slice, so absence there can
-// mean "scrolled out", not "gone".
-export function forgetNavPanelExpansion(workspaceId: string) {
-  _expandedWorkspaces.delete(workspaceId);
-}
 
 function NavigationPanel({
   workspaces,
@@ -160,73 +162,81 @@ function NavigationPanel({
   const dndSensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
   // Id of the workspace currently being dragged — drives the DragOverlay chip.
   const [activeDragId, setActiveDragId] = useState<string | null>(null);
-  // Expanded workspaces/threads. Backed by module-level sets because one
-  // NavigationPanel mounts per cached ChatView instance — without them, every
-  // thread switch would remount the panel and collapse the folders the user
-  // opened. Current workspace/thread are expanded by default. Resets on reload.
-  const [expandedWorkspaces, setExpandedWorkspaces] = useState<Set<string>>(() => {
-    if (currentWorkspaceId) _expandedWorkspaces.add(currentWorkspaceId);
-    return new Set(_expandedWorkspaces);
-  });
-  const [expandedThreads, setExpandedThreads] = useState<Set<string>>(() => {
-    if (currentThreadId && currentThreadId !== '__default__') _expandedThreads.add(currentThreadId);
-    return new Set(_expandedThreads);
-  });
+  // Subscribe to the shared expansion store (navExpansionStore). One panel mounts
+  // per cached ChatView instance; subscribing re-renders this panel whenever any
+  // instance toggles a folder, so cached ChatViews never show stale folder state.
+  // The render reads the sets directly (below), so only the subscription is
+  // needed, not the returned version value.
+  useSyncExternalStore(subscribeNavExpansion, getNavExpansionVersion);
 
-  // Repopulate thread lists for folders that were already open — the thread
-  // data lives in per-instance hook state, so a fresh mount must re-request it
-  // (served from the React Query cache when warm).
-  React.useEffect(() => {
-    _expandedWorkspaces.forEach((wsId) => expandWorkspace(wsId));
-    // Mount-only: expandWorkspace is stable and re-running on its identity churn would be redundant.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  // Seed the current workspace/thread as expanded on first mount so they render
+  // open on first paint (no flicker); the effects below broadcast to other panels.
+  const seededRef = useRef(false);
+  if (!seededRef.current) {
+    seededRef.current = true;
+    if (currentWorkspaceId) expandedWorkspaces.add(currentWorkspaceId);
+    if (currentThreadId && currentThreadId !== '__default__') expandedThreads.add(currentThreadId);
+  }
 
   // Keep current workspace and thread expanded when they change
   React.useEffect(() => {
     if (currentWorkspaceId) {
-      _expandedWorkspaces.add(currentWorkspaceId);
-      setExpandedWorkspaces((prev) => {
-        if (prev.has(currentWorkspaceId)) return prev;
-        const next = new Set(prev);
-        next.add(currentWorkspaceId);
-        return next;
-      });
+      if (!expandedWorkspaces.has(currentWorkspaceId)) {
+        expandedWorkspaces.add(currentWorkspaceId);
+        notifyNavExpansion();
+      }
       expandWorkspace(currentWorkspaceId);
     }
   }, [currentWorkspaceId, expandWorkspace]);
 
   React.useEffect(() => {
-    if (currentThreadId && currentThreadId !== '__default__') {
-      _expandedThreads.add(currentThreadId);
-      setExpandedThreads((prev) => {
-        if (prev.has(currentThreadId)) return prev;
-        const next = new Set(prev);
-        next.add(currentThreadId);
-        return next;
-      });
+    if (currentThreadId && currentThreadId !== '__default__' && !expandedThreads.has(currentThreadId)) {
+      expandedThreads.add(currentThreadId);
+      notifyNavExpansion();
     }
   }, [currentThreadId]);
 
+  // Auto-reveal the active thread when it lives beyond the first page. A thread
+  // you open can sit inside the collapsed "Show more" tail (it's older than the
+  // first page of recents), which would leave it highlighted-but-hidden. Page in
+  // successive batches until it surfaces so the open folder always holds the
+  // current thread — re-runs as each page lands, walking the tail. Skipped for
+  // flash (capped at 3, no "Show more") and bounded by MAX_REVEAL_PAGES.
+  const revealAttemptRef = useRef<{ key: string; pages: number }>({ key: '', pages: 0 });
+  React.useEffect(() => {
+    if (!onLoadMoreThreads || !currentWorkspaceId) return;
+    if (!currentThreadId || currentThreadId === '__default__') return;
+    if (!expandedWorkspaces.has(currentWorkspaceId)) return;
+    const currentWs = workspaces.find((ws) => ws.workspace_id === currentWorkspaceId);
+    if (!currentWs || currentWs.status === 'flash') return;
+    const data = workspaceThreads[currentWorkspaceId];
+    if (!data || data.loading) return;
+    const loaded = data.threads || [];
+    if (loaded.some((thr) => thr.thread_id === currentThreadId)) return; // already visible
+    if (typeof data.total !== 'number' || loaded.length >= data.total) return; // nothing more to page
+
+    const key = `${currentWorkspaceId}:${currentThreadId}`;
+    if (revealAttemptRef.current.key !== key) revealAttemptRef.current = { key, pages: 0 };
+    if (revealAttemptRef.current.pages >= MAX_REVEAL_PAGES) return; // give up — leave "Show more" for manual paging
+    revealAttemptRef.current.pages += 1;
+    onLoadMoreThreads(currentWorkspaceId);
+  }, [currentWorkspaceId, currentThreadId, workspaces, workspaceThreads, onLoadMoreThreads]);
+
   const toggleWorkspace = useCallback((wsId: string) => {
-    if (_expandedWorkspaces.has(wsId)) {
-      _expandedWorkspaces.delete(wsId);
-    } else {
-      _expandedWorkspaces.add(wsId);
-    }
-    setExpandedWorkspaces(new Set(_expandedWorkspaces));
-    // Lazy-load threads when expanding -- called outside updater to avoid setState-during-render warning.
-    // expandWorkspace is a no-op when data is already cached, so calling unconditionally is safe.
+    // Routed through the store so every collapse is traceable in one place.
+    toggleWorkspaceExpansion(wsId);
+    // Lazy-load threads when expanding -- expandWorkspace is a no-op when data is
+    // already cached, so calling unconditionally is safe.
     expandWorkspace(wsId);
   }, [expandWorkspace]);
 
   const toggleThread = useCallback((threadId: string) => {
-    if (_expandedThreads.has(threadId)) {
-      _expandedThreads.delete(threadId);
+    if (expandedThreads.has(threadId)) {
+      expandedThreads.delete(threadId);
     } else {
-      _expandedThreads.add(threadId);
+      expandedThreads.add(threadId);
     }
-    setExpandedThreads(new Set(_expandedThreads));
+    notifyNavExpansion();
   }, []);
 
   // Inline workspace rename — the name span becomes a text input while editing.

--- a/web/src/pages/ChatAgent/components/NavigationPanel.tsx
+++ b/web/src/pages/ChatAgent/components/NavigationPanel.tsx
@@ -540,7 +540,9 @@ function NavigationPanel({
                                 const isMainAgent = agent.isMainAgent;
                                 const isSelected = activeAgentId === agent.id;
                                 const status = getAgentStatus(agent);
-                                const isActive = status === 'active';
+                                // Narrow agent-running flag; named distinctly from the
+                                // component's isActive prop (panel visibility) to avoid shadowing.
+                                const isAgentActive = status === 'active';
                                 const isCompleted = status === 'completed';
 
                                 const trimmedDescription = typeof agent.description === 'string' ? agent.description.trim() : '';
@@ -553,7 +555,7 @@ function NavigationPanel({
                                     key={agent.id}
                                     data-testid="agent-row"
                                     data-agent-role={isMainAgent ? 'main' : 'sub'}
-                                    className={`nav-panel-agent-row group ${isActive && !isMainAgent ? 'nav-panel-agent-pulse' : ''}${isSelected ? ' is-selected' : ''}`}
+                                    className={`nav-panel-agent-row group ${isAgentActive && !isMainAgent ? 'nav-panel-agent-pulse' : ''}${isSelected ? ' is-selected' : ''}`}
                                     style={{
                                       backgroundColor: isSelected ? 'var(--color-border-muted)' : undefined,
                                     }}
@@ -578,7 +580,7 @@ function NavigationPanel({
                                       <span className="flex-shrink-0 ml-auto flex items-center">
                                         {isCompleted ? (
                                           <Check className="h-3 w-3" style={{ color: 'var(--color-text-tertiary)' }} />
-                                        ) : isActive ? (
+                                        ) : isAgentActive ? (
                                           <Loader2 className="h-3 w-3 animate-spin" style={{ color: 'var(--color-text-tertiary)' }} />
                                         ) : (
                                           <Circle className="h-3 w-3" style={{ color: 'var(--color-icon-muted)' }} />

--- a/web/src/pages/ChatAgent/components/NavigationPanel.tsx
+++ b/web/src/pages/ChatAgent/components/NavigationPanel.tsx
@@ -61,6 +61,9 @@ interface AgentEntry {
 }
 
 interface NavigationPanelProps {
+  /** Whether this panel's host ChatView is the visible one. Up to 5 ChatViews
+   *  stay mounted (display:none); only the active one should auto-page threads. */
+  isActive?: boolean;
   workspaces: WorkspaceEntry[];
   workspaceThreads: Record<string, ThreadsData>;
   currentWorkspaceId?: string | null;
@@ -136,6 +139,7 @@ const MAX_REVEAL_PAGES = 20;
  */
 
 function NavigationPanel({
+  isActive = true,
   workspaces,
   workspaceThreads,
   currentWorkspaceId,
@@ -169,17 +173,12 @@ function NavigationPanel({
   // needed, not the returned version value.
   useSyncExternalStore(subscribeNavExpansion, getNavExpansionVersion);
 
-  // Seed the current workspace/thread as expanded on first mount so they render
-  // open on first paint (no flicker); the effects below broadcast to other panels.
-  const seededRef = useRef(false);
-  if (!seededRef.current) {
-    seededRef.current = true;
-    if (currentWorkspaceId) expandedWorkspaces.add(currentWorkspaceId);
-    if (currentThreadId && currentThreadId !== '__default__') expandedThreads.add(currentThreadId);
-  }
-
-  // Keep current workspace and thread expanded when they change
-  React.useEffect(() => {
+  // Seed the current workspace/thread as expanded, then keep them expanded when
+  // they change. A layout effect (not a render-phase mutation) runs before paint,
+  // so the folder still renders open on first paint with no flicker — but it goes
+  // through notifyNavExpansion, so the useSyncExternalStore version always tracks
+  // the Set contents (no torn snapshot across cached panels under React 19).
+  React.useLayoutEffect(() => {
     if (currentWorkspaceId) {
       if (!expandedWorkspaces.has(currentWorkspaceId)) {
         expandedWorkspaces.add(currentWorkspaceId);
@@ -189,7 +188,7 @@ function NavigationPanel({
     }
   }, [currentWorkspaceId, expandWorkspace]);
 
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     if (currentThreadId && currentThreadId !== '__default__' && !expandedThreads.has(currentThreadId)) {
       expandedThreads.add(currentThreadId);
       notifyNavExpansion();
@@ -204,6 +203,10 @@ function NavigationPanel({
   // flash (capped at 3, no "Show more") and bounded by MAX_REVEAL_PAGES.
   const revealAttemptRef = useRef<{ key: string; pages: number }>({ key: '', pages: 0 });
   React.useEffect(() => {
+    // Only the visible ChatView's panel pages threads. Up to 5 panels stay
+    // mounted under display:none; without this each could fire MAX_REVEAL_PAGES
+    // fetches for its own (hidden) current thread.
+    if (!isActive) return;
     if (!onLoadMoreThreads || !currentWorkspaceId) return;
     if (!currentThreadId || currentThreadId === '__default__') return;
     if (!expandedWorkspaces.has(currentWorkspaceId)) return;
@@ -220,7 +223,7 @@ function NavigationPanel({
     if (revealAttemptRef.current.pages >= MAX_REVEAL_PAGES) return; // give up — leave "Show more" for manual paging
     revealAttemptRef.current.pages += 1;
     onLoadMoreThreads(currentWorkspaceId);
-  }, [currentWorkspaceId, currentThreadId, workspaces, workspaceThreads, onLoadMoreThreads]);
+  }, [isActive, currentWorkspaceId, currentThreadId, workspaces, workspaceThreads, onLoadMoreThreads]);
 
   const toggleWorkspace = useCallback((wsId: string) => {
     // Routed through the store so every collapse is traceable in one place.

--- a/web/src/pages/ChatAgent/components/WorkspaceGallery.tsx
+++ b/web/src/pages/ChatAgent/components/WorkspaceGallery.tsx
@@ -18,8 +18,8 @@ import { queryKeys } from '../../../lib/queryKeys';
 import { createWorkspace, deleteWorkspace, getFlashWorkspace, updateWorkspace, reorderWorkspaces } from '../utils/api';
 import { removeStoredThreadId } from '../hooks/useChatMessages';
 import { clearAllMarketThreadsForWorkspace } from '../../MarketView/utils/threadPersistence';
-import { forgetNavPanelExpansion } from './NavigationPanel';
-import { forgetStableNavOrder } from '../hooks/useNavigationData';
+import { forgetNavPanelExpansion } from './navExpansionStore';
+import { forgetStableNavOrder, forgetSharedWorkspaceThreads } from '../hooks/useNavigationData';
 import { clearChatSession } from '../hooks/utils/chatSessionRestore';
 
 const DEFAULT_PAGE_SIZE = 8;
@@ -572,6 +572,7 @@ function WorkspaceGallery({ onWorkspaceSelect, prefetchThreads }: WorkspaceGalle
       // and clear its frozen-order entries so they don't linger all session.
       forgetNavPanelExpansion(workspaceId);
       forgetStableNavOrder(workspaceId);
+      forgetSharedWorkspaceThreads(workspaceId);
 
       // Invalidate workspace list cache
       queryClient.invalidateQueries({ queryKey: queryKeys.workspaces.lists() });

--- a/web/src/pages/ChatAgent/components/__tests__/JumpToLatestPill.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/JumpToLatestPill.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import JumpToLatestPill from '../JumpToLatestPill';
+
+// i18n in tests returns the defaultValue (with {{count}} interpolation) — assert
+// on stable substrings rather than exact translated copy.
+describe('JumpToLatestPill', () => {
+  it('renders nothing when not visible', () => {
+    const { container } = render(<JumpToLatestPill visible={false} hasNew={false} onJump={() => {}} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows the default label when visible without new messages', () => {
+    render(<JumpToLatestPill visible hasNew={false} onJump={() => {}} />);
+    expect(screen.getByRole('button')).toHaveTextContent(/jump to latest/i);
+  });
+
+  it('shows the new-message count when hasNew', () => {
+    render(<JumpToLatestPill visible hasNew newCount={3} onJump={() => {}} />);
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveTextContent('3');
+    expect(btn).toHaveTextContent(/new/i);
+  });
+
+  it('falls back to the default label when hasNew but count is 0', () => {
+    render(<JumpToLatestPill visible hasNew newCount={0} onJump={() => {}} />);
+    expect(screen.getByRole('button')).toHaveTextContent(/jump to latest/i);
+  });
+
+  it('calls onJump when clicked', () => {
+    const onJump = vi.fn();
+    render(<JumpToLatestPill visible hasNew={false} onJump={onJump} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(onJump).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes an accessible label', () => {
+    render(<JumpToLatestPill visible hasNew={false} onJump={() => {}} />);
+    expect(screen.getByRole('button')).toHaveAttribute('aria-label');
+  });
+});

--- a/web/src/pages/ChatAgent/components/__tests__/NavigationPanel.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/NavigationPanel.test.tsx
@@ -10,10 +10,11 @@
  */
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, within, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
-import NavigationPanel, { resetNavPanelExpansion, forgetNavPanelExpansion } from '../NavigationPanel';
+import NavigationPanel from '../NavigationPanel';
+import { resetNavPanelExpansion, forgetNavPanelExpansion } from '../navExpansionStore';
 
 // `t()` identity mock — we don't depend on bundled English copy here, but
 // the component reads i18n keys for some labels and we want the fallback
@@ -242,6 +243,109 @@ describe('NavigationPanel — show more threads', () => {
   });
 });
 
+describe('NavigationPanel — active-thread auto-reveal', () => {
+  function renderWithActiveThread(opts: {
+    threadsData: { threads: { thread_id: string; title: string }[]; loading: boolean; total?: number };
+    currentThreadId: string | null;
+    status?: string;
+    onLoadMoreThreads?: ReturnType<typeof vi.fn>;
+  }) {
+    resetNavPanelExpansion();
+    const onLoadMoreThreads = opts.onLoadMoreThreads ?? vi.fn();
+    render(
+      <NavigationPanel
+        workspaces={[{ workspace_id: WS_ID, name: 'Test workspace', status: opts.status }]}
+        workspaceThreads={{ [WS_ID]: opts.threadsData }}
+        currentWorkspaceId={WS_ID}
+        currentThreadId={opts.currentThreadId}
+        agents={[]}
+        activeAgentId={null}
+        expandWorkspace={vi.fn()}
+        onSelectAgent={vi.fn()}
+        onRemoveAgent={vi.fn()}
+        onNavigateThread={vi.fn()}
+        onLoadMoreThreads={onLoadMoreThreads}
+      />,
+    );
+    return onLoadMoreThreads;
+  }
+
+  it('pages in more threads when the active thread is hidden in the collapsed tail', async () => {
+    const onLoadMoreThreads = renderWithActiveThread({
+      threadsData: {
+        threads: [
+          { thread_id: 't-1', title: 'Thread one' },
+          { thread_id: 't-2', title: 'Thread two' },
+        ],
+        loading: false,
+        total: 14,
+      },
+      currentThreadId: 't-9', // beyond the loaded page
+    });
+
+    await waitFor(() => expect(onLoadMoreThreads).toHaveBeenCalledWith(WS_ID));
+  });
+
+  it('does not page when the active thread is already visible', () => {
+    const onLoadMoreThreads = renderWithActiveThread({
+      threadsData: {
+        threads: [
+          { thread_id: 't-1', title: 'Thread one' },
+          { thread_id: 't-2', title: 'Thread two' },
+        ],
+        loading: false,
+        total: 14,
+      },
+      currentThreadId: 't-2', // present in the loaded set
+    });
+
+    expect(onLoadMoreThreads).not.toHaveBeenCalled();
+  });
+
+  it('does not page when every thread is already loaded', () => {
+    const onLoadMoreThreads = renderWithActiveThread({
+      threadsData: {
+        threads: [
+          { thread_id: 't-1', title: 'Thread one' },
+          { thread_id: 't-2', title: 'Thread two' },
+        ],
+        loading: false,
+        total: 2, // loaded.length >= total, nothing more to fetch
+      },
+      currentThreadId: 't-9',
+    });
+
+    expect(onLoadMoreThreads).not.toHaveBeenCalled();
+  });
+
+  it('does not auto-reveal in the flash workspace (capped at 3, no show-more)', () => {
+    const onLoadMoreThreads = renderWithActiveThread({
+      threadsData: {
+        threads: [{ thread_id: 't-1', title: 'Thread one' }],
+        loading: false,
+        total: 14,
+      },
+      currentThreadId: 't-9',
+      status: 'flash',
+    });
+
+    expect(onLoadMoreThreads).not.toHaveBeenCalled();
+  });
+
+  it('does not page while a fetch is already in flight', () => {
+    const onLoadMoreThreads = renderWithActiveThread({
+      threadsData: {
+        threads: [{ thread_id: 't-1', title: 'Thread one' }],
+        loading: true, // a page is loading; wait for it before paging again
+        total: 14,
+      },
+      currentThreadId: 't-9',
+    });
+
+    expect(onLoadMoreThreads).not.toHaveBeenCalled();
+  });
+});
+
 describe('NavigationPanel — workspace drag-reorder affordances', () => {
   function renderReorderPanel(onReorderWorkspace?: (a: string, b: string) => void) {
     return render(
@@ -337,5 +441,108 @@ describe('NavigationPanel — expansion survives remounts', () => {
     renderOrderPanel('ws-a', expandSpy);
     expect(screen.queryByText('Thread B1')).toBeNull();
     expect(expandSpy).not.toHaveBeenCalledWith('ws-b');
+  });
+});
+
+describe('NavigationPanel — shared expansion across instances', () => {
+  // One panel mounts per cached ChatView, all alive at once. Folder expansion
+  // must be consistent across them: opening a folder in the active panel must
+  // be reflected by every other mounted panel, not just the one toggled. (The
+  // bug: a per-instance snapshot left a panel cached before a folder was opened
+  // showing it collapsed, so the same folder appeared open or closed depending
+  // on which thread was active.)
+  function renderInstance(currentWorkspaceId: string) {
+    return render(
+      <NavigationPanel
+        workspaces={[
+          { workspace_id: 'ws-a', name: 'Workspace A' },
+          { workspace_id: 'ws-b', name: 'Workspace B' },
+        ]}
+        workspaceThreads={{
+          'ws-a': { threads: [{ thread_id: 'ta-1', title: 'Thread A1' }], loading: false },
+          'ws-b': { threads: [{ thread_id: 'tb-1', title: 'Thread B1' }], loading: false },
+        }}
+        currentWorkspaceId={currentWorkspaceId}
+        currentThreadId={null}
+        agents={[]}
+        activeAgentId={null}
+        expandWorkspace={vi.fn()}
+        onSelectAgent={vi.fn()}
+        onRemoveAgent={vi.fn()}
+        onNavigateThread={vi.fn()}
+      />,
+    );
+  }
+
+  it('reflects a folder toggle in one panel across all mounted panels', async () => {
+    resetNavPanelExpansion();
+    const user = userEvent.setup();
+    const a = renderInstance('ws-a');
+    const b = renderInstance('ws-a');
+
+    // ws-b starts collapsed in both panels.
+    expect(within(a.container).queryByText('Thread B1')).toBeNull();
+    expect(within(b.container).queryByText('Thread B1')).toBeNull();
+
+    // Open ws-b in panel A only.
+    await user.click(within(a.container).getByText('Workspace B'));
+
+    // Both panels show it open — the store is shared and live, not snapshotted.
+    expect(within(a.container).getByText('Thread B1')).toBeInTheDocument();
+    expect(within(b.container).getByText('Thread B1')).toBeInTheDocument();
+
+    // Collapsing in panel B also propagates back to panel A. Use waitFor: the
+    // in-place collapse runs an AnimatePresence exit, so the row lingers in the
+    // DOM for a tick before it's removed.
+    await user.click(within(b.container).getByText('Workspace B'));
+    await waitFor(() => expect(within(a.container).queryByText('Thread B1')).toBeNull());
+    await waitFor(() => expect(within(b.container).queryByText('Thread B1')).toBeNull());
+  });
+
+  // Models the reported repro: expand a NON-current folder, then navigate to a
+  // thread in a DIFFERENT workspace (fresh panel, different currentWorkspaceId).
+  // The manual expansion must persist — it should not auto-collapse.
+  function renderInstanceWithThreeWorkspaces(currentWorkspaceId: string) {
+    return render(
+      <NavigationPanel
+        workspaces={[
+          { workspace_id: 'ws-a', name: 'Workspace A' },
+          { workspace_id: 'ws-b', name: 'Workspace B' },
+          { workspace_id: 'ws-c', name: 'Workspace C' },
+        ]}
+        workspaceThreads={{
+          'ws-a': { threads: [{ thread_id: 'ta-1', title: 'Thread A1' }], loading: false },
+          'ws-b': { threads: [{ thread_id: 'tb-1', title: 'Thread B1' }], loading: false },
+          'ws-c': { threads: [{ thread_id: 'tc-1', title: 'Thread C1' }], loading: false },
+        }}
+        currentWorkspaceId={currentWorkspaceId}
+        currentThreadId={null}
+        agents={[]}
+        activeAgentId={null}
+        expandWorkspace={vi.fn()}
+        onSelectAgent={vi.fn()}
+        onRemoveAgent={vi.fn()}
+        onNavigateThread={vi.fn()}
+      />,
+    );
+  }
+
+  it('keeps a manually expanded non-current folder open after navigating to another workspace', async () => {
+    resetNavPanelExpansion();
+    const user = userEvent.setup();
+
+    // On a thread in ws-a; manually expand ws-b (not the current workspace).
+    const first = renderInstanceWithThreeWorkspaces('ws-a');
+    expect(within(first.container).queryByText('Thread B1')).toBeNull();
+    await user.click(within(first.container).getByText('Workspace B'));
+    expect(within(first.container).getByText('Thread B1')).toBeInTheDocument();
+
+    // Navigate to a thread in ws-c: old ChatView's panel unmounts, a fresh panel
+    // mounts with a different currentWorkspaceId.
+    first.unmount();
+    const second = renderInstanceWithThreeWorkspaces('ws-c');
+
+    // ws-b must still be expanded — manual expansion persists across navigation.
+    expect(within(second.container).getByText('Thread B1')).toBeInTheDocument();
   });
 });

--- a/web/src/pages/ChatAgent/components/__tests__/NavigationPanel.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/NavigationPanel.test.tsx
@@ -14,7 +14,7 @@ import { render, screen, within, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import NavigationPanel from '../NavigationPanel';
-import { resetNavPanelExpansion, forgetNavPanelExpansion } from '../navExpansionStore';
+import { resetNavPanelExpansion, forgetNavPanelExpansion, expandedWorkspaces } from '../navExpansionStore';
 
 // `t()` identity mock — we don't depend on bundled English copy here, but
 // the component reads i18n keys for some labels and we want the fallback
@@ -470,16 +470,18 @@ describe('NavigationPanel — expansion survives remounts', () => {
     const expandSpy = vi.fn();
     renderOrderPanel('ws-a', expandSpy);
 
-    // ws-b starts collapsed — opening it lazy-loads its threads.
+    // ws-b starts collapsed — opening it expands the folder and lazy-loads threads.
+    // Assert on the store (synchronously mutated by the toggle) rather than the
+    // rendered list, which is sensitive to cross-file re-render timing.
     await user.click(screen.getByText('Workspace B'));
-    expect(screen.getByText('Thread B1')).toBeInTheDocument();
+    expect(expandedWorkspaces.has('ws-b')).toBe(true);
     expect(expandSpy).toHaveBeenCalledWith('ws-b');
     expandSpy.mockClear();
 
     // Collapsing must not re-fetch: the shared store is capped and may have
     // evicted the list, so an unconditional expand would fire a needless load.
     await user.click(screen.getByText('Workspace B'));
-    expect(screen.queryByText('Thread B1')).toBeNull();
+    expect(expandedWorkspaces.has('ws-b')).toBe(false);
     expect(expandSpy).not.toHaveBeenCalled();
   });
 });

--- a/web/src/pages/ChatAgent/components/__tests__/NavigationPanel.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/NavigationPanel.test.tsx
@@ -463,6 +463,25 @@ describe('NavigationPanel — expansion survives remounts', () => {
     expect(screen.queryByText('Thread B1')).toBeNull();
     expect(expandSpy).not.toHaveBeenCalledWith('ws-b');
   });
+
+  it('lazy-loads threads only when opening a folder, not when collapsing it', async () => {
+    resetNavPanelExpansion();
+    const user = userEvent.setup();
+    const expandSpy = vi.fn();
+    renderOrderPanel('ws-a', expandSpy);
+
+    // ws-b starts collapsed — opening it lazy-loads its threads.
+    await user.click(screen.getByText('Workspace B'));
+    expect(screen.getByText('Thread B1')).toBeInTheDocument();
+    expect(expandSpy).toHaveBeenCalledWith('ws-b');
+    expandSpy.mockClear();
+
+    // Collapsing must not re-fetch: the shared store is capped and may have
+    // evicted the list, so an unconditional expand would fire a needless load.
+    await user.click(screen.getByText('Workspace B'));
+    expect(screen.queryByText('Thread B1')).toBeNull();
+    expect(expandSpy).not.toHaveBeenCalled();
+  });
 });
 
 describe('NavigationPanel — shared expansion across instances', () => {

--- a/web/src/pages/ChatAgent/components/__tests__/NavigationPanel.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/NavigationPanel.test.tsx
@@ -248,12 +248,14 @@ describe('NavigationPanel — active-thread auto-reveal', () => {
     threadsData: { threads: { thread_id: string; title: string }[]; loading: boolean; total?: number };
     currentThreadId: string | null;
     status?: string;
+    isActive?: boolean;
     onLoadMoreThreads?: ReturnType<typeof vi.fn>;
   }) {
     resetNavPanelExpansion();
     const onLoadMoreThreads = opts.onLoadMoreThreads ?? vi.fn();
     render(
       <NavigationPanel
+        isActive={opts.isActive ?? true}
         workspaces={[{ workspace_id: WS_ID, name: 'Test workspace', status: opts.status }]}
         workspaceThreads={{ [WS_ID]: opts.threadsData }}
         currentWorkspaceId={WS_ID}
@@ -284,6 +286,25 @@ describe('NavigationPanel — active-thread auto-reveal', () => {
     });
 
     await waitFor(() => expect(onLoadMoreThreads).toHaveBeenCalledWith(WS_ID));
+  });
+
+  it('does not auto-reveal when the panel is inactive (hidden cached instance)', async () => {
+    const onLoadMoreThreads = renderWithActiveThread({
+      threadsData: {
+        threads: [
+          { thread_id: 't-1', title: 'Thread one' },
+          { thread_id: 't-2', title: 'Thread two' },
+        ],
+        loading: false,
+        total: 14,
+      },
+      currentThreadId: 't-9', // beyond the loaded page — would page in if active
+      isActive: false,
+    });
+
+    // Give any effect a chance to (wrongly) fire before asserting it did not.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(onLoadMoreThreads).not.toHaveBeenCalled();
   });
 
   it('does not page when the active thread is already visible', () => {

--- a/web/src/pages/ChatAgent/components/navExpansionStore.ts
+++ b/web/src/pages/ChatAgent/components/navExpansionStore.ts
@@ -60,13 +60,28 @@ export function toggleWorkspaceExpansion(workspaceId: string): void {
   notifyNavExpansion();
 }
 
-// Housekeeping mutators (reset on logout/teardown, forget on workspace delete)
-// don't notify subscribers: the change only needs to take effect on the next
-// mount, and any live re-render is already driven elsewhere (the delete path
-// invalidates the workspace list, which drops the row).
+// Toggle a thread's agent-group open/closed. Mirrors toggleWorkspaceExpansion so
+// both expansion mutations live in the store rather than half here, half inline.
+export function toggleThreadExpansion(threadId: string): void {
+  if (state.threads.has(threadId)) {
+    state.threads.delete(threadId);
+  } else {
+    state.threads.add(threadId);
+  }
+  notifyNavExpansion();
+}
+
+// Reset on logout/teardown. Bumps the version via notifyNavExpansion() like
+// every other mutator, so the store API stays uniform and no future caller has
+// to know this path is special. On logout the panel is already unmounted, so
+// the notify is a harmless no-op there (zero subscribers) — the consistency is
+// the point. forgetNavPanelExpansion (below) stays quiet by design: it runs
+// only on workspace delete, where the workspace-list invalidation already
+// repaints the affected row.
 export function resetNavPanelExpansion(): void {
   state.workspaces.clear();
   state.threads.clear();
+  notifyNavExpansion();
 }
 
 // Forget a deleted workspace so the mount-effect doesn't re-expand it (and fire

--- a/web/src/pages/ChatAgent/components/navExpansionStore.ts
+++ b/web/src/pages/ChatAgent/components/navExpansionStore.ts
@@ -1,0 +1,78 @@
+// Shared expansion state for the workspace nav panel (which workspace folders and
+// which threads' agent groups are open). One NavigationPanel mounts per cached
+// ChatView instance, so this state must live OUTSIDE any component to stay
+// consistent as the user switches threads/workspaces.
+//
+// It lives in its own module (not in NavigationPanel.tsx) for two reasons:
+//   1. NavigationPanel.tsx can then export only its component, so Vite Fast
+//      Refresh hot-swaps it cleanly during dev instead of forcing a full reload.
+//   2. The state is anchored on `globalThis`, so even if this module is itself
+//      re-evaluated by HMR the panels keep reading the SAME sets. A second set
+//      instance would desync cached panels: a folder opened in one panel would
+//      render collapsed in another.
+//
+// State resets only on a real page reload (globalThis is fresh then). That
+// matches the product rule: a manually expanded folder stays open all session.
+
+interface NavExpansionState {
+  workspaces: Set<string>;
+  threads: Set<string>;
+  version: number;
+  listeners: Set<() => void>;
+}
+
+const KEY = '__langalpha_nav_expansion__';
+const root = globalThis as unknown as Record<string, unknown>;
+
+const state: NavExpansionState =
+  (root[KEY] as NavExpansionState | undefined) ??
+  ((root[KEY] = { workspaces: new Set<string>(), threads: new Set<string>(), version: 0, listeners: new Set<() => void>() }) as NavExpansionState);
+
+// Live sets — read directly in render; mutate then call notifyNavExpansion().
+export const expandedWorkspaces = state.workspaces;
+export const expandedThreads = state.threads;
+
+// Live external store: bump a version and ping every subscribed panel so cached
+// ChatViews re-render on any toggle and never show stale folder state.
+export function notifyNavExpansion(): void {
+  state.version += 1;
+  state.listeners.forEach((fn) => fn());
+}
+
+export function subscribeNavExpansion(fn: () => void): () => void {
+  state.listeners.add(fn);
+  return () => {
+    state.listeners.delete(fn);
+  };
+}
+
+export function getNavExpansionVersion(): number {
+  return state.version;
+}
+
+// Toggle a workspace folder open/closed.
+export function toggleWorkspaceExpansion(workspaceId: string): void {
+  if (state.workspaces.has(workspaceId)) {
+    state.workspaces.delete(workspaceId);
+  } else {
+    state.workspaces.add(workspaceId);
+  }
+  notifyNavExpansion();
+}
+
+// Housekeeping mutators (reset on logout/teardown, forget on workspace delete)
+// don't notify subscribers: the change only needs to take effect on the next
+// mount, and any live re-render is already driven elsewhere (the delete path
+// invalidates the workspace list, which drops the row).
+export function resetNavPanelExpansion(): void {
+  state.workspaces.clear();
+  state.threads.clear();
+}
+
+// Forget a deleted workspace so the mount-effect doesn't re-expand it (and fire
+// a spurious threads 404) on the next panel remount. Only deletion is a safe
+// prune signal — the workspace list is a paged/limited slice, so absence there
+// can mean "scrolled out", not "gone".
+export function forgetNavPanelExpansion(workspaceId: string): void {
+  state.workspaces.delete(workspaceId);
+}

--- a/web/src/pages/ChatAgent/hooks/__tests__/useNavigationData.test.tsx
+++ b/web/src/pages/ChatAgent/hooks/__tests__/useNavigationData.test.tsx
@@ -19,6 +19,7 @@ import {
   applyStableOrder,
   applyStableOrderBy,
   resetStableNavOrder,
+  resetSharedWorkspaceThreads,
   bumpThreadNavOrder,
 } from '../useNavigationData';
 import { resetNavPrefs, setNavPrefs } from '../../utils/navPrefs';
@@ -105,6 +106,7 @@ describe('useNavigationData — stable thread ordering', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetStableNavOrder();
+    resetSharedWorkspaceThreads();
     resetNavPrefs();
     threadsByWs = {
       'ws-1': threads('t-3', 't-1', 't-2'),
@@ -253,12 +255,34 @@ describe('useNavigationData — stable thread ordering', () => {
     await waitFor(() => expect(second.idsFor('ws-1').length).toBeGreaterThan(0));
     expect(second.idsFor('ws-1')).toEqual(['t-3', 't-1', 't-2']);
   });
+
+  it('shares loaded thread lists across concurrent hook instances (cached panels)', async () => {
+    // Two cached ChatView panels are alive at once, each its own hook instance.
+    // Thread lists live in a session-global shared store, so a folder loaded by
+    // one panel is visible to the other immediately. Before the shared store,
+    // the second panel rendered the folder open-but-empty (the flash that read
+    // as an auto-collapse) until its own fetch landed.
+    const a = setup('ws-1');
+    const b = setup('ws-1');
+    await waitFor(() => expect(a.idsFor('ws-1')).toEqual(['t-3', 't-1', 't-2']));
+
+    // Panel A opens ws-2 (neither panel's current workspace).
+    expect(b.idsFor('ws-2')).toEqual([]);
+    await act(async () => {
+      a.result.current.expandWorkspace('ws-2');
+    });
+
+    // Panel B sees A's load through the shared store — no empty flash.
+    await waitFor(() => expect(b.idsFor('ws-2')).toEqual(['u-2', 'u-1']));
+    expect(a.idsFor('ws-2')).toEqual(['u-2', 'u-1']);
+  });
 });
 
 describe('useNavigationData — stable workspace ordering', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetStableNavOrder();
+    resetSharedWorkspaceThreads();
     resetNavPrefs();
     mockGetWorkspaceThreads.mockResolvedValue({ threads: [] });
   });
@@ -436,6 +460,7 @@ describe('useNavigationData — drag-reorder workspaces', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetStableNavOrder();
+    resetSharedWorkspaceThreads();
     resetNavPrefs();
     mockGetWorkspaceThreads.mockResolvedValue({ threads: [] });
     mockReorderWorkspaces.mockResolvedValue(undefined);
@@ -525,6 +550,7 @@ describe('useNavigationData — pin & rename workspace', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetStableNavOrder();
+    resetSharedWorkspaceThreads();
     resetNavPrefs();
     mockGetWorkspaceThreads.mockResolvedValue({ threads: [] });
     server = [
@@ -603,6 +629,7 @@ describe('useNavigationData — thread paging', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetStableNavOrder();
+    resetSharedWorkspaceThreads();
     resetNavPrefs();
     mockGetWorkspaces.mockResolvedValue({
       workspaces: [{ workspace_id: 'ws-1' }],

--- a/web/src/pages/ChatAgent/hooks/useNavigationData.ts
+++ b/web/src/pages/ChatAgent/hooks/useNavigationData.ts
@@ -59,6 +59,50 @@ export function resetStableNavOrder() {
   _lastWorkspaceArrangement.clear();
 }
 
+// Loaded thread lists per workspace, shared across every cached ChatView's nav
+// panel — the SAME lifetime and sharing as the expansion set in navExpansionStore.
+// Hook-local state would let a panel that mounted before a folder was opened
+// render it open-but-empty (a flash that reads as an auto-collapse) until its own
+// fetch landed; a shared store means the instant any panel loads a folder, every
+// panel renders it on first paint. Page-session scoped: a reload starts fresh.
+let _sharedWorkspaceThreads: Record<string, ThreadsData> = {};
+const _navThreadsListeners = new Set<() => void>();
+
+function subscribeNavThreads(fn: () => void): () => void {
+  _navThreadsListeners.add(fn);
+  return () => _navThreadsListeners.delete(fn);
+}
+
+// Stable snapshot: the same ref until a write replaces it, so useSyncExternalStore
+// only re-renders on a real change.
+function getNavThreadsSnapshot(): Record<string, ThreadsData> {
+  return _sharedWorkspaceThreads;
+}
+
+function setSharedWorkspaceThreads(
+  updater: (prev: Record<string, ThreadsData>) => Record<string, ThreadsData>,
+): void {
+  _sharedWorkspaceThreads = updater(_sharedWorkspaceThreads);
+  _navThreadsListeners.forEach((fn) => fn());
+}
+
+// Drop all loaded thread lists. Mirrors resetStableNavOrder's session-reset role
+// (page-session scoped); used by tests to isolate the module-level store.
+export function resetSharedWorkspaceThreads(): void {
+  _sharedWorkspaceThreads = {};
+  _navThreadsListeners.forEach((fn) => fn());
+}
+
+// Forget one workspace's threads so a deleted workspace doesn't linger in the
+// shared store. Called from the workspace delete path (alongside forgetStableNavOrder).
+export function forgetSharedWorkspaceThreads(workspaceId: string): void {
+  if (!(workspaceId in _sharedWorkspaceThreads)) return;
+  const next = { ..._sharedWorkspaceThreads };
+  delete next[workspaceId];
+  _sharedWorkspaceThreads = next;
+  _navThreadsListeners.forEach((fn) => fn());
+}
+
 // Drop a deleted workspace from the frozen-order stores so they don't retain
 // ghost ids for the rest of the session. Deleted ids are already filtered out
 // of the rendered list (applyStableOrderBy drops map-misses), so this is
@@ -159,7 +203,10 @@ export function useNavigationData(currentWorkspaceId: string) {
   const allFetched: WorkspaceRecord[] = (wsData as WorkspacesResponse | undefined)?.workspaces || [];
   const totalCount = (wsData as WorkspacesResponse | undefined)?.total || 0;
 
-  const [workspaceThreads, setWorkspaceThreads] = useState<Record<string, ThreadsData>>({});
+  // Loaded thread lists, read from the session-global shared store so every
+  // cached panel sees the same data (see _sharedWorkspaceThreads above). Writes
+  // go through setSharedWorkspaceThreads, which notifies all subscribed panels.
+  const workspaceThreads = useSyncExternalStore(subscribeNavThreads, getNavThreadsSnapshot);
   // "Load all" clicked this session — overrides a numeric workspaceLimit pref.
   const [showAllWorkspaces, setShowAllWorkspaces] = useState(false);
   const showAll = workspaceLimit === 'all' || showAllWorkspaces;
@@ -352,37 +399,33 @@ export function useNavigationData(currentWorkspaceId: string) {
   });
 
   const mergedThreads = useMemo(() => {
-    if (!currentWorkspaceId) return workspaceThreads;
-    const stored = workspaceThreads[currentWorkspaceId];
-    if (currentWsThreadData === undefined) {
-      return {
-        ...workspaceThreads,
-        [currentWorkspaceId]: {
-          threads: stored?.threads || [],
-          loading: true,
-          total: stored?.total,
-        },
-      };
+    const result: Record<string, ThreadsData> = { ...workspaceThreads };
+
+    // Current workspace: union the React Query first page with any "Show more"
+    // pages held in the shared store (query page wins on overlap, so paging
+    // survives the query refetching its first page).
+    if (currentWorkspaceId) {
+      const stored = workspaceThreads[currentWorkspaceId];
+      if (currentWsThreadData === undefined) {
+        result[currentWorkspaceId] = { threads: stored?.threads || [], loading: true, total: stored?.total };
+      } else {
+        const page = (currentWsThreadData as ThreadsResponse)?.threads || [];
+        const pageIds = new Set(page.map((t) => t.thread_id));
+        const extras = (stored?.threads || []).filter((t) => !pageIds.has(t.thread_id));
+        result[currentWorkspaceId] = {
+          threads: orderThreads(currentWorkspaceId, [...page, ...extras]),
+          loading: currentWsThreadsLoading || stored?.loading || false,
+          total: (currentWsThreadData as ThreadsResponse)?.total ?? stored?.total,
+        };
+      }
     }
-    // The query holds the first page; "Show more" pages land in workspaceThreads.
-    // Union them (query page wins on overlap) so paging the current workspace
-    // survives the query refetching its first page.
-    const page = (currentWsThreadData as ThreadsResponse)?.threads || [];
-    const pageIds = new Set(page.map((t) => t.thread_id));
-    const extras = (stored?.threads || []).filter((t) => !pageIds.has(t.thread_id));
-    return {
-      ...workspaceThreads,
-      [currentWorkspaceId]: {
-        threads: orderThreads(currentWorkspaceId, [...page, ...extras]),
-        loading: currentWsThreadsLoading || stored?.loading || false,
-        total: (currentWsThreadData as ThreadsResponse)?.total ?? stored?.total,
-      },
-    };
+
+    return result;
   }, [workspaceThreads, currentWorkspaceId, currentWsThreadData, currentWsThreadsLoading, orderThreads]);
 
   const expandWorkspace = useCallback((wsId: string) => {
     const mergeFetched = (data: ThreadsResponse) => {
-      setWorkspaceThreads(prev => {
+      setSharedWorkspaceThreads(prev => {
         const have = prev[wsId]?.threads || [];
         // Keep already-paged-in threads; the fetched first page wins on overlap.
         const pageIds = new Set((data.threads || []).map((t) => t.thread_id));
@@ -404,7 +447,7 @@ export function useNavigationData(currentWorkspaceId: string) {
       return;
     }
 
-    setWorkspaceThreads(prev => ({
+    setSharedWorkspaceThreads(prev => ({
       ...prev,
       [wsId]: { threads: prev[wsId]?.threads || [], loading: true, total: prev[wsId]?.total },
     }));
@@ -416,7 +459,7 @@ export function useNavigationData(currentWorkspaceId: string) {
     }).then((data: unknown) => {
       mergeFetched(data as ThreadsResponse);
     }).catch(() => {
-      setWorkspaceThreads(prev => ({
+      setSharedWorkspaceThreads(prev => ({
         ...prev,
         [wsId]: { threads: prev[wsId]?.threads || [], loading: false, total: prev[wsId]?.total },
       }));
@@ -429,7 +472,7 @@ export function useNavigationData(currentWorkspaceId: string) {
     if (loadMoreInflightRef.current.has(wsId)) return;
     loadMoreInflightRef.current.add(wsId);
     const shown = mergedThreads[wsId]?.threads || [];
-    setWorkspaceThreads(prev => ({
+    setSharedWorkspaceThreads(prev => ({
       ...prev,
       [wsId]: {
         threads: prev[wsId]?.threads || shown,
@@ -439,7 +482,7 @@ export function useNavigationData(currentWorkspaceId: string) {
     }));
     try {
       const data = await getWorkspaceThreads(wsId, threadPageSize, shown.length) as ThreadsResponse;
-      setWorkspaceThreads(prev => {
+      setSharedWorkspaceThreads(prev => {
         const have = prev[wsId]?.threads?.length ? prev[wsId].threads : shown;
         const haveIds = new Set(have.map((t) => t.thread_id));
         const fresh = (data.threads || []).filter((t) => !haveIds.has(t.thread_id));
@@ -454,7 +497,7 @@ export function useNavigationData(currentWorkspaceId: string) {
       });
     } catch (e) {
       console.warn('[useNavigationData] Failed to load more threads:', e);
-      setWorkspaceThreads(prev => ({
+      setSharedWorkspaceThreads(prev => ({
         ...prev,
         [wsId]: {
           threads: prev[wsId]?.threads || shown,

--- a/web/src/pages/ChatAgent/hooks/useNavigationData.ts
+++ b/web/src/pages/ChatAgent/hooks/useNavigationData.ts
@@ -68,6 +68,11 @@ export function resetStableNavOrder() {
 let _sharedWorkspaceThreads: Record<string, ThreadsData> = {};
 const _navThreadsListeners = new Set<() => void>();
 
+// Cap on how many workspaces' thread lists the shared store retains. A long
+// session paging through many workspaces would otherwise grow this unbounded;
+// far above any realistic count of workspaces a user navigates in one session.
+const MAX_WORKSPACE_THREAD_LISTS = 50;
+
 function subscribeNavThreads(fn: () => void): () => void {
   _navThreadsListeners.add(fn);
   return () => _navThreadsListeners.delete(fn);
@@ -82,7 +87,15 @@ function getNavThreadsSnapshot(): Record<string, ThreadsData> {
 function setSharedWorkspaceThreads(
   updater: (prev: Record<string, ThreadsData>) => Record<string, ThreadsData>,
 ): void {
-  _sharedWorkspaceThreads = updater(_sharedWorkspaceThreads);
+  let next = updater(_sharedWorkspaceThreads);
+  const keys = Object.keys(next);
+  if (keys.length > MAX_WORKSPACE_THREAD_LISTS) {
+    // Evict oldest (insertion-order) entries to bound a long multi-workspace
+    // session; evicted lists are re-fetched on demand when revisited.
+    next = { ...next };
+    for (const k of keys.slice(0, keys.length - MAX_WORKSPACE_THREAD_LISTS)) delete next[k];
+  }
+  _sharedWorkspaceThreads = next;
   _navThreadsListeners.forEach((fn) => fn());
 }
 

--- a/web/src/pages/ChatAgent/utils/__tests__/scrollHelpers.test.ts
+++ b/web/src/pages/ChatAgent/utils/__tests__/scrollHelpers.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { isNearBottom } from '../scrollHelpers';
+
+describe('isNearBottom', () => {
+  it('is true at the very bottom', () => {
+    expect(isNearBottom({ scrollTop: 900, scrollHeight: 1000, clientHeight: 100 })).toBe(true);
+  });
+  it('is false far from the bottom', () => {
+    expect(isNearBottom({ scrollTop: 0, scrollHeight: 1000, clientHeight: 100 })).toBe(false);
+  });
+  it('respects the threshold boundary (default 120)', () => {
+    // distance = scrollHeight - scrollTop - clientHeight
+    expect(isNearBottom({ scrollTop: 781, scrollHeight: 1000, clientHeight: 100 })).toBe(true); // 119
+    expect(isNearBottom({ scrollTop: 779, scrollHeight: 1000, clientHeight: 100 })).toBe(false); // 121
+  });
+  it('honors a custom threshold', () => {
+    expect(isNearBottom({ scrollTop: 870, scrollHeight: 1000, clientHeight: 100 }, 40)).toBe(true); // 30
+    expect(isNearBottom({ scrollTop: 850, scrollHeight: 1000, clientHeight: 100 }, 40)).toBe(false); // 50
+  });
+});

--- a/web/src/pages/ChatAgent/utils/__tests__/scrollHelpers.test.ts
+++ b/web/src/pages/ChatAgent/utils/__tests__/scrollHelpers.test.ts
@@ -11,6 +11,7 @@ describe('isNearBottom', () => {
   it('respects the threshold boundary (default 120)', () => {
     // distance = scrollHeight - scrollTop - clientHeight
     expect(isNearBottom({ scrollTop: 781, scrollHeight: 1000, clientHeight: 100 })).toBe(true); // 119
+    expect(isNearBottom({ scrollTop: 780, scrollHeight: 1000, clientHeight: 100 })).toBe(true); // 120 (inclusive)
     expect(isNearBottom({ scrollTop: 779, scrollHeight: 1000, clientHeight: 100 })).toBe(false); // 121
   });
   it('honors a custom threshold', () => {

--- a/web/src/pages/ChatAgent/utils/scrollHelpers.ts
+++ b/web/src/pages/ChatAgent/utils/scrollHelpers.ts
@@ -1,0 +1,13 @@
+// Pure scroll decision logic for the chat transcript. Kept free of DOM/layout
+// so it is unit-testable under jsdom (which has no layout).
+
+export interface ScrollMetrics {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+}
+
+/** Distance from the bottom is within `threshold` px. */
+export function isNearBottom(m: ScrollMetrics, threshold = 120): boolean {
+  return m.scrollHeight - m.scrollTop - m.clientHeight < threshold;
+}

--- a/web/src/pages/ChatAgent/utils/scrollHelpers.ts
+++ b/web/src/pages/ChatAgent/utils/scrollHelpers.ts
@@ -7,7 +7,7 @@ export interface ScrollMetrics {
   clientHeight: number;
 }
 
-/** Distance from the bottom is within `threshold` px. */
+/** Distance from the bottom is within `threshold` px (inclusive). */
 export function isNearBottom(m: ScrollMetrics, threshold = 120): boolean {
-  return m.scrollHeight - m.scrollTop - m.clientHeight < threshold;
+  return m.scrollHeight - m.scrollTop - m.clientHeight <= threshold;
 }


### PR DESCRIPTION
## Summary

Two ChatAgent UX fixes plus a security fix that surfaced during review.

**Chat scroll-UX** — opening a long, chart/code-heavy thread used to land mid-thread:
the one-shot scroll-to-bottom fired before inline charts, code, and images expanded,
so the true bottom slid down afterward. Adds a pin controller that re-pins to bottom
on a `ResizeObserver` as content settles (1.5s quiet window, 8s hard cap,
programmatic-scroll guard), a jump-to-latest pill for when you've scrolled up during
streaming, and a `wheel`/`touch` interrupt so a user gesture always wins over the pin.

**Nav-panel folder fix** — folder expansion and loaded thread lists moved from
per-instance React state into session-global stores, so navigating into a thread in
another workspace no longer flashes an open folder closed across the (up to 5) cached
ChatView panels.

**Auth fix (P1)** — those new nav stores live on `globalThis` and survive logout (the
SPA doesn't reload), so on a shared tab one user's folders/thread lists leaked into the
next user's session. The sign-out path now resets them.

## Overview

| Category              | Files | +LOC | −LOC |
|-----------------------|------:|-----:|-----:|
| Modified (prod)       |     5 |  486 |  140 |
| New (prod)            |     4 |  192 |    0 |
| Tests (excluded)      |     5 |  354 |    2 |
| **Net (excl. tests)** |     9 | **678** | **140** |

**Chat scroll-UX**
- `components/ChatView.tsx` (+304 / −36, mod) — pin controller (ResizeObserver re-pin through async settle, settle timers, programmatic-scroll guard, wheel/touch user-gesture yield), jump-to-latest pill wiring, entry-restore that cancels its frame on thread switch, deferred-scroll cancellation, named scroll tuning constants.
- `components/JumpToLatestPill.tsx` (+42, new) — presentational floating "Jump to latest / N new" button (i18n + aria).
- `components/JumpToLatestPill.css` (+59, new) — 44px touch target, theme-aware `--shadow-card`, contrast-safe count, reduced-motion.
- `utils/scrollHelpers.ts` (+13, new) — pure `isNearBottom()` helper (DOM-free, jsdom-testable).

**Nav-panel folder fix**
- `components/navExpansionStore.ts` (+78, new) — globalThis-anchored expanded-workspaces/threads Sets + `useSyncExternalStore` bus + toggle/reset/forget.
- `hooks/useNavigationData.ts` (+88 / −32, mod) — session-global shared thread-list store via `useSyncExternalStore`, bounded at 50 workspaces with oldest-first eviction; reset/forget.
- `components/NavigationPanel.tsx` (+83 / −70, mod) — consumes the shared expansion store, seeds current ws/thread via a layout effect (no render-phase Set mutation), gates active-thread auto-reveal on a new `isActive` prop.
- `components/WorkspaceGallery.tsx` (+3 / −2, mod) — wires `forget*` into the workspace delete path.

**Auth lifecycle**
- `contexts/AuthContext.tsx` (+8, mod) — resets the three nav stores in the `onAuthStateChange` sign-out branch, alongside the existing query-cache clear.

**What this introduces:** the chat transcript reliably lands on the latest turn even as media expands after first paint (with a jump-to-latest pill and a pin that yields to the user); folder expansion and thread lists are session-shared so cross-workspace navigation no longer flashes folders closed; and logout no longer leaks one user's nav state into the next user's session.

## Diff Size
- Total: 14 files changed, 1032 insertions(+), 142 deletions(-)
- Net (excl. tests): 9 files changed, 678 insertions(+), 140 deletions(-)

## Test Coverage

Full frontend suite: **181 files, 2006 tests, all pass**. New/expanded coverage:
- `scrollHelpers.test.ts` — `isNearBottom` boundaries.
- `JumpToLatestPill.test.tsx` — visibility, "Jump to latest" vs "N new", click, aria.
- `NavigationPanel.test.tsx` — shared expansion across cached panels, expansion-survives-remount, and the inactive-panel auto-reveal gate.
- `useNavigationData.test.tsx` — shared thread-list store propagation.
- `AuthContext.test.tsx` — regression: sign-out resets the module-level nav stores.

**Known gap (intentional):** the layout-dependent scroll/pin machinery (ResizeObserver re-pin, settle timers, wheel/touch yield, deferred-scroll cancel) isn't unit-tested — jsdom has no layout. Verified manually on the dev server (land-at-bottom on a chart-heavy thread, interrupt a jump-to-latest, switch threads mid-settle).

## Pre-Landing Review

Reviewed against the checklist plus a cross-model adversarial pass (Codex). All findings addressed before merge:
- **P1** — cross-user nav-state leak on logout → fixed (`AuthContext` sign-out reset + regression test).
- **P2** — streaming auto-follow now cancels its deferred scroll and re-checks intent; user wheel/touch interrupts the pin; entry-restore cancels its frame on thread switch; auto-reveal gated to the active panel; shared thread store bounded.
- **P3** — render-phase Set mutation moved to a layout effect (no torn `useSyncExternalStore` snapshot under React 19); pill touch target / shadow / contrast fixed; scroll magic numbers named.

## Design Review

Pill (lite): touch target raised to 44px, shadow switched to the theme-aware token (the previous near-black shadow was invisible on the dark default theme), count recolored to a contrast-safe token, off-system color fallbacks removed.

## Test plan
- [x] `pnpm vitest run` — 2006 tests pass
- [x] `tsc --noEmit` — clean
- [x] `pnpm lint` — 0 errors (2 pre-existing warnings, unrelated)
- [ ] Manual: long chart/code thread lands at bottom; scroll up mid-stream → pill, no yank; interrupt jump-to-latest with a wheel gesture; logout→login on a shared tab shows no prior-user folders


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **“Jump to latest”** pill to the chat view for quick navigation to new messages.
* **Bug Fixes**
  * Improved chat auto-follow/pin-to-bottom reliability across async updates and tab switching, including safer scroll restoration and resize-aware settling.
  * Synced navigation panel expansion state across multiple open views, and improved active-thread auto-reveal paging.
  * Strengthened sign-out and workspace-deletion cleanup to prevent shared/tab cross-user leakage.
* **Tests**
  * Added/updated coverage for sign-out resets, shared navigation/thread state behavior, the jump pill, and scroll near-bottom logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->