### PR TITLE
fix(web): stop our dark color-scheme from whiting out TradingView embeds

### DIFF
--- a/web/e2e/export-print-color-scheme.spec.js
+++ b/web/e2e/export-print-color-scheme.spec.js
@@ -12,13 +12,11 @@
 // the first link; the pixel end of the chain was verified by hand at authoring
 // time (dark scheme rasterized to rgb(18,18,18), light to rgb(255,255,255)).
 import { test, expect } from '@playwright/test';
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { dirname, resolve } from 'node:path';
 import { PRINT_PAGE_STYLE } from '../src/pages/ChatAgent/components/printPageStyle.ts';
-
-const HERE = dirname(fileURLToPath(import.meta.url));
-const read = (p) => readFileSync(resolve(HERE, '..', p), 'utf8');
+// Shared with tv-embed-color-scheme.spec.js — both rebuild an embedded document
+// around the same index.html declaration, and a drifted copy would silently
+// guard a collision that no longer exists.
+import { readWebFile as read, indexHtmlInlineStyle } from './helpers/indexHtmlStyle.js';
 
 // Composite `color` over `backdrop` before measuring. Alpha has to be applied
 // here or a semi-transparent colour scores as its opaque base: several theme
@@ -31,19 +29,10 @@ function luminanceOver(color, backdrop) {
   return 0.2126 * mix(r, br) + 0.7152 * mix(g, bg) + 0.0722 * mix(b, bb);
 }
 
-// The rule that leaks into the print document: react-to-print builds its iframe
-// from srcdoc="<!DOCTYPE html>", so it carries no data-theme and this unscoped
-// dark branch matches for every user, light-theme ones included.
-function indexHtmlInlineStyle() {
-  const html = read('index.html');
-  const blocks = [...html.matchAll(/<style>([\s\S]*?)<\/style>/g)].map((m) => m[1]);
-  const scheme = blocks.find((b) => b.includes('color-scheme'));
-  // If index.html stops shipping an unscoped dark color-scheme, this test is
-  // guarding a collision that no longer exists — fail loudly rather than pass.
-  expect(scheme, 'index.html should still declare an inline color-scheme').toBeTruthy();
-  expect(scheme).toMatch(/html\s*\{[^}]*color-scheme:\s*dark/);
-  return scheme;
-}
+// `indexHtmlInlineStyle()` (imported above) reads the rule that leaks into the
+// print document: react-to-print builds its iframe from srcdoc="<!DOCTYPE
+// html>", so it carries no data-theme and index.html's unscoped dark branch
+// matches for every user, light-theme ones included.
 
 // Shape of what pagedjs injects into the parent document and react-to-print
 // then copies into the iframe. Asserted against the real dist bundle below.

--- a/web/e2e/helpers/indexHtmlStyle.js
+++ b/web/e2e/helpers/indexHtmlStyle.js
@@ -1,0 +1,26 @@
+import { expect } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const WEB_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+/** Read a file relative to `web/`. */
+export const readWebFile = (p) => readFileSync(resolve(WEB_ROOT, p), 'utf8');
+
+/**
+ * The unscoped `color-scheme: dark` from index.html's inline <style>.
+ *
+ * Two specs rebuild an embedded document to check a cascade this declaration
+ * drives, and both must source it from the real file — a copy that drifted
+ * would leave them guarding a collision that no longer exists while still
+ * passing. Fails loudly if index.html stops shipping it.
+ */
+export function indexHtmlInlineStyle() {
+  const html = readWebFile('index.html');
+  const blocks = [...html.matchAll(/<style>([\s\S]*?)<\/style>/g)].map((m) => m[1]);
+  const scheme = blocks.find((b) => b.includes('color-scheme'));
+  expect(scheme, 'index.html should still declare an inline color-scheme').toBeTruthy();
+  expect(scheme).toMatch(/html\s*\{[^}]*color-scheme:\s*dark/);
+  return scheme;
+}

--- a/web/e2e/tv-embed-color-scheme.spec.js
+++ b/web/e2e/tv-embed-color-scheme.spec.js
@@ -1,0 +1,154 @@
+// Regression lock for the white sheet behind every TradingView embed.
+//
+// The chain: index.html declares an unscoped `color-scheme: dark` on <html>,
+// TV's embed document declares none, and an embedded document whose used
+// color-scheme differs from its embedder's loses transparent compositing — the
+// browser paints the iframe canvas opaque white. TV is cross-origin, so the
+// only reachable end of the mismatch is ours; tvEmbed.css clears the scheme on
+// the container the iframe grows inside and inheritance carries it down.
+//
+// jsdom cannot see any of this — it has no cascade for color-scheme and no
+// compositing at all, so the unit tests can only check the class and the rule
+// text. This loads the REAL stylesheet under index.html's REAL inline style and
+// measures the REAL outcome: a lime backdrop behind a transparent-bodied
+// iframe, sampled from a screenshot. Lime means the iframe composited
+// transparently; white means the canvas was forced opaque and the bug is back.
+// Deleting the rule from tvEmbed.css fails these tests.
+//
+// Two things this deliberately does NOT cover, both verified by hand instead:
+//   - The child is a same-origin `srcdoc`, not a cross-origin document. The
+//     compositing rule is origin-independent, and the real cross-origin case
+//     was checked against live TradingView embeds in a 17-widget before/after
+//     sweep (12 fixed, 5 already correct, 0 regressions).
+//   - playwright.config.js runs Chromium only, while this behavior is
+//     engine-specific. Firefox and WebKit were verified manually; automating
+//     them means widening the shared project matrix for every e2e spec.
+import { test, expect } from '@playwright/test';
+import { readWebFile, indexHtmlInlineStyle } from './helpers/indexHtmlStyle.js';
+
+const TV_EMBED_CSS = 'src/pages/Dashboard/widgets/framework/tvEmbed.css';
+
+// Stands in for TV's embed document: a separate document that declares no
+// color-scheme of its own and paints nothing. That combination is the entire
+// precondition for the compositing rule.
+const EMBEDDED = `<!DOCTYPE html><html><head><meta charset="utf-8"></head><body style="margin:0;background:transparent"></body></html>`;
+
+const LIME = '0,255,0';
+
+/**
+ * Mirrors what both hosts render, with the real class names — the reset is
+ * keyed on them, so using anything else would test nothing. `#backdrop` is the
+ * lime sheet the iframe has to stay transparent over.
+ */
+function embedDocument({
+  container = 'tv-embed-container',
+  meta = null,
+  theme = null,
+  withStylesheet = true,
+} = {}) {
+  return `<!DOCTYPE html><html${theme ? ` data-theme="${theme}"` : ''}><head><meta charset="utf-8">
+    ${meta ? `<meta name="color-scheme" content="${meta}">` : ''}
+    <style>${indexHtmlInlineStyle()}</style>
+    ${withStylesheet ? `<style>${readWebFile(TV_EMBED_CSS)}</style>` : ''}
+    </head><body style="margin:0"><div id="chrome">
+      <div id="backdrop" style="background:rgb(${LIME});width:200px;height:200px">
+        <div class="${container}" style="width:200px;height:200px">
+          <div class="tradingview-widget-container__widget" style="width:200px;height:200px">
+            <iframe id="frame" srcdoc='${EMBEDDED}' style="border:0;width:200px;height:200px"></iframe>
+          </div>
+        </div>
+      </div>
+      <div id="fallback">Widget unavailable</div>
+    </div></body></html>`;
+}
+
+// Both hosts, because the rule has to cover both: 16 of the 17 TV widgets
+// render through TradingViewEmbed, the economic map through the web component.
+const CONTAINERS = ['tv-embed-container', 'tv-wc-container'];
+
+/**
+ * Sample the pixel at the centre of the iframe.
+ *
+ * A fresh context per scenario is load-bearing: shipping browsers don't
+ * re-evaluate the compositing decision when color-scheme changes on an existing
+ * page (fixed in Blink M152), so reusing one page across scenarios reports the
+ * first scenario's result for all of them.
+ */
+async function sampleFrame(browser, html) {
+  const context = await browser.newContext();
+  try {
+    const page = await context.newPage();
+    await page.setContent(html);
+    const shot = await page.screenshot({ clip: { x: 99, y: 99, width: 2, height: 2 } });
+    const computed = await page.evaluate(() => ({
+      frame: getComputedStyle(document.querySelector('#frame')).colorScheme,
+      fallback: getComputedStyle(document.querySelector('#fallback')).colorScheme,
+    }));
+    // Decode the PNG through a canvas — no image library is a dependency here.
+    const pixel = await page.evaluate(async (b64) => {
+      const img = new Image();
+      img.src = 'data:image/png;base64,' + b64;
+      await img.decode();
+      const canvas = document.createElement('canvas');
+      canvas.width = img.width;
+      canvas.height = img.height;
+      const ctx = canvas.getContext('2d');
+      ctx.drawImage(img, 0, 0);
+      const [r, g, b] = ctx.getImageData(0, 0, 1, 1).data;
+      return `${r},${g},${b}`;
+    }, shot.toString('base64'));
+    return { pixel, ...computed };
+  } finally {
+    await context.close();
+  }
+}
+
+test.describe('TradingView embeds — container color-scheme', () => {
+  for (const container of CONTAINERS) {
+    test(`${container} composites transparently over our dark page`, async ({ browser }) => {
+      const { pixel } = await sampleFrame(browser, embedDocument({ container }));
+      expect(pixel, 'iframe should composite transparently, showing the backdrop').toBe(LIME);
+    });
+
+    test(`negative control: without the rule ${container} is painted opaque`, async ({ browser }) => {
+      // Proves the assertion above discriminates the fix from the bug rather
+      // than passing on a document that was never dark to begin with. This is
+      // the reported defect, reproduced.
+      const { pixel } = await sampleFrame(
+        browser,
+        embedDocument({ container, withStylesheet: false }),
+      );
+      expect(pixel).not.toBe(LIME);
+    });
+  }
+
+  test('survives a page-level color-scheme meta tag', async ({ browser }) => {
+    // The landmine that killed the first version of this fix. `color-scheme:
+    // normal` means "whatever the page color scheme is", and the page color
+    // scheme comes from this meta tag — not from our CSS — so `normal` reverted
+    // to dark and repainted the sheet while computed styles still read
+    // `normal`. Adding the meta tag is the standard fix for pre-paint flash,
+    // which index.html already comments about, so this is a live risk. The
+    // shipped rule uses an explicit `light`, which is immune.
+    const { pixel } = await sampleFrame(browser, embedDocument({ meta: 'dark' }));
+    expect(pixel, 'an explicit scheme should not be resolved from the meta tag').toBe(LIME);
+  });
+
+  test('the reset stays inside the embed and leaves our own chrome dark', async ({ browser }) => {
+    // Scope matters: hoisting the reset onto the host or the card would hand our
+    // own UI — the fallback, scrollbars, any UA-painted control — the light
+    // treatment on a dark page.
+    const { fallback } = await sampleFrame(browser, embedDocument());
+    expect(fallback).toBe('dark');
+  });
+
+  test('holds in light theme, where there is no mismatch to fix', async ({ browser }) => {
+    // Light mode needs no reset — a light embedder and TV's undeclared scheme
+    // already agree, so nothing is forced opaque. The rule is unconditional
+    // anyway because browsers don't re-evaluate compositing when color-scheme
+    // changes on a live page (fixed only in Blink M152): a value that never
+    // transitions never depends on that buggy repaint path.
+    const { pixel } = await sampleFrame(browser, embedDocument({ theme: 'light' }));
+    expect(pixel).toBe(LIME);
+  });
+});

--- a/web/src/pages/Dashboard/widgets/framework/TradingViewEmbed.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/TradingViewEmbed.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useTheme } from '@/contexts/ThemeContext';
 import { getTVCommonConfig, mapLocaleForTV, resolveScriptSrc } from './tvConfig';
 import { EmbedFallback } from './EmbedFallback';
+import './tvEmbed.css';
 
 interface Props {
   /** Either a known short key (`ticker-tape`) or a full embed-widget URL. */
@@ -198,6 +199,9 @@ export function TradingViewEmbed({ scriptKey, config, className, card = false, c
             : 'relative flex-1 min-h-0'
         }
       >
+        {/* `tv-embed-container` is load-bearing beyond layout — tvEmbed.css
+            hangs the color-scheme reset off it that keeps the iframe
+            compositing transparently. TV's subtree must stay inside it. */}
         <div
           ref={containerRef}
           className="tv-embed-container tradingview-widget-container w-full"

--- a/web/src/pages/Dashboard/widgets/framework/TradingViewWebComponent.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/TradingViewWebComponent.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useTheme } from '@/contexts/ThemeContext';
 import { EmbedFallback } from './EmbedFallback';
 import { mapLocaleForTV } from './tvConfig';
+import './tvEmbed.css';
 
 /**
  * Per-element+locale module loader cache. Each TradingView web-component lives
@@ -282,11 +283,10 @@ export function TradingViewWebComponent({
   return (
     <div className={`tv-embed-host flex flex-col h-full ${cardClass} ${className ?? ''}`}>
       <div className="relative flex-1 min-h-0">
-        <div
-          ref={hostRef}
-          className="tv-wc-container w-full h-full"
-          style={{ minHeight: 80 }}
-        />
+        {/* `tv-wc-container` carries the color-scheme reset from tvEmbed.css —
+            see TradingViewEmbed.tsx. The custom element mounts inside it so
+            the reset inherits into the iframe it builds. */}
+        <div ref={hostRef} className="tv-wc-container w-full h-full" style={{ minHeight: 80 }} />
         {status === 'error' && <EmbedFallback onRetry={retry} />}
       </div>
     </div>

--- a/web/src/pages/Dashboard/widgets/framework/__tests__/TradingViewEmbed.test.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/__tests__/TradingViewEmbed.test.tsx
@@ -29,6 +29,27 @@ describe('TradingViewEmbed', () => {
     expect(payload.symbols).toBeTruthy();
   });
 
+  // The two halves of the color-scheme fix that jsdom can see: the class
+  // tvEmbed.css keys its reset on, and the iframe living inside the node that
+  // carries it. jsdom has no cascade for color-scheme, so the rule itself is
+  // checked in tvEmbedColorScheme.test.ts and its effect in real Chromium in
+  // e2e/tv-embed-color-scheme.spec.js.
+  it('keeps the tv-embed-container class the color-scheme reset is keyed on', () => {
+    const { container } = render(<TradingViewEmbed scriptKey="ticker-tape" config={{}} />);
+    expect(container.querySelector('.tv-embed-container')).toBeTruthy();
+  });
+
+  // Inheritance is the whole delivery mechanism — we can't style TV's
+  // cross-origin iframe, only the node it grows inside. A refactor that built
+  // the TV subtree as a sibling would silently bring the white sheet back.
+  it('grows the TV subtree inside the reset node, not beside it', () => {
+    const { container } = render(<TradingViewEmbed scriptKey="ticker-tape" config={{}} />);
+    const host = container.querySelector<HTMLElement>('.tv-embed-container')!;
+    const widget = container.querySelector('.tradingview-widget-container__widget');
+    expect(widget).toBeTruthy();
+    expect(host.contains(widget)).toBe(true);
+  });
+
   it('shows the fallback state when no iframe materialises within 10s', () => {
     render(<TradingViewEmbed scriptKey="ticker-tape" config={{}} />);
     // No iframe — the timeout should trip and the fallback appears.

--- a/web/src/pages/Dashboard/widgets/framework/__tests__/TradingViewWebComponent.test.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/__tests__/TradingViewWebComponent.test.tsx
@@ -46,6 +46,25 @@ describe('TradingViewWebComponent', () => {
     expect(el?.getAttribute('color-theme')).toBe('dark');
   });
 
+  // Same opaque-canvas regression the iframe host guards against — the custom
+  // element builds an iframe of its own, so it needs the same reset. tvEmbed.css
+  // keys that reset on `tv-wc-container` and inheritance carries it into the
+  // iframe, so what matters here is the class and the element being inside it.
+  it('mounts the custom element inside the tv-wc-container the reset is keyed on', async () => {
+    const { container } = render(
+      <TradingViewWebComponent element="tv-ticker-tape" config={{}} />,
+    );
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const host = container.querySelector<HTMLElement>('.tv-wc-container');
+    expect(host).toBeTruthy();
+    const el = container.querySelector('tv-ticker-tape');
+    expect(el).not.toBeNull();
+    expect(host!.contains(el)).toBe(true);
+  });
+
   it('skips false / null / undefined attribute values (presence trap)', async () => {
     const { container } = render(
       <TradingViewWebComponent

--- a/web/src/pages/Dashboard/widgets/framework/__tests__/tvEmbedColorScheme.test.ts
+++ b/web/src/pages/Dashboard/widgets/framework/__tests__/tvEmbedColorScheme.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/** Every `.css` file under `dir`, recursively. */
+function cssFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+    const full = resolve(dir, e.name);
+    if (e.isDirectory()) return cssFiles(full);
+    return e.name.endsWith('.css') ? [full] : [];
+  });
+}
+
+/**
+ * REGRESSION-CRITICAL — protects TradingView embeds from rendering on white.
+ *
+ * A browser drops transparent compositing when an embedded document's used
+ * color-scheme differs from its embedder's, painting the iframe canvas opaque
+ * white. Our <html> declares `color-scheme: dark` and TV's embed documents
+ * declare none, so without the reset in `tvEmbed.css` every TV widget gets a
+ * white sheet behind it — 12 of the 17 showed it; the heatmaps and the economic
+ * map only escaped because they paint an opaque canvas of their own over it.
+ *
+ * jsdom has no cascade for color-scheme, so it cannot observe the rule taking
+ * effect — that is checked in real Chromium by e2e/tv-embed-color-scheme.spec.js.
+ * What this file locks is that the rule still exists, still says `light`, and is
+ * still imported by both hosts. If it fails, do not change the assertions — fix
+ * the CSS.
+ */
+const here = (p: string) => resolve(__dirname, '..', p);
+const css = readFileSync(here('tvEmbed.css'), 'utf8');
+
+describe('TradingView embed color-scheme reset (regression)', () => {
+  it('resets color-scheme on both embed container classes', () => {
+    // Both hosts must be covered: 16 of the 17 TV widgets render through
+    // TradingViewEmbed, the economic map through TradingViewWebComponent.
+    // Matched as one rule block rather than three independent substrings, so
+    // two empty selectors plus an unrelated `color-scheme: light` elsewhere in
+    // the file can't satisfy this.
+    expect(css).toMatch(
+      /\.tv-embed-container\s*,\s*\.tv-wc-container\s*\{[^}]*color-scheme:\s*light[^}]*\}/,
+    );
+  });
+
+  it('does NOT use `normal`, which resolves from a page-level meta tag', () => {
+    // `normal` means "whatever the page color scheme is", and the page color
+    // scheme comes from <meta name="color-scheme"> — not from our CSS. It works
+    // today only because index.html ships no such meta tag. Adding one (the
+    // standard fix for pre-paint flash, which index.html already comments about)
+    // would flip `normal` back to dark and silently restore the white sheet,
+    // while computed styles still read `normal`. Verified opaque in Chromium,
+    // Firefox and WebKit. `light` is explicit and immune.
+    expect(css).not.toMatch(/color-scheme:\s*normal/);
+  });
+
+  it('is imported by both embed hosts, or the rule never ships', () => {
+    // The rule lives in CSS so a new embed host inherits it by reusing the
+    // class — but that only holds while the stylesheet is actually in the
+    // bundle. Vite drops a stylesheet nothing imports. Anchored to the start of
+    // a line so a commented-out import doesn't satisfy it.
+    for (const host of ['TradingViewEmbed.tsx', 'TradingViewWebComponent.tsx']) {
+      expect(readFileSync(here(host), 'utf8'), host).toMatch(/^import '\.\/tvEmbed\.css';$/m);
+    }
+  });
+
+  it('is the only stylesheet setting color-scheme on the embed containers', () => {
+    // The rule is a single-class selector, so anything more specific in another
+    // sheet would silently win and repaint the sheet. The e2e spec injects
+    // tvEmbed.css alone, so it cannot see such an override — this can.
+    const srcRoot = resolve(__dirname, '..', '..', '..', '..', '..');
+    const others = cssFiles(srcRoot)
+      .filter((p) => !p.endsWith('tvEmbed.css'))
+      .filter((p) =>
+        /tv-(embed|wc)-container[^{]*\{[^}]*color-scheme/.test(readFileSync(p, 'utf8')),
+      )
+      .map((p) => p.slice(srcRoot.length + 1));
+    expect(others, 'another stylesheet also sets color-scheme on a TV container').toEqual([]);
+  });
+});

--- a/web/src/pages/Dashboard/widgets/framework/tvEmbed.css
+++ b/web/src/pages/Dashboard/widgets/framework/tvEmbed.css
@@ -1,0 +1,19 @@
+/**
+ * Keeps TradingView embeds compositing transparently over our dark surfaces.
+ *
+ * A browser drops transparent compositing when an embedded document's used
+ * color-scheme differs from its embedder's, painting the iframe canvas opaque
+ * white — which silently overrides the `isTransparent: true` we send TV. Our
+ * <html> declares `color-scheme: dark` (index.html) and TV's embed documents
+ * declare none, so every embed mismatches. TV is cross-origin, so the only
+ * reachable end of the mismatch is ours: clear it on the container the iframe
+ * grows inside and let inheritance carry it down. `light`, not `normal` —
+ * `normal` resolves from a page-level <meta name="color-scheme">, so adding
+ * one to index.html would silently revert this while computed styles still
+ * read `normal` (verified opaque in Chromium, Firefox and WebKit). Keyed on
+ * the container classes so a new embed host inherits the fix by reusing them.
+ */
+.tv-embed-container,
+.tv-wc-container {
+  color-scheme: light;
+}


### PR DESCRIPTION
## Summary

Twelve of the seventeen TradingView dashboard widgets rendered on a white
panel in dark mode. This fixes the cause and locks it.

**The bug.** A browser drops transparent compositing when an embedded
document's *used* `color-scheme` differs from its embedder's — it paints the
iframe canvas opaque white instead. Our `<html>` declares `color-scheme: dark`
(`web/index.html:33`); TradingView's embed documents declare none. So the
`isTransparent: true` / `backgroundColor: rgba(0,0,0,0)` we send TV was being
silently overridden by a white sheet behind every embed. Only the text-only
widgets exposed it — the four heatmaps and the economic map paint an opaque
canvas of their own over the sheet, which is why this read as a single-widget
bug for so long.

**The fix.** A `color-scheme` reset in a new `tvEmbed.css`, keyed on the two
embed container classes. TV is cross-origin, so their document can't be given a
matching scheme — the only reachable end of the mismatch is ours. Keying it on
the container classes rather than inlining it per-host means a future embed host
inherits the fix by reusing the class. This is the cross-origin mirror of the
treatment already applied same-origin at
`viewers/html/buildHtmlSrcDoc.ts:64-71`.

**`light`, not `normal`.** `normal` means "whatever the *page* color scheme is",
and the page color scheme comes from `<meta name="color-scheme">` — not from our
CSS. It happens to work today only because `index.html` ships no such meta tag.
Adding one — the standard fix for the pre-paint flash `index.html:29-32` already
comments about — flips `normal` back to dark and repaints the sheet, *while
computed styles still read `normal`*. Measured opaque in Chromium, Firefox and
WebKit. `light` is explicit and immune, and a regression test now covers it.

## Overview

| | Files | +/− |
|---|---|---|
| New | 4 | +278 / −0 |
| Modified | 5 | +57 / −24 |
| **Total** | **9** | **+335 / −24** |
| **Net (excl. tests)** | **3** | **+28 / −5** |

**Dashboard / TradingView framework** — the fix itself.
- *new* `widgets/framework/tvEmbed.css` — the reset, plus the rationale it needs
  to survive a well-meaning edit.
- *mod* `TradingViewEmbed.tsx`, `TradingViewWebComponent.tsx` — import the
  stylesheet; drop the now-redundant inline style. Both containers keep a short
  comment noting the class is load-bearing beyond layout.

**Tests** — see Test Coverage below.
- *new* `__tests__/tvEmbedColorScheme.test.ts` — rule text, host imports, no
  competing stylesheet.
- *new* `e2e/tv-embed-color-scheme.spec.js` — real compositing in real Chromium.
- *mod* the two host test files — assert the class and the subtree containment
  that inheritance depends on.

**Shared e2e helper** — `e2e/helpers/indexHtmlStyle.js` extracts the `index.html`
style reader that the print color-scheme spec had duplicated verbatim; both
specs now read the declaration from one place.

**What this introduces:** no new user-facing capability — the dashboard's
TradingView widgets simply render on the dashboard's own dark surface instead of
a white panel.

## Diff Size
- Total: 9 files changed, 335 insertions(+), 24 deletions(-)
- Net (excl. tests): 3 files changed, 28 insertions(+), 5 deletions(-)

## Test Coverage

```
CODE PATHS
  tvEmbed.css — the reset
    ├─ rule text, both selectors, one block ............. ★★★ unit
    ├─ value is `light`, never `normal` ................. ★★★ unit + e2e
    ├─ imported by both hosts (or Vite drops it) ........ ★★★ unit
    └─ no competing stylesheet overrides it ............. ★★★ unit
  TradingViewEmbed.tsx      (16 of 17 widgets + MarketView chart)
    ├─ carries `tv-embed-container` ..................... ★★★ unit
    └─ TV subtree grows INSIDE it (inheritance) ......... ★★★ unit
  TradingViewWebComponent.tsx (economic map)
    └─ custom element mounts inside `tv-wc-container` ... ★★★ unit

USER FLOWS (real Chromium, sampled pixel)
  Embed composites transparently, both containers ....... ★★★ + negative control each
  Page-level color-scheme meta tag ...................... ★★★ the silent-revert guard
  Our own chrome (fallback) stays dark .................. ★★★ scope guard
  Light theme ........................................... ★★★

NOT AUTOMATED — verified by hand
  Cross-origin boundary (the e2e child is same-origin srcdoc)
  Firefox / WebKit (the Playwright matrix is Chromium-only)
  Both covered by a 17-widget before/after sweep against live TradingView.

COVERAGE: 100% of the diff's codepaths and automatable flows, 0 open gaps
```

Tests: 2834 → 2838 unit (+4), plus 7 Playwright tests. Mutation-verified —
deleting the rule fails 2 e2e + 1 unit; `light`→`normal` fails 1 e2e + 2 unit;
dropping either import fails 1 unit.

## Pre-Landing Review

Four reviewers (testing, maintainability, design specialists + adversarial),
plus a cross-model pass. Acted on:

- **`normal` → `light`** — silent-revert landmine, invisible to every test.
  Independently re-measured across three engines before changing it.
- **CSS rule instead of a TS constant** — nothing structurally stopped a third
  embed host from forgetting the reset.
- **The first e2e spec passed with the fix removed** — it asserted computed
  strings against a hand-built fixture. Rewritten to load the real stylesheet
  and sample a real pixel; mutation-tested.
- Dropped a brittle sizing assertion and two rebuild tests with no
  discriminating power; tightened CSS assertions that could pass on empty rules
  and an import check that matched a commented-out import.
- Extracted the duplicated `index.html` style reader.

Verified in the production bundle, not just in source:
`.tv-embed-container,.tv-wc-container{color-scheme:light}`.

## Design Review

No design-system violations — the diff introduces no color values, no
`!important`, no accent bars, no token changes. `color-scheme` is a rendering
mode rather than a palette entry, so it correctly lives outside `tokens.css`.
Nothing of ours renders inside either container (the fallback overlay is a
sibling), so the reset can't relight our own chrome — locked by a test.

## Eval Results
No prompt-related files changed — evals skipped.

## Scope Drift
Clean. No unrelated files, no opportunistic refactors.

## Plan Completion
4/4 items addressed (3 done, 1 changed — the culprit was the iframe's own
UA-painted canvas, not an ancestor element as the plan assumed). 0 deferred.

## Verification Results
Backend 7737 passed. Frontend 2838 passed, 268 files. `tsc --noEmit` clean.
ESLint clean on all changed files. Production build succeeds and ships the rule.

## Documentation
No documentation changes required. The diff adds one stylesheet and two imports
— no API, config, env var, or architecture surface changes, and nothing that
`AGENTS.md` or `web/AGENTS.md` describes. The rationale that would otherwise
need a doc home lives in `tvEmbed.css` itself, where an editor of the rule will
actually see it.

## Test plan
- [x] Frontend unit suite (2838 tests, 268 files)
- [x] Playwright: 7 new + 10 pre-existing print color-scheme tests
- [x] Backend unit suite (7737 passed, 1 xpassed) — untouched by this diff
- [x] Typecheck + lint + production build
- [x] Mutation-tested: every way of removing the fix fails a test
- [x] Live 17-widget before/after sweep against real TradingView embeds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TradingView embeds to preserve correct light-theme rendering and transparent iframe compositing across dark and light page themes.
  * Prevented fallback browser styling from affecting embedded TradingView content.

* **Tests**
  * Added regression coverage for TradingView embed appearance, theme isolation, iframe compositing, and container behavior.
  * Expanded print color-scheme checks using shared test utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->