### PR TITLE
feat(robinhood): wire Robinhood Agentic Trading MCP (read/preview only, trades hard-gated)

### DIFF
--- a/migrations/versions/016_add_robinhood_oauth.py
+++ b/migrations/versions/016_add_robinhood_oauth.py
@@ -1,0 +1,74 @@
+"""Add Robinhood OAuth (Agentic Trading MCP) connection table.
+
+Stores per-(user, workspace) OAuth state for Robinhood's Agentic Trading MCP:
+the dynamically-registered client (RFC 7591), the discovered authorization /
+token endpoints, and encrypted access/refresh tokens. The live access token is
+ALSO mirrored into the workspace vault (``ROBINHOOD_TOKEN``) so the sandbox can
+send it; this table holds the refresh context the vault can't carry (client_id,
+token endpoint, refresh token, expiry) plus the transient PKCE state while a
+connect is pending.
+
+Revision ID: 016
+Revises: 015
+Create Date: 2026-06-30
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "016"
+down_revision: Union[str, None] = "015"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS robinhood_oauth (
+            robinhood_oauth_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            user_id VARCHAR(255) NOT NULL
+                REFERENCES users(user_id) ON DELETE CASCADE,
+            workspace_id UUID NOT NULL
+                REFERENCES workspaces(workspace_id) ON DELETE CASCADE,
+            -- 'pending' between initiate and callback; 'connected' after exchange.
+            status VARCHAR(32) NOT NULL DEFAULT 'pending',
+            -- RFC 8707 resource indicator = the MCP server URL.
+            resource TEXT NOT NULL,
+            authorization_endpoint TEXT,
+            token_endpoint TEXT,
+            registration_endpoint TEXT,
+            client_id TEXT,
+            client_secret BYTEA,          -- encrypted; NULL for public clients
+            redirect_uri TEXT,
+            scopes TEXT DEFAULT '',
+            state TEXT,                    -- transient (pending only)
+            code_verifier BYTEA,           -- encrypted; transient (pending only)
+            access_token BYTEA,            -- encrypted; NULL until connected
+            refresh_token BYTEA,           -- encrypted; NULL until connected
+            expires_at TIMESTAMPTZ,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            UNIQUE(user_id, workspace_id)
+        )
+    """)
+
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS idx_robinhood_oauth_workspace
+        ON robinhood_oauth(workspace_id)
+    """)
+
+    # Auto-update updated_at on row modification (shared trigger fn from 001).
+    op.execute(
+        "DROP TRIGGER IF EXISTS update_robinhood_oauth_updated_at ON robinhood_oauth"
+    )
+    op.execute("""
+        CREATE TRIGGER update_robinhood_oauth_updated_at
+        BEFORE UPDATE ON robinhood_oauth
+        FOR EACH ROW EXECUTE FUNCTION update_updated_at_column()
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS robinhood_oauth CASCADE")

--- a/src/ptc_agent/config/core.py
+++ b/src/ptc_agent/config/core.py
@@ -129,6 +129,12 @@ class MCPServerConfig(BaseModel):
     # Workspace servers are untrusted: vault-only secret resolution, neutral prompt framing.
     source: Literal["builtin", "workspace"] = "builtin"
     discovery_uses_secrets: bool = False  # workspace servers: resolve vault secrets during discovery (default off = secret-less probe)
+    # Per-server hard gate: tool names that must NEVER be exposed. Denied tools
+    # are filtered out of both wrapper generation AND documentation in the
+    # sandbox, so the model can neither see nor call them (e.g. keep Robinhood's
+    # place/cancel order tools off by default). Removing tools only — it cannot
+    # escalate — so it is safe to honor even on untrusted workspace servers.
+    tool_deny: list[str] = Field(default_factory=list)
 
 
 class MCPConfig(BaseModel):

--- a/src/ptc_agent/core/sandbox/ptc_sandbox.py
+++ b/src/ptc_agent/core/sandbox/ptc_sandbox.py
@@ -2373,6 +2373,7 @@ except OSError as e:
                 retry_policy=RetryPolicy.SAFE,
             )
 
+        installed_tool_count = 0
         for server_name, tools in tools_by_server.items():
             # Hard gate: drop denied tools so they are neither emitted as callable
             # wrappers nor documented for the model (applies to the docs loop below
@@ -2380,6 +2381,7 @@ except OSError as e:
             deny = deny_by_name.get(server_name)
             if deny:
                 tools = [t for t in tools if t.name not in deny]
+            installed_tool_count += len(tools)
             source = source_by_name.get(server_name, "builtin")
             # Generate Python module
             module_code = self.tool_generator.generate_tool_module(
@@ -2459,11 +2461,10 @@ except OSError as e:
                 logger.debug(msg, **kwargs)
 
         server_count = len(tools_by_server)
-        tool_count = sum(len(t) for t in tools_by_server.values())
         logger.info(
             "Tool modules installed",
             servers=server_count,
-            tools=tool_count,
+            tools=installed_tool_count,
         )
 
     # Bound concurrent discovery so a burst of servers can't exhaust the

--- a/src/ptc_agent/core/sandbox/ptc_sandbox.py
+++ b/src/ptc_agent/core/sandbox/ptc_sandbox.py
@@ -2319,6 +2319,14 @@ except OSError as e:
             s.name: getattr(s, "source", "builtin")
             for s in self.config.mcp.servers
         }
+        # Per-server hard gate: tool names the operator has denied. Denied tools
+        # are filtered out of BOTH wrapper generation and doc generation below,
+        # so they are neither callable nor advertised to the model (e.g. keeps
+        # Robinhood's place/cancel order tools off by default).
+        deny_by_name = {
+            s.name: set(getattr(s, "tool_deny", None) or [])
+            for s in self.config.mcp.servers
+        }
 
         # 2. Tool modules and documentation
         assert self.mcp_registry is not None
@@ -2366,6 +2374,12 @@ except OSError as e:
             )
 
         for server_name, tools in tools_by_server.items():
+            # Hard gate: drop denied tools so they are neither emitted as callable
+            # wrappers nor documented for the model (applies to the docs loop below
+            # which reuses this same filtered ``tools`` list).
+            deny = deny_by_name.get(server_name)
+            if deny:
+                tools = [t for t in tools if t.name not in deny]
             source = source_by_name.get(server_name, "builtin")
             # Generate Python module
             module_code = self.tool_generator.generate_tool_module(

--- a/src/ptc_agent/core/tool_generator.py
+++ b/src/ptc_agent/core/tool_generator.py
@@ -29,7 +29,7 @@ logger = structlog.get_logger(__name__)
 # re-uploaded to a reused sandbox. Folding this constant into the tool_modules
 # version makes a bump force the regenerated client onto every workspace on its
 # next sync. See ptc_sandbox._compute_sandbox_manifest.
-MCP_CLIENT_CODEGEN_VERSION = "2"
+MCP_CLIENT_CODEGEN_VERSION = "3"
 
 # Aggregate per-execution ceiling on result_body bytes emitted BY THE GENERATED
 # CLIENT, interpolated into it. This keeps a cooperative run's trace small (per
@@ -121,10 +121,9 @@ def _discover_sse(server_name: str) -> list:
     url, headers = _resolve_sse(config, server_name, discovery=True)
     req = {"jsonrpc": "2.0", "id": _get_next_message_id(),
            "method": "tools/list", "params": {}}
-    with httpx.Client(timeout=30.0) as client:
-        response = client.post(url, json=req, headers=headers)
-        response.raise_for_status()
-        result = response.json()
+    result = _streamable_http_request(url, headers, req, server_name)
+    if not result:
+        raise RuntimeError(f"{server_name}: no response for tools/list")
     if "error" in result:
         raise RuntimeError(f"tools/list error: {result['error']}")
     return (result.get("result") or {}).get("tools", [])
@@ -146,6 +145,75 @@ if __name__ == "__main__":
         sys.exit(0)
     print("usage: mcp_client.py discover <server_name> <output_path>", file=sys.stderr)  # noqa: T201
     sys.exit(2)
+'''
+
+
+# Streamable-HTTP transport (MCP 2025-03-26+). Inserted verbatim into the
+# generated client via {streamable_block} (single braces, NOT f-string
+# interpolated). Accepts JSON or SSE responses, parses whichever the server
+# returns, and carries Mcp-Session-Id across initialize -> tools/*. Backward-
+# compatible with servers that answer a plain POST with application/json.
+_STREAMABLE_HTTP_SOURCE = '''
+_sse_session_ids: dict = {}            # server_name -> Mcp-Session-Id
+_MCP_PROTOCOL_VERSION = "2025-06-18"
+
+
+def _parse_sse_for_id(response, want_id):
+    """Return the JSON-RPC message with id == want_id from an SSE response, or
+    the first message carrying a result/error when nothing matches."""
+    fallback = None
+    for raw in response.iter_lines():
+        line = raw.decode() if isinstance(raw, (bytes, bytearray)) else raw
+        if not line or not line.startswith("data:"):
+            continue
+        data = line[5:].strip()
+        if not data or data == "[DONE]":
+            continue
+        try:
+            msg = json.loads(data)
+        except ValueError:
+            continue
+        if not isinstance(msg, dict):
+            continue
+        if want_id is not None and msg.get("id") == want_id:
+            return msg
+        if fallback is None and ("result" in msg or "error" in msg):
+            fallback = msg
+    return fallback
+
+
+def _streamable_http_request(url, headers, payload, server_name, is_init=False):
+    """One streamable-HTTP round trip. Returns the parsed JSON-RPC response
+    dict, or None for a notification (202 / empty body). Transport errors
+    raise; JSON-RPC errors are returned inside the dict for the caller."""
+    req_headers = dict(headers or {})
+    req_headers.setdefault("Content-Type", "application/json")
+    req_headers["Accept"] = "application/json, text/event-stream"
+    _sid = _sse_session_ids.get(server_name)
+    if _sid:
+        req_headers["Mcp-Session-Id"] = _sid
+    if not is_init:
+        req_headers["MCP-Protocol-Version"] = _MCP_PROTOCOL_VERSION
+    want_id = payload.get("id") if isinstance(payload, dict) else None
+    with httpx.Client(timeout=60.0, follow_redirects=True) as client:
+        with client.stream("POST", url, json=payload, headers=req_headers) as response:
+            new_sid = response.headers.get("mcp-session-id")
+            if new_sid:
+                _sse_session_ids[server_name] = new_sid
+            if response.status_code == 202:
+                return None
+            response.raise_for_status()
+            ctype = response.headers.get("content-type", "")
+            if "text/event-stream" in ctype:
+                msg = _parse_sse_for_id(response, want_id)
+                if msg is None and want_id is not None:
+                    raise RuntimeError("no JSON-RPC response in SSE stream from " + repr(server_name))
+                return msg
+            response.read()
+            body = (response.text or "").strip()
+            if not body:
+                return None
+            return json.loads(body)
 '''
 
 
@@ -905,7 +973,7 @@ def _resolve_sse(config, server_name, *, discovery=False):
             sse_call_resolve = (
                 "\n        url, _headers = _resolve_sse(config, server_name)\n"
             )
-            sse_post_kwargs = ", headers=_headers"
+            sse_headers_expr = "_headers"
         else:
             sse_init_resolve = (
                 "\n    # Resolve environment variables in URL\n"
@@ -924,7 +992,7 @@ def _resolve_sse(config, server_name, *, discovery=False):
                 "\n"
                 "        url = re.sub(r'\\$\\{([^}]+)\\}', resolve_env, url)\n"
             )
-            sse_post_kwargs = ""
+            sse_headers_expr = "{}"
 
         # Discovery entrypoint + CLI. Emitted only when a workspace server is
         # present so builtin-only clients stay byte-identical. Discovery lists a
@@ -950,6 +1018,8 @@ def _resolve_sse(config, server_name, *, discovery=False):
             discovery_param = ""
             discovery_doc = ""
             discovery_doc_sse = ""
+
+        streamable_block = _STREAMABLE_HTTP_SOURCE
 
         return f'''"""
 MCP Client for sandbox environment.
@@ -982,6 +1052,7 @@ _sse_sessions: dict[str, bool] = {{}}  # server_name -> initialized
 # MCP server configurations
 _SERVER_CONFIGS = {servers_dict}
 {vault_block}
+{streamable_block}
 # Per-execution running sum of emitted result_body bytes. Each execute_code runs
 # in a FRESH interpreter process — both the Daytona and Docker providers spawn a
 # new `python` per code_run (a one-shot run, NOT a persistent kernel/session), so
@@ -1165,7 +1236,7 @@ def _start_mcp_server(server_name: str{discovery_param}) -> subprocess.Popen:
         "id": _get_next_message_id(),
         "method": "initialize",
         "params": {{
-            "protocolVersion": "2024-11-05",
+            "protocolVersion": "2025-06-18",
             "capabilities": {{}},
             "clientInfo": {{
                 "name": "open-ptc-client",
@@ -1226,7 +1297,7 @@ def _initialize_sse_server(server_name: str{discovery_param}) -> None:
         "id": _get_next_message_id(),
         "method": "initialize",
         "params": {{
-            "protocolVersion": "2024-11-05",
+            "protocolVersion": "2025-06-18",
             "capabilities": {{}},
             "clientInfo": {{
                 "name": "open-ptc-client",
@@ -1236,21 +1307,21 @@ def _initialize_sse_server(server_name: str{discovery_param}) -> None:
     }}
 
     try:
-        with httpx.Client(timeout=30.0) as client:
-            response = client.post(url, json=init_request{sse_post_kwargs})
-            response.raise_for_status()
-            result = response.json()
+        result = _streamable_http_request(
+            url, {sse_headers_expr}, init_request, server_name, is_init=True
+        )
+        if result and "error" in result:
+            msg = f"MCP initialization failed: {{result['error']}}"
+            raise RuntimeError(msg)
 
-            if "error" in result:
-                msg = f"MCP SSE initialization failed: {{result['error']}}"
-                raise RuntimeError(msg)
-
-            # Send initialized notification
-            initialized_notif = {{
-                "jsonrpc": "2.0",
-                "method": "notifications/initialized"
-            }}
-            client.post(url, json=initialized_notif{sse_post_kwargs})
+        # Tell the server we're ready (notification — no response expected)
+        initialized_notif = {{
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized"
+        }}
+        _streamable_http_request(
+            url, {sse_headers_expr}, initialized_notif, server_name
+        )
 
         _sse_sessions[server_name] = True
 
@@ -1291,11 +1362,12 @@ def _call_mcp_tool_sse(server_name: str, tool_name: str, arguments: dict[str, An
             }}
         }}
 
-        # Send request via HTTP POST
-        with httpx.Client(timeout=60.0) as client:
-            response = client.post(url, json=request{sse_post_kwargs})
-            response.raise_for_status()
-            result = response.json()
+        # Send request via streamable-HTTP transport
+        result = _streamable_http_request(
+            url, {sse_headers_expr}, request, server_name
+        )
+        if result is None:
+            raise RuntimeError("MCP server returned no response for tools/call")
 
         # Check for errors
         if "error" in result:

--- a/src/server/app/mcp_servers.py
+++ b/src/server/app/mcp_servers.py
@@ -215,6 +215,7 @@ def _effective_server(
         instruction=srv.instruction or "",
         tool_exposure_mode=srv.tool_exposure_mode or "summary",
         discovery_uses_secrets=bool(getattr(srv, "discovery_uses_secrets", False)),
+        tool_deny=list(getattr(srv, "tool_deny", None) or []),
         command=srv.command,
         args=list(srv.args or []),
         url=srv.url,

--- a/src/server/app/robinhood.py
+++ b/src/server/app/robinhood.py
@@ -109,28 +109,54 @@ def _robinhood_server_blob() -> dict:
 async def initiate(workspace_id: str, user_id: CurrentUserId) -> dict:
     await _require_owned_workspace(workspace_id, user_id)
 
-    try:
-        meta = await discover_metadata(ROBINHOOD_MCP_URL)
-    except Exception as e:
-        raise HTTPException(
-            status_code=502, detail=f"Robinhood OAuth discovery failed: {e}"
-        )
-
     redirect_uri = _redirect_uri(workspace_id)
-    scope = " ".join(meta.get("scopes_supported") or [])
-    reg_ep = meta.get("registration_endpoint")
-    if not reg_ep:
-        raise HTTPException(
-            status_code=502,
-            detail="Robinhood OAuth server does not advertise dynamic client "
-            "registration; cannot connect automatically.",
-        )
-    try:
-        client = await register_client(reg_ep, redirect_uri, scope=scope)
-    except Exception as e:
-        raise HTTPException(
-            status_code=502, detail=f"Robinhood client registration failed: {e}"
-        )
+
+    # Reuse an already-registered client for this workspace instead of running
+    # dynamic client registration on every click. Repeated DCR + authorize
+    # attempts against the same account trip Robinhood's anti-abuse throttle
+    # ("Please try again later — we have blocked this action"). One stored client
+    # is reused across reconnects; `disconnect` clears it to force a fresh one.
+    existing = await ro_db.get(user_id, workspace_id)
+    if (
+        existing
+        and existing.get("client_id")
+        and existing.get("authorization_endpoint")
+        and existing.get("token_endpoint")
+        and existing.get("redirect_uri") == redirect_uri
+    ):
+        auth_ep = existing["authorization_endpoint"]
+        token_ep = existing["token_endpoint"]
+        reg_ep = existing.get("registration_endpoint")
+        client_id = existing["client_id"]
+        client_secret = existing.get("client_secret") or None
+        resource = existing["resource"]
+        scope = existing.get("scopes") or ""
+    else:
+        try:
+            meta = await discover_metadata(ROBINHOOD_MCP_URL)
+        except Exception as e:
+            raise HTTPException(
+                status_code=502, detail=f"Robinhood OAuth discovery failed: {e}"
+            )
+        reg_ep = meta.get("registration_endpoint")
+        if not reg_ep:
+            raise HTTPException(
+                status_code=502,
+                detail="Robinhood OAuth server does not advertise dynamic client "
+                "registration; cannot connect automatically.",
+            )
+        scope = " ".join(meta.get("scopes_supported") or [])
+        try:
+            client = await register_client(reg_ep, redirect_uri, scope=scope)
+        except Exception as e:
+            raise HTTPException(
+                status_code=502, detail=f"Robinhood client registration failed: {e}"
+            )
+        auth_ep = meta["authorization_endpoint"]
+        token_ep = meta["token_endpoint"]
+        resource = meta["resource"]
+        client_id = client["client_id"]
+        client_secret = client.get("client_secret")
 
     verifier, challenge = generate_pkce_pair()
     state = secrets.token_urlsafe(32)
@@ -138,12 +164,12 @@ async def initiate(workspace_id: str, user_id: CurrentUserId) -> dict:
     await ro_db.upsert_pending(
         user_id=user_id,
         workspace_id=workspace_id,
-        resource=meta["resource"],
-        authorization_endpoint=meta["authorization_endpoint"],
-        token_endpoint=meta["token_endpoint"],
+        resource=resource,
+        authorization_endpoint=auth_ep,
+        token_endpoint=token_ep,
         registration_endpoint=reg_ep,
-        client_id=client["client_id"],
-        client_secret=client.get("client_secret"),
+        client_id=client_id,
+        client_secret=client_secret,
         redirect_uri=redirect_uri,
         scopes=scope,
         state=state,
@@ -151,12 +177,12 @@ async def initiate(workspace_id: str, user_id: CurrentUserId) -> dict:
     )
 
     authorize_url = build_authorize_url(
-        authorization_endpoint=meta["authorization_endpoint"],
-        client_id=client["client_id"],
+        authorization_endpoint=auth_ep,
+        client_id=client_id,
         redirect_uri=redirect_uri,
         state=state,
         challenge=challenge,
-        resource=meta["resource"],
+        resource=resource,
         scope=scope,
     )
     return {"authorize_url": authorize_url}

--- a/src/server/app/robinhood.py
+++ b/src/server/app/robinhood.py
@@ -1,0 +1,304 @@
+"""Robinhood Agentic Trading MCP connect flow (per-workspace, OAuth).
+
+Connects a workspace to Robinhood's Agentic Trading MCP. The OAuth backend
+(``services/robinhood_oauth.py``) does discovery + dynamic client registration +
+PKCE; this router is the HTTP surface:
+
+- POST   /api/v1/workspaces/{id}/robinhood/initiate  → authorize URL (opened in a popup)
+- GET    /api/v1/workspaces/{id}/robinhood/callback   → browser redirect target; exchanges
+         the code, stores tokens, writes the ROBINHOOD_TOKEN vault secret, and
+         registers the gated Robinhood MCP server, then closes the popup
+- GET    /api/v1/workspaces/{id}/robinhood/status     → connection status
+- DELETE /api/v1/workspaces/{id}/robinhood            → disconnect (tokens + secret + server)
+
+The trade tools are registered behind the ``tool_deny`` hard gate, so the agent
+can read / quote / preview but never place or cancel an order on its own.
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+from datetime import datetime, timedelta, timezone
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import HTMLResponse
+
+from src.config.env import SERVER_BASE_URL
+from src.server.database import robinhood_oauth as ro_db
+from src.server.database.mcp_servers import upsert_workspace_server
+from src.server.database.vault_secrets import (
+    create_secret as create_secret_db,
+    delete_secret,
+    update_secret,
+)
+from src.server.database.workspace import get_workspace as db_get_workspace
+from src.server.models.mcp_server import McpServerInput
+from src.server.services.robinhood_oauth import (
+    ROBINHOOD_MCP_URL,
+    build_authorize_url,
+    discover_metadata,
+    exchange_code,
+    generate_pkce_pair,
+    register_client,
+)
+from src.server.utils.api import (
+    CurrentUserId,
+    handle_api_exceptions,
+    require_workspace_owner,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/workspaces", tags=["Robinhood"])
+
+ROBINHOOD_SERVER_NAME = "robinhood"
+VAULT_SECRET_NAME = "ROBINHOOD_TOKEN"
+# The vault secret holds the FULL header value ("Bearer <token>"), because the
+# MCP server model only allows a header value that is exactly ``${vault:NAME}``
+# (no embedded prefix). The in-sandbox resolver substitutes the whole value.
+BEARER_PREFIX = "Bearer "
+# Hard-gated trade tools — present on the server but never generated as callable
+# wrappers (see MCPServerConfig.tool_deny). Enabling trading is a deliberate edit.
+GATED_TRADE_TOOLS = ["place_equity_order", "cancel_equity_order"]
+
+_SERVER_DESCRIPTION = (
+    "Robinhood Agentic Trading — read your accounts, positions, portfolio, "
+    "equity quotes, and order history, and preview orders. Trade execution "
+    "(place/cancel) is disabled."
+)
+_SERVER_INSTRUCTION = (
+    "Use for Robinhood account reads, quotes, and order previews "
+    "(review_equity_order). Order placement and cancellation are intentionally "
+    "unavailable; do not claim to have placed or cancelled any order."
+)
+
+
+async def _require_owned_workspace(workspace_id: str, user_id: str) -> dict:
+    workspace = await db_get_workspace(workspace_id)
+    require_workspace_owner(workspace, user_id=user_id)
+    return workspace
+
+
+def _redirect_uri(workspace_id: str) -> str:
+    base = SERVER_BASE_URL.rstrip("/")
+    return f"{base}/api/v1/workspaces/{workspace_id}/robinhood/callback"
+
+
+def _robinhood_server_blob() -> dict:
+    """The gated Robinhood MCP server definition (validated through the model)."""
+    return McpServerInput(
+        name=ROBINHOOD_SERVER_NAME,
+        transport="http",
+        url=ROBINHOOD_MCP_URL,
+        headers={"Authorization": f"${{vault:{VAULT_SECRET_NAME}}}"},
+        tool_deny=list(GATED_TRADE_TOOLS),
+        discovery_uses_secrets=True,
+        description=_SERVER_DESCRIPTION,
+        instruction=_SERVER_INSTRUCTION,
+    ).to_config_blob()
+
+
+# ---------------------------------------------------------------------------
+# POST — initiate
+# ---------------------------------------------------------------------------
+
+
+@router.post("/{workspace_id}/robinhood/initiate")
+@handle_api_exceptions("initiate Robinhood connect", logger)
+async def initiate(workspace_id: str, user_id: CurrentUserId) -> dict:
+    await _require_owned_workspace(workspace_id, user_id)
+
+    try:
+        meta = await discover_metadata(ROBINHOOD_MCP_URL)
+    except Exception as e:
+        raise HTTPException(
+            status_code=502, detail=f"Robinhood OAuth discovery failed: {e}"
+        )
+
+    redirect_uri = _redirect_uri(workspace_id)
+    scope = " ".join(meta.get("scopes_supported") or [])
+    reg_ep = meta.get("registration_endpoint")
+    if not reg_ep:
+        raise HTTPException(
+            status_code=502,
+            detail="Robinhood OAuth server does not advertise dynamic client "
+            "registration; cannot connect automatically.",
+        )
+    try:
+        client = await register_client(reg_ep, redirect_uri, scope=scope)
+    except Exception as e:
+        raise HTTPException(
+            status_code=502, detail=f"Robinhood client registration failed: {e}"
+        )
+
+    verifier, challenge = generate_pkce_pair()
+    state = secrets.token_urlsafe(32)
+
+    await ro_db.upsert_pending(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        resource=meta["resource"],
+        authorization_endpoint=meta["authorization_endpoint"],
+        token_endpoint=meta["token_endpoint"],
+        registration_endpoint=reg_ep,
+        client_id=client["client_id"],
+        client_secret=client.get("client_secret"),
+        redirect_uri=redirect_uri,
+        scopes=scope,
+        state=state,
+        code_verifier=verifier,
+    )
+
+    authorize_url = build_authorize_url(
+        authorization_endpoint=meta["authorization_endpoint"],
+        client_id=client["client_id"],
+        redirect_uri=redirect_uri,
+        state=state,
+        challenge=challenge,
+        resource=meta["resource"],
+        scope=scope,
+    )
+    return {"authorize_url": authorize_url}
+
+
+# ---------------------------------------------------------------------------
+# GET — callback (browser redirect target; bound by state, not auth header)
+# ---------------------------------------------------------------------------
+
+
+def _close_popup_html(message: str, *, ok: bool) -> HTMLResponse:
+    """Return a tiny page that signals the opener and closes the popup."""
+    # BroadcastChannel name + message must match web/src/lib/oauthPopup.ts.
+    safe = message.replace("<", "&lt;").replace(">", "&gt;")
+    html = f"""<!doctype html><html><head><meta charset="utf-8">
+<title>Robinhood</title></head><body style="font:14px system-ui;padding:2rem">
+<p>{safe}</p>
+<script>
+try {{ new BroadcastChannel('langalpha-oauth').postMessage({{type:'oauth-complete'}}); }} catch (e) {{}}
+try {{ if (window.opener) window.opener.postMessage({{type:'oauth-complete'}}, '*'); }} catch (e) {{}}
+setTimeout(function(){{ try {{ window.close(); }} catch (e) {{}} }}, {800 if ok else 2500});
+</script></body></html>"""
+    return HTMLResponse(content=html, status_code=200)
+
+
+@router.get("/{workspace_id}/robinhood/callback")
+@handle_api_exceptions("Robinhood OAuth callback", logger)
+async def callback(
+    workspace_id: str,
+    state: str = "",
+    code: str = "",
+    error: str = "",
+    error_description: str = "",
+) -> HTMLResponse:
+    if error:
+        return _close_popup_html(
+            f"Robinhood connection was not completed: {error_description or error}",
+            ok=False,
+        )
+    if not state or not code:
+        return _close_popup_html("Missing authorization response.", ok=False)
+
+    row = await ro_db.get_pending_by_state(state)
+    if row is None or row["workspace_id"] != workspace_id:
+        return _close_popup_html("This connection request has expired.", ok=False)
+
+    user_id = row["user_id"]
+    try:
+        tokens = await exchange_code(
+            token_endpoint=row["token_endpoint"],
+            client_id=row["client_id"],
+            client_secret=row.get("client_secret") or None,
+            code=code,
+            redirect_uri=row["redirect_uri"],
+            code_verifier=row["code_verifier"],
+            resource=row["resource"],
+        )
+    except Exception as e:
+        logger.error("[robinhood] token exchange failed: %s", e)
+        return _close_popup_html(f"Token exchange failed: {e}", ok=False)
+
+    expires_at = datetime.now(timezone.utc) + timedelta(
+        seconds=tokens.get("expires_in", 3600)
+    )
+    await ro_db.set_tokens(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        access_token=tokens["access_token"],
+        refresh_token=tokens["refresh_token"],
+        expires_at=expires_at,
+    )
+
+    # Write the live token into the workspace vault (create or update). The
+    # secret value is the full "Bearer <token>" header value (see BEARER_PREFIX).
+    header_value = f"{BEARER_PREFIX}{tokens['access_token']}"
+    updated = await update_secret(
+        workspace_id, VAULT_SECRET_NAME, value=header_value, description=None
+    )
+    if not updated:
+        try:
+            await create_secret_db(
+                workspace_id,
+                VAULT_SECRET_NAME,
+                header_value,
+                "Robinhood Agentic Trading MCP access token",
+            )
+        except ValueError as e:
+            return _close_popup_html(f"Could not store token: {e}", ok=False)
+
+    # Register the gated Robinhood MCP server (create-or-replace).
+    await upsert_workspace_server(
+        workspace_id,
+        ROBINHOOD_SERVER_NAME,
+        source="workspace",
+        enabled=True,
+        config=_robinhood_server_blob(),
+    )
+
+    # Push the new secret + bring the new server config live before the next turn.
+    from src.server.app.mcp_servers import _push_vault_to_sandbox, _schedule_proactive_apply
+
+    await _push_vault_to_sandbox(workspace_id)
+    _schedule_proactive_apply(workspace_id, user_id)
+
+    return _close_popup_html("Robinhood connected. You can close this window.", ok=True)
+
+
+# ---------------------------------------------------------------------------
+# GET — status
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{workspace_id}/robinhood/status")
+@handle_api_exceptions("Robinhood status", logger)
+async def status(workspace_id: str, user_id: CurrentUserId) -> dict:
+    await _require_owned_workspace(workspace_id, user_id)
+    st = await ro_db.get_status(user_id, workspace_id)
+    return {
+        "connected": st["connected"],
+        "expires_at": st["expires_at"].isoformat() if st.get("expires_at") else None,
+        "trading_enabled": False,  # trade tools are always gated in this build
+        "server_name": ROBINHOOD_SERVER_NAME,
+    }
+
+
+# ---------------------------------------------------------------------------
+# DELETE — disconnect
+# ---------------------------------------------------------------------------
+
+
+@router.delete("/{workspace_id}/robinhood")
+@handle_api_exceptions("disconnect Robinhood", logger)
+async def disconnect(workspace_id: str, user_id: CurrentUserId) -> dict:
+    await _require_owned_workspace(workspace_id, user_id)
+
+    from src.server.database.mcp_servers import delete_workspace_server
+
+    await ro_db.delete(user_id, workspace_id)
+    await delete_secret(workspace_id, VAULT_SECRET_NAME)
+    await delete_workspace_server(workspace_id, ROBINHOOD_SERVER_NAME)
+
+    from src.server.app.mcp_servers import _schedule_proactive_apply
+
+    _schedule_proactive_apply(workspace_id, user_id)
+    return {"ok": True}

--- a/src/server/app/setup.py
+++ b/src/server/app/setup.py
@@ -747,6 +747,7 @@ from src.server.app.memo import router as memo_router
 from src.server.app.memory import router as memory_router
 from src.server.app.mcp_catalog import router as mcp_catalog_router
 from src.server.app.mcp_servers import router as mcp_servers_router
+from src.server.app.robinhood import router as robinhood_router
 
 # Conditionally import ginlix-data WS proxy (only when GINLIX_DATA_WS_URL is set)
 from src.config.settings import GINLIX_DATA_ENABLED
@@ -820,6 +821,9 @@ app.include_router(
 app.include_router(
     mcp_servers_router
 )  # /api/v1/workspaces/{id}/mcp/servers - Per-workspace MCP server config
+app.include_router(
+    robinhood_router
+)  # /api/v1/workspaces/{id}/robinhood/* - Robinhood Agentic Trading MCP connect
 app.include_router(health_router)  # /health - Health check
 app.include_router(
     preview_redirect_router

--- a/src/server/database/robinhood_oauth.py
+++ b/src/server/database/robinhood_oauth.py
@@ -1,0 +1,209 @@
+"""Database CRUD for Robinhood Agentic Trading MCP OAuth state (encrypted at rest).
+
+One row per (user_id, workspace_id). Holds the dynamically-registered client,
+the discovered authorization/token endpoints, the transient PKCE state while a
+connect is pending, and the encrypted access/refresh tokens once connected.
+
+Same ``pgp_sym_encrypt``/``pgp_sym_decrypt`` pattern as ``oauth_tokens.py``.
+Secret columns always store an ENCRYPTED STRING (never SQL NULL) — absent
+secrets are encrypted empty strings, so decrypt always yields a plain ``str``
+and we never hit pgcrypto's NULL-input edge cases.
+"""
+
+import logging
+from datetime import datetime
+from typing import Any, Optional
+
+from psycopg.rows import dict_row
+
+from src.server.database.conversation import get_db_connection
+from src.server.database.encryption import get_encryption_key
+
+logger = logging.getLogger(__name__)
+
+
+async def upsert_pending(
+    *,
+    user_id: str,
+    workspace_id: str,
+    resource: str,
+    authorization_endpoint: str,
+    token_endpoint: str,
+    registration_endpoint: Optional[str],
+    client_id: str,
+    client_secret: Optional[str],
+    redirect_uri: str,
+    scopes: str,
+    state: str,
+    code_verifier: str,
+) -> None:
+    """Create or reset a pending connect row (post-initiate, pre-callback).
+
+    Resets any prior row for this (user, workspace) back to ``pending`` and
+    clears stored tokens — a fresh authorize flow supersedes the old grant.
+    """
+    enc = get_encryption_key()
+    async with get_db_connection() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                """
+                INSERT INTO robinhood_oauth (
+                    user_id, workspace_id, status, resource,
+                    authorization_endpoint, token_endpoint, registration_endpoint,
+                    client_id, client_secret, redirect_uri, scopes,
+                    state, code_verifier, access_token, refresh_token, expires_at,
+                    created_at, updated_at
+                )
+                VALUES (
+                    %s, %s, 'pending', %s,
+                    %s, %s, %s,
+                    %s, pgp_sym_encrypt(%s, %s), %s, %s,
+                    %s, pgp_sym_encrypt(%s, %s),
+                    pgp_sym_encrypt('', %s), pgp_sym_encrypt('', %s), NULL,
+                    NOW(), NOW()
+                )
+                ON CONFLICT (user_id, workspace_id) DO UPDATE SET
+                    status                  = 'pending',
+                    resource                = EXCLUDED.resource,
+                    authorization_endpoint  = EXCLUDED.authorization_endpoint,
+                    token_endpoint          = EXCLUDED.token_endpoint,
+                    registration_endpoint   = EXCLUDED.registration_endpoint,
+                    client_id               = EXCLUDED.client_id,
+                    client_secret           = EXCLUDED.client_secret,
+                    redirect_uri            = EXCLUDED.redirect_uri,
+                    scopes                  = EXCLUDED.scopes,
+                    state                   = EXCLUDED.state,
+                    code_verifier           = EXCLUDED.code_verifier,
+                    access_token            = EXCLUDED.access_token,
+                    refresh_token           = EXCLUDED.refresh_token,
+                    expires_at              = NULL,
+                    updated_at              = NOW()
+                """,
+                (
+                    user_id, workspace_id, resource,
+                    authorization_endpoint, token_endpoint, registration_endpoint,
+                    client_id, (client_secret or ""), enc, redirect_uri, scopes,
+                    state, code_verifier, enc,
+                    enc, enc,
+                ),
+            )
+    logger.debug(
+        "[robinhood_oauth] pending upsert user_id=%s workspace_id=%s",
+        user_id, workspace_id,
+    )
+
+
+async def set_tokens(
+    *,
+    user_id: str,
+    workspace_id: str,
+    access_token: str,
+    refresh_token: str,
+    expires_at: Optional[datetime],
+) -> None:
+    """Store freshly-exchanged or refreshed tokens and mark the row connected.
+
+    Clears the transient PKCE state once the code has been redeemed.
+    """
+    enc = get_encryption_key()
+    async with get_db_connection() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                """
+                UPDATE robinhood_oauth SET
+                    status        = 'connected',
+                    access_token  = pgp_sym_encrypt(%s, %s),
+                    refresh_token = pgp_sym_encrypt(%s, %s),
+                    expires_at    = %s,
+                    state         = NULL,
+                    code_verifier = pgp_sym_encrypt('', %s),
+                    updated_at    = NOW()
+                WHERE user_id = %s AND workspace_id = %s
+                """,
+                (
+                    access_token, enc,
+                    refresh_token, enc,
+                    expires_at, enc,
+                    user_id, workspace_id,
+                ),
+            )
+    logger.debug(
+        "[robinhood_oauth] tokens set user_id=%s workspace_id=%s",
+        user_id, workspace_id,
+    )
+
+
+def _to_str(v: Any) -> str:
+    """pgp_sym_decrypt yields text but psycopg3 may return bytes/memoryview."""
+    if v is None:
+        return ""
+    return v.decode() if isinstance(v, (bytes, bytearray, memoryview)) else str(v)
+
+
+async def get(user_id: str, workspace_id: str) -> Optional[dict[str, Any]]:
+    """Return the full decrypted row, or None. Empty-string secrets = absent."""
+    enc = get_encryption_key()
+    async with get_db_connection() as conn:
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(
+                """
+                SELECT
+                    user_id, workspace_id, status, resource,
+                    authorization_endpoint, token_endpoint, registration_endpoint,
+                    client_id, redirect_uri, scopes, state, expires_at,
+                    pgp_sym_decrypt(client_secret, %s) AS client_secret,
+                    pgp_sym_decrypt(code_verifier, %s) AS code_verifier,
+                    pgp_sym_decrypt(access_token, %s)  AS access_token,
+                    pgp_sym_decrypt(refresh_token, %s) AS refresh_token
+                FROM robinhood_oauth
+                WHERE user_id = %s AND workspace_id = %s
+                """,
+                (enc, enc, enc, enc, user_id, workspace_id),
+            )
+            row = await cur.fetchone()
+            if not row:
+                return None
+            for key in (
+                "client_secret", "code_verifier", "access_token", "refresh_token",
+            ):
+                row[key] = _to_str(row[key])
+            return row
+
+
+async def get_status(user_id: str, workspace_id: str) -> dict[str, Any]:
+    """Quick status check (no decryption): {connected, status, expires_at, scopes}."""
+    async with get_db_connection() as conn:
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(
+                """
+                SELECT status, expires_at, scopes
+                FROM robinhood_oauth
+                WHERE user_id = %s AND workspace_id = %s
+                """,
+                (user_id, workspace_id),
+            )
+            row = await cur.fetchone()
+            if not row:
+                return {"connected": False, "status": None, "expires_at": None}
+            return {
+                "connected": row["status"] == "connected",
+                "status": row["status"],
+                "expires_at": row["expires_at"],
+                "scopes": row["scopes"] or "",
+            }
+
+
+async def delete(user_id: str, workspace_id: str) -> bool:
+    """Remove the row. Returns True if one was deleted."""
+    async with get_db_connection() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                "DELETE FROM robinhood_oauth WHERE user_id = %s AND workspace_id = %s",
+                (user_id, workspace_id),
+            )
+            deleted = cur.rowcount > 0
+    logger.info(
+        "[robinhood_oauth] delete user_id=%s workspace_id=%s deleted=%s",
+        user_id, workspace_id, deleted,
+    )
+    return deleted

--- a/src/server/database/robinhood_oauth.py
+++ b/src/server/database/robinhood_oauth.py
@@ -170,6 +170,36 @@ async def get(user_id: str, workspace_id: str) -> Optional[dict[str, Any]]:
             return row
 
 
+async def get_pending_by_state(state: str) -> Optional[dict[str, Any]]:
+    """Look up a pending connect row by its (high-entropy, single-use) state.
+
+    The OAuth callback is a top-level browser redirect with no auth header, so
+    the unguessable ``state`` is what binds it back to the initiating session.
+    Returns the decrypted row (client_secret / code_verifier as strings) or None.
+    """
+    enc = get_encryption_key()
+    async with get_db_connection() as conn:
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(
+                """
+                SELECT
+                    user_id, workspace_id, status, resource,
+                    token_endpoint, client_id, redirect_uri, scopes,
+                    pgp_sym_decrypt(client_secret, %s) AS client_secret,
+                    pgp_sym_decrypt(code_verifier, %s) AS code_verifier
+                FROM robinhood_oauth
+                WHERE state = %s AND status = 'pending'
+                """,
+                (enc, enc, state),
+            )
+            row = await cur.fetchone()
+            if not row:
+                return None
+            row["client_secret"] = _to_str(row["client_secret"])
+            row["code_verifier"] = _to_str(row["code_verifier"])
+            return row
+
+
 async def get_status(user_id: str, workspace_id: str) -> dict[str, Any]:
     """Quick status check (no decryption): {connected, status, expires_at, scopes}."""
     async with get_db_connection() as conn:

--- a/src/server/handlers/chat/ptc_workflow.py
+++ b/src/server/handlers/chat/ptc_workflow.py
@@ -631,6 +631,22 @@ async def astream_ptc_workflow(
         # to avoid claiming subagents that belong to prior turns.
         background_registry.current_run_id = run_id
 
+        # Keep the Robinhood MCP access token fresh in the workspace vault before
+        # the sandbox turn. No-op unless this workspace has connected Robinhood
+        # (a single indexed read returns None fast); refreshes + re-pushes the
+        # ROBINHOOD_TOKEN secret only when it is near expiry. Best-effort.
+        try:
+            from src.server.services.robinhood_oauth import (
+                get_valid_robinhood_token,
+            )
+
+            await get_valid_robinhood_token(user_id, workspace_id)
+        except Exception:
+            logger.debug(
+                "[PTC_CHAT] Robinhood token refresh check failed (non-fatal)",
+                exc_info=True,
+            )
+
         # Build graph with the workspace's session
         # Note: agent.md is injected dynamically by WorkspaceContextMiddleware
         # on every model call, ensuring it's always the latest content.

--- a/src/server/handlers/chat/ptc_workflow.py
+++ b/src/server/handlers/chat/ptc_workflow.py
@@ -634,36 +634,44 @@ async def astream_ptc_workflow(
         # Keep the Robinhood MCP access token fresh in the workspace vault before
         # the sandbox turn. No-op unless this workspace has connected Robinhood
         # (a single indexed read returns None fast); refreshes + re-pushes the
-        # ROBINHOOD_TOKEN secret only when it is near expiry. Best-effort.
-        try:
-            from src.server.services.robinhood_oauth import (
-                get_valid_robinhood_token,
-            )
+        # ROBINHOOD_TOKEN secret only when it is near expiry. Best-effort, and
+        # independent of graph construction — it only has to finish before the
+        # agent could call a Robinhood tool mid-turn — so it runs concurrently
+        # with the graph build instead of blocking the hot path for every
+        # workspace platform-wide.
+        async def _refresh_robinhood_token() -> None:
+            try:
+                from src.server.services.robinhood_oauth import (
+                    get_valid_robinhood_token,
+                )
 
-            await get_valid_robinhood_token(user_id, workspace_id)
-        except Exception:
-            logger.debug(
-                "[PTC_CHAT] Robinhood token refresh check failed (non-fatal)",
-                exc_info=True,
-            )
+                await get_valid_robinhood_token(user_id, workspace_id)
+            except Exception:
+                logger.debug(
+                    "[PTC_CHAT] Robinhood token refresh check failed (non-fatal)",
+                    exc_info=True,
+                )
 
         # Build graph with the workspace's session
         # Note: agent.md is injected dynamically by WorkspaceContextMiddleware
         # on every model call, ensuring it's always the latest content.
         from src.server.app.workspace_sandbox import _set_cached_signed_url
 
-        ptc_graph = await build_ptc_graph_with_session(
-            session=session,
-            config=config,
-            subagent_names=subagents,
-            operation_callback=None,
-            checkpointer=setup.checkpointer,
-            background_registry=background_registry,
-            user_id=user_id,
-            plan_mode=effective_plan_mode,
-            thread_id=thread_id,
-            store=setup.store,
-            on_signed_url=_set_cached_signed_url,
+        ptc_graph, _ = await asyncio.gather(
+            build_ptc_graph_with_session(
+                session=session,
+                config=config,
+                subagent_names=subagents,
+                operation_callback=None,
+                checkpointer=setup.checkpointer,
+                background_registry=background_registry,
+                user_id=user_id,
+                plan_mode=effective_plan_mode,
+                thread_id=thread_id,
+                store=setup.store,
+                on_signed_url=_set_cached_signed_url,
+            ),
+            _refresh_robinhood_token(),
         )
 
         _mark_phase("graph_build")

--- a/src/server/models/mcp_server.py
+++ b/src/server/models/mcp_server.py
@@ -199,6 +199,12 @@ class McpServerInput(BaseModel):
     # Off (default) = tool discovery runs secret-less. On = resolve real vault
     # secrets during discovery (for servers that need auth even to list tools).
     discovery_uses_secrets: bool = False
+    # Hard gate: tool names that must never be exposed to the model. Denied tools
+    # are filtered out of both the sandbox wrapper module and the per-tool docs,
+    # so the agent can neither see nor call them. Removing tools only — cannot
+    # escalate — so it is allowed on workspace servers (e.g. to keep Robinhood's
+    # place/cancel order tools off by default).
+    tool_deny: list[str] = Field(default_factory=list)
 
     model_config = {"extra": "forbid"}
 
@@ -251,6 +257,15 @@ class McpServerInput(BaseModel):
                 )
             validate_remote_url(self.url)
             _validate_secret_map(self.headers, kind="header", key_re=ENV_KEY_RE)
+
+        # tool_deny: a list of tool names to hard-gate from the model/sandbox.
+        if len(self.tool_deny) > 100:
+            raise ValueError("tool_deny may list at most 100 tools")
+        for i, tname in enumerate(self.tool_deny):
+            if not isinstance(tname, str) or not tname.strip():
+                raise ValueError(f"tool_deny[{i}] must be a non-empty string")
+            if len(tname) > 128:
+                raise ValueError(f"tool_deny[{i}] is too long (max 128 chars)")
         return self
 
     def to_config_blob(self) -> dict[str, Any]:
@@ -268,6 +283,7 @@ class McpServerInput(BaseModel):
             "instruction": self.instruction,
             "tool_exposure_mode": self.tool_exposure_mode,
             "discovery_uses_secrets": self.discovery_uses_secrets,
+            "tool_deny": list(self.tool_deny),
         }
 
 
@@ -492,6 +508,8 @@ class EffectiveServer(BaseModel):
     instruction: str = ""
     tool_exposure_mode: str = "summary"
     discovery_uses_secrets: bool = False
+    # Tool names hard-gated off this server (never advertised or callable).
+    tool_deny: list[str] = Field(default_factory=list)
     command: Optional[str] = None
     args: list[str] = Field(default_factory=list)
     url: Optional[str] = None

--- a/src/server/services/robinhood_oauth.py
+++ b/src/server/services/robinhood_oauth.py
@@ -434,21 +434,27 @@ async def get_valid_robinhood_token(
 
 
 async def _sync_vault_token(workspace_id: str, access_token: str) -> None:
-    """Write the access token into the workspace vault and push to the sandbox."""
+    """Write the access token into the workspace vault and push to the sandbox.
+
+    The stored value is the full ``Bearer <token>`` header value, because the
+    MCP server model only permits a header that is exactly ``${vault:NAME}`` —
+    the prefix lives in the secret, not the header (see app/robinhood.py).
+    """
     from src.server.database.vault_secrets import (
         create_secret as create_secret_db,
         update_secret,
     )
 
+    header_value = f"Bearer {access_token}"
     updated = await update_secret(
-        workspace_id, "ROBINHOOD_TOKEN", value=access_token, description=None
+        workspace_id, "ROBINHOOD_TOKEN", value=header_value, description=None
     )
     if not updated:
         try:
             await create_secret_db(
                 workspace_id,
                 "ROBINHOOD_TOKEN",
-                access_token,
+                header_value,
                 "Robinhood Agentic Trading MCP access token (auto-refreshed)",
             )
         except ValueError:

--- a/src/server/services/robinhood_oauth.py
+++ b/src/server/services/robinhood_oauth.py
@@ -1,0 +1,464 @@
+"""Robinhood Agentic Trading MCP OAuth service.
+
+Robinhood's MCP (``https://agent.robinhood.com/mcp/trading``) is protected by the
+STANDARD MCP OAuth flow — there is no static, pre-registered client. So unlike
+``claude_oauth.py`` (a fixed client_id + hosted paste page), this module adds the
+two MCP-specific steps before the familiar PKCE auth-code dance:
+
+  1. Discovery  — RFC 9728 protected-resource metadata → RFC 8414 authorization-
+                  server metadata (authorization / token / registration endpoints).
+  2. Registration — RFC 7591 Dynamic Client Registration to obtain a client_id.
+
+then PKCE authorize → code exchange → refresh. The discovered endpoints + the
+registered client + the refresh token are persisted per (user, workspace) in the
+``robinhood_oauth`` table; the live access token is mirrored into the workspace
+vault as ``ROBINHOOD_TOKEN`` so Phase 1's in-sandbox streamable-HTTP client can
+send ``Authorization: Bearer ${vault:ROBINHOOD_TOKEN}``.
+
+The ``mcp.shared.auth`` pydantic models are reused for safe parsing; the HTTP is
+hand-rolled (httpx) for the same reasons ``claude_oauth.py`` is.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import logging
+import re
+import secrets
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+from urllib.parse import urlencode, urlsplit
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# --- Constants ---
+
+ROBINHOOD_MCP_URL = "https://agent.robinhood.com/mcp/trading"
+CLIENT_NAME = "Ginlix LangAlpha"
+# Spec-pinned (matches the codegen client in tool_generator.py).
+MCP_PROTOCOL_VERSION = "2025-06-18"
+# Refresh a little early so a turn never races expiry.
+_REFRESH_BUFFER = timedelta(minutes=5)
+_HTTP_TIMEOUT = 30.0
+
+_RESOURCE_METADATA_RE = re.compile(r'resource_metadata="([^"]+)"')
+
+
+# --- PKCE (same construction as claude_oauth.py) ---
+
+def generate_pkce_pair() -> tuple[str, str]:
+    """Return (verifier, S256 challenge)."""
+    verifier = secrets.token_urlsafe(64)
+    digest = hashlib.sha256(verifier.encode()).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+    return verifier, challenge
+
+
+# --- Discovery (RFC 9728 → RFC 8414) ---
+
+def _wellknown_candidates(url: str, suffix: str) -> list[str]:
+    """Build ``.well-known`` candidate URLs for ``url``, path-aware then root.
+
+    RFC 8414/9728 insert the well-known segment after the host AND, for path-
+    bearing resources, also try the path-appended and root forms. Order matters:
+    the most specific (path-aware) first.
+    """
+    parts = urlsplit(url)
+    origin = f"{parts.scheme}://{parts.netloc}"
+    path = parts.path.rstrip("/")
+    candidates = []
+    if path:
+        candidates.append(f"{origin}/.well-known/{suffix}{path}")
+        candidates.append(f"{origin}/.well-known/{suffix}")
+        candidates.append(f"{origin}{path}/.well-known/{suffix}")
+    else:
+        candidates.append(f"{origin}/.well-known/{suffix}")
+    # De-dupe preserving order.
+    seen: set[str] = set()
+    return [c for c in candidates if not (c in seen or seen.add(c))]
+
+
+async def _probe_resource_metadata_url(
+    server_url: str, http: httpx.AsyncClient
+) -> Optional[str]:
+    """Read the ``resource_metadata`` hint from the MCP server's 401 challenge."""
+    try:
+        resp = await http.post(
+            server_url,
+            json={"jsonrpc": "2.0", "id": 0, "method": "ping"},
+            headers={
+                "Accept": "application/json, text/event-stream",
+                "MCP-Protocol-Version": MCP_PROTOCOL_VERSION,
+            },
+        )
+    except httpx.HTTPError:
+        return None
+    if resp.status_code == 401:
+        m = _RESOURCE_METADATA_RE.search(resp.headers.get("www-authenticate", ""))
+        if m:
+            return m.group(1)
+    return None
+
+
+async def _get_json(http: httpx.AsyncClient, url: str) -> Optional[dict[str, Any]]:
+    try:
+        resp = await http.get(url, headers={"Accept": "application/json"})
+    except httpx.HTTPError:
+        return None
+    if resp.status_code == 200:
+        try:
+            return resp.json()
+        except ValueError:
+            return None
+    return None
+
+
+async def discover_metadata(
+    server_url: str = ROBINHOOD_MCP_URL,
+    *,
+    http: Optional[httpx.AsyncClient] = None,
+) -> dict[str, Any]:
+    """Discover the authorization server's endpoints for an MCP resource.
+
+    Returns ``{authorization_endpoint, token_endpoint, registration_endpoint,
+    scopes_supported, resource}``. Raises ``RuntimeError`` if discovery fails.
+    """
+    from mcp.shared.auth import OAuthMetadata, ProtectedResourceMetadata
+
+    owns = http is None
+    http = http or httpx.AsyncClient(timeout=_HTTP_TIMEOUT, follow_redirects=True)
+    try:
+        # 1. Protected-resource metadata → authorization server URL(s).
+        prm_url = await _probe_resource_metadata_url(server_url, http)
+        prm_data = await _get_json(http, prm_url) if prm_url else None
+        if prm_data is None:
+            for cand in _wellknown_candidates(server_url, "oauth-protected-resource"):
+                prm_data = await _get_json(http, cand)
+                if prm_data:
+                    break
+        auth_servers: list[str] = []
+        resource = server_url
+        if prm_data:
+            try:
+                prm = ProtectedResourceMetadata.model_validate(prm_data)
+                auth_servers = [str(a) for a in (prm.authorization_servers or [])]
+                resource = str(prm.resource) if prm.resource else server_url
+            except Exception:
+                auth_servers = [
+                    str(a) for a in (prm_data.get("authorization_servers") or [])
+                ]
+        # Fallback: treat the resource origin itself as the auth server.
+        if not auth_servers:
+            parts = urlsplit(server_url)
+            auth_servers = [f"{parts.scheme}://{parts.netloc}"]
+
+        # 2. Authorization-server metadata.
+        for as_url in auth_servers:
+            for suffix in ("oauth-authorization-server", "openid-configuration"):
+                for cand in _wellknown_candidates(as_url, suffix):
+                    data = await _get_json(http, cand)
+                    if not data:
+                        continue
+                    try:
+                        meta = OAuthMetadata.model_validate(data)
+                        auth_ep = str(meta.authorization_endpoint)
+                        token_ep = str(meta.token_endpoint)
+                        reg_ep = (
+                            str(meta.registration_endpoint)
+                            if meta.registration_endpoint
+                            else None
+                        )
+                        scopes = list(meta.scopes_supported or [])
+                    except Exception:
+                        auth_ep = data.get("authorization_endpoint")
+                        token_ep = data.get("token_endpoint")
+                        reg_ep = data.get("registration_endpoint")
+                        scopes = list(data.get("scopes_supported") or [])
+                    if auth_ep and token_ep:
+                        return {
+                            "authorization_endpoint": auth_ep,
+                            "token_endpoint": token_ep,
+                            "registration_endpoint": reg_ep,
+                            "scopes_supported": scopes,
+                            "resource": resource,
+                        }
+        raise RuntimeError(
+            f"Could not discover OAuth metadata for {server_url!r} "
+            f"(tried auth servers: {auth_servers})"
+        )
+    finally:
+        if owns:
+            await http.aclose()
+
+
+# --- Dynamic Client Registration (RFC 7591) ---
+
+async def register_client(
+    registration_endpoint: str,
+    redirect_uri: str,
+    *,
+    scope: str = "",
+    http: Optional[httpx.AsyncClient] = None,
+) -> dict[str, Any]:
+    """Register a public OAuth client via RFC 7591 DCR.
+
+    Returns ``{client_id, client_secret}`` (client_secret may be ``None`` for a
+    public client). Raises ``RuntimeError`` on failure.
+    """
+    owns = http is None
+    http = http or httpx.AsyncClient(timeout=_HTTP_TIMEOUT, follow_redirects=True)
+    try:
+        body: dict[str, Any] = {
+            "client_name": CLIENT_NAME,
+            "redirect_uris": [redirect_uri],
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+            "token_endpoint_auth_method": "none",  # public client + PKCE
+        }
+        if scope:
+            body["scope"] = scope
+        resp = await http.post(
+            registration_endpoint,
+            json=body,
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+        )
+        if resp.status_code >= 400:
+            raise RuntimeError(
+                f"DCR failed: status={resp.status_code} body={resp.text[:300]}"
+            )
+        data = resp.json()
+        client_id = data.get("client_id")
+        if not client_id:
+            raise RuntimeError(f"DCR response missing client_id: {data}")
+        return {"client_id": client_id, "client_secret": data.get("client_secret")}
+    finally:
+        if owns:
+            await http.aclose()
+
+
+# --- Authorize URL ---
+
+def build_authorize_url(
+    *,
+    authorization_endpoint: str,
+    client_id: str,
+    redirect_uri: str,
+    state: str,
+    challenge: str,
+    resource: str,
+    scope: str = "",
+) -> str:
+    """Build the PKCE authorization-code URL."""
+    params = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "state": state,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "resource": resource,
+    }
+    if scope:
+        params["scope"] = scope
+    sep = "&" if "?" in authorization_endpoint else "?"
+    return f"{authorization_endpoint}{sep}{urlencode(params)}"
+
+
+# --- Token exchange / refresh ---
+
+async def _token_request(
+    token_endpoint: str, form: dict[str, str], *, http: httpx.AsyncClient
+) -> dict[str, Any]:
+    resp = await http.post(
+        token_endpoint,
+        data=form,
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept": "application/json",
+        },
+    )
+    if resp.status_code >= 400:
+        logger.error(
+            "[robinhood_oauth] token request failed: status=%s body=%s",
+            resp.status_code, resp.text[:300],
+        )
+    resp.raise_for_status()
+    data = resp.json()
+    return {
+        "access_token": data["access_token"],
+        "refresh_token": data.get("refresh_token", ""),
+        "expires_in": data.get("expires_in", 3600),
+        "scope": data.get("scope", ""),
+    }
+
+
+async def exchange_code(
+    *,
+    token_endpoint: str,
+    client_id: str,
+    client_secret: Optional[str],
+    code: str,
+    redirect_uri: str,
+    code_verifier: str,
+    resource: str,
+    http: Optional[httpx.AsyncClient] = None,
+) -> dict[str, Any]:
+    """Exchange an authorization code for tokens."""
+    owns = http is None
+    http = http or httpx.AsyncClient(timeout=_HTTP_TIMEOUT, follow_redirects=True)
+    try:
+        form = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "client_id": client_id,
+            "code_verifier": code_verifier,
+            "resource": resource,
+        }
+        if client_secret:
+            form["client_secret"] = client_secret
+        return await _token_request(token_endpoint, form, http=http)
+    finally:
+        if owns:
+            await http.aclose()
+
+
+async def refresh_tokens(
+    *,
+    token_endpoint: str,
+    client_id: str,
+    client_secret: Optional[str],
+    refresh_token: str,
+    resource: str,
+    http: Optional[httpx.AsyncClient] = None,
+) -> dict[str, Any]:
+    """Use a refresh token to get a new access token."""
+    owns = http is None
+    http = http or httpx.AsyncClient(timeout=_HTTP_TIMEOUT, follow_redirects=True)
+    try:
+        form = {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": client_id,
+            "resource": resource,
+        }
+        if client_secret:
+            form["client_secret"] = client_secret
+        out = await _token_request(token_endpoint, form, http=http)
+        # Some servers omit a rotated refresh token — keep the old one.
+        if not out["refresh_token"]:
+            out["refresh_token"] = refresh_token
+        return out
+    finally:
+        if owns:
+            await http.aclose()
+
+
+# --- Orchestrator: valid token with refresh-lock + vault sync ---
+
+async def get_valid_robinhood_token(
+    user_id: str, workspace_id: str
+) -> Optional[str]:
+    """Return a valid Robinhood access token for this workspace, refreshing if
+    needed and re-syncing the ``ROBINHOOD_TOKEN`` vault secret to the sandbox.
+
+    Returns None when not connected or refresh fails. Uses a Redis SETNX lock so
+    concurrent turns don't double-refresh (same pattern as claude_oauth).
+    """
+    from src.server.database import robinhood_oauth as db
+
+    row = await db.get(user_id, workspace_id)
+    if not row or row.get("status") != "connected":
+        return None
+
+    now = datetime.now(timezone.utc)
+    expires_at = row.get("expires_at")
+    if expires_at is not None and expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+
+    if expires_at is not None and expires_at > now + _REFRESH_BUFFER:
+        return row["access_token"] or None
+
+    if not row.get("refresh_token"):
+        # No way to refresh — surface the current token (may already be expired).
+        return row["access_token"] or None
+
+    from src.utils.cache.redis_cache import get_cache_client
+
+    cache = get_cache_client()
+    lock_key = f"oauth:refresh:robinhood:{workspace_id}"
+    if cache.enabled and cache.client:
+        acquired = await cache.client.set(lock_key, "1", nx=True, ex=35)
+        if not acquired:
+            await asyncio.sleep(1)
+            fresh = await db.get(user_id, workspace_id)
+            return (fresh or {}).get("access_token") or None
+
+    try:
+        new = await refresh_tokens(
+            token_endpoint=row["token_endpoint"],
+            client_id=row["client_id"],
+            client_secret=row.get("client_secret") or None,
+            refresh_token=row["refresh_token"],
+            resource=row["resource"],
+        )
+        new_expires = now + timedelta(seconds=new.get("expires_in", 3600))
+        await db.set_tokens(
+            user_id=user_id,
+            workspace_id=workspace_id,
+            access_token=new["access_token"],
+            refresh_token=new["refresh_token"],
+            expires_at=new_expires,
+        )
+        await _sync_vault_token(workspace_id, new["access_token"])
+        logger.debug(
+            "[robinhood_oauth] refreshed token for workspace_id=%s", workspace_id
+        )
+        return new["access_token"]
+    except Exception as e:
+        logger.error(
+            "[robinhood_oauth] refresh failed for workspace_id=%s: %s",
+            workspace_id, e,
+        )
+        return None
+    finally:
+        if cache.enabled and cache.client:
+            try:
+                await cache.client.delete(lock_key)
+            except Exception:
+                pass
+
+
+async def _sync_vault_token(workspace_id: str, access_token: str) -> None:
+    """Write the access token into the workspace vault and push to the sandbox."""
+    from src.server.database.vault_secrets import (
+        create_secret as create_secret_db,
+        update_secret,
+    )
+
+    updated = await update_secret(
+        workspace_id, "ROBINHOOD_TOKEN", value=access_token, description=None
+    )
+    if not updated:
+        try:
+            await create_secret_db(
+                workspace_id,
+                "ROBINHOOD_TOKEN",
+                access_token,
+                "Robinhood Agentic Trading MCP access token (auto-refreshed)",
+            )
+        except ValueError:
+            pass  # raced create / cap — the update path will catch it next turn
+    try:
+        from src.server.services.workspace_manager import WorkspaceManager
+
+        await WorkspaceManager.get_instance().push_vault_secrets(workspace_id)
+    except Exception:
+        logger.warning(
+            "[robinhood_oauth] vault push failed for workspace_id=%s",
+            workspace_id, exc_info=True,
+        )

--- a/tests/unit/core/sandbox/test_mcp_per_workspace_sync.py
+++ b/tests/unit/core/sandbox/test_mcp_per_workspace_sync.py
@@ -637,3 +637,65 @@ class TestDiscoverUserMcpSchemas:
             [_user("alpha", transport="http", url="https://a.test")]
         )
         assert call_order.index("upload_client") < call_order.index("discover")
+
+
+# ---------------------------------------------------------------------------
+# tool_deny — hard gate: denied tools never reach the sandbox (no wrapper, no doc)
+# ---------------------------------------------------------------------------
+
+
+class TestToolDenyHardGate:
+    """A server's ``tool_deny`` list removes those tools from BOTH the generated
+    wrapper module and the per-tool docs, so the model can neither call nor see
+    them (e.g. Robinhood's place/cancel order tools, off by default)."""
+
+    @pytest.mark.asyncio
+    async def test_denied_tools_absent_from_module_and_docs(self):
+        from ptc_agent.core.mcp_registry import MCPToolInfo
+
+        server = _user(
+            "robinhood",
+            transport="http",
+            url="https://agent.robinhood.com/mcp/trading",
+            headers={"Authorization": "Bearer ${vault:ROBINHOOD_TOKEN}"},
+            tool_deny=["place_equity_order", "cancel_equity_order"],
+        )
+        sandbox = _make_sandbox(_make_config(servers=[server]))
+        sandbox._work_dir = "/home/workspace"
+        sandbox.runtime = MagicMock()
+        sandbox.als_directory = AsyncMock(return_value=[])
+
+        schema = {"type": "object", "properties": {}}
+        tools = [
+            MCPToolInfo("get_portfolio", "Read portfolio", schema, "robinhood"),
+            MCPToolInfo("place_equity_order", "Place an order", schema, "robinhood"),
+            MCPToolInfo("cancel_equity_order", "Cancel an order", schema, "robinhood"),
+        ]
+        sandbox.mcp_registry = MagicMock()
+        sandbox.mcp_registry.get_all_tools = MagicMock(
+            return_value={"robinhood": tools}
+        )
+
+        captured: dict = {}
+
+        async def fake_runtime_call(func, *args, **kwargs):
+            if func is sandbox.runtime.upload_files:
+                captured["batch"] = args[0]
+            return None
+
+        sandbox._runtime_call = fake_runtime_call
+
+        await sandbox._install_tool_modules()
+
+        batch = {path: content.decode() for content, path in captured["batch"]}
+        module = batch["/home/workspace/tools/robinhood.py"]
+        # Allowed read tool present; both trade tools gone from the wrapper.
+        assert "get_portfolio" in module
+        assert "place_equity_order" not in module
+        assert "cancel_equity_order" not in module
+
+        # And no doc file is advertised for the denied tools.
+        doc_paths = [p for p in batch if "/tools/docs/robinhood/" in p]
+        assert any("get_portfolio" in p for p in doc_paths)
+        assert not any("place_equity_order" in p for p in doc_paths)
+        assert not any("cancel_equity_order" in p for p in doc_paths)

--- a/tests/unit/server/app/test_robinhood_router.py
+++ b/tests/unit/server/app/test_robinhood_router.py
@@ -1,0 +1,69 @@
+"""Unit tests for the Robinhood connect router's pure + state-bound logic.
+
+The full initiate/callback flow needs network + DB (covered by local e2e); here
+we lock the security-critical defaults (the registered server gates the trade
+tools) and the auth-less callback's state binding.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.responses import HTMLResponse
+
+from src.server.app import robinhood as rh
+
+
+def test_server_blob_gates_trade_tools_by_default():
+    blob = rh._robinhood_server_blob()
+    assert blob["name"] == rh.ROBINHOOD_SERVER_NAME
+    assert blob["transport"] == "http"
+    assert blob["url"] == rh.ROBINHOOD_MCP_URL
+    # The header is the exact vault ref (model only allows ${vault:NAME}); the
+    # "Bearer " prefix lives inside the stored secret value.
+    assert blob["headers"]["Authorization"] == "${vault:ROBINHOOD_TOKEN}"
+    # Trade tools are denied by default; reads/preview are not.
+    assert set(blob["tool_deny"]) == {"place_equity_order", "cancel_equity_order"}
+    assert "get_portfolio" not in blob["tool_deny"]
+    assert "review_equity_order" not in blob["tool_deny"]
+    assert blob["discovery_uses_secrets"] is True
+
+
+def test_redirect_uri_shape():
+    uri = rh._redirect_uri("ws-123")
+    assert uri.endswith("/api/v1/workspaces/ws-123/robinhood/callback")
+    assert uri.startswith("http")
+
+
+@pytest.mark.asyncio
+async def test_callback_error_param_returns_close_page():
+    resp = await rh.callback(
+        workspace_id="w", state="", code="", error="access_denied",
+        error_description="user said no",
+    )
+    assert isinstance(resp, HTMLResponse)
+    assert resp.status_code == 200
+    body = resp.body.decode()
+    assert "oauth-complete" in body
+    assert "user said no" in body
+
+
+@pytest.mark.asyncio
+async def test_callback_unknown_state_is_expired(monkeypatch):
+    async def fake_lookup(state):
+        return None
+
+    monkeypatch.setattr(rh.ro_db, "get_pending_by_state", fake_lookup)
+    resp = await rh.callback(workspace_id="w", state="bogus", code="c")
+    assert isinstance(resp, HTMLResponse)
+    assert "expired" in resp.body.decode()
+
+
+@pytest.mark.asyncio
+async def test_callback_rejects_workspace_mismatch(monkeypatch):
+    """A state row for another workspace must not connect this one."""
+    async def fake_lookup(state):
+        return {"workspace_id": "other-ws", "user_id": "u"}
+
+    monkeypatch.setattr(rh.ro_db, "get_pending_by_state", fake_lookup)
+    resp = await rh.callback(workspace_id="w", state="s", code="c")
+    assert "expired" in resp.body.decode()

--- a/tests/unit/server/app/test_robinhood_router.py
+++ b/tests/unit/server/app/test_robinhood_router.py
@@ -7,6 +7,8 @@ tools) and the auth-less callback's state binding.
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock
+
 import pytest
 from fastapi.responses import HTMLResponse
 
@@ -67,3 +69,64 @@ async def test_callback_rejects_workspace_mismatch(monkeypatch):
     monkeypatch.setattr(rh.ro_db, "get_pending_by_state", fake_lookup)
     resp = await rh.callback(workspace_id="w", state="s", code="c")
     assert "expired" in resp.body.decode()
+
+
+# ---------------------------------------------------------------------------
+# initiate — reuse one registered client per workspace (avoid Robinhood's
+# anti-abuse throttle from re-registering a new client on every click)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_initiate_reuses_existing_client(monkeypatch):
+    """When a client is already registered for the workspace, initiate must NOT
+    re-discover or re-register — it reuses the stored client_id."""
+    redirect = rh._redirect_uri("ws-1")
+    existing = {
+        "client_id": "reused-cid",
+        "authorization_endpoint": "https://robinhood.com/oauth",
+        "token_endpoint": "https://api.robinhood.com/oauth2/token/",
+        "registration_endpoint": "https://agent.robinhood.com/oauth/trading/register",
+        "redirect_uri": redirect,
+        "client_secret": "",
+        "resource": "https://agent.robinhood.com/mcp/trading",
+        "scopes": "internal",
+    }
+    monkeypatch.setattr(rh, "_require_owned_workspace", AsyncMock(return_value={}))
+    monkeypatch.setattr(rh.ro_db, "get", AsyncMock(return_value=existing))
+    upsert = AsyncMock()
+    monkeypatch.setattr(rh.ro_db, "upsert_pending", upsert)
+    disc = AsyncMock()
+    reg = AsyncMock()
+    monkeypatch.setattr(rh, "discover_metadata", disc)
+    monkeypatch.setattr(rh, "register_client", reg)
+
+    out = await rh.initiate("ws-1", "user-1")
+
+    assert "client_id=reused-cid" in out["authorize_url"]
+    disc.assert_not_called()      # no re-discovery
+    reg.assert_not_called()       # no new dynamic client registration
+    # A fresh PKCE state was still stored for this attempt.
+    assert upsert.await_args.kwargs["client_id"] == "reused-cid"
+
+
+@pytest.mark.asyncio
+async def test_initiate_registers_when_no_existing_client(monkeypatch):
+    """First connect (no stored client) discovers + registers once."""
+    monkeypatch.setattr(rh, "_require_owned_workspace", AsyncMock(return_value={}))
+    monkeypatch.setattr(rh.ro_db, "get", AsyncMock(return_value=None))
+    monkeypatch.setattr(rh.ro_db, "upsert_pending", AsyncMock())
+    monkeypatch.setattr(rh, "discover_metadata", AsyncMock(return_value={
+        "authorization_endpoint": "https://robinhood.com/oauth",
+        "token_endpoint": "https://api.robinhood.com/oauth2/token/",
+        "registration_endpoint": "https://agent.robinhood.com/oauth/trading/register",
+        "scopes_supported": ["internal"],
+        "resource": "https://agent.robinhood.com/mcp/trading",
+    }))
+    reg = AsyncMock(return_value={"client_id": "new-cid", "client_secret": None})
+    monkeypatch.setattr(rh, "register_client", reg)
+
+    out = await rh.initiate("ws-1", "user-1")
+
+    reg.assert_called_once()
+    assert "client_id=new-cid" in out["authorize_url"]

--- a/tests/unit/server/models/test_mcp_server_models.py
+++ b/tests/unit/server/models/test_mcp_server_models.py
@@ -428,3 +428,57 @@ def test_parse_undetermined_transport_marks_error():
 def test_parse_non_dict_payload_is_empty():
     assert parse_mcp_servers_payload("not a dict") == []
     assert parse_mcp_servers_payload(None) == []
+
+
+# ---------------------------------------------------------------------------
+# tool_deny — per-server hard gate (keeps e.g. Robinhood place/cancel off)
+# ---------------------------------------------------------------------------
+
+
+def test_tool_deny_defaults_empty_and_round_trips_in_blob():
+    srv = McpServerInput(**_http())
+    assert srv.tool_deny == []
+    assert srv.to_config_blob()["tool_deny"] == []
+
+    gated = McpServerInput(
+        **_http(tool_deny=["place_equity_order", "cancel_equity_order"])
+    )
+    assert gated.tool_deny == ["place_equity_order", "cancel_equity_order"]
+    assert gated.to_config_blob()["tool_deny"] == [
+        "place_equity_order",
+        "cancel_equity_order",
+    ]
+
+
+def test_tool_deny_is_allowed_on_workspace_servers():
+    """tool_deny only removes tools (cannot escalate), so it is NOT a
+    forbidden built-in-only key — a workspace server may set it."""
+    srv = McpServerInput(**_http(tool_deny=["x"]))
+    assert srv.tool_deny == ["x"]
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        [""],            # empty tool name
+        ["  "],          # blank tool name
+        [123],           # non-string
+        ["a" * 129],     # over length cap
+        ["ok"] * 101,    # over list cap
+    ],
+)
+def test_tool_deny_rejects_invalid(bad):
+    with pytest.raises(ValidationError):
+        McpServerInput(**_http(tool_deny=bad))
+
+
+def test_tool_deny_flows_into_server_config():
+    """A stored blob with tool_deny converts into an MCPServerConfig carrying it,
+    so the sandbox sees the gate."""
+    from src.server.handlers.chat.mcp_config import workspace_row_to_server_config
+
+    blob = McpServerInput(**_http(tool_deny=["place_equity_order"])).to_config_blob()
+    cfg = workspace_row_to_server_config(
+        {"name": "remote_server", "enabled": True, "config": blob}
+    )
+    assert cfg.tool_deny == ["place_equity_order"]

--- a/tests/unit/server/services/test_robinhood_oauth.py
+++ b/tests/unit/server/services/test_robinhood_oauth.py
@@ -1,0 +1,278 @@
+"""Unit tests for the Robinhood Agentic Trading MCP OAuth service.
+
+Drives the HTTP-bearing functions (discovery, DCR, token exchange/refresh)
+against an httpx.MockTransport — real request/response plumbing, no network —
+and the get_valid_robinhood_token orchestrator with the DB + vault + Redis
+seams monkeypatched.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from datetime import datetime, timedelta, timezone
+
+import httpx
+import pytest
+
+from src.server.services import robinhood_oauth as ro
+
+MCP_URL = ro.ROBINHOOD_MCP_URL
+ORIGIN = "https://agent.robinhood.com"
+AUTH_EP = f"{ORIGIN}/oauth/authorize"
+TOKEN_EP = f"{ORIGIN}/oauth/token"
+REG_EP = f"{ORIGIN}/oauth/register"
+
+
+def _client(handler) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+# --- PKCE + authorize URL ---------------------------------------------------
+
+
+def test_generate_pkce_pair_is_valid_s256():
+    verifier, challenge = ro.generate_pkce_pair()
+    expected = base64.urlsafe_b64encode(
+        hashlib.sha256(verifier.encode()).digest()
+    ).rstrip(b"=").decode()
+    assert challenge == expected
+
+
+def test_build_authorize_url_carries_pkce_and_resource():
+    url = ro.build_authorize_url(
+        authorization_endpoint=AUTH_EP,
+        client_id="cid",
+        redirect_uri="http://localhost:8000/cb",
+        state="st",
+        challenge="ch",
+        resource=MCP_URL,
+        scope="trade",
+    )
+    assert url.startswith(AUTH_EP + "?")
+    for frag in (
+        "response_type=code", "client_id=cid", "code_challenge=ch",
+        "code_challenge_method=S256", "state=st", "scope=trade",
+    ):
+        assert frag in url
+    assert "resource=https%3A%2F%2Fagent.robinhood.com%2Fmcp%2Ftrading" in url
+
+
+def test_wellknown_candidates_path_aware_first():
+    cands = ro._wellknown_candidates(MCP_URL, "oauth-protected-resource")
+    assert cands[0] == f"{ORIGIN}/.well-known/oauth-protected-resource/mcp/trading"
+    assert f"{ORIGIN}/.well-known/oauth-protected-resource" in cands
+
+
+# --- Discovery --------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_discover_via_www_authenticate_challenge():
+    prm_url = f"{ORIGIN}/.well-known/oauth-protected-resource/mcp/trading"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and str(request.url) == MCP_URL:
+            return httpx.Response(
+                401,
+                headers={"WWW-Authenticate": f'Bearer resource_metadata="{prm_url}"'},
+            )
+        if str(request.url) == prm_url:
+            return httpx.Response(
+                200,
+                json={"resource": MCP_URL, "authorization_servers": [ORIGIN]},
+            )
+        if str(request.url) == f"{ORIGIN}/.well-known/oauth-authorization-server":
+            return httpx.Response(200, json={
+                "issuer": ORIGIN,
+                "authorization_endpoint": AUTH_EP,
+                "token_endpoint": TOKEN_EP,
+                "registration_endpoint": REG_EP,
+                "scopes_supported": ["trade", "read"],
+            })
+        return httpx.Response(404)
+
+    async with _client(handler) as http:
+        meta = await ro.discover_metadata(MCP_URL, http=http)
+    assert meta["authorization_endpoint"] == AUTH_EP
+    assert meta["token_endpoint"] == TOKEN_EP
+    assert meta["registration_endpoint"] == REG_EP
+    assert meta["resource"] == MCP_URL
+
+
+@pytest.mark.asyncio
+async def test_discover_falls_back_to_wellknown_when_no_challenge():
+    """No 401 hint → walk the conventional well-known paths."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        u = str(request.url)
+        if request.method == "POST" and u == MCP_URL:
+            return httpx.Response(200, json={"jsonrpc": "2.0", "id": 0, "result": {}})
+        if u == f"{ORIGIN}/.well-known/oauth-protected-resource/mcp/trading":
+            return httpx.Response(200, json={"authorization_servers": [ORIGIN]})
+        if u == f"{ORIGIN}/.well-known/oauth-authorization-server":
+            return httpx.Response(200, json={
+                "issuer": ORIGIN,
+                "authorization_endpoint": AUTH_EP,
+                "token_endpoint": TOKEN_EP,
+            })
+        return httpx.Response(404)
+
+    async with _client(handler) as http:
+        meta = await ro.discover_metadata(MCP_URL, http=http)
+    assert meta["token_endpoint"] == TOKEN_EP
+    assert meta["registration_endpoint"] is None
+
+
+@pytest.mark.asyncio
+async def test_discover_raises_when_nothing_found():
+    async with _client(lambda r: httpx.Response(404)) as http:
+        with pytest.raises(RuntimeError):
+            await ro.discover_metadata(MCP_URL, http=http)
+
+
+# --- Dynamic Client Registration --------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_client_returns_client_id():
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        import json as _json
+        seen["body"] = _json.loads(request.content)
+        return httpx.Response(201, json={"client_id": "abc123"})
+
+    async with _client(handler) as http:
+        out = await ro.register_client(REG_EP, "http://localhost:8000/cb", http=http)
+    assert out["client_id"] == "abc123"
+    assert out["client_secret"] is None
+    assert seen["body"]["redirect_uris"] == ["http://localhost:8000/cb"]
+    assert seen["body"]["token_endpoint_auth_method"] == "none"
+    assert set(seen["body"]["grant_types"]) == {"authorization_code", "refresh_token"}
+
+
+@pytest.mark.asyncio
+async def test_register_client_raises_on_error():
+    async with _client(lambda r: httpx.Response(400, text="bad")) as http:
+        with pytest.raises(RuntimeError):
+            await ro.register_client(REG_EP, "http://localhost:8000/cb", http=http)
+
+
+# --- Token exchange / refresh -----------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_posts_form_with_resource_and_verifier():
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["ctype"] = request.headers["content-type"]
+        seen["body"] = request.content.decode()
+        return httpx.Response(200, json={
+            "access_token": "at", "refresh_token": "rt", "expires_in": 1800,
+        })
+
+    async with _client(handler) as http:
+        out = await ro.exchange_code(
+            token_endpoint=TOKEN_EP, client_id="cid", client_secret=None,
+            code="thecode", redirect_uri="http://localhost:8000/cb",
+            code_verifier="ver", resource=MCP_URL, http=http,
+        )
+    assert out == {"access_token": "at", "refresh_token": "rt",
+                   "expires_in": 1800, "scope": ""}
+    assert "application/x-www-form-urlencoded" in seen["ctype"]
+    assert "grant_type=authorization_code" in seen["body"]
+    assert "code_verifier=ver" in seen["body"]
+    assert "resource=" in seen["body"]
+
+
+@pytest.mark.asyncio
+async def test_refresh_keeps_old_refresh_token_when_server_omits_it():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"access_token": "new_at", "expires_in": 3600})
+
+    async with _client(handler) as http:
+        out = await ro.refresh_tokens(
+            token_endpoint=TOKEN_EP, client_id="cid", client_secret=None,
+            refresh_token="old_rt", resource=MCP_URL, http=http,
+        )
+    assert out["access_token"] == "new_at"
+    assert out["refresh_token"] == "old_rt"  # carried over
+
+
+# --- get_valid_robinhood_token orchestrator ---------------------------------
+
+
+class _DisabledCache:
+    enabled = False
+    client = None
+
+
+@pytest.fixture(autouse=True)
+def _no_redis(monkeypatch):
+    monkeypatch.setattr(
+        "src.utils.cache.redis_cache.get_cache_client", lambda: _DisabledCache()
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_valid_token_returns_unexpired_without_refresh(monkeypatch):
+    future = datetime.now(timezone.utc) + timedelta(hours=1)
+
+    async def fake_get(uid, wid):
+        return {"status": "connected", "access_token": "live", "refresh_token": "rt",
+                "expires_at": future, "token_endpoint": TOKEN_EP, "client_id": "c",
+                "resource": MCP_URL}
+
+    called = {"refresh": False}
+
+    async def fake_refresh(**kw):
+        called["refresh"] = True
+        return {}
+
+    monkeypatch.setattr(ro, "refresh_tokens", fake_refresh)
+    monkeypatch.setattr("src.server.database.robinhood_oauth.get", fake_get)
+
+    tok = await ro.get_valid_robinhood_token("u", "w")
+    assert tok == "live"
+    assert called["refresh"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_valid_token_refreshes_when_expired_and_syncs_vault(monkeypatch):
+    past = datetime.now(timezone.utc) - timedelta(minutes=1)
+    state: dict = {}
+
+    async def fake_get(uid, wid):
+        return {"status": "connected", "access_token": "stale", "refresh_token": "rt",
+                "expires_at": past, "token_endpoint": TOKEN_EP, "client_id": "c",
+                "client_secret": None, "resource": MCP_URL}
+
+    async def fake_refresh(**kw):
+        return {"access_token": "fresh_at", "refresh_token": "rt2", "expires_in": 3600}
+
+    async def fake_set(**kw):
+        state["set"] = kw
+
+    async def fake_sync(wid, token):
+        state["synced"] = token
+
+    monkeypatch.setattr(ro, "refresh_tokens", fake_refresh)
+    monkeypatch.setattr("src.server.database.robinhood_oauth.get", fake_get)
+    monkeypatch.setattr("src.server.database.robinhood_oauth.set_tokens", fake_set)
+    monkeypatch.setattr(ro, "_sync_vault_token", fake_sync)
+
+    tok = await ro.get_valid_robinhood_token("u", "w")
+    assert tok == "fresh_at"
+    assert state["set"]["access_token"] == "fresh_at"
+    assert state["set"]["refresh_token"] == "rt2"
+    assert state["synced"] == "fresh_at"
+
+
+@pytest.mark.asyncio
+async def test_get_valid_token_none_when_not_connected(monkeypatch):
+    async def fake_get(uid, wid):
+        return {"status": "pending", "access_token": "", "refresh_token": ""}
+
+    monkeypatch.setattr("src.server.database.robinhood_oauth.get", fake_get)
+    assert await ro.get_valid_robinhood_token("u", "w") is None

--- a/web/src/pages/ChatAgent/components/mcp/McpServerRow.tsx
+++ b/web/src/pages/ChatAgent/components/mcp/McpServerRow.tsx
@@ -116,6 +116,19 @@ function McpServerRowImpl({
           >
             {isBuiltin ? 'built-in' : 'workspace'}
           </span>
+          {server.tool_deny && server.tool_deny.length > 0 && (
+            <span
+              className="text-[10px] px-1.5 py-0.5 rounded uppercase tracking-wide"
+              style={{
+                color: 'var(--color-text-tertiary)',
+                backgroundColor: 'var(--color-bg-default)',
+                border: '1px solid var(--color-border-muted)',
+              }}
+              title={`Gated tools (never callable): ${server.tool_deny.join(', ')}`}
+            >
+              {server.tool_deny.length} gated
+            </span>
+          )}
         </div>
 
         {/* Lifecycle (verify + apply) + tool count */}

--- a/web/src/pages/ChatAgent/components/mcp/McpTab.tsx
+++ b/web/src/pages/ChatAgent/components/mcp/McpTab.tsx
@@ -16,6 +16,7 @@ import {
 import { toast } from '@/components/ui/use-toast';
 import { formatApiErrorDetail, getVaultSecrets, type EffectiveServer, type McpServerInput } from '../../utils/api';
 import { McpServerRow } from './McpServerRow';
+import { RobinhoodConnectCard } from './RobinhoodConnectCard';
 import { McpServerModal } from './McpServerModal';
 import { McpImportModal } from './McpImportModal';
 import { TemplatesView } from './TemplatesView';
@@ -339,6 +340,7 @@ export function McpTab({ workspaceId, onOpenVaultTab }: McpTabProps) {
 
       {view === 'workspace' ? (
         <div className="flex flex-col gap-3">
+          <RobinhoodConnectCard workspaceId={workspaceId} />
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <ServerCog className="h-4 w-4" style={{ color: 'var(--color-accent-primary)' }} />

--- a/web/src/pages/ChatAgent/components/mcp/RobinhoodConnectCard.tsx
+++ b/web/src/pages/ChatAgent/components/mcp/RobinhoodConnectCard.tsx
@@ -1,0 +1,157 @@
+import React, { useCallback, useEffect } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { LineChart, Lock, Loader2 } from 'lucide-react';
+import { queryKeys } from '@/lib/queryKeys';
+import { OAUTH_BROADCAST_CHANNEL, OAUTH_POPUP_WINDOW_NAME, OAUTH_POPUP_FEATURES } from '@/lib/oauthPopup';
+import { toast } from '@/components/ui/use-toast';
+import {
+  getRobinhoodStatus,
+  initiateRobinhood,
+  disconnectRobinhood,
+  formatApiErrorDetail,
+} from '../../utils/api';
+
+interface RobinhoodConnectCardProps {
+  workspaceId: string;
+}
+
+/**
+ * Connect a workspace to Robinhood's Agentic Trading MCP via OAuth.
+ *
+ * The flow: a popup (opened synchronously to keep the user-gesture) navigates to
+ * the authorize URL; the backend callback closes it and broadcasts
+ * `oauth-complete`, which refreshes the status + MCP server list. Trade execution
+ * stays gated server-side, so this card surfaces a read-only/preview-only note.
+ */
+export function RobinhoodConnectCard({ workspaceId }: RobinhoodConnectCardProps) {
+  const queryClient = useQueryClient();
+  const statusKey = ['robinhood', 'status', workspaceId];
+
+  const { data: status, isLoading } = useQuery({
+    queryKey: statusKey,
+    queryFn: () => getRobinhoodStatus(workspaceId),
+    enabled: !!workspaceId,
+  });
+
+  const refresh = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: statusKey });
+    queryClient.invalidateQueries({ queryKey: queryKeys.mcp.workspace(workspaceId) });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [queryClient, workspaceId]);
+
+  // The popup posts `oauth-complete` once the callback finishes.
+  useEffect(() => {
+    if (typeof BroadcastChannel === 'undefined') return;
+    const channel = new BroadcastChannel(OAUTH_BROADCAST_CHANNEL);
+    const onMessage = (event: MessageEvent) => {
+      if (event.data?.type === 'oauth-complete') refresh();
+    };
+    channel.addEventListener('message', onMessage);
+    return () => {
+      channel.removeEventListener('message', onMessage);
+      channel.close();
+    };
+  }, [refresh]);
+
+  const connectMutation = useMutation({
+    mutationFn: async () => {
+      // Open synchronously inside the click handler to preserve the user gesture.
+      const popup = window.open('about:blank', OAUTH_POPUP_WINDOW_NAME, OAUTH_POPUP_FEATURES);
+      try {
+        const { authorize_url } = await initiateRobinhood(workspaceId);
+        if (popup) popup.location.href = authorize_url;
+        else window.open(authorize_url, OAUTH_POPUP_WINDOW_NAME, OAUTH_POPUP_FEATURES);
+      } catch (err) {
+        if (popup) popup.close();
+        throw err;
+      }
+    },
+    onError: (err) => {
+      toast({
+        title: 'Could not start Robinhood connection',
+        description: formatApiErrorDetail(err),
+        variant: 'destructive',
+      });
+    },
+  });
+
+  const disconnectMutation = useMutation({
+    mutationFn: () => disconnectRobinhood(workspaceId),
+    onSuccess: () => {
+      refresh();
+      toast({ title: 'Robinhood disconnected' });
+    },
+    onError: (err) => {
+      toast({
+        title: 'Could not disconnect Robinhood',
+        description: formatApiErrorDetail(err),
+        variant: 'destructive',
+      });
+    },
+  });
+
+  const connected = !!status?.connected;
+
+  return (
+    <div
+      className="flex items-start justify-between gap-3 p-3 rounded-lg"
+      style={{ backgroundColor: 'var(--color-bg-card)', border: '1px solid var(--color-border-muted)' }}
+    >
+      <div className="min-w-0 flex flex-col gap-1">
+        <div className="flex items-center gap-2 flex-wrap">
+          <LineChart className="h-4 w-4 flex-shrink-0" style={{ color: 'var(--color-accent-primary)' }} />
+          <span className="text-sm font-medium" style={{ color: 'var(--color-text-primary)' }}>
+            Robinhood Agentic Trading
+          </span>
+          {connected && (
+            <span
+              className="text-[10px] px-1.5 py-0.5 rounded uppercase tracking-wide"
+              style={{ color: 'var(--color-text-on-accent)', backgroundColor: 'var(--color-accent-primary)' }}
+            >
+              connected
+            </span>
+          )}
+          <span
+            className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded uppercase tracking-wide"
+            style={{ color: 'var(--color-text-tertiary)', border: '1px solid var(--color-border-muted)' }}
+            title="Order placement and cancellation are disabled. The agent can read accounts, quotes, and preview orders only."
+          >
+            <Lock className="h-2.5 w-2.5" />
+            trading gated
+          </span>
+        </div>
+        <span className="text-[11px]" style={{ color: 'var(--color-text-tertiary)' }}>
+          {connected
+            ? 'Read accounts, positions, quotes, and order previews. Placing or cancelling orders is disabled.'
+            : 'Connect to let the agent read your Robinhood accounts and preview orders. Trade execution stays disabled.'}
+        </span>
+      </div>
+
+      <div className="flex-shrink-0">
+        {connected ? (
+          <button
+            type="button"
+            onClick={() => disconnectMutation.mutate()}
+            disabled={disconnectMutation.isPending}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-md transition-colors disabled:opacity-50"
+            style={{ color: 'var(--color-text-secondary)', border: '1px solid var(--color-border-muted)' }}
+          >
+            {disconnectMutation.isPending && <Loader2 className="h-3 w-3 animate-spin" />}
+            Disconnect
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={() => connectMutation.mutate()}
+            disabled={connectMutation.isPending || isLoading}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-md transition-colors disabled:opacity-50"
+            style={{ color: 'var(--color-text-on-accent)', backgroundColor: 'var(--color-accent-primary)' }}
+          >
+            {connectMutation.isPending && <Loader2 className="h-3 w-3 animate-spin" />}
+            Connect
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/ChatAgent/components/mcp/__tests__/RobinhoodConnectCard.test.tsx
+++ b/web/src/pages/ChatAgent/components/mcp/__tests__/RobinhoodConnectCard.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { RobinhoodConnectCard } from '../RobinhoodConnectCard';
+import * as api from '../../../utils/api';
+
+vi.mock('@/components/ui/use-toast', () => ({ toast: vi.fn() }));
+
+vi.mock('../../../utils/api', () => ({
+  getRobinhoodStatus: vi.fn(),
+  initiateRobinhood: vi.fn(),
+  disconnectRobinhood: vi.fn(),
+  formatApiErrorDetail: (e: unknown) => String(e),
+}));
+
+const mockApi = api as unknown as {
+  getRobinhoodStatus: ReturnType<typeof vi.fn>;
+  initiateRobinhood: ReturnType<typeof vi.fn>;
+  disconnectRobinhood: ReturnType<typeof vi.fn>;
+};
+
+function renderCard() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <RobinhoodConnectCard workspaceId="ws-1" />
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('RobinhoodConnectCard', () => {
+  it('shows Connect and the trading-gated note when not connected', async () => {
+    mockApi.getRobinhoodStatus.mockResolvedValue({
+      connected: false, expires_at: null, trading_enabled: false, server_name: 'robinhood',
+    });
+    renderCard();
+
+    expect(await screen.findByRole('button', { name: /connect/i })).toBeInTheDocument();
+    expect(screen.getByText(/trading gated/i)).toBeInTheDocument();
+    expect(screen.getByText(/Trade execution stays disabled/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /disconnect/i })).not.toBeInTheDocument();
+  });
+
+  it('shows the connected badge and Disconnect when connected', async () => {
+    mockApi.getRobinhoodStatus.mockResolvedValue({
+      connected: true, expires_at: '2026-07-01T00:00:00Z', trading_enabled: false, server_name: 'robinhood',
+    });
+    renderCard();
+
+    expect(await screen.findByRole('button', { name: /disconnect/i })).toBeInTheDocument();
+    expect(screen.getByText(/^connected$/i)).toBeInTheDocument();
+    // Trading stays gated even when connected.
+    expect(screen.getByText(/trading gated/i)).toBeInTheDocument();
+  });
+
+  it('opens the authorize popup on Connect', async () => {
+    mockApi.getRobinhoodStatus.mockResolvedValue({
+      connected: false, expires_at: null, trading_enabled: false, server_name: 'robinhood',
+    });
+    mockApi.initiateRobinhood.mockResolvedValue({ authorize_url: 'https://auth.example/go' });
+    const popup = { location: { href: '' }, close: vi.fn() };
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(popup as unknown as Window);
+
+    renderCard();
+    const btn = await screen.findByRole('button', { name: /connect/i });
+    await waitFor(() => expect(btn).toBeEnabled()); // status query resolved
+    fireEvent.click(btn);
+
+    await waitFor(() => expect(mockApi.initiateRobinhood).toHaveBeenCalledWith('ws-1'));
+    await waitFor(() => expect(popup.location.href).toBe('https://auth.example/go'));
+    expect(openSpy).toHaveBeenCalled();
+    openSpy.mockRestore();
+  });
+});

--- a/web/src/pages/ChatAgent/utils/api.ts
+++ b/web/src/pages/ChatAgent/utils/api.ts
@@ -1098,6 +1098,30 @@ export async function getVaultSecrets(workspaceId: string) {
   return data.secrets;
 }
 
+// --- Robinhood Agentic Trading MCP connect ---
+
+export interface RobinhoodStatus {
+  connected: boolean;
+  expires_at: string | null;
+  trading_enabled: boolean;
+  server_name: string;
+}
+
+export async function getRobinhoodStatus(workspaceId: string): Promise<RobinhoodStatus> {
+  const { data } = await api.get(`/api/v1/workspaces/${workspaceId}/robinhood/status`);
+  return data;
+}
+
+/** Start the OAuth flow; returns the authorize URL to open in a popup. */
+export async function initiateRobinhood(workspaceId: string): Promise<{ authorize_url: string }> {
+  const { data } = await api.post(`/api/v1/workspaces/${workspaceId}/robinhood/initiate`);
+  return data;
+}
+
+export async function disconnectRobinhood(workspaceId: string): Promise<void> {
+  await api.delete(`/api/v1/workspaces/${workspaceId}/robinhood`);
+}
+
 export async function createVaultSecret(workspaceId: string, body: { name: string; value: string; description?: string }) {
   const { data } = await api.post(`/api/v1/workspaces/${workspaceId}/vault/secrets`, body);
   return data;
@@ -1417,6 +1441,8 @@ export interface EffectiveServer {
   instruction: string;
   tool_exposure_mode: string | null;
   discovery_uses_secrets?: boolean;
+  /** Tool names hard-gated off this server (never advertised or callable). */
+  tool_deny?: string[];
   command: string | null;
   args: string[];
   url: string | null;


### PR DESCRIPTION
## What

Wires Robinhood's **Agentic Trading MCP** (`https://agent.robinhood.com/mcp/trading`) into the platform as a per-workspace MCP server. The agent can read accounts / positions / portfolio / quotes / order history and **preview** orders; the two trade tools (`place_equity_order`, `cancel_equity_order`) are **hard-gated off by default** — they are never generated as callable functions in the sandbox, so the agent cannot place or cancel an order.

> **Stacked on #294** (Phase 1 streamable-HTTP transport). This branch includes #294's commit; that diff drops out automatically once #294 merges. Review the four `feat(...)` commits below #294.

## Why

Robinhood's MCP uses the **standard MCP OAuth flow** — metadata discovery (RFC 9728 → 8414) + **Dynamic Client Registration** (RFC 7591) + PKCE — not a static client. The token is delivered to the sandbox via the workspace vault (`Authorization: ${vault:ROBINHOOD_TOKEN}`), which Phase 1's streamable-HTTP client now supports.

## Changes (4 commits)

1. **`feat(mcp): per-server tool_deny hard gate`** — new `tool_deny` on the MCP server config; denied tools are filtered out of both the sandbox wrapper module **and** the per-tool docs, so they're neither callable nor advertised. Threaded config → model → DB blob → `ptc_sandbox._install_tool_modules`.
2. **`feat(robinhood): OAuth backend`** — `services/robinhood_oauth.py` (discover + register + PKCE exchange + refresh + `get_valid_robinhood_token`), an encrypted `robinhood_oauth` table (migration `016`, `pgp_sym_encrypt` like `oauth_tokens`), reusing the `mcp` SDK's auth models.
3. **`feat(robinhood): connect API router + per-turn token refresh`** — `app/robinhood.py` (initiate / state-bound callback / status / disconnect); registers the gated server + writes the vault token on connect; refreshes the token (re-syncing the vault) before each sandbox turn in `ptc_workflow.py`.
4. **`feat(robinhood): frontend Connect Robinhood card`** — a Connect card in the workspace MCP settings (OAuth popup → broadcast → refresh), connected/disconnect states, and a "trading gated" badge.

## Safety

- Trade tools are gated at the **strongest** level (not emitted as sandbox functions). Enabling trading is a deliberate config edit, never a UI toggle.
- The bearer lives in the workspace vault; the model/API only ever sees the `${vault:NAME}` reference, never the token.
- Robinhood's own per-trade mobile approval + dedicated funded agentic account remain in force.

## Testing

- Backend unit: `tool_deny` behavioral test (denied tools absent from the uploaded module + docs), 13 OAuth tests via `httpx.MockTransport` (discovery via 401 challenge **and** well-known fallback, DCR, token exchange/refresh), router tests (server blob gates trades by default; callback state-binding). Migration `016` applied to a real Postgres.
- Frontend: typecheck + eslint clean; new card tests + existing 158 MCP component tests pass.
- **Pending:** live OAuth against Robinhood's real server (requires a funded agentic account + desktop login) — the discovery/DCR path is spec-correct but unverified end-to-end; `initiate` surfaces a clear `502` if their endpoints differ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a workspace-level Robinhood Agentic Trading OAuth flow with connect, status, and disconnect.
  * Added a Robinhood connect card to workspace MCP settings with OAuth popup flow and real-time status refresh.
  * Introduced per-server tool gating: denied tools are hidden from model access and shown in the MCP UI with a badge + tooltip.

* **Bug Fixes**
  * Improved Robinhood token lifecycle handling (best-effort refresh with safe fallback).
  * Improved MCP streaming/HTTP tool discovery reliability.

* **Tests**
  * Added unit tests for tool gating and Robinhood connect/status flows, plus UI tests for the connect card.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->