### PR TITLE
fix(cache): daily-bar staleness backstop with single-flight refetch

### DIFF
--- a/src/server/services/cache/_ohlcv_envelope.py
+++ b/src/server/services/cache/_ohlcv_envelope.py
@@ -11,9 +11,11 @@ from typing import Any, Dict, List, Optional
 from zoneinfo import ZoneInfo
 
 from src.config.core import get_infrastructure_config
+from src.data_client.market_data_provider import is_us_symbol
 from src.utils.market_hours import (
     current_trading_date,
     expected_latest_bar_ms,
+    expected_latest_daily_date,
     interval_seconds,
     is_market_closed,
 )
@@ -24,6 +26,43 @@ ENVELOPE_VERSION = 3  # v3: adds data_date and truncated fields
 _SOFT_TTL_RATIO: float = get_infrastructure_config().redis.swr.soft_ttl_ratio
 _TRUNCATED_TTL_RATIO = 0.25  # aggressive refresh for truncated data
 _EMPTY_RESULT_TTL = 30  # short TTL for empty upstream results
+# Floor between consecutive staleness-driven daily re-fetches. When the
+# provider itself is behind (e.g. today's daily bar not yet published right
+# after the open), re-asking immediately can't yield newer data — without
+# this floor every request would bypass the cache with a blocking fetch.
+_DAILY_STALE_REFETCH_COOLDOWN = 120
+
+# Bare index symbols whose daily bars follow the US (ET) trading calendar.
+# Index symbols aren't suffix-classifiable like stocks, so the daily
+# watermark backstop only trusts this allowlist.
+_US_INDEX_SYMBOLS = {
+    "GSPC", "SPX", "DJI", "IXIC", "COMP", "NDX", "RUT", "VIX",
+    "NYA", "XAX", "OEX", "MID", "SML", "SOX", "RUI", "RUA",
+    "DJT", "DJU", "W5000", "WLSH",
+}
+
+# Dotted suffixes that mark a US class share / security type (BRK.B, BF.B,
+# HEI.A). ``symbol_market`` maps these to "other" — not a foreign region — so
+# ``is_us_symbol`` returns False and they'd wrongly skip the US backstop.
+# Genuine foreign tickers resolve to a specific region (hk/uk/jp/...) via the
+# suffix map and never land in this set, so trusting these is safe.
+_US_DOTTED_SUFFIXES = {"A", "B", "C"}
+
+
+def _follows_us_daily_calendar(symbol: str, is_index: bool) -> bool:
+    """True if *symbol*'s daily bars anchor to the US (ET) trading calendar."""
+    if is_index:
+        bare = symbol.lstrip("^").upper()
+        if bare.startswith("I:"):
+            bare = bare[2:]
+        return bare in _US_INDEX_SYMBOLS
+    if is_us_symbol(symbol):
+        return True
+    # US dotted class-shares classify as "other" (unrecognized suffix), not a
+    # foreign region — treat the known US class suffixes as US-calendar.
+    if "." in symbol:
+        return symbol.rsplit(".", 1)[-1].upper() in _US_DOTTED_SUFFIXES
+    return False
 
 
 def _build_envelope(
@@ -122,6 +161,8 @@ def is_watermark_stale(
     envelope: Dict[str, Any],
     interval: str,
     now: Optional[datetime] = None,
+    symbol: Optional[str] = None,
+    is_index: bool = False,
 ) -> bool:
     """Return True if the envelope's watermark is meaningfully behind the
     most recent bar that *should* exist right now for this interval.
@@ -133,16 +174,37 @@ def is_watermark_stale(
     trading days ago even though the date-level check alone might miss it
     (e.g. a ``data_date`` that got refreshed without the bars advancing).
 
-    Daily (``1day``) is a no-op — daily staleness is already handled at the
-    date level by :func:`_is_stale_date`, and daily bars have provider-specific
-    timestamp anchors (00:00 vs 09:30 vs 16:00) that would make a timestamp-
-    level check brittle.
+    Daily (``1day``) is checked at the DATE level: the newest bar's ET trading
+    date vs ``expected_latest_daily_date()`` (the newest bar that should exist
+    now — the previous trading day during pre-market, since today's daily bar
+    doesn't appear until the session opens). This is the only backstop daily
+    has against a ``data_date`` that was silently re-stamped with today's date
+    by a prior refresh that fetched nothing new (``_is_stale_date`` alone can't
+    catch that). US symbols only: non-US daily bars anchor at exchange-local
+    midnight, which converts to the *previous* ET date and would read as
+    permanently stale against the US calendar — daily callers should pass
+    ``symbol`` (and ``is_index``) so non-US symbols keep the date-level
+    check via ``_is_stale_date`` alone.
 
     Tolerance: ``2 * interval_period``. Absorbs provider delay plus small
     clock skew without hiding real stagnation.
     """
     if interval == "1day":
-        return False
+        # Date-level: stale when the newest bar's trading date is behind the
+        # newest daily bar that should exist now. Uses the same watermark→date
+        # conversion the daily delta-refresh trusts for its from_date.
+        if symbol is not None and not _follows_us_daily_calendar(symbol, is_index):
+            return False  # non-US anchors don't map to ET dates — see docstring
+        if not envelope.get("bars"):
+            return False  # empty window — soft-TTL governs re-fetch timing
+        if time.time() - envelope.get("fetched_at", 0) < _DAILY_STALE_REFETCH_COOLDOWN:
+            # Just fetched — the provider simply hasn't published a newer bar
+            # yet; flagging stale again would re-fetch on every request.
+            return False
+        last_bar_date = watermark_to_date_str(envelope.get("watermark"))
+        if last_bar_date is None:
+            return True  # bars present but unusable watermark — corrupt
+        return last_bar_date < expected_latest_daily_date(now)
     # Empty envelopes (no bars in requested window) are not meaningfully stale
     # on a watermark basis — there's nothing to be behind. They're deliberately
     # cached with a short _EMPTY_RESULT_TTL to dampen fetch storms for symbols
@@ -166,6 +228,8 @@ def _needs_refresh(
     interval: Optional[str] = None,
     now: Optional[datetime] = None,
     is_live: bool = True,
+    symbol: Optional[str] = None,
+    is_index: bool = False,
 ) -> bool:
     """Determine whether an SWR background refresh should fire.
 
@@ -184,7 +248,9 @@ def _needs_refresh(
     getting retried on subsequent hits.
 
     ``interval`` is optional for backward compatibility, but callers should
-    pass it whenever available so the watermark check fires.
+    pass it whenever available so the watermark check fires. Daily callers
+    should also pass ``symbol`` so non-US symbols skip the US-calendar
+    watermark check (see :func:`is_watermark_stale`).
     """
     if is_live:
         # 1. Stale date — strongest signal
@@ -192,7 +258,7 @@ def _needs_refresh(
             return True
 
         # 2. Stale watermark — mid-session stagnation
-        if interval and is_watermark_stale(envelope, interval, now):
+        if interval and is_watermark_stale(envelope, interval, now, symbol=symbol, is_index=is_index):
             return True
 
         # 3. Complete + market reopened

--- a/src/server/services/cache/_ohlcv_envelope.py
+++ b/src/server/services/cache/_ohlcv_envelope.py
@@ -203,6 +203,8 @@ def is_watermark_stale(
         if time.time() - envelope.get("fetched_at", 0) < _DAILY_STALE_REFETCH_COOLDOWN:
             # Just fetched — the provider simply hasn't published a newer bar
             # yet; flagging stale again would re-fetch on every request.
+            # Deliberately ahead of the corrupt-watermark check: a persistently
+            # corrupt feed re-fetches once per cooldown, not per request.
             return False
         last_bar_date = watermark_to_date_str(envelope.get("watermark"))
         if last_bar_date is None:

--- a/src/server/services/cache/_ohlcv_envelope.py
+++ b/src/server/services/cache/_ohlcv_envelope.py
@@ -182,9 +182,10 @@ def is_watermark_stale(
     by a prior refresh that fetched nothing new (``_is_stale_date`` alone can't
     catch that). US symbols only: non-US daily bars anchor at exchange-local
     midnight, which converts to the *previous* ET date and would read as
-    permanently stale against the US calendar — daily callers should pass
-    ``symbol`` (and ``is_index``) so non-US symbols keep the date-level
-    check via ``_is_stale_date`` alone.
+    permanently stale against the US calendar — daily callers must pass
+    ``symbol`` (and ``is_index``); without a symbol the daily check is
+    skipped and non-US symbols keep the date-level check via
+    ``_is_stale_date`` alone.
 
     Tolerance: ``2 * interval_period``. Absorbs provider delay plus small
     clock skew without hiding real stagnation.
@@ -193,8 +194,10 @@ def is_watermark_stale(
         # Date-level: stale when the newest bar's trading date is behind the
         # newest daily bar that should exist now. Uses the same watermark→date
         # conversion the daily delta-refresh trusts for its from_date.
-        if symbol is not None and not _follows_us_daily_calendar(symbol, is_index):
-            return False  # non-US anchors don't map to ET dates — see docstring
+        if symbol is None or not _follows_us_daily_calendar(symbol, is_index):
+            # Unclassifiable (no symbol) or non-US: fail closed — a foreign
+            # anchor read against the ET calendar would look permanently stale.
+            return False
         if not envelope.get("bars"):
             return False  # empty window — soft-TTL governs re-fetch timing
         if time.time() - envelope.get("fetched_at", 0) < _DAILY_STALE_REFETCH_COOLDOWN:
@@ -249,8 +252,8 @@ def _needs_refresh(
 
     ``interval`` is optional for backward compatibility, but callers should
     pass it whenever available so the watermark check fires. Daily callers
-    should also pass ``symbol`` so non-US symbols skip the US-calendar
-    watermark check (see :func:`is_watermark_stale`).
+    must also pass ``symbol`` — without it the daily watermark check is
+    skipped (see :func:`is_watermark_stale`).
     """
     if is_live:
         # 1. Stale date — strongest signal

--- a/src/server/services/cache/daily_cache_service.py
+++ b/src/server/services/cache/daily_cache_service.py
@@ -22,6 +22,7 @@ from src.server.services.cache._ohlcv_envelope import (
     _merge_bars,
     _needs_refresh,
     _parse_envelope,
+    is_watermark_stale,
     watermark_to_date_str,
 )
 from src.utils.cache.redis_cache import get_cache_client
@@ -230,7 +231,6 @@ class DailyCacheService:
         normalized = symbol.lstrip("^").upper()
 
         base_ttl = self._base_ttl()
-        cache = get_cache_client()
         phase = current_market_phase()
 
         # --- Try cache (across all known sources) ---
@@ -238,19 +238,24 @@ class DailyCacheService:
         is_live = DailyCacheKeyBuilder._is_live(to_date)
 
         if envelope is not None:
-            bars = envelope["bars"]
-            watermark = envelope.get("watermark")
-            complete = envelope.get("complete", False)
-            stored_ttl = envelope.get("stored_ttl", 0)
-            elapsed = time.time() - envelope.get("fetched_at", 0)
-            ttl_remaining = max(0, int(stored_ttl - elapsed)) if stored_ttl else None
-
             bg_triggered = False
             # Historical daily envelopes skip live-only staleness checks but
             # still participate in truncated/soft-TTL refresh via is_live.
-            if _needs_refresh(envelope, base_ttl, interval="1day", is_live=is_live):
-                if is_live and (_is_stale_date(envelope) or envelope.get("complete")):
-                    # Stale date or day-boundary transition → sync re-fetch
+            if _needs_refresh(
+                envelope, base_ttl, interval="1day", is_live=is_live,
+                symbol=normalized, is_index=is_index,
+            ):
+                if is_live and (
+                    _is_stale_date(envelope)
+                    or is_watermark_stale(envelope, "1day", symbol=normalized, is_index=is_index)
+                    or envelope.get("complete")
+                ):
+                    # Bars are behind the current trading date (stale date or a
+                    # watermark that never advanced), a day-boundary transition,
+                    # or a completed envelope past market reopen → sync re-fetch.
+                    # Sync (not background) because the daily chart fetches this
+                    # series once and never polls — a background refresh wouldn't
+                    # reach the current request.
                     logger.info("Daily cache %s: stale/complete → sync re-fetch", normalized)
                     envelope = None
                 else:
@@ -261,54 +266,106 @@ class DailyCacheService:
                     )
 
             if envelope is not None:
-                return DailyFetchResult(
-                    symbol=normalized,
-                    data=bars,
-                    cached=True,
-                    ttl_remaining=ttl_remaining,
+                return self._cached_result(
+                    normalized, envelope, cache_key, phase,
                     background_refresh_triggered=bg_triggered,
-                    cache_key=cache_key,
-                    watermark=watermark,
-                    complete=complete,
-                    market_phase=phase,
-                    truncated=envelope.get("truncated"),
                 )
 
-        # --- Cache miss: full fetch ---
-        try:
-            data, source, truncated = await self._fetch_data(normalized, from_date, to_date, is_index=is_index, user_id=user_id)
-            cache_key = DailyCacheKeyBuilder.daily_key(normalized, from_date, to_date, source=source, is_index=is_index)
+        # --- Cache miss / stale-discard: serialized full fetch ---
+        return await self._full_fetch(
+            normalized, from_date, to_date, is_index, user_id, phase, base_ttl,
+        )
 
-            closed = phase == "closed"
-            complete = closed and len(data) > 0
-            eff_ttl = self._effective_ttl(base_ttl, complete)
-            if not data:
-                eff_ttl = _EMPTY_RESULT_TTL
-            env = _build_envelope(data, phase, complete, stored_ttl=eff_ttl, truncated=truncated)
+    @staticmethod
+    def _cached_result(
+        normalized: str,
+        envelope: Dict[str, Any],
+        cache_key: Optional[str],
+        phase: str,
+        *,
+        background_refresh_triggered: bool = False,
+    ) -> DailyFetchResult:
+        """Build a cache-hit result from an envelope."""
+        stored_ttl = envelope.get("stored_ttl", 0)
+        elapsed = time.time() - envelope.get("fetched_at", 0)
+        ttl_remaining = max(0, int(stored_ttl - elapsed)) if stored_ttl else None
+        return DailyFetchResult(
+            symbol=normalized,
+            data=envelope["bars"],
+            cached=True,
+            ttl_remaining=ttl_remaining,
+            background_refresh_triggered=background_refresh_triggered,
+            cache_key=cache_key,
+            watermark=envelope.get("watermark"),
+            complete=envelope.get("complete", False),
+            market_phase=phase,
+            truncated=envelope.get("truncated"),
+        )
 
-            await cache.set(cache_key, env, ttl=eff_ttl)
+    async def _full_fetch(
+        self,
+        normalized: str,
+        from_date: Optional[str],
+        to_date: Optional[str],
+        is_index: bool,
+        user_id: Optional[str],
+        phase: str,
+        base_ttl: int,
+    ) -> DailyFetchResult:
+        """Fetch the full series upstream, serialized per series.
 
-            return DailyFetchResult(
-                symbol=normalized,
-                data=data,
-                cached=False,
-                ttl_remaining=eff_ttl,
-                background_refresh_triggered=False,
-                cache_key=cache_key,
-                watermark=env["watermark"],
-                complete=complete,
-                market_phase=phase,
-                truncated=truncated,
-            )
+        Concurrent cold/stale readers of the same series contend on one lock
+        (mirroring :meth:`_delta_refresh`); the leader fetches and fills the
+        cache, and followers re-read the freshly filled envelope instead of
+        each firing their own blocking upstream fetch. A cancelled waiter just
+        releases the lock — it can't poison the others.
+        """
+        lock = self._get_refresh_lock(f"full:{normalized}:{from_date}:{to_date}:{int(is_index)}")
+        async with lock:
+            # Double-check: the leader may have filled the cache while we waited.
+            cache_key, envelope = await self._find_cached(normalized, from_date, to_date, is_index=is_index)
+            if envelope is not None and not _needs_refresh(
+                envelope, base_ttl, interval="1day",
+                is_live=DailyCacheKeyBuilder._is_live(to_date),
+                symbol=normalized, is_index=is_index,
+            ):
+                return self._cached_result(normalized, envelope, cache_key, phase)
 
-        except Exception as e:
-            logger.error(f"Failed to fetch daily data for {symbol}: {e}")
-            return DailyFetchResult(
-                symbol=normalized,
-                data=[],
-                cached=False,
-                ttl_remaining=None,
-                background_refresh_triggered=False,
-                market_phase=phase,
-                error=str(e),
-            )
+            cache = get_cache_client()
+            try:
+                data, source, truncated = await self._fetch_data(normalized, from_date, to_date, is_index=is_index, user_id=user_id)
+                cache_key = DailyCacheKeyBuilder.daily_key(normalized, from_date, to_date, source=source, is_index=is_index)
+
+                closed = phase == "closed"
+                complete = closed and len(data) > 0
+                eff_ttl = self._effective_ttl(base_ttl, complete)
+                if not data:
+                    eff_ttl = _EMPTY_RESULT_TTL
+                env = _build_envelope(data, phase, complete, stored_ttl=eff_ttl, truncated=truncated)
+
+                await cache.set(cache_key, env, ttl=eff_ttl)
+
+                return DailyFetchResult(
+                    symbol=normalized,
+                    data=data,
+                    cached=False,
+                    ttl_remaining=eff_ttl,
+                    background_refresh_triggered=False,
+                    cache_key=cache_key,
+                    watermark=env["watermark"],
+                    complete=complete,
+                    market_phase=phase,
+                    truncated=truncated,
+                )
+
+            except Exception as e:
+                logger.error(f"Failed to fetch daily data for {normalized}: {e}")
+                return DailyFetchResult(
+                    symbol=normalized,
+                    data=[],
+                    cached=False,
+                    ttl_remaining=None,
+                    background_refresh_triggered=False,
+                    market_phase=phase,
+                    error=str(e),
+                )

--- a/src/utils/market_hours.py
+++ b/src/utils/market_hours.py
@@ -7,6 +7,7 @@ used by the OHLCV cache to gate background refreshes and set TTL policies.
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from datetime import datetime, time, date, timedelta
 from zoneinfo import ZoneInfo
 
@@ -78,6 +79,18 @@ def _is_trading_day(d: date) -> bool:
     return d.weekday() < 5 and d not in _HOLIDAYS
 
 
+def _latest_trading_day(
+    start: date, ok: Callable[[date], bool] | None = None
+) -> date | None:
+    """Walk back from *start* to the most recent trading day satisfying *ok*."""
+    candidate = start
+    for _ in range(10):
+        if _is_trading_day(candidate) and (ok is None or ok(candidate)):
+            return candidate
+        candidate -= timedelta(days=1)
+    return None
+
+
 def current_market_phase(now: datetime | None = None) -> MarketPhase:
     """Classify the current moment into a market phase.
 
@@ -136,14 +149,31 @@ def current_trading_date(now: datetime | None = None) -> str:
     if now.time() < _PRE_OPEN:
         candidate -= timedelta(days=1)
 
-    # Walk backward to find the most recent trading day
-    for _ in range(10):
-        if _is_trading_day(candidate):
-            return candidate.strftime("%Y-%m-%d")
-        candidate -= timedelta(days=1)
+    found = _latest_trading_day(candidate)
+    return (found or now.date()).strftime("%Y-%m-%d")
 
-    # Fallback — shouldn't happen
-    return now.date().strftime("%Y-%m-%d")
+
+def expected_latest_daily_date(now: datetime | None = None) -> str:
+    """Return the trading date of the newest daily bar that should exist now.
+
+    A daily bar for trading day D only appears once D's regular session opens
+    (09:30 ET); pre-market produces no daily bar. So the answer is the most
+    recent trading day whose 09:30 ET open is at or before *now*. This equals
+    :func:`current_trading_date` in every phase except pre-market, where today's
+    session hasn't opened yet and the freshest possible bar is the previous
+    trading day's — the distinction the daily staleness backstop needs to avoid
+    falsely flagging a cache that correctly holds yesterday's completed bar.
+    """
+    if now is None:
+        now = datetime.now(ET)
+    else:
+        now = now.astimezone(ET)
+
+    found = _latest_trading_day(
+        now.date(),
+        lambda d: datetime.combine(d, _MARKET_OPEN, tzinfo=ET) <= now,
+    )
+    return (found or now.date()).strftime("%Y-%m-%d")
 
 
 def seconds_until_next_open(now: datetime | None = None) -> int:

--- a/tests/unit/server/services/test_daily_cache_dedup.py
+++ b/tests/unit/server/services/test_daily_cache_dedup.py
@@ -1,0 +1,128 @@
+"""Single-flight serialization on DailyCacheService's sync full-fetch path.
+
+Regression guard: a burst of concurrent requests for the same daily series
+(cache missing, or a watermark-stale envelope just discarded) must coalesce
+onto ONE upstream fetch. The full-fetch path serializes on the same per-key
+lock as _delta_refresh; the leader fetches and fills the cache, followers
+re-read the fill — otherwise N concurrent readers each fire their own blocking
+upstream fetch (thundering herd at the open before the provider publishes
+today's daily bar).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from src.server.services.cache import daily_cache_service as dcs
+from src.server.services.cache.daily_cache_service import DailyCacheService
+
+_WATERMARK_MS = 1_700_000_000_000  # arbitrary fixed epoch-ms for the stub bar
+
+
+class _StubCache:
+    """In-memory cache: async get/set over a dict, matching RedisCacheClient."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, dict] = {}
+
+    async def get(self, key: str):
+        return self.store.get(key)
+
+    async def set(self, key: str, value: dict, ttl: int | None = None) -> None:
+        self.store[key] = value
+
+
+class _GatedProvider:
+    """Provider stub whose daily fetch blocks on a gate, counting calls."""
+
+    def __init__(self, gate: asyncio.Event) -> None:
+        self._gate = gate
+        self.calls = 0
+        self.source_names = ["stub"]
+
+    async def get_daily_with_source(self, symbol, from_date, to_date, is_index, user_id):
+        self.calls += 1
+        await self._gate.wait()
+        return [{"time": _WATERMARK_MS, "close": 1.0}], "stub", False
+
+
+@pytest.fixture
+def fresh_service(monkeypatch):
+    """Reset the singleton so in-flight/lock state doesn't leak across tests."""
+    DailyCacheService._instance = None
+    gate = asyncio.Event()
+    provider = _GatedProvider(gate)
+    cache = _StubCache()
+
+    async def _get_provider():
+        return provider
+
+    monkeypatch.setattr(dcs, "get_cache_client", lambda: cache)
+    monkeypatch.setattr(dcs, "get_market_data_provider", _get_provider)
+    yield DailyCacheService(), provider, cache, gate
+    DailyCacheService._instance = None
+
+
+@pytest.mark.asyncio
+async def test_concurrent_cold_reads_coalesce_to_one_fetch(fresh_service):
+    svc, provider, _cache, gate = fresh_service
+
+    tasks = [asyncio.create_task(svc.get_stock_daily("AAPL")) for _ in range(5)]
+    # Let the leader grab the lock and the rest queue behind it on the gate.
+    await asyncio.sleep(0.02)
+    gate.set()
+    results = await asyncio.gather(*tasks)
+
+    assert provider.calls == 1  # single upstream fetch for the whole burst
+    assert all(r.data == [{"time": _WATERMARK_MS, "close": 1.0}] for r in results)
+    # Exactly one leader fetched (cached=False); the rest served the fill.
+    assert sum(r.cached is False for r in results) == 1
+    assert sum(r.cached is True for r in results) == 4
+
+
+@pytest.mark.asyncio
+async def test_distinct_symbols_do_not_coalesce(fresh_service):
+    svc, provider, _cache, gate = fresh_service
+    gate.set()  # no need to block; just verify per-key separation
+
+    await asyncio.gather(svc.get_stock_daily("AAPL"), svc.get_stock_daily("MSFT"))
+
+    assert provider.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_leader_cancellation_does_not_poison_follower(fresh_service):
+    # A waiter disconnecting (cancel) must not poison others: cancelling the
+    # lock leader just releases the lock. The follower becomes the new leader
+    # and fetches — it still resolves with data (never a CancelledError).
+    svc, provider, _cache, gate = fresh_service
+
+    t1 = asyncio.create_task(svc.get_stock_daily("AAPL"))  # becomes leader
+    t2 = asyncio.create_task(svc.get_stock_daily("AAPL"))  # waits on the lock
+    await asyncio.sleep(0.02)
+
+    t1.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await t1
+
+    gate.set()
+    result = await t2  # follower still resolves with data, not poisoned
+    assert result.data == [{"time": _WATERMARK_MS, "close": 1.0}]
+    # Leader's upstream fetch was abandoned on cancel, so the follower re-fetched.
+    assert provider.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_second_identical_call_serves_cache(fresh_service):
+    # After the leader fills the cache, an identical follow-up serves the fill
+    # (fresh fetched_at → not stale) instead of re-fetching.
+    svc, provider, _cache, gate = fresh_service
+    gate.set()
+
+    first = await svc.get_stock_daily("AAPL")
+    second = await svc.get_stock_daily("AAPL")
+
+    assert provider.calls == 1
+    assert first.cached is False and second.cached is True

--- a/tests/unit/server/services/test_ohlcv_envelope_staleness.py
+++ b/tests/unit/server/services/test_ohlcv_envelope_staleness.py
@@ -110,8 +110,8 @@ class TestIsWatermarkStale:
     def test_empty_daily_envelope_is_not_stale(self):
         # An empty daily window has nothing to be behind — soft-TTL handles it.
         env = {"watermark": 0, "data_date": "1970-01-01", "bars": []}
-        assert is_watermark_stale(env, "1day") is False
-        assert is_watermark_stale({"watermark": 0, "data_date": "1970-01-01"}, "1day") is False
+        assert is_watermark_stale(env, "1day", symbol="AAPL") is False
+        assert is_watermark_stale({"watermark": 0, "data_date": "1970-01-01"}, "1day", symbol="AAPL") is False
 
     def test_empty_envelope_is_not_stale(self):
         # Empty-bar envelopes (no data in requested window) are deliberately
@@ -193,42 +193,42 @@ class TestDailyWatermarkStale:
         # check must still flag it stale so the cache re-fetches.
         tue_open = datetime(2026, 5, 26, 11, 0, tzinfo=ET)
         env = self._daily_env(datetime(2026, 5, 21), data_date="2026-05-26")
-        assert is_watermark_stale(env, "1day", now=tue_open) is True
+        assert is_watermark_stale(env, "1day", now=tue_open, symbol="AAPL") is True
 
     def test_today_bar_present_is_fresh(self):
         # Provider returns the in-progress current-day daily bar → not stale.
         tue_open = datetime(2026, 5, 26, 11, 0, tzinfo=ET)
         env = self._daily_env(datetime(2026, 5, 26), data_date="2026-05-26")
-        assert is_watermark_stale(env, "1day", now=tue_open) is False
+        assert is_watermark_stale(env, "1day", now=tue_open, symbol="AAPL") is False
 
     def test_friday_bar_on_saturday_is_fresh(self):
         # Saturday's current trading date is Friday; a Friday bar is current.
         saturday = datetime(2026, 4, 18, 10, 0, tzinfo=ET)
         env = self._daily_env(datetime(2026, 4, 17), data_date="2026-04-17")
-        assert is_watermark_stale(env, "1day", now=saturday) is False
+        assert is_watermark_stale(env, "1day", now=saturday, symbol="AAPL") is False
 
     def test_missing_last_session_is_stale(self):
         # Saturday read, newest bar is Thursday — Friday's completed bar is
         # missing → stale.
         saturday = datetime(2026, 4, 18, 10, 0, tzinfo=ET)
         env = self._daily_env(datetime(2026, 4, 16), data_date="2026-04-17")
-        assert is_watermark_stale(env, "1day", now=saturday) is True
+        assert is_watermark_stale(env, "1day", now=saturday, symbol="AAPL") is True
 
     def test_holiday_walks_back_to_last_trading_day(self):
         # Memorial Day 2026-05-25 is a holiday; current trading date is Fri 05-22.
         holiday = datetime(2026, 5, 25, 11, 0, tzinfo=ET)
         fresh = self._daily_env(datetime(2026, 5, 22), data_date="2026-05-22")
         stale = self._daily_env(datetime(2026, 5, 21), data_date="2026-05-22")
-        assert is_watermark_stale(fresh, "1day", now=holiday) is False
-        assert is_watermark_stale(stale, "1day", now=holiday) is True
+        assert is_watermark_stale(fresh, "1day", now=holiday, symbol="AAPL") is False
+        assert is_watermark_stale(stale, "1day", now=holiday, symbol="AAPL") is True
 
     def test_empty_daily_window_is_not_stale(self):
         # No bars → nothing to be behind; soft-TTL governs re-fetch.
-        assert is_watermark_stale({"bars": [], "watermark": 0}, "1day") is False
+        assert is_watermark_stale({"bars": [], "watermark": 0}, "1day", symbol="AAPL") is False
 
     def test_corrupt_daily_watermark_is_stale(self):
         # Bars present but watermark is 0 → corrupt, force re-fetch.
-        assert is_watermark_stale({"bars": [{"time": 123}], "watermark": 0}, "1day") is True
+        assert is_watermark_stale({"bars": [{"time": 123}], "watermark": 0}, "1day", symbol="AAPL") is True
 
     # -- pre-market: today's daily bar doesn't exist yet -----------------
     # The freshest bar that can legitimately exist before 09:30 ET is the
@@ -241,28 +241,28 @@ class TestDailyWatermarkStale:
         # bar can't exist yet → yesterday's bar is fresh, NOT stale.
         wed_premkt = datetime(2026, 5, 27, 8, 0, tzinfo=ET)
         env = self._daily_env(datetime(2026, 5, 26), data_date="2026-05-27")
-        assert is_watermark_stale(env, "1day", now=wed_premkt) is False
+        assert is_watermark_stale(env, "1day", now=wed_premkt, symbol="AAPL") is False
 
     def test_premarket_gross_staleness_still_caught(self):
         # Pre-market does NOT mean "never stale": a week-old bar (with a lying
         # data_date) is still behind the previous trading day → stale.
         wed_premkt = datetime(2026, 5, 27, 8, 0, tzinfo=ET)
         env = self._daily_env(datetime(2026, 5, 20), data_date="2026-05-27")
-        assert is_watermark_stale(env, "1day", now=wed_premkt) is True
+        assert is_watermark_stale(env, "1day", now=wed_premkt, symbol="AAPL") is True
 
     def test_premarket_after_weekend_walks_back(self):
         # Mon 08:00 ET pre-market; freshest possible bar is Fri's (weekend has
         # no sessions). A Friday bar is fresh.
         mon_premkt = datetime(2026, 5, 18, 8, 0, tzinfo=ET)
         env = self._daily_env(datetime(2026, 5, 15), data_date="2026-05-18")
-        assert is_watermark_stale(env, "1day", now=mon_premkt) is False
+        assert is_watermark_stale(env, "1day", now=mon_premkt, symbol="AAPL") is False
 
     def test_at_open_today_bar_expected(self):
         # At 09:30 ET the session has opened — today's in-progress bar should
         # exist. A cache still on yesterday is now stale (chases today's bar).
         wed_open = datetime(2026, 5, 27, 9, 30, tzinfo=ET)
         env = self._daily_env(datetime(2026, 5, 26), data_date="2026-05-27")
-        assert is_watermark_stale(env, "1day", now=wed_open) is True
+        assert is_watermark_stale(env, "1day", now=wed_open, symbol="AAPL") is True
 
     # -- re-fetch cooldown: a just-fetched envelope is never stale ---------
     # Right after the open the provider may not have published today's daily
@@ -274,13 +274,13 @@ class TestDailyWatermarkStale:
         wed_open = datetime(2026, 5, 27, 9, 35, tzinfo=ET)
         env = self._daily_env(datetime(2026, 5, 26), data_date="2026-05-27")
         env["fetched_at"] = time.time()
-        assert is_watermark_stale(env, "1day", now=wed_open) is False
+        assert is_watermark_stale(env, "1day", now=wed_open, symbol="AAPL") is False
 
     def test_cooldown_expiry_restores_staleness(self):
         wed_open = datetime(2026, 5, 27, 9, 35, tzinfo=ET)
         env = self._daily_env(datetime(2026, 5, 26), data_date="2026-05-27")
         env["fetched_at"] = time.time() - 300  # past the 120s cooldown
-        assert is_watermark_stale(env, "1day", now=wed_open) is True
+        assert is_watermark_stale(env, "1day", now=wed_open, symbol="AAPL") is True
 
     # -- non-US symbols: the backstop is US-calendar only ------------------
     # Non-US daily bars anchor at exchange-local midnight (e.g. 00:00 HKT),
@@ -321,6 +321,14 @@ class TestDailyWatermarkStale:
         tue_open = datetime(2026, 5, 26, 11, 0, tzinfo=ET)
         env = self._daily_env(datetime(2026, 5, 21), data_date="2026-05-26")
         assert is_watermark_stale(env, "1day", now=tue_open, symbol="SOX", is_index=True) is True
+
+    def test_no_symbol_fails_closed(self):
+        # No symbol → can't classify the calendar anchor → the backstop is
+        # skipped entirely, even for a grossly behind watermark. Guards the
+        # symbol-less intraday call sites if "1day" ever routes through them.
+        tue_open = datetime(2026, 5, 26, 11, 0, tzinfo=ET)
+        env = self._daily_env(datetime(2026, 5, 21), data_date="2026-05-26")
+        assert is_watermark_stale(env, "1day", now=tue_open) is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/server/services/test_ohlcv_envelope_staleness.py
+++ b/tests/unit/server/services/test_ohlcv_envelope_staleness.py
@@ -11,10 +11,12 @@ reads serve envelopes whose ``data_date`` was multiple trading days stale.
 
 from __future__ import annotations
 
+import time
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
 from src.server.services.cache._ohlcv_envelope import (
+    _follows_us_daily_calendar,
     _is_stale_date,
     is_watermark_stale,
 )
@@ -105,10 +107,11 @@ class TestExpectedLatestBarMs:
 # ---------------------------------------------------------------------------
 
 class TestIsWatermarkStale:
-    def test_daily_is_always_false(self):
-        # Daily staleness is handled at the date level.
-        env = {"watermark": 0, "data_date": "1970-01-01"}
+    def test_empty_daily_envelope_is_not_stale(self):
+        # An empty daily window has nothing to be behind — soft-TTL handles it.
+        env = {"watermark": 0, "data_date": "1970-01-01", "bars": []}
         assert is_watermark_stale(env, "1day") is False
+        assert is_watermark_stale({"watermark": 0, "data_date": "1970-01-01"}, "1day") is False
 
     def test_empty_envelope_is_not_stale(self):
         # Empty-bar envelopes (no data in requested window) are deliberately
@@ -162,6 +165,192 @@ class TestIsWatermarkStale:
         watermark = int(friday_close.timestamp() * 1000)
         env = {"watermark": watermark, "bars": [{"time": watermark}]}
         assert is_watermark_stale(env, "5min", now=saturday) is False
+
+
+# ---------------------------------------------------------------------------
+# is_watermark_stale — daily (1day) date-level backstop
+# ---------------------------------------------------------------------------
+
+class TestDailyWatermarkStale:
+    """Daily staleness is judged DATE-level: the newest bar's ET trading date
+    vs ``current_trading_date()``. This is the backstop that catches an
+    envelope whose ``data_date`` was silently stamped with today's date by a
+    prior refresh even though the bars never advanced (the daily analogue of
+    the intraday screenshot bug). Daily bars are anchored to ET midnight, so a
+    date-level comparison sidesteps the provider timestamp-anchor brittleness
+    that motivated the old ``1day`` no-op.
+    """
+
+    @staticmethod
+    def _daily_env(bar_date: datetime, *, data_date: str) -> dict:
+        # Daily bars anchor to ET midnight of the trading day.
+        wm = int(datetime(bar_date.year, bar_date.month, bar_date.day, 0, 0, tzinfo=ET).timestamp() * 1000)
+        return {"watermark": wm, "bars": [{"time": wm}], "data_date": data_date}
+
+    def test_behind_today_is_stale_even_when_data_date_lies(self):
+        # The reported bug: Tue 2026-05-26 market open, newest bar is 2026-05-21,
+        # but a prior refresh stamped data_date="2026-05-26". The date-level
+        # check must still flag it stale so the cache re-fetches.
+        tue_open = datetime(2026, 5, 26, 11, 0, tzinfo=ET)
+        env = self._daily_env(datetime(2026, 5, 21), data_date="2026-05-26")
+        assert is_watermark_stale(env, "1day", now=tue_open) is True
+
+    def test_today_bar_present_is_fresh(self):
+        # Provider returns the in-progress current-day daily bar → not stale.
+        tue_open = datetime(2026, 5, 26, 11, 0, tzinfo=ET)
+        env = self._daily_env(datetime(2026, 5, 26), data_date="2026-05-26")
+        assert is_watermark_stale(env, "1day", now=tue_open) is False
+
+    def test_friday_bar_on_saturday_is_fresh(self):
+        # Saturday's current trading date is Friday; a Friday bar is current.
+        saturday = datetime(2026, 4, 18, 10, 0, tzinfo=ET)
+        env = self._daily_env(datetime(2026, 4, 17), data_date="2026-04-17")
+        assert is_watermark_stale(env, "1day", now=saturday) is False
+
+    def test_missing_last_session_is_stale(self):
+        # Saturday read, newest bar is Thursday — Friday's completed bar is
+        # missing → stale.
+        saturday = datetime(2026, 4, 18, 10, 0, tzinfo=ET)
+        env = self._daily_env(datetime(2026, 4, 16), data_date="2026-04-17")
+        assert is_watermark_stale(env, "1day", now=saturday) is True
+
+    def test_holiday_walks_back_to_last_trading_day(self):
+        # Memorial Day 2026-05-25 is a holiday; current trading date is Fri 05-22.
+        holiday = datetime(2026, 5, 25, 11, 0, tzinfo=ET)
+        fresh = self._daily_env(datetime(2026, 5, 22), data_date="2026-05-22")
+        stale = self._daily_env(datetime(2026, 5, 21), data_date="2026-05-22")
+        assert is_watermark_stale(fresh, "1day", now=holiday) is False
+        assert is_watermark_stale(stale, "1day", now=holiday) is True
+
+    def test_empty_daily_window_is_not_stale(self):
+        # No bars → nothing to be behind; soft-TTL governs re-fetch.
+        assert is_watermark_stale({"bars": [], "watermark": 0}, "1day") is False
+
+    def test_corrupt_daily_watermark_is_stale(self):
+        # Bars present but watermark is 0 → corrupt, force re-fetch.
+        assert is_watermark_stale({"bars": [{"time": 123}], "watermark": 0}, "1day") is True
+
+    # -- pre-market: today's daily bar doesn't exist yet -----------------
+    # The freshest bar that can legitimately exist before 09:30 ET is the
+    # PREVIOUS trading day's. Comparing against current_trading_date() (which
+    # advances to today at 04:00 ET) falsely flagged a healthy cache stale and
+    # caused a blocking sync re-fetch on every pre-market request.
+
+    def test_premarket_yesterday_bar_is_fresh(self):
+        # Wed 08:00 ET pre-market; cache holds Tue's completed bar. Wed's daily
+        # bar can't exist yet → yesterday's bar is fresh, NOT stale.
+        wed_premkt = datetime(2026, 5, 27, 8, 0, tzinfo=ET)
+        env = self._daily_env(datetime(2026, 5, 26), data_date="2026-05-27")
+        assert is_watermark_stale(env, "1day", now=wed_premkt) is False
+
+    def test_premarket_gross_staleness_still_caught(self):
+        # Pre-market does NOT mean "never stale": a week-old bar (with a lying
+        # data_date) is still behind the previous trading day → stale.
+        wed_premkt = datetime(2026, 5, 27, 8, 0, tzinfo=ET)
+        env = self._daily_env(datetime(2026, 5, 20), data_date="2026-05-27")
+        assert is_watermark_stale(env, "1day", now=wed_premkt) is True
+
+    def test_premarket_after_weekend_walks_back(self):
+        # Mon 08:00 ET pre-market; freshest possible bar is Fri's (weekend has
+        # no sessions). A Friday bar is fresh.
+        mon_premkt = datetime(2026, 5, 18, 8, 0, tzinfo=ET)
+        env = self._daily_env(datetime(2026, 5, 15), data_date="2026-05-18")
+        assert is_watermark_stale(env, "1day", now=mon_premkt) is False
+
+    def test_at_open_today_bar_expected(self):
+        # At 09:30 ET the session has opened — today's in-progress bar should
+        # exist. A cache still on yesterday is now stale (chases today's bar).
+        wed_open = datetime(2026, 5, 27, 9, 30, tzinfo=ET)
+        env = self._daily_env(datetime(2026, 5, 26), data_date="2026-05-27")
+        assert is_watermark_stale(env, "1day", now=wed_open) is True
+
+    # -- re-fetch cooldown: a just-fetched envelope is never stale ---------
+    # Right after the open the provider may not have published today's daily
+    # bar yet. A fresh fetch that still ends on yesterday must not be
+    # re-flagged stale immediately, or every request would bypass the cache
+    # with a blocking fetch until the provider catches up.
+
+    def test_just_fetched_envelope_is_not_stale(self):
+        wed_open = datetime(2026, 5, 27, 9, 35, tzinfo=ET)
+        env = self._daily_env(datetime(2026, 5, 26), data_date="2026-05-27")
+        env["fetched_at"] = time.time()
+        assert is_watermark_stale(env, "1day", now=wed_open) is False
+
+    def test_cooldown_expiry_restores_staleness(self):
+        wed_open = datetime(2026, 5, 27, 9, 35, tzinfo=ET)
+        env = self._daily_env(datetime(2026, 5, 26), data_date="2026-05-27")
+        env["fetched_at"] = time.time() - 300  # past the 120s cooldown
+        assert is_watermark_stale(env, "1day", now=wed_open) is True
+
+    # -- non-US symbols: the backstop is US-calendar only ------------------
+    # Non-US daily bars anchor at exchange-local midnight (e.g. 00:00 HKT),
+    # which converts to the *previous* ET date — a perfectly fresh envelope
+    # would read permanently stale against the US calendar and re-fetch on
+    # every request. Such symbols keep date-level staleness via
+    # ``_is_stale_date`` alone.
+
+    def test_non_us_symbol_skips_backstop(self):
+        tue_open = datetime(2026, 5, 26, 11, 0, tzinfo=ET)
+        env = self._daily_env(datetime(2026, 5, 21), data_date="2026-05-26")
+        assert is_watermark_stale(env, "1day", now=tue_open, symbol="0700.HK") is False
+        assert is_watermark_stale(env, "1day", now=tue_open, symbol="600519.SS") is False
+
+    def test_non_us_index_skips_backstop(self):
+        # Index symbols aren't suffix-classifiable; only allowlisted US
+        # indexes get the backstop.
+        tue_open = datetime(2026, 5, 26, 11, 0, tzinfo=ET)
+        env = self._daily_env(datetime(2026, 5, 21), data_date="2026-05-26")
+        assert is_watermark_stale(env, "1day", now=tue_open, symbol="HSI", is_index=True) is False
+
+    def test_us_symbol_and_index_keep_backstop(self):
+        tue_open = datetime(2026, 5, 26, 11, 0, tzinfo=ET)
+        env = self._daily_env(datetime(2026, 5, 21), data_date="2026-05-26")
+        assert is_watermark_stale(env, "1day", now=tue_open, symbol="AAPL") is True
+        assert is_watermark_stale(env, "1day", now=tue_open, symbol="GSPC", is_index=True) is True
+
+    def test_us_dotted_class_share_keeps_backstop(self):
+        # BRK.B / BF.B classify as "other" (unmapped suffix), not a foreign
+        # region, so the US backstop must still engage for them.
+        tue_open = datetime(2026, 5, 26, 11, 0, tzinfo=ET)
+        env = self._daily_env(datetime(2026, 5, 21), data_date="2026-05-26")
+        assert is_watermark_stale(env, "1day", now=tue_open, symbol="BRK.B") is True
+        assert is_watermark_stale(env, "1day", now=tue_open, symbol="BF.B") is True
+
+    def test_expanded_index_allowlist_keeps_backstop(self):
+        # An index added to _US_INDEX_SYMBOLS gets the backstop.
+        tue_open = datetime(2026, 5, 26, 11, 0, tzinfo=ET)
+        env = self._daily_env(datetime(2026, 5, 21), data_date="2026-05-26")
+        assert is_watermark_stale(env, "1day", now=tue_open, symbol="SOX", is_index=True) is True
+
+
+# ---------------------------------------------------------------------------
+# _follows_us_daily_calendar — symbol/index classification
+# ---------------------------------------------------------------------------
+
+class TestFollowsUsDailyCalendar:
+    def test_bare_us_ticker(self):
+        assert _follows_us_daily_calendar("AAPL", False) is True
+
+    def test_us_dot_us_suffix(self):
+        assert _follows_us_daily_calendar("AAPL.US", False) is True
+
+    def test_us_dotted_class_shares(self):
+        assert _follows_us_daily_calendar("BRK.B", False) is True
+        assert _follows_us_daily_calendar("BF.B", False) is True
+        assert _follows_us_daily_calendar("HEI.A", False) is True
+
+    def test_foreign_suffixes_are_not_us(self):
+        # Foreign tickers resolve to a specific region via the suffix map —
+        # including the single-letter .L (London) and .T (Tokyo) codes, which
+        # must NOT be mistaken for US class shares.
+        for sym in ("0700.HK", "600519.SS", "RDS.L", "7203.T"):
+            assert _follows_us_daily_calendar(sym, False) is False
+
+    def test_index_allowlist_membership(self):
+        assert _follows_us_daily_calendar("GSPC", True) is True
+        assert _follows_us_daily_calendar("^SOX", True) is True
+        assert _follows_us_daily_calendar("I:SPX", True) is True
+        assert _follows_us_daily_calendar("HSI", True) is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/server/services/test_ohlcv_envelope_staleness.py
+++ b/tests/unit/server/services/test_ohlcv_envelope_staleness.py
@@ -15,7 +15,9 @@ import time
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
+from src.data_client.market_data_provider import _SUFFIX_MAP
 from src.server.services.cache._ohlcv_envelope import (
+    _US_DOTTED_SUFFIXES,
     _follows_us_daily_calendar,
     _is_stale_date,
     is_watermark_stale,
@@ -336,6 +338,13 @@ class TestDailyWatermarkStale:
 # ---------------------------------------------------------------------------
 
 class TestFollowsUsDailyCalendar:
+    def test_us_dotted_suffixes_disjoint_from_foreign_suffix_map(self):
+        # Trusting _US_DOTTED_SUFFIXES as US-calendar is safe only while none
+        # of them doubles as a foreign region suffix in _SUFFIX_MAP (which
+        # already carries single-letter codes like L/T). A future addition
+        # must fail here, not silently misclassify foreign symbols as US.
+        assert _US_DOTTED_SUFFIXES.isdisjoint(_SUFFIX_MAP)
+
     def test_bare_us_ticker(self):
         assert _follows_us_daily_calendar("AAPL", False) is True
 

--- a/tests/unit/utils/test_market_hours.py
+++ b/tests/unit/utils/test_market_hours.py
@@ -1,0 +1,62 @@
+"""Direct tests for market_hours trading-date helpers.
+
+``expected_latest_daily_date`` differs from ``current_trading_date`` only
+during pre-market (04:00–09:30 ET), when today's daily bar doesn't exist yet.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from src.utils.market_hours import current_trading_date, expected_latest_daily_date
+
+ET = ZoneInfo("America/New_York")
+
+
+class TestCurrentTradingDate:
+    def test_midsession_is_today(self):
+        wed = datetime(2026, 5, 27, 11, 0, tzinfo=ET)
+        assert current_trading_date(wed) == "2026-05-27"
+
+    def test_before_premarket_open_is_previous_day(self):
+        wed_early = datetime(2026, 5, 27, 3, 0, tzinfo=ET)
+        assert current_trading_date(wed_early) == "2026-05-26"
+
+    def test_weekend_walks_back_to_friday(self):
+        saturday = datetime(2026, 4, 18, 10, 0, tzinfo=ET)
+        assert current_trading_date(saturday) == "2026-04-17"
+
+    def test_holiday_walks_back(self):
+        # Memorial Day 2026-05-25 → most recent trading day is Fri 05-22.
+        holiday = datetime(2026, 5, 25, 11, 0, tzinfo=ET)
+        assert current_trading_date(holiday) == "2026-05-22"
+
+
+class TestExpectedLatestDailyDate:
+    def test_midsession_is_today(self):
+        wed = datetime(2026, 5, 27, 11, 0, tzinfo=ET)
+        assert expected_latest_daily_date(wed) == "2026-05-27"
+
+    def test_at_open_boundary_is_today(self):
+        wed_open = datetime(2026, 5, 27, 9, 30, tzinfo=ET)
+        assert expected_latest_daily_date(wed_open) == "2026-05-27"
+
+    def test_premarket_is_previous_trading_day(self):
+        # 08:00 ET: pre-market is active (current_trading_date says today)
+        # but today's daily bar can't exist yet.
+        wed_premkt = datetime(2026, 5, 27, 8, 0, tzinfo=ET)
+        assert expected_latest_daily_date(wed_premkt) == "2026-05-26"
+        assert current_trading_date(wed_premkt) == "2026-05-27"
+
+    def test_premarket_monday_walks_back_to_friday(self):
+        mon_premkt = datetime(2026, 5, 18, 8, 0, tzinfo=ET)
+        assert expected_latest_daily_date(mon_premkt) == "2026-05-15"
+
+    def test_weekend_is_friday(self):
+        saturday = datetime(2026, 4, 18, 10, 0, tzinfo=ET)
+        assert expected_latest_daily_date(saturday) == "2026-04-17"
+
+    def test_holiday_walks_back(self):
+        holiday = datetime(2026, 5, 25, 11, 0, tzinfo=ET)
+        assert expected_latest_daily_date(holiday) == "2026-05-22"


### PR DESCRIPTION
## Overview

Adds a daily-bar **staleness backstop** to the OHLCV cache and serializes the cold/stale full-fetch path so a burst of concurrent readers can't stampede the upstream provider.

The core bug: an envelope's `data_date` can be silently re-stamped to today by a delta refresh that fetched **no new bars** (provider hadn't published today's daily bar yet). `_is_stale_date` then reads "fresh" forever while the actual bars are days behind. This adds a watermark-level backstop that compares the newest bar's ET trading date against the newest daily bar that *should* exist right now — pre-market aware, since day D's daily bar only appears at the 09:30 ET open.

### Net change

| Category            | Files | +LOC | −LOC |
|---------------------|------:|-----:|-----:|
| Production          |     3 |  225 |   69 |
| Tests               |     3 |  391 |    4 |
| **Net (excl. tests)** |   3 | **+156** |     |

### By module

**`src/utils/market_hours.py`** (+37/−7)
- New `expected_latest_daily_date(now)` — the newest daily bar that should exist now (previous trading day during pre-market; today once the session opens).
- Extracted `_latest_trading_day(start, ok=None)` helper; `current_trading_date` refactored onto it.

**`src/server/services/cache/_ohlcv_envelope.py`** (+76/−7)
- `is_watermark_stale(..., symbol, is_index)` extended with a `1day` branch: date-level compare of the watermark's ET date vs `expected_latest_daily_date()`, gated to US-calendar symbols with a `_DAILY_STALE_REFETCH_COOLDOWN` (120s) floor, empty-bar skip, and corrupt-watermark handling.
- `_follows_us_daily_calendar(symbol, is_index)` — US-calendar classifier. Broadened so US dotted class-shares (BRK.B, BF.B) and an expanded US index allowlist (SOX, RUT, …) keep the backstop, while genuine foreign tickers (.HK/.SS/.L/.T) correctly skip it.
- The daily branch **fails closed without a symbol**: callers that can't classify the calendar anchor skip the backstop instead of being judged against the US calendar (guards the symbol-less intraday call sites if `1day` ever routes through them).

**`src/server/services/cache/daily_cache_service.py`** (+112/−55)
- Cold/stale full-fetch path serialized on a per-series `asyncio.Lock` (same idiom as `_delta_refresh`) with a **double-check** re-read after acquiring the lock: the leader fetches + fills, followers serve the fill instead of each firing their own blocking upstream fetch.
- Extracted `_cached_result` helper so the double-check and the hit path build identical cache-hit results.

### What this introduces

A daily-granularity staleness signal that survives a `data_date` re-stamp, plus single-flight protection against a thundering herd at the open — without changing behavior for fresh envelopes or non-US symbols.

## Test coverage

- `tests/unit/utils/test_market_hours.py` (new) — `current_trading_date` + `expected_latest_daily_date` across phases/weekends.
- `tests/unit/server/services/test_ohlcv_envelope_staleness.py` — daily backstop (stale/fresh/cooldown/corrupt/empty), US dotted class-share + index-allowlist retention, `_follows_us_daily_calendar` classification matrix (US bare/.US/dotted, foreign suffixes, index membership).
- `tests/unit/server/services/test_daily_cache_dedup.py` (new) — concurrent cold reads coalesce to one fetch; distinct symbols don't coalesce; leader cancellation doesn't poison the follower; second identical call serves cache.

## Review

Six review passes (2 Opus adversarial + 2 Codex per request + 1 Codex on the final lock rewrite + 1 independent re-derivation). Consensus surfaced two issues, both addressed:
- **Cache stampede (P1)** on the lockless cold/stale path → serialized with per-key lock + double-check.
- **Symbol-classification gaps (P2)** — US dotted class-shares and several US indexes were skipping the backstop → classifier broadened.
- A concurrency defect in the first (shared-task + `asyncio.shield`) dedup implementation — one waiter's cancellation poisoning all coalesced callers — was found by Codex and eliminated by switching to the lock approach (a cancelled waiter just releases the lock).
- The final re-derivation pass verified the backstop's three silent assumptions: US daily bars are stamped at ET-midnight-or-later across all three sources (FMP stamps `tzinfo=ET`, ginlix-data passes through Polygon's midnight-ET stamps, yfinance ≥1.2 returns exchange-localized indexes), the holiday table covers 2025–2027 with a rollover warning, and `SUPPORTED_INTERVALS` excludes `1day` so the symbol-less intraday call sites can't reach the daily branch. It also produced the fail-closed hardening for the no-symbol case.

## Known limitations

- The backstop is US-calendar only by design; non-US daily symbols continue to rely on `_is_stale_date` (their exchange-local midnight maps to the previous ET date and would read as permanently stale against the US calendar).
- `_refresh_locks` grows one entry per distinct `(symbol, from, to, is_index)`; unbounded in principle but bounded by the tracked-symbol universe in practice, same as the pre-existing `_delta_refresh` lock map.

## Test plan

- `uv run pytest tests/unit/server/services/ tests/unit/utils/ -q` — green (cache + utils suites).
- `uv run ruff check src/server/services/cache/ src/utils/market_hours.py` — clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced daily OHLCV freshness logic using market trading-day awareness (including pre-market, weekends/holidays, and a short post-fetch cooldown).
  * Improved handling of US-market vs non-US calendars to ensure freshness checks apply only where appropriate.

* **Bug Fixes**
  * Reduced unnecessary duplicate upstream fetches by coalescing concurrent requests for the same daily series.
  * More consistent treatment of empty or malformed daily cache envelopes to prevent incorrect staleness decisions.

* **Tests**
  * Added unit coverage for daily freshness edge cases and cache coalescing/concurrency behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->