### PR TITLE
fix(web): provider attribution on every web tool run, and the breaker bugs it exposed

### DIFF
--- a/scripts/e2e/subagent_wire_pass.py
+++ b/scripts/e2e/subagent_wire_pass.py
@@ -25,7 +25,7 @@ Threads are kept for visual inspection (never deleted).
 
 Usage:
   uv run python scripts/e2e/subagent_wire_pass.py --user <user_id> \
-      [--workspace <ws_id>] [--base http://localhost:8020] [--model <model>] \
+      [--workspace <ws_id>] [--base http://localhost:8000] [--model <model>] \
       [--settle-timeout 600] [--turn-timeout 420]
 
 Auth: X-Service-Token from INTERNAL_SERVICE_TOKEN (repo .env or environment),

--- a/scripts/e2e/web_provider_pass.py
+++ b/scripts/e2e/web_provider_pass.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+"""Web provider pass: agent turns → LangSmith attribution → breaker classification.
+
+Proves the two halves of the web-provider work against a live stack and live
+upstreams, driven by the real agent rather than by mocks:
+
+  1. Agent turns (flash and ptc, both by default): each turn is told to run a
+     web search and fetch a page, so WebSearch/WebFetch run inside a real
+     traced turn.
+  2. LangSmith attribution: the runs those turns produced — correlated by
+     thread id, since several stacks can share one project — must carry the
+     provider that actually served them — ``search_engine``/``search_depth``
+     on WebSearch, ``fetch_provider``/``fetch_attempts`` plus a
+     ``fetch_provider:<p>`` tag on WebFetch. A chain that fell through must
+     record WHY (``firecrawl:budget_exceeded`` → ``inhouse:ok``), not just
+     that it did.
+  3. Breaker classification (the fix): a URL that fails target-side, driven
+     past the failure threshold, must leave every provider breaker CLOSED with
+     a zero failure count, and must not poison the next healthy fetch. Runs
+     in-process because breaker state is process-local and no endpoint exposes
+     it; the network calls are real.
+  4. Server-side quiet check: the backend must not have logged a single
+     breaker transition while all of that happened — healthy failures are
+     silent by design, so any ``Circuit breaker [...]`` line is a regression.
+
+Phase 3 imports ``src`` and fails loudly if it cannot — it is the phase that
+proves the fix, so it must never quietly self-skip. Phase 4 needs docker and
+does skip with an observation when it is absent.
+
+Usage:
+  uv run python scripts/e2e/web_provider_pass.py --user local-dev-user \
+      [--workspace <ws_id>] [--base http://localhost:8000] \
+      [--agents flash,ptc] [--model <model>] [--turn-timeout 420]
+
+Auth: X-Service-Token from INTERNAL_SERVICE_TOKEN (repo .env or environment),
+user id via --user or E2E_USER_ID. Threads are kept for visual inspection.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# A script's sys.path[0] is its own directory, never the cwd, so the repo root
+# has to be added explicitly — without it the breaker phase finds no ``src`` to
+# import and skips the one assertion that proves the fix.
+sys.path[:0] = [str(Path(__file__).resolve().parent), str(REPO_ROOT)]
+
+# The SSE/auth plumbing is identical for every wire pass — reuse it rather than
+# growing a second copy that can drift.
+from subagent_wire_pass import (  # noqa: E402
+    CHECKS,
+    Env,
+    check,
+    iter_frames,
+    observe,
+    read_env_file,
+)
+
+# A reserved TLD (RFC 2606) can never resolve, from any network, forever — the
+# only way to make "the target is unreachable" deterministic in a live test.
+UNREACHABLE = "https://nonexistent-host-{n}.invalid/"
+# Cache-busted per run: a cached URL never reaches the router, so it records no
+# provider at all — correct, but it would test nothing. The host has to tolerate
+# repeat automated traffic; example.com starts serving 403 after a few rounds,
+# which turns a provider-attribution assertion into a flake.
+HEALTHY = f"https://en.wikipedia.org/wiki/Circuit_breaker_design_pattern?e2e={int(time.time())}"
+
+SEARCH_QUERY = "circuit breaker pattern in distributed systems"
+
+TURN_PROMPT = (
+    f"Do exactly two things, then stop. First, run ONE web search for "
+    f"'{SEARCH_QUERY}'. Second, fetch the page {HEALTHY} and quote its main "
+    f"heading. Reply in two sentences. Do not write any files or code."
+)
+
+ATTEMPT_RE = re.compile(r"^[a-z0-9_]+:[a-z0-9_]+$")
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 — agent turns
+# ---------------------------------------------------------------------------
+
+
+def run_turn(env: Env, agent_mode: str, workspace_id: str, model: str | None) -> str | None:
+    """Post one turn and drain it. Returns the thread id (kept for inspection)."""
+    body: dict = {
+        "agent_mode": agent_mode,
+        "workspace_id": workspace_id,
+        "messages": [{"role": "user", "content": TURN_PROMPT}],
+    }
+    if model:
+        body["llm_model"] = model
+
+    outcome, thread_id, frames = None, None, 0
+    deadline = time.time() + env.turn_timeout
+    with env.client(read_timeout=env.turn_timeout) as c:
+        with c.stream("POST", "/api/v1/threads/messages", json=body) as resp:
+            if resp.status_code != 200:
+                resp.read()
+                check(f"{agent_mode}: turn accepted", False, f"HTTP {resp.status_code}: {resp.text[:200]}")
+                return None
+            for fr in iter_frames(resp):
+                frames += 1
+                thread_id = thread_id or str(fr.data.get("thread_id") or "") or None
+                if fr.event == "run_end":
+                    outcome = fr.data.get("outcome") or "completed"
+                    break
+                if fr.event == "error":
+                    outcome = "error"
+                    break
+                if time.time() > deadline:
+                    outcome = "timeout"
+                    break
+
+    check(
+        f"{agent_mode}: turn ran to completion",
+        outcome == "completed",
+        f"outcome={outcome} frames={frames} thread={thread_id}",
+    )
+    return thread_id
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — LangSmith attribution
+# ---------------------------------------------------------------------------
+
+
+def langsmith_checks(project: str, since: datetime, threads: list[str]) -> None:
+    try:
+        from langsmith import Client
+    except ImportError:
+        observe("langsmith SDK not installed — attribution checks skipped")
+        return
+    if not os.environ.get("LANGSMITH_API_KEY"):
+        observe("LANGSMITH_API_KEY unset — attribution checks skipped")
+        return
+    if not check("LangSmith: the turns yielded thread ids to correlate on", bool(threads),
+                 "no thread id was captured — nothing to attribute"):
+        return
+
+    client = Client()
+    by_thread: dict[str, dict[str, list[dict]]] = {}
+    # Ingest lags the turn; poll rather than sleeping a flat guess.
+    for _ in range(18):
+        time.sleep(5)
+        by_thread = {t: {"fetch": [], "search": []} for t in threads}
+        try:
+            for tid in threads:
+                # Scope to THIS pass's turns. Several stacks can share one
+                # project, and a project-wide time window silently grades
+                # another branch's runs as if they were ours.
+                runs = client.list_runs(
+                    project_name=project,
+                    start_time=since,
+                    limit=100,
+                    filter=f'and(eq(metadata_key,"thread_id"),eq(metadata_value,"{tid}"))',
+                )
+                for r in runs:
+                    # A run still in flight has not flushed its stamps yet;
+                    # asserting over one reports an empty stamp as a missing one.
+                    if r.end_time is None:
+                        continue
+                    md = (r.extra or {}).get("metadata") or {}
+                    row = {"metadata": md, "tags": list(r.tags or []), "name": r.name}
+                    if r.name == "WebFetch":
+                        by_thread[tid]["fetch"].append(row)
+                    elif r.name == "WebSearch":
+                        by_thread[tid]["search"].append(row)
+        except Exception as e:  # project may not exist yet on a fresh key
+            observe(f"LangSmith query failed ({type(e).__name__}: {e}) — retrying")
+            continue
+        if all(v["fetch"] and v["search"] for v in by_thread.values()):
+            break
+
+    fetches = [row for v in by_thread.values() for row in v["fetch"]]
+    searches = [row for v in by_thread.values() for row in v["search"]]
+    missing = [t for t, v in by_thread.items() if not (v["fetch"] and v["search"])]
+
+    if not check(
+        "LangSmith: every turn produced WebFetch and WebSearch runs",
+        not missing,
+        f"{len(fetches)} WebFetch, {len(searches)} WebSearch across {len(threads)} thread(s)"
+        + (f"; incomplete: {missing}" if missing else ""),
+    ):
+        return
+
+    # A cache hit never reaches a provider, so it has no provider to name — it
+    # is labelled fetch_source=cache instead. Only live fetches must attribute.
+    live = [f for f in fetches if f["metadata"].get("fetch_source") == "live"]
+    cached = [f for f in fetches if f["metadata"].get("fetch_source") == "cache"]
+    if cached:
+        observe(f"{len(cached)} WebFetch run(s) served from cache — exempt from provider attribution")
+
+    # A fetch that failed on every provider has no provider to name — it carries
+    # fetch_error and the attempt list instead, which is the whole point.
+    failed = [f for f in live if f["metadata"].get("fetch_error")]
+    served = [f for f in live if not f["metadata"].get("fetch_error")]
+    for f in failed:
+        observe(
+            f"fetch failed on every provider ({f['metadata']['fetch_error']}) — "
+            f"attributed by attempts: {f['metadata'].get('fetch_attempts')}"
+        )
+    check(
+        "LangSmith: a failed fetch still records the error and the attempts",
+        all(f["metadata"].get("fetch_attempts") for f in failed),
+        f"{len(failed)} failed run(s), all carrying attempts" if failed else "no failed fetches this run",
+    )
+
+    stamped = [f for f in served if f["metadata"].get("fetch_provider")]
+    check(
+        "LangSmith: every served WebFetch run names the provider that served it",
+        bool(served) and len(stamped) == len(served),
+        f"{len(stamped)}/{len(served)} served runs carry fetch_provider "
+        f"(e.g. {stamped[0]['metadata'].get('fetch_provider') if stamped else 'n/a'})",
+    )
+
+    # The exact tag, not merely some fetch_provider: tag — a run stamped
+    # inhouse but tagged firecrawl is the failure this check exists to catch.
+    tagged = [f for f in stamped if f"fetch_provider:{f['metadata']['fetch_provider']}" in f["tags"]]
+    check(
+        "LangSmith: WebFetch runs carry the filterable fetch_provider tag",
+        bool(stamped) and len(tagged) == len(stamped),
+        f"{len(tagged)}/{len(stamped)} tagged (e.g. "
+        f"{next((t for t in tagged[0]['tags'] if t.startswith('fetch_provider:')), '') if tagged else 'n/a'})",
+    )
+
+    with_attempts = [f for f in live if f["metadata"].get("fetch_attempts")]
+    malformed = [
+        a
+        for f in with_attempts
+        for a in f["metadata"]["fetch_attempts"]
+        if not ATTEMPT_RE.match(str(a))
+    ]
+    check(
+        "LangSmith: fetch_attempts are well-formed provider:outcome pairs",
+        bool(with_attempts) and not malformed,
+        f"{len(with_attempts)} runs carry attempts; malformed={malformed or 'none'}",
+    )
+
+    # The point of the attempt list: a fall-through records the reason, so a
+    # silent fallback is legible after the fact.
+    fellthrough = [
+        f["metadata"]["fetch_attempts"]
+        for f in with_attempts
+        if len(f["metadata"]["fetch_attempts"]) > 1
+    ]
+    if fellthrough:
+        check(
+            "LangSmith: a chain fall-through records why the primary lost",
+            all(not str(a[0]).endswith(":ok") for a in fellthrough),
+            f"e.g. {fellthrough[0]}",
+        )
+        # A served fetch's chain must end on the provider that served it —
+        # otherwise the attempt list and fetch_provider tell different stories.
+        served_chains = [
+            f["metadata"]["fetch_attempts"]
+            for f in served
+            if len(f["metadata"].get("fetch_attempts") or []) > 1
+        ]
+        check(
+            "LangSmith: a served fall-through ends on the provider that served it",
+            all(str(a[-1]).endswith(":ok") for a in served_chains),
+            f"terminal attempts={[str(a[-1]) for a in served_chains] or 'none'}",
+        )
+    else:
+        observe(
+            "no multi-provider attempt recorded — the primary served every fetch "
+            "(configure a failing primary in fetch_chain to cover fall-through)"
+        )
+
+    engines = {s["metadata"].get("search_engine") for s in searches}
+    depths = {s["metadata"].get("search_depth") for s in searches}
+    check(
+        "LangSmith: WebSearch runs name the engine and depth that served them",
+        all(e for e in engines) and all(d for d in depths),
+        f"engines={engines or 'none'} depths={depths or 'none'}",
+    )
+
+    if len(threads) > 1:
+        observe(f"attribution covers {len(fetches)} fetch / {len(searches)} search runs "
+                f"across {len(threads)} turns")
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — breaker classification (in-process, live network)
+# ---------------------------------------------------------------------------
+
+
+def breaker_checks() -> None:
+    try:
+        import asyncio
+
+        from src.tools.web.breaker import CircuitState
+        from src.tools.web.fetch import get_fetch_chain
+        from src.tools.web.router import FetchRouter
+        from src.tools.web.types import FetchRequest
+    except ImportError as e:
+        # Never an observation: a skipped breaker phase reports all-green while
+        # proving nothing, which is exactly the failure this pass exists to catch.
+        check("breaker: the in-process phase ran", False,
+              f"src not importable ({e}) — no breaker assertion was evaluated")
+        return
+
+    async def drive() -> None:
+        # Deliberately the in-house provider alone, not the configured chain: a
+        # primary that rate-limits US is a genuine provider fault and SHOULD
+        # open its breaker, which would mask the thing under test.
+        router = FetchRouter(["inhouse"])
+        observe(f"breaker phase isolates 'inhouse' (configured chain: {get_fetch_chain()})")
+        entries = router._chain
+        if not entries:
+            # Never an observation, for the same reason the import failure
+            # above is not: a skipped breaker phase reports all-green while
+            # proving nothing.
+            check("breaker: the in-house provider resolved to a breaker", False,
+                  "FetchRouter(['inhouse']) produced an empty chain — nothing to exercise")
+            return
+        threshold = min(e.breaker.failure_threshold for e in entries)
+        rounds = threshold + 2
+
+        target_results, labels = [], []
+        for n in range(rounds):
+            resp = await router.fetch(FetchRequest(urls=[UNREACHABLE.format(n=n)]))
+            target_results.extend(resp.results)
+            labels.extend(str(a) for a in resp.attempts)
+
+        # Without this the breaker assertions below can pass vacuously: a proxy
+        # that answers for .invalid would mean no target-side failure ever ran.
+        check(
+            "breaker: every unreachable URL failed, and none blamed the provider",
+            len(target_results) == rounds
+            and all(r.error is not None and not r.error.provider_fault for r in target_results),
+            f"{len(target_results)}/{rounds} results; "
+            f"e.g. {str(target_results[0].error) if target_results else 'none'}",
+        )
+        check(
+            "breaker: the attempt label names the target-side cause, not 'provider_error'",
+            bool(labels) and all(not lb.endswith(":provider_error") for lb in labels),
+            f"labels={sorted(set(labels))}",
+        )
+
+        opened = [e.adapter.name for e in entries if e.breaker.state is not CircuitState.CLOSED]
+        counted = {e.adapter.name: e.breaker.failure_count for e in entries}
+        check(
+            f"breaker: {rounds} target-side failures open no provider breaker",
+            not opened,
+            f"threshold={threshold} states="
+            f"{ {e.adapter.name: e.breaker.state.name for e in entries} }",
+        )
+        check(
+            "breaker: target-side failures are not counted against any provider",
+            all(v == 0 for v in counted.values()),
+            f"failure_count={counted}",
+        )
+
+        resp = await router.fetch(FetchRequest(urls=[HEALTHY]))
+        served = resp.results[0].ok if resp.results else False
+        check(
+            "breaker: a healthy fetch still succeeds afterwards (chain not poisoned)",
+            served,
+            f"provider={resp.provider} attempts={[str(a) for a in resp.attempts]}"
+            + ("" if served else f" error={resp.results[0].error if resp.results else 'no result'}"),
+        )
+
+    asyncio.run(drive())
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — the backend stayed quiet
+# ---------------------------------------------------------------------------
+
+
+def quiet_log_check(container: str, since: datetime) -> None:
+    try:
+        out = subprocess.run(
+            # Explicit Z: a naive timestamp is read in the daemon's local zone,
+            # which is not the container's.
+            ["docker", "logs", container, "--since", since.strftime("%Y-%m-%dT%H:%M:%SZ")],
+            capture_output=True, text=True, timeout=60,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError) as e:
+        observe(f"docker logs unavailable ({type(e).__name__}) — quiet-log check skipped")
+        return
+    if out.returncode != 0:
+        observe(f"docker logs {container} failed — quiet-log check skipped")
+        return
+
+    lines = [ln for ln in (out.stdout + out.stderr).splitlines() if "Circuit breaker [" in ln]
+    # Layers that serve every URL: nothing a single target does may open them.
+    # A primary provider rate-limiting us is a real provider fault, so its
+    # breaker opening is correct behaviour and only worth noting.
+    target_driven = [ln for ln in lines if "[fetch:inhouse]" in ln or "[crawler:" in ln]
+    for other in [ln for ln in lines if ln not in target_driven]:
+        observe(f"provider-fault breaker line (expected, not a failure): {other[:160]}")
+    check(
+        "server: no shared-layer breaker opened while serving real traffic",
+        not target_driven,
+        "no [fetch:inhouse] or [crawler:*] transitions"
+        if not target_driven
+        else f"{len(target_driven)} line(s): {[ln[-160:] for ln in target_driven[:2]]}",
+    )
+
+
+# ---------------------------------------------------------------------------
+
+
+def pick_workspace(env: Env) -> str:
+    with env.client() as c:
+        r = c.get("/api/v1/workspaces")
+        r.raise_for_status()
+        items = r.json().get("workspaces") or []
+    for ws in items:
+        if ws.get("status") not in ("archived", "error"):
+            return str(ws["workspace_id"])
+    sys.exit("No usable workspace for this user — pass --workspace explicitly.")
+
+
+def main() -> int:
+    envf = read_env_file()
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--user", default=os.environ.get("E2E_USER_ID"), help="user id (or E2E_USER_ID)")
+    ap.add_argument("--base", default=f"http://localhost:{envf.get('BACKEND_PORT', '8000')}")
+    ap.add_argument("--workspace", default=None)
+    ap.add_argument("--agents", default="flash,ptc", help="comma-separated: flash,ptc")
+    ap.add_argument("--model", default=None)
+    ap.add_argument("--turn-timeout", type=float, default=420.0)
+    ap.add_argument("--project", default=os.environ.get("LANGSMITH_PROJECT") or envf.get("LANGSMITH_PROJECT"))
+    # Compose names it "<project>-backend-1", and defaults the project to the
+    # checkout's directory name when COMPOSE_PROJECT_NAME is unset.
+    ap.add_argument("--backend-container",
+                    default=f"{envf.get('COMPOSE_PROJECT_NAME') or REPO_ROOT.name}-backend-1")
+    ap.add_argument("--skip-turns", action="store_true", help="breaker + log phases only")
+    args = ap.parse_args()
+
+    token = os.environ.get("INTERNAL_SERVICE_TOKEN") or envf.get("INTERNAL_SERVICE_TOKEN")
+    if not token:
+        sys.exit("INTERNAL_SERVICE_TOKEN not found (env or repo .env).")
+    if not args.user and not args.skip_turns:
+        sys.exit("--user (or E2E_USER_ID) is required.")
+
+    # A minute of slack: container clocks and the LangSmith window both drift.
+    started = datetime.now(timezone.utc) - timedelta(seconds=60)
+    env = Env(base=args.base, token=token, user_id=args.user or "", turn_timeout=args.turn_timeout)
+    agents = [a.strip() for a in args.agents.split(",") if a.strip()]
+    threads: list[str] = []
+
+    if not args.skip_turns:
+        ws = args.workspace or pick_workspace(env)
+        print(f"base={env.base} user={env.user_id} workspace={ws} agents={agents}")
+        for mode in agents:
+            print(f"\n== turn: {mode} agent — search + fetch ==")
+            tid = run_turn(env, mode, ws, args.model)
+            if tid:
+                threads.append(tid)
+
+        print(f"\n== LangSmith attribution (project={args.project}) ==")
+        if args.project:
+            langsmith_checks(args.project, started, threads)
+        else:
+            observe("no LANGSMITH_PROJECT — attribution checks skipped")
+
+    print("\n== breaker classification (live, in-process) ==")
+    breaker_checks()
+
+    print(f"\n== server quiet check ({args.backend_container}) ==")
+    quiet_log_check(args.backend_container, started)
+
+    failed = [c for c in CHECKS if not c[1]]
+    print(f"\n{'=' * 60}\n{len(CHECKS) - len(failed)}/{len(CHECKS)} checks passed"
+          + (f"; threads kept: {', '.join(threads)}" if threads else ""))
+    for name, ok, _ in CHECKS:
+        print(f"  {'✅' if ok else '❌'} {name}")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/observability/__init__.py
+++ b/src/observability/__init__.py
@@ -11,6 +11,7 @@ The full surface stays no-op when ``OTEL_EXPORTER_OTLP_ENDPOINT`` is unset — i
 call sites are always safe to leave in place.
 """
 
+from .langsmith_run import stamp_run
 from .otel import init_otel, init_otel_runtime, shutdown_otel_runtime
 from .tracing import (
     attached,
@@ -66,6 +67,7 @@ __all__ = [
     "init_otel",
     "init_otel_runtime",
     "shutdown_otel_runtime",
+    "stamp_run",
     "tracer",
     "meter",
     "hash_id",

--- a/src/observability/langsmith_run.py
+++ b/src/observability/langsmith_run.py
@@ -1,0 +1,42 @@
+"""LangSmith run stamping.
+
+Which provider served a call is decided at runtime — a fetch may fall through
+a chain, a search engine comes from user prefs. LangSmith filters on run
+metadata, not on the payload a tool returns, so that fact has to be written
+onto the enclosing run rather than handed back to the caller.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+
+def stamp_run(tags: Optional[Sequence[str]] = None, **fields: Any) -> None:
+    """Attach metadata (and optional tags) to the enclosing LangSmith run.
+
+    No-ops outside a traced run — which is every call when tracing is off — so
+    callers stamp unconditionally instead of guarding.
+    """
+    try:
+        from langsmith.run_helpers import get_current_run_tree
+
+        run = get_current_run_tree()
+        if run is None:
+            return
+        populated = {k: v for k, v in fields.items() if v is not None}
+        if populated:
+            run.metadata.update(populated)
+        if tags:
+            merged = list(run.tags or [])
+            seen = set(merged)
+            for t in tags:
+                if t not in seen:
+                    seen.add(t)
+                    merged.append(t)
+            run.tags = merged
+    except Exception as e:
+        # A tool call must never fail because its telemetry did.
+        logger.debug("stamp_run failed: %s", e)

--- a/src/tools/decorators.py
+++ b/src/tools/decorators.py
@@ -149,6 +149,7 @@ def create_logged_tool(
     tool_instance: T,
     name: Optional[str] = None,
     tracking_name: Optional[str] = None,
+    run_metadata: Optional[dict[str, Any]] = None,
 ) -> T:
     """
     Wrap a StructuredTool instance with usage tracking.
@@ -159,6 +160,9 @@ def create_logged_tool(
         tracking_name: Optional separate name for usage tracking (e.g., "SerperSearchTool").
             Defaults to ``name`` when not provided. Use this to map provider-specific
             billing keys while keeping a generic LLM-facing tool name.
+        run_metadata: Fields stamped onto every LangSmith run for this tool. For
+            build-time choices (which search engine, which depth) that the trace
+            would otherwise have no record of.
 
     Returns:
         A new tool instance with usage tracking
@@ -173,16 +177,24 @@ def create_logged_tool(
     tool_name = name or tool_instance.name
     usage_name = tracking_name or tool_name
 
+    def _stamp() -> None:
+        if run_metadata:
+            from src.observability import stamp_run
+
+            stamp_run(**run_metadata)
+
     async def tracked_coroutine(*args: Any, **kwargs: Any) -> Any:
         tracker = get_tool_tracker()
         if tracker:
             tracker.record_usage(usage_name, count=1)
+        _stamp()
         return await original_coroutine(*args, **kwargs)
 
     def tracked_func(*args: Any, **kwargs: Any) -> Any:
         tracker = get_tool_tracker()
         if tracker:
             tracker.record_usage(usage_name, count=1)
+        _stamp()
         return original_func(*args, **kwargs)
 
     tracked_tool = tool_instance.copy()

--- a/src/tools/manifest/web_providers.json
+++ b/src/tools/manifest/web_providers.json
@@ -197,7 +197,7 @@
             {
               "name": "fast",
               "display_name": "Fast",
-              "credits": 5,
+              "credits": 1,
               "native_params": {
                 "mode": "turbo"
               }
@@ -285,7 +285,7 @@
             {
               "name": "standard",
               "display_name": "Standard",
-              "credits": 1,
+              "credits": 4,
               "native_params": {
                 "proxy": "auto"
               }
@@ -293,7 +293,7 @@
             {
               "name": "stealth",
               "display_name": "Stealth",
-              "credits": 5,
+              "credits": 20,
               "native_params": {
                 "proxy": "stealth"
               }
@@ -307,7 +307,7 @@
             {
               "name": "standard",
               "display_name": "Standard",
-              "credits": 1,
+              "credits": 4,
               "native_params": {}
             }
           ]
@@ -319,7 +319,7 @@
             {
               "name": "map",
               "display_name": "Map",
-              "credits": 1,
+              "credits": 4,
               "native_params": {}
             }
           ]

--- a/src/tools/web/breaker.py
+++ b/src/tools/web/breaker.py
@@ -7,10 +7,13 @@ same class for its per-host and global-infra layers.
 import asyncio
 import logging
 import time
+from collections import Counter, deque
 from enum import Enum
 from typing import Callable, Optional
 
 logger = logging.getLogger(__name__)
+
+_MAX_REASON_CHARS = 200
 
 
 class CircuitState(Enum):
@@ -22,14 +25,25 @@ class CircuitState(Enum):
 
 class CircuitBreaker:
     """Circuit breaker. Used per fetch provider and for the in-house
-    crawler's per-host and global infra layers."""
+    crawler's per-host and global infra layers.
+
+    ``name`` is carried into every log line: several layers share this class
+    and each worker has its own instances, so an unlabelled transition cannot
+    be attributed to a layer — let alone to one breaker — in a merged log.
+    """
 
     def __init__(
         self,
+        name: str = "unnamed",
         failure_threshold: int = 5,
         recovery_timeout: float = 60.0,
         success_threshold: int = 2,
     ):
+        self.name = name
+        # Why the current failure streak happened. Held rather than logged per
+        # failure: routine failures are noise, but the transition they cause
+        # is invisible without them.
+        self._failure_reasons: deque[str] = deque(maxlen=failure_threshold)
         self.failure_threshold = failure_threshold
         self._base_recovery_timeout = recovery_timeout
         self._max_recovery_timeout = 900.0
@@ -52,27 +66,32 @@ class CircuitBreaker:
             if self.state == CircuitState.OPEN:
                 if self.last_failure_time and \
                    time.time() - self.last_failure_time > self.recovery_timeout:
-                    logger.info("Circuit breaker transitioning to half-open")
+                    logger.info(f"Circuit breaker [{self.name}] transitioning to half-open")
                     self.state = CircuitState.HALF_OPEN
                     self.success_count = 0
 
     async def record_success(self) -> None:
         async with self._lock:
             self.failure_count = 0
+            self._failure_reasons.clear()
             if self.state == CircuitState.HALF_OPEN:
                 self.success_count += 1
                 if self.success_count >= self.success_threshold:
-                    logger.info("Circuit breaker closing after recovery")
+                    logger.info(f"Circuit breaker [{self.name}] closing after recovery")
                     self.state = CircuitState.CLOSED
                     self._consecutive_opens = 0
                     self.recovery_timeout = self._base_recovery_timeout
 
-    async def record_failure(self, on_open: Optional[Callable] = None) -> None:
+    async def record_failure(
+        self, on_open: Optional[Callable] = None, reason: Optional[str] = None
+    ) -> None:
         """Count a failure; fire ``on_open`` (async, detached) if this one
-        opens the circuit."""
+        opens the circuit. ``reason`` surfaces in the open/re-open log line."""
         async with self._lock:
             self.failure_count += 1
             self.last_failure_time = time.time()
+            if reason:
+                self._failure_reasons.append(reason)
             should_open = False
 
             if self.state == CircuitState.HALF_OPEN:
@@ -82,22 +101,43 @@ class CircuitBreaker:
                     self._max_recovery_timeout,
                 )
                 logger.warning(
-                    f"Circuit breaker re-opening after half-open failure "
+                    f"Circuit breaker [{self.name}] re-opening after half-open failure "
                     f"(consecutive_opens={self._consecutive_opens}, "
-                    f"next_recovery={self.recovery_timeout}s)"
+                    f"next_recovery={self.recovery_timeout}s){self._reasons_suffix()}"
                 )
                 self.state = CircuitState.OPEN
                 should_open = True
-            elif self.failure_count >= self.failure_threshold:
-                logger.warning(f"Circuit breaker opening after {self.failure_count} failures")
+            # Once per transition INTO open, never per failure. An already-open
+            # breaker still collects failures from calls that were in flight
+            # when it tripped; re-firing on_open for each would repeat the
+            # recovery work (a browser reset, for one) and log the same
+            # transition several times. A re-open out of HALF_OPEN above does
+            # fire — the probe failed, so the remedy is owed another run.
+            elif self.state is CircuitState.CLOSED and self.failure_count >= self.failure_threshold:
+                logger.warning(
+                    f"Circuit breaker [{self.name}] opening after "
+                    f"{self.failure_count} failures{self._reasons_suffix()}"
+                )
                 self.state = CircuitState.OPEN
                 should_open = True
 
             if should_open and on_open:
-                logger.info("Running circuit-open callback")
+                logger.info(f"Circuit breaker [{self.name}] running circuit-open callback")
                 task = asyncio.create_task(on_open())
                 self._open_callbacks.add(task)
                 task.add_done_callback(self._open_callbacks.discard)
+
+    def _reasons_suffix(self) -> str:
+        """Streak causes, repeats collapsed — a breaker usually opens on five
+        copies of one error, and printing it five times is noise, not detail."""
+        if not self._failure_reasons:
+            return ""
+        counts = Counter(self._failure_reasons)
+        parts = [
+            (reason if n == 1 else f"{n}x {reason}")[:_MAX_REASON_CHARS]
+            for reason, n in counts.items()
+        ]
+        return ": " + " | ".join(parts)
 
     def is_open(self) -> bool:
         return self.state == CircuitState.OPEN

--- a/src/tools/web/crawl.py
+++ b/src/tools/web/crawl.py
@@ -19,6 +19,7 @@ from urllib.parse import urlparse
 from langchain_core.tools import tool
 
 from src.config.tool_settings import get_crawl_provider
+from src.observability import stamp_run
 from src.tools.decorators import create_logged_tool, get_tool_tracker
 from src.tools.web.manifest import (
     CAPABILITY_CRAWL,
@@ -170,6 +171,7 @@ def create_crawl_tools(filesystem_backend: Any) -> List[Any]:
                 <output_dir>/<host>/. Defaults to work/crawl. Pass your task's
                 work dir (e.g. work/<task>/crawl) when running a task workflow.
         """
+        stamp_run(crawl_provider=provider)
         limit_ = max(1, min(int(limit), _MAX_CRAWL_PAGES))
         base_dir = (output_dir or _DEFAULT_OUTPUT_DIR).rstrip("/")
         dest_dir = f"{base_dir}/{_host_dirname(url)}"
@@ -318,7 +320,14 @@ def create_crawl_tools(filesystem_backend: Any) -> List[Any]:
     tools: List[Any] = [web_crawl]
     if map_cap is not None:
         map_key = map_cap.tracking_key(map_cap.default_level_spec)
-        tools.append(create_logged_tool(web_map, name="WebMap", tracking_name=map_key))
+        tools.append(
+            create_logged_tool(
+                web_map,
+                name="WebMap",
+                tracking_name=map_key,
+                run_metadata={"map_provider": provider},
+            )
+        )
     else:
         # Capability-driven: a provider without a manifest map capability
         # simply doesn't offer WebMap (never ship an unmetered tool).

--- a/src/tools/web/fetch.py
+++ b/src/tools/web/fetch.py
@@ -24,7 +24,9 @@ from src.llms import LLM, format_llm_content, make_api_call, maybe_disable_strea
 from src.tools.web.inhouse.sitemap import get_sitemap_summary
 from src.tools.decorators import log_io
 from src.tools.web.router import FetchRouter
+from src.observability import stamp_run
 from src.tools.web.types import (
+    FetchAttempt,
     FetchRequest,
     FetchResponse,
     FetchResult,
@@ -130,7 +132,7 @@ class FetchService:
                         results[url] = FetchResult(url=url, markdown=cached, source="cache")
 
         remaining = [u for u in urls if u not in results]
-        providers_tried: List[str] = []
+        attempts: List[FetchAttempt] = []
         provider: Optional[str] = None
 
         if remaining and req.max_age_seconds != -1:
@@ -142,7 +144,7 @@ class FetchService:
                     max_age_seconds=req.max_age_seconds,
                 )
             )
-            providers_tried = resp.providers_tried
+            attempts = resp.attempts
             provider = resp.provider
             for result in resp.results:
                 results[result.url] = result
@@ -168,7 +170,7 @@ class FetchService:
                 )
 
         ordered = [results[u] for u in urls]
-        return FetchResponse(results=ordered, provider=provider, providers_tried=providers_tried)
+        return FetchResponse(results=ordered, provider=provider, attempts=attempts)
 
 
 _fetch_service: Optional[FetchService] = None
@@ -361,6 +363,7 @@ async def web_fetch(
             url = result.url
             artifact["url"] = url
             artifact["provider"] = response.provider
+            artifact["attempts"] = [str(a) for a in response.attempts]
             artifact["source"] = result.source
 
             if result.error is not None:
@@ -413,8 +416,22 @@ async def _web_fetch_tool_impl(
     url: Annotated[str, "The URL to fetch content from"],
     prompt: Annotated[str, "The prompt to run on the fetched content"],
 ) -> tuple[str, dict]:
-    """Delegate to web_fetch(); the agent-facing contract is ``description``."""
-    return await web_fetch(url=url, prompt=prompt)
+    """Delegate to web_fetch(); the agent-facing contract is ``description``.
+
+    Stamps here rather than inside web_fetch() because this is the one point
+    every branch — native excerpts, empty page, per-URL error, catch-all —
+    passes through on its way out of the tool run.
+    """
+    content, artifact = await web_fetch(url=url, prompt=prompt)
+    provider = artifact.get("provider")
+    stamp_run(
+        tags=[f"fetch_provider:{provider}"] if provider else None,
+        fetch_provider=provider,
+        fetch_attempts=artifact.get("attempts") or None,
+        fetch_source=artifact.get("source"),
+        fetch_error=artifact.get("error"),
+    )
+    return content, artifact
 
 
 # Apply decorator and create tool

--- a/src/tools/web/inhouse/safe_wrapper.py
+++ b/src/tools/web/inhouse/safe_wrapper.py
@@ -58,10 +58,17 @@ _REAPER_INTERVAL_SECONDS = 300.0   # opportunistic reap cadence
 _BLOCK_CACHE_THRESHOLD = 2
 _BLOCK_ATTEMPTS_LRU_CAP = 256      # bound block-attempt counter under churn
 
-# Exception substrings that classify as cross-cutting infra failures (trip the
-# global infra breaker in addition to the per-host breaker). Other exceptions
-# stay host-scoped.
-_INFRA_ERROR_TYPES = ("browser_closed", "dns_error", "connection_refused")
+# Failures that are OURS, not the target's — these alone may trip the global
+# breaker that fails-fast every crawl.
+#
+# DNS and connection-refused deliberately are not here. A broken resolver and a
+# domain that no longer exists are indistinguishable at this layer (both arrive
+# as one unreachable host), and the two mistakes are not equally cheap: five
+# dead links in a research burst would starve all crawling for 60s, ratcheting
+# to 900s, whereas a genuinely broken resolver fails every crawl anyway — the
+# breaker would only save the latency of trying. An unreachable host still
+# opens its own per-host breaker.
+_INFRA_ERROR_TYPES = ("browser_closed",)
 
 
 @dataclass
@@ -108,11 +115,12 @@ class SafeCrawlerWrapper:
         self._circuit_failure_threshold = circuit_failure_threshold
         self._circuit_recovery_timeout = circuit_recovery_timeout
         self._circuit_success_threshold = circuit_success_threshold
-        # Global infra breaker. Trips only on cross-cutting failures
-        # (browser_closed, dns_error, connection_refused). When open, all
-        # crawls fail-fast until recovery — DNS being broken is genuinely a
-        # cross-host problem.
+        # Global infra breaker. When open, every crawl fails fast, so only our
+        # own failures (_INFRA_ERROR_TYPES) may trip it — never a property of
+        # one target. Its on_open remedy is a browser reset, which is coherent
+        # precisely because that is the one thing it now trips on.
         self._infra_breaker = CircuitBreaker(
+            name="crawler:infra",
             failure_threshold=circuit_failure_threshold,
             recovery_timeout=circuit_recovery_timeout,
             success_threshold=circuit_success_threshold,
@@ -197,6 +205,7 @@ class SafeCrawlerWrapper:
         breaker = self._host_breakers.get(netloc)
         if breaker is None:
             breaker = CircuitBreaker(
+                name=f"crawler:host:{netloc}",
                 failure_threshold=self._circuit_failure_threshold,
                 recovery_timeout=self._circuit_recovery_timeout,
                 success_threshold=self._circuit_success_threshold,
@@ -421,13 +430,14 @@ class SafeCrawlerWrapper:
             )
 
         if kind == "infra_error":
-            # Cross-cutting failure → both breakers.
+            # Host-scoped despite the name: the only producer is the Tier-1
+            # unreachable short-circuit ("could not resolve", "connection
+            # refused"), which describes the target, not our infrastructure.
             if host_breaker is not None:
                 await host_breaker.record_failure(self._trigger_browser_reset)
-            await self._infra_breaker.record_failure(self._trigger_browser_reset)
             return CrawlResult(
                 success=False,
-                error="Crawler infrastructure error",
+                error="Target unreachable (host did not resolve or refused the connection)",
                 error_type="infra_error",
             )
 

--- a/src/tools/web/providers/firecrawl.py
+++ b/src/tools/web/providers/firecrawl.py
@@ -155,10 +155,21 @@ class FirecrawlFetchAdapter:
             return FetchResult(url=url, error=error_from_httpx(e, status_overrides=_STATUS_OVERRIDES))
 
         if not data.get("success", False):
+            # A 200 with success=false reports the outcome of scraping THIS url
+            # — a dead domain, a page no engine could render — so it must not
+            # count against the breaker every url shares. A real Firecrawl
+            # outage arrives as 5xx or a transport error and is classified
+            # above. Verified against the live API with an unresolvable host,
+            # which returns 200 with SCRAPE_DNS_RESOLUTION_ERROR.
+            code = data.get("code")
             message = str(data.get("error") or "Firecrawl returned success=false")
             return FetchResult(
                 url=url,
-                error=WebError(type=WebErrorType.PROVIDER_ERROR, message=clip_error(message)),
+                error=WebError(
+                    type=WebErrorType.PROVIDER_ERROR,
+                    message=clip_error(f"[{code}] {message}" if code else message),
+                    provider_fault=False,
+                ),
             )
 
         page = data.get("data") or {}

--- a/src/tools/web/providers/firecrawl.py
+++ b/src/tools/web/providers/firecrawl.py
@@ -169,6 +169,7 @@ class FirecrawlFetchAdapter:
                     type=WebErrorType.PROVIDER_ERROR,
                     message=clip_error(f"[{code}] {message}" if code else message),
                     provider_fault=False,
+                    native_kind=str(code).lower() if code else None,
                 ),
             )
 

--- a/src/tools/web/providers/inhouse.py
+++ b/src/tools/web/providers/inhouse.py
@@ -19,16 +19,33 @@ from src.tools.web.types import (
 
 logger = logging.getLogger(__name__)
 
-# SafeCrawlerWrapper CrawlResult.error_type → normalized taxonomy.
+# SafeCrawlerWrapper CrawlResult.error_type → (normalized type, provider_fault).
+#
+# provider_fault is stated for every outcome instead of falling back to the
+# error type's default: it means "this failure is independent of the URL we
+# asked for", so the chain should stop routing here entirely. A host that
+# blocks, rate-limits, times out or refuses the connection is a property of
+# that host — it must not open a breaker shared by every URL.
 _ERROR_TYPES = {
-    "blocked": WebErrorType.FORBIDDEN,
-    "stealth_failed": WebErrorType.ANTI_BOT,
-    "timeout": WebErrorType.TIMEOUT,
-    "connection_timeout": WebErrorType.TIMEOUT,
-    "rate_limited": WebErrorType.RATE_LIMITED,
-    "circuit_open": WebErrorType.CIRCUIT_OPEN,
-    "queue_full": WebErrorType.PROVIDER_ERROR,
-    "empty_content": WebErrorType.EMPTY,
+    # Target-side.
+    "blocked": (WebErrorType.FORBIDDEN, False),
+    "stealth_failed": (WebErrorType.ANTI_BOT, False),
+    "timeout": (WebErrorType.TIMEOUT, False),
+    "connection_timeout": (WebErrorType.TIMEOUT, False),
+    "rate_limited": (WebErrorType.RATE_LIMITED, False),
+    "circuit_open": (WebErrorType.CIRCUIT_OPEN, False),
+    "empty_content": (WebErrorType.EMPTY, False),
+    "dns_error": (WebErrorType.PROVIDER_ERROR, False),
+    "connection_refused": (WebErrorType.PROVIDER_ERROR, False),
+    "network_error": (WebErrorType.PROVIDER_ERROR, False),
+    "crawl_error": (WebErrorType.PROVIDER_ERROR, False),
+    # Despite the name, its only producer is the Tier 1 unreachable
+    # short-circuit (scrapling_crawler.py) — "could not resolve" and
+    # "connection refused" are the target's problem, not ours.
+    "infra_error": (WebErrorType.PROVIDER_ERROR, False),
+    # Our own capacity/infrastructure — any other URL would fail the same way.
+    "queue_full": (WebErrorType.PROVIDER_ERROR, True),
+    "browser_closed": (WebErrorType.PROVIDER_ERROR, True),
 }
 
 
@@ -43,17 +60,32 @@ class InhouseFetchAdapter:
             return FetchResult(url=url, title=result.title, markdown=result.markdown)
         kind = result.error_type or "crawl_error"
         if kind == "cancelled":
-            error = WebError(
-                type=WebErrorType.PROVIDER_ERROR,
-                message="Crawl was cancelled",
-                retryable=False,
+            # Not a failure at all — the caller stopped. Neither retry it on
+            # the next provider nor count it against this one.
+            return FetchResult(
+                url=url,
+                error=WebError(
+                    type=WebErrorType.PROVIDER_ERROR,
+                    message="Crawl was cancelled",
+                    retryable=False,
+                    provider_fault=False,
+                ),
             )
-        else:
-            error = WebError(
-                type=_ERROR_TYPES.get(kind, WebErrorType.PROVIDER_ERROR),
+        mapped = _ERROR_TYPES.get(kind)
+        if mapped is None:
+            # A crawler outcome added without a mapping here. Default to
+            # target-side so it cannot silently open the provider breaker.
+            logger.warning("inhouse fetch: unmapped crawler error_type %r", kind)
+            mapped = (WebErrorType.PROVIDER_ERROR, False)
+        error_type, provider_fault = mapped
+        return FetchResult(
+            url=url,
+            error=WebError(
+                type=error_type,
                 message=str(result.error or kind)[:300],
-            )
-        return FetchResult(url=url, error=error)
+                provider_fault=provider_fault,
+            ),
+        )
 
     async def fetch(self, req: FetchRequest, native_params: Dict[str, Any]) -> FetchResponse:
         from src.tools.web.inhouse.safe_wrapper import get_safe_crawler

--- a/src/tools/web/providers/inhouse.py
+++ b/src/tools/web/providers/inhouse.py
@@ -69,6 +69,7 @@ class InhouseFetchAdapter:
                     message="Crawl was cancelled",
                     retryable=False,
                     provider_fault=False,
+                    native_kind=kind,
                 ),
             )
         mapped = _ERROR_TYPES.get(kind)
@@ -84,6 +85,7 @@ class InhouseFetchAdapter:
                 type=error_type,
                 message=str(result.error or kind)[:300],
                 provider_fault=provider_fault,
+                native_kind=kind,
             ),
         )
 

--- a/src/tools/web/router.py
+++ b/src/tools/web/router.py
@@ -134,7 +134,7 @@ def build_chain(providers: List[str]) -> List["_ChainEntry"]:
                 provider=spec,
                 capability=cap,
                 adapter=builder(),
-                breaker=CircuitBreaker(),
+                breaker=CircuitBreaker(name=f"fetch:{name}"),
             )
         )
     return entries
@@ -335,7 +335,9 @@ class FetchRouter:
                 # its breaker. Per-URL failures (timeouts, anti_bot, and
                 # target-side 429/5xx) don't: a down target site must not
                 # open the shared provider breaker.
-                await entry.breaker.record_failure()
+                await entry.breaker.record_failure(
+                    reason="; ".join(str(r.error) for r in results if r.error)
+                )
 
             pending = [u for u in pending if u not in final]
             if not pending:

--- a/src/tools/web/router.py
+++ b/src/tools/web/router.py
@@ -30,6 +30,7 @@ import asyncio
 import logging
 import os
 import re
+from collections import Counter
 from dataclasses import dataclass
 from importlib import import_module
 from typing import Dict, List, Optional, Protocol, Tuple
@@ -45,6 +46,7 @@ from src.tools.web.manifest import (
     get_web_provider_spec,
 )
 from src.tools.web.types import (
+    FetchAttempt,
     FetchRequest,
     FetchResponse,
     FetchResult,
@@ -67,6 +69,22 @@ _INHOUSE_URL_PATTERNS = re.compile(
 def _needs_inhouse(url: str) -> bool:
     host = (urlparse(url).netloc or "").lower().split(":")[0]
     return bool(host and _INHOUSE_URL_PATTERNS.search(host))
+
+
+def _attempt_outcome(provider: str, results: List[FetchResult]) -> FetchAttempt:
+    """Summarize one provider's attempt. All-failed reports the dominant error,
+    so a fallback records why it happened, not just that it did — preferring the
+    provider's own name for it, since the normalized type buckets a dead target
+    and a broken provider into the same ``provider_error``."""
+    ok = sum(1 for r in results if r.ok)
+    if ok == len(results):
+        return FetchAttempt(provider, "ok")
+    if ok:
+        return FetchAttempt(provider, "partial")
+    kinds = Counter(
+        (r.error.native_kind or r.error.type.value) for r in results if r.error
+    )
+    return FetchAttempt(provider, kinds.most_common(1)[0][0] if kinds else "failed")
 
 
 class FetchAdapter(Protocol):
@@ -263,7 +281,7 @@ class FetchRouter:
         last_error: Dict[str, FetchResult] = {}
         pending: List[str] = list(dict.fromkeys(req.urls))  # de-dupe, keep order
         anti_bot: set = set()
-        providers_tried: List[str] = []
+        attempts: List[FetchAttempt] = []
         first_ok_provider: Optional[str] = None
         # Without a usable in-house entry, forced URLs degrade to ordinary
         # routing rather than failing outright.
@@ -310,9 +328,8 @@ class FetchRouter:
             if entry.breaker.is_open():
                 logger.debug("fetch: skipping %s (breaker open)", entry.adapter.name)
                 continue
-            providers_tried.append(entry.adapter.name)
-
             results = await self._attempt(entry, urls_now, req, anti_bot)
+            attempts.append(_attempt_outcome(entry.adapter.name, results))
 
             any_ok = False
             for result in results:
@@ -358,5 +375,5 @@ class FetchRouter:
         return FetchResponse(
             results=[final[u] for u in req.urls if u in final],
             provider=first_ok_provider,
-            providers_tried=providers_tried,
+            attempts=attempts,
         )

--- a/src/tools/web/search.py
+++ b/src/tools/web/search.py
@@ -88,5 +88,8 @@ def get_web_search_tool(
     )
 
     return create_logged_tool(
-        tool_fn, name="WebSearch", tracking_name=cap.tracking_key(depth_spec)
+        tool_fn,
+        name="WebSearch",
+        tracking_name=cap.tracking_key(depth_spec),
+        run_metadata={"search_engine": engine, "search_depth": depth_spec.name},
     )

--- a/src/tools/web/types.py
+++ b/src/tools/web/types.py
@@ -74,6 +74,11 @@ class WebError:
     # Whether the PROVIDER (not the target page) is at fault — drives circuit
     # breaker accounting. Target-side 429/5xx must not open a provider breaker.
     provider_fault: Optional[bool] = None
+    # The provider's own name for the failure, kept when normalizing discards
+    # it. PROVIDER_ERROR is a bucket: a dead domain and our own queue
+    # overflowing both land in it, so a label built from the type alone cannot
+    # tell a trace reader which of the two happened.
+    native_kind: Optional[str] = None
 
     def __post_init__(self) -> None:
         if self.retryable is None:
@@ -170,13 +175,34 @@ class FetchResult:
         return self.error is None
 
 
+@dataclass(frozen=True)
+class FetchAttempt:
+    """What one provider in the chain did with the URLs it was offered.
+
+    ``outcome`` is ``ok``/``partial``, or what ended the attempt — the
+    provider's own name for the failure where it has one, else the normalized
+    type. That is the difference between "firecrawl was tried" and "firecrawl
+    429'd", which is what makes a silent fallback legible after the fact.
+    """
+
+    provider: str
+    outcome: str
+
+    def __str__(self) -> str:
+        return f"{self.provider}:{self.outcome}"
+
+
 @dataclass
 class FetchResponse:
     """Order-preserving results for a FetchRequest, plus routing telemetry."""
 
     results: List[FetchResult] = field(default_factory=list)
     provider: Optional[str] = None
-    providers_tried: List[str] = field(default_factory=list)
+    attempts: List[FetchAttempt] = field(default_factory=list)
+
+    @property
+    def providers_tried(self) -> List[str]:
+        return [a.provider for a in self.attempts]
 
 
 @dataclass(frozen=True)

--- a/tests/unit/observability/test_stamp_run.py
+++ b/tests/unit/observability/test_stamp_run.py
@@ -1,0 +1,73 @@
+"""Tests for stamp_run — provider attribution written onto the LangSmith run."""
+
+import pytest
+
+from src.observability import stamp_run
+
+
+class _FakeRun:
+    def __init__(self, tags=None):
+        self.metadata = {}
+        self.tags = tags
+
+
+@pytest.fixture
+def fake_run(monkeypatch):
+    """Stand in for the enclosing run tree. ``run`` None = tracing disabled."""
+    holder = {"run": _FakeRun()}
+
+    def _get_current_run_tree():
+        return holder["run"]
+
+    monkeypatch.setattr(
+        "langsmith.run_helpers.get_current_run_tree", _get_current_run_tree
+    )
+    return holder
+
+
+def test_writes_metadata_and_tags(fake_run):
+    stamp_run(tags=["fetch_provider:inhouse"], fetch_provider="inhouse", fetch_source="live")
+
+    assert fake_run["run"].metadata == {"fetch_provider": "inhouse", "fetch_source": "live"}
+    assert fake_run["run"].tags == ["fetch_provider:inhouse"]
+
+
+def test_drops_none_fields(fake_run):
+    """A provider that never resolved must not write a null over the run."""
+    stamp_run(fetch_provider=None, fetch_error="timeout")
+
+    assert fake_run["run"].metadata == {"fetch_error": "timeout"}
+
+
+def test_preserves_and_dedupes_existing_tags(fake_run):
+    fake_run["run"] = _FakeRun(tags=["existing", "fetch_provider:inhouse"])
+
+    stamp_run(tags=["fetch_provider:inhouse", "new"])
+
+    assert fake_run["run"].tags == ["existing", "fetch_provider:inhouse", "new"]
+
+
+def test_dedupes_within_one_call(fake_run):
+    """Dedup was against the pre-existing tags only, so a repeat inside the
+    incoming list landed twice."""
+    stamp_run(tags=["fetch_provider:inhouse", "fetch_provider:inhouse"])
+
+    assert fake_run["run"].tags == ["fetch_provider:inhouse"]
+
+
+def test_no_run_is_a_noop(fake_run):
+    """Tracing off — callers stamp unconditionally, so this must not raise."""
+    fake_run["run"] = None
+
+    stamp_run(fetch_provider="inhouse")
+
+
+def test_never_raises_into_the_caller(monkeypatch):
+    """Telemetry failure must not take a tool call down with it."""
+
+    def _boom():
+        raise RuntimeError("run tree exploded")
+
+    monkeypatch.setattr("langsmith.run_helpers.get_current_run_tree", _boom)
+
+    stamp_run(fetch_provider="inhouse")

--- a/tests/unit/tools/web/inhouse/test_safe_wrapper.py
+++ b/tests/unit/tools/web/inhouse/test_safe_wrapper.py
@@ -126,9 +126,10 @@ class TestSafeCrawlerCrawl:
         result = await wrapper.crawl("https://bogus.invalid")
 
         assert result.error_type == "dns_error"
-        # DNS errors trip BOTH per-host AND infra breakers.
+        # Host-scoped only: a name that does not resolve is that host's problem,
+        # and must not fail-fast crawling for every other host.
         assert wrapper._host_breakers["bogus.invalid"].failure_count == 1
-        assert wrapper._infra_breaker.failure_count == 1
+        assert wrapper._infra_breaker.failure_count == 0
 
     @pytest.mark.asyncio
     async def test_browser_closed_classifies_correctly(self):
@@ -145,7 +146,7 @@ class TestSafeCrawlerCrawl:
         assert wrapper._infra_breaker.failure_count == 1
 
     @pytest.mark.asyncio
-    async def test_connection_refused_trips_infra(self):
+    async def test_connection_refused_stays_host_scoped(self):
         wrapper = _make_wrapper()
         mock_crawler = _inject_mock_crawler(wrapper)
         mock_crawler.crawl_with_metadata = AsyncMock(
@@ -155,7 +156,8 @@ class TestSafeCrawlerCrawl:
         result = await wrapper.crawl("https://example.com")
 
         assert result.error_type == "connection_refused"
-        assert wrapper._infra_breaker.failure_count == 1
+        assert wrapper._host_breakers["example.com"].failure_count == 1
+        assert wrapper._infra_breaker.failure_count == 0
 
     @pytest.mark.asyncio
     async def test_generic_crawl_error_host_only(self):
@@ -418,8 +420,9 @@ class TestThreeLayerHealth:
         assert result.success is True
 
     @pytest.mark.asyncio
-    async def test_infra_breaker_only_trips_on_infra_kind(self):
-        """failure_kind='infra_error' trips both per-host and infra breakers."""
+    async def test_unreachable_target_spares_the_global_breaker(self):
+        """'infra_error' is the Tier-1 unreachable short-circuit — it describes
+        the target, so it must not fail-fast crawling for every other host."""
         wrapper = _make_wrapper(circuit_failure_threshold=1)
         mock_crawler = _inject_mock_crawler(wrapper)
         mock_crawler.crawl_with_metadata = AsyncMock(
@@ -429,6 +432,18 @@ class TestThreeLayerHealth:
 
         await wrapper.crawl("https://example.com")
         assert wrapper._host_breakers["example.com"].state == CircuitState.OPEN
+        assert wrapper._infra_breaker.state == CircuitState.CLOSED
+
+    @pytest.mark.asyncio
+    async def test_dead_browser_trips_the_global_breaker(self):
+        """A closed browser is ours, not the target's — every host is affected."""
+        wrapper = _make_wrapper(circuit_failure_threshold=1)
+        mock_crawler = _inject_mock_crawler(wrapper)
+        mock_crawler.crawl_with_metadata = AsyncMock(
+            side_effect=RuntimeError("Target page, context or browser has been closed")
+        )
+
+        await wrapper.crawl("https://example.com")
         assert wrapper._infra_breaker.state == CircuitState.OPEN
 
     @pytest.mark.asyncio
@@ -517,10 +532,9 @@ class TestThreeLayerHealth:
         )
         mock_crawler = _inject_mock_crawler(wrapper)
 
-        # Trip infra breaker via an infra_error failure.
+        # Trip infra breaker via a failure that is genuinely ours.
         mock_crawler.crawl_with_metadata = AsyncMock(
-            return_value=CrawlOutput(title="", html="", markdown="",
-                                     status=None, failure_kind="infra_error")
+            side_effect=RuntimeError("Target page, context or browser has been closed")
         )
         await wrapper.crawl("https://example.com")
         infra = wrapper._infra_breaker

--- a/tests/unit/tools/web/test_breaker.py
+++ b/tests/unit/tools/web/test_breaker.py
@@ -42,3 +42,60 @@ class TestOnOpenCallback:
         assert breaker.state == CircuitState.CLOSED
         assert breaker._open_callbacks == set()
         assert calls == []
+
+    @pytest.mark.asyncio
+    async def test_callback_fires_once_per_open_not_once_per_failure(self):
+        """Calls already in flight when the circuit trips still report failures.
+        Recovery work (a browser reset, for one) must not run again for each."""
+        breaker = CircuitBreaker(failure_threshold=2)
+        calls = []
+
+        async def on_open():
+            calls.append(1)
+
+        for _ in range(5):
+            await breaker.record_failure(on_open)
+        await asyncio.sleep(0.05)  # on_open is detached; let it run
+
+        assert breaker.state == CircuitState.OPEN
+        assert len(calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_callback_fires_again_when_a_half_open_probe_fails(self):
+        """The one case where re-firing is right: the probe failed, so the
+        recovery work did not take and is owed another run. Without this, an
+        'only on the CLOSED→OPEN edge' reading would reset the browser once
+        ever, however many times the circuit re-opens."""
+        breaker = CircuitBreaker(failure_threshold=1, recovery_timeout=0.01)
+        calls = []
+
+        async def on_open():
+            calls.append(1)
+
+        await breaker.record_failure(on_open)
+        await asyncio.sleep(0.05)
+        assert breaker.state == CircuitState.OPEN
+        assert len(calls) == 1
+
+        await breaker.check_state()
+        assert breaker.state == CircuitState.HALF_OPEN
+
+        await breaker.record_failure(on_open)
+        await asyncio.sleep(0.05)
+        assert breaker.state == CircuitState.OPEN
+        assert len(calls) == 2
+
+
+class TestOpenLogging:
+    @pytest.mark.asyncio
+    async def test_open_logs_once_and_names_the_streak_cause(self, caplog):
+        breaker = CircuitBreaker(name="fetch:acme", failure_threshold=2)
+
+        with caplog.at_level("WARNING", logger="src.tools.web.breaker"):
+            for _ in range(4):
+                await breaker.record_failure(reason="[timeout] upstream stalled")
+
+        opens = [r for r in caplog.records if "opening" in r.message]
+        assert len(opens) == 1
+        assert "[fetch:acme]" in opens[0].message
+        assert "2x [timeout] upstream stalled" in opens[0].message

--- a/tests/unit/tools/web/test_fetch_adapters.py
+++ b/tests/unit/tools/web/test_fetch_adapters.py
@@ -366,6 +366,9 @@ class TestInhouseFetchAdapter:
         assert error.type == expected
         assert error.retryable is retryable
         assert error.provider_fault is provider_fault
+        # Several outcomes normalize to PROVIDER_ERROR; the crawler's own name
+        # is what keeps them apart in the attempt telemetry.
+        assert error.native_kind == error_type
 
     async def test_unmapped_outcome_is_not_a_provider_fault(self, monkeypatch):
         """An unrecognized outcome must not be able to open the breaker."""

--- a/tests/unit/tools/web/test_fetch_adapters.py
+++ b/tests/unit/tools/web/test_fetch_adapters.py
@@ -271,6 +271,58 @@ class TestFirecrawlFetchAdapter:
         resp = await self._run(monkeypatch, payload)
         assert resp.results[0].error.type == WebErrorType.PROVIDER_ERROR
 
+    async def test_success_false_does_not_fault_the_provider(self, monkeypatch):
+        """A 200 with success=false describes one url's scrape, not an outage.
+        PROVIDER_ERROR faults the provider by default, so this branch has to
+        say otherwise or a handful of dead links disables Firecrawl outright.
+        """
+        payload = {
+            "success": False,
+            "code": "SCRAPE_DNS_RESOLUTION_ERROR",
+            "error": 'DNS resolution failed for hostname "example.invalid".',
+        }
+        resp = await self._run(monkeypatch, payload)
+        error = resp.results[0].error
+
+        assert error.provider_fault is False
+        assert error.retryable  # the chain should still try the next provider
+        # The code is the only handle on which failure it was, so it must survive.
+        assert "SCRAPE_DNS_RESOLUTION_ERROR" in error.message
+
+
+# Every outcome SafeCrawlerWrapper can emit, with both routing axes.
+# provider_fault=True is what counts against the chain's breaker for this
+# provider, so it belongs only to failures another URL would not survive
+# either — never to a host that blocks, throttles, or fails to resolve.
+_CRAWLER_OUTCOMES = [
+    ("blocked", WebErrorType.FORBIDDEN, False, False),
+    ("stealth_failed", WebErrorType.ANTI_BOT, True, False),
+    ("timeout", WebErrorType.TIMEOUT, True, False),
+    ("connection_timeout", WebErrorType.TIMEOUT, True, False),
+    ("rate_limited", WebErrorType.RATE_LIMITED, True, False),
+    ("circuit_open", WebErrorType.CIRCUIT_OPEN, True, False),
+    ("empty_content", WebErrorType.EMPTY, True, False),
+    ("dns_error", WebErrorType.PROVIDER_ERROR, True, False),
+    ("connection_refused", WebErrorType.PROVIDER_ERROR, True, False),
+    ("network_error", WebErrorType.PROVIDER_ERROR, True, False),
+    ("crawl_error", WebErrorType.PROVIDER_ERROR, True, False),
+    ("infra_error", WebErrorType.PROVIDER_ERROR, True, False),
+    ("cancelled", WebErrorType.PROVIDER_ERROR, False, False),
+    ("queue_full", WebErrorType.PROVIDER_ERROR, True, True),
+    ("browser_closed", WebErrorType.PROVIDER_ERROR, True, True),
+]
+
+
+def test_inhouse_mapping_covers_every_crawler_outcome():
+    """The map is total. An outcome added to the crawler without a mapping here
+    would otherwise fall through to a breaker-tripping default."""
+    from src.tools.web.providers import inhouse
+
+    # ``cancelled`` is handled ahead of the map (it also clears retryable).
+    assert set(inhouse._ERROR_TYPES) | {"cancelled"} == {
+        kind for kind, *_ in _CRAWLER_OUTCOMES
+    }
+
 
 @pytest.mark.asyncio
 class TestInhouseFetchAdapter:
@@ -299,19 +351,11 @@ class TestInhouseFetchAdapter:
         assert resp.results[0].ok and resp.results[0].markdown == "content"
 
     @pytest.mark.parametrize(
-        ("error_type", "expected", "retryable"),
-        [
-            ("blocked", WebErrorType.FORBIDDEN, False),
-            ("stealth_failed", WebErrorType.ANTI_BOT, True),
-            ("timeout", WebErrorType.TIMEOUT, True),
-            ("rate_limited", WebErrorType.RATE_LIMITED, True),
-            ("circuit_open", WebErrorType.CIRCUIT_OPEN, True),
-            ("empty_content", WebErrorType.EMPTY, True),
-            ("dns_error", WebErrorType.PROVIDER_ERROR, True),
-            ("cancelled", WebErrorType.PROVIDER_ERROR, False),
-        ],
+        ("error_type", "expected", "retryable", "provider_fault"), _CRAWLER_OUTCOMES
     )
-    async def test_error_type_mapping(self, monkeypatch, error_type, expected, retryable):
+    async def test_error_type_mapping(
+        self, monkeypatch, error_type, expected, retryable, provider_fault
+    ):
         from src.tools.web.inhouse.safe_wrapper import CrawlResult
 
         resp = await self._run(
@@ -321,3 +365,16 @@ class TestInhouseFetchAdapter:
         error = resp.results[0].error
         assert error.type == expected
         assert error.retryable is retryable
+        assert error.provider_fault is provider_fault
+
+    async def test_unmapped_outcome_is_not_a_provider_fault(self, monkeypatch):
+        """An unrecognized outcome must not be able to open the breaker."""
+        from src.tools.web.inhouse.safe_wrapper import CrawlResult
+
+        resp = await self._run(
+            monkeypatch,
+            CrawlResult(success=False, error="scripted", error_type="brand_new_kind"),
+        )
+        error = resp.results[0].error
+        assert error.type == WebErrorType.PROVIDER_ERROR
+        assert error.provider_fault is False

--- a/tests/unit/tools/web/test_router.py
+++ b/tests/unit/tools/web/test_router.py
@@ -1,5 +1,6 @@
 """Tests for src/tools/web/router.py — chain semantics with fake adapters."""
 
+import logging
 from typing import Dict, List
 
 import pytest
@@ -429,6 +430,36 @@ class TestChainSemantics:
         assert not flaky.calls  # breaker open → provider never called
         assert second.provider == "inhouse"
         assert "flaky" not in second.providers_tried
+
+    async def test_breaker_open_log_carries_provider_and_cause(self, make_router, caplog):
+        """The transition is the only line emitted — routine failures stay
+        silent, so the one warning has to name the breaker and what opened it."""
+        flaky = FakeAdapter("flaky", {URL_A: WebErrorType.PROVIDER_ERROR})
+        router = make_router([flaky, FakeAdapter("inhouse", {})])
+        router._chain[0].breaker.failure_threshold = 1
+
+        with caplog.at_level(logging.WARNING, logger="src.tools.web.breaker"):
+            await router.fetch(FetchRequest(urls=[URL_A]))
+
+        opened = [r.getMessage() for r in caplog.records if "opening after" in r.getMessage()]
+        assert len(opened) == 1
+        assert "[fetch:flaky]" in opened[0]
+        assert "provider_error" in opened[0] and "scripted" in opened[0]
+
+    async def test_healthy_failures_emit_no_breaker_log(self, make_router, caplog):
+        """Target-side failures are routine; they must not log at all."""
+        flaky = FakeAdapter(
+            "flaky",
+            {URL_A: WebError(type=WebErrorType.PROVIDER_ERROR, message="Target server error",
+                             provider_fault=False)},
+        )
+        router = make_router([flaky, FakeAdapter("inhouse", {})])
+        router._chain[0].breaker.failure_threshold = 1
+
+        with caplog.at_level(logging.WARNING, logger="src.tools.web.breaker"):
+            await router.fetch(FetchRequest(urls=[URL_A]))
+
+        assert caplog.records == []
 
     async def test_target_fault_errors_do_not_trip_breaker(self, make_router):
         """All-URL failures that are the TARGET's fault (429/5xx from the

--- a/tests/unit/tools/web/test_router.py
+++ b/tests/unit/tools/web/test_router.py
@@ -87,6 +87,36 @@ URL_A = "https://a.example/1"
 URL_B = "https://b.example/2"
 
 
+class TestAttemptOutcome:
+    """The attempt label is the telemetry a fall-through is read from."""
+
+    def _failed(self, native_kind, provider_fault, etype=WebErrorType.PROVIDER_ERROR):
+        return FetchResult(
+            url=URL_A,
+            error=WebError(
+                type=etype,
+                message="scripted",
+                provider_fault=provider_fault,
+                native_kind=native_kind,
+            ),
+        )
+
+    def test_prefers_the_providers_own_name_for_the_failure(self):
+        """PROVIDER_ERROR buckets a dead target and a broken provider together,
+        so a label built from the type alone cannot tell the two apart."""
+        dead_target = self._failed("dns_error", provider_fault=False)
+        our_capacity = self._failed("queue_full", provider_fault=True)
+
+        assert str(router_module._attempt_outcome("inhouse", [dead_target])) == "inhouse:dns_error"
+        assert str(router_module._attempt_outcome("inhouse", [our_capacity])) == "inhouse:queue_full"
+
+    def test_falls_back_to_the_normalized_type(self):
+        """Providers whose taxonomy is already granular carry no native kind."""
+        timed_out = self._failed(None, provider_fault=False, etype=WebErrorType.TIMEOUT)
+
+        assert str(router_module._attempt_outcome("exa", [timed_out])) == "exa:timeout"
+
+
 @pytest.mark.asyncio
 class TestChainSemantics:
     async def test_primary_success_stops_chain(self, make_router):
@@ -430,6 +460,27 @@ class TestChainSemantics:
         assert not flaky.calls  # breaker open → provider never called
         assert second.provider == "inhouse"
         assert "flaky" not in second.providers_tried
+
+    async def test_attempts_record_why_the_chain_fell_through(self, make_router):
+        """providers_tried says a provider was tried; attempts says what it did.
+        Without the outcome a silent fallback is unattributable after the fact."""
+        primary = FakeAdapter("primary", {URL_A: WebErrorType.TIMEOUT})
+        router = make_router([primary, FakeAdapter("inhouse", {})])
+
+        resp = await router.fetch(FetchRequest(urls=[URL_A]))
+
+        assert [str(a) for a in resp.attempts] == ["primary:timeout", "inhouse:ok"]
+        assert resp.providers_tried == ["primary", "inhouse"]
+        assert resp.provider == "inhouse"
+
+    async def test_attempt_outcome_marks_partial_batches(self, make_router):
+        """One URL up, one down is neither ok nor an error type."""
+        only = FakeAdapter("only", {URL_B: WebErrorType.NOT_FOUND})
+        router = make_router([only])
+
+        resp = await router.fetch(FetchRequest(urls=[URL_A, URL_B]))
+
+        assert [str(a) for a in resp.attempts] == ["only:partial"]
 
     async def test_breaker_open_log_carries_provider_and_cause(self, make_router, caplog):
         """The transition is the only line emitted — routine failures stay

--- a/tests/unit/tools/web/test_types_and_service.py
+++ b/tests/unit/tools/web/test_types_and_service.py
@@ -87,12 +87,12 @@ class TestFetchService:
             provider_names = ["fake"]
 
             async def fetch(self, req):
-                from src.tools.web.types import FetchResponse
+                from src.tools.web.types import FetchAttempt, FetchResponse
 
                 return FetchResponse(
                     results=[FetchResult(url=u, markdown=f"got {u}") for u in req.urls],
                     provider="fake",
-                    providers_tried=["fake"],
+                    attempts=[FetchAttempt("fake", "ok")],
                 )
 
         service = FetchService(chain=["inhouse"])
@@ -107,6 +107,9 @@ class TestFetchService:
             "https://b.example/y",
         ]
         assert resp.provider == "fake"
+        # The service must forward routing telemetry, not just the winner.
+        assert [str(a) for a in resp.attempts] == ["fake:ok"]
+        assert resp.providers_tried == ["fake"]
 
     async def test_cache_only_miss_is_empty_error(self, monkeypatch):
         import src.tools.web.fetch as fetch_module


### PR DESCRIPTION
## Overview

| Category | Files | +LOC | −LOC |
|---|---:|---:|---:|
| Modified (excl. tests) | 13 | 244 | 60 |
| New (excl. tests) | 2 | 528 | 0 |
| Tests | 6 | 312 | 23 |
| **Total** | **21** | **1084** | **83** |
| **Net (excl. tests)** | **15** | | **+712** |

Two of those files are test tooling living outside `tests/` — `scripts/e2e/web_provider_pass.py` (486 lines, new) and a one-line docstring fix to its sibling `subagent_wire_pass.py` — so net *shipped* code is **+226** across 13 files.

### Breaker classification — the fix (net +96)
- `src/tools/web/providers/inhouse.py` (+52/−18) — crawler error map made total and stating `provider_fault` per outcome; an unmapped outcome warns instead of silently tripping the breaker
- `src/tools/web/breaker.py` (+50/−10) — breakers carry a name and their failure streak's causes; `on_open` fires once per transition into OPEN
- `src/tools/web/inhouse/safe_wrapper.py` (+21/−11) — the global infra breaker trips on `browser_closed` alone, and an unreachable target says so instead of blaming our infrastructure
- `src/tools/web/providers/firecrawl.py` (+13/−1) — an HTTP-200 `success: false` describes one URL's scrape, not an outage, so it no longer faults the provider

### Provider attribution — the feature (net +111)
- `src/observability/langsmith_run.py` (+42, new) — `stamp_run`, writes metadata/tags onto the enclosing LangSmith run; no-ops when tracing is off, never raises into the caller
- `src/tools/web/types.py` (+27/−1) — `FetchAttempt(provider, outcome)`; `WebError.native_kind` keeps the provider's own name for a failure; `providers_tried` kept as a derived property
- `src/tools/web/fetch.py` (+22/−5) — stamps at the single point every branch of the tool exits through
- `src/tools/decorators.py` (+12) — `run_metadata=` on `create_logged_tool`, for build-time choices the trace can't otherwise see
- `src/tools/web/crawl.py` (+10/−1), `src/tools/web/search.py` (+4/−1), `src/observability/__init__.py` (+2)

### Credit calibration (net 0, 5 values)
- `src/tools/manifest/web_providers.json` (+5/−5) — Firecrawl levels moved off an assumed 1:1 vendor-credit ratio onto measured consumption; Parallel's `fast` level corrected from 5 to 1

### Shared (net +19)
- `src/tools/web/router.py` (+25/−6) — names each provider's breaker and passes the failure reason (fix), and records each chain attempt's outcome (feature)

### Test tooling (+486 new, +1/−1)
- `scripts/e2e/web_provider_pass.py` — live agent pass; drives real flash and ptc turns, then asserts LangSmith attribution and breaker classification against a running stack
- `scripts/e2e/subagent_wire_pass.py` (+1/−1) — its usage example named a non-default port

**What this introduces:** provider attribution on every web tool run, so a fetch or search in a trace names what actually served it and why a chain fell through — plus the breaker-classification fix that attribution made visible, and a correction to two providers' credit values.

---

## Why

A fetch falls through a provider chain and a search engine comes from user prefs, both decided at runtime — but the trace kept no record of either. A run could not be attributed to a provider or filtered by one, which is what let two breaker bugs sit unnoticed.

### Bug 1 — target-side failures opened the shared provider breaker

`InhouseFetchAdapter` mapped every unlisted crawler outcome to `PROVIDER_ERROR`, and `PROVIDER_ERROR` counts against the provider's circuit breaker. So an unreachable host, a site that throttles, or a user cancelling a turn each counted as "the in-house provider is broken". Five of them disabled the in-house fallback for 60s, ratcheting toward a 900s cap.

The two routing axes are now orthogonal and both stated explicitly per outcome:

| | `retryable` | `provider_fault` |
|---|---|---|
| asks | try the next provider? | count against this provider's breaker? |
| true for | timeouts, anti-bot, empty, rate-limited | `queue_full`, `browser_closed` only |

The map is **total** — verified against every `error_type` `SafeCrawlerWrapper` can emit, and pinned by a test that fails if the crawler grows an outcome without a mapping. An unmapped outcome defaults to target-side and logs a warning, so the failure mode is a noisy log line rather than a silently disabled provider.

### Bug 2 — a few dead links fail-fast all crawling

Found by the E2E harness in this PR on its first run. The crawler's global infra breaker fails-fast *every* crawl while open, but it counted `dns_error`, `connection_refused` and the `infra_error` kind — all of which describe the target, not us. Five dead links in a research burst starved all crawling.

It now trips on `browser_closed` alone, which is genuinely ours and is the one thing its `on_open` browser-reset remedy actually fixes. A broken resolver and a domain that no longer exists are indistinguishable at that layer, and the two mistakes aren't equally cheap: a genuinely broken resolver fails every crawl anyway, so the breaker would only have saved the latency of trying. An unreachable host still opens its own per-host breaker.

### Bug 3 — Firecrawl's `success: false` faulted the provider

Same class as Bug 1, in the Firecrawl adapter: an HTTP 200 carrying `success: false` reports the outcome of scraping *that one URL* — a dead domain, a page no engine could render — but it mapped to `PROVIDER_ERROR` with `provider_fault` left at its default of `True`. A handful of dead links disabled Firecrawl outright. Verified against the live API: an unresolvable host returns exactly that shape, with `SCRAPE_DNS_RESOLUTION_ERROR`. A real Firecrawl outage arrives as a 5xx or a transport error and is still classified as a provider fault.

### Also

`on_open` fired once per failure rather than once per open. Calls already in flight when a breaker tripped kept recording failures, each re-running the recovery callback (a browser reset) and re-logging the same transition. It now fires once per transition *into* OPEN. A re-open out of HALF_OPEN still fires — the probe failed, so the remedy is owed another run — but failures recorded while already OPEN do not.

Breakers now carry a name and the causes of their current failure streak, so the one line a transition emits says *which* of a worker's breakers opened and why — `Circuit breaker [fetch:firecrawl] opening after 5 failures: 5x [rate_limited HTTP 429] Rate limit exceeded`. Repeats are collapsed (a breaker usually opens on five copies of one error), and routine failures stay silent.

## Credit calibration

Five values in `web_providers.json` changed. Each level should carry what a call actually consumes.

**Firecrawl** levels were set on the assumption that one Firecrawl credit maps to one of ours. Measuring the API directly gave the real ratios: a scrape consumes 1, a stealth scrape exactly 5, and map is flat per call however many links it returns — which confirmed the existing per-call unit for map was the right shape. The levels also carry headroom for failed scrapes, which consume a credit even though only successes are metered.

**Parallel's `fast` level** charged the same as `standard` and `deep` while sending `mode=turbo`, which the provider rates well below both. Beyond the overcharge, it left `fast` with no cost advantage over the levels above it — there was no reason to ever select it. Now corrected.

A sweep of the remaining providers found four smaller deviations (Tavily's research levels sit at their published band ceilings, Tavily fetch and Bocha are each slightly light, and Exa's fetch level is a flat value for a quantity that varies with the request shape). Those are left alone here — the Exa one needs a modelling decision rather than a new number — and are tracked as follow-up.

## What you get in a trace

`WebFetch` runs carry `fetch_provider`, `fetch_attempts`, `fetch_source`, `fetch_error` plus a filterable `fetch_provider:<p>` tag; `WebSearch` runs carry `search_engine` and `search_depth`. An attempt names the provider's own cause rather than the normalized bucket, so an unresolvable domain reads `inhouse:dns_error` and our own queue overflowing reads `inhouse:queue_full` — both previously `inhouse:provider_error`, which told a reader the provider was broken either way. A fallback reads `['firecrawl:budget_exceeded', 'inhouse:ok']` — the difference between "firecrawl was tried" and "firecrawl was out of budget", which is what makes a silent fallback legible after the fact. A degraded provider is now visible on the first call instead of staying silent until five failures open its breaker.

## Verification

Per repo convention, verified end-to-end against a live stack and live upstreams first; unit tests pin the settled contract.

- **Live agent pass.** Real flash and ptc turns against a running backend on the rebased tree. Breaker classification is green end to end: 7 unreachable hosts past a threshold of 5 left `inhouse` CLOSED at `failure_count=0`, the next healthy fetch was unpoisoned, and the server logged no shared-layer breaker transition while serving real traffic. Attribution is confirmed on the runs the pass produced — the flash turn's `WebFetch` recorded `fetch_provider=inhouse`, `fetch_source=live` and `fetch_attempts=['firecrawl:budget_exceeded', 'inhouse:ok']` with the `fetch_provider:inhouse` tag, both turns' `WebSearch` recorded `search_engine=tavily`/`search_depth=standard`, and the ptc turn's cache-served fetch correctly recorded `fetch_source=cache` and no provider.
- **Unit suite — 7649 passed**, 1 xfailed, 0 failed. Ruff clean; ESLint 0 errors.
- Bug 2 was caught by the harness before it was fixed, and the harness went green on the fix — the check that proves it is in the pass, not just in a unit test.
- Bug 3 was reproduced against the live Firecrawl API in both directions (faulting before the fix, not faulting after), which is what moved it from a documented residual to a shipped fix.

## Notes for review

- `providers_tried` survives as a derived property on `FetchResponse` — read only by tests now, but it's free and can't drift from `attempts`.
- The E2E pass fails rather than skips when it can't import `src`. A skipped breaker phase would report all-green while proving nothing, which is the exact failure this pass exists to catch.
- Firecrawl checks its rate limit *before* its credit balance, so an out-of-budget account presents as 429 under load. Worth knowing when reading `fetch_attempts` in production traces.
- The credit unit this manifest is denominated in isn't recorded anywhere in the file or its loader — worth a note there, since every future edit is otherwise a guess.

## Review round

- The attempt label collapsed a dead target and a broken provider into `provider_error` — the confusion Bug 1 is about, surviving in the telemetry this PR ships. `WebError` now carries the provider's native kind and the attempt prefers it. Found by probing a live `.invalid` fetch, not by either bot.
- The live pass graded every run in the LangSmith project's time window; it now correlates on the thread ids its own turns returned. On a machine running several stacks against one project it was judging other branches' runs.
- `stamp_run` de-duplicated an incoming tag against pre-existing tags only, so a repeat within one call landed twice. Unreachable from current call sites, fixed anyway.
- The E2E breaker phase discarded its fetch results, so its assertions could have passed without a target-side failure ever occurring; it now checks that first, and requires the exact `fetch_provider:<p>` tag rather than any tag with that prefix.
- A mutation check (suppressing the HALF_OPEN branch's `on_open`) left the whole suite green, so the callback behavior defended below had no coverage at all. Now pinned by a test that drives a failed recovery probe and fails under that same mutant.
- The E2E breaker phase returned an observation when the fetch chain resolved empty, so the pass could exit 0 with no breaker assertion evaluated — the same self-skip its own docstring forbids, and which its import-failure path already guards against. It now records a failed check.
- Declined: converting the sequential E2E driver to async (the convention governs the service; the one phase needing async already uses `asyncio.run`), and requiring a deterministic failed-primary scenario (it would fail the pass on any stack without a multi-provider chain configured — the assertion was tightened instead to require a served fall-through to end on `<provider>:ok`).
- `on_open` on a HALF_OPEN re-open is intentional, not a leak: the probe failed, so the browser reset is owed another run. Suppressing it would reset the browser once ever, across unlimited re-opens. The PR text above previously overstated this as "CLOSED→OPEN only" and has been corrected.
