### PR TITLE
fix(mcp): drop NaN OHLC bars from yfinance price history

### DIFF
--- a/mcp_servers/yf_price_mcp_server.py
+++ b/mcp_servers/yf_price_mcp_server.py
@@ -135,6 +135,9 @@ def _price_scale(stock: Any, ref_currency: Optional[str]) -> tuple[Optional[str]
     return ref_currency, 1.0
 
 
+_OHLC_COLUMNS = ("Open", "High", "Low", "Close")
+
+
 def _serialize_history(df: pd.DataFrame, price_divisor: float = 1.0) -> list[dict]:
     """OHLCV DataFrame → list of record dicts, ascending (oldest first).
 
@@ -142,21 +145,33 @@ def _serialize_history(df: pd.DataFrame, price_divisor: float = 1.0) -> list[dic
     "%Y-%m-%d %H:%M:%S" for intraday bars (those carrying a time component).
     ``price_divisor`` converts minor-unit quotes to major units (prices and
     dividend amounts only — never volume or split ratios).
+
+    Bars with any NaN OHLC value are dropped: yfinance appends a placeholder
+    row for an in-progress or dataless session, and a priceless bar is not a
+    real observation (NaN is also not valid JSON). A missing volume on an
+    otherwise-priced bar is coerced to 0 rather than dropped.
     """
     if df is None or df.empty:
+        return []
+
+    ohlc = [c for c in _OHLC_COLUMNS if c in df.columns]
+    if ohlc:
+        df = df.dropna(subset=ohlc)
+    if df.empty:
         return []
 
     decimals = 4 if price_divisor != 1 else 2
     records = []
     for idx, row in df.iterrows():
         dt_str = format_datetime(idx)
+        volume = row["Volume"]
         record = {
             "date": dt_str,
             "open": round(float(row["Open"]) / price_divisor, decimals),
             "high": round(float(row["High"]) / price_divisor, decimals),
             "low": round(float(row["Low"]) / price_divisor, decimals),
             "close": round(float(row["Close"]) / price_divisor, decimals),
-            "volume": int(row["Volume"]),
+            "volume": int(volume) if pd.notna(volume) else 0,
         }
         if "Dividends" in df.columns:
             record["dividends"] = round(float(row["Dividends"]) / price_divisor, 4)

--- a/tests/unit/mcp_servers/test_yf_price_mcp.py
+++ b/tests/unit/mcp_servers/test_yf_price_mcp.py
@@ -7,6 +7,7 @@ yfinance is mocked — no live network.
 
 from unittest.mock import Mock, patch
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -185,6 +186,101 @@ class TestGetStockHistory:
             result, "upstream_error", symbol="AAPL",
             detail_excludes=("Network error",),
         )
+
+
+# ============================================================================
+# NaN bars (yfinance placeholder / in-progress session rows)
+# ============================================================================
+
+
+class TestNaNBarHandling:
+    """yfinance appends a placeholder bar for an in-progress or dataless session
+    whose OHLC is NaN (timing-dependent — this is what makes VOD.L history flaky
+    around LSE hours). NaN is not valid JSON and a priceless bar is not a real
+    observation, so such rows must be dropped before serialization."""
+
+    @patch("mcp_servers.yf_price_mcp_server.yf.Ticker")
+    def test_trailing_nan_bar_dropped(self, mock_ticker_cls):
+        dates = pd.date_range("2024-01-01", periods=4, freq="D")
+        df = pd.DataFrame(
+            {
+                "Open": [150.0, 151.0, 152.0, np.nan],
+                "High": [152.0, 153.0, 154.0, np.nan],
+                "Low": [149.0, 150.0, 151.0, np.nan],
+                "Close": [151.0, 152.0, 153.0, np.nan],
+                "Volume": [1000000, 1100000, 1200000, 0],
+            },
+            index=dates,
+        )
+        mock_ticker_cls.return_value.history.return_value = df
+        result = get_stock_history("AAPL")
+
+        assert_ok_envelope(result, count=3)  # placeholder bar dropped
+        closes = [row["close"] for row in result["data"]]
+        assert all(isinstance(c, float) and c == c for c in closes)  # no NaN
+        assert result["data"][-1]["close"] == 153.0  # last surviving bar is real
+
+    @patch("mcp_servers.yf_price_mcp_server.yf.Ticker")
+    def test_all_nan_bars_is_not_found(self, mock_ticker_cls):
+        dates = pd.date_range("2024-01-01", periods=2, freq="D")
+        df = pd.DataFrame(
+            {
+                "Open": [np.nan, np.nan],
+                "High": [np.nan, np.nan],
+                "Low": [np.nan, np.nan],
+                "Close": [np.nan, np.nan],
+                "Volume": [0, 0],
+            },
+            index=dates,
+        )
+        mock_ticker_cls.return_value.history.return_value = df
+        result = get_stock_history("AAPL")
+
+        # Every bar dropped → same as an empty frame → not_found, never a crash.
+        assert_error(result, "not_found", symbol="AAPL")
+
+    @patch("mcp_servers.yf_price_mcp_server.yf.Ticker")
+    def test_nan_volume_on_valid_price_bar_coerced(self, mock_ticker_cls):
+        """A priced bar with a missing volume is kept (volume → 0), not dropped
+        and not crashed on int(NaN)."""
+        dates = pd.date_range("2024-01-01", periods=2, freq="D")
+        df = pd.DataFrame(
+            {
+                "Open": [150.0, 151.0],
+                "High": [152.0, 153.0],
+                "Low": [149.0, 150.0],
+                "Close": [151.0, 152.0],
+                "Volume": [1000000, np.nan],
+            },
+            index=dates,
+        )
+        mock_ticker_cls.return_value.history.return_value = df
+        result = get_stock_history("AAPL")
+
+        assert_ok_envelope(result, count=2)
+        assert result["data"][1]["close"] == 152.0
+        assert result["data"][1]["volume"] == 0
+
+    @patch("mcp_servers.yf_price_mcp_server.yf.Ticker")
+    def test_multi_history_drops_nan_bars(self, mock_ticker_cls):
+        dates = pd.date_range("2024-01-01", periods=3, freq="D")
+        df = pd.DataFrame(
+            {
+                "Open": [150.0, 151.0, np.nan],
+                "High": [152.0, 153.0, np.nan],
+                "Low": [149.0, 150.0, np.nan],
+                "Close": [151.0, 152.0, np.nan],
+                "Volume": [1000000, 1100000, 0],
+            },
+            index=dates,
+        )
+        mock_ticker_cls.return_value.history.return_value = df
+        result = get_multiple_stocks_history(["AAPL"])
+
+        assert result["data"]["AAPL"]["count"] == 2
+        assert result["count"] == 2
+        closes = [row["close"] for row in result["data"]["AAPL"]["data"]]
+        assert all(c == c for c in closes)  # no NaN
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
Fixes a flaky integration test (`test_get_stock_history_lse_minor_units`, `assert 0 < nan`) that was really surfacing a data-quality bug in the yfinance price server.

- **fix(mcp):** `_serialize_history` dropped nothing — it serialized every yfinance row verbatim. yfinance appends a placeholder bar for an in-progress or dataless session whose OHLC is `NaN`, so `data[-1]["close"]` came back as `NaN` whenever CI ran at the wrong time relative to LSE hours. Now any bar missing an OHLC value is dropped, and a `NaN` volume is coerced to `0` instead of crashing `int(NaN)`.
- **test(mcp):** deterministic coverage for every NaN mode.

## Overview
Net-change map of the whole branch.

| | Files | +lines | −lines |
|---|---|---|---|
| Modified | 2 | 112 | 1 |
| New | 0 | 0 | 0 |
| **Net (excl. tests)** | **1** | **16** | **1** |

**By module**
- **Backend / MCP market-data** — `mcp_servers/yf_price_mcp_server.py` *(modified)*: `_serialize_history` now drops bars with any NaN in Open/High/Low/Close and coerces a missing volume to 0. Shared path, so `get_stock_history` **and** `get_multiple_stocks_history` both benefit.
- **Tests** — `tests/unit/mcp_servers/test_yf_price_mcp.py` *(modified)*: +4 cases (trailing NaN bar dropped, all-NaN frame → `not_found`, NaN-volume coerced, multi-symbol path).

**What this introduces:** the yfinance price envelope can no longer emit a `NaN` price (invalid JSON that also misleads the agent) or fail a valid query on an `int(NaN)` volume. The two flaky modes are closed at the source, not papered over in the test.

## Diff Size
- Total: 2 files changed, 112 insertions(+), 1 deletion(-)
- Net (excl. tests): 1 file changed, 16 insertions(+), 1 deletion(-)

## Test Coverage
Both new code paths covered by dedicated tests:
- drop NaN-OHLC bars → `test_trailing_nan_bar_dropped`, `test_multi_history_drops_nan_bars`
- all-NaN frame → `not_found` → `test_all_nan_bars_is_not_found`
- NaN volume → 0 (no crash) → `test_nan_volume_on_valid_price_bar_coerced`

`tests/unit/mcp_servers/`: 338 passed. Affected file: 29 passed. Ruff clean. Live `TestYfPriceLive` (6 tests): pass.

## Pre-Landing Review
No issues found. `dropna` rebinds the local param (caller's `df.index` timezone lookup unaffected); real trading bars always populate OHLC so no legitimate bar is dropped; `count == len(data)` invariant preserved. `get_dividends_and_splits` does not use this path, so scoping the fix to the OHLC serializer is correct.

## Design Review
No frontend files changed — design review skipped.

## Plan Completion
No plan file detected.

## Test plan
- [x] `uv run pytest tests/unit/mcp_servers/` — 338 passed
- [x] `uv run ruff check` on changed files — clean
- [x] Live `tests/integration/test_yf_mcp_live.py::TestYfPriceLive` — 6 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stock history handling so incomplete or placeholder price bars are ignored.
  * Prevented failures when all returned bars are invalid by returning a not-found result instead of crashing.
  * Kept valid price bars even when volume is missing, with volume now shown as `0`.
  * Applied the same cleanup to multi-stock history so invalid bars no longer appear in results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->