### PR TITLE
feat(llms): add Claude Sonnet 5 to the model manifest

### DIFF
--- a/src/llms/manifest/models.json
+++ b/src/llms/manifest/models.json
@@ -102,6 +102,29 @@
       }
     }
   },
+  "claude-sonnet-5": {
+    "model_id": "claude-sonnet-5",
+    "provider": "anthropic",
+    "visible": true,
+    "speed": 3,
+    "intelligence": 5,
+    "context": 1000000,
+    "input_modalities": [
+      "text",
+      "image",
+      "pdf"
+    ],
+    "parameters": {
+      "max_tokens": 128000,
+      "thinking": {
+        "type": "adaptive",
+        "display": "summarized"
+      },
+      "output_config": {
+        "effort": "medium"
+      }
+    }
+  },
   "claude-opus-4-8": {
     "model_id": "claude-opus-4-8",
     "provider": "anthropic",
@@ -1174,6 +1197,29 @@
       },
       "output_config": {
         "effort": "high"
+      }
+    }
+  },
+  "claude-sonnet-5-oauth": {
+    "model_id": "claude-sonnet-5",
+    "provider": "claude-oauth",
+    "visible": true,
+    "speed": 3,
+    "intelligence": 5,
+    "context": 1000000,
+    "input_modalities": [
+      "text",
+      "image",
+      "pdf"
+    ],
+    "parameters": {
+      "max_tokens": 128000,
+      "thinking": {
+        "type": "adaptive",
+        "display": "summarized"
+      },
+      "output_config": {
+        "effort": "medium"
       }
     }
   },

--- a/src/llms/manifest/providers.json
+++ b/src/llms/manifest/providers.json
@@ -138,6 +138,20 @@
         }
       },
       {
+        "id": "claude-sonnet-5",
+        "name": "Claude Sonnet 5",
+        "is_reasoning": true,
+        "description": "Claude Sonnet 5 model",
+        "pricing": {
+          "input": 3.0,
+          "cached_input": 0.3,
+          "cache_5m": 3.75,
+          "cache_1h": 6.0,
+          "output": 15.0,
+          "unit": "per_1m_tokens"
+        }
+      },
+      {
         "id": "claude-opus-4-8",
         "name": "Claude 4.8 Opus",
         "is_reasoning": true,

--- a/tests/unit/llms/test_model_pricing_inheritance.py
+++ b/tests/unit/llms/test_model_pricing_inheritance.py
@@ -36,5 +36,12 @@ class TestModelPricingResolution:
         assert intl["input"] == 2.677
         assert cn["input"] != intl["input"]
 
+    def test_sonnet_5_resolves_and_oauth_inherits(self):
+        direct = find_model_pricing("claude-sonnet-5", provider="anthropic")
+        oauth = find_model_pricing("claude-sonnet-5", provider="claude-oauth")
+        assert direct is not None
+        assert direct["input"] > 0 and direct["output"] > 0
+        assert oauth == direct
+
     def test_unknown_model_returns_none(self):
         assert find_model_pricing("does-not-exist", provider="anthropic") is None


### PR DESCRIPTION
## Summary
Add Claude Sonnet 5 to the langalpha model manifest at $3/$15 per MTok with a
1M context window.

**Manifest**
- add `claude-sonnet-5` (API) + `claude-sonnet-5-oauth` keys and the anthropic
  pricing entry ($3 in / $15 out, cache tiers 0.3 / 3.75 / 6.0)

**Tests**
- pricing resolution test: direct anthropic rates resolve, OAuth inherits

## Overview
Totals (net excl. tests): 2 files modified, +60. No new files.

| File | Type | +lines | What |
|---|---|---|---|
| src/llms/manifest/models.json | modified | +46 | 2 new keys: `claude-sonnet-5` (anthropic) + `claude-sonnet-5-oauth` (claude-oauth), 1M native context, adaptive thinking, medium effort |
| src/llms/manifest/providers.json | modified | +14 | 1 anthropic pricing entry for `claude-sonnet-5` |
| tests/unit/llms/test_model_pricing_inheritance.py | test | +7 | resolution + OAuth-inherit assertion |

What this introduces: Sonnet 5 becomes selectable via both API key and OAuth. Shape
mirrors the `claude-fable-5` family exactly (natively 1M, so no `-oauth-1m` variant).
speed 3 / intelligence 5 are benchmark-grounded (peer to Opus 4.8 on intelligence,
~74-78 t/s output).

## Diff Size
- Total: 3 files changed, 67 insertions(+)
- Net (excl. tests): 2 files changed, 60 insertions(+)

## Test Coverage
Data-only change. The one behavioral invariant (pricing resolution + OAuth inheritance)
is covered by the new test. 471/471 llms unit tests pass.

## Pre-Landing Review
No issues. Claude + Codex adversarial passes both clean — shape matches siblings, no
duplicate keys/ids, no cross-file registration needed (manifest is single source of truth).

## Test plan
- [x] `uv run python -m pytest tests/unit/llms/` — 471 passed
- [x] JSON valid; `find_model_pricing` resolves $3/$15; OAuth inherits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new Anthropic model, **Claude Sonnet 5**.
  * Added an OAuth-based version of the same model for accounts that use OAuth authentication.
  * Included model availability details such as context size, supported inputs, and reasoning settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->