### PR TITLE
feat(llms): remove GPT-5.3 Codex from the model manifest

### DIFF
--- a/src/llms/manifest/models.json
+++ b/src/llms/manifest/models.json
@@ -1045,29 +1045,6 @@
       }
     }
   },
-  "gpt-5.3-codex-oauth": {
-    "model_id": "gpt-5.3-codex",
-    "provider": "codex-oauth",
-    "visible": true,
-    "speed": 3,
-    "intelligence": 4,
-    "context": 400000,
-    "input_modalities": [
-      "text",
-      "image",
-      "pdf"
-    ],
-    "parameters": {
-      "reasoning": {
-        "effort": "medium",
-        "summary": "auto"
-      },
-      "include": [
-        "reasoning.encrypted_content"
-      ],
-      "store": false
-    }
-  },
   "gpt-5.3-codex-spark-oauth": {
     "model_id": "gpt-5.3-codex-spark",
     "provider": "codex-oauth",


### PR DESCRIPTION
## Overview

| | Files | Net lines (excl. tests) |
|---|---|---|
| Modified | 1 | −23 |
| New | 0 | 0 |

By module: `src/llms/manifest/models.json` −23. Manifest-only change; no code paths touched.

## Why

Codex OAuth no longer officially supports `gpt-5.3-codex`, so the `gpt-5.3-codex-oauth` key is retired from the catalog. GPT-5.3 Codex Spark (`gpt-5.3-codex-spark-oauth`) is still supported and remains available — it is now the only 5.3-family model.

## Details

- The 5.3 family consisted of two OAuth-only keys under the `codex-oauth` provider; only the non-Spark one is removed.
- No `providers.json` changes — `codex-oauth` carries no pricing list, so there were no pricing entries to drop.
- The `gpt-5.3-codex` string in `tests/unit/llms/test_codex_extension.py` is a mock value in a hand-constructed Response for the null-output guard test, not a manifest lookup, so it is intentionally left as-is.

## Testing

- JSON validation of both manifest files.
- `tests/unit/llms/` — 474 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed one model option from the available manifest, so it will no longer appear as a selectable configuration.
  * Updated the model list order to follow the remaining entries cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->