### PR TITLE
feat: OpenAI GPT-5.6 series with explicit prompt caching, gated to api.openai.com

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     # LangChain core packages (v1)
     "langchain>=1.0.0",
     "langchain-core>=1.4.7",
-    "langchain-openai>=1.1.0",
+    "langchain-openai>=1.3.5",
     "langchain-anthropic>=1.0.0",
     "langchain_google_genai>=2.0.0",
     "langchain-deepseek>=0.1.4",

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -183,10 +183,10 @@ case $llm in
         sub=$(prompt_choice "Sub-choice" "a")
         case $sub in
             b)
-                set_llm_field "name" "gpt-5.4-oauth"
-                set_llm_field "flash" "gpt-5.4-mini-oauth"
-                set_llm_field "compaction" "gpt-5.4-mini-oauth"
-                set_llm_field "fetch" "gpt-5.4-mini-oauth"
+                set_llm_field "name" "gpt-5.6-sol-oauth"
+                set_llm_field "flash" "gpt-5.6-terra-oauth"
+                set_llm_field "compaction" "gpt-5.6-terra-oauth"
+                set_llm_field "fetch" "gpt-5.6-terra-oauth"
                 success "ChatGPT OAuth — connect your subscription in the UI after starting"
                 ;;
             *)

--- a/src/llms/endpoints.py
+++ b/src/llms/endpoints.py
@@ -1,0 +1,25 @@
+"""Endpoint eligibility checks for provider-specific request features."""
+
+import os
+from urllib.parse import urlparse
+
+_OFFICIAL_OPENAI_HOST = "api.openai.com"
+
+
+def is_official_openai_endpoint(base_url: str | None) -> bool:
+    """True when requests with this base_url would hit api.openai.com.
+
+    A ``None`` base_url falls through to the SDK default (api.openai.com)
+    unless an env override (``OPENAI_API_BASE`` / ``OPENAI_BASE_URL``)
+    redirects it — the same fallback chain langchain-openai and the openai
+    SDK apply.
+    """
+    url = base_url or os.getenv("OPENAI_API_BASE") or os.getenv("OPENAI_BASE_URL")
+    if not url:
+        return True
+    parsed = urlparse(url)
+    if parsed.hostname is None:
+        # Scheme-less values ("api.openai.com/v1") parse as path-only; re-parse
+        # as network location so the host comparison sees them.
+        parsed = urlparse(f"//{url}")
+    return (parsed.hostname or "").lower() == _OFFICIAL_OPENAI_HOST

--- a/src/llms/extension/codex.py
+++ b/src/llms/extension/codex.py
@@ -1,13 +1,13 @@
 """ChatOpenAI subclass for Codex store=false backends.
 
-The official Codex CLI (codex-rs) marks the `id` field on Reasoning items
-with #[serde(skip_serializing)] — IDs are read from responses but never
-re-sent. With store=false, the server can't resolve these IDs → "Item not
-found". We replicate that behavior here: strip `id` from reasoning items
-and any item whose ID the server would try to look up.
-
-encrypted_content is preserved so the model can resume reasoning across turns
-(requires `include: ["reasoning.encrypted_content"]` in model parameters).
+Layers two Codex-specific fixes on ChatOpenAI: system messages are promoted to
+the top-level ``instructions`` field (the Codex API rejects ``role:"system"`` in
+the input array), and a module-level guard coerces a null ``response.output`` —
+which the chatgpt.com backend sends on terminal stream frames — to ``[]`` before
+langchain iterates it. Cross-turn reasoning continuity relies on
+``include: ["reasoning.encrypted_content"]``; langchain-openai (>=1.3.4) drops
+unpersisted ids under store=false and keeps encrypted reasoning items itself, so
+no request-side id stripping is done here.
 """
 
 import logging
@@ -15,46 +15,6 @@ import logging
 from langchain_openai import ChatOpenAI
 
 logger = logging.getLogger(__name__)
-
-# Prefixes of server-generated IDs that require store=true to resolve.
-_UNPERSISTED_ID_PREFIXES = ("rs_",)
-
-
-def _sanitize_input_for_stateless(items: list) -> list:
-    """Sanitize a Responses API input array for store=false backends.
-
-    Matches the official Codex CLI behavior (codex-rs/protocol/src/models.rs):
-    - Strip `id` from reasoning/compaction items (skip_serializing in Rust)
-    - Strip any item `id` with an unpersisted prefix (rs_)
-    """
-    result = []
-    for item in items:
-        if not isinstance(item, dict):
-            result.append(item)
-            continue
-
-        item_type = item.get("type", "")
-        item_id = item.get("id", "")
-
-        # Strip id from reasoning/compaction items (Codex RS: skip_serializing)
-        if item_type in ("reasoning", "compaction") or item_type.startswith("reasoning"):
-            if item_id:
-                item = {k: v for k, v in item.items() if k != "id"}
-                logger.debug(f"[codex] Stripped id from {item_type} item (was {item_id[:20]}...)")
-            result.append(item)
-            continue
-
-        # Safety net: strip any id with an unpersisted prefix
-        if isinstance(item_id, str) and item_id.startswith(_UNPERSISTED_ID_PREFIXES):
-            item = {k: v for k, v in item.items() if k != "id"}
-            logger.debug(
-                f"[codex] Stripped unpersisted id from type={item_type} "
-                f"role={item.get('role', '')} (was {item_id[:20]}...)"
-            )
-
-        result.append(item)
-
-    return result
 
 
 def _extract_system_to_instructions(payload: dict) -> None:
@@ -102,17 +62,14 @@ def _extract_system_to_instructions(payload: dict) -> None:
 class ChatCodexOpenAI(ChatOpenAI):
     """ChatOpenAI for Codex store=false backends.
 
-    Replicates the official Codex CLI's behavior: reasoning item IDs are
-    never re-sent to the server (they're marked skip_serializing in Rust).
-    encrypted_content is preserved for reasoning continuity across turns.
+    Promotes system messages to the ``instructions`` field the Codex API
+    requires. Encrypted reasoning items are replayed as-is for cross-turn
+    continuity (langchain-openai handles store=false id dropping).
     """
 
     def _get_request_payload(self, input_, *, stop=None, **kwargs):
         payload = super()._get_request_payload(input_, stop=stop, **kwargs)
-        items = payload.get("input")
-        if items:
-            payload["input"] = _sanitize_input_for_stateless(items)
-        # Codex API rejects role:"system" — promote to instructions field
+        # Codex API rejects role:"system" — promote to the instructions field.
         _extract_system_to_instructions(payload)
         return payload
 
@@ -121,7 +78,7 @@ def _install_responses_output_guard() -> None:
     """Coerce a null Responses-API ``output`` to ``[]`` before langchain iterates it.
 
     The chatgpt.com Codex backend ships ``response.output = null`` on terminal
-    stream frames. langchain_openai (through 1.2.2, latest) iterates it unguarded
+    stream frames. langchain_openai (through 1.3.5, latest) iterates it unguarded
     in ``_construct_lc_result_from_responses_api`` and raises
     ``TypeError('NoneType' object is not iterable)``, killing the turn. The
     backend rejects the request-side ``exclude`` workaround with HTTP 400, so we

--- a/src/llms/llm.py
+++ b/src/llms/llm.py
@@ -9,6 +9,7 @@ from langchain_core.language_models import BaseChatModel
 from langchain_deepseek import ChatDeepSeek
 from langchain_qwq import ChatQwen
 
+from .endpoints import is_official_openai_endpoint
 from .pricing_utils import get_price_tier
 
 load_dotenv()
@@ -507,6 +508,14 @@ class LLM:
         # Add all parameters from llm_config
         params.update(self.parameters)
 
+        # Explicit prompt caching is api.openai.com-only: strip the opt-in when
+        # routed anywhere else (platform proxy, OpenAI-compatible endpoints) so
+        # ineligible backends never see the param or the breakpoint marker.
+        if params.get("prompt_cache_options") is not None and not is_official_openai_endpoint(
+            params.get("base_url") or params.get("openai_api_base")
+        ):
+            params.pop("prompt_cache_options")
+
         # Pass extra_body for provider-specific fields (e.g. caching, thinking)
         if self.extra_body:
             params["extra_body"] = self.extra_body
@@ -539,6 +548,9 @@ class LLM:
             params["output_version"] = "responses/v1"
 
         params.update(self.parameters)
+
+        # The codex backend 400s on explicit-caching params — never forward the opt-in.
+        params.pop("prompt_cache_options", None)
 
         if self.extra_body:
             params["extra_body"] = self.extra_body

--- a/src/llms/manifest/models.json
+++ b/src/llms/manifest/models.json
@@ -19,10 +19,33 @@
       }
     }
   },
-  "gpt-5.4": {
-    "model_id": "gpt-5.4",
+  "gpt-5.6-sol": {
+    "model_id": "gpt-5.6-sol",
     "provider": "openai",
-    "display_name": "GPT-5.4",
+    "display_name": "GPT-5.6 Sol",
+    "visible": true,
+    "speed": 2,
+    "intelligence": 5,
+    "context": 400000,
+    "input_modalities": [
+      "text",
+      "image",
+      "pdf"
+    ],
+    "parameters": {
+      "reasoning": {
+        "effort": "medium",
+        "summary": "auto"
+      },
+      "prompt_cache_options": {
+        "mode": "implicit"
+      }
+    }
+  },
+  "gpt-5.6-terra": {
+    "model_id": "gpt-5.6-terra",
+    "provider": "openai",
+    "display_name": "GPT-5.6 Terra",
     "visible": true,
     "speed": 3,
     "intelligence": 5,
@@ -36,16 +59,19 @@
       "reasoning": {
         "effort": "medium",
         "summary": "auto"
+      },
+      "prompt_cache_options": {
+        "mode": "implicit"
       }
     }
   },
-  "gpt-5.4-mini": {
-    "model_id": "gpt-5.4-mini",
+  "gpt-5.6-luna": {
+    "model_id": "gpt-5.6-luna",
     "provider": "openai",
-    "display_name": "GPT-5.4 Mini",
+    "display_name": "GPT-5.6 Luna",
     "visible": true,
-    "speed": 5,
-    "intelligence": 3,
+    "speed": 4,
+    "intelligence": 4,
     "context": 400000,
     "input_modalities": [
       "text",
@@ -56,26 +82,9 @@
       "reasoning": {
         "effort": "medium",
         "summary": "auto"
-      }
-    }
-  },
-  "gpt-5.4-nano": {
-    "model_id": "gpt-5.4-nano",
-    "provider": "openai",
-    "display_name": "GPT-5.4 Nano",
-    "visible": true,
-    "speed": 5,
-    "intelligence": 3,
-    "context": 400000,
-    "input_modalities": [
-      "text",
-      "image",
-      "pdf"
-    ],
-    "parameters": {
-      "reasoning": {
-        "effort": "medium",
-        "summary": "auto"
+      },
+      "prompt_cache_options": {
+        "mode": "implicit"
       }
     }
   },
@@ -1091,8 +1100,31 @@
       "store": false
     }
   },
-  "gpt-5.4-oauth": {
-    "model_id": "gpt-5.4",
+  "gpt-5.6-sol-oauth": {
+    "model_id": "gpt-5.6-sol",
+    "provider": "codex-oauth",
+    "visible": true,
+    "speed": 2,
+    "intelligence": 5,
+    "context": 400000,
+    "input_modalities": [
+      "text",
+      "image",
+      "pdf"
+    ],
+    "parameters": {
+      "reasoning": {
+        "effort": "medium",
+        "summary": "auto"
+      },
+      "include": [
+        "reasoning.encrypted_content"
+      ],
+      "store": false
+    }
+  },
+  "gpt-5.6-terra-oauth": {
+    "model_id": "gpt-5.6-terra",
     "provider": "codex-oauth",
     "visible": true,
     "speed": 3,
@@ -1114,12 +1146,12 @@
       "store": false
     }
   },
-  "gpt-5.4-mini-oauth": {
-    "model_id": "gpt-5.4-mini",
+  "gpt-5.6-luna-oauth": {
+    "model_id": "gpt-5.6-luna",
     "provider": "codex-oauth",
     "visible": true,
-    "speed": 5,
-    "intelligence": 3,
+    "speed": 4,
+    "intelligence": 4,
     "context": 400000,
     "input_modalities": [
       "text",

--- a/src/llms/manifest/models.json
+++ b/src/llms/manifest/models.json
@@ -26,7 +26,7 @@
     "visible": true,
     "speed": 2,
     "intelligence": 5,
-    "context": 400000,
+    "context": 1050000,
     "input_modalities": [
       "text",
       "image",
@@ -49,7 +49,7 @@
     "visible": true,
     "speed": 3,
     "intelligence": 5,
-    "context": 400000,
+    "context": 1050000,
     "input_modalities": [
       "text",
       "image",
@@ -72,7 +72,7 @@
     "visible": true,
     "speed": 4,
     "intelligence": 4,
-    "context": 400000,
+    "context": 1050000,
     "input_modalities": [
       "text",
       "image",
@@ -1106,7 +1106,7 @@
     "visible": true,
     "speed": 2,
     "intelligence": 5,
-    "context": 400000,
+    "context": 1050000,
     "input_modalities": [
       "text",
       "image",
@@ -1129,7 +1129,7 @@
     "visible": true,
     "speed": 3,
     "intelligence": 5,
-    "context": 400000,
+    "context": 1050000,
     "input_modalities": [
       "text",
       "image",
@@ -1152,7 +1152,7 @@
     "visible": true,
     "speed": 4,
     "intelligence": 4,
-    "context": 400000,
+    "context": 1050000,
     "input_modalities": [
       "text",
       "image",

--- a/src/llms/manifest/providers.json
+++ b/src/llms/manifest/providers.json
@@ -53,60 +53,64 @@
         }
       },
       {
-        "id": "gpt-5.4-mini",
-        "name": "GPT-5.4 Mini",
+        "id": "gpt-5.6-sol",
+        "name": "GPT-5.6 Sol",
         "is_reasoning": true,
-        "description": "OpenAI's strongest mini model for coding, computer use, and subagents",
-        "alias": [
-          "gpt-5.4-mini-2026-03-17"
-        ],
-        "context_window": 400000,
-        "max_output": 128000,
+        "description": "OpenAI's flagship GPT-5.6 reasoning model with tiered short/long-context pricing",
         "pricing": {
-          "input": 0.75,
-          "cached_input": 0.075,
-          "output": 4.5,
+          "input_tiers": [
+            {
+              "max_tokens": 272000,
+              "rate": 5.0,
+              "cached_input": 0.5,
+              "cache_5m": 6.25
+            },
+            {
+              "max_tokens": null,
+              "rate": 10.0,
+              "cached_input": 1.0,
+              "cache_5m": 12.5
+            }
+          ],
+          "cache_5m": 6.25,
+          "output_tiers": [
+            {
+              "max_tokens": 272000,
+              "rate": 30.0
+            },
+            {
+              "max_tokens": null,
+              "rate": 45.0
+            }
+          ],
+          "output_pricing_mode": "input_dependent",
+          "input_pricing_mode": "input_dependent",
           "unit": "per_1m_tokens"
-        }
+        },
+        "context_window": 1050000,
+        "max_output": 128000
       },
       {
-        "id": "gpt-5.4-nano",
-        "name": "GPT-5.4 Nano",
+        "id": "gpt-5.6-terra",
+        "name": "GPT-5.6 Terra",
         "is_reasoning": true,
-        "description": "OpenAI's cheapest GPT-5.4-class model for simple high-volume tasks",
-        "alias": [
-          "gpt-5.4-nano-2026-03-17"
-        ],
-        "context_window": 400000,
-        "max_output": 128000,
-        "pricing": {
-          "input": 0.2,
-          "cached_input": 0.02,
-          "output": 1.25,
-          "unit": "per_1m_tokens"
-        }
-      },
-      {
-        "id": "gpt-5.4",
-        "name": "GPT-5.4",
-        "is_reasoning": true,
-        "description": "OpenAI's latest and most capable reasoning model with tiered pricing",
-        "alias": [
-          "gpt-5.4-2026-03-05"
-        ],
+        "description": "OpenAI's mid-tier GPT-5.6 reasoning model with tiered short/long-context pricing",
         "pricing": {
           "input_tiers": [
             {
               "max_tokens": 272000,
               "rate": 2.5,
-              "cached_input": 0.25
+              "cached_input": 0.25,
+              "cache_5m": 3.125
             },
             {
               "max_tokens": null,
               "rate": 5.0,
-              "cached_input": 0.5
+              "cached_input": 0.5,
+              "cache_5m": 6.25
             }
           ],
+          "cache_5m": 3.125,
           "output_tiers": [
             {
               "max_tokens": 272000,
@@ -118,8 +122,49 @@
             }
           ],
           "output_pricing_mode": "input_dependent",
+          "input_pricing_mode": "input_dependent",
           "unit": "per_1m_tokens"
-        }
+        },
+        "context_window": 1050000,
+        "max_output": 128000
+      },
+      {
+        "id": "gpt-5.6-luna",
+        "name": "GPT-5.6 Luna",
+        "is_reasoning": true,
+        "description": "OpenAI's most cost-efficient GPT-5.6 reasoning model with tiered short/long-context pricing",
+        "pricing": {
+          "input_tiers": [
+            {
+              "max_tokens": 272000,
+              "rate": 1.0,
+              "cached_input": 0.1,
+              "cache_5m": 1.25
+            },
+            {
+              "max_tokens": null,
+              "rate": 2.0,
+              "cached_input": 0.2,
+              "cache_5m": 2.5
+            }
+          ],
+          "cache_5m": 1.25,
+          "output_tiers": [
+            {
+              "max_tokens": 272000,
+              "rate": 6.0
+            },
+            {
+              "max_tokens": null,
+              "rate": 9.0
+            }
+          ],
+          "output_pricing_mode": "input_dependent",
+          "input_pricing_mode": "input_dependent",
+          "unit": "per_1m_tokens"
+        },
+        "context_window": 1050000,
+        "max_output": 128000
       }
     ],
     "anthropic": [

--- a/src/llms/pricing_utils.py
+++ b/src/llms/pricing_utils.py
@@ -443,11 +443,21 @@ def find_2d_pricing_rates(
     return None
 
 
+def _select_tier(tiers: List[Dict[str, Any]], selector_tokens: int) -> Dict[str, Any]:
+    """Pick the tier a request falls into by its total prompt size."""
+    for tier in tiers:
+        max_tokens = tier.get('max_tokens')
+        if max_tokens is None or selector_tokens <= max_tokens:
+            return tier
+    return tiers[-1]
+
+
 def get_input_cost(
     tokens: int,
     pricing: Dict[str, Any],
     cached_tokens: int = 0,
-    output_tokens: int = 0
+    output_tokens: int = 0,
+    tier_selector_tokens: Optional[int] = None
 ) -> Tuple[float, float]:
     """
     Calculate input cost with support for flat, tiered, and 2D matrix pricing.
@@ -457,10 +467,14 @@ def get_input_cost(
         pricing: Pricing dictionary (may contain 'input', 'input_tiers', or 'matrix')
         cached_tokens: Number of tokens served from cache
         output_tokens: Total output tokens (for 2D matrix pricing)
+        tier_selector_tokens: Raw prompt total used to pick the tier (defaults
+            to ``tokens``); callers pass the unadjusted input so cache-write
+            subtraction can't demote a long-context request to the short tier
 
     Returns:
         Tuple of (regular_input_cost, cached_input_cost)
     """
+    selector = tier_selector_tokens if tier_selector_tokens is not None else tokens
     regular_tokens = tokens - cached_tokens
     regular_cost = 0.0
     cached_cost = 0.0
@@ -487,8 +501,15 @@ def get_input_cost(
     # Calculate regular (non-cached) input cost
     if regular_tokens > 0:
         if 'input_tiers' in pricing:
-            # Tiered pricing
-            regular_cost = calculate_tiered_cost(regular_tokens, pricing['input_tiers'])
+            if pricing.get('input_pricing_mode') == 'input_dependent':
+                # Threshold pricing: the whole request bills at the tier its
+                # total prompt size falls into (e.g. OpenAI GPT-5.6 charges
+                # 2x input on the full request once the prompt exceeds 272K).
+                rate = _select_tier(pricing['input_tiers'], selector).get('rate', 0)
+                regular_cost = (regular_tokens / 1_000_000) * rate
+            else:
+                # Progressive pricing: each tier range bills at its own rate
+                regular_cost = calculate_tiered_cost(regular_tokens, pricing['input_tiers'])
         elif 'input' in pricing:
             # Flat pricing
             regular_cost = (regular_tokens / 1_000_000) * pricing['input']
@@ -504,15 +525,7 @@ def get_input_cost(
             cached_cost = (cached_tokens / 1_000_000) * pricing['cached_input']
         elif 'input_tiers' in pricing:
             # Check for per-tier cached_input rates (e.g., Qwen models)
-            tiers = pricing['input_tiers']
-            tier_cached_rate = None
-
-            # Find the applicable tier based on total input tokens
-            for tier in tiers:
-                max_tokens = tier.get('max_tokens')
-                if max_tokens is None or tokens <= max_tokens:
-                    tier_cached_rate = tier.get('cached_input')
-                    break
+            tier_cached_rate = _select_tier(pricing['input_tiers'], selector).get('cached_input')
 
             if tier_cached_rate is not None:
                 # Use per-tier cached_input rate
@@ -546,7 +559,8 @@ def get_cache_storage_cost(storage_tokens: int, pricing: Dict[str, Any]) -> floa
 def get_cache_creation_cost(
     cache_5m_tokens: int,
     cache_1h_tokens: int,
-    pricing: Dict[str, Any]
+    pricing: Dict[str, Any],
+    tier_selector_tokens: Optional[int] = None
 ) -> Tuple[float, float]:
     """
     Calculate Anthropic-style cache creation costs.
@@ -555,6 +569,9 @@ def get_cache_creation_cost(
         cache_5m_tokens: Tokens written to 5-minute cache
         cache_1h_tokens: Tokens written to 1-hour cache
         pricing: Pricing dictionary
+        tier_selector_tokens: Raw prompt total; when the selected input tier
+            carries its own cache_5m/cache_1h rate (long-context write rates),
+            it overrides the flat top-level rate
 
     Returns:
         Tuple of (cache_5m_cost, cache_1h_cost)
@@ -562,11 +579,18 @@ def get_cache_creation_cost(
     cache_5m_cost = 0.0
     cache_1h_cost = 0.0
 
-    if cache_5m_tokens > 0 and 'cache_5m' in pricing:
-        cache_5m_cost = (cache_5m_tokens / 1_000_000) * pricing['cache_5m']
+    tiers = pricing.get('input_tiers')
+    tier = _select_tier(tiers, tier_selector_tokens) if tiers and tier_selector_tokens is not None else {}
 
-    if cache_1h_tokens > 0 and 'cache_1h' in pricing:
-        cache_1h_cost = (cache_1h_tokens / 1_000_000) * pricing['cache_1h']
+    if cache_5m_tokens > 0:
+        rate = tier.get('cache_5m', pricing.get('cache_5m'))
+        if rate is not None:
+            cache_5m_cost = (cache_5m_tokens / 1_000_000) * rate
+
+    if cache_1h_tokens > 0:
+        rate = tier.get('cache_1h', pricing.get('cache_1h'))
+        if rate is not None:
+            cache_1h_cost = (cache_1h_tokens / 1_000_000) * rate
 
     return cache_5m_cost, cache_1h_cost
 
@@ -644,26 +668,7 @@ def get_output_cost(tokens: int, pricing: Dict[str, Any], input_tokens: int = 0)
 
     if output_pricing_mode == 'input_dependent' and 'output_tiers' in pricing:
         # Input-dependent pricing: Output rate determined by INPUT token tier
-        # Find which tier the input falls into and use that tier's output rate
-        output_tiers = pricing['output_tiers']
-
-        # Determine the tier index based on input tokens
-        tier_index = 0
-
-        for idx, tier in enumerate(output_tiers):
-            max_tokens = tier.get('max_tokens')
-
-            if max_tokens is None:
-                # Last tier (infinite)
-                tier_index = idx
-                break
-            elif input_tokens <= max_tokens:
-                # Input falls in this tier
-                tier_index = idx
-                break
-
-        # Use the rate from the determined tier
-        output_rate = output_tiers[tier_index].get('rate', 0)
+        output_rate = _select_tier(pricing['output_tiers'], input_tokens).get('rate', 0)
         return (tokens / 1_000_000) * output_rate
 
     elif 'output_tiers' in pricing:
@@ -717,13 +722,19 @@ def calculate_total_cost(
     # Only subtract them when there's explicit cache creation pricing — otherwise they
     # should remain in input_tokens and be billed at the regular input rate (correct for
     # providers like DeepSeek where cache writes are charged at input rate).
-    subtract_5m = cache_5m_tokens if 'cache_5m' in pricing else 0
-    subtract_1h = cache_1h_tokens if 'cache_1h' in pricing else 0
+    def _has_write_rate(key: str) -> bool:
+        return key in pricing or any(key in t for t in pricing.get('input_tiers', []))
+
+    subtract_5m = cache_5m_tokens if _has_write_rate('cache_5m') else 0
+    subtract_1h = cache_1h_tokens if _has_write_rate('cache_1h') else 0
     adjusted_input = max(0, input_tokens - subtract_5m - subtract_1h)
 
-    # Calculate input costs (pass output_tokens for 2D matrix pricing)
+    # Calculate input costs (pass output_tokens for 2D matrix pricing). Tier
+    # selection uses the raw prompt total so the cache-write subtraction can't
+    # demote a long-context request to the short-context tier.
     regular_input_cost, cached_input_cost = get_input_cost(
-        adjusted_input, pricing, cached_tokens, output_tokens=output_tokens
+        adjusted_input, pricing, cached_tokens, output_tokens=output_tokens,
+        tier_selector_tokens=input_tokens
     )
 
     if regular_input_cost > 0:
@@ -750,7 +761,9 @@ def calculate_total_cost(
         total_cost += cache_storage_cost
 
     # Calculate cache creation costs (anthropic-style)
-    cache_5m_cost, cache_1h_cost = get_cache_creation_cost(cache_5m_tokens, cache_1h_tokens, pricing)
+    cache_5m_cost, cache_1h_cost = get_cache_creation_cost(
+        cache_5m_tokens, cache_1h_tokens, pricing, tier_selector_tokens=input_tokens
+    )
 
     if cache_5m_cost > 0:
         breakdown['cache_5m_creation'] = {

--- a/src/ptc_agent/agent/agent.py
+++ b/src/ptc_agent/agent/agent.py
@@ -66,6 +66,7 @@ from ptc_agent.core.paths import (
 )
 from ptc_agent.agent.backends.user_data import UserDataBackend
 from ptc_agent.agent.middleware.image_capture import ImageCaptureMiddleware
+from ptc_agent.agent.middleware.openai_prompt_caching import OpenAIPromptCachingMiddleware
 from ptc_agent.agent.middleware.runtime_context import RuntimeContextMiddleware
 from ptc_agent.agent.middleware.background_subagent.registry import (
     BackgroundTaskRegistry,
@@ -675,6 +676,7 @@ class PTCAgent:
                 compaction,
                 *model_resilience,
                 AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
+                OpenAIPromptCachingMiddleware(),
                 EmptyToolCallRetryMiddleware(),
                 PatchToolCallsMiddleware(),
                 AnthropicThinkingSanitizerMiddleware(),
@@ -700,8 +702,10 @@ class PTCAgent:
 
         # Main agent middleware (includes SubAgentMiddleware + main_only)
         # Ordering matters for prompt caching:
-        #   - AnthropicPromptCachingMiddleware places cache_control breakpoint on
-        #     the last system message block it sees (the static prompt + skills).
+        #   - AnthropicPromptCachingMiddleware (cache_control) and
+        #     OpenAIPromptCachingMiddleware (prompt_cache_breakpoint) each place
+        #     their provider's breakpoint on the last system message block they
+        #     see (the static prompt + skills); each no-ops for other providers.
         #   - WorkspaceContextMiddleware (agent.md) and RuntimeContextMiddleware
         #     (time + profile) are innermost — they append AFTER the breakpoint,
         #     so dynamic content doesn't invalidate the cached prefix.
@@ -725,6 +729,7 @@ class PTCAgent:
                 compaction,
                 *model_resilience,
                 AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
+                OpenAIPromptCachingMiddleware(),
                 EmptyToolCallRetryMiddleware(),
                 PatchToolCallsMiddleware(),
                 *workspace_context_middleware,

--- a/src/ptc_agent/agent/flash/agent.py
+++ b/src/ptc_agent/agent/flash/agent.py
@@ -24,6 +24,7 @@ from ptc_agent.agent.middleware import (
     LeakDetectionMiddleware,
     ProvenanceMiddleware,
 )
+from ptc_agent.agent.middleware.openai_prompt_caching import OpenAIPromptCachingMiddleware
 from ptc_agent.agent.middleware.runtime_context import RuntimeContextMiddleware
 from ptc_agent.agent.state import DeltaAgentState
 from ptc_agent.agent.prompts import format_current_time, get_loader
@@ -287,10 +288,12 @@ class FlashAgent:
             fallback_models=[name for name, _ in fallbacks],
         )
 
-        # Prompt caching, empty tool call retry, and tool call patching
+        # Prompt caching (per-provider breakpoints), empty tool call retry,
+        # and tool call patching
         main_middleware.extend(
             [
                 AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
+                OpenAIPromptCachingMiddleware(),
                 EmptyToolCallRetryMiddleware(),
                 PatchToolCallsMiddleware(),
             ]

--- a/src/ptc_agent/agent/middleware/__init__.py
+++ b/src/ptc_agent/agent/middleware/__init__.py
@@ -104,6 +104,11 @@ from .runtime_context import (
     RuntimeContextMiddleware,
 )
 
+# OpenAI prompt-cache breakpoint middleware (GPT-5.6+ explicit caching)
+from .openai_prompt_caching import (
+    OpenAIPromptCachingMiddleware,
+)
+
 # Anthropic thinking-block sanitizer (repairs orphan signature-only blocks)
 from .anthropic_thinking_sanitizer import (
     AnthropicThinkingSanitizerMiddleware,
@@ -173,6 +178,8 @@ __all__ = [
     "MemoAwarenessMiddleware",
     # Runtime context
     "RuntimeContextMiddleware",
+    # OpenAI prompt caching
+    "OpenAIPromptCachingMiddleware",
     # Anthropic thinking sanitizer
     "AnthropicThinkingSanitizerMiddleware",
     # Subagent middleware

--- a/src/ptc_agent/agent/middleware/openai_prompt_caching.py
+++ b/src/ptc_agent/agent/middleware/openai_prompt_caching.py
@@ -1,0 +1,99 @@
+"""Middleware for OpenAI explicit prompt-cache breakpoints (GPT-5.6+).
+
+OpenAI analog of ``AnthropicPromptCachingMiddleware``: tags the last system
+content block it sees with a ``prompt_cache_breakpoint`` marker so the static
+prefix (system prompt + skills) is written to cache at a stable boundary.
+Dynamic-context middlewares (workspace, runtime) run innermost and append
+after the marker, keeping the cached prefix stable across requests.
+"""
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from langchain.agents.middleware.types import AgentMiddleware, ModelRequest, ModelResponse
+from langchain_core.messages import SystemMessage
+from langchain_openai import ChatOpenAI
+
+from src.llms.endpoints import is_official_openai_endpoint
+
+# Explicit-breakpoint marker forwarded verbatim onto the wire content part.
+_BREAKPOINT: dict[str, Any] = {"mode": "explicit"}
+
+
+class OpenAIPromptCachingMiddleware(AgentMiddleware):
+    """Places an OpenAI prompt-cache breakpoint on the static system prefix.
+
+    Applies only to ``ChatOpenAI`` models constructed with a non-None
+    ``prompt_cache_options`` (opted in via the model manifest ``parameters``)
+    AND pointed at api.openai.com — other backends (codex, platform proxy,
+    OpenAI-compatible endpoints) reject or drop the marker, so anything with
+    a non-official base_url passes through untouched. ``create_llm`` applies
+    the same gate when attaching ``prompt_cache_options``; this check is
+    defense-in-depth for clients constructed outside the factory.
+    """
+
+    @staticmethod
+    def _should_apply(request: ModelRequest) -> bool:
+        model = request.model
+        return (
+            isinstance(model, ChatOpenAI)
+            and getattr(model, "prompt_cache_options", None) is not None
+            and is_official_openai_endpoint(getattr(model, "openai_api_base", None))
+        )
+
+    @staticmethod
+    def _tag_system_message(
+        system_message: SystemMessage | None,
+    ) -> SystemMessage | None:
+        if system_message is None:
+            return None
+        content = system_message.content
+        new_content: list[Any]
+        if isinstance(content, str):
+            if not content:
+                return system_message
+            new_content = [
+                {"type": "text", "text": content, "prompt_cache_breakpoint": dict(_BREAKPOINT)}
+            ]
+        elif isinstance(content, list):
+            if not content:
+                return system_message
+            new_content = list(content)
+            last = new_content[-1]
+            if isinstance(last, dict):
+                new_content[-1] = {**last, "prompt_cache_breakpoint": dict(_BREAKPOINT)}
+            elif isinstance(last, str):
+                new_content[-1] = {
+                    "type": "text",
+                    "text": last,
+                    "prompt_cache_breakpoint": dict(_BREAKPOINT),
+                }
+            else:
+                return system_message
+        else:
+            return system_message
+        return SystemMessage(content=new_content)
+
+    def _apply(self, request: ModelRequest) -> ModelRequest:
+        tagged = self._tag_system_message(request.system_message)
+        if tagged is request.system_message:
+            return request
+        return request.override(system_message=tagged)
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], ModelResponse],
+    ) -> ModelResponse:
+        if not self._should_apply(request):
+            return handler(request)
+        return handler(self._apply(request))
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelResponse:
+        if not self._should_apply(request):
+            return await handler(request)
+        return await handler(self._apply(request))

--- a/tests/unit/llms/test_api_call_streaming.py
+++ b/tests/unit/llms/test_api_call_streaming.py
@@ -22,7 +22,7 @@ def _make_codex() -> ChatCodexOpenAI:
     # explicitly; mirror that here so the test pins the factory-built
     # instance behavior, not the class default.
     return ChatCodexOpenAI(
-        model="gpt-5.4",
+        model="gpt-5.6-sol",
         api_key="fake",
         output_version="responses/v1",
         store=False,

--- a/tests/unit/llms/test_codex_extension.py
+++ b/tests/unit/llms/test_codex_extension.py
@@ -1,13 +1,13 @@
 """Tests for ChatCodexOpenAI system message → instructions promotion."""
 
-from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 
 from src.llms.extension.codex import ChatCodexOpenAI
 
 
 def _make_llm(**overrides):
     defaults = {
-        "model": "gpt-5.4",
+        "model": "gpt-5.6-sol",
         "api_key": "fake",
         "output_version": "responses/v1",
         "store": False,
@@ -74,6 +74,50 @@ class TestSystemToInstructions:
         assert payload["instructions"] == "Dynamic prompt\n\nstatic placeholder"
 
 
+class TestStatelessIdContract:
+    """Pins the langchain-openai store=False behavior we depend on since
+    dropping our own reasoning-id stripping: unpersisted msg_ ids are removed
+    from replayed assistant items, while encrypted reasoning items are kept
+    with their rs_ id. A dependency bump that regresses this breaks codex
+    turn replay (400s), so it must fail here first.
+    """
+
+    def test_msg_id_dropped_encrypted_reasoning_kept(self):
+        llm = _make_llm(
+            model_kwargs={}, include=["reasoning.encrypted_content"]
+        )
+        messages = [
+            HumanMessage(content="q1"),
+            AIMessage(
+                content=[
+                    {
+                        "type": "reasoning",
+                        "id": "rs_abc123",
+                        "summary": [],
+                        "encrypted_content": "enc-blob",
+                    },
+                    {"type": "text", "text": "Answer one.", "id": "msg_abc123"},
+                ]
+            ),
+            HumanMessage(content="q2"),
+        ]
+        payload = llm._get_request_payload(messages)
+
+        items = [i for i in payload["input"] if isinstance(i, dict)]
+        reasoning = [i for i in items if i.get("type") == "reasoning"]
+        assert reasoning == [
+            {
+                "type": "reasoning",
+                "id": "rs_abc123",
+                "summary": [],
+                "encrypted_content": "enc-blob",
+            }
+        ]
+        assistant = [i for i in items if i.get("role") == "assistant"]
+        assert len(assistant) == 1
+        assert "id" not in assistant[0]
+
+
 class TestNullOutputGuard:
     """chatgpt.com Codex backend ships response.output=null on terminal stream
     frames. langchain_openai iterates it unguarded and raises
@@ -110,22 +154,3 @@ class TestNullOutputGuard:
         assert getattr(fn, "_codex_output_guarded", False) is True
         _install_responses_output_guard()  # re-running must be a no-op
         assert base._construct_lc_result_from_responses_api is fn
-
-
-class TestStatelessIdSanitization:
-    """Existing behavior: reasoning item IDs stripped for store=false."""
-
-    def test_reasoning_id_stripped(self):
-        llm = _make_llm()
-        messages = [HumanMessage(content="Hello")]
-        payload = llm._get_request_payload(messages)
-
-        # Manually inject reasoning item to test sanitization
-        payload["input"].append(
-            {"type": "reasoning", "id": "rs_abc123", "content": []}
-        )
-        from src.llms.extension.codex import _sanitize_input_for_stateless
-
-        sanitized = _sanitize_input_for_stateless(payload["input"])
-        reasoning = [i for i in sanitized if i.get("type") == "reasoning"][0]
-        assert "id" not in reasoning

--- a/tests/unit/llms/test_input_modalities.py
+++ b/tests/unit/llms/test_input_modalities.py
@@ -17,7 +17,7 @@ class TestGetInputModalities:
         assert "pdf" in result
 
     def test_openai_model_supports_text_image_pdf(self, model_config):
-        result = model_config.get_input_modalities("gpt-5.4-mini")
+        result = model_config.get_input_modalities("gpt-5.6-luna")
         assert "text" in result
         assert "image" in result
         assert "pdf" in result
@@ -58,7 +58,7 @@ class TestGetInputModalities:
         assert "pdf" in result
 
     def test_codex_oauth_variant(self, model_config):
-        result = model_config.get_input_modalities("gpt-5.4-oauth")
+        result = model_config.get_input_modalities("gpt-5.6-sol-oauth")
         assert "image" in result
         assert "pdf" in result
 

--- a/tests/unit/llms/test_model_pricing_inheritance.py
+++ b/tests/unit/llms/test_model_pricing_inheritance.py
@@ -43,5 +43,31 @@ class TestModelPricingResolution:
         assert direct["input"] > 0 and direct["output"] > 0
         assert oauth == direct
 
+    def test_gpt_5_6_tiered_resolves_and_codex_oauth_inherits(self):
+        """The GPT-5.6 series uses short/long-context tiered pricing on `openai`;
+        the codex-oauth twins carry no pricing list and inherit the parent."""
+        for model_id in ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"):
+            direct = find_model_pricing(model_id, provider="openai")
+            oauth = find_model_pricing(model_id, provider="codex-oauth")
+            assert direct is not None, model_id
+            # Structural: tiered input + input-dependent output (values not pinned).
+            assert direct["input_tiers"][0]["rate"] > 0
+            assert direct["input_tiers"][0]["cached_input"] > 0
+            assert direct["output_pricing_mode"] == "input_dependent"
+            assert direct["output_tiers"][-1]["rate"] > direct["output_tiers"][0]["rate"]
+            assert oauth == direct
+
+    def test_gpt_5_6_threshold_billing_structure(self):
+        """OpenAI bills GPT-5.6 long context threshold-style ("2x input and
+        1.5x output for the full request" past 272K), so the entries must opt
+        into threshold input mode and carry per-tier cache-write rates
+        (values intentionally not pinned)."""
+        for model_id in ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"):
+            pricing = find_model_pricing(model_id, provider="openai")
+            assert pricing["input_pricing_mode"] == "input_dependent", model_id
+            for tier in pricing["input_tiers"]:
+                assert "cache_5m" in tier, model_id
+                assert "cached_input" in tier, model_id
+
     def test_unknown_model_returns_none(self):
         assert find_model_pricing("does-not-exist", provider="anthropic") is None

--- a/tests/unit/llms/test_prompt_cache_options_gate.py
+++ b/tests/unit/llms/test_prompt_cache_options_gate.py
@@ -1,0 +1,130 @@
+"""Endpoint gate for the ``prompt_cache_options`` explicit-caching opt-in.
+
+The manifest attaches ``prompt_cache_options`` to eligible OpenAI models, but
+the param (and the breakpoint marker it gates) is an api.openai.com-only
+surface. ``_get_openai_llm`` must strip it whenever the effective base_url
+points anywhere else (platform proxy, groq/cerebras/local endpoints, env
+redirects), and ``_get_codex_llm`` must never forward it (the codex backend
+400s on it).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.llms.endpoints import is_official_openai_endpoint
+from src.llms.llm import LLM
+
+_OPTIONS = {"mode": "implicit"}
+
+
+@pytest.fixture(autouse=True)
+def _clean_openai_base_env(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+
+def _build_llm(sdk: str, base_url: str | None, parameters: dict | None = None) -> LLM:
+    llm = LLM.__new__(LLM)
+    llm.sdk = sdk
+    llm.provider = f"test-{sdk}"
+    llm.provider_info = {"access_type": "api_key"}
+    llm.env_key = None
+    llm.base_url = base_url
+    llm.default_headers = None
+    llm.use_response_api = sdk == "codex"
+    llm.use_previous_response_id = False
+    llm.parameters = dict(parameters or {})
+    llm.extra_body = {}
+    llm.model = "gpt-5.6-sol"
+    llm.api_key_override = "dummy-key"
+    llm.prompt_cache_key_enabled = False
+    return llm
+
+
+class TestOpenAIEndpointGate:
+    def test_official_base_url_keeps_options(self):
+        llm = _build_llm(
+            "openai",
+            "https://api.openai.com/v1",
+            {"prompt_cache_options": dict(_OPTIONS)},
+        )
+        client = llm.get_llm()
+        assert client.prompt_cache_options == _OPTIONS
+
+    def test_default_base_url_keeps_options(self):
+        llm = _build_llm("openai", None, {"prompt_cache_options": dict(_OPTIONS)})
+        client = llm.get_llm()
+        assert client.prompt_cache_options == _OPTIONS
+
+    def test_non_official_base_url_strips_options(self):
+        llm = _build_llm(
+            "openai",
+            "https://proxy.example.com/v1",
+            {"prompt_cache_options": dict(_OPTIONS)},
+        )
+        client = llm.get_llm()
+        assert client.prompt_cache_options is None
+
+    def test_env_redirect_strips_options(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost:9000/v1")
+        llm = _build_llm("openai", None, {"prompt_cache_options": dict(_OPTIONS)})
+        client = llm.get_llm()
+        assert client.prompt_cache_options is None
+
+    def test_strip_leaves_other_parameters_intact(self):
+        llm = _build_llm(
+            "openai",
+            "https://proxy.example.com/v1",
+            {"prompt_cache_options": dict(_OPTIONS), "temperature": 0.3},
+        )
+        # gpt-5.x is a reasoning family: langchain-openai would normalize
+        # temperature away on its own, masking what this test asserts.
+        llm.model = "gpt-4o-mini"
+        client = llm.get_llm()
+        assert client.prompt_cache_options is None
+        assert client.temperature == 0.3
+
+    def test_codex_never_forwards_options(self):
+        llm = _build_llm("codex", None, {"prompt_cache_options": dict(_OPTIONS)})
+        client = llm.get_llm()
+        assert client.prompt_cache_options is None
+
+    def test_openai_api_base_alias_strips_options(self):
+        # ChatOpenAI accepts base_url under its openai_api_base alias; the
+        # gate must see through both spellings.
+        llm = _build_llm(
+            "openai",
+            None,
+            {
+                "prompt_cache_options": dict(_OPTIONS),
+                "openai_api_base": "https://proxy.example.com/v1",
+            },
+        )
+        client = llm.get_llm()
+        assert client.prompt_cache_options is None
+
+
+class TestIsOfficialOpenAIEndpoint:
+    def test_none_defaults_to_official(self):
+        assert is_official_openai_endpoint(None) is True
+
+    def test_official_url(self):
+        assert is_official_openai_endpoint("https://api.openai.com/v1") is True
+
+    def test_other_host(self):
+        assert is_official_openai_endpoint("https://api.groq.com/openai/v1") is False
+
+    def test_lookalike_host_rejected(self):
+        assert is_official_openai_endpoint("https://api.openai.com.evil.example/v1") is False
+
+    def test_env_api_base_fallback(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_BASE", "http://localhost:1234/v1")
+        assert is_official_openai_endpoint(None) is False
+
+    def test_schemeless_official_host(self):
+        assert is_official_openai_endpoint("api.openai.com/v1") is True
+
+    def test_schemeless_lookalike_rejected(self):
+        assert is_official_openai_endpoint("api.openai.com.evil.example/v1") is False
+        assert is_official_openai_endpoint("api.openai.com@evil.example/v1") is False

--- a/tests/unit/llms/test_threshold_pricing.py
+++ b/tests/unit/llms/test_threshold_pricing.py
@@ -1,0 +1,125 @@
+"""Threshold (whole-request) long-context pricing semantics.
+
+OpenAI GPT-5.6 bills long-context requests threshold-style — "Prompts with
+>272K input tokens are priced at 2x input and 1.5x output for the full
+request" — while the default ``input_tiers`` engine path is progressive
+(each tier range at its own rate). ``input_pricing_mode: "input_dependent"``
+opts a model into threshold input billing, per-tier ``cache_5m`` rates carry
+the long-context cache-write price, and tier selection always uses the raw
+prompt total so the cache-write subtraction can't demote a long request to
+the short tier. These tests pin the engine semantics with synthetic pricing
+dicts; manifest structure is asserted in test_model_pricing_inheritance.py.
+"""
+
+import pytest
+
+from src.llms.pricing_utils import (
+    calculate_total_cost,
+    get_cache_creation_cost,
+    get_input_cost,
+)
+
+# Synthetic rates (not manifest values): 5/10 input, 0.5/1.0 cached,
+# 6.25/12.5 cache write, boundary at 272K.
+THRESHOLD_PRICING = {
+    "input_tiers": [
+        {"max_tokens": 272_000, "rate": 5.0, "cached_input": 0.5, "cache_5m": 6.25},
+        {"max_tokens": None, "rate": 10.0, "cached_input": 1.0, "cache_5m": 12.5},
+    ],
+    "cache_5m": 6.25,
+    "output_tiers": [
+        {"max_tokens": 272_000, "rate": 30.0},
+        {"max_tokens": None, "rate": 45.0},
+    ],
+    "output_pricing_mode": "input_dependent",
+    "input_pricing_mode": "input_dependent",
+    "unit": "per_1m_tokens",
+}
+
+
+class TestThresholdInputMode:
+    def test_short_context_bills_low_tier(self):
+        regular, cached = get_input_cost(100_000, THRESHOLD_PRICING)
+        assert regular == pytest.approx(100_000 / 1e6 * 5.0)
+        assert cached == 0.0
+
+    def test_long_context_bills_whole_request_at_high_tier(self):
+        # Progressive would give 272K*5 + 28K*10 = $1.64; threshold gives $3.00.
+        regular, _ = get_input_cost(300_000, THRESHOLD_PRICING)
+        assert regular == pytest.approx(300_000 / 1e6 * 10.0)
+
+    def test_boundary_stays_in_low_tier(self):
+        regular, _ = get_input_cost(272_000, THRESHOLD_PRICING)
+        assert regular == pytest.approx(272_000 / 1e6 * 5.0)
+
+    def test_without_flag_stays_progressive(self):
+        pricing = {k: v for k, v in THRESHOLD_PRICING.items() if k != "input_pricing_mode"}
+        regular, _ = get_input_cost(300_000, pricing)
+        assert regular == pytest.approx((272_000 * 5.0 + 28_000 * 10.0) / 1e6)
+
+    def test_cached_reads_follow_the_selected_tier(self):
+        _, cached = get_input_cost(300_000, THRESHOLD_PRICING, cached_tokens=250_000)
+        assert cached == pytest.approx(250_000 / 1e6 * 1.0)
+
+
+class TestTieredCacheWrites:
+    def test_short_context_write_rate(self):
+        cost_5m, _ = get_cache_creation_cost(
+            50_000, 0, THRESHOLD_PRICING, tier_selector_tokens=100_000
+        )
+        assert cost_5m == pytest.approx(50_000 / 1e6 * 6.25)
+
+    def test_long_context_write_rate(self):
+        cost_5m, _ = get_cache_creation_cost(
+            50_000, 0, THRESHOLD_PRICING, tier_selector_tokens=300_000
+        )
+        assert cost_5m == pytest.approx(50_000 / 1e6 * 12.5)
+
+    def test_flat_fallback_without_selector(self):
+        cost_5m, _ = get_cache_creation_cost(50_000, 0, THRESHOLD_PRICING)
+        assert cost_5m == pytest.approx(50_000 / 1e6 * 6.25)
+
+    def test_flat_fallback_when_tier_lacks_write_rate(self):
+        # Anthropic-shaped pricing: per-tier cached_input but flat cache_5m.
+        pricing = {
+            "input_tiers": [
+                {"max_tokens": 200_000, "rate": 3.0, "cached_input": 0.3},
+                {"max_tokens": None, "rate": 6.0, "cached_input": 0.6},
+            ],
+            "cache_5m": 3.75,
+        }
+        cost_5m, _ = get_cache_creation_cost(
+            50_000, 0, pricing, tier_selector_tokens=300_000
+        )
+        assert cost_5m == pytest.approx(50_000 / 1e6 * 3.75)
+
+
+class TestRawPromptTierSelection:
+    def test_write_subtraction_cannot_demote_the_tier(self):
+        # 300K prompt, 290K of it written to cache: adjusted input is 10K but
+        # the request is still long-context — every component must use the
+        # high tier.
+        result = calculate_total_cost(
+            input_tokens=300_000,
+            output_tokens=10_000,
+            cache_5m_tokens=290_000,
+            pricing=THRESHOLD_PRICING,
+        )
+        breakdown = result["breakdown"]
+        assert breakdown["cache_5m_creation"]["cost"] == pytest.approx(290_000 / 1e6 * 12.5)
+        assert breakdown["input"]["cost"] == pytest.approx(10_000 / 1e6 * 10.0)
+        assert breakdown["output"]["cost"] == pytest.approx(10_000 / 1e6 * 45.0)
+
+    def test_end_to_end_long_context_total(self):
+        # The reviewer's canonical case: 300K in / 10K out, no cache.
+        # Progressive engine gave $2.09; the correct threshold total is $3.45.
+        result = calculate_total_cost(
+            input_tokens=300_000, output_tokens=10_000, pricing=THRESHOLD_PRICING
+        )
+        assert result["total_cost"] == pytest.approx(3.45)
+
+    def test_end_to_end_short_context_total(self):
+        result = calculate_total_cost(
+            input_tokens=100_000, output_tokens=10_000, pricing=THRESHOLD_PRICING
+        )
+        assert result["total_cost"] == pytest.approx(100_000 / 1e6 * 5.0 + 10_000 / 1e6 * 30.0)

--- a/tests/unit/middleware/test_openai_prompt_cache_breakpoint.py
+++ b/tests/unit/middleware/test_openai_prompt_cache_breakpoint.py
@@ -1,0 +1,239 @@
+"""OpenAI prompt-cache breakpoint placement across the middleware chain.
+
+Mirror of test_prompt_cache_breakpoint.py for OpenAIPromptCachingMiddleware:
+verifies the breakpoint marker lands on the last static block (skills), that
+dynamic blocks appended by inner middleware stay unmarked, that gating is
+manifest-driven (prompt_cache_options on the model), and that the marker plus
+prompt_cache_options survive all the way into the Responses API payload.
+"""
+
+from collections.abc import Awaitable, Callable
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
+from langchain_anthropic.chat_models import ChatAnthropic
+from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
+from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_openai import ChatOpenAI
+
+from ptc_agent.agent.middleware._utils import append_to_system_message
+from ptc_agent.agent.middleware.openai_prompt_caching import OpenAIPromptCachingMiddleware
+from ptc_agent.agent.middleware.runtime_context import RuntimeContextMiddleware
+from ptc_agent.agent.middleware.workspace_context import WorkspaceContextMiddleware
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_openai_base_env(monkeypatch):
+    """The endpoint gate reads these env fallbacks; isolate from the host env."""
+    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+
+def _make_openai_model(prompt_cache_options=None, openai_api_base=None):
+    model = MagicMock(spec=ChatOpenAI)
+    model.prompt_cache_options = prompt_cache_options
+    model.openai_api_base = openai_api_base
+    return model
+
+
+def _make_model_request(system_prompt: str, model) -> ModelRequest:
+    return ModelRequest(
+        model=model,
+        messages=[],
+        system_prompt=system_prompt,
+    )
+
+
+def _fake_skills_middleware():
+    class FakeSkillsMiddleware:
+        async def awrap_model_call(
+            self,
+            request: ModelRequest,
+            handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+        ) -> ModelResponse:
+            new_sys = append_to_system_message(
+                request.system_message,
+                "<skills_manifest>\n- skill_a\n- skill_b\n</skills_manifest>",
+            )
+            return await handler(request.override(system_message=new_sys))
+
+    return FakeSkillsMiddleware()
+
+
+def _compose_middleware(middlewares, final_handler):
+    """Compose middlewares: first in list = outermost = runs first."""
+
+    async def chain(request: ModelRequest) -> ModelResponse:
+        return await final_handler(request)
+
+    for mw in reversed(middlewares):
+        outer_handler = chain
+
+        async def wrapper(req, *, _mw=mw, _h=outer_handler):
+            return await _mw.awrap_model_call(req, _h)
+
+        chain = wrapper
+
+    return chain
+
+
+def _build_chain(captured: dict):
+    """The agent.py stack shape: skills → anthropic → openai → workspace → runtime."""
+    session = MagicMock()
+    session.get_agent_md = AsyncMock(return_value="# Workspace\nNotes")
+    session.conversation_id = "ws-test"
+
+    async def capture(req):
+        captured["req"] = req
+        return MagicMock()
+
+    return _compose_middleware(
+        [
+            _fake_skills_middleware(),
+            AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
+            OpenAIPromptCachingMiddleware(),
+            WorkspaceContextMiddleware(session=session),
+            RuntimeContextMiddleware(
+                current_time="12:00 PM UTC, Monday, April 5, 2027",
+                user_profile={"name": "Casey", "timezone": "UTC", "locale": "en-US"},
+            ),
+        ],
+        capture,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIPromptCacheBreakpoint:
+    @pytest.mark.asyncio
+    async def test_block_ordering_and_breakpoint(self):
+        """Marker on the skills block only; anthropic cache_control absent."""
+        captured: dict = {}
+        chain = _build_chain(captured)
+        model = _make_openai_model(prompt_cache_options={"mode": "implicit"})
+
+        await chain(_make_model_request("Static system prompt.", model))
+
+        content = captured["req"].system_message.content
+        assert isinstance(content, list)
+        assert len(content) == 4
+
+        assert "prompt_cache_breakpoint" not in content[0]
+        assert "skills_manifest" in content[1]["text"]
+        assert content[1]["prompt_cache_breakpoint"] == {"mode": "explicit"}
+        assert "prompt_cache_breakpoint" not in content[2]
+        assert "prompt_cache_breakpoint" not in content[3]
+
+        # AnthropicPromptCachingMiddleware must have no-opped for ChatOpenAI
+        for block in content:
+            assert "cache_control" not in block
+
+    @pytest.mark.asyncio
+    async def test_noop_without_prompt_cache_options(self):
+        """A ChatOpenAI model that hasn't opted in via the manifest is untouched."""
+        captured: dict = {}
+        chain = _build_chain(captured)
+        model = _make_openai_model(prompt_cache_options=None)
+
+        await chain(_make_model_request("Static system prompt.", model))
+
+        for block in captured["req"].system_message.content:
+            assert "prompt_cache_breakpoint" not in block
+
+    @pytest.mark.asyncio
+    async def test_noop_for_non_official_base_url(self):
+        """Opted-in options but a non-official endpoint → marker withheld."""
+        captured: dict = {}
+        chain = _build_chain(captured)
+        model = _make_openai_model(
+            prompt_cache_options={"mode": "implicit"},
+            openai_api_base="https://proxy.example.com/v1",
+        )
+
+        await chain(_make_model_request("Static system prompt.", model))
+
+        for block in captured["req"].system_message.content:
+            assert "prompt_cache_breakpoint" not in block
+
+    @pytest.mark.asyncio
+    async def test_applies_for_explicit_official_base_url(self):
+        captured: dict = {}
+        chain = _build_chain(captured)
+        model = _make_openai_model(
+            prompt_cache_options={"mode": "implicit"},
+            openai_api_base="https://api.openai.com/v1",
+        )
+
+        await chain(_make_model_request("Static system prompt.", model))
+
+        content = captured["req"].system_message.content
+        assert content[1]["prompt_cache_breakpoint"] == {"mode": "explicit"}
+
+    @pytest.mark.asyncio
+    async def test_noop_for_env_base_url_override(self, monkeypatch):
+        """OPENAI_BASE_URL env redirect counts as a non-official endpoint."""
+        monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost:9000/v1")
+        captured: dict = {}
+        chain = _build_chain(captured)
+        model = _make_openai_model(prompt_cache_options={"mode": "implicit"})
+
+        await chain(_make_model_request("Static system prompt.", model))
+
+        for block in captured["req"].system_message.content:
+            assert "prompt_cache_breakpoint" not in block
+
+    @pytest.mark.asyncio
+    async def test_noop_for_anthropic_model(self):
+        """Anthropic models get cache_control, never the OpenAI marker."""
+        captured: dict = {}
+        chain = _build_chain(captured)
+        model = MagicMock(spec=ChatAnthropic)
+
+        await chain(_make_model_request("Static system prompt.", model))
+
+        content = captured["req"].system_message.content
+        assert any("cache_control" in b for b in content)
+        for block in content:
+            assert "prompt_cache_breakpoint" not in block
+
+    def test_string_system_message_converted_to_tagged_block(self):
+        """A plain-string system message becomes a single tagged text block."""
+        mw = OpenAIPromptCachingMiddleware()
+        tagged = mw._tag_system_message(SystemMessage(content="Static prompt."))
+        assert tagged.content == [
+            {
+                "type": "text",
+                "text": "Static prompt.",
+                "prompt_cache_breakpoint": {"mode": "explicit"},
+            }
+        ]
+
+    def test_wire_payload_carries_marker_and_options(self):
+        """Marker + prompt_cache_options reach the Responses API payload."""
+        model = ChatOpenAI(
+            model="gpt-5.6-sol",
+            api_key="test",
+            reasoning={"effort": "medium", "summary": "auto"},
+            prompt_cache_options={"mode": "implicit"},
+        )
+        mw = OpenAIPromptCachingMiddleware()
+        sys_msg = mw._tag_system_message(SystemMessage(content="Static prompt."))
+        sys_msg = append_to_system_message(sys_msg, "dynamic context")
+
+        payload = model._get_request_payload([sys_msg, HumanMessage("hi")])
+
+        assert payload["prompt_cache_options"] == {"mode": "implicit"}
+        system_item = payload["input"][0]
+        assert system_item["role"] == "system"
+        parts = system_item["content"]
+        assert parts[0]["prompt_cache_breakpoint"] == {"mode": "explicit"}
+        assert "prompt_cache_breakpoint" not in parts[1]

--- a/tests/unit/server/handlers/test_resolve_llm_config.py
+++ b/tests/unit/server/handlers/test_resolve_llm_config.py
@@ -1015,14 +1015,14 @@ class TestClassifyModelDirect:
     async def test_returns_system_when_only_in_manifest(self):
         from src.server.handlers.chat.llm_config import classify_model, ModelSource
 
-        system_info = {"provider": "openai", "model_id": "gpt-5.4"}
+        system_info = {"provider": "openai", "model_id": "gpt-5.6-sol"}
         mock_mc = MagicMock()
         mock_mc.get_model_config.return_value = system_info
         with (
             patch(f"{HANDLER}.get_custom_model_config", new_callable=AsyncMock, return_value=None),
             patch("src.llms.llm.LLM.get_model_config", return_value=mock_mc),
         ):
-            source, cfg = await classify_model("user-1", "gpt-5.4")
+            source, cfg = await classify_model("user-1", "gpt-5.6-sol")
 
         assert source == ModelSource.SYSTEM
         assert cfg is system_info

--- a/tests/unit/server/services/test_llm_service.py
+++ b/tests/unit/server/services/test_llm_service.py
@@ -108,12 +108,12 @@ class TestUserIdNone:
             await service.complete(
                 user_id=None,
                 user_prompt="hi",
-                request_model="gpt-5.4-mini",
+                request_model="gpt-5.6-terra",
                 reasoning_effort="low",
             )
 
         mock_resolve.assert_not_called()
-        mock_create.assert_called_once_with("gpt-5.4-mini", reasoning_effort="low")
+        mock_create.assert_called_once_with("gpt-5.6-terra", reasoning_effort="low")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/tools/test_fetch_client_isolation.py
+++ b/tests/unit/tools/test_fetch_client_isolation.py
@@ -66,7 +66,7 @@ async def test_fetch_keeps_streaming_for_codex_override(monkeypatch):
     """Codex models ship with ``streaming=True`` for a reason — the proxy
     rejects ``stream=false``. The clone must keep streaming on."""
     override = ChatCodexOpenAI(
-        model="gpt-5.4",
+        model="gpt-5.6-sol",
         api_key="fake",
         output_version="responses/v1",
         store=False,

--- a/uv.lock
+++ b/uv.lock
@@ -2114,7 +2114,7 @@ requires-dist = [
     { name = "langchain-core", specifier = ">=1.4.7" },
     { name = "langchain-deepseek", specifier = ">=0.1.4" },
     { name = "langchain-google-genai", specifier = ">=2.0.0" },
-    { name = "langchain-openai", specifier = ">=1.1.0" },
+    { name = "langchain-openai", specifier = ">=1.3.5" },
     { name = "langchain-qwq", specifier = ">=0.3.0" },
     { name = "langgraph", specifier = ">=1.2.2,<2" },
     { name = "langgraph-checkpoint-postgres", specifier = ">=3.1,<4" },
@@ -2174,35 +2174,35 @@ dev = [
 
 [[package]]
 name = "langchain"
-version = "1.3.11"
+version = "1.3.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/a2/91a7197c604a3ce1b774b3c10dd114c3c745c6186a304fc2573b3f94d400/langchain-1.3.11.tar.gz", hash = "sha256:f3cf9cd4d2329b1a03eb8fd92b9d73e4e58a4d52570d67725fc77fbe0f104b32", size = 633374, upload_time = "2026-06-22T23:00:33.44Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/c0/8481c93a3899d7e05ac27f21a4e984dab613b72631f39fe01fe0100e3be0/langchain-1.3.12.tar.gz", hash = "sha256:3321f86824a0c0720004d28797d729a58b9bb8a0ac73c6ea2b856cac38117879", size = 642308, upload_time = "2026-07-08T22:38:12.466Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/a4/3a181967294f8876362cc4ba36840d50b8286fa23bb3f5e602b69eb3cb1e/langchain-1.3.11-py3-none-any.whl", hash = "sha256:7ae011f95a09b22feea1e8ae4e43f0b6164aebf4c61b8ad845b45f72ff3a90a2", size = 133639, upload_time = "2026-06-22T23:00:31.619Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/31/33ba60f3aaa88dc7b97f9c7680f431237466804bf6826efb75400dfd2e6c/langchain-1.3.12-py3-none-any.whl", hash = "sha256:19685eb9dce01ebd71b11281d5489453e7ab3d2caf61eacb2a76d15574246535", size = 136863, upload_time = "2026-07-08T22:38:11.003Z" },
 ]
 
 [[package]]
 name = "langchain-anthropic"
-version = "1.4.7"
+version = "1.4.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anthropic" },
     { name = "langchain-core" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/d0/5b117541b9e13619a387b3c829b97ef8d54f848716c0cb574df35a326dea/langchain_anthropic-1.4.7.tar.gz", hash = "sha256:34a7eb0db6bb7c92ff89b3f985de6417d5ef7a148d4595f4498fd3ca4f14aa77", size = 706692, upload_time = "2026-06-22T22:56:05.749Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/22/40ab129b08329ca295b391aa1d48267692b42594757084c6918e22b655ac/langchain_anthropic-1.4.8.tar.gz", hash = "sha256:c76891b2044d56105ff13c106ed12650637b53bd598a4bdf15b4796eefa2a4ec", size = 708524, upload_time = "2026-06-26T21:28:46.916Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/bf/78c71bdd7b9ec6fcd6ca45114d5910bfbad2fba21e5223523e793a17520d/langchain_anthropic-1.4.7-py3-none-any.whl", hash = "sha256:2e9d9dd4cb66de19394d7a9d552e1dbf2cd3c1da9f799a0c372b5fc84e298d8f", size = 51978, upload_time = "2026-06-22T22:56:04.349Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/14/746235c4da89d9bc6a608c5f489f628e03feb8f697195c146e452c8f23c8/langchain_anthropic-1.4.8-py3-none-any.whl", hash = "sha256:778e9301b6fd517824f76ec1776975ce8add97a1f6a36c50ae3c2f4b03a66f7f", size = 52366, upload_time = "2026-06-26T21:28:45.535Z" },
 ]
 
 [[package]]
 name = "langchain-core"
-version = "1.4.8"
+version = "1.4.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -2215,9 +2215,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/12/e3/bea6d0080acf183332f24dcd74c208aee5857cf8f783c3fb0bd86027d8fb/langchain_core-1.4.8.tar.gz", hash = "sha256:5bf1f8411077c904182ad8f975943d36adcbf579c4e017b3a118b719229ebf9a", size = 957974, upload_time = "2026-06-18T19:39:23.636Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/b9/e937d0a90b26540bff07e7a7c64349f3b29c2dcc36257cd1cd3fdce17f2a/langchain_core-1.4.9.tar.gz", hash = "sha256:f8078901145bed0466755277500a5a22822a7b628808c4c0a28d4fc88895fcf2", size = 967294, upload_time = "2026-07-08T20:06:54.191Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/d6/bdf6f0481cc57ef300d6b1eb48cf1400c0409be715d6eb3cabadd1142a09/langchain_core-1.4.8-py3-none-any.whl", hash = "sha256:d84c28b05e3ba8d4271d0827aad5b592ccdaaf986e76768c23503f0a2045e8aa", size = 557416, upload_time = "2026-06-18T19:39:21.902Z" },
+    { url = "https://files.pythonhosted.org/packages/84/70/ade2fada52772798ef815b6352b59e71b116aa0c32c3aef5be3dc2cbed12/langchain_core-1.4.9-py3-none-any.whl", hash = "sha256:28e3909e2a10cc81504952d795ac0a9e014c0018121ef89d48dd396fa09ec624", size = 558293, upload_time = "2026-07-08T20:06:52.382Z" },
 ]
 
 [[package]]
@@ -2250,16 +2250,16 @@ wheels = [
 
 [[package]]
 name = "langchain-openai"
-version = "1.2.2"
+version = "1.3.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "openai" },
     { name = "tiktoken" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/1b/c506c7f41156d3a6b4582b4c487f480001b8741deecc6e2d4931fdf4cf2c/langchain_openai-1.2.2.tar.gz", hash = "sha256:8698ffcee9a086e91ab6d207f0026181a03effcbf86bf9aee1808ee35af69dcc", size = 1147539, upload_time = "2026-05-21T22:08:31.123Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/7e/43eef3f8fae2668f52e2222fdc26b6de58acf158bcb580e32e88a299260d/langchain_openai-1.3.5.tar.gz", hash = "sha256:c1db2256a42ac46e8e7b0564c5ccb478b9f58dc047a58935da33c82e6e1f9a07", size = 3261548, upload_time = "2026-07-10T18:58:29.576Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/8e/7406c99afacafc8c2ce0fa4152f9f8b9598c93ceb291959821abd053b982/langchain_openai-1.2.2-py3-none-any.whl", hash = "sha256:7da39a3c70cbafa93853456199e39a264dc70651be79b12ac49b4f6a448bce2d", size = 99631, upload_time = "2026-05-21T22:08:29.527Z" },
+    { url = "https://files.pythonhosted.org/packages/61/64/4e0918cb96ff2b49e06acd9c11c250297d727d2fcce9e012d62efb73b4d6/langchain_openai-1.3.5-py3-none-any.whl", hash = "sha256:f586263b884bceb3d426ec84d3bfbd27051c3c92ae668da6175629e3f44dcec5", size = 121601, upload_time = "2026-07-10T18:58:28.327Z" },
 ]
 
 [[package]]
@@ -2298,7 +2298,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.6"
+version = "1.2.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -2308,9 +2308,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/7a/ea09b05bb0cbddfa43bd34fc581357e87fc3f21a751cc0d419688c3106da/langgraph-1.2.6.tar.gz", hash = "sha256:f9b45a34f13930c94d96cdb76277447ad2cc70ec2d18cd2764d7fdadb36cdc1b", size = 714400, upload_time = "2026-06-18T20:58:21.514Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/4b/0d1130e26b41a99dcc88353bbe7162a1f255c4db746bd94024268e6af27b/langgraph-1.2.9.tar.gz", hash = "sha256:385f87bc1802c35af7e0aa479278ecba8582d103515eb48256cb2ddcd42d0bd4", size = 722869, upload_time = "2026-07-10T01:30:14.985Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/32/772db1b00a9fe42f50320d1aa20caefb76e621eff1f7218b9918093d631d/langgraph-1.2.6-py3-none-any.whl", hash = "sha256:1cf94d3ca124f84f77ce408fa1b06c3dee680a8aafffe364a8fd5d7d03eb8695", size = 246132, upload_time = "2026-06-18T20:58:20.335Z" },
+    { url = "https://files.pythonhosted.org/packages/41/16/0b8dc48823f1326f3e0c8012a3c07a40da6f194299e2ec080df236287baf/langgraph-1.2.9-py3-none-any.whl", hash = "sha256:c2d98ad94333937922ba04148641c1da2bfe45b5b8e55d7b6dcb0bb2df809e76", size = 247473, upload_time = "2026-07-10T01:30:13.733Z" },
 ]
 
 [[package]]
@@ -3072,7 +3072,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.38.0"
+version = "2.45.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -3084,9 +3084,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8f/12/cfa322c5f5dd8fa21aab9a7a8e979e7a11123800f86ca8d82eb68a83d213/openai-2.38.0.tar.gz", hash = "sha256:798694c6cf74145541fda94325b6f8f72d8e1fd0262cc137c8d728177a6a4ce3", size = 772764, upload_time = "2026-05-21T21:23:42.105Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/60/d4219875289b11d2c2f7da93c36283da224a2e55865ed865ab64e0ce9217/openai-2.45.0.tar.gz", hash = "sha256:10d34ca9c5643bce775852fddbfc172505cb1d4de1ccd101696c3ecff358765d", size = 1109653, upload_time = "2026-07-09T18:02:44.091Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/bf/ccff9be562e24207716d04ef9dc931c76aff0c89a7265da43e2104d7fe06/openai-2.38.0-py3-none-any.whl", hash = "sha256:ec6661c57b2dcc47414a767e6e3335c7ed3d19c9696999283a3c82e95c756a3c", size = 1344910, upload_time = "2026-05-21T21:23:39.636Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b0/2291689e3ec4723fbf5bbf3b54afcd7b160f9ddc98ca7aedfd0132af5677/openai-2.45.0-py3-none-any.whl", hash = "sha256:5df105f5f8c9b711fcb9d06d2d3888cebc82506db216484c14a4e53cdf651777", size = 1629470, upload_time = "2026-07-09T18:02:42.21Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Overview

| Category | Files | +LOC | −LOC |
|---|---:|---:|---:|
| Modified | 11 | 256 | 182 |
| New | 2 | 124 | 0 |
| Tests (excluded) | 10 | 574 | 29 |
| **Net (excl. tests)** | **13** | **380** | **182** |

**By module**

- `src/llms/manifest/` (+134/−57) — add `gpt-5.6-sol/terra/luna` (api + codex-oauth twins) with long-context tiered pricing, per-tier cache-write rates, and 1,050,000/128,000 context metadata; retire the GPT-5.4 family.
- `src/llms/pricing_utils.py` (+55/−42) — long-context input billing via `input_pricing_mode: "input_dependent"`, per-tier `cache_5m`/`cache_1h` write rates, tier selection by raw prompt total; shared `_select_tier` helper.
- `src/ptc_agent/agent/` (+117/−3) — new `OpenAIPromptCachingMiddleware` (OpenAI analog of the Anthropic cache middleware) wired into the main, subagent, and flash stacks ahead of the dynamic-context middlewares.
- `src/llms/` core (+50/−56) — new `endpoints.py` host check; `create_llm` endpoint gate for the caching opt-in; codex extension drops its own reasoning-id stripping and defers to langchain-openai ≥1.3.5.
- `scripts/configure.sh` (+4/−4) — ChatGPT-OAuth wizard defaults repointed to the 5.6 series.
- deps (+20/−20) — langchain-openai 1.2.2→1.3.5 (floor raised to match), openai 2.38→2.45, langgraph 1.2.9, langchain-anthropic 1.4.8.

**What this introduces:** the GPT-5.6 model family with correct long-context and cache-write accounting, and explicit OpenAI prompt-cache breakpoints that pin a stable cached prefix (system prompt + skills) across requests — active only against `api.openai.com`.

## How the caching works

OpenAI's explicit caching adds two request surfaces: `prompt_cache_options` (request-level opt-in, we use `{"mode": "implicit"}` so automatic caching stays on) and a `prompt_cache_breakpoint` content-block marker that forces a cache entry ending exactly at that block. The middleware tags the last static system block, so the static prefix survives cross-turn prompt divergence (e.g. the minute-granular timestamp) instead of depending on where automatic caching happens to split.

Activation is double-gated:

1. **Factory** — `create_llm` strips the manifest opt-in unless the effective base_url (either `base_url` or the `openai_api_base` alias, env redirects `OPENAI_API_BASE`/`OPENAI_BASE_URL` included) resolves to `api.openai.com`. The codex factory never forwards it — that backend rejects the params with 400.
2. **Middleware** — re-checks endpoint + opt-in before tagging (`ChatCodexOpenAI` subclasses `ChatOpenAI`, so an isinstance check alone is not enough).

The host check normalizes scheme-less URLs and fails closed on lookalike (`api.openai.com.evil.example`), userinfo-spoofed (`api.openai.com@evil.example`), and unparseable inputs.

## Codex refactor

langchain-openai ≥1.3.4 natively handles `store=false` replay: it drops unpersisted `msg_` ids, drops reasoning blocks lacking `encrypted_content`, and keeps encrypted reasoning items with their `rs_` id. Our request-side sanitizer duplicated (and partially fought) that, so it's removed; a new contract test pins the upstream behavior so a future dependency bump that regresses it fails in the unit suite before it 400s in production. The system→instructions promotion and the null-output guard stay.

## Verification

- **Unit**: 6020 passed, 1 xfailed (fresh run at HEAD). Each of the 5 commits is independently green (498 / 498 / 510 / 3776 / full suite).
- **Pricing math**: engine semantics pinned with synthetic pricing dicts; live manifest check reproduces the canonical long-context case exactly (300K/10K sol → $3.45).
- **Live e2e against api.openai.com**: breakpoint marker accepted; cache writes bill at the 1.25× `cache_5m` rate and reads at the cached rate — reconciled exact to the cent across a 2-turn run.
- **Live e2e against codex-oauth**: encrypted reasoning captured and replayed across turns under `store=false`, 200 OK; confirmed the codex backend 400s on the caching params (hence the unconditional strip).
- **Adversarial review**: two independent passes (Claude + Codex CLI) plus security/perf/maintainability/testing/coverage specialists. Confirmed findings fixed in place: long-context pricing (verified against OpenAI's published docs), `openai_api_base` alias bypass of the factory gate, scheme-less base_url handling, stale ChatGPT-OAuth wizard defaults that would have broken fresh installs, langchain-openai version floor.

## Known limitations / follow-ups (out of scope here)

- **Other tiered vendors**: the ~23 pre-existing tiered models bill each tier range at its own rate; the new `input_pricing_mode: "input_dependent"` path could be adopted per-vendor after verification — the engine support now exists.
- **Service-tier usage keys**: langchain-openai prefixes cache usage keys under priority/flex service tiers (`flex_cache_read`), which `token_counter` doesn't parse. Not reachable today (service tier is only plumbed for subscription OAuth turns), noted for completeness.
- **Retired-model preferences**: saved gpt-5.4 model preferences self-heal (stale preference cleared, next request uses the default) at the cost of one failed request; fallback lists silently skip removed entries.
- **`cache_5m`/`cache_1h` naming**: the write-premium pricing fields inherit Anthropic's TTL vocabulary; for OpenAI (fixed TTL, single write price) the "5m" is meaningless. A mechanical rename to TTL-neutral keys (`cache_write` / `cache_write_1h` across engine, token buckets, breakdown keys, manifests) is a standalone follow-up — billed dollars are unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GPT-5.6 model variants for both standard and OAuth-based access, including updated cache-mode settings.
  * Enabled OpenAI prompt caching breakpoints for official OpenAI endpoints.

* **Bug Fixes**
  * Improved Codex compatibility for `store=false`, including safer handling of empty outputs and system instruction translation.
  * Prevented prompt-cache options from being sent to non-official OpenAI endpoints and Codex.

* **Bug Fixes**
  * Refined tier selection for long-context and cached-token pricing calculations.

* **Tests**
  * Updated and added coverage for GPT-5.6 model support, prompt-caching gating, Codex behavior, endpoint detection, and tiered pricing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->