### PR TITLE
fix(dispatch): reject unauthenticated background dispatch instead of running foreground

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -127,6 +127,14 @@ AUTH_USER_ID=local-dev-user
 # Set to your public-facing URL in production (e.g. https://app.example.com)
 # SERVER_BASE_URL=http://localhost:8000
 
+# Shared secret authenticating internal service-to-service calls (the backend
+# dispatching PTC/report-back workflows to its own /messages endpoint).
+# Required when HOST_MODE=platform; in oss mode the self-dispatch is trusted
+# without it. An unauthenticated background dispatch is rejected with 403,
+# never run in the foreground.
+# Generate manually: openssl rand -hex 32
+# INTERNAL_SERVICE_TOKEN=
+
 # =============================================================================
 # Infrastructure — controls whether Docker Compose starts PostgreSQL and Redis
 # =============================================================================

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -30,6 +30,15 @@ from src.config.env import (  # noqa: F401
 logger = logging.getLogger(__name__)
 
 
+def background_dispatch_requires_token() -> bool:
+    """True when auth is enabled but no INTERNAL_SERVICE_TOKEN is configured.
+
+    Internal background dispatch is rejected with 403 in that state, so callers
+    must not fire one. In oss mode the self-dispatch is trusted without a token.
+    """
+    return HOST_MODE != "oss" and not os.environ.get("INTERNAL_SERVICE_TOKEN", "").strip()
+
+
 # =============================================================================
 # Application Settings — delegates to InfrastructureConfig
 # =============================================================================

--- a/src/server/app/threads.py
+++ b/src/server/app/threads.py
@@ -574,10 +574,33 @@ async def _handle_send_message(
         #   debt from past platform usage, e.g. fallback routing).
         await enforce_credit_limit(user_id, byok=is_byok)
 
-        # Only honour X-Dispatch: background for internal service-to-service calls.
+        # Only honour X-Dispatch: background for internal service-to-service
+        # calls. In oss mode with no INTERNAL_SERVICE_TOKEN configured there is
+        # nothing to authenticate against, so the self-dispatch is trusted; a
+        # configured token is enforced in every mode.
         _req_token = (raw_request.headers.get("X-Service-Token", "") if raw_request else "")
         _svc_token = _get_service_token()
-        is_internal = bool(_svc_token and _req_token and hmac.compare_digest(_req_token, _svc_token))
+        is_internal = bool(
+            _svc_token and _req_token and hmac.compare_digest(_req_token, _svc_token)
+        ) or (HOST_MODE == "oss" and not _svc_token)
+
+        # An unauthenticated background dispatch is rejected, not silently
+        # downgraded to a foreground SSE run (which would execute the whole
+        # workflow synchronously and burn credits for an ack the caller can
+        # never parse).
+        if (
+            not is_internal
+            and raw_request
+            and raw_request.headers.get("X-Dispatch") == "background"
+        ):
+            raise HTTPException(
+                status_code=403,
+                detail=(
+                    "Background dispatch requires internal service auth. "
+                    "Configure INTERNAL_SERVICE_TOKEN and send it as "
+                    "X-Service-Token."
+                ),
+            )
 
         # Strip internal-only fields from non-internal requests (prevent
         # spoofing system messages / forging report-back watch cleanup).

--- a/src/server/app/threads.py
+++ b/src/server/app/threads.py
@@ -465,6 +465,32 @@ async def _handle_send_message(
                 },
             )
 
+        # Reject an unauthenticated background dispatch up front, before the
+        # owner lookup, workspace/LLM resolution, and credit check below — a
+        # request that will 403 anyway shouldn't do that work first. In oss mode
+        # with no INTERNAL_SERVICE_TOKEN configured there is nothing to
+        # authenticate against, so the self-dispatch is trusted; a configured
+        # token is enforced in every mode. This single is_internal value is
+        # reused by the field strip and both dispatch branches below.
+        _req_token = (raw_request.headers.get("X-Service-Token", "") if raw_request else "")
+        _svc_token = _get_service_token()
+        is_internal = bool(
+            _svc_token and _req_token and hmac.compare_digest(_req_token, _svc_token)
+        ) or (HOST_MODE == "oss" and not _svc_token)
+        if (
+            not is_internal
+            and raw_request
+            and raw_request.headers.get("X-Dispatch") == "background"
+        ):
+            raise HTTPException(
+                status_code=403,
+                detail=(
+                    "Background dispatch requires internal service auth. "
+                    "Configure INTERNAL_SERVICE_TOKEN and send it as "
+                    "X-Service-Token."
+                ),
+            )
+
         # IDOR guard: an existing thread must belong to the caller. A brand-new
         # thread_id has no owner yet -> creation proceeds. The internal report-back
         # dispatch sets X-User-Id to the owner, so it passes.
@@ -573,34 +599,6 @@ async def _handle_send_message(
         # - BYOK/OAuth (is_byok=True): block only on negative balance (outstanding
         #   debt from past platform usage, e.g. fallback routing).
         await enforce_credit_limit(user_id, byok=is_byok)
-
-        # Only honour X-Dispatch: background for internal service-to-service
-        # calls. In oss mode with no INTERNAL_SERVICE_TOKEN configured there is
-        # nothing to authenticate against, so the self-dispatch is trusted; a
-        # configured token is enforced in every mode.
-        _req_token = (raw_request.headers.get("X-Service-Token", "") if raw_request else "")
-        _svc_token = _get_service_token()
-        is_internal = bool(
-            _svc_token and _req_token and hmac.compare_digest(_req_token, _svc_token)
-        ) or (HOST_MODE == "oss" and not _svc_token)
-
-        # An unauthenticated background dispatch is rejected, not silently
-        # downgraded to a foreground SSE run (which would execute the whole
-        # workflow synchronously and burn credits for an ack the caller can
-        # never parse).
-        if (
-            not is_internal
-            and raw_request
-            and raw_request.headers.get("X-Dispatch") == "background"
-        ):
-            raise HTTPException(
-                status_code=403,
-                detail=(
-                    "Background dispatch requires internal service auth. "
-                    "Configure INTERNAL_SERVICE_TOKEN and send it as "
-                    "X-Service-Token."
-                ),
-            )
 
         # Strip internal-only fields from non-internal requests (prevent
         # spoofing system messages / forging report-back watch cleanup).

--- a/src/server/handlers/chat/report_back.py
+++ b/src/server/handlers/chat/report_back.py
@@ -962,9 +962,9 @@ async def _post_report_back(
     # With auth enabled, the endpoint rejects an unauthenticated background
     # dispatch (403) — a defer status for this loop, so firing it anyway would
     # busy-wait the whole cap. Drop immediately instead.
-    from src.config.settings import HOST_MODE
+    from src.config.settings import background_dispatch_requires_token
 
-    if HOST_MODE != "oss" and not service_token.strip():
+    if background_dispatch_requires_token():
         logger.error(
             "[FLASH_REPORT_BACK] INTERNAL_SERVICE_TOKEN is not set; report-back "
             "for PTC thread %s cannot be dispatched as background. Set it on "

--- a/src/server/handlers/chat/report_back.py
+++ b/src/server/handlers/chat/report_back.py
@@ -958,6 +958,21 @@ async def _post_report_back(
 
     self_base_url = os.environ.get("GINLIXFLOW_BASE_URL", "http://localhost:8000")
     service_token = os.environ.get("INTERNAL_SERVICE_TOKEN", "")
+
+    # With auth enabled, the endpoint rejects an unauthenticated background
+    # dispatch (403) — a defer status for this loop, so firing it anyway would
+    # busy-wait the whole cap. Drop immediately instead.
+    from src.config.settings import HOST_MODE
+
+    if HOST_MODE != "oss" and not service_token.strip():
+        logger.error(
+            "[FLASH_REPORT_BACK] INTERNAL_SERVICE_TOKEN is not set; report-back "
+            "for PTC thread %s cannot be dispatched as background. Set it on "
+            "the backend service.",
+            ptc_thread_id,
+        )
+        return "drop", None
+
     ws_label = origin.get("ptc_workspace_id") or "an auto-created workspace"
     message = (
         "<system>\n"

--- a/src/tools/secretary/tools.py
+++ b/src/tools/secretary/tools.py
@@ -410,9 +410,9 @@ async def ptc_agent(
     # With auth enabled, the endpoint rejects an unauthenticated background
     # dispatch (403); abort before any side effect (HITL prompt, workspace
     # creation, cap reservation) so the user gets the specific error instead.
-    from src.config.settings import HOST_MODE
+    from src.config.settings import background_dispatch_requires_token
 
-    if HOST_MODE != "oss" and not os.environ.get("INTERNAL_SERVICE_TOKEN", "").strip():
+    if background_dispatch_requires_token():
         logger.error(
             "PTC dispatch aborted: INTERNAL_SERVICE_TOKEN is not set, so the "
             "background dispatch cannot be authenticated. Set it on the "

--- a/src/tools/secretary/tools.py
+++ b/src/tools/secretary/tools.py
@@ -407,6 +407,19 @@ async def ptc_agent(
     if not user_id:
         return _error_command("user_id not found in config", tool_call_id)
 
+    # With auth enabled, the endpoint rejects an unauthenticated background
+    # dispatch (403); abort before any side effect (HITL prompt, workspace
+    # creation, cap reservation) so the user gets the specific error instead.
+    from src.config.settings import HOST_MODE
+
+    if HOST_MODE != "oss" and not os.environ.get("INTERNAL_SERVICE_TOKEN", "").strip():
+        logger.error(
+            "PTC dispatch aborted: INTERNAL_SERVICE_TOKEN is not set, so the "
+            "background dispatch cannot be authenticated. Set it on the "
+            "backend service to enable dispatch."
+        )
+        return _error_command("internal_service_token_missing", tool_call_id)
+
     is_continuation = thread_id is not None
 
     # Resolve workspace_id from existing thread or create/verify workspace

--- a/tests/unit/server/app/test_threads_authz.py
+++ b/tests/unit/server/app/test_threads_authz.py
@@ -160,9 +160,11 @@ async def test_post_new_thread_no_owner_proceeds():
     assert resp.status_code == 200
 
 
-# The former internal-dispatch case (X-Dispatch with no service token -> 200
-# via silent foreground downgrade) is deliberately repinned to a 403 in
-# test_threads_dispatch_auth.py, which owns the dispatch-auth matrix.
+# The former internal-dispatch case (X-Dispatch with no service token, no
+# HOST_MODE patch) asserted the old silent foreground downgrade returned 200.
+# Its outcome now depends on mode — 403 in platform, a trusted background
+# dispatch in oss — so it moved to test_threads_dispatch_auth.py, which patches
+# HOST_MODE explicitly and mocks the dispatch path for both.
 
 
 @pytest.mark.asyncio

--- a/tests/unit/server/app/test_threads_authz.py
+++ b/tests/unit/server/app/test_threads_authz.py
@@ -160,21 +160,9 @@ async def test_post_new_thread_no_owner_proceeds():
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
-async def test_internal_dispatch_with_owner_user_id_proceeds():
-    """Report-back dispatch sets X-User-Id to the owner -> owner_id == user_id.
-
-    The auth dependency reflects that X-User-Id resolution by pinning the auth
-    user to the owner; the guard must let the dispatch through (no 403).
-    """
-    app = _app_for(OWNER)
-    with _stub_downstream(owner_id=OWNER, ws_owner=OWNER):
-        resp = await _post(
-            app,
-            "/api/v1/threads/tid-dispatch/messages",
-            headers={"X-Dispatch": "background"},
-        )
-    assert resp.status_code == 200
+# The former internal-dispatch case (X-Dispatch with no service token -> 200
+# via silent foreground downgrade) is deliberately repinned to a 403 in
+# test_threads_dispatch_auth.py, which owns the dispatch-auth matrix.
 
 
 @pytest.mark.asyncio

--- a/tests/unit/server/app/test_threads_dispatch_auth.py
+++ b/tests/unit/server/app/test_threads_dispatch_auth.py
@@ -1,0 +1,235 @@
+"""Dispatch auth on ``X-Dispatch: background`` (``is_internal`` in threads.py).
+
+The header is honoured only for authenticated internal service calls: a
+matching ``X-Service-Token``, or oss mode with no ``INTERNAL_SERVICE_TOKEN``
+configured (nothing to authenticate against — the self-dispatch is trusted).
+Anything else is rejected with 403 rather than silently downgraded to a
+foreground SSE run that burns credits for an ack the caller can't parse.
+"""
+
+import asyncio
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from ptc_agent.config.agent import CredentialSource
+from tests.conftest import create_test_app
+
+USER = "usr-dispatch-001"
+TOKEN = "test-internal-service-token"
+
+_BODY = {
+    "workspace_id": "ws-placeholder",
+    "messages": [{"role": "user", "content": "test query"}],
+    "agent_mode": "ptc",
+}
+
+
+def _make_config():
+    """Stub ``AgentConfig`` returned by ``resolve_llm_config`` (platform key)."""
+    cfg = MagicMock()
+    cfg.credential_source = CredentialSource.PLATFORM
+    cfg.llm_client = None
+    cfg.llm = MagicMock()
+    cfg.llm.name = "claude-sonnet-placeholder"
+    return cfg
+
+
+def _empty_async_gen():
+    async def _gen():
+        if False:
+            yield ""
+
+    return _gen()
+
+
+def _unset_token(monkeypatch):
+    # setenv("") rather than delenv: a lazy import during the request may
+    # re-run load_dotenv(), which repopulates a deleted var from .env but
+    # never overrides an existing one. Empty and unset are equivalent here.
+    monkeypatch.setenv("INTERNAL_SERVICE_TOKEN", "")
+
+
+def _app():
+    from src.server.app.threads import router
+    from src.server.dependencies.usage_limits import ChatAuthResult, enforce_chat_limit
+
+    app = create_test_app(router)
+    app.dependency_overrides[enforce_chat_limit] = lambda: ChatAuthResult(
+        user_id=USER, access_tier=0
+    )
+    return app
+
+
+@contextmanager
+def _stub_workflow(release_burst=None):
+    """Patch everything past the dispatch-auth check, for both branches.
+
+    The dispatched branch's admission/tracking singletons are mocked so a
+    background dispatch returns its JSON ack without real Redis/task work.
+    """
+    from src.server.app import setup as setup_module
+
+    wm = MagicMock()
+    wm.has_ready_session.return_value = True
+
+    btm = MagicMock()
+    btm.get_admission_lock = AsyncMock(return_value=asyncio.Lock())
+    btm.wait_for_admission = AsyncMock(return_value="fresh")
+    btm.pre_register = AsyncMock()
+
+    tracker = MagicMock()
+    tracker.mark_active = AsyncMock()
+
+    with (
+        patch(
+            "src.server.app.threads.get_thread_owner_id",
+            new=AsyncMock(return_value=USER),
+        ),
+        patch(
+            "src.server.database.workspace.get_workspace",
+            new=AsyncMock(return_value={"user_id": USER, "status": "running"}),
+        ),
+        patch.object(setup_module, "agent_config", MagicMock()),
+        patch(
+            "src.server.handlers.chat.resolve_llm_config",
+            new=AsyncMock(return_value=_make_config()),
+        ),
+        patch(
+            "src.server.dependencies.usage_limits.enforce_credit_limit",
+            new=AsyncMock(),
+        ),
+        patch(
+            "src.server.services.workspace_manager.WorkspaceManager.get_instance",
+            return_value=wm,
+        ),
+        patch(
+            "src.server.handlers.chat.astream_ptc_workflow",
+            return_value=_empty_async_gen(),
+        ),
+        patch(
+            "src.server.app.threads.observe_chat_stream",
+            side_effect=lambda gen, **_: gen,
+        ),
+        patch(
+            "src.server.services.background_task_manager.BackgroundTaskManager.get_instance",
+            return_value=btm,
+        ),
+        patch(
+            "src.server.services.workflow_tracker.WorkflowTracker.get_instance",
+            return_value=tracker,
+        ),
+        patch("src.server.app.threads._consume_background_gen", new=AsyncMock()),
+        # Sync passthrough (patch() would auto-create an AsyncMock for this
+        # async function, whose wrapper coroutine returns — never awaits —
+        # the inner one, leaking it).
+        patch(
+            "src.server.app.threads.observe_background_chat_turn",
+            new=lambda coro, **_: coro,
+        ),
+        patch(
+            "src.server.dependencies.usage_limits.release_burst_slot",
+            new=release_burst if release_burst is not None else AsyncMock(),
+        ),
+    ):
+        yield
+
+
+async def _post(app, *, headers=None):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        resp = await c.post(
+            "/api/v1/threads/tid-dispatch/messages", json=_BODY, headers=headers or {}
+        )
+    # Drain the dispatched branch's fire-and-forget task so it finishes while
+    # the patches (and the test's event loop) are still alive.
+    for _ in range(3):
+        await asyncio.sleep(0)
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_oss_no_token_background_dispatch_returns_ack(monkeypatch):
+    """The oss zero-config promise: no token configured, self-dispatch trusted."""
+    monkeypatch.setattr("src.config.settings.HOST_MODE", "oss")
+    _unset_token(monkeypatch)
+    app = _app()
+    with _stub_workflow():
+        resp = await _post(app, headers={"X-Dispatch": "background"})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "dispatched"
+
+
+@pytest.mark.asyncio
+async def test_oss_matching_token_dispatches(monkeypatch):
+    monkeypatch.setattr("src.config.settings.HOST_MODE", "oss")
+    monkeypatch.setenv("INTERNAL_SERVICE_TOKEN", TOKEN)
+    app = _app()
+    with _stub_workflow():
+        resp = await _post(
+            app, headers={"X-Dispatch": "background", "X-Service-Token": TOKEN}
+        )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "dispatched"
+
+
+@pytest.mark.asyncio
+async def test_oss_configured_token_still_enforced(monkeypatch):
+    """A token set in oss mode must be honoured: request without it -> 403."""
+    monkeypatch.setattr("src.config.settings.HOST_MODE", "oss")
+    monkeypatch.setenv("INTERNAL_SERVICE_TOKEN", TOKEN)
+    app = _app()
+    with _stub_workflow():
+        resp = await _post(app, headers={"X-Dispatch": "background"})
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_platform_matching_token_dispatches(monkeypatch):
+    monkeypatch.setattr("src.config.settings.HOST_MODE", "platform")
+    monkeypatch.setenv("INTERNAL_SERVICE_TOKEN", TOKEN)
+    app = _app()
+    with _stub_workflow():
+        resp = await _post(
+            app, headers={"X-Dispatch": "background", "X-Service-Token": TOKEN}
+        )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "dispatched"
+
+
+@pytest.mark.asyncio
+async def test_platform_stray_dispatch_header_is_rejected(monkeypatch):
+    """No service token configured -> 403, and the burst slot is released.
+
+    Repins test_threads_authz.py's former internal-dispatch case, which
+    asserted the silent downgrade to a foreground 200.
+    """
+    monkeypatch.setattr("src.config.settings.HOST_MODE", "platform")
+    _unset_token(monkeypatch)
+    release = AsyncMock()
+    app = _app()
+    with _stub_workflow(release_burst=release):
+        resp = await _post(app, headers={"X-Dispatch": "background"})
+    assert resp.status_code == 403
+    assert "INTERNAL_SERVICE_TOKEN" in resp.json()["detail"]
+    release.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_no_dispatch_header_foreground_unchanged(monkeypatch):
+    """Without X-Dispatch nothing changes: plain foreground SSE."""
+    monkeypatch.setattr("src.config.settings.HOST_MODE", "platform")
+    _unset_token(monkeypatch)
+    app = _app()
+    with _stub_workflow():
+        resp = await _post(app)
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/event-stream")

--- a/tests/unit/server/handlers/chat/test_post_report_back.py
+++ b/tests/unit/server/handlers/chat/test_post_report_back.py
@@ -159,3 +159,15 @@ async def test_busy_wait_cap_exhausted_returns_drop():
         )
     assert outcome == ("drop", None)
     assert session.post_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# A configured INTERNAL_SERVICE_TOKEN is the normal production state and, with
+# auth enabled, a precondition for dispatch (the preflight guard drops without
+# it). These tests exercise the dispatch path itself, not the guard, so give
+# the whole module a token regardless of the ambient environment. The guard
+# test module asserts the unset behaviour separately.
+# ---------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def _internal_service_token(monkeypatch):
+    monkeypatch.setenv("INTERNAL_SERVICE_TOKEN", "test-internal-service-token")

--- a/tests/unit/tools/secretary/test_dispatch_service_token_guard.py
+++ b/tests/unit/tools/secretary/test_dispatch_service_token_guard.py
@@ -1,0 +1,189 @@
+"""Internal-service-token preflight guard on background dispatch.
+
+With auth enabled (HOST_MODE != "oss") and ``INTERNAL_SERVICE_TOKEN`` unset,
+the /messages endpoint rejects ``X-Dispatch: background`` with 403. Both
+internal dispatch call sites preflight the token and fail loud before any side
+effect (HITL prompt, workspace creation, cap reservation, HTTP). In oss mode
+with no token the endpoint trusts the self-dispatch, so the guard must not
+fire.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.server.handlers.chat import report_back as rb
+from src.tools.secretary.tools import ptc_agent
+
+USER_ID = "user-1"
+FLASH_THREAD_ID = "flash-thread-1"
+PTC_THREAD_ID = "ptc-thread-1"
+
+_ORIGIN = {
+    "user_id": USER_ID,
+    "flash_workspace_id": "ws-flash",
+    "ptc_workspace_id": "ws-ptc",
+}
+
+
+def _tool_call(args: dict, call_id: str = "call_test") -> dict:
+    return {"name": "ptc_agent", "args": args, "id": call_id, "type": "tool_call"}
+
+
+def _config() -> dict:
+    return {"configurable": {"user_id": USER_ID, "thread_id": FLASH_THREAD_ID}}
+
+
+def _payload(result) -> dict:
+    return json.loads(result.update["messages"][0].content)
+
+
+def _unset_token(monkeypatch):
+    # setenv("") rather than delenv: a lazy import may re-run load_dotenv(),
+    # which repopulates a deleted var from .env but never overrides an
+    # existing one. Empty and unset are equivalent to the guard.
+    monkeypatch.setenv("INTERNAL_SERVICE_TOKEN", "")
+
+
+class _FakeResp:
+    def __init__(self, status, json_data):
+        self.status = status
+        self._json_data = json_data
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def json(self):
+        return self._json_data
+
+
+class _FakeSession:
+    def __init__(self, resp):
+        self._resp = resp
+        self.post_calls = 0
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def post(self, *args, **kwargs):
+        self.post_calls += 1
+        return self._resp
+
+
+# ---------------------------------------------------------------------------
+# Auth enabled (platform): unset token aborts before any side effect
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ptc_agent_aborts_when_service_token_unset(monkeypatch):
+    """ptc_agent must fail loud (no HITL, no workspace, no HTTP) when the
+    token is unset: the endpoint would reject the dispatch with 403."""
+    monkeypatch.setattr("src.config.settings.HOST_MODE", "platform")
+    _unset_token(monkeypatch)
+
+    # If any of these run, the guard failed to short-circuit early enough.
+    with patch(
+        "src.tools.secretary.tools._hitl_confirm",
+        side_effect=AssertionError("HITL must not be reached"),
+    ), patch(
+        "aiohttp.ClientSession",
+        MagicMock(side_effect=AssertionError("dispatch HTTP must not run")),
+    ), patch(
+        "src.server.services.workspace_manager.WorkspaceManager.get_instance",
+        MagicMock(side_effect=AssertionError("workspace must not be created")),
+    ):
+        result = await ptc_agent.ainvoke(
+            _tool_call({"question": "analyze this"}), config=_config()
+        )
+
+    payload = _payload(result)
+    assert payload["success"] is False
+    assert payload["error"] == "internal_service_token_missing"
+
+
+@pytest.mark.asyncio
+async def test_ptc_agent_blank_service_token_is_treated_as_unset(monkeypatch):
+    """A whitespace-only token is not a real secret -> still aborts."""
+    monkeypatch.setattr("src.config.settings.HOST_MODE", "platform")
+    monkeypatch.setenv("INTERNAL_SERVICE_TOKEN", "   ")
+    with patch(
+        "src.tools.secretary.tools._hitl_confirm",
+        side_effect=AssertionError("HITL must not be reached"),
+    ), patch(
+        "aiohttp.ClientSession",
+        MagicMock(side_effect=AssertionError("dispatch HTTP must not run")),
+    ):
+        result = await ptc_agent.ainvoke(
+            _tool_call({"question": "analyze this"}), config=_config()
+        )
+
+    assert _payload(result)["error"] == "internal_service_token_missing"
+
+
+@pytest.mark.asyncio
+async def test_report_back_drops_when_service_token_unset(monkeypatch):
+    """The report-back dispatcher drops (no retry, no HTTP) when unset."""
+    monkeypatch.setattr("src.config.settings.HOST_MODE", "platform")
+    _unset_token(monkeypatch)
+
+    cache = MagicMock()  # guard returns before cache is touched
+    with patch(
+        "aiohttp.ClientSession",
+        MagicMock(side_effect=AssertionError("report-back HTTP must not run")),
+    ):
+        status, run_id = await rb._post_report_back(
+            cache, FLASH_THREAD_ID, PTC_THREAD_ID, _ORIGIN
+        )
+
+    assert status == "drop"
+    assert run_id is None
+
+
+# ---------------------------------------------------------------------------
+# oss mode: no token is the trusted zero-config path — guard must not fire
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ptc_agent_oss_mode_proceeds_without_token(monkeypatch):
+    """The flow must reach the HITL confirm (declined here to stop it)."""
+    monkeypatch.setattr("src.config.settings.HOST_MODE", "oss")
+    _unset_token(monkeypatch)
+
+    with patch(
+        "src.tools.secretary.tools._hitl_confirm", return_value=(False, {})
+    ) as hitl:
+        result = await ptc_agent.ainvoke(
+            _tool_call({"question": "analyze this"}), config=_config()
+        )
+
+    hitl.assert_called_once()
+    assert result.update["messages"][0].content == "User declined PTC agent dispatch."
+
+
+@pytest.mark.asyncio
+async def test_report_back_oss_mode_posts_without_token(monkeypatch):
+    monkeypatch.setattr("src.config.settings.HOST_MODE", "oss")
+    _unset_token(monkeypatch)
+
+    session = _FakeSession(_FakeResp(200, {"run_id": "rid-1"}))
+    with patch("aiohttp.ClientSession", MagicMock(return_value=session)):
+        outcome = await rb._post_report_back(
+            cache=None,
+            flash_thread_id=FLASH_THREAD_ID,
+            ptc_thread_id=PTC_THREAD_ID,
+            origin=_ORIGIN,
+        )
+
+    assert outcome == ("dispatched", "rid-1")
+    assert session.post_calls == 1

--- a/tests/unit/tools/secretary/test_dispatch_workspace_cleanup.py
+++ b/tests/unit/tools/secretary/test_dispatch_workspace_cleanup.py
@@ -223,3 +223,15 @@ async def test_dispatch_timeout_keeps_auto_created_workspace(cache):
     assert payload["error"] == "dispatch_timeout"
     mgr.create_workspace.assert_awaited_once()
     mgr.delete_workspace.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# A configured INTERNAL_SERVICE_TOKEN is the normal production state and, with
+# auth enabled, a precondition for dispatch (the preflight guard aborts without
+# it). These tests exercise the dispatch path itself, not the guard, so give
+# the whole module a token regardless of the ambient environment. The guard
+# test module asserts the unset behaviour separately.
+# ---------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def _internal_service_token(monkeypatch):
+    monkeypatch.setenv("INTERNAL_SERVICE_TOKEN", "test-internal-service-token")

--- a/tests/unit/tools/secretary/test_ptc_agent_continuation.py
+++ b/tests/unit/tools/secretary/test_ptc_agent_continuation.py
@@ -330,3 +330,15 @@ async def test_continuation_non_uuid_thread_id_short_circuits():
     assert "thread not found" in payload.get("error", ""), payload
     owner.assert_not_awaited()
     by_id.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# A configured INTERNAL_SERVICE_TOKEN is the normal production state and, with
+# auth enabled, a precondition for dispatch (the preflight guard aborts without
+# it). These tests exercise the dispatch path itself, not the guard, so give
+# the whole module a token regardless of the ambient environment. The guard
+# test module asserts the unset behaviour separately.
+# ---------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def _internal_service_token(monkeypatch):
+    monkeypatch.setenv("INTERNAL_SERVICE_TOKEN", "test-internal-service-token")


### PR DESCRIPTION
## Summary

A background dispatch (`X-Dispatch: background` on `POST /api/v1/threads/{id}/messages`) that could not be authenticated as internal was silently downgraded to a foreground SSE run. With `INTERNAL_SERVICE_TOKEN` unset, the whole PTC workflow executed synchronously inside the dispatch HTTP call: the caller cannot parse the SSE stream as the expected JSON ack, reports `dispatch_failed`, and the report-back wiring is rolled back, so even a completed run never reaches the flash conversation. Reported in #307 (one observed run: 34 minutes, ~70 LLM calls).

This fixes it at the endpoint instead of requiring the token client side:

- An unauthenticated `X-Dispatch: background` request is rejected with 403, never run in the foreground. The reject is computed up front (right after the no-provider guard), before the owner lookup, workspace/LLM resolution, and credit check — a request that will 403 anyway skips that work.
- In oss mode with no `INTERNAL_SERVICE_TOKEN` configured there is nothing to authenticate against, so the self dispatch is trusted. Fresh OSS installs dispatch with zero config. A token set in oss mode is still enforced.
- Both internal call sites (`ptc_agent` dispatch and the flash report-back) preflight the token when auth is enabled (`HOST_MODE != "oss"`) via a single shared helper, so a doomed dispatch fails loud with a specific error before any side effect (HITL prompt, workspace creation, cap reservation). The guards are adapted from #307.
- `.env.example` documents `INTERNAL_SERVICE_TOKEN` as required only for `HOST_MODE=platform`.

Supersedes #307. Credit to @dhishan for spotting the issue and proposing the client side guards (co-authored on the commit).

## Overview

| | files | + | − |
|---|---|---|---|
| Modified (non-test) | 5 | 71 | 5 |
| New (non-test) | 0 | 0 | 0 |
| Tests (2 new, 4 modified) | 6 | 465 | 15 |
| **Total** | **11** | **536** | **20** |

By module:

- **Server endpoint** (`src/server/app/threads.py`, modified): `is_internal` is computed once up front — trusted when `HOST_MODE == "oss"` and no token is configured, otherwise `hmac.compare_digest` on `X-Service-Token` — and the 403 for an unauthenticated `X-Dispatch: background` is raised there, ahead of the DB/LLM work. The single value feeds the internal-field strip and both the flash and ptc dispatch branches. The raise sits inside the existing try block that releases the burst slot.
- **Internal dispatch callers** (`src/tools/secretary/tools.py`, `src/server/handlers/chat/report_back.py`, modified): call-time preflight through the shared `settings.background_dispatch_requires_token()` helper, active only when `HOST_MODE != "oss"`. `ptc_agent` returns `internal_service_token_missing` before HITL/workspace/reserve work; `_post_report_back` drops immediately instead of burning its busy-wait retry cap on guaranteed 403s.
- **Config** (`src/config/settings.py`, `.env.example`, modified): `settings.py` adds `background_dispatch_requires_token()` — the one definition of the "auth enabled and no token configured" precondition; `.env.example` documents the token's scope and how to generate one.
- **Tests**: `tests/unit/server/app/test_threads_dispatch_auth.py` (new) owns the endpoint auth matrix; `tests/unit/tools/secretary/test_dispatch_service_token_guard.py` (new) pins the preflight guards, including that they do not fire in oss mode; 4 existing modules get the repinned authz case and autouse token fixtures.

What this introduces: OSS deployments get working background dispatch with zero configuration, and a misconfigured auth-enabled deployment gets an immediate, specific error instead of a silent synchronous run that burns provider credits and strands the result.

## Diff Size

- Total: 11 files changed, 536 insertions(+), 20 deletions(-)
- Net (excl. tests): 5 files changed, 71 insertions(+), 5 deletions(-)

## Test Coverage

Behavior matrix pinned in `test_threads_dispatch_auth.py`:

| HOST_MODE | token configured | request | result |
|---|---|---|---|
| oss | no | `X-Dispatch: background` | dispatched JSON ack |
| oss | yes | matching token | dispatched JSON ack |
| oss | yes | header without token | 403 |
| platform | yes | matching token | dispatched JSON ack |
| platform | no | stray `X-Dispatch` header | 403, burst slot released |
| any | no | no `X-Dispatch` header | foreground SSE, unchanged |

One repin: `test_threads_authz.py::test_internal_dispatch_with_owner_user_id_proceeds` asserted the old silent downgrade (200 foreground). That case's outcome is now mode-dependent — 403 in platform, a trusted background dispatch in oss — so it moved to the new matrix module, which patches `HOST_MODE` explicitly and mocks the dispatch path for both.

## Test plan

- [x] `uv run pytest tests/unit/ -q`: 5327 passed, 1 xfailed
- [x] Same run with the local `.env` moved aside (the config package auto-loads `.env` at import, which would mask token-unset behavior): 5327 passed, 1 xfailed
- [x] Live check on a running backend: oss + no token dispatches a PTC run that completes in the background; oss + configured token rejects a tokenless dispatch with 403; platform + matching token dispatches
- [x] `uv run ruff check` clean on all changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a shared internal service token in environment setup documentation.
  * Enabled secure handling for background dispatch requests when internal authentication is configured.

* **Bug Fixes**
  * Background dispatches now fail with a clear 403 response if they are not properly authenticated.
  * Report-back requests are dropped early when internal authentication is required but not configured.
  * Internal dispatch flows now stop before triggering follow-up work when the token is missing.

* **Tests**
  * Expanded coverage for authenticated and unauthenticated dispatch behavior across OSS and platform modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
