### PR TITLE
perf(web): cut first-load payload by 55%, and guard it against growing back

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,6 +119,21 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm run typecheck
       - run: pnpm vitest run --reporter=verbose
+      # Bundle the app to assert what lands on the critical path; typecheck above
+      # already covers the tsc half of `pnpm build`, so invoke vite directly.
+      #
+      # Build the deployed configuration, not the default one. Two knobs change
+      # what ships, and both are inlined at build time: VITE_HOST_MODE selects
+      # the auth provider, and the Supabase URL/key decide whether the SDK
+      # survives tree-shaking at all — `supabase.ts` guards the client behind
+      # `url && key`, so unset vars fold that to null and drop ~57 kB gz the
+      # real build carries. Placeholders are enough; nothing dials them.
+      - run: pnpm exec vite build
+        env:
+          VITE_HOST_MODE: platform
+          VITE_SUPABASE_URL: https://example.supabase.co
+          VITE_SUPABASE_PUBLISHABLE_KEY: ci-placeholder-key
+      - run: node scripts/check-critical-path.mjs
 
   frontend-e2e:
     runs-on: ubuntu-latest

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -48,6 +48,7 @@ pnpm lint         # ESLint 9 flat config (advisory — NOT gated in CI)
 | `VITE_HOST_MODE` | `oss` | `platform` → Supabase auth mode; `oss` → local-dev, no auth |
 | `VITE_API_BASE_URL` | (empty = same-origin) | Backend base URL for axios (dev: same-origin, proxied) |
 | `VITE_PROXY_BACKEND` | `http://localhost:8000` | Dev-server proxy target for `/api/v1` + `/ws/v1` |
+| `VITE_DEV_ALLOWED_HOSTS` | (unset = Vite default) | Comma-separated extra Host headers the dev server accepts, for tunnels (ngrok etc.) |
 | `VITE_SUPABASE_URL` | — | Supabase project URL (gates client creation, not mode) |
 | `VITE_SUPABASE_PUBLISHABLE_KEY` | — | Supabase anon key |
 | `VITE_AUTH_USER_ID` | `local-dev-user` | User id in `oss` mode |

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -8,7 +8,7 @@ Frontend for langalpha — React 19 + Vite + TypeScript SPA. Talks to the FastAP
 
 ```bash
 pnpm dev          # dev server on 127.0.0.1:5173 (proxies /api/v1 + /ws/v1 → VITE_PROXY_BACKEND, default :8000)
-pnpm build        # tsc --noEmit && vite build — typecheck gates every build
+pnpm build        # tsc --noEmit && vite build && check-critical-path — typecheck and first-load budget both gate the build
 pnpm typecheck    # tsc --noEmit (gated in CI)
 pnpm test         # vitest run;  test:e2e = Playwright
 pnpm lint         # ESLint 9 flat config (advisory — NOT gated in CI)
@@ -20,6 +20,7 @@ pnpm lint         # ESLint 9 flat config (advisory — NOT gated in CI)
 - **Chat/market SSE uses raw `fetch()` + `ReadableStream`, NOT axios** (axios can't stream) — `streamFetch()` in `pages/ChatAgent/utils/api.ts` + `pages/MarketView/utils/api.ts`. Its token comes straight from `supabase.auth.getSession()`, not the axios interceptor. Most *authenticated* REST goes through the shared axios instance (`api/client.ts`, auto-Bearer, base `VITE_API_BASE_URL`) — but public/unauthenticated calls (`pages/SharedChat/api.ts`), `auth/sync`, and market-data **WebSocket** use raw `fetch`/`WS`, not axios.
 - **Agent artifact path routing has ONE source of truth: `pages/ChatAgent/utils/agentPaths.ts`.** `classifyAgentPath` (→ `memory|memo|user-profile|skill|file`, normalizing `file://`, `/home/(workspace|daytona)/`, `./`, `__wsref__/<wsid>/…` cross-workspace refs) + `computeAgentArtifactRouting` (pure: which panel tab/key/workspace to open). Add new path types here, not in panel components — each new location duplicates the normalization rules.
 - **Zod validates untrusted *persisted/user* input at the boundary, not API responses.** Widget prefs (schemas in `configSchemas.ts`, applied via `safeParse` in `migrations.ts`), onboarding prefs, MCP config — all `safeParse` + per-field `.catch()` (never throw). Typed API responses are plain TS interfaces, not runtime-validated.
+- **First-load bundle is asserted, not eyeballed** (`scripts/check-critical-path.mjs`, gated in `pnpm build` + CI). Vite's build table lists every chunk as if it were lazy; only what `dist/index.html` references is actually on the critical path. A `manualChunks` entry naming a *lazy* vendor pins it to the entry — that is how the chart bundle rode first paint for five months. If the guard trips, fix the import graph; bump `EXPECTED`/`MAX_EAGER_KB` only deliberately. Reproducing the shipped bundle needs `VITE_HOST_MODE=platform` **and** `VITE_SUPABASE_URL`/`_PUBLISHABLE_KEY` — `lib/supabase.ts` guards the client behind `url && key`, so unset vars tree-shake the whole SDK out and understate first load by ~57 kB gz.
 - **i18n re-render gotcha:** locale lives in a `locale` cookie (cookie → browser → `en-US`), no live cross-tab sync. Components that format numbers/dates via `createFormatter`/`createDateFormatter` (`lib/format.ts`) MUST also call `useTranslation()`, or they won't re-render on a locale switch.
 
 ## Conventions

--- a/web/e2e/shared-chat.spec.js
+++ b/web/e2e/shared-chat.spec.js
@@ -113,8 +113,11 @@ test.describe('SharedChat page', () => {
     await page.goto(`/s/${TOKEN}`);
 
     // The glyph loader should be visible while waiting for metadata
-    // (Loader renders role="status" with aria-label "Loading")
-    const spinner = page.getByRole('status', { name: 'Loading' });
+    // (Loader renders role="status" with aria-label "Loading"). `exact` matters:
+    // the route is lazy now, so its Suspense fallback (PageLoading, named
+    // "Loading...") would satisfy a substring match and pass this test even if
+    // the metadata spinner never rendered.
+    const spinner = page.getByRole('status', { name: 'Loading', exact: true });
     await expect(spinner).toBeVisible({ timeout: 3000 });
   });
 

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -81,8 +81,10 @@ export default [
   },
 
   {
-    files: ['vite.config.js'],
+    files: ['vite.config.js', 'scripts/**/*.mjs'],
     languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
       globals: { ...globals.node },
     },
   },

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,7 @@
   "packageManager": "pnpm@10.18.1",
   "scripts": {
     "dev": "vite",
-    "build": "tsc --noEmit && vite build",
+    "build": "tsc --noEmit && vite build && node scripts/check-critical-path.mjs",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "preview": "vite preview",

--- a/web/scripts/check-critical-path.mjs
+++ b/web/scripts/check-critical-path.mjs
@@ -1,0 +1,97 @@
+// Asserts what the browser fetches before first paint: which chunks, and how many bytes.
+//
+// Vite's build summary lists every chunk in one flat table, which reads as though
+// they are all lazy. They are not: whatever the entry statically imports gets a
+// <link rel="modulepreload"> in index.html and is on the critical path of every
+// page load. A chunking change can silently move a 500 kB vendor bundle onto that
+// list, and no typecheck or unit test will notice. This did happen — a lazy-vendor
+// manualChunks entry pinned the chart bundle to the entry for five months.
+//
+// Two assertions, because names alone leak: a vendor that is eagerly imported gets
+// folded into `index` itself rather than gaining a chunk name, so the name set can
+// stay identical while the payload grows. The byte ceiling is the invariant that
+// matters; the name set localizes the blame when it trips.
+//
+// Update either constant deliberately, never to make a red build go green.
+
+import { readFileSync } from 'node:fs'
+import { gzipSync } from 'node:zlib'
+import { join } from 'node:path'
+
+const EXPECTED = ['index', 'vendor-dnd', 'vendor-motion', 'vendor-react']
+
+// Measured against platform mode, which is what ships (oss builds land ~60 kB
+// lower). Headroom is deliberately thin — routine growth should be visible here,
+// not quietly absorbed.
+const MAX_EAGER_KB = 450
+
+const outDir = process.argv[2] || 'dist'
+const indexPath = join(outDir, 'index.html')
+
+let html
+try {
+  html = readFileSync(indexPath, 'utf8')
+} catch {
+  console.error(`\n✗ ${indexPath} not found — run \`vite build\` first.\n`)
+  process.exit(1)
+}
+
+// Both the entry <script> and each <link rel="modulepreload"> are fetched up
+// front; a preload the entry did not import would not be emitted here. CSS counts
+// too — a stylesheet link is render-blocking.
+const assets = [...new Set(
+  [...html.matchAll(/(?:src|href)="[^"]*\/assets\/([^"]+?\.(?:js|css))"/g)].map((m) => m[1]),
+)]
+
+// Zero matches means the scrape went stale (assetsDir renamed, bundle inlined),
+// not that the critical path emptied. Without this it reports as "no longer
+// eager", which is the most misleading way to say "I broke".
+if (!assets.length) {
+  console.error(`\n✗ no /assets/* references found in ${indexPath}`)
+  console.error('  The scrape pattern is stale — check build.assetsDir / output options.\n')
+  process.exit(1)
+}
+
+const stripHash = (f) => f.replace(/\.(js|css)$/, '').replace(/-[A-Za-z0-9_-]{8}$/, '')
+
+const eager = [...new Set(assets.filter((f) => f.endsWith('.js')).map(stripHash))].sort()
+const expected = [...EXPECTED].sort()
+
+const bytes = assets.reduce(
+  (n, f) => n + gzipSync(readFileSync(join(outDir, 'assets', f))).length,
+  0,
+)
+const kb = bytes / 1024
+
+const added = eager.filter((c) => !expected.includes(c))
+const removed = expected.filter((c) => !eager.includes(c))
+const overBudget = kb > MAX_EAGER_KB
+
+if (added.length || removed.length || overBudget) {
+  console.error('\n✗ critical path changed\n')
+  console.error(`  chunks:   ${eager.join(', ')}`)
+  console.error(`  expected: ${expected.join(', ')}`)
+  console.error(`  payload:  ${kb.toFixed(1)} kB gz (ceiling ${MAX_EAGER_KB} kB)`)
+  if (added.length) {
+    console.error(`\n  NEW on the critical path: ${added.join(', ')}`)
+    console.error('  Every visitor now downloads these before first paint.')
+    console.error('  Usually an eager import reaching a lazy module, or a manualChunks')
+    console.error('  entry for a vendor that is not actually eager. Trace it with:')
+    console.error(`    grep -o 'from"\\./vendor-[^"]*"' ${outDir}/assets/index-*.js`)
+  }
+  if (removed.length) {
+    console.error(`\n  no longer eager: ${removed.join(', ')}`)
+    console.error('  Check the payload above before calling this a win — deleting a')
+    console.error('  manualChunks entry inlines that vendor into index instead, losing')
+    console.error('  the chunk name and its cross-deploy cache key at no byte saving.')
+  }
+  if (overBudget) {
+    console.error(`\n  OVER BUDGET by ${(kb - MAX_EAGER_KB).toFixed(1)} kB.`)
+    console.error('  Something eagerly reachable from the entry grew. Trace it with:')
+    console.error(`    pnpm exec vite build --sourcemap  # then inspect ${outDir}/assets/index-*.js.map`)
+  }
+  console.error('')
+  process.exit(1)
+}
+
+console.log(`✓ critical path: ${eager.join(', ')} — ${kb.toFixed(1)} kB gz (ceiling ${MAX_EAGER_KB} kB)`)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,7 +8,6 @@ import BottomTabBar from './components/BottomTabBar/BottomTabBar';
 import Main, { preloadRouteChunk } from './components/Main/Main';
 import PageLoading from './components/PageLoading/PageLoading';
 import AuthConfirm from './pages/Login/AuthConfirm';
-import SharedChatView from './pages/SharedChat/SharedChatView';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from './contexts/AuthContext';
 import { useIsMobile } from './hooks/useIsMobile';
@@ -22,6 +21,10 @@ import './App.css';
 // Login carries the market-tape canvas subsystem (~2k lines that only a
 // logged-out visitor ever renders) — split it out of the main bundle.
 const LoginPage = React.lazy(() => import('./pages/Login/LoginPage'));
+// The public share route reuses the chat transcript renderer, so a static import
+// pulled the whole ChatAgent tree — plus the markdown and chart vendors it reaches
+// — into the entry chunk that every visitor loads before login.
+const SharedChatView = React.lazy(() => import('./pages/SharedChat/SharedChatView'));
 const SetupWizard = React.lazy(() => import('./pages/Setup/SetupWizard'));
 const PrivacyPolicy = React.lazy(() => import('./pages/Legal/PrivacyPolicy'));
 const Legal = React.lazy(() => import('./pages/Legal/Legal'));
@@ -252,7 +255,11 @@ function App() {
           <ResetPassword />
         </Suspense>
       } />
-      <Route path="/s/:shareToken" element={<SharedChatView />} />
+      <Route path="/s/:shareToken" element={
+        <Suspense fallback={<PageLoading />}>
+          <SharedChatView />
+        </Suspense>
+      } />
       <Route path="/privacy" element={
         <Suspense fallback={<PageLoading />}>
           <PrivacyPolicy />

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -2,6 +2,14 @@ import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
+// Shared by the entry and the lazy vendors — see manualChunks below.
+const EAGER_SHARED = new Set(['clsx', 'use-sync-external-store'])
+const MARKDOWN = new Set([
+  'react-markdown', 'remark-gfm', 'remark-math', 'remark-cjk-friendly',
+  'rehype-katex', 'rehype-raw', 'katex',
+])
+const CHARTS = new Set(['recharts', 'lightweight-charts'])
+
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   // Load VITE_-prefixed vars from .env files (.env, .env.local, …) so they can
@@ -36,12 +44,25 @@ export default defineConfig(({ mode }) => {
         // or multi-page config change starts picking up root .html files.
         input: path.resolve(__dirname, 'index.html'),
         output: {
-          manualChunks: {
-            'vendor-react': ['react', 'react-dom', 'react-router-dom'],
-            'vendor-markdown': ['react-markdown', 'remark-gfm', 'remark-math', 'remark-cjk-friendly', 'rehype-katex', 'rehype-raw', 'katex'],
-            'vendor-charts': ['recharts', 'lightweight-charts'],
-            'vendor-motion': ['framer-motion'],
-            'vendor-dnd': ['@dnd-kit/core', '@dnd-kit/sortable', '@dnd-kit/utilities'],
+          // Vendors get a pinned chunk so app deploys don't re-invalidate them.
+          //
+          // The order below is load-bearing. `clsx` and `use-sync-external-store`
+          // are imported by both the entry and the lazy vendors; left to Rollup
+          // they land in a lazy vendor chunk, and the entry then has to preload
+          // that whole chunk to reach 3 kB — which is how 170 kB of charts sat on
+          // the critical path for five months. Claiming them for an already-eager
+          // chunk first keeps the lazy vendors genuinely lazy.
+          // Enforced by scripts/check-critical-path.mjs.
+          manualChunks(id) {
+            if (!id.includes('node_modules')) return
+            const tail = id.split(/[\\/]node_modules[\\/]/).pop().split(/[\\/]/)
+            const pkg = tail[0].startsWith('@') ? `${tail[0]}/${tail[1]}` : tail[0]
+            if (EAGER_SHARED.has(pkg)) return 'vendor-react'
+            if (['react', 'react-dom', 'react-router-dom'].includes(pkg)) return 'vendor-react'
+            if (pkg === 'framer-motion') return 'vendor-motion'
+            if (pkg.startsWith('@dnd-kit')) return 'vendor-dnd'
+            if (MARKDOWN.has(pkg)) return 'vendor-markdown'
+            if (CHARTS.has(pkg)) return 'vendor-charts'
           },
         },
       },

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -13,6 +13,13 @@ export default defineConfig(({ mode }) => {
   // otherwise yield NaN and silently break the HMR socket.
   const hmrClientPort = Number(env.VITE_HMR_CLIENT_PORT)
   const hasHmrClientPort = Number.isFinite(hmrClientPort) && hmrClientPort > 0
+  // Extra Host headers the dev server accepts, for tunnels (ngrok, Cloudflare)
+  // that front it under their own hostname. Comma-separated — kept in .env so a
+  // tunnel host never needs a local edit to this file.
+  const allowedHosts = (env.VITE_DEV_ALLOWED_HOSTS || '')
+    .split(',')
+    .map((host) => host.trim())
+    .filter(Boolean)
 
   return {
     base: env.VITE_CDN_BASE || '/',
@@ -41,6 +48,8 @@ export default defineConfig(({ mode }) => {
     },
     server: {
       host: '127.0.0.1',
+      // Unset leaves Vite's default host checking in place.
+      allowedHosts: allowedHosts.length ? allowedHosts : undefined,
       // In Docker on macOS the bind mount doesn't forward fsevents, so Vite's
       // watcher silently dies and HMR stops (edits don't hot-reload; a reload
       // can even serve the stale transform). Enable polling ONLY when


### PR DESCRIPTION
## Overview

Cuts what every visitor downloads before first paint by **more than half**, and adds a build gate so it cannot silently grow back.

| | Files | +lines | −lines | Net |
|---|---|---|---|---|
| Modified | 7 | 72 | 13 | +59 |
| New | 1 | 97 | 0 | +97 |
| **Total** | **8** | **169** | **13** | **+156** |
| Net excluding tests | | | | **+153** |

By module:

| Module | Change | Net |
|---|---|---|
| `web/scripts/check-critical-path.mjs` | new build guard | +97 |
| `.github/workflows/test.yml` | run the guard on the deployed config | +15 |
| `web/vite.config.js` | chunk boundaries + `allowedHosts` via env | +30 |
| `web/src/App.tsx` | lazy-load the public share route | +7 |
| `web/e2e/shared-chat.spec.js` | tighten a now-ambiguous role query | +3 |
| `web/AGENTS.md` | document the guard and its build-mode trap | +2 |
| `web/package.json`, `web/eslint.config.js` | wire the guard into `pnpm build` | +2 |

**What this introduces:** one new build-time assertion (`check-critical-path.mjs`) with no runtime footprint, and one new env knob (`VITE_DEV_ALLOWED_HOSTS`, dev-server only). No product code changes behaviour; the only shipped-code change is that `/s/:shareToken` now arrives as its own chunk behind a `Suspense` boundary.

## The problem

Two separate causes had put ~500 kB gzip of code on the critical path of *every* page load, including login:

1. **`/s/:shareToken` was a static import.** `SharedChatView` reuses the chat transcript renderer, so importing it eagerly pulled the entire `ChatAgent` tree — and the markdown vendor bundle with it — into the entry chunk.
2. **`manualChunks` named a chunk for a lazy vendor.** `clsx` and `use-sync-external-store` are imported by the entry *and* by charts/markdown. Whichever chunk claims them first wins, and `vendor-charts` won — so `index.html` had to preload 166.3 kB of charting to reach ~3 kB of utilities.

Neither is visible in Vite's build summary, which renders every chunk in one flat table as though they were all lazy. The chart bundle rode first paint for five months.

## Results

Gzip, first-load assets referenced by `dist/index.html` (JS + CSS), deployed configuration:

| | JS + CSS | JS only |
|---|---|---|
| `main` | 931.5 kB | 901.5 kB |
| after lazy share route | 590.3 kB | 571.5 kB |
| **after chunk fix** | **424.0 kB** | **405.2 kB** |

**−507.5 kB gzip, −54.5%.** Eager asset count drops 7 → 5. The second step's delta is exactly `vendor-charts` leaving the critical path.

A secondary win: `react-dom` now actually lands in `vendor-react` (11.6 → 67.8 kB) instead of riding inside `index`, so that much vendor code stops re-hashing on every application deploy.

Total bytes for the share route itself are a wash (841.3 → 834.7 KiB) — this trades one large eager download for a smaller one plus a lazy second phase. The win is first paint, not total transfer.

## The guard

`web/scripts/check-critical-path.mjs` runs in `pnpm build` and in CI. It asserts two things about `dist/index.html`:

- **which** chunks are eager (pinned set), and
- **how many** gzip bytes they cost (450 kB ceiling).

Both halves are load-bearing. Names alone would not have caught the original bug in every form: an eagerly imported vendor gets folded into `index` rather than gaining a chunk name, so the name set can read unchanged while first load grows. Bytes alone would not say *what* moved.

CI now builds the deployed configuration rather than the default one, because two build-time knobs change what ships — and one is non-obvious: `lib/supabase.ts` guards its client behind `url && key`, so with those vars unset the whole SDK tree-shakes out and the measured budget understates the real one by ~57 kB.

## Verification

- `pnpm build` green in both configurations — guard reports 363.8 kB (default) and 424.0 kB (deployed), both under the 450 kB ceiling.
- `tsc --noEmit` clean; ESLint clean.
- **2831 unit tests pass** (267 files).
- Guard failure paths exercised individually: over-budget, missing `dist/`, stale asset scrape, and the real regression — re-pinning `vendor-charts` to the entry trips *both* assertions (`NEW on the critical path: vendor-charts` + `OVER BUDGET by 139.0 kB`).
- 7 routes loaded in headless Chromium with zero chunk-load errors.
- Deploy contract unaffected: the entry filename still matches `assets/index-*.js`.

No backend code is touched, so the Python suite is unaffected.

## Diff size

8 files, +169/−13 across 3 commits. The largest single file is the new 97-line guard; no file is restructured.

## Test coverage

**~44% of the changed lines are covered by automated tests** — accepted as-is rather than raised, deliberately.

The uncovered majority is build configuration, which unit tests cannot meaningfully assert: a test that mocks Rollup's chunking proves nothing about Rollup's chunking. That surface is instead covered by the guard itself, running on every build in both configurations, and verified here against its own failure modes. The one behavioural change (`e2e/shared-chat.spec.js`) is covered by the existing E2E suite.

That E2E change is a fidelity fix, not cosmetic: the assertion used `getByRole('status', { name: 'Loading' })`, and Playwright matches names by case-insensitive *substring*. Once the route became lazy, its `Suspense` fallback (named "Loading...") satisfied that query — so the test would have passed even if the spinner it was written for never rendered. Now pinned with `exact: true`.

## Pre-landing review

An adversarial review pass produced three findings; all were investigated rather than assumed:

- **Confirmed** — the E2E substring collision above. Fixed.
- **Refuted** — a claim that resolving chunks by package name stops Rollup hoisting shared transitive dependencies, breaking cache stability. Sourcemap inspection shows `scheduler` and `@remix-run/router` in `vendor-react`, `motion-dom`/`motion-utils` in `vendor-motion`, as intended.
- **Refuted** — suspected module duplication across chunks. 3,077 modules, zero duplicated.

An earlier iteration of this branch deleted the lazy vendor chunk names entirely. That was measured and reverted: it inlines those vendors into `index`, losing both the chunk name and its cross-deploy cache key at no byte saving. The guard's error message now says so, so the next person does not repeat it.

## Plan completion

No plan file; scope was set conversationally and is fully delivered. Deliberately **not** included, and available as follow-ups:

- A chunk-load error boundary / retry for failed dynamic imports (a 404'd chunk is currently a blank page — pre-existing, but now also reachable on the public share route).
- Trimming the Supabase SDK to sub-packages (~91 kB).
- Lazy-loading the public `FilePanel` (blocked on a named export shared with `ThreadGallery`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved initial page loading by loading shared conversations only when opened.
  - Added a clear loading state while shared conversations are being prepared.
  - Optimized production asset delivery to reduce the amount loaded upfront.

- **Quality Improvements**
  - Added automated checks to detect missing assets and prevent oversized production bundles.
  - Strengthened loading-state validation and development host configuration for more reliable builds and testing.

- **Documentation**
  - Updated build guidance with bundle-size checks and configuration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->