### PR TITLE
fix(web): dedupe HITL interrupt cards by interrupt_id; hide orphan empty bubbles

### DIFF
--- a/web/src/pages/ChatAgent/components/MessageList.tsx
+++ b/web/src/pages/ChatAgent/components/MessageList.tsx
@@ -49,6 +49,33 @@ import { TextShimmer } from '@/components/ui/text-shimmer';
 // Stable empty object to avoid defeating React.memo with fresh `|| {}` fallbacks
 const EMPTY_OBJ = {} as Record<string, never>;
 
+/**
+ * An assistant bubble that settled with nothing to show. Some turns legitimately
+ * finalize empty in STATE — a HITL resume whose content landed on another bubble,
+ * or a history turn whose only event was a re-raised interrupt deduped by
+ * interrupt_id — and they must stay in state because edit/regenerate map UI
+ * position → backend turn_index by counting assistant bubbles. But painting them
+ * shows an orphan avatar + action row, so the list skips rendering them.
+ * Anything renderable keeps the bubble: a streaming indicator, text, segments,
+ * the Sources pill, the Stopped chip, or an error.
+ *
+ * INVARIANT: everything an assistant bubble can render must surface through
+ * content / contentSegments / provenanceRecords / error / stopped / isStreaming.
+ * A future assistant field that renders OUTSIDE those (e.g. assistant-side
+ * attachments) must be added to this guard or its bubbles will be hidden.
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export function isOrphanAssistantMessage(message: MessageRecord): boolean {
+  if (message.role !== 'assistant') return false;
+  if (message.isStreaming) return false;
+  const segments = message.contentSegments as unknown[] | undefined;
+  if (segments && segments.length > 0) return false;
+  if (message.content) return false;
+  const provenance = message.provenanceRecords as Record<string, unknown> | undefined;
+  if (provenance && Object.keys(provenance).length > 0) return false;
+  return !message.error && !message.stopped;
+}
+
 // --- Shared Types ---
 
 /** Loosely typed message record from SSE/API */
@@ -495,6 +522,7 @@ function MessageList({ messages, isLoading, isLoadingHistory, hideAvatar, compac
     <DispatchStatusProvider>
     <div className={isMobile ? 'space-y-4' : 'space-y-6'}>
       {messages.map((message) =>
+        isOrphanAssistantMessage(message) ? null :
         (message.role as string) === 'notification' ? (
           <NotificationDivider key={message.id as string} message={message} />
         ) : (

--- a/web/src/pages/ChatAgent/components/__tests__/MessageList.orphanBubble.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/MessageList.orphanBubble.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * Orphan-bubble suppression: assistant messages that settled with nothing to
+ * show (no segments, no text) stay in STATE — they are backend turns and
+ * edit/regenerate count assistant bubbles to map UI position → turn_index —
+ * but MessageList must not paint them, or the transcript shows a bare avatar +
+ * action-button row (the "orphan logo"). Real sources: a HITL-resume turn whose
+ * content landed on another bubble, or a history turn whose only event was a
+ * re-raised interrupt deduped by interrupt_id.
+ *
+ * Anything renderable keeps the bubble: streaming indicator, text, segments,
+ * the Sources pill, the Stopped chip, or an error.
+ */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import { renderWithProviders } from '@/test/utils';
+import MessageList, { isOrphanAssistantMessage } from '../MessageList';
+
+vi.mock('framer-motion', async () => {
+  const ReactActual = await vi.importActual<typeof import('react')>('react');
+  const FRAMER_ONLY_PROPS = new Set([
+    'initial', 'animate', 'exit', 'transition', 'variants',
+    'whileHover', 'whileTap', 'whileInView', 'layout', 'layoutId',
+    'onAnimationComplete', 'onAnimationStart',
+  ]);
+  const createEl = ReactActual.createElement as (type: unknown, props?: unknown, ...children: unknown[]) => React.ReactElement;
+  const make = (Comp: React.ElementType | string) =>
+    function MotionStub({ children, ...props }: { children?: React.ReactNode } & Record<string, unknown>) {
+      const domProps: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(props)) {
+        if (!FRAMER_ONLY_PROPS.has(k)) domProps[k] = v;
+      }
+      return createEl(Comp, domProps, children);
+    };
+  return {
+    motion: new Proxy({} as Record<string, unknown>, {
+      get: (_t, key: string) => (key === 'create' ? make : make(key)),
+    }),
+    AnimatePresence: ({ children }: { children?: React.ReactNode }) =>
+      ReactActual.createElement(ReactActual.Fragment, null, children),
+    animate: () => ({ stop: () => {} }),
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../Markdown', () => ({
+  default: ({ content }: { content: string }) => <div data-testid="markdown-content">{content}</div>,
+}));
+
+vi.mock('@/hooks/useUser', () => ({ useUser: () => ({ user: null }) }));
+
+vi.mock('@/contexts/ThemeContext', () => ({
+  useTheme: () => ({ theme: 'light', setTheme: () => {} }),
+}));
+
+type Msg = Record<string, unknown>;
+
+const assistant = (id: string, overrides: Msg = {}): Msg => ({
+  id,
+  role: 'assistant',
+  content: '',
+  contentType: 'text',
+  timestamp: new Date(),
+  isStreaming: false,
+  contentSegments: [],
+  reasoningProcesses: {},
+  toolCallProcesses: {},
+  ...overrides,
+});
+
+const userMsg = (id: string, content: string): Msg => ({
+  id, role: 'user', content, contentType: 'text', timestamp: new Date(), isStreaming: false,
+});
+
+const bubble = (container: HTMLElement, id: string) =>
+  container.querySelector(`[data-message-id="${id}"]`);
+
+describe('MessageList — orphan assistant bubble suppression', () => {
+  it('does not paint a settled empty assistant bubble (no orphan avatar/actions)', () => {
+    const messages = [
+      userMsg('u-1', 'dispatch two agents'),
+      assistant('history-assistant-0', {
+        contentSegments: [{ type: 'text', content: 'dispatching', order: 0 }],
+        content: 'dispatching',
+      }),
+      // The resume turn whose content landed elsewhere — stays in state, hidden.
+      assistant('assistant-hitl-1'),
+      assistant('history-assistant-2', {
+        contentSegments: [{ type: 'text', content: 'Both agents are dispatched.', order: 0 }],
+        content: 'Both agents are dispatched.',
+      }),
+    ];
+    const { container } = renderWithProviders(<MessageList messages={messages} isLoading={false} />);
+
+    expect(bubble(container, 'assistant-hitl-1')).toBeNull();
+    // Neighbors are unaffected.
+    expect(bubble(container, 'u-1')).not.toBeNull();
+    expect(bubble(container, 'history-assistant-0')).not.toBeNull();
+    expect(bubble(container, 'history-assistant-2')).not.toBeNull();
+  });
+
+  it('keeps empty bubbles that still communicate something', () => {
+    const messages = [
+      userMsg('u-1', 'hello'),
+      // Mid-stream placeholder: shows the streaming indicator.
+      assistant('a-streaming', { isStreaming: true }),
+      // Hard-stopped turn: shows the Stopped chip.
+      assistant('a-stopped', { stopped: true }),
+      // Failed turn: shows the error state.
+      assistant('a-error', { error: true }),
+      // Provenance-only turn: shows the Sources pill.
+      assistant('a-sources', {
+        provenanceRecords: {
+          r1: { record_id: 'r1', source_type: 'web', identifier: 'https://example.com/a', timestamp: '2026-01-01T00:00:00Z' },
+        },
+      }),
+    ];
+    const { container } = renderWithProviders(<MessageList messages={messages} isLoading={false} />);
+
+    for (const id of ['a-streaming', 'a-stopped', 'a-error', 'a-sources']) {
+      expect(bubble(container, id)).not.toBeNull();
+    }
+  });
+
+  it('predicate: user and notification messages are never orphans', () => {
+    expect(isOrphanAssistantMessage(userMsg('u-1', ''))).toBe(false);
+    expect(isOrphanAssistantMessage({ id: 'n-1', role: 'notification', content: 'x' })).toBe(false);
+    expect(isOrphanAssistantMessage(assistant('a-1'))).toBe(true);
+  });
+});

--- a/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.emptyBubble.test.ts
+++ b/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.emptyBubble.test.ts
@@ -1,0 +1,179 @@
+/**
+ * HITL-resume bubble turn-integrity on empty finalize.
+ *
+ * A HITL resume opens a fresh `assistant-hitl-*` bubble that can settle with
+ * nothing on it (content landed elsewhere, or the turn re-interrupted and the
+ * re-raise was deduped by interrupt_id). That bubble must STAY in state: a
+ * resume is a backend turn, and edit/regenerate map UI position → turn_index
+ * by counting non-steering assistant bubbles — pruning it would silently
+ * re-target later regenerates at the wrong checkpoint. The visual orphan
+ * (bare avatar + action row) is suppressed at render time instead — see
+ * MessageList.orphanBubble.test.tsx.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+import { act, waitFor } from '@testing-library/react';
+import { renderHookWithProviders } from '@/test/utils';
+import { settleMountEffect } from './chatHookHarness';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+vi.mock('@/lib/supabase', () => ({ supabase: null }));
+
+vi.mock('../utils/threadStorage', () => ({
+  getStoredThreadId: vi.fn().mockReturnValue(null),
+  setStoredThreadId: vi.fn(),
+  removeStoredThreadId: vi.fn(),
+}));
+
+vi.mock('../../utils/api', async () => (await import('./chatHookHarness')).apiMockModule());
+
+import {
+  fetchThreadTurns,
+  getWorkflowStatus,
+  replayThreadHistory,
+  sendChatMessageStream,
+  sendHitlResponse,
+} from '../../utils/api';
+import { useChatMessages } from '../useChatMessages';
+import type { AssistantMessage, ContentSegment } from '@/types/chat';
+
+const mockStatus = getWorkflowStatus as Mock;
+const mockReplay = replayThreadHistory as Mock;
+const mockSend = sendChatMessageStream as Mock;
+const mockSendHitl = sendHitlResponse as Mock;
+const mockTurns = fetchThreadTurns as Mock;
+
+const planInterrupt = {
+  event: 'interrupt',
+  interrupt_id: 'plan-1',
+  action_requests: [{ name: 'SubmitPlan', description: 'Step 1. Do the thing.' }],
+};
+
+const assistantBubbles = (messages: readonly unknown[]): AssistantMessage[] =>
+  messages.filter((m): m is AssistantMessage => (m as AssistantMessage).role === 'assistant');
+
+/** Send "make a plan", get a plan_approval interrupt on the main bubble. */
+async function sendAndInterrupt() {
+  mockSend.mockImplementation(async (...args: unknown[]) => {
+    const onEvent = args[5] as (e: Record<string, unknown>) => void;
+    onEvent(planInterrupt);
+    return { disconnected: false };
+  });
+
+  const rendered = renderHookWithProviders(() => useChatMessages('ws-x', 'th-x'));
+  await waitFor(() => expect(mockReplay).toHaveBeenCalled());
+  await settleMountEffect();
+
+  await act(async () => {
+    await rendered.result.current.handleSendMessage('make a plan', false);
+  });
+
+  // The plan card is on screen and pending approval.
+  await waitFor(() =>
+    expect(
+      assistantBubbles(rendered.result.current.messages).flatMap(
+        (m) => (m.contentSegments as ContentSegment[] | undefined) || [],
+      ).filter((s) => s.type === 'plan_approval'),
+    ).toHaveLength(1),
+  );
+  return rendered;
+}
+
+describe('useChatMessages — empty HITL-resume bubble stays in state (turn integrity)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // clearAllMocks clears call history but NOT implementations — reset and
+    // re-seed so no stream emitter leaks into the next test's mount.
+    mockReplay.mockReset();
+    mockReplay.mockResolvedValue(undefined);
+    mockSend.mockReset();
+    mockSendHitl.mockReset();
+    mockTurns.mockReset();
+    mockTurns.mockResolvedValue({ turns: [], retry_checkpoint_id: null });
+    mockStatus.mockReset();
+    mockStatus.mockResolvedValue({ can_reconnect: false, status: 'completed' });
+  });
+
+  it('an empty resume keeps its bubble in state, settled (render hides it)', async () => {
+    const { result } = await sendAndInterrupt();
+
+    // Approve → the resume stream emits NOTHING onto its fresh bubble.
+    mockSendHitl.mockImplementation(async () => ({ disconnected: false, aborted: false }));
+
+    await act(async () => {
+      result.current.handleApproveInterrupt();
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    await waitFor(() => expect(mockSendHitl).toHaveBeenCalled());
+    await settleMountEffect();
+
+    // TWO assistant bubbles: the plan-card turn AND the resume turn. The
+    // resume bubble is empty and settled — MessageList's orphan guard hides
+    // it — but it must remain so bubble-count → turn_index stays aligned.
+    const assistants = assistantBubbles(result.current.messages);
+    expect(assistants).toHaveLength(2);
+    const resumeBubble = assistants.find((m) => m.id.startsWith('assistant-hitl-'))!;
+    expect(resumeBubble).toBeDefined();
+    expect(resumeBubble.contentSegments).toHaveLength(0);
+    expect(resumeBubble.content).toBe('');
+    await waitFor(() => {
+      const settled = assistantBubbles(result.current.messages).find((m) => m.id.startsWith('assistant-hitl-'))!;
+      expect(settled.isStreaming).toBe(false);
+    });
+  });
+
+  it('a resume that streamed real content keeps it on its bubble', async () => {
+    const { result } = await sendAndInterrupt();
+
+    // Approve → the resume streams a real answer onto its bubble.
+    mockSendHitl.mockImplementation(async (...args: unknown[]) => {
+      const onEvent = args[3] as (e: Record<string, unknown>) => void;
+      onEvent({ event: 'message_chunk', role: 'assistant', agent: 'main', content_type: 'text', content: 'resumed answer' });
+      return { disconnected: false, aborted: false };
+    });
+
+    await act(async () => {
+      result.current.handleApproveInterrupt();
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    await waitFor(() => expect(mockSendHitl).toHaveBeenCalled());
+    await settleMountEffect();
+
+    await waitFor(() => expect(JSON.stringify(result.current.messages)).toContain('resumed answer'));
+    expect(assistantBubbles(result.current.messages)).toHaveLength(2);
+  });
+
+  it('edit truncation releases truncated interrupt ids so a re-raised id renders a card again', async () => {
+    const { result } = await sendAndInterrupt();
+
+    // Edit the original user message: truncation removes the plan card, and the
+    // forked run re-raises the SAME interrupt_id (LangGraph ids are
+    // deterministic). A stale rendered-id entry would suppress the new card and
+    // strand the interrupt unanswerable.
+    mockTurns.mockResolvedValue({
+      turns: [{ edit_checkpoint_id: 'ckpt-0', regenerate_checkpoint_id: 'ckpt-0r', turn_index: 0 }],
+      retry_checkpoint_id: null,
+    });
+    mockSend.mockImplementation(async (...args: unknown[]) => {
+      const onEvent = args[5] as (e: Record<string, unknown>) => void;
+      onEvent(planInterrupt); // same interrupt_id as the truncated card
+      return { disconnected: false };
+    });
+
+    const userMsg = result.current.messages.find((m) => m.role === 'user')!;
+    await act(async () => {
+      await result.current.handleEditMessage(userMsg.id, 'make a better plan');
+    });
+
+    // Exactly one plan card — the truncated id was released and re-rendered.
+    await waitFor(() => {
+      const cards = assistantBubbles(result.current.messages).flatMap(
+        (m) => (m.contentSegments as ContentSegment[] | undefined) || [],
+      ).filter((s) => s.type === 'plan_approval');
+      expect(cards).toHaveLength(1);
+    });
+  });
+});

--- a/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.interruptDedup.test.ts
+++ b/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.interruptDedup.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Interrupt-card de-duplication by interrupt_id.
+ *
+ * LangGraph re-raises an UNANSWERED interrupt with the SAME interrupt_id on every
+ * resume. Each re-raise arrives on a later turn's bubble (history replay) or on a
+ * fresh `assistant-hitl-*` bubble (live resume), so the per-message maps keyed by
+ * interrupt_id never collide and a duplicate CARD used to be appended. Repro from
+ * a Slack-driven thread: a still-pending "PTC Agent" (NVIDIA) interrupt showed up
+ * twice in the web transcript (3 cards for 2 real interrupts).
+ *
+ * These tests drive the REAL hook internals (api module mocked) and assert exactly
+ * one rendered card survives across both the replay and live-resume paths.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+import { act, waitFor } from '@testing-library/react';
+import { renderHookWithProviders } from '@/test/utils';
+import { settleMountEffect } from './chatHookHarness';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+vi.mock('@/lib/supabase', () => ({ supabase: null }));
+
+vi.mock('../utils/threadStorage', () => ({
+  getStoredThreadId: vi.fn().mockReturnValue(null),
+  setStoredThreadId: vi.fn(),
+  removeStoredThreadId: vi.fn(),
+}));
+
+vi.mock('../../utils/api', async () => (await import('./chatHookHarness')).apiMockModule());
+
+import {
+  fetchThreadTurns,
+  getWorkflowStatus,
+  replayThreadHistory,
+  reconnectToWorkflowStream,
+  sendChatMessageStream,
+  sendHitlResponse,
+} from '../../utils/api';
+import { useChatMessages } from '../useChatMessages';
+import type { AssistantMessage, ContentSegment } from '@/types/chat';
+
+const mockStatus = getWorkflowStatus as Mock;
+const mockReplay = replayThreadHistory as Mock;
+const mockReconnect = reconnectToWorkflowStream as Mock;
+const mockSend = sendChatMessageStream as Mock;
+const mockSendHitl = sendHitlResponse as Mock;
+const mockTurns = fetchThreadTurns as Mock;
+
+/** Live/replay-shaped ptc_agent interrupt action payload. */
+const ptcAction = (toolCallId: string) => ({
+  type: 'ptc_agent',
+  workspace_id: 'ws-x',
+  workspace_name: 'Analysis',
+  question: 'analyze the stock',
+  report_back: true,
+  tool_call_id: toolCallId,
+});
+
+/** Count content segments of a given type across every assistant message. */
+function countSegments(messages: readonly unknown[], type: string): number {
+  return messages
+    .filter((m): m is AssistantMessage => (m as AssistantMessage).role === 'assistant')
+    .reduce(
+      (n, m) => n + ((m.contentSegments as ContentSegment[] | undefined) || []).filter((s) => s.type === type).length,
+      0,
+    );
+}
+
+describe('useChatMessages — interrupt card de-dup by interrupt_id', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // clearAllMocks clears call history but NOT implementations — reset and
+    // re-seed the stream mocks so one test's emitter can't replay into the
+    // next test's mount (a leaked replay emitter injects phantom cards and
+    // pre-seeds the rendered-interrupt set).
+    mockReplay.mockReset();
+    mockReplay.mockResolvedValue(undefined);
+    mockSend.mockReset();
+    mockSendHitl.mockReset();
+    mockReconnect.mockReset();
+    mockReconnect.mockResolvedValue({ disconnected: false, aborted: false });
+    mockTurns.mockReset();
+    mockTurns.mockResolvedValue({ turns: [], retry_checkpoint_id: null });
+    mockStatus.mockReset();
+    mockStatus.mockResolvedValue({ can_reconnect: false, status: 'completed' });
+  });
+
+  it('history replay: a re-raised interrupt (same id, later turn) renders ONE card', async () => {
+    // Turn 0 raises two PTC-agent interrupts (nvidia + amd). The user answers amd
+    // on turn 1; nvidia stays pending, so turn 1's response RE-EMITS nvidia with
+    // the same interrupt_id on turn 1's bubble. Pre-fix that second emit appended
+    // a duplicate nvidia card (the reported 3-cards-for-2-interrupts bug).
+    const ptc = (interruptId: string, turn: number, question: string) => ({
+      event: 'interrupt',
+      turn_index: turn,
+      interrupt_id: interruptId,
+      action_requests: [{
+        type: 'ptc_agent',
+        workspace_id: 'ws-x',
+        workspace_name: 'Analysis',
+        question,
+        report_back: true,
+        tool_call_id: `tc-${interruptId}`,
+      }],
+    });
+
+    mockReplay.mockImplementation((_tid: string, onEvent: (e: Record<string, unknown>) => void) => {
+      onEvent({ event: 'user_message', turn_index: 0, content: 'compare nvidia and amd', role: 'user' });
+      onEvent(ptc('nvidia', 0, 'analyze nvidia'));
+      onEvent(ptc('amd', 0, 'analyze amd'));
+      // Resume turn: amd answered, nvidia re-raised (same id) on the new bubble.
+      onEvent({ event: 'user_message', turn_index: 1, content: '', role: 'user' });
+      onEvent(ptc('nvidia', 1, 'analyze nvidia'));
+      return Promise.resolve();
+    });
+
+    const { result } = renderHookWithProviders(() => useChatMessages('ws-x', 'th-x'));
+    await waitFor(() => expect(mockReplay).toHaveBeenCalled());
+    await settleMountEffect();
+
+    // Two distinct interrupts (nvidia + amd) → two cards, NOT three.
+    await waitFor(() => expect(countSegments(result.current.messages, 'ptc_agent')).toBe(2));
+
+    const nvidiaCards = result.current.messages
+      .filter((m): m is AssistantMessage => m.role === 'assistant')
+      .flatMap((m) => ((m.contentSegments as ContentSegment[] | undefined) || []))
+      .filter((s) => s.type === 'ptc_agent' && (s as { proposalId?: string }).proposalId === 'nvidia');
+    expect(nvidiaCards).toHaveLength(1);
+  });
+
+  it('live resume: a still-pending interrupt re-raised after HITL resume renders ONE card', async () => {
+    // Send → a plan_approval interrupt streams in (bubble A). The user approves;
+    // the resume stream lands on a fresh `assistant-hitl-*` bubble and RE-EMITS
+    // the same interrupt_id (LangGraph re-raising it). Pre-fix that painted a
+    // second plan card on the resume bubble.
+    const planInterrupt = {
+      event: 'interrupt',
+      interrupt_id: 'plan-1',
+      action_requests: [{ name: 'SubmitPlan', description: 'Step 1. Do the thing.' }],
+    };
+
+    mockSend.mockImplementation(async (...args: unknown[]) => {
+      const onEvent = args[5] as (e: Record<string, unknown>) => void;
+      onEvent(planInterrupt);
+      return { disconnected: false };
+    });
+
+    const { result } = renderHookWithProviders(() => useChatMessages('ws-x', 'th-x'));
+    await waitFor(() => expect(mockReplay).toHaveBeenCalled());
+    await settleMountEffect();
+
+    await act(async () => {
+      await result.current.handleSendMessage('make a plan', false);
+    });
+
+    // The first card is on screen and pending approval.
+    await waitFor(() => expect(countSegments(result.current.messages, 'plan_approval')).toBe(1));
+
+    // The resume re-raises the same still-pending interrupt on the new bubble.
+    mockSendHitl.mockImplementation(async (...args: unknown[]) => {
+      const onEvent = args[3] as (e: Record<string, unknown>) => void;
+      onEvent(planInterrupt);
+      return { disconnected: false, aborted: false };
+    });
+
+    await act(async () => {
+      result.current.handleApproveInterrupt();
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // The re-raise did NOT paint a twin: still exactly one plan card.
+    await waitFor(() => expect(mockSendHitl).toHaveBeenCalled());
+    await settleMountEffect();
+    expect(countSegments(result.current.messages, 'plan_approval')).toBe(1);
+    // ...and the suppression only dropped the CARD: the map write + pending
+    // tracking still ran, so the re-raised interrupt stays answerable.
+    expect(result.current.pendingInterrupt?.interruptId).toBe('plan-1');
+  });
+
+  it('interrupts without an interrupt_id are never deduped', async () => {
+    // Guard false-branch: id-less interrupt events skip dedup entirely — every
+    // occurrence renders its own card, and nothing is added to the rendered set.
+    mockSend.mockImplementation(async (...args: unknown[]) => {
+      const onEvent = args[5] as (e: Record<string, unknown>) => void;
+      onEvent({ event: 'interrupt', action_requests: [{ name: 'SubmitPlan', description: 'plan A' }] });
+      onEvent({ event: 'interrupt', action_requests: [{ name: 'SubmitPlan', description: 'plan B' }] });
+      return { disconnected: false };
+    });
+
+    const { result } = renderHookWithProviders(() => useChatMessages('ws-x', 'th-x'));
+    await waitFor(() => expect(mockReplay).toHaveBeenCalled());
+    await settleMountEffect();
+    await act(async () => {
+      await result.current.handleSendMessage('plan twice', false);
+    });
+
+    await waitFor(() => expect(countSegments(result.current.messages, 'plan_approval')).toBe(2));
+  });
+
+  it('reconnect: the stripped history card is re-rendered from the reconnect stream', async () => {
+    // Opening a thread whose workflow is still active strips the replay-rendered
+    // interrupt cards (the reconnect stream is authoritative and re-delivers
+    // them). The strip must RELEASE those ids from the rendered set — a stale
+    // entry would suppress the re-delivery, leaving the pending interrupt with
+    // no card anywhere (strip removed the only other copy) and unanswerable.
+    mockStatus.mockResolvedValue({
+      can_reconnect: true,
+      status: 'running',
+      run_id: 'run-1',
+      active_tasks: [],
+      pending_report_back: false,
+    });
+    mockReplay.mockImplementation((_tid: string, onEvent: (e: Record<string, unknown>) => void) => {
+      onEvent({ event: 'user_message', turn_index: 0, content: 'dispatch the agent', role: 'user' });
+      onEvent({ event: 'interrupt', turn_index: 0, interrupt_id: 'int-1', action_requests: [ptcAction('tc-int-1')] });
+      return Promise.resolve();
+    });
+    mockReconnect.mockImplementation(async (...args: unknown[]) => {
+      const onEvent = args[3] as (e: Record<string, unknown>) => void;
+      // The active run re-delivers the still-pending interrupt, same id.
+      onEvent({ event: 'interrupt', interrupt_id: 'int-1', action_requests: [ptcAction('tc-int-1')] });
+      return { disconnected: false, aborted: false };
+    });
+
+    const { result } = renderHookWithProviders(() => useChatMessages('ws-x', 'th-x'));
+    await waitFor(() => expect(mockReconnect).toHaveBeenCalled());
+    await settleMountEffect();
+
+    // Exactly one card: the strip removed the history copy, the reconnect
+    // stream repainted it (NOT suppressed by the dedup set).
+    await waitFor(() => expect(countSegments(result.current.messages, 'ptc_agent')).toBe(1));
+  });
+
+  it('edit of a later turn RETAINS the surviving earlier card id (re-raise stays suppressed)', async () => {
+    // Truncation rebuild, retain direction: editing turn 1 keeps turn 0's card
+    // on screen, so its id must SURVIVE the rebuild — the fork's re-raise of
+    // that id must stay suppressed or the transcript grows a duplicate card.
+    mockReplay.mockImplementation((_tid: string, onEvent: (e: Record<string, unknown>) => void) => {
+      onEvent({ event: 'user_message', turn_index: 0, content: 'dispatch the agent', role: 'user' });
+      onEvent({ event: 'interrupt', turn_index: 0, interrupt_id: 'int-keep', action_requests: [ptcAction('tc-keep')] });
+      onEvent({ event: 'user_message', turn_index: 1, content: 'and summarize', role: 'user' });
+      return Promise.resolve();
+    });
+    mockTurns.mockResolvedValue({
+      turns: [
+        { edit_checkpoint_id: 'ckpt-0', regenerate_checkpoint_id: 'ckpt-0r', turn_index: 0 },
+        { edit_checkpoint_id: 'ckpt-1', regenerate_checkpoint_id: 'ckpt-1r', turn_index: 1 },
+      ],
+      retry_checkpoint_id: null,
+    });
+    // The edit fork re-raises the surviving card's id.
+    mockSend.mockImplementation(async (...args: unknown[]) => {
+      const onEvent = args[5] as (e: Record<string, unknown>) => void;
+      onEvent({ event: 'interrupt', interrupt_id: 'int-keep', action_requests: [ptcAction('tc-keep')] });
+      return { disconnected: false };
+    });
+
+    const { result } = renderHookWithProviders(() => useChatMessages('ws-x', 'th-x'));
+    await waitFor(() => expect(mockReplay).toHaveBeenCalled());
+    await settleMountEffect();
+    await waitFor(() => expect(countSegments(result.current.messages, 'ptc_agent')).toBe(1));
+
+    const userMsgs = result.current.messages.filter((m) => m.role === 'user');
+    const laterUser = userMsgs[userMsgs.length - 1];
+    await act(async () => {
+      await result.current.handleEditMessage(laterUser.id, 'and compare to AMD');
+    });
+    await waitFor(() => expect(mockSend).toHaveBeenCalled());
+
+    // Still exactly one card: the surviving turn-0 card owns the id, the
+    // fork's re-raise did NOT paint a twin.
+    expect(countSegments(result.current.messages, 'ptc_agent')).toBe(1);
+  });
+
+  it('thread switch clears the rendered set so the next thread renders its own cards', async () => {
+    // Interrupt ids are only unique per thread. After switching threads, the
+    // prior thread's rendered set must not suppress the new thread's replay.
+    mockReplay.mockImplementation((_tid: string, onEvent: (e: Record<string, unknown>) => void) => {
+      onEvent({ event: 'user_message', turn_index: 0, content: 'dispatch', role: 'user' });
+      onEvent({ event: 'interrupt', turn_index: 0, interrupt_id: 'shared-id', action_requests: [ptcAction('tc-s')] });
+      return Promise.resolve();
+    });
+
+    let tid = 'th-A';
+    const { result, rerender } = renderHookWithProviders(() => useChatMessages('ws-x', tid));
+    await waitFor(() => expect(mockReplay).toHaveBeenCalled());
+    await settleMountEffect();
+    await waitFor(() => expect(countSegments(result.current.messages, 'ptc_agent')).toBe(1));
+
+    tid = 'th-B';
+    rerender();
+    await waitFor(() => expect(mockReplay).toHaveBeenCalledTimes(2));
+    await settleMountEffect();
+
+    // Thread B's card rendered — not suppressed by thread A's set.
+    await waitFor(() => expect(countSegments(result.current.messages, 'ptc_agent')).toBe(1));
+  });
+});

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -102,6 +102,32 @@ const PROPOSAL_DATA_KEY_MAP: Record<string, string> = {
 /** Secretary action interrupt types (for type guard in handlers). */
 const SECRETARY_ACTION_TYPES = new Set(['delete_workspace', 'stop_workspace', 'delete_thread']);
 
+/**
+ * Message-map buckets whose entries carry an `interruptId` (rendered HITL
+ * cards). `satisfies keyof AssistantMessage` makes a renamed/added bucket a
+ * compile error here instead of a silently-wrong dedup rebuild.
+ */
+const INTERRUPT_CARD_BUCKETS = [
+  'planApprovals', 'userQuestions', 'workspaceProposals',
+  'questionProposals', 'ptcAgentProposals', 'secretaryActionProposals',
+] as const satisfies readonly (keyof AssistantMessage)[];
+
+/** Collects the interrupt_ids of every HITL card rendered on the given messages. */
+function collectRenderedInterruptIds(messages: ChatMessage[]): Set<string> {
+  const ids = new Set<string>();
+  for (const m of messages) {
+    if (m.role !== 'assistant') continue;
+    for (const bucket of INTERRUPT_CARD_BUCKETS) {
+      const entries = m[bucket];
+      if (!entries) continue;
+      for (const entry of Object.values(entries)) {
+        if (entry?.interruptId) ids.add(entry.interruptId);
+      }
+    }
+  }
+  return ids;
+}
+
 /** Pending HITL interrupt state. */
 interface PendingInterrupt {
   type?: string;
@@ -670,6 +696,14 @@ export function useChatMessages(
   // Batch parallel interrupt responses: track all interrupt IDs in current batch
   // and collect individual responses until all are answered, then resume at once.
   const pendingInterruptIdsRef = useRef(new Set<string>());
+  // Thread-scoped set of interrupt_ids that already have a rendered card. An
+  // unanswered interrupt is re-raised by LangGraph with the SAME interrupt_id on
+  // every resume; each re-raise arrives on a later turn's bubble, so the per-map
+  // dedup (keyed by interrupt_id) never collides and a duplicate card would be
+  // appended. This ref survives resume (NOT cleared with pendingInterruptIdsRef),
+  // cleared only on thread switch / fresh history load. Shared by replay + live
+  // so a live re-raise after a history load dedupes against replayed cards too.
+  const renderedInterruptIdsRef = useRef(new Set<string>());
   const collectedHitlResponsesRef = useRef<Record<string, { decisions: Array<{ type: string; message?: string }> }>>({});
 
   // Track approved PTC agent proposals waiting for thread_id backfill from tool_call_result.
@@ -895,6 +929,9 @@ export function useChatMessages(
         turnCheckpointsRef.current = null;
         // The rendered-turn watermark belongs to the thread we're leaving.
         lastRenderedTurnIndexRef.current = null;
+        // Interrupt cards belong to the thread we're leaving; the next thread's
+        // replay repopulates this from its persisted interrupt events.
+        renderedInterruptIdsRef.current.clear();
       }
     }
   }, [workspaceId, initialThreadId]);
@@ -924,6 +961,10 @@ export function useChatMessages(
       // any in-flight streaming bubble survives the filter.
       historyMessagesRef.current.clear();
       newMessagesStartIndexRef.current = 0;
+      // A re-replay rebuilds every history bubble from persisted events, so the
+      // rendered-interrupt set must start empty and be repopulated by this pass;
+      // otherwise stale ids would suppress cards this replay legitimately renders.
+      renderedInterruptIdsRef.current.clear();
       setMessages((prev) => prev.filter((m) => !m.isHistory));
 
       // Fresh attach (refresh or thread switch): clear the live-stream cursor so
@@ -1628,11 +1669,21 @@ export function useChatMessages(
 
         // Handle interrupt events during history replay
         if (eventType === 'interrupt') {
+          // Skip a re-raised interrupt: LangGraph re-emits an unanswered
+          // interrupt with the same interrupt_id on every resume, landing on a
+          // later turn's bubble. The first occurrence owns the card (and its
+          // pendingHistoryInterrupts entry, which answer-replay resolves by id);
+          // re-emissions would append a duplicate card and a phantom pending
+          // entry, so drop them wholesale.
+          if (event.interrupt_id && renderedInterruptIdsRef.current.has(event.interrupt_id)) return;
           const pairIndex = event.turn_index ?? currentActivePairIndex;
           const interruptAssistantId = pairIndex != null ? assistantMessagesByPair.get(pairIndex) : null;
           const pairState = pairIndex != null ? pairStateByPair.get(pairIndex) : null;
 
           if (interruptAssistantId && pairState) {
+            // Mark rendered only once a card will actually attach — a pair-less
+            // event must not poison the set and drop a later valid re-raise.
+            if (event.interrupt_id) renderedInterruptIdsRef.current.add(event.interrupt_id);
             const actionRequests = event.action_requests || [];
             const actionType = actionRequests[0]?.type as string | undefined;
 
@@ -2250,6 +2301,14 @@ export function useChatMessages(
     // writes resolution status to where the proposal actually lives now.
     const stripList = unresolvedHistoryInterruptRef.current;
     if (stripList.length > 0) {
+      // Release the stripped ids from the rendered-interrupt set, synchronously
+      // before the stream opens: the reconnect stream re-delivers a still-pending
+      // interrupt with the same interrupt_id, and after this strip that
+      // re-delivery is the ONLY copy — a stale entry would suppress it and leave
+      // the interrupt with no card anywhere, unanswerable until a full reload.
+      for (const info of stripList) {
+        if (info.interruptId) renderedInterruptIdsRef.current.delete(info.interruptId);
+      }
       const stripsByMsgId = new Map<string, HistoryInterruptInfo[]>();
       for (const info of stripList) {
         const arr = stripsByMsgId.get(info.assistantMessageId) || [];
@@ -4069,6 +4128,23 @@ export function useChatMessages(
         const actionRequests = event.action_requests || [];
         const actionType = actionRequests[0]?.type as string | undefined;
 
+        // A still-pending interrupt re-raised after a HITL resume streams into a
+        // fresh `assistant-hitl-*` bubble with the same interrupt_id. Suppress the
+        // duplicate CARD (the segment push) while keeping the map write + pending
+        // tracking below, so the original card stays answerable and the resume's
+        // pending set (cleared at resume start) still re-tracks it.
+        const interruptAlreadyRendered = event.interrupt_id
+          ? renderedInterruptIdsRef.current.has(event.interrupt_id)
+          : false;
+        if (event.interrupt_id) renderedInterruptIdsRef.current.add(event.interrupt_id);
+        // Every branch below MUST push its card segment through this helper so
+        // the re-raise suppression can't be forgotten on a future interrupt type.
+        const appendCardSegment = (
+          segs: AssistantMessage['contentSegments'] | undefined,
+          seg: AssistantMessage['contentSegments'][number],
+        ): AssistantMessage['contentSegments'] =>
+          interruptAlreadyRendered ? (segs || []) : [...(segs || []), seg];
+
         if (actionType === 'ask_user_question') {
           // --- User question interrupt ---
           const questionId = event.interrupt_id || `question-${Date.now()}`;
@@ -4078,10 +4154,7 @@ export function useChatMessages(
           setMessages((prev) =>
             updateMessage(prev,assistantMessageId, (m) => { if (m.role !== 'assistant') return m; const msg = m as AssistantMessage; return {
               ...msg,
-              contentSegments: [
-                ...(msg.contentSegments || []),
-                { type: 'user_question', questionId, order },
-              ],
+              contentSegments: appendCardSegment(msg.contentSegments, { type: 'user_question', questionId, order }),
               userQuestions: {
                 ...(msg.userQuestions || {}),
                 [questionId]: {
@@ -4113,10 +4186,7 @@ export function useChatMessages(
           setMessages((prev) =>
             updateMessage(prev,assistantMessageId, (m) => { if (m.role !== 'assistant') return m; const msg = m as AssistantMessage; return {
               ...msg,
-              contentSegments: [
-                ...(msg.contentSegments || []),
-                { type: 'create_workspace', proposalId, order },
-              ],
+              contentSegments: appendCardSegment(msg.contentSegments, { type: 'create_workspace', proposalId, order }),
               workspaceProposals: {
                 ...(msg.workspaceProposals || {}),
                 [proposalId]: {
@@ -4146,10 +4216,7 @@ export function useChatMessages(
           setMessages((prev) =>
             updateMessage(prev,assistantMessageId, (m) => { if (m.role !== 'assistant') return m; const msg = m as AssistantMessage; return {
               ...msg,
-              contentSegments: [
-                ...(msg.contentSegments || []),
-                { type: 'start_question', proposalId, order },
-              ],
+              contentSegments: appendCardSegment(msg.contentSegments, { type: 'start_question', proposalId, order }),
               questionProposals: {
                 ...(msg.questionProposals || {}),
                 [proposalId]: {
@@ -4179,10 +4246,7 @@ export function useChatMessages(
           setMessages((prev) =>
             updateMessage(prev,assistantMessageId, (m) => { if (m.role !== 'assistant') return m; const msg = m as AssistantMessage; return {
               ...msg,
-              contentSegments: [
-                ...(msg.contentSegments || []),
-                { type: 'ptc_agent' as const, proposalId, order },
-              ],
+              contentSegments: appendCardSegment(msg.contentSegments, { type: 'ptc_agent' as const, proposalId, order }),
               ptcAgentProposals: {
                 ...(msg.ptcAgentProposals || {}),
                 [proposalId]: {
@@ -4219,10 +4283,7 @@ export function useChatMessages(
           setMessages((prev) =>
             updateMessage(prev,assistantMessageId, (m) => { if (m.role !== 'assistant') return m; const msg = m as AssistantMessage; return {
               ...msg,
-              contentSegments: [
-                ...(msg.contentSegments || []),
-                { type: actionType as 'delete_workspace' | 'stop_workspace' | 'delete_thread', proposalId, order },
-              ],
+              contentSegments: appendCardSegment(msg.contentSegments, { type: actionType as 'delete_workspace' | 'stop_workspace' | 'delete_thread', proposalId, order }),
               secretaryActionProposals: {
                 ...(msg.secretaryActionProposals || {}),
                 [proposalId]: {
@@ -4257,10 +4318,7 @@ export function useChatMessages(
           setMessages((prev) =>
             updateMessage(prev,assistantMessageId, (m) => { if (m.role !== 'assistant') return m; const msg = m as AssistantMessage; return {
               ...msg,
-              contentSegments: [
-                ...(msg.contentSegments || []),
-                { type: 'plan_approval', planApprovalId, order },
-              ],
+              contentSegments: appendCardSegment(msg.contentSegments, { type: 'plan_approval', planApprovalId, order }),
               planApprovals: {
                 ...(msg.planApprovals || {}),
                 [planApprovalId]: {
@@ -4992,27 +5050,36 @@ export function useChatMessages(
         const finalId = currentMessageRef.current || assistantMessageId;
         cleanupAfterStreamEnd(finalId);
       }
+      // NOTE: an `assistant-hitl-*` bubble that finalizes empty (content landed
+      // elsewhere, or the turn re-interrupted and the re-raise was deduped) must
+      // NOT be pruned from state: a HITL resume is a backend turn, and
+      // edit/regenerate map UI position → turn_index by counting non-steering
+      // assistant bubbles. MessageList hides empty settled bubbles instead.
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [workspaceId, threadId, updateTodoListCard, updateSubagentCard, inactivateAllSubagents, finalizePendingTodos]);
 
   const handleApproveInterrupt = useCallback(() => {
     if (!pendingInterrupt) return;
-    const { interruptId, assistantMessageId, planApprovalId, planMode } = pendingInterrupt;
+    const { interruptId, planApprovalId, planMode } = pendingInterrupt;
     const approvalId = planApprovalId!;
 
-    // Update plan card status to "approved"
+    // Flip the plan card to "approved" wherever it lives (mirrors
+    // resolveProposal): a deduped re-raise can point pendingInterrupt at a
+    // hidden resume bubble, so a single-bubble write could miss the visible card.
     setMessages((prev) =>
-      updateMessage(prev,assistantMessageId!, (m) => { if (m.role !== 'assistant') return m; const msg = m as AssistantMessage; return {
-        ...msg,
-        planApprovals: {
-          ...(msg.planApprovals || {}),
-          [approvalId]: {
-            ...(msg.planApprovals?.[approvalId] || {}),
-            status: 'approved',
+      prev.map((m) => {
+        if (m.role !== 'assistant') return m;
+        const msg = m as AssistantMessage;
+        if (!msg.planApprovals?.[approvalId]) return m;
+        return {
+          ...msg,
+          planApprovals: {
+            ...msg.planApprovals,
+            [approvalId]: { ...msg.planApprovals[approvalId], status: 'approved' },
           },
-        },
-      }; })
+        };
+      })
     );
 
     const hitlResponse = {
@@ -5023,21 +5090,23 @@ export function useChatMessages(
 
   const handleRejectInterrupt = useCallback(() => {
     if (!pendingInterrupt) return;
-    const { interruptId, assistantMessageId, planApprovalId, planMode } = pendingInterrupt;
+    const { interruptId, planApprovalId, planMode } = pendingInterrupt;
     const approvalId = planApprovalId!;
 
-    // Update plan card status to "rejected"
+    // Flip the plan card to "rejected" wherever it lives (see approve above).
     setMessages((prev) =>
-      updateMessage(prev,assistantMessageId!, (m) => { if (m.role !== 'assistant') return m; const msg = m as AssistantMessage; return {
-        ...msg,
-        planApprovals: {
-          ...(msg.planApprovals || {}),
-          [approvalId]: {
-            ...(msg.planApprovals?.[approvalId] || {}),
-            status: 'rejected',
+      prev.map((m) => {
+        if (m.role !== 'assistant') return m;
+        const msg = m as AssistantMessage;
+        if (!msg.planApprovals?.[approvalId]) return m;
+        return {
+          ...msg,
+          planApprovals: {
+            ...msg.planApprovals,
+            [approvalId]: { ...msg.planApprovals[approvalId], status: 'rejected' },
           },
-        },
-      }; })
+        };
+      })
     );
 
     // Store interruptId + planMode so next handleSendMessage routes as rejection feedback
@@ -5304,6 +5373,16 @@ export function useChatMessages(
       recentlySentTrackerRef.current.track(message!.trim(), userMessage.timestamp, userMessage.id);
     }
 
+    // Rebuild the rendered-interrupt set from the cards that survive the
+    // truncation. The fork re-executes the turn server-side, and LangGraph
+    // interrupt ids are deterministic — the new run can legitimately re-raise
+    // the id of a card this truncation removes; a stale entry would suppress
+    // the new card and leave the interrupt unanswerable. Done synchronously
+    // (not in the setMessages updater) so the first stream event can't race
+    // the rebuild. `messages` here is the same render snapshot the caller
+    // computed truncateIndex against.
+    renderedInterruptIdsRef.current = collectRenderedInterruptIds(messages.slice(0, truncateIndex));
+
     setMessages((prev) => {
       const truncated = prev.slice(0, truncateIndex);
       const newMsgs = userMessage
@@ -5413,8 +5492,10 @@ export function useChatMessages(
         cleanupAfterStreamEnd(finalId);
       }
     }
+  // `messages` is a real dep: the rendered-interrupt rebuild above needs the
+  // same render snapshot the caller computed truncateIndex against.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [workspaceId, threadId, agentMode]);
+  }, [messages, workspaceId, threadId, agentMode]);
 
   /**
    * Edit a user message: truncate to before that message, send modified content


### PR DESCRIPTION
## Summary

**Interrupt-card dedup** (`c93f6da6`): LangGraph re-raises an UNANSWERED interrupt with the SAME `interrupt_id` on every resume. The web transcript rendered each re-raise as a fresh approval card — a thread with 2 real interrupts showed 3 cards, one of them duplicated. A thread-scoped `renderedInterruptIdsRef` now dedupes cards in both the history-replay and live-stream paths:

- **Replay**: a re-raised id skips the whole branch (first occurrence owns the card and its pending-answer entry).
- **Live**: a re-raised id suppresses only the card segment via a shared `appendCardSegment` helper; the map write + pending tracking still run, so the interrupt stays answerable through the original card.
- **Truncation** (edit/regenerate): the set is rebuilt from surviving cards, synchronously before the fork stream opens — forks legitimately re-raise a truncated card's id (ids are deterministic), and a stale entry would suppress the new card.
- **Reconnect**: the reconnect flow strips replay-rendered cards (the reconnect stream is authoritative and re-delivers them); the strip now releases those ids so the re-delivery repaints instead of being suppressed.
- **Safety**: `interrupt_id = xxh3_128(task_checkpoint_ns)` folds in the per-turn checkpoint uuid — distinct interrupts in different turns can never collide, re-raises are byte-identical (verified from source and empirically). The set never needs clearing on normal sends.

**Orphan-bubble suppression** (`c93f6da6`): an assistant bubble that settles with nothing renderable used to paint a bare avatar + copy/thumbs/regenerate row. Such bubbles (a HITL resume whose content landed elsewhere, or a turn whose only event was a deduped re-raise) must STAY in state — edit/regenerate map UI position → backend `turn_index` by positionally counting assistant bubbles — so they are now hidden at render time via `isOrphanAssistantMessage()` in `MessageList` instead of being pruned. Streaming, stopped, errored, and Sources-pill bubbles are unaffected.

**Review hardening** (`c93f6da6`, from this ship's review pipeline): replay marks an id as rendered only once a card actually attaches (a pair-less event can't poison the set); `INTERRUPT_CARD_BUCKETS` is typed `satisfies keyof AssistantMessage` (bucket drift = compile error); plan approve/reject flip the card wherever it lives (mirrors `resolveProposal`) instead of writing to a single bubble.

**Tests** (`26803a96`): 12 regression tests across 3 new files; each core protection was verified to fail with its fix neutralized.

## Overview

| | Files | Lines |
|---|---|---|
| Modified (non-test) | 2 | +156 / −47 |
| New (tests) | 3 | +613 |
| **Net (excl. tests)** | **2** | **+156 / −47** |

**By module**

- **Frontend — ChatAgent hook** (`web/src/pages/ChatAgent/hooks/useChatMessages.ts`, modified +133/−47): dedup set + full lifecycle (thread-switch/history-load clear, truncation rebuild, reconnect-strip release, mark-on-attach), `appendCardSegment` helper across all six live interrupt branches, typed `INTERRUPT_CARD_BUCKETS`, iterate-all plan approve/reject.
- **Frontend — ChatAgent components** (`web/src/pages/ChatAgent/components/MessageList.tsx`, modified +23): exported `isOrphanAssistantMessage()` predicate + render-guard call site, with the renderability invariant documented.
- **Tests** (new): `useChatMessages.interruptDedup.test.ts` (6 — replay/live/reconnect dedup, truncation retain, thread-switch, id-less), `useChatMessages.emptyBubble.test.ts` (3 — turn integrity, truncation release), `MessageList.orphanBubble.test.tsx` (3 — suppression + keep-cases).

**What this introduces:** users of cross-channel (Slack/web) HITL threads see exactly one card per real interrupt across replay, live resumes, reconnects, and edit/regenerate forks; no more orphan avatar bubbles; and edit/regenerate keep forking from the correct checkpoint.

## Diff Size

- Total: 5 files changed, 769 insertions(+), 47 deletions(-)
- Net (excl. tests): 2 files changed, 156 insertions(+), 47 deletions(-)

## Test Coverage

Tests: 2100 → 2112 (+12 new, 3 new files). AI-audited coverage of new/changed paths: **~85%** (gate PASS, target 80%).

```
isOrphanAssistantMessage        8/8 branches ★★★ (incl. keep-cases: streaming/stopped/error/sources)
replay dedup                    skip + first-render + mark-on-attach ★★★
live dedup (6 branches)         suppress-decision shared via appendCardSegment → plan-path test
                                covers all types by construction; answerability asserted ★★★
truncation rebuild              RELEASE (edit turn-0) ★★★ + RETAIN (edit turn-1) ★★★
reconnect strip release         re-delivery repaints, fail-without-fix proven ★★★
thread-switch clear             ★★★        id-less interrupts never deduped ★★★
Remaining gaps: pre-existing per-type render branches (unchanged code), exercised indirectly.
```

## Pre-Landing Review

11 findings, 0 critical, all informational — 8 fixed, 3 verified no-change-needed/skipped:

- **[FIXED]** maint: `INTERRUPT_CARD_BUCKETS` untyped duplication risk → `satisfies keyof AssistantMessage`
- **[FIXED]** maint: `as unknown as` double-cast in `collectRenderedInterruptIds` → typed narrowing
- **[FIXED]** maint: suppression ternary copy-pasted ×6 → `appendCardSegment` helper
- **[FIXED]** maint+Codex (multi-specialist confirmed): replay marked id before render guard → mark-on-attach
- **[FIXED]** testing: `vi.clearAllMocks()` leaked mock implementations across tests (runtime-proven) → reset + re-seed per test
- **[FIXED]** testing: truncation test only proved RELEASE direction → retain test added
- **[FIXED]** testing: live-dedup test didn't assert answerability → `pendingInterrupt` assert added
- **[FIXED]** testing: id-less interrupt guard untested → dedup-skip test added
- **[NO CHANGE]** perf: `messages` in `streamFromCheckpoint` deps — verified zero re-render delta (all consumers already dep on `messages`; nothing memoizes on the callback identity)
- **[NO CHANGE]** perf: per-message orphan predicate — O(1) short-circuits, allocation only on rare orphan candidates
- **[SKIPPED]** maint (low-conf): shared test fixtures → harness

## Adversarial Review

**Codex** (5 findings): **1 confirmed regression — fixed + regression-tested**: reconnect strips replay cards while the dedup set still held their ids → the authoritative re-delivery was suppressed → pending interrupt unanswerable until reload. Also: mark-before-attach (fixed, above); pendingInterrupt single-slot staleness (pre-existing, now moot via iterate-all approve/reject); dedup-key-never-expires (disproven — ids are turn-unique by construction); orphan predicate hiding map-only bubbles (derivative — map entries without segments render nothing).

**Claude adversarial**: verdict *sound, ship-able*. Disproved the id-collision risk from LangGraph source + an empirical 3-turn repro. Belt-and-suspenders items F1 (iterate-all plan status) and F3 (invariant comment) both taken. Specifically failed to break: thread-switch mid-stream, edit stale-closure race, turn-index counting with hidden orphans, loading placeholders.

## Design Review

Design Review (lite): clean — no CSS changes; verified no layout jank from render-suppression (no AnimatePresence around the message map) and no lost renderable state (attachments/widgets are user-bubble-only).

## Eval Results

No prompt-related files changed — evals skipped.

## Scope Drift

Scope Check: CLEAN. Intent: dedupe interrupt cards by interrupt_id (replay + live, with tests). Delivered: that, plus two directly-coupled correctness pieces (orphan render suppression — explicit user request; truncation/reconnect lifecycle — required for the dedup to be safe).

## Plan Completion

- [x] Replay-path dedup by interrupt_id
- [x] Live-path dedup (re-raise updates, never appends)
- [x] Regression tests ("complete" scope)
- [x] Orphan bubble fix (user-added scope)
- [x] Truncation staleness rebuild
- [ ] SharedChatView replay dedup — **deferred** (public shared-transcript view can still show duplicate cards; read-only/cosmetic; separate follow-up pending approval)

FYI (backend, out of scope): `streaming_handler._handle_interrupt` reads only `__interrupt__[0]`; parallel interrupts arrive as separate events today, but this is a latent single-interrupt-per-event cap.

## Verification Results

Skipped browser verification — no dev server running; behavior is pinned by the 12 hook/component regression tests instead.

## Documentation

No documentation updates needed — internal frontend rendering behavior; nothing in README/CLAUDE.md documents HITL card rendering.

## Test plan

- [x] Full frontend suite: 191 files / 2112 tests pass (fresh run, post-all-fixes)
- [x] `tsc --noEmit` clean; ESLint clean on all changed files
- [x] Each protection proven to fail with its fix neutralized (dedup, orphan guard, reconnect release)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate interrupt/approval cards from appearing when the same step is resumed, reloaded, or reconnected.
  * Hidden empty assistant bubbles that have no visible content, reducing clutter in chat threads.
  * Kept approval/rejection statuses in sync with the visible card even after edits or thread changes.

* **Tests**
  * Added coverage for empty bubble suppression and interrupt card de-duplication across resume, reconnect, and edit flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->