### PR TITLE
fix(dispatch): fail loud when INTERNAL_SERVICE_TOKEN is unset instead of burning credits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -127,6 +127,13 @@ AUTH_USER_ID=local-dev-user
 # Set to your public-facing URL in production (e.g. https://app.example.com)
 # SERVER_BASE_URL=http://localhost:8000
 
+# Shared secret authenticating internal service-to-service calls (the backend
+# dispatching PTC/report-back workflows to its own /messages endpoint). REQUIRED
+# for background dispatch: when unset, dispatch cannot be authenticated and the
+# workflow runs in the foreground, burning model credits with no result.
+# Generate manually: openssl rand -hex 32
+INTERNAL_SERVICE_TOKEN=
+
 # =============================================================================
 # Infrastructure — controls whether Docker Compose starts PostgreSQL and Redis
 # =============================================================================

--- a/src/server/handlers/chat/report_back.py
+++ b/src/server/handlers/chat/report_back.py
@@ -958,6 +958,21 @@ async def _post_report_back(
 
     self_base_url = os.environ.get("GINLIXFLOW_BASE_URL", "http://localhost:8000")
     service_token = os.environ.get("INTERNAL_SERVICE_TOKEN", "")
+    # Same invariant as the ptc_agent dispatch tool: report-back POSTs to the
+    # internal /messages endpoint with ``X-Dispatch: background``, honoured only
+    # when ``INTERNAL_SERVICE_TOKEN`` matches. With the token unset the endpoint
+    # runs the flash summary in the *foreground* and streams SSE, burning
+    # credits for a report-back the caller can never consume. Drop loudly rather
+    # than dispatch a doomed, credit-burning request.
+    if not service_token.strip():
+        logger.error(
+            "[FLASH_REPORT_BACK] INTERNAL_SERVICE_TOKEN is not set; cannot "
+            "dispatch report-back for PTC thread %s without burning credits on "
+            "a foreground run. Set INTERNAL_SERVICE_TOKEN on the backend "
+            "service.",
+            ptc_thread_id,
+        )
+        return "drop", None
     ws_label = origin.get("ptc_workspace_id") or "an auto-created workspace"
     message = (
         "<system>\n"

--- a/src/tools/secretary/tools.py
+++ b/src/tools/secretary/tools.py
@@ -407,6 +407,27 @@ async def ptc_agent(
     if not user_id:
         return _error_command("user_id not found in config", tool_call_id)
 
+    # A PTC dispatch is delivered by POSTing to the internal /messages endpoint
+    # with ``X-Dispatch: background``. That header is only honoured when the
+    # request also carries a matching ``INTERNAL_SERVICE_TOKEN`` (see
+    # ``is_internal`` in src/server/app/threads.py). When the token is unset the
+    # endpoint silently downgrades to a *foreground* SSE stream: it runs the
+    # full PTC workflow synchronously (minutes, many LLM calls) and returns
+    # ``text/event-stream`` -- which this tool cannot parse as the JSON dispatch
+    # ack, so the user sees ``dispatch_failed`` while model credits are burned
+    # for a result that is never delivered. A dispatch that can never be
+    # honoured as background is a deployment misconfiguration; fail loud here
+    # instead of firing a doomed, credit-burning request.
+    if not os.environ.get("INTERNAL_SERVICE_TOKEN", "").strip():
+        logger.error(
+            "PTC dispatch aborted: INTERNAL_SERVICE_TOKEN is not set. Without "
+            "it the background dispatch cannot be authenticated and the "
+            "workflow would run in the foreground, burning credits with no "
+            "result. Set INTERNAL_SERVICE_TOKEN on the backend service to "
+            "enable dispatch."
+        )
+        return _error_command("internal_service_token_missing", tool_call_id)
+
     is_continuation = thread_id is not None
 
     # Resolve workspace_id from existing thread or create/verify workspace

--- a/tests/unit/server/handlers/chat/test_post_report_back.py
+++ b/tests/unit/server/handlers/chat/test_post_report_back.py
@@ -159,3 +159,15 @@ async def test_busy_wait_cap_exhausted_returns_drop():
         )
     assert outcome == ("drop", None)
     assert session.post_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# A configured INTERNAL_SERVICE_TOKEN is the normal production state and is now
+# a precondition for dispatch (the ptc_agent / _post_report_back preflight guard
+# aborts without it, to avoid a silent foreground credit burn). These tests
+# exercise the dispatch path itself, not the guard, so give the whole module a
+# token. The dedicated guard test module asserts the unset behaviour separately.
+# ---------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def _internal_service_token(monkeypatch):
+    monkeypatch.setenv("INTERNAL_SERVICE_TOKEN", "test-internal-service-token")

--- a/tests/unit/tools/secretary/test_dispatch_service_token_guard.py
+++ b/tests/unit/tools/secretary/test_dispatch_service_token_guard.py
@@ -1,0 +1,103 @@
+"""Internal-service-token preflight guard on background dispatch.
+
+A background dispatch (``X-Dispatch: background``) is only honoured by the
+/messages endpoint when the request carries a matching ``INTERNAL_SERVICE_TOKEN``
+(``is_internal`` in src/server/app/threads.py). With the token unset the
+endpoint silently downgrades to a *foreground* SSE stream that runs the whole
+workflow synchronously and burns model credits for a result the caller can
+never parse. Both internal dispatch call sites must therefore refuse to fire a
+dispatch they can't have honoured, rather than degrade into that credit sink.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.server.handlers.chat import report_back as rb
+from src.tools.secretary.tools import ptc_agent
+
+USER_ID = "user-1"
+FLASH_THREAD_ID = "flash-thread-1"
+PTC_THREAD_ID = "ptc-thread-1"
+
+
+def _tool_call(args: dict, call_id: str = "call_test") -> dict:
+    return {"name": "ptc_agent", "args": args, "id": call_id, "type": "tool_call"}
+
+
+def _config() -> dict:
+    return {"configurable": {"user_id": USER_ID, "thread_id": FLASH_THREAD_ID}}
+
+
+def _payload(result) -> dict:
+    return json.loads(result.update["messages"][0].content)
+
+
+@pytest.mark.asyncio
+async def test_ptc_agent_aborts_when_service_token_unset(monkeypatch):
+    """ptc_agent must fail loud (no HTTP, no workspace) when the token is unset:
+    firing the dispatch would run the workflow foreground and burn credits."""
+    monkeypatch.delenv("INTERNAL_SERVICE_TOKEN", raising=False)
+
+    # If any of these run, the guard failed to short-circuit early enough.
+    with patch(
+        "src.tools.secretary.tools._hitl_confirm",
+        side_effect=AssertionError("HITL must not be reached"),
+    ), patch(
+        "aiohttp.ClientSession",
+        MagicMock(side_effect=AssertionError("dispatch HTTP must not run")),
+    ), patch(
+        "src.server.services.workspace_manager.WorkspaceManager.get_instance",
+        MagicMock(side_effect=AssertionError("workspace must not be created")),
+    ):
+        result = await ptc_agent.ainvoke(
+            _tool_call({"question": "analyze this"}), config=_config()
+        )
+
+    payload = _payload(result)
+    assert payload["success"] is False
+    assert payload["error"] == "internal_service_token_missing"
+
+
+@pytest.mark.asyncio
+async def test_ptc_agent_blank_service_token_is_treated_as_unset(monkeypatch):
+    """A whitespace-only token is not a real secret -> still aborts."""
+    monkeypatch.setenv("INTERNAL_SERVICE_TOKEN", "   ")
+    with patch(
+        "src.tools.secretary.tools._hitl_confirm",
+        side_effect=AssertionError("HITL must not be reached"),
+    ), patch(
+        "aiohttp.ClientSession",
+        MagicMock(side_effect=AssertionError("dispatch HTTP must not run")),
+    ):
+        result = await ptc_agent.ainvoke(
+            _tool_call({"question": "analyze this"}), config=_config()
+        )
+
+    assert _payload(result)["error"] == "internal_service_token_missing"
+
+
+@pytest.mark.asyncio
+async def test_report_back_drops_when_service_token_unset(monkeypatch):
+    """The report-back dispatcher drops (no retry, no HTTP) when unset."""
+    monkeypatch.delenv("INTERNAL_SERVICE_TOKEN", raising=False)
+
+    origin = {
+        "user_id": USER_ID,
+        "flash_workspace_id": "ws-flash",
+        "ptc_workspace_id": "ws-ptc",
+    }
+    cache = MagicMock()  # guard returns before cache is touched
+    with patch(
+        "aiohttp.ClientSession",
+        MagicMock(side_effect=AssertionError("report-back HTTP must not run")),
+    ):
+        status, run_id = await rb._post_report_back(
+            cache, FLASH_THREAD_ID, PTC_THREAD_ID, origin
+        )
+
+    assert status == "drop"
+    assert run_id is None

--- a/tests/unit/tools/secretary/test_dispatch_workspace_cleanup.py
+++ b/tests/unit/tools/secretary/test_dispatch_workspace_cleanup.py
@@ -223,3 +223,15 @@ async def test_dispatch_timeout_keeps_auto_created_workspace(cache):
     assert payload["error"] == "dispatch_timeout"
     mgr.create_workspace.assert_awaited_once()
     mgr.delete_workspace.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# A configured INTERNAL_SERVICE_TOKEN is the normal production state and is now
+# a precondition for dispatch (the ptc_agent / _post_report_back preflight guard
+# aborts without it, to avoid a silent foreground credit burn). These tests
+# exercise the dispatch path itself, not the guard, so give the whole module a
+# token. The dedicated guard test module asserts the unset behaviour separately.
+# ---------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def _internal_service_token(monkeypatch):
+    monkeypatch.setenv("INTERNAL_SERVICE_TOKEN", "test-internal-service-token")

--- a/tests/unit/tools/secretary/test_ptc_agent_continuation.py
+++ b/tests/unit/tools/secretary/test_ptc_agent_continuation.py
@@ -330,3 +330,15 @@ async def test_continuation_non_uuid_thread_id_short_circuits():
     assert "thread not found" in payload.get("error", ""), payload
     owner.assert_not_awaited()
     by_id.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# A configured INTERNAL_SERVICE_TOKEN is the normal production state and is now
+# a precondition for dispatch (the ptc_agent / _post_report_back preflight guard
+# aborts without it, to avoid a silent foreground credit burn). These tests
+# exercise the dispatch path itself, not the guard, so give the whole module a
+# token. The dedicated guard test module asserts the unset behaviour separately.
+# ---------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def _internal_service_token(monkeypatch):
+    monkeypatch.setenv("INTERNAL_SERVICE_TOKEN", "test-internal-service-token")


### PR DESCRIPTION
## Problem

Running LangAlpha with an OAuth/subscription token, PTC dispatches consumed model credits but returned no output: the chat reported `dispatch_failed` while a full research workflow ran to completion in the background (observed: a single dispatch ran 34 minutes across 70 LLM calls). On OAuth/subscription tokens the spend is not tracked in the internal usage meter, so it stays invisible until the provider bill arrives.

## Root cause

Internal background dispatch (`X-Dispatch: background`) to `POST /api/v1/threads/{id}/messages` is only honoured when the request carries a matching `INTERNAL_SERVICE_TOKEN` (`is_internal` in `src/server/app/threads.py`). The dispatching caller (`ptc_agent` in `src/tools/secretary/tools.py`, and `_post_report_back` in `src/server/handlers/chat/report_back.py`) expects a JSON `{"status": "dispatched"}` ack and returns immediately.

When `INTERNAL_SERVICE_TOKEN` is unset the endpoint does not fail: it silently downgrades to the normal **foreground** path and returns a `text/event-stream` (SSE) `StreamingResponse`. That has two effects:

1. The full PTC/flash workflow runs synchronously in that request (minutes, many LLM calls), burning credits.
2. The caller cannot parse the SSE body as the JSON ack, so it reports `dispatch_failed` and the user sees nothing.

`INTERNAL_SERVICE_TOKEN` was also undocumented (absent from `.env.example`), so the default state of a fresh local deployment is exactly this silent credit sink.

## Fix

A dispatch that can never be honoured as background is a deployment misconfiguration, so fail loud at the source instead of firing a doomed, credit-burning request:

- `ptc_agent` aborts with `internal_service_token_missing` (before HITL / workspace creation) when the token is unset.
- `_post_report_back` drops (no retry, no HTTP) when the token is unset.
- Document `INTERNAL_SERVICE_TOKEN` in `.env.example`, noting it is required for background dispatch.

This is intentionally client-side. The endpoint still gracefully ignores a stray `X-Dispatch` header from a non-internal caller (existing `test_threads_authz.py` behaviour is unchanged); the guards only stop the internal callers from firing a request they know cannot be honoured.

## Tests

- New `test_dispatch_service_token_guard.py` pins the unset/blank-token abort for both call sites (no HTTP, no workspace side effects).
- Existing dispatch tests (`test_dispatch_workspace_cleanup.py`, `test_ptc_agent_continuation.py`, `test_post_report_back.py`) now set a token via a module autouse fixture, since a configured token is the normal production state and passing the new precondition is required to exercise the dispatch path.
- Full affected set: 60 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added safeguards so background dispatch now stops early when required internal authentication is missing, preventing unintended foreground runs and wasted processing.
  * Improved error handling to return a clear failure instead of attempting a dispatch that can’t be authenticated.

* **Documentation**
  * Updated the environment setup example to include the new required configuration and guidance.

* **Tests**
  * Expanded test coverage for missing/blank authentication and updated existing tests to run with the required test configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->