### PR TITLE
fix(web): anchor sidebar-dodging overlays to the real sidebar width

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -20,6 +20,15 @@
   transition: padding-left 0.25s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
+/* Fixed overlays positioned off --sidebar-width. They are viewport-anchored, so
+   nothing carries them along when the sidebar animates — without this they snap
+   to the new column while .app-main is still easing into it. */
+.sidebar-tracking {
+  transition:
+    left 0.25s cubic-bezier(0.22, 1, 0.36, 1),
+    transform 0.25s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
 .main {
   width: 100%;
   height: 100%;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useCallback, useEffect, useRef, useState } from 'react';
+import React, { Suspense, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { MotionConfig } from 'framer-motion';
 import { Routes, Route, Navigate, useNavigate, useLocation } from 'react-router-dom';
 import AppSidebar from './components/Sidebar/AppSidebar';
@@ -147,7 +147,6 @@ function AuthenticatedShell() {
   const mainRef = useRef<HTMLElement>(null);
   useScrollMemory(mainRef, `route:${location.pathname}`);
 
-  const layoutRef = useRef<HTMLDivElement>(null);
   const [sidebarWidth, setSidebarWidth] = useState(() => {
     try {
       const stored = Number(localStorage.getItem(SIDEBAR_WIDTH_KEY));
@@ -160,10 +159,11 @@ function AuthenticatedShell() {
   // per pointermove — the whole route tree lives under this shell); React state
   // and localStorage only sync on commit (drag end / double-click reset).
   const handleSidebarWidthChange = useCallback((width: number, commit = false) => {
-    if (!commit) {
-      layoutRef.current?.style.setProperty('--sidebar-width', `${width}px`);
-      return;
-    }
+    // Written on every call, commit or not: when the committed width equals the
+    // current state React bails out of the render, so the effect below never
+    // re-runs and the DOM would keep whatever the last pointermove left behind.
+    document.documentElement.style.setProperty('--sidebar-width', `${width}px`);
+    if (!commit) return;
     setSidebarWidth(width);
     try {
       localStorage.setItem(SIDEBAR_WIDTH_KEY, String(width));
@@ -171,6 +171,20 @@ function AuthenticatedShell() {
       // localStorage unavailable — width still applies for the session
     }
   }, []);
+  // Published on the document root, not on .app-layout: custom properties only
+  // inherit downward, and every fixed overlay that has to dodge the sidebar
+  // (the getting-started card, the dashboard's floating chat and edit toolbar)
+  // is viewport-anchored — some of them portalled clean out of the layout
+  // subtree. Off the root they'd read the collapsed default from tokens.css and
+  // sit under the sidebar. 0 on mobile, where no sidebar renders at all.
+  const sidebarWidthVar = isMobile ? '0px' : sidebarCollapsed ? '80px' : `${sidebarWidth}px`;
+  useLayoutEffect(() => {
+    const root = document.documentElement;
+    root.style.setProperty('--sidebar-width', sidebarWidthVar);
+    return () => {
+      root.style.removeProperty('--sidebar-width');
+    };
+  }, [sidebarWidthVar]);
 
   // While the user profile is loading, show the loading state to avoid
   // flashing protected content before the gate check completes.
@@ -185,11 +199,7 @@ function AuthenticatedShell() {
   return (
     <OnboardingProvider>
       <ThreadLifecycleFeed />
-      <div
-        ref={layoutRef}
-        className="app-layout"
-        style={!isMobile ? ({ '--sidebar-width': sidebarCollapsed ? '80px' : `${sidebarWidth}px` } as React.CSSProperties) : undefined}
-      >
+      <div className="app-layout">
         {!isMobile && (
           <AppSidebar
             collapsed={sidebarCollapsed}

--- a/web/src/components/Sidebar/Sidebar.css
+++ b/web/src/components/Sidebar/Sidebar.css
@@ -94,7 +94,8 @@ body.sidebar-resizing {
 }
 
 body.sidebar-resizing .sidebar,
-body.sidebar-resizing .app-main {
+body.sidebar-resizing .app-main,
+body.sidebar-resizing .sidebar-tracking {
   transition: none !important;
 }
 

--- a/web/src/pages/Dashboard/Dashboard.css
+++ b/web/src/pages/Dashboard/Dashboard.css
@@ -54,6 +54,9 @@
 /* === Suggestion bubbles above chat input === */
 .dashboard-suggestion-bubbles {
   display: flex;
+  /* Chips are nowrap and the row is capped by the content column, so without
+     wrapping they spill past the composer at narrower widths. */
+  flex-wrap: wrap;
   justify-content: center;
   gap: 8px;
   padding-bottom: 12px;

--- a/web/src/pages/Dashboard/DashboardCustom.tsx
+++ b/web/src/pages/Dashboard/DashboardCustom.tsx
@@ -140,8 +140,13 @@ function CustomInner({ mode, onModeChange }: DashboardCustomProps) {
       {/* Floating edit-mode toolbar */}
       {editMode && (
         <div
-          className="fixed left-1/2 -translate-x-1/2 z-40 flex items-center gap-1 rounded-full border shadow-lg px-2 py-1.5"
+          className="fixed left-1/2 sidebar-tracking z-40 flex items-center gap-1 rounded-full border shadow-lg px-2 py-1.5"
           style={{
+            // Centered on the content column rather than the viewport, whose
+            // midpoint sits half a sidebar left of the grid below. Shifted by
+            // transform, not by `left`: this box is width:auto, so moving `left`
+            // would also shrink the space it can grow into and crush the row.
+            transform: 'translateX(calc(-50% + var(--sidebar-width) / 2))',
             bottom: '1.5rem',
             backgroundColor: 'var(--color-bg-elevated)',
             borderColor: 'var(--color-border-elevated)',

--- a/web/src/pages/Dashboard/components/ChatInputCard.tsx
+++ b/web/src/pages/Dashboard/components/ChatInputCard.tsx
@@ -70,7 +70,10 @@ function ChatInputCard() {
   }
 
   return (
-    <div className="dashboard-floating-chat-wrapper fixed bottom-8 left-0 right-0 z-40 flex justify-center pointer-events-none">
+    // Insets to the content column, not the viewport: fixed positioning ignores
+    // <main>'s sidebar padding, so centering across the full width would park
+    // the composer half a sidebar left of the grid it floats over.
+    <div className="dashboard-floating-chat-wrapper sidebar-tracking fixed bottom-8 left-[var(--sidebar-width)] right-0 z-40 flex justify-center pointer-events-none">
       <div className="pointer-events-auto w-full max-w-2xl px-4">
         {/* Suggestion bubbles — above the input, outside focus container.
             Only mount when focused so they stay out of the DOM, a11y tree,

--- a/web/src/pages/Onboarding/engine/GettingStartedCard.tsx
+++ b/web/src/pages/Onboarding/engine/GettingStartedCard.tsx
@@ -35,7 +35,7 @@ export function GettingStartedCard() {
 
   return (
     <aside
-      className="fixed bottom-4 z-40 hidden w-80 rounded-2xl border p-4 shadow-lg md:block"
+      className="sidebar-tracking fixed bottom-4 z-40 hidden w-80 rounded-2xl border p-4 shadow-lg md:block"
       style={{
         left: 'calc(var(--sidebar-width) + 1rem)',
         backgroundColor: 'var(--color-bg-card)',


### PR DESCRIPTION
## Summary

`--sidebar-width` carried its live value as an inline style on the `.app-layout` div. CSS custom properties only inherit downward, so every `position: fixed` overlay rendered outside that subtree read the `80px` collapsed default declared at `:root` in `tokens.css` instead. The onboarding getting-started card sits at `calc(var(--sidebar-width) + 1rem)`, so it resolved to 96px and rendered underneath a 260px sidebar, clipped.

The variable now publishes on `document.documentElement` via `useLayoutEffect` — the same element where `tokens.css` declares its default, so the token has one home reachable from portals and viewport-anchored overlays alike. Mobile writes `0px` rather than falling back to `80px`, making the value honest at every viewport.

A sweep for the same defect class turned up two more instances, both non-modal Dashboard overlays that centered on the viewport rather than the content column. `position: fixed` ignores `.app-main`'s sidebar padding, so both sat half a sidebar (130px at the default 260) left of the grid they float over:

- the floating chat composer (`ChatInputCard`) insets to the content column
- the edit-mode toolbar (`DashboardCustom`) centers on it

Modals, lightboxes and the mobile sheet were checked and left alone — viewport centering is correct for those.

**Two consequences of re-anchoring, both handled here.** The toolbar is a `width: auto` box, so moving its `left` would also shrink the space it can grow into and crush the button row at narrower widths — it shifts by `transform` instead, which leaves its layout box exactly where it was. And the three overlays are viewport-anchored, so nothing carried them along while the sidebar animated; they now share a `.sidebar-tracking` class that eases `left`/`transform` on the same curve as `.app-main`'s padding and is covered by the existing `body.sidebar-resizing` transition suppression, so drags still track 1:1. The composer's suggestion chips also gained `flex-wrap` — they are `white-space: nowrap` and the column is narrower than the viewport was, so they would otherwise spill past the card.

## Overview

7 files changed, **+46 / −15**. No new files, no test churn, no new dependency.

| Module | Files | + | − | What changed |
|---|---|---|---|---|
| `web` — app shell | 3 (mod) | 32 | 12 | `--sidebar-width` published on the document root; drag path writes unconditionally; `.sidebar-tracking` transition + drag suppression |
| `web` — Dashboard | 3 (mod) | 13 | 2 | floating composer and edit-mode toolbar re-anchored to the content column; suggestion chips wrap |
| `web` — Onboarding | 1 (mod) | 1 | 1 | getting-started card joins the tracking class |

This introduces no new API, state, or abstraction — it moves where one existing CSS variable lives, corrects the positioning expressions that read it, and adds one class naming the "overlay that tracks the sidebar" role.

## Diff Size
- Total: 7 files changed, 46 insertions(+), 15 deletions(-)
- Net (excl. tests): 7 files changed, 46 insertions(+), 15 deletions(-)

## Verification

Measured in a real Chromium session against a running dev stack, comparing each overlay against the widget grid's content column. The toolbar probe carries the shipped className and inline style with its real button content and **no explicit width**, so shrink-to-fit is actually exercised:

| Viewport | `--sidebar-width` | Grid center | Composer center | Toolbar center | Toolbar width | Inside column | Chips overflow |
|---|---|---|---|---|---|---|---|
| 1440 | 260px | 850 | 850 | 850 | 311px | yes | no |
| 1024 | 260px | 642 | 642 | 642 | 311px | yes | no |
| 820 | 260px | 540 | 540 | 540 | 311px | yes | no |
| 768 | 260px | 514 | 514 | 514 | 311px | yes | no |
| 500 | 0px | 250 | — (mobile FAB) | 250 | 311px | yes | — |

Before the fix the same measurement put both Dashboard overlays at the viewport center (720 at 1440 wide) and the document root at `80px`. The getting-started card was confirmed fixed visually.

## Review

A cross-model adversarial pass (Codex, `model_reasoning_effort=high`) ran against the diff and raised five findings. Four were confirmed and fixed in this commit: the toolbar shrink-to-fit crush, the suggestion-chip overflow, a drag commit that could leave the DOM and React state disagreeing when the committed width equals current state (React bails out, so the effect never re-runs — the handler now writes the root property on every call), and the overlay/content animation mismatch.

The fifth — that taking ownership of a root custom property is destructive rather than save-and-restore — is not adopted. `--sidebar-width` is this app's own token, declared in its own `tokens.css`; there is no host integration or second shell to displace, and the machinery would exist only for a hypothetical.

## Test plan
- [x] `pnpm test` — 2813 passed across 263 files
- [x] `tsc --noEmit` clean
- [x] ESLint clean on the changed files
- [x] Overlay geometry measured across five viewports (table above)
- [x] Eyeball: edit-mode toolbar in custom layout mode (geometry measured by proxy; the real toolbar only mounts in custom layout)
- [x] Eyeball: sidebar drag + collapse easing, and sign-out → sign-in (the variable's write path moved)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard layout behavior when resizing or collapsing the sidebar.
  * Fixed floating controls and chat input positioning so they remain aligned with the content area.
  * Prevented dashboard suggestion bubbles from overflowing on narrow screens.
  * Improved sidebar transitions for smoother movement of fixed overlays.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->