### PR TITLE
fix(compaction): heal orphaned tool_result brick + id-persistence

### DIFF
--- a/src/ptc_agent/agent/middleware/_message_utils.py
+++ b/src/ptc_agent/agent/middleware/_message_utils.py
@@ -1,0 +1,17 @@
+"""Shared accessors for checkpoint messages (``BaseMessage`` objects or plain dicts).
+
+Messages in LangGraph state can be either ``BaseMessage`` instances or plain
+dicts (e.g. reconstructed skill markers), so field access must tolerate both.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def message_id(message: Any) -> str | None:
+    """Framework-assigned id of a checkpoint message (object ``.id`` or dict ``id``)."""
+    mid = getattr(message, "id", None)
+    if mid is None and isinstance(message, dict):
+        mid = message.get("id")
+    return mid

--- a/src/ptc_agent/agent/middleware/background_subagent/orchestrator.py
+++ b/src/ptc_agent/agent/middleware/background_subagent/orchestrator.py
@@ -10,6 +10,7 @@ from typing import Any
 import structlog
 from langchain_core.messages import HumanMessage
 
+from ptc_agent.agent.state import ensure_message_ids
 from ptc_agent.agent.middleware.background_subagent.middleware import (
     BackgroundSubagentMiddleware,
 )
@@ -113,7 +114,7 @@ class BackgroundSubagentOrchestrator:
                 )
                 await self.agent.aupdate_state(
                     config,
-                    {"messages": [notification_message]},
+                    {"messages": ensure_message_ids([notification_message])},
                     as_node="__start__",
                 )
                 current_state = None  # Resume from updated checkpoint
@@ -145,7 +146,7 @@ class BackgroundSubagentOrchestrator:
                     )
                     await self.agent.aupdate_state(
                         config,
-                        {"messages": [notification_message]},
+                        {"messages": ensure_message_ids([notification_message])},
                         as_node="__start__",
                     )
                     current_state = None  # Resume from updated checkpoint
@@ -250,7 +251,7 @@ class BackgroundSubagentOrchestrator:
                 )
                 await self.agent.aupdate_state(
                     config,
-                    {"messages": [notification_message]},
+                    {"messages": ensure_message_ids([notification_message])},
                     as_node="__start__",
                 )
                 current_state = None  # Resume from updated checkpoint
@@ -304,7 +305,7 @@ class BackgroundSubagentOrchestrator:
             )
             await self.agent.aupdate_state(
                 config,
-                {"messages": [notification_message]},
+                {"messages": ensure_message_ids([notification_message])},
                 as_node="__start__",
             )
             current_state = None  # Resume from updated checkpoint
@@ -420,7 +421,7 @@ class BackgroundSubagentOrchestrator:
         )
         await self.agent.aupdate_state(
             config,
-            {"messages": [trigger]},
+            {"messages": ensure_message_ids([trigger])},
             as_node="__start__",
         )
         return True

--- a/src/ptc_agent/agent/middleware/compaction/__init__.py
+++ b/src/ptc_agent/agent/middleware/compaction/__init__.py
@@ -15,6 +15,7 @@ from ptc_agent.agent.middleware.compaction.types import (
 )
 from ptc_agent.agent.middleware.compaction.utils import (
     DEFAULT_SUMMARY_PROMPT,
+    build_compaction_event,
     build_summary_message,
     compute_absolute_cutoff,
     count_tokens_tiktoken,
@@ -37,6 +38,7 @@ __all__ = [
     "CompactionState",
     "DEFAULT_SUMMARY_PROMPT",
     "aoffload_base64_content",
+    "build_compaction_event",
     "build_summary_message",
     "compact_messages",
     "compute_absolute_cutoff",

--- a/src/ptc_agent/agent/middleware/compaction/compact.py
+++ b/src/ptc_agent/agent/middleware/compaction/compact.py
@@ -5,9 +5,8 @@ import logging
 import uuid
 from typing import Any, cast
 
-from langchain_core.messages import AnyMessage, RemoveMessage, ToolMessage
+from langchain_core.messages import AnyMessage, ToolMessage
 from langchain_core.messages.utils import trim_messages
-from langgraph.graph.message import REMOVE_ALL_MESSAGES
 
 from langchain.chat_models import BaseChatModel
 
@@ -272,7 +271,8 @@ async def offload_tool_args(
 
     Returns:
         Dict with:
-        - "messages": The full message list with offloaded content (for aupdate_state)
+        - "messages": Only the changed messages, keyed by their existing ids, for
+          an in-place ``aupdate_state`` overwrite (NOT a REMOVE_ALL full rewrite)
         - "offloaded_args": Number of tool call args offloaded (Write/Edit/ExecuteCode)
         - "offloaded_reads": Number of Read results offloaded (duplicates + non-critical)
         - "original_count": Total message count (unchanged)
@@ -284,10 +284,15 @@ async def offload_tool_args(
     if not messages:
         raise ValueError("No messages to offload")
 
-    # Ensure all messages have IDs
+    # Ensure all messages have IDs, then snapshot the list so we can detect which
+    # messages truncation actually changed. The truncate_* helpers preserve order
+    # and length, returning the SAME object for unchanged messages and a
+    # model_copy (same id) for changed ones, so an identity diff isolates the
+    # changes.
     for msg in messages:
         if msg.id is None:
             msg.id = str(uuid.uuid4())
+    original_messages = list(messages)
 
     config = (compaction_config or CompactionConfig()).model_dump()
 
@@ -335,8 +340,21 @@ async def offload_tool_args(
     if originals and backend is not None:
         await aoffload_truncated_args(backend, originals)
 
+    # Return ONLY the messages truncation actually changed, keyed by their
+    # existing ids, so the DeltaChannel reducer overwrites them in place. A
+    # blanket REMOVE_ALL + full-list rewrite would, if it ran concurrently with a
+    # live turn (e.g. an offload during a Redis outage that bypassed the admission
+    # gate), rebuild from a stale snapshot and silently wipe messages appended in
+    # between. In-place id-keyed writes leave concurrently-appended messages
+    # untouched.
+    changed = [
+        msg
+        for original, msg in zip(original_messages, messages)
+        if msg is not original
+    ]
+
     return {
-        "messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES), *messages],
+        "messages": changed,
         "offloaded_args": len(originals),
         "offloaded_reads": len(read_ids),
         "original_count": len(messages),

--- a/src/ptc_agent/agent/middleware/compaction/compact.py
+++ b/src/ptc_agent/agent/middleware/compaction/compact.py
@@ -22,8 +22,8 @@ from ptc_agent.agent.middleware.compaction.types import (
 )
 from ptc_agent.agent.middleware.compaction.utils import (
     DEFAULT_SUMMARY_PROMPT,
+    build_compaction_event,
     build_summary_message,
-    compute_absolute_cutoff,
     count_tokens_tiktoken,
     get_effective_messages,
     truncate_message_args,
@@ -226,15 +226,18 @@ async def compact_messages(
     # Build summary message using shared utility
     summary_message = build_summary_message(summary_text, file_path)
 
-    # Compute absolute cutoff for chaining
-    absolute_cutoff = compute_absolute_cutoff(cutoff_index, previous_event)
+    # Build the event with an id anchor (cutoff grounded in the raw list)
+    event = build_compaction_event(
+        raw_messages=messages,
+        preserved_messages=preserved,
+        summary_message=summary_message,
+        file_path=file_path,
+        effective_cutoff=cutoff_index,
+        previous_event=previous_event,
+    )
 
     return {
-        "event": CompactionEvent(
-            cutoff_index=absolute_cutoff,
-            summary_message=summary_message,
-            file_path=file_path,
-        ),
+        "event": event,
         "summary_text": summary_text,
         "original_count": len(effective),
         "preserved_count": len(preserved) + 1,  # +1 for summary message

--- a/src/ptc_agent/agent/middleware/compaction/compact.py
+++ b/src/ptc_agent/agent/middleware/compaction/compact.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import logging
-import uuid
 from typing import Any, cast
 
 from langchain_core.messages import AnyMessage, ToolMessage
@@ -15,6 +14,7 @@ from src.llms.content_utils import format_llm_content
 from ptc_agent.config.agent import CompactionConfig
 from src.llms import get_llm_by_type
 
+from ptc_agent.agent.state import ensure_message_ids
 from ptc_agent.agent.middleware.compaction.types import (
     CompactionEvent,
     _DEFAULT_FALLBACK_MESSAGE_COUNT,
@@ -92,9 +92,7 @@ async def compact_messages(
         raise ValueError("No messages to compact")
 
     # Ensure all messages have IDs
-    for msg in messages:
-        if msg.id is None:
-            msg.id = str(uuid.uuid4())
+    ensure_message_ids(messages)
 
     # Reconstruct effective messages from previous event
     effective = get_effective_messages(messages, previous_event)
@@ -289,9 +287,7 @@ async def offload_tool_args(
     # and length, returning the SAME object for unchanged messages and a
     # model_copy (same id) for changed ones, so an identity diff isolates the
     # changes.
-    for msg in messages:
-        if msg.id is None:
-            msg.id = str(uuid.uuid4())
+    ensure_message_ids(messages)
     original_messages = list(messages)
 
     config = (compaction_config or CompactionConfig()).model_dump()

--- a/src/ptc_agent/agent/middleware/compaction/middleware.py
+++ b/src/ptc_agent/agent/middleware/compaction/middleware.py
@@ -53,8 +53,8 @@ from ptc_agent.agent.middleware.compaction.types import (
 )
 from ptc_agent.agent.middleware.compaction.utils import (
     DEFAULT_SUMMARY_PROMPT,
+    build_compaction_event,
     build_summary_message,
-    compute_absolute_cutoff,
     count_tokens_tiktoken,
     get_effective_messages,
     strip_base64_from_messages,
@@ -419,15 +419,15 @@ class CompactionMiddleware(AgentMiddleware):
         # Build summary message
         summary_message = self._build_summary_message(summary, file_path)
 
-        # Compute absolute cutoff for chained summarization tracking
-        state_cutoff_index = self._compute_absolute_cutoff(cutoff_index, previous_event)
-
-        # Create summarization event for state
-        new_event: CompactionEvent = {
-            "cutoff_index": state_cutoff_index,
-            "summary_message": summary_message,
-            "file_path": file_path,
-        }
+        # Create summarization event with an id anchor (cutoff grounded in raw list)
+        new_event = build_compaction_event(
+            raw_messages=request.messages,
+            preserved_messages=preserved_messages,
+            summary_message=summary_message,
+            file_path=file_path,
+            effective_cutoff=cutoff_index,
+            previous_event=previous_event,
+        )
 
         # Call handler with summarized messages
         modified_messages = [summary_message, *preserved_messages]
@@ -588,13 +588,15 @@ class CompactionMiddleware(AgentMiddleware):
             messages_to_summarize, original_count=len(truncated_messages)
         )
         summary_message = self._build_summary_message(summary, file_path)
-        state_cutoff_index = self._compute_absolute_cutoff(cutoff_index, previous_event)
 
-        new_event: CompactionEvent = {
-            "cutoff_index": state_cutoff_index,
-            "summary_message": summary_message,
-            "file_path": file_path,
-        }
+        new_event = build_compaction_event(
+            raw_messages=request.messages,
+            preserved_messages=preserved_messages,
+            summary_message=summary_message,
+            file_path=file_path,
+            effective_cutoff=cutoff_index,
+            previous_event=previous_event,
+        )
 
         modified_messages = [summary_message, *preserved_messages]
         response = handler(request.override(messages=modified_messages))
@@ -630,14 +632,6 @@ class CompactionMiddleware(AgentMiddleware):
     ) -> list[AnyMessage]:
         """Delegate to shared utility."""
         return get_effective_messages(messages, event)
-
-    @staticmethod
-    def _compute_absolute_cutoff(
-        effective_cutoff: int,
-        previous_event: CompactionEvent | None,
-    ) -> int:
-        """Delegate to shared utility."""
-        return compute_absolute_cutoff(effective_cutoff, previous_event)
 
     # =========================================================================
     # Token cache management

--- a/src/ptc_agent/agent/middleware/compaction/middleware.py
+++ b/src/ptc_agent/agent/middleware/compaction/middleware.py
@@ -13,7 +13,6 @@ Actions emitted via context_window events (values preserved as wire protocol):
 """
 
 import asyncio
-import uuid
 import warnings
 import logging
 from collections.abc import Awaitable, Callable, Mapping
@@ -41,6 +40,7 @@ from src.llms.token_counter import extract_token_usage
 from ptc_agent.config.agent import CompactionConfig
 from src.llms import get_llm_by_type, maybe_disable_streaming
 
+from ptc_agent.agent.state import ensure_message_ids
 from ptc_agent.agent.middleware.compaction.types import (
     CompactionEvent,
     CompactionState,
@@ -266,7 +266,7 @@ class CompactionMiddleware(AgentMiddleware):
         cached_output_tokens: int = request.state.get("_cached_output_tokens", 0)
 
         # 2. Reconstruct effective messages
-        self._ensure_message_ids(request.messages)
+        ensure_message_ids(request.messages)
         effective_messages = self._get_effective_messages(
             request.messages, previous_event
         )
@@ -481,7 +481,7 @@ class CompactionMiddleware(AgentMiddleware):
         cached_input_tokens: int = request.state.get("_cached_input_tokens", 0)
         cached_output_tokens: int = request.state.get("_cached_output_tokens", 0)
 
-        self._ensure_message_ids(request.messages)
+        ensure_message_ids(request.messages)
         effective_messages = self._get_effective_messages(
             request.messages, previous_event
         )
@@ -1082,12 +1082,6 @@ class CompactionMiddleware(AgentMiddleware):
             "_cached_input_tokens": cached_input_tokens,
             "_cached_output_tokens": cached_output_tokens,
         }
-
-    def _ensure_message_ids(self, messages: list[AnyMessage]) -> None:
-        """Ensure all messages have unique IDs for the add_messages reducer."""
-        for msg in messages:
-            if msg.id is None:
-                msg.id = str(uuid.uuid4())
 
     def _partition_messages(
         self,

--- a/src/ptc_agent/agent/middleware/compaction/types.py
+++ b/src/ptc_agent/agent/middleware/compaction/types.py
@@ -28,11 +28,17 @@ class CompactionEvent(TypedDict):
 
     Stored in private state so the middleware can reconstruct the effective
     message list on subsequent model calls without modifying the checkpoint.
+
+    ``cutoff_index`` is the positional boundary; ``anchor_message_id`` is the id
+    of the first preserved message, used to re-find the boundary by id when the
+    underlying list drifts (e.g. DeltaChannel reconstruction). Legacy persisted
+    events omit ``anchor_message_id`` and fall back to the positional index.
     """
 
     cutoff_index: int
     summary_message: HumanMessage
     file_path: str | None
+    anchor_message_id: NotRequired[str | None]
 
 
 class TruncateArgsSettings(TypedDict, total=False):

--- a/src/ptc_agent/agent/middleware/compaction/utils.py
+++ b/src/ptc_agent/agent/middleware/compaction/utils.py
@@ -499,6 +499,79 @@ def truncate_read_results(
 # =============================================================================
 
 
+def _message_id(message: Any) -> str | None:
+    """Framework-assigned id of a checkpoint message (object ``.id`` or dict ``id``)."""
+    mid = getattr(message, "id", None)
+    if mid is None and isinstance(message, dict):
+        mid = message.get("id")
+    return mid
+
+
+def _strip_leading_orphan_tool_messages(
+    tail: list[AnyMessage],
+) -> list[AnyMessage]:
+    """Drop leading ``ToolMessage``s from a reconstructed tail.
+
+    A summary message followed by a ``ToolMessage`` reconstructs into an
+    Anthropic ``user`` turn whose first content block is an orphaned
+    ``tool_result`` (no preceding ``tool_use``) -> 400. Stripping any leading
+    tool results makes that structurally impossible. Plain-dict messages are
+    left untouched (``isinstance`` is ``False``); they never carry the orphan.
+    """
+    i = 0
+    while i < len(tail) and isinstance(tail[i], ToolMessage):
+        i += 1
+    return tail[i:] if i else tail
+
+
+def _resolve_anchor_index(
+    messages: list[AnyMessage], anchor_id: str | None
+) -> int | None:
+    """Index of the message whose id equals ``anchor_id``, or ``None``.
+
+    Returns ``None`` immediately when ``anchor_id`` is ``None`` (legacy event)
+    so it can never match an id-less message.
+    """
+    if anchor_id is None:
+        return None
+    for i, msg in enumerate(messages):
+        if _message_id(msg) == anchor_id:
+            return i
+    return None
+
+
+def build_compaction_event(
+    raw_messages: list[AnyMessage],
+    preserved_messages: list[AnyMessage],
+    summary_message: HumanMessage,
+    file_path: str | None,
+    effective_cutoff: int,
+    previous_event: CompactionEvent | None,
+) -> CompactionEvent:
+    """Construct a ``CompactionEvent`` carrying both a positional cutoff and an id anchor.
+
+    The positional ``cutoff_index`` is grounded in ``raw_messages`` by locating
+    the first preserved message's id, falling back to the arithmetic
+    ``compute_absolute_cutoff`` when the anchor is absent (empty preserved tail).
+    ``anchor_message_id`` lets reconstruction re-find the boundary by id if the
+    raw list later drifts.
+    """
+    anchor_message_id = (
+        _message_id(preserved_messages[0]) if preserved_messages else None
+    )
+
+    cutoff_index: int | None = _resolve_anchor_index(raw_messages, anchor_message_id)
+    if cutoff_index is None:
+        cutoff_index = compute_absolute_cutoff(effective_cutoff, previous_event)
+
+    return CompactionEvent(
+        cutoff_index=cutoff_index,
+        summary_message=summary_message,
+        file_path=file_path,
+        anchor_message_id=anchor_message_id,
+    )
+
+
 def get_effective_messages(
     messages: list[AnyMessage],
     event: CompactionEvent | None,
@@ -507,7 +580,14 @@ def get_effective_messages(
 
     After compaction, the checkpoint still contains ALL messages. This function
     reconstructs what the model should see: the summary message plus messages
-    after the cutoff index.
+    after the cutoff boundary.
+
+    The boundary is tracked by ``anchor_message_id`` (the first preserved
+    message's id) and re-resolved against the current list only when the stored
+    positional ``cutoff_index`` no longer points at that anchor — so list
+    perturbation (DeltaChannel reconstruction, injected messages) can't silently
+    drift the boundary. Any leading orphaned ``ToolMessage`` in the tail is
+    stripped unconditionally as a crash backstop.
 
     Args:
         messages: Full message list from state.
@@ -519,9 +599,19 @@ def get_effective_messages(
     if event is None:
         return messages
 
-    result: list[AnyMessage] = [event["summary_message"]]
-    result.extend(messages[event["cutoff_index"]:])
-    return result
+    cutoff = event["cutoff_index"]
+    anchor_id = event.get("anchor_message_id")
+    # O(1) happy path: only re-scan when the positional cutoff has drifted off
+    # the anchor. Legacy events (no anchor) keep the positional index as-is.
+    if anchor_id is not None and not (
+        0 <= cutoff < len(messages) and _message_id(messages[cutoff]) == anchor_id
+    ):
+        resolved = _resolve_anchor_index(messages, anchor_id)
+        if resolved is not None:
+            cutoff = resolved
+
+    tail = _strip_leading_orphan_tool_messages(messages[cutoff:])
+    return [event["summary_message"], *tail]
 
 
 def compute_absolute_cutoff(

--- a/src/ptc_agent/agent/middleware/compaction/utils.py
+++ b/src/ptc_agent/agent/middleware/compaction/utils.py
@@ -500,19 +500,35 @@ def truncate_read_results(
 # =============================================================================
 
 
+def _is_tool_message(message: Any) -> bool:
+    """True for a tool result in either typed (``ToolMessage``) or dict shape.
+
+    The checkpoint reducer coerces every write via ``convert_to_messages`` (see
+    ``messages_delta_reducer``), so only typed messages should reach
+    reconstruction. But this predicate backs the orphaned-``tool_result`` crash
+    backstop, so it stays agnostic to message shape rather than trusting that
+    invariant — a dict-shaped tool result slipping in must still be caught.
+    """
+    if isinstance(message, ToolMessage):
+        return True
+    if isinstance(message, dict):
+        return message.get("role") == "tool" or message.get("type") == "tool"
+    return False
+
+
 def _strip_leading_orphan_tool_messages(
     tail: list[AnyMessage],
 ) -> list[AnyMessage]:
-    """Drop leading ``ToolMessage``s from a reconstructed tail.
+    """Drop leading tool-result messages from a reconstructed tail.
 
-    A summary message followed by a ``ToolMessage`` reconstructs into an
-    Anthropic ``user`` turn whose first content block is an orphaned
-    ``tool_result`` (no preceding ``tool_use``) -> 400. Stripping any leading
-    tool results makes that structurally impossible. Plain-dict messages are
-    left untouched (``isinstance`` is ``False``); they never carry the orphan.
+    A summary message followed by a tool result reconstructs into an Anthropic
+    ``user`` turn whose first content block is an orphaned ``tool_result`` (no
+    preceding ``tool_use``) -> 400. Stripping any leading tool results makes that
+    structurally impossible. This is the crash backstop, so it matches both typed
+    ``ToolMessage`` objects and dict-shaped tool results via ``_is_tool_message``.
     """
     i = 0
-    while i < len(tail) and isinstance(tail[i], ToolMessage):
+    while i < len(tail) and _is_tool_message(tail[i]):
         i += 1
     return tail[i:] if i else tail
 

--- a/src/ptc_agent/agent/middleware/compaction/utils.py
+++ b/src/ptc_agent/agent/middleware/compaction/utils.py
@@ -19,6 +19,7 @@ from langchain_core.messages import (
 from langchain_core.messages.human import HumanMessage
 from langchain_core.messages.utils import convert_to_messages
 
+from ptc_agent.agent.middleware._message_utils import message_id
 from ptc_agent.agent.middleware.compaction.types import (
     CONTEXT_SUMMARY_PREFIX,
     NON_CRITICAL_READ_PREFIXES,
@@ -499,14 +500,6 @@ def truncate_read_results(
 # =============================================================================
 
 
-def _message_id(message: Any) -> str | None:
-    """Framework-assigned id of a checkpoint message (object ``.id`` or dict ``id``)."""
-    mid = getattr(message, "id", None)
-    if mid is None and isinstance(message, dict):
-        mid = message.get("id")
-    return mid
-
-
 def _strip_leading_orphan_tool_messages(
     tail: list[AnyMessage],
 ) -> list[AnyMessage]:
@@ -535,7 +528,7 @@ def _resolve_anchor_index(
     if anchor_id is None:
         return None
     for i, msg in enumerate(messages):
-        if _message_id(msg) == anchor_id:
+        if message_id(msg) == anchor_id:
             return i
     return None
 
@@ -557,7 +550,7 @@ def build_compaction_event(
     raw list later drifts.
     """
     anchor_message_id = (
-        _message_id(preserved_messages[0]) if preserved_messages else None
+        message_id(preserved_messages[0]) if preserved_messages else None
     )
 
     cutoff_index: int | None = _resolve_anchor_index(raw_messages, anchor_message_id)
@@ -604,7 +597,7 @@ def get_effective_messages(
     # O(1) happy path: only re-scan when the positional cutoff has drifted off
     # the anchor. Legacy events (no anchor) keep the positional index as-is.
     if anchor_id is not None and not (
-        0 <= cutoff < len(messages) and _message_id(messages[cutoff]) == anchor_id
+        0 <= cutoff < len(messages) and message_id(messages[cutoff]) == anchor_id
     ):
         resolved = _resolve_anchor_index(messages, anchor_id)
         if resolved is not None:

--- a/src/ptc_agent/agent/middleware/skills/content.py
+++ b/src/ptc_agent/agent/middleware/skills/content.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
 
+from ptc_agent.agent.middleware._message_utils import message_id as _message_id
 from ptc_agent.agent.middleware.skills.registry import SkillMode, get_skill
 
 logger = logging.getLogger(__name__)
@@ -247,14 +248,6 @@ def build_skill_content(
         content=combined_content,
         loaded_skill_names=newly_loaded,
     )
-
-
-def _message_id(message: Any) -> Optional[str]:
-    """Framework-assigned id of a checkpoint message (object ``.id`` or dict ``id``)."""
-    mid = getattr(message, "id", None)
-    if mid is None and isinstance(message, dict):
-        mid = message.get("id")
-    return mid
 
 
 def _message_text(message: Any) -> str:

--- a/src/ptc_agent/agent/state.py
+++ b/src/ptc_agent/agent/state.py
@@ -18,6 +18,7 @@ downgrading langgraph below 1.2) cannot read — so keep the `langgraph`/
 
 from __future__ import annotations
 
+import uuid
 from typing import Annotated, Any, cast
 
 from langchain.agents import AgentState
@@ -37,6 +38,23 @@ from typing_extensions import Required
 MESSAGES_SNAPSHOT_FREQUENCY = 50
 
 
+def ensure_message_ids(messages: list[AnyMessage]) -> list[AnyMessage]:
+    """Stamp a stable uuid on any id-less message, in place, and return the list.
+
+    langgraph's own ``ensure_message_ids`` runs only inside the normal Pregel
+    execution loop, NOT on the ``graph.aupdate_state`` path. Messages injected
+    via ``aupdate_state`` (orchestrator notifications, steering triggers)
+    therefore persist with ``id=None`` under ``messages_delta_reducer`` — which
+    appends id-less writes verbatim, so a later full-list re-write duplicates
+    them and the compaction id-anchor can never match them. Call this before any
+    ``aupdate_state`` that injects new messages.
+    """
+    for msg in messages:
+        if getattr(msg, "id", None) is None:
+            msg.id = str(uuid.uuid4())
+    return messages
+
+
 def messages_delta_reducer(  # noqa: C901, PLR0912
     state: list[AnyMessage], writes: list[list[AnyMessage]]
 ) -> list[AnyMessage]:
@@ -48,9 +66,12 @@ def messages_delta_reducer(  # noqa: C901, PLR0912
     `ensure_message_ids` (>=1.2.2) stamps id-less writes before they are
     persisted, so by replay time messages already carry stable ids; minting in
     the reducer would re-roll a different uuid on every replay. id-less messages
-    are appended as-is (deterministic). Matches deepagents 0.6.11's batch
-    `_messages_delta_reducer` (the vendoring source), NOT `add_messages` (an
-    unknown-id `RemoveMessage` is silently ignored; chunks are not converted).
+    are appended as-is (deterministic) — note this only holds on the normal
+    Pregel path; the `aupdate_state` path does NOT run `ensure_message_ids`, so
+    injectors there must pre-stamp via `ensure_message_ids` (above) or their
+    writes persist id-less and duplicate on re-write. Matches deepagents 0.6.11's
+    batch `_messages_delta_reducer` (the vendoring source), NOT `add_messages`
+    (an unknown-id `RemoveMessage` is silently ignored; chunks are not converted).
     """
     # Each write is either a list of message-likes or a single message-like
     # (BaseMessage / dict / str / tuple). Only lists flatten; everything

--- a/src/server/handlers/workflow_handler.py
+++ b/src/server/handlers/workflow_handler.py
@@ -421,7 +421,26 @@ async def _update_graph_state(
         )
 
 
-async def _require_no_active_workflow(thread_id: str, verb: str) -> None:
+def _gate_unverifiable(verb: str) -> HTTPException:
+    """409 raised when the workflow-active gate can't be verified under a
+    fail-closed verb (offload)."""
+    return HTTPException(
+        status_code=409,
+        detail={
+            "code": "workflow_unverifiable",
+            "verb": verb,
+            "message": (
+                f"Cannot safely {verb} right now: the thread's activity status "
+                "is unavailable (the workflow tracker is down). Try again once "
+                "it recovers."
+            ),
+        },
+    )
+
+
+async def _require_no_active_workflow(
+    thread_id: str, verb: str, *, fail_closed: bool = False
+) -> None:
     """Reject manual compact/offload while a workflow is running on the thread.
 
     Both /compact and /offload perform read-modify-write on LangGraph state and
@@ -434,6 +453,12 @@ async def _require_no_active_workflow(thread_id: str, verb: str) -> None:
 
     Raises HTTPException(409) for ACTIVE / INTERRUPTED. Allows
     None / COMPLETED / CANCELLED.
+
+    When the gate can't be verified (tracker disabled / get_status raises) the
+    default is to fail OPEN — chat workflows are already degraded under a Redis
+    outage and admin actions should stay usable. ``fail_closed=True`` (used by
+    /offload, a non-critical optimization) instead raises 409 so the action is
+    skipped rather than run blind during a possibly-active turn.
     """
     from src.server.services.workflow_tracker import (
         WorkflowStatus,
@@ -443,13 +468,17 @@ async def _require_no_active_workflow(thread_id: str, verb: str) -> None:
     tracker = WorkflowTracker.get_instance()
     # When Redis is unavailable the tracker returns enabled=False and get_status
     # yields None, which would silently bypass this gate. Log a warning so the
-    # operator knows the protection is off; fail open because chat workflows are
-    # also degraded under a Redis outage and admin actions should remain usable.
+    # operator knows the protection is off; fail open (unless fail_closed)
+    # because chat workflows are also degraded under a Redis outage and admin
+    # actions should remain usable.
     if not getattr(tracker, "enabled", True):
         logger.warning(
             f"[{verb}] WorkflowTracker disabled (Redis unavailable); "
-            f"workflow-active gate bypassed for thread {thread_id}"
+            f"workflow-active gate {'skipped (fail-closed)' if fail_closed else 'bypassed'} "
+            f"for thread {thread_id}"
         )
+        if fail_closed:
+            raise _gate_unverifiable(verb)
         return
     # Transient Redis errors during a healthy session would otherwise bubble up
     # through trigger_compaction's broad except and surface as 500. Fail open
@@ -460,8 +489,11 @@ async def _require_no_active_workflow(thread_id: str, verb: str) -> None:
     except Exception as e:
         logger.warning(
             f"[{verb}] WorkflowTracker.get_status failed for thread {thread_id}: "
-            f"{e}; workflow-active gate bypassed"
+            f"{e}; workflow-active gate "
+            f"{'skipped (fail-closed)' if fail_closed else 'bypassed'}"
         )
+        if fail_closed:
+            raise _gate_unverifiable(verb)
         return
     if not status:
         return
@@ -738,7 +770,10 @@ async def trigger_offload(thread_id: str) -> dict:
 
         # Same gate as /compact — /offload also writes checkpoint state and
         # could race a running workflow's _offloaded_tool_call_ids updates.
-        await _require_no_active_workflow(thread_id, "offload")
+        # Fail CLOSED: offload is a non-critical optimization, so if the gate
+        # can't confirm the thread is idle we skip it rather than write into a
+        # possibly-active turn.
+        await _require_no_active_workflow(thread_id, "offload", fail_closed=True)
 
         # Open the admission guard (same rationale as /compact): hold a
         # concurrent message POST until this manual offload's checkpoint

--- a/src/server/handlers/workflow_handler.py
+++ b/src/server/handlers/workflow_handler.py
@@ -466,34 +466,27 @@ async def _require_no_active_workflow(
     )
 
     tracker = WorkflowTracker.get_instance()
-    # When Redis is unavailable the tracker returns enabled=False and get_status
-    # yields None, which would silently bypass this gate. Log a warning so the
-    # operator knows the protection is off; fail open (unless fail_closed)
-    # because chat workflows are also degraded under a Redis outage and admin
-    # actions should remain usable.
-    if not getattr(tracker, "enabled", True):
+
+    def _handle_unverifiable(reason: str) -> None:
+        # The gate can't confirm the thread is idle — Redis down, so either the
+        # tracker is disabled or get_status raised. Fail OPEN by default (log +
+        # continue) so admin actions stay usable while chat is already degraded;
+        # fail CLOSED (offload) by raising 409 so we never write blind into a
+        # possibly-active turn.
+        action = "skipped (fail-closed)" if fail_closed else "bypassed"
         logger.warning(
-            f"[{verb}] WorkflowTracker disabled (Redis unavailable); "
-            f"workflow-active gate {'skipped (fail-closed)' if fail_closed else 'bypassed'} "
-            f"for thread {thread_id}"
+            f"[{verb}] {reason}; workflow-active gate {action} for thread {thread_id}"
         )
         if fail_closed:
             raise _gate_unverifiable(verb)
+
+    if not getattr(tracker, "enabled", True):
+        _handle_unverifiable("WorkflowTracker disabled (Redis unavailable)")
         return
-    # Transient Redis errors during a healthy session would otherwise bubble up
-    # through trigger_compaction's broad except and surface as 500. Fail open
-    # (same as tracker.enabled=False) with a warning so admin actions stay
-    # usable and the operator can see that the gate was bypassed.
     try:
         status = await tracker.get_status(thread_id)
     except Exception as e:
-        logger.warning(
-            f"[{verb}] WorkflowTracker.get_status failed for thread {thread_id}: "
-            f"{e}; workflow-active gate "
-            f"{'skipped (fail-closed)' if fail_closed else 'bypassed'}"
-        )
-        if fail_closed:
-            raise _gate_unverifiable(verb)
+        _handle_unverifiable(f"WorkflowTracker.get_status failed: {e}")
         return
     if not status:
         return

--- a/src/server/services/background_task_manager.py
+++ b/src/server/services/background_task_manager.py
@@ -796,8 +796,19 @@ class BackgroundTaskManager:
             if not values:
                 return
 
+            # Exclude `messages` from the re-write. The committed messages are
+            # already in this snapshot and carry forward on the DeltaChannel, so
+            # re-writing the full list only re-applies every message as a delta —
+            # and any still-id-less tail message appends as a duplicate (the
+            # reducer keys dedup on id). The remaining keys (private compaction /
+            # offload state) are last-write-wins, so re-writing them is idempotent.
+            flush_values = {k: v for k, v in values.items() if k != "messages"}
+            if not flush_values:
+                return
+
             await asyncio.wait_for(
-                graph_any.aupdate_state(config, values), timeout=get_checkpoint_flush_timeout()
+                graph_any.aupdate_state(config, flush_values),
+                timeout=get_checkpoint_flush_timeout(),
             )
             logger.info(f"[BackgroundTaskManager] Flushed checkpoint for {thread_id}")
         except asyncio.TimeoutError:

--- a/tests/unit/middleware/compaction/test_offload_race.py
+++ b/tests/unit/middleware/compaction/test_offload_race.py
@@ -1,0 +1,81 @@
+"""offload_tool_args must write in place, not REMOVE_ALL (compaction Bug B).
+
+The old offload returned ``[RemoveMessage(REMOVE_ALL_MESSAGES), *full_list]`` —
+a blanket reset + full rebuild. If that ran concurrently with a live turn (e.g.
+an offload during a Redis outage that bypassed the admission gate), it rebuilt
+from a stale snapshot and silently wiped any message the live turn appended in
+between. The fix returns only the messages truncation actually changed, keyed by
+their existing ids, so the DeltaChannel reducer overwrites them in place and
+concurrently-appended messages survive.
+"""
+
+from __future__ import annotations
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, RemoveMessage
+
+from ptc_agent.agent.middleware.compaction.compact import offload_tool_args
+from ptc_agent.agent.state import messages_delta_reducer
+
+
+def _big_write_ai(idx: int) -> AIMessage:
+    """An AIMessage with a Write tool call whose `content` exceeds the 2000-char
+    truncation threshold, so offload truncates it."""
+    return AIMessage(
+        content="",
+        id=f"a{idx}",
+        tool_calls=[
+            {
+                "name": "Write",
+                "args": {"file_path": "/x", "content": "Z" * 3000},
+                "id": f"tc{idx}",
+                "type": "tool_call",
+            }
+        ],
+    )
+
+
+def _conversation() -> list:
+    # 1 truncatable AIMessage up front + 25 fillers so cutoff (= len - 20) > 0
+    # and the AIMessage sits before it.
+    return [_big_write_ai(0)] + [
+        HumanMessage(content=f"m{i}", id=f"h{i}") for i in range(25)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_offload_returns_only_changed_messages_no_remove_all():
+    msgs = _conversation()
+    result = await offload_tool_args(messages=msgs, backend=None)
+    changed = result["messages"]
+
+    # No blanket reset in the write.
+    assert all(not isinstance(m, RemoveMessage) for m in changed)
+    # Only the truncated AIMessage is returned, keyed by its existing id.
+    assert [m.id for m in changed] == ["a0"]
+    assert result["offloaded_args"] == 1
+
+
+@pytest.mark.asyncio
+async def test_offload_write_preserves_concurrent_append():
+    msgs = _conversation()
+    result = await offload_tool_args(messages=msgs, backend=None)
+    changed = result["messages"]
+
+    # `msgs` now carry stable ids (offload stamped them in place). Simulate the
+    # live state: the committed messages PLUS one appended concurrently after the
+    # offload took its snapshot.
+    concurrent = HumanMessage(content="appended mid-offload", id="concurrent")
+    live_state = [*msgs, concurrent]
+
+    # Apply the offload write through the real reducer.
+    new_state = messages_delta_reducer(live_state, [changed])
+
+    ids = [m.id for m in new_state]
+    # The concurrently-appended message survives — no REMOVE_ALL wipe.
+    assert "concurrent" in ids
+    # In-place overwrite: no duplication, no loss.
+    assert len(new_state) == len(live_state)
+    # The truncated message was overwritten in place.
+    a0_new = next(m for m in new_state if m.id == "a0")
+    assert "argument truncated" in a0_new.tool_calls[0]["args"]["content"]

--- a/tests/unit/middleware/compaction/test_utils.py
+++ b/tests/unit/middleware/compaction/test_utils.py
@@ -1,0 +1,188 @@
+"""Tests for compaction reconstruction: orphan-strip + id-anchored boundary.
+
+These cover the production "orphaned tool_result" brick: a positional
+``cutoff_index`` that drifts onto a ``ToolMessage`` reconstructs into a summary
+turn whose first content block is an orphaned ``tool_result`` (Anthropic 400).
+The fixes are (1) strip any leading ``ToolMessage`` from the reconstructed tail
+and (2) track the boundary by the first preserved message's id so list
+perturbation can't silently shift it.
+"""
+
+from __future__ import annotations
+
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from ptc_agent.agent.middleware.compaction.types import CompactionEvent
+from ptc_agent.agent.middleware.compaction.utils import (
+    build_compaction_event,
+    compute_absolute_cutoff,
+    get_effective_messages,
+)
+
+
+def _summary() -> HumanMessage:
+    return HumanMessage(content="[Context Summary] ...", id="summary")
+
+
+def _conversation() -> list:
+    """[H0, A1, T2, H3, A4, T5] — a tool call/result pair straddling the cutoff."""
+    return [
+        HumanMessage(content="q0", id="0"),
+        AIMessage(content="a1", id="1"),
+        ToolMessage(content="r2", id="2", tool_call_id="tc2"),
+        HumanMessage(content="q3", id="3"),
+        AIMessage(content="a4", id="4"),
+        ToolMessage(content="r5", id="5", tool_call_id="tc5"),
+    ]
+
+
+class TestBuildCompactionEvent:
+    def test_grounds_cutoff_at_anchor_position(self):
+        raw = _conversation()
+        preserved = raw[3:]
+        event = build_compaction_event(
+            raw_messages=raw,
+            preserved_messages=preserved,
+            summary_message=_summary(),
+            file_path=None,
+            effective_cutoff=3,
+            previous_event=None,
+        )
+        assert event["anchor_message_id"] == "3"
+        assert event["cutoff_index"] == 3
+        # cutoff_index must point at the anchor message in the raw list
+        assert raw[event["cutoff_index"]].id == event["anchor_message_id"]
+
+    def test_empty_preserved_falls_back_to_arithmetic(self):
+        raw = _conversation()
+        event = build_compaction_event(
+            raw_messages=raw,
+            preserved_messages=[],
+            summary_message=_summary(),
+            file_path=None,
+            effective_cutoff=6,
+            previous_event=None,
+        )
+        assert event["anchor_message_id"] is None
+        assert event["cutoff_index"] == 6  # compute_absolute_cutoff(6, None)
+
+    def test_empty_preserved_chained_uses_previous_event(self):
+        raw = _conversation()
+        prev: CompactionEvent = {
+            "cutoff_index": 2,
+            "summary_message": _summary(),
+            "file_path": None,
+        }
+        event = build_compaction_event(
+            raw_messages=raw,
+            preserved_messages=[],
+            summary_message=_summary(),
+            file_path=None,
+            effective_cutoff=4,
+            previous_event=prev,
+        )
+        assert event["anchor_message_id"] is None
+        # compute_absolute_cutoff(4, prev) == 2 + 4 - 1 == 5
+        assert event["cutoff_index"] == compute_absolute_cutoff(4, prev) == 5
+
+
+class TestGetEffectiveMessages:
+    def test_none_event_returns_messages_unchanged(self):
+        raw = _conversation()
+        assert get_effective_messages(raw, None) is raw
+
+    def test_happy_path_positional_still_valid(self):
+        raw = _conversation()
+        event = build_compaction_event(
+            raw_messages=raw,
+            preserved_messages=raw[3:],
+            summary_message=_summary(),
+            file_path=None,
+            effective_cutoff=3,
+            previous_event=None,
+        )
+        result = get_effective_messages(raw, event)
+        assert result[0] is event["summary_message"]
+        assert [m.id for m in result[1:]] == ["3", "4", "5"]
+
+    def test_id_anchor_overrides_drifted_positional_index(self):
+        raw = _conversation()
+        event = build_compaction_event(
+            raw_messages=raw,
+            preserved_messages=raw[3:],
+            summary_message=_summary(),
+            file_path=None,
+            effective_cutoff=3,
+            previous_event=None,
+        )
+        # Perturb: insert a message before the cutoff, shifting the tail right.
+        drifted = list(raw)
+        drifted.insert(3, HumanMessage(content="injected", id="x"))
+        result = get_effective_messages(drifted, event)
+        # Boundary must follow the anchor message, not the stale index 3.
+        assert [m.id for m in result[1:]] == ["3", "4", "5"]
+        assert all(m.id != "x" for m in result[1:])
+
+    def test_orphan_strip_on_legacy_event(self):
+        """Legacy event (no anchor) whose positional cutoff lands on a ToolMessage."""
+        raw = _conversation()
+        legacy: CompactionEvent = {
+            "cutoff_index": 2,  # points at ToolMessage T2
+            "summary_message": _summary(),
+            "file_path": None,
+        }
+        result = get_effective_messages(raw, legacy)
+        assert result[0] is legacy["summary_message"]
+        # The orphaned leading ToolMessage must be stripped.
+        assert not isinstance(result[1], ToolMessage)
+        assert [m.id for m in result[1:]] == ["3", "4", "5"]
+
+    def test_anchor_not_found_falls_back_to_positional_and_strips(self):
+        raw = _conversation()
+        event: CompactionEvent = {
+            "cutoff_index": 2,  # ToolMessage
+            "summary_message": _summary(),
+            "file_path": None,
+            "anchor_message_id": "missing",
+        }
+        result = get_effective_messages(raw, event)
+        # Anchor unresolvable -> positional fallback -> still strips the orphan.
+        assert not isinstance(result[1], ToolMessage)
+        assert [m.id for m in result[1:]] == ["3", "4", "5"]
+
+    def test_reconstruction_never_starts_with_tool_message(self):
+        """Exact brick reproduction: summary + leading orphaned tool_result."""
+        raw = [
+            HumanMessage(content="q0", id="0"),
+            AIMessage(content="a1", id="1"),
+            ToolMessage(content="orphan", id="2", tool_call_id="tc2"),
+            HumanMessage(content="q3", id="3"),
+        ]
+        # Drifted positional cutoff onto the ToolMessage with a stale/absent anchor.
+        event: CompactionEvent = {
+            "cutoff_index": 2,
+            "summary_message": _summary(),
+            "file_path": None,
+            "anchor_message_id": None,
+        }
+        result = get_effective_messages(raw, event)
+        assert len(result) >= 1
+        assert not any(
+            isinstance(m, ToolMessage) for m in result[1:2]
+        ), "reconstruction must not start with an orphaned tool_result"
+
+    def test_anchor_resolves_after_left_shift_removal(self):
+        """A removed pre-cutoff message left-shifts the tail; anchor still finds it."""
+        raw = _conversation()
+        event = build_compaction_event(
+            raw_messages=raw,
+            preserved_messages=raw[3:],
+            summary_message=_summary(),
+            file_path=None,
+            effective_cutoff=3,
+            previous_event=None,
+        )
+        # Remove a pre-cutoff message: anchor "3" now sits at index 2, not 3.
+        drifted = [m for m in raw if m.id != "1"]
+        result = get_effective_messages(drifted, event)
+        assert [m.id for m in result[1:]] == ["3", "4", "5"]

--- a/tests/unit/middleware/compaction/test_utils.py
+++ b/tests/unit/middleware/compaction/test_utils.py
@@ -171,6 +171,28 @@ class TestGetEffectiveMessages:
             isinstance(m, ToolMessage) for m in result[1:2]
         ), "reconstruction must not start with an orphaned tool_result"
 
+    def test_orphan_strip_matches_dict_shaped_tool_result(self):
+        """Backstop is format-agnostic: a dict-shaped tool result is stripped too.
+
+        The checkpoint reducer coerces writes to typed messages, so this can't
+        occur on the persisted path today — but the orphan-strip is the crash
+        backstop and must not rely on that invariant holding forever.
+        """
+        raw = [
+            {"role": "tool", "content": "orphan", "tool_call_id": "tc2", "id": "2"},
+            HumanMessage(content="q3", id="3"),
+            AIMessage(content="a4", id="4"),
+        ]
+        legacy: CompactionEvent = {
+            "cutoff_index": 0,  # lands on the dict-shaped tool result
+            "summary_message": _summary(),
+            "file_path": None,
+        }
+        result = get_effective_messages(raw, legacy)
+        assert result[0] is legacy["summary_message"]
+        # The leading dict-shaped tool result must be stripped, not passed through.
+        assert result[1:] == [raw[1], raw[2]]
+
     def test_anchor_resolves_after_left_shift_removal(self):
         """A removed pre-cutoff message left-shifts the tail; anchor still finds it."""
         raw = _conversation()

--- a/tests/unit/middleware/test_compaction_request_shape.py
+++ b/tests/unit/middleware/test_compaction_request_shape.py
@@ -146,6 +146,73 @@ async def test_compact_messages_calls_llm_with_system_message(monkeypatch):
     assert isinstance(sent[-1], HumanMessage)
 
 
+@pytest.mark.asyncio
+async def test_chained_compaction_anchors_and_reconstructs_safely(monkeypatch):
+    """Chained compact_messages must stamp an ``anchor_message_id`` on the new
+    event, ground ``cutoff_index`` at that anchor in the raw list, and never
+    reconstruct a summary immediately followed by an orphaned tool_result."""
+    from langchain_core.messages import AIMessage, ToolMessage
+
+    from ptc_agent.agent.middleware.compaction import compact as compact_module
+    from ptc_agent.agent.middleware.compaction.utils import get_effective_messages
+
+    fake_llm = MagicMock()
+    fake_llm.ainvoke = AsyncMock(
+        return_value=MagicMock(content="summary", additional_kwargs={})
+    )
+    monkeypatch.setattr(compact_module, "get_llm_by_type", lambda model_name: fake_llm)
+
+    async def _passthrough_offload(backend, messages):
+        return messages
+
+    monkeypatch.setattr(compact_module, "aoffload_base64_content", _passthrough_offload)
+
+    async def _noop_offload_to_backend(backend, messages):
+        return None
+
+    monkeypatch.setattr(compact_module, "aoffload_to_backend", _noop_offload_to_backend)
+
+    async def _noop_offload_args(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(compact_module, "aoffload_truncated_args", _noop_offload_args)
+
+    def _turn(i):
+        # Human -> AI -> Tool, so the safe cutoff often lands on a ToolMessage.
+        return [
+            HumanMessage(content=f"q{i}", id=f"h{i}"),
+            AIMessage(content=f"a{i}", id=f"a{i}"),
+            ToolMessage(content="r", id=f"t{i}", tool_call_id=f"tc{i}"),
+        ]
+
+    messages = [m for i in range(6) for m in _turn(i)]
+
+    first = await compact_module.compact_messages(
+        messages=messages, keep_messages=4, model_name="gpt-4o", backend=None
+    )
+    event1 = first["event"]
+    assert event1.get("anchor_message_id") is not None
+    eff1 = get_effective_messages(messages, event1)
+    assert not isinstance(eff1[1], ToolMessage)
+
+    # Chain: append a fresh turn and compact again from the prior event.
+    messages2 = messages + _turn(99)
+    second = await compact_module.compact_messages(
+        messages=messages2,
+        keep_messages=4,
+        model_name="gpt-4o",
+        backend=None,
+        previous_event=event1,
+    )
+    event2 = second["event"]
+    anchor = event2.get("anchor_message_id")
+    assert anchor is not None
+    # cutoff_index is grounded at the anchor message in the raw list.
+    assert messages2[event2["cutoff_index"]].id == anchor
+    eff2 = get_effective_messages(messages2, event2)
+    assert not isinstance(eff2[1], ToolMessage)
+
+
 class TestCompactMessagesErrorPath:
     """Manual /compact must fail loudly, not fabricate fake summary text. A
     silent fallback here corrupted thread state with a bogus "compacted"

--- a/tests/unit/ptc_agent/agent/test_aupdate_state_id_stamping.py
+++ b/tests/unit/ptc_agent/agent/test_aupdate_state_id_stamping.py
@@ -1,0 +1,99 @@
+"""`aupdate_state` injection must pre-stamp message ids (compaction Bug A).
+
+Unlike the normal Pregel write path (covered by
+`test_delta_channel_determinism.py`), `graph.aupdate_state` does NOT run
+langgraph's `ensure_message_ids`. A message injected id-less via `aupdate_state`
+(orchestrator notifications / steering triggers) therefore persists with
+`id=None` under `messages_delta_reducer`, and a later full-list re-write appends
+it again as a duplicate. `ptc_agent.agent.state.ensure_message_ids`, applied at
+the injection boundary, closes the hole — the injected message carries a stable
+id, reconstructs deterministically, and dedups on re-write.
+"""
+
+from __future__ import annotations
+
+from langchain_core.messages import HumanMessage
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import END, START, StateGraph
+
+from ptc_agent.agent.state import DeltaAgentState, ensure_message_ids
+
+
+def _build_graph(saver):
+    builder = StateGraph(DeltaAgentState)
+
+    def noop(_state: DeltaAgentState) -> dict:
+        return {}
+
+    builder.add_node("noop", noop)
+    builder.add_edge(START, "noop")
+    builder.add_edge("noop", END)
+    return builder.compile(checkpointer=saver)
+
+
+def _ids(graph, config) -> list:
+    return [getattr(m, "id", None) for m in graph.get_state(config).values["messages"]]
+
+
+def _full_rewrite(graph, config) -> None:
+    """Re-apply the reconstructed message list — the pre-fix flush shape."""
+    msgs = graph.get_state(config).values["messages"]
+    graph.update_state(config, {"messages": msgs}, as_node="noop")
+
+
+def test_aupdate_state_does_not_stamp_idless_injection():
+    """Baseline: an id-less `aupdate_state` injection persists with `id=None`.
+
+    This is the hole the fix closes. If a langgraph bump starts stamping here,
+    this assertion flips and `ensure_message_ids` becomes a redundant no-op
+    (still harmless) — a deliberate canary on that behaviour.
+    """
+    graph = _build_graph(InMemorySaver())
+    config = {"configurable": {"thread_id": "idless-inject"}}
+
+    graph.update_state(
+        config, {"messages": [HumanMessage(content="hi")]}, as_node="noop"
+    )
+
+    assert _ids(graph, config) == [None]
+
+
+def test_unstamped_injection_duplicates_on_full_rewrite():
+    """The concrete harm: an id-less injection duplicates on a full-list re-write."""
+    graph = _build_graph(InMemorySaver())
+    config = {"configurable": {"thread_id": "idless-dup"}}
+
+    graph.update_state(
+        config, {"messages": [HumanMessage(content="hi")]}, as_node="noop"
+    )
+    before = len(graph.get_state(config).values["messages"])
+
+    _full_rewrite(graph, config)
+    after = len(graph.get_state(config).values["messages"])
+
+    assert before == 1 and after == 2, (
+        "id-less injection must duplicate on full-list re-write (the bug the "
+        "injection-time stamp + flush exclusion fix together close)"
+    )
+
+
+def test_stamped_injection_is_stable_and_dedups_on_rewrite():
+    """With `ensure_message_ids` the injected message carries a stable id,
+    reconstructs deterministically, and a full-list re-write does not duplicate."""
+    graph = _build_graph(InMemorySaver())
+    config = {"configurable": {"thread_id": "stamped-inject"}}
+
+    graph.update_state(
+        config,
+        {"messages": ensure_message_ids([HumanMessage(content="hi")])},
+        as_node="noop",
+    )
+
+    ids_a = _ids(graph, config)
+    assert ids_a[0] is not None
+    assert _ids(graph, config) == ids_a  # deterministic across reconstruction
+
+    _full_rewrite(graph, config)
+    assert _ids(graph, config) == ids_a, (
+        "stamped injection must dedup on full-list re-write"
+    )

--- a/tests/unit/server/handlers/test_trigger_compaction.py
+++ b/tests/unit/server/handlers/test_trigger_compaction.py
@@ -534,6 +534,80 @@ class TestActiveWorkflowGate:
         assert offload_mock.await_count == 0
 
     @pytest.mark.asyncio
+    async def test_offload_fails_closed_when_tracker_disabled(self, base_config):
+        """Redis outage → tracker.enabled=False → /offload (a non-critical
+        optimization) is SKIPPED with 409 rather than writing into a
+        possibly-active turn. Contrast /compact, which fails open."""
+        from fastapi import HTTPException
+
+        from src.server.handlers.workflow_handler import trigger_offload
+
+        offload_mock = AsyncMock()  # should NEVER be called
+        stub_resolve = _stub_resolve_graph_and_state()
+
+        tracker = MagicMock()
+        tracker.enabled = False
+        tracker.get_status = AsyncMock(
+            side_effect=AssertionError("get_status must not be called when disabled")
+        )
+
+        with (
+            patch("src.server.app.setup.agent_config", base_config),
+            patch(f"{HANDLER}._resolve_graph_and_state", new=stub_resolve),
+            patch(
+                "ptc_agent.agent.middleware.compaction.offload_tool_args",
+                new=offload_mock,
+            ),
+            patch(
+                "src.server.services.workflow_tracker.WorkflowTracker.get_instance",
+                return_value=tracker,
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await trigger_offload("thread-1")
+
+        assert exc_info.value.status_code == 409
+        assert exc_info.value.detail["code"] == "workflow_unverifiable"
+        assert exc_info.value.detail["verb"] == "offload"
+        assert offload_mock.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_offload_fails_closed_on_transient_tracker_error(self, base_config):
+        """Redis blip mid-request → get_status raises → /offload fails closed
+        (409) instead of running blind."""
+        from fastapi import HTTPException
+
+        from src.server.handlers.workflow_handler import trigger_offload
+
+        offload_mock = AsyncMock()  # should NEVER be called
+        stub_resolve = _stub_resolve_graph_and_state()
+
+        tracker = MagicMock()
+        tracker.enabled = True
+        tracker.get_status = AsyncMock(
+            side_effect=RuntimeError("redis: connection reset")
+        )
+
+        with (
+            patch("src.server.app.setup.agent_config", base_config),
+            patch(f"{HANDLER}._resolve_graph_and_state", new=stub_resolve),
+            patch(
+                "ptc_agent.agent.middleware.compaction.offload_tool_args",
+                new=offload_mock,
+            ),
+            patch(
+                "src.server.services.workflow_tracker.WorkflowTracker.get_instance",
+                return_value=tracker,
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await trigger_offload("thread-1")
+
+        assert exc_info.value.status_code == 409
+        assert exc_info.value.detail["code"] == "workflow_unverifiable"
+        assert offload_mock.await_count == 0
+
+    @pytest.mark.asyncio
     async def test_compact_fails_open_when_tracker_disabled(self, base_config):
         """Redis outage → tracker.enabled=False → gate bypasses so admin
         actions stay usable while chat workflows are already degraded."""

--- a/tests/unit/server/services/test_flush_checkpoint.py
+++ b/tests/unit/server/services/test_flush_checkpoint.py
@@ -1,0 +1,99 @@
+"""`_flush_checkpoint` must exclude `messages` from the re-write (compaction Bug A).
+
+On user-stop the flush reads the committed snapshot and re-applies it via
+`aupdate_state`. Re-writing the full message list re-applies every message as a
+DeltaChannel delta, and any still-id-less tail message appends as a duplicate.
+The flush now strips `messages` from the payload: the committed messages already
+carry forward on the channel, and the remaining private keys are last-write-wins
+so re-writing them stays idempotent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from langchain_core.messages import HumanMessage
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import END, START, StateGraph
+
+from ptc_agent.agent.state import DeltaAgentState
+from src.server.services.background_task_manager import (
+    BackgroundTaskManager,
+    TaskInfo,
+    TaskStatus,
+)
+
+
+def _manager_with_graph(graph, thread_id: str, run_id: str) -> BackgroundTaskManager:
+    """A BackgroundTaskManager holding just the one task — `_flush_checkpoint`
+    only touches `self.tasks` and `self.task_lock`, so skip the config-heavy
+    __init__ entirely."""
+    mgr = BackgroundTaskManager.__new__(BackgroundTaskManager)
+    mgr.tasks = {}
+    mgr.task_lock = asyncio.Lock()
+    mgr.tasks[(thread_id, run_id)] = TaskInfo(
+        thread_id=thread_id,
+        run_id=run_id,
+        status=TaskStatus.RUNNING,
+        created_at=datetime.now(),
+        graph=graph,
+    )
+    return mgr
+
+
+def _build_graph(saver):
+    builder = StateGraph(DeltaAgentState)
+
+    def noop(_state: DeltaAgentState) -> dict:
+        return {}
+
+    builder.add_node("noop", noop)
+    builder.add_edge(START, "noop")
+    builder.add_edge("noop", END)
+    return builder.compile(checkpointer=saver)
+
+
+@pytest.mark.asyncio
+async def test_flush_excludes_messages_keeps_private_keys():
+    """The re-write payload drops `messages` and keeps the private state keys."""
+    graph = MagicMock()
+    snapshot = MagicMock()
+    snapshot.values = {
+        "messages": [HumanMessage(content="x", id="m1")],
+        "_summarization_event": {"cutoff_index": 3, "anchor_message_id": "m1"},
+        "_offloaded_tool_call_ids": {"tc1"},
+    }
+    graph.aget_state = AsyncMock(return_value=snapshot)
+    graph.aupdate_state = AsyncMock(return_value=None)
+
+    mgr = _manager_with_graph(graph, "t", "r")
+    await mgr._flush_checkpoint("t", "r")
+
+    graph.aupdate_state.assert_awaited_once()
+    payload = graph.aupdate_state.await_args.args[1]
+    assert "messages" not in payload
+    assert payload["_summarization_event"]["cutoff_index"] == 3
+    assert payload["_offloaded_tool_call_ids"] == {"tc1"}
+
+
+@pytest.mark.asyncio
+async def test_flush_does_not_duplicate_idless_message():
+    """End-to-end on a real DeltaChannel graph: an id-less injected message is
+    not duplicated no matter how many times the flush runs."""
+    graph = _build_graph(InMemorySaver())
+    config = {"configurable": {"thread_id": "flush-dup"}}
+    await graph.aupdate_state(
+        config, {"messages": [HumanMessage(content="hi")]}, as_node="noop"
+    )
+    before = len((await graph.aget_state(config)).values["messages"])
+    assert before == 1
+
+    mgr = _manager_with_graph(graph, "flush-dup", "run1")
+    await mgr._flush_checkpoint("flush-dup", "run1")
+    await mgr._flush_checkpoint("flush-dup", "run1")
+
+    after = len((await graph.aget_state(config)).values["messages"])
+    assert after == 1, f"flush must not duplicate the message, {before} -> {after}"


### PR DESCRIPTION
## Summary
Heals a production-bricked thread and closes the id-persistence holes that made the
brick possible once #283 moved the `messages` channel onto LangGraph DeltaChannel.

- **Part 1** `2880054e` — id-anchor the compaction cutoff + strip orphaned tool_results
- **Part 2 Bug A** `1ed9746d` — stamp ids on aupdate_state injections; drop messages from flush
- **Part 2 Bug B** `800f8ed6` — offload writes in place instead of a REMOVE_ALL reset
- **Cleanup** `03bd4591` — dedup id-stamping, message-id accessor, gate branches

Root cause: `CompactionEvent.cutoff_index` was a positional integer; `get_effective_messages`
re-sliced `[summary] + messages[cutoff:]` with no re-validation. DeltaChannel reconstructs
the list by replaying deltas, so any non-append perturbation drifts the index — when it lands
on a `ToolMessage`, reconstruction yields a leading orphaned `tool_result` → Anthropic 400,
persisted, re-bricking every turn.

## Overview
| | Files | +/− |
|---|---|---|
| Modified (production) | 10 | +241 / −91 |
| New (production) | 1 | +17 / −0 |
| **Net (excl. tests)** | **11** | **+258 / −91** |
| Tests (new + extended) | 6 | +608 / −0 |
| **Total** | **17** | **+866 / −91** |

**By module**
- **Compaction core** (`utils.py` +87/−4, `types.py` +6, `__init__.py` +2, `compact.py` +37/−20, `middleware.py` +21/−33) — id-anchored cutoff + orphan-strip inside the single `get_effective_messages` chokepoint (O(1) happy path, O(n) rescan only on drift); `build_compaction_event` shared constructor for all 3 sites; Bug B in-place offload return.
- **State / injection** (`state.py` +24/−3, `orchestrator.py` +6/−5, `background_task_manager.py` +12/−1) — app-side `ensure_message_ids`, stamped at the 5 orchestrator injection sites; `_flush_checkpoint` excludes `messages` from the aupdate_state payload.
- **Shared leaf** (`_message_utils.py` +17, NEW) — `message_id` accessor deduped out of compaction + skills.
- **Skills** (`content.py` +1/−8) — consume the shared accessor.
- **Server handler** (`workflow_handler.py` +45/−17) — `/offload` fails closed when the workflow-active gate can't be verified (Redis down); dedup the two gate-exit branches.
- **Tests** (+608) — new `test_utils`, `test_offload_race`, `test_flush_checkpoint`, `test_aupdate_state_id_stamping`; extended `test_compaction_request_shape`, `test_trigger_compaction`.

**What this introduces:** reconstruction can never emit a leading orphaned `tool_result` (self-heals the bricked thread on its next turn — no migration), the boundary tracks its message by id instead of a drift-prone integer, and messages injected via `aupdate_state` now carry stable ids so the anchor is reliable and full-list rewrites are idempotent.

## Diff Size
- Total: 17 files changed, 866 insertions(+), 91 deletions(-)
- Net (excl. tests): 11 files changed, 258 insertions(+), 91 deletions(-)

## Test Coverage
65 tests across the changed suites; all pass. New/extended coverage:
- `test_utils.py` — orphan-strip, id-anchor override of a drifted index, legacy/anchor-not-found positional fallback + strip, O(1) happy path, `build_compaction_event` anchor agreement, exact brick reproduction, left-shift re-resolve
- `test_compaction_request_shape.py` — chained-compaction: second event carries `anchor_message_id`, grounds cutoff at the anchor, never reconstructs a leading `ToolMessage`
- `test_aupdate_state_id_stamping.py` — id-less persists `None` (baseline), duplicates on full re-write, stamped id is stable across replays + dedups
- `test_flush_checkpoint.py` — `messages` absent from flush payload, private keys kept, count stable across double flush
- `test_offload_race.py` — no `RemoveMessage` in the write, only changed messages returned, concurrently-appended message survives the in-place reducer apply

## Pre-Landing Review
Branch went through a strict code-quality pass. F1 (id-stamp consolidation), F2 (`_message_id` dedup → shared leaf), F3 (gate-branch dedup) applied and committed as `03bd4591`. Net −14 LOC on production code.

## Design Review
No frontend files changed — design review skipped.

## Plan Completion
19/19 items complete (17 DONE, 2 CHANGED, 0 NOT DONE). Both CHANGED items are net improvements. Out of scope (per plan): manual bricked-thread remediation, dangling-`tool_use` sanitizer.

## Test plan
- [x] Targeted compaction/skills/services/handlers suites — 778 passed
- [x] Broad middleware + ptc_agent sweep — 838 passed, 1 xpassed
- [x] `ruff check` clean on all touched source

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added id-based anchoring for compaction so reconstructed message history remains correctly bounded and resilient to drift.

* **Bug Fixes**
  * Improved message-id consistency across state updates, background notifications, and compaction/offload to prevent duplicate or lost messages.
  * Enhanced compaction reconstruction to resolve cutoff by anchor id and strip orphaned leading tool results.
  * Updated manual offload gating to fail closed (HTTP 409) when workflow status can’t be verified.
  * Fixed checkpoint flush behavior to avoid rewriting message history unnecessarily.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->