### PR TITLE
feat(llms): add Claude Opus 5

### DIFF
--- a/src/llms/manifest/models.json
+++ b/src/llms/manifest/models.json
@@ -111,6 +111,29 @@
       }
     }
   },
+  "claude-opus-5": {
+    "model_id": "claude-opus-5",
+    "provider": "anthropic",
+    "visible": true,
+    "speed": 2,
+    "intelligence": 5,
+    "context": 1000000,
+    "input_modalities": [
+      "text",
+      "image",
+      "pdf"
+    ],
+    "parameters": {
+      "max_tokens": 128000,
+      "thinking": {
+        "type": "adaptive",
+        "display": "summarized"
+      },
+      "output_config": {
+        "effort": "high"
+      }
+    }
+  },
   "claude-sonnet-5": {
     "model_id": "claude-sonnet-5",
     "provider": "anthropic",
@@ -1215,6 +1238,29 @@
   },
   "claude-fable-5-oauth": {
     "model_id": "claude-fable-5",
+    "provider": "claude-oauth",
+    "visible": true,
+    "speed": 2,
+    "intelligence": 5,
+    "context": 1000000,
+    "input_modalities": [
+      "text",
+      "image",
+      "pdf"
+    ],
+    "parameters": {
+      "max_tokens": 128000,
+      "thinking": {
+        "type": "adaptive",
+        "display": "summarized"
+      },
+      "output_config": {
+        "effort": "high"
+      }
+    }
+  },
+  "claude-opus-5-oauth": {
+    "model_id": "claude-opus-5",
     "provider": "claude-oauth",
     "visible": true,
     "speed": 2,

--- a/src/llms/manifest/providers.json
+++ b/src/llms/manifest/providers.json
@@ -183,6 +183,20 @@
         }
       },
       {
+        "id": "claude-opus-5",
+        "name": "Claude Opus 5",
+        "is_reasoning": true,
+        "description": "Claude Opus 5 model",
+        "pricing": {
+          "input": 5.0,
+          "cached_input": 0.5,
+          "cache_5m": 6.25,
+          "cache_1h": 10.0,
+          "output": 25.0,
+          "unit": "per_1m_tokens"
+        }
+      },
+      {
         "id": "claude-sonnet-5",
         "name": "Claude Sonnet 5",
         "is_reasoning": true,


### PR DESCRIPTION
## Overview

| | Files | Lines |
|---|---|---|
| Modified | 2 | +60 / −0 |
| New | 0 | — |
| **Net (excl. tests)** | **2** | **+60 / −0** |

**By module**

| Module | Files | Change |
|---|---|---|
| `src/llms/manifest/` | 2 | +46 `models.json` (2 keys), +14 `providers.json` (1 pricing entry) |

**What this introduces:** two selectable model keys and one pricing row. No new
modules, no new code paths, no schema fields — purely data consumed by the
existing manifest loaders. The change is additive; nothing is removed or
repriced.

## What

Adds Claude Opus 5 to the model catalog:

| Key | `model_id` | Provider | Purpose |
|---|---|---|---|
| `claude-opus-5` | `claude-opus-5` | `anthropic` | API-key access |
| `claude-opus-5-oauth` | `claude-opus-5` | `claude-oauth` | Claude subscription access |

Specs follow Anthropic's published values: **1M native context**, **128k max
output**, adaptive thinking with summarized display, and the documented
`effort: high` output default.

## Pricing

One entry lands on the `anthropic` list — USD-native, no FX conversion involved:

| Field | $/MTok |
|---|---|
| `input` | 5.00 |
| `output` | 25.00 |
| `cached_input` (read) | 0.50 |
| `cache_5m` (write) | 6.25 |
| `cache_1h` (write) | 10.00 |

`claude-opus-5-oauth` deliberately carries **no** pricing entry. `claude-oauth`
declares `anthropic` as its parent, so `find_model_pricing` resolves
provider → parent and the OAuth key inherits these exact rates. Duplicating
them would create a second source of truth that silently drifts.

## Opus 4.8 stays

Opus 5 supersedes Opus 4.8 at identical pricing, but all three 4.8 keys
(`claude-opus-4-8`, `-oauth`, `-oauth-1m`) remain `visible: true` and
unchanged. Anyone pinned to 4.8 keeps a selectable entry rather than a
silently-hidden one; the keys are retired on a later release.

## Verification

```
JSON OK
6917 passed, 1 xfailed  (uv run pytest tests/unit/)

anthropic visible: [... 'claude-opus-5', ... 'claude-opus-5-oauth', ...]
opus-5 pricing   : {'input': 5.0, 'cached_input': 0.5, 'cache_5m': 6.25,
                    'cache_1h': 10.0, 'output': 25.0, 'unit': 'per_1m_tokens'}
oauth inherits   : True
```

Also confirmed: `extract_base_model` cannot strip the `-5` suffix (its snapshot
patterns require 4 or 6–8 trailing digits), so there is no risk of the pricing
lookup silently falling back to a different model's rates.

## Notes for reviewers

- **`context_window` is intentionally absent** on the OAuth key. Opus 5's 1M
  window is native, so the `context-1m-2025-08-07` beta that Opus 4.8's
  `-oauth-1m` variant needs does not apply here. (`context_window` is also a
  dead manifest field — only `context` is read.)
- **The default model is unchanged.** `agent_config.yaml` still names
  `claude-opus-4-8`, so users without an explicit preference keep running 4.8
  until that default is moved deliberately.
- **No pricing-parity test exists.** Nothing asserts that every `models.json`
  entry has a matching `providers.json` row, so a future model added without
  pricing would ship billing at $0. Out of scope here, worth a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claude Opus 5 as an available model.
  * Added an OAuth-enabled Claude Opus 5 option.
  * Added support for text, image, and PDF inputs.
  * Enabled adaptive thinking, high output effort, and expanded token capacity.
  * Added model pricing details and reasoning-model metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->