### PR TITLE
feat(llms): codex session-affinity cache headers derived from cache_key

### DIFF
--- a/src/llms/llm.py
+++ b/src/llms/llm.py
@@ -1,6 +1,7 @@
 import copy
 import os
 import json
+import uuid
 from pathlib import Path
 from typing import Dict, Optional, Any
 from dotenv import load_dotenv
@@ -215,6 +216,30 @@ class ModelConfig:
 
 _UNSET = object()  # Sentinel to distinguish "no override" from "override to None"
 
+# Header spellings the first-party codex clients send — codex-rs:
+# session-id/thread-id, opencode/hermes: session_id.
+_CODEX_SESSION_HEADERS = ("session-id", "thread-id", "session_id")
+
+
+def _derive_codex_affinity(cache_key: str) -> str:
+    """UUID-normalize a cache key for codex session headers — pass-through for
+    UUID keys, uuid5 otherwise so raw key material never egresses in a header."""
+    try:
+        return str(uuid.UUID(str(cache_key)))
+    except ValueError:
+        return str(uuid.uuid5(uuid.NAMESPACE_URL, f"codex-session:{cache_key}"))
+
+
+def _merged_default_headers(params: dict, *bases: dict | None) -> dict:
+    """Merge header sources left-to-right (later wins), ending with any
+    ``parameters``-level ``default_headers`` already expanded into ``params``
+    so it augments the base headers instead of replacing the mapping."""
+    merged: dict = {}
+    for base in bases:
+        merged.update(base or {})
+    merged.update(params.get("default_headers") or {})
+    return merged
+
 # Name regex for custom models: alphanumeric start, then alphanumeric/./_/-/:
 # Colon allowed for Ollama-style name:tag format (e.g. gemma4:31b)
 CUSTOM_MODEL_NAME_RE = r"^[a-zA-Z0-9][a-zA-Z0-9._:/-]{0,62}$"
@@ -356,7 +381,8 @@ class LLM:
             api_key: Optional API key override (e.g. from BYOK).
             base_url_override: Override base URL. _UNSET = no override.
             cache_key: Session-stable key sent as ``prompt_cache_key`` on
-                OpenAI/Codex requests (always-on for Codex; opt-in for OpenAI).
+                OpenAI/Codex requests (always-on for Codex, which also derives
+                session-affinity headers from it; opt-in for OpenAI).
             **override_params: Additional parameters to override defaults.
 
         Returns:
@@ -426,8 +452,9 @@ class LLM:
 
         ``cache_key`` becomes ``prompt_cache_key`` on OpenAI/Codex requests via
         ``model_kwargs`` (not ``bind()``) so it survives ``bind_tools()`` and
-        ``with_structured_output()``. Codex always applies the key; regular
-        OpenAI applies it only when the provider opts in via providers.json.
+        ``with_structured_output()``. Codex always applies the key — and also
+        derives session-affinity headers from it — while regular OpenAI applies
+        it only when the provider opts in via providers.json.
         """
         effective_cache_key: str | None = None
         if cache_key and (
@@ -498,9 +525,6 @@ class LLM:
         }
         params.update(self._resolve_base_url("base_url"))
 
-        if self.default_headers:
-            params["default_headers"] = self.default_headers
-
         # Handle Response API if configured
         if self.use_response_api:
             params["output_version"] = "responses/v1"
@@ -511,6 +535,12 @@ class LLM:
 
         # Add all parameters from llm_config
         params.update(self.parameters)
+
+        # Merged after the parameters expansion so a parameters["default_headers"]
+        # entry augments the provider-level headers instead of clobbering them.
+        merged_headers = _merged_default_headers(params, self.default_headers)
+        if merged_headers:
+            params["default_headers"] = merged_headers
 
         # Explicit prompt caching is api.openai.com-only: strip the opt-in when
         # routed anywhere else (platform proxy, OpenAI-compatible endpoints) so
@@ -545,19 +575,33 @@ class LLM:
         }
         params.update(self._resolve_base_url("base_url"))
 
-        # The codex backend gates newer models (e.g. GPT-5.6 Luna) to first-party
-        # clients: without an originator naming a known client AND a User-Agent
-        # carrying the matching "<originator>/" prefix, it 404s "Model not found".
-        params["default_headers"] = {
-            "originator": "codex_cli_rs",
-            "User-Agent": "codex_cli_rs/0.46.0",
-            **(self.default_headers or {}),
-        }
-
         if self.use_response_api:
             params["output_version"] = "responses/v1"
 
         params.update(self.parameters)
+
+        # The codex backend gates newer models (e.g. GPT-5.6 Luna) to first-party
+        # clients: without an originator naming a known client AND a User-Agent
+        # carrying the matching "<originator>/" prefix, it 404s "Model not found".
+        # Built after the parameters merge so a parameters["default_headers"]
+        # entry augments the mapping instead of clobbering it.
+        params["default_headers"] = _merged_default_headers(
+            params,
+            {"originator": "codex_cli_rs", "User-Agent": "codex_cli_rs/0.46.0"},
+            self.default_headers,
+        )
+
+        # Cache affinity: the codex backend routes its prompt cache by session
+        # headers, not by prompt_cache_key (wire-tested ~3× fewer warm-chain
+        # misses). Pinned headers win over the derived value, checked
+        # case-insensitively so a differently-cased pin can't end up
+        # contradicting a derived duplicate on the wire.
+        if cache_key:
+            affinity = _derive_codex_affinity(cache_key)
+            present = {k.lower() for k in params["default_headers"]}
+            for header in _CODEX_SESSION_HEADERS:
+                if header not in present:
+                    params["default_headers"][header] = affinity
 
         # The codex backend 400s on explicit-caching params — never forward the opt-in.
         params.pop("prompt_cache_options", None)
@@ -660,14 +704,17 @@ class LLM:
         if self.base_url:
             params["base_url"] = self.base_url
 
-        if self.default_headers:
-            params["default_headers"] = self.default_headers
-
         # Add all parameters from llm_config, excluding enable_caching
         # (enable_caching is not a ChatAnthropic parameter, it's used by our caching logic)
         # This will override max_tokens if explicitly set in model config
         filtered_params = {k: v for k, v in self.parameters.items() if k != "enable_caching"}
         params.update(filtered_params)
+
+        # Merged after the parameters expansion so a parameters["default_headers"]
+        # entry augments the provider-level headers instead of clobbering them.
+        merged_headers = _merged_default_headers(params, self.default_headers)
+        if merged_headers:
+            params["default_headers"] = merged_headers
 
         # Pass extra_body via model_kwargs so ChatAnthropic's Pydantic validator
         # doesn't warn about an unknown field (extra_body isn't a declared field).
@@ -725,7 +772,8 @@ def create_llm(
         base_url: Override base URL. None = SDK default, str = custom URL.
         reasoning_effort: Optional reasoning effort level ("low", "medium", "high").
         cache_key: Session-stable key sent as ``prompt_cache_key`` on
-            OpenAI/Codex requests (always-on for Codex; opt-in for OpenAI).
+            OpenAI/Codex requests (always-on for Codex, which also derives
+            session-affinity headers from it; opt-in for OpenAI).
         **kwargs: Additional parameters to override
 
     Returns:
@@ -759,7 +807,8 @@ def create_llm_from_custom(
         api_key: Optional API key override (e.g. from BYOK).
         base_url: Override base URL. _UNSET = no override, None = SDK default.
         cache_key: Session-stable key sent as ``prompt_cache_key`` on
-            OpenAI/Codex requests (always-on for Codex; opt-in for OpenAI).
+            OpenAI/Codex requests (always-on for Codex, which also derives
+            session-affinity headers from it; opt-in for OpenAI).
         **kwargs: Additional parameters to override.
 
     Returns:
@@ -775,7 +824,11 @@ def narrow_prompt_cache_key(model: Any, suffix: str) -> Any:
 
     Used to namespace parallel sub-tasks (subagent fanout, compaction) onto
     separate OpenAI cache shards — OpenAI rate-limits at ~15 RPM per
-    (prefix + ``prompt_cache_key``) bucket. No-op when the model has no
+    (prefix + ``prompt_cache_key``) bucket. Codex session-affinity headers are
+    deliberately NOT narrowed: they pin a replica (not a cache scope), the
+    copy shares the parent's already-built HTTP clients so a field-level
+    header update never reaches the wire anyway, and riding the parent
+    thread's lane is what codex-rs itself does. No-op when the model has no
     ``prompt_cache_key`` set or ``suffix`` is empty.
     """
     if not suffix:

--- a/tests/unit/llms/test_codex_client_headers.py
+++ b/tests/unit/llms/test_codex_client_headers.py
@@ -30,6 +30,46 @@ def _build_codex_llm(default_headers: dict | None = None) -> LLM:
     return llm
 
 
+def _build_openai_llm(
+    default_headers: dict | None = None, parameters: dict | None = None
+) -> LLM:
+    llm = LLM.__new__(LLM)
+    llm.sdk = "openai"
+    llm.provider = "test-openai"
+    llm.provider_info = {"access_type": "platform"}
+    llm.env_key = None
+    llm.base_url = None
+    llm.default_headers = default_headers
+    llm.use_response_api = False
+    llm.use_previous_response_id = False
+    llm.parameters = dict(parameters or {})
+    llm.extra_body = {}
+    llm.model = "gpt-4o-mini"
+    llm.api_key_override = "dummy-token"
+    llm.prompt_cache_key_enabled = False
+    return llm
+
+
+def _build_anthropic_llm(
+    default_headers: dict | None = None, parameters: dict | None = None
+) -> LLM:
+    llm = LLM.__new__(LLM)
+    llm.sdk = "anthropic"
+    llm.provider = "test-anthropic"
+    llm.provider_info = {"access_type": "platform"}
+    llm.env_key = None
+    llm.base_url = None
+    llm.default_headers = default_headers
+    llm.use_response_api = False
+    llm.use_previous_response_id = False
+    llm.parameters = dict(parameters or {})
+    llm.extra_body = {}
+    llm.model = "claude-test-model"
+    llm.api_key_override = "dummy-token"
+    llm.prompt_cache_key_enabled = False
+    return llm
+
+
 def test_first_party_headers_always_present():
     client = _build_codex_llm().get_llm()
     assert client.default_headers["originator"] == "codex_cli_rs"
@@ -43,3 +83,137 @@ def test_instance_headers_merged_and_override():
     assert client.default_headers["ChatGPT-Account-Id"] == "acct-123"
     assert client.default_headers["originator"] == "custom"
     assert client.default_headers["User-Agent"].startswith("codex_cli_rs/")
+
+
+class TestSessionAffinityHeaders:
+    """The codex backend routes its prompt cache by session headers, not by the
+    ``prompt_cache_key`` body param — without them, warm-chain reads scatter
+    across replicas (random total misses / stale hits)."""
+
+    HEADERS = ("session-id", "thread-id", "session_id")
+
+    def test_uuid_cache_key_passes_through(self):
+        tid = "00000000-0000-4000-8000-000000000001"
+        client = _build_codex_llm().get_llm(cache_key=tid)
+        for h in self.HEADERS:
+            assert client.default_headers[h] == tid
+
+    def test_non_uuid_cache_key_derives_stable_uuid(self):
+        import uuid as _uuid
+
+        a = _build_codex_llm().get_llm(cache_key="thread-abc:compact")
+        b = _build_codex_llm().get_llm(cache_key="thread-abc:compact")
+        val = a.default_headers["session-id"]
+        _uuid.UUID(val)  # must be a valid UUID string
+        assert all(b.default_headers[h] == val for h in self.HEADERS)
+
+    def test_distinct_cache_keys_derive_distinct_affinity(self):
+        a = _build_codex_llm().get_llm(cache_key="thread-a:compact")
+        b = _build_codex_llm().get_llm(cache_key="thread-b:compact")
+        assert a.default_headers["session-id"] != b.default_headers["session-id"]
+
+    def test_non_canonical_uuid_is_normalized(self):
+        import uuid as _uuid
+
+        raw = "0000000000004000800000000000000A"  # dashless, uppercase
+        client = _build_codex_llm().get_llm(cache_key=raw)
+        val = client.default_headers["session-id"]
+        assert val == str(_uuid.UUID(raw))
+        assert val != raw
+
+    def test_no_cache_key_sends_no_session_headers(self):
+        client = _build_codex_llm().get_llm()
+        for h in self.HEADERS:
+            assert h not in client.default_headers
+
+    def test_instance_headers_win_over_derived(self):
+        client = _build_codex_llm({"session-id": "pinned"}).get_llm(
+            cache_key="00000000-0000-4000-8000-000000000001"
+        )
+        assert client.default_headers["session-id"] == "pinned"
+
+    def test_partial_instance_pin_still_derives_others(self):
+        tid = "00000000-0000-4000-8000-000000000001"
+        client = _build_codex_llm({"session-id": "pinned"}).get_llm(cache_key=tid)
+        assert client.default_headers["session-id"] == "pinned"
+        assert client.default_headers["thread-id"] == tid
+        assert client.default_headers["session_id"] == tid
+
+    def test_differently_cased_pin_blocks_derived_duplicate(self):
+        tid = "00000000-0000-4000-8000-000000000001"
+        client = _build_codex_llm({"Session-Id": "pinned"}).get_llm(cache_key=tid)
+        assert client.default_headers["Session-Id"] == "pinned"
+        assert "session-id" not in client.default_headers
+        assert client.default_headers["thread-id"] == tid
+
+
+class TestNarrowedAffinityHeaders:
+    """Narrowing must NOT touch session headers: they pin a replica (not a
+    cache scope), and ``model_copy`` shares the parent's built HTTP clients so
+    a field-level header rewrite would be wire-inert anyway (verified against
+    the live backend — the copied client still sends the parent's headers)."""
+
+    TID = "00000000-0000-4000-8000-000000000001"
+
+    def test_narrow_keeps_parent_session_lane(self):
+        from src.llms.llm import narrow_prompt_cache_key
+
+        client = _build_codex_llm().get_llm(cache_key=self.TID)
+        narrowed = narrow_prompt_cache_key(client, "general-purpose")
+        assert (
+            narrowed.model_kwargs["prompt_cache_key"] == f"{self.TID}:general-purpose"
+        )
+        for h in TestSessionAffinityHeaders.HEADERS:
+            assert narrowed.default_headers[h] == self.TID
+
+
+class TestParametersDefaultHeadersMerge:
+    """A ``parameters['default_headers']`` entry is merged AFTER
+    ``params.update(self.parameters)`` on both factories, so it augments the
+    provider-level (and, for codex, the first-party) headers instead of
+    replacing the whole mapping the way the pre-merge assignment did."""
+
+    def test_codex_parameters_headers_augment_provider(self):
+        llm = _build_codex_llm({"ChatGPT-Account-Id": "acct-1"})
+        llm.parameters = {"default_headers": {"X-Extra": "from-params"}}
+        client = llm.get_llm()
+        # provider-level header survives the parameters merge
+        assert client.default_headers["ChatGPT-Account-Id"] == "acct-1"
+        # parameters-level header is added
+        assert client.default_headers["X-Extra"] == "from-params"
+        # first-party gating headers still present
+        assert client.default_headers["originator"] == "codex_cli_rs"
+        assert client.default_headers["User-Agent"].startswith("codex_cli_rs/")
+
+    def test_codex_parameters_header_overrides_provider_same_key(self):
+        llm = _build_codex_llm({"X-Dup": "provider"})
+        llm.parameters = {"default_headers": {"X-Dup": "params"}}
+        client = llm.get_llm()
+        assert client.default_headers["X-Dup"] == "params"
+
+    def test_openai_parameters_headers_augment_provider(self):
+        llm = _build_openai_llm(
+            default_headers={"X-Provider": "p"},
+            parameters={"default_headers": {"X-Param": "q"}},
+        )
+        client = llm.get_llm()
+        assert client.default_headers["X-Provider"] == "p"
+        assert client.default_headers["X-Param"] == "q"
+
+    def test_openai_provider_headers_land_on_client(self):
+        llm = _build_openai_llm(default_headers={"X-Provider": "p"})
+        client = llm.get_llm()
+        assert client.default_headers["X-Provider"] == "p"
+
+    def test_openai_no_headers_leaves_default_headers_unset(self):
+        client = _build_openai_llm().get_llm()
+        assert not client.default_headers
+
+    def test_anthropic_parameters_headers_augment_provider(self):
+        llm = _build_anthropic_llm(
+            default_headers={"X-Provider": "p"},
+            parameters={"default_headers": {"X-Param": "q"}},
+        )
+        client = llm.get_llm()
+        assert client.default_headers["X-Provider"] == "p"
+        assert client.default_headers["X-Param"] == "q"


### PR DESCRIPTION
## Summary

**Cache affinity (the feature)** — `e8b30c79`
The codex backend routes its prompt cache by session headers (`session-id` /
`thread-id` / `session_id`), not by the `prompt_cache_key` body param — without
them, warm-chain reads scatter across replicas (~30% sustained misses, verified
by raw wire probes). `_get_codex_llm` now derives all three headers from
`cache_key`: UUID keys pass through (normalized to canonical form), non-UUID
keys map via `uuid5`, so the emitted value is always a clean UUID and raw key
material never egresses in a header. Instance-pinned headers win over the
derived value, checked case-insensitively so a differently-cased pin can't
contradict a derived duplicate on the wire.

Wire-validated end-to-end on a real PTC chain (17 calls, 16–23k-token prompts):
**0 total misses, 92.8% aggregate warm hit rate, 15/16 warm calls at the
1024-token block floor** — vs ~30% sustained scatter without the headers.

**Header-merge hardening** — `e8b30c79`
A `parameters["default_headers"]` entry used to replace the provider-level
header mapping wholesale (silently dropping first-party gating headers like
`originator`, or OAuth account headers). A shared `_merged_default_headers`
helper now merges it after the parameters expansion on the openai, codex, and
anthropic factories — augmenting instead of clobbering.

**Tests** — `c84dc646`
Locks affinity derivation, pin precedence, the parameters-merge behavior on all
three factories, and the parent-lane behavior for narrowed models.

**Deliberate non-goal:** `narrow_prompt_cache_key` does NOT re-derive session
headers for narrowed (subagent/compaction) copies. The headers pin a replica,
not a cache scope; `model_copy` shares the parent's already-built HTTP clients
so a field-level rewrite never reaches the wire; and riding the parent thread's
lane is what codex-rs itself does. Documented in the docstring and locked by
`test_narrow_keeps_parent_session_lane`.

## Overview

| | Files | Lines |
|---|---|---|
| Modified | 2 | +248 / −21 |
| New | 0 | — |
| **Net (excl. tests)** | **1** | **+74 / −21** |

**Backend — `src/llms/`** (modified): `llm.py` — `_derive_codex_affinity` +
`_CODEX_SESSION_HEADERS`, session-header injection in `_get_codex_llm`, shared
`_merged_default_headers` across the openai/codex/anthropic factories,
`cache_key` docstring updates.

**Tests — `tests/unit/llms/`** (modified): `test_codex_client_headers.py` —
2 → 17 tests: affinity derivation, pin precedence, parameters-merge coverage
on all three factories, and the parent-lane lock for narrowed models.

**What this introduces:** long codex-backed threads (the OAuth path) keep their
prompt cache warm across turns — near-elimination of the random full-price
cache misses that previously hit ~1 in 3 warm calls.

## Diff Size
- Total: 2 files changed, 248 insertions(+), 21 deletions(-)
- Net (excl. tests): 1 file changed, 74 insertions(+), 21 deletions(-)

## Test Coverage

Tests: 2 → 17 in the header test file (+15 new). AI-assessed path coverage:
**100% (20/20 changed paths)** — 4 gaps found during audit, all closed.

<details><summary>Coverage diagram</summary>

```
Codex session-affinity headers + default_headers merge — coverage
═══════════════════════════════════════════════════════════════════════

_derive_codex_affinity(cache_key)              src/llms/llm.py:224
├─ UUID pass-through (canonical)               [★★  test_codex_client_headers.py:95]
├─ non-canonical UUID → normalized             [★★★ test_codex_client_headers.py:115]
└─ non-UUID → uuid5 (ValueError branch)        [★★  test_codex_client_headers.py:101,110]

_get_codex_llm(cache_key)                      src/llms/llm.py:564
├─ first-party originator/User-Agent present   [★   test_codex_client_headers.py:73]
├─ instance headers merged + override          [★★  test_codex_client_headers.py:79]
├─ cache_key → 3 session headers injected      [★★  test_codex_client_headers.py:95]
├─ no cache_key → no session headers           [★★  test_codex_client_headers.py:124]
├─ instance pin exact-case wins                [★★  test_codex_client_headers.py:129]
├─ partial pin → others still derived          [★★★ test_codex_client_headers.py:135]
├─ diff-case pin blocks derived duplicate      [★★★ test_codex_client_headers.py:142]
└─ params-level default_headers merge          [★★★ test_codex_client_headers.py:176,188]

_get_openai_llm(cache_key)                     src/llms/llm.py:517
├─ provider default_headers → client           [★★  test_codex_client_headers.py:203]
├─ params-level augments provider              [★★★ test_codex_client_headers.py:194]
└─ empty merge → default_headers unset         [★★  test_codex_client_headers.py:208]

_get_anthropic_llm                             src/llms/llm.py:687
└─ params-level augments provider              [★★★ test_codex_client_headers.py:212]

narrow_prompt_cache_key(model, suffix)         src/llms/llm.py:822
├─ empty suffix → unchanged                    [★★  test_prompt_cache_key.py:244]
├─ non-BaseChatModel → unchanged               [★★  test_prompt_cache_key.py:251]
├─ no parent prompt_cache_key → unchanged      [★★  test_prompt_cache_key.py:235]
├─ normal append + model_copy                  [★★  test_prompt_cache_key.py:224,261,278]
└─ codex session headers NOT narrowed          [★★★ test_codex_client_headers.py:158]

COVERAGE: 20/20 paths (100%)  ·  4 gaps found during audit, all closed  ·  0 remaining
```

</details>

## Pre-Landing Review

7 informational findings, 0 critical — 3 addressed, 4 rejected with rationale:

- 2 testing gaps (parameters-merge behavior untested on the openai/codex paths)
  → closed by the new merge tests
- 1 maintainability (anthropic factory kept the old clobber-prone ordering)
  → fixed by routing all three factories through the shared merge helper
- Partial-pin divergence + case-sensitive merge of hand-written config pins
  (adversarial, both models) → rejected: requires contradictory pins that no
  config sets; the reachable variant (derived-vs-pin duplicate) is exactly what
  the case-insensitive guard handles
- `parameters.default_headers = {}` no longer clears provider headers
  → intentional consequence of augment-not-clobber; per-key override still works
- Client-shape fingerprint watch-item (3/10 confidence) → speculative,
  mitigated by live wire evidence

Adversarial coverage: Claude structured ✓ · Claude adversarial ✓ · Codex ✓

## Design Review
No frontend files changed — design review skipped.

## Scope Drift
Scope Check: CLEAN — delivered exactly the affinity feature plus the reviewed
merge hardening; no unrelated changes.

## Plan Completion
No plan file detected (work arose from a live cache-miss investigation).

## Test plan
- [x] `tests/unit/llms/` — 552 passed (fresh, post-change)
- [x] Full unit suite — no regressions vs main (identical result set to base, +6 new tests green)
- [x] Live E2E — headers verified on the wire; real PTC chain measured at 92.8% warm hit rate / 0 misses
