### PR TITLE
fix(logging): silence yfinance no-data ERROR-log flood + bump to 1.5.1

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -41,6 +41,13 @@ module_log_levels:
   group:third_party_libraries: WARNING
   group:langchain_libraries: WARNING
 
+  # yfinance logs a normal no-data soft-miss at ERROR (and never raises), but the
+  # provider chain treats an empty result as a designed fallthrough — so every
+  # symbol Yahoo can't serve (bare CN/HK codes, fund codes, ^ index aliases) spams
+  # the ERROR stream from the last-resort fallback. CRITICAL (not WARNING) is
+  # required: the "possibly delisted" line is emitted at ERROR.
+  yfinance: CRITICAL
+
   # Application modules (hierarchical - parent loggers affect all children)
   src.tools: INFO
   src.deep_research: INFO

--- a/uv.lock
+++ b/uv.lock
@@ -5808,7 +5808,7 @@ wheels = [
 
 [[package]]
 name = "yfinance"
-version = "1.4.0"
+version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -5823,9 +5823,9 @@ dependencies = [
     { name = "requests" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/21/e2/b81f9cac78f1c23e444164f2135e19f849a66774474f8b156fc3702280c3/yfinance-1.4.0.tar.gz", hash = "sha256:6b049c3f28b0d66be54c32d84838ffd60c429277ba378afb0202c4792013c911", size = 153715, upload_time = "2026-05-23T16:28:08.961Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/f1/095457c99cd5fb44802e0dafbb17051e0bfdbf264bd4531556e662f57fbf/yfinance-1.5.1.tar.gz", hash = "sha256:89c48a1d45fb870f8e3066c22643c6911118ede9cead747b48925ce8e01a6940", size = 167897, upload_time = "2026-06-28T18:13:59.593Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/58/31561402a60d317f9c36288223be99eabedc25b61f18d0b69f0889726545/yfinance-1.4.0-py2.py3-none-any.whl", hash = "sha256:6513654be21bd80a4e9e4e24193255fb4b1921618443113826494bf6efcedcb0", size = 137749, upload_time = "2026-05-23T16:28:07.656Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/53/ba0f45c93c45cafe010c9fe2f509c70d1ad0f96ae7b6ca93369db0c17942/yfinance-1.5.1-py2.py3-none-any.whl", hash = "sha256:a5c9cfc1b9c990f217b643e4fb92444e023cc02b2bacdea9c1fb472509fdfe22", size = 144223, upload_time = "2026-06-28T18:13:58.349Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Two focused changes:

- **Logging fix** — the `yfinance` library logs a normal "no price data" soft-miss
  at **ERROR** level (and returns an empty result instead of raising), so every
  symbol Yahoo Finance can't serve — non-US tickers, thin/unlisted symbols — produced
  a steady flood of ERROR lines from the last-resort fallback provider. Our market-data
  provider chain already treats an empty result as a *designed* soft-miss / fallthrough,
  so these are not errors in our system. Pin the `yfinance` logger to `CRITICAL` in
  `module_log_levels` so the severity mismatch is corrected at the source. Genuine
  yfinance failures are still surfaced by our own `data_client` logger.
- **Dependency bump** — `yfinance` 1.4.0 → 1.5.1.

## Overview

| | Files | Lines |
|---|---|---|
| Modified | 2 | +10 / −3 |
| New | 0 | — |
| **Net (excl. tests)** | **2** | **+10 / −3** |

**By module**
- `config.yaml` (modified) — one new `module_log_levels` entry (`yfinance: CRITICAL`) plus an explanatory comment on why the level must be CRITICAL, not WARNING.
- `uv.lock` (modified) — yfinance 1.4.0 → 1.5.1.

**What this introduces:** quieter ERROR logs — removes a high-volume third-party noise
source — with zero change to data results or routing behavior.

## Diff Size
- Total: 2 files changed, 10 insertions(+), 3 deletions(-)
- Net (excl. tests): 2 files changed, 10 insertions(+), 3 deletions(-)

## Test Coverage
Config + lockfile only — no new application code paths to audit. Verified by driving
the real code path instead (below).

## Pre-Landing Review
No issues. 13-line config/dependency diff — no SQL, no LLM trust-boundary, no secrets.

## Verification
- **Flood reproduced + fixed** through the real `configure_logging()` path on 1.5.1:
  yfinance ERROR lines **6 → 0** for unservable symbols; empty results unchanged.
- **API contract** — every yfinance surface the code consumes (`history`, `fast_info`,
  `info`, income/cashflow statements, screener `EquityQuery`/`screen`, `Search`, `news`)
  verified present + shape-stable against 1.5.1 via static and live-shape checks.
- **Happy path intact** on 1.5.1: US daily + snapshot and non-US (`.HK`) daily all return data.

## Test plan
- [x] Full unit suite: 6043 passed (2 pre-existing failures unrelated to this diff — a local search-provider manifest env artifact)
- [x] yfinance API contract verified against 1.5.1
- [x] ERROR-flood suppression verified via the real logging path (6 → 0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced noise from third-party market-data logging by limiting non-actionable messages to critical severity.
  * Added configuration comments clarifying handling of empty data results and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->