### PR TITLE
fix: canonicalize the sandbox state so the settings panel stops hiding live tabs

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -92,7 +92,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/usr/local/ms-playwright
 RUN echo 'curl_cffi>=0.14' > /tmp/overrides.txt \
     && uv pip install --system \
     --override /tmp/overrides.txt \
-    mcp fastmcp fastapi \
+    mcp==1.29.0 fastmcp fastapi \
     pandas requests aiohttp "httpx[http2]" \
     numpy scipy scikit-learn statsmodels \
     yfinance \

--- a/src/ptc_agent/core/sandbox/_defaults.py
+++ b/src/ptc_agent/core/sandbox/_defaults.py
@@ -10,7 +10,10 @@ SANDBOX_NODE_VERSION = "24.14.1"  # Pinned; mirrored in Dockerfile.sandbox.
 
 DEFAULT_DEPENDENCIES = [
     # Core
-    "mcp",
+    # Pinned to 1.x: mcp 2.0.0 dropped ``mcp.server.fastmcp``, which scrapling's
+    # MCP entrypoint imports. Exact pin rather than "mcp<2" because mcp_setup
+    # joins this list into a shell command — "<" would parse as a redirect.
+    "mcp==1.29.0",
     "fastmcp",
     "fastapi",
     "pandas",

--- a/src/ptc_agent/core/sandbox/providers/docker.py
+++ b/src/ptc_agent/core/sandbox/providers/docker.py
@@ -150,10 +150,14 @@ class DockerRuntime(SandboxRuntime):
             pass
         await self._container.delete(force=True)
 
-    async def get_state(self) -> RuntimeState:
-        info = await self._container.show()
+    @staticmethod
+    def _state_from_inspect(info: dict[str, Any]) -> RuntimeState:
+        """Shared by get_state and get_metadata so the unknown-status fallback stays one rule."""
         status = info.get("State", {}).get("Status", "unknown")
         return _DOCKER_STATE_MAP.get(status, RuntimeState.ERROR)
+
+    async def get_state(self) -> RuntimeState:
+        return self._state_from_inspect(await self._container.show())
 
     # -- Execution --
 
@@ -568,14 +572,29 @@ class DockerRuntime(SandboxRuntime):
         raise NotImplementedError("Docker provider does not support archive")
 
     async def get_metadata(self) -> dict[str, Any]:
-        state = await self.get_state()
-        return {
+        """One inspect call serves state, limits and creation time.
+
+        Limits read back as 0 on a container created outside this provider's
+        config, so report nothing rather than a bogus zero. No ``disk`` key —
+        docker sets no size quota, so there is no sandbox-scoped figure to give.
+        """
+        info = await self._container.show()
+        host_config = info.get("HostConfig") or {}
+
+        meta: dict[str, Any] = {
             "id": self._id,
             "working_dir": self._working_dir,
-            "state": state.value,
+            "state": self._state_from_inspect(info).value,
             "dev_mode": self._dev_mode,
             "provider": "docker",
         }
+        if created := info.get("Created"):
+            meta["created_at"] = created
+        if nano_cpus := host_config.get("NanoCpus"):
+            meta["cpu"] = round(nano_cpus / 1e9, 2)
+        if memory := host_config.get("Memory"):
+            meta["memory"] = round(memory / 1024**3, 2)
+        return meta
 
     # -- Internal: tar-based file I/O --
 

--- a/src/server/app/workspace_sandbox.py
+++ b/src/server/app/workspace_sandbox.py
@@ -39,6 +39,60 @@ router = APIRouter(prefix="/api/v1/workspaces", tags=["Workspace Sandbox"])
 
 _SIGNED_URL_TTL = 3000  # 50 min (signed URLs expire in 1h)
 
+# Provider-native synonyms for "up and usable", canonicalized for the wire.
+# get_metadata() is provider-specific by contract, so daytona reports "started"
+# where docker reports "running". Daytona's own _STATE_MAP maps the same synonym
+# one layer down for RuntimeState — renaming a state there needs a change here too.
+_DISPLAY_STATE_SYNONYMS = {"started": "running"}
+
+
+def _configured_provider() -> str | None:
+    """Which provider this deployment runs, read from config rather than metadata.
+
+    Deliberately not ``meta["provider"]``: only the docker provider sets that key,
+    and the metadata read can fail — either would silently report "not docker" and
+    defeat the disk-quota branch this value exists to drive.
+
+    Reads ``config.sandbox`` directly rather than via ``to_core_config()``, which
+    deep-copies the MCP config to hand each workspace its own — wasted work here,
+    since it passes ``sandbox`` straight through.
+    """
+    try:
+        config = WorkspaceManager.get_instance().config
+        provider = getattr(getattr(config, "sandbox", None), "provider", None)
+        return provider if isinstance(provider, str) else None
+    except Exception as e:
+        logger.debug(f"Could not resolve the configured sandbox provider: {e}")
+        return None
+
+
+def _display_state(state: Any) -> str | None:
+    """Canonicalize a provider state for the wire; see _DISPLAY_STATE_SYNONYMS.
+
+    Unwraps enums defensively: ``get_metadata`` is provider-specific by contract,
+    and ``str()`` on a str-mixin enum yields ``"RuntimeState.RUNNING"`` rather
+    than its value. Both current providers already stringify.
+    """
+    if not state:
+        return None
+    raw = str(getattr(state, "value", state))
+    return _DISPLAY_STATE_SYNONYMS.get(raw, raw)
+
+
+def _offline_display_state(state: Any, row_status: str | None) -> str | None:
+    """Like _display_state, but never reports "running" — the offline path can't back it.
+
+    That path collects no disk usage, packages or skills, while the client reads
+    "running" as proof they are present and as licence to offer Stop. When the
+    provider says the sandbox is up but the row still says starting/stopping, the
+    row is the honest answer: it is what the action endpoints validate against,
+    and the full path takes over the moment it says running.
+    """
+    display = _display_state(state)
+    if display is None or display == "running":
+        return row_status
+    return display
+
 
 def _preview_cache_key(sandbox_id: str, port: int) -> str:
     """Redis key for cached signed preview URL."""
@@ -163,9 +217,19 @@ class SkillInfo(BaseModel):
 
 
 class SandboxStatsResponse(BaseModel):
+    """Sandbox stats for the workspace settings panel.
+
+    ``state`` is a display vocabulary, not ``RuntimeState``: "running" is canonical
+    across providers, anything else is a provider or workspace value passed through
+    as a label.
+    """
+
     workspace_id: str
     sandbox_id: str | None = None
     state: str | None = None
+    # Which provider answered. The UI needs it because disk_usage is a df(1) read
+    # inside the sandbox, and docker sets no disk quota, so its totals are the host's.
+    provider: str | None = None
     created_at: str | None = None
     auto_stop_interval: int | None = None
     resources: SandboxResources
@@ -313,6 +377,7 @@ async def _get_offline_sandbox_stats(
         return SandboxStatsResponse(
             workspace_id=workspace_id,
             state=workspace.get("status", "unknown"),
+            provider=_configured_provider(),
             created_at=str(workspace.get("created_at", "")),
             resources=SandboxResources(),
         )
@@ -328,7 +393,8 @@ async def _get_offline_sandbox_stats(
         return SandboxStatsResponse(
             workspace_id=workspace_id,
             sandbox_id=sandbox_id,
-            state=meta.get("state"),
+            state=_offline_display_state(meta.get("state"), workspace.get("status")),
+            provider=_configured_provider(),
             created_at=str(meta["created_at"]) if meta.get("created_at") else None,
             auto_stop_interval=meta.get("auto_stop_interval"),
             resources=SandboxResources(
@@ -344,6 +410,7 @@ async def _get_offline_sandbox_stats(
             workspace_id=workspace_id,
             sandbox_id=sandbox_id,
             state=workspace.get("status", "unknown"),
+            provider=_configured_provider(),
             created_at=str(workspace.get("created_at", "")),
             resources=SandboxResources(),
         )
@@ -362,7 +429,9 @@ async def _get_full_sandbox_stats(
 
     # --- 1. Static properties from the runtime metadata ---
     resources = SandboxResources()
-    state = None
+    # Seeded from the workspace status this path already gated on, so a missing
+    # or unreadable provider state can't downgrade a live sandbox to "offline".
+    state = workspace.get("status")
     created_at = None
     auto_stop_interval = None
     sandbox_id = getattr(sandbox, "sandbox_id", None)
@@ -377,13 +446,13 @@ async def _get_full_sandbox_stats(
                 disk=meta.get("disk"),
                 gpu=meta.get("gpu"),
             )
-            state = meta.get("state")
+            state = _display_state(meta.get("state")) or state
             raw_created = meta.get("created_at")
             if raw_created is not None:
                 created_at = str(raw_created)
             auto_stop_interval = meta.get("auto_stop_interval")
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(f"Failed to read sandbox metadata for {sandbox_id}: {e}")
 
     # --- 2. Concurrent bash commands for disk & packages ---
     work_dir = sandbox.working_dir
@@ -459,6 +528,7 @@ async def _get_full_sandbox_stats(
         workspace_id=workspace_id,
         sandbox_id=sandbox_id,
         state=state,
+        provider=_configured_provider(),
         created_at=created_at,
         auto_stop_interval=auto_stop_interval,
         resources=resources,

--- a/tests/unit/core/sandbox/test_docker_provider.py
+++ b/tests/unit/core/sandbox/test_docker_provider.py
@@ -215,6 +215,38 @@ class TestDockerRuntimeProperties:
         assert "state" in meta
         assert meta["state"] in {s.value for s in RuntimeState}
 
+    @pytest.mark.asyncio
+    async def test_get_metadata_reports_container_limits(self, container, runtime):
+        """Daytona reports cpu/memory/created_at, so without these the settings
+        panel shows "---" on every resource card for a local sandbox."""
+        container.show.return_value = {
+            **container.show.return_value,
+            "Created": "2026-01-02T03:04:05Z",
+            "HostConfig": {"NanoCpus": 2_000_000_000, "Memory": 4 * 1024**3},
+        }
+
+        meta = await runtime.get_metadata()
+
+        assert meta["cpu"] == 2.0
+        assert meta["memory"] == 4.0
+        assert meta["created_at"] == "2026-01-02T03:04:05Z"
+        # No size quota is set, so there is no sandbox-scoped disk figure to report.
+        assert "disk" not in meta
+
+    @pytest.mark.asyncio
+    async def test_get_metadata_omits_unset_limits(self, container, runtime):
+        """A container created outside this provider's config reads back 0, which
+        means "unlimited" — reporting it as a 0-core, 0-GiB sandbox would be wrong."""
+        container.show.return_value = {
+            **container.show.return_value,
+            "HostConfig": {"NanoCpus": 0, "Memory": 0},
+        }
+
+        meta = await runtime.get_metadata()
+
+        assert "cpu" not in meta
+        assert "memory" not in meta
+
 
 class TestDockerRuntimeLifecycle:
     @pytest.fixture

--- a/tests/unit/server/app/test_workspace_sandbox_stats.py
+++ b/tests/unit/server/app/test_workspace_sandbox_stats.py
@@ -1,0 +1,395 @@
+"""Tests for the sandbox stats state vocabulary (issue #333).
+
+Daytona reports "started" where docker reports "running"; the endpoint
+canonicalizes that one synonym and passes everything else through.
+"""
+
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from tests.conftest import create_test_app
+
+NOW = datetime.now(timezone.utc)
+
+
+def _ws(status="running", sandbox_id="sandbox-abc"):
+    return {
+        "workspace_id": str(uuid.uuid4()),
+        "user_id": "test-user-123",
+        "name": "Test Workspace",
+        "sandbox_id": sandbox_id,
+        "status": status,
+        "created_at": NOW,
+        "updated_at": NOW,
+    }
+
+
+@pytest_asyncio.fixture
+async def client():
+    from src.server.app.workspace_sandbox import router
+
+    app = create_test_app(router)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c
+
+
+def _sandbox_with_metadata(meta, *, side_effect=None):
+    """A PTCSandbox stand-in whose runtime returns (or raises on) get_metadata."""
+    runtime = MagicMock()
+    runtime.get_metadata = AsyncMock(return_value=meta, side_effect=side_effect)
+
+    sandbox = MagicMock()
+    sandbox.runtime = runtime
+    sandbox.sandbox_id = "sandbox-abc"
+    sandbox.working_dir = "/home/workspace"
+    # Every shell probe is best-effort; report failure so the test isolates state.
+    sandbox.execute_bash_command = AsyncMock(return_value={"success": False})
+
+    session = MagicMock()
+    session.mcp_registry = None
+    return session, sandbox
+
+
+def _config_with_provider(name):
+    """A WorkspaceManager stand-in whose config resolves a real provider string.
+
+    A bare MagicMock would hand ``_configured_provider`` a mock attribute, which
+    then fails response validation instead of behaving like a config. ``config``
+    stays a MagicMock so ``to_core_config()`` still answers for the offline path's
+    ``create_provider`` call; only ``sandbox`` needs to be real.
+    """
+    config = MagicMock()
+    config.sandbox = SimpleNamespace(provider=name)
+    manager = MagicMock()
+    manager.config = config
+    return MagicMock(get_instance=MagicMock(return_value=manager))
+
+
+async def _get_stats(
+    client, workspace, meta, *, side_effect=None, provider_name="daytona"
+):
+    session, sandbox = _sandbox_with_metadata(meta, side_effect=side_effect)
+    with (
+        patch(
+            "src.server.app.workspace_sandbox.db_get_workspace",
+            AsyncMock(return_value=workspace),
+        ),
+        patch(
+            "src.server.app.workspace_sandbox._get_sandbox",
+            AsyncMock(return_value=(session, sandbox)),
+        ),
+        patch(
+            "src.server.app.workspace_sandbox.WorkspaceManager",
+            _config_with_provider(provider_name),
+        ),
+    ):
+        return await client.get(
+            f"/api/v1/workspaces/{workspace['workspace_id']}/sandbox/stats"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cross-provider canonicalization
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_daytona_started_serializes_as_running(client):
+    """Daytona's native 'started' is the synonym that must be canonicalized."""
+    resp = await _get_stats(client, _ws(), {"state": "started"})
+
+    assert resp.status_code == 200
+    assert resp.json()["state"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_docker_running_passes_through_as_running(client):
+    """Non-discriminating by construction, and kept anyway as a smoke of the full
+    path: that path is gated on ``status == "running"``, so its seed is always
+    literally "running" and no fixture can make it differ from the expected value.
+    Pass-through is really pinned by ``test_non_running_provider_states_pass_through_verbatim``
+    and ``test_offline_path_keeps_stopped``, where the row and the provider disagree."""
+    resp = await _get_stats(client, _ws(), {"state": "running"})
+
+    assert resp.status_code == 200
+    assert resp.json()["state"] == "running"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "provider_state",
+    ["archiving", "stopping", "starting", "restoring", "resizing"],
+)
+async def test_non_running_provider_states_pass_through_verbatim(
+    client, provider_state
+):
+    """Only the one synonym is rewritten. ``archiving``/``stopping``/``starting``
+    are the values the panel keys its spinner off; the rest reach it as labels."""
+    resp = await _get_stats(client, _ws(), {"state": provider_state})
+
+    assert resp.status_code == 200
+    assert resp.json()["state"] == provider_state
+
+
+@pytest.mark.asyncio
+async def test_provider_reaches_the_wire(client):
+    """The panel keys its disk display off this: docker sets no size quota, so its
+    df(1) totals describe the host, not the sandbox."""
+    resp = await _get_stats(client, _ws(), {"state": "running"}, provider_name="docker")
+
+    assert resp.status_code == 200
+    assert resp.json()["provider"] == "docker"
+
+
+@pytest.mark.asyncio
+async def test_provider_ignores_metadata_and_survives_its_failure(client):
+    """Sourced from config, not ``meta["provider"]``: daytona never sets that key, and
+    the read can raise — either would report "not docker" and hand a self-hosted user
+    the host's disk totals labelled as their sandbox's."""
+    resp = await _get_stats(
+        client,
+        _ws(),
+        None,
+        side_effect=RuntimeError("daemon unreachable"),
+        provider_name="docker",
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["provider"] == "docker"
+
+
+@pytest.mark.asyncio
+async def test_offline_path_reports_provider(client):
+    resp = await _get_offline_stats(client, _ws(status="stopped"), {"state": "stopped"})
+
+    assert resp.status_code == 200
+    assert resp.json()["provider"] == "daytona"
+
+
+@pytest.mark.asyncio
+async def test_offline_provider_failure_still_reports_provider(client):
+    """Every response carries provider, including the ones that learned nothing from
+    the provider — so no consumer has to special-case a subset of the branches."""
+    resp = await _get_offline_stats(
+        client,
+        _ws(status="stopping"),
+        None,
+        side_effect=RuntimeError("provider unreachable"),
+        provider_name="docker",
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["provider"] == "docker"
+
+
+@pytest.mark.asyncio
+async def test_workspace_without_a_sandbox_still_reports_provider(client):
+    workspace = _ws(status="creating", sandbox_id=None)
+
+    with (
+        patch(
+            "src.server.app.workspace_sandbox.db_get_workspace",
+            AsyncMock(return_value=workspace),
+        ),
+        patch(
+            "src.server.app.workspace_sandbox.WorkspaceManager",
+            _config_with_provider("docker"),
+        ),
+    ):
+        resp = await client.get(
+            f"/api/v1/workspaces/{workspace['workspace_id']}/sandbox/stats"
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["provider"] == "docker"
+
+
+# ---------------------------------------------------------------------------
+# Fallbacks — a live sandbox must never report as offline
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_metadata_failure_falls_back_to_workspace_status(client):
+    resp = await _get_stats(
+        client, _ws(), None, side_effect=RuntimeError("provider unreachable")
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["state"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_metadata_without_a_state_key_falls_back(client):
+    """Daytona omits 'state' entirely when the SDK object hasn't populated it."""
+    resp = await _get_stats(client, _ws(), {"cpu": 2})
+
+    assert resp.status_code == 200
+    assert resp.json()["state"] == "running"
+
+
+# ---------------------------------------------------------------------------
+# Offline path
+# ---------------------------------------------------------------------------
+
+
+async def _get_offline_stats(
+    client, workspace, meta, *, side_effect=None, provider_name="daytona"
+):
+    """Drive the offline path: a real provider client, no sandbox session."""
+    runtime = MagicMock()
+    runtime.get_metadata = AsyncMock(return_value=meta, side_effect=side_effect)
+    provider = MagicMock()
+    provider.get = AsyncMock(return_value=runtime)
+    provider.close = AsyncMock()
+
+    with (
+        patch(
+            "src.server.app.workspace_sandbox.db_get_workspace",
+            AsyncMock(return_value=workspace),
+        ),
+        patch(
+            "ptc_agent.core.sandbox.providers.create_provider",
+            MagicMock(return_value=provider),
+        ),
+        patch(
+            "src.server.app.workspace_sandbox.WorkspaceManager",
+            _config_with_provider(provider_name),
+        ),
+    ):
+        return await client.get(
+            f"/api/v1/workspaces/{workspace['workspace_id']}/sandbox/stats"
+        )
+
+
+@pytest.mark.asyncio
+async def test_offline_path_keeps_stopped(client):
+    """The provider wins over the row: status is ``stopping`` but the sandbox has
+    finished stopping, so a fixture that merely echoed the row would read
+    ``stopping``. Nothing is started to find out."""
+    resp = await _get_offline_stats(
+        client, _ws(status="stopping"), {"state": "stopped", "cpu": 2}
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["state"] == "stopped"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider_state", ["running", "started"])
+async def test_offline_path_never_reports_running(client, provider_state):
+    """Both providers' "up" vocabularies, clamped to the row.
+
+    This path collects no disk usage, packages or skills, but the client reads
+    "running" as proof they are present and enables Stop on it — which the action
+    endpoint then rejects for any row that isn't running. The row wins here; the
+    full path takes over the moment it says running.
+    """
+    resp = await _get_offline_stats(
+        client, _ws(status="starting"), {"state": provider_state, "cpu": 2}
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["state"] == "starting"
+
+
+@pytest.mark.asyncio
+async def test_offline_path_clamp_is_not_a_blanket_row_echo(client):
+    """The clamp is confined to "running" — every other provider state still wins
+    over the row, which is the whole point of asking the provider at all."""
+    resp = await _get_offline_stats(
+        client, _ws(status="stopping"), {"state": "archiving", "cpu": 2}
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["state"] == "archiving"
+
+
+@pytest.mark.asyncio
+async def test_offline_path_without_a_state_key_falls_back(client):
+    """Daytona omits "state" entirely when the SDK object hasn't populated it, so
+    the workspace row is all that's left. ``error`` is distinct from every other
+    status in this file, so the fallback can't be satisfied by accident."""
+    resp = await _get_offline_stats(client, _ws(status="error"), {"cpu": 2})
+
+    assert resp.status_code == 200
+    assert resp.json()["state"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_offline_path_provider_failure_falls_back(client):
+    """Docker's get_metadata does a live daemon call, so it really can raise."""
+    resp = await _get_offline_stats(
+        client,
+        _ws(status="stopping"),
+        None,
+        side_effect=RuntimeError("provider unreachable"),
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["state"] == "stopping"
+
+
+@pytest.mark.asyncio
+async def test_no_sandbox_id_reports_workspace_status(client):
+    workspace = _ws(status="creating", sandbox_id=None)
+
+    with patch(
+        "src.server.app.workspace_sandbox.db_get_workspace",
+        AsyncMock(return_value=workspace),
+    ):
+        resp = await client.get(
+            f"/api/v1/workspaces/{workspace['workspace_id']}/sandbox/stats"
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["state"] == "creating"
+
+
+# ---------------------------------------------------------------------------
+# Ownership — the offline path has only the endpoint-level check to rely on
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["running", "stopped"])
+async def test_another_users_workspace_is_forbidden(client, status):
+    """Only ``stopped`` pins the endpoint-level check — the running path has a
+    second ``require_workspace_owner`` inside ``_get_sandbox``. WorkspaceManager is
+    patched so dropping that check fails as 200-vs-403, not as a config error."""
+    workspace = {**_ws(status=status), "user_id": "someone-else"}
+
+    with (
+        patch(
+            "src.server.app.workspace_sandbox.db_get_workspace",
+            AsyncMock(return_value=workspace),
+        ),
+        patch(
+            "src.server.app.workspace_sandbox.WorkspaceManager",
+            _config_with_provider("daytona"),
+        ),
+    ):
+        resp = await client.get(
+            f"/api/v1/workspaces/{workspace['workspace_id']}/sandbox/stats"
+        )
+
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_missing_workspace_is_not_found(client):
+    with patch(
+        "src.server.app.workspace_sandbox.db_get_workspace",
+        AsyncMock(return_value=None),
+    ):
+        resp = await client.get(f"/api/v1/workspaces/{uuid.uuid4()}/sandbox/stats")
+
+    assert resp.status_code == 404

--- a/web/src/pages/ChatAgent/components/SandboxSettingsPanel.tsx
+++ b/web/src/pages/ChatAgent/components/SandboxSettingsPanel.tsx
@@ -41,8 +41,13 @@ interface SandboxSkill {
 }
 
 interface SandboxStats {
-  state: string;
-  sandbox_id?: string;
+  /** Display vocabulary, not the backend RuntimeState enum: 'running' is canonical
+   *  across providers; anything outside TERMINAL_STATES is treated as in-progress. */
+  state: string | null;
+  /** Null, not absent, for a workspace that has no sandbox yet. */
+  sandbox_id?: string | null;
+  /** Which provider answered, e.g. 'daytona' | 'docker'. Null, not absent, when unresolved. */
+  provider?: string | null;
   created_at?: string;
   auto_stop_interval?: number;
   resources: {
@@ -101,25 +106,38 @@ export function SandboxSettingsContent({ workspaceId }: { workspaceId: string })
   // Start/stop
   const [actionLoading, setActionLoading] = useState(false);
 
+  // Only the newest stats request may commit. Refresh is deliberately never
+  // disabled, so a slow full-path read (~15s of probes) can still be in flight
+  // when a faster post-action read lands — without this the older response wins
+  // by arriving last and resurrects a stopped sandbox as running.
+  const statsRequestRef = useRef(0);
+
   // Vault deep-link: an MCP "Set up NAME" affordance switches to the Vault tab
   // and prefills the add form with that secret name.
   const [vaultPrefillSecret, setVaultPrefillSecret] = useState<string | null>(null);
 
   useEffect(() => {
     if (!workspaceId) return;
+    // Drop the outgoing workspace's stats before reading the new one. A refresh
+    // now keeps the panel on screen rather than blanking it, so without this a
+    // workspace switch would render the old sandbox under the new id.
+    setStats(null);
     loadStats();
   }, [workspaceId]);
 
   async function loadStats() {
+    const requestId = ++statsRequestRef.current;
     setLoading(true);
     setError(null);
     try {
       const data = await getSandboxStats(workspaceId);
+      if (requestId !== statsRequestRef.current) return;
       setStats(data);
     } catch (err: any) { // TODO: type properly
+      if (requestId !== statsRequestRef.current) return;
       setError(err?.response?.data?.detail || err.message || 'Failed to load sandbox stats');
     } finally {
-      setLoading(false);
+      if (requestId === statsRequestRef.current) setLoading(false);
     }
   }
 
@@ -202,7 +220,9 @@ export function SandboxSettingsContent({ workspaceId }: { workspaceId: string })
     setActiveTab('vault');
   }
 
-  const isRunning = stats?.state === 'started';
+  // Canonical value only. Provider synonyms are the API's job to translate — see
+  // _DISPLAY_STATE_SYNONYMS server-side.
+  const isRunning = stats?.state === 'running';
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
@@ -226,7 +246,10 @@ export function SandboxSettingsContent({ workspaceId }: { workspaceId: string })
 
       {/* Content */}
       <div style={{ flex: 1, minHeight: 0, overflowY: 'auto' }}>
-      {loading ? (
+      {/* Skeleton only before the first load. Refresh reads through the same
+          path, and blanking the panel would discard the status the user is
+          watching — and unmount the button they just pressed. */}
+      {loading && !stats ? (
         <LoadingSkeleton />
       ) : error ? (
         <ErrorState message={error} onRetry={loadStats} />
@@ -237,7 +260,9 @@ export function SandboxSettingsContent({ workspaceId }: { workspaceId: string })
               stats={stats!}
               isRunning={isRunning!}
               actionLoading={actionLoading}
+              refreshing={loading}
               onStartStop={handleStartStop}
+              onRefresh={loadStats}
             />
           )}
           {activeTab === 'vault' && (
@@ -396,17 +421,68 @@ function OfflineTabPlaceholder({ tabName }: OfflineTabPlaceholderProps) {
 // Overview Tab
 // ---------------------------------------------------------------------------
 
-const TRANSITIONAL_STATES = new Set(['archiving', 'stopping', 'starting']);
+// States where the sandbox has settled. Deliberately an allowlist of *terminal*
+// values rather than of in-progress ones: the provider has ~23 states and keeps
+// adding them, so anything unrecognized must fail safe to "in progress" (spinner,
+// actions disabled) instead of rendering as a settled failure with a live Start.
+// Provider synonyms are deliberately absent: the API canonicalizes them, and
+// compensating here too would let the two vocabularies drift apart silently.
+const TERMINAL_STATES = new Set([
+  'running',
+  'unknown',
+  'stopped',
+  'archived',
+  'error',
+  'paused',
+  'destroyed',
+  'build_failed',
+  'deleted',
+]);
+
+// Wire values are provider identifiers, not user copy. Unmapped values must not
+// reach the screen: daytona's SDK coerces anything it doesn't recognize to
+// 'unknown_default_open_api', and a bare capitalize would render that verbatim.
+const STATE_LABELS: Record<string, string> = {
+  running: 'Running',
+  stopped: 'Stopped',
+  starting: 'Starting',
+  stopping: 'Stopping',
+  archiving: 'Archiving',
+  archived: 'Archived',
+  restoring: 'Restoring',
+  resizing: 'Resizing',
+  creating: 'Creating',
+  destroying: 'Destroying',
+  destroyed: 'Destroyed',
+  pausing: 'Pausing',
+  paused: 'Paused',
+  resuming: 'Resuming',
+  snapshotting: 'Snapshotting',
+  forking: 'Forking',
+  error: 'Error',
+  deleted: 'Deleted',
+  build_failed: 'Build failed',
+  pending_build: 'Pending build',
+  building_snapshot: 'Building snapshot',
+  pulling_snapshot: 'Pulling snapshot',
+  unknown: 'Unknown',
+};
 
 interface OverviewTabProps {
   stats: SandboxStats;
   isRunning: boolean;
   actionLoading: boolean;
+  refreshing: boolean;
   onStartStop: (action: string) => void;
+  onRefresh: () => void;
 }
 
-function OverviewTab({ stats, isRunning, actionLoading, onStartStop }: OverviewTabProps) {
-  const isTransitioning = actionLoading || TRANSITIONAL_STATES.has(stats?.state);
+function OverviewTab({ stats, isRunning, actionLoading, refreshing, onStartStop, onRefresh }: OverviewTabProps) {
+  const isTransitioning =
+    actionLoading || (!!stats.state && !TERMINAL_STATES.has(stats.state));
+  const stateLabel = stats.state
+    ? (STATE_LABELS[stats.state] ?? 'Updating')
+    : 'Unknown';
   const resourceCards = [
     { icon: Cpu, label: 'CPU', value: stats.resources.cpu != null ? `${stats.resources.cpu} vCPU` : '---' },
     { icon: MemoryStick, label: 'Memory', value: stats.resources.memory != null ? `${stats.resources.memory} GiB` : '---' },
@@ -438,11 +514,16 @@ function OverviewTab({ stats, isRunning, actionLoading, onStartStop }: OverviewT
         className="flex items-center justify-between p-3 rounded-lg"
         style={{ backgroundColor: 'var(--color-bg-card)', border: '1px solid var(--color-border-muted)' }}
       >
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3" role="status" aria-live="polite">
           {isTransitioning ? (
-            <Loader2 className="h-3.5 w-3.5 animate-spin flex-shrink-0" style={{ color: 'var(--color-text-tertiary)' }} />
+            <Loader2
+              aria-hidden="true"
+              className="h-3.5 w-3.5 animate-spin flex-shrink-0"
+              style={{ color: 'var(--color-text-tertiary)' }}
+            />
           ) : (
             <div
+              aria-hidden="true"
               className="w-2.5 h-2.5 rounded-full flex-shrink-0"
               style={{ backgroundColor: isRunning ? 'var(--color-profit)' : 'var(--color-loss)' }}
             />
@@ -450,8 +531,8 @@ function OverviewTab({ stats, isRunning, actionLoading, onStartStop }: OverviewT
           <div>
             <div className="text-sm font-medium" style={{ color: 'var(--color-text-primary)' }}>
               {isTransitioning
-                ? (actionLoading ? 'Updating...' : stats.state.charAt(0).toUpperCase() + stats.state.slice(1) + '...')
-                : isRunning ? 'Running' : stats.state ? stats.state.charAt(0).toUpperCase() + stats.state.slice(1) : 'Unknown'}
+                ? (actionLoading ? 'Updating...' : `${stateLabel}...`)
+                : stateLabel}
             </div>
             {stats.created_at && (
               <div className="text-xs mt-0.5" style={{ color: 'var(--color-text-tertiary)' }}>
@@ -463,9 +544,25 @@ function OverviewTab({ stats, isRunning, actionLoading, onStartStop }: OverviewT
         <div className="flex items-center gap-2">
           {stats.auto_stop_interval != null && (
             <span className="text-xs px-2 py-1 rounded" style={{ color: 'var(--color-text-tertiary)', backgroundColor: 'var(--color-bg-card)' }}>
-              Auto-stop: {stats.auto_stop_interval}m
+              {/* 0 disables auto-stop entirely, so rendering "0m" states the opposite */}
+              {stats.auto_stop_interval === 0
+                ? 'Always on'
+                : `Auto-stop: ${stats.auto_stop_interval}m`}
             </span>
           )}
+          {/* Never disabled. In a transitional state every other control here is,
+              and nothing polls — without this the panel has no way to advance. */}
+          <button
+            onClick={onRefresh}
+            aria-label="Refresh sandbox status"
+            title="Refresh status"
+            className="flex items-center gap-1.5 px-2 py-1.5 text-xs rounded-md transition-colors hover:bg-foreground/10"
+            style={{ color: 'var(--color-text-tertiary)', border: '1px solid var(--color-border-muted)' }}
+          >
+            {refreshing
+              ? <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+              : <RefreshCw className="h-3 w-3" aria-hidden="true" />}
+          </button>
           {!isRunning && stats.state === 'stopped' && (
             <button
               onClick={() => onStartStop('archive')}
@@ -538,26 +635,35 @@ function StorageTab({ stats, showDirBreakdown, onToggleBreakdown }: StorageTabPr
 
   return (
     <div className="flex flex-col gap-5">
-      {/* Usage bar */}
-      <div className="flex flex-col gap-2">
-        <div className="flex justify-between text-sm" style={{ color: 'var(--color-text-primary)' }}>
-          <span>{disk.used} used</span>
-          <span>{disk.available} available</span>
+      {/* Usage bar. Docker sets no size quota, so df(1) inside the container reports
+          the host filesystem — showing it as the sandbox's disk would be a wrong number. */}
+      {stats.provider === 'docker' ? (
+        <div className="text-xs" style={{ color: 'var(--color-text-tertiary)' }}>
+          Local sandboxes run without a disk quota, so total usage would describe the
+          host filesystem rather than this sandbox. The per-directory sizes below are
+          sandbox-scoped.
         </div>
-        <div className="h-3 rounded-full overflow-hidden" style={{ backgroundColor: 'var(--color-bg-card)' }}>
-          <div
-            className="h-full rounded-full transition-all"
-            style={{
-              width: `${pct}%`,
-              backgroundColor: pct > 80 ? 'var(--color-loss)' : 'var(--color-accent-primary)',
-            }}
-          />
+      ) : (
+        <div className="flex flex-col gap-2">
+          <div className="flex justify-between text-sm" style={{ color: 'var(--color-text-primary)' }}>
+            <span>{disk.used} used</span>
+            <span>{disk.available} available</span>
+          </div>
+          <div className="h-3 rounded-full overflow-hidden" style={{ backgroundColor: 'var(--color-bg-card)' }}>
+            <div
+              className="h-full rounded-full transition-all"
+              style={{
+                width: `${pct}%`,
+                backgroundColor: pct > 80 ? 'var(--color-loss)' : 'var(--color-accent-primary)',
+              }}
+            />
+          </div>
+          <div className="flex justify-between text-xs" style={{ color: 'var(--color-text-tertiary)' }}>
+            <span>{disk.use_percent} used</span>
+            <span>{disk.total} total</span>
+          </div>
         </div>
-        <div className="flex justify-between text-xs" style={{ color: 'var(--color-text-tertiary)' }}>
-          <span>{disk.use_percent} used</span>
-          <span>{disk.total} total</span>
-        </div>
-      </div>
+      )}
 
       {/* Directory breakdown toggle */}
       {stats.directory_breakdown && stats.directory_breakdown.length > 0 && (
@@ -622,7 +728,7 @@ function PackagesTab({
           value={pkgSearch}
           onChange={e => onSearchChange(e.target.value)}
           placeholder="Filter packages..."
-          className="w-full pl-9 pr-3 py-2 text-sm rounded-md bg-transparent outline-none"
+          className="w-full pl-9 pr-3 py-2 text-sm rounded-md bg-transparent outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--color-accent-primary)]"
           style={{
             color: 'var(--color-text-primary)',
             border: '1px solid var(--color-border-muted)',
@@ -682,7 +788,7 @@ function PackagesTab({
             onChange={e => onInstallInputChange(e.target.value)}
             placeholder="Package names (e.g. torch transformers>=4.0)"
             onKeyDown={e => e.key === 'Enter' && !installing && onInstall()}
-            className="flex-1 px-3 py-2 text-sm rounded-md bg-transparent outline-none"
+            className="flex-1 px-3 py-2 text-sm rounded-md bg-transparent outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--color-accent-primary)]"
             style={{
               color: 'var(--color-text-primary)',
               border: '1px solid var(--color-border-muted)',
@@ -1187,7 +1293,7 @@ function SecretsTab({ workspaceId, prefillSecretName, onPrefillConsumed }: Secre
             value={newName}
             onChange={e => setNewName(e.target.value.toUpperCase().replace(/[^A-Z0-9_]/g, '').replace(/^[0-9]+/, ''))}
             placeholder="SECRET_NAME"
-            className="w-full px-3 py-2 text-sm rounded-md bg-transparent outline-none font-mono"
+            className="w-full px-3 py-2 text-sm rounded-md bg-transparent outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--color-accent-primary)] font-mono"
             style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
             maxLength={64}
           />
@@ -1197,7 +1303,7 @@ function SecretsTab({ workspaceId, prefillSecretName, onPrefillConsumed }: Secre
               value={newValue}
               onChange={e => setNewValue(e.target.value)}
               placeholder="Secret value"
-              className="w-full px-3 py-2 pr-9 text-sm rounded-md bg-transparent outline-none"
+              className="w-full px-3 py-2 pr-9 text-sm rounded-md bg-transparent outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--color-accent-primary)]"
               style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
               maxLength={4096}
             />
@@ -1223,7 +1329,7 @@ function SecretsTab({ workspaceId, prefillSecretName, onPrefillConsumed }: Secre
             value={newDesc}
             onChange={e => setNewDesc(e.target.value)}
             placeholder="Description (optional)"
-            className="w-full px-3 py-2 text-sm rounded-md bg-transparent outline-none"
+            className="w-full px-3 py-2 text-sm rounded-md bg-transparent outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--color-accent-primary)]"
             style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
             maxLength={256}
           />
@@ -1272,7 +1378,7 @@ function SecretsTab({ workspaceId, prefillSecretName, onPrefillConsumed }: Secre
                       value={editValue}
                       onChange={e => setEditValue(e.target.value)}
                       placeholder="New value (leave empty to keep current)"
-                      className="w-full px-3 py-2 pr-9 text-sm rounded-md bg-transparent outline-none"
+                      className="w-full px-3 py-2 pr-9 text-sm rounded-md bg-transparent outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--color-accent-primary)]"
                       style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
                       maxLength={4096}
                     />
@@ -1291,7 +1397,7 @@ function SecretsTab({ workspaceId, prefillSecretName, onPrefillConsumed }: Secre
                     value={editDesc}
                     onChange={e => setEditDesc(e.target.value)}
                     placeholder="Description"
-                    className="w-full px-3 py-2 text-sm rounded-md bg-transparent outline-none"
+                    className="w-full px-3 py-2 text-sm rounded-md bg-transparent outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--color-accent-primary)]"
                     style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
                     maxLength={256}
                   />

--- a/web/src/pages/ChatAgent/components/__tests__/SandboxSettingsPanel.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/SandboxSettingsPanel.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
 import { SandboxSettingsContent } from '../SandboxSettingsPanel';
+import { api } from '@/api/client';
 
 // ---------------------------------------------------------------------------
 // Mocks — cover the full API surface SecretsTab uses
@@ -319,5 +320,283 @@ describe('SecretsTab — blueprint lifecycle', () => {
       expect(mockGetVaultBlueprints).toHaveBeenCalledTimes(2);
       expect(screen.queryByText('Recommended credentials')).not.toBeInTheDocument();
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Live-sandbox tabs gate on state (issue #333)
+// ---------------------------------------------------------------------------
+
+/** A populated payload — the sandbox is up and returned real data. */
+function liveStats(state: string | null) {
+  return {
+    ...defaultStats(),
+    state,
+    resources: { cpu: 2, memory: 4, disk: 10 },
+    packages: [{ name: 'pandas', version: '2.2.0' }],
+    default_packages: ['pandas'],
+    skills: [{ name: 'demo-skill', description: 'a skill that exists' }],
+    mcp_servers: ['demo-mcp'],
+    disk_usage: { total: '10G', used: '1G', available: '9G', use_percent: '10%' },
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+async function openTab(name: RegExp) {
+  render(<SandboxSettingsContent workspaceId="ws-1" />);
+  await waitFor(() => expect(mockGetSandboxStats).toHaveBeenCalled());
+  fireEvent.click(screen.getByRole('button', { name }));
+}
+
+describe('gated tabs render when the API reports the canonical running state', () => {
+  it('shows skills on the Tools & Skills tab', async () => {
+    mockGetSandboxStats.mockResolvedValue(liveStats('running'));
+    await openTab(/tools & skills/i);
+    await waitFor(() => expect(screen.getByText(/demo-skill/i)).toBeInTheDocument());
+  });
+
+  it('shows installed packages on the Packages tab', async () => {
+    mockGetSandboxStats.mockResolvedValue(liveStats('running'));
+    await openTab(/packages/i);
+    await waitFor(() => expect(screen.getByText(/pandas/i)).toBeInTheDocument());
+  });
+
+  it('offers Stop, not Start, for a running sandbox on Overview', async () => {
+    mockGetSandboxStats.mockResolvedValue(liveStats('running'));
+    await openTab(/overview/i);
+    // Wait on the button, not the "Running" label — the label capitalizes
+    // whatever state arrives, so it reads "Running" on the buggy code too.
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /^stop$/i })).toBeInTheDocument()
+    );
+    expect(screen.queryByRole('button', { name: /^start$/i })).not.toBeInTheDocument();
+  });
+
+  it('still hides the tabs when the sandbox is genuinely stopped', async () => {
+    mockGetSandboxStats.mockResolvedValue(liveStats('stopped'));
+    await openTab(/tools & skills/i);
+    await waitFor(() => expect(screen.getByText(/start the workspace/i)).toBeInTheDocument());
+    expect(screen.queryByText(/demo-skill/i)).not.toBeInTheDocument();
+  });
+
+  it('survives a null state without crashing on the label', async () => {
+    mockGetSandboxStats.mockResolvedValue(liveStats(null));
+    await openTab(/overview/i);
+    await waitFor(() => expect(screen.getByText('Unknown')).toBeInTheDocument());
+  });
+
+  it('keeps the transitional spinner label for a provider-native archiving state', async () => {
+    mockGetSandboxStats.mockResolvedValue(liveStats('archiving'));
+    await openTab(/overview/i);
+    await waitFor(() => expect(screen.getByText('Archiving...')).toBeInTheDocument());
+  });
+});
+
+describe('non-terminal provider states fail safe', () => {
+  // The old three-item transitional list left these rendering as a settled
+  // failure with a working Start button, so a user could start a mid-restore
+  // sandbox. Anything outside TERMINAL_STATES must now read as in-progress.
+  it.each(['restoring', 'resizing', 'creating', 'destroying'])(
+    'treats %s as in-progress and disables Start',
+    async state => {
+      mockGetSandboxStats.mockResolvedValue(liveStats(state));
+      await openTab(/overview/i);
+
+      const start = await waitFor(() =>
+        screen.getByRole('button', { name: /^start$/i })
+      );
+      expect(start).toBeDisabled();
+    }
+  );
+
+  it('does not leak an unrecognized provider identifier into the label', async () => {
+    // Daytona's SDK coerces any state it does not know to this sentinel, so a
+    // bare capitalize would render "Unknown_default_open_api" as product copy.
+    mockGetSandboxStats.mockResolvedValue(liveStats('unknown_default_open_api'));
+    await openTab(/overview/i);
+
+    await waitFor(() => expect(screen.getByText('Updating...')).toBeInTheDocument());
+    expect(screen.queryByText(/unknown_default_open_api/i)).not.toBeInTheDocument();
+  });
+
+  it('renders a mapped label rather than a snake_case identifier', async () => {
+    mockGetSandboxStats.mockResolvedValue(liveStats('build_failed'));
+    await openTab(/overview/i);
+    await waitFor(() => expect(screen.getByText('Build failed')).toBeInTheDocument());
+  });
+});
+
+describe('provider-specific overview and storage', () => {
+  it('reports an always-on sandbox as such instead of "Auto-stop: 0m"', async () => {
+    // 0 disables auto-stop; rendering it as a 0-minute interval says the opposite.
+    mockGetSandboxStats.mockResolvedValue({
+      ...liveStats('running'),
+      auto_stop_interval: 0,
+    });
+    await openTab(/overview/i);
+
+    await waitFor(() => expect(screen.getByText('Always on')).toBeInTheDocument());
+    expect(screen.queryByText(/auto-stop: 0m/i)).not.toBeInTheDocument();
+  });
+
+  it('still shows a real auto-stop interval', async () => {
+    mockGetSandboxStats.mockResolvedValue({
+      ...liveStats('running'),
+      auto_stop_interval: 30,
+    });
+    await openTab(/overview/i);
+    await waitFor(() => expect(screen.getByText('Auto-stop: 30m')).toBeInTheDocument());
+  });
+
+  it('suppresses the disk totals for docker, whose df reads the host filesystem', async () => {
+    mockGetSandboxStats.mockResolvedValue({ ...liveStats('running'), provider: 'docker' });
+    await openTab(/storage/i);
+
+    await waitFor(() => expect(screen.getByText(/without a disk quota/i)).toBeInTheDocument());
+    expect(screen.queryByText('10G total')).not.toBeInTheDocument();
+  });
+
+  it('shows the disk totals for daytona, which is quota-backed', async () => {
+    mockGetSandboxStats.mockResolvedValue({ ...liveStats('running'), provider: 'daytona' });
+    await openTab(/storage/i);
+
+    await waitFor(() => expect(screen.getByText('10G total')).toBeInTheDocument());
+    expect(screen.queryByText(/without a disk quota/i)).not.toBeInTheDocument();
+  });
+});
+
+describe('the client does not translate provider synonyms', () => {
+  // Canonicalization belongs to the API alone. Pinned so nobody re-adds a client-side
+  // 'started' shim: two places deciding what "running" means is how the vocabularies
+  // drift apart. The raw synonym is just an unrecognized value here, and fails safe.
+  it('treats the raw provider synonym as unrecognized, not as running', async () => {
+    mockGetSandboxStats.mockResolvedValue(liveStats('started'));
+    await openTab(/overview/i);
+
+    await waitFor(() => expect(screen.getByText('Updating...')).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: /^stop$/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^start$/i })).toBeDisabled();
+  });
+
+  it('keeps the gated tabs closed on the raw synonym', async () => {
+    mockGetSandboxStats.mockResolvedValue(liveStats('started'));
+    await openTab(/tools & skills/i);
+
+    await waitFor(() => expect(screen.getByText(/start the workspace/i)).toBeInTheDocument());
+    expect(screen.queryByText(/demo-skill/i)).not.toBeInTheDocument();
+  });
+});
+
+describe('refresh is reachable while every other action is disabled', () => {
+  // Nothing polls: stats load on mount and after explicit actions only. Without an
+  // always-enabled refresh, a transitional state disables Start/Stop and the panel
+  // has no way to ever advance.
+  it('refetches from a transitional state', async () => {
+    mockGetSandboxStats.mockResolvedValue(liveStats('resizing'));
+    await openTab(/overview/i);
+
+    const refresh = await waitFor(() =>
+      screen.getByRole('button', { name: /refresh sandbox status/i })
+    );
+    expect(refresh).toBeEnabled();
+    expect(screen.getByRole('button', { name: /^start$/i })).toBeDisabled();
+
+    mockGetSandboxStats.mockResolvedValue(liveStats('running'));
+    fireEvent.click(refresh);
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /^stop$/i })).toBeInTheDocument()
+    );
+  });
+
+  it('keeps the panel on screen while the refresh it started is in flight', async () => {
+    // Refresh reads through loadStats, which sets `loading`. Blanking to the
+    // skeleton would discard the status the user is watching and unmount the
+    // button they just pressed.
+    mockGetSandboxStats.mockResolvedValue(liveStats('resizing'));
+    await openTab(/overview/i);
+
+    const slow = deferred<any>();
+    mockGetSandboxStats.mockReturnValueOnce(slow.promise);
+    fireEvent.click(screen.getByRole('button', { name: /refresh sandbox status/i }));
+
+    expect(screen.getByRole('button', { name: /refresh sandbox status/i })).toBeInTheDocument();
+    expect(screen.getByText(/resizing/i)).toBeInTheDocument();
+
+    await act(async () => {
+      slow.resolve(liveStats('running'));
+    });
+    expect(screen.getByRole('button', { name: /^stop$/i })).toBeInTheDocument();
+  });
+
+  it('does not show one workspace under another id while the switch loads', async () => {
+    mockGetSandboxStats.mockResolvedValue(liveStats('running'));
+    const { rerender } = render(<SandboxSettingsContent workspaceId="ws-1" />);
+    await waitFor(() => expect(screen.getByText(/sandbox-abc/i)).toBeInTheDocument());
+
+    const pending = deferred<any>();
+    mockGetSandboxStats.mockReturnValueOnce(pending.promise);
+    await act(async () => {
+      rerender(<SandboxSettingsContent workspaceId="ws-2" />);
+    });
+
+    expect(screen.queryByText(/sandbox-abc/i)).not.toBeInTheDocument();
+
+    await act(async () => {
+      pending.resolve({ ...liveStats('running'), sandbox_id: 'sandbox-xyz' });
+    });
+    expect(screen.getByText(/sandbox-xyz/i)).toBeInTheDocument();
+  });
+});
+
+describe('a superseded stats response cannot overwrite a newer one', () => {
+  // The price of an always-enabled Refresh. handleStartStop never sets `loading`,
+  // so Refresh stays on screen while a Stop is in flight; the read it starts takes
+  // the full path (~15s of probes) while the post-Stop read takes the fast offline
+  // one. Committing by arrival order would put a stopped sandbox back into
+  // "running" with its live-only tabs open and Stop offered — which the API then
+  // rejects, since stop_workspace requires a running row.
+  it('drops the slow refresh that resolves after the post-stop read', async () => {
+    mockGetSandboxStats.mockResolvedValue(liveStats('running'));
+    await openTab(/overview/i);
+
+    const stopPost = deferred<any>();
+    (api.post as any).mockReturnValueOnce(stopPost.promise);
+
+    fireEvent.click(await waitFor(() => screen.getByRole('button', { name: /^stop$/i })));
+
+    // Still reachable: the Stop POST is in flight but `loading` is untouched.
+    const refresh = screen.getByRole('button', { name: /refresh sandbox status/i });
+
+    const slowRefresh = deferred<any>();
+    const fastPostStop = deferred<any>();
+    mockGetSandboxStats
+      .mockReturnValueOnce(slowRefresh.promise)
+      .mockReturnValueOnce(fastPostStop.promise);
+
+    fireEvent.click(refresh);
+    await act(async () => {
+      stopPost.resolve({ data: { status: 'stopped' } });
+    });
+    await waitFor(() => expect(mockGetSandboxStats).toHaveBeenCalledTimes(3));
+
+    await act(async () => {
+      fastPostStop.resolve({ ...defaultStats(), state: 'stopped' });
+    });
+    expect(screen.getByRole('button', { name: /^start$/i })).toBeInTheDocument();
+
+    await act(async () => {
+      slowRefresh.resolve(liveStats('running'));
+    });
+
+    expect(screen.getByRole('button', { name: /^start$/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^stop$/i })).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Overview

A **running sandbox reported itself as not-running**, so the settings panel hid the Packages, Tools & Skills and MCP tabs. Fixes #333. The gate fix is three lines; the rest is the fallout of finding out *who* the bug was actually hitting. Carries one unrelated commit — an `mcp` pin that unblocks the sandbox image build (see below).

| | Files | Added | Removed |
|---|---|---|---|
| Modified (production) | 5 | 234 | 48 |
| New (production) | 0 | — | — |
| **Net excl. tests** | **5** | **+234** | **−48** |
| Tests (1 new, 2 modified) | 3 | 668 | 1 |
| **Total** | **8** | **+902** | **−49** |

**By module**

| Module | File | Δ | What |
|---|---|---|---|
| `src/server/app/` | `workspace_sandbox.py` | +75/−5 | `_display_state()` adapter at the API boundary; offline path never claims `running`; `provider` on the wire, read from config |
| `web/…/components/` | `SandboxSettingsPanel.tsx` | +130/−36 | Gate on canonical `'running'`; terminal-state allowlist + label map; always-enabled Refresh + newest-response-wins guard; provider-aware Storage; auto-stop and a11y fixes |
| `src/ptc_agent/core/sandbox/providers/` | `docker.py` | +24/−5 | `get_metadata` returns cpu/memory/created_at from the inspect call it already made; status parse shared with `get_state` |
| `Dockerfile.sandbox`, `core/sandbox/` | `_defaults.py` | +5/−2 | Pin `mcp==1.29.0` in both mirrored dependency lists |
| `tests/unit/server/app/` | `test_workspace_sandbox_stats.py` | +395 (new) | 24 tests — canonicalization, the offline clamp, both fallback branches, provider sourcing, ownership |
| `web/…/__tests__/` | `SandboxSettingsPanel.test.tsx` | +241/−1 | 20 tests — gated tabs, fail-safe states, label leaks, auto-stop, provider-aware Storage, the synonym boundary, refresh, response ordering |
| `tests/unit/core/sandbox/` | `test_docker_provider.py` | +32 | Docker metadata limits, and that unset limits are omitted rather than reported as 0 |

**What this introduces:** two adapter functions, one wire field (`provider`), a state→label map, one button, and a request-sequence guard. No new endpoint, dependency, migration, or config.

## The bug

`SandboxRuntime.get_metadata()` is provider-specific by contract (`runtime.py:271-272`). For the same healthy sandbox:

- **Daytona** (hosted) reports `"started"`
- **Docker** (local self-host) reports `"running"`

The endpoint forwarded that raw value and the panel compared `state === 'started'`. The gate was reading a provider dialect as if it were a shared vocabulary.

## Who it was actually hitting

Not symmetrically — and not the way the issue reads:

- **Self-hosted (Docker): always broken.** `DockerRuntime.get_metadata` derives state from `get_state()`, which can only return `RuntimeState` values — never `"started"`. `isRunning` was therefore *structurally, permanently false*. Storage, Packages and Tools & Skills have never rendered once outside hosted.
- **Hosted (Daytona): broken only when the metadata read failed.** The raw `"started"` matched the old gate, so the ordinary path worked. But the full-stats path seeded `state = None` and swallowed metadata errors with a bare `except: pass` — so any read failure silently downgraded a live sandbox to "offline", with no log line to explain it.

So the gate fix and the fallback fix are doing two different jobs: one makes three tabs reachable for self-hosted users for the first time, the other removes a silent hosted failure mode. That is why the PR does not stop at the gate.

## The fix

**1. Canonicalize at the API boundary** (not in the provider):

```python
_DISPLAY_STATE_SYNONYMS = {"started": "running"}
```

The boundary is the right owner precisely *because* `get_metadata()` is documented provider-specific — normalizing inside `DaytonaRuntime` would make one provider secretly speak another's dialect and leave the next provider to rediscover the trap. Only the one synonym is rewritten; everything else passes through, so this layer never enumerates Daytona's ~23 states.

**The offline path is the exception: it never reports `running` at all.** That path answers for a workspace whose row says `starting`/`stopping`, and it collects no disk usage, packages or skills — while the client reads `running` as proof they are present and as licence to offer Stop, which `stop_workspace` then rejects for any non-running row. So when the provider says the sandbox is up but the row disagrees, the row wins; every other provider state still passes through. The full path takes over the moment the row says running.

**2. Invert the frontend state list.** `TRANSITIONAL_STATES` (3 entries) became `TERMINAL_STATES` (9 settled values) plus a `STATE_LABELS` map. Previously any state outside those three — `creating`, `restoring`, `resizing`, `destroying`, `pulling_snapshot`, … — rendered as a settled failure with a **working Start button**, so a user could start a mid-resize sandbox. Unrecognized states now fail safe to in-progress with actions disabled. This also stops two identifiers reaching the screen as copy: `build_failed` → "Build_failed", and Daytona's `_missing_` sentinel → "Unknown_default_open_api".

Failing safe has one cost that has to be paid explicitly: **nothing polls** — stats load on mount and after explicit actions only. So the status row gains an always-enabled **Refresh**. In a transitional state every other control is disabled, and without it the panel has no way to advance short of a remount.

That affordance brings its own hazard, so it is paid for in the same change: `handleStartStop` never sets `loading`, so Refresh stays clickable while a Stop is in flight. The read it starts takes the full path and its ~15s of probes while the post-stop read takes the fast offline one, and committing by arrival order let the stale response resurrect a stopped sandbox as running. A monotonic request id now lets only the newest response commit.

The client deliberately does **not** carry its own `'started'` shim. Canonicalization belongs to the API alone — two layers each deciding what "running" means is how the vocabularies drift apart, and the client would have no way to know which one was authoritative. A test pins that absence so it doesn't get re-added casually.

**3. Make the newly-reachable tabs honest for Docker.** `get_metadata` now returns cpu/memory/created_at (from the `container.show()` call it already made), so the Overview cards aren't four `---`. And `provider` is on the wire because the Storage tab must suppress its totals for Docker: `df -h` inside a container with no size quota reports the **host** filesystem, so a self-hosted user would see their laptop's disk pressure labelled as their sandbox's. The per-directory breakdown is sandbox-scoped and stays.

`provider` is read from the configured sandbox provider, *not* from `meta["provider"]` — only the Docker provider sets that key, and the metadata read can raise. Either would report "not docker" on the exact path the field exists to protect.

**4. Three adjacent corrections.** `auto_stop_interval == 0` renders "Always on" — 0 *disables* auto-stop, so "Auto-stop: 0m" told the user the exact opposite of what the sandbox would do. `role="status" aria-live="polite"` on the status row, `aria-hidden` on the decorative dot and spinner. `focus-visible` outlines on 7 inputs that had bare `outline-none` and no replacement, including every Vault credential field.

## The unrelated commit: pinning `mcp`

`ff107fea` is not part of the fix. `mcp 2.0.0` (2026-07-28) dropped the `mcp.server.fastmcp` module that scrapling's MCP entrypoint imports, and the dependency was unpinned in both mirrored lists — so every sandbox image build since has failed. The 1.29.0 wheel ships 19 files under `mcp/server/fastmcp/`; the 2.0.0 wheel ships zero. CI history shows no run of the sandbox workflow between the release and this branch, which is why nothing caught it earlier; `main` fails the same way today.

Pinned to `mcp==1.29.0` rather than `mcp<2` because `mcp_setup` joins `DEFAULT_DEPENDENCIES` into a shell command, where `<` parses as a redirect and would quietly install `mcp` unpinned again. Verified by resolution, not assumption: `mcp==1.29.0`, `fastmcp==3.4.5` and `scrapling==0.4.12` resolve together. This is a stopgap — the 2.x migration is a separate PR.

## Verification

- Backend `tests/unit/` (7152 passed) and frontend `vitest run` (2534 passed) both fully green; `tsc --noEmit` and `ruff check` clean.
- **Every new behaviour was mutation-tested, not just covered.** Each production change was reverted in turn and the intended test failed, with checksum-verified restores:
  - offline path allowed to report `running` again → both clamp tests fail
  - drop the offline metadata fallback → caught by the no-state-key test *(this branch previously survived deletion with the whole suite green)*
  - offline exception fallback → `None` → caught by the provider-failure test
  - treat the 4 in-progress states as terminal → the 4 fail-safe tests fail
  - restore the bare capitalize → the identifier-leak test fails
  - always render the raw auto-stop interval → the "Always on" test fails
  - show Docker the host disk totals → the Storage suppression test fails
  - drop `meta["cpu"]` → the Docker limits test fails
  - re-add a client-side `'started'` shim → both synonym-boundary tests fail, so the absence is pinned rather than merely current
  - disable Refresh while transitioning → the refresh test fails
  - remove the newest-response-wins guard → the response-ordering test fails
  - source `provider` from metadata again → 3 provider tests fail, one of them by crashing on the unbound `meta` in the exception path
- **End-to-end on a running stack against live Daytona**, not just unit-mocked. Booted the backend, provisioned a real sandbox, and hit the endpoint over HTTP:

  ```
  GET /api/v1/workspaces/{id}/sandbox/stats
  → "state": "running", "provider": "daytona", "auto_stop_interval": 60,
    resources {cpu 1.0, memory 1.0, disk 3.0}, disk_usage {total "3.0G", used "6.3M"},
    directory_breakdown [...6 entries...]
  ```

  Then read the raw provider value for that same sandbox to prove the adapter did the work:

  ```
  RAW provider state          'started'      ← what Daytona actually reports
  after _display_state        'running'      ← what reaches the wire
  meta has a "provider" key    False         ← why provider is read from config
  configured provider         'daytona'
  ```

  The `meta` result is worth calling out: Daytona genuinely never sets a `provider` key, so sourcing that field from metadata would have silently reported "not docker" — confirmed by observation rather than by reading the provider source.
- **Docker's `get_metadata` exercised against real containers** — the shipped code against a throwaway container created with real cgroup limits (`NanoCpus=2e9`, `Memory=4GiB`): returned `cpu: 2.0`, `memory: 4.0`, a real `created_at`, and no `disk` key. A second container with no limits omitted `cpu`/`memory` rather than reporting `0`. It also reported `state: "running"`, confirming by observation that Docker can never emit `"started"`. The full self-hosted stack was not exercised end-to-end — `sandbox-docker` in CI covers that.
- Ownership pinned on both paths; the docstring records that only the `stopped` case pins the endpoint-level check, since the running path re-checks inside `_get_sandbox`.
- Each of the 4 commits was verified green independently (backend unit at every slice), and the consolidation was verified as a pure reshaping — identical tree, empty diff against the pre-consolidation branch.

## Scope check

- **This endpoint has no consumer outside this service.** Swept every sibling codebase we deploy alongside langalpha: zero references to `sandbox/stats`, zero sandbox-state `"started"` comparisons. The settings panel is the only caller.
- No JSON fixture or snapshot holds a sandbox state of `"started"`. Raw-SDK fixtures exercise `_STATE_MAP`/the CLI, not this endpoint, and are untouched.
- Hosted risk is limited by construction — the only `src/ptc_agent/` changes are `docker.py`, the local-only provider, and the pinned dependency list — and a live hosted sandbox still reports as running through the real endpoint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added sandbox provider information to workspace statistics.
  - Added a manual refresh control for sandbox status.
  - Added clearer status labels and progress indicators, including “Always on” auto-stop settings.
  - Added provider-specific storage usage messaging for Docker sandboxes.
  - Added resource and creation-time details where available.

- **Bug Fixes**
  - Improved status consistency across sandbox providers.
  - Prevented outdated status responses from overwriting newer information.
  - Improved fallback behavior when sandbox details are unavailable.
  - Enhanced accessibility for live status updates and loading indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->