### PR TITLE
Allow switching models across providers mid-thread

### DIFF
--- a/agent_config.yaml
+++ b/agent_config.yaml
@@ -256,7 +256,6 @@ logging:
   file: "logs/ptc.log"
 
 agent:
-  enable_view_image: true
   background_auto_wait: false
 
 # Subagent configuration

--- a/src/llms/llm.py
+++ b/src/llms/llm.py
@@ -270,6 +270,12 @@ class LLM:
     # Class-level model config instance
     _model_config = None
 
+    # Both real constructors set this; the default only covers instances built
+    # attribute-by-attribute off ``__new__``. Downstream reads fail closed
+    # (get_input_modalities treats an unknown model as text-only), so a missing
+    # stamp costs a stripped image block, never a rejected request.
+    custom_model_name: str | None = None
+
     @classmethod
     def get_model_config(cls) -> ModelConfig:
         """Get or create the model configuration singleton."""
@@ -489,12 +495,18 @@ class LLM:
         # request actually takes — langchain's own ``model_provider`` field
         # cannot be trusted here (ChatAnthropic reports "anthropic" for every
         # Anthropic-compatible shim).
+        # ``manifest_model`` is the models.json key, not ``self.model`` (the API
+        # model id) — it is what get_input_modalities() looks up. Middleware that
+        # runs inside ModelResilienceMiddleware sees a substituted client, so a
+        # capability read has to come off the client in hand rather than off a
+        # name captured when the stack was built.
         billing_type = self._resolve_billing_type()
         existing = client.metadata or {}
         client.metadata = {
             **existing,
             "billing_type": billing_type,
             "provider_route": self._provider_route(),
+            "manifest_model": self.custom_model_name,
         }
 
         return client

--- a/src/llms/llm.py
+++ b/src/llms/llm.py
@@ -941,6 +941,41 @@ def get_input_modalities(
     return LLM.get_model_config().get_input_modalities(model_name)
 
 
+# Published per-request PDF page ceilings. Anthropic's is the only one that
+# moves with the context window (600 at 1M, 100 below it), and it is the reason
+# a single global cap can't be right: the same document is fine on Sonnet 5 and
+# rejected on Sonnet 4.6. OpenAI documents a size limit but no page limit, hence
+# None — "not bounded by pages" rather than "unknown".
+_ANTHROPIC_SDK_PROVIDERS = frozenset({"anthropic", "claude-oauth", "doubao-anthropic"})
+_GEMINI_MAX_PDF_PAGES = 1000
+_ANTHROPIC_MAX_PDF_PAGES_1M = 600
+_ANTHROPIC_MAX_PDF_PAGES = 100
+
+
+def get_max_pdf_pages(model_name: str) -> int | None:
+    """Documented per-request PDF page ceiling for a model, or None if unbounded.
+
+    Unknown models get the tightest published ceiling rather than None: this
+    gates what we transmit, so guessing generously turns an unknown into a 400
+    the caller has no way to recover.
+    """
+    model_info = LLM.get_model_config().get_model_config(model_name) or {}
+    provider = model_info.get("provider", "")
+
+    if provider in _ANTHROPIC_SDK_PROVIDERS:
+        context = model_info.get("context") or 0
+        return (
+            _ANTHROPIC_MAX_PDF_PAGES_1M
+            if context >= 1_000_000
+            else _ANTHROPIC_MAX_PDF_PAGES
+        )
+    if provider == "gemini":
+        return _GEMINI_MAX_PDF_PAGES
+    if provider in ("openai", "codex-oauth"):
+        return None
+    return _ANTHROPIC_MAX_PDF_PAGES
+
+
 def should_enable_caching(model_name: str) -> bool:
     """
     Check if a model should enable Anthropic prompt caching.

--- a/src/ptc_agent/agent/agent.py
+++ b/src/ptc_agent/agent/agent.py
@@ -621,14 +621,6 @@ class PTCAgent:
         shared_middleware.append(ProvenanceMiddleware(redactor=leak_detection.redact))
         shared_middleware.append(TodoWriteMiddleware())
 
-        # Add multimodal middleware for read_file image/PDF support (when enabled)
-        if self.config.enable_view_image and self.config.llm:
-            shared_middleware.append(MultimodalMiddleware(
-                sandbox=sandbox,
-                model_name=self.config.llm.name,
-                custom_modalities=self.config.input_modalities,
-            ))
-
         skill_sources = (
             [f"{self.config.skills.sandbox_skills_base}/"]
             if self.config.skills.enabled
@@ -784,6 +776,22 @@ class PTCAgent:
 
         model_resilience = self._build_model_resilience_middleware()
 
+        # Inside model_resilience so it strips against the post-fallback model:
+        # a vision primary falling back to a text-only candidate would otherwise
+        # replay image/PDF blocks and earn the 400 the fallback exists to avoid.
+        # In both stacks because a subagent on its own model needs the same
+        # protection; it reads that model off each request, so the two stacks
+        # can share one instance rather than needing one apiece.
+        multimodal = (
+            MultimodalMiddleware(
+                sandbox=sandbox,
+                model_name=self.config.llm.name,
+                custom_modalities=self.config.input_modalities,
+            )
+            if self.config.llm
+            else None
+        )
+
         # Placed before (outer to) model_resilience so sandbox images are
         # captured once, on the final response only — not per retry attempt.
         image_capture = (
@@ -802,6 +810,7 @@ class PTCAgent:
                 image_capture,
                 compaction,
                 *model_resilience,
+                multimodal,
                 AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
                 OpenAIPromptCachingMiddleware(),
                 EmptyToolCallRetryMiddleware(),
@@ -897,6 +906,7 @@ class PTCAgent:
                 image_capture,
                 compaction,
                 *model_resilience,
+                multimodal,
                 AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
                 OpenAIPromptCachingMiddleware(),
                 # Market watch (main agent only): appends the ephemeral

--- a/src/ptc_agent/agent/flash/agent.py
+++ b/src/ptc_agent/agent/flash/agent.py
@@ -22,6 +22,7 @@ from ptc_agent.agent.middleware import (
     SkillsMiddleware,
     AskUserMiddleware,
     LeakDetectionMiddleware,
+    MultimodalMiddleware,
     ProvenanceMiddleware,
     ReasoningCompatibilityMiddleware,
 )
@@ -287,6 +288,19 @@ class FlashAgent:
             "Flash model resilience enabled",
             max_retries=3,
             fallback_models=[name for name, _ in fallbacks],
+        )
+
+        # Only the read-side strip is live here: Flash exposes no filesystem
+        # tool at all, so the injection half has nothing to intercept. Without
+        # it, a mid-thread switch to a text-only model replays an earlier turn's
+        # image/PDF blocks and strict providers reject the request outright.
+        # Inside model resilience so it strips against the post-fallback model.
+        main_middleware.append(
+            MultimodalMiddleware(
+                sandbox=None,
+                model_name=self.config.llm.flash or self.config.llm.name,
+                custom_modalities=self.config.input_modalities,
+            )
         )
 
         # Prompt caching (per-provider breakpoints), empty tool call retry,

--- a/src/ptc_agent/agent/middleware/compaction/offloading.py
+++ b/src/ptc_agent/agent/middleware/compaction/offloading.py
@@ -328,14 +328,14 @@ async def aoffload_base64_content(
                     new_blocks.append(
                         {
                             "type": "text",
-                            "text": f"[PDF saved to {path} — use read_file to view]",
+                            "text": f"[PDF saved to {path} — use Read to view]",
                         }
                     )
                 else:
                     new_blocks.append(
                         {
                             "type": "text",
-                            "text": f"[Image saved to {path} — use read_file to view]",
+                            "text": f"[Image saved to {path} — use Read to view]",
                         }
                     )
                 msg_changed = True

--- a/src/ptc_agent/agent/middleware/file_operations/__init__.py
+++ b/src/ptc_agent/agent/middleware/file_operations/__init__.py
@@ -1,8 +1,8 @@
 """File operation middlewares.
 
 This module provides middleware for intercepting file operations:
-- FileOperationMiddleware: SSE event emission for write_file/edit_file
-- MultimodalMiddleware: Image/PDF injection for read_file with visual file paths/URLs
+- FileOperationMiddleware: SSE event emission for Write/Edit
+- MultimodalMiddleware: Image/PDF injection for Read with visual file paths/URLs
 """
 
 from ptc_agent.agent.middleware.file_operations.sse_middleware import (

--- a/src/ptc_agent/agent/middleware/file_operations/multimodal.py
+++ b/src/ptc_agent/agent/middleware/file_operations/multimodal.py
@@ -45,7 +45,7 @@ DOCUMENT_EXTENSIONS = frozenset({".pdf"})
 VISUAL_EXTENSIONS = IMAGE_EXTENSIONS | DOCUMENT_EXTENSIONS
 
 # PIL reports a format name; providers speak MIME. A format outside this map is
-# one no provider accepts, so it resolves to None rather than a near-miss guess.
+# one no provider accepts, so it is refused rather than given a near-miss guess.
 _PIL_FORMAT_TO_MIME = {
     "PNG": "image/png",
     "JPEG": "image/jpeg",
@@ -53,23 +53,48 @@ _PIL_FORMAT_TO_MIME = {
     "WEBP": "image/webp",
 }
 
+# The tightest published per-request page ceiling (Anthropic's, below a 1M-token
+# context). Page count is what binds for PDFs — a 300-page report can sit well
+# under MAX_CONTENT_BYTES and still be rejected on arrival.
+MAX_PDF_PAGES = 100
 
-def _detect_mime_type(content: bytes) -> str | None:
-    """MIME type read off the bytes, or None if they are neither PDF nor image.
+
+class _UnusableContent(Exception):
+    """Why bytes can't be injected. The text reaches the agent, so it reads as a
+    predicate ("not a readable PDF") that slots into the caller's message."""
+
+
+def _detect_mime_type(content: bytes) -> str:
+    """MIME type read off the bytes, raising `_UnusableContent` if nothing accepts them.
 
     The name can't decide this: a URL may carry no extension at all, and a
     sandbox path is only as accurate as whatever wrote the file. Both callers
-    checkpoint what they inject, so a mislabeled or truncated file would replay
-    its provider 400 on every later turn rather than failing once.
+    checkpoint what they inject, so anything a provider would reject has to be
+    caught here — otherwise it replays its 400 on every later turn instead of
+    failing once. Hence structural verification, not just a magic-byte peek.
     """
     if content.startswith(b"%PDF"):
+        import pypdf
+
+        try:
+            pages = len(pypdf.PdfReader(io.BytesIO(content)).pages)
+        except Exception:
+            raise _UnusableContent("not a readable PDF") from None
+        if pages > MAX_PDF_PAGES:
+            raise _UnusableContent(
+                f"a {pages}-page PDF, over the {MAX_PDF_PAGES}-page limit"
+            )
         return "application/pdf"
+
     try:
         img = Image.open(io.BytesIO(content))
         img.verify()
     except Exception:
-        return None
-    return _PIL_FORMAT_TO_MIME.get(img.format or "")
+        raise _UnusableContent("not a readable image or PDF") from None
+    mime_type = _PIL_FORMAT_TO_MIME.get(img.format or "")
+    if mime_type is None:
+        raise _UnusableContent(f"in {img.format} format, which no provider accepts")
+    return mime_type
 
 
 def _strip_unsupported_content_blocks(
@@ -232,10 +257,11 @@ class MultimodalMiddleware(AgentMiddleware):
     # injection half into dead code rather than failing anywhere visible.
     TOOL_NAME = "Read"
 
-    # Anthropic caps a single image at 5MB, which binds well before any
-    # per-request ceiling. Both injection paths return a Command that writes the
-    # block into graph state, so an oversized block is not a one-turn error: it
-    # is checkpointed and replayed on every later turn, and the modality strip
+    # Raw bytes, deliberately below every provider's published ceiling: those are
+    # quoted on the base64 string, which is 4/3 larger, so 5 MiB here is ~6.7 MiB
+    # on the wire. Both injection paths return a Command that writes the block
+    # into graph state, so an oversized block is not a one-turn error: it is
+    # checkpointed and replayed on every later turn, and the modality strip
     # cannot save a target that legitimately has the image modality. Refuse
     # before encoding rather than brick the thread.
     MAX_CONTENT_BYTES = 5 * 1024 * 1024
@@ -516,11 +542,12 @@ class MultimodalMiddleware(AgentMiddleware):
             # Typed from the bytes, not the URL: a signed or redirected URL can
             # end without an extension, and branching on that would send a PDF
             # down the image path and reject it as corrupt.
-            mime_type = _detect_mime_type(content_bytes)
-            if mime_type is None:
-                logger.warning(f"[MULTIMODAL] Unreadable content from URL: {url}")
+            try:
+                mime_type = _detect_mime_type(content_bytes)
+            except _UnusableContent as exc:
+                logger.warning(f"[MULTIMODAL] Refusing content from URL ({exc}): {url}")
                 return ToolMessage(
-                    content=f"ERROR: Content is not a readable image or PDF: {url}",
+                    content=f"ERROR: Content is {exc}: {url}",
                     tool_call_id=tool_call_id,
                 )
 
@@ -625,11 +652,12 @@ class MultimodalMiddleware(AgentMiddleware):
             # Typed from the bytes for the same reason the URL path is: the
             # extension is whatever wrote the file claimed, and a truncated
             # chart named .png is checkpointed before any provider sees it.
-            mime_type = _detect_mime_type(file_bytes)
-            if mime_type is None:
-                logger.warning(f"[MULTIMODAL] Unreadable content in file: {file_path}")
+            try:
+                mime_type = _detect_mime_type(file_bytes)
+            except _UnusableContent as exc:
+                logger.warning(f"[MULTIMODAL] Refusing file ({exc}): {file_path}")
                 return ToolMessage(
-                    content=f"ERROR: File is not a readable image or PDF: {file_path}",
+                    content=f"ERROR: File is {exc}: {file_path}",
                     tool_call_id=tool_call_id,
                 )
 

--- a/src/ptc_agent/agent/middleware/file_operations/multimodal.py
+++ b/src/ptc_agent/agent/middleware/file_operations/multimodal.py
@@ -15,20 +15,21 @@ Supported formats:
 - Documents: PDF
 """
 
+import asyncio
 import base64
 import io
 import logging
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
 
 import httpx
 from langchain.agents.middleware import AgentMiddleware
-from langchain_core.messages import HumanMessage, ToolMessage
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langgraph.types import Command
 from PIL import Image
 
+from ptc_agent.agent.middleware._utils import append_to_system_message
 from ptc_agent.agent.tools.file_ops import is_memo_text_path
 from src.llms.llm import get_input_modalities
 from src.tools.web.inhouse.guard import BlockedAddressError, GuardedAsyncTransport
@@ -186,17 +187,54 @@ _UNSUPPORTED_NOTE = (
 )
 
 
-def _can_view(ext: str, modalities: list[str]) -> bool:
-    """Whether *modalities* cover the kind of file *ext* names.
+def _tool_results_first(messages: list) -> list:
+    """Order each tool-result run so its ToolMessages precede injected content.
 
-    A URL carrying no recognizable extension could resolve to either kind, so it
-    needs one of the two rather than a specific one.
+    A visual Read resolves to a Command carrying ``[ToolMessage, HumanMessage]``,
+    and a parallel batch interleaves that with the other calls' results —
+    ``tool_result, text, image, tool_result``. Anthropic requires a user turn's
+    tool_result blocks to come before any other content and 400s otherwise, and
+    since the Command is checkpointed the bad order would replay every turn.
+    Repaired here rather than at injection time because only this side sees the
+    whole batch; the checkpoint keeps the original order and heals on read.
     """
-    if ext in DOCUMENT_EXTENSIONS:
-        return "pdf" in modalities
-    if ext in IMAGE_EXTENSIONS:
-        return "image" in modalities
-    return "image" in modalities or "pdf" in modalities
+    out: list = []
+    run: list = []
+    in_run = False
+    changed = False
+
+    def flush() -> None:
+        nonlocal changed
+        if not run:
+            return
+        needs, seen_other = False, False
+        for msg in run:
+            if isinstance(msg, ToolMessage):
+                if seen_other:
+                    needs = True
+                    break
+            else:
+                seen_other = True
+        if needs:
+            changed = True
+            out.extend(m for m in run if isinstance(m, ToolMessage))
+            out.extend(m for m in run if not isinstance(m, ToolMessage))
+        else:
+            out.extend(run)
+        run.clear()
+
+    for msg in messages:
+        if isinstance(msg, AIMessage):
+            flush()
+            in_run = bool(getattr(msg, "tool_calls", None))
+            out.append(msg)
+        elif in_run:
+            run.append(msg)
+        else:
+            out.append(msg)
+    flush()
+
+    return out if changed else messages
 
 
 def _is_visual_request(file_path: str) -> bool:
@@ -369,19 +407,30 @@ class MultimodalMiddleware(AgentMiddleware):
         the checkpoint contains image/PDF content blocks that would cause 400 errors.
         This method replaces those blocks with text placeholders.
         """
+        # Runs for every target, not just modality-limited ones: the interleaving
+        # only arises where injection succeeded, which is a model that can see it.
+        messages = _tool_results_first(request.messages)
+        overrides: dict[str, Any] = {}
+
         modalities = self._resolve_modalities(request)
         has_image = "image" in modalities
         has_pdf = "pdf" in modalities
 
-        # Fast path: model supports all visual types
-        if has_image and has_pdf:
-            return await handler(request)
+        if not (has_image and has_pdf):
+            sanitized = _strip_unsupported_content_blocks(messages, has_image, has_pdf)
+            if sanitized is not messages:
+                messages = sanitized
+                # Told to the model that actually can't see the file, on the call
+                # where that is true. The tool-time note this replaces judged the
+                # configured model and froze that verdict into the transcript,
+                # which a subagent on its own model then inherited wrongly.
+                overrides["system_message"] = append_to_system_message(
+                    request.system_message, _UNSUPPORTED_NOTE
+                )
 
-        # Strip unsupported content blocks from messages
-        sanitized = _strip_unsupported_content_blocks(request.messages, has_image, has_pdf)
-        if sanitized is not request.messages:
-            return await handler(request.override(messages=sanitized))
-        return await handler(request)
+        if messages is not request.messages:
+            overrides["messages"] = messages
+        return await handler(request.override(**overrides) if overrides else request)
 
     async def awrap_tool_call(
         self,
@@ -413,30 +462,13 @@ class MultimodalMiddleware(AgentMiddleware):
         if not _is_visual_request(file_path):
             return await handler(request)
 
-        # Check model capabilities — skip content injection for unsupported
-        # modalities. The configured model is the right basis here: which model
-        # actually consumes the injected blocks isn't decided until the next
-        # model call, and awrap_model_call re-checks against that one anyway. So
-        # this note is a UX affordance, not the thing preventing a 400.
-        model = self.model_name
-        modalities = get_input_modalities(model, custom_modalities=self.custom_modalities) if model else ["text"]
-
-        # Determine file extension (from local path or URL path)
-        if file_path.startswith(("http://", "https://")):
-            ext = Path(urlparse(file_path).path).suffix.lower()
-        else:
-            ext = Path(file_path).suffix.lower()
-
-        if not _can_view(ext, modalities):
-            # Run the tool anyway and append the note — the text output is still
-            # useful, and replacing it would lose a read the agent asked for.
-            result = await handler(request)
-            result_content = result.content if hasattr(result, "content") else str(result)
-            return ToolMessage(
-                content=result_content + _UNSUPPORTED_NOTE,
-                tool_call_id=tool_call_id,
-            )
-
+        # Injected unconditionally, without asking whether the model can view it.
+        # This middleware is a single instance shared with every subagent, so the
+        # only model it could ask about is the configured one — and gating on that
+        # withheld the blocks from a subagent running its own vision model, which
+        # awrap_model_call cannot undo because it only ever removes blocks. The
+        # cost is that a text-only turn still checkpoints content it will strip on
+        # every read; that is the accepted price of never silently losing a read.
         logger.debug(f"[MULTIMODAL] Intercepting Read for visual content: {file_path}")
 
         # Execute the tool to get the acknowledgment message
@@ -543,7 +575,10 @@ class MultimodalMiddleware(AgentMiddleware):
             # end without an extension, and branching on that would send a PDF
             # down the image path and reject it as corrupt.
             try:
-                mime_type = _detect_mime_type(content_bytes)
+                # Off-loop: pypdf walks the xref of up to MAX_CONTENT_BYTES of
+                # model-chosen content, which is milliseconds on a real document
+                # but ~100ms on one padded with junk after %%EOF.
+                mime_type = await asyncio.to_thread(_detect_mime_type, content_bytes)
             except _UnusableContent as exc:
                 logger.warning(f"[MULTIMODAL] Refusing content from URL ({exc}): {url}")
                 return ToolMessage(
@@ -653,7 +688,7 @@ class MultimodalMiddleware(AgentMiddleware):
             # extension is whatever wrote the file claimed, and a truncated
             # chart named .png is checkpointed before any provider sees it.
             try:
-                mime_type = _detect_mime_type(file_bytes)
+                mime_type = await asyncio.to_thread(_detect_mime_type, file_bytes)
             except _UnusableContent as exc:
                 logger.warning(f"[MULTIMODAL] Refusing file ({exc}): {file_path}")
                 return ToolMessage(

--- a/src/ptc_agent/agent/middleware/file_operations/multimodal.py
+++ b/src/ptc_agent/agent/middleware/file_operations/multimodal.py
@@ -1,14 +1,14 @@
 """Multimodal middleware for injecting images and PDFs into LLM conversations.
 
-This middleware intercepts read_file tool calls for image/PDF paths and URLs,
+This middleware intercepts Read tool calls for image/PDF paths and URLs,
 downloading the content and injecting it as a HumanMessage content block
 for multimodal models.
 
 Architecture:
-- Intercepts read_file tool calls that match image/PDF patterns
+- Intercepts Read tool calls that match image/PDF patterns
 - Downloads content from sandbox or URL
 - Injects as HumanMessage using LangGraph's Command pattern
-- Passes through non-visual read_file calls unchanged
+- Passes through non-visual Read calls unchanged
 
 Supported formats:
 - Images: PNG, JPG, JPEG, GIF, WebP
@@ -16,7 +16,6 @@ Supported formats:
 """
 
 import base64
-import contextvars
 import io
 import logging
 from collections.abc import Awaitable, Callable
@@ -30,7 +29,9 @@ from langchain_core.messages import HumanMessage, ToolMessage
 from langgraph.types import Command
 from PIL import Image
 
+from ptc_agent.agent.tools.file_ops import is_memo_text_path
 from src.llms.llm import get_input_modalities
+from src.tools.web.inhouse.guard import BlockedAddressError, GuardedAsyncTransport
 
 logger = logging.getLogger(__name__)
 
@@ -42,11 +43,6 @@ DOCUMENT_EXTENSIONS = frozenset({".pdf"})
 
 # Combined visual extensions
 VISUAL_EXTENSIONS = IMAGE_EXTENSIONS | DOCUMENT_EXTENSIONS
-
-# Active model for the current async context (set in awrap_model_call, read in awrap_tool_call)
-_active_model: contextvars.ContextVar[str | None] = contextvars.ContextVar(
-    'multimodal_model', default=None
-)
 
 
 def _strip_unsupported_content_blocks(
@@ -84,8 +80,24 @@ def _strip_unsupported_content_blocks(
                 msg_modified = True
                 continue
 
-            # Check file blocks (PDF)
-            if block_type == "file" and block.get("mime_type", "").startswith("application/pdf") and not has_pdf:
+            # Any block typed "image" — covers the Anthropic-native `source`
+            # shape and the langchain v1 `base64` one. Matched on the type alone
+            # rather than a key, so a shape that drifts on a lib bump still gets
+            # stripped: this is the only thing standing between a mid-thread
+            # switch and a 400, and failing closed here only costs a placeholder.
+            if block_type == "image" and not has_image:
+                new_blocks.append({
+                    "type": "text",
+                    "text": "[Image attached in prior turn — not visible to current model]"
+                })
+                msg_modified = True
+                continue
+
+            # Any block typed "file", matched on the type alone for the same
+            # reason as "image" above: `pdf` is the only file-modality flag the
+            # manifest carries, so a file block we can't classify — mime absent,
+            # null, or non-PDF — is one a model without it has no way to accept.
+            if block_type == "file" and not has_pdf:
                 new_blocks.append({
                     "type": "text",
                     "text": "[PDF attached in prior turn — not visible to current model]"
@@ -112,6 +124,29 @@ def _strip_unsupported_content_blocks(
     return result if modified else messages
 
 
+_UNSUPPORTED_NOTE = (
+    "\n\n<system-reminder>"
+    "You cannot view this file directly because the current model does not support "
+    "this input type. Be transparent with the user about this limitation and suggest "
+    "they try switching to a model that supports image/PDF input. "
+    "Work in best effort to answer their query."
+    "</system-reminder>"
+)
+
+
+def _can_view(ext: str, modalities: list[str]) -> bool:
+    """Whether *modalities* cover the kind of file *ext* names.
+
+    A URL carrying no recognizable extension could resolve to either kind, so it
+    needs one of the two rather than a specific one.
+    """
+    if ext in DOCUMENT_EXTENSIONS:
+        return "pdf" in modalities
+    if ext in IMAGE_EXTENSIONS:
+        return "image" in modalities
+    return "image" in modalities or "pdf" in modalities
+
+
 def _is_visual_request(file_path: str) -> bool:
     """Check if the file_path is a visual file (image or PDF - URL or file extension).
 
@@ -125,15 +160,20 @@ def _is_visual_request(file_path: str) -> bool:
     if file_path.startswith(("http://", "https://")):
         return True
 
+    # A memo PDF is served as extracted text and has no sandbox-FS copy to
+    # fetch, so intercepting it would trade real content for a not-found error.
+    if is_memo_text_path(file_path):
+        return False
+
     # Check for visual file extensions (images + documents)
     suffix = Path(file_path).suffix.lower()
     return suffix in VISUAL_EXTENSIONS
 
 
 class MultimodalMiddleware(AgentMiddleware):
-    """Middleware that intercepts read_file for images/PDFs and injects them as HumanMessage.
+    """Middleware that intercepts Read for images/PDFs and injects them as HumanMessage.
 
-    When read_file is called with an image/PDF path or URL, this middleware:
+    When Read is called with an image/PDF path or URL, this middleware:
     1. Executes the tool to get the acknowledgment message
     2. Downloads the content (from URL or sandbox)
     3. Converts to base64 for universal LLM provider compatibility
@@ -141,7 +181,13 @@ class MultimodalMiddleware(AgentMiddleware):
        - The ToolMessage (for tool call completion)
        - A HumanMessage with the base64 content (for multimodal model processing)
 
-    Non-visual read_file calls pass through unchanged.
+    Non-visual Read calls pass through unchanged.
+
+    Independently of that, it strips image/PDF blocks out of history when the
+    current model lacks the modality — the half that keeps a mid-thread switch
+    to a text-only model from replaying an earlier turn's blocks. That half
+    needs no sandbox, so an agent with no Read tool wires it with
+    ``sandbox=None`` to get the strip alone.
 
     Note: Content is always downloaded and converted to base64 because many LLM
     providers (like Anthropic) cannot fetch external URLs directly.
@@ -154,7 +200,18 @@ class MultimodalMiddleware(AgentMiddleware):
         sandbox: PTCSandbox instance for reading files from sandbox paths
     """
 
-    TOOL_NAME = "read_file"
+    # Must track the name file_ops.py registers (``@tool("Read")``) — this is
+    # what awrap_tool_call matches on, and a mismatch silently turns the whole
+    # injection half into dead code rather than failing anywhere visible.
+    TOOL_NAME = "Read"
+
+    # Anthropic caps a single image at 5MB, which binds well before any
+    # per-request ceiling. Both injection paths return a Command that writes the
+    # block into graph state, so an oversized block is not a one-turn error: it
+    # is checkpointed and replayed on every later turn, and the modality strip
+    # cannot save a target that legitimately has the image modality. Refuse
+    # before encoding rather than brick the thread.
+    MAX_CONTENT_BYTES = 5 * 1024 * 1024
 
     # MIME type mapping for supported extensions
     MIME_TYPES = {
@@ -219,6 +276,49 @@ class MultimodalMiddleware(AgentMiddleware):
         )
         return handler(request)
 
+    def _too_large_message(self, source: str, tool_call_id: str) -> ToolMessage:
+        """Refuse an oversized block as a plain ToolMessage, never a Command.
+
+        A Command would write the block into graph state; the point of refusing
+        is that nothing oversized reaches the checkpoint.
+        """
+        limit_mb = self.MAX_CONTENT_BYTES // (1024 * 1024)
+        logger.warning(
+            f"[MULTIMODAL] Content exceeds {self.MAX_CONTENT_BYTES} bytes, refusing: {source}"
+        )
+        return ToolMessage(
+            content=(
+                f"ERROR: Content is larger than the {limit_mb}MB limit and was "
+                f"not loaded: {source}"
+            ),
+            tool_call_id=tool_call_id,
+        )
+
+    def _resolve_modalities(self, request: Any) -> list[str]:
+        """Modalities of the model this request will actually reach.
+
+        Read off ``request.model`` rather than the configured name so a
+        resilience fallback — or a subagent running its own model — is judged on
+        the client in hand.
+        """
+        metadata = getattr(request.model, "metadata", None)
+        stamped = metadata.get("manifest_model") if isinstance(metadata, dict) else None
+
+        if not isinstance(stamped, str) or not stamped:
+            # Unattributable: the client skipped LLM.get_llm(), which today means
+            # a subagent whose config names a bare model string for deepagents to
+            # resolve via init_chat_model. Falling back to the configured name
+            # would lend a vision parent's modalities to a text-only target and
+            # replay exactly the blocks this strip exists to remove, so an
+            # unstamped client is judged text-only — the same fail-closed reading
+            # LLM.get_llm() documents when it writes the stamp.
+            return ["text"]
+        # ``custom_modalities`` is a per-model override from user preferences, so
+        # it describes only the model it was configured for — a fallback is a
+        # different model and has to be judged on its own manifest entry.
+        overrides = self.custom_modalities if stamped == self.model_name else None
+        return get_input_modalities(stamped, custom_modalities=overrides)
+
     async def awrap_model_call(self, request, handler):
         """Strip unsupported content blocks from historical messages for text-only models.
 
@@ -226,31 +326,26 @@ class MultimodalMiddleware(AgentMiddleware):
         the checkpoint contains image/PDF content blocks that would cause 400 errors.
         This method replaces those blocks with text placeholders.
         """
-        model = self.model_name
-        token = _active_model.set(model)
-        try:
-            modalities = get_input_modalities(model, custom_modalities=self.custom_modalities) if model else ["text"]
-            has_image = "image" in modalities
-            has_pdf = "pdf" in modalities
+        modalities = self._resolve_modalities(request)
+        has_image = "image" in modalities
+        has_pdf = "pdf" in modalities
 
-            # Fast path: model supports all visual types
-            if has_image and has_pdf:
-                return await handler(request)
-
-            # Strip unsupported content blocks from messages
-            sanitized = _strip_unsupported_content_blocks(request.messages, has_image, has_pdf)
-            if sanitized is not request.messages:
-                return await handler(request.override(messages=sanitized))
+        # Fast path: model supports all visual types
+        if has_image and has_pdf:
             return await handler(request)
-        finally:
-            _active_model.reset(token)
+
+        # Strip unsupported content blocks from messages
+        sanitized = _strip_unsupported_content_blocks(request.messages, has_image, has_pdf)
+        if sanitized is not request.messages:
+            return await handler(request.override(messages=sanitized))
+        return await handler(request)
 
     async def awrap_tool_call(
         self,
         request: Any,
         handler: Callable[[Any], Awaitable[Any]],
     ) -> Any:
-        """Async wrapper that intercepts read_file for images/PDFs and injects as HumanMessage.
+        """Async wrapper that intercepts Read for images/PDFs and injects as HumanMessage.
 
         Args:
             request: Tool call request containing tool_call dict with name, args, id
@@ -275,8 +370,12 @@ class MultimodalMiddleware(AgentMiddleware):
         if not _is_visual_request(file_path):
             return await handler(request)
 
-        # Check model capabilities — skip content injection for unsupported modalities
-        model = _active_model.get() or self.model_name
+        # Check model capabilities — skip content injection for unsupported
+        # modalities. The configured model is the right basis here: which model
+        # actually consumes the injected blocks isn't decided until the next
+        # model call, and awrap_model_call re-checks against that one anyway. So
+        # this note is a UX affordance, not the thing preventing a 400.
+        model = self.model_name
         modalities = get_input_modalities(model, custom_modalities=self.custom_modalities) if model else ["text"]
 
         # Determine file extension (from local path or URL path)
@@ -285,39 +384,17 @@ class MultimodalMiddleware(AgentMiddleware):
         else:
             ext = Path(file_path).suffix.lower()
 
-        _unsupported_note = (
-            "\n\n<system-reminder>"
-            "You cannot view this file directly because the current model does not support "
-            "this input type. Be transparent with the user about this limitation and suggest "
-            "they try switching to a model that supports image/PDF input. "
-            "Work in best effort to answer their query."
-            "</system-reminder>"
-        )
-        if ext in IMAGE_EXTENSIONS and "image" not in modalities:
-            # Model can't view images — run the tool normally, append a note
+        if not _can_view(ext, modalities):
+            # Run the tool anyway and append the note — the text output is still
+            # useful, and replacing it would lose a read the agent asked for.
             result = await handler(request)
             result_content = result.content if hasattr(result, "content") else str(result)
             return ToolMessage(
-                content=result_content + _unsupported_note,
-                tool_call_id=tool_call_id,
-            )
-        if ext in DOCUMENT_EXTENSIONS and "pdf" not in modalities:
-            result = await handler(request)
-            result_content = result.content if hasattr(result, "content") else str(result)
-            return ToolMessage(
-                content=result_content + _unsupported_note,
-                tool_call_id=tool_call_id,
-            )
-        # URLs without recognizable extension: block if model is text-only
-        if ext not in VISUAL_EXTENSIONS and "image" not in modalities and "pdf" not in modalities:
-            result = await handler(request)
-            result_content = result.content if hasattr(result, "content") else str(result)
-            return ToolMessage(
-                content=result_content + _unsupported_note,
+                content=result_content + _UNSUPPORTED_NOTE,
                 tool_call_id=tool_call_id,
             )
 
-        logger.debug(f"[MULTIMODAL] Intercepting read_file for visual content: {file_path}")
+        logger.debug(f"[MULTIMODAL] Intercepting Read for visual content: {file_path}")
 
         # Execute the tool to get the acknowledgment message
         result = await handler(request)
@@ -387,18 +464,31 @@ class MultimodalMiddleware(AgentMiddleware):
             Command with ToolMessage + HumanMessage, or ToolMessage with error
         """
         try:
-            # Download the content
-            async with httpx.AsyncClient(http2=True, timeout=30.0) as client:
-                response = await client.get(url, follow_redirects=True)
+            # Download the content. The URL is model-chosen and this fetch runs
+            # in the backend process — not the sandbox — so it inherits the
+            # backend's reach into the private network. GuardedAsyncTransport
+            # re-checks the resolved address on every hop, which is what keeps a
+            # public page from redirecting the fetch at 169.254.169.254.
+            async with httpx.AsyncClient(
+                transport=GuardedAsyncTransport(), timeout=30.0
+            ) as client:
+                async with client.stream("GET", url, follow_redirects=True) as response:
+                    if response.status_code != 200:
+                        logger.warning(
+                            f"[MULTIMODAL] Failed to download content: {url} (status {response.status_code})"
+                        )
+                        return ToolMessage(
+                            content=f"ERROR: Could not download content (HTTP {response.status_code}): {url}",
+                            tool_call_id=tool_call_id,
+                        )
 
-                if response.status_code != 200:
-                    logger.warning(f"[MULTIMODAL] Failed to download content: {url} (status {response.status_code})")
-                    return ToolMessage(
-                        content=f"ERROR: Could not download content (HTTP {response.status_code}): {url}",
-                        tool_call_id=tool_call_id,
-                    )
+                    buffer = bytearray()
+                    async for chunk in response.aiter_bytes():
+                        buffer.extend(chunk)
+                        if len(buffer) > self.MAX_CONTENT_BYTES:
+                            return self._too_large_message(url, tool_call_id)
+                    content_bytes = bytes(buffer)
 
-                content_bytes = response.content
                 if not content_bytes:
                     logger.warning(f"[MULTIMODAL] Empty content from URL: {url}")
                     return ToolMessage(
@@ -473,6 +563,16 @@ class MultimodalMiddleware(AgentMiddleware):
                 content=f"ERROR: Timeout downloading content: {url}",
                 tool_call_id=tool_call_id,
             )
+        except BlockedAddressError as e:
+            # The message names the resolved address ("Blocked private/reserved
+            # address 10.1.2.3 for host x"). The URL is model-chosen, so echoing
+            # that back turns Read into a DNS-to-IP probe steerable by anything
+            # the agent reads. Keep the detail in the log, not in the transcript.
+            logger.warning(f"[MULTIMODAL] Blocked address for {url}: {e}")
+            return ToolMessage(
+                content=f"ERROR: This address is not allowed: {url}",
+                tool_call_id=tool_call_id,
+            )
         except httpx.RequestError as e:
             logger.warning(f"[MULTIMODAL] Network error downloading content {url}: {e}")
             return ToolMessage(
@@ -518,6 +618,9 @@ class MultimodalMiddleware(AgentMiddleware):
                     content=f"ERROR: Could not read file: {file_path}",
                     tool_call_id=tool_call_id,
                 )
+
+            if len(file_bytes) > self.MAX_CONTENT_BYTES:
+                return self._too_large_message(file_path, tool_call_id)
 
             # Determine MIME type from extension
             ext = Path(file_path).suffix.lower()

--- a/src/ptc_agent/agent/middleware/file_operations/multimodal.py
+++ b/src/ptc_agent/agent/middleware/file_operations/multimodal.py
@@ -44,6 +44,33 @@ DOCUMENT_EXTENSIONS = frozenset({".pdf"})
 # Combined visual extensions
 VISUAL_EXTENSIONS = IMAGE_EXTENSIONS | DOCUMENT_EXTENSIONS
 
+# PIL reports a format name; providers speak MIME. A format outside this map is
+# one no provider accepts, so it resolves to None rather than a near-miss guess.
+_PIL_FORMAT_TO_MIME = {
+    "PNG": "image/png",
+    "JPEG": "image/jpeg",
+    "GIF": "image/gif",
+    "WEBP": "image/webp",
+}
+
+
+def _detect_mime_type(content: bytes) -> str | None:
+    """MIME type read off the bytes, or None if they are neither PDF nor image.
+
+    The name can't decide this: a URL may carry no extension at all, and a
+    sandbox path is only as accurate as whatever wrote the file. Both callers
+    checkpoint what they inject, so a mislabeled or truncated file would replay
+    its provider 400 on every later turn rather than failing once.
+    """
+    if content.startswith(b"%PDF"):
+        return "application/pdf"
+    try:
+        img = Image.open(io.BytesIO(content))
+        img.verify()
+    except Exception:
+        return None
+    return _PIL_FORMAT_TO_MIME.get(img.format or "")
+
 
 def _strip_unsupported_content_blocks(
     messages: list, has_image: bool, has_pdf: bool
@@ -212,16 +239,6 @@ class MultimodalMiddleware(AgentMiddleware):
     # cannot save a target that legitimately has the image modality. Refuse
     # before encoding rather than brick the thread.
     MAX_CONTENT_BYTES = 5 * 1024 * 1024
-
-    # MIME type mapping for supported extensions
-    MIME_TYPES = {
-        ".png": "image/png",
-        ".jpg": "image/jpeg",
-        ".jpeg": "image/jpeg",
-        ".gif": "image/gif",
-        ".webp": "image/webp",
-        ".pdf": "application/pdf",
-    }
 
     def __init__(
         self,
@@ -496,39 +513,16 @@ class MultimodalMiddleware(AgentMiddleware):
                         tool_call_id=tool_call_id,
                     )
 
-            # Detect type from URL extension
-            suffix = Path(urlparse(url).path).suffix.lower()
-
-            if suffix in DOCUMENT_EXTENSIONS:
-                # PDF: validate magic bytes
-                if not content_bytes.startswith(b"%PDF"):
-                    logger.warning(f"[MULTIMODAL] Invalid PDF data from URL {url}")
-                    return ToolMessage(
-                        content=f"ERROR: Invalid PDF file from URL: {url}",
-                        tool_call_id=tool_call_id,
-                    )
-                mime_type = "application/pdf"
-            else:
-                # Image: validate and detect format using PIL
-                try:
-                    img = Image.open(io.BytesIO(content_bytes))
-                    img.verify()
-                    pil_format = img.format
-                except Exception as e:
-                    logger.warning(f"[MULTIMODAL] Invalid image data from URL {url}: {e}")
-                    return ToolMessage(
-                        content=f"ERROR: Invalid image data from URL: {url}",
-                        tool_call_id=tool_call_id,
-                    )
-
-                # Map PIL format to MIME type
-                format_to_mime = {
-                    "PNG": "image/png",
-                    "JPEG": "image/jpeg",
-                    "GIF": "image/gif",
-                    "WEBP": "image/webp",
-                }
-                mime_type = format_to_mime.get(pil_format, "image/png")
+            # Typed from the bytes, not the URL: a signed or redirected URL can
+            # end without an extension, and branching on that would send a PDF
+            # down the image path and reject it as corrupt.
+            mime_type = _detect_mime_type(content_bytes)
+            if mime_type is None:
+                logger.warning(f"[MULTIMODAL] Unreadable content from URL: {url}")
+                return ToolMessage(
+                    content=f"ERROR: Content is not a readable image or PDF: {url}",
+                    tool_call_id=tool_call_id,
+                )
 
             # Encode as base64
             b64_string = base64.b64encode(content_bytes).decode("utf-8")
@@ -610,8 +604,14 @@ class MultimodalMiddleware(AgentMiddleware):
             )
 
         try:
-            # Download file bytes from sandbox
-            file_bytes = await self.sandbox.adownload_file_bytes(file_path)
+            # The Read tool reaches the sandbox through SandboxBackend, which
+            # normalizes first; this middleware holds the sandbox itself, whose
+            # adownload_file_bytes does not. Without this, a virtual path the
+            # tool resolved fine ("/results/chart.png") misses here and replaces
+            # the tool's success with a not-found error.
+            file_bytes = await self.sandbox.adownload_file_bytes(
+                self.sandbox.normalize_path(file_path)
+            )
             if not file_bytes:
                 logger.warning(f"[MULTIMODAL] Failed to download file: {file_path}")
                 return ToolMessage(
@@ -622,21 +622,14 @@ class MultimodalMiddleware(AgentMiddleware):
             if len(file_bytes) > self.MAX_CONTENT_BYTES:
                 return self._too_large_message(file_path, tool_call_id)
 
-            # Determine MIME type from extension
-            ext = Path(file_path).suffix.lower()
-            mime_type = self.MIME_TYPES.get(ext)
-
-            if not mime_type:
+            # Typed from the bytes for the same reason the URL path is: the
+            # extension is whatever wrote the file claimed, and a truncated
+            # chart named .png is checkpointed before any provider sees it.
+            mime_type = _detect_mime_type(file_bytes)
+            if mime_type is None:
+                logger.warning(f"[MULTIMODAL] Unreadable content in file: {file_path}")
                 return ToolMessage(
-                    content=f"ERROR: Unsupported file type: {ext}",
-                    tool_call_id=tool_call_id,
-                )
-
-            # Validate PDF magic bytes
-            if mime_type == "application/pdf" and not file_bytes.startswith(b"%PDF"):
-                logger.warning(f"[MULTIMODAL] Invalid PDF file: {file_path}")
-                return ToolMessage(
-                    content=f"ERROR: Invalid PDF file: {file_path}",
+                    content=f"ERROR: File is not a readable image or PDF: {file_path}",
                     tool_call_id=tool_call_id,
                 )
 

--- a/src/ptc_agent/agent/middleware/file_operations/multimodal.py
+++ b/src/ptc_agent/agent/middleware/file_operations/multimodal.py
@@ -31,7 +31,7 @@ from PIL import Image
 
 from ptc_agent.agent.middleware._utils import append_to_system_message
 from ptc_agent.agent.tools.file_ops import is_memo_text_path
-from src.llms.llm import get_input_modalities
+from src.llms.llm import get_input_modalities, get_max_pdf_pages
 from src.tools.web.inhouse.guard import BlockedAddressError, GuardedAsyncTransport
 
 logger = logging.getLogger(__name__)
@@ -54,10 +54,13 @@ _PIL_FORMAT_TO_MIME = {
     "WEBP": "image/webp",
 }
 
-# The tightest published per-request page ceiling (Anthropic's, below a 1M-token
-# context). Page count is what binds for PDFs — a 300-page report can sit well
-# under MAX_CONTENT_BYTES and still be rejected on arrival.
-MAX_PDF_PAGES = 100
+# The widest per-request page ceiling any provider we ship publishes (Gemini's).
+# Deliberately not the tightest: injection cannot know which model will consume
+# the block — the middleware instance is shared with every subagent — so a cap
+# picked for the strictest target would refuse documents the actual target
+# accepts. What each target can really take is enforced on the read side, where
+# the model is known; this bound only rejects what nobody would accept.
+MAX_PDF_PAGES = 1000
 
 
 class _UnusableContent(Exception):
@@ -65,14 +68,18 @@ class _UnusableContent(Exception):
     predicate ("not a readable PDF") that slots into the caller's message."""
 
 
-def _detect_mime_type(content: bytes) -> str:
-    """MIME type read off the bytes, raising `_UnusableContent` if nothing accepts them.
+def _detect_mime_type(content: bytes) -> tuple[str, int | None]:
+    """MIME type and page count, raising `_UnusableContent` if nothing accepts the bytes.
 
     The name can't decide this: a URL may carry no extension at all, and a
     sandbox path is only as accurate as whatever wrote the file. Both callers
     checkpoint what they inject, so anything a provider would reject has to be
     caught here — otherwise it replays its 400 on every later turn instead of
     failing once. Hence structural verification, not just a magic-byte peek.
+
+    The page count is returned so it can be stamped on the block: the read side
+    needs it to judge the PDF against the target's own ceiling, and re-deriving
+    it there would mean decoding and reparsing every PDF in history per call.
     """
     if content.startswith(b"%PDF"):
         import pypdf
@@ -85,7 +92,7 @@ def _detect_mime_type(content: bytes) -> str:
             raise _UnusableContent(
                 f"a {pages}-page PDF, over the {MAX_PDF_PAGES}-page limit"
             )
-        return "application/pdf"
+        return "application/pdf", pages
 
     try:
         img = Image.open(io.BytesIO(content))
@@ -95,13 +102,22 @@ def _detect_mime_type(content: bytes) -> str:
     mime_type = _PIL_FORMAT_TO_MIME.get(img.format or "")
     if mime_type is None:
         raise _UnusableContent(f"in {img.format} format, which no provider accepts")
-    return mime_type
+    return mime_type, None
 
 
 def _strip_unsupported_content_blocks(
-    messages: list, has_image: bool, has_pdf: bool
+    messages: list,
+    has_image: bool,
+    has_pdf: bool,
+    max_pdf_pages: int | None = None,
 ) -> list:
     """Replace unsupported image/file content blocks with text placeholders.
+
+    ``max_pdf_pages`` is the target's own page ceiling (None = unbounded). A PDF
+    over it is dropped here rather than refused at injection, because the ceiling
+    is a property of the model that reads the block, not of the tool call that
+    created it — the same document is fine on a 1M-context route and rejected on
+    a 200K one, and only this side knows which one is being called.
 
     Returns the original list if no changes needed (avoids unnecessary copies).
     Does not mutate the original messages (checkpoint integrity).
@@ -158,6 +174,26 @@ def _strip_unsupported_content_blocks(
                 msg_modified = True
                 continue
 
+            # Over the target's page ceiling. Unstamped blocks pass: they predate
+            # the stamp, and re-deriving the count would mean decoding every PDF
+            # in history on every call. They keep the old failure mode; nothing
+            # that already worked starts failing here.
+            if (
+                block_type == "file"
+                and max_pdf_pages is not None
+                and isinstance(block.get("pages"), int)
+                and block["pages"] > max_pdf_pages
+            ):
+                new_blocks.append({
+                    "type": "text",
+                    "text": (
+                        f"[PDF attached in prior turn — {block['pages']} pages, over "
+                        f"the current model's {max_pdf_pages}-page limit]"
+                    ),
+                })
+                msg_modified = True
+                continue
+
             new_blocks.append(block)
 
         if msg_modified:
@@ -177,12 +213,16 @@ def _strip_unsupported_content_blocks(
     return result if modified else messages
 
 
+# One note for both strip reasons: the placeholder already states which one
+# applied, next to the block it replaced, so branching the reminder would only
+# duplicate that where the model is less likely to be reading.
 _UNSUPPORTED_NOTE = (
     "\n\n<system-reminder>"
-    "You cannot view this file directly because the current model does not support "
-    "this input type. Be transparent with the user about this limitation and suggest "
-    "they try switching to a model that supports image/PDF input. "
-    "Work in best effort to answer their query."
+    "Content shown as a bracketed placeholder is not visible to the current model; "
+    "the placeholder states why. Be transparent with the user about the limitation: "
+    "an unsupported input type means switching to a model that accepts it, and a "
+    "page-limit rejection means splitting the document or moving to a model with a "
+    "longer context. Work in best effort to answer their query."
     "</system-reminder>"
 )
 
@@ -375,12 +415,13 @@ class MultimodalMiddleware(AgentMiddleware):
             tool_call_id=tool_call_id,
         )
 
-    def _resolve_modalities(self, request: Any) -> list[str]:
-        """Modalities of the model this request will actually reach.
+    def _resolve_target(self, request: Any) -> tuple[str | None, list[str]]:
+        """Name and modalities of the model this request will actually reach.
 
         Read off ``request.model`` rather than the configured name so a
         resilience fallback — or a subagent running its own model — is judged on
-        the client in hand.
+        the client in hand. The name comes back too because the PDF page ceiling
+        is per-model and has to be looked up against the same target.
         """
         metadata = getattr(request.model, "metadata", None)
         stamped = metadata.get("manifest_model") if isinstance(metadata, dict) else None
@@ -393,12 +434,12 @@ class MultimodalMiddleware(AgentMiddleware):
             # replay exactly the blocks this strip exists to remove, so an
             # unstamped client is judged text-only — the same fail-closed reading
             # LLM.get_llm() documents when it writes the stamp.
-            return ["text"]
+            return None, ["text"]
         # ``custom_modalities`` is a per-model override from user preferences, so
         # it describes only the model it was configured for — a fallback is a
         # different model and has to be judged on its own manifest entry.
         overrides = self.custom_modalities if stamped == self.model_name else None
-        return get_input_modalities(stamped, custom_modalities=overrides)
+        return stamped, get_input_modalities(stamped, custom_modalities=overrides)
 
     async def awrap_model_call(self, request, handler):
         """Strip unsupported content blocks from historical messages for text-only models.
@@ -412,21 +453,26 @@ class MultimodalMiddleware(AgentMiddleware):
         messages = _tool_results_first(request.messages)
         overrides: dict[str, Any] = {}
 
-        modalities = self._resolve_modalities(request)
+        stamped, modalities = self._resolve_target(request)
         has_image = "image" in modalities
         has_pdf = "pdf" in modalities
+        # Looked up even for a fully multimodal target: a model that accepts PDFs
+        # can still be handed one past its page ceiling, which is the judgement
+        # the tool side deliberately no longer attempts.
+        max_pdf_pages = get_max_pdf_pages(stamped) if stamped and has_pdf else None
 
-        if not (has_image and has_pdf):
-            sanitized = _strip_unsupported_content_blocks(messages, has_image, has_pdf)
-            if sanitized is not messages:
-                messages = sanitized
-                # Told to the model that actually can't see the file, on the call
-                # where that is true. The tool-time note this replaces judged the
-                # configured model and froze that verdict into the transcript,
-                # which a subagent on its own model then inherited wrongly.
-                overrides["system_message"] = append_to_system_message(
-                    request.system_message, _UNSUPPORTED_NOTE
-                )
+        sanitized = _strip_unsupported_content_blocks(
+            messages, has_image, has_pdf, max_pdf_pages
+        )
+        if sanitized is not messages:
+            messages = sanitized
+            # Told to the model that actually can't see the file, on the call
+            # where that is true. The tool-time note this replaces judged the
+            # configured model and froze that verdict into the transcript,
+            # which a subagent on its own model then inherited wrongly.
+            overrides["system_message"] = append_to_system_message(
+                request.system_message, _UNSUPPORTED_NOTE
+            )
 
         if messages is not request.messages:
             overrides["messages"] = messages
@@ -491,13 +537,19 @@ class MultimodalMiddleware(AgentMiddleware):
         b64_string: str,
         file_path: str,
         mime_type: str,
+        pages: int | None = None,
     ) -> list[dict[str, Any]]:
         """Build appropriate content blocks based on file type.
+
+        ``pages`` is stamped on the PDF block for the read-side ceiling check.
+        Every provider converter drops keys it doesn't recognise, so it stays a
+        local annotation and never reaches the wire.
 
         Args:
             b64_string: Base64-encoded file content
             file_path: Original file path (for display name)
             mime_type: MIME type of the content
+            pages: PDF page count, or None for images
 
         Returns:
             List of content block dicts for HumanMessage
@@ -512,9 +564,17 @@ class MultimodalMiddleware(AgentMiddleware):
         elif mime_type == "application/pdf":
             # PDF: use LangChain's file content block format (converts to Anthropic's document format)
             filename = Path(file_path).name
+            block = {
+                "type": "file",
+                "base64": b64_string,
+                "mime_type": mime_type,
+                "filename": filename,
+            }
+            if pages is not None:
+                block["pages"] = pages
             return [
                 {"type": "text", "text": f"[Viewing PDF: {filename}]"},
-                {"type": "file", "base64": b64_string, "mime_type": mime_type, "filename": filename},
+                block,
             ]
         return []
 
@@ -578,7 +638,9 @@ class MultimodalMiddleware(AgentMiddleware):
                 # Off-loop: pypdf walks the xref of up to MAX_CONTENT_BYTES of
                 # model-chosen content, which is milliseconds on a real document
                 # but ~100ms on one padded with junk after %%EOF.
-                mime_type = await asyncio.to_thread(_detect_mime_type, content_bytes)
+                mime_type, pages = await asyncio.to_thread(
+                    _detect_mime_type, content_bytes
+                )
             except _UnusableContent as exc:
                 logger.warning(f"[MULTIMODAL] Refusing content from URL ({exc}): {url}")
                 return ToolMessage(
@@ -590,7 +652,9 @@ class MultimodalMiddleware(AgentMiddleware):
             b64_string = base64.b64encode(content_bytes).decode("utf-8")
 
             # Build content blocks based on type
-            content_blocks = self._build_content_blocks(b64_string, url, mime_type)
+            content_blocks = self._build_content_blocks(
+                b64_string, url, mime_type, pages
+            )
             if not content_blocks:
                 return ToolMessage(
                     content=f"ERROR: Unsupported content type: {mime_type}",
@@ -688,7 +752,9 @@ class MultimodalMiddleware(AgentMiddleware):
             # extension is whatever wrote the file claimed, and a truncated
             # chart named .png is checkpointed before any provider sees it.
             try:
-                mime_type = await asyncio.to_thread(_detect_mime_type, file_bytes)
+                mime_type, pages = await asyncio.to_thread(
+                    _detect_mime_type, file_bytes
+                )
             except _UnusableContent as exc:
                 logger.warning(f"[MULTIMODAL] Refusing file ({exc}): {file_path}")
                 return ToolMessage(
@@ -700,7 +766,9 @@ class MultimodalMiddleware(AgentMiddleware):
             b64_string = base64.b64encode(file_bytes).decode("utf-8")
 
             # Build content blocks based on type
-            content_blocks = self._build_content_blocks(b64_string, file_path, mime_type)
+            content_blocks = self._build_content_blocks(
+                b64_string, file_path, mime_type, pages
+            )
             if not content_blocks:
                 return ToolMessage(
                     content=f"ERROR: Unsupported content type: {mime_type}",

--- a/src/ptc_agent/agent/middleware/file_operations/sse_middleware.py
+++ b/src/ptc_agent/agent/middleware/file_operations/sse_middleware.py
@@ -48,7 +48,7 @@ class FileOperationMiddleware(AgentMiddleware):
     Middleware that emits file_operation SSE events after tool execution.
 
     Hooks into tool execution to emit custom events with full file content
-    for write_file and edit_file operations, enabling frontend to display
+    for Write and Edit operations, enabling frontend to display
     file changes without polluting agent context.
     """
 

--- a/src/ptc_agent/agent/middleware/memo_awareness.py
+++ b/src/ptc_agent/agent/middleware/memo_awareness.py
@@ -5,7 +5,7 @@ agent has read-only access. Unlike memory (agent-written), injecting every
 memo title into every turn is noisy and leaks potentially private contents.
 
 Instead we inject a single ~80-byte block advertising how many memos exist and
-where they live. The agent follows up on demand via ``read_file`` / ``glob``.
+where they live. The agent follows up on demand via ``Read`` / ``Glob``.
 The block is appended AFTER the prompt-cache breakpoint, mirroring
 ``MemoryContextMiddleware``.
 """

--- a/src/ptc_agent/agent/middleware/reasoning_compat.py
+++ b/src/ptc_agent/agent/middleware/reasoning_compat.py
@@ -154,8 +154,12 @@ def _sanitize(
     cross-lineage message, so gate B sees nothing left to judge there.
     """
     stats = SanitizeStats()
-    # UNKNOWN targets carry no provenance to compare against, so gate A would
-    # strip the entire history on no evidence. Skip it and keep the repair.
+    # A target goes UNKNOWN only when its client skipped LLM.get_llm() — today
+    # that is a subagent whose config declares a bare model string, which
+    # deepagents resolves via init_chat_model. Gate A would then strip that
+    # subagent's whole history every turn on no evidence, and skipping it is
+    # safe: such a target only sees its own output, and a resilience fallback
+    # moves it onto a stamped candidate that re-arms both gates. Repair stays.
     origin_gate = target_lineage != UNKNOWN_LINEAGE
     drop_unsigned = target_lineage == ANTHROPIC_LINEAGE
 

--- a/src/ptc_agent/agent/prompts/templates/components/memo.md.j2
+++ b/src/ptc_agent/agent/prompts/templates/components/memo.md.j2
@@ -22,7 +22,7 @@ How memos get created
   filesystem becomes a memo.
 
 Reading memos
-- `read_file`, `glob`, and `grep` work normally inside `.agents/user/memo/`.
+- `Read`, `Glob`, and `Grep` work normally inside `.agents/user/memo/`.
 - Read `.agents/user/memo/memo.md` first — the server maintains it as a
   catalog of `<filename>` + one-sentence description for every memo. Use it
   to decide which memos are relevant, then read the individual files by

--- a/src/ptc_agent/agent/prompts/templates/components/memory.md.j2
+++ b/src/ptc_agent/agent/prompts/templates/components/memory.md.j2
@@ -54,7 +54,7 @@ Save when: the user points you at a specific resource, or a particular source/to
 
 ## How to save a memory
 
-Two-step process. Use `write_file` to create the detail file, then `edit_file` (or another `write_file`) to add a pointer line to `memory.md`.
+Two-step process. Use `Write` to create the detail file, then `Edit` (or another `Write`) to add a pointer line to `memory.md`.
 
 **Step 1** — write the detail file with frontmatter:
 
@@ -109,4 +109,4 @@ Memory can go stale. Before acting on a recalled fact — especially prices, hol
 
 ## Limitations
 
-- **Workspace Python code cannot open memory files directly.** `open(".agents/user/memory/foo.md")` inside `execute_code` will fail — memory lives outside the workspace filesystem. If your code needs a memory file's content, read it with `read_file` first and pass it as a string into your script.
+- **Workspace Python code cannot open memory files directly.** `open(".agents/user/memory/foo.md")` inside `execute_code` will fail — memory lives outside the workspace filesystem. If your code needs a memory file's content, read it with `Read` first and pass it as a string into your script.

--- a/src/ptc_agent/agent/prompts/templates/subagents/roles/researcher.md.j2
+++ b/src/ptc_agent/agent/prompts/templates/subagents/roles/researcher.md.j2
@@ -7,7 +7,7 @@ Research the delegated topic using web search and content extraction. Produce a 
 <available_tools>
 - `WebSearch`: Search the web for information. Returns titles, snippets, and URLs.
 - `WebFetch`: Extract and read full content from a specific URL. Use to go deeper on promising search results.
-- `read_file` / `write_file` / `edit_file`: Read existing workspace files for context, and save research findings for downstream use by other agents.
+- `Read` / `Write` / `Edit`: Read existing workspace files for context, and save research findings for downstream use by other agents.
 </available_tools>
 
 <workflow>

--- a/src/ptc_agent/agent/tools/file_ops.py
+++ b/src/ptc_agent/agent/tools/file_ops.py
@@ -10,6 +10,7 @@ import structlog
 from langchain_core.tools import tool
 
 from ptc_agent.agent.backends import FilesystemBackend, ReadOnlyStoreError
+from ptc_agent.core.paths import MEMO_USER_DIR
 from src.server.services.user_data_io import UserDataValidationError
 
 logger = structlog.get_logger(__name__)
@@ -27,7 +28,29 @@ VISUAL_EXTENSIONS = IMAGE_EXTENSIONS | DOCUMENT_EXTENSIONS
 # tier; serve their extracted text through the regular read path instead of
 # the multimodal/document middleware (which is wired to the sandbox FS, not
 # the composite memo backend).
-_MEMO_TEXT_PREFIX = ".agents/user/memo/"
+_MEMO_TEXT_PREFIX = f"{MEMO_USER_DIR}/"
+
+
+def is_memo_text_path(file_path: str) -> bool:
+    """Whether this path lives in the store-backed memo tier, not the sandbox FS.
+
+    Both the Read tool and MultimodalMiddleware classify against this, and they
+    have to agree: if the middleware disagrees it intercepts a memo PDF, looks
+    for it on the sandbox FS, and replaces the extracted text the tool just
+    returned with a not-found error. Note this is a location test, not a content
+    test — it answers True for a memo *image* too, which the read path then
+    serves as text. That is a pre-existing gap in the memo tier (binaries have
+    no public URL either), not something the caller can distinguish here.
+    """
+    # Glob/Grep virtualize store-backed matches as ``/.agents/...`` and users
+    # may pass ``./.agents/...`` from a relative cwd. ``lstrip`` would strip
+    # every leading ``.`` and ``/`` indiscriminately (it's a charset, not a
+    # substring), so we match each literal prefix.
+    if file_path.startswith("./"):
+        file_path = file_path[2:]
+    elif file_path.startswith("/"):
+        file_path = file_path[1:]
+    return file_path.startswith(_MEMO_TEXT_PREFIX)
 
 # Type alias for operation callback
 OperationCallback = Callable[[dict[str, Any]], None]
@@ -84,17 +107,7 @@ def create_filesystem_tools(
             # in the store and the multimodal middleware would otherwise fail
             # to find the file on the sandbox FS.
             suffix = Path(file_path).suffix.lower()
-            # Glob/Grep virtualize store-backed matches as ``/.agents/...`` and
-            # users may pass ``./.agents/...`` from a relative cwd. ``lstrip``
-            # would strip every leading ``.`` and ``/`` indiscriminately (it's
-            # a charset, not a substring), so we match each literal prefix.
-            _stripped = file_path
-            if _stripped.startswith("./"):
-                _stripped = _stripped[2:]
-            elif _stripped.startswith("/"):
-                _stripped = _stripped[1:]
-            is_memo_path = _stripped.startswith(_MEMO_TEXT_PREFIX)
-            if suffix in VISUAL_EXTENSIONS and not is_memo_path:
+            if suffix in VISUAL_EXTENSIONS and not is_memo_text_path(file_path):
                 # Validate the path exists before returning acknowledgment
                 normalized_path = backend.normalize_path(file_path)
                 logger.info("Loading image file", file_path=file_path, normalized_path=normalized_path)

--- a/src/ptc_agent/config/agent.py
+++ b/src/ptc_agent/config/agent.py
@@ -221,10 +221,6 @@ class AgentConfig(BaseModel):
     # Custom model input modalities override (set by resolve_llm_config for custom models)
     input_modalities: list[str] | None = None
 
-    # Vision tool configuration
-    # If True, enable view_image tool for viewing images (requires vision-capable model)
-    enable_view_image: bool = True
-
     # Subagent configuration
     subagents: SubagentsConfig = Field(default_factory=SubagentsConfig)
 
@@ -324,7 +320,6 @@ class AgentConfig(BaseModel):
             log_level: Logging level (default: "INFO")
             allowed_directories: Sandbox paths (default: ["/home/workspace", "/tmp"])
             subagents: SubagentsConfig or use subagents_enabled for backward compat
-            enable_view_image: Enable image viewing (default: True)
             background_auto_wait: Wait for background tasks (default: False)
 
         Returns:
@@ -473,7 +468,6 @@ class AgentConfig(BaseModel):
             logging=logging_config,
             filesystem=filesystem_config,
             skills=skills_config,
-            enable_view_image=kwargs.pop("enable_view_image", True),
             subagents=SubagentsConfig(
                 enabled=kwargs.pop("subagents_enabled", ["general-purpose"]),
                 definitions=kwargs.pop("subagents_definitions", {}),

--- a/src/ptc_agent/config/loaders.py
+++ b/src/ptc_agent/config/loaders.py
@@ -287,7 +287,6 @@ def load_from_dict(
     # Load Agent configuration (optional section)
     # Note: YAML sections with only comments parse as None, not {}
     agent_data = config_data.get("agent") or {}
-    enable_view_image = agent_data.get("enable_view_image", True)
     background_auto_wait = agent_data.get("background_auto_wait", False)
 
     # Load Subagent configuration (optional section)
@@ -353,7 +352,6 @@ def load_from_dict(
         filesystem=filesystem_config,
         skills=skills_config,
         flash=flash_config,
-        enable_view_image=enable_view_image,
         subagents=subagents_config,
         compaction=compaction_config,
         search_api=search_api,
@@ -439,7 +437,6 @@ filesystem:
 # Agent Settings (optional)
 # -------------------------
 agent:
-  enable_view_image: true
   background_auto_wait: false  # true to wait for background tasks before returning to CLI
 
 # Subagents (optional)

--- a/src/tools/web/crawl.py
+++ b/src/tools/web/crawl.py
@@ -153,7 +153,7 @@ def create_crawl_tools(filesystem_backend: Any) -> List[Any]:
 
         Starts an asynchronous crawl at ``url``, follows internal links up to
         ``limit`` pages, and writes one .md file per page plus an index.jsonl
-        manifest. Read the dumped files with glob/read_file afterwards — page
+        manifest. Read the dumped files with Glob/Read afterwards — page
         content is never returned inline. Scope a site with WebMap first, and
         prefer WebFetch when you already know the handful of URLs you need.
         Crawling bills per delivered page, so keep ``limit`` tight and focus
@@ -266,7 +266,7 @@ def create_crawl_tools(filesystem_backend: Any) -> List[Any]:
             lines.append(f"{failures} page(s) failed — see {index_path}.")
         if ok_pages:
             lines.append(
-                f"Manifest: {index_path}. Use glob('{dest_dir}/*.md') and read_file to work "
+                f"Manifest: {index_path}. Use Glob('{dest_dir}/*.md') and Read to work "
                 f"through the pages."
             )
         artifact = {

--- a/tests/unit/config/test_agent_config.py
+++ b/tests/unit/config/test_agent_config.py
@@ -154,13 +154,11 @@ class TestAgentConfigCreate:
                 daytona_api_key="key",
                 python_version="3.11",
                 log_level="DEBUG",
-                enable_view_image=False,
                 background_auto_wait=True,
                 subagents_enabled=["general-purpose", "research"],
             )
         assert config.daytona.python_version == "3.11"
         assert config.logging.level == "DEBUG"
-        assert config.enable_view_image is False
         assert config.background_auto_wait is True
         assert config.subagents.enabled == ["general-purpose", "research"]
 

--- a/tests/unit/config/test_loaders.py
+++ b/tests/unit/config/test_loaders.py
@@ -149,20 +149,18 @@ class TestLoadFromDictOptionalSections:
     def test_no_agent_section(self):
         """Missing agent section uses defaults."""
         config = load_from_dict(_full_config_dict())
-        assert config.enable_view_image is True
         assert config.background_auto_wait is False
 
     def test_agent_section_with_values(self):
-        data = _full_config_dict(agent={"enable_view_image": False, "background_auto_wait": True})
+        data = _full_config_dict(agent={"background_auto_wait": True})
         config = load_from_dict(data)
-        assert config.enable_view_image is False
         assert config.background_auto_wait is True
 
     def test_agent_section_none(self):
         """YAML sections with only comments parse as None."""
         data = _full_config_dict(agent=None)
         config = load_from_dict(data)
-        assert config.enable_view_image is True
+        assert config.background_auto_wait is False
 
     def test_no_skills_section(self):
         config = load_from_dict(_full_config_dict())

--- a/tests/unit/llms/test_max_pdf_pages.py
+++ b/tests/unit/llms/test_max_pdf_pages.py
@@ -1,0 +1,46 @@
+import pytest
+
+from src.llms.llm import get_max_pdf_pages
+
+
+class TestGetMaxPdfPages:
+    """The published per-request PDF page ceilings, read off the manifest.
+
+    These pin the *shape* of the rule, not vendor numbers: that Anthropic's
+    ceiling moves with the context window, that a provider documenting no page
+    limit reports None rather than a guess, and that an unknown model fails
+    closed. A vendor raising a limit should update the constant and these move
+    with it; a vendor being read the wrong way should fail here.
+    """
+
+    @pytest.mark.parametrize(
+        "model",
+        ["claude-sonnet-5", "claude-opus-5", "claude-opus-4-8-oauth-1m"],
+    )
+    def test_a_1m_context_anthropic_route_gets_the_higher_ceiling(self, model):
+        assert get_max_pdf_pages(model) == 600
+
+    @pytest.mark.parametrize(
+        "model",
+        ["claude-sonnet-4-6", "claude-haiku-4-5", "claude-sonnet-4-6-oauth"],
+    )
+    def test_a_sub_1m_anthropic_route_gets_the_tighter_one(self, model):
+        """The pair that makes a single global cap impossible: same vendor, same
+        modality support, six-fold difference in what a request may carry."""
+        assert get_max_pdf_pages(model) == 100
+
+    def test_an_anthropic_sdk_endpoint_we_have_no_docs_for_is_treated_as_anthropic(self):
+        """Volcengine's Anthropic-compatible route publishes no page limit. It
+        speaks the same protocol, so it inherits the same reading rather than
+        being assumed unbounded."""
+        assert get_max_pdf_pages("doubao-seed-2.0-pro-anthropic") == 100
+
+    def test_a_provider_with_no_documented_page_limit_reports_none(self):
+        """None means 'not bounded by pages', which is a different claim from
+        'we don't know' — the latter has to fail closed instead."""
+        assert get_max_pdf_pages("gpt-5.5") is None
+
+    def test_an_unknown_model_fails_closed(self):
+        """This gates transmission, so an over-generous guess becomes a 400 the
+        caller cannot recover; an over-tight one only costs a placeholder."""
+        assert get_max_pdf_pages("not-a-real-model") == 100

--- a/tests/unit/ptc_agent/agent/test_middleware_composition_order.py
+++ b/tests/unit/ptc_agent/agent/test_middleware_composition_order.py
@@ -1,0 +1,164 @@
+"""CI guard: MultimodalMiddleware must be composed INSIDE ModelResilienceMiddleware.
+
+Position in a LangChain ``middleware`` list is composition order — index 0 is
+outermost. Resilience substitutes the model inside its own ``awrap_model_call``
+via ``request.override(model=...)``, so a capability sanitizer placed outside it
+reads the pre-fallback client and judges the request against a model that is not
+the one being called.
+
+That failure is silent. Nothing raises; the strip simply stops matching the real
+target, and a vision-primary → text-only-fallback replays image blocks into the
+400 the fallback existed to avoid. A comment cannot hold this invariant, so it is
+asserted against the source of every stack that wires both.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+
+# Repo root = five levels up from tests/unit/ptc_agent/agent/<this file>.
+REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), *([os.pardir] * 4))
+)
+
+# Every stack that composes both middlewares. A new agent stack wiring them must
+# be added here, or its ordering goes unguarded.
+SCAN_FILES = (
+    "src/ptc_agent/agent/agent.py",
+    "src/ptc_agent/agent/flash/agent.py",
+)
+
+# Sites expected to wire both: agent.py's subagent + deepagent lists, and flash's
+# append sequence. The floor makes the guard non-vacuous — a rename that stopped
+# matching would otherwise leave zero sites and pass.
+MIN_SITES = 3
+
+_RESILIENCE_NAMES = frozenset({"model_resilience", "ModelResilienceMiddleware"})
+_MULTIMODAL_NAMES = frozenset({"multimodal", "MultimodalMiddleware"})
+
+
+def _markers(node: ast.AST) -> set[str]:
+    """Which of the two middlewares *node* refers to, by name or by constructor.
+
+    Matches the local variable and the class alike, since agent.py splices
+    pre-built locals (``*model_resilience``, ``multimodal``) while flash appends
+    the constructor calls directly.
+    """
+    found: set[str] = set()
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Name):
+            name = sub.id
+        elif isinstance(sub, ast.Attribute):
+            name = sub.attr
+        else:
+            continue
+        if name in _RESILIENCE_NAMES:
+            found.add("resilience")
+        elif name in _MULTIMODAL_NAMES:
+            found.add("multimodal")
+    return found
+
+
+def _list_literal_sites(tree: ast.AST, rel_path: str) -> list[tuple[str, list[set[str]]]]:
+    """Ordered markers for each list literal — agent.py's middleware stacks."""
+    sites = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.List):
+            continue
+        ordered = [_markers(el) for el in node.elts]
+        sites.append((f"{rel_path}:{node.lineno} (list literal)", ordered))
+    return sites
+
+
+def _append_sites(tree: ast.AST, rel_path: str) -> list[tuple[str, list[set[str]]]]:
+    """Ordered markers for each ``<var>.append/extend`` sequence — flash's stack.
+
+    Source line order stands in for statement order; both calls sit in one
+    straight-line function body, so the two agree.
+    """
+    by_var: dict[str, list[tuple[int, set[str]]]] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr not in ("append", "extend"):
+            continue
+        if not isinstance(node.func.value, ast.Name):
+            continue
+        marks = set()
+        for arg in node.args:
+            marks |= _markers(arg)
+        by_var.setdefault(node.func.value.id, []).append((node.lineno, marks))
+
+    sites = []
+    for var, calls in by_var.items():
+        ordered = [marks for _lineno, marks in sorted(calls)]
+        sites.append((f"{rel_path}: {var}.append(...) sequence", ordered))
+    return sites
+
+
+def _assembly_sites() -> list[tuple[str, list[set[str]]]]:
+    sites: list[tuple[str, list[set[str]]]] = []
+    for rel_path in SCAN_FILES:
+        abs_path = os.path.join(REPO_ROOT, rel_path)
+        assert os.path.isfile(abs_path), f"scan target missing: {rel_path}"
+        with open(abs_path, encoding="utf-8") as fh:
+            tree = ast.parse(fh.read(), filename=rel_path)
+        sites.extend(_list_literal_sites(tree, rel_path))
+        sites.extend(_append_sites(tree, rel_path))
+    return sites
+
+
+def _ordering_violations(sites: list[tuple[str, list[set[str]]]]) -> tuple[list[str], int]:
+    """Messages for sites wiring both in the wrong order, and how many wired both."""
+    messages: list[str] = []
+    wired_both = 0
+    for label, ordered in sites:
+        resilience = next((i for i, m in enumerate(ordered) if "resilience" in m), None)
+        multimodal = next((i for i, m in enumerate(ordered) if "multimodal" in m), None)
+        if resilience is None or multimodal is None:
+            continue
+        wired_both += 1
+        if multimodal < resilience:
+            messages.append(
+                f"{label}: multimodal is at index {multimodal}, model_resilience at "
+                f"{resilience} — multimodal must come AFTER (inside) resilience"
+            )
+    return messages, wired_both
+
+
+_REMEDIATION = (
+    "\n\nMultimodalMiddleware reads the model off the request to decide which "
+    "content blocks a target can accept. Outside ModelResilienceMiddleware it "
+    "sees the pre-fallback client, so after a fallback it strips against the "
+    "wrong model — silently. Move it after *model_resilience in the list."
+)
+
+
+def test_multimodal_is_composed_inside_model_resilience() -> None:
+    messages, wired_both = _ordering_violations(_assembly_sites())
+    assert not messages, "middleware composition order violations:\n" + "\n".join(
+        messages
+    ) + _REMEDIATION
+    assert wired_both >= MIN_SITES, (
+        f"expected at least {MIN_SITES} sites wiring both middlewares, found "
+        f"{wired_both} — a rename likely broke this guard's matching"
+    )
+
+
+def test_guard_catches_an_inverted_order() -> None:
+    """Self-test: the guard is not vacuous — an inverted stack is flagged."""
+    snippet = "stack = [multimodal, *model_resilience]\n"
+    tree = ast.parse(snippet)
+    messages, wired_both = _ordering_violations(_list_literal_sites(tree, "fake.py"))
+    assert wired_both == 1
+    assert messages and "must come AFTER" in messages[0]
+
+
+def test_guard_accepts_the_correct_order() -> None:
+    """Self-test: the correct order produces no violation."""
+    snippet = "stack = [*model_resilience, multimodal]\n"
+    tree = ast.parse(snippet)
+    messages, wired_both = _ordering_violations(_list_literal_sites(tree, "fake.py"))
+    assert wired_both == 1
+    assert not messages

--- a/tests/unit/ptc_agent/middleware/test_multimodal_model_call.py
+++ b/tests/unit/ptc_agent/middleware/test_multimodal_model_call.py
@@ -17,6 +17,16 @@ from ptc_agent.agent.middleware.file_operations.multimodal import (
 from src.llms.llm import LLM, get_input_modalities
 
 
+def _system_text(request) -> str:
+    """The system message as flat text, whether it is a string or block list."""
+    content = request.system_message.content
+    if isinstance(content, list):
+        return "".join(
+            b.get("text", "") for b in content if isinstance(b, dict)
+        )
+    return str(content)
+
+
 def _pdf_bytes(pages: int = 1) -> bytes:
     """A structurally valid PDF. Generated rather than committed as a blob so the
     page count is a parameter — that is what the provider ceiling is measured in."""
@@ -207,7 +217,7 @@ class TestStripUnsupportedContentBlocks:
 
 
 def _request(manifest_model):
-    """A model-call request carrying only what _resolve_modalities reads."""
+    """A model-call request carrying only what _resolve_target reads."""
     metadata = {"manifest_model": manifest_model} if manifest_model else {}
     return types.SimpleNamespace(model=types.SimpleNamespace(metadata=metadata))
 
@@ -221,13 +231,13 @@ class TestResolveModalities:
         mw = MultimodalMiddleware(model_name="gpt-5.5")
         # Configured for a vision model, but resilience substituted a text-only
         # client; judging on the configured name would replay image blocks at it.
-        assert mw._resolve_modalities(_request("deepseek-v4-pro")) == ["text"]
+        assert mw._resolve_target(_request("deepseek-v4-pro"))[1] == ["text"]
 
     def test_custom_modalities_apply_only_to_the_configured_model(self):
         mw = MultimodalMiddleware(model_name="my-custom-vlm", custom_modalities=["text", "image"])
-        assert mw._resolve_modalities(_request("my-custom-vlm")) == ["text", "image"]
+        assert mw._resolve_target(_request("my-custom-vlm"))[1] == ["text", "image"]
         # A fallback is a different model — the override must not follow it over.
-        assert mw._resolve_modalities(_request("deepseek-v4-pro")) == ["text"]
+        assert mw._resolve_target(_request("deepseek-v4-pro"))[1] == ["text"]
 
     def test_an_unstamped_client_is_text_only_even_under_a_vision_parent(self):
         """Regression: a bare-string subagent resolves via ``init_chat_model`` and
@@ -236,23 +246,23 @@ class TestResolveModalities:
         400 this strip exists to prevent."""
         mw = MultimodalMiddleware(model_name="claude-sonnet-4-6")
         assert "image" in get_input_modalities("claude-sonnet-4-6")  # parent sees images
-        assert mw._resolve_modalities(_request(None)) == ["text"]
+        assert mw._resolve_target(_request(None))[1] == ["text"]
 
     def test_a_client_with_no_metadata_at_all_is_text_only(self):
         mw = MultimodalMiddleware(model_name="claude-sonnet-4-6")
         no_metadata = types.SimpleNamespace(model=types.SimpleNamespace())
-        assert mw._resolve_modalities(no_metadata) == ["text"]
+        assert mw._resolve_target(no_metadata)[1] == ["text"]
 
     def test_no_model_name_at_all_is_text_only(self):
         """Fail closed: over-stripping costs a placeholder, under-stripping a 400."""
         mw = MultimodalMiddleware()
-        assert mw._resolve_modalities(_request(None)) == ["text"]
+        assert mw._resolve_target(_request(None))[1] == ["text"]
 
     def test_a_custom_modalities_override_does_not_survive_an_unstamped_client(self):
         """The override describes the configured model; an unattributable client
         is not that model."""
         mw = MultimodalMiddleware(model_name="my-custom-vlm", custom_modalities=["text", "image"])
-        assert mw._resolve_modalities(_request(None)) == ["text"]
+        assert mw._resolve_target(_request(None))[1] == ["text"]
 
 
 class _ModelCallRequest:
@@ -341,7 +351,7 @@ class TestManifestModelStampRoundTrip:
         # Configured for a text-only model, handed a vision client: the stamp is
         # what must win, which only works if both sides name the same key.
         mw = MultimodalMiddleware(model_name="deepseek-v4-pro")
-        modalities = mw._resolve_modalities(types.SimpleNamespace(model=client))
+        _, modalities = mw._resolve_target(types.SimpleNamespace(model=client))
         assert "image" in modalities
 
     def test_the_stamp_is_the_manifest_key_not_the_provider_model_id(self):
@@ -433,7 +443,7 @@ class TestUnsupportedModalityIsJudgedReadSide:
         ])
         await MultimodalMiddleware().awrap_model_call(request, handler)
 
-        assert "does not support" in str(seen["request"].system_message.content)
+        assert multimodal._UNSUPPORTED_NOTE in _system_text(seen["request"])
 
 
 class TestContentSizeCap:
@@ -786,30 +796,46 @@ class TestPDFsAreVerifiedNotSniffed:
         assert "not a readable PDF" in result.content
 
     @pytest.mark.asyncio
-    async def test_a_pdf_over_the_page_ceiling_is_refused_with_its_count(self):
+    async def test_a_pdf_over_the_page_ceiling_is_refused_with_its_count(
+        self, monkeypatch
+    ):
         """Page count is the ceiling that binds: this fixture is a few KB, so no
         byte cap would catch it. The message names the count so the agent can
-        split the document rather than retry the same read."""
-        mw = MultimodalMiddleware(
-            sandbox=_Sandbox(_pdf_bytes(multimodal.MAX_PDF_PAGES + 1))
-        )
+        split the document rather than retry the same read. The cap is patched
+        down because what is under test is that it is enforced, not its value."""
+        monkeypatch.setattr(multimodal, "MAX_PDF_PAGES", 3)
+        mw = MultimodalMiddleware(sandbox=_Sandbox(_pdf_bytes(4)))
 
         result = await mw._handle_sandbox_content(
             "long.pdf", AIMessage(content="ok"), "call-1"
         )
         assert isinstance(result, ToolMessage)
         assert not isinstance(result, Command)
-        assert f"{multimodal.MAX_PDF_PAGES + 1}-page" in result.content
+        assert "4-page" in result.content
 
     @pytest.mark.asyncio
-    async def test_a_pdf_at_the_page_ceiling_is_accepted(self):
+    async def test_a_pdf_at_the_page_ceiling_is_accepted(self, monkeypatch):
         """The limit is inclusive — off-by-one here silently rejects a legal doc."""
-        mw = MultimodalMiddleware(sandbox=_Sandbox(_pdf_bytes(multimodal.MAX_PDF_PAGES)))
+        monkeypatch.setattr(multimodal, "MAX_PDF_PAGES", 3)
+        mw = MultimodalMiddleware(sandbox=_Sandbox(_pdf_bytes(3)))
 
         result = await mw._handle_sandbox_content(
             "long.pdf", AIMessage(content="ok"), "call-1"
         )
         assert isinstance(result, Command)
+
+    @pytest.mark.asyncio
+    async def test_the_injection_cap_is_the_widest_ceiling_not_the_tightest(self):
+        """The case that motivated splitting the cap in two: a 150-page filing is
+        legal on a 1M-context route, and injection cannot know it isn't headed
+        there, so refusing it at tool time would be a guess against the user."""
+        mw = MultimodalMiddleware(sandbox=_Sandbox(_pdf_bytes(150)))
+
+        result = await mw._handle_sandbox_content(
+            "filing.pdf", AIMessage(content="ok"), "call-1"
+        )
+        assert isinstance(result, Command)
+        assert result.update["messages"][-1].content[-1]["pages"] == 150
 
     @pytest.mark.asyncio
     async def test_trailing_bytes_do_not_condemn_an_otherwise_readable_pdf(self):
@@ -822,3 +848,79 @@ class TestPDFsAreVerifiedNotSniffed:
         )
         assert isinstance(result, Command)
         assert result.update["messages"][-1].content[-1]["mime_type"] == "application/pdf"
+
+
+def _pdf_block(pages):
+    return HumanMessage(content=[
+        {"type": "text", "text": "[Viewing PDF: filing.pdf]"},
+        {"type": "file", "base64": "abc", "mime_type": "application/pdf",
+         "filename": "filing.pdf", "pages": pages},
+    ])
+
+
+async def _blocks_reaching(model, message):
+    """The content blocks the middleware actually hands the target."""
+    seen = {}
+
+    async def handler(request):
+        seen["request"] = request
+        return "ok"
+
+    await MultimodalMiddleware().awrap_model_call(
+        _ModelCallRequest(model, [message]), handler
+    )
+    return seen["request"].messages[0].content, seen["request"]
+
+
+class TestPDFPageCeilingIsPerTarget:
+    """The page ceiling belongs to the model that reads the block, not to the
+    tool call that made it: Anthropic publishes 600 at a 1M context and 100
+    below it, so one global cap is wrong for someone whichever value it takes."""
+
+    @pytest.mark.asyncio
+    async def test_a_long_pdf_survives_to_a_1m_context_route(self):
+        blocks, _ = await _blocks_reaching("claude-sonnet-5", _pdf_block(300))
+        assert [b["type"] for b in blocks] == ["text", "file"]
+
+    @pytest.mark.asyncio
+    async def test_the_same_pdf_is_stripped_for_a_200k_route(self):
+        blocks, request = await _blocks_reaching("claude-sonnet-4-6", _pdf_block(300))
+        assert [b["type"] for b in blocks] == ["text", "text"]
+        assert "300 pages" in blocks[1]["text"]
+        assert multimodal._UNSUPPORTED_NOTE in _system_text(request)
+
+    @pytest.mark.asyncio
+    async def test_a_pdf_inside_the_200k_ceiling_still_reaches_it(self):
+        blocks, _ = await _blocks_reaching("claude-sonnet-4-6", _pdf_block(80))
+        assert [b["type"] for b in blocks] == ["text", "file"]
+
+    @pytest.mark.asyncio
+    async def test_a_provider_documenting_no_page_limit_keeps_the_block(self):
+        blocks, _ = await _blocks_reaching("gpt-5.5", _pdf_block(900))
+        assert [b["type"] for b in blocks] == ["text", "file"]
+
+    @pytest.mark.asyncio
+    async def test_an_unstamped_block_is_left_alone(self):
+        """Blocks written before the stamp existed. Re-deriving the count would
+        mean decoding every PDF in history per call; leaving them keeps the old
+        behaviour rather than regressing threads that already work."""
+        legacy = HumanMessage(content=[
+            {"type": "text", "text": "[Viewing PDF: old.pdf]"},
+            {"type": "file", "base64": "abc", "mime_type": "application/pdf",
+             "filename": "old.pdf"},
+        ])
+        blocks, _ = await _blocks_reaching("claude-sonnet-4-6", legacy)
+        assert [b["type"] for b in blocks] == ["text", "file"]
+
+
+class TestPageStampStaysLocal:
+    def test_the_stamp_never_reaches_the_wire(self):
+        """The count rides on the block so the read side can judge it. That is
+        only safe because every provider converter drops keys it doesn't know —
+        if one passed it through, it would be an unknown field in the payload."""
+        from langchain_anthropic.chat_models import _format_messages
+
+        _, payload = _format_messages([_pdf_block(300)])
+        document = [b for b in payload[0]["content"] if b["type"] == "document"][0]
+        assert "pages" not in document
+        assert "pages" not in document["source"]

--- a/tests/unit/ptc_agent/middleware/test_multimodal_model_call.py
+++ b/tests/unit/ptc_agent/middleware/test_multimodal_model_call.py
@@ -2,6 +2,7 @@ import io
 import types
 
 import httpx
+import pypdf
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langgraph.types import Command
@@ -14,6 +15,17 @@ from ptc_agent.agent.middleware.file_operations.multimodal import (
     _strip_unsupported_content_blocks,
 )
 from src.llms.llm import LLM, get_input_modalities
+
+
+def _pdf_bytes(pages: int = 1) -> bytes:
+    """A structurally valid PDF. Generated rather than committed as a blob so the
+    page count is a parameter — that is what the provider ceiling is measured in."""
+    writer = pypdf.PdfWriter()
+    for _ in range(pages):
+        writer.add_blank_page(width=72, height=72)
+    buf = io.BytesIO()
+    writer.write(buf)
+    return buf.getvalue()
 
 
 def _png_bytes() -> bytes:
@@ -524,7 +536,7 @@ class TestContentIsTypedByItsBytes:
 
     @pytest.mark.asyncio
     async def test_a_sandbox_pdf_named_png_is_read_as_a_pdf(self):
-        mw = MultimodalMiddleware(sandbox=_Sandbox(b"%PDF-1.4 body"))
+        mw = MultimodalMiddleware(sandbox=_Sandbox(_pdf_bytes()))
 
         result = await mw._handle_sandbox_content(
             "report.png", AIMessage(content="ok"), "call-1"
@@ -544,7 +556,7 @@ class TestContentIsTypedByItsBytes:
             multimodal,
             "GuardedAsyncTransport",
             lambda: httpx.MockTransport(
-                lambda request: httpx.Response(200, content=b"%PDF-1.4 body")
+                lambda request: httpx.Response(200, content=_pdf_bytes())
             ),
         )
 
@@ -575,4 +587,76 @@ class TestContentIsTypedByItsBytes:
             "https://example.com/a.bmp", AIMessage(content="ok"), "call-1"
         )
         assert isinstance(result, ToolMessage)
-        assert "not a readable image or PDF" in result.content
+        assert not isinstance(result, Command)
+        assert "BMP" in result.content
+
+
+class TestPDFsAreVerifiedNotSniffed:
+    """A `%PDF` prefix is four bytes of claim. Everything past it — the xref, the
+    page tree, the page count — is what a provider actually validates, and the
+    Command that carries the block is written to the checkpoint before any
+    provider sees it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_header_only_pdf_never_reaches_graph_state(self):
+        """The bytes that pass a prefix check and nothing else."""
+        mw = MultimodalMiddleware(sandbox=_Sandbox(b"%PDF-1.4 body"))
+
+        result = await mw._handle_sandbox_content(
+            "report.pdf", AIMessage(content="ok"), "call-1"
+        )
+        assert isinstance(result, ToolMessage)
+        assert not isinstance(result, Command)
+        assert "not a readable PDF" in result.content
+
+    @pytest.mark.asyncio
+    async def test_a_truncated_pdf_is_refused(self):
+        """The realistic shape: an interrupted download or a half-written report,
+        whose head is a genuine PDF."""
+        whole = _pdf_bytes()
+        mw = MultimodalMiddleware(sandbox=_Sandbox(whole[: len(whole) * 6 // 10]))
+
+        result = await mw._handle_sandbox_content(
+            "report.pdf", AIMessage(content="ok"), "call-1"
+        )
+        assert isinstance(result, ToolMessage)
+        assert "not a readable PDF" in result.content
+
+    @pytest.mark.asyncio
+    async def test_a_pdf_over_the_page_ceiling_is_refused_with_its_count(self):
+        """Page count is the ceiling that binds: this fixture is a few KB, so no
+        byte cap would catch it. The message names the count so the agent can
+        split the document rather than retry the same read."""
+        mw = MultimodalMiddleware(
+            sandbox=_Sandbox(_pdf_bytes(multimodal.MAX_PDF_PAGES + 1))
+        )
+
+        result = await mw._handle_sandbox_content(
+            "long.pdf", AIMessage(content="ok"), "call-1"
+        )
+        assert isinstance(result, ToolMessage)
+        assert not isinstance(result, Command)
+        assert f"{multimodal.MAX_PDF_PAGES + 1}-page" in result.content
+
+    @pytest.mark.asyncio
+    async def test_a_pdf_at_the_page_ceiling_is_accepted(self):
+        """The limit is inclusive — off-by-one here silently rejects a legal doc."""
+        mw = MultimodalMiddleware(sandbox=_Sandbox(_pdf_bytes(multimodal.MAX_PDF_PAGES)))
+
+        result = await mw._handle_sandbox_content(
+            "long.pdf", AIMessage(content="ok"), "call-1"
+        )
+        assert isinstance(result, Command)
+
+    @pytest.mark.asyncio
+    async def test_trailing_bytes_do_not_condemn_an_otherwise_readable_pdf(self):
+        """Verification has to reject damage, not tidiness. Real PDFs routinely
+        carry junk after the final %%EOF, and providers accept them."""
+        mw = MultimodalMiddleware(sandbox=_Sandbox(_pdf_bytes() + b"\n<!-- appended -->"))
+
+        result = await mw._handle_sandbox_content(
+            "report.pdf", AIMessage(content="ok"), "call-1"
+        )
+        assert isinstance(result, Command)
+        assert result.update["messages"][-1].content[-1]["mime_type"] == "application/pdf"

--- a/tests/unit/ptc_agent/middleware/test_multimodal_model_call.py
+++ b/tests/unit/ptc_agent/middleware/test_multimodal_model_call.py
@@ -1,9 +1,17 @@
-import pytest
-from langchain_core.messages import AIMessage, HumanMessage
+import types
 
+import httpx
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langgraph.types import Command
+
+from ptc_agent.agent.middleware.file_operations import multimodal
 from ptc_agent.agent.middleware.file_operations.multimodal import (
+    MultimodalMiddleware,
+    _is_visual_request,
     _strip_unsupported_content_blocks,
 )
+from src.llms.llm import LLM, get_input_modalities
 
 
 class TestStripUnsupportedContentBlocks:
@@ -44,6 +52,68 @@ class TestStripUnsupportedContentBlocks:
         content = result[0].content
         assert content[0]["type"] == "text"
         assert "PDF" in content[0]["text"]
+
+    def test_text_only_strips_anthropic_native_image_blocks(self):
+        """Regression: an Anthropic-lineage turn leaves ``type: image`` blocks,
+        not ``image_url``. Missing that shape let the most common vision→text-only
+        switch replay raw blocks and 400."""
+        msgs = [
+            HumanMessage(content=[
+                {"type": "text", "text": "Look at this"},
+                {"type": "image", "source": {
+                    "type": "base64", "media_type": "image/png", "data": "abc",
+                }},
+            ]),
+        ]
+        result = _strip_unsupported_content_blocks(msgs, has_image=False, has_pdf=False)
+        assert result is not msgs
+        content = result[0].content
+        assert content[0] == {"type": "text", "text": "Look at this"}
+        assert content[1]["type"] == "text"
+        assert "not visible" in content[1]["text"]
+        # The checkpoint keeps the original block — the strip is read-side only.
+        assert msgs[0].content[1]["type"] == "image"
+
+    def test_text_only_strips_langchain_v1_image_blocks(self):
+        """The v1 shape keys the payload on `base64` instead of `source`; matching
+        on the block type alone keeps either from slipping through."""
+        msgs = [
+            HumanMessage(content=[
+                {"type": "image", "base64": "abc", "mime_type": "image/png"},
+            ]),
+        ]
+        result = _strip_unsupported_content_blocks(msgs, has_image=False, has_pdf=False)
+        assert result is not msgs
+        assert result[0].content[0]["type"] == "text"
+
+    @pytest.mark.parametrize(
+        "block",
+        [
+            {"type": "file", "base64": "abc", "mime_type": None},
+            {"type": "file", "base64": "abc"},
+            {"type": "file", "base64": "abc", "mime_type": "image/png"},
+        ],
+        ids=["null-mime", "no-mime-key", "non-pdf-mime"],
+    )
+    def test_unclassifiable_file_blocks_fail_closed(self, block):
+        """`pdf` is the only file-modality flag we have, so a file block we can't
+        classify is one a model without it cannot accept. Matching on mime left
+        these through — and on a null mime the old `.startswith` raised outright."""
+        msgs = [HumanMessage(content=[block])]
+        result = _strip_unsupported_content_blocks(msgs, has_image=False, has_pdf=False)
+        assert result is not msgs
+        assert result[0].content[0]["type"] == "text"
+
+    def test_vision_model_keeps_anthropic_native_image_blocks(self):
+        msgs = [
+            HumanMessage(content=[
+                {"type": "image", "source": {
+                    "type": "base64", "media_type": "image/png", "data": "abc",
+                }},
+            ]),
+        ]
+        result = _strip_unsupported_content_blocks(msgs, has_image=True, has_pdf=False)
+        assert result is msgs
 
     def test_mixed_content_preserves_text_blocks(self):
         msgs = [
@@ -96,3 +166,296 @@ class TestStripUnsupportedContentBlocks:
         ]
         result = _strip_unsupported_content_blocks(msgs, has_image=False, has_pdf=False)
         assert result is msgs
+
+
+def _request(manifest_model):
+    """A model-call request carrying only what _resolve_modalities reads."""
+    metadata = {"manifest_model": manifest_model} if manifest_model else {}
+    return types.SimpleNamespace(model=types.SimpleNamespace(metadata=metadata))
+
+
+class TestResolveModalities:
+    """The middleware runs inside ModelResilienceMiddleware, so the client on the
+    request is the one that will actually be called — including after a fallback.
+    """
+
+    def test_reads_the_stamped_model_not_the_configured_one(self):
+        mw = MultimodalMiddleware(model_name="gpt-5.5")
+        # Configured for a vision model, but resilience substituted a text-only
+        # client; judging on the configured name would replay image blocks at it.
+        assert mw._resolve_modalities(_request("deepseek-v4-pro")) == ["text"]
+
+    def test_custom_modalities_apply_only_to_the_configured_model(self):
+        mw = MultimodalMiddleware(model_name="my-custom-vlm", custom_modalities=["text", "image"])
+        assert mw._resolve_modalities(_request("my-custom-vlm")) == ["text", "image"]
+        # A fallback is a different model — the override must not follow it over.
+        assert mw._resolve_modalities(_request("deepseek-v4-pro")) == ["text"]
+
+    def test_an_unstamped_client_is_text_only_even_under_a_vision_parent(self):
+        """Regression: a bare-string subagent resolves via ``init_chat_model`` and
+        carries no stamp. Lending it the configured model's modalities let a
+        vision parent replay image blocks into a text-only subagent — the exact
+        400 this strip exists to prevent."""
+        mw = MultimodalMiddleware(model_name="claude-sonnet-4-6")
+        assert "image" in get_input_modalities("claude-sonnet-4-6")  # parent sees images
+        assert mw._resolve_modalities(_request(None)) == ["text"]
+
+    def test_a_client_with_no_metadata_at_all_is_text_only(self):
+        mw = MultimodalMiddleware(model_name="claude-sonnet-4-6")
+        no_metadata = types.SimpleNamespace(model=types.SimpleNamespace())
+        assert mw._resolve_modalities(no_metadata) == ["text"]
+
+    def test_no_model_name_at_all_is_text_only(self):
+        """Fail closed: over-stripping costs a placeholder, under-stripping a 400."""
+        mw = MultimodalMiddleware()
+        assert mw._resolve_modalities(_request(None)) == ["text"]
+
+    def test_a_custom_modalities_override_does_not_survive_an_unstamped_client(self):
+        """The override describes the configured model; an unattributable client
+        is not that model."""
+        mw = MultimodalMiddleware(model_name="my-custom-vlm", custom_modalities=["text", "image"])
+        assert mw._resolve_modalities(_request(None)) == ["text"]
+
+
+class _ModelCallRequest:
+    """Minimal stand-in for the model-call request: a stamped client, a history,
+    and the ``override`` the middleware must go through to replace messages."""
+
+    def __init__(self, manifest_model, messages):
+        self.model = types.SimpleNamespace(metadata={"manifest_model": manifest_model})
+        self.messages = messages
+
+    def override(self, **kwargs):
+        clone = _ModelCallRequest.__new__(_ModelCallRequest)
+        clone.model = self.model
+        clone.messages = kwargs.get("messages", self.messages)
+        return clone
+
+
+class TestAwrapModelCall:
+    """The seam itself: capability resolution and the strip are covered above,
+    but nothing exercised the method that joins them and calls ``override``."""
+
+    @staticmethod
+    def _image_history():
+        return [
+            HumanMessage(content=[
+                {"type": "text", "text": "Look at this"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+            ]),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_vision_target_is_handed_the_request_untouched(self):
+        seen = {}
+
+        async def handler(request):
+            seen["request"] = request
+            return "ok"
+
+        request = _ModelCallRequest("claude-sonnet-4-6", self._image_history())
+        assert await MultimodalMiddleware().awrap_model_call(request, handler) == "ok"
+        assert seen["request"] is request, "vision target must not be cloned or stripped"
+
+    @pytest.mark.asyncio
+    async def test_a_text_only_target_is_handed_stripped_messages(self):
+        seen = {}
+
+        async def handler(request):
+            seen["request"] = request
+            return "ok"
+
+        history = self._image_history()
+        request = _ModelCallRequest("deepseek-v4-pro", history)
+        await MultimodalMiddleware().awrap_model_call(request, handler)
+
+        forwarded = seen["request"]
+        assert forwarded is not request, "must forward an override, not the original"
+        assert forwarded.messages[0].content[1]["type"] == "text"
+        # Read-side only: the checkpoint's copy still holds the real block.
+        assert history[0].content[1]["type"] == "image_url"
+
+    @pytest.mark.asyncio
+    async def test_a_text_only_target_with_nothing_to_strip_is_not_cloned(self):
+        """No visual blocks means no override — the request passes through as-is."""
+        seen = {}
+
+        async def handler(request):
+            seen["request"] = request
+            return "ok"
+
+        request = _ModelCallRequest("deepseek-v4-pro", [HumanMessage(content="plain text")])
+        await MultimodalMiddleware().awrap_model_call(request, handler)
+        assert seen["request"] is request
+
+
+class TestManifestModelStampRoundTrip:
+    """Producer and consumer of ``manifest_model`` live in different modules and
+    agree only by string. Both sides are asserted against one real client so a
+    rename on either cannot pass."""
+
+    def test_the_key_the_producer_writes_is_the_key_the_middleware_reads(self):
+        client = LLM("claude-sonnet-4-6", api_key="unused-offline").get_llm()
+        assert client.metadata["manifest_model"] == "claude-sonnet-4-6"
+
+        # Configured for a text-only model, handed a vision client: the stamp is
+        # what must win, which only works if both sides name the same key.
+        mw = MultimodalMiddleware(model_name="deepseek-v4-pro")
+        modalities = mw._resolve_modalities(types.SimpleNamespace(model=client))
+        assert "image" in modalities
+
+    def test_the_stamp_is_the_manifest_key_not_the_provider_model_id(self):
+        """``get_input_modalities`` looks up models.json keys; the API model id
+        would silently resolve to text-only for every renamed model."""
+        client = LLM("claude-sonnet-4-6", api_key="unused-offline").get_llm()
+        stamped = client.metadata["manifest_model"]
+        assert get_input_modalities(stamped) != ["text"]
+
+
+class TestVisualRequestRouting:
+    def test_memo_pdf_is_not_intercepted(self):
+        """Read serves memo PDFs as extracted text; they have no sandbox-FS copy,
+        so intercepting would swap real content for a not-found error."""
+        assert not _is_visual_request(".agents/user/memo/report.pdf")
+        assert not _is_visual_request("/.agents/user/memo/report.pdf")
+        assert not _is_visual_request("./.agents/user/memo/report.pdf")
+
+    def test_workspace_pdf_is_intercepted(self):
+        assert _is_visual_request("results/report.pdf")
+
+    def test_tool_name_matches_the_registered_read_tool(self):
+        """A drift here silently disables the whole injection half — it fails by
+        matching nothing, not by raising, which is how it went unnoticed before."""
+        from ptc_agent.agent.tools.file_ops import create_filesystem_tools
+
+        # The factory only closes over the backend; nothing touches it until a
+        # tool is actually invoked, so a bare stub is enough to read the names.
+        names = {t.name for t in create_filesystem_tools(types.SimpleNamespace())}
+        assert MultimodalMiddleware.TOOL_NAME in names
+
+
+class TestUnsupportedModalityNote:
+    """A file the model can't consume still runs the tool — the note is appended
+    to the real output, never substituted for it, so the agent can say why it is
+    answering blind instead of silently losing the read.
+    """
+
+    @staticmethod
+    def _read(file_path):
+        return types.SimpleNamespace(
+            tool_call={"name": "Read", "args": {"file_path": file_path}, "id": "tc-1"}
+        )
+
+    @staticmethod
+    async def _handler(_request):
+        return ToolMessage(content="ok", tool_call_id="tc-1")
+
+    @pytest.mark.parametrize(
+        "file_path",
+        ["chart.png", "report.pdf", "https://example.com/asset"],
+        ids=["image-ext", "pdf-ext", "url-without-extension"],
+    )
+    @pytest.mark.asyncio
+    async def test_text_only_model_gets_the_note(self, file_path):
+        """The extensionless URL is the interesting one: it could resolve to
+        either kind, so a model with neither modality has to be told."""
+        mw = MultimodalMiddleware(model_name="stub", custom_modalities=["text"])
+        result = await mw.awrap_tool_call(self._read(file_path), self._handler)
+        assert result.content.startswith("ok")
+        assert "does not support" in result.content
+
+    @pytest.mark.asyncio
+    async def test_a_model_holding_the_modality_is_not_noted(self):
+        """Routed to the injection path instead — which fails here only because
+        this middleware has no sandbox, well past the branch under test."""
+        mw = MultimodalMiddleware(model_name="stub", custom_modalities=["text", "image"])
+        result = await mw.awrap_tool_call(self._read("chart.png"), self._handler)
+        assert "does not support" not in result.content
+
+
+class TestContentSizeCap:
+    @pytest.mark.asyncio
+    async def test_oversized_download_is_aborted(self, monkeypatch):
+        """The body is streamed so the cap can fire mid-transfer — a Content-Length
+        check alone is a header a server can simply lie about."""
+        mw = MultimodalMiddleware()
+        monkeypatch.setattr(mw, "MAX_CONTENT_BYTES", 1024)
+
+        def handler(request):
+            return httpx.Response(200, content=b"x" * 4096)
+
+        monkeypatch.setattr(
+            multimodal, "GuardedAsyncTransport", lambda: httpx.MockTransport(handler)
+        )
+
+        result = await mw._handle_url_content(
+            "https://example.com/big.png", AIMessage(content="ok"), "call-1"
+        )
+        assert "larger than" in result.content
+        assert result.tool_call_id == "call-1"
+
+    @pytest.mark.asyncio
+    async def test_oversized_sandbox_file_is_refused(self, monkeypatch):
+        """The sandbox path was uncapped while the URL path was not. Both write
+        into graph state, so an oversized block there is checkpointed and
+        replayed on every later turn — a permanent 400, not a one-turn error."""
+
+        class _Sandbox:
+            async def adownload_file_bytes(self, path):
+                return b"x" * 4096
+
+        mw = MultimodalMiddleware(sandbox=_Sandbox())
+        monkeypatch.setattr(mw, "MAX_CONTENT_BYTES", 1024)
+
+        result = await mw._handle_sandbox_content(
+            "/home/workspace/big.png", AIMessage(content="ok"), "call-1"
+        )
+        assert "larger than" in result.content
+        assert result.tool_call_id == "call-1"
+
+    @pytest.mark.asyncio
+    async def test_a_refusal_never_reaches_graph_state(self, monkeypatch):
+        """A Command would write the block into the checkpoint; refusing has to
+        stay a plain ToolMessage or the cap accomplishes nothing."""
+
+        class _Sandbox:
+            async def adownload_file_bytes(self, path):
+                return b"x" * 4096
+
+        mw = MultimodalMiddleware(sandbox=_Sandbox())
+        monkeypatch.setattr(mw, "MAX_CONTENT_BYTES", 1024)
+
+        result = await mw._handle_sandbox_content(
+            "/home/workspace/big.png", AIMessage(content="ok"), "call-1"
+        )
+        assert isinstance(result, ToolMessage)
+        assert not isinstance(result, Command)
+
+    @pytest.mark.asyncio
+    async def test_a_blocked_address_does_not_name_the_resolved_ip(self, monkeypatch):
+        """The URL is model-chosen, so echoing the guard's message back — it names
+        the resolved address — turns Read into a DNS-to-IP probe steerable by
+        anything the agent reads."""
+        from src.tools.web.inhouse.guard import BlockedAddressError
+
+        class _Blocking(httpx.AsyncBaseTransport):
+            async def handle_async_request(self, request):
+                raise BlockedAddressError(
+                    "Blocked private/reserved address 10.11.12.13 for host 'x.corp'",
+                    request=request,
+                )
+
+        mw = MultimodalMiddleware()
+        monkeypatch.setattr(multimodal, "GuardedAsyncTransport", _Blocking)
+
+        result = await mw._handle_url_content(
+            "http://x.corp/a.png", AIMessage(content="ok"), "call-1"
+        )
+        assert "10.11.12.13" not in result.content
+        assert "x.corp" in result.content  # the URL the model already knows
+        assert "not allowed" in result.content
+
+    def test_the_cap_matches_the_binding_provider_limit(self):
+        """5MB is Anthropic's per-image ceiling, which binds before any
+        per-request limit. Raising this re-opens the checkpoint brick."""
+        assert MultimodalMiddleware.MAX_CONTENT_BYTES == 5 * 1024 * 1024

--- a/tests/unit/ptc_agent/middleware/test_multimodal_model_call.py
+++ b/tests/unit/ptc_agent/middleware/test_multimodal_model_call.py
@@ -1,9 +1,11 @@
+import io
 import types
 
 import httpx
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langgraph.types import Command
+from PIL import Image
 
 from ptc_agent.agent.middleware.file_operations import multimodal
 from ptc_agent.agent.middleware.file_operations.multimodal import (
@@ -12,6 +14,30 @@ from ptc_agent.agent.middleware.file_operations.multimodal import (
     _strip_unsupported_content_blocks,
 )
 from src.llms.llm import LLM, get_input_modalities
+
+
+def _png_bytes() -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (2, 2), "red").save(buf, format="PNG")
+    return buf.getvalue()
+
+
+class _Sandbox:
+    """Stands in for PTCSandbox — which normalizes on its own, not on download."""
+
+    def __init__(self, content: bytes = b"", *, work_dir: str = "/home/workspace"):
+        self._content = content
+        self._work_dir = work_dir
+        self.downloaded: str | None = None
+
+    def normalize_path(self, path: str) -> str:
+        if path.startswith((self._work_dir, "/tmp")):
+            return path
+        return f"{self._work_dir}/{path.lstrip('/')}"
+
+    async def adownload_file_bytes(self, path: str) -> bytes:
+        self.downloaded = path
+        return self._content
 
 
 class TestStripUnsupportedContentBlocks:
@@ -399,12 +425,7 @@ class TestContentSizeCap:
         """The sandbox path was uncapped while the URL path was not. Both write
         into graph state, so an oversized block there is checkpointed and
         replayed on every later turn — a permanent 400, not a one-turn error."""
-
-        class _Sandbox:
-            async def adownload_file_bytes(self, path):
-                return b"x" * 4096
-
-        mw = MultimodalMiddleware(sandbox=_Sandbox())
+        mw = MultimodalMiddleware(sandbox=_Sandbox(b"x" * 4096))
         monkeypatch.setattr(mw, "MAX_CONTENT_BYTES", 1024)
 
         result = await mw._handle_sandbox_content(
@@ -417,12 +438,7 @@ class TestContentSizeCap:
     async def test_a_refusal_never_reaches_graph_state(self, monkeypatch):
         """A Command would write the block into the checkpoint; refusing has to
         stay a plain ToolMessage or the cap accomplishes nothing."""
-
-        class _Sandbox:
-            async def adownload_file_bytes(self, path):
-                return b"x" * 4096
-
-        mw = MultimodalMiddleware(sandbox=_Sandbox())
+        mw = MultimodalMiddleware(sandbox=_Sandbox(b"x" * 4096))
         monkeypatch.setattr(mw, "MAX_CONTENT_BYTES", 1024)
 
         result = await mw._handle_sandbox_content(
@@ -459,3 +475,104 @@ class TestContentSizeCap:
         """5MB is Anthropic's per-image ceiling, which binds before any
         per-request limit. Raising this re-opens the checkpoint brick."""
         assert MultimodalMiddleware.MAX_CONTENT_BYTES == 5 * 1024 * 1024
+
+
+class TestSandboxPathNormalization:
+    @pytest.mark.asyncio
+    async def test_a_virtual_path_is_normalized_before_download(self):
+        """The Read tool normalizes through SandboxBackend, this middleware holds
+        the sandbox itself. Skipping it makes the middleware miss a file the tool
+        just read and overwrite that success with a not-found error."""
+        sandbox = _Sandbox(_png_bytes())
+        mw = MultimodalMiddleware(sandbox=sandbox)
+
+        result = await mw._handle_sandbox_content(
+            "/results/chart.png", AIMessage(content="ok"), "call-1"
+        )
+        assert sandbox.downloaded == "/home/workspace/results/chart.png"
+        assert isinstance(result, Command)
+
+    @pytest.mark.asyncio
+    async def test_an_already_absolute_path_is_left_alone(self):
+        sandbox = _Sandbox(_png_bytes())
+        mw = MultimodalMiddleware(sandbox=sandbox)
+
+        await mw._handle_sandbox_content(
+            "/home/workspace/work/t/charts/fig.png", AIMessage(content="ok"), "call-1"
+        )
+        assert sandbox.downloaded == "/home/workspace/work/t/charts/fig.png"
+
+
+class TestContentIsTypedByItsBytes:
+    """The extension is whatever wrote the file claimed, and a URL may carry none
+    at all. Both injection paths checkpoint what they build, so a wrong call here
+    is replayed on every later turn instead of failing once.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_corrupt_sandbox_image_is_refused(self):
+        """The URL path already ran PIL over its bytes; the sandbox path trusted
+        the extension, so a truncated chart reached graph state unexamined."""
+        mw = MultimodalMiddleware(sandbox=_Sandbox(_png_bytes()[:20]))
+
+        result = await mw._handle_sandbox_content(
+            "chart.png", AIMessage(content="ok"), "call-1"
+        )
+        assert isinstance(result, ToolMessage)
+        assert not isinstance(result, Command)
+        assert "not a readable image or PDF" in result.content
+
+    @pytest.mark.asyncio
+    async def test_a_sandbox_pdf_named_png_is_read_as_a_pdf(self):
+        mw = MultimodalMiddleware(sandbox=_Sandbox(b"%PDF-1.4 body"))
+
+        result = await mw._handle_sandbox_content(
+            "report.png", AIMessage(content="ok"), "call-1"
+        )
+        blocks = result.update["messages"][-1].content
+        assert [b["type"] for b in blocks] == ["text", "file"]
+        assert blocks[-1]["mime_type"] == "application/pdf"
+
+    @pytest.mark.asyncio
+    async def test_an_extensionless_url_serving_a_pdf_is_not_judged_as_an_image(
+        self, monkeypatch
+    ):
+        """Signed and redirected URLs routinely end without a suffix; branching on
+        it sent every one of them down the image path."""
+        mw = MultimodalMiddleware()
+        monkeypatch.setattr(
+            multimodal,
+            "GuardedAsyncTransport",
+            lambda: httpx.MockTransport(
+                lambda request: httpx.Response(200, content=b"%PDF-1.4 body")
+            ),
+        )
+
+        result = await mw._handle_url_content(
+            "https://files.example.com/d/abc123", AIMessage(content="ok"), "call-1"
+        )
+        assert isinstance(result, Command)
+        assert result.update["messages"][-1].content[-1]["mime_type"] == "application/pdf"
+
+    @pytest.mark.asyncio
+    async def test_a_format_no_provider_accepts_is_refused_not_relabeled(
+        self, monkeypatch
+    ):
+        """The old URL path defaulted an unmapped PIL format to image/png, which
+        ships a BMP under a PNG mime and earns a 400 on every replay."""
+        buf = io.BytesIO()
+        Image.new("RGB", (2, 2), "blue").save(buf, format="BMP")
+        mw = MultimodalMiddleware()
+        monkeypatch.setattr(
+            multimodal,
+            "GuardedAsyncTransport",
+            lambda: httpx.MockTransport(
+                lambda request: httpx.Response(200, content=buf.getvalue())
+            ),
+        )
+
+        result = await mw._handle_url_content(
+            "https://example.com/a.bmp", AIMessage(content="ok"), "call-1"
+        )
+        assert isinstance(result, ToolMessage)
+        assert "not a readable image or PDF" in result.content

--- a/tests/unit/ptc_agent/middleware/test_multimodal_model_call.py
+++ b/tests/unit/ptc_agent/middleware/test_multimodal_model_call.py
@@ -259,14 +259,16 @@ class _ModelCallRequest:
     """Minimal stand-in for the model-call request: a stamped client, a history,
     and the ``override`` the middleware must go through to replace messages."""
 
-    def __init__(self, manifest_model, messages):
+    def __init__(self, manifest_model, messages, system_message=None):
         self.model = types.SimpleNamespace(metadata={"manifest_model": manifest_model})
         self.messages = messages
+        self.system_message = system_message
 
     def override(self, **kwargs):
         clone = _ModelCallRequest.__new__(_ModelCallRequest)
         clone.model = self.model
         clone.messages = kwargs.get("messages", self.messages)
+        clone.system_message = kwargs.get("system_message", self.system_message)
         return clone
 
 
@@ -372,10 +374,13 @@ class TestVisualRequestRouting:
         assert MultimodalMiddleware.TOOL_NAME in names
 
 
-class TestUnsupportedModalityNote:
-    """A file the model can't consume still runs the tool — the note is appended
-    to the real output, never substituted for it, so the agent can say why it is
-    answering blind instead of silently losing the read.
+class TestUnsupportedModalityIsJudgedReadSide:
+    """Which model can see the file is decided where the model is known.
+
+    One middleware instance is shared with every subagent, so the configured name
+    is not the consuming model. Deciding at tool-call time withheld the block from
+    a subagent running its own vision model — and the read side only ever removes
+    blocks, so nothing downstream could recover a block never created.
     """
 
     @staticmethod
@@ -388,27 +393,47 @@ class TestUnsupportedModalityNote:
     async def _handler(_request):
         return ToolMessage(content="ok", tool_call_id="tc-1")
 
+    @pytest.mark.asyncio
+    async def test_a_text_only_configured_model_still_injects(self):
+        """The block has to exist for a vision subagent sharing this instance."""
+        mw = MultimodalMiddleware(
+            sandbox=_Sandbox(_png_bytes()), model_name="stub", custom_modalities=["text"]
+        )
+
+        result = await mw.awrap_tool_call(self._read("chart.png"), self._handler)
+        assert isinstance(result, Command)
+        assert result.update["messages"][-1].content[-1]["type"] == "image_url"
+
     @pytest.mark.parametrize(
         "file_path",
         ["chart.png", "report.pdf", "https://example.com/asset"],
         ids=["image-ext", "pdf-ext", "url-without-extension"],
     )
     @pytest.mark.asyncio
-    async def test_text_only_model_gets_the_note(self, file_path):
+    async def test_no_verdict_is_frozen_into_the_transcript(self, file_path):
         """The extensionless URL is the interesting one: it could resolve to
-        either kind, so a model with neither modality has to be told."""
+        either kind, and the old gate judged all three off the configured name."""
         mw = MultimodalMiddleware(model_name="stub", custom_modalities=["text"])
         result = await mw.awrap_tool_call(self._read(file_path), self._handler)
-        assert result.content.startswith("ok")
-        assert "does not support" in result.content
+        assert "does not support" not in str(result.content)
 
     @pytest.mark.asyncio
-    async def test_a_model_holding_the_modality_is_not_noted(self):
-        """Routed to the injection path instead — which fails here only because
-        this middleware has no sandbox, well past the branch under test."""
-        mw = MultimodalMiddleware(model_name="stub", custom_modalities=["text", "image"])
-        result = await mw.awrap_tool_call(self._read("chart.png"), self._handler)
-        assert "does not support" not in result.content
+    async def test_the_note_reaches_the_model_that_actually_cannot_see(self):
+        seen = {}
+
+        async def handler(request):
+            seen["request"] = request
+            return "ok"
+
+        request = _ModelCallRequest("deepseek-v4-pro", [
+            HumanMessage(content=[
+                {"type": "text", "text": "Look at this"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+            ]),
+        ])
+        await MultimodalMiddleware().awrap_model_call(request, handler)
+
+        assert "does not support" in str(seen["request"].system_message.content)
 
 
 class TestContentSizeCap:
@@ -589,6 +614,143 @@ class TestContentIsTypedByItsBytes:
         assert isinstance(result, ToolMessage)
         assert not isinstance(result, Command)
         assert "BMP" in result.content
+
+
+def _batch(*after_ai):
+    """A turn whose assistant message issued two parallel tool calls."""
+    return [
+        HumanMessage(content="look at the chart and list the files"),
+        AIMessage(content="", tool_calls=[
+            {"name": "Read", "args": {"file_path": "chart.png"}, "id": "toolu_A",
+             "type": "tool_call"},
+            {"name": "bash", "args": {"command": "ls"}, "id": "toolu_B",
+             "type": "tool_call"},
+        ]),
+        *after_ai,
+    ]
+
+
+def _media():
+    return HumanMessage(content=[
+        {"type": "text", "text": "[Viewing image]"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+    ])
+
+
+class TestToolResultsPrecedeInjectedMedia:
+    """Injection returns a Command carrying [ToolMessage, HumanMessage], so a
+    visual Read that is not last in a parallel batch interleaves its media between
+    two tool results. Anthropic requires a user turn's tool_result blocks to come
+    before any other content; the raw order earns a 400, and the Command is
+    checkpointed, so the 400 repeats on every replay.
+    """
+
+    @pytest.mark.asyncio
+    async def test_media_between_two_results_is_moved_after_both(self):
+        seen = {}
+
+        async def handler(request):
+            seen["request"] = request
+            return "ok"
+
+        history = _batch(
+            ToolMessage(content="Read image", tool_call_id="toolu_A"),
+            _media(),
+            ToolMessage(content="file1", tool_call_id="toolu_B"),
+        )
+        request = _ModelCallRequest("claude-sonnet-4-6", history)
+        await MultimodalMiddleware().awrap_model_call(request, handler)
+
+        kinds = [type(m).__name__ for m in seen["request"].messages]
+        assert kinds == ["HumanMessage", "AIMessage", "ToolMessage", "ToolMessage",
+                         "HumanMessage"]
+        # Read-side only: the checkpoint's copy keeps the order it was written in.
+        assert [type(m).__name__ for m in history][2:] == ["ToolMessage", "HumanMessage",
+                                                            "ToolMessage"]
+
+    def test_the_repair_produces_a_payload_anthropic_accepts(self):
+        """The contract this exists for, asserted where it is actually enforced —
+        block order inside the converted user turn, not message order."""
+        from langchain_anthropic.chat_models import _format_messages
+
+        broken = _batch(
+            ToolMessage(content="Read image", tool_call_id="toolu_A"),
+            _media(),
+            ToolMessage(content="file1", tool_call_id="toolu_B"),
+        )
+        _, before = _format_messages(broken)
+        assert [b["type"] for b in before[-1]["content"]] == [
+            "tool_result", "text", "image", "tool_result"
+        ], "precondition: the raw order interleaves a tool_result after content"
+
+        _, after = _format_messages(multimodal._tool_results_first(broken))
+        kinds = [b["type"] for b in after[-1]["content"]]
+        assert kinds.index("text") > max(
+            i for i, k in enumerate(kinds) if k == "tool_result"
+        ), "every tool_result must precede any other block"
+
+    @pytest.mark.parametrize(
+        "tail",
+        [
+            pytest.param(
+                [ToolMessage(content="a", tool_call_id="toolu_A"),
+                 ToolMessage(content="b", tool_call_id="toolu_B"), _media()],
+                id="media-already-last",
+            ),
+            pytest.param(
+                [ToolMessage(content="a", tool_call_id="toolu_A")],
+                id="single-result",
+            ),
+            pytest.param([], id="no-results-yet"),
+        ],
+    )
+    def test_an_already_valid_turn_is_returned_unchanged(self, tail):
+        """Identity, not equality — an unnecessary copy would defeat the caller's
+        `is not` check and clone every request in the process."""
+        messages = _batch(*tail)
+        assert multimodal._tool_results_first(messages) is messages
+
+    def test_a_turn_with_no_tool_calls_is_untouched(self):
+        messages = [
+            HumanMessage(content="hi"),
+            AIMessage(content="hello"),
+            HumanMessage(content="thanks"),
+        ]
+        assert multimodal._tool_results_first(messages) is messages
+
+    def test_relative_order_inside_each_group_is_preserved(self):
+        """Two injected reads in one batch must stay in the order they ran."""
+        first, second = _media(), _media()
+        messages = _batch(
+            ToolMessage(content="a", tool_call_id="toolu_A"),
+            first,
+            ToolMessage(content="b", tool_call_id="toolu_B"),
+            second,
+        )
+        tail = multimodal._tool_results_first(messages)[2:]
+        assert [m.content for m in tail[:2]] == ["a", "b"]
+        assert tail[2] is first and tail[3] is second
+
+    def test_an_earlier_healthy_batch_is_left_alone(self):
+        """Only the offending run is rewritten; earlier turns keep their shape."""
+        good_media = _media()
+        messages = [
+            *_batch(ToolMessage(content="a", tool_call_id="toolu_A"), good_media),
+            AIMessage(content="", tool_calls=[
+                {"name": "Read", "args": {"file_path": "x.png"}, "id": "toolu_C",
+                 "type": "tool_call"},
+                {"name": "bash", "args": {"command": "ls"}, "id": "toolu_D",
+                 "type": "tool_call"},
+            ]),
+            ToolMessage(content="c", tool_call_id="toolu_C"),
+            _media(),
+            ToolMessage(content="d", tool_call_id="toolu_D"),
+        ]
+        result = multimodal._tool_results_first(messages)
+        assert result[2].content == "a" and result[3] is good_media
+        assert [type(m).__name__ for m in result[5:]] == [
+            "ToolMessage", "ToolMessage", "HumanMessage"
+        ]
 
 
 class TestPDFsAreVerifiedNotSniffed:

--- a/web/src/components/ui/__tests__/chat-input.quickAccess.test.ts
+++ b/web/src/components/ui/__tests__/chat-input.quickAccess.test.ts
@@ -1,15 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { deriveQuickAccessModels, areModelsCompatible, type QuickAccessParams, type ModelMetadata } from '../chat-input.models';
-
-const META: ModelMetadata = {
-  'claude-opus': { sdk: 'anthropic', provider: 'anthropic' },
-  'claude-sonnet': { sdk: 'anthropic', provider: 'anthropic' },
-  'gpt-5': { sdk: 'openai', provider: 'openai' },
-  'gpt-5-azure': { sdk: 'openai', provider: 'azure' },
-  'codex-openai': { sdk: 'codex', provider: 'openai' },
-  'codex-openai-2': { sdk: 'codex', provider: 'openai' },
-  'codex-azure': { sdk: 'codex', provider: 'azure' },
-};
+import {
+  derivePrimaryModels,
+  deriveQuickAccessModels,
+  type QuickAccessParams,
+} from '../chat-input.models';
 
 function params(overrides: Partial<QuickAccessParams> = {}): QuickAccessParams {
   return {
@@ -17,9 +11,6 @@ function params(overrides: Partial<QuickAccessParams> = {}): QuickAccessParams {
     preferredFlashModel: null,
     starredModels: [],
     validModelNames: new Set(),
-    initialModel: null,
-    selectedModel: null,
-    modelMetadata: META,
     ...overrides,
   };
 }
@@ -75,72 +66,26 @@ describe('deriveQuickAccessModels', () => {
     ).toEqual(['some-model']);
   });
 
-  it('mid-thread, drops models from a different SDK than the thread model', () => {
-    expect(
-      deriveQuickAccessModels(params({
-        preferredModel: 'gpt-5', // openai → incompatible with anthropic thread
-        starredModels: ['claude-sonnet'], // anthropic → compatible
-        initialModel: 'claude-opus',
-        selectedModel: 'claude-opus',
-      })),
-    ).toEqual(['claude-sonnet']);
-  });
-
-  it('mid-thread, drops same-SDK openai models from a different provider', () => {
-    expect(
-      deriveQuickAccessModels(params({
-        starredModels: ['gpt-5', 'gpt-5-azure'],
-        initialModel: 'gpt-5',
-        selectedModel: 'gpt-5',
-      })),
-    ).toEqual(['gpt-5']);
-  });
-
-  it('in a fresh thread (no initialModel), keeps incompatible models', () => {
+  it('offers models from any provider, whatever the thread already used', () => {
+    // Reasoning payloads are sanitized per-provider server-side
+    // (ReasoningCompatibilityMiddleware), so a mid-thread switch to a foreign
+    // provider is no longer a 400 and the menu must not hide it.
     expect(
       deriveQuickAccessModels(params({
         preferredModel: 'gpt-5',
-        starredModels: ['claude-opus'],
-        initialModel: null,
-        selectedModel: 'claude-opus',
+        starredModels: ['claude-sonnet', 'gemini-3'],
       })),
-    ).toEqual(['gpt-5', 'claude-opus']);
+    ).toEqual(['gpt-5', 'claude-sonnet', 'gemini-3']);
   });
 
-  it('anchors the compatibility filter on selectedModel, not initialModel', () => {
-    // initialModel is anthropic but the user switched selectedModel to gpt-5.
-    // The gpt-5 star (compatible with the current selection) survives; the
-    // anthropic star (compatible with initialModel, not the selection) drops.
-    expect(
-      deriveQuickAccessModels(params({
-        starredModels: ['gpt-5', 'claude-sonnet'],
-        initialModel: 'claude-opus',
-        selectedModel: 'gpt-5',
-      })),
-    ).toEqual(['gpt-5']);
-  });
-
-  it('mid-thread with a null selectedModel, keeps everything (null anchor is compatible)', () => {
-    expect(
-      deriveQuickAccessModels(params({
-        starredModels: ['gpt-5'], // incompatible with the anthropic thread
-        initialModel: 'claude-opus',
-        selectedModel: null,
-      })),
-    ).toEqual(['gpt-5']);
-  });
-
-  it('applies the availability and compatibility gates together', () => {
-    // revoked-anthropic dropped by availability; gpt-5 dropped by SDK mismatch.
+  it('applies the availability gate to defaults and stars alike', () => {
     expect(
       deriveQuickAccessModels(params({
         preferredModel: 'claude-opus',
-        starredModels: ['claude-sonnet', 'gpt-5', 'revoked-anthropic'],
+        starredModels: ['claude-sonnet', 'gpt-5', 'revoked-model'],
         validModelNames: new Set(['claude-opus', 'claude-sonnet', 'gpt-5']),
-        initialModel: 'claude-opus',
-        selectedModel: 'claude-opus',
       })),
-    ).toEqual(['claude-opus', 'claude-sonnet']);
+    ).toEqual(['claude-opus', 'claude-sonnet', 'gpt-5']);
   });
 
   it('excludes models already shown in the primary section (no duplicate rows)', () => {
@@ -171,32 +116,89 @@ describe('deriveQuickAccessModels', () => {
   });
 });
 
-describe('areModelsCompatible', () => {
-  it('treats a null model as compatible', () => {
-    expect(areModelsCompatible(null, 'claude-opus', META)).toBe(true);
-    expect(areModelsCompatible('claude-opus', null, META)).toBe(true);
+describe('derivePrimaryModels', () => {
+  it('lists the thread models, then the current selection', () => {
+    expect(
+      derivePrimaryModels({
+        selectedModel: 'gpt-5',
+        threadModels: ['claude-opus', 'claude-sonnet'],
+        validModelNames: new Set(),
+      }),
+    ).toEqual(['claude-opus', 'claude-sonnet', 'gpt-5']);
   });
 
-  it('allows unknown models (missing metadata), either side', () => {
-    expect(areModelsCompatible('claude-opus', 'mystery-model', META)).toBe(true);
-    expect(areModelsCompatible('mystery-model', 'claude-opus', META)).toBe(true);
+  it('dedupes a selection the thread already used', () => {
+    expect(
+      derivePrimaryModels({
+        selectedModel: 'claude-opus',
+        threadModels: ['claude-opus'],
+        validModelNames: new Set(),
+      }),
+    ).toEqual(['claude-opus']);
   });
 
-  it('matches on SDK for non-openai SDKs', () => {
-    expect(areModelsCompatible('claude-opus', 'claude-sonnet', META)).toBe(true);
+  it('drops a thread model the user can no longer reach', () => {
+    // A model can be revoked (BYOK key removed, plan downgrade) long after a
+    // turn used it. Leaving it clickable fails only once the user sends.
+    expect(
+      derivePrimaryModels({
+        selectedModel: 'gpt-5',
+        threadModels: ['claude-opus', 'revoked-model'],
+        validModelNames: new Set(['claude-opus', 'gpt-5']),
+      }),
+    ).toEqual(['claude-opus', 'gpt-5']);
   });
 
-  it('rejects across different SDKs', () => {
-    expect(areModelsCompatible('claude-opus', 'gpt-5', META)).toBe(false);
+  it('keeps the current selection even when it is not in the valid set', () => {
+    // The trigger renders the selection; gating it would leave the menu unable
+    // to show what is currently selected.
+    expect(
+      derivePrimaryModels({
+        selectedModel: 'not-yet-loaded',
+        threadModels: ['claude-opus'],
+        validModelNames: new Set(['claude-opus']),
+      }),
+    ).toEqual(['claude-opus', 'not-yet-loaded']);
   });
 
-  it('requires the same provider for openai SDKs', () => {
-    expect(areModelsCompatible('gpt-5', 'gpt-5-azure', META)).toBe(false);
-    expect(areModelsCompatible('gpt-5', 'gpt-5', META)).toBe(true);
+  it('skips the availability gate while the model list is still loading', () => {
+    expect(
+      derivePrimaryModels({
+        selectedModel: null,
+        threadModels: ['claude-opus', 'gpt-5'],
+        validModelNames: new Set(),
+      }),
+    ).toEqual(['claude-opus', 'gpt-5']);
   });
 
-  it('requires the same provider for codex SDK', () => {
-    expect(areModelsCompatible('codex-openai', 'codex-azure', META)).toBe(false);
-    expect(areModelsCompatible('codex-openai', 'codex-openai-2', META)).toBe(true);
+  it('offers thread models from any provider, not just the selection\'s', () => {
+    // The point of the change: history spanning providers stays reachable.
+    expect(
+      derivePrimaryModels({
+        selectedModel: 'gpt-5',
+        threadModels: ['claude-opus', 'glm-5.2'],
+        validModelNames: new Set(['claude-opus', 'glm-5.2', 'gpt-5']),
+      }),
+    ).toEqual(['claude-opus', 'glm-5.2', 'gpt-5']);
+  });
+
+  it('returns an empty list with no selection and no history', () => {
+    expect(
+      derivePrimaryModels({
+        selectedModel: null,
+        threadModels: [],
+        validModelNames: new Set(),
+      }),
+    ).toEqual([]);
+  });
+
+  it('drops malformed thread-model entries', () => {
+    expect(
+      derivePrimaryModels({
+        selectedModel: 'gpt-5',
+        threadModels: [123, '', null, 'claude-opus'] as unknown as string[],
+        validModelNames: new Set(),
+      }),
+    ).toEqual(['claude-opus', 'gpt-5']);
   });
 });

--- a/web/src/components/ui/chat-input.modelMenu.tsx
+++ b/web/src/components/ui/chat-input.modelMenu.tsx
@@ -9,8 +9,8 @@ import {
   DropdownMenuSeparator, DropdownMenuSub, DropdownMenuSubTrigger, DropdownMenuSubContent,
 } from './dropdown-menu';
 import { useIsMobile } from '@/hooks/useIsMobile';
-import { areModelsCompatible, type ModelMetadata } from './chat-input.models';
 import { getModelDisplayName } from './chat-input.helpers';
+import { derivePrimaryModels } from './chat-input.models';
 
 /** Pill geometry for the model trigger — shared with the measure chip so the
  *  fold budget can never drift from what actually renders. */
@@ -54,8 +54,7 @@ export function ChatInputModelMenu({
   selectedModel,
   onSelectModel,
   threadModels,
-  initialModel,
-  modelMetadata,
+  validModelNames,
   moreModelsItems,
   hasStarredModels,
   reasoningEffort,
@@ -70,8 +69,8 @@ export function ChatInputModelMenu({
   selectedModel: string | null;
   onSelectModel: (model: string) => void;
   threadModels: string[];
-  initialModel: string | null;
-  modelMetadata: ModelMetadata;
+  /** Gates thread history — a model can be revoked after a turn used it. */
+  validModelNames: Set<string>;
   moreModelsItems: string[];
   hasStarredModels: boolean;
   reasoningEffort: string | null;
@@ -95,9 +94,7 @@ export function ChatInputModelMenu({
   // the settings link reachable).
   if (moreModelsItems.length === 0 && !hasStarredModels && !selectedModel) return null;
 
-  const primaryModels: string[] = threadModels.length > 0
-    ? [...new Set([...threadModels, selectedModel].filter((m): m is string => !!m))]
-    : [selectedModel].filter((m): m is string => !!m);
+  const primaryModels = derivePrimaryModels({ selectedModel, threadModels, validModelNames });
 
   return (
     <DropdownMenu modal={false} open={menuOpen} onOpenChange={(open) => { setMenuOpen(open); if (!open) setShowMoreModels(false); }}>
@@ -121,19 +118,17 @@ export function ChatInputModelMenu({
         style={{ backgroundColor: 'var(--color-bg-elevated)', borderColor: 'var(--color-border-muted)' }}
       >
         {/* Thread models */}
-        {primaryModels
-          .filter((m) => !initialModel || areModelsCompatible(selectedModel, m, modelMetadata))
-          .map((m) => (
-            <DropdownMenuItem
-              key={m}
-              onSelect={() => onSelectModel(m)}
-              className="text-[0.8125rem] justify-between"
-              style={{ color: 'var(--color-text-primary)' }}
-            >
-              <span>{getModelDisplayName(m)}</span>
-              {m === selectedModel && <Check className="h-4 w-4 flex-shrink-0" style={{ color: 'var(--color-accent-primary)' }} />}
-            </DropdownMenuItem>
-          ))}
+        {primaryModels.map((m) => (
+          <DropdownMenuItem
+            key={m}
+            onSelect={() => onSelectModel(m)}
+            className="text-[0.8125rem] justify-between"
+            style={{ color: 'var(--color-text-primary)' }}
+          >
+            <span>{getModelDisplayName(m)}</span>
+            {m === selectedModel && <Check className="h-4 w-4 flex-shrink-0" style={{ color: 'var(--color-accent-primary)' }} />}
+          </DropdownMenuItem>
+        ))}
         <DropdownMenuSeparator style={{ backgroundColor: 'var(--color-border-muted)' }} />
         {/* Reasoning effort (custom control — not a menu item, won't close on click) */}
         <div className="model-effort-section">

--- a/web/src/components/ui/chat-input.models.ts
+++ b/web/src/components/ui/chat-input.models.ts
@@ -5,23 +5,41 @@
  * testable without pulling in the full `chat-input` component graph.
  */
 
-export type ModelMetadata = Record<string, { sdk?: string; provider?: string }>;
+/**
+ * Whether the user can still reach *model*.
+ *
+ * Stays open while the model list is empty so a slow or failed fetch degrades to
+ * showing everything rather than blanking the menu.
+ */
+export function isModelAvailable(model: string, validModelNames: Set<string>): boolean {
+  return validModelNames.size === 0 || validModelNames.has(model);
+}
+
+export interface PrimaryModelsParams {
+  selectedModel: string | null;
+  /** Models this thread has already used, from replayed turn metadata. */
+  threadModels: string[];
+  validModelNames: Set<string>;
+}
 
 /**
- * Check if two models are compatible for mid-session switching.
- * - Different SDKs → incompatible
- * - openai/codex SDK → must be same provider (sub-provider)
- * - Other SDKs (anthropic, gemini, etc.) → compatible if same SDK
+ * Models listed in the menu's primary section: the ones this thread already used,
+ * then the current selection.
+ *
+ * Thread history is gated on availability because a model can be revoked long
+ * after a turn used it, and an unreachable row only fails once the user sends.
+ * The selection itself is never gated — the trigger displays it, so dropping it
+ * would leave the menu unable to show what is currently selected.
  */
-export function areModelsCompatible(modelA: string | null, modelB: string | null, metadata: ModelMetadata): boolean {
-  if (!modelA || !modelB) return true;
-  const a = metadata[modelA], b = metadata[modelB];
-  if (!a || !b) return true; // allow unknown models (no metadata on either side)
-  if (a.sdk !== b.sdk) return false;
-  if (a.sdk === 'openai' || a.sdk === 'codex') {
-    return a.provider === b.provider;
-  }
-  return true;
+export function derivePrimaryModels({
+  selectedModel,
+  threadModels,
+  validModelNames,
+}: PrimaryModelsParams): string[] {
+  const reachable = threadModels.filter(
+    (m) => typeof m === 'string' && m.length > 0 && isModelAvailable(m, validModelNames),
+  );
+  return [...new Set([...reachable, selectedModel].filter((m): m is string => !!m))];
 }
 
 export interface QuickAccessParams {
@@ -29,9 +47,6 @@ export interface QuickAccessParams {
   preferredFlashModel: string | null;
   starredModels: string[];
   validModelNames: Set<string>;
-  initialModel: string | null;
-  selectedModel: string | null;
-  modelMetadata: ModelMetadata;
   /** Models already shown in the menu's primary section; excluded to avoid duplicate rows. */
   excludeModels?: string[];
 }
@@ -39,17 +54,14 @@ export interface QuickAccessParams {
 /**
  * Quick-access models for the chat model menu — the current primary + flash
  * defaults unioned with the user's manual stars, gated by availability (drops
- * removed/revoked models) and, mid-thread, by SDK compatibility. Derived
- * per-render so switching a default never leaves a stale pin behind.
+ * removed/revoked models). Derived per-render so switching a default never
+ * leaves a stale pin behind.
  */
 export function deriveQuickAccessModels({
   preferredModel,
   preferredFlashModel,
   starredModels,
   validModelNames,
-  initialModel,
-  selectedModel,
-  modelMetadata,
   excludeModels = [],
 }: QuickAccessParams): string[] {
   const exclude = new Set(excludeModels);
@@ -63,10 +75,6 @@ export function deriveQuickAccessModels({
   return union.filter((m) => {
     // Already rendered in the primary section (selected + thread models).
     if (exclude.has(m)) return false;
-    // Skip the availability gate while the model list is still loading (empty
-    // set) so a slow/failed fetch can't blank the menu.
-    if (validModelNames.size > 0 && !validModelNames.has(m)) return false;
-    // Mid-thread, only offer models compatible with the thread's model.
-    return !initialModel || areModelsCompatible(selectedModel, m, modelMetadata);
+    return isModelAvailable(m, validModelNames);
   });
 }

--- a/web/src/components/ui/chat-input.tsx
+++ b/web/src/components/ui/chat-input.tsx
@@ -13,7 +13,8 @@ import { usePreferences } from '@/hooks/usePreferences';
 import { useFeatureEnabled } from '@/hooks/useFeatures';
 import { useAllModels } from '@/hooks/useAllModels';
 import { useIsMobile } from '@/hooks/useIsMobile';
-import { deriveQuickAccessModels, type ModelMetadata } from './chat-input.models';
+import { deriveQuickAccessModels } from './chat-input.models';
+import type { ModelMetadataEntry } from '@/hooks/useFilteredModels';
 import { supportsXhighEffort } from '@/lib/modelCapabilities';
 import { getModelMetadata } from '../../pages/ChatAgent/utils/api';
 import { ChatInputRegistry, ContextBus } from '@/lib/contextBus';
@@ -166,7 +167,7 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
   const [reasoningEffort, setReasoningEffort] = useState<string | null>(null);
   const [fastMode, setFastMode] = useState(false);
 
-  const [modelMetadata, setModelMetadata] = useState<ModelMetadata>({});
+  const [modelMetadata, setModelMetadata] = useState<Record<string, ModelMetadataEntry>>({});
 
   // Sync selectedModel when initialModel or preferredModel changes
   useEffect(() => {
@@ -179,7 +180,7 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
     onModelChange?.(selectedModel);
   }, [selectedModel, onModelChange]);
 
-  // Fetch model metadata for compatibility checking (eager prefetch, resolves instantly after first load)
+  // Fetch model metadata to detect Codex-SDK models (eager prefetch, resolves instantly after first load)
   useEffect(() => { getModelMetadata().then((d: Record<string, unknown>) => setModelMetadata(d as typeof modelMetadata)).catch(() => { }); }, []);
 
   const isCodexModel = selectedModel ? modelMetadata[selectedModel]?.sdk === 'codex' : false;
@@ -542,12 +543,11 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
   /** Quick-access models for both the desktop submenu and mobile inline expand */
   const moreModelsItems = useMemo(
     () => deriveQuickAccessModels({
-      preferredModel, preferredFlashModel, starredModels,
-      validModelNames, initialModel, selectedModel, modelMetadata,
+      preferredModel, preferredFlashModel, starredModels, validModelNames,
       // Don't repeat models already shown in the primary (selected + thread) section.
       excludeModels: [selectedModel, ...threadModelsProp].filter((m): m is string => !!m),
     }),
-    [preferredModel, preferredFlashModel, starredModels, validModelNames, initialModel, selectedModel, modelMetadata, threadModelsProp],
+    [preferredModel, preferredFlashModel, starredModels, validModelNames, selectedModel, threadModelsProp],
   );
 
   return (
@@ -827,8 +827,7 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
                 selectedModel={selectedModel}
                 onSelectModel={setSelectedModel}
                 threadModels={threadModelsProp}
-                initialModel={initialModel}
-                modelMetadata={modelMetadata}
+                validModelNames={validModelNames}
                 moreModelsItems={moreModelsItems}
                 hasStarredModels={starredModels.length > 0}
                 reasoningEffort={reasoningEffort}

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -21,7 +21,11 @@ const DropdownMenuContent = React.forwardRef<
       sideOffset={sideOffset}
       collisionPadding={collisionPadding}
       className={cn(
-        "z-[1030] min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
+        // Radix measures the space left to the collision boundary and publishes
+        // it as --radix-…-available-height; capping there is what keeps a long
+        // menu (the model list) from running off-screen with no way to reach
+        // the items past the fold.
+        "z-[1030] min-w-[8rem] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
@@ -107,7 +111,7 @@ const DropdownMenuSubContent = React.forwardRef<
       ref={ref}
       collisionPadding={collisionPadding}
       className={cn(
-        "z-[1030] min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg",
+        "z-[1030] min-w-[8rem] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg",
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -1472,7 +1472,6 @@
       "effortMedium": "Medium",
       "effortHigh": "High",
       "effortXhigh": "X-High",
-      "incompatibleSdk": "Cannot switch to this model in the current session (different provider)",
       "fastMode": "Fast",
       "fastModeDesc": "Priority routing for faster responses",
       "fastModeHelpLine1": "Equivalent to /fast in Codex",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -1471,7 +1471,6 @@
       "effortMedium": "中",
       "effortHigh": "高",
       "effortXhigh": "极高",
-      "incompatibleSdk": "当前会话无法切换到此模型（提供商不同）",
       "fastMode": "快速",
       "fastModeDesc": "优先路由以获得更快响应",
       "fastModeHelpLine1": "等同于 Codex 中的 /fast",


### PR DESCRIPTION
## Overview

PR #336 made a mid-thread cross-provider switch safe: every assistant message is stamped with the provider route that produced it, reasoning whose lineage doesn't match the target is stripped on the way out, and a reasoning-payload 400 is recovered by one retry instead of burning the fallback chain. The composer's model menu still carried the guard that predated it — a compatibility filter that hid every model from a different SDK once a thread had started. That guard no longer protects against anything, and it was the only thing stopping users from switching models freely mid-thread.

This removes it. The audit found the backend had nothing left to remove (the old `AnthropicThinkingSanitizerMiddleware` went in #336; there is no thread/workspace provider pin and no provider restriction on fallback candidates), so the change is one frontend filter, defined once and applied at two call sites.

The rest of the branch is the precondition. Removing the SDK filter is only safe because `MultimodalMiddleware` independently strips image/PDF blocks on a vision→text-only switch — and while verifying that claim, it turned out not to hold. Most of the diff is making it true.

| Category | Files | +LOC | −LOC |
|---|---:|---:|---:|
| Modified | 23 | 327 | 177 |
| New | 0 | 0 | 0 |
| Tests (excluded) | 5 | 618 | 93 |
| **Net (excl. tests)** | **23** | **+327** | **−177** |

### Model menu — the guard removal (net +4)

- `web/src/components/ui/chat-input.models.ts` (+35 / −27) — deletes `areModelsCompatible` and the compat gate; extracts the shared `isModelAvailable` rule and adds `derivePrimaryModels`.
- `web/src/components/ui/chat-input.modelMenu.tsx` (+16 / −21) — primary section derives from the helper instead of an inline union.
- `web/src/components/ui/chat-input.tsx` (+7 / −8) — drops the compat filter on the thread-models list and the three params only it consumed.
- `web/src/components/ui/dropdown-menu.tsx` (+6 / −2) — the menu now lists more models, so a long one scrolls instead of running off-screen.
- `web/src/locales/{en-US,zh-CN}.json` (+0 / −1 each) — removes `incompatibleSdk`, already dead before this branch.

Side benefit: the deleted filter anchored on `selectedModel`, not `initialModel`, so once a user switched selection it hid models **the thread had actually already used**.

### The dormant injection path, and what waking it required (net +156)

`MultimodalMiddleware.TOOL_NAME` was `"read_file"`, the sole occurrence of that string in all of `src/`. The tool has been registered `@tool("Read")` since February. So `awrap_tool_call` never matched, and the entire image/PDF injection half — sandbox download, URL fetch, base64 encode — has been dead for roughly six months.

Fixing the name is correct and necessary (the strip half is what replaces the removed frontend guard). But it turns that code back on, so the branch also has to make it safe:

- `src/ptc_agent/agent/middleware/file_operations/multimodal.py` (+176 / −73) — resolves the target's modalities from the client actually being called rather than a name captured when the stack was built; fails closed on blocks it can't classify and on an unstamped client; caps injected content; and stops the SSRF guard's error naming the resolved IP back to the model.
- `src/llms/llm.py` (+12 / −0) — stamps `manifest_model` (the models.json key, not the API model id) onto every client `get_llm()` builds; that is what the modality lookup reads.
- `src/ptc_agent/agent/agent.py` (+18 / −8), `flash/agent.py` (+14 / −0) — composes the strip **inside** `ModelResilienceMiddleware` on both agents. Resilience substitutes the model within its own wrapper, so an outer sanitizer never observes the substitution.
- `src/ptc_agent/agent/tools/file_ops.py` (+25 / −12) — extracts `is_memo_text_path` so the Read tool and the middleware classify memo-tier paths identically; a disagreement replaces extracted text with a not-found error.

**The size cap is the load-bearing one.** Both injection paths return a `Command` that writes the base64 block into graph state, so an oversized block isn't a one-turn error — it is checkpointed and replayed on every later turn, and the modality strip can't rescue a target that legitimately has the image modality. The sandbox path had no size check at all; the URL path capped at 20MB, above Anthropic's 5MB per-image ceiling. A large sandbox image would have bricked the thread permanently. One `MAX_CONTENT_BYTES` now governs both and refuses as a plain `ToolMessage`, which never reaches the checkpoint.

### Agent-facing tool names (net ±0)

`offloading.py`, `sse_middleware.py`, `memo_awareness.py`, `crawl.py`, and three prompt templates said `read_file` / `write_file` / `glob`. These strings ship into agent prompts, so they were naming tools that do not exist.

### `enable_view_image` removal (net −10)

`src/ptc_agent/config/agent.py` (−6), `config/loaders.py` (−3), `agent_config.yaml` (−1).

**This is a deliberate behavior change.** The flag was undocumented and defaulted to `true`, but it gated the *entire* middleware — including the read-side strip that is now the sole replacement for the removed frontend guard. There is no longer an opt-out. Note `AgentConfig.create(enable_view_image=…)` now silently ignores the kwarg rather than erroring, so an existing self-hosted config carrying it will not fail loudly.

**What this introduces:** users can switch models across providers at any point in a thread, and the read-side layers — reasoning lineage and image/PDF modality — are what keep the request valid, rather than a menu that hides the option.

## Verification

`pnpm typecheck` clean · `pnpm test` green · `uv run pytest tests/unit/` green · `ruff` clean.

Guards were proven load-bearing rather than trusted on a fresh green — inverting the real middleware order in `agent.py` fails the AST guard; reverting `_resolve_modalities` fails three modality tests; removing the sandbox cap fails exactly the two tests that cover it.

Live, against a running stack with real network:

| Check | Result |
|---|---|
| Dispatch actually matches the registered tool | `TOOL_NAME='Read'` vs `['Read','Write','Edit']` → matches |
| Real image over the wire | injects `['text','image_url']` |
| 10MB payload | refused mid-stream, **does not enter the checkpoint** |
| Cloud-metadata IP / localhost | blocked by the guard |
| Blocked-address error text | no longer names the resolved IP |

## Follow-ups, not fixed here

- **Foreign assistant-message `id` on the Responses API.** `langchain_openai` stamps the input item `id` from the content block whenever `store is not False`. With list content — which the reasoning strip produces — that serializes as `"id": null`, and a codex-oauth turn replays a real foreign id. Payload shape confirmed at every layer. Provider reaction is **partly settled**: dashscope returns 200 for null *and* foreign ids, so it is tolerated there; api.openai.com is untested because the repo's OpenAI key currently 401s. Worth one live call with a valid key before relying on it.
- **`localhost` and private IPs are now unreachable from `Read`.** Correct hardening, but self-hosted deployments serving artifacts from a local MinIO will see this as a new failure on a newly-live path.
- The strip's type allowlist covers `image_url` / `image` / `file`; `input_image`, `input_file`, `document` and nested `tool_result` images would slip. Not reachable today — the repo only emits the first set.
- `adownload_file_bytes` remains uncapped at its other 8+ call sites; the cap belongs inside the sandbox helper as its own change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved image and file handling with safer downloads, validation, size limits, PDF page limits, and clearer unsupported-content handling.
  * Model selection now includes available conversation and primary models more consistently.
  * Dropdown menus now scroll when options exceed available space.

* **Bug Fixes**
  * Improved model fallback behavior and preserved history for certain subagents.
  * Memo files now bypass unnecessary visual processing.

* **Changes**
  * Removed the deprecated image-viewing configuration option.
  * Updated file-tool references to use the current tool names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->