### PR TITLE
fix(dashboard): restore Market Overview index cards (#287)

### DIFF
--- a/src/data_client/market_data_provider.py
+++ b/src/data_client/market_data_provider.py
@@ -221,7 +221,10 @@ class MarketDataProvider:
     ) -> list[dict[str, Any]]:
         """Fetch batch snapshots with per-symbol market routing and fallback."""
         def normalize_symbol(value: Any) -> str:
-            return str(value).strip().upper()
+            # lstrip("^") so a provider returning the Yahoo caret form ("^GSPC")
+            # still matches the bare requested index symbol ("GSPC"). Request
+            # symbols are caret-free, so this is a no-op for them.
+            return str(value).strip().upper().lstrip("^")
 
         pending = [s for s in symbols if str(s).strip()]
         if not pending:

--- a/src/data_client/market_data_provider.py
+++ b/src/data_client/market_data_provider.py
@@ -221,10 +221,13 @@ class MarketDataProvider:
     ) -> list[dict[str, Any]]:
         """Fetch batch snapshots with per-symbol market routing and fallback."""
         def normalize_symbol(value: Any) -> str:
-            # lstrip("^") so a provider returning the Yahoo caret form ("^GSPC")
-            # still matches the bare requested index symbol ("GSPC"). Request
-            # symbols are caret-free, so this is a no-op for them.
-            return str(value).strip().upper().lstrip("^")
+            # removeprefix("^") so a provider returning the Yahoo caret form
+            # ("^GSPC") still matches the bare requested index symbol ("GSPC").
+            # Strips exactly one leading caret (Yahoo's index prefix) — unlike
+            # lstrip, a malformed "^^X" won't collapse onto a bare "X" request
+            # and resolve it against the wrong source. Request symbols are
+            # caret-free, so this is a no-op for them.
+            return str(value).strip().upper().removeprefix("^")
 
         pending = [s for s in symbols if str(s).strip()]
         if not pending:

--- a/src/data_client/yfinance/data_source.py
+++ b/src/data_client/yfinance/data_source.py
@@ -161,7 +161,18 @@ class YFinanceDataSource:
         results = await asyncio.gather(
             *(asyncio.to_thread(_fetch_single_snapshot, s) for s in prepared)
         )
-        return [r for r in results if r is not None]
+        # gather preserves order, so results[i] maps back to symbols[i]. Restore
+        # the originally-requested (bare) symbol — the caret was only for the
+        # Yahoo query — so the provider chain matches on the requested ticker
+        # instead of dropping "^GSPC" as unrequested. Keeps yfinance consistent
+        # with FMP/ginlix-data, which already return bare index symbols.
+        out: list[dict[str, Any]] = []
+        for original, snap in zip(symbols, results):
+            if snap is None:
+                continue
+            snap["symbol"] = original
+            out.append(snap)
+        return out
 
     async def get_market_status(
         self,

--- a/tests/unit/data_client/test_market_data_provider.py
+++ b/tests/unit/data_client/test_market_data_provider.py
@@ -366,6 +366,23 @@ class TestMarketDataProvider:
         assert "market_data.snapshot.drop_unrequested" in caplog.text
 
     @pytest.mark.asyncio
+    async def test_get_snapshots_keeps_caret_prefixed_index_symbol(self, caplog):
+        # A provider that echoes the Yahoo caret form ("^GSPC") for a bare
+        # requested index symbol ("GSPC") must be matched, not dropped —
+        # normalize_symbol strips the caret. Regression for the index-card
+        # 0.00 bug (#287).
+        src = SnapshotSource(
+            "caret",
+            extra_rows=[{"symbol": "^GSPC", "price": 5000.0}],
+        )
+        provider = MarketDataProvider([ProviderEntry("caret", src, {"all"})])
+
+        result = await provider.get_snapshots(["GSPC"], asset_type="indices")
+
+        assert result == [{"symbol": "^GSPC", "price": 5000.0}]
+        assert "market_data.snapshot.drop_unrequested" not in caplog.text
+
+    @pytest.mark.asyncio
     async def test_get_snapshots_falls_back_when_provider_returns_no_rows(self):
         empty_src = SnapshotSource("primary")
         fallback_src = SnapshotSource(

--- a/tests/unit/data_client/test_market_data_provider.py
+++ b/tests/unit/data_client/test_market_data_provider.py
@@ -383,6 +383,23 @@ class TestMarketDataProvider:
         assert "market_data.snapshot.drop_unrequested" not in caplog.text
 
     @pytest.mark.asyncio
+    async def test_get_snapshots_double_caret_row_does_not_alias_bare_index(self, caplog):
+        # normalize_symbol strips exactly ONE leading caret (removeprefix, not
+        # lstrip), so a malformed "^^GSPC" row normalizes to "^GSPC" and must
+        # NOT alias the bare requested "GSPC" — it's dropped as unrequested
+        # instead of resolving the request against the wrong data.
+        src = SnapshotSource(
+            "caret",
+            extra_rows=[{"symbol": "^^GSPC", "price": 5000.0}],
+        )
+        provider = MarketDataProvider([ProviderEntry("caret", src, {"all"})])
+
+        result = await provider.get_snapshots(["GSPC"], asset_type="indices")
+
+        assert result == []
+        assert "market_data.snapshot.drop_unrequested" in caplog.text
+
+    @pytest.mark.asyncio
     async def test_get_snapshots_falls_back_when_provider_returns_no_rows(self):
         empty_src = SnapshotSource("primary")
         fallback_src = SnapshotSource(

--- a/tests/unit/data_client/test_yfinance_data_source.py
+++ b/tests/unit/data_client/test_yfinance_data_source.py
@@ -1,0 +1,62 @@
+"""Unit tests for the yfinance data source snapshots — no network."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from src.data_client.yfinance.data_source import YFinanceDataSource
+
+
+@pytest.mark.asyncio
+async def test_get_snapshots_returns_bare_index_symbol():
+    """Indices are queried from Yahoo with a caret ("^GSPC"), but the snapshot
+    must echo back the bare requested symbol ("GSPC") so the provider chain
+    matches it instead of dropping it as unrequested. Regression for #287.
+    """
+    def fake_fetch(sym: str) -> dict:
+        # Mirrors the real fetch: echoes whatever symbol it was queried with.
+        return {"symbol": sym, "price": 5000.0}
+
+    with patch(
+        "src.data_client.yfinance.data_source._fetch_single_snapshot",
+        side_effect=fake_fetch,
+    ):
+        result = await YFinanceDataSource().get_snapshots(
+            ["GSPC"], asset_type="indices"
+        )
+
+    assert result == [{"symbol": "GSPC", "price": 5000.0}]
+
+
+@pytest.mark.asyncio
+async def test_get_snapshots_preserves_order_and_drops_failures():
+    """Symbol restoration stays aligned when a fetch returns None."""
+    def fake_fetch(sym: str) -> dict | None:
+        return None if sym == "^IXIC" else {"symbol": sym, "price": 1.0}
+
+    with patch(
+        "src.data_client.yfinance.data_source._fetch_single_snapshot",
+        side_effect=fake_fetch,
+    ):
+        result = await YFinanceDataSource().get_snapshots(
+            ["GSPC", "IXIC", "DJI"], asset_type="indices"
+        )
+
+    assert [r["symbol"] for r in result] == ["GSPC", "DJI"]
+
+
+@pytest.mark.asyncio
+async def test_get_snapshots_stocks_pass_symbol_through_unchanged():
+    """Stocks aren't caret-prefixed; the symbol is returned as requested."""
+    def fake_fetch(sym: str) -> dict:
+        return {"symbol": sym, "price": 190.0}
+
+    with patch(
+        "src.data_client.yfinance.data_source._fetch_single_snapshot",
+        side_effect=fake_fetch,
+    ):
+        result = await YFinanceDataSource().get_snapshots(["AAPL"])
+
+    assert result == [{"symbol": "AAPL", "price": 190.0}]

--- a/web/src/pages/Dashboard/components/IndexMovementCard.tsx
+++ b/web/src/pages/Dashboard/components/IndexMovementCard.tsx
@@ -5,6 +5,7 @@ import { LineChart, Line, ResponsiveContainer, YAxis, Tooltip } from 'recharts';
 import { motion, AnimatePresence, type PanInfo } from 'framer-motion';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { createFormatter } from '@/lib/format';
+import { utcMsToETDate } from '@/lib/utils';
 import type { IndexData } from '@/types/market';
 
 const fmt2 = createFormatter({ minimumFractionDigits: 2, maximumFractionDigits: 2 });
@@ -46,14 +47,15 @@ function IndexCardContent({ index }: { index: IndexData }) {
   );
 
   // Show the date of the session the data belongs to (e.g. the last trading day
-  // when the market is closed/pre-open), falling back to today if unknown.
+  // when the market is closed/pre-open), falling back to today (ET) if unknown
+  // or malformed. ET — not browser-local — so the fallback matches the
+  // ET-derived asOfDate on sibling cards for users outside US timezones.
   const dateStr = (() => {
-    if (index.asOfDate) {
-      const [, mo, d] = index.asOfDate.split('-');
-      return `${Number(mo)}/${Number(d)}`;
-    }
-    const today = new Date();
-    return `${today.getMonth() + 1}/${today.getDate()}`;
+    const iso = /^\d{4}-\d{2}-\d{2}$/.test(index.asOfDate ?? '')
+      ? (index.asOfDate as string)
+      : utcMsToETDate(Date.now());
+    const [, mo, d] = iso.split('-');
+    return `${Number(mo)}/${Number(d)}`;
   })();
 
   return (
@@ -106,7 +108,11 @@ function IndexCardContent({ index }: { index: IndexData }) {
               <Line
                 type="monotone"
                 dataKey="val"
-                stroke={pos ? 'var(--color-profit)' : 'var(--color-loss)'}
+                stroke={
+                  hasQuote
+                    ? pos ? 'var(--color-profit)' : 'var(--color-loss)'
+                    : 'var(--color-text-secondary)'
+                }
                 strokeWidth={1.5}
                 dot={false}
                 isAnimationActive={false}

--- a/web/src/pages/Dashboard/components/IndexMovementCard.tsx
+++ b/web/src/pages/Dashboard/components/IndexMovementCard.tsx
@@ -35,6 +35,7 @@ interface IndexMovementCardProps {
 
 function IndexCardContent({ index }: { index: IndexData }) {
   useTranslation();
+  const hasQuote = index.quoteAvailable !== false;
   const pos = index.isPositive;
   const ch = Number(index.change);
   const pct = Number(index.changePercent);
@@ -73,13 +74,17 @@ function IndexCardContent({ index }: { index: IndexData }) {
               className="text-lg font-bold tracking-tight dashboard-mono"
               style={{ color: 'var(--color-text-primary)' }}
             >
-              {fmt2(Number(index.price))}
+              {hasQuote ? fmt2(Number(index.price)) : 'N/A'}
             </div>
             <div
               className="text-xs dashboard-mono"
-              style={{ color: pos ? 'var(--color-profit)' : 'var(--color-loss)' }}
+              style={{
+                color: hasQuote
+                  ? pos ? 'var(--color-profit)' : 'var(--color-loss)'
+                  : 'var(--color-text-secondary)',
+              }}
             >
-              {changeStr} {pctStr}
+              {hasQuote ? `${changeStr} ${pctStr}` : 'N/A'}
             </div>
           </div>
         </div>

--- a/web/src/pages/Dashboard/components/IndexMovementCard.tsx
+++ b/web/src/pages/Dashboard/components/IndexMovementCard.tsx
@@ -45,8 +45,16 @@ function IndexCardContent({ index }: { index: IndexData }) {
     typeof pt === 'object' ? { ...pt, i } : { val: pt as unknown as number, i },
   );
 
-  const today = new Date();
-  const dateStr = `${today.getMonth() + 1}/${today.getDate()}`;
+  // Show the date of the session the data belongs to (e.g. the last trading day
+  // when the market is closed/pre-open), falling back to today if unknown.
+  const dateStr = (() => {
+    if (index.asOfDate) {
+      const [, mo, d] = index.asOfDate.split('-');
+      return `${Number(mo)}/${Number(d)}`;
+    }
+    const today = new Date();
+    return `${today.getMonth() + 1}/${today.getDate()}`;
+  })();
 
   return (
     <>

--- a/web/src/pages/Dashboard/components/__tests__/IndexMovementCard.test.tsx
+++ b/web/src/pages/Dashboard/components/__tests__/IndexMovementCard.test.tsx
@@ -36,6 +36,14 @@ describe('IndexMovementCard', () => {
     expect(screen.queryByText('N/A')).not.toBeInTheDocument();
   });
 
+  it('renders the price when quoteAvailable is undefined (backward compat)', () => {
+    // Pre-existing IndexData has no quoteAvailable field; the `!== false`
+    // sentinel must treat undefined as "has quote" so old data still renders.
+    renderCard(baseIndex());
+    expect(screen.getByText(noGrouping('5000.12'))).toBeInTheDocument();
+    expect(screen.queryByText('N/A')).not.toBeInTheDocument();
+  });
+
   it('masks price and change as N/A when the quote is unavailable', () => {
     renderCard(
       baseIndex({ quoteAvailable: false, price: 0, change: 0, changePercent: 0 }),

--- a/web/src/pages/Dashboard/components/__tests__/IndexMovementCard.test.tsx
+++ b/web/src/pages/Dashboard/components/__tests__/IndexMovementCard.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import IndexMovementCard from '../IndexMovementCard';
+import type { IndexData } from '@/types/market';
+
+const baseIndex = (over: Partial<IndexData> = {}): IndexData => ({
+  symbol: 'GSPC',
+  name: 'S&P 500',
+  price: 5000.12,
+  change: 12.34,
+  changePercent: 0.25,
+  isPositive: true,
+  sparklineData: [
+    { time: '09:30', val: 4990 },
+    { time: '16:00', val: 5000.12 },
+  ],
+  ...over,
+});
+
+const renderCard = (index: IndexData) =>
+  render(
+    <MemoryRouter>
+      <IndexMovementCard indices={[index]} />
+    </MemoryRouter>,
+  );
+
+// fmt2 is locale-aware; strip grouping separators before comparing.
+const noGrouping = (expected: string) => (content: string) =>
+  content.replace(/[\s,]/g, '') === expected;
+
+describe('IndexMovementCard', () => {
+  it('renders the formatted price when a quote is available', () => {
+    renderCard(baseIndex({ quoteAvailable: true }));
+    expect(screen.getByText(noGrouping('5000.12'))).toBeInTheDocument();
+    expect(screen.queryByText('N/A')).not.toBeInTheDocument();
+  });
+
+  it('masks price and change as N/A when the quote is unavailable', () => {
+    renderCard(
+      baseIndex({ quoteAvailable: false, price: 0, change: 0, changePercent: 0 }),
+    );
+    // both the price and the change/percent line render N/A
+    expect(screen.getAllByText('N/A')).toHaveLength(2);
+    expect(screen.queryByText(noGrouping('0.00'))).not.toBeInTheDocument();
+  });
+
+  it('labels the card with the asOfDate session date (M/D), not today', () => {
+    renderCard(baseIndex({ asOfDate: '2025-01-13' }));
+    expect(screen.getByText('1/13')).toBeInTheDocument();
+  });
+
+  it('falls back to a valid current date label when asOfDate is missing', () => {
+    renderCard(baseIndex({ asOfDate: undefined }));
+    const label = screen.getByText(/^\d{1,2}\/\d{1,2}$/);
+    expect(label.textContent).not.toContain('NaN');
+  });
+
+  it('falls back to a valid current date label when asOfDate is malformed', () => {
+    renderCard(baseIndex({ asOfDate: 'not-a-date' }));
+    const label = screen.getByText(/^\d{1,2}\/\d{1,2}$/);
+    expect(label.textContent).not.toContain('NaN');
+  });
+});

--- a/web/src/pages/Dashboard/utils/__tests__/api.test.ts
+++ b/web/src/pages/Dashboard/utils/__tests__/api.test.ts
@@ -9,7 +9,7 @@ const apiMock = vi.hoisted(() => ({
 
 vi.mock('@/api/client', () => ({ api: apiMock }));
 
-import { getStockPrices } from '../api';
+import { getIndex, getIndices, getStockPrices } from '../api';
 
 describe('getStockPrices', () => {
   beforeEach(() => {
@@ -61,5 +61,80 @@ describe('getStockPrices', () => {
         quoteAvailable: false,
       },
     ]);
+  });
+});
+
+// ET times expressed as UTC ms (Jan = EST = UTC-5).
+const ET = (y: number, mo: number, d: number, h: number, mi: number) =>
+  Date.UTC(y, mo, d, h + 5, mi);
+
+describe('getIndex', () => {
+  beforeEach(() => {
+    apiMock.get.mockReset();
+  });
+
+  it('builds the sparkline from the most recent date that has regular-hours bars', async () => {
+    // VIX shape: a complete prior session (D1) plus a later date (D2) carrying
+    // only pre-market/overnight bars. The old code keyed off D2 (the
+    // chronologically last bar) and filtered to regular hours -> empty.
+    apiMock.get.mockResolvedValueOnce({
+      data: {
+        data: [
+          // D1 (2025-01-13) — regular hours
+          { time: ET(2025, 0, 13, 9, 30), open: 100, close: 100 },
+          { time: ET(2025, 0, 13, 12, 0), open: 100, close: 102 },
+          { time: ET(2025, 0, 13, 16, 0), open: 100, close: 101 },
+          // D2 (2025-01-14) — pre-market only, before 09:30 ET
+          { time: ET(2025, 0, 14, 4, 0), open: 99, close: 99 },
+          { time: ET(2025, 0, 14, 8, 0), open: 99, close: 98 },
+        ],
+      },
+    });
+
+    const result = await getIndex('VIX');
+
+    expect(result.sparklineData.map((p) => p.val)).toEqual([100, 102, 101]);
+    expect(result.sparklineData[0].time).toBe('09:30');
+    expect(result.sparklineData[result.sparklineData.length - 1].time).toBe('16:00');
+    // price/change derive from the D1 regular-hours session, not the D2 bars.
+    expect(result.price).toBe(101);
+  });
+});
+
+describe('getIndices', () => {
+  beforeEach(() => {
+    apiMock.get.mockReset();
+  });
+
+  it('flags quoteAvailable true when a snapshot is present and false when missing', async () => {
+    apiMock.get.mockImplementation((url: string) => {
+      if (url.includes('/snapshots/indexes')) {
+        return Promise.resolve({
+          data: {
+            snapshots: [
+              {
+                symbol: 'GSPC',
+                price: 5000.12,
+                change: 10.5,
+                change_percent: 0.21,
+                previous_close: 4989.62,
+              },
+            ],
+          },
+        });
+      }
+      // intraday — no data; getIndex throws and getIndices falls back to []
+      return Promise.resolve({ data: { data: [] } });
+    });
+
+    const { indices, failedCount } = await getIndices(['GSPC', 'VIX']);
+    const gspc = indices.find((i) => i.symbol === 'GSPC')!;
+    const vix = indices.find((i) => i.symbol === 'VIX')!;
+
+    expect(gspc.quoteAvailable).toBe(true);
+    expect(gspc.price).toBe(5000.12);
+    expect(vix.quoteAvailable).toBe(false);
+    expect(vix.price).toBe(0);
+    expect(failedCount).toBe(1);
   });
 });

--- a/web/src/pages/Dashboard/utils/__tests__/api.test.ts
+++ b/web/src/pages/Dashboard/utils/__tests__/api.test.ts
@@ -100,6 +100,27 @@ describe('getIndex', () => {
     expect(result.price).toBe(101);
     // date label reflects the session the data belongs to, not "today".
     expect(result.asOfDate).toBe('2025-01-13');
+    // a positive close is a real quote.
+    expect(result.quoteAvailable).toBe(true);
+  });
+
+  it('marks the quote unavailable when the latest regular-hours close is non-positive', async () => {
+    // The session's last regular-hours bar has a 0 close (a partial/bad bar);
+    // price derives from it, so getIndex must flag the quote as unavailable for
+    // direct consumers instead of returning a real-looking 0.00.
+    apiMock.get.mockResolvedValueOnce({
+      data: {
+        data: [
+          { time: ET(2025, 0, 13, 9, 30), open: 100, close: 100 },
+          { time: ET(2025, 0, 13, 16, 0), open: 100, close: 0 },
+        ],
+      },
+    });
+
+    const result = await getIndex('VIX');
+
+    expect(result.quoteAvailable).toBe(false);
+    expect(result.price).toBe(0);
   });
 
   it('falls back to the chronologically-last bar when no regular-hours bars exist', async () => {

--- a/web/src/pages/Dashboard/utils/__tests__/api.test.ts
+++ b/web/src/pages/Dashboard/utils/__tests__/api.test.ts
@@ -101,6 +101,27 @@ describe('getIndex', () => {
     // date label reflects the session the data belongs to, not "today".
     expect(result.asOfDate).toBe('2025-01-13');
   });
+
+  it('falls back to the chronologically-last bar when no regular-hours bars exist', async () => {
+    // Every bar is pre-market/overnight (before 09:30 ET) across two dates, so
+    // the regular-hours slice is empty and the selector falls back to the last
+    // bar's date rather than blanking the card.
+    apiMock.get.mockResolvedValueOnce({
+      data: {
+        data: [
+          { time: ET(2025, 0, 13, 6, 0), open: 100, close: 100 },
+          { time: ET(2025, 0, 14, 7, 0), open: 100, close: 105 },
+          { time: ET(2025, 0, 14, 8, 0), open: 100, close: 110 },
+        ],
+      },
+    });
+
+    const result = await getIndex('VIX');
+
+    expect(result.asOfDate).toBe('2025-01-14');
+    expect(result.sparklineData.map((p) => p.val)).toEqual([105, 110]);
+    expect(result.price).toBe(110);
+  });
 });
 
 describe('getIndices', () => {
@@ -138,5 +159,57 @@ describe('getIndices', () => {
     expect(vix.quoteAvailable).toBe(false);
     expect(vix.price).toBe(0);
     expect(failedCount).toBe(1);
+  });
+
+  it('treats a zero-price index snapshot as no quote (N/A, not a fake 0.00)', async () => {
+    // Index prices are never legitimately 0; a partial provider snapshot
+    // (missing lastPrice coerced to 0) must not render as a real quote.
+    apiMock.get.mockImplementation((url: string) => {
+      if (url.includes('/snapshots/indexes')) {
+        return Promise.resolve({
+          data: {
+            snapshots: [
+              { symbol: 'GSPC', price: 0, change: 0, change_percent: 0, previous_close: 0 },
+            ],
+          },
+        });
+      }
+      return Promise.resolve({ data: { data: [] } });
+    });
+
+    const { indices, failedCount } = await getIndices(['GSPC']);
+    const gspc = indices.find((i) => i.symbol === 'GSPC')!;
+
+    expect(gspc.quoteAvailable).toBe(false);
+    expect(failedCount).toBe(1);
+  });
+
+  it('threads the intraday session asOfDate onto the index when the snapshot is present', async () => {
+    apiMock.get.mockImplementation((url: string) => {
+      if (url.includes('/snapshots/indexes')) {
+        return Promise.resolve({
+          data: {
+            snapshots: [
+              { symbol: 'GSPC', price: 5000, change: 1, change_percent: 0.1, previous_close: 4999 },
+            ],
+          },
+        });
+      }
+      // intraday — a complete regular-hours session on 2025-01-13
+      return Promise.resolve({
+        data: {
+          data: [
+            { time: ET(2025, 0, 13, 9, 30), open: 100, close: 100 },
+            { time: ET(2025, 0, 13, 16, 0), open: 100, close: 101 },
+          ],
+        },
+      });
+    });
+
+    const { indices } = await getIndices(['GSPC']);
+    const gspc = indices.find((i) => i.symbol === 'GSPC')!;
+
+    expect(gspc.quoteAvailable).toBe(true);
+    expect(gspc.asOfDate).toBe('2025-01-13');
   });
 });

--- a/web/src/pages/Dashboard/utils/__tests__/api.test.ts
+++ b/web/src/pages/Dashboard/utils/__tests__/api.test.ts
@@ -98,6 +98,8 @@ describe('getIndex', () => {
     expect(result.sparklineData[result.sparklineData.length - 1].time).toBe('16:00');
     // price/change derive from the D1 regular-hours session, not the D2 bars.
     expect(result.price).toBe(101);
+    // date label reflects the session the data belongs to, not "today".
+    expect(result.asOfDate).toBe('2025-01-13');
   });
 });
 

--- a/web/src/pages/Dashboard/utils/api.ts
+++ b/web/src/pages/Dashboard/utils/api.ts
@@ -32,6 +32,7 @@ interface IndexData {
   changePercent: number;
   isPositive: boolean;
   sparklineData: SparklinePoint[];
+  quoteAvailable?: boolean;
   previousClose?: number | null;
 }
 
@@ -111,6 +112,7 @@ function fallbackIndex(norm: string): IndexData {
     changePercent: 0,
     isPositive: true,
     sparklineData: [],
+    quoteAvailable: false,
   };
 }
 
@@ -133,13 +135,21 @@ export async function getIndex(symbol: string, _opts: Record<string, unknown> = 
     // Sort ascending by time (Unix ms)
     const sorted = [...pts].sort((a: IntradayPoint, b: IntradayPoint) => a.time - b.time);
 
-    // Isolate the most recent trading day, regular hours only (9:30–16:00)
-    const latestDate = utcMsToETDate(sorted[sorted.length - 1].time);
-    const todayPoints = sorted.filter((p: IntradayPoint) => {
-      if (utcMsToETDate(p.time) !== latestDate) return false;
+    // Isolate regular-hours points (9:30–16:00 ET) first, then take the most
+    // recent date that actually has them. Some indices (e.g. VIX) carry
+    // overnight/pre-market bars, so the chronologically-last bar's date can have
+    // zero regular-hours points on a pre-open day — which would blank the
+    // sparkline. `sorted` is ascending, so the regular-hours slice is too.
+    const regularHours = sorted.filter((p: IntradayPoint) => {
       const t = utcMsToETTime(p.time);
       return t >= '09:30' && t <= '16:00';
     });
+    const latestDate = regularHours.length
+      ? utcMsToETDate(regularHours[regularHours.length - 1].time)
+      : utcMsToETDate(sorted[sorted.length - 1].time);
+    const todayPoints = regularHours.length
+      ? regularHours.filter((p: IntradayPoint) => utcMsToETDate(p.time) === latestDate)
+      : sorted.filter((p: IntradayPoint) => utcMsToETDate(p.time) === latestDate);
 
     const oldest = todayPoints[0];
     const mostRecent = todayPoints[todayPoints.length - 1];
@@ -211,6 +221,7 @@ export async function getIndices(symbols: string[] = INDEX_SYMBOLS, _opts: Recor
         isPositive: change >= 0,
         previousClose: snap.previous_close ?? null,
         sparklineData: sparklineMap[norm] || [],
+        quoteAvailable: true,
       };
     }
     failedCount++;

--- a/web/src/pages/Dashboard/utils/api.ts
+++ b/web/src/pages/Dashboard/utils/api.ts
@@ -212,7 +212,11 @@ export async function getIndices(symbols: string[] = INDEX_SYMBOLS, _opts: Recor
   let failedCount = 0;
   const indices: IndexData[] = list.map((norm: string) => {
     const snap = snapshotMap[norm];
-    if (snap && snap.price != null) {
+    // Index prices are never legitimately 0; a zero/negative price means a
+    // partial provider snapshot (e.g. yfinance coercing a missing lastPrice to
+    // 0). Treat it as no quote so the card renders N/A instead of a fake
+    // "0.00 / +0.00%" — the same symptom #287 set out to kill.
+    if (snap && snap.price != null && snap.price > 0) {
       const change = snap.change ?? 0;
       const changePct = snap.change_percent ?? (snap.previous_close ? ((change / snap.previous_close) * 100) : 0);
       return {

--- a/web/src/pages/Dashboard/utils/api.ts
+++ b/web/src/pages/Dashboard/utils/api.ts
@@ -4,6 +4,7 @@
  */
 import { api } from '@/api/client';
 import { utcMsToETDate, utcMsToETTime } from '@/lib/utils';
+import type { IndexData, SparklinePoint } from '@/types/market';
 import * as portfolioApi from './portfolio';
 import * as watchlistApi from './watchlist';
 import * as watchlistItemsApi from './watchlistItems';
@@ -17,24 +18,6 @@ interface IntradayPoint {
   high?: number;
   low?: number;
   volume?: number;
-}
-
-interface SparklinePoint {
-  time: string;
-  val: number;
-}
-
-interface IndexData {
-  symbol: string;
-  name: string;
-  price: number;
-  change: number;
-  changePercent: number;
-  isPositive: boolean;
-  sparklineData: SparklinePoint[];
-  quoteAvailable?: boolean;
-  asOfDate?: string;
-  previousClose?: number | null;
 }
 
 interface StockPrice {
@@ -167,6 +150,9 @@ export async function getIndex(symbol: string, _opts: Record<string, unknown> = 
       change: Math.round(change * 100) / 100,
       changePercent: Math.round(changePercent * 100) / 100,
       isPositive: change >= 0,
+      // Direct getIndex consumers get the same zero/invalid-close masking the
+      // dashboard applies via the snapshot: a non-positive close isn't a quote.
+      quoteAvailable: close > 0,
       asOfDate: latestDate,
       sparklineData: todayPoints
         .filter((p: IntradayPoint) => Number(p.close) > 0)
@@ -197,7 +183,7 @@ export async function getIndices(symbols: string[] = INDEX_SYMBOLS, _opts: Recor
         const result = await getIndex(norm);
         return { symbol: norm, sparklineData: result.sparklineData, asOfDate: result.asOfDate };
       } catch {
-        return { symbol: norm, sparklineData: [] as SparklinePoint[], asOfDate: undefined as string | undefined };
+        return { symbol: norm, sparklineData: [] as SparklinePoint[], asOfDate: undefined };
       }
     })),
   ]);

--- a/web/src/pages/Dashboard/utils/api.ts
+++ b/web/src/pages/Dashboard/utils/api.ts
@@ -33,6 +33,7 @@ interface IndexData {
   isPositive: boolean;
   sparklineData: SparklinePoint[];
   quoteAvailable?: boolean;
+  asOfDate?: string;
   previousClose?: number | null;
 }
 
@@ -166,6 +167,7 @@ export async function getIndex(symbol: string, _opts: Record<string, unknown> = 
       change: Math.round(change * 100) / 100,
       changePercent: Math.round(changePercent * 100) / 100,
       isPositive: change >= 0,
+      asOfDate: latestDate,
       sparklineData: todayPoints
         .filter((p: IntradayPoint) => Number(p.close) > 0)
         .map((p: IntradayPoint) => ({ time: utcMsToETTime(p.time), val: Number(p.close) })),
@@ -193,14 +195,15 @@ export async function getIndices(symbols: string[] = INDEX_SYMBOLS, _opts: Recor
     Promise.all(list.map(async (norm: string) => {
       try {
         const result = await getIndex(norm);
-        return { symbol: norm, sparklineData: result.sparklineData };
+        return { symbol: norm, sparklineData: result.sparklineData, asOfDate: result.asOfDate };
       } catch {
-        return { symbol: norm, sparklineData: [] as SparklinePoint[] };
+        return { symbol: norm, sparklineData: [] as SparklinePoint[], asOfDate: undefined as string | undefined };
       }
     })),
   ]);
 
   const sparklineMap: Record<string, SparklinePoint[]> = Object.fromEntries(sparklineResults.map((r) => [r.symbol, r.sparklineData]));
+  const asOfMap: Record<string, string | undefined> = Object.fromEntries(sparklineResults.map((r) => [r.symbol, r.asOfDate]));
   const snapshotList: SnapshotEntry[] = snapshots?.snapshots || snapshots?.results || snapshots?.data || [];
   const snapshotMap: Record<string, SnapshotEntry> = Array.isArray(snapshotList)
     ? Object.fromEntries(snapshotList.map((s: SnapshotEntry) => [normalizeIndexSymbol(s.symbol), s]))
@@ -222,10 +225,11 @@ export async function getIndices(symbols: string[] = INDEX_SYMBOLS, _opts: Recor
         previousClose: snap.previous_close ?? null,
         sparklineData: sparklineMap[norm] || [],
         quoteAvailable: true,
+        asOfDate: asOfMap[norm],
       };
     }
     failedCount++;
-    return { ...fallbackIndex(norm), sparklineData: sparklineMap[norm] || [] };
+    return { ...fallbackIndex(norm), sparklineData: sparklineMap[norm] || [], asOfDate: asOfMap[norm] };
   });
 
   return { indices, failedCount };

--- a/web/src/types/market.ts
+++ b/web/src/types/market.ts
@@ -15,6 +15,7 @@ export interface IndexData {
   changePercent: number;
   isPositive: boolean;
   sparklineData: SparklinePoint[];
+  quoteAvailable?: boolean;
   previousClose?: number | null;
 }
 

--- a/web/src/types/market.ts
+++ b/web/src/types/market.ts
@@ -16,6 +16,8 @@ export interface IndexData {
   isPositive: boolean;
   sparklineData: SparklinePoint[];
   quoteAvailable?: boolean;
+  /** ET date (YYYY-MM-DD) of the trading session the price/sparkline reflect. */
+  asOfDate?: string;
   previousClose?: number | null;
 }
 


### PR DESCRIPTION
## Summary

Fixes #287 — the Market Overview dashboard's index cards rendered `0.00` prices and an empty VIX sparkline. Two root causes, plus review-driven hardening.

**Bug fix (#287)**
- **Backend caret mismatch** — yfinance echoed the caret-prefixed Yahoo symbol (`^GSPC`) back, so the provider chain dropped it as "unrequested" and the card got no price. `get_snapshots` now restores the originally-requested bare symbol, and the chain's symbol matcher tolerates the caret form.
- **Frontend sparkline date** — `getIndex` keyed off the chronologically-last intraday bar, which on a pre-open day can be a pre-market-only session, blanking the sparkline. It now picks the most recent date that actually has regular-hours (09:30–16:00 ET) bars.

**Session-date label**
- Index cards now show the date of the trading session the data belongs to (e.g. the last close when the market is pre-open), via a new `asOfDate` threaded from `getIndex`/`getIndices` to the card — instead of always showing "today".

**Quote masking (extends #254 to index cards)**
- A genuinely-missing snapshot renders `N/A` instead of a fake `0.00`, via `quoteAvailable`.

**Review hardening (this run)**
- Both Codex and the Claude reviewer independently flagged a *residual* `0.00` path: a partial provider snapshot coerces a missing `lastPrice` to `0`, which was still shown as a real quote. `getIndices` now treats a non-positive index price as no quote (`N/A`).
- Symbol matcher uses `removeprefix("^")` (strips exactly one Yahoo caret) instead of `lstrip("^")` (which would alias a malformed `^^GSPC` onto a bare `GSPC`).
- The card's fallback date now derives from ET (not browser-local) and validates the `asOfDate` shape; the sparkline draws neutral when no quote is available so a missing quote can't imply a direction.

## Overview

Net-change map of the whole branch (vs `origin/main`).

| Bucket | Files | +/− |
|---|---|---|
| Modified (non-test) | 5 | +74 / −16 |
| New (non-test) | 0 | — |
| Modified tests | 2 | +185 / −1 |
| New tests | 2 | +126 / 0 |
| **Total** | **9** | **+385 / −17** |

**By module**
- **Backend · `src/data_client/` (modified)** — `yfinance/data_source.py` restores the bare requested index symbol after the caret-prefixed Yahoo fetch; `market_data_provider.py` matches snapshot symbols on exactly one leading caret.
- **Frontend · Dashboard (modified)** — `utils/api.ts`: regular-hours-first sparkline date, `price > 0` quote masking, `asOfDate` threading; `components/IndexMovementCard.tsx`: `N/A` masking, ET session-date label, neutral sparkline on missing quote; `types/market.ts`: adds `quoteAvailable?` and `asOfDate?`.
- **Tests (new + modified)** — backend: `test_yfinance_data_source.py` (new) + `test_market_data_provider.py` (caret regression + precision); frontend: `IndexMovementCard.test.tsx` (new, component had zero coverage) + `utils/__tests__/api.test.ts` (getIndex/getIndices paths).

**What this introduces:** index cards on the Market Overview dashboard show correct prices and the VIX sparkline, labeled with the actual trading-session date, and degrade to `N/A` instead of a misleading `0.00` when a quote is genuinely missing.

## Diff Size
- Total: 9 files changed, 385 insertions(+), 17 deletions(-)
- Net (excl. tests): 5 files changed, 74 insertions(+), 16 deletions(-)

## Test Coverage

The audit found the data layer well covered (~80%) but `IndexMovementCard.tsx` had **no test file** (0% on the user-visible masking + date-label render). This run added the missing component tests and the data-layer gap tests.

```
BACKEND
  data_source.get_snapshots .... bare-symbol restore, order-preserve, stock passthrough  ★★
  provider.normalize_symbol .... caret match (^GSPC→GSPC) + double-caret precision        ★★★
FRONTEND — data layer
  getIndex ..................... regular-hours date, no-RTH fallback, price/asOfDate       ★★★
  getIndices .................. quoteAvailable true/false, zero-price mask, asOfDate thread ★★
FRONTEND — component (now covered)
  IndexMovementCard ........... N/A masking, asOfDate label, ET fallback, malformed date   ★★★
```

Tests: backend `data_client` 37 → 38; frontend Dashboard suite +8 (2 new test files). Full suites: backend **4922 passed / 1 xfailed**, frontend **2029 passed (183 files)**.

## Pre-Landing Review

No P0/P1 — both the Claude pre-landing reviewer and Codex adversarial said "land it." All actionable findings were fixed in this run:
- **[fixed]** residual zero-price `0.00` render (cross-model, high confidence) → `price > 0` gate.
- **[fixed]** `lstrip("^")` over-strip → `removeprefix("^")`.
- **[fixed]** fallback date used browser-local time → ET-derived + shape-validated.
- **[fixed]** sparkline could imply a direction when the quote is missing → neutral color.

Deliberately not changed: the date-label-vs-snapshot-price nuance (showing the last *session* date next to a pre-open snapshot is the requested behavior). Noted follow-up: `_fetch_single_snapshot` still coerces a missing `lastPrice` to `0` server-side — now masked at the consumer, but a deeper provider-side guard is a separate, pre-existing improvement.

## Design Review

Frontend render logic only (text content, date label, line color) — no layout, spacing, or visual-system changes. Lite check clean; no AI-slop.

## Eval Results

No prompt-related files changed — evals skipped.

## Scope Drift

CLEAN. Every change maps to #287 (caret + sparkline), the requested session-date label, the #254 masking extension, or the review findings above.

## Plan Completion

Plan items: 8 DONE, 2 CHANGED (documented deviations: `'—'`→`'N/A'` sentinel per post-plan #252; yfinance regression test in a module-aligned new file). All implementation shipped.

## Verification Results

- Backend `uv run pytest tests/unit/` — **4922 passed, 1 xfailed**; `ruff` clean.
- Frontend `pnpm vitest run` — **2029 passed (183 files)**; `eslint` clean; `tsc --noEmit` clean.
- Live E2E (executed in the implementation session): L1 A/B backend curl proved the caret fix (BEFORE: 5× `drop_unrequested`, COUNT=0 → AFTER: COUNT=5 bare symbols with real prices), and the Dashboard was visually verified in an OSS / yfinance-only container.

## Test plan
- [x] Backend unit suite passes (4922 passed, 1 xfailed)
- [x] Frontend vitest passes (2029 tests, 183 files)
- [x] ruff + eslint + tsc clean
- [x] Backend A/B curl proves the index snapshot fix end-to-end


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved market index cards to use the correct ET session date (`asOfDate`) and to clearly mask missing/unavailable quotes.
  * Index data now carries `quoteAvailable` and `asOfDate` through to the UI for consistent labeling.
* **Bug Fixes**
  * Fixed snapshot matching for caret-prefixed index symbols by aligning normalization and restoring requested symbols.
  * Preserved requested order while dropping failed snapshot fetches; invalid/zero quotes no longer appear as real prices.
* **Tests**
  * Added/expanded unit tests for caret-prefix handling, ordering, quote availability, and robust session-date rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->