### PR TITLE
fix(llms): Codex OAuth model access — first-party client headers, per-plan gating, fresh model lists

### DIFF
--- a/src/llms/llm.py
+++ b/src/llms/llm.py
@@ -170,6 +170,10 @@ class ModelConfig:
             # Only include tier when explicitly set — absence means "not platform-managed"
             if "tier" in model_info:
                 entry["tier"] = model_info["tier"]
+            # OAuth plan allowlist — the connected subscription's plan_type must
+            # be one of these for the model to be usable (absence = no gate).
+            if "oauth_plans" in model_info:
+                entry["oauth_plans"] = model_info["oauth_plans"]
             # Optional editorial metadata for the model-detail flyout. Additive —
             # only surfaced for models that authored it in models.json; the
             # frontend renders only the rows that are present.

--- a/src/llms/llm.py
+++ b/src/llms/llm.py
@@ -541,8 +541,14 @@ class LLM:
         }
         params.update(self._resolve_base_url("base_url"))
 
-        if self.default_headers:
-            params["default_headers"] = self.default_headers
+        # The codex backend gates newer models (e.g. GPT-5.6 Luna) to first-party
+        # clients: without an originator naming a known client AND a User-Agent
+        # carrying the matching "<originator>/" prefix, it 404s "Model not found".
+        params["default_headers"] = {
+            "originator": "codex_cli_rs",
+            "User-Agent": "codex_cli_rs/0.46.0",
+            **(self.default_headers or {}),
+        }
 
         if self.use_response_api:
             params["output_version"] = "responses/v1"

--- a/src/llms/manifest/models.json
+++ b/src/llms/manifest/models.json
@@ -1057,6 +1057,7 @@
   "gpt-5.3-codex-spark-oauth": {
     "model_id": "gpt-5.3-codex-spark",
     "provider": "codex-oauth",
+    "oauth_plans": ["pro", "prolite"],
     "visible": true,
     "speed": 5,
     "intelligence": 4,

--- a/src/server/handlers/chat/llm_config.py
+++ b/src/server/handlers/chat/llm_config.py
@@ -369,6 +369,25 @@ async def resolve_oauth_llm_client(
             },
         )
 
+    # Plan-gated OAuth models (manifest `oauth_plans`): reject early with a
+    # clear message instead of an opaque upstream error. Unknown plan_type
+    # fails open — the upstream backend remains the authority.
+    allowed_plans = model_info.get("oauth_plans")
+    plan_type = (token_data.get("plan_type") or "").lower()
+    if allowed_plans and plan_type and plan_type not in {p.lower() for p in allowed_plans}:
+        from fastapi import HTTPException
+
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "message": (
+                    f"Model '{model_name}' is not available on your connected "
+                    f"'{plan_type}' plan (available on: {', '.join(allowed_plans)})."
+                ),
+                "type": "oauth_plan_unsupported",
+            },
+        )
+
     access_token = token_data["access_token"]
     if not access_token or not isinstance(access_token, str):
         logger.error(

--- a/src/server/services/claude_oauth.py
+++ b/src/server/services/claude_oauth.py
@@ -225,7 +225,7 @@ async def get_valid_token(user_id: str) -> dict | None:
 
     # Token still valid (with 5-min buffer)
     if expires_at > now + timedelta(minutes=5):
-        return {"access_token": tokens["access_token"]}
+        return {"access_token": tokens["access_token"], "plan_type": tokens.get("plan_type")}
 
     # Need to refresh — acquire Redis lock
     from src.utils.cache.redis_cache import get_cache_client
@@ -240,7 +240,7 @@ async def get_valid_token(user_id: str) -> dict | None:
             await asyncio.sleep(1)
             tokens = await get_oauth_tokens(user_id, CLAUDE_PROVIDER)
             if tokens:
-                return {"access_token": tokens["access_token"]}
+                return {"access_token": tokens["access_token"], "plan_type": tokens.get("plan_type")}
             return None
 
     try:
@@ -265,7 +265,7 @@ async def get_valid_token(user_id: str) -> dict | None:
             pass
 
         logger.debug(f"[claude_oauth] Refreshed tokens for user_id={user_id}")
-        return {"access_token": new["access_token"]}
+        return {"access_token": new["access_token"], "plan_type": tokens.get("plan_type")}
     except Exception as e:
         logger.error(f"[claude_oauth] Token refresh failed for user_id={user_id}: {e}")
         return None

--- a/src/server/services/codex_oauth.py
+++ b/src/server/services/codex_oauth.py
@@ -210,6 +210,7 @@ async def get_valid_token(user_id: str) -> dict | None:
         return {
             "access_token": tokens["access_token"],
             "account_id": tokens["account_id"],
+            "plan_type": tokens.get("plan_type"),
         }
 
     # Need to refresh — acquire Redis lock
@@ -228,6 +229,7 @@ async def get_valid_token(user_id: str) -> dict | None:
                 return {
                     "access_token": tokens["access_token"],
                     "account_id": tokens["account_id"],
+                    "plan_type": tokens.get("plan_type"),
                 }
             return None
 
@@ -264,6 +266,7 @@ async def get_valid_token(user_id: str) -> dict | None:
         return {
             "access_token": new["access_token"],
             "account_id": account_id,
+            "plan_type": claims.get("plan_type") or tokens.get("plan_type"),
         }
     except Exception as e:
         logger.error(f"[codex_oauth] Token refresh failed for user_id={user_id}: {e}")

--- a/tests/unit/llms/test_codex_client_headers.py
+++ b/tests/unit/llms/test_codex_client_headers.py
@@ -1,0 +1,45 @@
+"""First-party client headers on codex requests.
+
+The codex backend serves some models (e.g. GPT-5.6 Luna) only to recognized
+first-party clients: a request must carry an ``originator`` naming a known
+client AND a ``User-Agent`` with the matching ``<originator>/`` prefix, or it
+404s "Model not found". ``_get_codex_llm`` must always inject the pair while
+still honoring per-instance headers (ChatGPT-Account-Id, explicit overrides).
+"""
+
+from __future__ import annotations
+
+from src.llms.llm import LLM
+
+
+def _build_codex_llm(default_headers: dict | None = None) -> LLM:
+    llm = LLM.__new__(LLM)
+    llm.sdk = "codex"
+    llm.provider = "test-codex"
+    llm.provider_info = {"access_type": "oauth"}
+    llm.env_key = None
+    llm.base_url = None
+    llm.default_headers = default_headers
+    llm.use_response_api = True
+    llm.use_previous_response_id = False
+    llm.parameters = {}
+    llm.extra_body = {}
+    llm.model = "gpt-5.6-luna"
+    llm.api_key_override = "dummy-token"
+    llm.prompt_cache_key_enabled = False
+    return llm
+
+
+def test_first_party_headers_always_present():
+    client = _build_codex_llm().get_llm()
+    assert client.default_headers["originator"] == "codex_cli_rs"
+    assert client.default_headers["User-Agent"].startswith("codex_cli_rs/")
+
+
+def test_instance_headers_merged_and_override():
+    client = _build_codex_llm(
+        {"ChatGPT-Account-Id": "acct-123", "originator": "custom"}
+    ).get_llm()
+    assert client.default_headers["ChatGPT-Account-Id"] == "acct-123"
+    assert client.default_headers["originator"] == "custom"
+    assert client.default_headers["User-Agent"].startswith("codex_cli_rs/")

--- a/web/src/hooks/__tests__/useFilteredModels.test.ts
+++ b/web/src/hooks/__tests__/useFilteredModels.test.ts
@@ -582,3 +582,55 @@ describe('variant isolation (no brand_key promotion)', () => {
     expect(augmented.byok_providers).not.toContain('z-ai');
   });
 });
+
+// ---------------------------------------------------------------------------
+// oauth_plans gate (buildVisibleModels step 3b)
+// ---------------------------------------------------------------------------
+
+describe('oauth_plans gate', () => {
+  const rawApiModels = {
+    openai: { models: ['gpt-5.3-codex-spark-oauth', 'gpt-5.6-sol-oauth'], display_name: 'OpenAI' },
+  };
+  const rawMetadata: Record<string, ModelMetadataEntry> = {
+    'gpt-5.3-codex-spark-oauth': {
+      provider: 'codex-oauth',
+      access_type: 'oauth',
+      oauth_plans: ['pro', 'prolite'],
+    },
+    'gpt-5.6-sol-oauth': { provider: 'codex-oauth', access_type: 'oauth' },
+  };
+  const codexConnected = (planType: string | null): ConfiguredProvider[] => [
+    {
+      provider: 'codex-oauth',
+      display_name: 'ChatGPT Codex',
+      access_type: 'oauth',
+      plan_type: planType,
+    },
+  ];
+
+  it('hides a plan-gated model when the connected plan is not allowed', () => {
+    const result = buildVisibleModels(rawApiModels, rawMetadata, [], {}, null, codexConnected('team'));
+    expect(result.models.openai?.models).toEqual(['gpt-5.6-sol-oauth']);
+  });
+
+  it('keeps a plan-gated model when the connected plan is allowed (case-insensitive)', () => {
+    const result = buildVisibleModels(rawApiModels, rawMetadata, [], {}, null, codexConnected('Prolite'));
+    expect(result.models.openai?.models).toEqual(['gpt-5.3-codex-spark-oauth', 'gpt-5.6-sol-oauth']);
+  });
+
+  it('fails open when the connected plan is unknown', () => {
+    const result = buildVisibleModels(rawApiModels, rawMetadata, [], {}, null, codexConnected(null));
+    expect(result.models.openai?.models).toEqual(['gpt-5.3-codex-spark-oauth', 'gpt-5.6-sol-oauth']);
+  });
+
+  it('applies the gate in platform mode too', () => {
+    const platform = {
+      tier: 0,
+      model_tier: 0,
+      byok_providers: [],
+      oauth_providers: ['codex-oauth'],
+    } as unknown as PlatformModelsResponse;
+    const result = buildVisibleModels(rawApiModels, rawMetadata, [], {}, platform, codexConnected('team'));
+    expect(result.models.openai?.models).toEqual(['gpt-5.6-sol-oauth']);
+  });
+});

--- a/web/src/hooks/useConfiguredProviders.ts
+++ b/web/src/hooks/useConfiguredProviders.ts
@@ -12,6 +12,9 @@ export interface ConfiguredProvider {
    * itself. Carried through so model filters can treat the brand as
    * configured when any of its variants are (e.g. z-ai-coding → z-ai). */
   brand_key?: string;
+  /** Connected subscription plan for OAuth providers (e.g. "pro", "team").
+   * Consulted by the ``oauth_plans`` per-model gate; null/absent = unknown. */
+  plan_type?: string | null;
 }
 
 /**
@@ -67,6 +70,7 @@ export function useConfiguredProviders() {
         provider: 'codex-oauth',
         display_name: 'ChatGPT Codex',
         access_type: 'oauth',
+        plan_type: codexStatus.plan_type ?? null,
       });
     }
     if (claudeStatus?.connected) {
@@ -74,6 +78,7 @@ export function useConfiguredProviders() {
         provider: 'claude-oauth',
         display_name: 'Claude (OAuth)',
         access_type: 'oauth',
+        plan_type: claudeStatus.plan_type ?? null,
       });
     }
 

--- a/web/src/hooks/useFilteredModels.ts
+++ b/web/src/hooks/useFilteredModels.ts
@@ -14,6 +14,9 @@ export interface ModelMetadataEntry {
   requires_own_key?: string;
   /** Numeric tier for platform-served access. Absent = 0. */
   tier?: number;
+  /** OAuth-plan allowlist — the connected subscription's plan_type must be
+   * one of these for the model to show. Absent = no plan gate. */
+  oauth_plans?: string[];
   /** True for user-added custom models — bypasses all access filters. */
   is_custom_model?: boolean;
 }
@@ -303,6 +306,26 @@ export function buildVisibleModels(
     data.models = data.models.filter(
       (m) => !Object.hasOwn(shadowOwner, m) || shadowOwner[m] === groupKey,
     );
+  }
+
+  // 3b. OAuth plan gate — drop models whose `oauth_plans` allowlist excludes
+  // the connected subscription's plan. Unknown plan fails open; the backend
+  // enforces the same gate at turn admission either way.
+  const oauthPlanByProvider = new Map<string, string>();
+  for (const p of configuredProviders) {
+    if (p.access_type === 'oauth' && p.plan_type) {
+      oauthPlanByProvider.set(p.provider, p.plan_type.toLowerCase());
+    }
+  }
+  for (const data of Object.values(normalized)) {
+    if (!data.models) continue;
+    data.models = data.models.filter((m) => {
+      const plans = metadata[m]?.oauth_plans;
+      if (!plans || plans.length === 0) return true;
+      const provider = metadata[m]?.provider;
+      const plan = provider ? oauthPlanByProvider.get(provider) : undefined;
+      return !plan || plans.some((allowed) => allowed.toLowerCase() === plan);
+    });
   }
 
   // 4. Filter

--- a/web/src/pages/Settings/Settings.tsx
+++ b/web/src/pages/Settings/Settings.tsx
@@ -394,6 +394,8 @@ function Settings() {
               email: result.email as string,
               plan_type: result.plan_type as string,
             });
+            queryClient.invalidateQueries({ queryKey: queryKeys.oauth.codex() });
+            queryClient.invalidateQueries({ queryKey: queryKeys.platform.models() });
           }
           // result.pending → keep polling
         } catch {
@@ -471,6 +473,8 @@ function Settings() {
           email: (result.email as string) || null,
           plan_type: (result.plan_type as string) || null,
         });
+        queryClient.invalidateQueries({ queryKey: queryKeys.oauth.claude() });
+        queryClient.invalidateQueries({ queryKey: queryKeys.platform.models() });
       }
     } catch (e: unknown) {
       const axiosError = e as { response?: { data?: { detail?: string } } };

--- a/web/src/pages/Setup/steps/ConnectStep.tsx
+++ b/web/src/pages/Setup/steps/ConnectStep.tsx
@@ -429,6 +429,7 @@ export default function ConnectStep() {
           if ('success' in pollResult && pollResult.success) {
             await queryClient.invalidateQueries({ queryKey: queryKeys.user.me() });
             await queryClient.invalidateQueries({ queryKey: queryKeys.oauth.codex() });
+            await queryClient.invalidateQueries({ queryKey: queryKeys.platform.models() });
             navigate('/setup/models', {
               state: { method, provider, displayName, brandKey },
             });
@@ -475,6 +476,7 @@ export default function ConnectStep() {
       if (result.success) {
         await queryClient.invalidateQueries({ queryKey: queryKeys.user.me() });
         await queryClient.invalidateQueries({ queryKey: queryKeys.oauth.claude() });
+        await queryClient.invalidateQueries({ queryKey: queryKeys.platform.models() });
         navigate('/setup/models', {
           state: { method, provider, displayName, brandKey },
         });


### PR DESCRIPTION
## Overview

| | Files | Lines |
|---|---|---|
| Modified (non-test) | 8 | +72 / −5 |
| Tests (1 new file, 1 extended) | 2 | +97 / −0 |
| **Net (excl. tests)** | **8** | **+67** |

**By module**

| Module | Change |
|---|---|
| `src/llms` | First-party client headers on Codex requests (`llm.py`); `oauth_plans` field on `gpt-5.3-codex-spark-oauth` (`models.json`); `oauth_plans` passthrough in `get_model_metadata` |
| `src/server` | Plan gate at OAuth turn admission (`llm_config.py`); `get_valid_token` (codex + claude) now returns the stored `plan_type` |
| `web` | OAuth connect-success now invalidates model-list caches (`Settings.tsx`, `ConnectStep.tsx`); model picker hides plan-gated models (`useConfiguredProviders.ts`, `useFilteredModels.ts`) |
| tests | Codex header contract lock (new `test_codex_client_headers.py`); picker plan-gate cases (`useFilteredModels.test.ts`) |

**What this introduces:** Codex requests identify as a first-party client; a new per-model `oauth_plans` manifest allowlist enforced at both turn admission and the model picker; immediate model-list refresh after connecting an OAuth account.

## Fixes

### 1. Newer Codex models 404 through langalpha while working in the official CLI

The Codex backend serves some newer models (e.g. GPT-5.6 Luna) only to recognized first-party clients: a request must carry an `originator` naming a known client **and** a `User-Agent` with the matching `<originator>/` prefix — either alone still fails. Without them the backend returns 404 `"Model not found <id>"`, which masquerades as an availability/plan problem. langalpha's client (vanilla `AsyncOpenAI` via langchain) sent neither.

`_get_codex_llm` now always injects the pair into `default_headers`; per-instance headers (`ChatGPT-Account-Id`, explicit overrides) still merge in and win on conflict. Isolated with a header-matrix probe: no headers → 404, `originator` alone → 404, UA alone → 404, both → 200.

### 2. Per-plan model gating (`oauth_plans`)

Some OAuth models are only served on specific subscription plans (`gpt-5.3-codex-spark` → `pro`/`prolite`). Previously any connected user could select them and got an opaque upstream error. A models.json entry may now declare:

```json
"oauth_plans": ["pro", "prolite"]
```

Enforced in two places, both fail-open when the plan is unknown:

- **Turn admission** (`resolve_oauth_llm_client`): other plans get a clear `400 {"type": "oauth_plan_unsupported", "message": "Model '…' is not available on your connected '<plan>' plan (available on: …)"}` before the request leaves the server.
- **Model picker** (`buildVisibleModels`): plan-gated models are hidden when the connected plan isn't in the allowlist, in both the platform-tier and configured-provider filter paths.

### 3. Stale model list after connecting Codex/Claude OAuth

The Settings-page connect-**success** handlers only set local component state, while the disconnect handlers invalidate the React Query caches. The dropdown pipeline kept serving cached pre-connect data (OAuth status: 60s staleTime; platform models: 5min + `gcTime: Infinity`) until a later window-focus refetch — newly unlocked `-oauth` models looked missing. Connect-success now invalidates the same keys disconnect always did; the setup wizard additionally invalidates `platform.models()`.

## Verification

- **Live E2E against a running backend + real Codex OAuth:** GPT-5.6 Luna turn previously errored with the upstream 404 and now streams to completion; `gpt-5.3-codex-spark-oauth` streams on an allowed plan and returns the new 400 with a `team` plan; sol/terra unaffected.
- **Backend:** full unit suite green (6022 passed). New `test_codex_client_headers.py` fails without the header fix, passes with it.
- **Frontend:** `tsc --noEmit` clean; full Vitest green (2317 passed) including 4 new plan-gate cases (blocked plan / allowed plan case-insensitively / unknown plan fails open / platform mode).

## Notes for reviewers

- The header pair matches the official Codex CLI's defaults (`codex_cli_rs`), consistent with this integration already using the CLI's OAuth client id. Traffic will attribute to that client upstream.
- `oauth_plans` is deliberately fail-open on unknown `plan_type` — the upstream backend remains the authority; the gate exists to replace opaque upstream errors with actionable ones.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - OAuth model availability now reflects the connected subscription plan.
  - Plan-restricted models are hidden when unavailable, while unknown plans remain compatible.
  - Added plan information for Codex and Claude OAuth connections.
- **Improvements**
  - Model listings now refresh automatically after completing an OAuth connection.
  - Improved Codex integration compatibility by applying required request identification headers while preserving custom provider headers.
- **Bug Fixes**
  - Prevented unsupported plan-specific models from being selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->