### PR TITLE
fix(web): stop a lookup nobody asked for evicting the user from /chat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ TODO.md
 .claude/
 
 docs/pr_context/
+.astack/

--- a/web/src/lib/queryKeys.ts
+++ b/web/src/lib/queryKeys.ts
@@ -1,5 +1,8 @@
+import type { QueryMeta } from '@tanstack/react-query';
+
 /**
- * Hierarchical query key factory for React Query.
+ * Hierarchical query key factory for React Query, plus the query `meta`
+ * contract that rides alongside it (see {@link CACHE_ONLY_META}).
  *
  * Each level builds on its parent to enable prefix-based invalidation:
  *   invalidateQueries({ queryKey: queryKeys.user.all })
@@ -92,3 +95,21 @@ export const queryKeys = {
     detail: (symbol: string) => [...queryKeys.quote.all, symbol],
   },
 };
+
+/**
+ * Marks a query as observed cache-only *by choice* — its arguments are complete
+ * and its queryFn would succeed, it simply must not fetch on its own schedule.
+ * Carrying it is what lets `refetchCacheOnlyLists`
+ * (lib/threadLifecycle/feedClient.ts) fetch a query behind `enabled: false`.
+ *
+ * Never put it on a query that is disabled because an argument is missing:
+ * those queryFns throw on the absent id, and the parked error is then read as a
+ * real failure by whatever watches the query — which is how a thread lookup
+ * with no id once evicted the user from every /chat route.
+ */
+export const CACHE_ONLY_META = { cacheOnly: true } as const;
+
+/** Reader for {@link CACHE_ONLY_META} — keeps the flag's name in one module. */
+export function isCacheOnlyMeta(meta: QueryMeta | undefined): boolean {
+  return meta?.cacheOnly === true;
+}

--- a/web/src/lib/threadLifecycle/__tests__/feedClient.test.ts
+++ b/web/src/lib/threadLifecycle/__tests__/feedClient.test.ts
@@ -22,7 +22,7 @@ import {
   getEffectiveObservation,
   resetThreadLifecycle,
 } from '../store';
-import { queryKeys } from '@/lib/queryKeys';
+import { CACHE_ONLY_META, queryKeys } from '@/lib/queryKeys';
 import {
   getNavThreadsSnapshot,
   resetSharedWorkspaceThreads,
@@ -354,7 +354,7 @@ describe('threadLifecycleFeed — thread_pinned', () => {
 });
 
 describe('threadLifecycleFeed — cache-only list refetch', () => {
-  it('explicitly fetches an invalidated list whose only observers are disabled', async () => {
+  it('explicitly fetches an invalidated list whose only observers opt in', async () => {
     // The nav tree's page-0 queries observe with `enabled: false`, which
     // invalidateQueries (refetchType 'active') marks stale but never refetches
     // — a thread started in the background would stay missing until the user
@@ -365,7 +365,12 @@ describe('threadLifecycleFeed — cache-only list refetch', () => {
     const finiteKey = [...queryKeys.threads.byWorkspace('w1'), 10, 0];
     queryClient.setQueryData(finiteKey, { threads: [], total: 0 });
     const queryFn = vi.fn().mockResolvedValue({ threads: [{ thread_id: 't-new' }], total: 1 });
-    const observer = new QueryObserver(queryClient, { queryKey: finiteKey, queryFn, enabled: false });
+    const observer = new QueryObserver(queryClient, {
+      queryKey: finiteKey,
+      queryFn,
+      enabled: false,
+      meta: CACHE_ONLY_META,
+    });
     const unsubscribe = observer.subscribe(() => {});
 
     conns[0].emit({
@@ -388,11 +393,15 @@ describe('threadLifecycleFeed — cache-only list refetch', () => {
   it('leaves observer-less queries lazy', async () => {
     // An unmounted gallery's cache entry has zero observers — invalidation
     // alone is right there (it refetches on next mount); eager-fetching every
-    // stale entry would refetch views nobody is rendering.
+    // stale entry would refetch views nobody is rendering. The queryFn arrives
+    // via defaults rather than an observer so the entry stays observer-less
+    // while still being fetchable — otherwise nothing here can fail.
     startThreadLifecycleFeed(queryClient);
     await flush();
 
     const finiteKey = [...queryKeys.threads.byWorkspace('w1'), 10, 0];
+    const queryFn = vi.fn().mockResolvedValue({ threads: [{ thread_id: 't-new' }], total: 1 });
+    queryClient.setQueryDefaults(finiteKey, { queryFn });
     queryClient.setQueryData(finiteKey, { threads: [], total: 0 });
 
     conns[0].emit({
@@ -406,8 +415,77 @@ describe('threadLifecycleFeed — cache-only list refetch', () => {
     });
     await flush(400);
 
+    expect(queryFn).not.toHaveBeenCalled();
     const finite = queryClient.getQueryData(finiteKey) as { threads: Array<{ thread_id: string }> };
     expect(finite.threads).toEqual([]);
+  });
+
+  it('still fetches when only one of several observers opts in', async () => {
+    // Observers on one key share its arguments, so one voucher covers the key.
+    // This is the production shape, not an edge case: a page-0 list is observed
+    // by the sidebar tree (opted in) AND by every parked ChatView, which mounts
+    // useNavigationData disabled and registers a plain no-meta observer on its
+    // own workspace's list. Requiring every observer to opt in froze exactly
+    // the lists this refetch exists to thaw.
+    startThreadLifecycleFeed(queryClient);
+    await flush();
+
+    const finiteKey = [...queryKeys.threads.byWorkspace('w1'), 10, 0];
+    queryClient.setQueryData(finiteKey, { threads: [], total: 0 });
+    const queryFn = vi.fn().mockResolvedValue({ threads: [{ thread_id: 't-new' }], total: 1 });
+    const navObserver = new QueryObserver(queryClient, {
+      queryKey: finiteKey,
+      queryFn,
+      enabled: false,
+      meta: CACHE_ONLY_META,
+    });
+    const parkedChatView = new QueryObserver(queryClient, {
+      queryKey: finiteKey,
+      queryFn,
+      enabled: false,
+    });
+    const unsubscribes = [navObserver.subscribe(() => {}), parkedChatView.subscribe(() => {})];
+
+    conns[0].emit({
+      event: 'thread_lifecycle',
+      type: 'run_started',
+      thread_id: 't-new',
+      workspace_id: 'w1',
+      run_id: 'r1',
+      run_seq: 1,
+      status: 'running',
+    });
+    await flush(400);
+
+    expect(queryFn).toHaveBeenCalledTimes(1);
+    const finite = queryClient.getQueryData(finiteKey) as { threads: Array<{ thread_id: string }> };
+    expect(finite.threads.map((t) => t.thread_id)).toEqual(['t-new']);
+    unsubscribes.forEach((u) => u());
+  });
+
+  it('leaves a disabled query that never opted in alone on a full resync', async () => {
+    // `enabled: false` also means "the argument isn't here yet" — ChatAgent's
+    // thread lookup with no :threadId, the nav tree's page-0 query with no
+    // current workspace. Those queryFns throw on the missing id, so fetching
+    // them parks a permanent error that ChatAgent's redirect effect then reads
+    // on every navigation, bouncing the user out of /chat/* forever. The
+    // connection's first snapshot invalidates the whole threads prefix, which
+    // is what used to sweep these argument-less entries in.
+    startThreadLifecycleFeed(queryClient);
+    await flush();
+
+    const detailKey = queryKeys.threads.detail(undefined as unknown as string);
+    queryClient.setQueryData(detailKey, { thread_id: null });
+    const queryFn = vi.fn().mockRejectedValue(new Error('Thread ID is required'));
+    const observer = new QueryObserver(queryClient, { queryKey: detailKey, queryFn, enabled: false });
+    const unsubscribe = observer.subscribe(() => {});
+
+    conns[0].emit({ event: 'snapshot', as_of_seq: 1, oldest_included_unseen_seq: 0, live: [], unseen: [] });
+    await flush(400);
+
+    expect(queryFn).not.toHaveBeenCalled();
+    expect(queryClient.getQueryState(detailKey)?.status).not.toBe('error');
+    unsubscribe();
   });
 });
 

--- a/web/src/lib/threadLifecycle/feedClient.ts
+++ b/web/src/lib/threadLifecycle/feedClient.ts
@@ -21,7 +21,7 @@
  * would be worse than a lib→pages import.
  */
 import type { QueryClient } from '@tanstack/react-query';
-import { queryKeys } from '@/lib/queryKeys';
+import { isCacheOnlyMeta, queryKeys } from '@/lib/queryKeys';
 import { patchThreadTitle } from '@/lib/threadListCache';
 import { isArchivedThreadsKey, patchThreadRows } from '@/lib/threadRowActions';
 import {
@@ -107,18 +107,23 @@ function sleep(ms: number, signal: AbortSignal): Promise<void> {
 
 /** invalidateQueries only refetches enabled observers, and the nav tree's
  * page-0 lists observe cache-only (`enabled: false`) — a stale marking alone
- * leaves them frozen until the user navigates into the workspace. Explicitly
- * fetch every invalidated query whose observers are ALL disabled; queries
- * with no observers at all (unmounted galleries) stay lazy. */
+ * leaves them frozen until the user navigates into the workspace. Fetch the
+ * invalidated ones a {@link CACHE_ONLY_META} observer vouches for.
+ *
+ * One voucher is enough: a key's observers all share its arguments, and
+ * unrelated disabled observers do attach to these keys — a parked ChatView
+ * holds one on its own workspace's list — so demanding unanimity would
+ * refreeze exactly the lists this exists to thaw. */
 function refetchCacheOnlyLists(qc: QueryClient, queryKey: readonly unknown[]): void {
   for (const query of qc.getQueryCache().findAll({ queryKey })) {
-    // state.isInvalidated, not the `stale` filter: the filter reads observer
-    // results, which recompute in a batched notification AFTER this runs.
+    // state.isInvalidated, not the `stale` filter: with observers attached
+    // isStale() reads their results, and a disabled observer never reports
+    // stale, so the filter matches none of these.
     if (!query.state.isInvalidated) continue;
-    const observers = query.observers;
-    if (observers.length > 0 && observers.every((o) => o.options.enabled === false)) {
-      void query.fetch().catch(() => {});
-    }
+    // An enabled observer means invalidateQueries already refetched it.
+    if (query.isActive()) continue;
+    if (!query.observers.some((o) => isCacheOnlyMeta(o.options.meta))) continue;
+    void query.fetch().catch(() => {});
   }
 }
 

--- a/web/src/pages/ChatAgent/ChatAgent.tsx
+++ b/web/src/pages/ChatAgent/ChatAgent.tsx
@@ -13,6 +13,7 @@ import { useActiveThreadPublisher } from '@/lib/threadLifecycle/useActiveThreadP
 import { useWarmWorkspaceSandbox } from './hooks/useWarmWorkspaceSandbox';
 import { warmWorkspace } from './utils/warmWorkspace';
 import { isValidUuid } from './utils/uuid';
+import { shouldLeaveThreadRoute } from './utils/threadRouteGuard';
 import ChatView from './components/ChatView';
 import './ChatAgent.css';
 
@@ -149,12 +150,11 @@ function ChatAgent(): React.ReactElement | null {
     }
   }, [resolvedThread]);
 
-  // Redirect on non-403 thread lookup errors
   useEffect(() => {
-    if (threadError && !accessDenied) {
+    if (shouldLeaveThreadRoute(needsThreadLookup, threadError, accessDenied)) {
       navigate('/chat', { replace: true });
     }
-  }, [threadError, accessDenied, navigate]);
+  }, [needsThreadLookup, threadError, accessDenied, navigate]);
 
   // __default__ with lost state — redirect
   useEffect(() => {

--- a/web/src/pages/ChatAgent/hooks/__tests__/useNavigationData.test.tsx
+++ b/web/src/pages/ChatAgent/hooks/__tests__/useNavigationData.test.tsx
@@ -23,7 +23,7 @@ import {
 } from '../useNavigationData';
 import { resetSharedWorkspaceThreads } from '@/lib/navThreadsStore';
 import { isArchivedThreadsKey, patchThreadRows } from '@/lib/threadRowActions';
-import { queryKeys } from '@/lib/queryKeys';
+import { isCacheOnlyMeta, queryKeys } from '@/lib/queryKeys';
 import { resetNavPrefs, setNavPrefs } from '../../utils/navPrefs';
 
 vi.mock('../../utils/api', () => ({
@@ -158,6 +158,23 @@ describe('useNavigationData — stable thread ordering', () => {
     });
 
     await waitFor(() => expect(mockGetWorkspaceThreads).toHaveBeenCalledWith('ws-1', 20, 0));
+  });
+
+  it('page-0 observers opt into the lifecycle-feed thaw', async () => {
+    // The other half of this contract lives in refetchCacheOnlyLists
+    // (lib/threadLifecycle/feedClient.ts), which fetches a stale page-0 list
+    // only when an observer vouches for it via meta. Nothing else fails if this
+    // hook stops sending the flag — the tree would just silently stop picking
+    // up background runs — so assert the exact predicate that consumer uses.
+    const { queryClient, idsFor } = setup();
+    await waitFor(() => expect(idsFor('ws-1')).toEqual(['t-3', 't-1', 't-2']));
+
+    const pageZero = queryClient
+      .getQueryCache()
+      .findAll({ queryKey: [...queryKeys.threads.byWorkspace('ws-1'), 10, 0] });
+
+    expect(pageZero).toHaveLength(1);
+    expect(pageZero[0].observers.some((o) => isCacheOnlyMeta(o.options.meta))).toBe(true);
   });
 
   it('refetch with reshuffled updated_at keeps the frozen order', async () => {

--- a/web/src/pages/ChatAgent/hooks/useNavigationData.ts
+++ b/web/src/pages/ChatAgent/hooks/useNavigationData.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from 'react';
 import { useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useWorkspaces } from '../../../hooks/useWorkspaces';
-import { queryKeys } from '../../../lib/queryKeys';
+import { CACHE_ONLY_META, queryKeys } from '../../../lib/queryKeys';
 import { createEmitter } from '@/lib/emitter';
 import { isArchivedThreadsKey, patchThreadRows, rollbackThreadRows } from '@/lib/threadRowActions';
 import type { ThreadRowMapper } from '@/lib/threadRowActions';
@@ -531,11 +531,14 @@ export function useNavigationData(currentWorkspaceId: string, { enabled = true }
   // refetch every retained workspace on every mounted panel — so these observe
   // without ever fetching. `combine` returns the data refs, which
   // replaceEqualDeep keeps identity-stable while nothing changes.
+  // Every id here is a real workspace, so these may be thawed after a
+  // lifecycle-feed resync — see CACHE_ONLY_META for what that opt-in attests to.
   const pageData = useQueries({
     queries: observedWsIds.map((wsId) => ({
       queryKey: threadPageKey(wsId, threadPageSize),
       queryFn: () => getWorkspaceThreads(wsId, threadPageSize, 0),
       enabled: false,
+      meta: CACHE_ONLY_META,
       staleTime: 30_000,
     })),
     combine: (results) => results.map((r) => r.data as ThreadsResponse | undefined),

--- a/web/src/pages/ChatAgent/utils/__tests__/threadRouteGuard.test.ts
+++ b/web/src/pages/ChatAgent/utils/__tests__/threadRouteGuard.test.ts
@@ -1,0 +1,30 @@
+/**
+ * The gate on ChatAgent's redirect-out-of-a-thread-route effect.
+ *
+ * Regression: a disabled `threads.detail` query can hold an error this route
+ * never asked for — the lookup only runs when the workspace id can't be read
+ * off the URL or the navigation state. The redirect effect re-runs on every
+ * navigation, so an ungated read of that error replaced every push into
+ * /chat/* with a bounce back to the workspace gallery, making workspace cards,
+ * thread rows and new-thread all look dead.
+ */
+import { describe, it, expect } from 'vitest';
+import { shouldLeaveThreadRoute } from '../threadRouteGuard';
+
+describe('shouldLeaveThreadRoute', () => {
+  it('ignores an error parked on a lookup this route never requested', () => {
+    expect(shouldLeaveThreadRoute(false, new Error('Thread ID is required'), false)).toBe(false);
+  });
+
+  it('leaves the route when the lookup we asked for actually failed', () => {
+    expect(shouldLeaveThreadRoute(true, new Error('not found'), false)).toBe(true);
+  });
+
+  it('stays put on 403 so the access-denied surface can render', () => {
+    expect(shouldLeaveThreadRoute(true, new Error('forbidden'), true)).toBe(false);
+  });
+
+  it('stays put when the lookup succeeded', () => {
+    expect(shouldLeaveThreadRoute(true, null, false)).toBe(false);
+  });
+});

--- a/web/src/pages/ChatAgent/utils/threadRouteGuard.ts
+++ b/web/src/pages/ChatAgent/utils/threadRouteGuard.ts
@@ -1,0 +1,15 @@
+/** Whether a failed thread lookup should evict the user back to the gallery.
+ *
+ * `needsThreadLookup` is the load-bearing term. ChatAgent's redirect effect
+ * re-runs on every navigation (useNavigate's identity tracks the location), so
+ * acting on an error from a lookup this route never asked for bounces the user
+ * out of every /chat/* they click into. A 403 keeps them here for the
+ * access-denied surface instead of silently dropping them at the gallery.
+ */
+export function shouldLeaveThreadRoute(
+  needsThreadLookup: boolean,
+  threadError: unknown,
+  accessDenied: boolean,
+): boolean {
+  return needsThreadLookup && !!threadError && !accessDenied;
+}


### PR DESCRIPTION
## Summary

Clicking a workspace card, a thread row, or new-thread did nothing — every push into `/chat/*` was immediately replaced back to the workspace gallery, so the chat surface was effectively unusable.

**Root cause.** `enabled: false` carries two unrelated meanings in `web/`: *observe cache-only by choice* (the nav tree's page-0 lists) and *the required argument has not arrived* (ChatAgent's thread lookup with no `:threadId`). The lifecycle feed's `refetchCacheOnlyLists` selected queries to force-fetch by "all observers disabled", which swept in the second kind — whose queryFns throw by contract — parking a permanent error on the cache entry. `ChatAgent`'s redirect-on-`threadError` effect then re-read that error on *every* navigation, because `useNavigate`'s identity tracks the location.

Both halves are fixed:

- **Explicit opt-in** — `CACHE_ONLY_META` / `isCacheOnlyMeta` in `lib/queryKeys.ts`, carried only by queries whose arguments are genuinely complete. The selector no longer infers intent from `enabled`.
- **One voucher per key, not unanimity** — observers on a key share that key's arguments, so a single opt-in vouches for all of them. `query.isActive()` handles the case an enabled observer already covers.
- **Gated redirect** — the eviction now requires that this route actually asked for the lookup, extracted to `shouldLeaveThreadRoute` so the rule is testable.

**A regression was caught and fixed inside this PR.** The first version of the fix required *every* observer to opt in. Adversarial review proved by measurement — and I then reproduced it in the running app — that a page-0 list routinely carries two observers: the sidebar tree's (opted in) and a parked ChatView's (`useNavigationData(ws, { enabled: false })`, no meta, and ChatAgent keeps several ChatViews mounted at once). Unanimity therefore froze exactly the lists this refresh exists to thaw. Live measurement on a non-current workspace with a parked view:

```
{"observers":2, "withMeta":1, "active":false,
 "thaws_with_some":true,    ← shipped
 "thaws_with_every":false}  ← the version nearly shipped
```

## Overview

| | Files | + | − |
|---|---|---|---|
| Modified | 7 | 145 | 20 |
| New | 2 | 45 | 0 |
| **Total** | **9** | **190** | **20** |
| **Net (excl. tests)** | **6** | **60** | **15** |

**By module**

| Module | Change | What it does |
|---|---|---|
| `lib/queryKeys.ts` | modified | Adds the `CACHE_ONLY_META` contract + `isCacheOnlyMeta` reader; the flag's name now lives in exactly one module, typed against React Query's own `QueryMeta` |
| `lib/threadLifecycle/feedClient.ts` | modified | `refetchCacheOnlyLists` selects on the opt-in and `isActive()` instead of on `enabled`; corrects a comment whose stated reason was wrong |
| `pages/ChatAgent/ChatAgent.tsx` | modified | Redirect effect calls the extracted predicate and depends on it |
| `pages/ChatAgent/utils/threadRouteGuard.ts` | **new** | The redirect rule as a pure predicate — its own module so ChatAgent keeps fast refresh |
| `pages/ChatAgent/hooks/useNavigationData.ts` | modified | The genuinely cache-only page-0 queries carry the opt-in |
| tests (3 files) | 2 modified, 1 new | Pins all four seams; see Test Coverage |

**What this introduces:** a query may now declare *why* it is disabled, and only a query that declares "cache-only by choice" can be fetched behind `enabled: false`. That replaces an inference that was silently wrong for a whole class of queries.

## Diff Size
- Total: 9 files changed, 190 insertions(+), 20 deletions(-)
- Net (excl. tests): 6 files changed, 60 insertions(+), 15 deletions(-)

## Test Coverage

Every new test was verified by mutation rather than assumed. Before this PR, the whole suite stayed green through all four defects:

| Mutation | Result |
|---|---|
| `some` → `every` (the regression caught in review) | 2 tests fail |
| drop the meta opt-in (the original lockout) | 2 tests fail |
| remove `meta: CACHE_ONLY_META` from the nav hook | 1 test fails |
| ungate the redirect | 1 test fails |

Tests: 2827 → 2833 (+6).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread synchronization so explicitly opted-in cached data refreshes correctly.
  * Preserved cached and unobserved data without triggering unnecessary requests.
  * Fixed thread-route handling after lookup failures while preserving access-denied pages.
* **Tests**
  * Added coverage for cache refresh behavior and thread-route navigation scenarios.
* **Chores**
  * Updated ignore rules for generated project files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->