### PR TITLE
fix(automations): verify the caller owns the targets an automation names

### DIFF
--- a/src/server/handlers/automation_handler.py
+++ b/src/server/handlers/automation_handler.py
@@ -173,7 +173,8 @@ async def update_automation(
         Updated automation dict, or None if not found
 
     Raises:
-        ValueError: On invalid cron/timezone
+        ValueError: On invalid cron/timezone, or a merged state that leaves
+            agent_mode='ptc' without a workspace
     """
     # Get current automation for reference
     current = await auto_db.get_automation(automation_id, user_id)
@@ -212,6 +213,14 @@ async def update_automation(
     new_cron = update_kwargs.get("cron_expression")
     if new_cron:
         validate_cron_expression(new_cron)
+
+    # create enforces this, but a PATCH can flip agent_mode without naming a
+    # workspace — check the merged state, or 'ptc' activates on a row that has
+    # none and the executor only finds out at run time, burning a failure.
+    merged_mode = update_kwargs.get("agent_mode") or current.get("agent_mode")
+    merged_workspace = update_kwargs.get("workspace_id") or current.get("workspace_id")
+    if merged_mode == "ptc" and not merged_workspace:
+        raise ValueError("workspace_id is required for agent_mode='ptc'")
 
     # Recalculate next_run_at if cron expression or timezone changed
     cron_expr = new_cron or current["cron_expression"]

--- a/src/server/handlers/automation_handler.py
+++ b/src/server/handlers/automation_handler.py
@@ -8,15 +8,42 @@ and delegates to the database layer.
 import logging
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
+from uuid import UUID
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from croniter import croniter
 
 from src.server.database import automation as auto_db
+from src.server.database.workspace import get_workspace
 from src.server.services.automation_scheduler import AutomationScheduler
 from src.server.services.automation_executor import AutomationExecutor
+from src.server.utils.api import require_thread_owner, require_workspace_owner
 
 logger = logging.getLogger(__name__)
+
+
+async def require_target_ownership(
+    user_id: str,
+    workspace_id: UUID | str | None,
+    conversation_thread_id: UUID | str | None,
+) -> None:
+    """Verify caller-supplied automation targets belong to ``user_id``.
+
+    Gated here rather than in the router because the REST endpoints and the
+    agent's automation tool both reach the database through this module. The
+    check mostly holds for the row's life: nothing reassigns
+    ``workspaces.user_id`` and nothing moves a thread between workspaces, so a
+    workspace owned at write time stays owned. A pinned thread is the gap —
+    deleting one hard-deletes the row and frees its id for whoever posts to it
+    next, and the column carries no FK to catch that. Raises 404/403, never
+    ValueError, which these routes map to 409.
+    """
+    if workspace_id:
+        require_workspace_owner(
+            await get_workspace(str(workspace_id)), user_id=user_id
+        )
+    if conversation_thread_id:
+        await require_thread_owner(str(conversation_thread_id), user_id)
 
 
 def validate_cron_expression(expr: str) -> None:
@@ -93,6 +120,14 @@ async def create_automation(
     if agent_mode == "ptc" and not data.get("workspace_id"):
         raise ValueError("workspace_id is required for agent_mode='ptc'")
 
+    # Targets are checked whatever the mode: flash ignores workspace_id at run
+    # time, but a later PATCH to agent_mode='ptc' activates the stored one.
+    await require_target_ownership(
+        user_id,
+        data.get("workspace_id"),
+        data.get("conversation_thread_id"),
+    )
+
     # Create in database
     automation = await auto_db.create_automation(
         user_id=user_id,
@@ -144,6 +179,12 @@ async def update_automation(
     current = await auto_db.get_automation(automation_id, user_id)
     if not current:
         return None
+
+    await require_target_ownership(
+        user_id,
+        data.get("workspace_id"),
+        data.get("conversation_thread_id"),
+    )
 
     # Build update kwargs (only non-None values)
     update_kwargs: Dict[str, Any] = {}

--- a/src/server/services/automation_executor.py
+++ b/src/server/services/automation_executor.py
@@ -108,7 +108,8 @@ class AutomationExecutor:
 
         Steps:
         1. Mark execution as running
-        2. Resolve workspace (flash auto-creates, ptc validates)
+        2. Resolve workspace (flash auto-creates; ptc uses the stored id,
+           whose ownership was verified when the automation was written)
         3. Determine thread_id (new or continue)
         4. Build ChatRequest and invoke agent workflow
         5. Drain the async generator

--- a/tests/unit/server/handlers/test_automation_handler_ownership.py
+++ b/tests/unit/server/handlers/test_automation_handler_ownership.py
@@ -1,0 +1,261 @@
+"""Ownership gating for caller-supplied automation targets.
+
+Locks the cross-tenant contract: a ``workspace_id`` / ``conversation_thread_id``
+naming something the caller does not own is rejected before any row is written.
+The gate lives in the handler because the REST router and the agent's
+automation tool both write through it.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from src.server.handlers.automation_handler import create_automation, update_automation
+
+OWNER = "user-owner"
+OTHER = "user-other"
+AUTOMATION_ID = str(uuid.uuid4())
+WORKSPACE_ID = str(uuid.uuid4())
+THREAD_ID = str(uuid.uuid4())
+
+_THREAD_OWNER = "src.server.database.conversation.get_thread_owner_id"
+
+
+def _create_data(**overrides):
+    data = {
+        "name": "daily digest",
+        "instruction": "summarize the watchlist",
+        "trigger_type": "cron",
+        "cron_expression": "0 9 * * 1-5",
+        "timezone": "UTC",
+    }
+    data.update(overrides)
+    return data
+
+
+def _current_row(**overrides):
+    row = {
+        "automation_id": AUTOMATION_ID,
+        "user_id": OWNER,
+        "trigger_type": "cron",
+        "cron_expression": "0 9 * * 1-5",
+        "timezone": "UTC",
+        "status": "active",
+    }
+    row.update(overrides)
+    return row
+
+
+# ---------------------------------------------------------------------------
+# create
+# ---------------------------------------------------------------------------
+
+
+class TestCreateTargetOwnership:
+    @pytest.mark.asyncio
+    @patch("src.server.handlers.automation_handler.auto_db")
+    @patch("src.server.handlers.automation_handler.get_workspace")
+    async def test_rejects_workspace_owned_by_another_user(
+        self, mock_get_workspace, mock_auto_db,
+    ):
+        mock_get_workspace.return_value = {
+            "workspace_id": WORKSPACE_ID, "user_id": OTHER,
+        }
+
+        with pytest.raises(HTTPException) as exc:
+            await create_automation(
+                OWNER, _create_data(agent_mode="ptc", workspace_id=WORKSPACE_ID),
+            )
+
+        assert exc.value.status_code == 403
+        mock_auto_db.create_automation.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("src.server.handlers.automation_handler.auto_db")
+    @patch("src.server.handlers.automation_handler.get_workspace")
+    async def test_rejects_workspace_that_does_not_exist(
+        self, mock_get_workspace, mock_auto_db,
+    ):
+        mock_get_workspace.return_value = None
+
+        with pytest.raises(HTTPException) as exc:
+            await create_automation(
+                OWNER, _create_data(agent_mode="ptc", workspace_id=WORKSPACE_ID),
+            )
+
+        assert exc.value.status_code == 404
+        mock_auto_db.create_automation.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("src.server.handlers.automation_handler.auto_db")
+    @patch("src.server.handlers.automation_handler.get_workspace")
+    async def test_rejects_foreign_workspace_even_in_flash_mode(
+        self, mock_get_workspace, mock_auto_db,
+    ):
+        """Flash ignores workspace_id at run time, but a later PATCH to
+        agent_mode='ptc' activates whatever was stored — so it is gated on the
+        way in regardless of mode."""
+        mock_get_workspace.return_value = {
+            "workspace_id": WORKSPACE_ID, "user_id": OTHER,
+        }
+
+        with pytest.raises(HTTPException) as exc:
+            await create_automation(
+                OWNER, _create_data(agent_mode="flash", workspace_id=WORKSPACE_ID),
+            )
+
+        assert exc.value.status_code == 403
+        mock_auto_db.create_automation.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("src.server.handlers.automation_handler.auto_db")
+    @patch(_THREAD_OWNER, new_callable=AsyncMock)
+    async def test_rejects_pinned_thread_owned_by_another_user(
+        self, mock_thread_owner, mock_auto_db,
+    ):
+        mock_thread_owner.return_value = OTHER
+
+        with pytest.raises(HTTPException) as exc:
+            await create_automation(
+                OWNER,
+                _create_data(
+                    thread_strategy="continue", conversation_thread_id=THREAD_ID,
+                ),
+            )
+
+        assert exc.value.status_code == 403
+        mock_auto_db.create_automation.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("src.server.handlers.automation_handler.auto_db")
+    @patch(_THREAD_OWNER, new_callable=AsyncMock)
+    async def test_rejects_pinned_thread_that_does_not_exist(
+        self, mock_thread_owner, mock_auto_db,
+    ):
+        mock_thread_owner.return_value = None
+
+        with pytest.raises(HTTPException) as exc:
+            await create_automation(
+                OWNER,
+                _create_data(
+                    thread_strategy="continue", conversation_thread_id=THREAD_ID,
+                ),
+            )
+
+        assert exc.value.status_code == 404
+        mock_auto_db.create_automation.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("src.server.handlers.automation_handler.auto_db")
+    @patch(_THREAD_OWNER, new_callable=AsyncMock)
+    @patch("src.server.handlers.automation_handler.get_workspace")
+    async def test_accepts_targets_the_caller_owns(
+        self, mock_get_workspace, mock_thread_owner, mock_auto_db,
+    ):
+        mock_get_workspace.return_value = {
+            "workspace_id": WORKSPACE_ID, "user_id": OWNER,
+        }
+        mock_thread_owner.return_value = OWNER
+        mock_auto_db.create_automation = AsyncMock(
+            return_value={"automation_id": AUTOMATION_ID}
+        )
+
+        await create_automation(
+            OWNER,
+            _create_data(
+                agent_mode="ptc",
+                workspace_id=WORKSPACE_ID,
+                thread_strategy="continue",
+                conversation_thread_id=THREAD_ID,
+            ),
+        )
+
+        mock_auto_db.create_automation.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("src.server.handlers.automation_handler.auto_db")
+    @patch("src.server.handlers.automation_handler.get_workspace")
+    async def test_skips_lookup_when_no_targets_supplied(
+        self, mock_get_workspace, mock_auto_db,
+    ):
+        mock_auto_db.create_automation = AsyncMock(
+            return_value={"automation_id": AUTOMATION_ID}
+        )
+
+        await create_automation(OWNER, _create_data())
+
+        mock_get_workspace.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# update — the second door onto the same columns
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateTargetOwnership:
+    @pytest.mark.asyncio
+    @patch("src.server.handlers.automation_handler.auto_db")
+    @patch("src.server.handlers.automation_handler.get_workspace")
+    async def test_rejects_repointing_at_another_users_workspace(
+        self, mock_get_workspace, mock_auto_db,
+    ):
+        mock_auto_db.get_automation = AsyncMock(return_value=_current_row())
+        mock_get_workspace.return_value = {
+            "workspace_id": WORKSPACE_ID, "user_id": OTHER,
+        }
+
+        with pytest.raises(HTTPException) as exc:
+            await update_automation(
+                AUTOMATION_ID, OWNER, {"workspace_id": WORKSPACE_ID},
+            )
+
+        assert exc.value.status_code == 403
+        mock_auto_db.update_automation.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("src.server.handlers.automation_handler.auto_db")
+    @patch(_THREAD_OWNER, new_callable=AsyncMock)
+    async def test_rejects_repointing_at_another_users_thread(
+        self, mock_thread_owner, mock_auto_db,
+    ):
+        mock_auto_db.get_automation = AsyncMock(return_value=_current_row())
+        mock_thread_owner.return_value = OTHER
+
+        with pytest.raises(HTTPException) as exc:
+            await update_automation(
+                AUTOMATION_ID, OWNER, {"conversation_thread_id": THREAD_ID},
+            )
+
+        assert exc.value.status_code == 403
+        mock_auto_db.update_automation.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("src.server.handlers.automation_handler.auto_db")
+    @patch("src.server.handlers.automation_handler.get_workspace")
+    async def test_untargeted_update_skips_the_lookup(
+        self, mock_get_workspace, mock_auto_db,
+    ):
+        mock_auto_db.get_automation = AsyncMock(return_value=_current_row())
+        mock_auto_db.update_automation = AsyncMock(return_value=_current_row())
+
+        await update_automation(AUTOMATION_ID, OWNER, {"name": "renamed"})
+
+        mock_get_workspace.assert_not_called()
+        mock_auto_db.update_automation.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("src.server.handlers.automation_handler.auto_db")
+    @patch("src.server.handlers.automation_handler.get_workspace")
+    async def test_missing_automation_returns_none_without_checking_targets(
+        self, mock_get_workspace, mock_auto_db,
+    ):
+        mock_auto_db.get_automation = AsyncMock(return_value=None)
+
+        result = await update_automation(
+            AUTOMATION_ID, OWNER, {"workspace_id": WORKSPACE_ID},
+        )
+
+        assert result is None
+        mock_get_workspace.assert_not_called()

--- a/tests/unit/server/handlers/test_automation_handler_price.py
+++ b/tests/unit/server/handlers/test_automation_handler_price.py
@@ -228,13 +228,19 @@ class TestCreatePriceAutomation:
         mock_auto_db.create_automation.assert_not_called()
 
     @pytest.mark.asyncio
+    @patch("src.server.handlers.automation_handler.get_workspace")
     @patch("src.server.handlers.automation_handler.auto_db")
-    async def test_create_price_automation_ptc_with_workspace_id(self, mock_auto_db):
+    async def test_create_price_automation_ptc_with_workspace_id(
+        self, mock_auto_db, mock_get_workspace,
+    ):
         """Successfully creates price automation with ptc mode when workspace_id provided."""
         expected = _make_automation_row(
             agent_mode="ptc", workspace_id=WORKSPACE_ID,
         )
         mock_auto_db.create_automation = AsyncMock(return_value=expected)
+        mock_get_workspace.return_value = {
+            "workspace_id": WORKSPACE_ID, "user_id": USER_ID,
+        }
 
         data = _make_create_data(
             agent_mode="ptc",

--- a/tests/unit/server/handlers/test_automation_handler_update_validation.py
+++ b/tests/unit/server/handlers/test_automation_handler_update_validation.py
@@ -1,0 +1,108 @@
+"""Mode/workspace consistency on the automation PATCH path.
+
+``create_automation`` refuses ``agent_mode='ptc'`` without a workspace. A PATCH
+can flip the mode on its own, so the same requirement has to hold against the
+merged state — otherwise the row is only rejected by the executor at run time,
+which spends a failure against ``max_failures``.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.server.handlers.automation_handler import update_automation
+
+OWNER = "user-owner"
+AUTOMATION_ID = str(uuid.uuid4())
+WORKSPACE_ID = str(uuid.uuid4())
+
+
+def _row(**overrides):
+    row = {
+        "automation_id": AUTOMATION_ID,
+        "user_id": OWNER,
+        "trigger_type": "cron",
+        "cron_expression": "0 9 * * 1-5",
+        "timezone": "UTC",
+        "status": "active",
+        "agent_mode": "flash",
+        "workspace_id": None,
+    }
+    row.update(overrides)
+    return row
+
+
+class TestPtcRequiresAWorkspace:
+    @pytest.mark.asyncio
+    @patch("src.server.handlers.automation_handler.auto_db")
+    async def test_activating_ptc_without_any_workspace_is_rejected(self, mock_auto_db):
+        mock_auto_db.get_automation = AsyncMock(return_value=_row())
+
+        with pytest.raises(ValueError, match="workspace_id is required"):
+            await update_automation(AUTOMATION_ID, OWNER, {"agent_mode": "ptc"})
+
+        mock_auto_db.update_automation.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("src.server.handlers.automation_handler.auto_db")
+    @patch("src.server.handlers.automation_handler.get_workspace")
+    async def test_activating_ptc_with_a_workspace_in_the_same_patch_proceeds(
+        self, mock_get_workspace, mock_auto_db,
+    ):
+        mock_auto_db.get_automation = AsyncMock(return_value=_row())
+        mock_auto_db.update_automation = AsyncMock(return_value=_row(agent_mode="ptc"))
+        mock_get_workspace.return_value = {
+            "workspace_id": WORKSPACE_ID, "user_id": OWNER,
+        }
+
+        await update_automation(
+            AUTOMATION_ID, OWNER,
+            {"agent_mode": "ptc", "workspace_id": WORKSPACE_ID},
+        )
+
+        mock_auto_db.update_automation.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("src.server.handlers.automation_handler.auto_db")
+    @patch("src.server.handlers.automation_handler.get_workspace")
+    async def test_activating_ptc_on_a_row_that_already_stores_one_proceeds(
+        self, mock_get_workspace, mock_auto_db,
+    ):
+        """The stored workspace was ownership-checked when it was written, so
+        the mode flip alone neither re-looks it up nor needs to."""
+        mock_auto_db.get_automation = AsyncMock(
+            return_value=_row(workspace_id=WORKSPACE_ID)
+        )
+        mock_auto_db.update_automation = AsyncMock(return_value=_row(agent_mode="ptc"))
+
+        await update_automation(AUTOMATION_ID, OWNER, {"agent_mode": "ptc"})
+
+        mock_get_workspace.assert_not_called()
+        mock_auto_db.update_automation.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("src.server.handlers.automation_handler.auto_db")
+    async def test_leaving_ptc_for_flash_does_not_require_a_workspace(
+        self, mock_auto_db,
+    ):
+        mock_auto_db.get_automation = AsyncMock(return_value=_row(agent_mode="ptc"))
+        mock_auto_db.update_automation = AsyncMock(return_value=_row())
+
+        await update_automation(AUTOMATION_ID, OWNER, {"agent_mode": "flash"})
+
+        mock_auto_db.update_automation.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("src.server.handlers.automation_handler.auto_db")
+    async def test_unrelated_patch_on_a_ptc_row_is_not_falsely_rejected(
+        self, mock_auto_db,
+    ):
+        mock_auto_db.get_automation = AsyncMock(
+            return_value=_row(agent_mode="ptc", workspace_id=WORKSPACE_ID)
+        )
+        mock_auto_db.update_automation = AsyncMock(return_value=_row())
+
+        await update_automation(AUTOMATION_ID, OWNER, {"name": "renamed"})
+
+        mock_auto_db.update_automation.assert_called_once()


### PR DESCRIPTION
## Summary

The automations API accepted `workspace_id` and `conversation_thread_id` straight from the request and never checked that the caller owned them. Anyone could create a scheduled automation that runs inside another tenant's workspace, or pin one to another tenant's conversation thread. This closes that.

**The fix** — `require_target_ownership()` resolves each supplied target and verifies the owner before any row is written, on both `create_automation` and `update_automation`.

Two shape decisions worth calling out:

- **The gate lives in the handler, not the router.** Every other router in the codebase gates its own workspace/thread ids, but automations has a second writer: the agent's own automation tool (`src/tools/automation/tools.py`) calls the handler directly and never passes through a route. The handler is the only chokepoint both doors share.
- **It fires on every `agent_mode`, not just `ptc`.** Flash ignores `workspace_id` at run time, but a later `PATCH agent_mode='ptc'` activates whatever was stored — so the value is checked on the way in regardless of mode.

It raises `HTTPException` rather than `ValueError`: both routes are wrapped in `handle_api_exceptions(conflict_on_value_error=True)`, which would have surfaced an authorization failure as a 409.

**Docstring correction** — `automation_executor.py` claimed the ptc path validated the stored workspace. It never did (it is a null check). That inaccurate comment is a fair part of why the gap stayed invisible, so it is corrected here rather than left to mislead the next reader.

**Second fix, from review** — `create_automation` refuses `agent_mode='ptc'` without a `workspace_id`, but `update_automation` had no equivalent check. `PATCH {"agent_mode":"ptc"}` therefore succeeded on a row storing no workspace at all, and only failed at execution — where the executor's `ValueError("PTC mode requires a workspace_id")` counts against `max_failures` until the automation auto-disables. The requirement is now re-checked against the merged state (patch value falling back to the stored one), so it fails at the PATCH. A validation asymmetry rather than a cross-tenant hole, but it lives in the same two functions.

## Overview

| | Files | +/− |
|---|---|---|
| Modified | 3 | +60 / −3 |
| New | 2 | +369 / −0 |
| **Total** | **5** | **+429 / −3** |
| **Net (excl. tests)** | **2** | **+53 / −2** |

**By module**

| Module | File | | What it does |
|---|---|---|---|
| Backend — handlers | `src/server/handlers/automation_handler.py` | modified | Adds `require_target_ownership()` and calls it from `create_automation` and `update_automation` before any write; also re-checks the ptc/workspace requirement against the merged PATCH state |
| Backend — services | `src/server/services/automation_executor.py` | modified | Docstring only — corrects a false claim that the ptc path validated workspace ownership |
| Tests | `tests/unit/server/handlers/test_automation_handler_ownership.py` | **new** | 11 cases locking all four gate outcomes across create and update |
| Tests | `tests/unit/server/handlers/test_automation_handler_update_validation.py` | **new** | 5 cases locking the ptc/workspace requirement on the PATCH path |
| Tests | `tests/unit/server/handlers/test_automation_handler_price.py` | modified | Fixture update — the one existing test that supplies a `workspace_id` now mocks the new lookup |

**What this introduces:** a single ownership chokepoint for automation targets. There is no new abstraction and no new helper — the gate composes the two ownership predicates (`require_workspace_owner`, `require_thread_owner`) that the rest of the codebase already uses, so automations now behave like every other resource that accepts a caller-supplied id.

## Diff Size
- Total: 5 files changed, 429 insertions(+), 3 deletions(-)
- Net (excl. tests): 2 files changed, 53 insertions(+), 2 deletions(-)

## Verification

Verified end-to-end against a running backend before any unit test was written, with the fix stashed and then restored so `--reload` swapped the handler underneath the same harness.

| Attack | Before | After |
|---|---|---|
| A creates a ptc automation in B's workspace | **201** — row persisted | 403 |
| A pins an automation to B's thread (`thread_strategy=continue`) | **201** | 403 |
| A stores B's workspace under flash mode | **201** | 403 |
| A repoints their own automation at B's workspace | **200** | 403 |
| A repoints their own automation at B's thread | **200** | 403 |
| Nonexistent workspace | **500** — raw FK violation | 404 |
| A's own workspace / own thread / untargeted rename | 201 / 201 / 200 | 201 / 201 / 200 |

**10/10 after, 4/10 before.**

The ptc/workspace PATCH fix landed after this run and is covered by unit tests only.

## Test Coverage

```
CODE PATHS
[+] src/server/handlers/automation_handler.py
  ├── require_target_ownership()
  │   ├── workspace arm
  │   │   ├── [★★★] absent          -> lookup skipped entirely
  │   │   ├── [★★★] not found       -> 404, no row written
  │   │   ├── [★★★] foreign         -> 403, no row written  (create ptc, create flash, update)
  │   │   └── [★★★] owned           -> proceeds
  │   └── thread arm
  │       ├── [★★★] absent          -> lookup skipped
  │       ├── [★★★] not found       -> 404, no row written
  │       ├── [★★★] foreign         -> 403, no row written  (create + update)
  │       └── [★★★] owned           -> proceeds
  ├── create_automation()
  │   ├── [★★★] gate precedes the write  -> zero writes on every rejection
  │   └── [★★★] flash is gated too       -> a later PATCH to ptc cannot activate a foreign id
  └── update_automation()
      ├── [★★★] missing automation returns None before the gate  (404 beats 403)
      ├── [★★★] untargeted PATCH skips the lookup and still updates
      └── ptc/workspace requirement, merged state
          ├── [★★★] activate ptc, no workspace anywhere    -> rejected, no write
          ├── [★★★] activate ptc + workspace in same PATCH -> proceeds
          ├── [★★★] activate ptc, workspace already stored -> proceeds, no lookup
          ├── [★★★] leave ptc for flash                    -> not required
          └── [★★★] unrelated PATCH on a ptc row           -> not falsely rejected

[=] src/server/services/automation_executor.py — docstring only, no code path.

COVERAGE: 17/17 gate paths tested (100%)   QUALITY: ★★★:17
```

Tests: 3390 → 3392 files (+2 new, 16 cases). **Non-vacuity checked on both.** With `require_target_ownership` stubbed to a no-op, 7 of the 11 ownership tests fail; the other 4 are the positive and skip-the-lookup cases, which pin the no-regression and no-extra-round-trip halves of the contract. With the ptc/workspace condition stubbed to `False`, 1 of the 5 fails — the rejection lock; the other 4 are no-false-positive guards and correctly pass either way.

Not covered, deliberately: the router→handler seam and the agent-tool path. Route tests mock the handler wholesale, and `handle_api_exceptions` re-raises `HTTPException` untouched, so the passthrough is mechanical. Both were verified by the live E2E above instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automation security by verifying workspace and conversation-thread ownership before creating or updating automations.
  * Added clear handling for missing or inaccessible targets, preventing unauthorized changes.
* **Documentation**
  * Clarified that verified workspace information is used when executing PTC automations.
* **Tests**
  * Added coverage for valid, missing, and unauthorized workspace and conversation-thread targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
