### PR TITLE
feat(threads): channel-identity stamp endpoint + external-id conflict handling

### DIFF
--- a/migrations/versions/011_backfill_thread_platform_web.py
+++ b/migrations/versions/011_backfill_thread_platform_web.py
@@ -1,6 +1,6 @@
 """Backfill conversation_threads.platform = 'web' for pre-tracking rows.
 
-Before this commit, only ginlix-integration set `platform` (telegram/slack/
+Before this commit, only channel integrations set `platform` (telegram/slack/
 discord/feishu). All web-originated threads (ChatAgent and MarketView) wrote
 NULL. From this commit on, web clients send 'web' or 'market_view:<SYMBOL>'.
 

--- a/src/config/env.py
+++ b/src/config/env.py
@@ -41,7 +41,7 @@ PDF_RENDER_INTERNAL_BASE: str = os.getenv("PDF_RENDER_INTERNAL_BASE", "http://12
 # Credit conversion rate (USD → credits).  Override with USD_TO_CREDITS_RATE env var.
 USD_TO_CREDITS_RATE: int = int(os.getenv("USD_TO_CREDITS_RATE", "1000"))
 
-# Automation webhook delivery (ginlix-integration)
+# Automation webhook delivery (channel gateway)
 AUTOMATION_WEBHOOK_URL: str = os.getenv("AUTOMATION_WEBHOOK_URL", "")
 AUTOMATION_WEBHOOK_SECRET: str = os.getenv("AUTOMATION_WEBHOOK_SECRET", "")
 

--- a/src/ptc_agent/agent/middleware/background_subagent/subagent.py
+++ b/src/ptc_agent/agent/middleware/background_subagent/subagent.py
@@ -257,7 +257,7 @@ class _SubagentTokenForwarder:
 
         Without this, both success and failure terminate the per-task stream
         with only the ``subagent_stream_end`` sentinel — leaving downstream
-        trackers (ginlix-integration's Slack/Discord/Feishu task tracker, the
+        trackers (the channel gateway's Slack/Discord/Feishu task tracker, the
         web frontend, ptc-cli) unable to surface failure to the user.
 
         Best-effort: failures here are absorbed so they cannot mask the

--- a/src/server/app/threads.py
+++ b/src/server/app/threads.py
@@ -13,7 +13,6 @@ from typing import Annotated, Optional
 from uuid import uuid4
 
 import asyncio
-import hmac
 import os
 
 from fastapi import APIRouter, Header, HTTPException, Path, Query, Request
@@ -21,14 +20,17 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from src.server.utils.api import (
     CurrentUserId,
+    StampThreadAuth,
     require_thread_owner,
     require_workspace_owner,
+    service_token_matches,
 )
 from src.server.models.chat import ChatRequest, SubagentMessageRequest
 from src.server.models.conversation import (
     WorkspaceThreadListItem,
     WorkspaceThreadsListResponse,
     ThreadUpdateRequest,
+    ThreadExternalIdRequest,
     ThreadDeleteResponse,
     ThreadShareRequest,
     ThreadShareResponse,
@@ -38,10 +40,13 @@ from src.server.models.conversation import (
 )
 from src.server.models.workflow import RetryRequest
 from src.server.database.conversation import (
+    ExternalIdConflictError,
+    external_id_conflict_payload,
     get_workspace_threads,
     get_threads_for_user,
     delete_thread,
     update_thread_title,
+    update_thread_external_id,
     get_thread_by_id,
     get_thread_owner_id,
     update_thread_sharing,
@@ -348,30 +353,34 @@ async def delete_thread_endpoint(thread_id: str, x_user_id: CurrentUserId):
         )
 
 
+def _thread_list_item(row: dict) -> WorkspaceThreadListItem:
+    """Build the list-item response from an updated thread row."""
+    return WorkspaceThreadListItem(
+        thread_id=str(row["conversation_thread_id"]),
+        workspace_id=str(row["workspace_id"]),
+        thread_index=row["thread_index"],
+        current_status=row["current_status"],
+        msg_type=row.get("msg_type"),
+        title=row.get("title"),
+        platform=row.get("platform"),
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
 @router.patch("/{thread_id}", response_model=WorkspaceThreadListItem)
 async def update_thread_endpoint(
     thread_id: str, request: ThreadUpdateRequest, x_user_id: CurrentUserId
 ):
-    """Update thread properties (currently only title)."""
+    """Rename a thread's title."""
     try:
         await require_thread_owner(thread_id, x_user_id)
         updated_thread = await update_thread_title(thread_id, request.title)
-
         if not updated_thread:
             raise HTTPException(
                 status_code=404, detail=f"Thread not found: {thread_id}"
             )
-
-        return WorkspaceThreadListItem(
-            thread_id=str(updated_thread["conversation_thread_id"]),
-            workspace_id=str(updated_thread["workspace_id"]),
-            thread_index=updated_thread["thread_index"],
-            current_status=updated_thread["current_status"],
-            msg_type=updated_thread.get("msg_type"),
-            title=updated_thread.get("title"),
-            created_at=updated_thread["created_at"],
-            updated_at=updated_thread["updated_at"],
-        )
+        return _thread_list_item(updated_thread)
 
     except HTTPException:
         raise
@@ -379,6 +388,45 @@ async def update_thread_endpoint(
         logger.exception(f"Error updating thread {thread_id}: {e}")
         raise HTTPException(
             status_code=500, detail=f"Failed to update thread: {str(e)}"
+        )
+
+
+@router.put("/{thread_id}/external-id", response_model=WorkspaceThreadListItem)
+async def stamp_thread_external_id_endpoint(
+    thread_id: str, request: ThreadExternalIdRequest, user_id: StampThreadAuth
+):
+    """Stamp a channel identity (``platform`` + ``external_id``) onto a thread.
+
+    A user-scoped caller must own the thread. A privileged service caller (valid
+    ``X-Service-Token`` with no ``X-User-Id``) skips the ownership check and
+    stamps by thread_id alone — used by the one-time external-id backfill, which
+    cannot know each thread's owner. A ``(platform, external_id)`` already held by
+    another thread maps to a 409 carrying the shared conflict payload.
+    """
+    try:
+        if user_id is not None:
+            await require_thread_owner(thread_id, user_id)
+        try:
+            updated_thread = await update_thread_external_id(
+                thread_id, request.platform, request.external_id
+            )
+        except ExternalIdConflictError as e:
+            raise HTTPException(
+                status_code=409,
+                detail=external_id_conflict_payload(e.platform, e.external_id),
+            )
+        if not updated_thread:
+            raise HTTPException(
+                status_code=404, detail=f"Thread not found: {thread_id}"
+            )
+        return _thread_list_item(updated_thread)
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception(f"Error stamping thread {thread_id}: {e}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to stamp thread: {str(e)}"
         )
 
 
@@ -474,9 +522,9 @@ async def _handle_send_message(
         # reused by the field strip and both dispatch branches below.
         _req_token = (raw_request.headers.get("X-Service-Token", "") if raw_request else "")
         _svc_token = _get_service_token()
-        is_internal = bool(
-            _svc_token and _req_token and hmac.compare_digest(_req_token, _svc_token)
-        ) or (HOST_MODE == "oss" and not _svc_token)
+        is_internal = service_token_matches(_req_token, _svc_token) or (
+            HOST_MODE == "oss" and not _svc_token
+        )
         if (
             not is_internal
             and raw_request

--- a/src/server/database/conversation.py
+++ b/src/server/database/conversation.py
@@ -42,6 +42,74 @@ class QueryConflictError(Exception):
         )
 
 
+class ExternalIdConflictError(Exception):
+    """Raised when a ``(platform, external_id)`` pair is already claimed by a
+    DIFFERENT thread, violating ``idx_conversation_threads_external`` (the global
+    partial-unique index on ``(platform, external_id) WHERE external_id IS NOT NULL``).
+
+    Surfaced by:
+      - ``update_thread_external_id`` (the stamp API) when the UPDATE collides.
+      - ``create_thread`` when a create race loses the ``(platform, external_id)``
+        unique-index check; the winner resolves upstream via
+        ``lookup_thread_by_external_id`` and the loser regenerates a fresh key.
+
+    Routers convert it to an HTTP 409 whose body carries
+    ``error_type="external_id_conflict"`` plus the offending pair, so channel
+    clients can detect the collision and fall back to their own dedup.
+    """
+
+    def __init__(self, platform: str, external_id: str):
+        self.platform = platform
+        self.external_id = external_id
+        super().__init__(
+            f"external_id already in use: platform={platform} external_id={external_id}"
+        )
+
+
+# Name of the global partial-unique index on (platform, external_id). Matched
+# against ``UniqueViolation.diag.constraint_name`` to tell an external-id dedup
+# collision apart from the per-workspace thread_index uniqueness constraint.
+_EXTERNAL_ID_INDEX = "idx_conversation_threads_external"
+
+# Stable ``error_type`` discriminator emitted whenever a (platform, external_id)
+# pair collides. Channel clients key on this exact string to fall back to their
+# own dedup, so every surface that reports the conflict — the HTTP 409 detail and
+# the in-stream SSE error frame — MUST carry it. Centralized here (next to the
+# error it describes) so the two surfaces can't drift.
+EXTERNAL_ID_CONFLICT_ERROR_TYPE = "external_id_conflict"
+
+# Canonical human-facing wording for the conflict (originally the HTTP 409
+# detail's message). Shared so the SSE frame reads identically.
+_EXTERNAL_ID_CONFLICT_MESSAGE = (
+    "This (platform, external_id) is already linked to another thread."
+)
+
+
+def external_id_conflict_payload(platform: str, external_id: str) -> Dict[str, Any]:
+    """Core fields describing a (platform, external_id) collision.
+
+    Single source of truth shared by the HTTP 409 detail body and the SSE error
+    frame so their ``error_type``, offending pair, and human message stay in
+    lockstep. Callers layer any surface-specific fields on top.
+    """
+    return {
+        "error_type": EXTERNAL_ID_CONFLICT_ERROR_TYPE,
+        "message": _EXTERNAL_ID_CONFLICT_MESSAGE,
+        "platform": platform,
+        "external_id": external_id,
+    }
+
+
+def _unique_violation_constraint(exc: Exception) -> Optional[str]:
+    """Best-effort constraint/index name from a psycopg UniqueViolation.
+
+    For a standalone unique index (like ``idx_conversation_threads_external``)
+    psycopg reports the index name in ``diag.constraint_name``; returns ``None``
+    when the diagnostic is unavailable.
+    """
+    return getattr(getattr(exc, "diag", None), "constraint_name", None)
+
+
 # Cache key helpers — single source of truth for key format.
 # Invalidation sites import these instead of hardcoding the prefix.
 _EXISTS_TTL = 86400  # 24h — freshness via explicit invalidation
@@ -308,9 +376,15 @@ async def create_thread(
     `platform` records where the chat originated. Conventions:
       - "web"                   — main ChatAgent page
       - "market_view:<SYMBOL>"  — MarketView side panel, symbol uppercased
-      - "telegram" | "slack" | "discord" | "feishu" — ginlix-integration channels
+      - "telegram" | "slack" | "discord" | "feishu" — channel integrations
     `external_id` is only set by channel integrations and combined with platform
     is unique-indexed for dedup. Web-originated threads have external_id NULL.
+
+    A concurrent create that loses the `(platform, external_id)` dedup index
+    raises ``ExternalIdConflictError`` (routes map it to a 409 / an in-stream
+    ``external_id_conflict`` SSE error); it is never silently resolved to the
+    winning thread here — the channel client regenerates under a fresh external
+    key. The winner already resolves upstream via ``lookup_thread_by_external_id``.
     """
     columns = [
         "conversation_thread_id",
@@ -365,7 +439,22 @@ async def create_thread(
                         result = await cur.fetchone()
                         return dict(result)
 
-        except psycopg.errors.UniqueViolation:
+        except psycopg.errors.UniqueViolation as e:
+            # A collision on the external-id dedup index can't be fixed by
+            # retrying — (platform, external_id) is fixed for this insert, so a
+            # concurrent create won the race. Surface a typed conflict (routes map
+            # it to a 409 / an in-stream ``external_id_conflict`` SSE error) that
+            # channel clients recover from by regenerating under a fresh external
+            # key. Only the per-workspace thread_index constraint is the retryable
+            # race handled below (recalc thread_index + reinsert).
+            if (
+                _unique_violation_constraint(e) == _EXTERNAL_ID_INDEX
+                and platform
+                and external_id
+            ):
+                raise ExternalIdConflictError(
+                    platform=platform, external_id=external_id
+                )
             if attempt == max_retries - 1:
                 logger.error(
                     f"thread_index conflict after {max_retries} attempts for workspace {workspace_id}"
@@ -416,6 +505,65 @@ async def lookup_thread_by_external_id(
     except Exception as e:
         logger.error(f"Error looking up thread by external_id: {e}")
         return None
+
+
+async def update_thread_external_id(
+    thread_id: str, platform: str, external_id: str
+) -> Optional[Dict[str, Any]]:
+    """Stamp ``platform`` + ``external_id`` onto an already-created thread.
+
+    Post-creation counterpart to passing external linkage into ``create_thread``:
+    lets a client attach a channel identity to an existing thread. A blind
+    ``UPDATE ... WHERE conversation_thread_id = %s`` mirroring
+    ``update_thread_title`` — ownership is enforced by the route
+    (``require_thread_owner``) before this is called, or intentionally skipped for
+    the privileged service backfill, so no ownership join is re-checked here.
+
+    Re-stamping the same values is idempotent: the row already holds them, so the
+    unique index sees no conflicting peer. If ANOTHER thread already holds this
+    ``(platform, external_id)`` the UPDATE violates
+    ``idx_conversation_threads_external``; that is caught and re-raised as
+    ``ExternalIdConflictError`` instead of escaping as a 500.
+
+    Returns the updated thread dict, or ``None`` when no matching thread was found.
+    """
+    try:
+        async with get_db_connection() as conn:
+            async with conn.cursor(row_factory=dict_row) as cur:
+                await cur.execute(
+                    """
+                    UPDATE conversation_threads
+                    SET platform = %s, external_id = %s, updated_at = NOW()
+                    WHERE conversation_thread_id = %s
+                    RETURNING conversation_thread_id, workspace_id, current_status, msg_type, thread_index, title, platform, created_at, updated_at
+                """,
+                    (platform, external_id, thread_id),
+                )
+                result = await cur.fetchone()
+                if result:
+                    logger.info(
+                        f"[conversation_db] update_thread_external_id "
+                        f"thread_id={thread_id} platform={platform} external_id={external_id}"
+                    )
+                    return dict(result)
+                return None
+
+    except psycopg.errors.UniqueViolation as e:
+        # Another thread already holds this (platform, external_id). Surface a
+        # typed conflict the router maps to 409 rather than a raw 500. Guard on
+        # the index name so an unrelated unique violation still bubbles as-is.
+        if _unique_violation_constraint(e) == _EXTERNAL_ID_INDEX:
+            logger.info(
+                f"[conversation_db] update_thread_external_id conflict "
+                f"platform={platform} external_id={external_id}"
+            )
+            raise ExternalIdConflictError(platform=platform, external_id=external_id)
+        logger.error(f"Error updating thread external_id: {e}")
+        raise
+
+    except Exception as e:
+        logger.error(f"Error updating thread external_id: {e}")
+        raise
 
 
 async def update_thread_status(
@@ -1831,7 +1979,7 @@ async def update_thread_title(
                     UPDATE conversation_threads
                     SET title = %s, updated_at = NOW()
                     WHERE conversation_thread_id = %s
-                    RETURNING conversation_thread_id, workspace_id, current_status, msg_type, thread_index, title, created_at, updated_at
+                    RETURNING conversation_thread_id, workspace_id, current_status, msg_type, thread_index, title, platform, created_at, updated_at
                 """,
                     (title, conversation_thread_id),
                 )

--- a/src/server/handlers/chat/_common.py
+++ b/src/server/handlers/chat/_common.py
@@ -780,6 +780,17 @@ async def wait_or_steer(
     )
 
 
+def _emit_sse_error(handler, payload: dict) -> str:
+    """Format an ``error`` SSE frame via *handler* when present, else raw.
+
+    Single source for the ``if handler: _format_sse_event else: raw f-string``
+    shape repeated across ``handle_workflow_error``'s terminal branches.
+    """
+    if handler:
+        return handler._format_sse_event("error", payload)
+    return f"event: error\ndata: {json.dumps(payload)}\n\n"
+
+
 async def handle_workflow_error(
     e: Exception,
     thread_id: str,
@@ -833,10 +844,34 @@ async def handle_workflow_error(
             "error_class": type(e).__name__,
             "code": detail["code"],
         }
-        if handler:
-            yield handler._format_sse_event("error", error_payload)
-        else:
-            yield f"event: error\ndata: {json.dumps(error_payload)}\n\n"
+        yield _emit_sse_error(handler, error_payload)
+        return
+
+    # A (platform, external_id) create race won by a DIFFERENT user is a
+    # deterministic protocol conflict, not a workflow execution failure: thread
+    # creation lost the ``idx_conversation_threads_external`` check. Surface it
+    # as a clean SSE error carrying the same structured ``error_type`` as the
+    # stamp API's HTTP 409, and (like the admission-conflict path above) never
+    # persist it or call ``mark_failed``. Thread creation runs inside the
+    # already-started stream, so this is the response surface — a synchronous
+    # HTTP 409 status is not reachable from here.
+    if isinstance(e, qr_db.ExternalIdConflictError):
+        await release_burst_slot(user_id)
+        # Same core fields (error_type discriminator + offending pair + human
+        # wording) as the stamp API's HTTP 409, built from the shared helper so
+        # the two surfaces never drift; the SSE-envelope fields (thread_id, type,
+        # error_class) are layered on top.
+        conflict = qr_db.external_id_conflict_payload(e.platform, e.external_id)
+        error_payload = {
+            "thread_id": thread_id,
+            "error": conflict["message"],
+            "type": "workflow_error",
+            "error_type": conflict["error_type"],
+            "error_class": type(e).__name__,
+            "platform": conflict["platform"],
+            "external_id": conflict["external_id"],
+        }
+        yield _emit_sse_error(handler, error_payload)
         return
 
     MAX_RETRIES = get_max_workflow_retries()
@@ -987,8 +1022,4 @@ async def handle_workflow_error(
             "error_type": error_type_label,
             "error_class": type(e).__name__,
         }
-        if handler:
-            error_event = handler._format_sse_event("error", error_payload)
-            yield error_event
-        else:
-            yield f"event: error\ndata: {json.dumps(error_payload)}\n\n"
+        yield _emit_sse_error(handler, error_payload)

--- a/src/server/models/conversation.py
+++ b/src/server/models/conversation.py
@@ -152,11 +152,37 @@ class WorkspaceMessagesResponse(BaseModel):
 # ==================== Thread Management Request/Response Models ====================
 
 class ThreadUpdateRequest(BaseModel):
-    """Request model for updating a thread."""
+    """Request model for updating a thread (currently only title)."""
     title: Optional[str] = Field(None, max_length=255, description="New thread title")
 
     model_config = ConfigDict(json_schema_extra={
         "example": {"title": "Tesla Stock Analysis"},
+    })
+
+
+class ThreadExternalIdRequest(BaseModel):
+    """Request model for stamping a channel identity onto a thread.
+
+    Both fields are required and non-empty — the stamp API never clears
+    ``external_id`` back to NULL (the partial-unique dedup index relies on it).
+    """
+    platform: str = Field(
+        ...,
+        min_length=1,
+        max_length=50,
+        description="Origin platform to stamp (e.g. 'telegram', 'slack', "
+        "'discord', 'feishu').",
+    )
+    external_id: str = Field(
+        ...,
+        min_length=1,
+        max_length=255,
+        description="External channel thread identifier to stamp "
+        "(e.g. 'chat_id:topic_id').",
+    )
+
+    model_config = ConfigDict(json_schema_extra={
+        "example": {"platform": "telegram", "external_id": "chat_id:topic_id"},
     })
 
 

--- a/src/server/utils/api.py
+++ b/src/server/utils/api.py
@@ -26,6 +26,46 @@ _optional_bearer = HTTPBearer(auto_error=False)
 _SERVICE_TOKEN = os.getenv("INTERNAL_SERVICE_TOKEN", "")
 
 
+def service_token_matches(candidate: str, secret: str) -> bool:
+    """Constant-time check that a client-supplied service token equals ``secret``.
+
+    Compares as UTF-8 bytes: ``hmac.compare_digest`` raises ``TypeError`` on
+    non-ASCII ``str`` and header values arrive latin-1-decoded, so a non-ASCII
+    token must not 500. An empty ``candidate`` or ``secret`` (service auth
+    unconfigured, or no header sent) is never a match.
+    """
+    return bool(
+        secret
+        and candidate
+        and hmac.compare_digest(candidate.encode("utf-8"), secret.encode("utf-8"))
+    )
+
+
+def _service_token_user_id(request: Request) -> tuple[bool, Optional[str]]:
+    """Resolve a service-to-service caller from the request headers.
+
+    Returns ``(matched, user_id)``:
+      - ``matched`` is ``True`` only when a valid ``X-Service-Token`` is present
+        (a present-but-wrong token raises 401). ``user_id`` is then the
+        ``X-User-Id`` header, which MAY be ``None`` (a token-only privileged
+        caller).
+      - ``matched`` is ``False`` when service auth is not in play (no
+        ``INTERNAL_SERVICE_TOKEN`` configured, or no ``X-Service-Token`` header);
+        the caller falls through to the normal auth path.
+
+    Shared by ``get_current_user_id`` (which then requires ``X-User-Id``) and
+    ``get_stamp_auth`` (which tolerates its absence).
+    """
+    if not _SERVICE_TOKEN:
+        return False, None
+    token = request.headers.get("X-Service-Token")
+    if not token:
+        return False, None
+    if not service_token_matches(token, _SERVICE_TOKEN):
+        raise HTTPException(status_code=401, detail="Invalid service token")
+    return True, request.headers.get("X-User-Id")
+
+
 async def get_current_user_id(
     request: Request,
     credentials: HTTPAuthorizationCredentials | None = Depends(_optional_bearer),
@@ -39,15 +79,11 @@ async def get_current_user_id(
     When auth is enabled, requires a valid Bearer JWT (Supabase).
     """
     # Service-to-service auth (only active if INTERNAL_SERVICE_TOKEN is set)
-    if _SERVICE_TOKEN:
-        token = request.headers.get("X-Service-Token")
-        if token:
-            if not hmac.compare_digest(token, _SERVICE_TOKEN):
-                raise HTTPException(status_code=401, detail="Invalid service token")
-            user_id = request.headers.get("X-User-Id")
-            if not user_id:
-                raise HTTPException(status_code=401, detail="Missing X-User-Id")
-            return user_id
+    matched, user_id = _service_token_user_id(request)
+    if matched:
+        if not user_id:
+            raise HTTPException(status_code=401, detail="Missing X-User-Id")
+        return user_id
 
     if HOST_MODE == "oss":
         return LOCAL_DEV_USER_ID
@@ -60,6 +96,34 @@ async def get_current_user_id(
 
 # Annotated type for cleaner endpoint signatures
 CurrentUserId = Annotated[str, Depends(get_current_user_id)]
+
+
+async def get_stamp_auth(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials | None = Depends(_optional_bearer),
+) -> Optional[str]:
+    """Auth resolver for the external-id stamp route (PUT /threads/{id}/external-id).
+
+    Returns the user id to enforce thread ownership against, or ``None`` for a
+    privileged service caller — a valid ``X-Service-Token`` with no ``X-User-Id``
+    (the one-time external-id backfill, which cannot know each thread's owner).
+    Such a caller may stamp any thread; the service token already permits
+    impersonating any user via ``X-User-Id``, so omitting the ownership check for
+    a token-only call is not an escalation. A service token WITH ``X-User-Id``
+    resolves to that user (ownership enforced). Every other caller resolves to a
+    concrete id via the normal ``get_current_user_id`` path.
+    """
+    matched, user_id = _service_token_user_id(request)
+    if matched:
+        # X-User-Id optional here (unlike get_current_user_id): a token-only
+        # caller is a privileged service acting without a specific owner.
+        return user_id
+    return await get_current_user_id(request, credentials)
+
+
+# Annotated type for the stamp route's auth dependency: the resolved owner id, or
+# None for a privileged service caller.
+StampThreadAuth = Annotated[Optional[str], Depends(get_stamp_auth)]
 
 
 def handle_api_exceptions(

--- a/tests/unit/server/app/test_threads_dispatch_auth.py
+++ b/tests/unit/server/app/test_threads_dispatch_auth.py
@@ -233,3 +233,20 @@ async def test_no_dispatch_header_foreground_unchanged(monkeypatch):
         resp = await _post(app)
     assert resp.status_code == 200
     assert resp.headers["content-type"].startswith("text/event-stream")
+
+
+@pytest.mark.asyncio
+async def test_non_ascii_service_token_rejected_not_500(monkeypatch):
+    """A non-ASCII X-Service-Token must 403, not 500. Header values arrive
+    latin-1-decoded, and the compare now runs through service_token_matches
+    (bytes), so a high byte can't raise TypeError out of hmac.compare_digest."""
+    monkeypatch.setattr("src.config.settings.HOST_MODE", "platform")
+    monkeypatch.setenv("INTERNAL_SERVICE_TOKEN", TOKEN)
+    app = _app()
+    with _stub_workflow():
+        # Raw latin-1 byte 0xE5 → Starlette decodes it to a non-ASCII str.
+        resp = await _post(
+            app,
+            headers={"X-Dispatch": "background", "X-Service-Token": b"\xe5-not-ascii"},
+        )
+    assert resp.status_code == 403

--- a/tests/unit/server/app/test_threads_stamp.py
+++ b/tests/unit/server/app/test_threads_stamp.py
@@ -1,0 +1,416 @@
+"""PUT /threads/{thread_id}/external-id stamp + PATCH /threads/{thread_id} rename.
+
+The channel-identity stamp and the title rename are separate routes with separate
+auth: the stamp accepts a privileged service caller (valid X-Service-Token, no
+X-User-Id) that skips the ownership check; the rename requires a concrete user.
+
+Covers the stamp path (happy, idempotent re-stamp, conflict → 409, missing/empty
+field → 422 via the required model, not-owner → 403, vanished thread → 404, and
+the service-token backfill) plus the rename path (renames, service-only → 401).
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+from httpx import ASGITransport, AsyncClient
+
+from src.server.database.conversation import ExternalIdConflictError
+from src.server.utils.api import get_current_user_id, get_stamp_auth
+from tests.conftest import create_test_app
+
+USER = "test-user-123"
+
+# Sentinel so _stamp_app() can distinguish "use the default user-scoped caller"
+# from an explicit ``None`` (the privileged service caller, resolved user_id None).
+_UNSET = object()
+
+
+def _stamp_app(auth=_UNSET):
+    """Threads router with the stamp route's auth (``get_stamp_auth``) pinned.
+
+    ``get_stamp_auth`` resolves to ``Optional[str]`` — the owner id, or ``None``
+    for a privileged service caller. Defaults to a user-scoped caller (``USER``);
+    pass ``None`` for a token-only service caller, or a user id for a service
+    token acting as that user.
+    """
+    from src.server.app.threads import router
+
+    app = create_test_app(router)
+    resolved = USER if auth is _UNSET else auth
+    app.dependency_overrides[get_stamp_auth] = lambda: resolved
+    return app
+
+
+def _title_app(user=USER):
+    """Threads router with the rename route's auth (``get_current_user_id``) pinned."""
+    from src.server.app.threads import router
+
+    app = create_test_app(router)
+    app.dependency_overrides[get_current_user_id] = lambda: user
+    return app
+
+
+def _real_app():
+    """Threads router with NO auth override → the real dependencies run."""
+    from src.server.app.threads import router
+
+    return create_test_app(router)
+
+
+def _thread_row(**overrides):
+    now = datetime.now(timezone.utc)
+    row = {
+        "conversation_thread_id": "t-1",
+        "workspace_id": "ws-1",
+        "current_status": "completed",
+        "msg_type": "ptc",
+        "thread_index": 0,
+        "title": "Test Thread",
+        "platform": None,
+        "external_id": None,
+        "created_at": now,
+        "updated_at": now,
+    }
+    row.update(overrides)
+    return row
+
+
+async def _put(app, body, headers=None):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        return await c.put("/api/v1/threads/t-1/external-id", json=body, headers=headers)
+
+
+async def _patch(app, body, headers=None):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        return await c.patch("/api/v1/threads/t-1", json=body, headers=headers)
+
+
+# ---------------------------------------------------------------------------
+# Stamp path — PUT /threads/{id}/external-id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stamp_success():
+    app = _stamp_app()
+    row = _thread_row(platform="telegram", external_id="chat:42")
+    with (
+        patch("src.server.app.threads.require_thread_owner", new=AsyncMock()),
+        patch(
+            "src.server.app.threads.update_thread_external_id",
+            new=AsyncMock(return_value=row),
+        ) as m,
+    ):
+        resp = await _put(app, {"platform": "telegram", "external_id": "chat:42"})
+
+    assert resp.status_code == 200
+    assert resp.json()["platform"] == "telegram"
+    m.assert_awaited_once_with("t-1", "telegram", "chat:42")
+
+
+@pytest.mark.asyncio
+async def test_stamp_idempotent_restamp():
+    """Re-stamping the same values returns 200 (DB-level no-op-safe)."""
+    app = _stamp_app()
+    row = _thread_row(platform="telegram", external_id="chat:42")
+    with (
+        patch("src.server.app.threads.require_thread_owner", new=AsyncMock()),
+        patch(
+            "src.server.app.threads.update_thread_external_id",
+            new=AsyncMock(return_value=row),
+        ),
+    ):
+        first = await _put(app, {"platform": "telegram", "external_id": "chat:42"})
+        second = await _put(app, {"platform": "telegram", "external_id": "chat:42"})
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_stamp_conflict_returns_409():
+    app = _stamp_app()
+    with (
+        patch("src.server.app.threads.require_thread_owner", new=AsyncMock()),
+        patch(
+            "src.server.app.threads.update_thread_external_id",
+            new=AsyncMock(
+                side_effect=ExternalIdConflictError(
+                    platform="telegram", external_id="chat:42"
+                )
+            ),
+        ),
+    ):
+        resp = await _put(app, {"platform": "telegram", "external_id": "chat:42"})
+
+    assert resp.status_code == 409
+    detail = resp.json()["detail"]
+    assert detail["error_type"] == "external_id_conflict"
+    assert detail["platform"] == "telegram"
+    assert detail["external_id"] == "chat:42"
+
+
+@pytest.mark.asyncio
+async def test_stamp_platform_only_is_422():
+    """external_id is required — a lone field is rejected by the model (422)."""
+    app = _stamp_app()
+    with patch(
+        "src.server.app.threads.update_thread_external_id", new=AsyncMock()
+    ) as m:
+        resp = await _put(app, {"platform": "telegram"})
+
+    assert resp.status_code == 422
+    m.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stamp_external_id_only_is_422():
+    app = _stamp_app()
+    with patch(
+        "src.server.app.threads.update_thread_external_id", new=AsyncMock()
+    ) as m:
+        resp = await _put(app, {"external_id": "chat:42"})
+
+    assert resp.status_code == 422
+    m.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stamp_empty_fields_is_422():
+    """Empty strings never clear external_id back to NULL — min_length rejects."""
+    app = _stamp_app()
+    with patch(
+        "src.server.app.threads.update_thread_external_id", new=AsyncMock()
+    ) as m:
+        resp = await _put(app, {"platform": "", "external_id": ""})
+
+    assert resp.status_code == 422
+    m.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stamp_not_owner_is_forbidden():
+    app = _stamp_app()
+    with (
+        patch(
+            "src.server.app.threads.require_thread_owner",
+            new=AsyncMock(
+                side_effect=HTTPException(status_code=403, detail="Forbidden")
+            ),
+        ),
+        patch(
+            "src.server.app.threads.update_thread_external_id",
+            new=AsyncMock(),
+        ) as m,
+    ):
+        resp = await _put(app, {"platform": "telegram", "external_id": "chat:42"})
+
+    assert resp.status_code == 403
+    m.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stamp_thread_missing_is_404():
+    """update_thread_external_id returns None (thread vanished) → 404."""
+    app = _stamp_app()
+    with (
+        patch("src.server.app.threads.require_thread_owner", new=AsyncMock()),
+        patch(
+            "src.server.app.threads.update_thread_external_id",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        resp = await _put(app, {"platform": "telegram", "external_id": "chat:42"})
+
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Privileged service caller (X-Service-Token, no X-User-Id): the backfill path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stamp_service_no_user_skips_ownership():
+    """Service-token-only caller (user_id=None) stamps without an ownership
+    check, passing user_id-agnostic args to the DB (thread-id-scoped UPDATE)."""
+    app = _stamp_app(None)
+    row = _thread_row(platform="telegram", external_id="chat:42")
+    with (
+        patch("src.server.app.threads.require_thread_owner", new=AsyncMock()) as owner,
+        patch(
+            "src.server.app.threads.update_thread_external_id",
+            new=AsyncMock(return_value=row),
+        ) as m,
+    ):
+        resp = await _put(app, {"platform": "telegram", "external_id": "chat:42"})
+
+    assert resp.status_code == 200
+    owner.assert_not_awaited()  # ownership check skipped for the service caller
+    m.assert_awaited_once_with("t-1", "telegram", "chat:42")
+
+
+@pytest.mark.asyncio
+async def test_stamp_service_with_user_keeps_ownership():
+    """A service token WITH X-User-Id still enforces ownership on the stamp."""
+    app = _stamp_app(USER)
+    row = _thread_row(platform="telegram", external_id="chat:42")
+    with (
+        patch("src.server.app.threads.require_thread_owner", new=AsyncMock()) as owner,
+        patch(
+            "src.server.app.threads.update_thread_external_id",
+            new=AsyncMock(return_value=row),
+        ) as m,
+    ):
+        resp = await _put(app, {"platform": "telegram", "external_id": "chat:42"})
+
+    assert resp.status_code == 200
+    owner.assert_awaited_once_with("t-1", USER)
+    m.assert_awaited_once_with("t-1", "telegram", "chat:42")
+
+
+@pytest.mark.asyncio
+async def test_stamp_service_conflict_still_409():
+    """The service path surfaces the same 409 conflict body as the user path."""
+    app = _stamp_app(None)
+    with (
+        patch("src.server.app.threads.require_thread_owner", new=AsyncMock()),
+        patch(
+            "src.server.app.threads.update_thread_external_id",
+            new=AsyncMock(
+                side_effect=ExternalIdConflictError(
+                    platform="telegram", external_id="chat:42"
+                )
+            ),
+        ),
+    ):
+        resp = await _put(app, {"platform": "telegram", "external_id": "chat:42"})
+
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["error_type"] == "external_id_conflict"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through the REAL get_stamp_auth dependency (header handling)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stamp_real_service_token_no_user_id():
+    """Real dependency: valid X-Service-Token with NO X-User-Id → privileged
+    service caller, ownership skipped, DB called for the stamp."""
+    app = _real_app()
+    row = _thread_row(platform="telegram", external_id="chat:42")
+    with (
+        patch("src.server.utils.api._SERVICE_TOKEN", "svc-secret"),
+        patch("src.server.app.threads.require_thread_owner", new=AsyncMock()) as owner,
+        patch(
+            "src.server.app.threads.update_thread_external_id",
+            new=AsyncMock(return_value=row),
+        ) as m,
+    ):
+        resp = await _put(
+            app,
+            {"platform": "telegram", "external_id": "chat:42"},
+            headers={"X-Service-Token": "svc-secret"},
+        )
+
+    assert resp.status_code == 200
+    owner.assert_not_awaited()
+    m.assert_awaited_once_with("t-1", "telegram", "chat:42")
+
+
+@pytest.mark.asyncio
+async def test_stamp_real_service_token_with_user_enforces_ownership():
+    """Real dependency: X-Service-Token WITH X-User-Id acts as that user and the
+    stamp keeps the ownership check."""
+    app = _real_app()
+    row = _thread_row(platform="telegram", external_id="chat:42")
+    with (
+        patch("src.server.utils.api._SERVICE_TOKEN", "svc-secret"),
+        patch("src.server.app.threads.require_thread_owner", new=AsyncMock()) as owner,
+        patch(
+            "src.server.app.threads.update_thread_external_id",
+            new=AsyncMock(return_value=row),
+        ) as m,
+    ):
+        resp = await _put(
+            app,
+            {"platform": "telegram", "external_id": "chat:42"},
+            headers={"X-Service-Token": "svc-secret", "X-User-Id": "alice"},
+        )
+
+    assert resp.status_code == 200
+    owner.assert_awaited_once_with("t-1", "alice")
+    m.assert_awaited_once_with("t-1", "telegram", "chat:42")
+
+
+@pytest.mark.asyncio
+async def test_stamp_real_invalid_service_token_is_401():
+    """Real dependency: a bad X-Service-Token is rejected before the handler."""
+    app = _real_app()
+    with (
+        patch("src.server.utils.api._SERVICE_TOKEN", "svc-secret"),
+        patch(
+            "src.server.app.threads.update_thread_external_id", new=AsyncMock()
+        ) as m,
+    ):
+        resp = await _put(
+            app,
+            {"platform": "telegram", "external_id": "chat:42"},
+            headers={"X-Service-Token": "wrong-token"},
+        )
+
+    assert resp.status_code == 401
+    m.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Rename path — PATCH /threads/{id} (title only, requires a concrete user)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_title_renames():
+    app = _title_app()
+    row = _thread_row(title="Renamed")
+    with (
+        patch("src.server.app.threads.require_thread_owner", new=AsyncMock()),
+        patch(
+            "src.server.app.threads.update_thread_title",
+            new=AsyncMock(return_value=row),
+        ) as m,
+    ):
+        resp = await _patch(app, {"title": "Renamed"})
+
+    assert resp.status_code == 200
+    assert resp.json()["title"] == "Renamed"
+    m.assert_awaited_once_with("t-1", "Renamed")
+
+
+@pytest.mark.asyncio
+async def test_patch_title_service_no_user_is_401():
+    """Rename requires a concrete user; a service-token-only caller → 401 from
+    the real get_current_user_id dependency."""
+    app = _real_app()
+    # create_test_app bypasses get_current_user_id by default; drop that override
+    # so the real dependency (which enforces X-User-Id) runs here.
+    app.dependency_overrides.pop(get_current_user_id, None)
+    with (
+        patch("src.server.utils.api._SERVICE_TOKEN", "svc-secret"),
+        patch("src.server.app.threads.require_thread_owner", new=AsyncMock()) as owner,
+        patch("src.server.app.threads.update_thread_title", new=AsyncMock()) as title,
+    ):
+        resp = await _patch(
+            app, {"title": "Renamed"}, headers={"X-Service-Token": "svc-secret"}
+        )
+
+    assert resp.status_code == 401
+    owner.assert_not_awaited()
+    title.assert_not_awaited()

--- a/tests/unit/server/database/test_conversation_db.py
+++ b/tests/unit/server/database/test_conversation_db.py
@@ -7,7 +7,9 @@ thread sharing, and pagination logic.
 
 import uuid
 from datetime import datetime, timezone
+from types import SimpleNamespace
 
+import psycopg
 import pytest
 
 
@@ -16,6 +18,21 @@ import pytest
 # conftest mock_db_connection fixture (which patches exactly that path)
 # is sufficient here.
 # ---------------------------------------------------------------------------
+
+
+def _make_unique_violation(constraint_name):
+    """A raisable ``psycopg.errors.UniqueViolation`` whose ``diag.constraint_name``
+    reports ``constraint_name`` (psycopg exposes the offending index name there).
+
+    Sets ``diag`` as a subclass attribute so it shadows the base read-only
+    property in the MRO — the production code reads it via ``getattr``.
+    """
+
+    class _UV(psycopg.errors.UniqueViolation):
+        pass
+
+    _UV.diag = SimpleNamespace(constraint_name=constraint_name)
+    return _UV("duplicate key value violates unique constraint")
 
 
 def _thread_row(
@@ -187,6 +204,9 @@ async def test_update_thread_title(mock_db_connection, mock_cursor):
     params = mock_cursor.execute.call_args[0][1]
     assert params[0] == "New Title"
     assert params[1] == "t-1"
+    # RETURNING now includes platform so the endpoint response carries it.
+    sql = mock_cursor.execute.call_args[0][0]
+    assert "platform" in sql
 
 
 @pytest.mark.asyncio
@@ -210,6 +230,173 @@ async def test_delete_thread(mock_db_connection, mock_cursor):
     assert result is True
     sql = mock_cursor.execute.call_args[0][0]
     assert "DELETE FROM conversation_threads" in sql
+
+
+# ===========================================================================
+# External-id stamping (update_thread_external_id) + create-race hardening
+# ===========================================================================
+
+_EXTERNAL_INDEX = "idx_conversation_threads_external"
+
+
+@pytest.mark.asyncio
+async def test_update_thread_external_id_success(mock_db_connection, mock_cursor):
+    """Happy path: blind-by-thread_id UPDATE stamps platform + external_id.
+
+    Ownership is enforced by the route before this is called, so the DB layer
+    mirrors update_thread_title — a single UPDATE keyed on conversation_thread_id
+    with no workspace join.
+    """
+    from src.server.database.conversation import update_thread_external_id
+
+    row = _thread_row(
+        thread_id="t-1", workspace_id="ws-1", platform="telegram", external_id="chat:42"
+    )
+    mock_cursor.fetchone.return_value = row
+
+    result = await update_thread_external_id("t-1", "telegram", "chat:42")
+
+    assert result is not None
+    assert result["platform"] == "telegram"
+    assert result["external_id"] == "chat:42"
+    sql = mock_cursor.execute.call_args[0][0]
+    assert "UPDATE conversation_threads" in sql
+    # Blind by thread_id — no ownership join re-checked in SQL.
+    assert "w.user_id" not in sql
+    assert "FROM workspaces" not in sql
+    params = mock_cursor.execute.call_args[0][1]
+    assert params == ("telegram", "chat:42", "t-1")
+
+
+@pytest.mark.asyncio
+async def test_update_thread_external_id_idempotent_restamp(
+    mock_db_connection, mock_cursor
+):
+    """Re-stamping identical values is a no-op-safe success: the row already
+    holds them, so the unique index sees no conflicting peer."""
+    from src.server.database.conversation import update_thread_external_id
+
+    row = _thread_row(thread_id="t-1", platform="telegram", external_id="chat:42")
+    mock_cursor.fetchone.return_value = row
+
+    result = await update_thread_external_id("t-1", "telegram", "chat:42")
+
+    assert result["external_id"] == "chat:42"
+
+
+@pytest.mark.asyncio
+async def test_update_thread_external_id_conflict_raises(
+    mock_db_connection, mock_cursor
+):
+    """A collision on idx_conversation_threads_external → ExternalIdConflictError."""
+    from src.server.database.conversation import (
+        ExternalIdConflictError,
+        update_thread_external_id,
+    )
+
+    mock_cursor.execute.side_effect = _make_unique_violation(_EXTERNAL_INDEX)
+
+    with pytest.raises(ExternalIdConflictError) as exc_info:
+        await update_thread_external_id("t-1", "telegram", "chat:42")
+
+    assert exc_info.value.platform == "telegram"
+    assert exc_info.value.external_id == "chat:42"
+
+
+@pytest.mark.asyncio
+async def test_update_thread_external_id_missing_returns_none(
+    mock_db_connection, mock_cursor
+):
+    """UPDATE ... WHERE conversation_thread_id = %s matches no row → None
+    (thread vanished; route maps to 404)."""
+    from src.server.database.conversation import update_thread_external_id
+
+    mock_cursor.fetchone.return_value = None
+
+    result = await update_thread_external_id("t-1", "telegram", "chat:42")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_update_thread_external_id_other_unique_violation_bubbles(
+    mock_db_connection, mock_cursor
+):
+    """A unique violation on some OTHER index is not masked as a conflict."""
+    from src.server.database.conversation import update_thread_external_id
+
+    mock_cursor.execute.side_effect = _make_unique_violation("some_other_index")
+
+    with pytest.raises(psycopg.errors.UniqueViolation):
+        await update_thread_external_id("t-1", "telegram", "chat:42")
+
+
+@pytest.mark.asyncio
+async def test_create_thread_external_race_raises_conflict(
+    mock_db_connection, mock_cursor
+):
+    """A create that loses the (platform, external_id) dedup index raises a typed
+    ExternalIdConflictError — never silently resolved to the winner. Routes map it
+    to a 409 / external_id_conflict SSE error the channel client recovers from by
+    regenerating under a fresh external key."""
+    from src.server.database.conversation import (
+        ExternalIdConflictError,
+        create_thread,
+    )
+
+    # execute: [calc-index, INSERT raises the external-index UV]. No re-lookup —
+    # the conflict is raised straight away.
+    mock_cursor.execute.side_effect = [
+        None,
+        _make_unique_violation(_EXTERNAL_INDEX),
+    ]
+    mock_cursor.fetchone.side_effect = [
+        {"next_index": 0},
+    ]
+
+    with pytest.raises(ExternalIdConflictError) as exc_info:
+        await create_thread(
+            conversation_thread_id="new-thread",
+            workspace_id="ws-1",
+            current_status="in_progress",
+            external_id="chat:42",
+            platform="telegram",
+        )
+
+    assert exc_info.value.platform == "telegram"
+    assert exc_info.value.external_id == "chat:42"
+
+
+@pytest.mark.asyncio
+async def test_create_thread_thread_index_conflict_still_retries(
+    mock_db_connection, mock_cursor
+):
+    """A thread_index unique violation keeps the existing recalc-and-retry path
+    (unchanged by the external-id branch)."""
+    from src.server.database.conversation import create_thread
+
+    row = _thread_row(thread_id="t-1", workspace_id="ws-1")
+
+    # attempt 0: calc, INSERT raises thread_index UV. attempt 1: recalc, INSERT ok.
+    mock_cursor.execute.side_effect = [
+        None,
+        _make_unique_violation("unique_thread_index_per_workspace"),
+        None,
+        None,
+    ]
+    mock_cursor.fetchone.side_effect = [
+        {"next_index": 0},
+        {"next_index": 1},
+        row,
+    ]
+
+    result = await create_thread(
+        conversation_thread_id="t-1",
+        workspace_id="ws-1",
+        current_status="in_progress",
+    )
+
+    assert result["conversation_thread_id"] == "t-1"
 
 
 # ===========================================================================

--- a/tests/unit/server/handlers/chat/test_handle_workflow_error.py
+++ b/tests/unit/server/handlers/chat/test_handle_workflow_error.py
@@ -145,3 +145,44 @@ async def test_tracker_failure_does_not_break_error_flow(patch_tracker):
         ))
 
     assert sse in events
+
+
+@pytest.mark.asyncio
+async def test_external_id_conflict_branch_emits_conflict_and_skips_mark_failed(
+    patch_tracker,
+):
+    # A cross-user (platform, external_id) create race surfaces as a clean SSE
+    # error carrying error_type=external_id_conflict, and (like the admission-
+    # conflict path) must NOT mark the thread failed or persist an error.
+    import json as _json
+
+    from src.server.database.conversation import ExternalIdConflictError
+
+    err = ExternalIdConflictError(platform="telegram", external_id="chat:42")
+
+    with patch.object(_common, "release_burst_slot", new=AsyncMock()), \
+         patch.object(_common, "get_max_workflow_retries", return_value=3):
+        # handler=None takes the json.dumps SSE branch, easy to parse.
+        events = await _consume(_common.handle_workflow_error(
+            e=err,
+            thread_id="t-ext",
+            user_id="u-1",
+            workspace_id="ws-1",
+            handler=None,
+            token_callback=None,
+            persistence_service=None,
+            start_time=0.0,
+            request=_make_request(),
+            is_byok=False,
+            msg_type="user",
+            log_prefix="CHAT",
+        ))
+
+    assert len(events) == 1
+    assert events[0].startswith("event: error\n")
+    payload = _json.loads(events[0].split("data: ", 1)[1].strip())
+    assert payload["error_type"] == "external_id_conflict"
+    assert payload["platform"] == "telegram"
+    assert payload["external_id"] == "chat:42"
+    # Deterministic protocol conflict — not a workflow failure.
+    patch_tracker.mark_failed.assert_not_awaited()

--- a/tests/unit/server/models/test_conversation_models.py
+++ b/tests/unit/server/models/test_conversation_models.py
@@ -18,6 +18,7 @@ from src.server.models.conversation import (
     ResponseFullDetail,
     SharePermissions,
     ThreadDeleteResponse,
+    ThreadExternalIdRequest,
     ThreadShareRequest,
     ThreadShareResponse,
     ThreadUpdateRequest,
@@ -221,7 +222,7 @@ class TestWorkspaceMessagesResponse:
 
 
 class TestThreadUpdateRequest:
-    """ThreadUpdateRequest title constraint."""
+    """ThreadUpdateRequest title constraint (rename only)."""
 
     def test_valid_title(self):
         req = ThreadUpdateRequest(title="My Thread")
@@ -234,3 +235,37 @@ class TestThreadUpdateRequest:
     def test_empty_allowed(self):
         req = ThreadUpdateRequest()
         assert req.title is None
+
+
+# ---------------------------------------------------------------------------
+# ThreadExternalIdRequest
+# ---------------------------------------------------------------------------
+
+
+class TestThreadExternalIdRequest:
+    """ThreadExternalIdRequest — both fields required and non-empty."""
+
+    def test_valid(self):
+        req = ThreadExternalIdRequest(platform="telegram", external_id="chat:42")
+        assert req.platform == "telegram"
+        assert req.external_id == "chat:42"
+
+    def test_platform_required(self):
+        with pytest.raises(ValidationError):
+            ThreadExternalIdRequest(external_id="chat:42")
+
+    def test_external_id_required(self):
+        with pytest.raises(ValidationError):
+            ThreadExternalIdRequest(platform="telegram")
+
+    def test_empty_rejected(self):
+        with pytest.raises(ValidationError):
+            ThreadExternalIdRequest(platform="", external_id="")
+
+    def test_platform_too_long(self):
+        with pytest.raises(ValidationError):
+            ThreadExternalIdRequest(platform="x" * 51, external_id="chat:42")
+
+    def test_external_id_too_long(self):
+        with pytest.raises(ValidationError):
+            ThreadExternalIdRequest(platform="telegram", external_id="x" * 256)

--- a/tests/unit/server/utils/test_stamp_auth.py
+++ b/tests/unit/server/utils/test_stamp_auth.py
@@ -1,0 +1,146 @@
+"""Unit tests for the service-token auth resolvers in server/utils/api.py.
+
+Covers ``_service_token_user_id`` (the shared header parser) and
+``get_stamp_auth`` (the stamp route's ``Optional[str]`` resolver) at the
+function level — the header-matching, fall-through, and delegation branches
+that the route-level tests in ``test_threads_stamp.py`` don't exercise directly.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from src.server.utils import api
+
+
+def _req(headers=None):
+    """Duck-typed request: ``_service_token_user_id`` only calls headers.get()."""
+    return SimpleNamespace(headers=headers or {})
+
+
+# ---------------------------------------------------------------------------
+# _service_token_user_id — the shared (matched, user_id) parser
+# ---------------------------------------------------------------------------
+
+
+def test_no_service_token_configured_falls_through():
+    """No INTERNAL_SERVICE_TOKEN set → service auth off → (False, None),
+    regardless of any headers the caller sends."""
+    with patch.object(api, "_SERVICE_TOKEN", ""):
+        matched, user_id = api._service_token_user_id(
+            _req({"X-Service-Token": "anything", "X-User-Id": "alice"})
+        )
+    assert matched is False
+    assert user_id is None
+
+
+def test_service_token_configured_but_header_absent_falls_through():
+    """Token configured but request omits X-Service-Token → (False, None),
+    so the caller falls through to the normal auth path (not a 401)."""
+    with patch.object(api, "_SERVICE_TOKEN", "svc-secret"):
+        matched, user_id = api._service_token_user_id(_req({"X-User-Id": "alice"}))
+    assert matched is False
+    assert user_id is None
+
+
+def test_valid_token_with_user_id_matches():
+    with patch.object(api, "_SERVICE_TOKEN", "svc-secret"):
+        matched, user_id = api._service_token_user_id(
+            _req({"X-Service-Token": "svc-secret", "X-User-Id": "alice"})
+        )
+    assert matched is True
+    assert user_id == "alice"
+
+
+def test_valid_token_without_user_id_matches_none():
+    """Token-only privileged caller: matched True, user_id None."""
+    with patch.object(api, "_SERVICE_TOKEN", "svc-secret"):
+        matched, user_id = api._service_token_user_id(
+            _req({"X-Service-Token": "svc-secret"})
+        )
+    assert matched is True
+    assert user_id is None
+
+
+def test_wrong_token_raises_401():
+    with patch.object(api, "_SERVICE_TOKEN", "svc-secret"):
+        with pytest.raises(HTTPException) as exc_info:
+            api._service_token_user_id(_req({"X-Service-Token": "wrong"}))
+    assert exc_info.value.status_code == 401
+
+
+def test_non_ascii_token_raises_401_not_500():
+    """A non-ASCII X-Service-Token returns 401, not a TypeError→500.
+
+    hmac.compare_digest rejects non-ASCII str, and header values arrive
+    latin-1-decoded, so the comparison is done on bytes.
+    """
+    with patch.object(api, "_SERVICE_TOKEN", "svc-secret"):
+        with pytest.raises(HTTPException) as exc_info:
+            api._service_token_user_id(_req({"X-Service-Token": "å-not-ascii"}))
+    assert exc_info.value.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# get_stamp_auth — Optional[str] resolver for the stamp route
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_stamp_auth_service_caller_returns_user_id_verbatim():
+    """A matched service call returns the (possibly None) X-User-Id without
+    delegating to get_current_user_id."""
+    with patch.object(api, "_SERVICE_TOKEN", "svc-secret"):
+        with patch.object(
+            api, "get_current_user_id", new=AsyncMock()
+        ) as delegate:
+            result = await api.get_stamp_auth(
+                _req({"X-Service-Token": "svc-secret"}), None
+            )
+    assert result is None
+    delegate.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_stamp_auth_non_service_caller_delegates():
+    """Not a service call → delegate to get_current_user_id and pass its result
+    straight through."""
+    with patch.object(api, "_SERVICE_TOKEN", ""):
+        with patch.object(
+            api, "get_current_user_id", new=AsyncMock(return_value="delegated-user")
+        ) as delegate:
+            result = await api.get_stamp_auth(_req(), None)
+    assert result == "delegated-user"
+    delegate.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# service_token_matches — the pure constant-time compare primitive
+# (shared with threads.py's dispatch preflight)
+# ---------------------------------------------------------------------------
+
+
+def test_service_token_matches_true_on_exact_match():
+    assert api.service_token_matches("svc-secret", "svc-secret") is True
+
+
+def test_service_token_matches_false_on_mismatch():
+    assert api.service_token_matches("wrong", "svc-secret") is False
+
+
+def test_service_token_matches_false_when_secret_unset():
+    """No configured secret → never a match, even for an empty candidate."""
+    assert api.service_token_matches("svc-secret", "") is False
+    assert api.service_token_matches("", "") is False
+
+
+def test_service_token_matches_false_when_candidate_empty():
+    assert api.service_token_matches("", "svc-secret") is False
+
+
+def test_service_token_matches_non_ascii_returns_false_not_typeerror():
+    """A non-ASCII candidate must compare False, never raise TypeError — the bug
+    that made both auth paths 500 on a latin-1 header byte."""
+    assert api.service_token_matches("å-not-ascii", "svc-secret") is False


### PR DESCRIPTION
## Summary

Adds a post-creation channel-identity stamp API and end-to-end `(platform, external_id)`
conflict signaling so channel gateways can attach and dedup external thread identities, and
unifies the service-token check both this feature and the merged dispatch guard (#308) rely on.

**Feature (`feat(threads)`)**
- Split the fused `PATCH /threads/{id}` into a **title-only rename** plus a new
  **`PUT /threads/{id}/external-id`** that stamps a channel identity onto an existing thread.
- New `update_thread_external_id` DB fn + `create_thread` now raise a typed
  `ExternalIdConflictError` → **HTTP 409 `external_id_conflict`** (and an in-stream SSE
  error frame sharing one payload helper) when a `(platform, external_id)` pair is already
  claimed. A create race no longer silently resolves to the winner — the client recovers
  via its own dedup.
- New `get_stamp_auth` / `StampThreadAuth` resolver: the stamp route accepts a privileged
  service-token caller (valid `X-Service-Token`, no `X-User-Id`) that skips the ownership
  check; every other caller resolves to a concrete owner.
- `update_thread_title`'s `RETURNING` now carries `platform` so responses include it.

**Service-token hardening**
- Extracted `api.service_token_matches(candidate, secret)` — one constant-time, **bytes**
  comparison that both the stamp/auth resolver and #308's dispatch preflight now call.
  Fixes a `TypeError`→500 on a non-ASCII `X-Service-Token` (headers arrive latin-1-decoded)
  in **both** paths, and removes the duplicated inline compare (dropped the now-unused
  `import hmac` from `threads.py`). Each caller keeps its own policy (strict-401 vs
  permissive oss-trust) and its own secret source.

**Tests (`test(threads)`)**
- New `test_threads_stamp.py` and `test_stamp_auth.py`; plus DB-layer conflict paths, the
  SSE conflict branch, model validation, `service_token_matches` unit tests (incl.
  non-ASCII → `False`, never raise), and a dispatch-path regression (non-ASCII token → 403,
  not 500).

## Overview

| Category               | Files | +LOC | −LOC |
|------------------------|------:|-----:|-----:|
| Modified (non-test)    |     8 |  359 |   42 |
| New (non-test)         |     0 |    0 |    0 |
| Tests (new + modified) |     6 |  843 |    1 |
| **Net (excl. tests)**  | **8** |**359**|**42**|

**By module**
- **Backend · DB** — `src/server/database/conversation.py` (M, +151/−3): `ExternalIdConflictError`
  + `external_id_conflict_payload` / `_unique_violation_constraint` helpers; `create_thread`
  raises the typed conflict on an external-id create race (thread_index retry unchanged);
  new `update_thread_external_id`; `platform` added to `update_thread_title` RETURNING.
- **Backend · Auth** — `src/server/utils/api.py` (M, +73/−9): `service_token_matches` primitive
  (constant-time bytes compare); `_service_token_user_id` extraction; `get_stamp_auth` /
  `StampThreadAuth` (Optional owner id; None = token-only service caller).
- **Backend · Routes** — `src/server/app/threads.py` (M, +65/−17): PATCH rename split from the
  new `PUT /external-id`; shared `_thread_list_item` helper; dispatch preflight now routes its
  service-token compare through `service_token_matches` (drops inline `hmac`).
- **Backend · Chat handler** — `src/server/handlers/chat/_common.py` (M, +40/−9): `_emit_sse_error`
  helper collapses three duplicated emit branches; new `ExternalIdConflictError` SSE branch
  (releases the burst slot, never `mark_failed`).
- **Backend · Models** — `src/server/models/conversation.py` (M, +27/−1): required `ThreadExternalIdRequest`;
  `ThreadUpdateRequest` reverted to title-only.
- **Comments** — `env.py`, `background_subagent/subagent.py`, `migrations/011_*` (M, +3/−3): comment
  wording touch-ups, no behavior change.
- **Tests** — 6 files (+843/−1): 2 new, 4 modified.

**What this introduces:** channel gateways can now stamp/dedup an external channel identity
on a thread after creation, and receive a stable `external_id_conflict` signal (both as an
HTTP 409 and an in-stream SSE frame) to recover from collisions and create races. Service-token
verification is now defined once and correct on non-ASCII input across both auth paths.

## Base / rebase note

Rebased onto `main` **after #308 merged**, so this is built on top of the dispatch-auth guard.
The one shared file (`threads.py`) is edited in disjoint regions from #308 — verified clean
three-way merge; `threads.py` carries both #308's `_get_service_token()` preflight and this
PR's stamp endpoint. This PR also **addresses the two CodeRabbit findings** on the earlier
revision (stale `ExternalIdConflictError` docstring; `hmac.compare_digest` non-ASCII 500),
and fixes the same non-ASCII bug in #308's dispatch preflight via the shared primitive.

## Diff Size
- Total: 14 files changed, 1202 insertions(+), 43 deletions(-)
- Net (excl. tests): 8 files changed, 359 insertions(+), 42 deletions(-)

## Test Coverage
Backend server unit tree + secretary suite: **2449 passed** (ignoring one env-dependent,
CI-green manifest test unrelated to this change). New-code paths covered: stamp endpoint
(happy / idempotent / 409 / 422 / 404 / ownership skip+enforce / real service-token headers),
`update_thread_external_id` (success / None / external-index conflict / other-UV re-raise),
`create_thread` external-id race → conflict (thread_index retry preserved), the
`ExternalIdConflictError` SSE branch, `ThreadExternalIdRequest` validation, the
`_service_token_user_id` / `get_stamp_auth` resolver branches, `service_token_matches`
(match / mismatch / empty secret / empty candidate / non-ASCII → False), and a dispatch
regression (non-ASCII token → 403, not 500).

## Pre-Landing Review
Independent adversarial review (correctness / security / races): **no P0/P1/P2**. Verified:
`diag.constraint_name` reliably identifies the bare partial-unique index; thread_index and
external-id violations can't cross-route; connection is autocommit so the raise leaves no
aborted transaction; the service-token ownership skip is not an escalation (the token already
permits `X-User-Id` impersonation); the SSE branch is reachable/unshadowed and shares the 409
payload. CodeRabbit's two findings (docstring, non-ASCII compare) were addressed in this
revision, and the fix extended to #308's twin dispatch-preflight compare.

## Design Review
No frontend files changed — design review skipped.

## Scope Drift
Scope Check: **CLEAN.** The service-token unification lands in files this PR already touches
(`api.py`, `threads.py`); no unrelated feature changes.

## Test plan
- [x] Server unit tree + secretary suite green (2449 passed)
- [x] Ruff clean (`uv run ruff check src/`)
- [x] Clean three-way merge on top of merged #308; `threads.py` carries both features
- [x] Adversarial review: no P0/P1/P2; CodeRabbit findings addressed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `PUT /api/v1/threads/{thread_id}/external-id` to stamp/update a thread’s external platform identity.
  * Added enhanced service-token handling for stamping and internal dispatch authentication.

* **Bug Fixes**
  * External identity deduplication conflicts now return a clear `409` with `external_id_conflict` details.
  * Thread title updates now return more consistent thread details (including platform).
  * SSE workflow errors now consistently emit external-id conflict events and formatting.

* **Tests**
  * Added/expanded unit tests covering stamping, validation, permissions, conflict behavior, and non-ASCII service tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->