### PR TITLE
feat: adopt Daytona provider-managed Secrets for sandbox egress credential injection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,10 @@
 # When empty, falls back to "docker" (local Docker containers).
 DAYTONA_API_KEY=
 
+# Required only for HOST_MODE=platform with Daytona. Use a deployment-unique
+# namespace so staging and production never reconcile the same organization Secret.
+DAYTONA_SECRET_NAMESPACE=
+
 # Sandbox provider — auto-detected from DAYTONA_API_KEY if not set.
 # Explicit values: "daytona" (hosted sandbox) or "docker" (local containers).
 SANDBOX_PROVIDER=
@@ -31,6 +35,7 @@ DOCKER_HOST_SOCKET=/var/run/docker.sock
 # Financial Modeling Prep — high-quality financial data for tools and MCP servers
 # Free tier available at https://site.financialmodelingprep.com/
 # Without this key, enable Yahoo Finance MCP servers in agent_config.yaml for free data.
+# Required for HOST_MODE=platform with Daytona (delivered as a platform Secret).
 FMP_API_KEY=
 
 # =============================================================================

--- a/.github/workflows/sandbox-integration.yml
+++ b/.github/workflows/sandbox-integration.yml
@@ -11,6 +11,7 @@ on:
       - src/server/app/workspace_files/**
       - src/server/app/workspace_sandbox.py
       - src/server/services/workspace_manager.py
+      - src/server/services/platform_secret_rollout.py
       - Dockerfile.sandbox
       - docker-compose.yml
       - tests/integration/sandbox/**
@@ -19,6 +20,7 @@ on:
     paths:
       - src/ptc_agent/core/sandbox/**
       - src/ptc_agent/agent/backends/**
+      - src/server/services/platform_secret_rollout.py
       - Dockerfile.sandbox
       - tests/integration/sandbox/**
   workflow_dispatch:
@@ -115,6 +117,7 @@ jobs:
           SANDBOX_TEST_PROVIDERS: daytona
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
           DAYTONA_BASE_URL: ${{ secrets.DAYTONA_BASE_URL }}
+          FMP_API_KEY: ${{ secrets.FMP_API_KEY }}
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -293,6 +296,7 @@ jobs:
           SANDBOX_TEST_PROVIDERS: ${{ inputs.providers }}
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
           DAYTONA_BASE_URL: ${{ secrets.DAYTONA_BASE_URL }}
+          FMP_API_KEY: ${{ secrets.FMP_API_KEY }}
           DOCKER_SANDBOX_IMAGE: langalpha-sandbox:latest
 
       - uses: actions/upload-artifact@v4

--- a/agent_config.yaml
+++ b/agent_config.yaml
@@ -37,6 +37,21 @@ sandbox:
     snapshot_name: "langalpha" # Base name for snapshot (hash will be appended)
     snapshot_auto_create: true # Automatically create snapshot if it doesn't exist
 
+  # Platform-secret catalog — Daytona provider only (ignored under docker/memory).
+  # Each entry delivers a backend-owned API key into sandboxes as a managed
+  # Secret: the sandbox env var holds an opaque placeholder, and Daytona
+  # substitutes the real value into outbound HTTPS request *headers* for the
+  # allowlisted hosts only. Declared per deployment (not code); an entry is the
+  # opt-in and works in OSS mode too. Uncomment the FMP example to enable —
+  # boot then fail-closes unless DAYTONA_SECRET_NAMESPACE and the source env
+  # var are set.
+  # platform_secrets:
+  #   - source_env_var: "FMP_API_KEY"        # read from the host .env
+  #     sandbox_env_var: "FMP_API_KEY"       # placeholder-bearing var in the sandbox
+  #     name_suffix: "platform-fmp-api-key"  # Secret name = <DAYTONA_SECRET_NAMESPACE>-<suffix>
+  #     description: "Platform FMP API key"
+  #     hosts: ["financialmodelingprep.com"] # egress substitution allowlist
+
   # Docker local sandbox configuration
   # Ignored when provider is "daytona". Override with DOCKER_SANDBOX_* env vars.
   docker:

--- a/migrations/versions/021_add_platform_secret_state.py
+++ b/migrations/versions/021_add_platform_secret_state.py
@@ -1,0 +1,49 @@
+"""Add trusted platform-secret rollout state.
+
+Workspace ``config`` is user-replaceable, so security-critical rollout state
+must live in a server-owned column.  Rollout rows track each provider Secret's
+identity without storing either the placeholder or the plaintext value; the
+fleet generation is MAX(generation) over the set, and a workspace's
+``platform_secret_version`` records the generation its sandbox was certified
+against (0 = never certified).
+
+Revision ID: 021
+Revises: 020
+"""
+
+from alembic import op
+
+
+revision = "021"
+down_revision = "020"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS platform_secret_rollouts (
+            secret_key VARCHAR(128) PRIMARY KEY,
+            provider VARCHAR(64) NOT NULL,
+            secret_name VARCHAR(255) NOT NULL,
+            provider_secret_id VARCHAR(255) NOT NULL,
+            placeholder_sha256 VARCHAR(64) NOT NULL,
+            current_credential_sha256 VARCHAR(64) NOT NULL,
+            generation INTEGER NOT NULL CHECK (generation > 0),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+    """)
+
+    op.execute("""
+        ALTER TABLE workspaces
+            ADD COLUMN IF NOT EXISTS platform_secret_version
+                INTEGER NOT NULL DEFAULT 0
+    """)
+
+
+def downgrade() -> None:
+    op.execute("""
+        ALTER TABLE workspaces
+            DROP COLUMN IF EXISTS platform_secret_version
+    """)
+    op.execute("DROP TABLE IF EXISTS platform_secret_rollouts")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ dependencies = [
     # langgraph's ensure_message_ids covers every id-less messages write and no
     # app-side id-stamping shim is needed.
     "deepagents>=0.6.11",
-    "daytona-sdk>=0.130.0",
+    "daytona>=0.200.1",
     "boto3>=1.42.28",
     "tavily-python>=0.7.18",
     "PyJWT[crypto]>=2.8",

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -360,8 +360,22 @@ case $sandbox in
     2)
         key=$(prompt_secret "DAYTONA_API_KEY")
         [ -n "$key" ] && set_env "DAYTONA_API_KEY" "$key"
+        # Daytona Secrets are organization-scoped. Derive a stable default from
+        # this machine + checkout path so local/staging deployments cannot
+        # accidentally update another deployment's platform Secret (path alone
+        # collides across containers that all mount /app), while still letting
+        # operators choose an explicit production namespace.
+        namespace_default="langalpha-local-$(printf '%s' "$(hostname)-$REPO_ROOT" | cksum | awk '{print $1}')"
+        # Enforce the same format resolve_platform_secrets requires at boot so an
+        # invalid entry fails here, not as a fail-closed startup error later.
+        while true; do
+            namespace=$(prompt_choice "DAYTONA_SECRET_NAMESPACE" "$namespace_default")
+            printf '%s' "$namespace" | grep -Eq '^[A-Za-z_][A-Za-z0-9_-]{0,62}$' && break
+            printf "  Invalid namespace: must match ^[A-Za-z_][A-Za-z0-9_-]{0,62}\$ (letters/digits/_/-, max 63 chars)\n" >&2
+        done
+        set_env "DAYTONA_SECRET_NAMESPACE" "$namespace"
         set_env "SANDBOX_PROVIDER" "daytona"
-        success "Daytona configured — cloud sandboxes with workspace persistence"
+        success "Daytona configured — namespace: $namespace"
         ;;
     *)
         info "Skipping sandbox config."

--- a/src/data_client/fmp/fmp_client.py
+++ b/src/data_client/fmp/fmp_client.py
@@ -20,7 +20,7 @@ class FMPRequestError(Exception):
     """FMP request failure with a sanitized message and optional HTTP status.
 
     ``str(exc)`` is safe to surface to callers/agents: it never embeds the
-    request URL, which carries the API key as a query parameter.
+    request URL or headers; the key travels in the ``apikey`` header.
     """
 
     def __init__(self, message: str, *, status_code: Optional[int] = None):
@@ -112,7 +112,6 @@ class FMPClient:
         use_cache: bool = True,
     ) -> Union[Dict, List]:
         params = params or {}
-        params["apikey"] = self.api_key
 
         cache_key = f"{endpoint}:{json.dumps(params, sort_keys=True)}"
 
@@ -124,7 +123,9 @@ class FMPClient:
         client = await self._get_client()
 
         try:
-            response = await client.get(url, params=params)
+            response = await client.get(
+                url, params=params, headers={"apikey": self.api_key}
+            )
             response.raise_for_status()
             data = response.json()
 
@@ -138,8 +139,8 @@ class FMPClient:
             return data
 
         except httpx.HTTPStatusError as e:
-            # Never stringify the httpx error: its message embeds the request
-            # URL, which carries the API key as a query parameter.
+            # Defense in depth: never stringify the httpx error. Its message
+            # embeds the request URL; auth must never depend on URL hygiene.
             raise FMPRequestError(
                 f"FMP API request failed ({e.response.status_code})",
                 status_code=e.response.status_code,

--- a/src/ptc_agent/config/agent.py
+++ b/src/ptc_agent/config/agent.py
@@ -376,6 +376,7 @@ class AgentConfig(BaseModel):
             _daytona_defaults = DaytonaConfig()
             daytona_config = DaytonaConfig(
                 api_key=api_key,
+                secret_namespace=os.getenv("DAYTONA_SECRET_NAMESPACE", ""),
                 base_url=daytona_base_url,
                 auto_stop_interval=kwargs.pop(
                     "auto_stop_interval", _daytona_defaults.auto_stop_interval

--- a/src/ptc_agent/config/core.py
+++ b/src/ptc_agent/config/core.py
@@ -57,6 +57,7 @@ class DaytonaConfig(BaseModel):
 
     api_key: str = ""  # Set via DAYTONA_API_KEY env var, validated later
     base_url: str = "https://app.daytona.io/api"
+    secret_namespace: str = ""  # Set via DAYTONA_SECRET_NAMESPACE
     auto_stop_interval: int = 3600  # 1 hour
     auto_archive_interval: int = 604800  # 7 days — keep stopped (fast restart) before cold storage
     auto_delete_interval: int = 7776000  # 90 days — total dormant lifetime
@@ -290,12 +291,73 @@ class DockerConfig(BaseModel):
     preview_base_url: str | None = None
 
 
+class PlatformSecretDefinition(BaseModel):
+    """One backend-owned platform credential, declared in agent_config.yaml.
+
+    The set of entries is the deployment's platform-secret catalog: convergence,
+    certification, and the fleet generation all operate on every entry at once,
+    and any set change registers as an identity change that re-pends the fleet.
+    Declared in deployment config (not code) so the OSS repo reveals the
+    mechanism without the hosted vendor list.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    source_env_var: str
+    sandbox_env_var: str
+    name_suffix: str
+    description: str
+    hosts: tuple[str, ...]
+
+    @field_validator("source_env_var", "sandbox_env_var")
+    @classmethod
+    def _validate_env_var(cls, v: str) -> str:
+        if not re.fullmatch(r"[A-Z][A-Z0-9_]*", v):
+            raise ValueError(f"invalid environment variable name: {v!r}")
+        return v
+
+    @field_validator("name_suffix")
+    @classmethod
+    def _validate_name_suffix(cls, v: str) -> str:
+        # Length-bounded so the derived Secret name (namespace + '-' + suffix)
+        # stays under the provider/DB limit enforced in resolve_platform_secrets.
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_-]{0,62}", v):
+            raise ValueError(f"invalid Secret name suffix: {v!r}")
+        return v
+
+    @field_validator("hosts")
+    @classmethod
+    def _validate_hosts(cls, v: tuple[str, ...]) -> tuple[str, ...]:
+        if not v:
+            raise ValueError("hosts must name at least one egress target")
+        for host in v:
+            if not re.fullmatch(r"[a-z0-9]([a-z0-9.-]*[a-z0-9])?", host):
+                raise ValueError(f"invalid egress host: {host!r}")
+        return v
+
+
 class SandboxConfig(BaseModel):
     """Provider-agnostic sandbox configuration wrapper."""
 
     provider: Literal["daytona", "docker", "memory"] = "daytona"
     daytona: DaytonaConfig = Field(default_factory=DaytonaConfig)
     docker: DockerConfig = Field(default_factory=DockerConfig)
+    platform_secrets: tuple[PlatformSecretDefinition, ...] = ()
+
+    @model_validator(mode="after")
+    def _validate_unique_platform_secrets(self) -> "SandboxConfig":
+        # Both keys must be unique across the catalog: a duplicate
+        # sandbox_env_var collapses the binding map (and collides the rollout
+        # row keyed on it), and a duplicate name_suffix resolves two entries to
+        # one provider Secret — either silently mounts the wrong credential.
+        for field in ("sandbox_env_var", "name_suffix"):
+            values = [getattr(d, field) for d in self.platform_secrets]
+            duplicates = sorted({v for v in values if values.count(v) > 1})
+            if duplicates:
+                raise ValueError(
+                    f"duplicate {field} in platform_secrets: {duplicates}"
+                )
+        return self
 
 
 class CoreConfig(BaseModel):

--- a/src/ptc_agent/config/utils.py
+++ b/src/ptc_agent/config/utils.py
@@ -120,6 +120,7 @@ def create_daytona_config(data: dict[str, Any]) -> DaytonaConfig:
     }
     return DaytonaConfig(
         api_key=os.getenv("DAYTONA_API_KEY", ""),
+        secret_namespace=os.getenv("DAYTONA_SECRET_NAMESPACE", ""),
         base_url=data["base_url"],
         auto_stop_interval=data["auto_stop_interval"],
         auto_archive_interval=data["auto_archive_interval"],
@@ -164,12 +165,14 @@ def create_sandbox_config(config_data: dict[str, Any]) -> SandboxConfig:
             if "docker" in sandbox_data
             else DockerConfig()
         )
+        platform_secrets = sandbox_data.get("platform_secrets") or []
     elif "daytona" in config_data:
         # Backward compat: top-level "daytona:" key — implicitly daytona provider
         provider_explicit = True
         provider = "daytona"
         daytona_cfg = create_daytona_config(config_data["daytona"])
         docker_cfg = DockerConfig()
+        platform_secrets = []
     else:
         raise ValueError(
             "Missing required section: either 'sandbox' or 'daytona' must be present "
@@ -188,6 +191,7 @@ def create_sandbox_config(config_data: dict[str, Any]) -> SandboxConfig:
         provider=provider,
         daytona=daytona_cfg,
         docker=docker_cfg,
+        platform_secrets=platform_secrets,
     )
 
     # Docker-specific env var overrides

--- a/src/ptc_agent/core/sandbox/platform_secrets.py
+++ b/src/ptc_agent/core/sandbox/platform_secrets.py
@@ -1,0 +1,343 @@
+"""Platform-secret catalog, hosted resolution, and sandbox convergence mechanics."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+from ptc_agent.config.core import CoreConfig, PlatformSecretDefinition
+from ptc_agent.core.sandbox.runtime import RuntimeState, SandboxRuntime
+
+
+# Bounded so derived Secret names (namespace + catalog suffix) stay well under
+# provider and DB VARCHAR(255) limits; mirrors the vault-secret name cap.
+_DAYTONA_SECRET_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_-]{0,62}$")
+_ENV_VAR_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_SHA256_HEX_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+class PlatformSecretError(RuntimeError):
+    """Base class for failures that must fail hosted platform-secret readiness."""
+
+
+class PlatformSecretConfigurationError(PlatformSecretError):
+    """Hosted platform-secret configuration is missing or invalid."""
+
+
+class PlatformSecretReconciliationError(PlatformSecretError):
+    """A required provider-managed Secret could not be reconciled."""
+
+
+class PlatformSecretVerificationError(PlatformSecretError):
+    """The in-sandbox placeholder did not match the active rollout."""
+
+
+@dataclass(frozen=True)
+class ResolvedPlatformSecret:
+    """One catalog entry resolved against the hosted deployment environment."""
+
+    definition: PlatformSecretDefinition
+    name: str
+    value: str
+
+
+@dataclass(frozen=True)
+class ReconciledPlatformSecret:
+    """Provider identity returned after one Secret is created or updated."""
+
+    definition: PlatformSecretDefinition
+    name: str
+    provider_secret_id: str
+    placeholder: str
+
+
+#: The runtime gate: sandbox providers whose egress layer can substitute
+#: platform secrets. The single source of capability truth.
+PLATFORM_SECRET_CAPABLE_PROVIDERS = frozenset({"daytona"})
+
+
+def _capable_provider(config: CoreConfig) -> bool:
+    return config.sandbox.provider in PLATFORM_SECRET_CAPABLE_PROVIDERS
+
+
+def platform_secrets_active(config: CoreConfig) -> bool:
+    """Whether managed secrets run for this configuration.
+
+    Host-mode-agnostic: active whenever a capable provider has a configured
+    catalog. Configuring ``sandbox.platform_secrets`` is the opt-in, so hosted
+    deployments and OSS + Daytona users alike get managed-secret injection; an
+    empty catalog leaves the sandbox on plaintext env (unchanged behavior).
+    """
+
+    return _capable_provider(config) and bool(config.sandbox.platform_secrets)
+
+
+def platform_secrets_required(
+    config: CoreConfig, *, host_mode: str | None = None
+) -> bool:
+    """Whether managed secrets are mandatory (the hosted fail-closed guard).
+
+    Hosted platform mode on a capable provider must inject managed secrets: an
+    empty catalog there is a deploy error, never a silent plaintext fallback.
+    """
+
+    if host_mode is None:
+        from src.config.env import HOST_MODE
+
+        host_mode = HOST_MODE
+    return host_mode == "platform" and _capable_provider(config)
+
+
+def resolve_platform_secrets(
+    config: CoreConfig,
+    *,
+    environ: Mapping[str, str] | None = None,
+    host_mode: str | None = None,
+) -> tuple[ResolvedPlatformSecret, ...]:
+    """Resolve the catalog, failing closed once managed secrets are in play.
+
+    Active when a capable provider has a configured catalog (hosted, or an
+    opt-in OSS + Daytona deployment). A hosted capable deployment that ships an
+    empty catalog fails closed rather than silently injecting plaintext.
+    """
+
+    # The catalog lives in deployment config (sandbox.platform_secrets in
+    # agent_config.yaml), never code — the OSS repo ships the mechanism, each
+    # deployment declares its vendors. Empty is the opt-out (plaintext) except
+    # in hosted capable mode, where it is a deploy error.
+    catalog = tuple(config.sandbox.platform_secrets)
+    if not catalog:
+        if platform_secrets_required(config, host_mode=host_mode):
+            raise PlatformSecretConfigurationError(
+                "sandbox.platform_secrets is empty — hosted Daytona mode requires "
+                "the platform-secret catalog in agent_config.yaml"
+            )
+        return ()
+    if not _capable_provider(config):
+        return ()
+
+    env = os.environ if environ is None else environ
+    daytona_config = config.sandbox.daytona
+    namespace = str(getattr(daytona_config, "secret_namespace", "") or "")
+    if not namespace:
+        raise PlatformSecretConfigurationError(
+            "DAYTONA_SECRET_NAMESPACE is required when a platform-secret catalog "
+            "is configured"
+        )
+    if not _DAYTONA_SECRET_NAME_RE.fullmatch(namespace):
+        raise PlatformSecretConfigurationError(
+            "DAYTONA_SECRET_NAMESPACE must match ^[A-Za-z_][A-Za-z0-9_-]*$"
+        )
+
+    resolved: list[ResolvedPlatformSecret] = []
+    for definition in catalog:
+        value = env.get(definition.source_env_var, "")
+        if not value:
+            raise PlatformSecretConfigurationError(
+                f"{definition.source_env_var} is required when a platform-secret "
+                "catalog is configured"
+            )
+        name = f"{namespace}-{definition.name_suffix}"
+        if not _DAYTONA_SECRET_NAME_RE.fullmatch(name):
+            raise PlatformSecretConfigurationError(
+                f"Derived Secret name {name!r} exceeds the provider/DB name "
+                "limit — shorten DAYTONA_SECRET_NAMESPACE or the catalog "
+                "name_suffix"
+            )
+        resolved.append(
+            ResolvedPlatformSecret(
+                definition=definition,
+                name=name,
+                value=value,
+            )
+        )
+    return tuple(resolved)
+
+
+def build_platform_secret_bindings(
+    config: CoreConfig,
+    *,
+    environ: Mapping[str, str] | None = None,
+    host_mode: str | None = None,
+) -> dict[str, str]:
+    """Build the sandbox env-var to provider Secret-name mount map."""
+
+    return {
+        secret.definition.sandbox_env_var: secret.name
+        for secret in resolve_platform_secrets(
+            config, environ=environ, host_mode=host_mode
+        )
+    }
+
+
+# -- Sandbox convergence mechanics (provider-neutral, via SandboxRuntime) --
+
+_STABLE_STATES = {
+    RuntimeState.RUNNING,
+    RuntimeState.STOPPED,
+    RuntimeState.ARCHIVED,
+    RuntimeState.ERROR,
+}
+
+# Worst case is an archived sandbox restoring from cold storage.
+_STABILIZE_TIMEOUT_S = 300
+
+
+def _probe_env_command(env_vars: Sequence[str]) -> str:
+    for env_var in env_vars:
+        if not _ENV_VAR_RE.fullmatch(env_var):
+            raise PlatformSecretConfigurationError(
+                f"Invalid platform-secret env var name: {env_var!r}"
+            )
+    names = ",".join(f'"{env_var}"' for env_var in env_vars)
+    # Hash in-sandbox: one exec covers the whole set and plaintext never
+    # crosses the exec boundary.
+    return (
+        "python3 -c 'import hashlib,os\n"
+        f"for v in [{names}]:\n"
+        '    val = os.environ.get(v, "")\n'
+        '    print(hashlib.sha256(val.encode()).hexdigest() if val else "")\''
+    )
+
+
+async def _wait_for_state(
+    runtime: SandboxRuntime,
+    accepted: set[RuntimeState],
+    *,
+    timeout: float,
+) -> RuntimeState:
+    deadline = time.monotonic() + timeout
+    while True:
+        state = await runtime.refresh_state()
+        if state in accepted:
+            return state
+        if state == RuntimeState.ERROR:
+            raise RuntimeError("Sandbox entered an error state")
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError("Timed out waiting for sandbox state")
+        await asyncio.sleep(min(0.5, remaining))
+
+
+async def _stabilize_state(runtime: SandboxRuntime) -> RuntimeState:
+    state = await runtime.refresh_state()
+    if state in _STABLE_STATES:
+        return state
+    return await _wait_for_state(
+        runtime, _STABLE_STATES, timeout=_STABILIZE_TIMEOUT_S
+    )
+
+
+async def _ensure_running(runtime: SandboxRuntime, *, timeout: int) -> None:
+    state = await _stabilize_state(runtime)
+    if state == RuntimeState.ERROR:
+        raise RuntimeError("Cannot operate on a sandbox in error state")
+    if state != RuntimeState.RUNNING:
+        try:
+            await runtime.start(timeout=timeout)
+        except Exception:
+            # Start timeouts are observationally ambiguous. Refresh before
+            # deciding whether the remote transition actually failed.
+            pass
+    await _wait_for_state(runtime, {RuntimeState.RUNNING}, timeout=timeout)
+
+
+async def force_stop_runtime(runtime: SandboxRuntime, *, timeout: int = 120) -> None:
+    """Force-stop a sandbox so no process retains plaintext env values."""
+
+    state = await _stabilize_state(runtime)
+    if state in {RuntimeState.STOPPED, RuntimeState.ARCHIVED}:
+        return
+    try:
+        await runtime.stop(timeout=timeout, force=True)
+    except Exception:
+        # Stop timeouts are also ambiguous; the state poll below is authoritative.
+        pass
+    await _wait_for_state(runtime, {RuntimeState.STOPPED}, timeout=timeout)
+
+
+async def probe_runtime_platform_secrets(
+    runtime: SandboxRuntime, *, env_vars: Sequence[str]
+) -> dict[str, str]:
+    """Return sha256 per env var of its in-sandbox value ('' if unset)."""
+
+    result = await runtime.exec(_probe_env_command(env_vars), timeout=60)
+    if result.exit_code != 0:
+        raise PlatformSecretVerificationError(
+            f"Platform-secret env probe failed (exit_code={result.exit_code})"
+        )
+    lines = [line.strip() for line in result.stdout.splitlines()]
+    # Trailing empty lines (unset vars) may be stripped by the exec transport.
+    lines += [""] * (len(env_vars) - len(lines))
+    if len(lines) != len(env_vars) or any(
+        line and not _SHA256_HEX_RE.fullmatch(line) for line in lines
+    ):
+        raise PlatformSecretVerificationError(
+            "Platform-secret env probe returned malformed output"
+        )
+    return dict(zip(env_vars, lines))
+
+
+async def verify_runtime_platform_secrets(
+    runtime: SandboxRuntime,
+    *,
+    expected: Mapping[str, str],
+) -> None:
+    """Require every env var to hash to its registered rollout placeholder."""
+
+    observed = await probe_runtime_platform_secrets(
+        runtime, env_vars=sorted(expected)
+    )
+    for env_var, placeholder_sha256 in expected.items():
+        if not observed.get(env_var) or observed[env_var] != placeholder_sha256:
+            raise PlatformSecretVerificationError(
+                "Platform-secret placeholder verification failed"
+            )
+
+
+async def remount_platform_secret_bindings(
+    runtime: SandboxRuntime,
+    *,
+    expected: Mapping[str, str],
+    bindings: dict[str, str],
+) -> None:
+    """Hot-swap the placeholder mounts on a running sandbox; never restarts.
+
+    New processes see the new placeholders immediately (live-verified);
+    existing processes keep whatever they held — opaque placeholders on a
+    certified sandbox, so this is safe mid-serve. A sandbox that ever held
+    plaintext needs the scrub-restart in ``converge_sandbox_platform_secrets``.
+    """
+
+    await runtime.update_env({}, unset=sorted(expected))
+    await runtime.update_secrets(bindings)
+
+
+async def converge_sandbox_platform_secrets(
+    runtime: SandboxRuntime,
+    *,
+    expected: Mapping[str, str],
+    bindings: dict[str, str],
+) -> None:
+    """Scrub one sandbox onto the active rollout placeholder set.
+
+    The caller's DB row is the decision authority — this scrubs
+    unconditionally and probes the sandbox only to verify the result.
+    """
+
+    # _STABILIZE_TIMEOUT_S, not a shorter start timeout: the first call may be
+    # restoring an archived sandbox from cold storage (the DB row says running,
+    # but the provider-side state can have drifted via autostop/archival).
+    await _ensure_running(runtime, timeout=_STABILIZE_TIMEOUT_S)
+    # update_env needs the running daemon; existing processes may retain the
+    # plaintext values until the mandatory force-stop below.
+    await remount_platform_secret_bindings(
+        runtime, expected=expected, bindings=bindings
+    )
+    await force_stop_runtime(runtime)
+    await _ensure_running(runtime, timeout=_STABILIZE_TIMEOUT_S)
+    await verify_runtime_platform_secrets(runtime, expected=expected)

--- a/src/ptc_agent/core/sandbox/providers/daytona.py
+++ b/src/ptc_agent/core/sandbox/providers/daytona.py
@@ -3,19 +3,21 @@
 import asyncio
 import hashlib
 import json
+from collections.abc import Sequence
 from typing import Any
 
 import structlog
-from daytona_sdk import AsyncDaytona
-from daytona_sdk import DaytonaConfig as SDKDaytonaConfig
-from daytona_sdk import FileUpload
-from daytona_sdk.common.daytona import (
+from daytona import (
+    AsyncDaytona,
+    CodeRunParams,
     CreateSandboxFromSnapshotParams,
+    CreateSnapshotParams,
+    DaytonaConfig as SDKDaytonaConfig,
+    FileUpload,
     Image,
+    Resources,
+    SessionExecuteRequest,
 )
-from daytona_sdk.common.sandbox import Resources
-from daytona_sdk.common.process import CodeRunParams, SessionExecuteRequest
-from daytona_sdk.common.snapshot import CreateSnapshotParams
 
 from ptc_agent.config.core import DaytonaConfig
 from ptc_agent.core.sandbox._defaults import (
@@ -32,6 +34,14 @@ from ptc_agent.core.sandbox.runtime import (
     SandboxProvider,
     SandboxRuntime,
     SessionCommandResult,
+)
+from ptc_agent.core.sandbox.platform_secrets import (
+    ReconciledPlatformSecret,
+    ResolvedPlatformSecret,
+)
+from ptc_agent.core.sandbox.providers.daytona_secrets import (
+    DaytonaSecretReconciler,
+    is_transient_daytona_error,
 )
 
 logger = structlog.get_logger(__name__)
@@ -107,11 +117,21 @@ class DaytonaRuntime(SandboxRuntime):
     async def start(self, timeout: int = 120) -> None:
         await self._sandbox.start(timeout=timeout)
 
-    async def stop(self, timeout: int = 120) -> None:
-        await self._sandbox.stop(timeout=timeout)
+    async def stop(self, timeout: int = 120, *, force: bool = False) -> None:
+        await self._sandbox.stop(timeout=timeout, force=force)
 
     async def delete(self) -> None:
         await self._sandbox.delete()
+
+    async def update_env(
+        self, env: dict[str, str], *, unset: Sequence[str] = ()
+    ) -> None:
+        """Update the daemon environment inherited by newly spawned processes."""
+        await self._sandbox.update_env(env, unset=list(unset))
+
+    async def update_secrets(self, secrets: dict[str, str]) -> None:
+        """Replace the complete set of Daytona Secret mounts."""
+        await self._sandbox.update_secrets(secrets)
 
     async def get_state(self) -> RuntimeState:
         state = getattr(self._sandbox, "state", None)
@@ -119,6 +139,10 @@ class DaytonaRuntime(SandboxRuntime):
             return RuntimeState.ERROR
         state_value = state.value if hasattr(state, "value") else str(state)
         return _STATE_MAP.get(state_value, RuntimeState.ERROR)
+
+    async def refresh_state(self) -> RuntimeState:
+        await self._sandbox.refresh_data()
+        return await self.get_state()
 
     # -- Execution --
 
@@ -158,9 +182,7 @@ class DaytonaRuntime(SandboxRuntime):
         # Parse stderr
         if hasattr(result, "stderr"):
             stderr = result.stderr or ""
-        elif hasattr(result, "artifacts") and hasattr(
-            result.artifacts, "stderr"
-        ):
+        elif hasattr(result, "artifacts") and hasattr(result.artifacts, "stderr"):
             stderr = result.artifacts.stderr or ""
         else:
             stderr = ""
@@ -204,9 +226,7 @@ class DaytonaRuntime(SandboxRuntime):
         await self._sandbox.fs.upload_file(content, dest_path, timeout=_FS_TIMEOUT_S)
 
     async def upload_files(self, files: list[tuple[bytes | str, str]]) -> None:
-        batch = [
-            FileUpload(source=src, destination=dst) for src, dst in files
-        ]
+        batch = [FileUpload(source=src, destination=dst) for src, dst in files]
         await self._sandbox.fs.upload_files(batch, timeout=_FS_TIMEOUT_S)
 
     async def download_file(self, path: str) -> bytes:
@@ -244,15 +264,12 @@ class DaytonaRuntime(SandboxRuntime):
             stderr=result.stderr or "",
         )
 
-
     async def session_command_logs(
         self, session_id: str, command_id: str
     ) -> SessionCommandResult:
         cmd, logs = await asyncio.gather(
             self._sandbox.process.get_session_command(session_id, command_id),
-            self._sandbox.process.get_session_command_logs(
-                session_id, command_id
-            ),
+            self._sandbox.process.get_session_command_logs(session_id, command_id),
         )
         return SessionCommandResult(
             cmd_id=command_id,
@@ -317,15 +334,21 @@ class DaytonaRuntime(SandboxRuntime):
             "id": self.id,
             "working_dir": self.working_dir,
         }
-        for attr in ("cpu", "memory", "disk", "gpu", "created_at", "auto_stop_interval"):
+        for attr in (
+            "cpu",
+            "memory",
+            "disk",
+            "gpu",
+            "created_at",
+            "auto_stop_interval",
+            "recoverable",
+        ):
             val = getattr(self._sandbox, attr, None)
             if val is not None:
                 meta[attr] = val
         state = getattr(self._sandbox, "state", None)
         if state is not None:
-            meta["state"] = (
-                state.value if hasattr(state, "value") else str(state)
-            )
+            meta["state"] = state.value if hasattr(state, "value") else str(state)
         return meta
 
     @property
@@ -347,9 +370,7 @@ class DaytonaProvider(SandboxProvider):
     def __init__(self, config: DaytonaConfig, working_dir: str | None = None) -> None:
         self._config = config
         self._working_dir = working_dir or "/home/workspace"
-        sdk_config = SDKDaytonaConfig(
-            api_key=config.api_key, api_url=config.base_url
-        )
+        sdk_config = SDKDaytonaConfig(api_key=config.api_key, api_url=config.base_url)
         self._client = AsyncDaytona(sdk_config)
 
     # -- SandboxProvider interface --
@@ -358,6 +379,7 @@ class DaytonaProvider(SandboxProvider):
         self,
         *,
         env_vars: dict[str, str] | None = None,
+        platform_secret_bindings: dict[str, str] | None = None,
         mcp_packages: list[str] | None = None,
         tier: str | None = None,
         auto_stop_minutes: int | None = None,
@@ -367,6 +389,8 @@ class DaytonaProvider(SandboxProvider):
 
         Args:
             env_vars: Environment variables injected at creation time.
+            platform_secret_bindings: Environment-variable to organization
+                Secret-name mappings mounted by Daytona.
             mcp_packages: NPM packages for MCP servers (needed for snapshot).
             tier: Resource tier name. Hosted Daytona can't resize a snapshot
                 sandbox or override its resources at create time, so a tier's
@@ -436,6 +460,7 @@ class DaytonaProvider(SandboxProvider):
         params = CreateSandboxFromSnapshotParams(
             snapshot=snapshot_name if snapshot_name else None,
             env_vars=env_vars or None,
+            secrets=platform_secret_bindings or None,
             auto_stop_interval=auto_stop,
             auto_archive_interval=self._config.auto_archive_interval // 60,
             auto_delete_interval=self._config.auto_delete_interval // 60,
@@ -451,7 +476,8 @@ class DaytonaProvider(SandboxProvider):
     async def get(self, sandbox_id: str) -> DaytonaRuntime:
         sdk_sandbox = await self._client.get(sandbox_id)
         return DaytonaRuntime(
-            sdk_sandbox, default_working_dir=self._working_dir,
+            sdk_sandbox,
+            default_working_dir=self._working_dir,
         )
 
     async def close(self) -> None:
@@ -460,38 +486,16 @@ class DaytonaProvider(SandboxProvider):
         except Exception as e:
             logger.debug("Failed to close Daytona client", error=str(e))
 
+    async def reconcile_platform_secrets(
+        self, secrets: Sequence[ResolvedPlatformSecret]
+    ) -> tuple[ReconciledPlatformSecret, ...]:
+        """Create or update every required organization-scoped Secret."""
+
+        return await DaytonaSecretReconciler(self._client).reconcile(secrets)
+
     def is_transient_error(self, exc: Exception) -> bool:
         """Classify whether *exc* is a transient Daytona SDK error."""
-        message = str(exc).lower()
-
-        # A closed HTTP client means the command never reached the server.
-        # The SDK wraps these as "Failed to execute command: Session is closed"
-        # so we must check BEFORE the execution-error guard.
-        client_dead_markers = ("session is closed", "client is closed")
-        if any(marker in message for marker in client_dead_markers):
-            return True
-
-        # Execution errors are not transient — the command ran and the server
-        # responded. Don't let "timeout" in the server message trigger
-        # transient handling.
-        if message.startswith("failed to execute command"):
-            return False
-        transient_markers = (
-            "remote end closed connection",
-            "remotedisconnected",
-            "connection aborted",
-            "connection reset",
-            "broken pipe",
-            "timed out",
-            "timeout",
-            "service unavailable",
-            "no ip address found",
-            "400",
-            "502",
-            "503",
-            "504",
-        )
-        return any(marker in message for marker in transient_markers)
+        return is_transient_daytona_error(exc)
 
     # -- Snapshot management --
 
@@ -555,9 +559,7 @@ class DaytonaProvider(SandboxProvider):
         config_str = json.dumps(config_data, sort_keys=True)
         return hashlib.sha256(config_str.encode()).hexdigest()[:8]
 
-    def _create_snapshot_image(
-        self, mcp_packages: list[str] | None = None
-    ) -> Image:
+    def _create_snapshot_image(self, mcp_packages: list[str] | None = None) -> Image:
         """Build the declarative Image definition for a snapshot."""
         dependencies = self.DEFAULT_DEPENDENCIES
         pkgs = mcp_packages or []
@@ -585,7 +587,7 @@ class DaytonaProvider(SandboxProvider):
                 "mv /root/.local/bin/uv /root/.local/bin/uvx /usr/local/bin/",
                 # Node.js: pinned direct binary (matches Dockerfile.sandbox;
                 # avoids apt-mirror flakiness and unpinned-version drift).
-                "NODE_ARCH=$([ \"$(dpkg --print-architecture)\" = \"arm64\" ]"
+                'NODE_ARCH=$([ "$(dpkg --print-architecture)" = "arm64" ]'
                 " && echo arm64 || echo x64)"
                 f" && curl -fsSL https://nodejs.org/dist/v{SANDBOX_NODE_VERSION}/"
                 f"node-v{SANDBOX_NODE_VERSION}-linux-${{NODE_ARCH}}.tar.xz"
@@ -594,16 +596,16 @@ class DaytonaProvider(SandboxProvider):
                 " && rm /tmp/node.tar.xz",
                 *[f"npm install -g {pkg}" for pkg in pkgs],
                 "npm install -g docx pptxgenjs",
-                'GH_ARCH=$(dpkg --print-architecture)'
+                "GH_ARCH=$(dpkg --print-architecture)"
                 " && curl -fsSL https://github.com/cli/cli/releases/download/"
-                'v2.87.3/gh_2.87.3_linux_${GH_ARCH}.tar.gz -o /tmp/gh.tar.gz'
+                "v2.87.3/gh_2.87.3_linux_${GH_ARCH}.tar.gz -o /tmp/gh.tar.gz"
                 " && tar -xzf /tmp/gh.tar.gz -C /tmp"
-                ' && mv /tmp/gh_2.87.3_linux_${GH_ARCH}/bin/gh /usr/local/bin/gh'
-                ' && rm -rf /tmp/gh.tar.gz /tmp/gh_2.87.3_linux_${GH_ARCH}',
+                " && mv /tmp/gh_2.87.3_linux_${GH_ARCH}/bin/gh /usr/local/bin/gh"
+                " && rm -rf /tmp/gh.tar.gz /tmp/gh_2.87.3_linux_${GH_ARCH}",
                 "POLY_ARCH=$(uname -m)"
                 " && curl -fsSL https://github.com/Polymarket/polymarket-cli/"
                 "releases/download/v0.1.4/"
-                'polymarket-v0.1.4-${POLY_ARCH}-unknown-linux-gnu.tar.gz'
+                "polymarket-v0.1.4-${POLY_ARCH}-unknown-linux-gnu.tar.gz"
                 " -o /tmp/polymarket.tar.gz"
                 " && tar -xzf /tmp/polymarket.tar.gz -C /tmp"
                 " && mv /tmp/polymarket /usr/local/bin/polymarket"
@@ -781,9 +783,7 @@ class DaytonaProvider(SandboxProvider):
                         logger.warning("Snapshot build timed out")
                         snapshot_exists = False
                 else:
-                    logger.warning(
-                        f"Snapshot in unexpected state: {state}"
-                    )
+                    logger.warning(f"Snapshot in unexpected state: {state}")
                     snapshot_exists = False
             else:
                 snapshot_exists = False
@@ -802,9 +802,7 @@ class DaytonaProvider(SandboxProvider):
                     CreateSnapshotParams(
                         name=snapshot_name, image=image, resources=resources
                     ),
-                    on_logs=lambda log: logger.debug(
-                        "Snapshot build", log=log
-                    ),
+                    on_logs=lambda log: logger.debug("Snapshot build", log=log),
                 )
                 logger.info(
                     "Snapshot created successfully",
@@ -823,9 +821,7 @@ class DaytonaProvider(SandboxProvider):
                 return None
 
         if snapshot_exists:
-            logger.info(
-                "Using existing snapshot", snapshot_name=snapshot_name
-            )
+            logger.info("Using existing snapshot", snapshot_name=snapshot_name)
             return snapshot_name
 
         logger.warning("Snapshot not found and auto_create disabled")

--- a/src/ptc_agent/core/sandbox/providers/daytona_secrets.py
+++ b/src/ptc_agent/core/sandbox/providers/daytona_secrets.py
@@ -1,0 +1,220 @@
+"""Daytona organization-Secret reconciliation, split from the provider proper."""
+
+import asyncio
+from collections.abc import Awaitable, Callable, Sequence
+from typing import Any
+
+import structlog
+from daytona import CreateSecretParams, UpdateSecretParams
+
+from ptc_agent.core.sandbox.platform_secrets import (
+    PlatformSecretConfigurationError,
+    PlatformSecretReconciliationError,
+    ReconciledPlatformSecret,
+    ResolvedPlatformSecret,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+def is_transient_daytona_error(exc: Exception) -> bool:
+    """Classify a Daytona SDK error as transient (retryable).
+
+    Status-less transport failures (connection reset, timeouts, a closed
+    client) carry no HTTP status, so 429/5xx classification misses them —
+    status-BEARING errors are classified by status at the retry sites, never
+    here (bare digit markers would misclassify e.g. "400 Bad Request" as
+    transient). Execution errors (the command ran and the server answered)
+    are not transient even when the server's message mentions a timeout.
+    """
+
+    # Transport exception types are transient even with an empty message
+    # (a bare ConnectionResetError / TimeoutError carries no text).
+    if isinstance(exc, (ConnectionError, TimeoutError)):
+        return True
+    message = str(exc).lower()
+    # A closed HTTP client means the request never reached the server. The SDK
+    # wraps these as "Failed to execute command: Session is closed", so check
+    # BEFORE the execution-error guard below.
+    if any(marker in message for marker in ("session is closed", "client is closed")):
+        return True
+    if "failed to execute command" in message:
+        return False
+    # 5xx/429 phrases cover SDK errors stringified without a status attribute;
+    # phrases, never bare digits, so "400 Bad Request" stays terminal.
+    transient_markers = (
+        "remote end closed connection",
+        "remotedisconnected",
+        "connection aborted",
+        "connection reset",
+        "broken pipe",
+        "timed out",
+        "timeout",
+        "bad gateway",
+        "service unavailable",
+        "too many requests",
+        "no ip address found",
+    )
+    return any(marker in message for marker in transient_markers)
+
+
+class DaytonaSecretReconciler:
+    """Creates or updates organization-scoped Daytona Secrets idempotently."""
+
+    def __init__(self, client: Any) -> None:
+        self._client = client
+
+    async def reconcile(
+        self, secrets: Sequence[ResolvedPlatformSecret]
+    ) -> tuple[ReconciledPlatformSecret, ...]:
+        reconciled: list[ReconciledPlatformSecret] = []
+        for secret in secrets:
+            reconciled.append(
+                await self._call_with_retry(
+                    secret.name,
+                    lambda secret=secret: self._reconcile_one(secret),
+                )
+            )
+        return tuple(reconciled)
+
+    async def _reconcile_one(
+        self, secret: ResolvedPlatformSecret
+    ) -> ReconciledPlatformSecret:
+        existing = await self._find_secret_exact(secret.name)
+        if existing is None:
+            try:
+                created_secret = await self._client.secret.create(
+                    CreateSecretParams(
+                        name=secret.name,
+                        value=secret.value,
+                        description=secret.definition.description,
+                        hosts=list(secret.definition.hosts),
+                    )
+                )
+                logger.info(
+                    "Created Daytona platform Secret",
+                    secret_name=secret.name,
+                    hosts=list(secret.definition.hosts),
+                )
+                return self._reconciled_secret(secret, created_secret)
+            except Exception as exc:
+                status = self._exception_status(exc)
+                if status not in (None, 409):
+                    raise
+                # A 409 means another worker won the create. A status-less
+                # transport error is ambiguous: the create may have committed
+                # before the connection dropped. Refetch before retrying so we
+                # never create a duplicate or fail readiness unnecessarily.
+                existing = await self._find_secret_exact(secret.name)
+                if existing is None:
+                    raise
+
+        updated = await self._client.secret.update(
+            existing.id,
+            UpdateSecretParams(
+                value=secret.value,
+                description=secret.definition.description,
+                hosts=list(secret.definition.hosts),
+            ),
+        )
+        logger.info(
+            "Updated Daytona platform Secret",
+            secret_name=secret.name,
+            hosts=list(secret.definition.hosts),
+        )
+        return self._reconciled_secret(secret, updated)
+
+    @staticmethod
+    def _reconciled_secret(
+        secret: ResolvedPlatformSecret,
+        provider_secret: Any,
+    ) -> ReconciledPlatformSecret:
+        provider_secret_id = str(getattr(provider_secret, "id", "") or "")
+        placeholder = str(getattr(provider_secret, "placeholder", "") or "")
+        if not provider_secret_id or not placeholder.startswith("dtn_secret_"):
+            raise PlatformSecretReconciliationError(
+                "Daytona returned incomplete platform Secret metadata"
+            )
+        return ReconciledPlatformSecret(
+            definition=secret.definition,
+            name=secret.name,
+            provider_secret_id=provider_secret_id,
+            placeholder=placeholder,
+        )
+
+    async def _find_secret_exact(self, name: str) -> Any | None:
+        cursor: str | None = None
+        while True:
+            page = await self._client.secret.list(
+                cursor=cursor,
+                limit=200,
+                name=name,
+            )
+            for item in page.items:
+                if item.name == name:
+                    return item
+            cursor = page.next_cursor
+            if cursor is None:
+                return None
+
+    async def _call_with_retry(
+        self,
+        secret_name: str,
+        operation: Callable[[], Awaitable[Any]],
+    ) -> Any:
+        """Retry 429/5xx and status-less transient failures without logging bodies."""
+
+        delay_s = 0.25
+        for attempt in range(1, 4):
+            try:
+                return await operation()
+            except Exception as exc:
+                status = self._exception_status(exc)
+                retryable = (
+                    status == 429
+                    or (status is not None and 500 <= status <= 599)
+                    # Transport failures (connection reset, timeout, closed
+                    # client) carry no status; classify them by message so a
+                    # first-boot network blip doesn't hard-fail reconciliation.
+                    or (status is None and is_transient_daytona_error(exc))
+                )
+                logger.warning(
+                    "Daytona platform Secret reconciliation failed",
+                    secret_name=secret_name,
+                    attempt=attempt,
+                    status=status,
+                    error_type=type(exc).__name__,
+                    retrying=retryable and attempt < 3,
+                )
+                if not retryable or attempt == 3:
+                    if status == 403:
+                        # Operator misconfiguration, not provider availability:
+                        # must fail boot loudly, never fall back to a previous
+                        # rollout identity.
+                        raise PlatformSecretConfigurationError(
+                            "Daytona API key is missing the manage:secrets "
+                            "permission required for platform Secret reconciliation"
+                        ) from None
+                    status_text = str(status) if status is not None else "unknown"
+                    raise PlatformSecretReconciliationError(
+                        "Failed to reconcile Daytona platform Secret "
+                        f"{secret_name!r} (status={status_text}, "
+                        f"error_type={type(exc).__name__})"
+                    ) from None
+                await asyncio.sleep(delay_s)
+                delay_s *= 2
+
+    @staticmethod
+    def _exception_status(exc: Exception) -> int | None:
+        """Extract an HTTP status through SDK wrapper exception chains."""
+
+        current: BaseException | None = exc
+        seen: set[int] = set()
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+            for attr in ("status", "status_code"):
+                status = getattr(current, attr, None)
+                if isinstance(status, int):
+                    return status
+            current = current.__cause__ or current.__context__
+        return None

--- a/src/ptc_agent/core/sandbox/providers/docker.py
+++ b/src/ptc_agent/core/sandbox/providers/docker.py
@@ -140,8 +140,8 @@ class DockerRuntime(SandboxRuntime):
     async def start(self, timeout: int = 120) -> None:
         await self._container.start()
 
-    async def stop(self, timeout: int = 60) -> None:
-        await self._container.stop(t=timeout)
+    async def stop(self, timeout: int = 60, *, force: bool = False) -> None:
+        await self._container.stop(t=0 if force else timeout)
 
     async def delete(self) -> None:
         try:

--- a/src/ptc_agent/core/sandbox/ptc_sandbox.py
+++ b/src/ptc_agent/core/sandbox/ptc_sandbox.py
@@ -14,6 +14,7 @@ import structlog
 
 from ptc_agent.config.core import CoreConfig
 from ptc_agent.core.sandbox._defaults import DEFAULT_DEPENDENCIES, SNAPSHOT_PYTHON_VERSION
+from ptc_agent.core.sandbox.platform_secrets import build_platform_secret_bindings
 from ptc_agent.core.sandbox.providers import create_provider
 from ptc_agent.core.sandbox.retry import RetryPolicy, async_retry_with_backoff
 from ptc_agent.core.sandbox.runtime import (
@@ -258,11 +259,16 @@ class PTCSandbox:
         return mcp_packages
 
 
-    def _build_sandbox_env_vars(self) -> dict[str, str]:
+    def _build_sandbox_env_vars(
+        self,
+        platform_secret_bindings: dict[str, str],
+    ) -> dict[str, str]:
         """Build environment variables to inject at sandbox creation time.
 
         Resolves MCP server env vars (${VAR} placeholders from host) and
         GitHub bot credentials so they're available to all sandbox processes.
+        Vars named in ``platform_secret_bindings`` are excluded — Daytona
+        mounts those as managed Secrets.
         """
         import os
 
@@ -287,6 +293,11 @@ class PTCSandbox:
                 for key, value in server.env.items():
                     if key == "INTERNAL_SERVICE_TOKEN":
                         continue  # Never inject platform token into sandbox
+                    if key in platform_secret_bindings:
+                        # Daytona injects an opaque placeholder for managed
+                        # platform Secrets. Never put the real host value in
+                        # ordinary sandbox environment variables as fallback.
+                        continue
                     if value.startswith("${") and value.endswith("}"):
                         var_name = value[2:-1]
                         resolved_value = os.getenv(var_name)
@@ -335,13 +346,15 @@ class PTCSandbox:
 
         # Build env vars once — injected at sandbox creation time so they're
         # available to all processes (Python, bash, MCP servers)
-        sandbox_env = self._build_sandbox_env_vars()
+        platform_secret_bindings = build_platform_secret_bindings(self.config)
+        sandbox_env = self._build_sandbox_env_vars(platform_secret_bindings)
 
         # Create sandbox via provider (handles snapshot logic internally)
         mcp_packages = self._get_mcp_packages()
         self.runtime = await self._runtime_call(
             self.provider.create,
             env_vars=sandbox_env or None,
+            platform_secret_bindings=platform_secret_bindings or None,
             mcp_packages=mcp_packages,
             tier=tier,
             auto_stop_minutes=auto_stop_minutes,
@@ -672,6 +685,12 @@ class PTCSandbox:
                 )
             _mark_rc("wait_stopping")
         elif state_value == "archived":
+            metadata = await self.runtime.get_metadata()
+            if metadata.get("recoverable") is False:
+                raise SandboxGoneError(
+                    sandbox_id,
+                    "archived sandbox is no longer recoverable",
+                )
             logger.info(
                 "Starting archived sandbox (restore may take longer)",
                 sandbox_id=sandbox_id,

--- a/src/ptc_agent/core/sandbox/runtime.py
+++ b/src/ptc_agent/core/sandbox/runtime.py
@@ -1,9 +1,16 @@
 """Abstract runtime and provider interfaces for sandbox backends."""
 
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ptc_agent.core.sandbox.platform_secrets import (
+        ReconciledPlatformSecret,
+        ResolvedPlatformSecret,
+    )
 
 
 class SandboxTransientError(RuntimeError):
@@ -122,8 +129,8 @@ class SandboxRuntime(ABC):
         ...
 
     @abstractmethod
-    async def stop(self, timeout: int = 60) -> None:
-        """Stop the runtime."""
+    async def stop(self, timeout: int = 60, *, force: bool = False) -> None:
+        """Stop the runtime, forcefully when the provider supports it."""
         ...
 
     @abstractmethod
@@ -135,6 +142,25 @@ class SandboxRuntime(ABC):
     async def get_state(self) -> RuntimeState:
         """Return the current lifecycle state."""
         ...
+
+    async def update_env(
+        self, env: dict[str, str], *, unset: Sequence[str] = ()
+    ) -> None:
+        """Set/unset sandbox-level env vars; providers without support raise."""
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support sandbox env updates"
+        )
+
+    async def update_secrets(self, secrets: dict[str, str]) -> None:
+        """Attach provider-managed secret bindings; providers without support raise."""
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support platform secrets"
+        )
+
+    async def refresh_state(self) -> RuntimeState:
+        """Refresh and return lifecycle state; defaults to ``get_state``."""
+
+        return await self.get_state()
 
     # -- Execution --
 
@@ -250,11 +276,20 @@ class SandboxRuntime(ABC):
 class SandboxProvider(ABC):
     """Factory that creates and reconnects to sandbox runtime instances."""
 
+    async def reconcile_platform_secrets(
+        self, secrets: "Sequence[ResolvedPlatformSecret]"
+    ) -> "list[ReconciledPlatformSecret]":
+        """Create/update provider-managed Secrets; capability-absent by default."""
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support platform secrets"
+        )
+
     @abstractmethod
     async def create(
         self,
         *,
         env_vars: dict[str, str] | None = None,
+        platform_secret_bindings: dict[str, str] | None = None,
         tier: str | None = None,
         auto_stop_minutes: int | None = None,
         **kwargs: Any,
@@ -263,6 +298,8 @@ class SandboxProvider(ABC):
 
         Args:
             env_vars: Environment variables injected at creation time.
+            platform_secret_bindings: Provider-specific secret mounts. Providers
+                without managed-secret support may ignore this mapping.
             tier: Resource tier name (provider-resolved; may be ignored by
                 providers without tiered sizing).
             auto_stop_minutes: Auto-stop interval override in minutes (0 disables).

--- a/src/ptc_agent/core/session.py
+++ b/src/ptc_agent/core/session.py
@@ -53,6 +53,11 @@ class Session:
         self.mcp_tool_summary: str | None = None
         self.mcp_config_version: int | None = None
 
+        # The platform-secret fleet generation whose bindings were last applied
+        # to this session's sandbox (the ``mcp_config_version`` analog) — lets
+        # the per-acquisition resync short-circuit without touching the provider.
+        self.platform_secret_version: int | None = None
+
         # agent.md cache with dirty flag (force first read)
         self._agent_md_cache: str | None = None
         self._agent_md_dirty: bool = True

--- a/src/server/app/setup.py
+++ b/src/server/app/setup.py
@@ -37,6 +37,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.gzip import GZipMiddleware
 
+from ptc_agent.core.sandbox.platform_secrets import PlatformSecretError
 from src.config.logging_config import configure_logging
 from src.config.settings import (
     get_allowed_origins,
@@ -60,6 +61,8 @@ from src.server.utils.api import find_malformed_route_ids  # TEMP (malformed-id-
 _otel_enabled = init_otel()
 
 logger = logging.getLogger(__name__)
+
+
 INTERNAL_SERVER_ERROR_DETAIL = "Internal Server Error"
 
 # Global variables
@@ -77,7 +80,13 @@ llm_service = None  # Generic one-shot LLM call wrapper (BYOK/OAuth-aware)
 # equivalent shim rootless podman injects for `init: true` (catatonit under the
 # hood). Must be in the allowlist or this diagnostic logs a false "init: true
 # failed" warning on every startup of an otherwise-correctly-hardened container.
-_ACCEPTABLE_INIT_COMMS = ("tini", "docker-init", "catatonit", "dumb-init", "podman-init")
+_ACCEPTABLE_INIT_COMMS = (
+    "tini",
+    "docker-init",
+    "catatonit",
+    "dumb-init",
+    "podman-init",
+)
 
 
 def _log_container_hardening() -> None:
@@ -91,7 +100,9 @@ def _log_container_hardening() -> None:
     try:
         with open("/sys/fs/cgroup/pids.max", encoding="utf-8", errors="replace") as f:
             pids_max = f.read().strip()
-        with open("/sys/fs/cgroup/pids.current", encoding="utf-8", errors="replace") as f:
+        with open(
+            "/sys/fs/cgroup/pids.current", encoding="utf-8", errors="replace"
+        ) as f:
             pids_current = f.read().strip()
     except (FileNotFoundError, OSError):
         pids_max = pids_current = "unknown"
@@ -114,7 +125,13 @@ def _log_container_hardening() -> None:
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Initialize resources when server starts, cleanup when stops."""
-    global agent_config, session_service, workspace_manager, checkpointer, store, llm_service
+    global \
+        agent_config, \
+        session_service, \
+        workspace_manager, \
+        checkpointer, \
+        store, \
+        llm_service
 
     # Configure logging based on environment settings (first thing on startup)
     configure_logging()
@@ -227,8 +244,27 @@ async def lifespan(app: FastAPI):
 
         logger.info("Loading PTC Agent configuration...")
         agent_config = await load_from_files(context=ConfigContext.SDK)
-        agent_config.validate_api_keys()
+
+        from src.server.services.platform_secret_rollout import (
+            reconcile_platform_secrets_at_boot,
+        )
+
+        await reconcile_platform_secrets_at_boot(agent_config)
         logger.info("PTC Agent configuration loaded successfully")
+
+        # Platform-secret migration sweep: converges running sandboxes left
+        # behind the fleet generation (always-on sandboxes never re-init, so
+        # only this sweep ever scrubs them). Inert without an active catalog.
+        try:
+            from src.server.services.platform_secret_sweep import (
+                PlatformSecretSweeper,
+            )
+
+            PlatformSecretSweeper.get_instance().start(
+                agent_config.to_core_config()
+            )
+        except Exception as e:
+            logger.warning(f"Failed to start PlatformSecretSweeper: {e}")
 
         # Connect once, freeze, install as the process-global registry so every
         # Session borrows the same tool snapshot instead of spawning its own
@@ -371,6 +407,10 @@ async def lifespan(app: FastAPI):
     except FileNotFoundError as e:
         logger.warning(f"PTC Agent config not found: {e}")
         logger.warning("PTC Agent endpoints will not be available")
+    except PlatformSecretError:
+        # Required platform Secrets are a configuration gate. Hosted mode
+        # must never continue into a plaintext fallback or partial startup.
+        raise
     except Exception as e:
         logger.warning(f"Failed to initialize PTC Agent: {e}")
         logger.warning("PTC Agent endpoints may not work correctly")
@@ -435,7 +475,10 @@ async def lifespan(app: FastAPI):
 
     # Start MarketDataFeed (shared upstream WS to ginlix-data)
     try:
-        from src.server.services.market_data_feed import DEFAULT_WS_FEEDS, MarketDataFeed
+        from src.server.services.market_data_feed import (
+            DEFAULT_WS_FEEDS,
+            MarketDataFeed,
+        )
 
         for market, interval, tier in DEFAULT_WS_FEEDS:
             ws = MarketDataFeed.get_instance(market, interval, tier)
@@ -507,6 +550,16 @@ async def lifespan(app: FastAPI):
         await RecoveryScanner.get_instance().stop()
     except Exception as e:
         logger.warning(f"Error stopping RecoveryScanner: {e}")
+
+    # 0.0a. Stop the platform-secret sweep — no new scrubs while draining.
+    try:
+        from src.server.services.platform_secret_sweep import (
+            PlatformSecretSweeper,
+        )
+
+        await PlatformSecretSweeper.get_instance().stop()
+    except Exception as e:
+        logger.warning(f"Error stopping PlatformSecretSweeper: {e}")
 
     # 0.0b. Stop the turn-cancel nudge listener.
     try:
@@ -919,7 +972,9 @@ app.include_router(
 )  # /api/v1/workspaces/{id}/chart-annotations - Agent-drawn chart annotations
 app.include_router(cache_router)  # /api/v1/cache/* - Cache management
 app.include_router(market_data_router)  # /api/v1/market-data/* - Market data proxy
-app.include_router(bars_router)  # /api/v1/market-data/bars/* - Protocol-native progressive bars
+app.include_router(
+    bars_router
+)  # /api/v1/market-data/bars/* - Protocol-native progressive bars
 app.include_router(users_router)  # /api/v1/users/* - User management
 app.include_router(features_router)  # /api/v1/features/* - Feature flags (per-user resolved)
 app.include_router(
@@ -929,7 +984,9 @@ app.include_router(
     portfolio_router
 )  # /api/v1/users/me/portfolio/* - Portfolio management
 app.include_router(news_router)  # /api/v1/news - News feed (general + ticker-filtered)
-app.include_router(calendar_router)  # /api/v1/calendar/* - Economic & earnings calendars
+app.include_router(
+    calendar_router
+)  # /api/v1/calendar/* - Economic & earnings calendars
 app.include_router(sec_proxy_router)  # /api/v1/sec-proxy/* - SEC EDGAR document proxy
 app.include_router(
     api_keys_router

--- a/src/server/database/workspace.py
+++ b/src/server/database/workspace.py
@@ -28,7 +28,7 @@ FLASH_WORKSPACE_NAMESPACE = uuid.UUID("f1a50000-0000-5000-e000-f1a500000000")
 _WS_COLS = (
     "workspace_id, user_id, name, description, sandbox_id, status, created_at, "
     "updated_at, last_activity_at, stopped_at, config, artifacts, is_pinned, "
-    "sort_order, resource_tier, is_always_on"
+    "sort_order, resource_tier, is_always_on, platform_secret_version"
 )
 
 # Scalar workspace columns that may be set via `_set_workspace_scalar`. The

--- a/src/server/services/platform_secret_rollout.py
+++ b/src/server/services/platform_secret_rollout.py
@@ -1,0 +1,488 @@
+"""Platform-secret rollout state machine for hosted workspaces.
+
+The rollout rows record the active provider Secret identity SET; a
+workspace's ``platform_secret_version`` records the fleet generation its
+sandbox was last certified against, so ``version == 0`` always means "never
+certified — the sandbox may hold plaintext env" and ``0 < version <
+generation`` means "certified placeholders, behind an identity bump".
+Generations are one shared sequence: the fleet generation is the MAX over
+rollout rows, and any row's identity change (or removal) bumps it — which
+alone re-pends every workspace, so certified rows keep their generation and
+the plaintext/placeholder discriminator survives bumps. The identity only
+changes at boot registration, so the active set is cached per process and
+the per-acquisition resync costs zero extra DB queries. Sandbox-facing
+mechanics live in ``ptc_agent.core.sandbox.platform_secrets``; the
+scrub-restart for never-certified sandboxes is owned by the background
+``PlatformSecretSweeper`` — the request path only ever hot-remounts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from psycopg.rows import dict_row
+
+from ptc_agent.core.sandbox.platform_secrets import (
+    PlatformSecretConfigurationError,
+    PlatformSecretError,
+    PlatformSecretReconciliationError,
+    ReconciledPlatformSecret,
+    platform_secrets_active,
+    remount_platform_secret_bindings,
+    resolve_platform_secrets,
+    verify_runtime_platform_secrets,
+)
+from src.server.database.pool import get_db_connection
+
+
+logger = logging.getLogger(__name__)
+
+
+class PlatformSecretReadinessError(PlatformSecretError):
+    """The rollout identity is missing or the workspace cannot be served."""
+
+
+@dataclass(frozen=True)
+class PlatformSecretRollout:
+    secret_key: str
+    provider: str
+    secret_name: str
+    provider_secret_id: str
+    placeholder_sha256: str
+    current_credential_sha256: str
+    generation: int
+
+
+@dataclass(frozen=True)
+class PlatformSecretRolloutSet:
+    """The active secret set; ``generation`` is the fleet generation."""
+
+    rollouts: tuple[PlatformSecretRollout, ...]
+    generation: int
+
+    @property
+    def bindings(self) -> dict[str, str]:
+        return {r.secret_key: r.secret_name for r in self.rollouts}
+
+    @property
+    def placeholders(self) -> dict[str, str]:
+        return {r.secret_key: r.placeholder_sha256 for r in self.rollouts}
+
+
+def _sha256(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def _rollout_from_row(row: dict[str, Any]) -> PlatformSecretRollout:
+    return PlatformSecretRollout(
+        secret_key=str(row["secret_key"]),
+        provider=str(row["provider"]),
+        secret_name=str(row["secret_name"]),
+        provider_secret_id=str(row["provider_secret_id"]),
+        placeholder_sha256=str(row["placeholder_sha256"]),
+        current_credential_sha256=str(row["current_credential_sha256"]),
+        generation=int(row["generation"]),
+    )
+
+
+def _rollout_set_from_rows(rows: Sequence[Any]) -> PlatformSecretRolloutSet:
+    rollouts = tuple(
+        sorted(
+            (_rollout_from_row(dict(row)) for row in rows),
+            key=lambda r: r.secret_key,
+        )
+    )
+    return PlatformSecretRolloutSet(
+        rollouts=rollouts,
+        generation=max(r.generation for r in rollouts),
+    )
+
+
+#: Per-process cache of the active set. The identity only changes at boot
+#: registration, so a populated cache never goes stale within a process.
+_active_rollout_set: PlatformSecretRolloutSet | None = None
+
+
+async def register_platform_secret_rollouts(
+    secrets: Sequence[ReconciledPlatformSecret],
+    *,
+    credential_values: Mapping[str, str],
+    provider: str,
+) -> PlatformSecretRolloutSet:
+    """Record the provider identity set; bump the generation when it changes.
+
+    Any row's identity change — or a removal from the catalog — bumps the
+    shared fleet generation, which alone re-pends every live workspace
+    (their stored versions now compare behind). Workspace rows are never
+    zeroed: version 0 stays reserved for "never certified" so the
+    plaintext/placeholder discriminator survives identity bumps. Every
+    rollout row is stamped with the fleet generation, so MAX over rows never
+    regresses and generation values are never reused. Credential rotation
+    without an identity change updates the stored hash in place.
+    """
+
+    async with get_db_connection() as conn:
+        async with conn.transaction():
+            async with conn.cursor(row_factory=dict_row) as cur:
+                # Serialize concurrent boot registration (multi-worker uvicorn).
+                await cur.execute(
+                    "LOCK TABLE platform_secret_rollouts IN EXCLUSIVE MODE"
+                )
+                await cur.execute("SELECT * FROM platform_secret_rollouts")
+                existing = {
+                    str(row["secret_key"]): row for row in await cur.fetchall()
+                }
+                fleet_generation = max(
+                    (int(row["generation"]) for row in existing.values()),
+                    default=0,
+                )
+
+                def identity_changed(secret: ReconciledPlatformSecret) -> bool:
+                    row = existing.get(secret.definition.sandbox_env_var)
+                    return row is None or any(
+                        str(row[field]) != value
+                        for field, value in (
+                            ("provider", provider),
+                            ("secret_name", secret.name),
+                            ("provider_secret_id", secret.provider_secret_id),
+                            ("placeholder_sha256", _sha256(secret.placeholder)),
+                        )
+                    )
+
+                removed = sorted(
+                    set(existing)
+                    - {s.definition.sandbox_env_var for s in secrets}
+                )
+                set_changed = bool(removed) or any(
+                    identity_changed(secret) for secret in secrets
+                )
+                if set_changed:
+                    fleet_generation += 1
+
+                if removed:
+                    await cur.execute(
+                        "DELETE FROM platform_secret_rollouts"
+                        " WHERE secret_key = ANY(%s)",
+                        (removed,),
+                    )
+                for secret in secrets:
+                    secret_key = secret.definition.sandbox_env_var
+                    await cur.execute(
+                        """
+                        INSERT INTO platform_secret_rollouts (
+                            secret_key, provider, secret_name,
+                            provider_secret_id, placeholder_sha256,
+                            current_credential_sha256, generation
+                        ) VALUES (%s, %s, %s, %s, %s, %s, %s)
+                        ON CONFLICT (secret_key) DO UPDATE SET
+                            provider = EXCLUDED.provider,
+                            secret_name = EXCLUDED.secret_name,
+                            provider_secret_id = EXCLUDED.provider_secret_id,
+                            placeholder_sha256 = EXCLUDED.placeholder_sha256,
+                            current_credential_sha256 =
+                                EXCLUDED.current_credential_sha256,
+                            generation = EXCLUDED.generation,
+                            updated_at = NOW()
+                        """,
+                        (
+                            secret_key,
+                            provider,
+                            secret.name,
+                            secret.provider_secret_id,
+                            _sha256(secret.placeholder),
+                            _sha256(credential_values[secret_key]),
+                            fleet_generation,
+                        ),
+                    )
+
+                await cur.execute("SELECT * FROM platform_secret_rollouts")
+                rows = await cur.fetchall()
+                rollout_set = _rollout_set_from_rows(rows)
+
+    global _active_rollout_set
+    _active_rollout_set = rollout_set
+    return rollout_set
+
+
+async def get_platform_secret_rollouts() -> PlatformSecretRolloutSet:
+    global _active_rollout_set
+    if _active_rollout_set is not None:
+        return _active_rollout_set
+    async with get_db_connection() as conn:
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute("SELECT * FROM platform_secret_rollouts")
+            rows = await cur.fetchall()
+    if not rows:
+        raise PlatformSecretReadinessError(
+            "Platform-secret rollout identity is not initialized"
+        )
+    _active_rollout_set = _rollout_set_from_rows(rows)
+    return _active_rollout_set
+
+
+async def list_workspaces_behind_platform_secret(
+    rollout_set: PlatformSecretRolloutSet,
+    *,
+    limit: int = 25,
+) -> list[dict[str, Any]]:
+    """Running workspaces whose sandbox is behind the fleet generation.
+
+    Only 'running' rows: a stopped sandbox has no live processes to scrub and
+    converges through normal bringup plus a later sweep pass once running.
+    """
+
+    async with get_db_connection() as conn:
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(
+                """
+                SELECT workspace_id, sandbox_id, platform_secret_version,
+                       is_always_on
+                FROM workspaces
+                WHERE status = 'running'
+                  AND sandbox_id IS NOT NULL
+                  AND COALESCE(platform_secret_version, 0) != %s
+                ORDER BY updated_at ASC
+                LIMIT %s
+                """,
+                (rollout_set.generation, limit),
+            )
+            return [dict(row) for row in await cur.fetchall()]
+
+
+async def certify_new_workspace_sandbox(
+    config: Any,
+    *,
+    workspace_id: str,
+    expected_previous_sandbox_id: str | None,
+    sandbox_id: str,
+    runtime: Any,
+) -> dict[str, Any] | None:
+    """Verify and atomically attach one newly created hosted sandbox."""
+
+    if not platform_secrets_active(config):
+        return None
+    rollout_set = await get_platform_secret_rollouts()
+    await verify_runtime_platform_secrets(
+        runtime, expected=rollout_set.placeholders
+    )
+
+    async with get_db_connection() as conn:
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(
+                """
+                UPDATE workspaces
+                SET status = 'running',
+                    sandbox_id = %s,
+                    platform_secret_version = %s,
+                    updated_at = NOW()
+                WHERE workspace_id = %s
+                  AND status != 'deleted'
+                  AND sandbox_id IS NOT DISTINCT FROM %s
+                RETURNING workspace_id
+                """,
+                (
+                    sandbox_id,
+                    rollout_set.generation,
+                    workspace_id,
+                    expected_previous_sandbox_id,
+                ),
+            )
+            row = await cur.fetchone()
+    if row is None:
+        raise RuntimeError("Workspace changed before platform Secret certification")
+    from src.server.database.workspace import get_workspace
+
+    return await get_workspace(workspace_id)
+
+
+async def stamp_workspace_platform_secret_version(
+    workspace_id: str,
+    *,
+    expected_sandbox_id: str | None,
+    rollout_set: PlatformSecretRolloutSet,
+) -> None:
+    """CAS the exact sandbox (or lack of one) to the current fleet generation."""
+
+    async with get_db_connection() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                """
+                UPDATE workspaces
+                SET platform_secret_version = %s,
+                    updated_at = NOW()
+                WHERE workspace_id = %s
+                  AND status != 'deleted'
+                  AND sandbox_id IS NOT DISTINCT FROM %s
+                """,
+                (
+                    rollout_set.generation,
+                    workspace_id,
+                    expected_sandbox_id,
+                ),
+            )
+            if cur.rowcount != 1:
+                raise RuntimeError("Workspace changed before platform Secret stamp")
+
+
+async def resync_workspace_platform_secret(
+    config: Any,
+    runtime: Any,
+    *,
+    workspace_id: str,
+    sandbox_id: str | None,
+    db_version: int,
+    applied_generation: int | None,
+) -> int | None:
+    """Hot-resync one live sandbox onto the active rollout; never restarts.
+
+    The request-path half of convergence, run on every session (re)init and
+    warm slow-path acquisition. ``applied_generation`` is the session's stamp
+    of the generation already applied (short-circuits the common case with
+    zero provider calls); ``db_version`` is the workspace row's certified
+    generation, piggybacked off an existing read. Returns the generation now
+    applied — for the caller to stamp on the session — or None when managed
+    secrets are inactive or the workspace has no sandbox.
+
+    Only a certified-but-behind sandbox (``0 < db_version < generation``,
+    placeholders throughout) is verified and stamped here. A never-certified
+    sandbox (``db_version == 0``) still gets the hot remount — protecting
+    every new process immediately — but keeps its row behind: live processes
+    may retain plaintext, and the scrub-restart that purges them belongs to
+    the background sweep, never to a turn.
+    """
+
+    if not platform_secrets_active(config):
+        return None
+    rollout_set = await get_platform_secret_rollouts()
+    generation = rollout_set.generation
+    if applied_generation == generation:
+        return generation
+    if not sandbox_id:
+        # Nothing to converge; the fresh-provision path certifies atomically.
+        return None
+    if db_version == generation:
+        # Certified out-of-band (fresh provision, sweep) — bindings are
+        # already mounted; only the session stamp was missing.
+        return generation
+
+    try:
+        await remount_platform_secret_bindings(
+            runtime,
+            expected=rollout_set.placeholders,
+            bindings=rollout_set.bindings,
+        )
+        if db_version > 0:
+            await verify_runtime_platform_secrets(
+                runtime, expected=rollout_set.placeholders
+            )
+    except Exception as exc:
+        logger.warning(
+            "Platform-secret hot resync failed",
+            extra={
+                "workspace_id": workspace_id,
+                "sandbox_id": sandbox_id,
+                "error_type": type(exc).__name__,
+            },
+        )
+        raise PlatformSecretReadinessError(
+            f"Platform-secret resync failed for workspace {workspace_id}"
+        ) from exc
+
+    if db_version > 0:
+        # A stamp CAS conflict means the workspace row moved under us — the
+        # failure propagates and the next acquisition retries.
+        await stamp_workspace_platform_secret_version(
+            workspace_id,
+            expected_sandbox_id=sandbox_id,
+            rollout_set=rollout_set,
+        )
+    logger.info(
+        "Platform secret hot-resynced",
+        extra={
+            "workspace_id": workspace_id,
+            "sandbox_id": sandbox_id,
+            "generation": generation,
+            "certified": db_version > 0,
+        },
+    )
+    return generation
+
+
+async def reconcile_platform_secrets_at_boot(
+    agent_config: Any,
+) -> PlatformSecretRolloutSet | None:
+    """Reconcile the managed Secret catalog before the application is ready.
+
+    A no-op when no catalog is configured. Fails closed on configuration.
+    Provider unavailability is softened when a previously registered rollout
+    exists: boot continues on that identity (sandboxes still converge lazily)
+    instead of crash-looping the server.
+    """
+
+    core_config = agent_config.to_core_config()
+    try:
+        agent_config.validate_api_keys()
+    except Exception:
+        if platform_secrets_active(core_config):
+            raise PlatformSecretConfigurationError(
+                "Sandbox provider credentials are required when a platform "
+                "Secret catalog is configured"
+            ) from None
+        raise
+    secrets = resolve_platform_secrets(core_config)
+    if not secrets:
+        return None
+
+    provider = None
+    try:
+        from ptc_agent.core.sandbox.providers import create_provider
+
+        provider = create_provider(core_config)
+        reconciled = await provider.reconcile_platform_secrets(secrets)
+        if len(reconciled) != len(secrets):
+            # A count mismatch is a reconciler contract violation, not a
+            # provider outage — fail closed (hard) rather than letting the broad
+            # handler below soften it to a prior rollout and mask the bug.
+            raise PlatformSecretConfigurationError(
+                "Unexpected platform Secret reconciliation result "
+                f"(expected {len(secrets)}, got {len(reconciled)})"
+            )
+        return await register_platform_secret_rollouts(
+            reconciled,
+            credential_values={
+                secret.definition.sandbox_env_var: secret.value
+                for secret in secrets
+            },
+            provider=core_config.sandbox.provider,
+        )
+    except PlatformSecretConfigurationError:
+        raise
+    except Exception as exc:
+        existing = await _existing_rollouts_or_none()
+        if existing is not None:
+            logger.error(
+                "Platform Secret reconciliation failed at boot; continuing on "
+                "the previously registered rollout (error_type=%s)",
+                type(exc).__name__,
+            )
+            return existing
+        if isinstance(exc, PlatformSecretError):
+            raise
+        raise PlatformSecretReconciliationError(
+            "Failed to initialize platform Secret reconciliation "
+            f"(error_type={type(exc).__name__})"
+        ) from None
+    finally:
+        if provider is not None:
+            await provider.close()
+
+
+async def _existing_rollouts_or_none() -> PlatformSecretRolloutSet | None:
+    try:
+        return await get_platform_secret_rollouts()
+    except Exception:
+        return None

--- a/src/server/services/platform_secret_sweep.py
+++ b/src/server/services/platform_secret_sweep.py
@@ -1,0 +1,308 @@
+"""Background sweep converging behind sandboxes onto the platform-secret rollout.
+
+The request path only ever hot-remounts placeholder bindings (never
+destructive), so the scrub-restart that purges legacy plaintext from live
+processes needs an owner that is NOT a turn. This sweeper enumerates running
+workspaces behind the fleet generation — always-on sandboxes never re-init,
+so no bringup would ever converge them — takes a per-workspace advisory lock
+(one worker migrates each), skips any workspace with an active turn (the
+sweep owns no turn, so the predicate never self-counts), and converges in
+the idle gap: a scrub-restart for never-certified sandboxes, a hot remount
+for certified-but-behind ones. Always-on workspaces are guaranteed to
+converge because the sweep retries every cycle until it catches an
+inter-turn gap. A turn beginning between the idle check and the force-stop
+remains possible (the check is an observation, not admission-coupled); that
+window is a few provider calls wide and a hit degrades to the existing
+sandbox-transient retry paths.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+SWEEP_INTERVAL_S = 60.0
+SWEEP_BATCH_LIMIT = 25
+
+# A busy workspace defers its scrub to the next cycle; warn periodically so a
+# never-idle always-on workspace surfaces in logs instead of silently lagging.
+BUSY_WARN_EVERY = 30
+
+# Grace for a scrub in flight at shutdown before it is cancelled.
+STOP_GRACE = 30.0
+
+
+class PlatformSecretSweeper:
+    _instance: Optional["PlatformSecretSweeper"] = None
+
+    def __init__(self, *, interval: float = SWEEP_INTERVAL_S) -> None:
+        self._interval = interval
+        self._config: Any = None
+        self._loop_task: Optional[asyncio.Task] = None
+        self._stop_event = asyncio.Event()
+        self._busy_skips: dict[str, int] = {}
+
+    @classmethod
+    def get_instance(cls) -> "PlatformSecretSweeper":
+        if cls._instance is None:
+            cls._instance = PlatformSecretSweeper()
+        return cls._instance
+
+    @classmethod
+    def reset_instance(cls) -> None:
+        cls._instance = None
+
+    # ------------------------------------------------------------ lifecycle
+
+    def start(self, config: Any) -> None:
+        """Start the periodic sweep loop; inert unless managed secrets are active."""
+        from ptc_agent.core.sandbox.platform_secrets import platform_secrets_active
+
+        if not platform_secrets_active(config):
+            return
+        if self._loop_task is not None and not self._loop_task.done():
+            return
+        self._config = config
+        self._stop_event = asyncio.Event()
+        self._loop_task = asyncio.create_task(
+            self._loop(), name="platform-secret-sweeper"
+        )
+        logger.info(
+            f"[PlatformSecretSweeper] started (interval={self._interval:.0f}s)"
+        )
+
+    async def stop(self) -> None:
+        if self._loop_task is None:
+            return
+        self._stop_event.set()
+        try:
+            await asyncio.wait_for(self._loop_task, timeout=STOP_GRACE)
+        except TimeoutError:
+            logger.warning(
+                "[PlatformSecretSweeper] sweep exceeded stop grace; cancelling"
+            )
+            self._loop_task.cancel()
+            try:
+                await self._loop_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        except Exception:
+            logger.warning(
+                "[PlatformSecretSweeper] sweep loop ended with an error at "
+                "shutdown",
+                exc_info=True,
+            )
+        self._loop_task = None
+        self._stop_event = asyncio.Event()
+
+    async def _loop(self) -> None:
+        # Immediate startup pass — this IS the fleet migration after a deploy
+        # or an identity bump; the periodic loop is the retry engine.
+        while not self._stop_event.is_set():
+            try:
+                await self.sweep_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.error("[PlatformSecretSweeper] sweep failed", exc_info=True)
+            # Jitter desynchronizes sibling workers so the advisory-lock
+            # probes don't land in lockstep every cycle.
+            jitter = self._interval * (0.8 + 0.4 * random.random())
+            try:
+                await asyncio.wait_for(self._stop_event.wait(), timeout=jitter)
+                return
+            except TimeoutError:
+                pass
+
+    # ---------------------------------------------------------------- sweep
+
+    async def sweep_once(self) -> int:
+        """One bounded pass; returns how many workspaces converged."""
+        from ptc_agent.core.sandbox.providers import create_provider
+        from src.server.services.platform_secret_rollout import (
+            get_platform_secret_rollouts,
+            list_workspaces_behind_platform_secret,
+        )
+
+        try:
+            rollout_set = await get_platform_secret_rollouts()
+        except Exception:
+            # Rollout identity not registered (boot reconcile softened to a
+            # missing prior rollout) — nothing to converge onto yet.
+            logger.debug(
+                "[PlatformSecretSweeper] no active rollout; skipping pass"
+            )
+            return 0
+
+        rows = await list_workspaces_behind_platform_secret(
+            rollout_set, limit=SWEEP_BATCH_LIMIT
+        )
+        if not rows:
+            return 0
+
+        provider = create_provider(self._config)
+        converged = 0
+        try:
+            for row in rows:
+                if self._stop_event.is_set():
+                    break
+                if await self._sweep_one(row, rollout_set, provider):
+                    converged += 1
+        finally:
+            await provider.close()
+        if len(rows) == SWEEP_BATCH_LIMIT:
+            logger.info(
+                "[PlatformSecretSweeper] batch limit reached; more behind "
+                "workspaces pending next pass"
+            )
+        return converged
+
+    async def _sweep_one(
+        self, row: dict[str, Any], rollout_set: Any, provider: Any
+    ) -> bool:
+        from src.server.database.pool import get_db_connection
+        from src.server.services.writer_guard import advisory_key
+
+        workspace_id = str(row["workspace_id"])
+        sandbox_id = str(row["sandbox_id"])
+        lock_key = advisory_key("PS", workspace_id)
+
+        # A session-level advisory lock held for this workspace's convergence
+        # only — one pool connection, sequential, released in finally (and by
+        # the server on connection loss), so a crash cannot wedge the fleet.
+        async with get_db_connection() as conn:
+            cur = await conn.execute(
+                "SELECT pg_try_advisory_lock(%s)", (lock_key,)
+            )
+            acquired = (await cur.fetchone())[0]
+            if not acquired:
+                return False  # a sibling worker owns this workspace's migration
+            try:
+                return await self._converge_locked(
+                    workspace_id, sandbox_id, row, rollout_set, provider
+                )
+            finally:
+                try:
+                    await conn.execute(
+                        "SELECT pg_advisory_unlock(%s)", (lock_key,)
+                    )
+                except Exception:
+                    pass
+
+    async def _converge_locked(
+        self,
+        workspace_id: str,
+        sandbox_id: str,
+        row: dict[str, Any],
+        rollout_set: Any,
+        provider: Any,
+    ) -> bool:
+        from ptc_agent.core.sandbox.platform_secrets import (
+            converge_sandbox_platform_secrets,
+            remount_platform_secret_bindings,
+            verify_runtime_platform_secrets,
+        )
+        from src.server.services.platform_secret_rollout import (
+            stamp_workspace_platform_secret_version,
+        )
+        from src.server.services.runs.executor import LocalRunExecutor
+
+        version = int(row.get("platform_secret_version") or 0)
+        needs_scrub = version == 0
+
+        if needs_scrub:
+            # The scrub force-stops the sandbox; never under an active turn.
+            # The sweep is not a turn, so this predicate cannot self-count.
+            executor = LocalRunExecutor.get_instance()
+            if await executor.has_active_tasks_for_workspace(workspace_id):
+                self._note_busy_skip(workspace_id)
+                return False
+        self._busy_skips.pop(workspace_id, None)
+
+        try:
+            runtime = await provider.get(sandbox_id)
+            if needs_scrub:
+                await converge_sandbox_platform_secrets(
+                    runtime,
+                    expected=rollout_set.placeholders,
+                    bindings=rollout_set.bindings,
+                )
+                # Auto-stop persists across restarts; re-assert defensively so
+                # a scrubbed always-on sandbox provably stays always-on.
+                if row.get("is_always_on") and "autostop" in runtime.capabilities:
+                    try:
+                        await runtime.set_autostop_interval(0)
+                    except Exception:
+                        logger.warning(
+                            "[PlatformSecretSweeper] always-on re-assert "
+                            f"failed for workspace {workspace_id}"
+                        )
+            else:
+                # Certified placeholders, behind an identity bump: hot swap.
+                await remount_platform_secret_bindings(
+                    runtime,
+                    expected=rollout_set.placeholders,
+                    bindings=rollout_set.bindings,
+                )
+                await verify_runtime_platform_secrets(
+                    runtime, expected=rollout_set.placeholders
+                )
+            await stamp_workspace_platform_secret_version(
+                workspace_id,
+                expected_sandbox_id=sandbox_id,
+                rollout_set=rollout_set,
+            )
+        except Exception as exc:
+            logger.warning(
+                "[PlatformSecretSweeper] convergence failed for workspace "
+                f"{workspace_id} (error_type={type(exc).__name__}); will retry"
+            )
+            return False
+
+        if needs_scrub:
+            await self._drop_local_session(workspace_id)
+        logger.info(
+            f"[PlatformSecretSweeper] converged workspace {workspace_id} "
+            f"(generation={rollout_set.generation}, scrubbed={needs_scrub})"
+        )
+        return True
+
+    async def _drop_local_session(self, workspace_id: str) -> None:
+        """Best-effort eviction of this worker's cached session after a scrub.
+
+        The restart killed the session's exec processes; evicting makes the
+        next acquisition re-init instead of tripping a transient. Other
+        workers' caches recover through the existing sandbox-transient paths,
+        the same as any out-of-band sandbox restart.
+        """
+        try:
+            from src.server.services.workspace_manager import WorkspaceManager
+
+            manager = WorkspaceManager._instance
+            if manager is not None:
+                await manager.evict_session_if_present(workspace_id)
+        except Exception:
+            logger.warning(
+                "[PlatformSecretSweeper] local session eviction failed for "
+                f"workspace {workspace_id}",
+                exc_info=True,
+            )
+
+    def _note_busy_skip(self, workspace_id: str) -> None:
+        count = self._busy_skips.get(workspace_id, 0) + 1
+        self._busy_skips[workspace_id] = count
+        if count % BUSY_WARN_EVERY == 0:
+            logger.warning(
+                f"[PlatformSecretSweeper] workspace {workspace_id} has "
+                f"deferred its plaintext scrub {count} cycles (always busy); "
+                "it converges at the next inter-turn gap"
+            )
+        else:
+            logger.debug(
+                f"[PlatformSecretSweeper] workspace {workspace_id} busy; "
+                "deferring scrub to next cycle"
+            )

--- a/src/server/services/workspace_manager.py
+++ b/src/server/services/workspace_manager.py
@@ -87,9 +87,7 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
         # duplicate restart. 2x gives headroom past the 60-300s worst case;
         # only a genuinely-wedged start exceeds it.
         self.reap_stuck_after = (
-            reap_stuck_after
-            if reap_stuck_after is not None
-            else start_wait_timeout * 2
+            reap_stuck_after if reap_stuck_after is not None else start_wait_timeout * 2
         )
 
         # In-memory session cache (workspace_id -> Session)
@@ -247,8 +245,68 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
         self._pending_lazy_sync.discard(workspace_id)
         self._pending_tier_recheck.discard(workspace_id)
 
+    async def evict_session_if_present(self, workspace_id: str) -> bool:
+        """Evict this worker's cached session so the next acquisition re-inits.
+
+        The public entry point for out-of-band invalidation (e.g. the
+        platform-secret sweeper after a scrub-restart kills the session's exec
+        processes). Returns False without locking when nothing is cached.
+        """
+        if workspace_id not in self._sessions:
+            return False
+        async with self._acquire_workspace_lock(workspace_id):
+            if workspace_id not in self._sessions:
+                return False
+            await self._clear_session(workspace_id)
+        return True
+
+    async def _apply_session_platform_secret(
+        self,
+        workspace_id: str,
+        session: "Session",
+        *,
+        ws_version: int | None,
+    ) -> None:
+        """Hot-resync the sandbox onto the active platform-secret rollout.
+
+        The platform-secret analog of ``_apply_session_mcp``: a session-stamp
+        short-circuit, a piggybacked row version (``ws_version``), and only
+        non-destructive work — the scrub-restart for never-certified sandboxes
+        is owned by the background ``PlatformSecretSweeper``, so no busy-guard
+        or session eviction is needed here. Failures propagate; the warm path
+        re-checks on every slow-path acquisition, so retry is structural.
+        """
+        from ptc_agent.core.sandbox.platform_secrets import (
+            platform_secrets_active,
+        )
+
+        core_config = self.config.to_core_config()
+        if not platform_secrets_active(core_config):
+            return
+        sandbox = session.sandbox
+        runtime = getattr(sandbox, "runtime", None) if sandbox else None
+        if runtime is None:
+            return
+
+        from src.server.services.platform_secret_rollout import (
+            resync_workspace_platform_secret,
+        )
+
+        applied = await resync_workspace_platform_secret(
+            core_config,
+            runtime,
+            workspace_id=workspace_id,
+            sandbox_id=getattr(sandbox, "sandbox_id", None),
+            db_version=ws_version or 0,
+            applied_generation=session.platform_secret_version,
+        )
+        if applied is not None:
+            session.platform_secret_version = applied
+
     async def push_vault_secrets(
-        self, workspace_id: str, sandbox: "PTCSandbox | None" = None,
+        self,
+        workspace_id: str,
+        sandbox: "PTCSandbox | None" = None,
     ) -> None:
         """Push vault secrets to the running sandbox.
 
@@ -367,9 +425,7 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
         await self._install_session_composite(session, resolved)
         return resolved
 
-    async def _install_session_composite(
-        self, session: Session, resolved: Any
-    ) -> None:
+    async def _install_session_composite(self, session: Session, resolved: Any) -> None:
         """Build the composite registry + tool summary from ``resolved`` and stash.
 
         The session's CoreConfig is already a per-workspace deep copy, so we make
@@ -408,7 +464,9 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
             rows = await get_tool_schemas(session.conversation_id)
             for row in rows:
                 name = row["server_name"]
-                if row.get("status") == "ok" and row.get("config_hash") == fp_by_name.get(name):
+                if row.get("status") == "ok" and row.get(
+                    "config_hash"
+                ) == fp_by_name.get(name):
                     tool_schemas[name] = row.get("tools") or []
 
         # Always build from the BUILTIN registry, never a prior composite —
@@ -434,9 +492,7 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
         )
         session.mcp_config_version = resolved.version
 
-    def _servers_needing_discovery(
-        self, session: Session, resolved: Any
-    ) -> list[Any]:
+    def _servers_needing_discovery(self, session: Session, resolved: Any) -> list[Any]:
         """User servers in ``resolved`` lacking an ok-status schema in the composite.
 
         Used to decide whether to kick background discovery. A server with cached
@@ -451,7 +507,8 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
                 if tools:
                     present_with_tools.add(name)
         return [
-            s for s in resolved.servers
+            s
+            for s in resolved.servers
             if is_user_server(s) and s.name not in present_with_tools
         ]
 
@@ -504,10 +561,7 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
                 # new tools without waiting for the next post-cooldown acquire.
                 # Only swap if the session's config version is still ``version``
                 # (no newer mutation landed) AND this is still the live session.
-                if (
-                    session.mcp_config_version == version
-                    and _session_live()
-                ):
+                if session.mcp_config_version == version and _session_live():
                     from src.server.services.mcp_config import (
                         resolve_mcp_config,
                     )
@@ -611,7 +665,9 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
         # Vault secrets — piggyback on existing parallel gather so
         # secrets are available after stop/start and sandbox recovery.
         # Pass sandbox directly: session may not be in self._sessions yet.
-        tasks.append(_timed("vault", self.push_vault_secrets(workspace_id, sandbox=sandbox)))
+        tasks.append(
+            _timed("vault", self.push_vault_secrets(workspace_id, sandbox=sandbox))
+        )
 
         results = await asyncio.gather(*tasks, return_exceptions=True)
         for result in results:
@@ -688,6 +744,7 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
         kick_discovery: bool,
         post_init: "Callable[[Session], Any]",
         core_config: Any = None,
+        expected_previous_sandbox_id: str | None = None,
     ) -> tuple[Session, Any]:
         """Mint tokens, create + hydrate a fresh sandbox session, and mark it running.
 
@@ -752,11 +809,26 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
                 if session.sandbox
                 else None
             )
-            workspace = await update_workspace_status(
-                workspace_id=workspace_id,
-                status="running",
-                sandbox_id=sandbox_id,
+            if not sandbox_id or not session.sandbox or not session.sandbox.runtime:
+                raise RuntimeError("Fresh sandbox is missing its runtime identity")
+
+            from src.server.services.platform_secret_rollout import (
+                certify_new_workspace_sandbox,
             )
+
+            workspace = await certify_new_workspace_sandbox(
+                core_config,
+                workspace_id=workspace_id,
+                expected_previous_sandbox_id=expected_previous_sandbox_id,
+                sandbox_id=sandbox_id,
+                runtime=session.sandbox.runtime,
+            )
+            if workspace is None:
+                workspace = await update_workspace_status(
+                    workspace_id=workspace_id,
+                    status="running",
+                    sandbox_id=sandbox_id,
+                )
 
             self._record_sync(workspace_id)
             return session, workspace
@@ -807,6 +879,7 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
             kick_discovery=True,
             post_init=_post_init,
             core_config=core_config,
+            expected_previous_sandbox_id=(workspace or {}).get("sandbox_id"),
         )
         await update_workspace_activity(workspace_id)
         return session
@@ -883,9 +956,7 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
             "provider": config.sandbox.provider,
             "working_dir": config.filesystem.working_directory,
         }
-        return hashlib.sha256(
-            json.dumps(data, sort_keys=True).encode()
-        ).hexdigest()[:8]
+        return hashlib.sha256(json.dumps(data, sort_keys=True).encode()).hexdigest()[:8]
 
     def _sandbox_config_stamp(self) -> Dict[str, Any]:
         """Build the sandbox config fields to persist in workspace config JSONB.
@@ -927,9 +998,7 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
                         (Json(fields), workspace_id),
                     )
         except Exception as e:
-            logger.warning(
-                f"Failed to update config for workspace {workspace_id}: {e}"
-            )
+            logger.warning(f"Failed to update config for workspace {workspace_id}: {e}")
             if raise_on_error:
                 raise
 
@@ -974,8 +1043,7 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
 
         # --- Full migration needed ---
         logger.info(
-            f"Migrating workspace {workspace_id} sandbox: "
-            f"{actual_wd} -> {expected_wd}"
+            f"Migrating workspace {workspace_id} sandbox: {actual_wd} -> {expected_wd}"
         )
 
         # 1. Backup files to DB (must succeed or we abort — data loss prevention)
@@ -1004,9 +1072,7 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
 
         # 3. Create fresh sandbox + restore files from DB
         core_config = self.config.to_core_config()
-        new_session = await self._recover_sandbox(
-            workspace_id, user_id, core_config
-        )
+        new_session = await self._recover_sandbox(workspace_id, user_id, core_config)
 
         # 4. Stamp DB so future reconnects skip migration.
         # Retry once on failure — an unstamped workspace would re-migrate every
@@ -1020,9 +1086,7 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
                 break
             except Exception:
                 if attempt == 0:
-                    logger.warning(
-                        f"Retrying config stamp for {workspace_id}"
-                    )
+                    logger.warning(f"Retrying config stamp for {workspace_id}")
                 else:
                     logger.error(
                         f"Failed to stamp sandbox config for {workspace_id} "
@@ -1249,10 +1313,12 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
         needs_deferred_sync = False
         pending_start_wait = False
         workspace_user_id = user_id
-        # mcp_config_version from the post-cooldown workspaces read (piggyback —
-        # no extra query). None when we never reach the slow-path DB read (cooldown
-        # warm hit / still-initializing — both early-return before this point).
+        # mcp_config_version + platform_secret_version from the post-cooldown
+        # workspaces read (piggyback — no extra query). None when we never reach
+        # the slow-path DB read (cooldown warm hit / still-initializing — both
+        # early-return before this point).
         ws_mcp_version: int | None = None
+        ws_platform_secret_version: int | None = None
 
         async with self._observed_lock(
             workspace_id, "workspace.session.acquire", cached_on_entry=_was_cached
@@ -1315,11 +1381,15 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
             status = workspace["status"]
             sandbox_id_from_db = workspace.get("sandbox_id")
             workspace_user_id = workspace.get("user_id") or user_id
-            # Piggyback the MCP config version off this existing read.
+            # Piggyback the MCP config + platform-secret versions off this
+            # existing read.
             ws_mcp_version = (
                 int(workspace.get("mcp_config_version") or 0)
                 if workspace.get("mcp_config_version") is not None
                 else 0
+            )
+            ws_platform_secret_version = int(
+                workspace.get("platform_secret_version") or 0
             )
             logger.debug(
                 f"Workspace {workspace_id} from DB: status={status}, sandbox_id={sandbox_id_from_db}, user_id={workspace_user_id}"
@@ -1404,7 +1474,9 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
                         sandbox_id = workspace.get("sandbox_id")
                         if sandbox_id:
                             try:
-                                from ptc_agent.core.sandbox.providers import create_provider
+                                from ptc_agent.core.sandbox.providers import (
+                                    create_provider,
+                                )
 
                                 provider = create_provider(self.config.to_core_config())
                                 try:
@@ -1463,7 +1535,9 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
                                     # because the per-workspace asyncio.Lock is held
                                     # and is not reentrant)
                                     core_config = self.config.to_core_config()
-                                    session = SessionManager.get_session(workspace_id, core_config)
+                                    session = SessionManager.get_session(
+                                        workspace_id, core_config
+                                    )
                                     if not session._initialized:
                                         await session.initialize(
                                             sandbox_id=sandbox_id,
@@ -1560,6 +1634,7 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
             phase2_event=phase2_event,
             mark=_mark,
             ws_mcp_version=ws_mcp_version,
+            ws_platform_secret_version=ws_platform_secret_version,
         )
 
         if _session_phases:
@@ -1652,6 +1727,7 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
         phase2_event: Optional[asyncio.Event],
         mark: Callable[[str], None],
         ws_mcp_version: int | None = None,
+        ws_platform_secret_version: int | None = None,
     ) -> Session | None:
         """Run the post-lock sync/promote step and return the usable session.
 
@@ -1718,6 +1794,16 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
                 await session.sandbox.ensure_sandbox_ready()
                 mark("sandbox_ready")
 
+                # Hot-resync the platform-secret bindings on EVERY slow-path
+                # sync (the MCP-shaped warm re-check) — an identity bump thus
+                # reaches warm and always-on sandboxes within one cooldown
+                # window, before MCP/asset work. Non-destructive by design;
+                # the session stamp makes the in-sync case free.
+                await self._apply_session_platform_secret(
+                    workspace_id, session, ws_version=ws_platform_secret_version
+                )
+                mark("platform_secret")
+
                 # Resolve + apply the per-workspace MCP composite BEFORE asset
                 # sync so codegen (which reads session.sandbox.mcp_registry) sees
                 # the effective set. Cheap (resolve + in-memory build); the slow
@@ -1734,8 +1820,7 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
                 mcp_changed = resolved_mcp is not None
                 if mcp_changed:
                     logger.info(
-                        "[ASSET_SYNC] workspace_id=%s mcp_resolve=%.0fms "
-                        "version=%s",
+                        "[ASSET_SYNC] workspace_id=%s mcp_resolve=%.0fms version=%s",
                         workspace_id,
                         (time.time() - _t_resolve) * 1000,
                         session.mcp_config_version,
@@ -1903,9 +1988,7 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
                     pass
                 raise
             except Exception as e:
-                logger.warning(
-                    f"Phase 2 sync failed for workspace {workspace_id}: {e}"
-                )
+                logger.warning(f"Phase 2 sync failed for workspace {workspace_id}: {e}")
                 # Capture before reverting — the revert clears _pending_lazy_sync.
                 was_unpromoted_lazy = workspace_id in self._pending_lazy_sync
                 await self._revert_unpromoted_lazy_start(workspace_id)
@@ -2011,6 +2094,16 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
                 return recovered, True
             mark("session_initialize")
 
+            # Reattached to a pre-existing running sandbox (e.g. after a server
+            # restart): hot-resync it onto the active platform-secret rollout
+            # before any further in-sandbox work.
+            await self._apply_session_platform_secret(
+                workspace_id,
+                session,
+                ws_version=int(workspace.get("platform_secret_version") or 0),
+            )
+            mark("platform_secret")
+
             # Resolve + install the per-workspace composite before asset sync so
             # codegen uploads user-server wrappers. Cheap; discovery kicked in
             # the background (fire-and-forget — doesn't hold the lock).
@@ -2103,9 +2196,7 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
                 task.add_done_callback(self._status_publish_tasks.discard)
 
         try:
-            logger.info(
-                f"Restarting workspace {workspace_id} (claimed for start)"
-            )
+            logger.info(f"Restarting workspace {workspace_id} (claimed for start)")
             return await self._restart_workspace(
                 claimed,
                 user_id=workspace_user_id,
@@ -2152,7 +2243,9 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
         """
         timeout = self.start_wait_timeout if max_wait_s is None else max_wait_s
         base_interval = (
-            self.start_wait_poll_interval if poll_interval_s is None else poll_interval_s
+            self.start_wait_poll_interval
+            if poll_interval_s is None
+            else poll_interval_s
         )
         max_interval = max(base_interval, 2.0)
         deadline = time.monotonic() + timeout
@@ -2296,6 +2389,16 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
             if sandbox_gone:
                 return await self._recover_sandbox(workspace_id, user_id, core_config)
 
+            # Existing sandbox reconnected: hot-resync it onto the active
+            # platform-secret rollout before any further in-sandbox work. Lazy
+            # path defers to Phase 2, where the sandbox is actually up.
+            if not lazy_init:
+                await self._apply_session_platform_secret(
+                    workspace_id,
+                    session,
+                    ws_version=int(workspace.get("platform_secret_version") or 0),
+                )
+
             # Reconnected to the existing sandbox. Auto-stop is a persisted
             # Daytona property that a plain reconnect does NOT re-assert, so the
             # live interval drifts from the always-on flag whenever the flag was
@@ -2340,7 +2443,10 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
 
                 # Check if sandbox needs config migration (e.g., working dir change)
                 migrated = await self._maybe_migrate_sandbox(
-                    workspace_id, user_id, session, workspace,
+                    workspace_id,
+                    user_id,
+                    session,
+                    workspace,
                     expected_hash=expected_hash,
                 )
                 if migrated is not None:
@@ -2377,7 +2483,10 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
             # the second-stage init runs in the background. Record both to keep
             # the histogram non-empty on the lazy path — frontend latency is
             # dominated by the non-lazy phase regardless.
-            safe_record(workspace_cold_start_duration_ms, (time.monotonic() - _cold_start_t0) * 1000.0)
+            safe_record(
+                workspace_cold_start_duration_ms,
+                (time.monotonic() - _cold_start_t0) * 1000.0,
+            )
             return session
 
         except Exception as e:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -49,6 +49,7 @@ async def _reset_ginlix_singleton():
 
 # Tables in dependency (FK) order -- children first so TRUNCATE CASCADE is safe
 _ALL_TABLES = [
+    "platform_secret_rollouts",
     "automation_executions",
     "automations",
     "conversation_feedback",
@@ -227,6 +228,7 @@ async def patched_get_db_connection(test_db_pool):
         "src.server.database.mcp_servers.get_db_connection",
         # Services that hold their own from-import of get_db_connection
         "src.server.services.user_data_io.get_db_connection",
+        "src.server.services.platform_secret_rollout.get_db_connection",
     ]
     from contextlib import ExitStack
 

--- a/tests/integration/sandbox/memory_provider.py
+++ b/tests/integration/sandbox/memory_provider.py
@@ -80,7 +80,7 @@ class MemoryRuntime(SandboxRuntime):
             return
         self._state = RuntimeState.RUNNING
 
-    async def stop(self, timeout: int = 60) -> None:
+    async def stop(self, timeout: int = 60, *, force: bool = False) -> None:
         if self._deleted:
             raise RuntimeError("Cannot stop a deleted runtime")
         self._state = RuntimeState.STOPPED
@@ -296,5 +296,4 @@ class MemoryProvider(SandboxProvider):
     def is_transient_error(self, exc: Exception) -> bool:
         msg = str(exc).lower()
         return "transient" in msg or "connection" in msg
-
 

--- a/tests/integration/sandbox/providers/test_daytona_platform_secrets.py
+++ b/tests/integration/sandbox/providers/test_daytona_platform_secrets.py
@@ -1,0 +1,298 @@
+"""Live Daytona Secret tests: placeholder mount, egress substitution, host restriction, rotation.
+
+FMP is the substitution oracle: a request via the ``apikey`` header returns
+200 only if Daytona substituted the placeholder at egress; an unsubstituted
+placeholder always yields 401. Substitution happens ONLY in HTTPS request
+headers (never query strings), and echo services such as httpbin.org are
+substitution dead zones — never use them to canary substitution.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shlex
+import uuid
+
+import pytest
+
+from ptc_agent.config.core import DaytonaConfig
+from ptc_agent.core.sandbox.platform_secrets import (
+    PlatformSecretDefinition,
+    ResolvedPlatformSecret,
+)
+from ptc_agent.core.sandbox.providers.daytona import DaytonaProvider
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.provider_daytona,
+    pytest.mark.asyncio,
+    pytest.mark.skipif(
+        "daytona"
+        not in os.getenv(
+            "SANDBOX_TEST_PROVIDERS",
+            os.getenv("SANDBOX_TEST_PROVIDER", "memory"),
+        )
+        .lower()
+        .split(","),
+        reason="requires Daytona provider",
+    ),
+]
+
+FMP_HOST = "financialmodelingprep.com"
+
+
+def _required_env(name: str) -> str:
+    value = os.getenv(name, "")
+    if not value:
+        pytest.skip(f"{name} is required for the live Daytona Secret test")
+    return value
+
+
+def _resolved(
+    *,
+    env_var: str,
+    name: str,
+    value: str,
+    hosts: tuple[str, ...],
+) -> tuple[ResolvedPlatformSecret, ...]:
+    definition = PlatformSecretDefinition(
+        source_env_var=env_var,
+        sandbox_env_var=env_var,
+        name_suffix=name,
+        description="LangAlpha Daytona Secret integration test",
+        hosts=hosts,
+    )
+    return (ResolvedPlatformSecret(definition=definition, name=name, value=value),)
+
+
+def _fmp_probe_command(env_var: str) -> str:
+    """In-sandbox FMP quote request with the key in the `apikey` header.
+
+    Emits only booleans and the HTTP status — never the key or placeholder.
+    """
+    code = f"""
+import json, os, urllib.error, urllib.request
+key = os.environ[{env_var!r}]
+request = urllib.request.Request(
+    'https://{FMP_HOST}/stable/quote?symbol=AAPL',
+    headers={{'apikey': key}},
+)
+try:
+    with urllib.request.urlopen(request, timeout=30) as response:
+        status = response.status
+        ok = isinstance(json.loads(response.read()), list)
+except urllib.error.HTTPError as e:
+    status = e.code
+    ok = False
+print(json.dumps({{'placeholder': key.startswith('dtn_secret_'), 'status': status, 'ok': ok}}))
+"""
+    return f"python3 -c {shlex.quote(code)}"
+
+
+def _provider() -> DaytonaProvider:
+    api_key = _required_env("DAYTONA_API_KEY")
+    base_url = os.getenv("DAYTONA_BASE_URL", "https://app.daytona.io/api")
+    return DaytonaProvider(
+        DaytonaConfig(api_key=api_key, base_url=base_url, snapshot_enabled=False)
+    )
+
+
+async def _probe(runtime, env_var: str) -> dict:
+    result = await runtime.exec(_fmp_probe_command(env_var))
+    return json.loads(result.stdout)
+
+
+async def test_substitution_and_rotation_through_fmp():
+    """Junk value -> 401; rotate to the real key -> 200 without sandbox recreation.
+
+    The 401 -> 200 transition proves substitution AND rotation in one signal:
+    an unsubstituted placeholder can never produce 200.
+    """
+    fmp_key = _required_env("FMP_API_KEY")
+    provider = _provider()
+    runtime = None
+    identity = None
+    name = f"langalpha_test_{uuid.uuid4().hex}"
+    junk = uuid.uuid4().hex
+    try:
+        identity = (
+            await provider.reconcile_platform_secrets(
+                _resolved(
+                    env_var="FMP_API_KEY", name=name, value=junk, hosts=(FMP_HOST,)
+                )
+            )
+        )[0]
+        runtime = await provider.create(platform_secret_bindings={"FMP_API_KEY": name})
+
+        env_result = await runtime.exec(
+            "python3 -c 'import os; print(os.environ[\"FMP_API_KEY\"])'"
+        )
+        placeholder = env_result.stdout.strip()
+        assert placeholder == identity.placeholder
+        assert placeholder.startswith("dtn_secret_")
+        assert placeholder != junk
+        assert placeholder != fmp_key
+
+        before = await _probe(runtime, "FMP_API_KEY")
+        assert before["placeholder"] is True
+        assert before["status"] == 401
+
+        rotated_identity = (
+            await provider.reconcile_platform_secrets(
+                _resolved(
+                    env_var="FMP_API_KEY", name=name, value=fmp_key, hosts=(FMP_HOST,)
+                )
+            )
+        )[0]
+        assert rotated_identity.placeholder == placeholder
+
+        # Rotation propagates through the egress layer asynchronously
+        # (~30s observed live), so allow a 90s window.
+        after = None
+        for _ in range(30):
+            after = await _probe(runtime, "FMP_API_KEY")
+            if after["status"] == 200:
+                break
+            await asyncio.sleep(3)
+        assert after == {"placeholder": True, "status": 200, "ok": True}
+    finally:
+        try:
+            if runtime is not None:
+                await runtime.delete()
+        finally:
+            try:
+                if identity is not None:
+                    await provider._client.secret.delete(identity.provider_secret_id)
+            finally:
+                await provider.close()
+
+
+async def test_hot_identity_swap_reaches_new_processes_without_restart():
+    """Identity swap via remount on a RUNNING sandbox — no restart needed.
+
+    The restart-free half of convergence: after ``update_secrets`` a fresh
+    exec process sees the NEW placeholder immediately, and egress substitutes
+    it (junk-bound baseline 401 -> real-key secret 200). This is the
+    assumption the request-path hot resync and the sweep's certified-behind
+    branch stand on (probe run 2026-07-23 measured 0s to first 200).
+    """
+    import hashlib
+
+    from ptc_agent.core.sandbox.platform_secrets import (
+        remount_platform_secret_bindings,
+    )
+
+    fmp_key = _required_env("FMP_API_KEY")
+    provider = _provider()
+    runtime = None
+    identity_a = identity_b = None
+    name_a = f"langalpha_test_a_{uuid.uuid4().hex}"
+    name_b = f"langalpha_test_b_{uuid.uuid4().hex}"
+    junk = uuid.uuid4().hex
+    try:
+        # Secret A: junk value (401 oracle). Secret B: real key (200 oracle).
+        identity_a = (
+            await provider.reconcile_platform_secrets(
+                _resolved(
+                    env_var="FMP_API_KEY", name=name_a, value=junk, hosts=(FMP_HOST,)
+                )
+            )
+        )[0]
+        identity_b = (
+            await provider.reconcile_platform_secrets(
+                _resolved(
+                    env_var="FMP_API_KEY",
+                    name=name_b,
+                    value=fmp_key,
+                    hosts=(FMP_HOST,),
+                )
+            )
+        )[0]
+        assert identity_a.placeholder != identity_b.placeholder
+        runtime = await provider.create(
+            platform_secret_bindings={"FMP_API_KEY": name_a}
+        )
+
+        before = await _probe(runtime, "FMP_API_KEY")
+        assert before["placeholder"] is True
+        assert before["status"] == 401
+
+        # Hot swap A -> B on the running sandbox; no stop/start anywhere.
+        await remount_platform_secret_bindings(
+            runtime,
+            expected={
+                "FMP_API_KEY": hashlib.sha256(
+                    identity_b.placeholder.encode()
+                ).hexdigest()
+            },
+            bindings={"FMP_API_KEY": name_b},
+        )
+
+        env_result = await runtime.exec(
+            "python3 -c 'import os; print(os.environ[\"FMP_API_KEY\"])'"
+        )
+        assert env_result.stdout.strip() == identity_b.placeholder
+
+        after = None
+        for _ in range(30):
+            after = await _probe(runtime, "FMP_API_KEY")
+            if after["status"] == 200:
+                break
+            await asyncio.sleep(3)
+        assert after == {"placeholder": True, "status": 200, "ok": True}
+    finally:
+        try:
+            if runtime is not None:
+                await runtime.delete()
+        finally:
+            try:
+                for identity in (identity_a, identity_b):
+                    if identity is not None:
+                        await provider._client.secret.delete(
+                            identity.provider_secret_id
+                        )
+            finally:
+                await provider.close()
+
+
+async def test_host_restriction_blocks_substitution():
+    """A Secret allowed only for another host must NOT be substituted toward FMP.
+
+    Uses the real key as the value so a restriction failure is observable as
+    an improper 200; the value can only ever reach FMP's own servers.
+    """
+    fmp_key = _required_env("FMP_API_KEY")
+    provider = _provider()
+    runtime = None
+    identity = None
+    name = f"langalpha_test_{uuid.uuid4().hex}"
+    try:
+        identity = (
+            await provider.reconcile_platform_secrets(
+                _resolved(
+                    env_var="FMP_API_KEY",
+                    name=name,
+                    value=fmp_key,
+                    hosts=("example.com",),
+                )
+            )
+        )[0]
+        runtime = await provider.create(platform_secret_bindings={"FMP_API_KEY": name})
+
+        result = await _probe(runtime, "FMP_API_KEY")
+        assert result["placeholder"] is True
+        assert result["status"] == 401
+        assert result["ok"] is False
+    finally:
+        try:
+            if runtime is not None:
+                await runtime.delete()
+        finally:
+            try:
+                if identity is not None:
+                    await provider._client.secret.delete(identity.provider_secret_id)
+            finally:
+                await provider.close()

--- a/tests/integration/test_platform_secret_rollout_db.py
+++ b/tests/integration/test_platform_secret_rollout_db.py
@@ -1,0 +1,290 @@
+"""PostgreSQL invariants for trusted platform-secret rollout state."""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from ptc_agent.core.sandbox.platform_secrets import (
+    PlatformSecretDefinition,
+    ReconciledPlatformSecret,
+)
+from ptc_agent.core.sandbox.runtime import ExecResult
+
+
+# The shared psycopg pool owns background connection workers on the session
+# event loop. Run this module on that same loop so held ``db_conn`` fixtures can
+# acquire a second service connection without starving a dormant pool worker.
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio(loop_scope="session")]
+
+
+@pytest.fixture(autouse=True)
+def _reset_rollout_cache():
+    """The per-process rollout cache must not leak identity between tests."""
+
+    from src.server.services import platform_secret_rollout
+
+    platform_secret_rollout._active_rollout_set = None
+    yield
+    platform_secret_rollout._active_rollout_set = None
+
+
+def _identity(*, secret_id: str, placeholder: str) -> ReconciledPlatformSecret:
+    definition = PlatformSecretDefinition(
+        source_env_var="FMP_API_KEY",
+        sandbox_env_var="FMP_API_KEY",
+        name_suffix="platform-fmp-api-key",
+        description="Platform FMP API key",
+        hosts=("financialmodelingprep.com",),
+    )
+    return ReconciledPlatformSecret(
+        definition=definition,
+        name=f"prod-{definition.name_suffix}",
+        provider_secret_id=secret_id,
+        placeholder=placeholder,
+    )
+
+
+def _capable_config():
+    """CoreConfig stand-in for certify: a capable provider with a non-empty
+    catalog, so ``platform_secrets_active`` is True (certify never iterates it)."""
+
+    definition = PlatformSecretDefinition(
+        source_env_var="FMP_API_KEY",
+        sandbox_env_var="FMP_API_KEY",
+        name_suffix="platform-fmp-api-key",
+        description="Platform FMP API key",
+        hosts=("financialmodelingprep.com",),
+    )
+    sandbox = type(
+        "Sandbox", (), {"provider": "daytona", "platform_secrets": (definition,)}
+    )()
+    return type("Config", (), {"sandbox": sandbox})()
+
+
+def _extra_identity() -> ReconciledPlatformSecret:
+    definition = PlatformSecretDefinition(
+        source_env_var="EXTRA_API_KEY",
+        sandbox_env_var="EXTRA_API_KEY",
+        name_suffix="platform-extra-api-key",
+        description="Test-only extra platform key",
+        hosts=("example.com",),
+    )
+    return ReconciledPlatformSecret(
+        definition=definition,
+        name=f"prod-{definition.name_suffix}",
+        provider_secret_id="extra-id",
+        placeholder="dtn_secret_extra",
+    )
+
+
+async def _register(*identities: ReconciledPlatformSecret, provider: str = "daytona"):
+    from src.server.services.platform_secret_rollout import (
+        register_platform_secret_rollouts,
+    )
+
+    return await register_platform_secret_rollouts(
+        list(identities),
+        credential_values={
+            identity.definition.sandbox_env_var: "credential-value"
+            for identity in identities
+        },
+        provider=provider,
+    )
+
+
+class _VerifiedRuntime:
+    """Emulates the in-sandbox hashing probe for the registered placeholder."""
+
+    def __init__(self, *placeholders: str):
+        self._lines = "\n".join(
+            hashlib.sha256(p.encode()).hexdigest() for p in placeholders
+        )
+
+    async def exec(self, command: str, timeout: int = 60) -> ExecResult:
+        return ExecResult(f"{self._lines}\n", "", 0)
+
+
+async def test_user_config_cannot_modify_trusted_rollout_columns(
+    seed_workspace, patched_get_db_connection
+):
+    from src.server.database.workspace import get_workspace, update_workspace
+
+    workspace_id = str(seed_workspace["workspace_id"])
+    await update_workspace(
+        workspace_id,
+        config={"platform_secret_version": 999},
+    )
+    workspace = await get_workspace(workspace_id)
+
+    assert workspace["config"]["platform_secret_version"] == 999
+    assert workspace["platform_secret_version"] == 0
+
+
+async def test_identity_change_bumps_generation_and_keeps_certified_version(
+    seed_workspace, patched_get_db_connection, db_conn
+):
+    from src.server.services.platform_secret_rollout import (
+        stamp_workspace_platform_secret_version,
+    )
+
+    first = await _register(
+        _identity(secret_id="secret-1", placeholder="dtn_secret_one")
+    )
+    workspace_id = str(seed_workspace["workspace_id"])
+    await stamp_workspace_platform_secret_version(
+        workspace_id,
+        expected_sandbox_id=None,
+        rollout_set=first,
+    )
+
+    second = await _register(
+        _identity(secret_id="secret-2", placeholder="dtn_secret_two")
+    )
+    row = await db_conn.execute(
+        "SELECT platform_secret_version FROM workspaces WHERE workspace_id = %s",
+        (workspace_id,),
+    )
+    workspace = await row.fetchone()
+
+    assert second.generation == first.generation + 1
+    # The row keeps the generation it was certified at — behind the new
+    # generation (so it re-pends), but never zeroed: version 0 stays reserved
+    # for "never certified", preserving the plaintext/placeholder
+    # discriminator that routes hot-swap vs scrub-restart.
+    assert workspace["platform_secret_version"] == first.generation
+
+
+async def test_set_membership_change_bumps_generation_monotonically(
+    seed_workspace, patched_get_db_connection
+):
+    fmp = _identity(secret_id="secret-1", placeholder="dtn_secret_one")
+
+    first = await _register(fmp)
+    grown = await _register(fmp, _extra_identity())
+    shrunk = await _register(fmp)
+
+    # Addition and removal are both identity changes; the shared sequence
+    # never regresses even though the removed row carried the highest value.
+    assert grown.generation == first.generation + 1
+    assert sorted(grown.bindings) == ["EXTRA_API_KEY", "FMP_API_KEY"]
+    assert shrunk.generation == grown.generation + 1
+    assert sorted(shrunk.bindings) == ["FMP_API_KEY"]
+
+
+async def test_credential_rotation_without_identity_change_keeps_generation(
+    seed_workspace, patched_get_db_connection
+):
+    from src.server.services.platform_secret_rollout import (
+        register_platform_secret_rollouts,
+    )
+
+    identity = _identity(secret_id="secret-1", placeholder="dtn_secret_one")
+    first = await _register(identity)
+    second = await register_platform_secret_rollouts(
+        [identity],
+        credential_values={"FMP_API_KEY": "rotated-credential-value"},
+        provider="daytona",
+    )
+
+    assert second.generation == first.generation
+    assert (
+        second.rollouts[0].current_credential_sha256
+        != first.rollouts[0].current_credential_sha256
+    )
+
+
+async def test_provider_change_is_an_identity_change(
+    seed_workspace, patched_get_db_connection
+):
+    first = await _register(
+        _identity(secret_id="secret-1", placeholder="dtn_secret_one")
+    )
+    second = await _register(
+        _identity(secret_id="secret-1", placeholder="dtn_secret_one"),
+        provider="microvm",
+    )
+
+    assert second.rollouts[0].provider == "microvm"
+    assert second.generation == first.generation + 1
+
+
+async def test_certification_attaches_a_verified_replacement(
+    seed_workspace, patched_get_db_connection, db_conn
+):
+    from src.server.services.platform_secret_rollout import (
+        certify_new_workspace_sandbox,
+    )
+
+    rollout_set = await _register(
+        _identity(secret_id="secret-1", placeholder="dtn_secret_one")
+    )
+    workspace_id = str(seed_workspace["workspace_id"])
+
+    config = _capable_config()
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr("src.config.env.HOST_MODE", "platform")
+        workspace = await certify_new_workspace_sandbox(
+            config,
+            workspace_id=workspace_id,
+            expected_previous_sandbox_id=None,
+            sandbox_id="replacement-sandbox",
+            runtime=_VerifiedRuntime("dtn_secret_one"),
+        )
+
+    assert workspace["platform_secret_version"] == rollout_set.generation
+    assert workspace["sandbox_id"] == "replacement-sandbox"
+
+
+async def test_stamp_cas_rejects_a_moved_workspace(
+    seed_workspace, patched_get_db_connection
+):
+    from src.server.services.platform_secret_rollout import (
+        stamp_workspace_platform_secret_version,
+    )
+
+    rollout_set = await _register(
+        _identity(secret_id="secret-1", placeholder="dtn_secret_one")
+    )
+    workspace_id = str(seed_workspace["workspace_id"])
+
+    with pytest.raises(RuntimeError, match="before platform Secret stamp"):
+        await stamp_workspace_platform_secret_version(
+            workspace_id,
+            expected_sandbox_id="not-the-attached-sandbox",
+            rollout_set=rollout_set,
+        )
+
+
+async def test_certify_cas_rejects_a_concurrent_attachment(
+    seed_workspace, patched_get_db_connection
+):
+    from src.server.services.platform_secret_rollout import (
+        certify_new_workspace_sandbox,
+    )
+
+    await _register(_identity(secret_id="secret-1", placeholder="dtn_secret_one"))
+    workspace_id = str(seed_workspace["workspace_id"])
+
+    config = _capable_config()
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr("src.config.env.HOST_MODE", "platform")
+        with pytest.raises(RuntimeError, match="before platform Secret"):
+            await certify_new_workspace_sandbox(
+                config,
+                workspace_id=workspace_id,
+                expected_previous_sandbox_id="stale-previous-sandbox",
+                sandbox_id="replacement-sandbox",
+                runtime=_VerifiedRuntime("dtn_secret_one"),
+            )
+
+
+async def test_missing_rollout_row_fails_readiness(patched_get_db_connection):
+    from src.server.services.platform_secret_rollout import (
+        PlatformSecretReadinessError,
+        get_platform_secret_rollouts,
+    )
+
+    with pytest.raises(PlatformSecretReadinessError, match="not initialized"):
+        await get_platform_secret_rollouts()

--- a/tests/unit/config/test_core_config.py
+++ b/tests/unit/config/test_core_config.py
@@ -85,6 +85,7 @@ class TestDaytonaConfig:
         cfg = DaytonaConfig()
         assert cfg.api_key == ""
         assert cfg.base_url == "https://app.daytona.io/api"
+        assert cfg.secret_namespace == ""
         assert cfg.python_version == "3.12"
         assert cfg.auto_stop_interval == 3600
         assert cfg.snapshot_enabled is True

--- a/tests/unit/config/test_sandbox_config.py
+++ b/tests/unit/config/test_sandbox_config.py
@@ -23,6 +23,7 @@ from ptc_agent.config.core import (
     FilesystemConfig,
     LoggingConfig,
     MCPConfig,
+    PlatformSecretDefinition,
     SandboxConfig,
     SecurityConfig,
 )
@@ -112,6 +113,7 @@ class TestCreateSandboxConfigNewFormat:
     @pytest.fixture(autouse=True)
     def _clean_env(self, monkeypatch):
         monkeypatch.delenv("SANDBOX_PROVIDER", raising=False)
+        monkeypatch.delenv("DAYTONA_SECRET_NAMESPACE", raising=False)
         monkeypatch.delenv("DOCKER_SANDBOX_IMAGE", raising=False)
         monkeypatch.delenv("DOCKER_SANDBOX_DEV_MODE", raising=False)
         monkeypatch.delenv("DOCKER_SANDBOX_HOST_DIR", raising=False)
@@ -132,6 +134,53 @@ class TestCreateSandboxConfigNewFormat:
         cfg = create_sandbox_config(config_data)
         assert cfg.provider == "daytona"
         assert cfg.daytona.base_url == "https://app.daytona.io/api"
+
+    def test_reads_secret_namespace_from_environment(self, monkeypatch):
+        monkeypatch.setenv("DAYTONA_SECRET_NAMESPACE", "staging")
+        config_data = {
+            "sandbox": {
+                "provider": "daytona",
+                "daytona": {
+                    "base_url": "https://app.daytona.io/api",
+                    "auto_stop_interval": 3600,
+                    "auto_archive_interval": 86400,
+                    "auto_delete_interval": 604800,
+                    "python_version": "3.12",
+                },
+            }
+        }
+        cfg = create_sandbox_config(config_data)
+        assert cfg.daytona.secret_namespace == "staging"
+
+    def test_reads_platform_secrets_catalog(self):
+        config_data = {
+            "sandbox": {
+                "provider": "daytona",
+                "platform_secrets": [
+                    {
+                        "source_env_var": "EXAMPLE_API_KEY",
+                        "sandbox_env_var": "EXAMPLE_API_KEY",
+                        "name_suffix": "platform-example-api-key",
+                        "description": "Platform example API key",
+                        "hosts": ["api.example.com"],
+                    }
+                ],
+            }
+        }
+        cfg = create_sandbox_config(config_data)
+        assert cfg.platform_secrets == (
+            PlatformSecretDefinition(
+                source_env_var="EXAMPLE_API_KEY",
+                sandbox_env_var="EXAMPLE_API_KEY",
+                name_suffix="platform-example-api-key",
+                description="Platform example API key",
+                hosts=("api.example.com",),
+            ),
+        )
+
+    def test_platform_secrets_default_empty(self):
+        config_data = {"sandbox": {"provider": "daytona"}}
+        assert create_sandbox_config(config_data).platform_secrets == ()
 
     def test_reads_docker_provider(self):
         config_data = {
@@ -228,3 +277,48 @@ class TestSandboxProviderEnvOverride:
             os.environ.pop("SANDBOX_PROVIDER", None)
             cfg = create_sandbox_config(config_data)
         assert cfg.provider == "docker"
+
+
+class TestPlatformSecretCatalogValidation:
+    """SandboxConfig rejects a catalog that would silently mis-bind."""
+
+    @staticmethod
+    def _def(*, sandbox_env_var="FMP_API_KEY", name_suffix="platform-fmp"):
+        return PlatformSecretDefinition(
+            source_env_var="SRC_KEY",
+            sandbox_env_var=sandbox_env_var,
+            name_suffix=name_suffix,
+            description="test",
+            hosts=("example.com",),
+        )
+
+    def test_rejects_duplicate_sandbox_env_var(self):
+        # Duplicate sandbox_env_var collapses the binding map (and collides the
+        # rollout row keyed on it).
+        with pytest.raises(ValueError, match="duplicate sandbox_env_var"):
+            SandboxConfig(
+                platform_secrets=(
+                    self._def(name_suffix="a"),
+                    self._def(name_suffix="b"),
+                )
+            )
+
+    def test_rejects_duplicate_name_suffix(self):
+        # Duplicate name_suffix resolves two entries to one provider Secret —
+        # the later credential silently overwrites the former.
+        with pytest.raises(ValueError, match="duplicate name_suffix"):
+            SandboxConfig(
+                platform_secrets=(
+                    self._def(sandbox_env_var="A_KEY", name_suffix="dup"),
+                    self._def(sandbox_env_var="B_KEY", name_suffix="dup"),
+                )
+            )
+
+    def test_accepts_a_unique_catalog(self):
+        cfg = SandboxConfig(
+            platform_secrets=(
+                self._def(sandbox_env_var="A_KEY", name_suffix="a"),
+                self._def(sandbox_env_var="B_KEY", name_suffix="b"),
+            )
+        )
+        assert len(cfg.platform_secrets) == 2

--- a/tests/unit/core/sandbox/test_daytona_platform_secret_provider.py
+++ b/tests/unit/core/sandbox/test_daytona_platform_secret_provider.py
@@ -1,0 +1,329 @@
+"""Daytona provider Secret reconciliation and mount forwarding tests."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ptc_agent.config.core import DaytonaConfig, PlatformSecretDefinition
+from ptc_agent.core.sandbox.platform_secrets import (
+    PlatformSecretConfigurationError,
+    PlatformSecretReconciliationError,
+    resolve_platform_secrets,
+)
+
+
+class _StatusError(Exception):
+    def __init__(self, status: int, message: str = "provider error") -> None:
+        super().__init__(message)
+        self.status = status
+
+
+def _resolved_secret():
+    config = SimpleNamespace(
+        sandbox=SimpleNamespace(
+            provider="daytona",
+            daytona=DaytonaConfig(api_key="daytona-key", secret_namespace="prod"),
+            platform_secrets=(
+                PlatformSecretDefinition(
+                    source_env_var="FMP_API_KEY",
+                    sandbox_env_var="FMP_API_KEY",
+                    name_suffix="platform-fmp-api-key",
+                    description="Platform FMP API key",
+                    hosts=("financialmodelingprep.com",),
+                ),
+            ),
+        )
+    )
+    return resolve_platform_secrets(
+        config,
+        environ={"FMP_API_KEY": "never-log-this-value"},
+        host_mode="platform",
+    )
+
+
+def _provider(client):
+    from ptc_agent.core.sandbox.providers.daytona import DaytonaProvider
+
+    provider = DaytonaProvider.__new__(DaytonaProvider)
+    provider._config = DaytonaConfig(api_key="daytona-key")
+    provider._working_dir = "/home/workspace"
+    provider._client = client
+    return provider
+
+
+def _secret_meta(
+    *,
+    secret_id: str = "secret-id",
+    name: str = "prod-platform-fmp-api-key",
+):
+    return SimpleNamespace(
+        id=secret_id,
+        name=name,
+        placeholder="dtn_secret_opaque",
+    )
+
+
+@pytest.mark.asyncio
+async def test_reconcile_creates_absent_secret():
+    client = MagicMock()
+    client.secret.list = AsyncMock(
+        return_value=SimpleNamespace(items=[], next_cursor=None)
+    )
+    client.secret.create = AsyncMock(return_value=_secret_meta())
+    provider = _provider(client)
+
+    reconciled = await provider.reconcile_platform_secrets(_resolved_secret())
+
+    params = client.secret.create.await_args.args[0]
+    assert params.name == "prod-platform-fmp-api-key"
+    assert params.value == "never-log-this-value"
+    assert params.hosts == ["financialmodelingprep.com"]
+    assert reconciled[0].provider_secret_id == "secret-id"
+
+
+@pytest.mark.asyncio
+async def test_reconcile_paginates_exact_match_and_updates():
+    client = MagicMock()
+    partial = SimpleNamespace(id="partial", name="prod-platform-fmp-api-key-copy")
+    exact = _secret_meta(secret_id="exact-id")
+    client.secret.list = AsyncMock(
+        side_effect=[
+            SimpleNamespace(items=[partial], next_cursor="next"),
+            SimpleNamespace(items=[exact], next_cursor=None),
+        ]
+    )
+    client.secret.update = AsyncMock(return_value=exact)
+    provider = _provider(client)
+
+    await provider.reconcile_platform_secrets(_resolved_secret())
+
+    assert client.secret.list.await_args_list[1].kwargs["cursor"] == "next"
+    assert client.secret.update.await_args.args[0] == "exact-id"
+    assert client.secret.update.await_args.args[1].value == "never-log-this-value"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_create_conflict_refetches_and_updates():
+    client = MagicMock()
+    exact = _secret_meta(secret_id="winner-id")
+    client.secret.list = AsyncMock(
+        side_effect=[
+            SimpleNamespace(items=[], next_cursor=None),
+            SimpleNamespace(items=[exact], next_cursor=None),
+        ]
+    )
+    client.secret.create = AsyncMock(side_effect=_StatusError(409))
+    client.secret.update = AsyncMock(return_value=exact)
+    provider = _provider(client)
+
+    await provider.reconcile_platform_secrets(_resolved_secret())
+
+    client.secret.update.assert_awaited_once()
+    assert client.secret.update.await_args.args[0] == "winner-id"
+
+
+@pytest.mark.asyncio
+async def test_retryable_failure_retries_three_attempts():
+    client = MagicMock()
+    client.secret.list = AsyncMock(
+        side_effect=[
+            _StatusError(503),
+            _StatusError(429),
+            SimpleNamespace(items=[], next_cursor=None),
+        ]
+    )
+    client.secret.create = AsyncMock(return_value=_secret_meta())
+    provider = _provider(client)
+
+    with patch(
+        "ptc_agent.core.sandbox.providers.daytona_secrets.asyncio.sleep",
+        AsyncMock(),
+    ):
+        await provider.reconcile_platform_secrets(_resolved_secret())
+
+    assert client.secret.list.await_count == 3
+    client.secret.create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_nonretryable_error_is_sanitized():
+    client = MagicMock()
+    client.secret.list = AsyncMock(side_effect=ValueError("never-log-this-value"))
+    provider = _provider(client)
+
+    with pytest.raises(PlatformSecretReconciliationError) as exc_info:
+        await provider.reconcile_platform_secrets(_resolved_secret())
+
+    assert "never-log-this-value" not in str(exc_info.value)
+    assert client.secret.list.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_retry_exhaustion_is_sanitized_and_bounded():
+    client = MagicMock()
+    client.secret.list = AsyncMock(
+        side_effect=[_StatusError(503, "never-log-this-value")] * 3
+    )
+    provider = _provider(client)
+
+    with (
+        patch(
+            "ptc_agent.core.sandbox.providers.daytona_secrets.asyncio.sleep",
+            AsyncMock(),
+        ),
+        pytest.raises(PlatformSecretReconciliationError) as exc_info,
+    ):
+        await provider.reconcile_platform_secrets(_resolved_secret())
+
+    assert client.secret.list.await_count == 3
+    assert "never-log-this-value" not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_ordinary_4xx_is_not_retried():
+    client = MagicMock()
+    client.secret.list = AsyncMock(side_effect=_StatusError(400))
+    provider = _provider(client)
+
+    with pytest.raises(PlatformSecretReconciliationError):
+        await provider.reconcile_platform_secrets(_resolved_secret())
+
+    assert client.secret.list.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_status_less_transient_is_retried():
+    # A transport failure (connection reset) carries no HTTP status; classify it
+    # by message so a first-boot network blip retries instead of hard-failing
+    # reconciliation (there is no prior rollout to fall back on at first boot).
+    client = MagicMock()
+    client.secret.list = AsyncMock(
+        side_effect=[
+            ConnectionError("Connection reset by peer"),
+            SimpleNamespace(items=[], next_cursor=None),
+        ]
+    )
+    client.secret.create = AsyncMock(return_value=_secret_meta())
+    provider = _provider(client)
+
+    with patch(
+        "ptc_agent.core.sandbox.providers.daytona_secrets.asyncio.sleep",
+        AsyncMock(),
+    ):
+        await provider.reconcile_platform_secrets(_resolved_secret())
+
+    assert client.secret.list.await_count == 2
+    client.secret.create.assert_awaited_once()
+
+
+def test_is_transient_daytona_error_classification():
+    from ptc_agent.core.sandbox.providers.daytona_secrets import (
+        is_transient_daytona_error,
+    )
+
+    assert is_transient_daytona_error(ConnectionError("Connection reset by peer"))
+    assert is_transient_daytona_error(TimeoutError("request timed out"))
+    # Transport exception types are transient even with an empty message.
+    assert is_transient_daytona_error(ConnectionResetError())
+    assert is_transient_daytona_error(TimeoutError())
+    assert is_transient_daytona_error(Exception("Session is closed"))
+    assert is_transient_daytona_error(Exception("503 Service Unavailable"))
+    # Bare digits never classify: a status-less "400 Bad Request" is terminal
+    # (status-bearing errors are classified by status at the retry sites).
+    assert not is_transient_daytona_error(Exception("400 Bad Request"))
+    # Execution errors are terminal even when the server message says
+    # "timeout", including when the SDK prefixes the message.
+    assert not is_transient_daytona_error(
+        Exception("Failed to execute command: timed out")
+    )
+    assert not is_transient_daytona_error(
+        Exception("DaytonaError: Failed to execute command: timeout reached")
+    )
+    assert not is_transient_daytona_error(ValueError("bad secret name"))
+    assert not is_transient_daytona_error(Exception(""))
+
+
+@pytest.mark.asyncio
+async def test_forbidden_error_names_required_secret_permission():
+    client = MagicMock()
+    client.secret.list = AsyncMock(side_effect=_StatusError(403))
+    provider = _provider(client)
+
+    with pytest.raises(
+        PlatformSecretConfigurationError,
+        match="manage:secrets",
+    ):
+        await provider.reconcile_platform_secrets(_resolved_secret())
+
+    assert client.secret.list.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_create_error_refetches_committed_secret():
+    client = MagicMock()
+    exact = _secret_meta(secret_id="committed-id")
+    client.secret.list = AsyncMock(
+        side_effect=[
+            SimpleNamespace(items=[], next_cursor=None),
+            SimpleNamespace(items=[exact], next_cursor=None),
+        ]
+    )
+    client.secret.create = AsyncMock(side_effect=ConnectionError("connection lost"))
+    client.secret.update = AsyncMock(return_value=exact)
+    provider = _provider(client)
+
+    reconciled = await provider.reconcile_platform_secrets(_resolved_secret())
+
+    assert reconciled[0].provider_secret_id == "committed-id"
+    client.secret.update.assert_awaited_once()
+
+
+def test_exception_status_supports_both_sdk_error_shapes():
+    from ptc_agent.core.sandbox.providers.daytona_secrets import (
+        DaytonaSecretReconciler,
+    )
+
+    assert DaytonaSecretReconciler._exception_status(_StatusError(409)) == 409
+    assert (
+        DaytonaSecretReconciler._exception_status(
+            SimpleNamespace(status_code=503)  # type: ignore[arg-type]
+        )
+        == 503
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_forwards_secret_bindings():
+    client = MagicMock()
+    sdk_sandbox = MagicMock(id="new-id")
+    client.create = AsyncMock(return_value=sdk_sandbox)
+    provider = _provider(client)
+
+    with patch.object(provider, "_ensure_snapshot", AsyncMock(return_value=None)):
+        await provider.create(
+            env_vars={"ORDINARY": "value"},
+            platform_secret_bindings={"FMP_API_KEY": "prod-platform-fmp-api-key"},
+        )
+
+    params = client.create.await_args.args[0]
+    assert params.env_vars == {"ORDINARY": "value"}
+    assert params.secrets == {"FMP_API_KEY": "prod-platform-fmp-api-key"}
+
+
+@pytest.mark.asyncio
+async def test_runtime_wraps_update_env_and_update_secrets():
+    from ptc_agent.core.sandbox.providers.daytona import DaytonaRuntime
+
+    sdk_sandbox = MagicMock(id="sandbox-id")
+    sdk_sandbox.update_env = AsyncMock()
+    sdk_sandbox.update_secrets = AsyncMock()
+    runtime = DaytonaRuntime(sdk_sandbox)
+
+    await runtime.update_env({}, unset=["FMP_API_KEY"])
+    await runtime.update_secrets({"FMP_API_KEY": "prod-platform-fmp-api-key"})
+
+    sdk_sandbox.update_env.assert_awaited_once_with({}, unset=["FMP_API_KEY"])
+    sdk_sandbox.update_secrets.assert_awaited_once_with(
+        {"FMP_API_KEY": "prod-platform-fmp-api-key"}
+    )

--- a/tests/unit/core/sandbox/test_daytona_provider.py
+++ b/tests/unit/core/sandbox/test_daytona_provider.py
@@ -240,7 +240,7 @@ class TestDaytonaProvider:
     def test_snapshot_hash_changes_on_resource_retune(self):
         """C1: retuning a tier's cpu (same packages) must change the snapshot
         hash so the stale-sized snapshot isn't silently reused."""
-        from daytona_sdk.common.sandbox import Resources
+        from daytona import Resources
 
         from ptc_agent.core.sandbox.providers.daytona import DaytonaProvider
 
@@ -277,7 +277,7 @@ class TestDaytonaProvider:
     async def test_ensure_snapshot_name_changes_on_resource_retune(self):
         """C1 end-to-end: the built snapshot NAME differs across a resize, so a
         retune yields a new snapshot instead of reusing the stale-sized one."""
-        from daytona_sdk.common.sandbox import Resources
+        from daytona import Resources
 
         from ptc_agent.core.sandbox.providers.daytona import DaytonaProvider
 

--- a/tests/unit/core/sandbox/test_mcp_per_workspace_sync.py
+++ b/tests/unit/core/sandbox/test_mcp_per_workspace_sync.py
@@ -414,8 +414,9 @@ class TestServerSplit:
         sandbox = _make_sandbox(config)
         assert sandbox._get_mcp_packages() == ["builtin-pkg"]
 
-    def test_build_env_vars_excludes_user_env(self):
+    def test_build_env_vars_excludes_user_env(self, monkeypatch):
         """User-server env is never injected into the sandbox os.environ."""
+        monkeypatch.setattr("src.config.env.HOST_MODE", "oss")
         config = _make_config(
             servers=[
                 _builtin("bi", env={"BUILTIN_KEY": "literal-val"}),
@@ -423,7 +424,7 @@ class TestServerSplit:
             ]
         )
         sandbox = _make_sandbox(config)
-        env = sandbox._build_sandbox_env_vars()
+        env = sandbox._build_sandbox_env_vars({})
         assert env.get("BUILTIN_KEY") == "literal-val"
         assert "USER_KEY" not in env
 

--- a/tests/unit/core/sandbox/test_no_sdk_leaks.py
+++ b/tests/unit/core/sandbox/test_no_sdk_leaks.py
@@ -1,7 +1,7 @@
-"""Phase 3 gate test: verify daytona_sdk imports are confined to the provider module.
+"""Gate test: verify Daytona SDK imports are confined to the provider module.
 
 Uses AST analysis to scan all .py files under src/ and ensure that only the
-allowed file (providers/daytona.py) imports from daytona_sdk.  This prevents
+allowed file (providers/daytona.py) imports from daytona. This prevents
 SDK coupling from leaking back into the rest of the codebase.
 """
 
@@ -10,11 +10,10 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-import pytest
-
-# The only file allowed to import daytona_sdk
+# The only file allowed to import the Daytona SDK
 ALLOWED_DAYTONA_IMPORTS = {
     "src/ptc_agent/core/sandbox/providers/daytona.py",
+    "src/ptc_agent/core/sandbox/providers/daytona_secrets.py",
 }
 
 SRC_ROOT = Path(__file__).resolve().parents[4] / "src"
@@ -29,8 +28,8 @@ def _collect_python_files(root: Path) -> list[Path]:
     ]
 
 
-def _file_imports_daytona_sdk(filepath: Path) -> bool:
-    """Return True if *filepath* contains any import of daytona_sdk (AST-based)."""
+def _file_imports_daytona(filepath: Path) -> bool:
+    """Return True if *filepath* contains any import of daytona (AST-based)."""
     try:
         source = filepath.read_text(encoding="utf-8")
         tree = ast.parse(source, filename=str(filepath))
@@ -40,19 +39,19 @@ def _file_imports_daytona_sdk(filepath: Path) -> bool:
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
-                if alias.name == "daytona_sdk" or alias.name.startswith("daytona_sdk."):
+                if alias.name == "daytona" or alias.name.startswith("daytona."):
                     return True
         elif isinstance(node, ast.ImportFrom):
             if node.module and (
-                node.module == "daytona_sdk"
-                or node.module.startswith("daytona_sdk.")
+                node.module == "daytona"
+                or node.module.startswith("daytona.")
             ):
                 return True
     return False
 
 
-def test_no_daytona_sdk_leaks() -> None:
-    """All daytona_sdk imports must be inside the allowed provider module."""
+def test_no_daytona_import_leaks() -> None:
+    """All Daytona imports must be inside the allowed provider module."""
     assert SRC_ROOT.is_dir(), f"src root not found: {SRC_ROOT}"
 
     violations: list[str] = []
@@ -60,11 +59,11 @@ def test_no_daytona_sdk_leaks() -> None:
         rel = py_file.relative_to(SRC_ROOT.parent)
         if str(rel) in ALLOWED_DAYTONA_IMPORTS:
             continue
-        if _file_imports_daytona_sdk(py_file):
+        if _file_imports_daytona(py_file):
             violations.append(str(rel))
 
     assert violations == [], (
-        f"daytona_sdk imported outside allowed modules:\n"
+        "daytona imported outside allowed modules:\n"
         + "\n".join(f"  - {v}" for v in sorted(violations))
     )
 
@@ -76,10 +75,10 @@ def test_allowed_file_exists() -> None:
         assert path.is_file(), f"Allowed file not found: {path}"
 
 
-def test_allowed_file_does_import_daytona_sdk() -> None:
-    """Sanity check: the provider file does actually import daytona_sdk."""
+def test_allowed_file_does_import_daytona() -> None:
+    """Sanity check: the provider file does actually import daytona."""
     for allowed in ALLOWED_DAYTONA_IMPORTS:
         path = SRC_ROOT.parent / allowed
-        assert _file_imports_daytona_sdk(path), (
-            f"Expected {allowed} to import daytona_sdk but it does not"
+        assert _file_imports_daytona(path), (
+            f"Expected {allowed} to import daytona but it does not"
         )

--- a/tests/unit/core/sandbox/test_platform_secrets.py
+++ b/tests/unit/core/sandbox/test_platform_secrets.py
@@ -1,0 +1,436 @@
+"""Platform-secret catalog, classification, hosted env, and convergence tests."""
+
+import hashlib
+import re
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ptc_agent.config.core import (
+    CoreConfig,
+    DaytonaConfig,
+    DockerConfig,
+    FilesystemConfig,
+    LoggingConfig,
+    MCPConfig,
+    MCPServerConfig,
+    PlatformSecretDefinition,
+    SandboxConfig,
+    SecurityConfig,
+)
+from ptc_agent.core.sandbox.platform_secrets import (
+    PlatformSecretConfigurationError,
+    build_platform_secret_bindings,
+    platform_secrets_active,
+    platform_secrets_required,
+    resolve_platform_secrets,
+)
+
+
+_FMP_DEFINITION = PlatformSecretDefinition(
+    source_env_var="FMP_API_KEY",
+    sandbox_env_var="FMP_API_KEY",
+    name_suffix="platform-fmp-api-key",
+    description="Platform FMP API key",
+    hosts=("financialmodelingprep.com",),
+)
+
+
+def _config(
+    *,
+    provider: str = "daytona",
+    namespace: str = "prod",
+    platform_secrets: tuple[PlatformSecretDefinition, ...] = (_FMP_DEFINITION,),
+) -> CoreConfig:
+    return CoreConfig(
+        sandbox=SandboxConfig(
+            provider=provider,
+            daytona=DaytonaConfig(
+                api_key="daytona-key",
+                secret_namespace=namespace,
+            ),
+            docker=DockerConfig(),
+            platform_secrets=platform_secrets,
+        ),
+        security=SecurityConfig(),
+        mcp=MCPConfig(
+            servers=[
+                MCPServerConfig(
+                    name="price_data",
+                    env={"FMP_API_KEY": "${FMP_API_KEY}"},
+                )
+            ]
+        ),
+        logging=LoggingConfig(),
+        filesystem=FilesystemConfig(),
+    )
+
+
+def test_resolve_hosted_platform_secret(monkeypatch):
+    monkeypatch.setattr("src.config.env.HOST_MODE", "platform")
+    resolved = resolve_platform_secrets(
+        _config(), environ={"FMP_API_KEY": "real-fmp-value"}
+    )
+
+    assert len(resolved) == 1
+    assert resolved[0].name == "prod-platform-fmp-api-key"
+    assert resolved[0].definition.hosts == ("financialmodelingprep.com",)
+    assert build_platform_secret_bindings(
+        _config(), environ={"FMP_API_KEY": "real-fmp-value"}
+    ) == {"FMP_API_KEY": "prod-platform-fmp-api-key"}
+
+
+@pytest.mark.parametrize(
+    ("namespace", "environ", "missing_name"),
+    [
+        ("", {"FMP_API_KEY": "value"}, "DAYTONA_SECRET_NAMESPACE"),
+        ("bad namespace", {"FMP_API_KEY": "value"}, "must match"),
+        ("prod", {}, "FMP_API_KEY"),
+    ],
+)
+def test_resolve_hosted_configuration_fails_closed(
+    monkeypatch, namespace, environ, missing_name
+):
+    monkeypatch.setattr("src.config.env.HOST_MODE", "platform")
+    with pytest.raises(PlatformSecretConfigurationError, match=missing_name):
+        resolve_platform_secrets(_config(namespace=namespace), environ=environ)
+
+
+def test_resolve_hosted_empty_catalog_fails_closed():
+    # An empty catalog in hosted Daytona mode is a deploy error, never a
+    # silent gate-off.
+    with pytest.raises(
+        PlatformSecretConfigurationError, match="platform_secrets is empty"
+    ):
+        resolve_platform_secrets(
+            _config(platform_secrets=()),
+            environ={"FMP_API_KEY": "value"},
+            host_mode="platform",
+        )
+
+def test_resolve_rejects_an_overlong_derived_name():
+    # namespace + '-' + suffix must fit the provider/DB name bound; a suffix
+    # that pushes the derived name past it fails closed at resolution, matching
+    # the invariant the module comment claims.
+    definition = PlatformSecretDefinition(
+        source_env_var="FMP_API_KEY",
+        sandbox_env_var="FMP_API_KEY",
+        name_suffix="x" * 62,
+        description="Platform FMP API key",
+        hosts=("financialmodelingprep.com",),
+    )
+    with pytest.raises(PlatformSecretConfigurationError, match="Derived Secret name"):
+        resolve_platform_secrets(
+            _config(namespace="prod", platform_secrets=(definition,)),
+            environ={"FMP_API_KEY": "real-fmp-value"},
+        )
+
+
+def test_oss_daytona_with_catalog_opts_in(monkeypatch):
+    # Configuring a catalog on a capable provider is the opt-in — it activates
+    # in OSS mode too, no HOST_MODE=platform required.
+    monkeypatch.setattr("src.config.env.HOST_MODE", "oss")
+    resolved = resolve_platform_secrets(
+        _config(), environ={"FMP_API_KEY": "real-fmp-value"}
+    )
+    assert len(resolved) == 1
+    assert resolved[0].name == "prod-platform-fmp-api-key"
+
+
+def test_empty_catalog_is_the_opt_out(monkeypatch):
+    # No catalog on a capable provider stays on plaintext env (unchanged
+    # behavior) — but only when not hosted-required.
+    monkeypatch.setattr("src.config.env.HOST_MODE", "oss")
+    assert resolve_platform_secrets(_config(platform_secrets=()), environ={}) == ()
+
+
+def test_incapable_provider_never_activates():
+    # Docker/memory can't substitute placeholders, so a catalog is inert there.
+    assert resolve_platform_secrets(_config(provider="docker"), environ={}) == ()
+    assert not platform_secrets_active(_config(provider="docker"))
+    assert not platform_secrets_active(_config(provider="memory"))
+
+
+def test_active_gate_is_host_agnostic():
+    assert platform_secrets_active(_config())
+    assert not platform_secrets_active(_config(platform_secrets=()))
+    assert not platform_secrets_active(_config(provider="docker"))
+
+
+def test_required_gate_is_the_hosted_fail_closed_guard():
+    assert platform_secrets_required(_config(), host_mode="platform")
+    assert not platform_secrets_required(_config(), host_mode="oss")
+    assert not platform_secrets_required(
+        _config(provider="docker"), host_mode="platform"
+    )
+    # Required is capability-only — an empty catalog is still "required" so the
+    # hosted deploy fails closed rather than silently running on plaintext.
+    assert platform_secrets_required(
+        _config(platform_secrets=()), host_mode="platform"
+    )
+
+
+def _hash(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+class _FakeRuntime:
+    """Emulates the in-sandbox hashing probe; env flips to the mount on restart."""
+
+    def __init__(self, *, env_value: str, post_scrub_value: str = "dtn_secret_new"):
+        from ptc_agent.core.sandbox.runtime import RuntimeState
+
+        self.env_value = env_value
+        self.post_scrub_value = post_scrub_value
+        self.calls: list[tuple] = []
+        self._state = RuntimeState.RUNNING
+        self._states = RuntimeState
+
+    def _env_lookup(self, name):
+        return self.env_value
+
+    async def exec(self, command, timeout=60):
+        from ptc_agent.core.sandbox.runtime import ExecResult
+
+        self.calls.append(("exec", command))
+        names = re.findall(r'"([A-Za-z_][A-Za-z0-9_]*)"', command)
+        lines = [
+            _hash(value) if (value := self._env_lookup(name)) else ""
+            for name in names
+        ]
+        return ExecResult(stdout="\n".join(lines) + "\n", stderr="", exit_code=0)
+
+    async def update_env(self, env, *, unset=()):
+        self.calls.append(("update_env", dict(env), tuple(unset)))
+        self.env_value = ""
+
+    async def update_secrets(self, secrets):
+        self.calls.append(("update_secrets", dict(secrets)))
+
+    async def stop(self, timeout=60, *, force=False):
+        self.calls.append(("stop", force))
+        self._state = self._states.STOPPED
+
+    async def start(self, timeout=120):
+        self.calls.append(("start",))
+        self._state = self._states.RUNNING
+        self.env_value = self.post_scrub_value
+
+    async def get_state(self):
+        return self._state
+
+    async def refresh_state(self):
+        return await self.get_state()
+
+
+@pytest.mark.asyncio
+async def test_probe_hashes_the_whole_set_in_one_exec():
+    from ptc_agent.core.sandbox.platform_secrets import (
+        probe_runtime_platform_secrets,
+    )
+
+    class _TwoVarRuntime(_FakeRuntime):
+        env = {"FMP_API_KEY": "value-a", "OTHER_KEY": ""}
+
+        def _env_lookup(self, name):
+            return self.env.get(name, "")
+
+    runtime = _TwoVarRuntime(env_value="")
+    observed = await probe_runtime_platform_secrets(
+        runtime, env_vars=["FMP_API_KEY", "OTHER_KEY"]
+    )
+
+    assert observed == {"FMP_API_KEY": _hash("value-a"), "OTHER_KEY": ""}
+    assert [call[0] for call in runtime.calls] == ["exec"]
+
+
+@pytest.mark.asyncio
+async def test_probe_rejects_invalid_env_var_name():
+    from ptc_agent.core.sandbox.platform_secrets import (
+        probe_runtime_platform_secrets,
+    )
+
+    with pytest.raises(PlatformSecretConfigurationError, match="env var"):
+        await probe_runtime_platform_secrets(
+            _FakeRuntime(env_value="x"), env_vars=['FMP"; rm -rf /']
+        )
+
+
+@pytest.mark.asyncio
+async def test_probe_raises_on_nonzero_exit():
+    from ptc_agent.core.sandbox.platform_secrets import (
+        PlatformSecretVerificationError,
+        probe_runtime_platform_secrets,
+    )
+    from ptc_agent.core.sandbox.runtime import ExecResult
+
+    class _BrokenExecRuntime(_FakeRuntime):
+        async def exec(self, command, timeout=60):
+            return ExecResult(stdout="", stderr="", exit_code=127)
+
+    with pytest.raises(PlatformSecretVerificationError, match="exit_code=127"):
+        await probe_runtime_platform_secrets(
+            _BrokenExecRuntime(env_value=""), env_vars=["FMP_API_KEY"]
+        )
+
+
+@pytest.mark.asyncio
+async def test_probe_rejects_malformed_output():
+    from ptc_agent.core.sandbox.platform_secrets import (
+        PlatformSecretVerificationError,
+        probe_runtime_platform_secrets,
+    )
+    from ptc_agent.core.sandbox.runtime import ExecResult
+
+    class _GarbageRuntime(_FakeRuntime):
+        async def exec(self, command, timeout=60):
+            return ExecResult(stdout="not-a-hash\n", stderr="", exit_code=0)
+
+    with pytest.raises(PlatformSecretVerificationError, match="malformed"):
+        await probe_runtime_platform_secrets(
+            _GarbageRuntime(env_value="x"), env_vars=["FMP_API_KEY"]
+        )
+
+
+@pytest.mark.asyncio
+async def test_wait_for_state_times_out_and_rejects_error_state():
+    from ptc_agent.core.sandbox.platform_secrets import _wait_for_state
+    from ptc_agent.core.sandbox.runtime import RuntimeState
+
+    stuck = _FakeRuntime(env_value="x")
+    stuck._state = RuntimeState.STARTING
+    with pytest.raises(TimeoutError):
+        await _wait_for_state(stuck, {RuntimeState.RUNNING}, timeout=0.05)
+
+    errored = _FakeRuntime(env_value="x")
+    errored._state = RuntimeState.ERROR
+    with pytest.raises(RuntimeError, match="error state"):
+        await _wait_for_state(errored, {RuntimeState.RUNNING}, timeout=0.05)
+
+
+@pytest.mark.asyncio
+async def test_ensure_running_swallows_start_error_when_state_recovers():
+    from ptc_agent.core.sandbox.platform_secrets import _ensure_running
+
+    class _AmbiguousStartRuntime(_FakeRuntime):
+        async def start(self, timeout=120):
+            # The remote transition succeeds even though the call errors.
+            await super().start(timeout=timeout)
+            raise TimeoutError("start call timed out")
+
+    runtime = _AmbiguousStartRuntime(env_value="x")
+    runtime._state = runtime._states.STOPPED
+    await _ensure_running(runtime, timeout=1)
+
+    assert runtime._state == runtime._states.RUNNING
+
+
+@pytest.mark.asyncio
+async def test_converge_scrubs_unconditionally_in_order():
+    from ptc_agent.core.sandbox.platform_secrets import (
+        converge_sandbox_platform_secrets,
+    )
+
+    runtime = _FakeRuntime(
+        env_value="old-plaintext", post_scrub_value="dtn_secret_new"
+    )
+    await converge_sandbox_platform_secrets(
+        runtime,
+        expected={"FMP_API_KEY": _hash("dtn_secret_new")},
+        bindings={"FMP_API_KEY": "prod-platform-fmp-api-key"},
+    )
+
+    assert [call[0] for call in runtime.calls] == [
+        "update_env",
+        "update_secrets",
+        "stop",
+        "start",
+        "exec",  # verify
+    ]
+    assert runtime.calls[0] == ("update_env", {}, ("FMP_API_KEY",))
+    assert runtime.calls[1] == (
+        "update_secrets",
+        {"FMP_API_KEY": "prod-platform-fmp-api-key"},
+    )
+    assert runtime.calls[2] == ("stop", True)
+
+
+@pytest.mark.asyncio
+async def test_converge_raises_when_verification_fails():
+    from ptc_agent.core.sandbox.platform_secrets import (
+        PlatformSecretVerificationError,
+        converge_sandbox_platform_secrets,
+    )
+
+    runtime = _FakeRuntime(env_value="old-plaintext", post_scrub_value="wrong")
+    with pytest.raises(PlatformSecretVerificationError):
+        await converge_sandbox_platform_secrets(
+            runtime,
+            expected={"FMP_API_KEY": _hash("dtn_secret_new")},
+            bindings={"FMP_API_KEY": "prod-platform-fmp-api-key"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_capability_absent_defaults_raise():
+    from ptc_agent.core.sandbox.runtime import SandboxProvider, SandboxRuntime
+
+    class _Stub:
+        pass
+
+    with pytest.raises(NotImplementedError, match="env updates"):
+        await SandboxRuntime.update_env(_Stub(), {"A": "b"})
+    with pytest.raises(NotImplementedError, match="platform secrets"):
+        await SandboxRuntime.update_secrets(_Stub(), {"A": "b"})
+    with pytest.raises(NotImplementedError, match="platform secrets"):
+        await SandboxProvider.reconcile_platform_secrets(_Stub(), [])
+
+
+def test_hosted_daytona_env_excludes_plaintext_and_mounts_secret(monkeypatch):
+    from ptc_agent.core.sandbox.ptc_sandbox import PTCSandbox
+
+    monkeypatch.setattr("src.config.env.HOST_MODE", "platform")
+    monkeypatch.setenv("FMP_API_KEY", "real-fmp-value")
+    with patch(
+        "ptc_agent.core.sandbox.ptc_sandbox.create_provider",
+        return_value=MagicMock(),
+    ):
+        sandbox = PTCSandbox(_config())
+
+    bindings = build_platform_secret_bindings(sandbox.config)
+    env_vars = sandbox._build_sandbox_env_vars(bindings)
+
+    assert bindings == {"FMP_API_KEY": "prod-platform-fmp-api-key"}
+    assert "FMP_API_KEY" not in env_vars
+
+
+@pytest.mark.parametrize(
+    ("host_mode", "provider", "platform_secrets"),
+    [
+        # Incapable providers can't substitute placeholders — a catalog is inert.
+        ("platform", "docker", (_FMP_DEFINITION,)),
+        ("platform", "memory", (_FMP_DEFINITION,)),
+        # Daytona with no catalog is the opt-out — stays on plaintext env.
+        ("oss", "daytona", ()),
+    ],
+)
+def test_ungated_modes_keep_current_plaintext_behavior(
+    monkeypatch, host_mode, provider, platform_secrets
+):
+    from ptc_agent.core.sandbox.ptc_sandbox import PTCSandbox
+
+    monkeypatch.setattr("src.config.env.HOST_MODE", host_mode)
+    monkeypatch.setenv("FMP_API_KEY", "real-fmp-value")
+    with patch(
+        "ptc_agent.core.sandbox.ptc_sandbox.create_provider",
+        return_value=MagicMock(),
+    ):
+        sandbox = PTCSandbox(
+            _config(provider=provider, namespace="", platform_secrets=platform_secrets)
+        )
+
+    bindings = build_platform_secret_bindings(sandbox.config)
+    env_vars = sandbox._build_sandbox_env_vars(bindings)
+
+    assert bindings == {}
+    assert env_vars["FMP_API_KEY"] == "real-fmp-value"

--- a/tests/unit/core/sandbox/test_ptc_sandbox_delegation.py
+++ b/tests/unit/core/sandbox/test_ptc_sandbox_delegation.py
@@ -32,6 +32,7 @@ from ptc_agent.core.sandbox.runtime import (
     CodeRunResult,
     ExecResult,
     RuntimeState,
+    SandboxGoneError,
     SandboxProvider,
     SandboxRuntime,
 )
@@ -59,9 +60,7 @@ def mock_runtime():
     runtime.upload_files = AsyncMock()
     runtime.download_file = AsyncMock(return_value=b"data")
     runtime.list_files = AsyncMock(return_value=[{"name": "file.txt", "is_dir": False}])
-    runtime.code_run = AsyncMock(
-        return_value=CodeRunResult("result", "", 0, [])
-    )
+    runtime.code_run = AsyncMock(return_value=CodeRunResult("result", "", 0, []))
     runtime.get_state = AsyncMock(return_value=RuntimeState.RUNNING)
     runtime.start = AsyncMock()
     runtime.stop = AsyncMock()
@@ -208,6 +207,23 @@ class TestPTCSandboxDelegation:
 
         await sandbox.close()
         mock_provider.close.assert_called()
+
+    @patch("ptc_agent.core.sandbox.ptc_sandbox.create_provider")
+    @pytest.mark.asyncio
+    async def test_unrecoverable_archive_uses_secure_replacement_path(
+        self, mock_create_provider, mock_provider, mock_runtime
+    ):
+        from ptc_agent.core.sandbox.ptc_sandbox import PTCSandbox
+
+        mock_create_provider.return_value = mock_provider
+        mock_runtime.get_state.return_value = RuntimeState.ARCHIVED
+        mock_runtime.get_metadata.return_value = {"recoverable": False}
+        sandbox = PTCSandbox(config=_make_config())
+
+        with pytest.raises(SandboxGoneError, match="no longer recoverable"):
+            await sandbox.reconnect("archived-sandbox")
+
+        mock_runtime.start.assert_not_awaited()
 
 
 class TestBackgroundBashTrace:

--- a/tests/unit/data_client/test_fmp_client.py
+++ b/tests/unit/data_client/test_fmp_client.py
@@ -1,11 +1,12 @@
-"""API-key leak guard for the FMP client's error path.
+"""Auth-mechanism and key-leak guards for the FMP client.
 
-Every FMP request carries the API key as an ``apikey`` query param, so the
-request URL is a secret. httpx bakes that URL into its exception messages
-(``str(HTTPStatusError)`` → ``... for url 'https://...apikey=...'``).
-``FMPClient._make_request`` must therefore never stringify the underlying httpx
-error into ``FMPRequestError`` — it surfaces only the status code (or a static
-message), so the key can't reach a caller, an agent, or a log line.
+The API key travels ONLY in the ``apikey`` request header — never the URL.
+Query-string auth is forbidden because Daytona substitutes sandbox secret
+placeholders exclusively in HTTPS request headers, and because httpx bakes
+request URLs into exception messages. ``FMPClient._make_request``
+additionally never stringifies the underlying httpx error into
+``FMPRequestError`` (defense in depth): it surfaces only the status code or
+a static message.
 """
 
 from unittest.mock import AsyncMock
@@ -67,3 +68,32 @@ class TestFmpErrorKeyLeakGuard:
         assert _SECRET not in str(exc.value)
         assert str(exc.value) == "FMP API request failed"
         assert exc.value.status_code is None
+
+
+class TestFmpHeaderAuth:
+    """The key must travel ONLY in the `apikey` request header.
+
+    Query-string auth is forbidden: Daytona sandbox placeholders are
+    substituted exclusively in HTTPS request headers, so a query-param key
+    breaks hosted sandboxes (placeholder egresses verbatim -> FMP 401).
+    """
+
+    @pytest.mark.asyncio
+    async def test_key_sent_in_header_not_query_or_cache(self):
+        request = httpx.Request(
+            "GET", "https://financialmodelingprep.com/stable/profile?symbol=AAPL"
+        )
+        response = httpx.Response(200, request=request, json=[{"symbol": "AAPL"}])
+        get_mock = AsyncMock(return_value=response)
+        client = _client_with_mocked_http(get_mock)
+        try:
+            await client.get_profile("AAPL")
+        finally:
+            await client.close()
+
+        assert get_mock.await_count == 1
+        kwargs = get_mock.await_args.kwargs
+        assert kwargs["headers"] == {"apikey": _SECRET}
+        assert "apikey" not in kwargs["params"]
+        assert client._cache
+        assert all(_SECRET not in key for key in client._cache)

--- a/tests/unit/server/services/test_platform_secret_rollout.py
+++ b/tests/unit/server/services/test_platform_secret_rollout.py
@@ -1,0 +1,452 @@
+"""Platform-secret rollout state machine, hot resync, and boot tests."""
+
+from __future__ import annotations
+
+import hashlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ptc_agent.config.core import (
+    CoreConfig,
+    DaytonaConfig,
+    FilesystemConfig,
+    LoggingConfig,
+    MCPConfig,
+    PlatformSecretDefinition,
+    SandboxConfig,
+    SecurityConfig,
+)
+from ptc_agent.core.sandbox.platform_secrets import (
+    PlatformSecretConfigurationError,
+    PlatformSecretReconciliationError,
+    ReconciledPlatformSecret,
+    resolve_platform_secrets,
+)
+from ptc_agent.core.sandbox.runtime import ExecResult, RuntimeState
+from src.server.services.platform_secret_rollout import (
+    PlatformSecretReadinessError,
+    PlatformSecretRollout,
+    PlatformSecretRolloutSet,
+    reconcile_platform_secrets_at_boot,
+    resync_workspace_platform_secret,
+)
+
+
+PLACEHOLDER = "dtn_secret_opaque"
+
+_MODULE = "src.server.services.platform_secret_rollout"
+
+
+_FMP_DEFINITION = PlatformSecretDefinition(
+    source_env_var="FMP_API_KEY",
+    sandbox_env_var="FMP_API_KEY",
+    name_suffix="platform-fmp-api-key",
+    description="Platform FMP API key",
+    hosts=("financialmodelingprep.com",),
+)
+
+
+def _config(
+    *,
+    provider: str = "daytona",
+    platform_secrets: tuple[PlatformSecretDefinition, ...] = (_FMP_DEFINITION,),
+) -> CoreConfig:
+    return CoreConfig(
+        sandbox=SandboxConfig(
+            provider=provider,
+            daytona=DaytonaConfig(api_key="daytona-key", secret_namespace="prod"),
+            platform_secrets=platform_secrets,
+        ),
+        security=SecurityConfig(),
+        mcp=MCPConfig(),
+        logging=LoggingConfig(),
+        filesystem=FilesystemConfig(),
+    )
+
+
+def _rollout_set(generation: int = 1) -> PlatformSecretRolloutSet:
+    rollout = PlatformSecretRollout(
+        secret_key="FMP_API_KEY",
+        provider="daytona",
+        secret_name="prod-platform-fmp-api-key",
+        provider_secret_id="secret-id",
+        placeholder_sha256=hashlib.sha256(PLACEHOLDER.encode()).hexdigest(),
+        current_credential_sha256="current",
+        generation=generation,
+    )
+    return PlatformSecretRolloutSet(rollouts=(rollout,), generation=generation)
+
+
+class _Runtime:
+    async def exec(self, command: str, timeout: int = 60) -> ExecResult:
+        return ExecResult(f"{PLACEHOLDER}\n", "", 0)
+
+    async def get_state(self) -> RuntimeState:
+        return RuntimeState.RUNNING
+
+
+async def _resync(
+    config,
+    runtime=None,
+    *,
+    sandbox_id: str | None = "sb",
+    db_version: int = 0,
+    applied_generation: int | None = None,
+):
+    return await resync_workspace_platform_secret(
+        config,
+        runtime if runtime is not None else _Runtime(),
+        workspace_id="ws",
+        sandbox_id=sandbox_id,
+        db_version=db_version,
+        applied_generation=applied_generation,
+    )
+
+
+@pytest.mark.asyncio
+async def test_resync_is_inert_without_catalog(monkeypatch):
+    # No catalog configured (opt-out) — the resync never touches rollout
+    # state, regardless of host mode.
+    monkeypatch.setattr("src.config.env.HOST_MODE", "oss")
+    get_rollouts = AsyncMock()
+    monkeypatch.setattr(f"{_MODULE}.get_platform_secret_rollouts", get_rollouts)
+
+    assert await _resync(_config(platform_secrets=())) is None
+
+    get_rollouts.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_resync_short_circuits_on_session_generation(monkeypatch):
+    # The session already applied the active generation: zero provider calls.
+    monkeypatch.setattr("src.config.env.HOST_MODE", "platform")
+    monkeypatch.setenv("FMP_API_KEY", "real-fmp-value")
+    monkeypatch.setattr(
+        f"{_MODULE}.get_platform_secret_rollouts",
+        AsyncMock(return_value=_rollout_set()),
+    )
+    remount = AsyncMock()
+    monkeypatch.setattr(f"{_MODULE}.remount_platform_secret_bindings", remount)
+
+    result = await _resync(_config(), db_version=0, applied_generation=1)
+
+    assert result == 1
+    remount.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_resync_trusts_a_certified_current_row(monkeypatch):
+    # Row already at the active generation (fresh provision / sweep): bindings
+    # are mounted; only the session stamp was missing.
+    monkeypatch.setattr("src.config.env.HOST_MODE", "platform")
+    monkeypatch.setenv("FMP_API_KEY", "real-fmp-value")
+    monkeypatch.setattr(
+        f"{_MODULE}.get_platform_secret_rollouts",
+        AsyncMock(return_value=_rollout_set()),
+    )
+    remount = AsyncMock()
+    monkeypatch.setattr(f"{_MODULE}.remount_platform_secret_bindings", remount)
+
+    result = await _resync(_config(), db_version=1, applied_generation=None)
+
+    assert result == 1
+    remount.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_resync_hot_swaps_verifies_and_stamps_a_certified_behind_row(
+    monkeypatch,
+):
+    monkeypatch.setattr("src.config.env.HOST_MODE", "platform")
+    monkeypatch.setenv("FMP_API_KEY", "real-fmp-value")
+    rollout_set = _rollout_set(generation=2)
+    monkeypatch.setattr(
+        f"{_MODULE}.get_platform_secret_rollouts",
+        AsyncMock(return_value=rollout_set),
+    )
+    remount = AsyncMock()
+    verify = AsyncMock()
+    stamp = AsyncMock()
+    monkeypatch.setattr(f"{_MODULE}.remount_platform_secret_bindings", remount)
+    monkeypatch.setattr(f"{_MODULE}.verify_runtime_platform_secrets", verify)
+    monkeypatch.setattr(f"{_MODULE}.stamp_workspace_platform_secret_version", stamp)
+    runtime = _Runtime()
+
+    result = await _resync(_config(), runtime, db_version=1)
+
+    assert result == 2
+    remount.assert_awaited_once_with(
+        runtime,
+        expected=rollout_set.placeholders,
+        bindings={"FMP_API_KEY": "prod-platform-fmp-api-key"},
+    )
+    verify.assert_awaited_once_with(runtime, expected=rollout_set.placeholders)
+    stamp.assert_awaited_once_with(
+        "ws", expected_sandbox_id="sb", rollout_set=rollout_set
+    )
+
+
+@pytest.mark.asyncio
+async def test_resync_remounts_a_legacy_row_without_certifying_it(monkeypatch):
+    # version 0 = never certified: live processes may retain plaintext, so the
+    # hot remount protects new processes but the row must stay behind for the
+    # sweep's scrub-restart — no verify, no stamp.
+    monkeypatch.setattr("src.config.env.HOST_MODE", "platform")
+    monkeypatch.setenv("FMP_API_KEY", "real-fmp-value")
+    monkeypatch.setattr(
+        f"{_MODULE}.get_platform_secret_rollouts",
+        AsyncMock(return_value=_rollout_set()),
+    )
+    remount = AsyncMock()
+    verify = AsyncMock()
+    stamp = AsyncMock()
+    monkeypatch.setattr(f"{_MODULE}.remount_platform_secret_bindings", remount)
+    monkeypatch.setattr(f"{_MODULE}.verify_runtime_platform_secrets", verify)
+    monkeypatch.setattr(f"{_MODULE}.stamp_workspace_platform_secret_version", stamp)
+
+    result = await _resync(_config(), db_version=0)
+
+    assert result == 1
+    remount.assert_awaited_once()
+    verify.assert_not_awaited()
+    stamp.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_resync_raises_on_remount_failure_without_stamping(monkeypatch):
+    monkeypatch.setattr("src.config.env.HOST_MODE", "platform")
+    monkeypatch.setenv("FMP_API_KEY", "real-fmp-value")
+    monkeypatch.setattr(
+        f"{_MODULE}.get_platform_secret_rollouts",
+        AsyncMock(return_value=_rollout_set(generation=2)),
+    )
+    remount = AsyncMock(side_effect=RuntimeError("daemon unreachable"))
+    stamp = AsyncMock()
+    monkeypatch.setattr(f"{_MODULE}.remount_platform_secret_bindings", remount)
+    monkeypatch.setattr(f"{_MODULE}.stamp_workspace_platform_secret_version", stamp)
+
+    with pytest.raises(PlatformSecretReadinessError, match="ws"):
+        await _resync(_config(), db_version=1)
+
+    # The row stays behind; the next slow-path acquisition retries.
+    stamp.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_resync_skips_sandboxless_workspace(monkeypatch):
+    monkeypatch.setattr("src.config.env.HOST_MODE", "platform")
+    monkeypatch.setenv("FMP_API_KEY", "real-fmp-value")
+    monkeypatch.setattr(
+        f"{_MODULE}.get_platform_secret_rollouts",
+        AsyncMock(return_value=_rollout_set()),
+    )
+    remount = AsyncMock()
+    monkeypatch.setattr(f"{_MODULE}.remount_platform_secret_bindings", remount)
+
+    assert await _resync(_config(), sandbox_id=None) is None
+
+    remount.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_boot_missing_provider_credentials_fail_hosted_readiness(monkeypatch):
+    monkeypatch.setattr("src.config.env.HOST_MODE", "platform")
+    config = _config()
+    agent_config = SimpleNamespace(
+        to_core_config=lambda: config,
+        validate_api_keys=MagicMock(side_effect=ValueError("raw config error")),
+    )
+
+    with pytest.raises(PlatformSecretConfigurationError, match="credentials"):
+        await reconcile_platform_secrets_at_boot(agent_config)
+
+
+@pytest.mark.asyncio
+async def test_boot_reconciles_and_registers_provider(monkeypatch):
+    monkeypatch.setattr("src.config.env.HOST_MODE", "platform")
+    monkeypatch.setenv("FMP_API_KEY", "real-fmp-value")
+    config = _config()
+    agent_config = SimpleNamespace(
+        to_core_config=lambda: config,
+        validate_api_keys=MagicMock(),
+    )
+    definition = resolve_platform_secrets(
+        config,
+        environ={"FMP_API_KEY": "real-fmp-value"},
+        host_mode="platform",
+    )[0].definition
+    reconciled = ReconciledPlatformSecret(
+        definition=definition,
+        name="prod-platform-fmp-api-key",
+        provider_secret_id="secret-id",
+        placeholder="dtn_secret_opaque",
+    )
+    provider = MagicMock()
+    provider.reconcile_platform_secrets = AsyncMock(return_value=(reconciled,))
+    provider.close = AsyncMock()
+    register = AsyncMock(return_value=MagicMock())
+
+    with (
+        patch(
+            "ptc_agent.core.sandbox.providers.create_provider",
+            return_value=provider,
+        ),
+        patch(f"{_MODULE}.register_platform_secret_rollouts", register),
+    ):
+        await reconcile_platform_secrets_at_boot(agent_config)
+
+    provider.reconcile_platform_secrets.assert_awaited_once()
+    provider.close.assert_awaited_once()
+    register.assert_awaited_once_with(
+        (reconciled,),
+        credential_values={"FMP_API_KEY": "real-fmp-value"},
+        provider="daytona",
+    )
+
+
+@pytest.mark.asyncio
+async def test_boot_without_catalog_skips_reconciliation(monkeypatch):
+    # No catalog is the opt-out — boot reconciles nothing, in any host mode.
+    monkeypatch.setattr("src.config.env.HOST_MODE", "oss")
+    config = _config(platform_secrets=())
+    agent_config = SimpleNamespace(
+        to_core_config=lambda: config,
+        validate_api_keys=MagicMock(),
+    )
+
+    with patch(
+        "ptc_agent.core.sandbox.providers.create_provider"
+    ) as create_provider:
+        result = await reconcile_platform_secrets_at_boot(agent_config)
+
+    assert result is None
+    create_provider.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_boot_oss_with_catalog_opts_in(monkeypatch):
+    # OSS + Daytona + a configured catalog opts in: boot reconciles and
+    # registers, no HOST_MODE=platform required.
+    monkeypatch.setattr("src.config.env.HOST_MODE", "oss")
+    monkeypatch.setenv("FMP_API_KEY", "real-fmp-value")
+    config = _config()
+    agent_config = SimpleNamespace(
+        to_core_config=lambda: config,
+        validate_api_keys=MagicMock(),
+    )
+    definition = resolve_platform_secrets(
+        config, environ={"FMP_API_KEY": "real-fmp-value"}
+    )[0].definition
+    reconciled = ReconciledPlatformSecret(
+        definition=definition,
+        name="prod-platform-fmp-api-key",
+        provider_secret_id="secret-id",
+        placeholder="dtn_secret_opaque",
+    )
+    provider = MagicMock()
+    provider.reconcile_platform_secrets = AsyncMock(return_value=(reconciled,))
+    provider.close = AsyncMock()
+    register = AsyncMock(return_value=MagicMock())
+
+    with (
+        patch(
+            "ptc_agent.core.sandbox.providers.create_provider",
+            return_value=provider,
+        ),
+        patch(f"{_MODULE}.register_platform_secret_rollouts", register),
+    ):
+        await reconcile_platform_secrets_at_boot(agent_config)
+
+    provider.reconcile_platform_secrets.assert_awaited_once()
+    register.assert_awaited_once_with(
+        (reconciled,),
+        credential_values={"FMP_API_KEY": "real-fmp-value"},
+        provider="daytona",
+    )
+
+
+@pytest.mark.asyncio
+async def test_boot_reconcile_softens_provider_outage_with_existing_rollout(
+    monkeypatch,
+):
+    monkeypatch.setattr("src.config.env.HOST_MODE", "platform")
+    monkeypatch.setenv("FMP_API_KEY", "real-fmp-value")
+    rollout_set = _rollout_set()
+    provider = MagicMock()
+    provider.reconcile_platform_secrets = AsyncMock(
+        side_effect=ConnectionError("daytona down")
+    )
+    provider.close = AsyncMock()
+    monkeypatch.setattr(
+        "ptc_agent.core.sandbox.providers.create_provider", lambda _config: provider
+    )
+    monkeypatch.setattr(
+        f"{_MODULE}.get_platform_secret_rollouts",
+        AsyncMock(return_value=rollout_set),
+    )
+    agent_config = MagicMock()
+    agent_config.to_core_config.return_value = _config()
+    agent_config.validate_api_keys.return_value = None
+
+    result = await reconcile_platform_secrets_at_boot(agent_config)
+
+    assert result is rollout_set
+    provider.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_boot_reconcile_count_mismatch_fails_closed_despite_prior_rollout(
+    monkeypatch,
+):
+    # A reconciled/secrets count mismatch is a reconciler contract violation,
+    # not a provider outage — it must fail closed even when a prior rollout
+    # exists (the outage path would soften here; this must not).
+    monkeypatch.setattr("src.config.env.HOST_MODE", "platform")
+    monkeypatch.setenv("FMP_API_KEY", "real-fmp-value")
+    provider = MagicMock()
+    provider.reconcile_platform_secrets = AsyncMock(return_value=())  # 0 != 1
+    provider.close = AsyncMock()
+    monkeypatch.setattr(
+        "ptc_agent.core.sandbox.providers.create_provider", lambda _config: provider
+    )
+    monkeypatch.setattr(
+        f"{_MODULE}.get_platform_secret_rollouts",
+        AsyncMock(return_value=_rollout_set()),
+    )
+    agent_config = MagicMock()
+    agent_config.to_core_config.return_value = _config()
+    agent_config.validate_api_keys.return_value = None
+
+    with pytest.raises(
+        PlatformSecretConfigurationError, match="reconciliation result"
+    ):
+        await reconcile_platform_secrets_at_boot(agent_config)
+    provider.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_boot_reconcile_fails_closed_without_prior_rollout(monkeypatch):
+    monkeypatch.setattr("src.config.env.HOST_MODE", "platform")
+    monkeypatch.setenv("FMP_API_KEY", "real-fmp-value")
+    provider = MagicMock()
+    provider.reconcile_platform_secrets = AsyncMock(
+        side_effect=ConnectionError("daytona down")
+    )
+    provider.close = AsyncMock()
+    monkeypatch.setattr(
+        "ptc_agent.core.sandbox.providers.create_provider", lambda _config: provider
+    )
+    monkeypatch.setattr(
+        f"{_MODULE}.get_platform_secret_rollouts",
+        AsyncMock(side_effect=PlatformSecretReadinessError("not initialized")),
+    )
+    agent_config = MagicMock()
+    agent_config.to_core_config.return_value = _config()
+    agent_config.validate_api_keys.return_value = None
+
+    with pytest.raises(PlatformSecretReconciliationError):
+        await reconcile_platform_secrets_at_boot(agent_config)
+
+    provider.close.assert_awaited_once()

--- a/tests/unit/server/services/test_platform_secret_sweep.py
+++ b/tests/unit/server/services/test_platform_secret_sweep.py
@@ -1,0 +1,288 @@
+"""Platform-secret migration sweep: lock/skip/scrub dispatch tests."""
+
+from __future__ import annotations
+
+import hashlib
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.server.services.platform_secret_rollout import (
+    PlatformSecretRollout,
+    PlatformSecretRolloutSet,
+)
+from src.server.services.platform_secret_sweep import PlatformSecretSweeper
+
+
+PLACEHOLDER = "dtn_secret_opaque"
+
+_SWEEP = "src.server.services.platform_secret_sweep"
+_ROLLOUT = "src.server.services.platform_secret_rollout"
+_MECHANICS = "ptc_agent.core.sandbox.platform_secrets"
+
+
+def _rollout_set(generation: int = 1) -> PlatformSecretRolloutSet:
+    rollout = PlatformSecretRollout(
+        secret_key="FMP_API_KEY",
+        provider="daytona",
+        secret_name="prod-platform-fmp-api-key",
+        provider_secret_id="secret-id",
+        placeholder_sha256=hashlib.sha256(PLACEHOLDER.encode()).hexdigest(),
+        current_credential_sha256="current",
+        generation=generation,
+    )
+    return PlatformSecretRolloutSet(rollouts=(rollout,), generation=generation)
+
+
+def _row(*, version: int = 0, always_on: bool = False) -> dict:
+    return {
+        "workspace_id": "ws",
+        "sandbox_id": "sb",
+        "platform_secret_version": version,
+        "is_always_on": always_on,
+    }
+
+
+def _runtime(*, autostop: bool = True) -> MagicMock:
+    runtime = MagicMock()
+    runtime.capabilities = {"autostop"} if autostop else set()
+    runtime.set_autostop_interval = AsyncMock()
+    return runtime
+
+
+def _executor(*, busy: bool) -> MagicMock:
+    executor = MagicMock()
+    executor.has_active_tasks_for_workspace = AsyncMock(return_value=busy)
+    return executor
+
+
+@pytest.fixture(autouse=True)
+def _fresh_sweeper():
+    PlatformSecretSweeper.reset_instance()
+    yield
+    PlatformSecretSweeper.reset_instance()
+
+
+@asynccontextmanager
+async def _fake_conn(acquired: bool):
+    cur = MagicMock()
+    cur.fetchone = AsyncMock(return_value=(acquired,))
+    conn = MagicMock()
+    conn.execute = AsyncMock(return_value=cur)
+    yield conn
+
+
+@pytest.mark.asyncio
+async def test_legacy_row_gets_scrub_restart_and_always_on_reassert():
+    sweeper = PlatformSecretSweeper()
+    rollout_set = _rollout_set()
+    runtime = _runtime()
+    provider = MagicMock()
+    provider.get = AsyncMock(return_value=runtime)
+    converge = AsyncMock()
+    stamp = AsyncMock()
+    drop = AsyncMock()
+
+    with (
+        patch(f"{_MECHANICS}.converge_sandbox_platform_secrets", converge),
+        patch(f"{_ROLLOUT}.stamp_workspace_platform_secret_version", stamp),
+        patch(
+            "src.server.services.runs.executor.LocalRunExecutor.get_instance",
+            return_value=_executor(busy=False),
+        ),
+        patch.object(sweeper, "_drop_local_session", drop),
+    ):
+        converged = await sweeper._converge_locked(
+            "ws", "sb", _row(always_on=True), rollout_set, provider
+        )
+
+    assert converged is True
+    converge.assert_awaited_once_with(
+        runtime,
+        expected=rollout_set.placeholders,
+        bindings=rollout_set.bindings,
+    )
+    runtime.set_autostop_interval.assert_awaited_once_with(0)
+    stamp.assert_awaited_once_with(
+        "ws", expected_sandbox_id="sb", rollout_set=rollout_set
+    )
+    # The restart killed the cached session's exec processes.
+    drop.assert_awaited_once_with("ws")
+
+
+@pytest.mark.asyncio
+async def test_active_turn_defers_the_scrub_to_the_next_cycle():
+    sweeper = PlatformSecretSweeper()
+    provider = MagicMock()
+    provider.get = AsyncMock()
+    converge = AsyncMock()
+
+    with (
+        patch(f"{_MECHANICS}.converge_sandbox_platform_secrets", converge),
+        patch(
+            "src.server.services.runs.executor.LocalRunExecutor.get_instance",
+            return_value=_executor(busy=True),
+        ),
+    ):
+        converged = await sweeper._converge_locked(
+            "ws", "sb", _row(), _rollout_set(), provider
+        )
+
+    assert converged is False
+    provider.get.assert_not_awaited()
+    converge.assert_not_awaited()
+    assert sweeper._busy_skips["ws"] == 1
+
+
+@pytest.mark.asyncio
+async def test_certified_behind_row_hot_swaps_without_restart():
+    # 0 < version < generation: placeholders throughout — hot remount + verify,
+    # never a scrub (and no busy gate: nothing destructive happens).
+    sweeper = PlatformSecretSweeper()
+    rollout_set = _rollout_set(generation=2)
+    runtime = _runtime()
+    provider = MagicMock()
+    provider.get = AsyncMock(return_value=runtime)
+    converge = AsyncMock()
+    remount = AsyncMock()
+    verify = AsyncMock()
+    stamp = AsyncMock()
+    drop = AsyncMock()
+
+    with (
+        patch(f"{_MECHANICS}.converge_sandbox_platform_secrets", converge),
+        patch(f"{_MECHANICS}.remount_platform_secret_bindings", remount),
+        patch(f"{_MECHANICS}.verify_runtime_platform_secrets", verify),
+        patch(f"{_ROLLOUT}.stamp_workspace_platform_secret_version", stamp),
+        patch.object(sweeper, "_drop_local_session", drop),
+    ):
+        converged = await sweeper._converge_locked(
+            "ws", "sb", _row(version=1), rollout_set, provider
+        )
+
+    assert converged is True
+    converge.assert_not_awaited()
+    remount.assert_awaited_once_with(
+        runtime,
+        expected=rollout_set.placeholders,
+        bindings=rollout_set.bindings,
+    )
+    verify.assert_awaited_once_with(runtime, expected=rollout_set.placeholders)
+    stamp.assert_awaited_once()
+    drop.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_convergence_failure_is_contained_and_retried_next_pass():
+    sweeper = PlatformSecretSweeper()
+    provider = MagicMock()
+    provider.get = AsyncMock(side_effect=RuntimeError("sandbox gone"))
+    stamp = AsyncMock()
+
+    with (
+        patch(f"{_ROLLOUT}.stamp_workspace_platform_secret_version", stamp),
+        patch(
+            "src.server.services.runs.executor.LocalRunExecutor.get_instance",
+            return_value=_executor(busy=False),
+        ),
+    ):
+        converged = await sweeper._converge_locked(
+            "ws", "sb", _row(), _rollout_set(), provider
+        )
+
+    assert converged is False
+    stamp.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_lock_loser_skips_without_touching_the_workspace():
+    sweeper = PlatformSecretSweeper()
+    provider = MagicMock()
+    provider.get = AsyncMock()
+    locked = AsyncMock()
+
+    with (
+        patch(
+            "src.server.database.pool.get_db_connection",
+            lambda: _fake_conn(acquired=False),
+        ),
+        patch.object(sweeper, "_converge_locked", locked),
+    ):
+        converged = await sweeper._sweep_one(_row(), _rollout_set(), provider)
+
+    assert converged is False
+    locked.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_lock_winner_converges_and_releases():
+    sweeper = PlatformSecretSweeper()
+    provider = MagicMock()
+    locked = AsyncMock(return_value=True)
+    executed: list[str] = []
+
+    @asynccontextmanager
+    async def _conn_cm():
+        cur = MagicMock()
+        cur.fetchone = AsyncMock(return_value=(True,))
+
+        async def _execute(sql, params=None):
+            executed.append(sql)
+            return cur
+
+        conn = MagicMock()
+        conn.execute = AsyncMock(side_effect=_execute)
+        yield conn
+
+    with (
+        patch("src.server.database.pool.get_db_connection", _conn_cm),
+        patch.object(sweeper, "_converge_locked", locked),
+    ):
+        converged = await sweeper._sweep_one(_row(), _rollout_set(), provider)
+
+    assert converged is True
+    locked.assert_awaited_once()
+    assert any("pg_try_advisory_lock" in sql for sql in executed)
+    assert any("pg_advisory_unlock" in sql for sql in executed)
+
+
+@pytest.mark.asyncio
+async def test_sweep_once_is_inert_without_a_registered_rollout():
+    sweeper = PlatformSecretSweeper()
+    sweeper._config = MagicMock()
+    list_behind = AsyncMock()
+
+    with (
+        patch(
+            f"{_ROLLOUT}.get_platform_secret_rollouts",
+            AsyncMock(side_effect=RuntimeError("not initialized")),
+        ),
+        patch(f"{_ROLLOUT}.list_workspaces_behind_platform_secret", list_behind),
+    ):
+        assert await sweeper.sweep_once() == 0
+
+    list_behind.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_start_is_inert_when_platform_secrets_inactive():
+    sweeper = PlatformSecretSweeper()
+    with patch(
+        f"{_MECHANICS}.platform_secrets_active", return_value=False
+    ):
+        sweeper.start(MagicMock())
+    assert sweeper._loop_task is None
+
+
+@pytest.mark.asyncio
+async def test_start_and_stop_lifecycle():
+    sweeper = PlatformSecretSweeper(interval=0.01)
+    with (
+        patch(f"{_MECHANICS}.platform_secrets_active", return_value=True),
+        patch.object(sweeper, "sweep_once", AsyncMock(return_value=0)),
+    ):
+        sweeper.start(MagicMock())
+        assert sweeper._loop_task is not None
+        await sweeper.stop()
+    assert sweeper._loop_task is None

--- a/tests/unit/server/services/test_workspace_manager.py
+++ b/tests/unit/server/services/test_workspace_manager.py
@@ -3133,3 +3133,157 @@ class TestDuplicateWorkspace:
         mock_status.assert_awaited_once_with(workspace_id=new_id, status="error")
         # Orphaned sandbox is torn down, not left billing.
         mock_session_mgr.cleanup_session.assert_awaited_once_with(new_id)
+
+
+# ---------------------------------------------------------------------------
+# Platform-secret wiring
+# ---------------------------------------------------------------------------
+
+class TestPlatformSecretWiring:
+    """Wiring between the platform-secret hooks and session lifecycle."""
+
+    def setup_method(self):
+        WorkspaceManager.reset_instance()
+
+    def teardown_method(self):
+        WorkspaceManager.reset_instance()
+
+    @pytest.mark.asyncio
+    async def test_evict_session_if_present(self):
+        # Public out-of-band invalidation (used by the sweeper after a scrub):
+        # evicts under the workspace lock when cached, no-ops otherwise.
+        manager = WorkspaceManager.get_instance(config=_make_config())
+        session = _make_mock_session()
+        workspace_id = "ws-evict"
+        manager._sessions[workspace_id] = session
+
+        with patch(
+            "src.server.services.workspace_manager."
+            "SessionManager.cleanup_session",
+            AsyncMock(),
+        ) as cleanup:
+            assert await manager.evict_session_if_present(workspace_id) is True
+            cleanup.assert_awaited_once_with(workspace_id)
+            assert workspace_id not in manager._sessions
+            assert await manager.evict_session_if_present(workspace_id) is False
+
+    @pytest.mark.asyncio
+    async def test_hot_resync_failure_propagates_without_evicting_session(self):
+        # The resync is non-destructive and re-checked on every slow-path
+        # acquisition, so a failure must NOT evict the session caches (retry
+        # is structural) and must NOT touch the lazy-start lifecycle state.
+        manager = WorkspaceManager.get_instance(config=_make_config())
+        session = _make_mock_session()
+        session.sandbox.runtime = MagicMock()
+        session.platform_secret_version = None
+        workspace = _make_workspace()
+        workspace_id = workspace["workspace_id"]
+        manager._sessions[workspace_id] = session
+        manager._pending_lazy_sync.add(workspace_id)
+        manager._pending_tier_recheck.add(workspace_id)
+
+        with (
+            patch(
+                "ptc_agent.core.sandbox.platform_secrets."
+                "platform_secrets_active",
+                return_value=True,
+            ),
+            patch(
+                "src.server.services.platform_secret_rollout."
+                "resync_workspace_platform_secret",
+                AsyncMock(side_effect=RuntimeError("remount failed")),
+            ),
+            patch(
+                "src.server.services.workspace_manager."
+                "SessionManager.cleanup_session",
+                AsyncMock(),
+            ) as cleanup,
+        ):
+            with pytest.raises(RuntimeError, match="remount failed"):
+                await manager._apply_session_platform_secret(
+                    workspace_id, session, ws_version=1
+                )
+
+        cleanup.assert_not_awaited()
+        assert manager._sessions.get(workspace_id) is session
+        assert workspace_id in manager._pending_lazy_sync
+        assert workspace_id in manager._pending_tier_recheck
+        assert session.platform_secret_version is None
+
+    @pytest.mark.asyncio
+    async def test_hot_resync_stamps_session_with_applied_generation(self):
+        manager = WorkspaceManager.get_instance(config=_make_config())
+        session = _make_mock_session()
+        session.sandbox.runtime = MagicMock()
+        session.platform_secret_version = None
+        workspace = _make_workspace()
+        workspace_id = workspace["workspace_id"]
+
+        resync = AsyncMock(return_value=3)
+        with (
+            patch(
+                "ptc_agent.core.sandbox.platform_secrets."
+                "platform_secrets_active",
+                return_value=True,
+            ),
+            patch(
+                "src.server.services.platform_secret_rollout."
+                "resync_workspace_platform_secret",
+                resync,
+            ),
+        ):
+            await manager._apply_session_platform_secret(
+                workspace_id, session, ws_version=2
+            )
+
+        assert session.platform_secret_version == 3
+        kwargs = resync.await_args.kwargs
+        assert kwargs["workspace_id"] == workspace_id
+        assert kwargs["sandbox_id"] == "sandbox-abc"
+        assert kwargs["db_version"] == 2
+        assert kwargs["applied_generation"] is None
+
+    @pytest.mark.asyncio
+    async def test_provision_falls_back_to_plain_running_when_certify_is_inert(
+        self,
+    ):
+        manager = WorkspaceManager.get_instance(config=_make_config())
+        session = _make_mock_session()
+        session.sandbox.runtime = MagicMock()
+        workspace = _make_workspace()
+        workspace_id = workspace["workspace_id"]
+
+        certify = AsyncMock(return_value=None)
+        status = AsyncMock(return_value=workspace)
+        with (
+            patch.object(manager, "_mint_sandbox_tokens", AsyncMock(return_value={})),
+            patch(
+                "src.server.services.workspace_manager.SessionManager"
+            ) as session_mgr,
+            patch.object(manager, "_apply_session_mcp", AsyncMock(return_value=None)),
+            patch.object(manager, "_sync_sandbox_assets", AsyncMock()),
+            patch(
+                "src.server.services.platform_secret_rollout."
+                "certify_new_workspace_sandbox",
+                certify,
+            ),
+            patch(
+                "src.server.services.workspace_manager.update_workspace_status",
+                status,
+            ),
+        ):
+            session_mgr.get_session.return_value = session
+            result_session, record = await manager._provision_sandbox_session(
+                workspace_id,
+                "user-1",
+                ws_version=None,
+                kick_discovery=False,
+                post_init=AsyncMock(),
+            )
+
+        assert result_session is session
+        assert record is workspace
+        certify.assert_awaited_once()
+        status.assert_awaited_once_with(
+            workspace_id=workspace_id, status="running", sandbox_id="sandbox-abc"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -48,7 +48,7 @@ wheels = [
 
 [[package]]
 name = "aiohttp"
-version = "3.13.5"
+version = "3.14.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohappyeyeballs" },
@@ -57,78 +57,93 @@ dependencies = [
     { name = "frozenlist" },
     { name = "multidict" },
     { name = "propcache" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/9a/152096d4808df8e4268befa55fba462f440f14beab85e8ad9bf990516918/aiohttp-3.13.5.tar.gz", hash = "sha256:9d98cc980ecc96be6eb4c1994ce35d28d8b1f5e5208a23b421187d1209dbb7d1", size = 7858271, upload_time = "2026-03-31T22:01:03.343Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/d9/22ce5786ac0c1653ae8b6c23bded02c1686d11f0dbb45b31ce128e0df985/aiohttp-3.14.3.tar.gz", hash = "sha256:9491196535a88924a60afd5b5f434b5b203b6cc616250878dbdb223a8f7844bc", size = 7971213, upload_time = "2026-07-23T01:57:27.037Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/6f/353954c29e7dcce7cf00280a02c75f30e133c00793c7a2ed3776d7b2f426/aiohttp-3.13.5-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:023ecba036ddd840b0b19bf195bfae970083fd7024ce1ac22e9bba90464620e9", size = 748876, upload_time = "2026-03-31T21:57:36.319Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/1b/428a7c64687b3b2e9cd293186695affc0e1e54a445d0361743b231f11066/aiohttp-3.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15c933ad7920b7d9a20de151efcd05a6e38302cbf0e10c9b2acb9a42210a2416", size = 499557, upload_time = "2026-03-31T21:57:38.236Z" },
-    { url = "https://files.pythonhosted.org/packages/29/47/7be41556bfbb6917069d6a6634bb7dd5e163ba445b783a90d40f5ac7e3a7/aiohttp-3.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab2899f9fa2f9f741896ebb6fa07c4c883bfa5c7f2ddd8cf2aafa86fa981b2d2", size = 500258, upload_time = "2026-03-31T21:57:39.923Z" },
-    { url = "https://files.pythonhosted.org/packages/67/84/c9ecc5828cb0b3695856c07c0a6817a99d51e2473400f705275a2b3d9239/aiohttp-3.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a60eaa2d440cd4707696b52e40ed3e2b0f73f65be07fd0ef23b6b539c9c0b0b4", size = 1749199, upload_time = "2026-03-31T21:57:41.938Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/d3/3c6d610e66b495657622edb6ae7c7fd31b2e9086b4ec50b47897ad6042a9/aiohttp-3.13.5-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:55b3bdd3292283295774ab585160c4004f4f2f203946997f49aac032c84649e9", size = 1721013, upload_time = "2026-03-31T21:57:43.904Z" },
-    { url = "https://files.pythonhosted.org/packages/49/a0/24409c12217456df0bae7babe3b014e460b0b38a8e60753d6cb339f6556d/aiohttp-3.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2b2355dc094e5f7d45a7bb262fe7207aa0460b37a0d87027dcf21b5d890e7d5", size = 1781501, upload_time = "2026-03-31T21:57:46.285Z" },
-    { url = "https://files.pythonhosted.org/packages/98/9d/b65ec649adc5bccc008b0957a9a9c691070aeac4e41cea18559fef49958b/aiohttp-3.13.5-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b38765950832f7d728297689ad78f5f2cf79ff82487131c4d26fe6ceecdc5f8e", size = 1878981, upload_time = "2026-03-31T21:57:48.734Z" },
-    { url = "https://files.pythonhosted.org/packages/57/d8/8d44036d7eb7b6a8ec4c5494ea0c8c8b94fbc0ed3991c1a7adf230df03bf/aiohttp-3.13.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b18f31b80d5a33661e08c89e202edabf1986e9b49c42b4504371daeaa11b47c1", size = 1767934, upload_time = "2026-03-31T21:57:51.171Z" },
-    { url = "https://files.pythonhosted.org/packages/31/04/d3f8211f273356f158e3464e9e45484d3fb8c4ce5eb2f6fe9405c3273983/aiohttp-3.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:33add2463dde55c4f2d9635c6ab33ce154e5ecf322bd26d09af95c5f81cfa286", size = 1566671, upload_time = "2026-03-31T21:57:53.326Z" },
-    { url = "https://files.pythonhosted.org/packages/41/db/073e4ebe00b78e2dfcacff734291651729a62953b48933d765dc513bf798/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:327cc432fdf1356fb4fbc6fe833ad4e9f6aacb71a8acaa5f1855e4b25910e4a9", size = 1705219, upload_time = "2026-03-31T21:57:55.385Z" },
-    { url = "https://files.pythonhosted.org/packages/48/45/7dfba71a2f9fd97b15c95c06819de7eb38113d2cdb6319669195a7d64270/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:7c35b0bf0b48a70b4cb4fc5d7bed9b932532728e124874355de1a0af8ec4bc88", size = 1743049, upload_time = "2026-03-31T21:57:57.341Z" },
-    { url = "https://files.pythonhosted.org/packages/18/71/901db0061e0f717d226386a7f471bb59b19566f2cae5f0d93874b017271f/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:df23d57718f24badef8656c49743e11a89fd6f5358fa8a7b96e728fda2abf7d3", size = 1749557, upload_time = "2026-03-31T21:57:59.626Z" },
-    { url = "https://files.pythonhosted.org/packages/08/d5/41eebd16066e59cd43728fe74bce953d7402f2b4ddfdfef2c0e9f17ca274/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:02e048037a6501a5ec1f6fc9736135aec6eb8a004ce48838cb951c515f32c80b", size = 1558931, upload_time = "2026-03-31T21:58:01.972Z" },
-    { url = "https://files.pythonhosted.org/packages/30/e6/4a799798bf05740e66c3a1161079bda7a3dd8e22ca392481d7a7f9af82a6/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:31cebae8b26f8a615d2b546fee45d5ffb76852ae6450e2a03f42c9102260d6fe", size = 1774125, upload_time = "2026-03-31T21:58:04.007Z" },
-    { url = "https://files.pythonhosted.org/packages/84/63/7749337c90f92bc2cb18f9560d67aa6258c7060d1397d21529b8004fcf6f/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:888e78eb5ca55a615d285c3c09a7a91b42e9dd6fc699b166ebd5dee87c9ccf14", size = 1732427, upload_time = "2026-03-31T21:58:06.337Z" },
-    { url = "https://files.pythonhosted.org/packages/98/de/cf2f44ff98d307e72fb97d5f5bbae3bfcb442f0ea9790c0bf5c5c2331404/aiohttp-3.13.5-cp312-cp312-win32.whl", hash = "sha256:8bd3ec6376e68a41f9f95f5ed170e2fcf22d4eb27a1f8cb361d0508f6e0557f3", size = 433534, upload_time = "2026-03-31T21:58:08.712Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/ca/eadf6f9c8fa5e31d40993e3db153fb5ed0b11008ad5d9de98a95045bed84/aiohttp-3.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:110e448e02c729bcebb18c60b9214a87ba33bac4a9fa5e9a5f139938b56c6cb1", size = 460446, upload_time = "2026-03-31T21:58:10.945Z" },
-    { url = "https://files.pythonhosted.org/packages/78/e9/d76bf503005709e390122d34e15256b88f7008e246c4bdbe915cd4f1adce/aiohttp-3.13.5-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a5029cc80718bbd545123cd8fe5d15025eccaaaace5d0eeec6bd556ad6163d61", size = 742930, upload_time = "2026-03-31T21:58:13.155Z" },
-    { url = "https://files.pythonhosted.org/packages/57/00/4b7b70223deaebd9bb85984d01a764b0d7bd6526fcdc73cca83bcbe7243e/aiohttp-3.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4bb6bf5811620003614076bdc807ef3b5e38244f9d25ca5fe888eaccea2a9832", size = 496927, upload_time = "2026-03-31T21:58:15.073Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/f5/0fb20fb49f8efdcdce6cd8127604ad2c503e754a8f139f5e02b01626523f/aiohttp-3.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a84792f8631bf5a94e52d9cc881c0b824ab42717165a5579c760b830d9392ac9", size = 497141, upload_time = "2026-03-31T21:58:17.009Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/86/b7c870053e36a94e8951b803cb5b909bfbc9b90ca941527f5fcafbf6b0fa/aiohttp-3.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57653eac22c6a4c13eb22ecf4d673d64a12f266e72785ab1c8b8e5940d0e8090", size = 1732476, upload_time = "2026-03-31T21:58:18.925Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/e5/4e161f84f98d80c03a238671b4136e6530453d65262867d989bbe78244d0/aiohttp-3.13.5-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e5e5f7debc7a57af53fdf5c5009f9391d9f4c12867049d509bf7bb164a6e295b", size = 1706507, upload_time = "2026-03-31T21:58:21.094Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/56/ea11a9f01518bd5a2a2fcee869d248c4b8a0cfa0bb13401574fa31adf4d4/aiohttp-3.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c719f65bebcdf6716f10e9eff80d27567f7892d8988c06de12bbbd39307c6e3a", size = 1773465, upload_time = "2026-03-31T21:58:23.159Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/40/333ca27fb74b0383f17c90570c748f7582501507307350a79d9f9f3c6eb1/aiohttp-3.13.5-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d97f93fdae594d886c5a866636397e2bcab146fd7a132fd6bb9ce182224452f8", size = 1873523, upload_time = "2026-03-31T21:58:25.59Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/d2/e2f77eef1acb7111405433c707dc735e63f67a56e176e72e9e7a2cd3f493/aiohttp-3.13.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3df334e39d4c2f899a914f1dba283c1aadc311790733f705182998c6f7cae665", size = 1754113, upload_time = "2026-03-31T21:58:27.624Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/56/3f653d7f53c89669301ec9e42c95233e2a0c0a6dd051269e6e678db4fdb0/aiohttp-3.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fe6970addfea9e5e081401bcbadf865d2b6da045472f58af08427e108d618540", size = 1562351, upload_time = "2026-03-31T21:58:29.918Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/a6/9b3e91eb8ae791cce4ee736da02211c85c6f835f1bdfac0594a8a3b7018c/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7becdf835feff2f4f335d7477f121af787e3504b48b449ff737afb35869ba7bb", size = 1693205, upload_time = "2026-03-31T21:58:32.214Z" },
-    { url = "https://files.pythonhosted.org/packages/98/fc/bfb437a99a2fcebd6b6eaec609571954de2ed424f01c352f4b5504371dd3/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:676e5651705ad5d8a70aeb8eb6936c436d8ebbd56e63436cb7dd9bb36d2a9a46", size = 1730618, upload_time = "2026-03-31T21:58:34.728Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/b6/c8534862126191a034f68153194c389addc285a0f1347d85096d349bbc15/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:9b16c653d38eb1a611cc898c41e76859ca27f119d25b53c12875fd0474ae31a8", size = 1745185, upload_time = "2026-03-31T21:58:36.909Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/93/4ca8ee2ef5236e2707e0fd5fecb10ce214aee1ff4ab307af9c558bda3b37/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:999802d5fa0389f58decd24b537c54aa63c01c3219ce17d1214cbda3c2b22d2d", size = 1557311, upload_time = "2026-03-31T21:58:39.38Z" },
-    { url = "https://files.pythonhosted.org/packages/57/ae/76177b15f18c5f5d094f19901d284025db28eccc5ae374d1d254181d33f4/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:ec707059ee75732b1ba130ed5f9580fe10ff75180c812bc267ded039db5128c6", size = 1773147, upload_time = "2026-03-31T21:58:41.476Z" },
-    { url = "https://files.pythonhosted.org/packages/01/a4/62f05a0a98d88af59d93b7fcac564e5f18f513cb7471696ac286db970d6a/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2d6d44a5b48132053c2f6cd5c8cb14bc67e99a63594e336b0f2af81e94d5530c", size = 1730356, upload_time = "2026-03-31T21:58:44.049Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/85/fc8601f59dfa8c9523808281f2da571f8b4699685f9809a228adcc90838d/aiohttp-3.13.5-cp313-cp313-win32.whl", hash = "sha256:329f292ed14d38a6c4c435e465f48bebb47479fd676a0411936cc371643225cc", size = 432637, upload_time = "2026-03-31T21:58:46.167Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/1b/ac685a8882896acf0f6b31d689e3792199cfe7aba37969fa91da63a7fa27/aiohttp-3.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:69f571de7500e0557801c0b51f4780482c0ec5fe2ac851af5a92cfce1af1cb83", size = 458896, upload_time = "2026-03-31T21:58:48.119Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/ce/46572759afc859e867a5bc8ec3487315869013f59281ce61764f76d879de/aiohttp-3.13.5-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:eb4639f32fd4a9904ab8fb45bf3383ba71137f3d9d4ba25b3b3f3109977c5b8c", size = 745721, upload_time = "2026-03-31T21:58:50.229Z" },
-    { url = "https://files.pythonhosted.org/packages/13/fe/8a2efd7626dbe6049b2ef8ace18ffda8a4dfcbe1bcff3ac30c0c7575c20b/aiohttp-3.13.5-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:7e5dc4311bd5ac493886c63cbf76ab579dbe4641268e7c74e48e774c74b6f2be", size = 497663, upload_time = "2026-03-31T21:58:52.232Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/91/cc8cc78a111826c54743d88651e1687008133c37e5ee615fee9b57990fac/aiohttp-3.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:756c3c304d394977519824449600adaf2be0ccee76d206ee339c5e76b70ded25", size = 499094, upload_time = "2026-03-31T21:58:54.566Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/33/a8362cb15cf16a3af7e86ed11962d5cd7d59b449202dc576cdc731310bde/aiohttp-3.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecc26751323224cf8186efcf7fbcbc30f4e1d8c7970659daf25ad995e4032a56", size = 1726701, upload_time = "2026-03-31T21:58:56.864Z" },
-    { url = "https://files.pythonhosted.org/packages/45/0c/c091ac5c3a17114bd76cbf85d674650969ddf93387876cf67f754204bd77/aiohttp-3.13.5-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:10a75acfcf794edf9d8db50e5a7ec5fc818b2a8d3f591ce93bc7b1210df016d2", size = 1683360, upload_time = "2026-03-31T21:58:59.072Z" },
-    { url = "https://files.pythonhosted.org/packages/23/73/bcee1c2b79bc275e964d1446c55c54441a461938e70267c86afaae6fba27/aiohttp-3.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0f7a18f258d124cd678c5fe072fe4432a4d5232b0657fca7c1847f599233c83a", size = 1773023, upload_time = "2026-03-31T21:59:01.776Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/ef/720e639df03004fee2d869f771799d8c23046dec47d5b81e396c7cda583a/aiohttp-3.13.5-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:df6104c009713d3a89621096f3e3e88cc323fd269dbd7c20afe18535094320be", size = 1853795, upload_time = "2026-03-31T21:59:04.568Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/c9/989f4034fb46841208de7aeeac2c6d8300745ab4f28c42f629ba77c2d916/aiohttp-3.13.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:241a94f7de7c0c3b616627aaad530fe2cb620084a8b144d3be7b6ecfe95bae3b", size = 1730405, upload_time = "2026-03-31T21:59:07.221Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/75/ee1fd286ca7dc599d824b5651dad7b3be7ff8d9a7e7b3fe9820d9180f7db/aiohttp-3.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c974fb66180e58709b6fc402846f13791240d180b74de81d23913abe48e96d94", size = 1558082, upload_time = "2026-03-31T21:59:09.484Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/20/1e9e6650dfc436340116b7aa89ff8cb2bbdf0abc11dfaceaad8f74273a10/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:6e27ea05d184afac78aabbac667450c75e54e35f62238d44463131bd3f96753d", size = 1692346, upload_time = "2026-03-31T21:59:12.068Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/40/8ebc6658d48ea630ac7903912fe0dd4e262f0e16825aa4c833c56c9f1f56/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a79a6d399cef33a11b6f004c67bb07741d91f2be01b8d712d52c75711b1e07c7", size = 1698891, upload_time = "2026-03-31T21:59:14.552Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/78/ea0ae5ec8ba7a5c10bdd6e318f1ba5e76fcde17db8275188772afc7917a4/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c632ce9c0b534fbe25b52c974515ed674937c5b99f549a92127c85f771a78772", size = 1742113, upload_time = "2026-03-31T21:59:17.068Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/66/9d308ed71e3f2491be1acb8769d96c6f0c47d92099f3bc9119cada27b357/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:fceedde51fbd67ee2bcc8c0b33d0126cc8b51ef3bbde2f86662bd6d5a6f10ec5", size = 1553088, upload_time = "2026-03-31T21:59:19.541Z" },
-    { url = "https://files.pythonhosted.org/packages/da/a6/6cc25ed8dfc6e00c90f5c6d126a98e2cf28957ad06fa1036bd34b6f24a2c/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:f92995dfec9420bb69ae629abf422e516923ba79ba4403bc750d94fb4a6c68c1", size = 1757976, upload_time = "2026-03-31T21:59:22.311Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/2b/cce5b0ffe0de99c83e5e36d8f828e4161e415660a9f3e58339d07cce3006/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:20ae0ff08b1f2c8788d6fb85afcb798654ae6ba0b747575f8562de738078457b", size = 1712444, upload_time = "2026-03-31T21:59:24.635Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/cf/9e1795b4160c58d29421eafd1a69c6ce351e2f7c8d3c6b7e4ca44aea1a5b/aiohttp-3.13.5-cp314-cp314-win32.whl", hash = "sha256:b20df693de16f42b2472a9c485e1c948ee55524786a0a34345511afdd22246f3", size = 438128, upload_time = "2026-03-31T21:59:27.291Z" },
-    { url = "https://files.pythonhosted.org/packages/22/4d/eaedff67fc805aeba4ba746aec891b4b24cebb1a7d078084b6300f79d063/aiohttp-3.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:f85c6f327bf0b8c29da7d93b1cabb6363fb5e4e160a32fa241ed2dce21b73162", size = 464029, upload_time = "2026-03-31T21:59:29.429Z" },
-    { url = "https://files.pythonhosted.org/packages/79/11/c27d9332ee20d68dd164dc12a6ecdef2e2e35ecc97ed6cf0d2442844624b/aiohttp-3.13.5-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:1efb06900858bb618ff5cee184ae2de5828896c448403d51fb633f09e109be0a", size = 778758, upload_time = "2026-03-31T21:59:31.547Z" },
-    { url = "https://files.pythonhosted.org/packages/04/fb/377aead2e0a3ba5f09b7624f702a964bdf4f08b5b6728a9799830c80041e/aiohttp-3.13.5-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:fee86b7c4bd29bdaf0d53d14739b08a106fdda809ca5fe032a15f52fae5fe254", size = 512883, upload_time = "2026-03-31T21:59:34.098Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/a6/aa109a33671f7a5d3bd78b46da9d852797c5e665bfda7d6b373f56bff2ec/aiohttp-3.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:20058e23909b9e65f9da62b396b77dfa95965cbe840f8def6e572538b1d32e36", size = 516668, upload_time = "2026-03-31T21:59:36.497Z" },
-    { url = "https://files.pythonhosted.org/packages/79/b3/ca078f9f2fa9563c36fb8ef89053ea2bb146d6f792c5104574d49d8acb63/aiohttp-3.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cf20a8d6868cb15a73cab329ffc07291ba8c22b1b88176026106ae39aa6df0f", size = 1883461, upload_time = "2026-03-31T21:59:38.723Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/e3/a7ad633ca1ca497b852233a3cce6906a56c3225fb6d9217b5e5e60b7419d/aiohttp-3.13.5-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:330f5da04c987f1d5bdb8ae189137c77139f36bd1cb23779ca1a354a4b027800", size = 1747661, upload_time = "2026-03-31T21:59:41.187Z" },
-    { url = "https://files.pythonhosted.org/packages/33/b9/cd6fe579bed34a906d3d783fe60f2fa297ef55b27bb4538438ee49d4dc41/aiohttp-3.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f1cbf0c7926d315c3c26c2da41fd2b5d2fe01ac0e157b78caefc51a782196cf", size = 1863800, upload_time = "2026-03-31T21:59:43.84Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/3f/2c1e2f5144cefa889c8afd5cf431994c32f3b29da9961698ff4e3811b79a/aiohttp-3.13.5-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:53fc049ed6390d05423ba33103ded7281fe897cf97878f369a527070bd95795b", size = 1958382, upload_time = "2026-03-31T21:59:46.187Z" },
-    { url = "https://files.pythonhosted.org/packages/66/1d/f31ec3f1013723b3babe3609e7f119c2c2fb6ef33da90061a705ef3e1bc8/aiohttp-3.13.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:898703aa2667e3c5ca4c54ca36cd73f58b7a38ef87a5606414799ebce4d3fd3a", size = 1803724, upload_time = "2026-03-31T21:59:48.656Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/b4/57712dfc6f1542f067daa81eb61da282fab3e6f1966fca25db06c4fc62d5/aiohttp-3.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0494a01ca9584eea1e5fbd6d748e61ecff218c51b576ee1999c23db7066417d8", size = 1640027, upload_time = "2026-03-31T21:59:51.284Z" },
-    { url = "https://files.pythonhosted.org/packages/25/3c/734c878fb43ec083d8e31bf029daae1beafeae582d1b35da234739e82ee7/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6cf81fe010b8c17b09495cbd15c1d35afbc8fb405c0c9cf4738e5ae3af1d65be", size = 1806644, upload_time = "2026-03-31T21:59:53.753Z" },
-    { url = "https://files.pythonhosted.org/packages/20/a5/f671e5cbec1c21d044ff3078223f949748f3a7f86b14e34a365d74a5d21f/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:c564dd5f09ddc9d8f2c2d0a301cd30a79a2cc1b46dd1a73bef8f0038863d016b", size = 1791630, upload_time = "2026-03-31T21:59:56.239Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/63/fb8d0ad63a0b8a99be97deac8c04dacf0785721c158bdf23d679a87aa99e/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2994be9f6e51046c4f864598fd9abeb4fba6e88f0b2152422c9666dcd4aea9c6", size = 1809403, upload_time = "2026-03-31T21:59:59.103Z" },
-    { url = "https://files.pythonhosted.org/packages/59/0c/bfed7f30662fcf12206481c2aac57dedee43fe1c49275e85b3a1e1742294/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:157826e2fa245d2ef46c83ea8a5faf77ca19355d278d425c29fda0beb3318037", size = 1634924, upload_time = "2026-03-31T22:00:02.116Z" },
-    { url = "https://files.pythonhosted.org/packages/17/d6/fd518d668a09fd5a3319ae5e984d4d80b9a4b3df4e21c52f02251ef5a32e/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:a8aca50daa9493e9e13c0f566201a9006f080e7c50e5e90d0b06f53146a54500", size = 1836119, upload_time = "2026-03-31T22:00:04.756Z" },
-    { url = "https://files.pythonhosted.org/packages/78/b7/15fb7a9d52e112a25b621c67b69c167805cb1f2ab8f1708a5c490d1b52fe/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3b13560160d07e047a93f23aaa30718606493036253d5430887514715b67c9d9", size = 1772072, upload_time = "2026-03-31T22:00:07.494Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/df/57ba7f0c4a553fc2bd8b6321df236870ec6fd64a2a473a8a13d4f733214e/aiohttp-3.13.5-cp314-cp314t-win32.whl", hash = "sha256:9a0f4474b6ea6818b41f82172d799e4b3d29e22c2c520ce4357856fced9af2f8", size = 471819, upload_time = "2026-03-31T22:00:10.277Z" },
-    { url = "https://files.pythonhosted.org/packages/62/29/2f8418269e46454a26171bfdd6a055d74febf32234e474930f2f60a17145/aiohttp-3.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:18a2f6c1182c51baa1d28d68fea51513cb2a76612f038853c0ad3c145423d3d9", size = 505441, upload_time = "2026-03-31T22:00:12.791Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d4/eb96299230e20acf2efae207cb8d69051f1f68e357e5ea5e479bf6fb097a/aiohttp-3.14.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:39aded8c7f3b935b54aab1d8d73c70ec0ee2d3ec3b943e0e86611bc150ba47f5", size = 754690, upload_time = "2026-07-23T01:53:47.332Z" },
+    { url = "https://files.pythonhosted.org/packages/88/11/e7a70a209eb9a067c0d3212b518a0134e3484f5178c7533878b6b514d469/aiohttp-3.14.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5bcb6ff3fdab1258a192679ff1a05d44f59626430aa05cd1a9d2447423599228", size = 509484, upload_time = "2026-07-23T01:53:51.159Z" },
+    { url = "https://files.pythonhosted.org/packages/30/07/4bbc222cc8dbe31d4c3e8a5baad2286e4d42026ac0c570027b89afce6344/aiohttp-3.14.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:617105e2c3018ee38d0c8ce5ee3c84f621a6d8b9f723202aacaff28449ca91ee", size = 511949, upload_time = "2026-07-23T01:53:55.083Z" },
+    { url = "https://files.pythonhosted.org/packages/54/b9/42e74c46b7b7c794b995bbc1f573fb48950c38b19d8600c62a6804ee2d67/aiohttp-3.14.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f631fe87a6f30df5fbe6d79640b25e4cffb38c31c7fb6f10871517b84b0f8c1a", size = 1765282, upload_time = "2026-07-23T01:53:59.662Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ed/62bc4d74363ad346d518e0720363a949f63e2e23439a79eb5813d4d29bb3/aiohttp-3.14.3-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a94dbaae5ae27bd849c93570669bff91e0510f33a80805738e3de72a7be0447b", size = 1741511, upload_time = "2026-07-23T01:54:04.063Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9f/181e8a8bc79e47d13c7fc4540bd7a3b729d9505609c61f392a8dd2fbfe55/aiohttp-3.14.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8f2f1c4c032c7cedd7d8da6f54c97b70266c6570c3108d3fdffee7188bb70529", size = 1810680, upload_time = "2026-07-23T01:54:09.882Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/9a/dec94d6ad694552fe3424e3f1928d7a606a5d9d9433a04e7ecdd9d38ae7f/aiohttp-3.14.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ea05e1f97ceea523942d9b2a7d7c0359d781d683d6b043f5943a602b14da4787", size = 1905646, upload_time = "2026-07-23T01:54:13.475Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b7/7cd31f29d6055bd711ae6e669367fba6f5ae9de463910a793e30556a8db7/aiohttp-3.14.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:543906c127fb1d929b95076db19b83fa2d46751006ff1e23b093aa5ac4d8db42", size = 1792122, upload_time = "2026-07-23T01:54:15.752Z" },
+    { url = "https://files.pythonhosted.org/packages/66/73/10b1ef93afa61f4963c746257b70ced619cf31a4798671de5fdb2608501d/aiohttp-3.14.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0a5ff2dfbb9ce645fa5b8ef3e02c6c0b9cc3f6030ff863d0c51fffc50cb5541b", size = 1591127, upload_time = "2026-07-23T01:54:19.489Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ed/3b203fa6de1b338c14acdc06bf6ca9b043b7944f005966958c2ced932cde/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:041badb8f84396357c4d3ad26de6afd7a32b112f43d3c63045c0c8278cfd2043", size = 1725210, upload_time = "2026-07-23T01:54:24.129Z" },
+    { url = "https://files.pythonhosted.org/packages/28/b7/1c2aab8c706436dcc28598452488ac9cd7c409da815237c28c27d58993e6/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:530125ee1163c4219af35dc3aa1206e541e7b31b6efc1a3f93b70a136f65d427", size = 1764848, upload_time = "2026-07-23T01:54:27.973Z" },
+    { url = "https://files.pythonhosted.org/packages/54/50/94c28f08b131c4bf10984ea2c7a536c9920608bb2d6e7f95642c30cc87b7/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c8653fd547c93a61aadc612007790f5555cdd18946fa48cf45e26d8ea4ea473d", size = 1777102, upload_time = "2026-07-23T01:54:31.775Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d4/e7d09ba7d345fb2d74440fd2fa033c5e079fac05552927705986f41a364f/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:89176250f686cb9853c0fb7ead90e639e915b84a6f43eedc2a4e7ec21f1037f0", size = 1580205, upload_time = "2026-07-23T01:54:34.518Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/84/072a91d68e1e1eb587985b54baab94221277f877e8ef274fc213a0ceae28/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:3a26434dafe408229ff3403458ca58de24fb51936504decac49ce6755f77e59d", size = 1797219, upload_time = "2026-07-23T01:54:36.995Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/eb/aad34e897e668424d6e995da5dff8a4a09af93363d3392488772957a63aa/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d1558173930a5a8d3069cee5c92fc91c87c4dbcb099debbb3622053717145a19", size = 1768629, upload_time = "2026-07-23T01:54:40.103Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/2b/6bb88ddba0fecd9122aa3ebcad25996cf6c083a4a7040dbb3a4f97972af6/aiohttp-3.14.3-cp312-cp312-win32.whl", hash = "sha256:16100ad3ab8d649fdfbee87602d9d2dcdca9df0b9eda8a1b5fdc0d41f96da559", size = 451481, upload_time = "2026-07-23T01:54:42.547Z" },
+    { url = "https://files.pythonhosted.org/packages/76/9b/f2f8f108da17ecef2cc3efc424e8b7ad3782b1a8360f7b8eae8ced84f6ea/aiohttp-3.14.3-cp312-cp312-win_amd64.whl", hash = "sha256:33a2d7c28d33797a2e99923dffa63f83d908a19b6bf26cfe80fa790aa5e1a75a", size = 476845, upload_time = "2026-07-23T01:54:44.853Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/44/28dac80a8941b604f4da10ce21097614ca1bf905ce93dca28d8d7de9c1e7/aiohttp-3.14.3-cp312-cp312-win_arm64.whl", hash = "sha256:362a3fd481769cac1a824514bcd86fda51c65e8fe6e051099e008fddde6db17c", size = 448050, upload_time = "2026-07-23T01:54:47.087Z" },
+    { url = "https://files.pythonhosted.org/packages/57/be/5afd201cc0ab139029aadb75392efe85a293403d9dd3a3226161c21ce00c/aiohttp-3.14.3-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:2e9878ae68e4a5f1c0abe4dd497dbc3d51946f5837b56759e2a02e78fa90ef86", size = 506269, upload_time = "2026-07-23T01:54:49.075Z" },
+    { url = "https://files.pythonhosted.org/packages/22/09/dec8189d62b45ade009f6792a2264b942a90cb88aeaf181239933cd72c3c/aiohttp-3.14.3-cp313-cp313-android_21_x86_64.whl", hash = "sha256:f3d2669fe7dec7fc359ecdb5984b29b50d85d5d00f8c1cb61de4f4a24ee42627", size = 515166, upload_time = "2026-07-23T01:54:51.894Z" },
+    { url = "https://files.pythonhosted.org/packages/28/24/2854869d29ed8a8b19d74f9ec6629515f7e04d02dd329d9d179201e58e47/aiohttp-3.14.3-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:cc7cb243a68167172f48c1fd43cee91ec4b1d40cefd190edd43369d1a6bc9c82", size = 486263, upload_time = "2026-07-23T01:54:54.223Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/dd/57187c8be2a35aea65eaee3bd2c3dcbbcf0204f5106c89637e3610380cd1/aiohttp-3.14.3-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:78253b573e6ffab5028924fc98bc281aae05445969982a10864bc360dea2016c", size = 492299, upload_time = "2026-07-23T01:54:56.236Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/11/06ae6ed8f0d414edf4068861e233d8fe23ee699bfd4b3ceb8663db948a62/aiohttp-3.14.3-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:7041d52c3a7fa20c9e8c182b534704abb19502c8bdcbde7ab23bfda6f642394f", size = 502235, upload_time = "2026-07-23T01:54:58.377Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/a3/559639c34a345d2cf7c52dff6838119f2eaf29eb508227b5b83f573af813/aiohttp-3.14.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ac74facc01463f138b0da5580329cfcc82818dea5656e83ddcd11268fc12ff80", size = 750883, upload_time = "2026-07-23T01:55:00.65Z" },
+    { url = "https://files.pythonhosted.org/packages/91/cd/41e131f13afd1e7b0172a9d9eda085ef90eb8439f41f0d279db81ed3ae60/aiohttp-3.14.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d6218d92e450824e9b4881f44e8c09f1853b490f9a64130801024a4793b1b3b0", size = 508473, upload_time = "2026-07-23T01:55:02.945Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/6b/e7f13410d391c6e55b4c007a8de024355389d7d459e3d64c42b2d33617e5/aiohttp-3.14.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:11fb37ef075669eee52ab1928fbf6e1741fada40409fa309ebde9607a962aebf", size = 509190, upload_time = "2026-07-23T01:55:05.173Z" },
+    { url = "https://files.pythonhosted.org/packages/97/21/6464573e53d69672cc1eada3e5c5cb2d2efa82701e8305a0f2047a576967/aiohttp-3.14.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55bdcc472aafe2de4a253045cc128007a64f1e0264fb675791e132ea5edaa3bd", size = 1761478, upload_time = "2026-07-23T01:55:07.383Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/81/d217043a4c17fbce360905e3b2bdd20139ebc9a2de836d035d179c4da006/aiohttp-3.14.3-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c39846c3aad97a8530c89d7a3869a8f8e9e3762c6ac0504481e5c80948f7e807", size = 1735092, upload_time = "2026-07-23T01:55:09.803Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/66/e13a02d0eeb1a9a502402a977abb4e4abff9fe4051c26f80558c57a7c975/aiohttp-3.14.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5895ef58c4620afe02fa16044f023dc4dafec08158f9d08874a46a7dbc0341b8", size = 1800546, upload_time = "2026-07-23T01:55:12.012Z" },
+    { url = "https://files.pythonhosted.org/packages/26/5e/57d42fca1d18cb5acc1cad945d017fabc5d6ae71d8a08ad66be8dc3ee544/aiohttp-3.14.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa9467a8113aa69d3d7c55a70ef0b7c636010a40993f3df9d9d0d73b3eb7ef24", size = 1895250, upload_time = "2026-07-23T01:55:14.357Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/1c/7da8d08e74d56f00070822f9638ff3f1c563f8ad87d1efa996c87bfc8644/aiohttp-3.14.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d7d2deec16eeedf55f2c7cf75b521ea3856a5177e123844f8fd0f114ce252cb5", size = 1789289, upload_time = "2026-07-23T01:55:16.668Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/0f/cf16bcf56896981c1a0319f5d5db9337994b5165730c48a8fa07e9b34be6/aiohttp-3.14.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dd54d0e8717de95939766febac482ac0474d8ac3b048115f9f2b1d23a16e7db4", size = 1586706, upload_time = "2026-07-23T01:55:18.913Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/6f/76eac12a7f2480e1e304f842efdb07db33256b0d9165b866b6ef0806c202/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:df82f3787c940c94986b34222d59c9e38843fba85139f36e85255a82ad5355a9", size = 1724652, upload_time = "2026-07-23T01:55:21.296Z" },
+    { url = "https://files.pythonhosted.org/packages/39/b6/19c8c592baeeb94b75f966547d40c02ac7590902306ec5863d5c027cf506/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:42a67efc36300d052fb4508a53e8b6901b9284b599ae63945c377569c5fcc1e1", size = 1756239, upload_time = "2026-07-23T01:55:23.705Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c9/4e9383150296f97f873b680c4de8fb2cd88608fb9f48c79edcb111611abc/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7a75aa63cbf9b21cfaf60dc2657e19df2c2867d91707d653fee171ffeedd1371", size = 1769161, upload_time = "2026-07-23T01:55:26.082Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1e/147bdc6cc5de5f3ab011be8bf5d6e786633249f22c20bae06f85e45f5387/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:e92eb8acc45eb6a9f4935071a77edf5b85cc6f8dfad5cd99e97653c26593cdde", size = 1578759, upload_time = "2026-07-23T01:55:28.846Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/31/78388a9d6040ece2e11df62ea229a822cf5e52d238374b220ae9975b2623/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:b014a6ed7cf912e787149fdc529166d3ceabac23f26efeea3158c9aba2354e7e", size = 1792025, upload_time = "2026-07-23T01:55:31.457Z" },
+    { url = "https://files.pythonhosted.org/packages/03/51/a3d29fdf2c25d796746af8ad6fe56a45d6256c38b0a8a2ed752e1160b3a2/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3d4f72af88ac2474bb5bca640030320e3d38a0163a1d7533500e87be458eef71", size = 1768477, upload_time = "2026-07-23T01:55:33.87Z" },
+    { url = "https://files.pythonhosted.org/packages/29/a6/442e18b5afeade534d877a2dc3c3e392aff8d49787890b0cf84790410267/aiohttp-3.14.3-cp313-cp313-win32.whl", hash = "sha256:5f08ec777f35ee70720233b8b9811d3bb5d728137f30ac91b7457709c3261ac0", size = 451069, upload_time = "2026-07-23T01:55:36.121Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/69/3d876ac02659f271cf7f6769f14a8e3de5b6e888ed8b5a7e998086a4cec8/aiohttp-3.14.3-cp313-cp313-win_amd64.whl", hash = "sha256:dff9461ec275f22135650d5ba4b4931a11f3958df7dfbb8db630000d4dee0883", size = 476518, upload_time = "2026-07-23T01:55:38.303Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/0e/50d6e6471cd31edce8b282bdec59375a3a69124d8a989a0b1313355cae52/aiohttp-3.14.3-cp313-cp313-win_arm64.whl", hash = "sha256:ddcac3c6b382e81f1dd0499199d4136b877beb4cb5ef770bbbfba56c4b8f55d2", size = 447676, upload_time = "2026-07-23T01:55:40.451Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/20/887fdcf832326571b370ffc347b3e70abe101096f3720126aac161b1d872/aiohttp-3.14.3-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:49f7325beb0f85ef4aef5f48f490269575f83e6e2acad00a1d80b807eb027062", size = 509067, upload_time = "2026-07-23T01:55:42.618Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/a3/92cec936f78cc4bf0fa5554ebe593b73459d94e3c62303e1902a4cccb6f7/aiohttp-3.14.3-cp314-cp314-android_24_x86_64.whl", hash = "sha256:e3be98a7c30b8c25d573dafba7171d66dfb05ee6a9070fc46535464ff97700a6", size = 514774, upload_time = "2026-07-23T01:55:44.937Z" },
+    { url = "https://files.pythonhosted.org/packages/29/ba/2a0c38df3fc557620b6a5acd98364af050053b6285b4dc7ee74100c63c18/aiohttp-3.14.3-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:614c61d478b83953e261d02bb2df750f17227cd33ef8002945bf5aebbde21919", size = 488134, upload_time = "2026-07-23T01:55:47.135Z" },
+    { url = "https://files.pythonhosted.org/packages/48/d6/d51b7d4bf309af3693940d8ffd2b9ed0b682434ef85959b7c9c137f60cf8/aiohttp-3.14.3-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:1caa7b0d05f3e3a36f87788c59e970a7ee1cefcfcbb924a9f138c4a6551c9cb7", size = 494201, upload_time = "2026-07-23T01:55:49.451Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/5a/8f624384e5f1efabb5229b94157eb966b021e97bdb188c62860c2ae243c2/aiohttp-3.14.3-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:dfa68deb2a443bdaa3ea5297b0699c1464f08aef3812b486d1348eee61b07dc0", size = 502766, upload_time = "2026-07-23T01:55:51.656Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/26/4ff0164370deec18fb19254ee4ab10b7a73304ac0c860b13f5f84663759b/aiohttp-3.14.3-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:e72ee89e28d907a18f46959b4eb0bb06701cc7f8cf4366e00029e2ccfaaf5924", size = 756557, upload_time = "2026-07-23T01:55:53.964Z" },
+    { url = "https://files.pythonhosted.org/packages/97/a3/7056b86dc0d9ec709ea9777eae3b0161428f943372f8b98c01c11593b682/aiohttp-3.14.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ad4c8b7488d745d2ca4838ebd8ae5ba9b56341d30b1da43640e4ce87f9f49646", size = 510168, upload_time = "2026-07-23T01:55:56.22Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ed/0357a015892fd68058bf2d39d3fd1958e459b997a7db30aaa6aaa434ae96/aiohttp-3.14.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:db332af25642007330fca8be5c4d194caf2bea7a7fc84415aff3497af5dfee6b", size = 512957, upload_time = "2026-07-23T01:55:58.437Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d1/8aba53f15ccb2238405f5e9d30e2a8ca44f93878c26e7165ade00d374b1c/aiohttp-3.14.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:25bd2708db6bdf6a6630dd37bdcdfcb47c4434d22ac69c64665b802910140b30", size = 1750149, upload_time = "2026-07-23T01:56:00.856Z" },
+    { url = "https://files.pythonhosted.org/packages/49/bd/40c3fee327529284375c6701cbb0fa4600cc2e8432af1378f897e2ef7d3a/aiohttp-3.14.3-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:cef89a58e628c4efcac3275c2d68083f82426dcdc89c1492a6f654f9f7ea6ab9", size = 1707685, upload_time = "2026-07-23T01:56:03.371Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/a3/ca0cc6724cca8114b05694abd916060758c79894c3aa5b012cdadc1bc28e/aiohttp-3.14.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c23ec8ee9d5ab2f5421f9c7fffce208435607af27fd46d4a44e031954352838f", size = 1803911, upload_time = "2026-07-23T01:56:05.817Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b5/85b099c299c3ffd38ad9b3e43694c8a346934e4a30c88c4fd5a841234f77/aiohttp-3.14.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e2667f0bbe7eb6c74eae5e9691441ad186e5845ca3cff63230fc09c4e7514f5d", size = 1876929, upload_time = "2026-07-23T01:56:08.413Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/b7/1da684a04175473fa4cddbf9a2f572e79514c3fd27a74597f43057d4f3da/aiohttp-3.14.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:18cb43369747b2ae007bd2655fb8e63a099c2ff1d207962943636dac989b3147", size = 1761112, upload_time = "2026-07-23T01:56:10.918Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/16/bc4b55e3e5cb175fd69c53c90d60d2f47797cb343da5106e23863dc4dba4/aiohttp-3.14.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d77640cc618c1d99fc4f8589c0f24a730adfa54eb1e57ef7bf0c8dfb78da898c", size = 1583500, upload_time = "2026-07-23T01:56:13.613Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/e8/13a9d957a1ee40837f46aa30f0f4c657e673ad86a2e6362a9f9be20d26d9/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:53e5179d8abb5710f8e83ba207c41c8d1261fcffd4616500e15ca2b7a33be10a", size = 1713940, upload_time = "2026-07-23T01:56:15.969Z" },
+    { url = "https://files.pythonhosted.org/packages/38/05/d33c680c1bcf1c7e130f9cbfc1fc02fe8bb0c4af2a94a53dd5fb56131e5c/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:cd817772b2fcf2b8c0905795318485f9ec16eae60b29feb7f4c77085311637f0", size = 1724413, upload_time = "2026-07-23T01:56:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/85/1d/af798d306f7a74b6a632dbcabcf62a4c91391b7582d2a8c6d7712e2cc54e/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:4e3ac92d90e92773b2362d506068e9a948192bd553e743c5b2429e28527c8661", size = 1770748, upload_time = "2026-07-23T01:56:21.074Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/92/ad720d472556a995049206867765e9410969684f86ee09423ff9969044c1/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:3f42e9b78301f11c8f861746175d8b9c1ccef713fcad9eab396e2f6db8ed4a22", size = 1577564, upload_time = "2026-07-23T01:56:23.475Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ad/0ed7586cbef7a884e23a752fa2bb987a122e6a5dd50dab109258d0a95193/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:9d9edccfe496b476db5f398d97b865e9a6752bcf8aec4eef8390ce20fb64bb41", size = 1782080, upload_time = "2026-07-23T01:56:25.994Z" },
+    { url = "https://files.pythonhosted.org/packages/97/ea/dbaed0d73e8a69aad653b045dab451c67c2454bb731a37b45a86593e9422/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1c5ec8fb1bcc31a8466f74aaf26c345d5c386fa4bd08a3f0eb9c7a4a3fe8b5bf", size = 1745813, upload_time = "2026-07-23T01:56:28.604Z" },
+    { url = "https://files.pythonhosted.org/packages/81/1b/6893d4bc57e434fc93a6c9217c637d967a0b651d989f6e3265179375754a/aiohttp-3.14.3-cp314-cp314-win32.whl", hash = "sha256:38901a84da3ce22249f6e860bf8f90d141bcab7da090cc398f8bb58c0e44b7da", size = 455872, upload_time = "2026-07-23T01:56:31.031Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/8b/c7baa1ba1eda4db6989baefe5de6d99834921b84ebd7918624febcb9f290/aiohttp-3.14.3-cp314-cp314-win_amd64.whl", hash = "sha256:8b3b60de05f3dcb6f6a00f818bb2ec781cee4de0645f59ccaf99b1d1823b6100", size = 481030, upload_time = "2026-07-23T01:56:33.365Z" },
+    { url = "https://files.pythonhosted.org/packages/22/8c/c29d067df825a2df88ca432db848aa2fe8199598359cc06c12b09320cac9/aiohttp-3.14.3-cp314-cp314-win_arm64.whl", hash = "sha256:1576145bdceeb92382d899751e12743a3a5b8e460a841e3e50543859e54864dc", size = 453669, upload_time = "2026-07-23T01:56:35.731Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/a4/9c033beb355d39b6147980597ec9645e4729243f686ee4dc73945de72030/aiohttp-3.14.3-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:8800c996b01c2772a783e3e46f3e1abd5823029adca0df54231960de9bfefa5b", size = 791403, upload_time = "2026-07-23T01:56:37.972Z" },
+    { url = "https://files.pythonhosted.org/packages/80/ca/87c32a0a7704583cfc49660bd817889bae5b830bf53b5dcb4e92145ac2da/aiohttp-3.14.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:ebe8e504f058fe91223351cecd2d9d6946c9d241bb0250d898ffbdf584cc72b0", size = 526413, upload_time = "2026-07-23T01:56:40.523Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d8/8ec0e471248c500acdce2be3f46db8fb62b5eb60efef072529cc85ee1d26/aiohttp-3.14.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:30402d03a7c0ff52bce290b57e564e9079fd9d0cb545c8aba73f86a103162d2e", size = 532135, upload_time = "2026-07-23T01:56:42.876Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/45/f8919fd936e8b79fcd9bda7b6d8e62613462a713f4f17987fd7c34399142/aiohttp-3.14.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9fc7b5bfec6573f3ae844f457fdde5adeb713f8b8e4a81ad64fc207b49383716", size = 1922742, upload_time = "2026-07-23T01:56:45.528Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/ec/9ca76b28a27525b0cc53e20842e0228b022f301ce1f436b7d814b4aaf2df/aiohttp-3.14.3-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:8a5fd34f7f7410d1730d5c2ba873cacb2eed3fede366feb268a70ba22581ed8f", size = 1787371, upload_time = "2026-07-23T01:56:48.045Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/04/6acdbf17315f7b55f1937e3387acb89a3cddeb4995689553d064af8e92ab/aiohttp-3.14.3-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:270d3dace9ca2f10f0da5d8ebe519b7a310fc6112ed916e32df5866df0888553", size = 1912623, upload_time = "2026-07-23T01:56:50.605Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e6/438b0c79ca6f45eb9fd9817dd4c01a91919a38c0de5ee9e05e2b4dc0ece7/aiohttp-3.14.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3ae5b3a59436d089b5395d910121a390feed4d00578eb95a0fd1a329fe963100", size = 2005515, upload_time = "2026-07-23T01:56:53.153Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/6b/62cbd6577758699525f5c712d1ddef57d9875fbab0ae8d5f5a202fd598f8/aiohttp-3.14.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2498f0fe69ead802f9675beca44a7c21c62fdaa4ec5145ea1c3ad6edbee29f85", size = 1879906, upload_time = "2026-07-23T01:56:55.818Z" },
+    { url = "https://files.pythonhosted.org/packages/00/95/18bcbf830a21dc3aae24d8f6b6feaf3db1d2090242d00a7868db2ffb0b67/aiohttp-3.14.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a0dc483c00da8b673abbb367eb6f8d8f4bcec30eb58529ea13cb42e7fd2dfa33", size = 1675849, upload_time = "2026-07-23T01:56:58.861Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/19/47f4968659c5e23606c3790c80fc624e691c153d036148449ee84d31b287/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c7d3a97c678d34fc5b59da671ee9cd630096ddc643e7b5a30d54a2a6f3574d3f", size = 1843496, upload_time = "2026-07-23T01:57:01.591Z" },
+    { url = "https://files.pythonhosted.org/packages/64/af/38c33c4dd82fddcb4e56c4653b6f1072a8edbc6b7fa15809f14932c41e2d/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:f8fb78a83c9e5f741ca3a68cfb455c1f5bb83b4e7249a3848b3cd78d0a8563b0", size = 1827746, upload_time = "2026-07-23T01:57:05.131Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/9d/0537cda4885ac8f5b7053d164dd06312f4c483a4edcb8ee5b8aaf2a989bf/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:74ab5b6a9fb13e873e5a90946588baecaf488745e1db1a4a5c433f971f035098", size = 1853810, upload_time = "2026-07-23T01:57:08.043Z" },
+    { url = "https://files.pythonhosted.org/packages/19/fe/26f9c5e6458385aa86497836b0dea6fb2f027827d63f37c7856cce9286ee/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:bd52f811e65f6fb634b1047159657c98f52b407f8efec907bcfc09da9a4c0a25", size = 1668895, upload_time = "2026-07-23T01:57:10.837Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/4c/618b1db9b9ba079b8875d2cdf78e7c4a3bf72903bd5850fee7dd9544600a/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:f0f177d1b195b9e06376cfd7d308d8a1b920909a609d03ac82a8c73bbb16d3b9", size = 1883833, upload_time = "2026-07-23T01:57:13.672Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c6/bd959bd1e4771f9fd944e9e436224c48c77b018b73b519b5aad346335bcc/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:498c6c623134f8e09a3c4e60bcd607a0b4590dd7dbf08dd40851b27cbb520ccb", size = 1844251, upload_time = "2026-07-23T01:57:16.593Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/19/08d41839658bdd44a0ed2480f3891705ecb487ce28c0dde62c9040c997e0/aiohttp-3.14.3-cp314-cp314t-win32.whl", hash = "sha256:b304db572b4368edd8dda8a2274f73156fe15558fca4a917cb8a09fc47af5963", size = 474180, upload_time = "2026-07-23T01:57:19.306Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5d/3cd6ef0a2b2851f7ab913b5b079334781bd50ff56a323e4454063377a080/aiohttp-3.14.3-cp314-cp314t-win_amd64.whl", hash = "sha256:b20032766aedf6261c7a566585a40867d092ac03a0d81592d5370ef9b054f99b", size = 500528, upload_time = "2026-07-23T01:57:21.762Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/37/cfd1ed540a4d318da025590d96b728e63713c09e9377950fc655dadeb856/aiohttp-3.14.3-cp314-cp314t-win_arm64.whl", hash = "sha256:2e1161602f45a54de2ce0905243a95f58cb42dcd378402f3697f5e0b21e9d2e7", size = 469280, upload_time = "2026-07-23T01:57:24.241Z" },
 ]
 
 [[package]]
@@ -280,6 +295,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload_time = "2025-11-30T15:08:26.084Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload_time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
+name = "bidict"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/6e/026678aa5a830e07cd9498a05d3e7e650a4f56a42f267a53d22bcda1bdc9/bidict-0.23.1.tar.gz", hash = "sha256:03069d763bc387bbd20e7d49914e75fc4132a41937fa3405417e1a5a2d006d71", size = 29093, upload_time = "2024-02-18T19:09:05.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/37/e8730c3587a65eb5645d4aba2d27aae48e8003614d6aaf15dda67f702f1f/bidict-0.23.1-py3-none-any.whl", hash = "sha256:5dae8d4d79b552a71cbabc7deb25dfe8ce710b17ff41711e13010ead2abfc3e5", size = 32764, upload_time = "2024-02-18T19:09:04.156Z" },
 ]
 
 [[package]]
@@ -882,43 +906,14 @@ wheels = [
 ]
 
 [[package]]
-name = "daytona-api-client"
-version = "0.190.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dateutil" },
-    { name = "typing-extensions" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/de/33/b0fe2b8f2f0babe68d16e5f3726b35f2e3b3c20a99ea4528f569d6a7cf11/daytona_api_client-0.190.1.tar.gz", hash = "sha256:1c9bef7f21f27590abe5fea6e07489e592b95845d3b0a8271d4b5e780d3f3ae5", size = 147981, upload_time = "2026-06-23T15:11:35.536Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/91/38abc3e2431e4d7107ba3c59cf045864066eb4c887bbd118e1d53cf96091/daytona_api_client-0.190.1-py3-none-any.whl", hash = "sha256:eba08a999718a3467d88462cf21c5d59ebc1a83960c2ac56df2bb84582b29a4b", size = 408338, upload_time = "2026-06-23T15:11:32.179Z" },
-]
-
-[[package]]
-name = "daytona-api-client-async"
-version = "0.190.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohttp" },
-    { name = "aiohttp-retry" },
-    { name = "pydantic" },
-    { name = "python-dateutil" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/62/ab/83e316bc78df0013239b43f173c8b865387a0c975f3913f0b59b209664de/daytona_api_client_async-0.190.1.tar.gz", hash = "sha256:455e9cc7599b10f05b4dba4ffe769b064025156a3f54fcf94a79b67124ba1d3f", size = 148794, upload_time = "2026-06-23T15:11:34.502Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/95/ba611420271e0aba6bf16a3ac5af7bc5b762f6343fc26c4588d106651a93/daytona_api_client_async-0.190.1-py3-none-any.whl", hash = "sha256:1857382c3a48a28f79bfbf0506b8cbc21c70f4eec44420726c98abfcbddfb20b", size = 411627, upload_time = "2026-06-23T15:11:32.424Z" },
-]
-
-[[package]]
-name = "daytona-sdk"
-version = "0.190.1"
+name = "daytona"
+version = "0.200.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
     { name = "aiohttp" },
+    { name = "daytona-analytics-api-client" },
+    { name = "daytona-analytics-api-client-async" },
     { name = "daytona-api-client" },
     { name = "daytona-api-client-async" },
     { name = "daytona-toolbox-api-client" },
@@ -934,18 +929,20 @@ dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
+    { name = "python-socketio", extra = ["asyncio-client", "client"] },
     { name = "toml" },
+    { name = "typing-extensions" },
     { name = "urllib3" },
     { name = "wsproto" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/a7/13a1013b2bfcb97c2fbad74e2bbfd2d9a5443a0ff35e750e038d4f69814d/daytona_sdk-0.190.1.tar.gz", hash = "sha256:406ed7d587c578c0029107cad621a2afbb38dde74861de9aebd5c98949d08882", size = 146435, upload_time = "2026-06-23T15:12:27.997Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/eb/2d2db2068f23697964b2aab383bb8391b618462df1ae6dca1df464f27259/daytona-0.200.1.tar.gz", hash = "sha256:02fc040cdbb54417ba7c1dc6bc1aa7489543bd15fc3fe9aea6968b0516f7ea4b", size = 177604, upload_time = "2026-07-22T12:23:22.305Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/fb/b1a239ee9156535aaa232ddf04a25a64b368bb2b1d8f44219ba0395b69f8/daytona_sdk-0.190.1-py3-none-any.whl", hash = "sha256:0360737103350cb883e45e2e30000b403f80c371855abd1f32dd73213a0f9c07", size = 177838, upload_time = "2026-06-23T15:12:26.225Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/32/87982084d380e6a34aff1b2fac8eb6f8649f831c4f8f39c8d0eb90a0749f/daytona-0.200.1-py3-none-any.whl", hash = "sha256:68029ff267499a8dcc9d946fc71e79b9ea456170c77fb836bf4b0cd3c1e59959", size = 213381, upload_time = "2026-07-22T12:23:23.43Z" },
 ]
 
 [[package]]
-name = "daytona-toolbox-api-client"
-version = "0.190.1"
+name = "daytona-analytics-api-client"
+version = "0.200.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -953,14 +950,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b8/5c/f3441577b2e0acf2caca1fe36140dcc3151f24d105fbad76da53dc30351d/daytona_toolbox_api_client-0.190.1.tar.gz", hash = "sha256:cac961750a8219df47b734e6de6ab27adc2b43b5a9cf21511605344c32a9ff45", size = 79767, upload_time = "2026-06-23T15:11:56.953Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/de/9e95c70c792f20ef0c43e157a5a8f56d71d57b716335da2dc7d29ddb082a/daytona_analytics_api_client-0.200.1.tar.gz", hash = "sha256:1624d437cbc50c91f921c4b46567f55f8ddf89894fa80840acf01788daf85a4b", size = 30058, upload_time = "2026-07-22T12:22:47.817Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/de/33fb18b33b4bf9a209f98b1d74e3ba24243dc447d17267498ad6804ee3ef/daytona_toolbox_api_client-0.190.1-py3-none-any.whl", hash = "sha256:ff772813d308d5aa000cdec6c9c0f20061f8823026eeda05bac3ee3bb01ae353", size = 220033, upload_time = "2026-06-23T15:11:55.377Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/34/e17297664a6e8a0a921ad971683e220bce69e57a3c97f37c2815a3f70991/daytona_analytics_api_client-0.200.1-py3-none-any.whl", hash = "sha256:9f8ad5648f0da73b34ce9b13ce3c60173562d48404ddc7f6331eeec4beb2c772", size = 45010, upload_time = "2026-07-22T12:22:48.643Z" },
 ]
 
 [[package]]
-name = "daytona-toolbox-api-client-async"
-version = "0.190.1"
+name = "daytona-analytics-api-client-async"
+version = "0.200.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -969,9 +966,71 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/22/c3ad8ef73bae1da2ee0b0ad4e280ba38d3eadd7ff0ed7a31c7235ed71fa8/daytona_toolbox_api_client_async-0.190.1.tar.gz", hash = "sha256:1c51799def00447fc8acefef5a172ed4db8059c1d317b7260e7ad3f22a3dfc30", size = 73273, upload_time = "2026-06-23T15:11:33.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/ec/e9bd405a74382f97b1a16376686bf90ed9c3b183718897d519eb8ced73d9/daytona_analytics_api_client_async-0.200.1.tar.gz", hash = "sha256:f5edc0b1a6590ae802490d97789f21f94d3bf73c53a4d984c980d89cc0eca132", size = 30071, upload_time = "2026-07-22T12:22:39.053Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/aa/07f74858d57d9cac59879824f0701f45ff8cb2eefff0fb3d109915a71000/daytona_toolbox_api_client_async-0.190.1-py3-none-any.whl", hash = "sha256:c1831cede8b6121fbef01b8c5db4292625d51b1bdfc9593a90b17b07628e8450", size = 218334, upload_time = "2026-06-23T15:11:32.127Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/c5/2979f438def31f26dc98b3e23a9e8787570d2bb95019f85596fa7eafb8a6/daytona_analytics_api_client_async-0.200.1-py3-none-any.whl", hash = "sha256:637106455f9498d6785efb51be9d589a2ecd3f257e2a3d9f1c7b6bd8c461721a", size = 45283, upload_time = "2026-07-22T12:22:39.882Z" },
+]
+
+[[package]]
+name = "daytona-api-client"
+version = "0.200.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/be/9e604a59ea3b3dc5a120b9dd216b1db12f4da2e6b8601e7d4f49b1874c96/daytona_api_client-0.200.1.tar.gz", hash = "sha256:fcf17e051eb7e0a9b8a38d02ef74f7ed67f84c3b4d150c8dd76c8c942f521fa9", size = 124815, upload_time = "2026-07-22T12:22:56.725Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/1a/094725c4f495eba4411666a12307f885cead3aa29917eccf72f3630f36ff/daytona_api_client-0.200.1-py3-none-any.whl", hash = "sha256:7d7c41d7c5b601d9df908bd0ab0f0f567ade2913edf2eb087f65cfc6fcbe73a0", size = 316076, upload_time = "2026-07-22T12:22:57.798Z" },
+]
+
+[[package]]
+name = "daytona-api-client-async"
+version = "0.200.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "aiohttp-retry" },
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/dc/132b3ac1f44434ef4115abe99761542da9ac025a20f011fc081638148245/daytona_api_client_async-0.200.1.tar.gz", hash = "sha256:269874af7f97368531a08762639590a59f0ece95e194fa6ebe998fbf8258d4dd", size = 125346, upload_time = "2026-07-22T12:22:39.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/47/ea80967ccdcc4fbabbf628a1b162f0f500edd75eebffc55fea88ada41ea8/daytona_api_client_async-0.200.1-py3-none-any.whl", hash = "sha256:df80d0aeb52c82a4660d746464842bdb6c8a2e0203b0cdc6374037b164c47824", size = 318668, upload_time = "2026-07-22T12:22:41.49Z" },
+]
+
+[[package]]
+name = "daytona-toolbox-api-client"
+version = "0.200.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/d8/650c9b70734931ac369dc5369d4168bc81e65fca244d19afb6d77b496bd9/daytona_toolbox_api_client-0.200.1.tar.gz", hash = "sha256:c5c74b390c20396494a3a70e843a5da70187ba5d197b26fe98be366e2a1a81da", size = 86312, upload_time = "2026-07-22T12:22:49.038Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/a2/329d03f4898e3b768bf285b3353f3db347e6946f8f7a3b7587325f7e6468/daytona_toolbox_api_client-0.200.1-py3-none-any.whl", hash = "sha256:7baaebf323d663e669db6dbbba816fccd7facca101d6cffa86959dee06593ce3", size = 247064, upload_time = "2026-07-22T12:22:50.356Z" },
+]
+
+[[package]]
+name = "daytona-toolbox-api-client-async"
+version = "0.200.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "aiohttp-retry" },
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/ad/92aa88099f210e2ff73cebfa0ca08538f05068e6c5c25a3e565eb9438d75/daytona_toolbox_api_client_async-0.200.1.tar.gz", hash = "sha256:ffe6c6bd9289b56a448a7e0f1f36a295fda431e0d73fc74c53cfb9492f590174", size = 80178, upload_time = "2026-07-22T12:22:39.642Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/00/b3f5b3e40a37af8b883590d78a7d6935a464e74364129732daa322c4bd37/daytona_toolbox_api_client_async-0.200.1-py3-none-any.whl", hash = "sha256:fc953a1ee1d9967900b21c5eb6188c54617b1d66d5ad6b737e457a9e76a4fb4a", size = 245534, upload_time = "2026-07-22T12:22:40.771Z" },
 ]
 
 [[package]]
@@ -2005,7 +2064,7 @@ dependencies = [
     { name = "certifi" },
     { name = "charset-normalizer" },
     { name = "croniter" },
-    { name = "daytona-sdk" },
+    { name = "daytona" },
     { name = "deepagents" },
     { name = "edgartools" },
     { name = "exchange-calendars" },
@@ -2101,7 +2160,7 @@ requires-dist = [
     { name = "certifi", specifier = ">=2026.1.4" },
     { name = "charset-normalizer", specifier = ">=3.4.0" },
     { name = "croniter", specifier = ">=2.0.0" },
-    { name = "daytona-sdk", specifier = ">=0.130.0" },
+    { name = "daytona", specifier = ">=0.200.1" },
     { name = "deepagents", specifier = ">=0.6.11" },
     { name = "edgartools", specifier = ">=5.7.2" },
     { name = "exchange-calendars", specifier = ">=4.13.2" },
@@ -4295,12 +4354,46 @@ wheels = [
 ]
 
 [[package]]
-name = "python-multipart"
-version = "0.0.29"
+name = "python-engineio"
+version = "4.13.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4e/fe/70bd71a6738b09a0bdf6480ca6436b167469ca4578b2a0efbe390b4b0e70/python_multipart-0.0.29.tar.gz", hash = "sha256:643e93849196645e2dbdd81a0f8829a23123ad7f797a84a364c6fb3563f18904", size = 45678, upload_time = "2026-05-17T17:29:47.654Z" }
+dependencies = [
+    { name = "simple-websocket" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/a0/f75491f942184d9960b15e763270f765fe9f239745ca5f9e16289011aed4/python_engineio-4.13.3.tar.gz", hash = "sha256:572b7783e341fed21edbc7cea297ccd378dad79265fdde96aa4664420a7c06c9", size = 79734, upload_time = "2026-06-20T22:53:52.197Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/cb/769cfc37177252872a45a71f3fbdde9d51b471a3f3c14bfe95dde3407386/python_multipart-0.0.29-py3-none-any.whl", hash = "sha256:2ddcc971cef266225f54f552d8fa10bcfbb1f14446caec199060daac59ff2d69", size = 29640, upload_time = "2026-05-17T17:29:45.69Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/96/82f6328e410515fab21d5602ba35b9377a47b5a141a0c1f9efa00ce21eb4/python_engineio-4.13.3-py3-none-any.whl", hash = "sha256:1f60ecaf1358190f0e26c48c578a60428dc02a8f1295bc3dbf53d1b31116821f", size = 59993, upload_time = "2026-06-20T22:53:50.775Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload_time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload_time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
+name = "python-socketio"
+version = "5.16.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bidict" },
+    { name = "python-engineio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/2d/ffce71017c106b75099fea569df6518c63fee5d6202ce0cfe7b01e6f22c3/python_socketio-5.16.3.tar.gz", hash = "sha256:89b136f677ae65607a84cecda9b4d6c5377b40a97582c504c25df89af16d520e", size = 128095, upload_time = "2026-06-15T22:07:04.003Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/38/8c5e72d53ff8eb27497c4f268a7f6d9121e727a50b65248288ad79a93053/python_socketio-5.16.3-py3-none-any.whl", hash = "sha256:e7ad14202a5e6448824c7c2f86161d04e13dec05992257df5c709e6a2798c041", size = 82087, upload_time = "2026-06-15T22:07:02.498Z" },
+]
+
+[package.optional-dependencies]
+asyncio-client = [
+    { name = "aiohttp" },
+]
+client = [
+    { name = "requests" },
+    { name = "websocket-client" },
 ]
 
 [[package]]
@@ -4906,6 +4999,18 @@ wheels = [
 ]
 
 [[package]]
+name = "simple-websocket"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wsproto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/d4/bfa032f961103eba93de583b161f0e6a5b63cebb8f2c7d0c6e6efe1e3d2e/simple_websocket-1.1.0.tar.gz", hash = "sha256:7939234e7aa067c534abdab3a9ed933ec9ce4691b0713c78acb195560aa52ae4", size = 17300, upload_time = "2024-10-10T22:39:31.412Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/59/0782e51887ac6b07ffd1570e0364cf901ebc36345fea669969d2084baebb/simple_websocket-1.1.0-py3-none-any.whl", hash = "sha256:4af6069630a38ed6c561010f0e11a5bc0d4ca569b36306eb257cd9a192497c8c", size = 13842, upload_time = "2024-10-10T22:39:29.645Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5223,11 +5328,11 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.15.0"
+version = "4.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload_time = "2025-08-25T13:49:26.313Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload_time = "2026-07-02T08:40:05.92Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload_time = "2025-08-25T13:49:24.86Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload_time = "2026-07-02T08:40:04.659Z" },
 ]
 
 [[package]]
@@ -5518,6 +5623,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload_time = "2026-05-02T16:04:12.653Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload_time = "2026-05-02T16:04:11.033Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload_time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload_time = "2025-10-07T21:16:34.951Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adopts Daytona's **provider-managed Secrets** so outbound API keys can be
registered on the Daytona control plane and substituted into sandbox egress
traffic — the plaintext credential never enters the sandbox environment, the
checkpoint, or the exec boundary.

Each configured secret is registered with Daytona as a managed Secret. Inside
the sandbox the corresponding env var holds only an opaque `dtn_secret_`
placeholder; Daytona's egress layer swaps in the real value on outbound **HTTPS
request headers** toward the allowlisted hosts. Query params and bodies are
never substituted, so credentials must be sent as request headers.

Activation is **catalog-driven and host-agnostic**: any deployment running the
Daytona provider opts in by declaring `sandbox.platform_secrets` in
`agent_config.yaml`. Providers without an egress-substitution capability
(docker/memory) ignore the catalog entirely.

## Overview (net change)

| Category | Files | +LOC | −LOC |
|---|---:|---:|---:|
| Modified (production) | 16 | — | — |
| New (production) | 4 | — | — |
| **Net production (excl. tests & lockfile)** | **20** | **1370** | **113** |
| Tests | 15 | 1824 | 35 |
| Lockfile (`uv.lock`) | 1 | 229 | 115 |

**By module (production, excl. tests):**

- **`src/ptc_agent/`** (+669/−52, 9 files) — `core/sandbox/platform_secrets.py` (new, catalog model + resolution/gate + sandbox convergence mechanics), `core/sandbox/providers/daytona_secrets.py` (new, Daytona Secret reconciler), `providers/daytona.py` (wire the reconciler + Secret CRUD), `ptc_sandbox.py` (bind secrets, exclude bound keys from plaintext env), `runtime.py` (state/exec helpers for convergence), `config/core.py` (`PlatformSecretDefinition` model), `config/utils.py`, `config/agent.py`, `providers/docker.py`.
- **`src/server/`** (+614/−54, 4 files) — `services/platform_secret_rollout.py` (new, rollout state machine: generation sequence, boot reconciliation, lazy bringup convergence), `services/workspace_manager.py` (bringup hook + eviction-on-failure), `app/setup.py` (boot reconcile call), `database/workspace.py`.
- **`migrations/`** (+49, 1 file) — `021_add_platform_secret_state.py`: `platform_secret_rollouts` table + `workspaces.platform_secret_version`.
- **`src/data_client/`** (+6/−5) — FMP client authenticates via the `apikey` request header (was a URL query param), so the credential rides in a substitutable header.
- **config/CI/scripts** (+32/−2) — `agent_config.yaml` (commented catalog + FMP example entry), `.env.example` (`DAYTONA_SECRET_NAMESPACE`), `scripts/configure.sh`, `pyproject.toml` (daytona SDK floor), CI workflow.

## What this introduces

A rollout state machine that keeps every sandbox converged on the registered
Secret set. `workspaces.platform_secret_version` records the generation a sandbox
was certified against (0 = never); rollout rows share one generation sequence; a
structural identity change (recreate/rename/switch provider/add-remove catalog
entry) bumps the generation and re-pends the fleet in one locked transaction. New
sandboxes certify atomically at provision; existing sandboxes converge lazily at
bringup and self-heal on transient Daytona outages. Rotating a credential's
*value* does **not** bump the generation.

## Gate model (catalog-driven)

- `platform_secrets_active(config)` — a capable provider (`{"daytona"}`) **and** a
  non-empty catalog. Host-agnostic; drives every runtime call site.
- `platform_secrets_required(config, host_mode)` — a capable provider **and**
  `host_mode == "platform"`; the fail-closed guard only.
- An empty catalog keeps sandboxes on plaintext env (unchanged), **except** in
  `platform` host mode on a capable provider, where an empty catalog fails
  startup rather than silently falling back. Any active catalog fails closed on a
  missing namespace/credential, in any host mode.

## Verification

- Full unit suite: **6893 passed, 1 xpassed** (known nondeterministic
  delta-channel xpass, unrelated). Ruff clean.
- Live-verified end-to-end against real Daytona + FMP on Daytona SDK 0.200.1:
  Secret CRUD, egress header substitution, credential rotation (401→200), and
  host-restriction all pass.

## Configuration

`agent_config.yaml` ships the mechanism plus a commented catalog and the FMP
entry as a working example. Each deployment declares which vendors it carries;
without a catalog entry the feature is inert (or fails closed at boot in
`platform` host mode on Daytona). `DAYTONA_SECRET_NAMESPACE` and the source
credential env vars must be set in the deployment environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added managed Daytona “platform secret” support with secure placeholder mounting, rotation, and in-runtime verification.
  * Introduced hosted platform secret catalog configuration (including Daytona namespace selection) with boot-time reconciliation, hot-resync for active sessions, and a background sweeper to keep workspaces converged.
* **Bug Fixes**
  * FMP API keys are now sent via request headers (not URL/query parameters), improving cache/auth safety.
  * Archived sandboxes now correctly fail for unrecoverable cases.
* **Tests**
  * Added unit and live integration coverage for substitution/rotation, hot swapping, rollout-state invariants, and sweeper behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->