### PR TITLE
fix(chat): recover the chat stream after iOS Safari backgrounds the tab

### DIFF
--- a/web/src/api/__tests__/client.test.ts
+++ b/web/src/api/__tests__/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { setTokenGetter } from '../client';
+import { api, setTokenGetter, setTokenRefresher } from '../client';
 
 interface InterceptorHandler<T = unknown> {
   fulfilled: (value: T) => T | Promise<T>;
@@ -127,5 +127,109 @@ describe('response interceptor behavior (429 handling)', () => {
 
     await expect(errorHandler(error)).rejects.toBe(error);
     expect(error.rateLimitInfo).toBeUndefined();
+  });
+});
+
+describe('response interceptor behavior (401 refresh-and-retry)', () => {
+  // Module singletons persist across tests — reset both.
+  beforeEach(() => {
+    setTokenGetter(null as unknown as () => Promise<string | null>);
+    setTokenRefresher(null as unknown as () => Promise<string | null>);
+  });
+
+  /** Reads the Authorization header off a config robust to AxiosHeaders normalization. */
+  function readAuth(config: { headers?: { get?: (k: string) => unknown; Authorization?: unknown } }) {
+    const headers = config.headers;
+    if (!headers) return undefined;
+    return headers.get ? headers.get('Authorization') : headers.Authorization;
+  }
+
+  it('refreshes once and retries with the fresh Bearer token on 401, then succeeds', async () => {
+    const refresher = vi.fn(() => Promise.resolve('refreshed-token'));
+    setTokenRefresher(refresher);
+
+    const adapter = vi.fn(async (config: unknown) => ({
+      data: { ok: true },
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config,
+    }));
+    const originalAdapter = api.defaults.adapter;
+    api.defaults.adapter = adapter as unknown as typeof api.defaults.adapter;
+
+    try {
+      const resInterceptors = api.interceptors.response as unknown as InterceptorManager<unknown>;
+      const errorHandler = resInterceptors.handlers[0].rejected;
+
+      const error = {
+        response: { status: 401, data: {}, headers: {} },
+        config: { url: '/test', method: 'get', headers: {} },
+      };
+
+      const result = (await errorHandler(error)) as { status: number; data: unknown };
+
+      expect(refresher).toHaveBeenCalledTimes(1);
+      expect(adapter).toHaveBeenCalledTimes(1);
+      const retriedConfig = adapter.mock.calls[0][0] as { headers?: { get?: (k: string) => unknown; Authorization?: unknown } };
+      expect(readAuth(retriedConfig)).toBe('Bearer refreshed-token');
+      expect(result.status).toBe(200);
+      expect(result.data).toEqual({ ok: true });
+    } finally {
+      api.defaults.adapter = originalAdapter;
+    }
+  });
+
+  it('rejects on a second 401 without refreshing again (no loop)', async () => {
+    const refresher = vi.fn(() => Promise.resolve('refreshed-token'));
+    setTokenRefresher(refresher);
+
+    // A custom adapter is responsible for rejecting on bad status (axios only applies
+    // validateStatus inside its built-in adapters). Reject 401 with the merged config so
+    // the retry re-enters the interceptor with config._retry already true → branch skipped.
+    const adapter = vi.fn((config: unknown) =>
+      Promise.reject({ response: { status: 401, data: {}, headers: {} }, config }),
+    );
+    const originalAdapter = api.defaults.adapter;
+    api.defaults.adapter = adapter as unknown as typeof api.defaults.adapter;
+
+    try {
+      const resInterceptors = api.interceptors.response as unknown as InterceptorManager<unknown>;
+      const errorHandler = resInterceptors.handlers[0].rejected;
+
+      const error = {
+        response: { status: 401, data: {}, headers: {} },
+        config: { url: '/test', method: 'get', headers: {} },
+      };
+
+      await expect(errorHandler(error)).rejects.toBeDefined();
+      expect(refresher).toHaveBeenCalledTimes(1);
+      expect(adapter).toHaveBeenCalledTimes(1);
+    } finally {
+      api.defaults.adapter = originalAdapter;
+    }
+  });
+
+  it('rejects a 401 unchanged when no refresher is registered (local-dev parity)', async () => {
+    // No refresher registered (cleared in beforeEach). Adapter must never be reached.
+    const adapter = vi.fn();
+    const originalAdapter = api.defaults.adapter;
+    api.defaults.adapter = adapter as unknown as typeof api.defaults.adapter;
+
+    try {
+      const resInterceptors = api.interceptors.response as unknown as InterceptorManager<unknown>;
+      const errorHandler = resInterceptors.handlers[0].rejected;
+
+      const error: Record<string, unknown> = {
+        response: { status: 401, data: {} },
+        config: { headers: {} },
+      };
+
+      await expect(errorHandler(error)).rejects.toBe(error);
+      expect(adapter).not.toHaveBeenCalled();
+      expect(error.rateLimitInfo).toBeUndefined();
+    } finally {
+      api.defaults.adapter = originalAdapter;
+    }
   });
 });

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -8,11 +8,21 @@ const baseURL = import.meta.env.VITE_API_BASE_URL ?? '';
 
 type TokenGetter = () => Promise<string | null>;
 
+/** Axios request config carrying a single-shot 401-retry guard. */
+type RetriableRequestConfig = InternalAxiosRequestConfig & { _retry?: boolean };
+
 /** Async function that returns the current access token (set by AuthContext). */
 let _getAccessToken: TokenGetter | null = null;
 
 export function setTokenGetter(fn: TokenGetter) {
   _getAccessToken = fn;
+}
+
+/** Async function that force-refreshes the session and returns a fresh token (set by AuthContext). */
+let _refreshToken: TokenGetter | null = null;
+
+export function setTokenRefresher(fn: TokenGetter) {
+  _refreshToken = fn;
 }
 
 export const api = axios.create({
@@ -34,16 +44,33 @@ api.interceptors.request.use(async (config: InternalAxiosRequestConfig) => {
   return config;
 });
 
-// Enrich 429 errors with structured rate limit info
+// Enrich 429 errors with structured rate limit info; single-shot 401 refresh-and-retry.
 api.interceptors.response.use(
   (response) => response,
-  (error: AxiosError & { status?: number; rateLimitInfo?: Record<string, unknown>; retryAfter?: number | null }) => {
+  async (error: AxiosError & { status?: number; rateLimitInfo?: Record<string, unknown>; retryAfter?: number | null }) => {
     if (error.response?.status === 429) {
       const detail = (error.response.data as Record<string, unknown>)?.detail || {};
       error.status = 429;
       error.rateLimitInfo = typeof detail === 'object' ? detail as Record<string, unknown> : {};
       error.retryAfter = parseInt(error.response.headers?.['retry-after'] as string, 10) || null;
     }
+
+    // iOS Safari returns from a frozen tab with a stale token before Supabase's auto-refresh
+    // runs, so a refetch hits a 401. Force-refresh once and replay the request.
+    const config = error.config as RetriableRequestConfig | undefined;
+    if (error.response?.status === 401 && config && !config._retry && _refreshToken) {
+      config._retry = true;
+      try {
+        const token = await _refreshToken();
+        if (token) {
+          config.headers.Authorization = `Bearer ${token}`;
+          return api(config);
+        }
+      } catch {
+        /* refresh failed — fall through and reject with the original error */
+      }
+    }
+
     return Promise.reject(error);
   },
 );

--- a/web/src/contexts/AuthContext.tsx
+++ b/web/src/contexts/AuthContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { supabase } from '../lib/supabase';
-import { setTokenGetter } from '../api/client';
+import { setTokenGetter, setTokenRefresher } from '../api/client';
 import { queryKeys } from '../lib/queryKeys';
 import { OAUTH_BROADCAST_CHANNEL, OAUTH_POPUP_WINDOW_NAME, OAUTH_POPUP_FEATURES } from '../lib/oauthPopup';
 import { clearFlashWorkspaceCache } from '@/pages/MarketView/utils/flashWorkspace';
@@ -67,6 +67,9 @@ function SupabaseAuthProvider({ children }: { children: React.ReactNode }) {
   const wireTokenGetter = useCallback(() => {
     setTokenGetter(() =>
       sb.auth.getSession().then((r) => r.data.session?.access_token ?? null)
+    );
+    setTokenRefresher(() =>
+      sb.auth.refreshSession().then((r) => r.data.session?.access_token ?? null)
     );
   }, [sb]);
 
@@ -151,6 +154,7 @@ function SupabaseAuthProvider({ children }: { children: React.ReactNode }) {
         resetStableNavOrder();
         resetSharedWorkspaceThreads();
         setTokenGetter(() => Promise.resolve(null));
+        setTokenRefresher(() => Promise.resolve(null));
       }
     });
 

--- a/web/src/contexts/__tests__/AuthContext.test.tsx
+++ b/web/src/contexts/__tests__/AuthContext.test.tsx
@@ -29,6 +29,7 @@ vi.mock('../../lib/supabase', () => ({
 
 vi.mock('../../api/client', () => ({
   setTokenGetter: vi.fn(),
+  setTokenRefresher: vi.fn(),
 }));
 
 // Spy on the module-level nav stores so we can assert sign-out resets them.

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -700,7 +700,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     setIsCompacting,
     queuedSend,
     isLoadingHistory,
-    isReconnecting: _isReconnecting,
+    isReconnecting,
     messageError,
     returnedSteering,
     clearReturnedSteering,
@@ -2858,6 +2858,14 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
                     )}
                     {messageError && !isLoading && (
                       <ErrorBanner error={messageError} />
+                    )}
+                    {isReconnecting && (
+                      <div className="flex items-center gap-2 px-3 py-1.5 text-xs"
+                        role="status" aria-live="polite"
+                        style={{ color: 'var(--color-text-tertiary)' }}>
+                        <Loader2 aria-hidden="true" className="h-3.5 w-3.5 animate-spin" style={{ color: 'var(--color-accent-primary)' }} />
+                        {t('chat.reconnecting', 'Reconnecting…')}
+                      </div>
                     )}
                     {/* Tail mode: main turn finished but a dispatched subagent is
                         still running in the backend. Independent of stop. */}

--- a/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.visibilityReconnect.test.ts
+++ b/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.visibilityReconnect.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Regression: returning a backgrounded tab to the foreground must proactively
+ * recover an in-flight main stream rather than hang.
+ *
+ * iOS Safari freezes a backgrounded tab and tears down its SSE socket; the
+ * frozen `reader.read()` may not reject promptly on resume, so nothing kicks
+ * the existing reconnect and the UI looks frozen. `useChatMessages` registers a
+ * `visibilitychange`/`pageshow` handler that — only when a main stream is
+ * genuinely active and reconnectable — flags a background abort and aborts the
+ * (likely dead) reader. The stream's result handler then re-kicks the existing
+ * `attemptReconnectAfterDisconnect` machinery (status check → reconnect stream)
+ * instead of treating the abort as a user stop.
+ *
+ * We use the REAL hook internals and mock only the api module: the send path and
+ * reconnect path touch sendChatMessageStream / getWorkflowStatus /
+ * reconnectToWorkflowStream, none of which need real network.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+import { act, waitFor } from '@testing-library/react';
+import { renderHookWithProviders } from '@/test/utils';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+vi.mock('@/lib/supabase', () => ({ supabase: null }));
+
+vi.mock('../utils/threadStorage', () => ({
+  getStoredThreadId: vi.fn().mockReturnValue(null),
+  setStoredThreadId: vi.fn(),
+  removeStoredThreadId: vi.fn(),
+}));
+
+vi.mock('../../utils/api', () => ({
+  sendChatMessageStream: vi.fn(),
+  sendHitlResponse: vi.fn(),
+  cancelWorkflow: vi.fn().mockResolvedValue({ success: true }),
+  replayThreadHistory: vi.fn().mockResolvedValue(undefined),
+  getWorkflowStatus: vi.fn().mockResolvedValue({ can_reconnect: false, status: 'completed' }),
+  reconnectToWorkflowStream: vi.fn().mockResolvedValue({ disconnected: false, aborted: false }),
+  streamSubagentTaskEvents: vi.fn(),
+  fetchThreadTurns: vi.fn().mockResolvedValue({ turns: [], retry_checkpoint_id: null }),
+  submitFeedback: vi.fn(),
+  removeFeedback: vi.fn(),
+  getThreadFeedback: vi.fn().mockResolvedValue([]),
+  watchThread: vi.fn(() => ({ abort: new AbortController() })),
+}));
+
+import { sendChatMessageStream, getWorkflowStatus, reconnectToWorkflowStream } from '../../utils/api';
+import { useChatMessages } from '../useChatMessages';
+
+const mockSend = sendChatMessageStream as Mock;
+const mockStatus = getWorkflowStatus as Mock;
+const mockReconnect = reconnectToWorkflowStream as Mock;
+
+// A sendChatMessageStream impl that mimics a long-lived SSE stream: it latches
+// the run_id (2nd-to-last arg) synchronously so currentRunIdRef is set, and the
+// returned promise stays pending until the AbortController.signal (last arg)
+// fires — then it resolves `{ aborted: true }`, exactly as the real streamFetch
+// does when the reader is aborted. This keeps isLoading true until the
+// foreground handler aborts the stream.
+function deferredStreamMock(runId = 'run-1', threadId = 'th-1') {
+  return vi.fn((...args: unknown[]) => {
+    const latch = args[args.length - 2] as (rid: string, tid: string) => void;
+    const signal = args[args.length - 1] as AbortSignal;
+    latch(runId, threadId);
+    return new Promise((resolve) => {
+      const onAbort = () => resolve({ disconnected: false, aborted: true, contentLocation: null });
+      if (signal.aborted) onAbort();
+      else signal.addEventListener('abort', onAbort, { once: true });
+    });
+  });
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+// Start an in-flight main stream and wait until it is live (isLoading true,
+// run_id latched). Returns the rendered hook result.
+async function startActiveStream(visibility: { value: string }) {
+  // Thread is NOT reconnectable on mount so the thread-load effect doesn't
+  // reconnect — isolates the post-resume reconnect under test.
+  mockStatus.mockResolvedValue({ can_reconnect: false, status: 'completed' });
+  mockSend.mockImplementation(deferredStreamMock('run-1', 'th-1'));
+
+  const { result } = renderHookWithProviders(() => useChatMessages('ws', 'th-1'));
+
+  // Let mount/history settle (no reconnect — can_reconnect:false).
+  await act(async () => { await flush(); });
+
+  await act(async () => {
+    void result.current.handleSendMessage('hello');
+    await flush();
+  });
+  await waitFor(() => expect(result.current.isLoading).toBe(true));
+  expect(mockSend).toHaveBeenCalledTimes(1);
+
+  // From here the run IS reconnectable; isolate the calls the resume produces.
+  mockStatus.mockResolvedValue({ can_reconnect: true, status: 'running', run_id: 'run-1', active_tasks: [] });
+  mockStatus.mockClear();
+  mockReconnect.mockClear();
+
+  void visibility; // visibility getter is wired by the suite's beforeEach
+  return result;
+}
+
+describe('useChatMessages — foreground (visibility) reconnect', () => {
+  const visibility = { value: 'visible' };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    visibility.value = 'visible';
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => visibility.value,
+    });
+  });
+
+  it('re-kicks reconnect for an in-flight main stream when the tab returns to foreground', async () => {
+    await startActiveStream(visibility);
+
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+      await flush();
+    });
+
+    // The frozen stream was aborted and the existing reconnect machinery fired.
+    await waitFor(() => expect(mockReconnect).toHaveBeenCalled());
+    expect(mockStatus).toHaveBeenCalled();
+    expect(mockReconnect.mock.calls[0][0]).toBe('th-1');
+    expect(mockReconnect.mock.calls[0][1]).toBe('run-1');
+  });
+
+  it('re-kicks reconnect on a pageshow event too', async () => {
+    await startActiveStream(visibility);
+
+    await act(async () => {
+      window.dispatchEvent(new Event('pageshow'));
+      await flush();
+    });
+
+    await waitFor(() => expect(mockReconnect).toHaveBeenCalled());
+    expect(mockStatus).toHaveBeenCalled();
+  });
+
+  it('does nothing when the tab becomes visible but no main stream is active', async () => {
+    mockStatus.mockResolvedValue({ can_reconnect: false, status: 'completed' });
+    renderHookWithProviders(() => useChatMessages('ws', 'th-1'));
+    await act(async () => { await flush(); });
+
+    mockStatus.mockClear();
+    mockReconnect.mockClear();
+
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+      await flush();
+    });
+
+    expect(mockReconnect).not.toHaveBeenCalled();
+  });
+
+  it('does nothing while the tab is still hidden (event fired but not visible)', async () => {
+    await startActiveStream(visibility);
+
+    visibility.value = 'hidden';
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+      await flush();
+    });
+
+    expect(mockReconnect).not.toHaveBeenCalled();
+  });
+
+  // Regression: a brand-new chat sends its FIRST message while the route prop is
+  // still '__default__' (it only flips to the real id on the first SSE event,
+  // which for a PTC turn can be 5–30s out during sandbox spin-up). The real
+  // server-assigned id is latched into threadIdRef by the Content-Location
+  // callback BEFORE the first byte. If the user backgrounds the tab in that
+  // window and returns, recovery must reconnect to the REAL thread — not bail
+  // because the prop reads '__default__'. Pre-fix, attemptReconnectAfterDisconnect
+  // (and reconnectToStream) keyed off the prop and broke immediately, so the
+  // first-answer window — the most common "ask, switch apps, come back" moment —
+  // never recovered.
+  it('reconnects to the latched real thread id when a first-turn ("__default__") send is backgrounded', async () => {
+    mockStatus.mockResolvedValue({ can_reconnect: false, status: 'completed' });
+    // Latch a REAL id while the prop stays '__default__' — what Content-Location
+    // does mid-send before the route updates.
+    mockSend.mockImplementation(deferredStreamMock('run-first', 'th-real'));
+
+    const { result } = renderHookWithProviders(() => useChatMessages('ws', '__default__'));
+    await act(async () => { await flush(); });
+
+    await act(async () => {
+      void result.current.handleSendMessage('hello');
+      await flush();
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(true));
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    // The POST itself carried the '__default__' prop as its thread arg…
+    expect(mockSend.mock.calls[0][2]).toBe('__default__');
+
+    // …but the run is now reconnectable under the real id.
+    mockStatus.mockResolvedValue({ can_reconnect: true, status: 'running', run_id: 'run-first', active_tasks: [] });
+    mockStatus.mockClear();
+    mockReconnect.mockClear();
+
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+      await flush();
+    });
+
+    await waitFor(() => expect(mockReconnect).toHaveBeenCalled());
+    // Status check + reconnect both target the latched real id, never '__default__'.
+    expect(mockStatus.mock.calls[0][0]).toBe('th-real');
+    expect(mockReconnect.mock.calls[0][0]).toBe('th-real');
+    expect(mockReconnect.mock.calls[0][1]).toBe('run-first');
+  });
+
+  // Regression: a steering follow-up sent mid-turn can be DEMOTED to a fresh
+  // backend turn (the prior turn went terminal before the POST landed). That
+  // demoted turn registers its own controller on mainStreamAbortRef, so the
+  // foreground handler can abort it on resume. Its result site must re-kick the
+  // existing reconnect — not fall through and finalize the live turn as
+  // truncated-complete (the silent-loss bug for the demote path).
+  it('re-kicks reconnect for a DEMOTED steering turn when the tab returns to foreground', async () => {
+    mockStatus.mockResolvedValue({ can_reconnect: false, status: 'completed' });
+
+    let steeringOnEvent: ((e: Record<string, unknown>) => void) | null = null;
+    mockSend.mockImplementation((...args: unknown[]) => {
+      const onEvent = args[5] as (e: Record<string, unknown>) => void;
+      const latch = args[args.length - 2] as (rid: string, tid: string) => void;
+      const signal = args[args.length - 1] as AbortSignal;
+      if (mockSend.mock.calls.length === 1) {
+        // Primary turn: latch a run so isLoading stays true, then hang. We never
+        // abort this stream — demotion reassigns mainStreamAbortRef away from it.
+        latch('run-main', 'th-1');
+        return new Promise(() => {});
+      }
+      // Steering POST: capture its onEvent so the test can drive demotion, and
+      // resolve { aborted } when its signal fires (what streamFetch does).
+      steeringOnEvent = onEvent;
+      return new Promise((resolve) => {
+        const onAbort = () =>
+          resolve({ disconnected: false, aborted: true, contentLocation: null });
+        if (signal.aborted) onAbort();
+        else signal.addEventListener('abort', onAbort, { once: true });
+      });
+    });
+
+    const { result } = renderHookWithProviders(() => useChatMessages('ws', 'th-1'));
+    await act(async () => { await flush(); });
+
+    // Primary turn → isLoading true.
+    await act(async () => {
+      void result.current.handleSendMessage('hello');
+      await flush();
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(true));
+
+    // Follow-up while streaming → handleSendSteering POSTs a second stream.
+    await act(async () => {
+      void result.current.handleSendMessage('steer me');
+      await flush();
+    });
+    await waitFor(() => expect(mockSend).toHaveBeenCalledTimes(2));
+    expect(steeringOnEvent).not.toBeNull();
+
+    // First non-steering frame = backend opened a NEW turn → demotion. The
+    // metadata frame carries the demoted run_id, latched into currentRunIdRef.
+    await act(async () => {
+      steeringOnEvent!({ event: 'metadata', thread_id: 'th-1', run_id: 'run-demoted' });
+      await flush();
+    });
+
+    // The demoted run is now reconnectable; isolate the resume's calls.
+    mockStatus.mockResolvedValue({
+      can_reconnect: true,
+      status: 'running',
+      run_id: 'run-demoted',
+      active_tasks: [],
+    });
+    mockStatus.mockClear();
+    mockReconnect.mockClear();
+
+    // Tab returns → foreground handler aborts the demoted stream → re-kick.
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+      await flush();
+    });
+
+    await waitFor(() => expect(mockReconnect).toHaveBeenCalled());
+    expect(mockStatus).toHaveBeenCalled();
+    expect(mockReconnect.mock.calls[0][0]).toBe('th-1');
+    expect(mockReconnect.mock.calls[0][1]).toBe('run-demoted');
+  });
+});

--- a/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.visibilityReconnect.test.ts
+++ b/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.visibilityReconnect.test.ts
@@ -75,6 +75,11 @@ function deferredStreamMock(runId = 'run-1', threadId = 'th-1') {
 
 const flush = () => new Promise((r) => setTimeout(r, 0));
 
+// Simulate a GENUINE tab suspend — iOS app-background / bfcache fires `pagehide`,
+// Chromium background-tab freeze fires `freeze`. The foreground reconnect only
+// arms after one of these; a bare `visibilitychange` (desktop alt-tab) must not.
+const suspendTab = () => window.dispatchEvent(new Event('pagehide'));
+
 // Start an in-flight main stream and wait until it is live (isLoading true,
 // run_id latched). Returns the rendered hook result.
 async function startActiveStream(visibility: { value: string }) {
@@ -120,6 +125,7 @@ describe('useChatMessages — foreground (visibility) reconnect', () => {
     await startActiveStream(visibility);
 
     await act(async () => {
+      suspendTab();
       document.dispatchEvent(new Event('visibilitychange'));
       await flush();
     });
@@ -135,6 +141,7 @@ describe('useChatMessages — foreground (visibility) reconnect', () => {
     await startActiveStream(visibility);
 
     await act(async () => {
+      suspendTab();
       window.dispatchEvent(new Event('pageshow'));
       await flush();
     });
@@ -171,6 +178,27 @@ describe('useChatMessages — foreground (visibility) reconnect', () => {
     expect(mockReconnect).not.toHaveBeenCalled();
   });
 
+  // Regression guard for the rest of users: a desktop tab-switch fires
+  // `visibilitychange` (and sometimes `pageshow`) but NOT `pagehide`/`freeze`,
+  // and the SSE socket stays alive. Without a genuine suspend the handler must
+  // NOT abort the live stream — else every alt-tab during a turn would needlessly
+  // tear it down and flash "Reconnecting…".
+  it('does NOT reconnect on a bare visibilitychange with no genuine suspend (desktop alt-tab)', async () => {
+    const result = await startActiveStream(visibility);
+
+    // No pagehide/freeze — just the visibility flip a desktop tab-switch produces.
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+      window.dispatchEvent(new Event('pageshow'));
+      await flush();
+    });
+
+    expect(mockReconnect).not.toHaveBeenCalled();
+    expect(mockStatus).not.toHaveBeenCalled();
+    // The live stream was left intact (still loading), not aborted.
+    expect(result.current.isLoading).toBe(true);
+  });
+
   // Regression: a brand-new chat sends its FIRST message while the route prop is
   // still '__default__' (it only flips to the real id on the first SSE event,
   // which for a PTC turn can be 5–30s out during sandbox spin-up). The real
@@ -205,6 +233,7 @@ describe('useChatMessages — foreground (visibility) reconnect', () => {
     mockReconnect.mockClear();
 
     await act(async () => {
+      suspendTab();
       document.dispatchEvent(new Event('visibilitychange'));
       await flush();
     });
@@ -284,6 +313,7 @@ describe('useChatMessages — foreground (visibility) reconnect', () => {
 
     // Tab returns → foreground handler aborts the demoted stream → re-kick.
     await act(async () => {
+      suspendTab();
       document.dispatchEvent(new Event('visibilitychange'));
       await flush();
     });

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -614,6 +614,14 @@ export function useChatMessages(
   // handler re-entry) doesn't append duplicate synthetic close events. Cleared
   // on the next send.
   const wasStoppedRef = useRef(false);
+  // Set by the foreground (visibilitychange/pageshow) handler when it aborts a
+  // likely-dead main stream on tab resume, so the stream's result handler
+  // re-kicks the existing reconnect instead of treating the abort as a user
+  // stop. Consumed (cleared) by the send/reconnect/HITL/checkpoint result
+  // sites; also reset at every stream entry point (alongside wasStoppedRef) so
+  // a stream type that doesn't consume it (e.g. steering) can't leak a stale
+  // flag into a later abort and mis-fire a reconnect onto the wrong turn.
+  const backgroundReconnectRef = useRef(false);
 
   // Refs for history loading state
   const historyLoadingRef = useRef(false);
@@ -755,6 +763,35 @@ export function useChatMessages(
       setStoredThreadId(workspaceId, threadId);
     }
   }, [workspaceId, threadId]);
+
+  // iOS Safari freezes a backgrounded tab and tears down its SSE socket; the
+  // frozen reader.read() may not reject promptly on return, hanging the turn.
+  // On foreground, if a main stream is genuinely active and reconnectable,
+  // abort the (likely dead) reader and flag it so the stream's result handler
+  // runs the existing reconnect rather than treating the abort as a user stop.
+  useEffect(() => {
+    const onForeground = () => {
+      if (typeof document === 'undefined' || document.visibilityState !== 'visible') return;
+      if (!isLoading || !mainStreamAbortRef.current) return;        // nothing streaming
+      // Use the latched thread ref, not the threadId prop: a brand-new chat
+      // keeps the prop at '__default__' until the first SSE event updates the
+      // route, but Content-Location already latched the real thread into
+      // threadIdRef. Keying off the prop would skip recovery for the entire
+      // first-answer window (e.g. a PTC sandbox spin-up), which is the most
+      // common "ask, switch apps, come back" moment.
+      const tid = threadIdRef.current;
+      if (!tid || tid === '__default__') return;                    // no addressable run
+      if (!currentRunIdRef.current || wasStoppedRef.current) return; // not reconnectable / user stop
+      backgroundReconnectRef.current = true;
+      mainStreamAbortRef.current.abort();
+    };
+    document.addEventListener('visibilitychange', onForeground);
+    window.addEventListener('pageshow', onForeground);
+    return () => {
+      document.removeEventListener('visibilitychange', onForeground);
+      window.removeEventListener('pageshow', onForeground);
+    };
+  }, [isLoading, threadId]); // refs are stable
 
   // Reset thread ID when workspace or initialThreadId changes
   useEffect(() => {
@@ -2090,7 +2127,14 @@ export function useChatMessages(
    * Creates an assistant message placeholder and processes live SSE events.
    */
   const reconnectToStream = async ({ activeTasks = [], runId, resetCursor = false }: { activeTasks?: string[]; runId?: string | null; resetCursor?: boolean } = {}) => {
-    if (!threadId || threadId === '__default__') return;
+    // Reconnect targets the LATCHED thread, not the threadId prop. A brand-new
+    // chat keeps the prop at '__default__' until the first SSE event updates the
+    // route, but Content-Location already latched the real id into threadIdRef.
+    // Keying off the prop would bail this whole first-answer window (the most
+    // common "ask, background the tab, come back" moment). Snapshot once so the
+    // id stays stable across this single reconnect attempt.
+    const tid = threadIdRef.current;
+    if (!tid || tid === '__default__') return;
 
     // Callers that (re)attach to the thread's CURRENT active run — thread-load,
     // cross-thread navigation, post-HITL resume, report-back — pass that run's
@@ -2101,7 +2145,7 @@ export function useChatMessages(
     if (runId !== undefined) currentRunIdRef.current = runId;
     if (resetCursor) lastEventIdRef.current = null;
 
-    console.log('[Reconnect] Starting reconnection for thread:', threadId);
+    console.log('[Reconnect] Starting reconnection for thread:', tid);
 
     // Clear subagent cards to prevent duplicate content from cache + Redis overlap
     if (clearSubagentCards) {
@@ -2111,13 +2155,14 @@ export function useChatMessages(
 
     setIsLoading(true);
     setIsReconnecting(true);
-    acquireStreamOwnership(threadId);
+    acquireStreamOwnership(tid);
     // Fresh stream: clear any stale stop flag from a PRIOR turn (e.g. user
     // hard-stopped thread A, then switched to live thread B). Without this the
     // stop-during-reconnect guards below (result.aborted || wasStoppedRef) would
     // bail this legitimate reconnect and leave isLoading stuck. Matches the reset
     // every other stream entry point does (handleSendMessage, resume, steering).
     wasStoppedRef.current = false;
+    backgroundReconnectRef.current = false;
 
     // Create assistant message placeholder for reconnection
     const assistantMessageId = `assistant-reconnect-${Date.now()}`;
@@ -2250,14 +2295,20 @@ export function useChatMessages(
       // which create subagent cards with the correct description/type. Per-task streams
       // are opened AFTER so they merge into existing cards instead of creating empty ones.
       const result = await reconnectToWorkflowStream(
-        threadId,
+        tid,
         currentRunIdRef.current,
         lastEventIdRef.current as number | null,
         processEvent,
         abortController.signal,
       );
       // User stop aborted the reader — stopWorkflow owns teardown; bail.
+      // Exception: a foreground handler aborted this stream because the tab
+      // resumed (background abort, not a user stop) — re-kick the reconnect.
       if (result?.aborted || wasStoppedRef.current) {
+        if (backgroundReconnectRef.current && !wasStoppedRef.current) {
+          backgroundReconnectRef.current = false;
+          attemptReconnectAfterDisconnect(currentMessageRef.current || assistantMessageId);
+        }
         return;
       }
       if (result?.disconnected) {
@@ -2305,7 +2356,7 @@ export function useChatMessages(
       if (activeTasks.length > 0) {
         console.log('[Reconnect] Opening per-task streams for active tasks:', activeTasks);
         for (const taskId of activeTasks) {
-          openSubagentStream(threadId, taskId, processEvent);
+          openSubagentStream(tid, taskId, processEvent);
         }
       }
     } catch (err: unknown) {
@@ -2344,8 +2395,17 @@ export function useChatMessages(
       const stillActive = mainStreamAbortRef.current === abortController;
       // Skip cleanup on a user stop too — stopWorkflow already cleared isLoading /
       // hasActiveSubagents and ran finalize; re-running it here would re-toggle
-      // loading and re-open the report-back watch after the stop.
-      if (stillActive && !wasInterruptedRef.current && !wasStoppedRef.current) {
+      // loading and re-open the report-back watch after the stop. Also skip when
+      // this reconnect's own stream was aborted (a foreground re-kick on tab
+      // resume): the re-kicked reconnect, suspended at its getWorkflowStatus
+      // await, still owns mainStreamAbortRef, so cleaning up here would null the
+      // spinner mid-resume. The per-stream abort signal is the reliable guard.
+      if (
+        stillActive &&
+        !wasInterruptedRef.current &&
+        !wasStoppedRef.current &&
+        !abortController.signal.aborted
+      ) {
         cleanupAfterStreamEnd(assistantMessageId);
       }
       // Clear the spinner only if THIS reconnect still owns it. A newer reconnect
@@ -2374,15 +2434,22 @@ export function useChatMessages(
 
     setIsReconnecting(true);
 
+    // Target the latched thread, not the threadId prop: a first-turn disconnect
+    // (background during a brand-new chat's first answer) still has the prop at
+    // '__default__' while the real id lives in threadIdRef. Snapshot once so the
+    // ~31s retry loop stays pinned to the run we started reconnecting, matching
+    // the prior closure-captured semantics.
+    const tid = threadIdRef.current;
+
     for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
-      if (!threadId || threadId === '__default__') break;
+      if (!tid || tid === '__default__') break;
 
       if (attempt > 0) {
         await new Promise((r) => setTimeout(r, BASE_DELAY * Math.pow(2, attempt - 1)));
       }
 
       try {
-        const status = await getWorkflowStatus(threadId);
+        const status = await getWorkflowStatus(tid);
         if (!status.can_reconnect) {
           console.log('[Reconnect] Workflow no longer reconnectable, cleaning up');
           break;
@@ -4246,6 +4313,7 @@ export function useChatMessages(
       // This demoted POST is now the active main turn; clear the stopped guard
       // and register its controller so stopWorkflow can abort it.
       wasStoppedRef.current = false;
+      backgroundReconnectRef.current = false;
       mainStreamAbortRef.current = steeringAbort;
       const refs = {
         contentOrderCounterRef,
@@ -4262,7 +4330,7 @@ export function useChatMessages(
 
     try {
       // Send to same endpoint — backend will auto-accept steering and return steering_accepted SSE
-      await sendChatMessageStream(
+      const result = await sendChatMessageStream(
         message,
         workspaceId,
         threadId,
@@ -4323,8 +4391,32 @@ export function useChatMessages(
       if (mainStreamAbortRef.current === steeringAbort) {
         mainStreamAbortRef.current = null;
       }
-      // User hit stop on the demoted turn: stopWorkflow owns the teardown.
-      if (wasStoppedRef.current) {
+      // A background abort (foreground handler on tab resume) or a transport
+      // drop returns a result flag instead of throwing. This is the one steering
+      // sub-case the foreground handler can hit: once we demote to a real new
+      // turn, steeringAbort owns mainStreamAbortRef, so an abort here lands on a
+      // live backend turn. Re-kick the existing reconnect instead of finalizing
+      // it as truncated-complete. A user stop is owned by stopWorkflow.
+      if (result?.aborted || wasStoppedRef.current) {
+        const reconnectId = currentMessageRef.current || demotedAssistantId;
+        if (
+          demotedToNewTurn &&
+          backgroundReconnectRef.current &&
+          !wasStoppedRef.current &&
+          reconnectId
+        ) {
+          backgroundReconnectRef.current = false;
+          attemptReconnectAfterDisconnect(reconnectId);
+        }
+        return;
+      }
+      // Natural transport drop on the demoted turn: reconnect rather than
+      // finalizing — the turn may still be running on the backend.
+      if (result?.disconnected && demotedToNewTurn) {
+        const reconnectId = currentMessageRef.current || demotedAssistantId;
+        if (reconnectId) {
+          attemptReconnectAfterDisconnect(reconnectId);
+        }
         return;
       }
       if (demotedToNewTurn) {
@@ -4493,6 +4585,7 @@ export function useChatMessages(
     completedTaskIdsRef.current.clear();
     // Clear the stopped guard so a fresh send can finalize again on stop.
     wasStoppedRef.current = false;
+    backgroundReconnectRef.current = false;
     // Mark streaming as in progress (prevents history loading during streaming)
     // AND claim ownership for this thread, so navigating to another thread mid-send
     // supersedes this stream rather than leaving it orphaned (the load guard would
@@ -4572,8 +4665,14 @@ export function useChatMessages(
       );
 
       // The user hit stop: stopWorkflow already finalized the message and ran
-      // teardown. Skip reconnect/cleanup so we don't double-fire.
+      // teardown. Skip reconnect/cleanup so we don't double-fire. Exception: a
+      // foreground handler aborted this stream because the tab resumed
+      // (background abort, not a user stop) — re-kick the reconnect instead.
       if (result?.aborted || wasStoppedRef.current) {
+        if (backgroundReconnectRef.current && !wasStoppedRef.current) {
+          backgroundReconnectRef.current = false;
+          attemptReconnectAfterDisconnect(currentMessageRef.current || assistantMessageId);
+        }
         return;
       }
 
@@ -4740,6 +4839,7 @@ export function useChatMessages(
     setIsLoading(true);
     setMessageError(null);
     wasStoppedRef.current = false;
+    backgroundReconnectRef.current = false;
     acquireStreamOwnership(threadId);
     // Fresh AbortController so stopWorkflow can abort this resumed stream.
     const abortController = new AbortController();
@@ -4781,8 +4881,16 @@ export function useChatMessages(
         abortController.signal,
       );
 
-      // User hit stop: stopWorkflow already finalized + tore down.
+      // User hit stop: stopWorkflow already finalized + tore down. Exception: a
+      // foreground handler aborted this stream on tab resume (background abort,
+      // not a user stop) — treat it as a disconnect and re-kick the reconnect so
+      // the resumed-from-stop turn recovers instead of dying silently.
       if (result?.aborted || wasStoppedRef.current) {
+        if (backgroundReconnectRef.current && !wasStoppedRef.current) {
+          backgroundReconnectRef.current = false;
+          wasDisconnected = true;
+          attemptReconnectAfterDisconnect(assistantMessageId);
+        }
         return;
       }
 
@@ -5076,6 +5184,7 @@ export function useChatMessages(
     setHasActiveSubagents(false);
     completedTaskIdsRef.current.clear();
     wasStoppedRef.current = false;
+    backgroundReconnectRef.current = false;
     acquireStreamOwnership(threadId);
 
     // Truncate messages and add new user message (if editing) + assistant placeholder
@@ -5150,8 +5259,16 @@ export function useChatMessages(
         abortController.signal,
       );
 
-      // User hit stop: stopWorkflow already finalized + tore down.
+      // User hit stop: stopWorkflow already finalized + tore down. Exception: a
+      // foreground handler aborted this stream on tab resume (background abort,
+      // not a user stop) — treat it as a disconnect and re-kick the reconnect so
+      // the resumed turn recovers instead of dying silently.
       if (result?.aborted || wasStoppedRef.current) {
+        if (backgroundReconnectRef.current && !wasStoppedRef.current) {
+          backgroundReconnectRef.current = false;
+          wasDisconnected = true;
+          attemptReconnectAfterDisconnect(assistantMessageId);
+        }
         return;
       }
 

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -622,6 +622,14 @@ export function useChatMessages(
   // a stream type that doesn't consume it (e.g. steering) can't leak a stale
   // flag into a later abort and mis-fire a reconnect onto the wrong turn.
   const backgroundReconnectRef = useRef(false);
+  // True once the tab was GENUINELY suspended (Page Lifecycle `pagehide`/`freeze`)
+  // since it last became visible — the only state in which the SSE socket was
+  // actually torn down. A plain desktop tab-switch fires `visibilitychange` but
+  // NOT these, and keeps the socket alive; gating the foreground reconnect on
+  // this flag means alt-tabbing never aborts a healthy stream (no regression for
+  // non-suspended users). Set on suspend, consumed+cleared by the first resume
+  // handler so one suspend→resume cycle triggers at most one reconnect.
+  const tabSuspendedRef = useRef(false);
 
   // Refs for history loading state
   const historyLoadingRef = useRef(false);
@@ -769,9 +777,22 @@ export function useChatMessages(
   // On foreground, if a main stream is genuinely active and reconnectable,
   // abort the (likely dead) reader and flag it so the stream's result handler
   // runs the existing reconnect rather than treating the abort as a user stop.
+  //
+  // CRITICAL: only act when the tab was ACTUALLY suspended (`pagehide`/`freeze`),
+  // not on a bare `visibilitychange`. A desktop alt-tab fires visibility events
+  // but keeps the socket alive — aborting there would needlessly tear down a
+  // healthy stream and flash "Reconnecting…" on every refocus. The lifecycle
+  // suspend events fire only when the OS froze the tab (the case the socket
+  // dies), so gating on tabSuspendedRef keeps non-suspended users unaffected.
   useEffect(() => {
+    const onSuspend = () => { tabSuspendedRef.current = true; };
     const onForeground = () => {
       if (typeof document === 'undefined' || document.visibilityState !== 'visible') return;
+      // No genuine suspend since we were last visible → socket is still alive,
+      // nothing to recover. Consume the flag so each suspend→resume cycle
+      // triggers at most one reconnect (pageshow + visibilitychange both fire).
+      if (!tabSuspendedRef.current) return;
+      tabSuspendedRef.current = false;
       if (!isLoading || !mainStreamAbortRef.current) return;        // nothing streaming
       // Use the latched thread ref, not the threadId prop: a brand-new chat
       // keeps the prop at '__default__' until the first SSE event updates the
@@ -785,9 +806,16 @@ export function useChatMessages(
       backgroundReconnectRef.current = true;
       mainStreamAbortRef.current.abort();
     };
+    // Suspend signals: pagehide (iOS app-background / bfcache) + freeze (Chromium
+    // background-tab freeze). Both fire only on a real suspend, never on a tab-switch.
+    window.addEventListener('pagehide', onSuspend);
+    document.addEventListener('freeze', onSuspend);
+    // Resume triggers: pageshow (bfcache restore) + visibilitychange (return to visible).
     document.addEventListener('visibilitychange', onForeground);
     window.addEventListener('pageshow', onForeground);
     return () => {
+      window.removeEventListener('pagehide', onSuspend);
+      document.removeEventListener('freeze', onSuspend);
       document.removeEventListener('visibilitychange', onForeground);
       window.removeEventListener('pageshow', onForeground);
     };

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -819,7 +819,10 @@ export function useChatMessages(
       document.removeEventListener('visibilitychange', onForeground);
       window.removeEventListener('pageshow', onForeground);
     };
-  }, [isLoading, threadId]); // refs are stable
+    // Only isLoading is read in the handler closure; the thread identity comes
+    // from threadIdRef.current, not the prop, so threadId is intentionally NOT a
+    // dep — including it would re-register the listeners on every thread nav.
+  }, [isLoading]); // refs are stable
 
   // Reset thread ID when workspace or initialThreadId changes
   useEffect(() => {

--- a/web/src/pages/ChatAgent/utils/__tests__/api.test.ts
+++ b/web/src/pages/ChatAgent/utils/__tests__/api.test.ts
@@ -34,6 +34,7 @@ import {
   sendHitlResponse,
   streamWorkspaceEvents,
   watchThread,
+  reconnectToWorkflowStream,
 } from '../api';
 
 const mockGet = api.get as Mock;
@@ -474,6 +475,54 @@ describe('ChatAgent API utilities', () => {
       ]);
       await runWatch();
       expect(reader.cancel).toHaveBeenCalled();
+    });
+  });
+
+  describe('reconnectToWorkflowStream transport-error classification (Prong A)', () => {
+    let originalFetch: typeof global.fetch;
+
+    beforeEach(() => {
+      originalFetch = global.fetch;
+    });
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    /** Build a fetch mock whose reader.read() rejects with the given error. */
+    function mockRejectingReader(error: Error) {
+      const reader = {
+        read: vi.fn().mockRejectedValue(error),
+        cancel: vi.fn(async () => {}),
+      };
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        body: { getReader: () => reader },
+      });
+      global.fetch = fetchMock as unknown as typeof fetch;
+      return { fetchMock, reader };
+    }
+
+    it('classifies a TypeError("Load failed") read rejection as a disconnect (iOS Safari background-kill)', async () => {
+      // The fail-first proof: "Load failed" contains no "network" substring, so
+      // the old classifier re-threw it (error banner, no reconnect). After Prong
+      // A, any TypeError out of the read loop resolves as a disconnect.
+      mockRejectingReader(new TypeError('Load failed'));
+      const result = await reconnectToWorkflowStream('t-1');
+      expect(result.disconnected).toBe(true);
+      expect(result.aborted).toBe(false);
+    });
+
+    it('classifies a TypeError("The network connection was lost.") read rejection as a disconnect', async () => {
+      // Forward-looking guard for the other iOS Safari string. (This literal
+      // already contains "network", so the old classifier handled it too; this
+      // test pins it down regardless of the substring.)
+      mockRejectingReader(new TypeError('The network connection was lost.'));
+      const result = await reconnectToWorkflowStream('t-1');
+      expect(result.disconnected).toBe(true);
+      expect(result.aborted).toBe(false);
     });
   });
 });

--- a/web/src/pages/ChatAgent/utils/api.ts
+++ b/web/src/pages/ChatAgent/utils/api.ts
@@ -11,7 +11,25 @@ const baseURL = api.defaults.baseURL;
 async function getAuthHeaders(): Promise<Record<string, string>> {
   if (!supabase) return {};
   const { data } = await supabase.auth.getSession();
-  const token = data.session?.access_token;
+  const session = data.session;
+  let token = session?.access_token;
+  // Supabase's auto-refresh timer is frozen while the tab is backgrounded, so on
+  // resume the cached session may already be expired. If it's past (or within
+  // ~60s of) expiry, force a refresh so SSE reconnects don't fire with a dead
+  // token and 401. expires_at is a Unix timestamp in SECONDS. Never throw from
+  // this helper: a failed refresh falls back to whatever token we already have.
+  if (session && token && typeof session.expires_at === 'number') {
+    const nowSec = Math.floor(Date.now() / 1000);
+    if (session.expires_at - nowSec <= 60) {
+      try {
+        const { data: refreshed } = await supabase.auth.refreshSession();
+        const newToken = refreshed.session?.access_token;
+        if (newToken) token = newToken;
+      } catch {
+        /* refresh failed — keep the existing (possibly stale) token */
+      }
+    }
+  }
   return token ? { Authorization: `Bearer ${token}` } : {};
 }
 
@@ -426,9 +444,16 @@ async function streamFetch(
     // callers skip reconnect/error-toast/double-cleanup.
     if ((error as { name?: string })?.name === 'AbortError') {
       aborted = true;
-    } else if (error instanceof Error && error.name === 'TypeError' && error.message.includes('network')) {
-      // Handle incomplete chunked encoding or other stream errors
-      console.warn('[api] Stream interrupted (network error):', error.message);
+    } else if (error instanceof Error && error.name === 'TypeError') {
+      // iOS Safari freezes a backgrounded tab and tears down its connection,
+      // rejecting reader.read() with "Load failed" / "The network connection was
+      // lost." — neither reliably contains "network", so the old substring guard
+      // re-threw it and surfaced a dead-end error banner with no reconnect. Per
+      // the Streams/Fetch spec, reader.read() only rejects with a TypeError on a
+      // transport-level network error; the loop body (decode/split/processLine,
+      // which guards its own JSON.parse) won't otherwise throw one. So treat any
+      // TypeError here as a dropped stream and route it into the reconnect path.
+      console.warn('[api] Stream interrupted (transport error):', error.message);
       disconnected = true;
     } else {
       throw error;


### PR DESCRIPTION
## Problem

On iPhone Safari, backgrounding the browser during an active chat turn and returning hangs the chat and shows a dead-end **"failed to load"** banner. iOS Safari freezes a backgrounded tab's JS and tears down its network connections; the chat consumes a long-lived SSE stream over raw `fetch()` + `ReadableStream`, so the frozen-then-killed socket breaks the stream. The app already has full reconnect/resume infrastructure — a string-match bug just stopped Safari from ever reaching it.

## Root cause

The SSE reader loop in `streamFetch()` only classified a thrown error as a recoverable disconnect when `error.name === 'TypeError' && message.includes('network')`. iOS Safari's background-kill rejects the read with `TypeError: Load failed` — no `"network"` substring — so it fell through to `throw`, surfacing the error banner and never triggering the existing 5-retry reconnect.

Secondary gaps: nothing kicked recovery if the frozen `read()` didn't reject promptly on resume (the hang); the reconnect path keyed off the `threadId` prop, which is still `'__default__'` during a brand-new chat's first-answer window; and a refetch-on-focus storm could 401 before Supabase's frozen auto-refresh timer caught up.

## What changed (A + B + C)

- **A — Classify Safari transport drops as reconnects.** Any `TypeError` escaping the SSE read loop is now treated as a transport drop and routed into `attemptReconnectAfterDisconnect`, reusing the existing resume machinery (`getWorkflowStatus().can_reconnect` → `Last-Event-ID` resume, or history reload if the run already finished).
- **B — Proactive foreground reconnect + visible state.** A return-to-foreground handler aborts the likely-dead reader and re-kicks reconnect at every main-stream result site (send, reconnect, HITL, checkpoint, demoted steering) — gated so a background abort is never mistaken for a user stop. The reconnect path keys off the **latched `threadIdRef`** instead of the `threadId` prop, so a first-turn chat still on the `'__default__'` route recovers. A "Reconnecting…" indicator surfaces the resume.
  - **Scoped to genuine suspends only:** the reconnect arms on `pagehide`/`freeze` (the OS actually froze the tab and killed the socket), not on a bare `visibilitychange`. A desktop alt-tab fires neither and keeps the socket alive, so non-suspended users see **no behavior change** — no needless teardown, no "Reconnecting…" flash on refocus.
- **C — Token-refresh resilience.** The axios response interceptor does a single-shot refresh-and-retry on 401 (`config._retry` guards against loops); `AuthContext` registers/clears the refresher; `getAuthHeaders` force-refreshes an expired/near-expiry token before opening the SSE stream. Local-dev (no Supabase) registers none and behaves exactly as before.

## Overview

**Totals** — 9 files, **+713 / −24**

| | Files | Net (excl. tests) |
|---|---|---|
| Source (modified) | 5 | **+232 / −23** |
| Tests (1 new, 3 modified) | 4 | +481 / −1 |

**By module (source):**

| File | Δ | What |
|---|---|---|
| `ChatAgent/hooks/useChatMessages.ts` | +160 / −15 | suspend-gated foreground-reconnect effect, re-kick at all result sites, `__default__`-aware reconnect keying, demote-path re-kick |
| `ChatAgent/utils/api.ts` | +29 / −4 | broaden read-loop `TypeError` → disconnect; force-refresh SSE auth token |
| `api/client.ts` | +29 / −2 | `setTokenRefresher` + single-shot 401 refresh-and-retry |
| `ChatAgent/components/ChatView.tsx` | +9 / −1 | "Reconnecting…" indicator |
| `contexts/AuthContext.tsx` | +5 / −1 | register refresher on login, clear on logout |

**What this introduces:** a small foreground-reconnect lifecycle surface (one effect + per-result-site re-kicks) armed only on genuine tab suspend, latched-thread reconnect keying for the first-answer window, and a reactive 401 refresh interceptor on the REST path. No architectural change — all resume logic is reused, not reinvented.

## Testing

- New `useChatMessages.visibilityReconnect.test.ts` (7 tests): foreground re-kick after a real suspend on `visibilitychange`/`pageshow`; **no reconnect on a bare tab-switch with no suspend** (desktop no-regression guard); inert when no stream is active / tab still hidden; demoted-steering re-kick; and the **first-turn `'__default__'` reconnect** (renders on `'__default__'`, latches a real server id, asserts reconnect targets the real id — verified fail-before/pass-after).
- `api.test.ts`: `TypeError: Load failed` and `The network connection was lost.` both resolve `{ disconnected: true }` instead of throwing.
- `client.test.ts`: 401→200 single refresh+retry succeeds; 401→401 rejects (no loop); no refresher ⇒ rejects (local-dev parity).
- Full suite: **182 files, 2019 passed**. `tsc --noEmit` clean. Lint clean on changed files. Each of the 4 commits is green in isolation — bisectable.

## Still pending / follow-ups

- **True-device verification** (gold standard): physical iPhone Safari (or iOS Simulator) — background a long PTC turn ~30–60s, return, expect a brief "Reconnecting…" then resume/complete with no error banner. Desktop Safari only partially reproduces (keeps the socket alive — now intentionally a no-op).
- **Fast-follow #2 — connect-time TypeError:** the initial-fetch catch in `api.ts` still throws on a *reconnect's* opening fetch (Prong A is scoped to the mid-read catch).
- **Fast-follow #3 — SSE-path 401 retry:** raw-`fetch()` SSE streams aren't covered by the axios 401 interceptor; `getAuthHeaders` force-refresh mitigates proactively, but there's no reactive refresh-and-retry if an SSE reconnect itself 401s.
- **iOS edge case:** if iOS freezes a tab without firing `pagehide`/`freeze` (rare), the proactive handler won't arm — Prong A still recovers it once the frozen `read()` eventually rejects.
- **i18n:** add `chat.reconnecting` to `en-US.json` / `zh-CN.json` (currently an inline English fallback).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a visible “Reconnecting…” status indicator in the chat UI while the app recovers.

* **Bug Fixes**
  * Improved chat stream recovery after tab switching and app backgrounding, preventing stuck or lost streams.
  * Enhanced request retry behavior: failed requests refresh the token once on unauthorized responses, then retry safely without looping.
  * Improved live-stream reliability by refreshing near-expiry sessions and treating mobile transport interruptions as reconnectable events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->