### PR TITLE
fix(chat): steer_only contract + unify the admission decision

### DIFF
--- a/src/server/handlers/chat/_common.py
+++ b/src/server/handlers/chat/_common.py
@@ -668,19 +668,28 @@ def build_graph_config(
 # keys its skip-persist/skip-mark_failed path on these so a non-admission 409
 # can't be mistaken for one. ``request_cancelled`` (from the cancellation
 # wrapper) is included defensively though it does not currently reach this path.
-ADMISSION_CONFLICT_CODES = {"stopping", "compacting", "running", "request_cancelled"}
+# ``not_running`` (steer_only probe against a fresh thread) is likewise an
+# admission outcome, not a workflow failure — nothing was admitted to persist
+# or mark failed.
+ADMISSION_CONFLICT_CODES = {
+    "stopping",
+    "compacting",
+    "running",
+    "not_running",
+    "request_cancelled",
+}
 
 
-def admission_conflict_detail(thread_id: str, state: str) -> dict:
-    """Map a non-fresh admission state to the dispatched-flow 409 detail.
+def admission_conflict_detail(state: str) -> dict:
+    """Map an admission outcome to its 409 ``{"code", "message"}`` detail.
 
-    Dispatched (X-Dispatch=background) turns can't steer, so any non-fresh peer
-    is a conflict. Returns a structured ``{"code", "message"}`` dict so
-    ``handle_workflow_error`` can tag the SSE error with the code and the client
-    can recognize the transient state; ``thread_id`` is kept out of the
-    user-facing message so it can't leak into the UI on a client-state desync.
-    Shared by the PTC and Flash handlers so the per-state wording lives in one
-    place.
+    The single wording source for every in-generator admission 409 (see
+    ``ADMISSION_CONFLICT_CODES``): the ``stopping``/``compacting``/``running``
+    conflicts and the ``steer_only`` probe's ``not_running`` refusal. Returns a
+    structured dict so ``handle_workflow_error`` can tag the SSE error with the
+    code and the client can recognize the state; the thread_id is deliberately
+    absent from the user-facing message so it can't leak into the UI on a
+    client-state desync.
     """
     if state == "stopping":
         return {
@@ -692,9 +701,17 @@ def admission_conflict_detail(thread_id: str, state: str) -> dict:
             "code": "compacting",
             "message": "The assistant is compacting its context. Wait a moment, then retry.",
         }
+    if state == "not_running":
+        return {
+            "code": "not_running",
+            "message": "No workflow is running to steer. Resubmit as a new message.",
+        }
     return {
         "code": "running",
-        "message": "The workflow is still running; the follow-up could not be admitted.",
+        "message": (
+            "The workflow is still running. Wait a moment, then retry — "
+            "or use /reconnect to continue streaming, or /cancel to stop it."
+        ),
     }
 
 
@@ -703,81 +720,98 @@ async def wait_or_steer(
     thread_id: str,
     user_input: str,
     user_id: str,
+    *,
+    steer_only: bool = False,
+    can_steer: bool = True,
+    exclude_run_id: str | None = None,
 ) -> tuple[bool, str | None]:
-    """Admit a new turn, or steer the genuinely-running one.
+    """Admit a new turn, steer the running one, or 409.
 
-    Returns ``(ready, steering_event)`` where ``ready=True`` means the caller
-    should proceed with a new workflow.  If ``ready=False`` and
-    ``steering_event`` is not None, the caller should yield that SSE string
-    and return.  If neither succeeds, raises HTTP 409.
+    The single admission decision for both the foreground and dispatched
+    paths. Returns ``(ready, steering_event)``: ``ready=True`` → start a new
+    workflow; ``ready=False`` with a non-None ``steering_event`` → yield that
+    SSE string and return. A non-admissible state raises HTTP 409 whose detail
+    carries a structured ``admission_conflict_detail`` code (surfaced as an SSE
+    ``error`` event once the stream has started).
+
+    ``steer_only=True`` (gateway steer probes) forbids the fresh-admission
+    fallback: the probe's SSE reader only understands ``steering_accepted``/
+    ``error``, so admitting a full turn on that connection streams the whole
+    response — interrupts included — into a client that ignores it. A steer
+    that finds no running turn gets ``not_running`` and the gateway resubmits
+    it as a normal message. A steer accepted just before the workflow's exit
+    may still go unconsumed — the final drain returns it via
+    ``steering_returned`` on the turn stream, not this connection.
+
+    ``can_steer=False`` (dispatched X-Dispatch=background flows) forbids
+    steering entirely: they own a pre-registered ``(thread_id, run_id)``
+    placeholder — passed as ``exclude_run_id`` so the admission scan ignores
+    it — and any OTHER in-flight run is a hard conflict, never a steer.
 
     Admission states (see ``BackgroundTaskManager.wait_for_admission``):
-    - ``"fresh"``    → start a new turn ``(True, None)``.
-    - ``"stopping"`` → an explicitly-cancelled turn is still tearing down;
-      409 "stopping, retry" (never start a second checkpoint writer).
-    - ``"running"``  → steer immediately (no wait); 409 only if steering fails.
+    - ``"fresh"``     → start a new turn ``(True, None)``; with ``steer_only``,
+      409 ``not_running`` instead.
+    - ``"stopping"``/``"compacting"`` → 409 (never start a second checkpoint
+      writer, never steer mid-summarize).
+    - ``"running"``   → steer immediately (no wait); an accept that raced the
+      workflow's exit is reclaimed and re-routed as "fresh"; 409 only if
+      steering fails. With ``can_steer=False`` a running peer is a 409 too.
     """
     # Deferred to avoid circular import: steering imports _common at
     # module level, so _common must not import steering at module level.
-    from src.server.handlers.chat.steering import steer_thread
+    from src.server.handlers.chat.steering import steer_thread, unsteer_thread
 
-    state = await manager.wait_for_admission(thread_id)
+    state = await manager.wait_for_admission(thread_id, exclude_run_id=exclude_run_id)
     if state == "fresh":
+        if steer_only:
+            raise HTTPException(
+                status_code=409, detail=admission_conflict_detail("not_running")
+            )
         return True, None
 
-    if state == "stopping":
+    # Only a genuinely-running turn on a steerable path can be steered; every
+    # other non-fresh state — and every dispatched peer (``can_steer=False``) —
+    # is a conflict. Steering mid-stopping would start a second checkpoint
+    # writer; mid-compaction would corrupt the context rewrite.
+    if state != "running" or not can_steer:
         raise HTTPException(
-            status_code=409,
-            detail={
-                "code": "stopping",
-                "message": (
-                    "The workflow is stopping. "
-                    "Wait a moment, then retry your message."
-                ),
-            },
+            status_code=409, detail=admission_conflict_detail(state)
         )
 
-    # An in-progress compaction outlasted the admission wait. Must come BEFORE
-    # the steer fallback — steering mid-summarize corrupts the context rewrite,
-    # and a manual compaction has no turn to steer into. Structured detail
-    # (code) so the client can recognize this as a transient/retryable state and
-    # re-queue rather than surfacing a hard error banner; no thread_id in the
-    # user-facing message (it would leak into the UI on a client-state desync).
-    if state == "compacting":
-        raise HTTPException(
-            status_code=409,
-            detail={
-                "code": "compacting",
-                "message": (
-                    "The assistant is compacting its context. "
-                    "Wait a moment, then resend your message."
-                ),
-            },
-        )
-
-    # state == "running" → steer the running workflow immediately.
+    # state == "running" and steerable → steer the running workflow immediately.
     result = await steer_thread(thread_id, user_input, user_id)
-    if result:
-        event_data = json.dumps(
-            {
-                "thread_id": thread_id,
-                "content": user_input,
-                "position": result["position"],
-            }
+    if not result:
+        # Steering failed (e.g. Redis unavailable) on a running turn.
+        raise HTTPException(
+            status_code=409, detail=admission_conflict_detail("running")
         )
-        return False, f"event: steering_accepted\ndata: {event_data}\n\n"
 
-    # Fallback: raise 409 if steering failed
-    raise HTTPException(
-        status_code=409,
-        detail={
-            "code": "running",
-            "message": (
-                "The workflow is still running. Wait a moment, then retry — "
-                "or use /reconnect to continue streaming, or /cancel to stop it."
-            ),
-        },
+    # Close the accept-after-exit race: the admission snapshot said "running",
+    # but the workflow may have exited — and run its final steering drain —
+    # between that snapshot and the Redis push. If the thread has no live task
+    # anymore, try to reclaim the message: a successful reclaim proves nothing
+    # consumed it, so route as if admission had said "fresh". Reclaim failure is
+    # the best-effort branch: almost always the exit drain got there first and
+    # ``steering_returned`` carried the text back on the turn stream, so report
+    # accepted — but a Redis fault on the reclaim also lands here, so "accepted"
+    # is the graceful default, not a hard delivery guarantee.
+    if not await manager.has_active_task_for_thread(thread_id):
+        reclaimed = await unsteer_thread(thread_id, result["payload"])
+        if reclaimed:
+            if steer_only:
+                raise HTTPException(
+                    status_code=409,
+                    detail=admission_conflict_detail("not_running"),
+                )
+            return True, None
+    event_data = json.dumps(
+        {
+            "thread_id": thread_id,
+            "content": user_input,
+            "position": result["position"],
+        }
     )
+    return False, f"event: steering_accepted\ndata: {event_data}\n\n"
 
 
 def _emit_sse_error(handler, payload: dict) -> str:
@@ -816,12 +850,13 @@ async def handle_workflow_error(
     ``timezone_str`` is the resolved timezone; falls back to ``request.timezone``.
     """
     # An admission-conflict 409 is a deliberate protocol response (raised
-    # in-generator by ``wait_or_steer`` or the dispatched gate), not a workflow
-    # execution failure. Surface it to the client as an SSE error, but never
-    # persist it as a conversation error or call ``mark_failed``: this path runs
-    # with ``run_id=None``, the run_id guard is skipped when run_id is None, so
-    # marking failed would clobber a concurrently-running peer turn's status
-    # (defeating the guard). Keyed on the structured admission CODE, not the bare
+    # in-generator by ``wait_or_steer`` for both the foreground and dispatched
+    # paths), not a workflow execution failure. Surface it to the client as an
+    # SSE error, but never persist it as a conversation error or call
+    # ``mark_failed``: this path runs with ``run_id=None``, the run_id guard is
+    # skipped when run_id is None, so marking failed would clobber a
+    # concurrently-running peer turn's status (defeating the guard). Keyed on
+    # the structured admission CODE, not the bare
     # 409 status: every admission 409 now carries ``detail={"code", ...}`` (see
     # ``admission_conflict_detail`` / ``wait_or_steer``), so any other
     # HTTPException — a 503, or even a future non-admission 409 from middleware —

--- a/src/server/handlers/chat/flash_workflow.py
+++ b/src/server/handlers/chat/flash_workflow.py
@@ -194,26 +194,21 @@ async def astream_flash_workflow(
         # on the same thread, and ``qr_db.create_query`` uses ``ON CONFLICT
         # (thread_id, turn_index) DO UPDATE``, so a second ``persist_query_start``
         # here would overwrite the running turn's query content with the
-        # steering text. Dispatched flow owns the BTM placeholder ``threads.py``
-        # already reserved for it under the same ``(thread_id, run_id)`` key. We
-        # still must guarantee at most one in-flight LangGraph ``astream`` per
-        # ``thread_id`` (the checkpointer is thread-keyed), so admit only when
-        # no OTHER run is active on the thread. ``exclude_run_id`` skips our own
-        # placeholder; a running or still-stopping peer means 409.
-        if dispatched:
-            state = await manager.wait_for_admission(
-                thread_id, exclude_run_id=run_id
-            )
-            if state != "fresh":
-                raise HTTPException(
-                    status_code=409,
-                    detail=admission_conflict_detail(thread_id, state),
-                )
-            ready, steering_event = True, None
-        else:
-            ready, steering_event = await wait_or_steer(
-                manager, thread_id, user_input, user_id
-            )
+        # steering text. Admit a fresh turn, steer the running one, or 409 —
+        # see ``wait_or_steer``. Dispatched flows own the pre-registered
+        # ``(thread_id, run_id)`` placeholder, so they pass it as
+        # ``exclude_run_id`` (ignore it in the admission scan) and
+        # ``can_steer=False`` (any OTHER in-flight run is a hard conflict,
+        # never a steer). Foreground turns steer.
+        ready, steering_event = await wait_or_steer(
+            manager,
+            thread_id,
+            user_input,
+            user_id,
+            steer_only=request.steer_only,
+            can_steer=not dispatched,
+            exclude_run_id=run_id if dispatched else None,
+        )
         if not ready:
             slot_owned = False
             await release_burst_slot(user_id)
@@ -601,14 +596,7 @@ async def astream_flash_workflow(
                 return
 
             raise HTTPException(
-                status_code=409,
-                detail={
-                    "code": "running",
-                    "message": (
-                        "The workflow is still running. Wait a moment, then "
-                        "retry — or use /reconnect to continue, /cancel to stop."
-                    ),
-                },
+                status_code=409, detail=admission_conflict_detail("running")
             )
         else:
             slot_owned = False  # Manager owns burst slot release from here

--- a/src/server/handlers/chat/flash_workflow.py
+++ b/src/server/handlers/chat/flash_workflow.py
@@ -579,7 +579,12 @@ async def astream_flash_workflow(
             # Race condition: another request registered first -- queue the
             # message. The admission lock should normally prevent reaching
             # this branch, but it's kept as a belt-and-braces fallback.
-            result = await steer_thread(thread_id, user_input, user_id)
+            # Dispatched flows (can_steer=False) must never steer, even in this
+            # fallback: leave result None so they fall through to the 409, same
+            # as the primary wait_or_steer path.
+            result = None if dispatched else await steer_thread(
+                thread_id, user_input, user_id
+            )
             if result:
                 slot_owned = False
                 await release_burst_slot(user_id)

--- a/src/server/handlers/chat/ptc_workflow.py
+++ b/src/server/handlers/chat/ptc_workflow.py
@@ -67,7 +67,6 @@ from ._common import (
     _is_plan_interrupt_pending,
     _resolve_timezone,
     _setup_fork_and_persistence,
-    admission_conflict_detail,
     apply_fetch_override,
     build_graph_config,
     ensure_thread,
@@ -181,27 +180,21 @@ async def astream_ptc_workflow(
         # cold-start cleanup cancels the very run it is about to start.
         if needs_startup:
             await manager.cancel_stale_workflow(thread_id, exclude_run_id=run_id)
-        # Dispatched flow owns the BTM placeholder ``threads.py`` already
-        # reserved for it under the same ``(thread_id, run_id)`` key.
-        # We still must guarantee at most one in-flight LangGraph ``astream``
-        # per ``thread_id`` (the checkpointer is thread-keyed), so admit only
-        # when no OTHER run is active on the thread. ``exclude_run_id`` skips
-        # our own placeholder; a running or still-stopping peer means 409
-        # (dispatched flows can't steer).
-        if dispatched:
-            state = await manager.wait_for_admission(
-                thread_id, exclude_run_id=run_id
-            )
-            if state != "fresh":
-                raise HTTPException(
-                    status_code=409,
-                    detail=admission_conflict_detail(thread_id, state),
-                )
-            ready, steering_event = True, None
-        else:
-            ready, steering_event = await wait_or_steer(
-                manager, thread_id, user_input, user_id
-            )
+        # Admit a fresh turn, steer the running one, or 409 — see
+        # ``wait_or_steer``. Dispatched flows own the pre-registered
+        # ``(thread_id, run_id)`` placeholder, so they pass it as
+        # ``exclude_run_id`` (ignore it in the admission scan) and
+        # ``can_steer=False`` (any OTHER in-flight run is a hard conflict,
+        # never a steer). Foreground turns steer.
+        ready, steering_event = await wait_or_steer(
+            manager,
+            thread_id,
+            user_input,
+            user_id,
+            steer_only=request.steer_only,
+            can_steer=not dispatched,
+            exclude_run_id=run_id if dispatched else None,
+        )
         if not ready:
             slot_owned = False
             await release_burst_slot(user_id)

--- a/src/server/handlers/chat/steering.py
+++ b/src/server/handlers/chat/steering.py
@@ -98,7 +98,12 @@ async def drain_pending_steerings(thread_id: str) -> list[dict] | None:
 
     try:
         key = f"workflow:steering:{thread_id}"
-        pipe = cache.client.pipeline()
+        # transaction=True (MULTI/EXEC) is load-bearing, not incidental: the
+        # LRANGE+DELETE must be atomic so it can never interleave with a
+        # concurrent ``unsteer_thread`` LREM. That atomicity is what gives
+        # wait_or_steer's reclaim its delivered-XOR-reclaimed guarantee — a
+        # message is returned here or reclaimed there, never both, never lost.
+        pipe = cache.client.pipeline(transaction=True)
         pipe.lrange(key, 0, -1)
         pipe.delete(key)
         results = await pipe.execute()
@@ -136,7 +141,9 @@ async def steer_thread(
         user_id: User identifier
 
     Returns:
-        Dict with queue position if successful, None if steering failed
+        Dict with queue position and the exact queued payload (for a
+        possible ``unsteer_thread`` reclaim) if successful, None if
+        steering failed
     """
     from src.utils.cache.redis_cache import get_cache_client
 
@@ -159,10 +166,33 @@ async def steer_thread(
             f"[CHAT] Steering for running workflow: "
             f"thread_id={thread_id} position={position}"
         )
-        return {"position": position}
+        return {"position": position, "payload": message}
     except Exception as e:
         logger.error(f"[CHAT] Failed to steer thread: {e}")
         return None
+
+
+async def unsteer_thread(thread_id: str, payload: str) -> bool:
+    """Reclaim a just-pushed steering message by exact payload (``LREM``).
+
+    Used by ``wait_or_steer`` when the workflow turned out to have exited
+    between the admission snapshot and the push. True means the message was
+    still queued (nothing consumed it); False means a drain got it first —
+    the caller must then treat the steer as delivered-or-returned, not lost.
+    """
+    from src.utils.cache.redis_cache import get_cache_client
+
+    cache = get_cache_client()
+    if not cache.enabled or not cache.client:
+        return False
+
+    try:
+        key = f"workflow:steering:{thread_id}"
+        removed = await cache.client.lrem(key, 1, payload)
+        return bool(removed)
+    except Exception as e:
+        logger.error(f"[CHAT] Failed to unsteer thread: {e}")
+        return False
 
 
 async def steer_subagent(

--- a/src/server/models/chat.py
+++ b/src/server/models/chat.py
@@ -245,6 +245,16 @@ class ChatRequest(BaseModel):
         default=False,
         description="When True, agent must submit a plan for approval via submit_plan tool before execution",
     )
+    steer_only: bool = Field(
+        default=False,
+        description="When True, this POST may only steer an in-flight workflow; "
+        "if the thread has none, reject with admission-conflict "
+        "code='not_running' (an SSE error event once the stream has started, "
+        "HTTP 409 otherwise) instead of starting a new turn. Set by gateway "
+        "steer probes, whose SSE readers ignore turn events — without this, a "
+        "steer racing the workflow's exit silently spawns a turn whose output "
+        "(interrupts included) is dropped.",
+    )
 
     # Interrupt/resume support (HITL)
     hitl_response: Optional[Dict[str, HITLResponse]] = Field(

--- a/tests/unit/server/handlers/chat/redis_fakes.py
+++ b/tests/unit/server/handlers/chat/redis_fakes.py
@@ -75,11 +75,12 @@ class FakeClient:
         lst = self.lists.get(key, [])
         return lst[index] if -len(lst) <= index < len(lst) else None
 
-    async def lrem(self, key, count, value) -> None:
+    async def lrem(self, key, count, value) -> int:
         lst = self.lists.get(key, [])
         if count == 0:
-            self.lists[key] = [x for x in lst if x != value]
-            return
+            kept = [x for x in lst if x != value]
+            self.lists[key] = kept
+            return len(lst) - len(kept)
         removed = 0
         out = []
         for x in lst:
@@ -88,6 +89,7 @@ class FakeClient:
                 continue
             out.append(x)
         self.lists[key] = out
+        return removed
 
     async def llen(self, key) -> int:
         return len(self.lists.get(key, []))

--- a/tests/unit/server/handlers/chat/test_steering_redis.py
+++ b/tests/unit/server/handlers/chat/test_steering_redis.py
@@ -1,0 +1,113 @@
+"""Redis-level contract for the steer / reclaim primitives.
+
+``wait_or_steer``'s accept-after-exit reclaim rests entirely on two Redis
+facts that the higher-level tests only ever mock: ``steer_thread`` returns the
+*exact* payload string it queued, and ``unsteer_thread`` removes that same
+string by an exact-match ``LREM`` (True iff it was still there). These tests
+exercise both against a stateful fake Redis so a wrong key, a wrong LREM count,
+or a broken truthiness mapping fails here instead of silently in production.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from .redis_fakes import FakeCache
+
+CACHE = "src.utils.cache.redis_cache.get_cache_client"
+KEY = "workflow:steering:t-1"
+
+
+@pytest.mark.asyncio
+async def test_steer_thread_queues_and_returns_the_exact_payload(monkeypatch):
+    from src.server.handlers.chat.steering import steer_thread
+
+    cache = FakeCache()
+    monkeypatch.setattr(CACHE, lambda: cache)
+
+    result = await steer_thread("t-1", "hello", "u-1")
+
+    assert result is not None
+    # The returned payload is byte-identical to what landed in the queue — the
+    # reclaim's exact-match LREM depends on this identity.
+    assert cache.client.lists[KEY] == [result["payload"]]
+    assert result["position"] == 1
+    body = json.loads(result["payload"])
+    assert body["content"] == "hello" and body["user_id"] == "u-1"
+    # An EXPIRE was issued so an unconsumed steer can't leak forever.
+    assert KEY in cache.client.ttls
+
+
+@pytest.mark.asyncio
+async def test_unsteer_reclaims_the_just_queued_payload(monkeypatch):
+    from src.server.handlers.chat.steering import steer_thread, unsteer_thread
+
+    cache = FakeCache()
+    monkeypatch.setattr(CACHE, lambda: cache)
+
+    result = await steer_thread("t-1", "hello", "u-1")
+    reclaimed = await unsteer_thread("t-1", result["payload"])
+
+    assert reclaimed is True
+    assert cache.client.lists[KEY] == []
+
+
+@pytest.mark.asyncio
+async def test_unsteer_false_when_a_drain_consumed_it_first(monkeypatch):
+    """Drain won the race (the payload is already gone): LREM removes 0, so the
+    caller must report accepted, not route fresh."""
+    from src.server.handlers.chat.steering import steer_thread, unsteer_thread
+
+    cache = FakeCache()
+    monkeypatch.setattr(CACHE, lambda: cache)
+
+    result = await steer_thread("t-1", "hello", "u-1")
+    await cache.client.delete(KEY)  # simulate the exit drain's atomic wipe
+
+    assert await unsteer_thread("t-1", result["payload"]) is False
+
+
+@pytest.mark.asyncio
+async def test_unsteer_only_removes_the_exact_payload(monkeypatch):
+    """LREM is exact-match, not a blanket clear — a different steer left by
+    another request must survive the reclaim."""
+    from src.server.handlers.chat.steering import steer_thread, unsteer_thread
+
+    cache = FakeCache()
+    monkeypatch.setattr(CACHE, lambda: cache)
+
+    mine = await steer_thread("t-1", "mine", "u-1")
+    other = await steer_thread("t-1", "other", "u-2")
+
+    assert await unsteer_thread("t-1", mine["payload"]) is True
+    assert cache.client.lists[KEY] == [other["payload"]]
+
+
+@pytest.mark.asyncio
+async def test_unsteer_false_when_cache_disabled(monkeypatch):
+    from src.server.handlers.chat.steering import unsteer_thread
+
+    cache = FakeCache()
+    cache.enabled = False
+    monkeypatch.setattr(CACHE, lambda: cache)
+
+    assert await unsteer_thread("t-1", "whatever") is False
+
+
+@pytest.mark.asyncio
+async def test_unsteer_false_on_redis_error(monkeypatch):
+    """A Redis fault on the LREM must degrade to False (report accepted), never
+    raise into the streaming generator."""
+    from src.server.handlers.chat.steering import unsteer_thread
+
+    cache = FakeCache()
+
+    async def _boom(*_args):
+        raise ConnectionError("redis down")
+
+    cache.client.lrem = _boom
+    monkeypatch.setattr(CACHE, lambda: cache)
+
+    assert await unsteer_thread("t-1", "whatever") is False

--- a/tests/unit/server/handlers/test_chat_common.py
+++ b/tests/unit/server/handlers/test_chat_common.py
@@ -822,6 +822,144 @@ class TestWaitOrSteer:
         assert event is None
 
     @pytest.mark.asyncio
+    async def test_steer_only_fresh_raises_409_not_running(self):
+        """A steer_only probe must never be admitted as a fresh turn — the
+        probe's SSE reader ignores turn events, so a turn admitted on that
+        connection streams its output (interrupts included) into a void.
+        409 'not_running' routes the gateway to its resubmit path instead."""
+        from fastapi import HTTPException
+
+        from src.server.handlers.chat._common import wait_or_steer
+
+        manager = AsyncMock()
+        manager.wait_for_admission = AsyncMock(return_value="fresh")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await wait_or_steer(
+                manager, "t-1", "hello", "u-1", steer_only=True
+            )
+
+        assert exc_info.value.status_code == 409
+        detail = exc_info.value.detail
+        assert isinstance(detail, dict)
+        assert detail["code"] == "not_running"
+        assert "t-1" not in detail["message"]
+
+    @pytest.mark.asyncio
+    async def test_steer_only_still_steers_running(self):
+        """steer_only forbids only the fresh-admission fallback; a
+        genuinely-running turn steers exactly as before."""
+        from src.server.handlers.chat._common import wait_or_steer
+
+        manager = AsyncMock()
+        manager.wait_for_admission = AsyncMock(return_value="running")
+        # Live task present → no accept-after-exit reclaim; steer straight through.
+        manager.has_active_task_for_thread = AsyncMock(return_value=True)
+
+        with patch(
+            "src.server.handlers.chat.steering.steer_thread",
+            new_callable=AsyncMock,
+            return_value={"position": 2, "payload": "QUEUED_JSON"},
+        ):
+            ready, event = await wait_or_steer(
+                manager, "t-1", "hello", "u-1", steer_only=True
+            )
+
+        assert ready is False
+        assert "steering_accepted" in event
+
+    @pytest.mark.asyncio
+    async def test_steer_accept_racing_exit_reclaims_and_admits_fresh(self):
+        """The admission snapshot said "running" but the workflow exited before
+        the Redis push landed: the message must be reclaimed and the POST
+        routed as a fresh turn — never a false steering_accepted for a
+        message nothing will consume."""
+        from src.server.handlers.chat._common import wait_or_steer
+
+        manager = AsyncMock()
+        manager.wait_for_admission = AsyncMock(return_value="running")
+        manager.has_active_task_for_thread = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "src.server.handlers.chat.steering.steer_thread",
+                new_callable=AsyncMock,
+                return_value={"position": 1, "payload": "QUEUED_JSON"},
+            ),
+            patch(
+                "src.server.handlers.chat.steering.unsteer_thread",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_unsteer,
+        ):
+            ready, event = await wait_or_steer(manager, "t-1", "hello", "u-1")
+
+        assert ready is True
+        assert event is None
+        mock_unsteer.assert_awaited_once_with("t-1", "QUEUED_JSON")
+
+    @pytest.mark.asyncio
+    async def test_steer_accept_racing_exit_steer_only_raises_not_running(self):
+        """Same race under steer_only: a reclaimed accept surfaces as
+        not_running so the gateway resubmits — not as a fresh admission."""
+        from fastapi import HTTPException
+
+        from src.server.handlers.chat._common import wait_or_steer
+
+        manager = AsyncMock()
+        manager.wait_for_admission = AsyncMock(return_value="running")
+        manager.has_active_task_for_thread = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "src.server.handlers.chat.steering.steer_thread",
+                new_callable=AsyncMock,
+                return_value={"position": 1, "payload": "QUEUED_JSON"},
+            ),
+            patch(
+                "src.server.handlers.chat.steering.unsteer_thread",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await wait_or_steer(
+                    manager, "t-1", "hello", "u-1", steer_only=True
+                )
+
+        assert exc_info.value.status_code == 409
+        assert exc_info.value.detail["code"] == "not_running"
+
+    @pytest.mark.asyncio
+    async def test_steer_accept_drained_by_exit_still_reports_accepted(self):
+        """If the reclaim misses, the exiting workflow's final drain got the
+        message first and steering_returned already carried it back on the
+        turn stream — the POST keeps the queue contract and reports
+        accepted."""
+        from src.server.handlers.chat._common import wait_or_steer
+
+        manager = AsyncMock()
+        manager.wait_for_admission = AsyncMock(return_value="running")
+        manager.has_active_task_for_thread = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "src.server.handlers.chat.steering.steer_thread",
+                new_callable=AsyncMock,
+                return_value={"position": 1, "payload": "QUEUED_JSON"},
+            ),
+            patch(
+                "src.server.handlers.chat.steering.unsteer_thread",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            ready, event = await wait_or_steer(manager, "t-1", "hello", "u-1")
+
+        assert ready is False
+        assert "steering_accepted" in event
+
+    @pytest.mark.asyncio
     async def test_running_steers_immediately_with_no_wait(self):
         """CRITICAL regression: a genuinely-running turn is steered immediately
         — admission returns "running" and steer_thread is called without any
@@ -830,11 +968,13 @@ class TestWaitOrSteer:
 
         manager = AsyncMock()
         manager.wait_for_admission = AsyncMock(return_value="running")
+        # Live task present → no accept-after-exit reclaim; steer straight through.
+        manager.has_active_task_for_thread = AsyncMock(return_value=True)
 
         with patch(
             "src.server.handlers.chat.steering.steer_thread",
             new_callable=AsyncMock,
-            return_value={"position": 1},
+            return_value={"position": 1, "payload": "QUEUED_JSON"},
         ) as mock_steer:
             ready, event = await wait_or_steer(
                 manager, "t-1", "hello", "u-1"
@@ -930,21 +1070,66 @@ class TestWaitOrSteer:
         assert "t-1" not in detail["message"]
         mock_steer.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_cannot_steer_running_is_a_conflict(self):
+        """Dispatched flows (can_steer=False) never steer: a running peer is a
+        409, not a steering_accepted — a second astream on a thread-keyed
+        checkpointer would collide."""
+        from fastapi import HTTPException
+
+        from src.server.handlers.chat._common import wait_or_steer
+
+        manager = AsyncMock()
+        manager.wait_for_admission = AsyncMock(return_value="running")
+
+        with (
+            patch(
+                "src.server.handlers.chat.steering.steer_thread",
+                new_callable=AsyncMock,
+            ) as mock_steer,
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await wait_or_steer(manager, "t-1", "hi", "u-1", can_steer=False)
+
+        assert exc_info.value.status_code == 409
+        assert exc_info.value.detail["code"] == "running"
+        mock_steer.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_exclude_run_id_reaches_admission_scan(self):
+        """A dispatched flow passes its own pre-registered run_id so the
+        admission scan ignores its placeholder and only sees OTHER runs."""
+        from src.server.handlers.chat._common import wait_or_steer
+
+        manager = AsyncMock()
+        manager.wait_for_admission = AsyncMock(return_value="fresh")
+
+        ready, event = await wait_or_steer(
+            manager, "t-1", "hi", "u-1", exclude_run_id="r-9"
+        )
+
+        assert ready is True
+        assert event is None
+        manager.wait_for_admission.assert_awaited_once_with(
+            "t-1", exclude_run_id="r-9"
+        )
+
 
 # ---------------------------------------------------------------------------
-# admission_conflict_detail (dispatched-flow 409 message mapping)
+# admission_conflict_detail (single 409 wording source)
 # ---------------------------------------------------------------------------
 
 
 class TestAdmissionConflictDetail:
-    """The dispatched (X-Dispatch=background) flow can't steer, so a non-fresh
-    admission state becomes a 409. This shared helper maps the admission state
-    to its retry message — same mapping for PTC and Flash."""
+    """The single wording source for every in-generator admission 409 — the
+    ``stopping``/``compacting``/``running`` conflicts and the ``steer_only``
+    probe's ``not_running`` refusal. Same mapping for PTC and Flash, foreground
+    and dispatched."""
 
     def test_compacting_state_names_compaction(self):
         from src.server.handlers.chat._common import admission_conflict_detail
 
-        detail = admission_conflict_detail("t-1", "compacting")
+        detail = admission_conflict_detail("compacting")
         # Structured detail (code + message) so handle_workflow_error can tag the
         # SSE error with a code and the client can recognize a transient state.
         assert isinstance(detail, dict)
@@ -955,25 +1140,39 @@ class TestAdmissionConflictDetail:
     def test_stopping_state_names_stopping(self):
         from src.server.handlers.chat._common import admission_conflict_detail
 
-        detail = admission_conflict_detail("t-1", "stopping")
+        detail = admission_conflict_detail("stopping")
         assert isinstance(detail, dict)
         assert detail["code"] == "stopping"
         assert "stopping" in detail["message"].lower()
+
+    def test_not_running_names_the_steer_refusal(self):
+        from src.server.handlers.chat._common import admission_conflict_detail
+
+        # The steer_only probe against an idle thread: not a wait_for_admission
+        # state, but routed through the same mapper so the wording lives here too.
+        detail = admission_conflict_detail("not_running")
+        assert isinstance(detail, dict)
+        assert detail["code"] == "not_running"
+        assert "running" in detail["message"].lower()
 
     def test_running_state_is_the_generic_fallback(self):
         from src.server.handlers.chat._common import admission_conflict_detail
 
         # Any other non-fresh state (e.g. "running") falls through to the
         # "still running" code.
-        detail = admission_conflict_detail("t-1", "running")
+        detail = admission_conflict_detail("running")
         assert isinstance(detail, dict)
         assert detail["code"] == "running"
         assert "still running" in detail["message"].lower()
+        # The actionable hint (reconnect / cancel) is part of the contract —
+        # the web UI renders this message verbatim, so keep it pinned.
+        assert "reconnect" in detail["message"].lower()
+        assert "cancel" in detail["message"].lower()
 
     def test_unknown_state_falls_back_to_generic(self):
         from src.server.handlers.chat._common import admission_conflict_detail
 
-        detail = admission_conflict_detail("t-1", "wedged")
+        detail = admission_conflict_detail("wedged")
         assert detail["code"] == "running"
         assert "still running" in detail["message"].lower()
 
@@ -1051,6 +1250,67 @@ class TestHandleWorkflowErrorHTTPException:
         assert any("compacting" in ev for ev in events)
         # ...but the conflict is never persisted as a turn failure and never
         # clobbers the (possibly peer-owned) tracker status.
+        persistence_service.persist_error.assert_not_awaited()
+        tracker.mark_failed.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_not_running_conflict_skips_persist_and_mark_failed(self):
+        """not_running (steer_only probe on an idle thread) is an admission
+        outcome: it must reach the client as an SSE error but never be
+        persisted or mark a (possibly peer-owned) turn failed. Pins the
+        ADMISSION_CONFLICT_CODES membership added for steer_only."""
+        from fastapi import HTTPException
+
+        from src.server.handlers.chat._common import handle_workflow_error
+
+        exc = HTTPException(
+            status_code=409,
+            detail={"code": "not_running", "message": "no workflow to steer"},
+        )
+
+        persistence_service = AsyncMock()
+        tracker = AsyncMock()
+        handler = MagicMock()
+        handler.get_tool_usage = MagicMock(return_value=None)
+        handler.get_sse_events = MagicMock(return_value=None)
+        handler._format_sse_event = MagicMock(
+            side_effect=lambda ev, data: f"event: {ev}\ndata: {data}\n\n"
+        )
+        request = MagicMock()
+        request.workspace_id = None
+        request.locale = None
+        request.timezone = None
+
+        with (
+            patch(
+                "src.server.handlers.chat._common.WorkflowTracker"
+            ) as mock_tracker_cls,
+            patch(
+                "src.server.handlers.chat._common.release_burst_slot",
+                new_callable=AsyncMock,
+            ),
+        ):
+            mock_tracker_cls.get_instance.return_value = tracker
+            events = [
+                ev
+                async for ev in handle_workflow_error(
+                    exc,
+                    thread_id="t-1",
+                    user_id="u-1",
+                    workspace_id="w-1",
+                    handler=handler,
+                    token_callback=None,
+                    persistence_service=persistence_service,
+                    start_time=0.0,
+                    request=request,
+                    is_byok=False,
+                    msg_type="ptc",
+                    log_prefix="PTC_TEST",
+                )
+            ]
+
+        assert any("event: error" in ev for ev in events)
+        assert any("not_running" in ev for ev in events)
         persistence_service.persist_error.assert_not_awaited()
         tracker.mark_failed.assert_not_awaited()
 

--- a/tests/unit/server/handlers/test_ptc_workflow_workspace_status.py
+++ b/tests/unit/server/handlers/test_ptc_workflow_workspace_status.py
@@ -56,6 +56,9 @@ def _make_request():
     req.locale = "en-US"
     req.subagents_enabled = None
     req.llm_model = None
+    # Explicit bool: a bare MagicMock attribute is truthy, which would trip
+    # the steer_only fresh-admission rejection in the real wait_or_steer.
+    req.steer_only = False
     return req
 
 

--- a/tests/unit/server/handlers/test_workflow_steer_only.py
+++ b/tests/unit/server/handlers/test_workflow_steer_only.py
@@ -1,0 +1,227 @@
+"""steer_only wiring at the workflow entrypoints.
+
+Both the foreground and dispatched paths now flow through the single
+``wait_or_steer`` admission decision; the entrypoint's only job is to hand it
+the right knobs. Per mode (PTC and Flash) this pins that wiring:
+- the foreground path forwards ``request.steer_only`` with ``can_steer=True``
+  and no ``exclude_run_id`` (dropping ``steer_only`` would silently revert the
+  gateway-probe fix), and
+- the dispatched path (X-Dispatch=background) forwards ``can_steer=False`` and
+  its own pre-registered ``exclude_run_id`` so it can never steer.
+
+The admission *behavior* those knobs select (fresh+steer_only → not_running,
+non-fresh + can't-steer → 409) lives in ``TestWaitOrSteer``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+PTC = "src.server.handlers.chat.ptc_workflow"
+FLASH = "src.server.handlers.chat.flash_workflow"
+
+
+def _make_request(steer_only: bool = True):
+    req = MagicMock()
+    req.workspace_id = "ws-1"
+    req.additional_context = None
+    req.hitl_response = None
+    req.checkpoint_id = None
+    req.messages = [MagicMock(role="user", content="hi")]
+    req.plan_mode = False
+    req.timezone = "UTC"
+    req.locale = None
+    req.subagents_enabled = None
+    req.llm_model = None
+    req.steer_only = steer_only
+    return req
+
+
+def _make_manager(admission_state: str = "fresh"):
+    manager = MagicMock()
+    manager.get_admission_lock = AsyncMock(return_value=asyncio.Lock())
+    manager.wait_for_admission = AsyncMock(return_value=admission_state)
+    manager.cancel_stale_workflow = AsyncMock()
+    return manager
+
+
+async def _drain(gen) -> list[str]:
+    """Collect events; tolerate the workflow's post-error re-raise (the
+    generator yields the SSE error events, then re-raises for the route
+    layer — see the ``except Exception`` tail of both astream functions)."""
+    collected: list[str] = []
+    try:
+        async for event in gen:
+            collected.append(event)
+    except Exception:
+        pass
+    finally:
+        await gen.aclose()
+    return collected
+
+
+# ---------------------------------------------------------------------------
+# Foreground: steer_only forwarded, steering permitted
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ptc_foreground_forwards_steer_only_and_can_steer():
+    from src.server.handlers.chat.ptc_workflow import astream_ptc_workflow
+
+    wm = MagicMock()
+    wm.has_ready_session = MagicMock(return_value=True)
+
+    with (
+        patch(f"{PTC}.setup") as mock_setup,
+        patch(f"{PTC}.ExecutionTracker"),
+        patch(f"{PTC}.BackgroundTaskManager") as mock_btm_cls,
+        patch(f"{PTC}.WorkspaceManager") as mock_wm_cls,
+        patch(f"{PTC}.release_burst_slot", new_callable=AsyncMock),
+        patch(
+            f"{PTC}.wait_or_steer",
+            new_callable=AsyncMock,
+            return_value=(False, None),
+        ) as mock_wos,
+    ):
+        mock_setup.agent_config = MagicMock()
+        mock_btm_cls.get_instance.return_value = _make_manager()
+        mock_wm_cls.get_instance.return_value = wm
+
+        await _drain(
+            astream_ptc_workflow(
+                request=_make_request(steer_only=True),
+                thread_id="t-1",
+                run_id="r-1",
+                user_input="hi",
+                user_id="u-1",
+                workspace_id="ws-1",
+            )
+        )
+
+    mock_wos.assert_awaited_once()
+    kwargs = mock_wos.await_args.kwargs
+    assert kwargs["steer_only"] is True
+    assert kwargs["can_steer"] is True
+    assert kwargs["exclude_run_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_flash_foreground_forwards_steer_only_and_can_steer():
+    from src.server.handlers.chat.flash_workflow import astream_flash_workflow
+
+    with (
+        patch(f"{FLASH}.setup") as mock_setup,
+        patch(f"{FLASH}.ExecutionTracker"),
+        patch(f"{FLASH}.BackgroundTaskManager") as mock_btm_cls,
+        patch(f"{FLASH}.release_burst_slot", new_callable=AsyncMock),
+        patch(
+            f"{FLASH}.wait_or_steer",
+            new_callable=AsyncMock,
+            return_value=(False, None),
+        ) as mock_wos,
+    ):
+        mock_setup.agent_config = MagicMock()
+        mock_btm_cls.get_instance.return_value = _make_manager()
+
+        await _drain(
+            astream_flash_workflow(
+                request=_make_request(steer_only=True),
+                thread_id="t-1",
+                run_id="r-1",
+                user_input="hi",
+                user_id="u-1",
+            )
+        )
+
+    mock_wos.assert_awaited_once()
+    kwargs = mock_wos.await_args.kwargs
+    assert kwargs["steer_only"] is True
+    assert kwargs["can_steer"] is True
+    assert kwargs["exclude_run_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# Dispatched: steering disabled, own placeholder excluded
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ptc_dispatched_forwards_can_steer_false_and_exclude_run_id():
+    from src.server.handlers.chat.ptc_workflow import astream_ptc_workflow
+
+    wm = MagicMock()
+    wm.has_ready_session = MagicMock(return_value=True)
+
+    with (
+        patch(f"{PTC}.setup") as mock_setup,
+        patch(f"{PTC}.ExecutionTracker"),
+        patch(f"{PTC}.BackgroundTaskManager") as mock_btm_cls,
+        patch(f"{PTC}.WorkspaceManager") as mock_wm_cls,
+        patch(f"{PTC}.release_burst_slot", new_callable=AsyncMock),
+        patch(
+            f"{PTC}.wait_or_steer",
+            new_callable=AsyncMock,
+            return_value=(False, None),
+        ) as mock_wos,
+    ):
+        mock_setup.agent_config = MagicMock()
+        mock_btm_cls.get_instance.return_value = _make_manager("fresh")
+        mock_wm_cls.get_instance.return_value = wm
+
+        await _drain(
+            astream_ptc_workflow(
+                request=_make_request(steer_only=True),
+                thread_id="t-1",
+                run_id="r-1",
+                user_input="hi",
+                user_id="u-1",
+                workspace_id="ws-1",
+                dispatched=True,
+            )
+        )
+
+    mock_wos.assert_awaited_once()
+    kwargs = mock_wos.await_args.kwargs
+    assert kwargs["steer_only"] is True
+    assert kwargs["can_steer"] is False
+    assert kwargs["exclude_run_id"] == "r-1"
+
+
+@pytest.mark.asyncio
+async def test_flash_dispatched_forwards_can_steer_false_and_exclude_run_id():
+    from src.server.handlers.chat.flash_workflow import astream_flash_workflow
+
+    with (
+        patch(f"{FLASH}.setup") as mock_setup,
+        patch(f"{FLASH}.ExecutionTracker"),
+        patch(f"{FLASH}.BackgroundTaskManager") as mock_btm_cls,
+        patch(f"{FLASH}.release_burst_slot", new_callable=AsyncMock),
+        patch(
+            f"{FLASH}.wait_or_steer",
+            new_callable=AsyncMock,
+            return_value=(False, None),
+        ) as mock_wos,
+    ):
+        mock_setup.agent_config = MagicMock()
+        mock_btm_cls.get_instance.return_value = _make_manager("fresh")
+
+        await _drain(
+            astream_flash_workflow(
+                request=_make_request(steer_only=True),
+                thread_id="t-1",
+                run_id="r-1",
+                user_input="hi",
+                user_id="u-1",
+                dispatched=True,
+            )
+        )
+
+    mock_wos.assert_awaited_once()
+    kwargs = mock_wos.await_args.kwargs
+    assert kwargs["steer_only"] is True
+    assert kwargs["can_steer"] is False
+    assert kwargs["exclude_run_id"] == "r-1"


### PR DESCRIPTION
## Overview

Net change (excluding tests): **5 files, +193 / −132**. No new endpoints, migrations, dependencies, or config.

| Scope | Files | +/− |
|---|---|---|
| Modified (source) | 5 | +193 / −132 |
| New (source) | 0 | — |
| Tests (3 modified, 2 new) | 5 | +617 / −12 |

By module:
- **Admission decision** — `handlers/chat/_common.py` (+113/−78): `wait_or_steer` becomes the single admission decision for both the foreground and dispatched paths (via `can_steer` + `exclude_run_id`); `admission_conflict_detail` becomes the single 409-wording source (adds `not_running`, drops a vestigial `thread_id` param). Guard-clause flatten of the reclaim block.
- **Steering primitives** — `handlers/chat/steering.py` (+33/−3): new `unsteer_thread` (exact-payload `LREM` reclaim); `steer_thread` now returns the queued payload; the exit drain's `pipeline(transaction=True)` made explicit as load-bearing.
- **Call sites** — `handlers/chat/ptc_workflow.py` (+15/−22), `handlers/chat/flash_workflow.py` (+22/−29): collapse the duplicated dispatched-admission block into one `wait_or_steer(...)` call; flash's belt-and-braces 409 routed through the canonical helper, and its `RuntimeError` fallback no longer steers dispatched flows.
- **Request model** — `models/chat.py` (+10): `steer_only` bool field.

What this introduces: one public request flag (`steer_only`), one admission code (`not_running`, added to `ADMISSION_CONFLICT_CODES`), one steering primitive (`unsteer_thread`).

## The bug

A gateway steer `POST` that raced the workflow's exit hit **fresh** admission and ran as a full new turn on the steer connection. That connection's SSE reader understands only `steering_accepted`/`error`, so the entire turn output — `ask_user_question` interrupts included — streamed into a void while the gateway resubmitted a duplicate turn. (Field symptom: a Slack interrupt card never posted; the question stranded pending server-side.)

## The fix

- `ChatRequest.steer_only=True` makes `wait_or_steer` answer fresh admission with **409 `code=not_running`** (an admission conflict — no persist / `mark_failed`), routing the gateway to its existing resubmit path.
- An accept that races the exit is **reclaimed** by exact-payload `LREM` and re-routed as fresh (or `not_running` under `steer_only`) instead of being silently dropped. The exit drain is an atomic `MULTI/EXEC`, so a steer is consumed, returned via `steering_returned`, or reclaimed — **exactly once, never lost, never doubled**.
- `wait_or_steer` is now the single admission decision for foreground and dispatched paths; `admission_conflict_detail` the single 409-wording source — collapsing per-path blocks that had diverged.

## Test plan

- `uv run python -m pytest tests/unit/` → 5856 passed (2 pre-existing local-only failures unrelated to this branch).
- New direct fake-Redis coverage for `steer_thread`'s payload round-trip and `unsteer_thread`'s exact-match reclaim (key format, LREM count, Redis-error degradation); the three accept-after-exit race outcomes; dispatched `can_steer=False` conflict; `exclude_run_id` forwarding; the `not_running` mapper.

## Post-review follow-ups

- **CodeRabbit — flash `except RuntimeError` fallback (Major): fixed.** The belt-and-braces fallback in `astream_flash_workflow` steered unconditionally, so a dispatched (`can_steer=False`) request that raced `start_workflow` could accept a steer despite the contract. Now guarded with `if not dispatched`, so dispatched flows fall through to the same 409 as the primary `wait_or_steer` path. (`ptc_workflow.py` has no such fallback.)
- **CodeRabbit — reclaim by `steering_id` instead of raw payload: declined.** The queued payload already embeds `time.time()`, so each push is unique; `LREM count=1` removes exactly one occurrence, and byte-identical duplicates are interchangeable for reclaim (we only need to reclaim one unit of "this steer"). A dedicated id would widen the payload / `steering_returned` / backfill contract for a collision that cannot occur with sequential sub-microsecond-timestamped pushes.
- **claude[bot] — stale `position` in `steering_accepted` on the drained-race path: no change.** The gateway resubmits from `steering_returned`, not from that `position`; the value is advisory. (claude[bot] flagged this as non-blocking and did not request a change.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a **“steer only”** option for chat requests to target in-flight conversations; when none is running, requests are rejected with a structured conflict code.

- **Bug Fixes**
  - Improved admission-conflict handling and messaging, including clearer “not running” guidance and updated instructions for reconnect/cancel/retry when applicable.
  - Enhanced steering queue behavior to safely drain and reclaim queued steering items with more precise acceptance behavior.

- **Tests**
  - Added/expanded unit coverage for steer-only routing, admission-conflict outcomes, and Redis steering reclaim.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->