### PR TITLE
fix: recover from sandbox transport failures and 404 malformed thread ids

### DIFF
--- a/src/ptc_agent/core/session.py
+++ b/src/ptc_agent/core/session.py
@@ -71,6 +71,13 @@ class Session:
                         self.sandbox.normalize_path("agent.md")
                     )
                 except Exception:
+                    # A missing agent.md is a silent None from aread_file_text;
+                    # reaching here means the read itself failed.
+                    logger.warning(
+                        "Failed to read agent.md",
+                        conversation_id=self.conversation_id,
+                        exc_info=True,
+                    )
                     self._agent_md_cache = None
             else:
                 self._agent_md_cache = None

--- a/src/server/database/conversation.py
+++ b/src/server/database/conversation.py
@@ -2007,6 +2007,10 @@ async def get_thread_by_id(conversation_thread_id: str) -> Optional[Dict[str, An
     Returns:
         Thread dict or None if not found
     """
+    conversation_thread_id = normalize_uuid(conversation_thread_id)
+    if conversation_thread_id is None:
+        return None
+
     try:
         async with get_db_connection() as conn:
             async with conn.cursor(row_factory=dict_row) as cur:
@@ -2944,6 +2948,10 @@ async def get_replay_thread_data(
     Returns:
         (owner_user_id, thread_summary, queries, responses, usages, provenance)
     """
+    thread_id = normalize_uuid(thread_id)
+    if thread_id is None:
+        return None, None, [], [], [], []
+
     async with get_db_connection() as conn:
         async with conn.cursor(row_factory=dict_row) as cur:
             # 1. Owner check (join threads -> workspaces)

--- a/src/server/handlers/chat/_common.py
+++ b/src/server/handlers/chat/_common.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, Optional
 import psycopg
 from fastapi import HTTPException
 
+from ptc_agent.core.sandbox.runtime import SandboxGoneError, SandboxTransientError
 from src.config.settings import (
     get_langsmith_metadata,
     get_langsmith_tags,
@@ -256,6 +257,8 @@ def classify_error(e: Exception) -> dict:
     is_non_recoverable = isinstance(e, non_recoverable_types)
 
     # Recoverable error patterns (transient issues)
+    is_sandbox_error = isinstance(e, (SandboxTransientError, SandboxGoneError))
+
     is_postgres_connection = isinstance(
         e, psycopg.OperationalError
     ) and "server closed the connection" in str(e)
@@ -300,12 +303,18 @@ def classify_error(e: Exception) -> dict:
     )
 
     is_recoverable = (
-        is_postgres_connection or is_timeout or is_network_issue or is_api_error
+        is_sandbox_error
+        or is_postgres_connection
+        or is_timeout
+        or is_network_issue
+        or is_api_error
     ) and not is_non_recoverable
 
     # Determine specific error_type label
     if is_recoverable:
-        if is_postgres_connection or is_network_issue:
+        if is_sandbox_error:
+            error_type = "transient_error"
+        elif is_postgres_connection or is_network_issue:
             error_type = "connection_error"
         elif is_timeout:
             error_type = "timeout_error"

--- a/src/tools/secretary/tools.py
+++ b/src/tools/secretary/tools.py
@@ -427,10 +427,9 @@ async def ptc_agent(
         from src.server.database.conversation import get_thread_by_id
         from src.server.utils.pg_sanitize import normalize_uuid
 
-        # Normalize once so the owner check and the fetch bind the same canonical
-        # UUID. get_thread_owner_id normalizes internally; get_thread_by_id binds
-        # raw, so a non-canonical id (e.g. urn:uuid:...) would pass the owner
-        # check yet 22P02 on the fetch. None means not a UUID -> not found.
+        # Normalize once so the owner check and every downstream bind use the
+        # same canonical UUID (get_thread_owner_id and get_thread_by_id also
+        # normalize internally). None means not a UUID -> not found.
         normalized_id = normalize_uuid(thread_id)
         if normalized_id is None:
             return _error_command(

--- a/tests/unit/ptc_agent/core/test_session_agent_md.py
+++ b/tests/unit/ptc_agent/core/test_session_agent_md.py
@@ -1,0 +1,56 @@
+"""Session.get_agent_md fault tolerance: sandbox read failures must not kill the turn."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.ptc_agent.core.sandbox.runtime import SandboxTransientError
+from src.ptc_agent.core.session import Session
+
+
+def _make_sandbox(read_result=None, read_side_effect=None):
+    sandbox = MagicMock()
+    sandbox.normalize_path = MagicMock(side_effect=lambda p: f"/workspace/{p}")
+    sandbox.aread_file_text = AsyncMock(
+        return_value=read_result, side_effect=read_side_effect
+    )
+    return sandbox
+
+
+def _make_session(sandbox):
+    config = MagicMock()
+    config.mcp.servers = []
+    session = Session("test-conversation", config)
+    session.sandbox = sandbox
+    return session
+
+
+class TestGetAgentMd:
+    @pytest.mark.asyncio
+    async def test_missing_file_returns_none(self):
+        session = _make_session(_make_sandbox(read_result=None))
+        assert await session.get_agent_md() is None
+
+    @pytest.mark.asyncio
+    async def test_transient_error_returns_none_and_recovers(self):
+        failing = _make_sandbox(read_side_effect=SandboxTransientError("boom"))
+        session = _make_session(failing)
+        assert await session.get_agent_md() is None
+
+        # After the transport recovers, an invalidation must allow a re-read.
+        session.invalidate_agent_md()
+        session.sandbox = _make_sandbox(read_result="# agent.md")
+        assert await session.get_agent_md() == "# agent.md"
+
+    @pytest.mark.asyncio
+    async def test_content_cached_until_invalidated(self):
+        sandbox = _make_sandbox(read_result="# agent.md")
+        session = _make_session(sandbox)
+
+        assert await session.get_agent_md() == "# agent.md"
+        assert await session.get_agent_md() == "# agent.md"
+        assert sandbox.aread_file_text.await_count == 1
+
+        session.invalidate_agent_md()
+        assert await session.get_agent_md() == "# agent.md"
+        assert sandbox.aread_file_text.await_count == 2

--- a/tests/unit/server/app/test_threads_malformed_id.py
+++ b/tests/unit/server/app/test_threads_malformed_id.py
@@ -38,3 +38,11 @@ async def test_thread_status_malformed_id_returns_404(threads_client):
         "/api/v1/threads/my_notes.md/status"
     )
     assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_thread_replay_malformed_id_returns_404(threads_client):
+    resp = await threads_client.get(
+        "/api/v1/threads/results/messages/replay"
+    )
+    assert resp.status_code == 404

--- a/tests/unit/server/database/test_conversation_db.py
+++ b/tests/unit/server/database/test_conversation_db.py
@@ -169,24 +169,37 @@ async def test_get_thread_by_id_found(mock_db_connection, mock_cursor):
     """get_thread_by_id returns dict when thread exists."""
     from src.server.database.conversation import get_thread_by_id
 
-    row = _thread_row(thread_id="t-1")
+    thread_id = str(uuid.uuid4())
+    row = _thread_row(thread_id=thread_id)
     mock_cursor.fetchone.return_value = row
 
-    result = await get_thread_by_id("t-1")
+    result = await get_thread_by_id(thread_id)
 
     assert result is not None
-    assert result["conversation_thread_id"] == "t-1"
+    assert result["conversation_thread_id"] == thread_id
 
 
 @pytest.mark.asyncio
 async def test_get_thread_by_id_not_found(mock_db_connection, mock_cursor):
-    """get_thread_by_id returns None when thread does not exist."""
+    """get_thread_by_id returns None when a valid id does not exist."""
     from src.server.database.conversation import get_thread_by_id
 
     mock_cursor.fetchone.return_value = None
 
-    result = await get_thread_by_id("nonexistent")
+    result = await get_thread_by_id(str(uuid.uuid4()))
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_thread_by_id_malformed_id_skips_database(
+    mock_db_connection, mock_cursor
+):
+    from src.server.database.conversation import get_thread_by_id
+
+    result = await get_thread_by_id("results")
+
+    assert result is None
+    mock_cursor.execute.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -566,20 +579,33 @@ async def test_replay_data_excludes_subagent_usage_rows(
     task billing rows that share its response id."""
     from src.server.database.conversation import get_replay_thread_data
 
+    thread_id = str(uuid.uuid4())
     mock_cursor.fetchone.side_effect = [
         {"user_id": "user-1"},
         {
-            "conversation_thread_id": "thread-1",
+            "conversation_thread_id": thread_id,
             "latest_checkpoint_id": "cp-1",
         },
     ]
     mock_cursor.fetchall.side_effect = [[], [], [], []]
 
-    await get_replay_thread_data("thread-1")
+    await get_replay_thread_data(thread_id)
 
     usage_sql = mock_cursor.execute.call_args_list[4].args[0]
     assert "SELECT conversation_response_id, msg_type" in usage_sql
     assert "msg_type <> 'task'" in usage_sql
+
+
+@pytest.mark.asyncio
+async def test_get_replay_thread_data_malformed_id_skips_database(
+    mock_db_connection, mock_cursor
+):
+    from src.server.database.conversation import get_replay_thread_data
+
+    result = await get_replay_thread_data("results")
+
+    assert result == (None, None, [], [], [], [])
+    mock_cursor.execute.assert_not_awaited()
 
 
 # ===========================================================================

--- a/tests/unit/server/handlers/test_chat_common.py
+++ b/tests/unit/server/handlers/test_chat_common.py
@@ -21,6 +21,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import psycopg
 import pytest
 
+from ptc_agent.core.sandbox.runtime import SandboxGoneError, SandboxTransientError
 from src.server.models.additional_context import SkillContext
 
 COMMON = "src.server.handlers.chat._common"
@@ -104,6 +105,20 @@ class TestClassifyError:
         result = self._classify(err)
         assert result["is_recoverable"] is True
         assert result["error_type"] == "connection_error"
+
+    def test_recoverable_sandbox_transient_error(self):
+        result = self._classify(
+            SandboxTransientError(
+                "Transient sandbox transport error; operation failed after retries"
+            )
+        )
+        assert result["is_recoverable"] is True
+        assert result["error_type"] == "transient_error"
+
+    def test_recoverable_sandbox_gone_error(self):
+        result = self._classify(SandboxGoneError("sandbox-placeholder", "not found"))
+        assert result["is_recoverable"] is True
+        assert result["error_type"] == "transient_error"
 
     def test_generic_runtime_error_not_recoverable(self):
         result = self._classify(RuntimeError("something went wrong"))

--- a/tests/unit/server/utils/test_pg_sanitize.py
+++ b/tests/unit/server/utils/test_pg_sanitize.py
@@ -13,7 +13,12 @@ import time
 
 import pytest
 
-from src.server.utils.pg_sanitize import SafeJson, _safe_dumps, strip_pg_nul_str
+from src.server.utils.pg_sanitize import (
+    SafeJson,
+    _safe_dumps,
+    normalize_uuid,
+    strip_pg_nul_str,
+)
 
 
 class TestStripPgNulStr:
@@ -94,3 +99,37 @@ def test_safe_dumps_performance_smoke(size_mb: int):
     _safe_dumps(blob)
     elapsed = time.perf_counter() - start
     assert elapsed < 5.0, f"_safe_dumps too slow: {elapsed:.2f}s for {size_mb} MB"
+
+
+CANONICAL = "123e4567-e89b-12d3-a456-426614174000"
+
+
+class TestNormalizeUuid:
+    def test_canonical_passthrough(self):
+        assert normalize_uuid(CANONICAL) == CANONICAL
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "123E4567-E89B-12D3-A456-426614174000",
+            "urn:uuid:123e4567-e89b-12d3-a456-426614174000",
+            "123e4567e89b12d3a456426614174000",
+            "{123e4567-e89b-12d3-a456-426614174000}",
+        ],
+    )
+    def test_non_canonical_forms_normalize(self, value):
+        assert normalize_uuid(value) == CANONICAL
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "results",
+            "notes.md",
+            "",
+            None,
+            12345,
+            "123e4567-e89b-12d3-a456",
+        ],
+    )
+    def test_non_uuid_returns_none(self, value):
+        assert normalize_uuid(value) is None

--- a/web/e2e/chat.spec.js
+++ b/web/e2e/chat.spec.js
@@ -22,14 +22,14 @@ import { loadFixture } from './helpers/loadFixture.js';
 
 const ws1 = sampleWorkspace();
 const ws2 = sampleWorkspace({
-  workspace_id: 'ws-2',
+  workspace_id: 'a0000002-0000-4000-8000-000000000002',
   name: 'Alpha Research',
   description: 'Second workspace',
 });
 const th1 = sampleThread();
 const th2 = sampleThread({
-  thread_id: 'th-2',
-  workspace_id: 'ws-1',
+  thread_id: 'b0000002-0000-4000-8000-000000000002',
+  workspace_id: 'a0000001-0000-4000-8000-000000000001',
   title: 'Second thread',
 });
 
@@ -40,11 +40,11 @@ function workspaceOverrides() {
   };
 }
 
-/** Overrides that populate a thread list for ws-1. */
+/** Overrides that populate a thread list for a0000001-0000-4000-8000-000000000001. */
 function threadOverrides() {
   return {
     ...workspaceOverrides(),
-    'GET /workspaces/ws-1': ws1,
+    'GET /workspaces/a0000001-0000-4000-8000-000000000001': ws1,
     'GET /threads': { threads: [th1, th2], total: 2 },
   };
 }
@@ -53,10 +53,10 @@ function threadOverrides() {
 function chatViewOverrides() {
   return {
     ...threadOverrides(),
-    'GET /threads/th-1': th1,
-    'GET /threads/th-1/status': { can_reconnect: false, status: 'idle' },
-    'GET /threads/th-1/turns': {
-      thread_id: 'th-1',
+    'GET /threads/b0000001-0000-4000-8000-000000000001': th1,
+    'GET /threads/b0000001-0000-4000-8000-000000000001/status': { can_reconnect: false, status: 'idle' },
+    'GET /threads/b0000001-0000-4000-8000-000000000001/turns': {
+      thread_id: 'b0000001-0000-4000-8000-000000000001',
       turns: [
         {
           turn_index: 0,
@@ -66,7 +66,7 @@ function chatViewOverrides() {
       ],
       retry_checkpoint_id: 'cp-retry-0',
     },
-    'GET /workspaces/ws-1/files': { files: [] },
+    'GET /workspaces/a0000001-0000-4000-8000-000000000001/files': { files: [] },
   };
 }
 
@@ -74,7 +74,7 @@ function chatViewOverrides() {
 async function configureEmptyReplay() {
   await configureSSE({
     method: 'GET',
-    path: '/api/v1/threads/th-1/messages/replay',
+    path: '/api/v1/threads/b0000001-0000-4000-8000-000000000001/messages/replay',
     events: [sseEvents.replayDone()],
     delay: 10,
   });
@@ -141,7 +141,7 @@ test.describe('Workspace Gallery', () => {
   });
 
   test('delete workspace removes card', async ({ page }) => {
-    // Use a dynamic mock: after DELETE is called, GET /workspaces returns without ws-1
+    // Use a dynamic mock: after DELETE is called, GET /workspaces returns without a0000001-0000-4000-8000-000000000001
     let wsDeleted = false;
     await mockAPI(page, {
       'GET /workspaces': (route) => {
@@ -154,7 +154,7 @@ test.describe('Workspace Gallery', () => {
           body: JSON.stringify(data),
         });
       },
-      'DELETE /workspaces/ws-1': (route) => {
+      'DELETE /workspaces/a0000001-0000-4000-8000-000000000001': (route) => {
         wsDeleted = true;
         return route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
       },
@@ -179,7 +179,7 @@ test.describe('Workspace Gallery', () => {
     await expect(page.locator('h2', { hasText: 'Delete Workspace' })).toBeVisible();
     await page.getByRole('button', { name: 'Delete' }).click();
 
-    // The Research card should disappear (refetch returns without ws-1)
+    // The Research card should disappear (refetch returns without a0000001-0000-4000-8000-000000000001)
     await expect(page.getByText('Research', { exact: true })).not.toBeVisible({ timeout: 10000 });
   });
 
@@ -213,10 +213,10 @@ test.describe('Thread Gallery', () => {
   test('thread list renders', async ({ page }) => {
     await mockAPI(page, {
       ...threadOverrides(),
-      'GET /workspaces/ws-1/files': { files: [] },
+      'GET /workspaces/a0000001-0000-4000-8000-000000000001/files': { files: [] },
     });
 
-    await page.goto('/chat/ws-1');
+    await page.goto('/chat/a0000001-0000-4000-8000-000000000001');
 
     // Thread titles should be visible
     await expect(page.locator('h3.text-sm.font-normal.truncate', { hasText: 'Test conversation' })).toBeVisible({ timeout: 10000 });
@@ -227,11 +227,11 @@ test.describe('Thread Gallery', () => {
     await mockAPI(page, {
       ...threadOverrides(),
       ...chatViewOverrides(),
-      'GET /workspaces/ws-1/files': { files: [] },
+      'GET /workspaces/a0000001-0000-4000-8000-000000000001/files': { files: [] },
     });
     await configureEmptyReplay();
 
-    await page.goto('/chat/ws-1');
+    await page.goto('/chat/a0000001-0000-4000-8000-000000000001');
 
     // Click on first thread
     const threadCard = page.locator('h3.text-sm.font-normal.truncate', { hasText: 'Test conversation' });
@@ -245,11 +245,11 @@ test.describe('Thread Gallery', () => {
   test('delete thread removes from list', async ({ page }) => {
     await mockAPI(page, {
       ...threadOverrides(),
-      'DELETE /threads/th-1': { success: true },
-      'GET /workspaces/ws-1/files': { files: [] },
+      'DELETE /threads/b0000001-0000-4000-8000-000000000001': { success: true },
+      'GET /workspaces/a0000001-0000-4000-8000-000000000001/files': { files: [] },
     });
 
-    await page.goto('/chat/ws-1');
+    await page.goto('/chat/a0000001-0000-4000-8000-000000000001');
 
     // Wait for thread to appear
     const threadTitle = page.locator('h3.text-sm.font-normal.truncate', { hasText: 'Test conversation' });
@@ -289,7 +289,7 @@ test.describe('Chat View -- SSE Streaming', () => {
     // Configure replay with a user message and assistant response
     await configureSSE({
       method: 'GET',
-      path: '/api/v1/threads/th-1/messages/replay',
+      path: '/api/v1/threads/b0000001-0000-4000-8000-000000000001/messages/replay',
       events: [
         sseEvents.userMessage('What is AAPL trading at?', 0),
         sseEvents.messageChunk('Apple (AAPL) is currently trading at $185.50.'),
@@ -300,7 +300,7 @@ test.describe('Chat View -- SSE Streaming', () => {
       delay: 10,
     });
 
-    await page.goto('/chat/t/th-1');
+    await page.goto('/chat/t/b0000001-0000-4000-8000-000000000001');
 
     // Both user and assistant messages should appear
     await expect(page.getByText('What is AAPL trading at?')).toBeVisible({ timeout: 10000 });
@@ -314,7 +314,7 @@ test.describe('Chat View -- SSE Streaming', () => {
     // Configure the SSE response for sending a message
     await configureSSE({
       method: 'POST',
-      path: '/api/v1/threads/th-1/messages',
+      path: '/api/v1/threads/b0000001-0000-4000-8000-000000000001/messages',
       events: [
         sseEvents.messageChunk('The S&P 500 '),
         sseEvents.messageChunk('is up 1.2% today.'),
@@ -324,7 +324,7 @@ test.describe('Chat View -- SSE Streaming', () => {
       delay: 30,
     });
 
-    await page.goto('/chat/t/th-1');
+    await page.goto('/chat/t/b0000001-0000-4000-8000-000000000001');
     await page.waitForSelector('textarea', { timeout: 10000 });
 
     // Type a message and send
@@ -343,7 +343,7 @@ test.describe('Chat View -- SSE Streaming', () => {
     // Replay with a tool call sequence
     await configureSSE({
       method: 'GET',
-      path: '/api/v1/threads/th-1/messages/replay',
+      path: '/api/v1/threads/b0000001-0000-4000-8000-000000000001/messages/replay',
       events: [
         sseEvents.userMessage('Search for NVDA earnings'),
         sseEvents.toolCalls([{ name: 'WebSearch', args: { query: 'NVDA earnings Q4 2025' }, id: toolCallId }]),
@@ -357,7 +357,7 @@ test.describe('Chat View -- SSE Streaming', () => {
       delay: 10,
     });
 
-    await page.goto('/chat/t/th-1');
+    await page.goto('/chat/t/b0000001-0000-4000-8000-000000000001');
 
     // The tool call card should appear. The accordion header is now
     // content-aware (skill/memory/memo/code/web/search/file/generic) — for
@@ -373,7 +373,7 @@ test.describe('Chat View -- SSE Streaming', () => {
     // Replay that ends with an interrupt
     await configureSSE({
       method: 'GET',
-      path: '/api/v1/threads/th-1/messages/replay',
+      path: '/api/v1/threads/b0000001-0000-4000-8000-000000000001/messages/replay',
       events: [
         sseEvents.userMessage('Analyze TSLA'),
         sseEvents.interrupt('int-1', 'Here is my plan:\n1. Fetch TSLA financials\n2. Create a chart'),
@@ -382,7 +382,7 @@ test.describe('Chat View -- SSE Streaming', () => {
       delay: 10,
     });
 
-    await page.goto('/chat/t/th-1');
+    await page.goto('/chat/t/b0000001-0000-4000-8000-000000000001');
 
     // Plan approval card should be visible
     await expect(page.getByText('Plan Approval Required')).toBeVisible({ timeout: 10000 });
@@ -399,7 +399,7 @@ test.describe('Chat View -- SSE Streaming', () => {
     // Replay with interrupt
     await configureSSE({
       method: 'GET',
-      path: '/api/v1/threads/th-1/messages/replay',
+      path: '/api/v1/threads/b0000001-0000-4000-8000-000000000001/messages/replay',
       events: [
         sseEvents.userMessage('Analyze TSLA'),
         sseEvents.interrupt('int-1', 'Plan:\n1. Fetch data\n2. Analyze'),
@@ -411,7 +411,7 @@ test.describe('Chat View -- SSE Streaming', () => {
     // Configure the POST for plan approval (HITL response sends as message)
     await configureSSE({
       method: 'POST',
-      path: '/api/v1/threads/th-1/messages',
+      path: '/api/v1/threads/b0000001-0000-4000-8000-000000000001/messages',
       events: [
         sseEvents.messageChunk('Executing the plan...'),
         sseEvents.finishStop(),
@@ -420,7 +420,7 @@ test.describe('Chat View -- SSE Streaming', () => {
       delay: 30,
     });
 
-    await page.goto('/chat/t/th-1');
+    await page.goto('/chat/t/b0000001-0000-4000-8000-000000000001');
 
     // Wait for approval UI
     await expect(page.getByText('Plan Approval Required')).toBeVisible({ timeout: 10000 });
@@ -450,7 +450,7 @@ test.describe('Chat View -- SSE Streaming', () => {
     // Configure a slow SSE stream
     await configureSSE({
       method: 'POST',
-      path: '/api/v1/threads/th-1/messages',
+      path: '/api/v1/threads/b0000001-0000-4000-8000-000000000001/messages',
       events: [
         sseEvents.messageChunk('Starting analysis...'),
         sseEvents.messageChunk(' Step 1 complete.'),
@@ -462,7 +462,7 @@ test.describe('Chat View -- SSE Streaming', () => {
       delay: 500, // Slow enough to click stop
     });
 
-    await page.goto('/chat/t/th-1');
+    await page.goto('/chat/t/b0000001-0000-4000-8000-000000000001');
     await page.waitForSelector('textarea', { timeout: 10000 });
 
     // Send a message
@@ -502,13 +502,13 @@ test.describe('Chat View -- SSE Streaming', () => {
     // Configure the send endpoint to return 429
     await configureSSE({
       method: 'POST',
-      path: '/api/v1/threads/th-1/messages',
+      path: '/api/v1/threads/b0000001-0000-4000-8000-000000000001/messages',
       status: 429,
       errorBody: { detail: 'Rate limit exceeded. Please try again later.' },
       events: [],
     });
 
-    await page.goto('/chat/t/th-1');
+    await page.goto('/chat/t/b0000001-0000-4000-8000-000000000001');
     await page.waitForSelector('textarea', { timeout: 10000 });
 
     // Send a message
@@ -525,7 +525,7 @@ test.describe('Chat View -- SSE Streaming', () => {
     // Replay with a conversation
     await configureSSE({
       method: 'GET',
-      path: '/api/v1/threads/th-1/messages/replay',
+      path: '/api/v1/threads/b0000001-0000-4000-8000-000000000001/messages/replay',
       events: [
         sseEvents.userMessage('Tell me about AAPL'),
         sseEvents.messageChunk('Apple Inc. is a technology company.'),
@@ -539,7 +539,7 @@ test.describe('Chat View -- SSE Streaming', () => {
     // Configure the response after editing
     await configureSSE({
       method: 'POST',
-      path: '/api/v1/threads/th-1/messages',
+      path: '/api/v1/threads/b0000001-0000-4000-8000-000000000001/messages',
       events: [
         sseEvents.messageChunk('Google (GOOGL) is a subsidiary of Alphabet.'),
         sseEvents.finishStop(),
@@ -548,7 +548,7 @@ test.describe('Chat View -- SSE Streaming', () => {
       delay: 30,
     });
 
-    await page.goto('/chat/t/th-1');
+    await page.goto('/chat/t/b0000001-0000-4000-8000-000000000001');
 
     // Wait for the user message to appear
     await expect(page.getByText('Tell me about AAPL')).toBeVisible({ timeout: 10000 });
@@ -578,7 +578,7 @@ test.describe('Chat View -- SSE Streaming', () => {
     // Replay with a conversation
     await configureSSE({
       method: 'GET',
-      path: '/api/v1/threads/th-1/messages/replay',
+      path: '/api/v1/threads/b0000001-0000-4000-8000-000000000001/messages/replay',
       events: [
         sseEvents.userMessage('Explain options trading'),
         sseEvents.messageChunk('Options are financial derivatives.'),
@@ -592,7 +592,7 @@ test.describe('Chat View -- SSE Streaming', () => {
     // Configure regenerate response
     await configureSSE({
       method: 'POST',
-      path: '/api/v1/threads/th-1/messages',
+      path: '/api/v1/threads/b0000001-0000-4000-8000-000000000001/messages',
       events: [
         sseEvents.messageChunk('Options trading involves contracts that give the holder the right to buy or sell.'),
         sseEvents.finishStop(),
@@ -601,7 +601,7 @@ test.describe('Chat View -- SSE Streaming', () => {
       delay: 30,
     });
 
-    await page.goto('/chat/t/th-1');
+    await page.goto('/chat/t/b0000001-0000-4000-8000-000000000001');
 
     // Wait for the assistant message
     await expect(page.getByText('Options are financial derivatives.')).toBeVisible({ timeout: 10000 });
@@ -620,11 +620,11 @@ test.describe('Chat View -- SSE Streaming', () => {
   test('file panel opens and lists files', async ({ page }) => {
     await mockAPI(page, {
       ...chatViewOverrides(),
-      'GET /workspaces/ws-1/files': { files: ['report.pdf', 'analysis.py', 'chart.png'] },
+      'GET /workspaces/a0000001-0000-4000-8000-000000000001/files': { files: ['report.pdf', 'analysis.py', 'chart.png'] },
     });
     await configureEmptyReplay();
 
-    await page.goto('/chat/t/th-1');
+    await page.goto('/chat/t/b0000001-0000-4000-8000-000000000001');
     await page.waitForSelector('textarea', { timeout: 10000 });
 
     // Click the file panel toggle button (title="Workspace Files")
@@ -642,7 +642,7 @@ test.describe('Chat View -- SSE Streaming', () => {
     // Replay includes workspace_status starting event before content
     await configureSSE({
       method: 'GET',
-      path: '/api/v1/threads/th-1/messages/replay',
+      path: '/api/v1/threads/b0000001-0000-4000-8000-000000000001/messages/replay',
       events: [sseEvents.replayDone()],
       delay: 10,
     });
@@ -650,7 +650,7 @@ test.describe('Chat View -- SSE Streaming', () => {
     // Configure send to show workspace starting status
     await configureSSE({
       method: 'POST',
-      path: '/api/v1/threads/th-1/messages',
+      path: '/api/v1/threads/b0000001-0000-4000-8000-000000000001/messages',
       events: [
         sseEvents.workspaceStatus('starting'),
         sseEvents.workspaceStatus('ready'),
@@ -661,7 +661,7 @@ test.describe('Chat View -- SSE Streaming', () => {
       delay: 100,
     });
 
-    await page.goto('/chat/t/th-1');
+    await page.goto('/chat/t/b0000001-0000-4000-8000-000000000001');
     await page.waitForSelector('textarea', { timeout: 10000 });
 
     // Send a message to trigger workspace starting
@@ -678,13 +678,13 @@ test.describe('Chat View -- SSE Streaming', () => {
   test('reconnect resumes in-progress stream', async ({ page }) => {
     await mockAPI(page, {
       ...chatViewOverrides(),
-      'GET /threads/th-1/status': { can_reconnect: true, status: 'streaming' },
+      'GET /threads/b0000001-0000-4000-8000-000000000001/status': { can_reconnect: true, status: 'streaming' },
     });
 
     // Replay returns conversation history
     await configureSSE({
       method: 'GET',
-      path: '/api/v1/threads/th-1/messages/replay',
+      path: '/api/v1/threads/b0000001-0000-4000-8000-000000000001/messages/replay',
       events: [
         sseEvents.userMessage('Analyze the portfolio'),
         sseEvents.messageChunk('Starting portfolio analysis...'),
@@ -696,7 +696,7 @@ test.describe('Chat View -- SSE Streaming', () => {
     // Reconnect stream picks up where it left off
     await configureSSE({
       method: 'GET',
-      path: '/api/v1/threads/th-1/messages/stream',
+      path: '/api/v1/threads/b0000001-0000-4000-8000-000000000001/messages/stream',
       events: [
         sseEvents.messageChunk(' Your portfolio returned 12% YTD.'),
         sseEvents.finishStop(),
@@ -705,7 +705,7 @@ test.describe('Chat View -- SSE Streaming', () => {
       delay: 30,
     });
 
-    await page.goto('/chat/t/th-1');
+    await page.goto('/chat/t/b0000001-0000-4000-8000-000000000001');
 
     // The reconnected stream content should appear
     await expect(page.getByText('Your portfolio returned 12% YTD.')).toBeVisible({ timeout: 15000 });
@@ -725,14 +725,14 @@ function steeringChatOverrides(turnCount = 1) {
   }));
   return {
     ...threadOverrides(),
-    'GET /threads/th-1': th1,
-    'GET /threads/th-1/status': { can_reconnect: false, status: 'idle' },
-    'GET /threads/th-1/turns': {
-      thread_id: 'th-1',
+    'GET /threads/b0000001-0000-4000-8000-000000000001': th1,
+    'GET /threads/b0000001-0000-4000-8000-000000000001/status': { can_reconnect: false, status: 'idle' },
+    'GET /threads/b0000001-0000-4000-8000-000000000001/turns': {
+      thread_id: 'b0000001-0000-4000-8000-000000000001',
       turns,
       retry_checkpoint_id: 'cp-retry-0',
     },
-    'GET /workspaces/ws-1/files': { files: [] },
+    'GET /workspaces/a0000001-0000-4000-8000-000000000001/files': { files: [] },
   };
 }
 
@@ -750,7 +750,7 @@ test.describe('Steering -- History Replay', () => {
 
     await configureSSE({
       method: 'GET',
-      path: '/api/v1/threads/th-1/messages/replay',
+      path: '/api/v1/threads/b0000001-0000-4000-8000-000000000001/messages/replay',
       events: [
         sseEvents.userMessage('any investment opportunity?', 0),
         ...turn0Events,
@@ -759,7 +759,7 @@ test.describe('Steering -- History Replay', () => {
       delay: 5,
     });
 
-    await page.goto('/chat/t/th-1');
+    await page.goto('/chat/t/b0000001-0000-4000-8000-000000000001');
 
     // User query should appear
     await expect(page.getByText('any investment opportunity?')).toBeVisible({ timeout: 15000 });
@@ -791,7 +791,7 @@ test.describe('Steering -- History Replay', () => {
 
     await configureSSE({
       method: 'GET',
-      path: '/api/v1/threads/th-1/messages/replay',
+      path: '/api/v1/threads/b0000001-0000-4000-8000-000000000001/messages/replay',
       events: [
         sseEvents.userMessage('any investment opportunity?', 0),
         ...turn0Events,
@@ -802,7 +802,7 @@ test.describe('Steering -- History Replay', () => {
       delay: 2,
     });
 
-    await page.goto('/chat/t/th-1');
+    await page.goto('/chat/t/b0000001-0000-4000-8000-000000000001');
 
     // Wait for post-steering content to confirm replay completed
     await expect(page.getByText('All three subagents updated')).toBeVisible({ timeout: 30000 });

--- a/web/e2e/helpers/loadFixture.js
+++ b/web/e2e/helpers/loadFixture.js
@@ -15,10 +15,10 @@ const fixturesDir = join(__dirname, '..', 'fixtures');
  * Load a fixture JSON file and enrich each event with replay metadata.
  * @param {string} filename - Fixture filename (e.g., 'turn0_steer.json')
  * @param {number} turnIndex - The turn_index to inject
- * @param {string} [threadId='th-1'] - Thread ID override
+ * @param {string} [threadId='b0000001-0000-4000-8000-000000000001'] - Thread ID override
  * @returns {Array<Object>} Enriched SSE events ready for configureSSE
  */
-export function loadFixture(filename, turnIndex, threadId = 'th-1') {
+export function loadFixture(filename, turnIndex, threadId = 'b0000001-0000-4000-8000-000000000001') {
   const raw = JSON.parse(readFileSync(join(fixturesDir, filename), 'utf8'));
   return raw.map((event) => ({
     ...event,

--- a/web/e2e/helpers/mockResponses.js
+++ b/web/e2e/helpers/mockResponses.js
@@ -72,7 +72,7 @@ export const defaultResponses = {
 // ── Sample data factories ──
 
 export const sampleWorkspace = (overrides = {}) => ({
-  workspace_id: 'ws-1',
+  workspace_id: 'a0000001-0000-4000-8000-000000000001',
   name: 'Research',
   description: 'Main workspace',
   status: 'ready',
@@ -83,8 +83,8 @@ export const sampleWorkspace = (overrides = {}) => ({
 });
 
 export const sampleThread = (overrides = {}) => ({
-  thread_id: 'th-1',
-  workspace_id: 'ws-1',
+  thread_id: 'b0000001-0000-4000-8000-000000000001',
+  workspace_id: 'a0000001-0000-4000-8000-000000000001',
   title: 'Test conversation',
   created_at: '2025-01-01T00:00:00Z',
   ...overrides,
@@ -137,18 +137,18 @@ export const sseEvents = {
   userMessage: (content, turnIndex = 0) => ({
     event: 'user_message',
     data: {
-      thread_id: 'th-1',
+      thread_id: 'b0000001-0000-4000-8000-000000000001',
       turn_index: turnIndex,
       content,
       timestamp: new Date().toISOString(),
-      metadata: { msg_type: 'ptc', workspace_id: 'ws-1' },
+      metadata: { msg_type: 'ptc', workspace_id: 'a0000001-0000-4000-8000-000000000001' },
     },
   }),
 
   messageChunk: (content, contentType = 'text', turnIndex = 0) => ({
     event: 'message_chunk',
     data: {
-      thread_id: 'th-1',
+      thread_id: 'b0000001-0000-4000-8000-000000000001',
       agent: 'model:test',
       id: 'lc_run--test',
       role: 'assistant',
@@ -161,7 +161,7 @@ export const sseEvents = {
   finishStop: (turnIndex = 0) => ({
     event: 'message_chunk',
     data: {
-      thread_id: 'th-1',
+      thread_id: 'b0000001-0000-4000-8000-000000000001',
       agent: 'model:test',
       id: 'lc_run--test',
       role: 'assistant',
@@ -175,7 +175,7 @@ export const sseEvents = {
   finishToolCalls: (turnIndex = 0) => ({
     event: 'message_chunk',
     data: {
-      thread_id: 'th-1',
+      thread_id: 'b0000001-0000-4000-8000-000000000001',
       agent: 'model:test',
       id: 'lc_run--test',
       role: 'assistant',
@@ -189,7 +189,7 @@ export const sseEvents = {
   toolCalls: (calls, turnIndex = 0) => ({
     event: 'tool_calls',
     data: {
-      thread_id: 'th-1',
+      thread_id: 'b0000001-0000-4000-8000-000000000001',
       agent: 'model:test',
       id: 'lc_run--test',
       role: 'assistant',
@@ -207,7 +207,7 @@ export const sseEvents = {
   toolCallResult: (toolCallId, content, artifact = null, turnIndex = 0) => ({
     event: 'tool_call_result',
     data: {
-      thread_id: 'th-1',
+      thread_id: 'b0000001-0000-4000-8000-000000000001',
       agent: 'tools',
       id: `result-${toolCallId}`,
       role: 'assistant',
@@ -222,7 +222,7 @@ export const sseEvents = {
   interrupt: (interruptId, plan = 'Here is my plan:\n1. Step one\n2. Step two') => ({
     event: 'interrupt',
     data: {
-      thread_id: 'th-1',
+      thread_id: 'b0000001-0000-4000-8000-000000000001',
       turn_index: 0,
       interrupts: [
         {
@@ -267,7 +267,7 @@ export const sseEvents = {
     },
   }),
 
-  replayDone: (threadId = 'th-1') => ({
+  replayDone: (threadId = 'b0000001-0000-4000-8000-000000000001') => ({
     event: 'replay_done',
     data: { thread_id: threadId },
   }),
@@ -285,7 +285,7 @@ export const sseEvents = {
   contextWindow: (inputTokens = 1000, outputTokens = 100) => ({
     event: 'context_window',
     data: {
-      thread_id: 'th-1',
+      thread_id: 'b0000001-0000-4000-8000-000000000001',
       agent: 'model:test',
       action: 'token_usage',
       signal: 'complete',
@@ -304,7 +304,7 @@ export const sseEvents = {
   creditUsage: (totalCredits = 1.5) => ({
     event: 'credit_usage',
     data: {
-      thread_id: 'th-1',
+      thread_id: 'b0000001-0000-4000-8000-000000000001',
       tokens: {
         input_tokens: 10000,
         output_tokens: 500,
@@ -318,7 +318,7 @@ export const sseEvents = {
   createWorkspaceInterrupt: (interruptId, name, description) => ({
     event: 'interrupt',
     data: {
-      thread_id: 'th-1',
+      thread_id: 'b0000001-0000-4000-8000-000000000001',
       interrupt_id: interruptId,
       finish_reason: 'interrupt',
       action_requests: [{
@@ -332,7 +332,7 @@ export const sseEvents = {
   startQuestionInterrupt: (interruptId, workspaceId, question) => ({
     event: 'interrupt',
     data: {
-      thread_id: 'th-1',
+      thread_id: 'b0000001-0000-4000-8000-000000000001',
       interrupt_id: interruptId,
       finish_reason: 'interrupt',
       action_requests: [{
@@ -346,7 +346,7 @@ export const sseEvents = {
   navigateToWorkspaceResult: (toolCallId, workspaceId, question) => ({
     event: 'tool_call_result',
     data: {
-      thread_id: 'th-1',
+      thread_id: 'b0000001-0000-4000-8000-000000000001',
       agent: 'tools',
       id: `result-${toolCallId}`,
       role: 'assistant',
@@ -359,7 +359,7 @@ export const sseEvents = {
   createWorkspaceResult: (toolCallId, workspaceId, workspaceName) => ({
     event: 'tool_call_result',
     data: {
-      thread_id: 'th-1',
+      thread_id: 'b0000001-0000-4000-8000-000000000001',
       agent: 'tools',
       id: `result-${toolCallId}`,
       role: 'assistant',
@@ -372,7 +372,7 @@ export const sseEvents = {
   askUserInterrupt: (interruptId, questionId, question, options = null) => ({
     event: 'interrupt',
     data: {
-      thread_id: 'th-1',
+      thread_id: 'b0000001-0000-4000-8000-000000000001',
       interrupt_id: interruptId,
       finish_reason: 'interrupt',
       action_requests: [{

--- a/web/src/pages/ChatAgent/ChatAgent.tsx
+++ b/web/src/pages/ChatAgent/ChatAgent.tsx
@@ -10,6 +10,7 @@ import { getChatSession } from './hooks/utils/chatSessionRestore';
 import { useChatViewCache } from './hooks/useChatViewCache';
 import { useWarmWorkspaceSandbox } from './hooks/useWarmWorkspaceSandbox';
 import { warmWorkspace } from './utils/warmWorkspace';
+import { isValidUuid } from './utils/uuid';
 import ChatView from './components/ChatView';
 import './ChatAgent.css';
 
@@ -60,12 +61,17 @@ interface ThreadErrorResponse {
  * Uses React Router to determine which view to display.
  */
 function ChatAgent(): React.ReactElement | null {
-  const { workspaceId: urlWorkspaceId, threadId, taskId } = useParams<{ workspaceId?: string; threadId?: string; taskId?: string }>();
+  const { workspaceId: rawUrlWorkspaceId, threadId, taskId } = useParams<{ workspaceId?: string; threadId?: string; taskId?: string }>();
   const navigate = useNavigate();
   const location = useLocation();
   const { t } = useTranslation();
   const isMobile = useIsMobile();
   const state = location.state as LocationState | null;
+
+  // Malformed workspace ids from the URL or navigation state are treated as
+  // absent so they never reach workspace routes or API calls.
+  const urlWorkspaceId = isValidUuid(rawUrlWorkspaceId) ? rawUrlWorkspaceId : undefined;
+  const stateWorkspaceId = state?.workspaceId && isValidUuid(state.workspaceId) ? state.workspaceId : null;
 
   // Detect browser-initiated navigation (iOS swipe-back, Android back button).
   // When popstate triggers navigation, iOS Safari already shows its own page
@@ -105,20 +111,20 @@ function ChatAgent(): React.ReactElement | null {
     const session = pendingSessionRef.current;
     pendingSessionRef.current = null;
     if (!session) return;
-    if (session.threadId) {
+    if (session.threadId && isValidUuid(session.threadId)) {
       navigate(`/chat/t/${session.threadId}`, {
-        state: { workspaceId: session.workspaceId },
+        state: { workspaceId: isValidUuid(session.workspaceId) ? session.workspaceId : null },
       });
-    } else {
+    } else if (isValidUuid(session.workspaceId)) {
       navigate(`/chat/${session.workspaceId}`);
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Resolve workspaceId: URL param (thread gallery) > location state (navigated from app) > API lookup
   const [resolvedWorkspaceId, setResolvedWorkspaceId] = useState<string | null>(
-    urlWorkspaceId || state?.workspaceId || null
+    urlWorkspaceId || stateWorkspaceId || null
   );
-  const needsThreadLookup = !!threadId && threadId !== '__default__' && !urlWorkspaceId && !state?.workspaceId;
+  const needsThreadLookup = !!threadId && threadId !== '__default__' && !urlWorkspaceId && !stateWorkspaceId;
 
   const { data: resolvedThread, error: threadError } = useQuery({
     queryKey: queryKeys.threads.detail(threadId!),
@@ -152,7 +158,7 @@ function ChatAgent(): React.ReactElement | null {
 
   // Sync resolvedWorkspaceId when URL params or location state change
   // Use synchronous update to avoid stale workspace on first render after navigation
-  const incomingWsId = urlWorkspaceId || state?.workspaceId || null;
+  const incomingWsId = urlWorkspaceId || stateWorkspaceId || null;
   if (incomingWsId && incomingWsId !== resolvedWorkspaceId) {
     setResolvedWorkspaceId(incomingWsId);
   }
@@ -233,6 +239,7 @@ function ChatAgent(): React.ReactElement | null {
    * Passes workspace name via route state to avoid refetching all workspaces
    */
   const handleWorkspaceSelect = useCallback((selectedWorkspaceId: string, workspaceName?: string, workspaceStatus?: string) => {
+    if (!isValidUuid(selectedWorkspaceId)) return;
     if (workspaceStatus === 'stopped') {
       void warmWorkspace(selectedWorkspaceId, queryClient);
     }

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -25,6 +25,7 @@ import { clampPanelWidth as clampPanelWidthUtil } from '@/lib/panelUtils';
 import { useCardState } from '../hooks/useCardState';
 import { useWorkspaceFiles } from '../hooks/useWorkspaceFiles';
 import { classifyAgentPath, computeAgentArtifactRouting, type MemoryTier } from '../utils/agentPaths';
+import { isValidUuid } from '../utils/uuid';
 import {
   routeStopAction,
   compactionErrorCode,
@@ -1499,6 +1500,10 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
    */
   const handleOpenAgentArtifactFromChat = useCallback((rawPath: string, targetWorkspaceId?: string) => {
     const r = computeAgentArtifactRouting(rawPath, targetWorkspaceId);
+    if (r.setWorkspaceId && !isValidUuid(r.setWorkspaceId)) {
+      console.warn('[ChatView] ignoring artifact ref with invalid workspace id', r.setWorkspaceId);
+      return;
+    }
 
     setFilePanelTargetDir(null);
     setFilePanelTargetFile(r.targetFile);

--- a/web/src/pages/ChatAgent/components/ThreadGallery.tsx
+++ b/web/src/pages/ChatAgent/components/ThreadGallery.tsx
@@ -17,6 +17,7 @@ import RightPanel from './RightPanel';
 import { clampPanelWidth as clampPanelWidthUtil } from '@/lib/panelUtils';
 import SandboxSettingsPanel from './SandboxSettingsPanel';
 import { getWorkspaceThreads, deleteThread, updateThreadTitle } from '../utils/api';
+import { isValidUuid } from '../utils/uuid';
 import { useWorkspaceFiles } from '../hooks/useWorkspaceFiles';
 import { removeStoredThreadId } from '../hooks/utils/threadStorage';
 import { saveChatSession } from '../hooks/utils/chatSessionRestore';
@@ -333,7 +334,7 @@ function ThreadGallery({ workspaceId, onBack, onThreadSelect }: ThreadGalleryPro
 
       // If the deleted thread is currently active, navigate back to thread gallery
       if (currentThreadId === threadId) {
-        navigate(`/chat/${workspaceId}`);
+        navigate(isValidUuid(workspaceId) ? `/chat/${workspaceId}` : '/chat');
       }
 
       // Close modal

--- a/web/src/pages/ChatAgent/utils/__tests__/uuid.test.ts
+++ b/web/src/pages/ChatAgent/utils/__tests__/uuid.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { isValidUuid } from '../uuid';
+
+describe('isValidUuid', () => {
+  it('accepts canonical UUID strings case-insensitively', () => {
+    expect(isValidUuid('123e4567-e89b-12d3-a456-426614174000')).toBe(true);
+    expect(isValidUuid('123E4567-E89B-12D3-A456-426614174000')).toBe(true);
+  });
+
+  it('rejects malformed ids and non-string values', () => {
+    expect(isValidUuid('results')).toBe(false);
+    expect(isValidUuid('notes.md')).toBe(false);
+    expect(isValidUuid('123e4567e89b12d3a456426614174000')).toBe(false);
+    expect(isValidUuid('')).toBe(false);
+    expect(isValidUuid(undefined)).toBe(false);
+  });
+});

--- a/web/src/pages/ChatAgent/utils/uuid.ts
+++ b/web/src/pages/ChatAgent/utils/uuid.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+// Workspace/thread ids arrive from untrusted boundaries — URL params,
+// location.state, sessionStorage — so validate with safeParse (never throws)
+// per the boundary-validation convention.
+const uuidSchema = z.string().uuid();
+
+export function isValidUuid(value: unknown): value is string {
+  return uuidSchema.safeParse(value).success;
+}


### PR DESCRIPTION
## Summary

Two production hardening fixes on the request/replay path:

1. **Sandbox transport errors are now recoverable.** When Daytona's transport
   flakes mid-turn, the sandbox layer raises `SandboxTransientError` /
   `SandboxGoneError`. `classify_error` matched on error-message substrings and
   missed these types, so a transient transport blip was classified as
   non-recoverable and killed the turn with a terminal `[PTC_ERROR]` instead of
   handing off to the existing workflow auto-retry. It now classifies these
   exceptions by type as recoverable, so the turn lands `interrupted`
   (resumable) and the client-driven retry path can pick it up.

2. **Malformed thread ids return 404, not 500.** `get_thread_by_id` and
   `get_replay_thread_data` bound the raw `thread_id` straight into the query,
   so a non-canonical or non-UUID id (e.g. a filename that reached a thread
   route) raised Postgres `22P02` and surfaced as an HTTP 500. Both paths now
   run the id through `normalize_uuid` first and return "not found" for
   anything that isn't a UUID — closing the two binds missed by the earlier
   normalization sweep. The web client mirrors this: workspace ids from the URL
   and navigation state are sanitized once at the route boundary in
   `ChatAgent`, so a malformed id never reaches a workspace route or API call.

## Overview

**Net change (excluding tests):** 9 files, +73 / −14.

| | Files | +/− |
|---|---|---|
| Product code | 8 | +60 / −14 |
| Tests + e2e fixtures | 9 | +251 / −89 |
| **Total** | **17** | **+311 / −103** |

Most of the test/fixture volume is a pure e2e id swap (`chat.spec.js` 60/60,
`mockResponses.js` 19/19 — placeholder ids → valid UUIDs), which nets to ~0.

**By module:**

- **Backend — error classification** (`src/server/handlers/chat/_common.py`, +11/−2):
  classify `SandboxTransientError`/`SandboxGoneError` as recoverable.
- **Backend — thread id normalization** (`src/server/database/conversation.py`, +8;
  `src/tools/secretary/tools.py`, +3/−4): `normalize_uuid` on the two
  remaining raw binds; freshen a now-stale comment.
- **Backend — agent.md fault tolerance** (`src/ptc_agent/core/session.py`, +7):
  log read failures in the `except Exception` handler (missing files already
  return `None` from `aread_file_text` and never raise), and record that
  invariant in a comment.
- **Web — workspace-id boundary** (`ChatAgent.tsx` +14/−7, `ChatView.tsx` +5,
  `ThreadGallery.tsx` +2/−1, `utils/uuid.ts` +10 new): sanitize once at the
  route boundary via Zod `safeParse`; graceful `/chat` fallback + console
  warning instead of silent drops.

**What this introduces:** no new endpoints, config, or dependencies. One new
web util (`isValidUuid`, Zod-backed) and one behavioral change to error
classification; everything else tightens existing binds and removes dead code.

## Diff Size

17 files, +311 / −103. Product code (excl. tests + e2e fixtures): 8 files,
+60 / −14. The remaining 9 files are unit tests + e2e fixtures, dominated by
the placeholder-id → UUID swap that nets to ~0.

## Test Coverage

- Backend unit suite: **6058 passed, 1 xfailed** (30s). Ruff clean on all
  changed files.
- Web: **2394 passed** + **42 e2e**. `tsc --noEmit` clean; ESLint 0 errors
  in changed files.
- New/updated tests:
  - `test_session_agent_md.py` (new): missing-file → `None`, transient-error →
    `None` + recovery after invalidate, cache-until-invalidated.
  - `test_pg_sanitize.py`: `normalize_uuid` canonical / non-canonical
    (uppercase, `urn:uuid:`, hyphenless, braced) / non-UUID contract.
  - `test_chat_common.py`, `test_conversation_db.py`,
    `test_threads_malformed_id.py`: sandbox-error classification + malformed-id
    404 on replay/fetch.
  - `uuid.test.ts` (new): `isValidUuid` guard (Zod `safeParse`).
- **Red/green reproduction:** reverting `_common.py` + `conversation.py` to
  base flips the 5 replay/classification regression tests to failing
  (`assert 500 == 404`); restoring turns them green.

## Pre-Landing Review

Multi-specialist + adversarial pass. Findings: design 5, testing 4, security 2,
maintainability 0, performance 0 — all actionable ones applied (route-boundary
sanitization consolidation, dead-branch removal, added coverage).

**Known pre-existing gaps in the shared retry rails** (documented, not
introduced here; timeout/network/api errors already ride these same rails in
prod today — deferred to the turn-lifecycle rework):

- The web client has no handler for the `retry` SSE event / `auto_retry` flag,
  so recovery is human-in-the-loop (the thread lands `interrupted` and the user
  resumes) rather than automatic.
- `increment_retry_count` returns 0 when no tracker status exists yet, so a
  failure during turn setup (before the turn is marked active) doesn't count
  against the retry cap.
- A recoverable setup-phase failure can leave an orphan in-progress query row.

The net user-facing win of this PR stands independent of those: a transient
sandbox blip now yields a resumable `interrupted` thread instead of a dead turn.

## Plan Completion

6 done / 4 deferred / 0 not-done. Deferred items are the retry-rail gaps above
plus the polish items scoped out at the start (jitter, config-lift, message
copy).

## Test plan

- [x] `uv run pytest tests/unit/ -q` — 6058 passed, 1 xfailed
- [x] `cd web && pnpm test` — 2394 passed
- [x] `cd web && pnpm test:e2e` — 42 passed
- [x] `cd web && pnpm typecheck` — clean
- [x] Ruff clean on changed files
- [x] Red/green regression reproduction verified
