### PR TITLE
fix(web): drop black page frame from PDF export

### DIFF
--- a/web/e2e/export-print-color-scheme.spec.js
+++ b/web/e2e/export-print-color-scheme.spec.js
@@ -1,0 +1,265 @@
+// Regression lock for the black frame around every page of an exported PDF.
+//
+// The defect was a cascade collision that only exists in print media, inside
+// the iframe react-to-print builds — so jsdom cannot see it (it hardcodes
+// screen media) and neither can a plain app-level assertion. This rebuilds the
+// print document the way react-to-print documents and implements it, sourcing
+// every ingredient from the real files rather than copies, and checks the
+// cascade in real Chromium under real print emulation.
+//
+// Chain: color-scheme dark wins -> Paged.js's print-color-adjust:exact inks
+// the dark UA canvas over the white background -> black frame. This test locks
+// the first link; the pixel end of the chain was verified by hand at authoring
+// time (dark scheme rasterized to rgb(18,18,18), light to rgb(255,255,255)).
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { PRINT_PAGE_STYLE } from '../src/pages/ChatAgent/components/printPageStyle.ts';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const read = (p) => readFileSync(resolve(HERE, '..', p), 'utf8');
+
+// Composite `color` over `backdrop` before measuring. Alpha has to be applied
+// here or a semi-transparent colour scores as its opaque base: several theme
+// tokens are rgba, and rgba(0,0,0,.08) on white reads as full black otherwise.
+function luminanceOver(color, backdrop) {
+  const parse = (c) => c.match(/[\d.]+/g).map(Number);
+  const [br, bg, bb] = parse(backdrop);
+  const [r, g, b, a = 1] = parse(color);
+  const mix = (fg, bgc) => fg * a + bgc * (1 - a);
+  return 0.2126 * mix(r, br) + 0.7152 * mix(g, bg) + 0.0722 * mix(b, bb);
+}
+
+// The rule that leaks into the print document: react-to-print builds its iframe
+// from srcdoc="<!DOCTYPE html>", so it carries no data-theme and this unscoped
+// dark branch matches for every user, light-theme ones included.
+function indexHtmlInlineStyle() {
+  const html = read('index.html');
+  const blocks = [...html.matchAll(/<style>([\s\S]*?)<\/style>/g)].map((m) => m[1]);
+  const scheme = blocks.find((b) => b.includes('color-scheme'));
+  // If index.html stops shipping an unscoped dark color-scheme, this test is
+  // guarding a collision that no longer exists — fail loudly rather than pass.
+  expect(scheme, 'index.html should still declare an inline color-scheme').toBeTruthy();
+  expect(scheme).toMatch(/html\s*\{[^}]*color-scheme:\s*dark/);
+  return scheme;
+}
+
+// Shape of what pagedjs injects into the parent document and react-to-print
+// then copies into the iframe. Asserted against the real dist bundle below.
+const PAGED_PRINT_STYLES = `@media print {
+  html { width: 100%; height: 100%;
+    -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+}`;
+
+// react-to-print@3.3.0 appends pageStyle to the iframe head FIRST, then copies
+// parent <style>/<link> nodes after it. That ordering is the whole reason the
+// declaration needs !important, so the fixture must preserve it.
+function printDocument({ pageStyle, modalSheet = '' }) {
+  return `<!DOCTYPE html><html><head><meta charset="utf-8">
+    <style>${pageStyle}</style>
+    <style>${indexHtmlInlineStyle()}</style>
+    ${modalSheet ? `<style>${modalSheet}</style>` : ''}
+    <style>${PAGED_PRINT_STYLES}</style>
+    </head><body><h1>Export</h1></body></html>`;
+}
+
+async function colorSchemeInPrint(page, html) {
+  await page.emulateMedia({ media: 'print' });
+  await page.setContent(html);
+  return page.evaluate(() => getComputedStyle(document.documentElement).colorScheme);
+}
+
+async function rootStylesInPrint(page, html) {
+  await page.emulateMedia({ media: 'print' });
+  await page.setContent(html);
+  return page.evaluate(() => {
+    const root = getComputedStyle(document.documentElement);
+    return { colorScheme: root.colorScheme, background: root.backgroundColor };
+  });
+}
+
+test.describe('PDF export — print color-scheme', () => {
+  test('pageStyle forces the light scheme over index.html\'s dark rule', async ({ page }) => {
+    const scheme = await colorSchemeInPrint(page, printDocument({ pageStyle: PRINT_PAGE_STYLE }));
+    expect(scheme).toBe('light');
+  });
+
+  test('negative control: without pageStyle the dark scheme wins', async ({ page }) => {
+    // Proves the assertion above discriminates the fix from the bug rather than
+    // passing on a document that was never dark to begin with.
+    const scheme = await colorSchemeInPrint(page, printDocument({ pageStyle: '' }));
+    expect(scheme).toBe('dark');
+  });
+
+  test('holds when the lazy chunk stylesheet never reaches the iframe', async ({ page }) => {
+    // react-to-print re-fetches <link> stylesheets inside the iframe and prints
+    // anyway if the fetch fails ("unable to load a resource but will continue").
+    // The modal's CSS ships in a lazy chunk under VITE_CDN_BASE, so that miss is
+    // reachable in production; index.html's inline dark rule always survives.
+    const withSheet = await colorSchemeInPrint(
+      page,
+      printDocument({ pageStyle: PRINT_PAGE_STYLE, modalSheet: read('src/pages/ChatAgent/components/ExportPreviewModal.css') }),
+    );
+    const withoutSheet = await colorSchemeInPrint(page, printDocument({ pageStyle: PRINT_PAGE_STYLE }));
+    expect(withSheet).toBe('light');
+    expect(withoutSheet).toBe('light');
+  });
+
+  test('scheme and background travel together, or the fallback is unreadable', async ({ page }) => {
+    // index.html's `html { background: #000 }` is on the un-failable inlined
+    // path, so if only the scheme ships here a missing chunk yields the dark
+    // background with light-scheme black text — black on black. Shipping the
+    // white background alongside it keeps the failure legible.
+    const { colorScheme, background } = await rootStylesInPrint(
+      page,
+      printDocument({ pageStyle: PRINT_PAGE_STYLE }),
+    );
+    expect(colorScheme).toBe('light');
+    expect(background).toBe('rgb(255, 255, 255)');
+  });
+
+  test('negative control: shipping the scheme without the background is unreadable', async ({ page }) => {
+    // The claim above is that the two must travel together. This is the state
+    // that claim rejects — scheme pinned here, background left in the lazy chunk
+    // — so a future "simplification" that splits them again fails here instead
+    // of shipping a page whose text and paper are both the same colour.
+    const schemeOnly = '@page { size: A4 !important; margin: 15mm !important; }\n' +
+      'html, body { color-scheme: light !important; }';
+    const { colorScheme, background } = await rootStylesInPrint(
+      page,
+      printDocument({ pageStyle: schemeOnly }),
+    );
+    expect(colorScheme).toBe('light');
+    // index.html's black survives on the un-failable inlined path, and a light
+    // scheme paints the UA's default text black on top of it.
+    expect(background).toBe('rgb(0, 0, 0)');
+  });
+
+  test('the page stays legible when only the lazy chunk is missing', async ({ page }) => {
+    // The asymmetric miss: tokens.css ships in the main bundle behind a static
+    // <link> that every page load warms, while the modal's chunk is fetched once
+    // per session — so "tokens present, chunk absent" is the likely half of the
+    // failure, and it is the one a white page makes worse. Markdown.tsx sets
+    // color/background inline from var(--color-*), and the iframe has no
+    // data-theme, so those resolve to tokens.css's dark :root branch.
+    //
+    // Foregrounds and backgrounds are checked in pairs on purpose: pinning text
+    // without its background turns white-on-black into dark-on-black, which is
+    // just as invisible and passes any test that only looks at the text.
+    await page.emulateMedia({ media: 'print' });
+    await page.setContent(`<!DOCTYPE html><html><head><meta charset="utf-8">
+      <style>${PRINT_PAGE_STYLE}</style>
+      <style>${indexHtmlInlineStyle()}</style>
+      <style>${read('src/styles/tokens.css')}</style>
+      <!-- ExportPreviewModal.css never arrives -->
+      <style>${PAGED_PRINT_STYLES}</style>
+      </head><body><div class="markdown-print-content">
+        <p id="para" style="color: var(--color-text-primary)">Paragraph.</p>
+        <code id="code" style="background-color: var(--color-bg-code); color: var(--color-text-primary)">inline</code>
+        <table><thead id="head" style="background-color: var(--color-bg-input)">
+          <tr><th style="color: var(--color-text-primary)">Header</th></tr></thead></table>
+        <del id="del" style="color: var(--color-text-tertiary)">struck</del>
+      </div></body></html>`);
+
+    const probes = await page.evaluate(() => {
+      const pageBg = getComputedStyle(document.documentElement).backgroundColor;
+      // An element with no background of its own sits on the page canvas.
+      const pair = (id) => {
+        const s = getComputedStyle(document.getElementById(id));
+        return { fg: s.color, bg: s.backgroundColor === 'rgba(0, 0, 0, 0)' ? pageBg : s.backgroundColor };
+      };
+      return { para: pair('para'), code: pair('code'), head: pair('head'), del: pair('del') };
+    });
+
+    for (const [name, { fg, bg }] of Object.entries(probes)) {
+      expect(
+        Math.abs(luminanceOver(fg, bg) - luminanceOver(bg, bg)),
+        `${name} rendered ${fg} on ${bg} — invisible without the modal stylesheet`,
+      ).toBeGreaterThan(40);
+    }
+  });
+
+  test('table rules and dividers are visible with or without the lazy chunk', async ({ page }) => {
+    // Unlike the colour pins, this one also repairs the happy path: the chunk
+    // styles `hr` and `td` but never the table wrapper or `tr`, which carry only
+    // var(--color-border-muted) — the dark rgba(255,255,255,.08). Those rules
+    // were invisible in every export, not just the fallback.
+    const chrome = read('src/pages/ChatAgent/components/ExportPreviewModal.css');
+    for (const chunkArrives of [true, false]) {
+      await page.emulateMedia({ media: 'print' });
+      await page.setContent(`<!DOCTYPE html><html><head><meta charset="utf-8">
+        <style>${PRINT_PAGE_STYLE}</style>
+        <style>${indexHtmlInlineStyle()}</style>
+        <style>${read('src/styles/tokens.css')}</style>
+        ${chunkArrives ? `<style>${chrome}</style>` : ''}
+        <style>${PAGED_PRINT_STYLES}</style>
+        </head><body><div class="markdown-print-content">
+          <hr id="hr" style="border-color: var(--color-border-muted)">
+          <div id="wrap" style="border: 1px solid var(--color-border-muted)">
+            <table><tbody><tr id="row" style="border-bottom: 1px solid var(--color-border-muted)">
+              <td>cell</td></tr></tbody></table></div>
+        </div></body></html>`);
+
+      const borders = await page.evaluate(() => {
+        const pageBg = getComputedStyle(document.documentElement).backgroundColor;
+        const edge = (id, prop) => getComputedStyle(document.getElementById(id))[prop];
+        return {
+          pageBg,
+          hr: edge('hr', 'borderTopColor'),
+          wrapper: edge('wrap', 'borderTopColor'),
+          row: edge('row', 'borderBottomColor'),
+        };
+      });
+
+      const { pageBg, ...edges } = borders;
+      for (const [name, color] of Object.entries(edges)) {
+        expect(
+          Math.abs(luminanceOver(color, pageBg) - luminanceOver(pageBg, pageBg)),
+          `${name} border rendered ${color} on ${pageBg} (chunk ${chunkArrives ? 'present' : 'missing'})`,
+        ).toBeGreaterThan(15);
+      }
+    }
+  });
+
+  test('every themed var Markdown.tsx renders inline is pinned or known-safe', async () => {
+    // The probes above are hand-written, so they only ever cover the elements
+    // someone thought to list. This derives the list from Markdown.tsx instead,
+    // so an eighth var added later fails here rather than shipping an invisible
+    // element nobody probed. Anything not pinned needs a measured reason.
+    const SAFE_UNPINNED = {
+      '--color-accent-primary': 'dark value #4161A4 — mid blue, legible on white',
+      '--color-accent-overlay': 'rgba(75,107,174,.5) — blockquote rule, visible on white',
+    };
+    const used = new Set(
+      [...read('src/pages/ChatAgent/components/Markdown.tsx').matchAll(/var\((--color-[a-z0-9-]+)\)/g)]
+        .map((m) => m[1]),
+    );
+    expect(used.size, 'expected Markdown.tsx to still render themed vars inline').toBeGreaterThan(0);
+
+    const unaccounted = [...used].filter(
+      (v) => !PRINT_PAGE_STYLE.includes(`${v}:`) && !(v in SAFE_UNPINNED),
+    );
+    expect(
+      unaccounted,
+      `${unaccounted.join(', ')} resolve to tokens.css's dark :root inside the print iframe. ` +
+        'Pin in PRINT_PAGE_STYLE (foreground and background together), or add to SAFE_UNPINNED with a measured reason.',
+    ).toEqual([]);
+  });
+
+  test('the stylesheet does not reintroduce color-scheme outside the print iframe', async () => {
+    // Keeping it in pageStyle is what confines it to the export; a declaration
+    // in the component stylesheet would also retint the app's own Ctrl+P output,
+    // because the lazy chunk stays in the document after the modal closes.
+    const css = read('src/pages/ChatAgent/components/ExportPreviewModal.css');
+    const withoutComments = css.replace(/\/\*[\s\S]*?\*\//g, '');
+    expect(withoutComments).not.toMatch(/color-scheme\s*:/);
+  });
+
+  test('pagedjs still sets print-color-adjust:exact, the co-factor being defended against', async () => {
+    // If pagedjs stops forcing exact color adjustment the dark canvas would no
+    // longer ink, and this whole defense could be reconsidered.
+    const paged = read('node_modules/pagedjs/dist/paged.js');
+    expect(paged).toMatch(/print-color-adjust:\s*exact/);
+  });
+});

--- a/web/src/pages/ChatAgent/components/ExportPreviewModal.css
+++ b/web/src/pages/ChatAgent/components/ExportPreviewModal.css
@@ -477,7 +477,9 @@
     margin: 15mm; /* Paged.js @page{margin:0} is scoped to media=screen during print */
   }
 
-  /* Unclip ancestor chain — react-to-print iframe inherits parent stylesheets */
+  /* Unclip ancestor chain — react-to-print iframe inherits parent stylesheets.
+     The matching `color-scheme: light` lives in the pageStyle prop, not here —
+     see the comment on useReactToPrint in ExportPreviewModal.tsx. */
   html, body {
     height: auto !important;
     overflow: visible !important;

--- a/web/src/pages/ChatAgent/components/ExportPreviewModal.tsx
+++ b/web/src/pages/ChatAgent/components/ExportPreviewModal.tsx
@@ -10,6 +10,7 @@ import { Select } from '@/components/ui/select';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import Markdown from './Markdown';
 import { stripLineNumbers } from './toolDisplayConfig';
+import { PRINT_PAGE_STYLE } from './printPageStyle';
 import './ExportPreviewModal.css';
 
 // ---------------------------------------------------------------------------
@@ -306,9 +307,15 @@ export default function ExportPreviewModal({
   // <style data-pagedjs-inserted-styles> with @page{margin:0} into the parent,
   // so those copied styles win by cascade order. Using !important ensures our
   // margins take precedence regardless of source order.
+  //
+  // color-scheme belongs here rather than in the stylesheet: pageStyle is
+  // inlined into the iframe, whereas this component's lazy chunk arrives as a
+  // <link> that the iframe re-fetches — and react-to-print prints anyway if
+  // that fetch fails, which would leave index.html's unscoped dark scheme in
+  // force. Scoping it here also keeps it off the app's own Ctrl+P output.
   const handlePrint = useReactToPrint({
     contentRef: printRef,
-    pageStyle: '@page { size: A4 !important; margin: 15mm !important; }',
+    pageStyle: PRINT_PAGE_STYLE,
   });
 
   // ---- CSS vars for source (used by react-to-print) ----

--- a/web/src/pages/ChatAgent/components/printPageStyle.ts
+++ b/web/src/pages/ChatAgent/components/printPageStyle.ts
@@ -1,0 +1,31 @@
+/**
+ * Print-document preamble for react-to-print's iframe.
+ *
+ * Everything needed for a legible page must live here, and every rule needs
+ * `!important`. This is the only stylesheet guaranteed to reach the iframe —
+ * react-to-print inlines it, but re-fetches parent <link>s and prints anyway if
+ * one 404s, so `ExportPreviewModal.css` (a lazy chunk under VITE_CDN_BASE) and
+ * `tokens.css` (main bundle) can each go missing independently. It is also
+ * appended *before* the parent's styles, so at equal specificity source order
+ * would otherwise hand the win to index.html's unscoped dark rule.
+ *
+ * The token pins exist because Markdown.tsx sets `color`/`background`/`border`
+ * inline from `var(--color-*)`, and the iframe carries no `data-theme` — so
+ * those vars resolve to tokens.css's dark `:root` branch. Each pinned pair must
+ * stay paired: fixing a foreground without its background just swaps one
+ * invisible combination for another (dark ink on `--color-bg-code`'s near-black).
+ * `--color-border-muted` is pinned to the tone the stylesheet already gives
+ * `hr`/`td`, which also reveals the table wrapper and row rules — those carry
+ * only the var, so they were invisible in every export, not just the fallback.
+ */
+export const PRINT_PAGE_STYLE = `
+  @page { size: A4 !important; margin: 15mm !important; }
+  html, body { color-scheme: light !important; background: #ffffff !important; }
+  html {
+    --color-text-primary: #1a1a1a !important;
+    --color-text-tertiary: #6b7280 !important;
+    --color-bg-code: #f7f6f3 !important;
+    --color-bg-input: #f7f6f3 !important;
+    --color-border-muted: #d1d5db !important;
+  }
+`;


### PR DESCRIPTION
## Summary

Exported PDFs came out with a black frame around the content on every page.

react-to-print builds its print iframe from `srcdoc="<!DOCTYPE html>"`, so the print document carries no `data-theme` and matches `index.html`'s unscoped `html { color-scheme: dark }` — for light-theme users too. Paged.js's polyfill then sets `print-color-adjust: exact`, which inks that dark UA canvas *over* the `background: #ffffff !important` the print block already declared. That is why the existing white-background rule could never fix it.

**Fix** (`cd16323c`) — the print preamble moves into a `PRINT_PAGE_STYLE` constant handed to react-to-print's `pageStyle`, the only stylesheet guaranteed to reach the iframe. It pins the light scheme, the white page, and the theme tokens the content resolves inline.

**Regression lock** (`fba3301e`) — a Playwright spec that rebuilds the print document from the real ingredients and asserts the cascade under print emulation.

## Overview

| | files | +/- |
|---|---|---|
| Modified | 2 | +11 / −2 |
| New | 2 | +296 / −0 |
| **Total** | **4** | **+307 / −2** |
| **Net (excl. tests)** | **3** | **+42 / −2** |

**Frontend — ChatAgent/components**
- *new* `printPageStyle.ts` (31) — exports `PRINT_PAGE_STYLE`, the print-document preamble. Its own module so the E2E test asserts the exact string the app ships rather than a copy.
- *modified* `ExportPreviewModal.tsx` (+8/−1) — consumes the constant; comment records why these declarations belong in `pageStyle` and not the stylesheet.
- *modified* `ExportPreviewModal.css` (+3/−1) — comment only, pointing at the new home. No declaration change relative to `main`.

**Frontend — e2e**
- *new* `export-print-color-scheme.spec.js` (265) — 10 tests covering the cascade, its negative control, both stylesheet-missing quadrants, rendered contrast on four element types, table-rule visibility, and a structural guard deriving the themed-var list from `Markdown.tsx`.

**What this introduces:** no user-facing feature. It repairs PDF export output and adds the first print-media regression coverage in the suite.

## Diff Size
- Total: 4 files changed, 307 insertions(+), 2 deletions(-)
- Net (excl. tests): 3 files changed, 42 insertions(+), 2 deletions(-)

## Test Coverage

Tests: 236 files → 237 (+10 tests). Coverage of the changed lines: **0% at the outset, now locked by E2E.**

These rules apply only in print media, inside a generated iframe. jsdom hardcodes `screen`, so it computes the *buggy* value even with the fix applied — a unit test asserting correct behavior would fail against correct code, and a CSS string-match would have passed while the bug was live. Verified by probe, not assumed.

Every assertion is mutation-verified — each declaration was removed in turn and the resulting failure recorded:

| mutation | failure |
|---|---|
| drop `color-scheme` | `Expected "light", Received "dark"` (3 tests) |
| drop `background` | `Expected "rgb(255,255,255)", Received "rgb(0,0,0)"` |
| drop `!important` (either) | dark wins on source order |
| `html, body` → `body` | `Expected "light", Received "dark"` (3 tests) |
| drop `--color-text-primary` | `para rendered rgb(255,255,255) on rgb(255,255,255)` |
| drop `--color-text-tertiary` | `del rendered rgba(255,255,255,0.6) on rgb(255,255,255)` |
| drop `--color-bg-code` | `code rendered rgb(26,26,26) on rgb(15,15,15)` |
| drop `--color-bg-input` | `head rendered rgb(0,0,0) on rgb(10,10,10)` |
| drop `--color-border-muted` | `wrapper border rendered rgba(255,255,255,0.08)` (both quadrants) |
| add an 8th var to `Markdown.tsx` | structural guard names the unpinned var |

```
EXPORT-TO-PDF                                          STATUS
 click "Save as PDF" → react-to-print
   ├─ pageStyle inlined into iframe head          [★★★] cascade asserted, print media
   │    └─ beats index.html's copied dark rule    [★★★] negative control proves it
   ├─ parent <link> re-fetched, may fail          [★★★] both miss-quadrants covered
   │    └─ fallback stays legible                 [★★★] 4 elements, each token mutated
   │    └─ table rules stay visible               [★★★] fixes the happy path too
   ├─ pagedjs print-color-adjust:exact co-factor  [★★ ] pinned against upstream drift
   ├─ future themed vars                          [★★★] derived from Markdown.tsx
   └─ rasterize → white canvas, no frame          [ — ] unreachable in-harness (below)
```

Not covered: the final pixel. react-to-print terminates in `contentWindow.print()`, which Playwright cannot capture into a PDF. That link was verified by hand with a CDP print-to-PDF + `pdftoppm` harness — dark scheme rasterizes to `rgb(18,18,18)`, the fix to `rgb(255,255,255)`, with background graphics both on and off.

## Pre-Landing Review

Five findings fixed, two recorded and not actioned. The first four were each a defect in the *previous* attempt at this fix — the pattern being that the export resolves style through paths that can fail independently, so a partial fix moves the failure rather than removing it.

**[CRITICAL] the fix depended on a network fetch.** In production the modal is a `React.lazy` chunk (`FilePanel.tsx:29`) whose CSS is emitted as a `<link>` under `VITE_CDN_BASE`. Confirmed in react-to-print@3.3.0's source: parent `<style>` tags are re-inlined via `.cssRules` and always survive, but `<link>` tags are re-created and **re-fetched inside the iframe**, and on error it logs *"unable to load a resource but will continue attempting to print the page"* and prints anyway. `index.html`'s dark rule is inline, so it always wins that race. Moving the declaration into `pageStyle` removes the dependency.

**[CRITICAL] the rule leaked past the export.** The lazy chunk's stylesheet stays in the document after the modal closes, so an `@media print` rule on `html, body` also retinted the app's own Ctrl+P output. `pageStyle` is scoped to the generated iframe.

**[CRITICAL] the fix split itself across two delivery paths.** Moving only `color-scheme` left the white background in the failable chunk while `index.html`'s `html { background: #000 }` stayed on the un-failable inline path — giving a black page with light-scheme *black* text, worse than the original bug. Both now ship together.

**[CRITICAL] pinning the page white made the likelier failure worse.** `Markdown.tsx` sets `color`/`background` inline from `var(--color-*)` at 36 sites; the iframe has no `data-theme`, so those resolve to `tokens.css`'s dark `:root` (`--color-text-primary: #FFFFFF`). `tokens.css` ships in the main bundle and the modal's CSS does not, so they miss independently — and with a white page, "tokens arrive, chunk does not" renders **white text on white**. Measured across all three quadrants. Fixed by pinning the legibility-deciding tokens **in foreground/background pairs**: pinning only the text turned readable white-on-`#0F0F0F` inline code into `#1a1a1a`-on-`#0F0F0F`. Syntax highlighting survives because those spans carry literal inline colours rather than the var.

**[MAJOR] one themed var was unpinned and already broken in production.** `--color-border-muted` reaches `hr`, the table wrapper, `tr` and `th` inline. The print block styles `hr` and `td` but never the wrapper or `tr`, so those carried the dark `rgba(255,255,255,0.08)` and rendered **invisible in every export**, chunk present or not. Pinned to `#d1d5db`, the tone the stylesheet already gives `hr`/`td`.

The same pass fixed a defect in the suite itself: the luminance helper parsed with `match(/\d+/g)` and took the first three numbers, so `rgba(0,0,0,0.08)` scored as opaque black — a clean pass for a border that composites to Δ≈20 and shows nothing. It now composites alpha over the backdrop, verified by pinning `rgba(0,0,0,0.02)` and watching the test fail.

**[INFORMATIONAL] rejected — `!important` flagged by the design checklist.** It is load-bearing. `html {color-scheme:dark}` and `html, body {color-scheme:light}` are both specificity (0,0,1) against `<html>`, so without it source order decides — and react-to-print appends `pageStyle` *first*, then copies the dark rule in *after*.

**[INFORMATIONAL] recorded — preview/export widget mismatch.** Markdown task lists render native `<input type="checkbox">` (`Markdown.tsx:185`). The exported PDF renders them light-on-white, correctly; the on-screen preview keeps the app's dark scheme. Pre-existing and cosmetic.

## Automated Review Dispositions

**Codex (P2) — "force the print document's background white as well": VALID, fixed.** It independently found the split-path bug and was right that the then-current test only inspected `colorScheme`. Both are closed, and the suite now carries a negative control proving the rejected state is unreadable.

**Claude — two non-blocking flags.** The missing negative control on the paired declarations is added. The pagedjs `dist` coupling is kept deliberately: the regex tolerates whitespace and minification, and a dist reformat surfaces as a loud failure rather than a silent pass — being alerted when pagedjs changes is the intent, since the fix's rationale depends on its behavior.

**CodeRabbit — "align the print cascade fixture with the installed behavior": REBUTTED.** It claims `pageStyle` is appended *after* the parent's styles, which would make the `!important` decorative. The installed `react-to-print@3.3.0` dist says otherwise; inside `handlePrintWindowOnLoad` the sequence is linear:

```js
const P = C ?? G;                     // C = pageStyle
const x = d.createElement("style");
x.appendChild(d.createTextNode(P));
d.head.appendChild(x);                // pageStyle appended FIRST
…
if (!p) {                             // p = ignoreGlobalStyles
  const s = document.querySelectorAll("style, link[rel~='stylesheet'], link[as='style']");
  for (…) { … d.head.appendChild(u) } // parent styles copied AFTER
}
```

The fixture models this correctly, and the ordering is exactly why `!important` is load-bearing. The `PAGED_PRINT_STYLES` placement follows for the same reason — Paged.js injects into the *parent* document, so it is copied after `index.html`'s inline block. The review reached its conclusion from a web search; its own `node_modules` probe returned 260 bytes, so it never read the installed code. Its one accurate observation — `package.json` declares `^3.2.0` while the lockfile pins `3.3.0` — is ordinary caret-range semantics, not a defect.

## Scope

```
Scope Check: CLEAN
Intent:    Fix the black frame on exported PDFs; investigate the preview/print drift (report only).
Delivered: The frame fix + its regression lock. No pagination code.
```

- [x] **Fix the black frame** — root-caused to the two-ingredient collision above and isolated with a 2×2 matrix: dark+exact → `rgb(18,18,18)`; forcing light, dropping `exact`, or supplying `data-theme="light"` each independently → `rgb(255,255,255)`.
- [x] **Investigate the preview/print drift (report only)** — verified in a harness. Printing the Paged.js output at `@page margin:0` reproduces the preview exactly (3 pages, identical page starts) where today's native re-pagination drifts. Requires a print reset that restores `.pagedjs_page` visibility, un-clips `.export-preview-paged`, neutralizes the inline zoom transform, and strips sheet chrome; without it the export is one blank page. No pagination code in this PR.
- [ ] **Implement the drift fix** — deferred by explicit scope decision.

## Verification

Each CI job's exact command was run locally before pushing, and both commits were verified independently — the fix commit stands alone as a valid state:

| CI job | command | result |
|---|---|---|
| `frontend-unit` | `pnpm run typecheck` | exit 0 |
| `frontend-unit` | `pnpm vitest run` | 2514 passed (236 files) |
| `frontend-e2e` | `CI=1 pnpm exec playwright test` | 52 passed (10 new) |
| `frontend-e2e` @ `cd16323c` alone | `CI=1 pnpm exec playwright test` | 42 passed |
| `backend-unit` | `uv run pytest tests/unit/` | 6917 passed, 1 xfailed |

CI-only failure modes checked rather than assumed: no dependency or lockfile change (so `--frozen-lockfile` is safe and the pinned `playwright:v1.58.2-noble` container still matches), `pagedjs` is a direct dependency so the path the spec reads exists in CI, and the spec resolves paths from `import.meta.url` rather than cwd.

`backend-integration` failed on two earlier pushes of this branch — both on `DaytonaError: Failed to create sandbox … SandboxState.ERROR`, hitting a different test each time. It passed on the next run with no change from this branch, so it was a transient provisioning window on Daytona's side. This diff touches four files, all under `web/`.

## Follow-ups

1. **Drift fix (Path B)** — verified but uncommitted, and the harness lives in ephemeral scratch. Worth capturing as an issue before it is lost.
2. **Preview widget scheme** — align the preview's native controls with the exported page.
3. **`opacity: 0.9` leaks into every export.** The `panel` variant wrapper carries it (`Markdown.tsx:450`) and the print block declares no override, so text authored `#1a1a1a` reaches paper near `rgb(48,48,48)`. Contrast stays high, so this is fidelity rather than legibility — one line whenever it is wanted.
4. **Dark chart images are outside CSS reach.** Charts cannot enter the export as components — `PANEL_COMPONENTS` (`Markdown.tsx:403-410`) holds only HTML tags plus `cite-bubble` — but a matplotlib/plotly PNG rendered with a dark style is a dark rectangle in the pixel data, and `print-color-adjust: exact` inks it. Fixable only upstream or by compositing onto white at export.
5. **Citation pill in the on-screen preview.** `CitationBubble.css`'s `all: unset` is `@media print` only, so the preview shows a dark pill under a dark app theme while the PDF neutralizes it. Preview fidelity, pre-existing. (Not a delivery-path risk — its tokens and its rescue compile into the same bundle file, so they cannot miss independently.)

## Test plan
- [x] Vitest — 2514 tests, 236 files, 0 failures
- [x] Playwright — 52 tests, 0 failures (10 new, each mutation-verified)
- [x] `pnpm typecheck` — clean
- [x] Backend unit — 6917 passed
- [x] Rasterized-PDF verification by hand — white canvas, background graphics on and off
