### PR TITLE
fix(storage): canonical Content-Type resolution across upload and serve

### DIFF
--- a/src/server/app/workspace_files/crud.py
+++ b/src/server/app/workspace_files/crud.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
-import mimetypes
 import shlex
 from typing import Any
 
@@ -20,6 +19,7 @@ from src.server.database.workspace import get_workspace as db_get_workspace
 from src.server.services.workspace_manager import WorkspaceManager
 from src.server.services.persistence.file import FilePersistenceService
 from src.server.utils.secret_redactor import get_redactor, get_vault_secrets_for_redaction
+from src.utils.mime import resolve_content_type
 
 from ._shared import (
     DEFAULT_READ_LIMIT_LINES,
@@ -328,7 +328,7 @@ async def read_workspace_file(
     if _is_always_hidden_path(client_path):
         raise HTTPException(status_code=404, detail="File not found")
 
-    mime, _enc = mimetypes.guess_type(client_path)
+    mime = resolve_content_type(client_path, default="text/plain")
 
     _record_fs_bytes("read", len(raw_bytes))
 
@@ -338,7 +338,7 @@ async def read_workspace_file(
         "offset": offset,
         "limit": limit,
         "content": content,
-        "mime": mime or "text/plain",
+        "mime": mime,
         "truncated": False,  # limit is enforced; UI can request more with offset.
     }
 
@@ -519,17 +519,15 @@ async def download_workspace_file(
         raise HTTPException(status_code=404, detail="File not found")
 
     filename = client_path.split("/")[-1] if client_path else "download"
-    mime, _enc = mimetypes.guess_type(filename)
+    mime = resolve_content_type(filename)
 
-    if _is_text_content_type(mime or "") or _is_utf8(content):
+    if _is_text_content_type(mime) or _is_utf8(content):
         vault_secrets = await get_vault_secrets_for_redaction(workspace_id)
         content = get_redactor().redact_bytes(content, vault_secrets=vault_secrets)
 
     _record_fs_bytes("download", len(content))
 
-    return _build_download_response(
-        content, filename, mime or "application/octet-stream", request
-    )
+    return _build_download_response(content, filename, mime, request)
 
 
 @router.post("/{workspace_id}/files/upload")

--- a/src/server/app/workspace_files/serve.py
+++ b/src/server/app/workspace_files/serve.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import mimetypes
 import re
 from typing import Any
 from urllib.parse import quote
@@ -18,6 +17,7 @@ from src.server.database.workspace import get_workspace as db_get_workspace
 from src.server.services.workspace_manager import WorkspaceManager
 from src.server.services.persistence.file import FilePersistenceService
 from src.server.utils.secret_redactor import get_redactor, get_vault_secrets_for_redaction
+from src.utils.mime import resolve_content_type
 
 from ._shared import (
     _acquire_sandbox,
@@ -87,35 +87,6 @@ _WSFILES_CSP = (
     "form-action 'none'"
 )
 
-# Explicit MIME map for common web asset types. mimetypes' platform tables are
-# inconsistent for several of these (notably .js, .mjs, .woff2), so we pin them.
-_EXPLICIT_MIME_TYPES: dict[str, str] = {
-    ".html": "text/html; charset=utf-8",
-    ".htm": "text/html; charset=utf-8",
-    ".js": "text/javascript; charset=utf-8",
-    ".mjs": "text/javascript; charset=utf-8",
-    ".css": "text/css; charset=utf-8",
-    ".json": "application/json; charset=utf-8",
-    ".map": "application/json; charset=utf-8",
-    ".svg": "image/svg+xml",
-    ".png": "image/png",
-    ".jpg": "image/jpeg",
-    ".jpeg": "image/jpeg",
-    ".gif": "image/gif",
-    ".webp": "image/webp",
-    ".ico": "image/x-icon",
-    ".avif": "image/avif",
-    ".woff": "font/woff",
-    ".woff2": "font/woff2",
-    ".ttf": "font/ttf",
-    ".otf": "font/otf",
-    ".txt": "text/plain; charset=utf-8",
-    ".csv": "text/csv; charset=utf-8",
-    ".xml": "application/xml; charset=utf-8",
-    ".pdf": "application/pdf",
-    ".wasm": "application/wasm",
-}
-
 # Theme-sync script spliced after <head> when `?inject=theme` is set. Listens
 # for `widget:themeUpdate` postMessages and applies the `--color-*` custom
 # properties to :root via a dedicated style element. The payload field (`css`,
@@ -137,14 +108,8 @@ _THEME_INJECTION = (
 
 
 def _guess_content_type(path: str) -> str:
-    """Resolve a Content-Type for a served file, preferring the explicit map."""
-    suffix = ""
-    if "." in path:
-        suffix = "." + path.rsplit(".", 1)[-1].lower()
-    if suffix in _EXPLICIT_MIME_TYPES:
-        return _EXPLICIT_MIME_TYPES[suffix]
-    guessed, _enc = mimetypes.guess_type(path)
-    return guessed or "application/octet-stream"
+    """Resolve a Content-Type for a served file via the canonical pinned map."""
+    return resolve_content_type(path)
 
 
 def _is_html_content_type(content_type: str) -> bool:

--- a/src/utils/mime.py
+++ b/src/utils/mime.py
@@ -1,0 +1,71 @@
+"""Canonical Content-Type resolution.
+
+One pinned extension→type map, consulted at both upload and serve time, so a
+file gets the *same* Content-Type wherever it is handed out. The stdlib
+`mimetypes` tables vary by platform and base image — e.g. `python:3.12-slim`
+returns None for `.woff2` and `text/xml` for `.xml`, differing from macOS — and
+some served types (`.md`, `.yaml`) resolve inconsistently or not at all. Pinning
+removes that variance; `resolve_content_type` never returns None, so a caller
+can always set an explicit type rather than omitting the header (an omitted or
+generic type breaks inline rendering behind a `nosniff` policy).
+"""
+
+from __future__ import annotations
+
+import mimetypes
+from pathlib import Path
+
+# Pinned types. Superset of every extension the workspace-file serve path and
+# the object-storage uploaders previously mapped locally, plus text types the
+# stdlib tables miss or resolve inconsistently (`.md`, `.yaml`). Text types
+# carry an explicit charset; binary types do not.
+CONTENT_TYPES: dict[str, str] = {
+    # Documents / markup
+    ".html": "text/html; charset=utf-8",
+    ".htm": "text/html; charset=utf-8",
+    ".txt": "text/plain; charset=utf-8",
+    ".md": "text/markdown; charset=utf-8",
+    ".markdown": "text/markdown; charset=utf-8",
+    ".csv": "text/csv; charset=utf-8",
+    ".xml": "application/xml; charset=utf-8",
+    ".pdf": "application/pdf",
+    # Data / config
+    ".json": "application/json; charset=utf-8",
+    ".map": "application/json; charset=utf-8",
+    ".ipynb": "application/json; charset=utf-8",
+    ".yaml": "application/yaml; charset=utf-8",
+    ".yml": "application/yaml; charset=utf-8",
+    # Web assets
+    ".js": "text/javascript; charset=utf-8",
+    ".mjs": "text/javascript; charset=utf-8",
+    ".css": "text/css; charset=utf-8",
+    ".wasm": "application/wasm",
+    # Images
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".svg": "image/svg+xml",
+    ".ico": "image/x-icon",
+    ".avif": "image/avif",
+    ".bmp": "image/bmp",
+    ".tiff": "image/tiff",
+    ".tif": "image/tiff",
+    # Fonts
+    ".woff": "font/woff",
+    ".woff2": "font/woff2",
+    ".ttf": "font/ttf",
+    ".otf": "font/otf",
+}
+
+
+def resolve_content_type(name: str, *, default: str = "application/octet-stream") -> str:
+    """Resolve a Content-Type from a filename/key: pinned map, then stdlib, then default.
+
+    Never returns None — callers should always send an explicit Content-Type.
+    """
+    suffix = Path(name).suffix.lower()
+    if suffix in CONTENT_TYPES:
+        return CONTENT_TYPES[suffix]
+    return mimetypes.guess_type(name)[0] or default

--- a/src/utils/storage/oss_uploader.py
+++ b/src/utils/storage/oss_uploader.py
@@ -38,7 +38,6 @@ Configuration:
 
 import base64
 import logging
-import mimetypes
 import os
 from datetime import UTC, datetime
 from pathlib import Path
@@ -46,43 +45,10 @@ from pathlib import Path
 import alibabacloud_oss_v2 as oss
 import alibabacloud_oss_v2.exceptions as oss_exceptions
 
+from src.utils.mime import resolve_content_type
+
 # Configure logging
 logger = logging.getLogger(__name__)
-
-# MIME type mapping for common image formats
-# Used as fallback when mimetypes module doesn't recognize extension
-IMAGE_MIME_TYPES = {
-    ".png": "image/png",
-    ".jpg": "image/jpeg",
-    ".jpeg": "image/jpeg",
-    ".gif": "image/gif",
-    ".webp": "image/webp",
-    ".svg": "image/svg+xml",
-    ".ico": "image/x-icon",
-    ".bmp": "image/bmp",
-    ".tiff": "image/tiff",
-    ".tif": "image/tiff",
-}
-
-
-def _get_content_type(key: str) -> str | None:
-    """Get the MIME content type for a file based on its extension.
-
-    Args:
-        key: File path or OSS key with extension
-
-    Returns:
-        MIME type string, or None if unknown
-    """
-    ext = Path(key).suffix.lower()
-
-    # Try our image-specific mapping first
-    if ext in IMAGE_MIME_TYPES:
-        return IMAGE_MIME_TYPES[ext]
-
-    # Fall back to mimetypes module
-    mime_type, _ = mimetypes.guess_type(key)
-    return mime_type
 
 
 class OSSConfig:
@@ -156,8 +122,8 @@ def upload_file(key: str, file_path: str, content_type: str | None = None) -> bo
         return False
 
     # Auto-detect content type from key (OSS path) or file path
-    if content_type is None:
-        content_type = _get_content_type(key) or _get_content_type(file_path)
+    if not content_type:
+        content_type = resolve_content_type(key, default=resolve_content_type(file_path))
 
     try:
         client = get_oss_client()
@@ -243,8 +209,8 @@ def upload_bytes(key: str, data: bytes, content_type: str | None = None) -> bool
         return False
 
     # Auto-detect content type from key extension if not provided
-    if content_type is None:
-        content_type = _get_content_type(key)
+    if not content_type:
+        content_type = resolve_content_type(key)
 
     try:
         client = get_oss_client()

--- a/src/utils/storage/s3_compatible.py
+++ b/src/utils/storage/s3_compatible.py
@@ -36,7 +36,6 @@ bucket double-prefixes object keys under virtual addressing.
 
 import base64
 import logging
-import mimetypes
 import os
 from datetime import UTC, datetime
 from pathlib import Path
@@ -46,29 +45,9 @@ import boto3
 from botocore.config import Config
 from botocore.exceptions import ClientError
 
+from src.utils.mime import resolve_content_type
+
 logger = logging.getLogger(__name__)
-
-IMAGE_MIME_TYPES = {
-    ".png": "image/png",
-    ".jpg": "image/jpeg",
-    ".jpeg": "image/jpeg",
-    ".gif": "image/gif",
-    ".webp": "image/webp",
-    ".svg": "image/svg+xml",
-    ".ico": "image/x-icon",
-    ".bmp": "image/bmp",
-    ".tiff": "image/tiff",
-    ".tif": "image/tiff",
-}
-
-
-def _get_content_type(key: str) -> str | None:
-    """Get MIME content type for a file based on its extension."""
-    ext = Path(key).suffix.lower()
-    if ext in IMAGE_MIME_TYPES:
-        return IMAGE_MIME_TYPES[ext]
-    mime_type, _ = mimetypes.guess_type(key)
-    return mime_type
 
 
 _VALID_ADDRESSING_STYLES = {"virtual", "path", "auto"}
@@ -176,14 +155,16 @@ def upload_file(key: str, file_path: str, content_type: str | None = None) -> bo
         logger.error(f"File too large: {file_size} bytes > {StorageConfig.MAX_UPLOAD_SIZE} bytes")
         return False
 
-    if content_type is None:
-        content_type = _get_content_type(key) or _get_content_type(file_path)
+    if not content_type:
+        content_type = resolve_content_type(key, default=resolve_content_type(file_path))
 
     try:
         client = _get_client()
-        put_args: dict[str, Any] = {"Bucket": StorageConfig.BUCKET_NAME, "Key": key}
-        if content_type:
-            put_args["ContentType"] = content_type
+        put_args: dict[str, Any] = {
+            "Bucket": StorageConfig.BUCKET_NAME,
+            "Key": key,
+            "ContentType": content_type,
+        }
         with path_obj.open("rb") as f:
             put_args["Body"] = f
             client.put_object(**put_args)
@@ -219,14 +200,17 @@ def upload_bytes(key: str, data: bytes, content_type: str | None = None) -> bool
         logger.error(f"Data too large: {len(data)} bytes > {StorageConfig.MAX_UPLOAD_SIZE} bytes")
         return False
 
-    if content_type is None:
-        content_type = _get_content_type(key)
+    if not content_type:
+        content_type = resolve_content_type(key)
 
     try:
         client = _get_client()
-        put_args: dict[str, Any] = {"Bucket": StorageConfig.BUCKET_NAME, "Key": key, "Body": data}
-        if content_type:
-            put_args["ContentType"] = content_type
+        put_args: dict[str, Any] = {
+            "Bucket": StorageConfig.BUCKET_NAME,
+            "Key": key,
+            "Body": data,
+            "ContentType": content_type,
+        }
         client.put_object(**put_args)
         logger.debug(f"Uploaded bytes as {key}")
         return True


### PR DESCRIPTION
## Summary
Object-storage uploads derived Content-Type from Python's `mimetypes` tables, which vary by base image (`python:3.12-slim` returns `None` for `.woff2` and `text/xml` for `.xml`) and miss common text types (`.md`, `.yaml`). On an unknown extension the uploader **omitted the `ContentType` header entirely**, letting the storage backend fall back to `application/octet-stream`. Three modules each carried their own private image-only map, and the file *download* and *serve* endpoints could label the same file differently.

This introduces one canonical resolver, `src/utils/mime.py`, with a single pinned extension→type map. Both S3/OSS uploaders, the workspace-file serve path, and the download/read endpoints consult it. It never returns `None`, so uploads now set `ContentType` unconditionally.

**Backend**
- New `src/utils/mime.py` — pinned `CONTENT_TYPES` map + `resolve_content_type()`.
- `s3_compatible.py` / `oss_uploader.py` — drop local maps/guessers; set `ContentType` unconditionally via the resolver.
- `workspace_files/serve.py` — `_guess_content_type` delegates to the resolver (identical output contract; the existing 43-case test is unchanged).
- `workspace_files/crud.py` — `download_workspace_file` and `read_workspace_file` route through the resolver instead of bare `mimetypes.guess_type`, so the download served Content-Type matches serve (e.g. `.md` → `text/markdown; charset=utf-8`, not platform-variant/`None`). The read endpoint keeps its `text/plain` default; `import mimetypes` is dropped.

## Overview
| | Files | +/− |
|---|---|---|
| Modified | 4 | +32 / −119 |
| New | 1 | +71 |
| **Net (excl. tests)** | **5** | **+103 / −119** |

**By module**
- `src/utils/mime.py` *(new)* — canonical Content-Type resolver, one pinned map.
- `src/utils/storage/s3_compatible.py` *(modified)* — uses resolver; `ContentType` unconditional.
- `src/utils/storage/oss_uploader.py` *(modified)* — same, for the OSS backend (dormant provider).
- `src/server/app/workspace_files/serve.py` *(modified)* — serve path delegates to the resolver.
- `src/server/app/workspace_files/crud.py` *(modified)* — download/read endpoints delegate to the resolver; bare `mimetypes` removed.

**What this introduces:** every stored/served object gets a stable, platform-independent Content-Type. Removes the three-way map duplication and the download-vs-serve divergence.

## Diff Size
- Total: 5 files changed, 103 insertions(+), 119 deletions(−)
- Net (excl. tests): identical — no test files in this change

## Test Coverage
No new tests added (deliberate — see Verification). The change is behavior-preserving on the serve path (locked by the existing 43-case `test_workspace_file_serving.py`, still green) and verified end-to-end on the storage path (below).

## Verification
- `tests/unit/utils/storage/` + workspace-file suites (`serving` / `decode` / `routing`) — **63 passed**.
- Ruff clean on all changed files.
- **Live round-trip through the edited functions** against the real S3-compatible backend, reading back stored Content-Type via `head_object`: `.md` → `text/markdown; charset=utf-8` (the fix); unknown extension → `application/octet-stream` *set, not omitted*; `.png` → `image/png`; `upload_file` key→filepath fallback → `image/png`. Probes deleted after.

## Test plan
- [x] Storage + workspace-file unit suites pass (63 tests)
- [x] Live upload/head_object round-trip confirms stored Content-Type


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file type detection for workspace files and uploads.
  * Ensured downloaded and served files consistently receive accurate `Content-Type` headers (including correct UTF-8 handling for text formats).
  * Added deterministic fallback behavior for unknown or missing MIME types to avoid empty/incorrect headers.
* **Consistency**
  * Standardized content-type resolution across workspace file serving and supported storage uploads, ensuring uniform behavior end-to-end.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->