### PR TITLE
fix(glob): bound Glob tool output to prevent context overflow

### DIFF
--- a/src/ptc_agent/agent/middleware/large_result_eviction.py
+++ b/src/ptc_agent/agent/middleware/large_result_eviction.py
@@ -23,10 +23,12 @@ from deepagents.backends.utils import (
 NUM_CHARS_PER_TOKEN = 4
 
 # Tools excluded from eviction (PascalCase versions of the original snake_case tools)
-# These either have built-in truncation or are problematic to evict
+# These either have built-in truncation or are problematic to evict.
+# Glob is deliberately NOT excluded: it self-caps (GLOB_MATCH_LIMIT) for the common
+# case, but eviction is kept as a backstop so a pathological result can never reach
+# the model — the same protection Bash already relies on.
 TOOLS_EXCLUDED_FROM_EVICTION = (
-    "Glob",  # Has built-in truncation
-    "Grep",  # Has built-in truncation
+    "Grep",  # Has built-in truncation (ripgrep + head_limit)
     "Read",  # Problematic truncation behavior (single long lines)
     "Write",  # Returns minimal confirmation
     "Edit",  # Returns minimal confirmation

--- a/src/ptc_agent/agent/tools/glob.py
+++ b/src/ptc_agent/agent/tools/glob.py
@@ -7,6 +7,14 @@ from ptc_agent.agent.backends import FilesystemBackend
 
 logger = structlog.get_logger(__name__)
 
+# Hard cap on paths returned to the model. A recursive glob over a project with a
+# dependency tree (node_modules, etc.) can match tens of thousands of files; without
+# a cap the single tool message can exceed every model's context window. Matches are
+# backend-sorted (sandbox: most-recent first), so the head is the most useful slice.
+# Kept well under LargeResultEvictionMiddleware's threshold, which now also backstops
+# this tool if the cap is ever raised.
+GLOB_MATCH_LIMIT = 1000
+
 
 def create_glob_tool(backend: FilesystemBackend) -> BaseTool:
     """Factory function to create Glob tool.
@@ -54,16 +62,25 @@ def create_glob_tool(backend: FilesystemBackend) -> BaseTool:
             # Virtualize paths in output (strip working directory prefix)
             virtual_matches = [backend.virtualize_path(m) for m in matches]
 
-            # Format output with virtual paths
-            result = f"Found {len(virtual_matches)} file(s) matching '{pattern}':\n"
-            for match in virtual_matches:
-                result += f"{match}\n"
+            # Cap the number of paths returned to the model (see GLOB_MATCH_LIMIT).
+            total = len(virtual_matches)
+            truncated = total > GLOB_MATCH_LIMIT
+            shown = virtual_matches[:GLOB_MATCH_LIMIT]
+
+            lines = [f"Found {total} file(s) matching '{pattern}':", *shown]
+            if truncated:
+                lines.append(
+                    f"\n[showing first {GLOB_MATCH_LIMIT} of {total} matches — narrow "
+                    f"the pattern or pass a subdirectory path to see the rest]"
+                )
+            result = "\n".join(lines)
 
             logger.info(
                 "Glob completed successfully",
                 pattern=pattern,
                 path=search_path,
-                matches=len(virtual_matches),
+                matches=total,
+                truncated=truncated,
             )
 
             return result.rstrip()

--- a/src/ptc_agent/agent/tools/glob.py
+++ b/src/ptc_agent/agent/tools/glob.py
@@ -59,13 +59,12 @@ def create_glob_tool(backend: FilesystemBackend) -> BaseTool:
                 logger.info("No files found", pattern=pattern, path=search_path)
                 return f"No files matching pattern '{pattern}' found in '{search_path}'"
 
-            # Virtualize paths in output (strip working directory prefix)
-            virtual_matches = [backend.virtualize_path(m) for m in matches]
-
-            # Cap the number of paths returned to the model (see GLOB_MATCH_LIMIT).
-            total = len(virtual_matches)
+            # Cap the number of paths returned to the model (see GLOB_MATCH_LIMIT),
+            # virtualizing only the shown slice so a pathological match set doesn't pay
+            # full virtualization cost before truncation. The header keeps the true total.
+            total = len(matches)
             truncated = total > GLOB_MATCH_LIMIT
-            shown = virtual_matches[:GLOB_MATCH_LIMIT]
+            shown = [backend.virtualize_path(m) for m in matches[:GLOB_MATCH_LIMIT]]
 
             lines = [f"Found {total} file(s) matching '{pattern}':", *shown]
             if truncated:

--- a/src/ptc_agent/core/sandbox/ptc_sandbox.py
+++ b/src/ptc_agent/core/sandbox/ptc_sandbox.py
@@ -26,6 +26,7 @@ from src.observability import (
 from src.observability.tracing import tracer as _otel_tracer
 
 from ptc_agent.config.core import CoreConfig
+from ptc_agent.core.paths import ALWAYS_HIDDEN_DIR_NAMES
 from ptc_agent.core.sandbox._defaults import DEFAULT_DEPENDENCIES, SNAPSHOT_PYTHON_VERSION
 from ptc_agent.core.sandbox.migration import CURRENT_LAYOUT_VERSION, run_layout_migrations
 from ptc_agent.core.sandbox.providers import create_provider
@@ -4308,16 +4309,34 @@ except OSError as e:
             if "**" not in pattern and "/" not in pattern:
                 pattern = f"**/{pattern}"
 
+            # Drop dependency/build/cache dirs (node_modules, .git, caches, …) so a
+            # recursive glob can't walk a huge dependency tree into the model context.
+            # AGENT_SYSTEM_DIRS (.agents, .system) are intentionally NOT in this set,
+            # so the agent's own workspace stays visible. __pycache__ is added since
+            # paths.py tracks it as a segment rather than a bare dir name.
+            excluded_dirs = sorted(ALWAYS_HIDDEN_DIR_NAMES | {"__pycache__"})
+
             glob_code = textwrap.dedent(f"""\
                 import glob
                 import os
 
                 pattern = {pattern!r}
                 search_path = {search_path!r}
+                excluded_dirs = set({excluded_dirs!r})
 
                 full_pattern = os.path.join(search_path, pattern)
                 matches = glob.glob(full_pattern, recursive=True, include_hidden=True)
-                files = [f for f in matches if os.path.isfile(f)]
+                # Exclude only the directory components *between* the search root and
+                # the file: never the search-root prefix (so globbing directly into an
+                # excluded dir still works) and never the basename (so a regular file
+                # that happens to share a noise-dir name is not dropped).
+                files = []
+                for f in matches:
+                    if not os.path.isfile(f):
+                        continue
+                    inner_dirs = os.path.relpath(f, search_path).split(os.sep)[:-1]
+                    if not (set(inner_dirs) & excluded_dirs):
+                        files.append(f)
 
                 try:
                     files_with_mtime = [(f, os.path.getmtime(f)) for f in files]

--- a/src/ptc_agent/core/sandbox/ptc_sandbox.py
+++ b/src/ptc_agent/core/sandbox/ptc_sandbox.py
@@ -4317,6 +4317,7 @@ except OSError as e:
             excluded_dirs = sorted(ALWAYS_HIDDEN_DIR_NAMES | {"__pycache__"})
 
             glob_code = textwrap.dedent(f"""\
+                import fnmatch
                 import glob
                 import os
 
@@ -4324,19 +4325,37 @@ except OSError as e:
                 search_path = {search_path!r}
                 excluded_dirs = set({excluded_dirs!r})
 
-                full_pattern = os.path.join(search_path, pattern)
-                matches = glob.glob(full_pattern, recursive=True, include_hidden=True)
-                # Exclude only the directory components *between* the search root and
-                # the file: never the search-root prefix (so globbing directly into an
-                # excluded dir still works) and never the basename (so a regular file
-                # that happens to share a noise-dir name is not dropped).
-                files = []
-                for f in matches:
-                    if not os.path.isfile(f):
-                        continue
-                    inner_dirs = os.path.relpath(f, search_path).split(os.sep)[:-1]
-                    if not (set(inner_dirs) & excluded_dirs):
-                        files.append(f)
+                # Fast path: '**/<tail>' with a basename-only tail — the recursive
+                # patterns ('**/*', '**/*.py', …) that would otherwise walk the whole
+                # tree. Prune excluded dirs *during* the walk so we never descend into
+                # node_modules/.git/etc. instead of enumerating them and filtering
+                # afterward. For these patterns this is equivalent to glob's recursive
+                # match: a case-sensitive basename match at any non-excluded depth.
+                tail = pattern[3:] if pattern.startswith("**/") else None
+                if tail is not None and "/" not in tail and "**" not in tail:
+                    files = []
+                    for dirpath, dirnames, filenames in os.walk(search_path):
+                        dirnames[:] = [d for d in dirnames if d not in excluded_dirs]
+                        for fn in filenames:
+                            if fnmatch.fnmatchcase(fn, tail):
+                                full = os.path.join(dirpath, fn)
+                                if os.path.isfile(full):
+                                    files.append(full)
+                else:
+                    # General path: exact glob semantics, then drop matches whose
+                    # *intermediate* dir components intersect the excluded set — never
+                    # the search-root prefix (so globbing directly into an excluded dir
+                    # still works) and never the basename (so a regular file that shares
+                    # a noise-dir name is not dropped).
+                    full_pattern = os.path.join(search_path, pattern)
+                    matches = glob.glob(full_pattern, recursive=True, include_hidden=True)
+                    files = []
+                    for f in matches:
+                        if not os.path.isfile(f):
+                            continue
+                        inner_dirs = os.path.relpath(f, search_path).split(os.sep)[:-1]
+                        if not (set(inner_dirs) & excluded_dirs):
+                            files.append(f)
 
                 try:
                     files_with_mtime = [(f, os.path.getmtime(f)) for f in files]

--- a/tests/integration/sandbox/ptc/test_file_operations.py
+++ b/tests/integration/sandbox/ptc/test_file_operations.py
@@ -93,6 +93,34 @@ class TestFileOperations:
         py_matches = [m for m in matches if m.endswith(".py")]
         assert len(py_matches) >= 2
 
+    async def test_glob_excludes_dependency_dirs(self, shared_sandbox):
+        """Recursive glob must skip dependency/build/cache dirs so it can't walk a
+        huge dependency tree into the model context — but only the intermediate dir
+        components: a file that merely shares a noise-dir name must survive."""
+        wd = shared_sandbox._work_dir
+        await shared_sandbox.aupload_file_bytes(f"{wd}/proj/app.py", b"# app")
+        await shared_sandbox.aupload_file_bytes(f"{wd}/proj/node_modules/pkg/index.js", b"// dep")
+        await shared_sandbox.aupload_file_bytes(f"{wd}/proj/.git/config", b"[core]")
+        # A regular file named exactly like an excluded dir must not be dropped.
+        await shared_sandbox.aupload_file_bytes(f"{wd}/proj/vendor", b"# a file, not a dir")
+
+        matches = await shared_sandbox.aglob_files("**/*", path=f"{wd}/proj")
+
+        assert any(m.endswith("/app.py") for m in matches)
+        assert any(m.endswith("/vendor") for m in matches)
+        assert not any("node_modules" in m for m in matches)
+        assert not any("/.git/" in m for m in matches)
+
+    async def test_glob_into_excluded_dir_still_works(self, shared_sandbox):
+        """Exclusion applies to the tree walked from the search root, not the root
+        itself: pointing glob directly inside an excluded dir must return its files."""
+        wd = shared_sandbox._work_dir
+        await shared_sandbox.aupload_file_bytes(f"{wd}/proj/node_modules/pkg/index.js", b"// dep")
+
+        matches = await shared_sandbox.aglob_files("**/*", path=f"{wd}/proj/node_modules")
+
+        assert any(m.endswith("/index.js") for m in matches)
+
     async def test_grep_content(self, shared_sandbox):
         wd = shared_sandbox._work_dir
         await shared_sandbox.aupload_file_bytes(

--- a/tests/unit/middleware/test_large_result_eviction.py
+++ b/tests/unit/middleware/test_large_result_eviction.py
@@ -176,6 +176,23 @@ class TestAwrapToolCall:
         from langgraph.types import Command
         assert isinstance(result, Command)
 
+    @pytest.mark.asyncio
+    async def test_glob_result_is_evicted_when_large(self):
+        """Glob is no longer on the exclusion list, so a pathological result must be
+        evicted to the filesystem instead of reaching the model (Glob self-caps for
+        the common case; eviction is the backstop)."""
+        assert "Glob" not in TOOLS_EXCLUDED_FROM_EVICTION
+        backend = _make_backend()
+        limit = 10
+        mw = LargeResultEvictionMiddleware(backend=backend, tool_token_limit_before_evict=limit)
+        request = _make_tool_request("Glob")
+        large_content = "x" * (NUM_CHARS_PER_TOKEN * limit + 100)
+        msg = ToolMessage(content=large_content, tool_call_id="call_1", name="Glob")
+        handler = AsyncMock(return_value=msg)
+        result = await mw.awrap_tool_call(request, handler)
+        from langgraph.types import Command
+        assert isinstance(result, Command)
+
 
 class TestAinterceptCommandBranch:
     """Tests for `_aintercept_large_tool_result` handling pre-wrapped Commands.

--- a/tests/unit/ptc_agent/agent/tools/test_glob.py
+++ b/tests/unit/ptc_agent/agent/tools/test_glob.py
@@ -1,0 +1,73 @@
+"""Tests for the Glob tool's result cap.
+
+A recursive glob over a project with a dependency tree can match tens of
+thousands of files; without a cap the single tool message can exceed the model
+context window. These pin down the cap and the truncation banner. Directory
+exclusion (node_modules, .git, …) happens in the sandbox backend and is covered
+by the integration suite.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ptc_agent.agent.tools.glob import GLOB_MATCH_LIMIT, create_glob_tool
+
+
+def _make_backend(matches: list[str]) -> Any:
+    """Build a minimal backend stub the Glob tool will accept.
+
+    Only the surface the tool uses is mocked: `normalize_path`,
+    `virtualize_path`, `validate_path`, `filesystem_config`, `aglob_paths`.
+    """
+    backend = SimpleNamespace()
+    backend.normalize_path = lambda p: p
+    backend.virtualize_path = lambda p: p
+    backend.validate_path = lambda p: True
+    backend.filesystem_config = SimpleNamespace(enable_path_validation=False)
+    backend.aglob_paths = AsyncMock(return_value=matches)
+    return backend
+
+
+class TestGlobCap:
+    @pytest.mark.asyncio
+    async def test_result_capped_and_banner_present(self):
+        total = GLOB_MATCH_LIMIT + 500
+        backend = _make_backend([f"/w/f{i}.py" for i in range(total)])
+        glob = create_glob_tool(backend)
+
+        result = await glob.ainvoke({"pattern": "**/*.py"})
+
+        # Header reports the true total, not the capped count.
+        assert f"Found {total} file(s)" in result
+        # Only GLOB_MATCH_LIMIT paths are listed.
+        listed = [ln for ln in result.splitlines() if ln.startswith("/w/f")]
+        assert len(listed) == GLOB_MATCH_LIMIT
+        # Truncation banner tells the agent how to narrow.
+        assert f"showing first {GLOB_MATCH_LIMIT} of {total}" in result
+        assert "narrow the pattern" in result
+
+    @pytest.mark.asyncio
+    async def test_under_cap_has_no_banner(self):
+        backend = _make_backend([f"/w/f{i}.py" for i in range(3)])
+        glob = create_glob_tool(backend)
+
+        result = await glob.ainvoke({"pattern": "**/*.py"})
+
+        assert "Found 3 file(s)" in result
+        assert "showing first" not in result
+        listed = [ln for ln in result.splitlines() if ln.startswith("/w/f")]
+        assert len(listed) == 3
+
+    @pytest.mark.asyncio
+    async def test_no_matches_message(self):
+        backend = _make_backend([])
+        glob = create_glob_tool(backend)
+
+        result = await glob.ainvoke({"pattern": "**/*.py"})
+
+        assert "No files matching" in result


### PR DESCRIPTION
## Summary

Bounds the **Glob** file-search tool so a single call can't overflow the model's context window and poison a thread. A recursive `Glob('**/*')` over a workspace that contains a large dependency tree (`node_modules`, `.venv`, build/cache dirs) could return tens of thousands of paths in one tool message; that message is persisted into thread history, so every subsequent turn re-sends it and can exceed the context window.

Glob was the only file-search tool with no guard: Grep shells out to ripgrep (skips noise dirs, supports `head_limit`), Bash is caught by the large-result eviction backstop — but Glob had no cap, no directory exclusion, and was explicitly exempt from eviction. This aligns it with its neighbors.

Backend changes:
- **Output cap** (`glob.py`) — cap returned paths at `GLOB_MATCH_LIMIT = 1000` with a truncation banner; the header still reports the true total. Single choke point in `create_glob_tool`, so it applies to every backend. No new tool params — Glob stays a `find`/`ls`, not a paginated search. Only the shown slice is virtualized, so a pathological match set doesn't pay full virtualization cost before truncation.
- **Directory exclusion + traversal pruning** (`ptc_sandbox.py::aglob_files`) — the in-sandbox walk drops `ALWAYS_HIDDEN_DIR_NAMES` (+`__pycache__`), reusing the canonical `core/paths.py` constant. For the recursive `**/<basename>` patterns (`**/*`, `**/*.py`, …) that would otherwise walk the whole tree, excluded dirs are **pruned during an `os.walk`** so the sandbox never descends into a dependency tree; complex patterns keep the exact `glob` path. Exclusion is scoped to the directory components *between the search root and each file*, so `.agents`/`.system` stay visible, a regular file that shares a noise-dir name isn't dropped, and globbing directly into an excluded dir still works.
- **Eviction backstop** (`large_result_eviction.py`) — remove `"Glob"` from `TOOLS_EXCLUDED_FROM_EVICTION` (its "has built-in truncation" comment was false), so any pathological result is evicted to disk instead of reaching the model — the same protection Bash already relies on.

## Overview

**Totals**

| Bucket | Files | +lines | −lines |
|---|---|---|---|
| Modified | 5 | 116 | 15 |
| New | 1 | 73 | 0 |
| **Net (excl. tests)** | **3** | **71** | **15** |

**By module**

- **Backend / agent tools** — `glob.py` (modified): output cap + truncation banner; virtualize only the shown slice.
- **Backend / sandbox** — `ptc_sandbox.py` (modified): `aglob_files` prunes excluded dirs during the walk (recursive patterns) / post-filters intermediate components (complex patterns).
- **Backend / middleware** — `large_result_eviction.py` (modified): Glob no longer exempt from the 40K-token eviction backstop.
- **Tests / unit** — `test_glob.py` (new): cap + banner; `test_large_result_eviction.py` (modified): large Glob result is evicted.
- **Tests / integration** — `test_file_operations.py` (modified): sandbox walk drops noise dirs, keeps a like-named file, still globs into an excluded dir.

**What this introduces:** a bounded, noise-free Glob that can't blow up thread context and can't waste a sandbox walk on a dependency tree — guards compose (prune → cap → eviction backstop).

## Diff Size
- Total: 6 files changed, 189 insertions(+), 15 deletions(-)
- Net (excl. tests): 3 files changed, 71 insertions(+), 15 deletions(-)

## Test Coverage

New code paths covered:
- Glob cap + banner (header shows true total, only 1000 paths listed, banner present) — `test_glob.py` (unit)
- Under-cap: no banner; empty match set: "No files matching" — `test_glob.py` (unit)
- Large Glob result is evicted (was previously exempt) — `test_large_result_eviction.py` (unit)
- Sandbox walk excludes dependency dirs, keeps a like-named file, and globs into an excluded dir — `test_file_operations.py` (integration)

Unit: 21 passed. The sandbox walk (exclusion + pruning) runs in the live-Daytona integration suite (green in CI) and is additionally verified host-side: the new pruning path returns a result set **identical** to the previous `glob` approach across pattern shapes (`**/*`, `**/*.py`, `**/vendor`, `**/.env`, `src/**/*.py`, `src/*.py`), and a 2k-file `node_modules` is skipped entirely (walk visits 6 dirs, 0 excluded-subdir descents).

Tests: 5 → 6 test files (+1 new); +3 unit cases, +2 integration cases.

## Pre-Landing Review

- Self / adversarial review flagged that the first-cut exclusion (`set(f.split(os.sep)) & excluded`) tested the whole absolute path — which would drop a file whose *basename* collides with a noise-dir name (a file-panel regression), return nothing when globbing into an excluded dir, and break non-default work dirs. Fixed before the first commit by scoping the match to the intermediate directory components.
- `claude[bot]`: no blocking issues; its non-blocking note (virtualize-before-slice) is addressed in `fdedf138`.
- `CodeRabbit` (🟠 Major): the recursive glob still enumerated `node_modules`/`.git` before filtering, leaving the 30s exec timeout as the only guard on huge trees. Addressed in `fdedf138` by pruning excluded dirs during the `os.walk` for recursive patterns (verified result-equivalent to the prior glob path). f-string injection ruled out (`!r` + base64 payload).

## Design Review
No frontend files changed — design review skipped.

## Eval Results
No prompt-related files changed — evals skipped.

## Scope Drift
Scope Check: CLEAN — implements the approved plan (cap + dir-exclusion + eviction backstop + tests), plus two review-driven improvements (intermediate-scoped exclusion; traversal pruning) that harden the exact pathological-tree case the PR targets.

## Plan Completion
All plan items DONE: output cap + banner, sandbox dir-exclusion, eviction backstop, unit tests, integration test. Improved beyond plan: exclusion scoped to intermediate dirs, and traversal pruned during the walk (review fixes).

## Verification Results
- Unit: 21 passed (`test_glob.py`, `test_large_result_eviction.py`).
- CI: all checks green — `backend-unit`, `backend-integration`, `sandbox-daytona` (live sandbox), `sandbox-memory`, `frontend-*`.
- Sandbox walk: host-side check confirms result-equivalence to the prior glob approach across pattern shapes and that excluded subtrees are pruned (never descended).
- Lint: `ruff check` clean; generated sandbox code parses + base64 round-trips + compiles.

## Test plan
- [x] Glob + eviction unit tests pass (21 passed)
- [x] Ruff clean; generated sandbox code compiles
- [x] Host-side equivalence + pruning check of the sandbox exclusion/walk
- [x] Integration `test_file_operations.py` on live Daytona (green in CI: `sandbox-daytona`)
