### PR TITLE
fix(workspaces): fence the per-worker sandbox cache against Postgres

### DIFF
--- a/scripts/multiworker_gate/README.md
+++ b/scripts/multiworker_gate/README.md
@@ -1,11 +1,18 @@
 # Multi-worker gate
 
-Re-runnable fault-injection suite for the v4 turn-lifecycle multi-worker
-contract, distilled from the pre-merge fault-injection matrix (17/17 PASS).
-Run the automated cells whenever a change touches **turn lifecycle,
-streaming/SSE, the hook outbox, or subagent ownership** — the failure mode
-they catch is always the same: *works when producer and consumer land on
-the same worker, breaks ~50% of the time at `--workers 2`.*
+Re-runnable fault-injection suite for the multi-worker contract, distilled from
+the v4 turn-lifecycle pre-merge fault-injection matrix (17/17 PASS) and since
+extended past the turn tier. Run the automated cells whenever a change touches
+**turn lifecycle, streaming/SSE, the hook outbox, subagent ownership, or the
+workspace↔sandbox binding** — the failure mode they catch is always the same:
+*works when producer and consumer land on the same worker, breaks ~50% of the
+time at `--workers 2`.*
+
+Cells 1–17 cover the turn/run tier. Cell 18 opened the **workspace/sandbox**
+tier: v4 put runs under a durable-truth contract and left
+`WorkspaceManager._sessions` on process memory, which is how a worker can go on
+calling a sandbox Postgres has already replaced, serving "File not found" for
+files that exist.
 
 ## Topology
 
@@ -57,6 +64,7 @@ the run and which worker attacks it.
 | 15 | Steering vs root finalization | manual | steer cross-worker to the live owner; archived on the response's `steering_inputs` |
 | 16 | `--workers 2` boot / split-DB / pool exhaustion | manual | 16b: split unreachable by construction in the server path; 16c: `POSTGRES_WRITER_POOL_MAX=1` → bounded 503 |
 | 17 | Graceful SIGTERM with open run | ✅ | owner-finalized `cancelled` (`cancelled_by_user=false`, no `recovery`) before exit |
+| 18 | Sandbox replaced behind a worker → re-attach | ✅ | first **workspace/sandbox**-tier cell (1–17 are all turn/run tier). `/spec` on A recreates the sandbox while B is probed concurrently; requires `sandbox_id` changed, B converged to 200 with the exact sentinel bytes, zero 404s, and a `is stale` detection in B's log. A 503 inside the window is fine; a 503 at the end is not |
 
 Manual procedures and full evidence for every cell live in the original
 fault-injection report (kept out of the repo — summarized in the PR that

--- a/scripts/multiworker_gate/gate.py
+++ b/scripts/multiworker_gate/gate.py
@@ -6,16 +6,18 @@ running backend container — multiple processes against one Postgres + Redis is
 the multi-worker topology every cell exercises — then drives real turns across
 them and asserts terminal state on the run ledger (conversation_responses).
 
-Run it whenever a change touches turn lifecycle, streaming, outbox, or
-subagent ownership:
+Run it whenever a change touches turn lifecycle, streaming, outbox, subagent
+ownership, or the workspace<->sandbox binding:
 
     uv run python scripts/multiworker_gate/gate.py --user <user_id>
     uv run python scripts/multiworker_gate/gate.py --cells 1,7,13   # subset
 
 Requires: the worktree's docker stack up, service-token auth
 (INTERNAL_SERVICE_TOKEN in the container env), and a flash-capable LLM key.
-Threads created by the gate are kept for inspection (--clean deletes them).
-See README.md for the full 17-cell matrix and the manual-only cells.
+Cell 18 additionally needs a working sandbox provider — it creates, recreates
+and deletes a real sandbox. Threads created by the gate are kept for inspection
+(--clean deletes them); cell 18 always deletes its own workspace.
+See README.md for the full matrix and the manual-only cells.
 """
 
 from __future__ import annotations
@@ -123,12 +125,17 @@ class Stack:
     def teardown_workers(self) -> None:
         # Kill by cmdline pattern, not only the pidfile: an aborted run can
         # overwrite the pidfile while an older server still holds the port.
+        # Skip $$ — this shell's own cmdline contains the pattern, and the glob
+        # sorts /proc lexicographically, so a 4-digit teardown pid is visited
+        # before a 3-digit server: without the guard the loop SIGKILLs itself
+        # first and silently leaves the worker alive for the next run.
         for name, port in WORKERS.items():
             script = (
-                "for d in /proc/[0-9]*; do "
+                "self=$$; for d in /proc/[0-9]*; do "
+                "p=$(basename $d); [ \"$p\" = \"$self\" ] && continue; "
                 "c=$(tr '\\0' ' ' < $d/cmdline 2>/dev/null); "
                 f"case \"$c\" in *\"server.py --host 127.0.0.1 --port {port}\"*) "
-                "kill -9 $(basename $d) 2>/dev/null;; esac; done; "
+                "kill -9 $p 2>/dev/null;; esac; done; "
                 f"rm -f /tmp/gate_{name}.pid"
             )
             sh(["docker", "exec", self.backend, "sh", "-c", script])
@@ -385,6 +392,114 @@ def cell_17_graceful_sigterm(st: Stack) -> tuple[bool, str]:
     return ok, f"row={row} worker_exited={exited} thread={tid}"
 
 
+def cell_18_sandbox_replacement(st: Stack) -> tuple[bool, str]:
+    """Sandbox replaced behind worker B → B re-attaches, never 404s a live file.
+
+    The workspace/sandbox tier's counterpart to the run-ledger cells.
+    ``WorkspaceManager._sessions`` is process memory, so B keeps a handle to
+    whatever sandbox it last attached to; when A's ``/spec`` recreates the
+    sandbox, B must notice from ``workspaces.sandbox_id`` and re-attach. The
+    symptom when it doesn't is a 404 "File not found" for a file that exists.
+
+    B is probed CONCURRENTLY with the replacement, not after it: once ``/spec``
+    returns the row is already ``running`` on the new id, so a post-hoc read
+    proves nothing about the window where DB and cache both name a sandbox that
+    is being destroyed. 503 is an acceptable transient verdict inside the
+    window but not a terminal one — the cell requires convergence to 200 with
+    the exact sentinel bytes.
+    """
+    sentinel = f"gate-18-{uuid.uuid4().hex}"
+    path = "gate_18.txt"
+    code, text = st.api("A", "POST", "/api/v1/workspaces",
+                        {"name": "gate-18 sandbox replacement"}, max_time=240)
+    if code != 201:
+        return False, f"workspace create failed: {code} {text[:200]}"
+    ws = json.loads(text)["workspace_id"]
+
+    # Everything past the create goes inside the try: a real sandbox exists from
+    # here on, and st.pq raises on a psql failure, so a setup line left outside
+    # would skip the finally and leak the sandbox to bill on.
+    try:
+        tier_before = st.pq("SELECT COALESCE(resource_tier,'standard') FROM "
+                            f"workspaces WHERE workspace_id='{ws}'")
+        target = "performance" if tier_before == "standard" else "standard"
+        read_path = (
+            f"/api/v1/workspaces/{ws}/files/read?path={path}&unlimited=true"
+        )
+
+        # 1. Write through A — A must own the session /spec will replace.
+        wcode, wtext = st.api("A", "PUT",
+                              f"/api/v1/workspaces/{ws}/files/write?path={path}",
+                              {"content": sentinel}, max_time=90)
+        if wcode != 200:
+            return False, f"write failed: {wcode} {wtext[:200]} ws={ws}"
+
+        # 2. Warm B, so B holds a cached handle to the pre-replacement sandbox.
+        bcode, btext = st.api("B", "GET", read_path, max_time=90)
+        if bcode != 200 or sentinel not in btext:
+            return False, f"B warm read failed: {bcode} {btext[:200]} ws={ws}"
+        sandbox_before = st.pq(
+            f"SELECT sandbox_id FROM workspaces WHERE workspace_id='{ws}'")
+
+        # 3. Replace the sandbox through A while hammering B throughout.
+        b_codes: list[int] = []
+        stop_probing = False
+
+        def probe_b() -> None:
+            while not stop_probing:
+                c, _ = st.api("B", "GET", read_path, max_time=20)
+                b_codes.append(c)
+                time.sleep(1)
+
+        with concurrent.futures.ThreadPoolExecutor(2) as pool:
+            prober = pool.submit(probe_b)
+            spec = pool.submit(st.api, "A", "POST",
+                               f"/api/v1/workspaces/{ws}/spec",
+                               {"tier": target}, False, 300)
+            scode, stext = spec.result()
+            stop_probing = True
+            prober.result()
+
+        if scode != 200:
+            return False, f"/spec failed: {scode} {stext[:200]} ws={ws}"
+        sandbox_after = st.pq(
+            f"SELECT sandbox_id FROM workspaces WHERE workspace_id='{ws}'")
+        if not sandbox_after or sandbox_after == sandbox_before:
+            return False, (f"sandbox_id did not change ({sandbox_before!r}) — "
+                           f"/spec did not recreate; ws={ws}")
+
+        # 4. B must converge to the real content, not merely stop 404ing.
+        converged, last = False, ""
+        deadline = time.time() + 120
+        while time.time() < deadline:
+            c, t = st.api("B", "GET", read_path, max_time=30)
+            b_codes.append(c)
+            last = f"{c} {t[:160]}"
+            if c == 200 and sentinel in t:
+                converged = True
+                break
+            if c == 404:  # the reported bug: absence claimed for a live file
+                break
+            time.sleep(3)
+
+        # 5. B must have *noticed*, not just gotten lucky on a cold cache.
+        # Scoped to THIS workspace: /tmp/gate_B.log is opened append-only and
+        # survives teardown, so a bare 'is stale' count is satisfied by any
+        # previous run's detection and would keep passing after a regression.
+        log = sh(["docker", "exec", st.backend, "sh", "-c",
+                  f"grep -c 'Cached session for {ws} is stale' "
+                  "/tmp/gate_B.log || true"]).stdout.strip()
+        noticed = (log or "0") != "0"
+        never_404 = 404 not in b_codes
+        ok = converged and never_404 and noticed
+        return ok, (f"sandbox {sandbox_before[:8]}→{sandbox_after[:8]} "
+                    f"B_codes={sorted(set(b_codes))} converged={converged} "
+                    f"stale_detections={log} last={last} ws={ws}")
+    finally:
+        # Before teardown_workers, or the Daytona sandbox leaks and bills on.
+        st.api("A", "DELETE", f"/api/v1/workspaces/{ws}", max_time=180)
+
+
 CELLS = {
     "1": ("Two-process START slot exclusivity", cell_1_start_race),
     "7": ("Cancel: cross-worker + idempotent", cell_7_cancel_races),
@@ -392,6 +507,7 @@ CELLS = {
     "10": ("Delete vs live run → 409", cell_10_delete_vs_live),
     "13": ("Request-key replay → one run", cell_13_request_key_replay),
     "14": ("Retry race → one attempt-2", cell_14_retry_race),
+    "18": ("Sandbox replaced behind a worker → re-attach", cell_18_sandbox_replacement),
     "2": ("SIGKILL mid-run → scanner finalize", cell_2_sigkill_scanner),
     "17": ("Graceful SIGTERM with open run", cell_17_graceful_sigterm),
 }

--- a/src/ptc_agent/agent/backends/sandbox.py
+++ b/src/ptc_agent/agent/backends/sandbox.py
@@ -225,7 +225,15 @@ class SandboxBackend(SandboxBackendProtocol):
             if reserved is None:
                 return WriteResult(error=f"Failed to reserve '{normalized_path}'")
 
-        ok = await self.sandbox.awrite_file_text(normalized_path, content)
+        try:
+            ok = await self.sandbox.awrite_file_text(normalized_path, content)
+        except Exception as exc:
+            # A sandbox failure has to come back as a tool error, like every
+            # other method here. The large-result eviction middleware writes
+            # through this path from *outside* the tool-error middleware, so an
+            # exception escaping here is never caught and kills the whole turn.
+            logger.exception("Failed to write file", path=normalized_path)
+            return WriteResult(error=f"write_failed: {exc}")
         if not ok:
             return WriteResult(error=f"Failed to write to '{normalized_path}'")
 
@@ -246,19 +254,32 @@ class SandboxBackend(SandboxBackendProtocol):
     ) -> EditResult:
         """Edit a file by exact-string replacement."""
         normalized_path = self._normalize_path(file_path)
-        result = await self.sandbox.aedit_file_text(
-            normalized_path,
-            old_string,
-            new_string,
-            replace_all=replace_all,
-        )
+        try:
+            result = await self.sandbox.aedit_file_text(
+                normalized_path,
+                old_string,
+                new_string,
+                replace_all=replace_all,
+            )
+        except Exception as exc:
+            logger.exception("Failed to edit file", path=normalized_path)
+            return EditResult(error=f"edit_failed: {exc}")
         if not result.get("success"):
             return EditResult(error=str(result.get("error", "Edit failed")))
 
         occurrences = int(result.get("occurrences", 1))
         content = None
         if self.operation_callback:
-            content = await self.sandbox.aread_file_text(normalized_path)
+            try:
+                content = await self.sandbox.aread_file_text(normalized_path)
+            except Exception:
+                # The edit is already committed. Now that a read raises instead
+                # of returning None, letting this escape would fail the whole
+                # tool call over a snapshot the callback can do without.
+                logger.warning(
+                    "Could not read back edited file for the operation callback",
+                    path=normalized_path,
+                )
         self._invoke_operation_callback(
             "edit_file",
             normalized_path,
@@ -359,9 +380,12 @@ class SandboxBackend(SandboxBackendProtocol):
                 if content is None:
                     return FileDownloadResponse(path=p, error="file_not_found")
                 return FileDownloadResponse(path=p, content=content)
-            except Exception:
+            except Exception as exc:
+                # Never report a sandbox failure as file_not_found: the agent
+                # reads that as "this file does not exist" and moves on, quietly
+                # building on missing data instead of retrying.
                 logger.exception("Failed to download file", path=p)
-                return FileDownloadResponse(path=p, error="file_not_found")
+                return FileDownloadResponse(path=p, error=f"read_failed: {exc}")
 
         return await asyncio.gather(*[_download_one(p) for p in paths])
 
@@ -375,9 +399,13 @@ class SandboxBackend(SandboxBackendProtocol):
                 if ok:
                     return FileUploadResponse(path=path)
                 return FileUploadResponse(path=path, error="permission_denied")
-            except Exception:
+            except Exception as exc:
+                # Mirrors the download path: never report a sandbox failure as a
+                # per-path verdict. "permission_denied" reads to the agent as
+                # "this path is not writable", so it stops trying instead of
+                # retrying something that was only ever temporarily unreachable.
                 logger.exception("Failed to upload file", path=path)
-                return FileUploadResponse(path=path, error="permission_denied")
+                return FileUploadResponse(path=path, error=f"write_failed: {exc}")
 
         return await asyncio.gather(*[_upload_one(p, c) for p, c in files])
 

--- a/src/ptc_agent/config/utils.py
+++ b/src/ptc_agent/config/utils.py
@@ -320,6 +320,17 @@ def configure_structlog(level: str = "INFO") -> None:
             # NOTE: ConsoleRenderer formats exceptions itself; do NOT add
             # structlog.processors.format_exc_info upstream of it or structlog
             # warns about double-processing.
-            structlog.dev.ConsoleRenderer(),
+            #
+            # show_locals defaults to True, which writes every frame local into
+            # the log: a single handled `exc_info=True` becomes ~100 lines, and
+            # the locals go out verbatim — sandbox commands, script bodies,
+            # anything holding a token. Log output never passes through
+            # src/server/utils/secret_redactor.py (that covers user-facing file
+            # content), so this was the one path that could print a credential.
+            structlog.dev.ConsoleRenderer(
+                exception_formatter=structlog.dev.RichTracebackFormatter(
+                    show_locals=False
+                )
+            ),
         ],
     )

--- a/src/ptc_agent/core/sandbox/files.py
+++ b/src/ptc_agent/core/sandbox/files.py
@@ -22,6 +22,9 @@ from src.observability import (
 from ptc_agent.core.paths import ALWAYS_HIDDEN_DIR_NAMES
 from ptc_agent.core.sandbox.retry import RetryPolicy
 from ptc_agent.core.sandbox.runtime import (
+    RuntimeState,
+    SandboxFailureKind,
+    SandboxGoneError,
     SandboxTransientError,
 )
 
@@ -35,6 +38,97 @@ if TYPE_CHECKING:
     from ptc_agent.core.sandbox.ptc_sandbox import PTCSandbox
 
 logger = structlog.get_logger(__name__)
+
+# States a sandbox can still come back from. ``reconnect`` knows how to start a
+# stopped or archived sandbox, so reporting those as Gone would answer a merely
+# idle sandbox by deleting it and rebuilding from the last backup — losing
+# everything written since. Only an unrecoverable state counts as absence.
+#
+# ERROR belongs here for that same reason: ``reconnect`` answers an error-state
+# sandbox with a recovery ``start`` rather than giving up on it, so calling it
+# absence here would destroy a sandbox that path would have revived.
+_RECOVERABLE_STATES = frozenset(
+    {
+        RuntimeState.RUNNING,
+        RuntimeState.STARTING,
+        RuntimeState.STOPPED,
+        RuntimeState.STOPPING,
+        RuntimeState.ARCHIVED,
+        RuntimeState.ERROR,
+    }
+)
+
+
+async def _raise_normalized(
+    sandbox: "PTCSandbox", exc: Exception, *, op: str, path: str
+) -> None:
+    """Re-raise *exc* as a ``Sandbox*`` error, or return if it is confirmed absence.
+
+    The single place this module decides what a failure means. Returning is the
+    caller's licence to emit its "not there" sentinel; every other outcome
+    raises, because a sentinel that also means "I couldn't reach the sandbox" is
+    what turned a replaced sandbox into "File not found — the file has been
+    deleted" for files that existed.
+
+    ``SandboxGoneError``/``SandboxTransientError`` are ``RuntimeError`` subclasses,
+    so HTTP call sites keep mapping them to 503; raw SDK errors are not, and
+    would surface as a 500.
+    """
+    if isinstance(exc, (SandboxTransientError, SandboxGoneError)):
+        raise exc
+
+    kind = sandbox.provider.classify_error(exc)
+
+    if kind is SandboxFailureKind.PATH_ABSENT:
+        logger.debug(
+            "Sandbox path not found", op=op, filepath=path, error=str(exc)
+        )
+        return
+
+    if kind is SandboxFailureKind.SANDBOX_GONE:
+        raise SandboxGoneError(str(sandbox.sandbox_id or "unknown"), str(exc)) from exc
+
+    if kind is SandboxFailureKind.TRANSIENT:
+        raise SandboxTransientError(f"{op} failed on {path}: {exc}") from exc
+
+    # UNKNOWN — undecidable from the exception alone (a deleted sandbox answers a
+    # bulk download with a status-less 404). Ask the control plane which it was
+    # instead of guessing; this costs a round trip but only on failures we
+    # genuinely cannot classify.
+    raise await _classify_by_liveness(sandbox, exc, op=op, path=path) from exc
+
+
+async def _classify_by_liveness(
+    sandbox: "PTCSandbox", exc: Exception, *, op: str, path: str
+) -> Exception:
+    """Decide gone-vs-transient for an unclassifiable failure by probing the runtime.
+
+    Uses ``refresh_state`` deliberately: ``get_state`` reads the SDK's cached
+    ``.state`` and would confirm a sandbox that has been deleted for an hour.
+    """
+    runtime = sandbox.runtime
+    sandbox_id = str(sandbox.sandbox_id or "unknown")
+    if runtime is None:
+        return SandboxTransientError(f"{op} failed on {path} with no runtime: {exc}")
+
+    try:
+        state = await runtime.refresh_state()
+    except Exception as probe_exc:
+        if sandbox.provider.classify_error(probe_exc) is SandboxFailureKind.SANDBOX_GONE:
+            return SandboxGoneError(sandbox_id, str(exc))
+        logger.warning(
+            "Could not confirm sandbox liveness after an unclassifiable failure",
+            op=op,
+            filepath=path,
+            sandbox_id=sandbox_id,
+            error=str(exc),
+            probe_error=str(probe_exc),
+        )
+        return SandboxTransientError(f"{op} failed on {path}: {exc}")
+
+    if state not in _RECOVERABLE_STATES:
+        return SandboxGoneError(sandbox_id, f"state={state.value}: {exc}")
+    return SandboxTransientError(f"{op} failed on {path}: {exc}")
 
 
 def _normalize_search_path(sandbox: "PTCSandbox", path: str) -> str:
@@ -62,9 +156,10 @@ async def adownload_file_bytes(sandbox: "PTCSandbox", filepath: str) -> bytes | 
         semaphore to limit event-loop pressure from concurrent downloads.
 
         Returns:
-            Bytes if downloaded, or None if missing.
+            Bytes if downloaded, or None if the file genuinely does not exist.
 
         Raises:
+            SandboxGoneError: If the sandbox itself is no longer there.
             SandboxTransientError: If a transient sandbox transport error persists.
         """
     await sandbox._wait_ready()
@@ -79,19 +174,17 @@ async def adownload_file_bytes(sandbox: "PTCSandbox", filepath: str) -> bytes | 
         if result:
             safe_record(workspace_fs_bytes, len(result), {"op": "read"})
         return result
-    except SandboxTransientError:
-        raise
     except Exception as e:
-        logger.debug(
-            "Failed to download file bytes", filepath=filepath, error=str(e)
-        )
+        await _raise_normalized(sandbox, e, op="download_file", path=filepath)
         return None
 
 
 async def aread_file_text(sandbox: "PTCSandbox", filepath: str) -> str | None:
     """Read a UTF-8 text file from the sandbox.
 
-        This path is safe to retry automatically.
+        This path is safe to retry automatically. ``None`` means absent (or not
+        decodable as UTF-8); sandbox failures propagate from
+        ``adownload_file_bytes``.
         """
     content_bytes = await sandbox.adownload_file_bytes(filepath)
     if not content_bytes:
@@ -109,8 +202,12 @@ async def aupload_file_bytes(sandbox: "PTCSandbox", filepath: str, content: byte
     """Upload raw bytes to the sandbox.
 
         This path is safe to retry automatically because uploads overwrite the target.
+        ``False`` means the path was rejected by validation — a sandbox failure
+        raises, since silently reporting "write failed" for an unreachable sandbox
+        makes a recoverable outage look like a permission problem.
 
         Raises:
+            SandboxGoneError: If the sandbox itself is no longer there.
             SandboxTransientError: If a transient sandbox transport error persists.
         """
     await sandbox._wait_ready()
@@ -135,10 +232,11 @@ async def aupload_file_bytes(sandbox: "PTCSandbox", filepath: str, content: byte
         )
         safe_record(workspace_fs_bytes, len(content), {"op": "write"})
         return True
-    except SandboxTransientError:
-        raise
     except Exception as e:
-        logger.debug(
+        # A write has no "absent" outcome, so a returned PATH_ABSENT (e.g. a
+        # missing parent directory) is still a failure for this caller.
+        await _raise_normalized(sandbox, e, op="upload_file", path=normalized_path)
+        logger.warning(
             "Failed to upload file bytes",
             filepath=filepath,
             normalized_path=normalized_path,
@@ -191,10 +289,13 @@ async def aread_file_range(
         if result.exit_code != 0:
             return await sandbox._aread_file_range_fallback(file_path, offset, limit)
         return result.stdout or ""
-    except SandboxTransientError:
-        raise
     except Exception as e:
-        logger.debug("Failed to read file range", filepath=file_path, error=str(e))
+        # The fallback re-reads through ``aread_file_text``, which now raises on
+        # sandbox failures — so falling back is only meaningful when the sandbox
+        # is actually reachable. Normalize first so an unreachable sandbox
+        # surfaces instead of burning a second doomed round trip.
+        await _raise_normalized(sandbox, e, op="read_file_range", path=normalized)
+        logger.warning("Failed to read file range", filepath=file_path, error=str(e))
         return await sandbox._aread_file_range_fallback(file_path, offset, limit)
 
 
@@ -334,51 +435,56 @@ def validate_and_normalize_path(sandbox: "PTCSandbox", path: str) -> tuple[str, 
 async def als_directory(sandbox: "PTCSandbox", directory: str = ".") -> list[dict[str, Any]]:
     """List contents of a directory.
 
-        Returns entries as dicts with at least: name, path, is_dir.
+        Returns entries as dicts with at least: name, path, is_dir. An empty list
+        means the directory is empty or absent — a sandbox failure raises, because
+        "200 with no files" for a broken sandbox reads as a deliberately emptied
+        workspace.
         """
     await sandbox._wait_ready()
 
-    try:
-        if sandbox.config.filesystem.enable_path_validation and not sandbox.validate_path(
-            directory
-        ):
-            logger.error(
-                f"Access denied: {directory} is not in allowed directories"
-            )
-            return []
+    if sandbox.config.filesystem.enable_path_validation and not sandbox.validate_path(
+        directory
+    ):
+        logger.error(f"Access denied: {directory} is not in allowed directories")
+        return []
 
+    try:
         assert sandbox.runtime is not None
         file_infos = await sandbox._runtime_call(
             sandbox.runtime.list_files,
             directory,
             retry_policy=RetryPolicy.SAFE,
         )
-        if not file_infos:
-            return []
-
-        results: list[dict[str, Any]] = []
-        for entry in file_infos:
-            name = _entry_name(entry)
-            is_dir = _entry_is_dir(entry)
-            entry_path = f"{directory}/{name}" if directory != "." else name
-            results.append({"name": name, "path": entry_path, "is_dir": is_dir})
-        return results
     except Exception as e:
-        logger.debug("Error listing directory", directory=directory, error=str(e))
+        await _raise_normalized(sandbox, e, op="list_files", path=directory)
         return []
+
+    if not file_infos:
+        return []
+
+    results: list[dict[str, Any]] = []
+    for entry in file_infos:
+        name = _entry_name(entry)
+        is_dir = _entry_is_dir(entry)
+        entry_path = f"{directory}/{name}" if directory != "." else name
+        results.append({"name": name, "path": entry_path, "is_dir": is_dir})
+    return results
 
 
 async def acreate_directory(sandbox: "PTCSandbox", dirpath: str) -> bool:
-    """Create a directory in the sandbox."""
+    """Create a directory in the sandbox.
+
+        ``False`` means path validation rejected it; sandbox failures raise.
+        """
     await sandbox._wait_ready()
 
-    try:
-        if sandbox.config.filesystem.enable_path_validation and not sandbox.validate_path(
-            dirpath
-        ):
-            logger.error(f"Access denied: {dirpath} is not in allowed directories")
-            return False
+    if sandbox.config.filesystem.enable_path_validation and not sandbox.validate_path(
+        dirpath
+    ):
+        logger.error(f"Access denied: {dirpath} is not in allowed directories")
+        return False
 
+    try:
         assert sandbox.runtime is not None
         await sandbox._runtime_call(
             sandbox.runtime.exec,
@@ -387,7 +493,8 @@ async def acreate_directory(sandbox: "PTCSandbox", dirpath: str) -> bool:
         )
         return True
     except Exception as e:
-        logger.debug("Failed to create directory", dirpath=dirpath, error=str(e))
+        await _raise_normalized(sandbox, e, op="mkdir", path=dirpath)
+        logger.warning("Failed to create directory", dirpath=dirpath, error=str(e))
         return False
 
 
@@ -421,7 +528,8 @@ async def acreate_directories(sandbox: "PTCSandbox", dirpaths: Iterable[str]) ->
         )
         return True
     except Exception as e:
-        logger.debug(
+        await _raise_normalized(sandbox, e, op="mkdir_bulk", path=paths[0])
+        logger.warning(
             "Failed to bulk-create directories",
             count=len(paths),
             error=str(e),
@@ -440,18 +548,20 @@ async def aedit_file_text(
     """Async edit for tools; safe to retry underlying I/O.
 
         This does not retry the logical edit itself; it only makes file I/O resilient.
+        Sandbox failures propagate rather than becoming ``{"success": False}`` — the
+        agent must not read "the sandbox is unreachable" as "your edit was wrong".
         """
     await sandbox._wait_ready()
 
-    try:
-        if sandbox.config.filesystem.enable_path_validation and not sandbox.validate_path(
-            filepath
-        ):
-            return {
-                "success": False,
-                "error": f"Access denied: {filepath} is not in allowed directories",
-            }
+    if sandbox.config.filesystem.enable_path_validation and not sandbox.validate_path(
+        filepath
+    ):
+        return {
+            "success": False,
+            "error": f"Access denied: {filepath} is not in allowed directories",
+        }
 
+    try:
         content = await sandbox.aread_file_text(filepath)
         if content is None:
             return {"success": False, "error": "File not found"}
@@ -494,8 +604,10 @@ async def aedit_file_text(
             "message": "File edited successfully",
         }
 
+    except (SandboxGoneError, SandboxTransientError):
+        raise
     except Exception as e:
-        logger.debug("Async edit_file failed", filepath=filepath, error=str(e))
+        logger.warning("Async edit_file failed", filepath=filepath, error=str(e))
         return {"success": False, "error": f"Edit operation failed: {e!s}"}
 
 
@@ -518,20 +630,25 @@ def _validate_path_allow_denied(sandbox: "PTCSandbox", path: str) -> bool:
 async def aglob_files(
     sandbox: "PTCSandbox", pattern: str, path: str = ".", *, allow_denied: bool = False
 ) -> list[str]:
-    """Async glob; safe to retry automatically."""
+    """Async glob; safe to retry automatically.
+
+        An empty list means no matches. A broken sandbox raises — returning ``[]``
+        made "the sandbox is unreachable" indistinguishable from "this workspace
+        has no files", which call sites then reported as success.
+        """
     await sandbox._wait_ready()
 
-    try:
-        if sandbox.config.filesystem.enable_path_validation:
-            is_allowed = (
-                sandbox._validate_path_allow_denied(path)
-                if allow_denied
-                else sandbox.validate_path(path)
-            )
-            if not is_allowed:
-                logger.error(f"Access denied: {path} is not in allowed directories")
-                return []
+    if sandbox.config.filesystem.enable_path_validation:
+        is_allowed = (
+            sandbox._validate_path_allow_denied(path)
+            if allow_denied
+            else sandbox.validate_path(path)
+        )
+        if not is_allowed:
+            logger.error(f"Access denied: {path} is not in allowed directories")
+            return []
 
+    try:
         search_path = sandbox._normalize_search_path(path)
 
         if "**" not in pattern and "/" not in pattern:
@@ -612,6 +729,7 @@ async def aglob_files(
         return output.split("\n")
 
     except Exception as e:
+        await _raise_normalized(sandbox, e, op="glob", path=path)
         logger.warning(
             "Async glob failed", pattern=pattern, path=path, error=str(e)
         )
@@ -635,16 +753,19 @@ async def agrep_content(
     head_limit: int | None = None,
     offset: int = 0,
 ) -> Any:
-    """Async ripgrep; safe to retry automatically."""
+    """Async ripgrep; safe to retry automatically.
+
+        An empty result means no matches; a broken sandbox raises.
+        """
     await sandbox._wait_ready()
 
-    try:
-        if sandbox.config.filesystem.enable_path_validation and not sandbox.validate_path(
-            path
-        ):
-            logger.error(f"Access denied: {path} is not in allowed directories")
-            return []
+    if sandbox.config.filesystem.enable_path_validation and not sandbox.validate_path(
+        path
+    ):
+        logger.error(f"Access denied: {path} is not in allowed directories")
+        return []
 
+    try:
         cmd = ["rg"]
         if output_mode == "files_with_matches":
             cmd.append("-l")
@@ -716,5 +837,6 @@ async def agrep_content(
         return results_strs
 
     except Exception as e:
-        logger.debug("Async grep failed", pattern=pattern, path=path, error=str(e))
+        await _raise_normalized(sandbox, e, op="grep", path=path)
+        logger.warning("Async grep failed", pattern=pattern, path=path, error=str(e))
         return []

--- a/src/ptc_agent/core/sandbox/providers/daytona.py
+++ b/src/ptc_agent/core/sandbox/providers/daytona.py
@@ -31,6 +31,7 @@ from ptc_agent.core.sandbox.runtime import (
     ExecResult,
     PreviewInfo,
     RuntimeState,
+    SandboxFailureKind,
     SandboxProvider,
     SandboxRuntime,
     SessionCommandResult,
@@ -41,6 +42,8 @@ from ptc_agent.core.sandbox.platform_secrets import (
 )
 from ptc_agent.core.sandbox.providers.daytona_secrets import (
     DaytonaSecretReconciler,
+    daytona_error_code as _daytona_error_code,
+    daytona_error_status as _daytona_error_status,
     is_transient_daytona_error,
 )
 
@@ -496,6 +499,39 @@ class DaytonaProvider(SandboxProvider):
     def is_transient_error(self, exc: Exception) -> bool:
         """Classify whether *exc* is a transient Daytona SDK error."""
         return is_transient_daytona_error(exc)
+
+    def classify_error(self, exc: Exception) -> SandboxFailureKind:
+        """Classify a Daytona failure from its structured error metadata.
+
+        ``DaytonaError`` carries ``status_code`` and a machine-readable
+        ``error_code``; both are needed because a missing *file* and a missing
+        *sandbox* are both HTTP 404. Measured against the live API (SDK 0.200.1):
+        a per-path miss reports ``FILE_NOT_FOUND``, a dead sandbox reports
+        ``NOT_FOUND``, and a bulk-download against a deleted sandbox reports
+        *neither* — it arrives with no status at all, which is why status-less
+        failures must stay ``UNKNOWN`` instead of collapsing into "absent".
+
+        Absence is checked before ``is_transient_daytona_error`` for the reason
+        the base classifier gives: that helper scans the message, and the server
+        echoes the path into it ("file not found: /home/workspace/x.log"), so a
+        missing file named ``session_timeout.log`` read as a timeout and turned
+        an ordinary 404 into a permanent 503. The 404 → ``SANDBOX_GONE`` check
+        deliberately stays *after* the scan: gone authorizes destroying and
+        replacing the sandbox, so a transient-looking failure must not reach it.
+        """
+        error_code = _daytona_error_code(exc)
+        if error_code == "FILE_NOT_FOUND":
+            return SandboxFailureKind.PATH_ABSENT
+
+        if is_transient_daytona_error(exc):
+            return SandboxFailureKind.TRANSIENT
+
+        status = _daytona_error_status(exc)
+        if status == 404:
+            return SandboxFailureKind.SANDBOX_GONE
+        if status == 429 or (status is not None and 500 <= status <= 599):
+            return SandboxFailureKind.TRANSIENT
+        return SandboxFailureKind.UNKNOWN
 
     # -- Snapshot management --
 

--- a/src/ptc_agent/core/sandbox/providers/daytona_secrets.py
+++ b/src/ptc_agent/core/sandbox/providers/daytona_secrets.py
@@ -17,6 +17,42 @@ from ptc_agent.core.sandbox.platform_secrets import (
 logger = structlog.get_logger(__name__)
 
 
+def daytona_error_status(exc: Exception) -> int | None:
+    """Extract an HTTP status through SDK wrapper exception chains."""
+
+    return _walk_chain_attrs(exc, ("status", "status_code"))
+
+
+def daytona_error_code(exc: Exception) -> str | None:
+    """Extract the SDK's machine-readable ``error_code`` through wrapper chains.
+
+    Structured and stable where the message text is not — it is what separates a
+    per-path ``FILE_NOT_FOUND`` from a sandbox-level ``NOT_FOUND``, both of which
+    arrive as HTTP 404.
+    """
+
+    code = _walk_chain_attrs(exc, ("error_code",))
+    return str(code) if code else None
+
+
+def _walk_chain_attrs(exc: Exception, attrs: tuple[str, ...]) -> Any | None:
+    """First truthy *attrs* value found walking the ``__cause__``/``__context__`` chain."""
+
+    current: BaseException | None = exc
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        for attr in attrs:
+            value = getattr(current, attr, None)
+            if attr in ("status", "status_code"):
+                if isinstance(value, int):
+                    return value
+            elif value:
+                return value
+        current = current.__cause__ or current.__context__
+    return None
+
+
 def is_transient_daytona_error(exc: Exception) -> bool:
     """Classify a Daytona SDK error as transient (retryable).
 
@@ -208,13 +244,4 @@ class DaytonaSecretReconciler:
     def _exception_status(exc: Exception) -> int | None:
         """Extract an HTTP status through SDK wrapper exception chains."""
 
-        current: BaseException | None = exc
-        seen: set[int] = set()
-        while current is not None and id(current) not in seen:
-            seen.add(id(current))
-            for attr in ("status", "status_code"):
-                status = getattr(current, attr, None)
-                if isinstance(status, int):
-                    return status
-            current = current.__cause__ or current.__context__
-        return None
+        return daytona_error_status(exc)

--- a/src/ptc_agent/core/sandbox/ptc_sandbox.py
+++ b/src/ptc_agent/core/sandbox/ptc_sandbox.py
@@ -21,6 +21,7 @@ from ptc_agent.core.sandbox.retry import RetryPolicy, async_retry_with_backoff
 from ptc_agent.core.sandbox.runtime import (
     PreviewInfo,
     RuntimeState,
+    SandboxFailureKind,
     SandboxGoneError,
     SandboxRuntime,
     SandboxTransientError,
@@ -150,17 +151,30 @@ class PTCSandbox:
         return [s for s in self.config.mcp.servers if is_untrusted_server(s)]
 
     async def _wait_ready(self) -> None:
-        """Wait for sandbox to be ready. Call at start of methods needing sandbox."""
+        """Wait for sandbox to be ready. Call at start of methods needing sandbox.
+
+        Raises typed sandbox errors, never a bare ``RuntimeError``: this runs
+        *before* the ``try`` that normalizes each operation's failures, so an
+        untyped error here escapes every classifier downstream — the HTTP layer
+        turns "sandbox isn't up yet" into a 500 instead of a 503, and the chat
+        funnel stops recognizing it as a sandbox condition at all.
+
+        The wording matters too. The file panel selects its "starting" card by
+        looking for that word in the detail, so only the genuinely-in-flight case
+        may claim it.
+        """
         if self._ready_event is None:
             # Not using lazy init - sandbox should already be ready
             if self.runtime is None:
-                raise RuntimeError("Sandbox not initialized")
+                raise SandboxTransientError("Sandbox is not initialized")
             return
 
         try:
             await asyncio.wait_for(self._ready_event.wait(), timeout=300)
         except asyncio.TimeoutError:
-            raise RuntimeError("Sandbox initialization timed out after 300s")
+            raise SandboxTransientError(
+                "Sandbox is still starting: initialization timed out after 300s"
+            )
 
         if self._init_error:
             raise self._init_error
@@ -214,6 +228,12 @@ class PTCSandbox:
         if self._init_task is not None:
             return  # Already started
 
+        # Bind the intended identity synchronously. ``reconnect`` only sets
+        # ``sandbox_id`` after ``provider.get`` returns, so without this a
+        # still-initializing sandbox has no identity for callers to validate
+        # against the workspace row — and a stale handle would be handed out on
+        # the "still initializing" fast path unchecked.
+        self.sandbox_id = sandbox_id
         self._ready_event = asyncio.Event()
         self._init_task = asyncio.create_task(
             self._lazy_reconnect(sandbox_id, on_state_observed=on_state_observed)
@@ -236,7 +256,9 @@ class PTCSandbox:
             # with no error, and concurrent _wait_ready() callers
             # proceed with a None runtime.
             logger.debug("Lazy sandbox init cancelled", sandbox_id=sandbox_id)
-            self._init_error = RuntimeError("Sandbox init was cancelled")
+            # Typed, because _wait_ready re-raises this verbatim — see its
+            # docstring on why a bare RuntimeError escapes every classifier.
+            self._init_error = SandboxTransientError("Sandbox init was cancelled")
         except Exception as e:
             logger.error("Lazy sandbox init failed", error=str(e))
             self._init_error = e
@@ -680,8 +702,25 @@ class PTCSandbox:
                 retry_policy=RetryPolicy.SAFE,
                 allow_reconnect=False,
             )
+        except SandboxTransientError:
+            # A transport blip is NOT a missing sandbox. Converting every failure
+            # here into SandboxGoneError made a network hiccup trigger recovery —
+            # which creates a replacement sandbox and abandons the real one, and
+            # several workers can do it at once.
+            raise
         except Exception as e:
-            raise SandboxGoneError(sandbox_id, f"not found: {e}") from e
+            # Only a positively identified absence may authorize Gone. The caller
+            # answers Gone by building a replacement and abandoning this sandbox,
+            # so an undecidable failure must not reach it: UNKNOWN is where a
+            # rotated or under-privileged provider key (401/403) lands, and there
+            # the sandbox is fine and the credential is not. Treating that as
+            # absence recreates a live sandbox on every request and leaks the
+            # original each time.
+            if self.provider.classify_error(e) is SandboxFailureKind.SANDBOX_GONE:
+                raise SandboxGoneError(sandbox_id, f"not found: {e}") from e
+            raise SandboxTransientError(
+                f"Could not reach sandbox {sandbox_id}: {e}"
+            ) from e
         _mark_rc("provider_get")
 
         assert self.runtime is not None
@@ -734,9 +773,16 @@ class PTCSandbox:
                 if state_value == "running":
                     break
             if state_value != "running":
-                raise SandboxGoneError(
-                    sandbox_id,
-                    f"stuck in state '{state_value}', expected 'running'",
+                # Transient, not gone: the state was just read back, which is
+                # positive evidence the sandbox exists. ``SandboxGoneError`` is
+                # the authorization to replace, and its handlers in
+                # ``workspace_manager`` call ``_clear_session`` first, which
+                # deletes the runtime — so calling a slow boot "gone" destroys a
+                # live sandbox and restores it from a DB backup. The word
+                # "starting" is load-bearing: it is what renders the retry card.
+                raise SandboxTransientError(
+                    f"Sandbox {sandbox_id} is still starting "
+                    f"(state '{state_value}' after ~20s)"
                 )
             _mark_rc("wait_starting")
         elif state_value == "stopping":
@@ -768,9 +814,11 @@ class PTCSandbox:
                     retry_policy=RetryPolicy.SAFE,
                 )
             else:
-                raise SandboxGoneError(
-                    sandbox_id,
-                    f"stuck in state '{state_value}', expected 'stopped'",
+                # Same reasoning as the 'starting' wait above: still mid-stop is
+                # a sandbox that exists, so this is a retry, not a replacement.
+                raise SandboxTransientError(
+                    f"Sandbox {sandbox_id} has not finished stopping "
+                    f"(state '{state_value}' after ~10s)"
                 )
             _mark_rc("wait_stopping")
         elif state_value == "archived":
@@ -1104,11 +1152,38 @@ class PTCSandbox:
             retry_policy=retry_policy,
             is_transient=self.provider.is_transient_error,
             on_transient=on_transient,
+            rebind=self._make_rebinder(self.runtime) if allow_reconnect else None,
             retries=retries,
             initial_delay_s=initial_delay_s,
             total_timeout=total_timeout,
             **kwargs,
         )
+
+    def _make_rebinder(
+        self, entry_runtime: SandboxRuntime | None
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        """Build the retry-loop hook that re-resolves a method onto a new runtime.
+
+        Callers pass already-bound methods (``sandbox.runtime.download_file``), so
+        after ``_ensure_sandbox_connected`` swaps ``self.runtime`` every remaining
+        attempt ran against the old runtime — whose provider had just been closed,
+        making retries 2-5 guaranteed failures.
+
+        Narrow by construction: rebinding happens only for a method bound to the
+        exact runtime this call started with. ``provider.create``/``provider.get``
+        are bound to the provider, so they are never touched.
+        """
+
+        def rebind(func: Callable[..., Any]) -> Callable[..., Any]:
+            current = self.runtime
+            if entry_runtime is None or current is None or current is entry_runtime:
+                return func
+            if getattr(func, "__self__", None) is not entry_runtime:
+                return func
+            replacement = getattr(current, getattr(func, "__name__", ""), None)
+            return replacement if callable(replacement) else func
+
+        return rebind
 
 
     # Bound concurrent discovery so a burst of servers can't exhaust the

--- a/src/ptc_agent/core/sandbox/retry.py
+++ b/src/ptc_agent/core/sandbox/retry.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import structlog
 
-from ptc_agent.core.sandbox.runtime import SandboxTransientError
+from ptc_agent.core.sandbox.runtime import SandboxGoneError, SandboxTransientError
 
 logger = structlog.get_logger(__name__)
 
@@ -26,6 +26,7 @@ async def async_retry_with_backoff(
     retry_policy: RetryPolicy,
     is_transient: Callable[[Exception], bool],
     on_transient: Callable[[], Awaitable[None]] | None = None,
+    rebind: Callable[[Callable[..., Any]], Callable[..., Any]] | None = None,
     retries: int = 5,
     initial_delay_s: float = 0.25,
     total_timeout: float = 120.0,
@@ -40,6 +41,9 @@ async def async_retry_with_backoff(
         is_transient: Predicate — return True if the exception is transient.
         on_transient: Optional async callback invoked once after the first
             transient error (e.g. to trigger a reconnect).
+        rebind: Optional hook applied to *func* after ``on_transient`` runs. A
+            reconnect can replace the object *func* was bound to, leaving the
+            remaining attempts pointed at a dead receiver; the hook re-resolves it.
         retries: Maximum number of attempts.
         initial_delay_s: Backoff seed (doubles each attempt).
         total_timeout: Hard wall-clock deadline in seconds.
@@ -49,6 +53,9 @@ async def async_retry_with_backoff(
         The return value of *func* on success.
 
     Raises:
+        SandboxGoneError: When the reconnect callback determines the sandbox no
+            longer exists — propagated so the caller can recover rather than
+            burning every remaining attempt against a sandbox that is not there.
         SandboxTransientError: When retries or timeout are exhausted, or when
             an UNSAFE policy encounters a transient error.
     """
@@ -73,11 +80,20 @@ async def async_retry_with_backoff(
                 try:
                     await on_transient()
                     on_transient_called = True
+                except SandboxGoneError:
+                    # The reconnect proved the sandbox is gone — a verdict, not a
+                    # callback failure. Swallowing it costs four more doomed
+                    # attempts and hands the caller a generic transient, so the
+                    # recovery path that recreates the sandbox never runs.
+                    raise
                 except Exception as cb_err:
                     logger.debug(
                         "on_transient callback failed",
                         error=str(cb_err),
                     )
+                else:
+                    if rebind is not None:
+                        func = rebind(func)
 
             if retry_policy == RetryPolicy.UNSAFE:
                 message = (

--- a/src/ptc_agent/core/sandbox/runtime.py
+++ b/src/ptc_agent/core/sandbox/runtime.py
@@ -35,6 +35,21 @@ class SandboxGoneError(RuntimeError):
         super().__init__(full_msg)
 
 
+class SandboxFailureKind(str, Enum):
+    """What a failed sandbox operation actually means.
+
+    Exists so callers never have to infer "the file isn't there" from "the call
+    didn't work". ``UNKNOWN`` is a first-class outcome, not a fallback bucket:
+    a status-less transport failure is genuinely undecidable from the exception
+    alone and must be confirmed against the runtime rather than guessed at.
+    """
+
+    PATH_ABSENT = "path_absent"  # positively identified per-path not-found
+    SANDBOX_GONE = "sandbox_gone"  # the sandbox itself is not there
+    TRANSIENT = "transient"  # transport-level, may succeed on retry
+    UNKNOWN = "unknown"  # undecidable — never treat as absence
+
+
 class RuntimeState(str, Enum):
     """Possible states of a sandbox runtime."""
 
@@ -322,3 +337,26 @@ class SandboxProvider(ABC):
         Providers should override to classify provider-specific errors.
         """
         return False
+
+    def classify_error(self, exc: Exception) -> SandboxFailureKind:
+        """Classify *exc* into a failure kind for callers to act on.
+
+        Providers should override with SDK-specific structured signals (status
+        codes, machine-readable error codes) — never message matching, which
+        breaks silently when a vendor rewords a string. Beyond the two cases
+        below the default cannot tell, so everything else is honestly
+        ``UNKNOWN``.
+
+        ``FileNotFoundError`` is the one absence signal a provider can raise
+        without an SDK of its own, and it is checked before
+        ``is_transient_error`` because that is a message scan: a path like
+        ``/data/connection.log`` would otherwise read as a connection fault.
+        Without it, a provider that cannot say "this path is missing" sends
+        every genuine miss to the liveness probe, which finds the sandbox alive
+        and reports a transient — turning an ordinary 404 into a 503.
+        """
+        if isinstance(exc, FileNotFoundError):
+            return SandboxFailureKind.PATH_ABSENT
+        if self.is_transient_error(exc):
+            return SandboxFailureKind.TRANSIENT
+        return SandboxFailureKind.UNKNOWN

--- a/src/ptc_agent/core/session.py
+++ b/src/ptc_agent/core/session.py
@@ -443,6 +443,15 @@ class SessionManager:
         return cls._sessions[conversation_id]
 
     @classmethod
+    def get_cached_session(cls, conversation_id: str) -> Session | None:
+        """Return the cached session without creating one.
+
+        Lets callers identity-check what this process has cached before evicting
+        it, so a concurrent replacement isn't thrown away.
+        """
+        return cls._sessions.get(conversation_id)
+
+    @classmethod
     def remove_session(cls, conversation_id: str) -> None:
         """Remove a session from cache without stopping it.
 

--- a/src/server/app/mcp_servers.py
+++ b/src/server/app/mcp_servers.py
@@ -306,7 +306,7 @@ async def list_servers(workspace_id: str, user_id: CurrentUserId) -> EffectiveSe
     applied_version: int | None = None
     try:
         applied_version = WorkspaceManager.get_instance().get_applied_mcp_config_version(
-            workspace_id
+            workspace_id, expected_sandbox_id=workspace.get("sandbox_id")
         )
     except Exception:
         logger.debug("[mcp] applied version lookup failed for %s", workspace_id)
@@ -845,16 +845,18 @@ def _get_live_sandbox(workspace_id: str, workspace: dict) -> Any | None:
     """Return the in-memory live sandbox if one is ready, else None.
 
     Reads the cached session directly (no lock, no acquire) so discovery never
-    races the warm/Phase-2 machinery. A stopped/cold workspace ⇒ None, which
-    ``discover_and_cache`` turns into ``pending`` rows.
+    races the warm/Phase-2 machinery, but fenced against the row's binding: a
+    handle for a replaced sandbox would have discovery probe the dead one and
+    persist its schemas under this workspace. A stopped/cold workspace, or a
+    superseded handle, ⇒ None, which ``discover_and_cache`` turns into
+    ``pending`` rows.
     """
     if not _sandbox_running(workspace):
         return None
     try:
-        wm = WorkspaceManager.get_instance()
-        if not wm.has_ready_session(workspace_id):
-            return None
-        session = wm._sessions.get(workspace_id)
+        session = WorkspaceManager.get_instance().get_session_if_ready(
+            workspace_id, expected_sandbox_id=workspace.get("sandbox_id")
+        )
         return session.sandbox if session else None
     except Exception:
         logger.warning(

--- a/src/server/app/public.py
+++ b/src/server/app/public.py
@@ -22,7 +22,9 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Path, Query, Request
 from fastapi.responses import Response, StreamingResponse
 
+from ptc_agent.core.sandbox.runtime import SandboxGoneError, SandboxTransientError
 from src.observability import observe_replay_stream
+from src.server.utils.error_sanitization import single_line
 from src.server.utils.http_headers import content_disposition
 from src.server.utils.secret_redactor import get_redactor, get_vault_secrets_for_redaction
 
@@ -87,6 +89,24 @@ def _prefers_chinese(request: Request) -> bool:
     """Whether the browser's top Accept-Language tag is Chinese."""
     primary = request.headers.get("accept-language", "").split(",")[0].strip().lower()
     return primary.startswith("zh")
+
+
+def _share_unavailable_response(request: Request, status_code: int) -> "Response | None":
+    """The branded page for a failed share serve, or None to keep the JSON error.
+
+    Shared by both failure routes into this page. An ``HTTPException`` raised
+    inside one ``except`` clause is not caught by a sibling clause of the same
+    ``try``, so the sandbox path cannot reach the ``HTTPException`` handler by
+    raising and has to render through here itself.
+    """
+    if status_code not in (403, 404) or not _wants_html(request):
+        return None
+    return Response(
+        content=_share_unavailable_page(status_code, chinese=_prefers_chinese(request)),
+        status_code=status_code,
+        media_type="text/html; charset=utf-8",
+        headers={"Cache-Control": "no-store", "X-Robots-Tag": "noindex"},
+    )
 
 
 def _share_unavailable_page(status_code: int, *, chinese: bool) -> str:
@@ -398,7 +418,9 @@ async def list_shared_files(
     if workspace.get("status") == "running":
         try:
             manager = WorkspaceManager.get_instance()
-            session = manager.get_session_if_ready(workspace_id)
+            session = manager.get_session_if_ready(
+                workspace_id, expected_sandbox_id=workspace.get("sandbox_id")
+            )
             sandbox = getattr(session, "sandbox", None) if session else None
             if sandbox:
                 absolute_paths = await sandbox.aglob_files("**/*", path=path)
@@ -409,8 +431,15 @@ async def list_shared_files(
                         continue
                     files.append(cp)
                 return {"path": path, "files": files, "source": "sandbox"}
-        except Exception:
-            logger.debug(f"Sandbox not available for shared files in workspace {workspace_id}")
+        except Exception as e:
+            # Warning, not debug: this route collapses every sandbox failure into
+            # a uniform 404 on purpose (unauthenticated — a 503 would confirm a
+            # guessed workspace UUID), so the log line is the only place the real
+            # cause survives. At the default INFO level a debug line is dropped.
+            logger.warning(
+                f"Sandbox not available for shared files in workspace "
+                f"{workspace_id}: {single_line(str(e))}"
+            )
 
     return {"path": path, "files": files, "source": "database"}
 
@@ -477,7 +506,9 @@ async def read_shared_file(
     if workspace.get("status") == "running":
         try:
             manager = WorkspaceManager.get_instance()
-            session = manager.get_session_if_ready(workspace_id)
+            session = manager.get_session_if_ready(
+                workspace_id, expected_sandbox_id=workspace.get("sandbox_id")
+            )
             sandbox = getattr(session, "sandbox", None) if session else None
             if sandbox:
                 norm, error = sandbox.validate_and_normalize_path(path)
@@ -514,8 +545,15 @@ async def read_shared_file(
                 }
         except HTTPException:
             raise
-        except Exception:
-            logger.debug(f"Sandbox not available for shared file read in workspace {workspace_id}")
+        except Exception as e:
+            # Warning, not debug: this route collapses every sandbox failure into
+            # a uniform 404 on purpose (unauthenticated — a 503 would confirm a
+            # guessed workspace UUID), so the log line is the only place the real
+            # cause survives. At the default INFO level a debug line is dropped.
+            logger.warning(
+                f"Sandbox not available for shared file read in workspace "
+                f"{workspace_id}: {single_line(str(e))}"
+            )
 
     raise HTTPException(status_code=404, detail="File not found")
 
@@ -582,7 +620,9 @@ async def download_shared_file(
     if workspace.get("status") == "running":
         try:
             manager = WorkspaceManager.get_instance()
-            session = manager.get_session_if_ready(workspace_id)
+            session = manager.get_session_if_ready(
+                workspace_id, expected_sandbox_id=workspace.get("sandbox_id")
+            )
             sandbox = getattr(session, "sandbox", None) if session else None
             if sandbox:
                 norm, error = sandbox.validate_and_normalize_path(path)
@@ -611,8 +651,15 @@ async def download_shared_file(
                 )
         except HTTPException:
             raise
-        except Exception:
-            logger.debug(f"Sandbox not available for shared file download in workspace {workspace_id}")
+        except Exception as e:
+            # Warning, not debug: this route collapses every sandbox failure into
+            # a uniform 404 on purpose (unauthenticated — a 503 would confirm a
+            # guessed workspace UUID), so the log line is the only place the real
+            # cause survives. At the default INFO level a debug line is dropped.
+            logger.warning(
+                f"Sandbox not available for shared file download in workspace "
+                f"{workspace_id}: {single_line(str(e))}"
+            )
 
     raise HTTPException(status_code=404, detail="File not found")
 
@@ -671,15 +718,20 @@ async def serve_shared_file(
             inject_theme=(inject == "theme"),
             workspace=workspace,
         )
+    except (SandboxGoneError, SandboxTransientError):
+        # This route is unauthenticated, so it must never distinguish "sandbox
+        # down" from "no such file" — a 503 would confirm that a guessed
+        # workspace UUID is real. Today serve.py absorbs these before they get
+        # here; this keeps the 404 posture from depending on that.
+        page = _share_unavailable_response(request, 404)
+        if page is not None:
+            return page
+        raise HTTPException(status_code=404, detail="File not found") from None
     except HTTPException as exc:
         # A browser/iframe opening a revoked (404) or forbidden (403) shared link
         # should see a branded page, not raw JSON. Other statuses and API clients
         # (Accept without text/html) keep the default JSON error.
-        if exc.status_code in (403, 404) and _wants_html(request):
-            return Response(
-                content=_share_unavailable_page(exc.status_code, chinese=_prefers_chinese(request)),
-                status_code=exc.status_code,
-                media_type="text/html; charset=utf-8",
-                headers={"Cache-Control": "no-store", "X-Robots-Tag": "noindex"},
-            )
+        page = _share_unavailable_response(request, exc.status_code)
+        if page is not None:
+            return page
         raise

--- a/src/server/app/setup.py
+++ b/src/server/app/setup.py
@@ -34,11 +34,13 @@ os.environ["REQUESTS_CA_BUNDLE"] = certifi.where()
 from contextlib import asynccontextmanager
 from uuid import uuid4
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from starlette.middleware.gzip import GZipMiddleware
 
 from ptc_agent.core.sandbox.platform_secrets import PlatformSecretError
+from ptc_agent.core.sandbox.runtime import SandboxGoneError, SandboxTransientError
 from src.config.logging_config import configure_logging
 from src.config.settings import (
     get_allowed_origins,
@@ -47,6 +49,10 @@ from src.observability import init_otel, init_otel_runtime, shutdown_otel_runtim
 from src.server.services.runs.executor import LocalRunExecutor
 from src.server.services.background_registry_store import BackgroundRegistryStore
 from src.server.utils.api import find_malformed_route_ids  # TEMP (malformed-id-diag)
+from src.server.utils.error_sanitization import (
+    sandbox_unreachable_detail,
+    single_line,
+)
 
 # Phase 1: install fork-safe class-level instrumentor patches BEFORE FastAPI(...)
 # is constructed. FastAPIInstrumentor patches the FastAPI class — must run
@@ -984,6 +990,36 @@ app.add_middleware(
     ],  # Use the configured list of methods
     allow_headers=["*"],  # Now allow all headers, but can be restricted further
 )
+
+
+# ============================================================================
+# Exception Handlers
+# ============================================================================
+
+
+async def _sandbox_unreachable_handler(request: Request, exc: Exception) -> JSONResponse:
+    """Map an unreachable sandbox to 503 once, for every route.
+
+    The detail wording is a wire contract, not a message: the file panel
+    categorizes the error by matching this string, so it must stay identical
+    across producers rather than being re-spelled per route. It is built by
+    ``sandbox_unreachable_detail`` because the raw exception carries provider
+    URLs and SDK response bodies that must not leave the server.
+    """
+    # The exception is the live carrier: it quotes provider response bodies, so
+    # it can hold a newline and a forged entry. Starlette's path is already
+    # CR/LF-free (urlsplit drops them); it is escaped to keep the rule uniform.
+    logger.warning(
+        f"Sandbox unreachable for {single_line(request.url.path)}: {single_line(str(exc))}"
+    )
+    return JSONResponse(
+        status_code=503,
+        content={"detail": sandbox_unreachable_detail(exc)},
+    )
+
+
+app.add_exception_handler(SandboxGoneError, _sandbox_unreachable_handler)
+app.add_exception_handler(SandboxTransientError, _sandbox_unreachable_handler)
 
 
 # ============================================================================

--- a/src/server/app/workspace_files/_shared.py
+++ b/src/server/app/workspace_files/_shared.py
@@ -24,6 +24,10 @@ from ptc_agent.core.paths import (
 )
 from src.server.services.workspace_manager import WorkspaceManager
 from src.server.services import user_data_io
+from src.server.utils.error_sanitization import (
+    sandbox_unreachable_detail,
+    single_line,
+)
 from src.observability import safe_record, workspace_fs_bytes
 
 logger = logging.getLogger(__name__)
@@ -187,11 +191,23 @@ async def _acquire_sandbox(workspace_id: str, user_id: str) -> Any:
     try:
         session = await manager.get_session_for_workspace(workspace_id, user_id=user_id)
     except Exception as e:
-        raise HTTPException(status_code=503, detail=f"Sandbox not ready: {e}") from None
+        # Same wording as the app-level SandboxGoneError/SandboxTransientError
+        # handler: the file panel categorizes on this string, and the "starting"
+        # sub-case has to survive the boundary — which is exactly what
+        # sandbox_unreachable_detail preserves while dropping the raw text.
+        logger.warning(
+            f"Sandbox unreachable for workspace {workspace_id}: {single_line(str(e))}"
+        )
+        raise HTTPException(
+            status_code=503, detail=sandbox_unreachable_detail(e)
+        ) from None
 
     sandbox = getattr(session, "sandbox", None)
     if sandbox is None:
-        raise HTTPException(status_code=503, detail="Sandbox not available")
+        raise HTTPException(
+            status_code=503,
+            detail="Sandbox is not reachable: no sandbox attached to the session",
+        )
     return sandbox
 
 

--- a/src/server/app/workspace_files/crud.py
+++ b/src/server/app/workspace_files/crud.py
@@ -12,6 +12,10 @@ from fastapi import APIRouter, Body, File, HTTPException, Query, Request, Upload
 from pydantic import BaseModel, Field
 
 from src.server.utils.api import CurrentUserId, require_workspace_owner
+from src.server.utils.error_sanitization import (
+    sandbox_unreachable_detail,
+    single_line,
+)
 from src.server.utils.http_headers import content_disposition
 from fastapi.responses import Response
 
@@ -119,26 +123,14 @@ async def list_workspace_files(
     if not wait_for_sandbox and not sandbox.is_ready():
         return {"files": [], "sandbox_ready": False}
 
-    # Pre-check sandbox health before file listing.
-    # aglob_files swallows all exceptions and returns [], which turns a broken
-    # sandbox into "200 with no files". This check surfaces the real error.
-    try:
-        await sandbox.ensure_sandbox_ready()
-    except Exception as e:
-        logger.warning(f"Sandbox health check failed for workspace {workspace_id}: {e}")
-        raise HTTPException(
-            status_code=503,
-            detail=f"Sandbox is not reachable: {e}",
-        )
-
     # Allow explicit listing of hidden internal paths (e.g. _internal/...).
+    # No pre-flight health probe: ``aglob_files`` raises on an unreachable
+    # sandbox rather than returning [], so the glob already reports the truth
+    # and an extra round trip on every listing would buy nothing.
     allow_denied = _requested_hidden_ok(path, work_dir)
-    try:
-        absolute_paths: list[str] = await sandbox.aglob_files(
-            pattern, path=path, allow_denied=allow_denied
-        )
-    except RuntimeError:
-        raise HTTPException(status_code=503, detail="Sandbox is still starting")
+    absolute_paths: list[str] = await sandbox.aglob_files(
+        pattern, path=path, allow_denied=allow_denied
+    )
 
     allow_hidden = _requested_hidden_ok(path, work_dir)
 
@@ -291,11 +283,11 @@ async def read_workspace_file(
     if error:
         raise HTTPException(status_code=403, detail=error)
 
-    # Download raw bytes first to distinguish "not found" from "binary file"
-    try:
-        raw_bytes = await sandbox.adownload_file_bytes(normalized)
-    except RuntimeError:
-        raise HTTPException(status_code=503, detail="Sandbox is still starting")
+    # Download raw bytes first to distinguish "not found" from "binary file".
+    # ``None`` means the file genuinely is not there; an unreachable or replaced
+    # sandbox raises (SandboxGoneError / SandboxTransientError, both
+    # RuntimeError) so it cannot masquerade as "the file was deleted".
+    raw_bytes = await sandbox.adownload_file_bytes(normalized)
     if raw_bytes is None:
         raise HTTPException(status_code=404, detail="File not found")
 
@@ -399,10 +391,7 @@ async def write_workspace_file(
     if error:
         raise HTTPException(status_code=403, detail=error)
 
-    try:
-        ok = await sandbox.awrite_file_text(normalized, body.content)
-    except RuntimeError:
-        raise HTTPException(status_code=503, detail="Sandbox is still starting")
+    ok = await sandbox.awrite_file_text(normalized, body.content)
     if not ok:
         raise HTTPException(status_code=500, detail="Write failed")
 
@@ -507,10 +496,7 @@ async def download_workspace_file(
     if error:
         raise HTTPException(status_code=403, detail=error)
 
-    try:
-        content = await sandbox.adownload_file_bytes(normalized)
-    except RuntimeError:
-        raise HTTPException(status_code=503, detail="Sandbox is still starting")
+    content = await sandbox.adownload_file_bytes(normalized)
     if content is None:
         raise HTTPException(status_code=404, detail="File not found")
 
@@ -575,10 +561,7 @@ async def upload_workspace_file(
             detail=f"File is too large ({size_mb:.1f} MB). Maximum upload size is {limit_mb} MB.",
         )
 
-    try:
-        ok = await sandbox.aupload_file_bytes(normalized, content)
-    except RuntimeError:
-        raise HTTPException(status_code=503, detail="Sandbox is still starting")
+    ok = await sandbox.aupload_file_bytes(normalized, content)
     if not ok:
         raise HTTPException(status_code=500, detail="Upload failed")
 
@@ -618,9 +601,15 @@ async def backup_workspace_files(
     try:
         result = await FilePersistenceService.sync_to_db(workspace_id, sandbox)
     except RuntimeError as e:
+        # Same wording as every other producer: the file panel keys its error
+        # card off this string, so a fourth variant here would render a
+        # different card for the same condition.
+        logger.warning(
+            f"Sandbox unreachable syncing {workspace_id}: {single_line(str(e))}"
+        )
         raise HTTPException(
             status_code=503,
-            detail=f"Sandbox not ready: {e}",
+            detail=sandbox_unreachable_detail(e),
         )
     return {
         "workspace_id": workspace_id,
@@ -786,10 +775,7 @@ async def delete_workspace_files(
     deleted: list[str] = []
     if valid_paths:
         rm_args = " ".join(shlex.quote(p) for p, _ in valid_paths)
-        try:
-            result = await sandbox.execute_bash_command(f"rm -f {rm_args}")
-        except RuntimeError:
-            raise HTTPException(status_code=503, detail="Sandbox is still starting")
+        result = await sandbox.execute_bash_command(f"rm -f {rm_args}")
         if result.get("success"):
             deleted = [cp for _, cp in valid_paths]
         else:

--- a/src/server/app/workspace_files/serve.py
+++ b/src/server/app/workspace_files/serve.py
@@ -10,6 +10,7 @@ from urllib.parse import quote
 from fastapi import APIRouter, HTTPException, Query
 
 from src.config.env import PDF_RENDER_INTERNAL_BASE
+from src.server.utils.error_sanitization import single_line
 from src.server.utils.http_headers import content_disposition
 from fastapi.responses import Response
 
@@ -20,7 +21,6 @@ from src.server.utils.secret_redactor import get_redactor, get_vault_secrets_for
 from src.utils.mime import resolve_content_type
 
 from ._shared import (
-    _acquire_sandbox,
     _is_text_content_type,
     _is_utf8,
     _get_work_dir,
@@ -190,41 +190,49 @@ async def _resolve_serve_bytes(
     """Resolve raw bytes + content type for a file, sandbox-first with DB fallback.
 
     Returns ``(content, content_type)`` or ``None`` when the file is missing.
-    Live bytes are read only when the sandbox is already warm in this worker
-    (``has_ready_session``); otherwise — including a stale ``running`` DB row
-    whose Daytona sandbox has auto-stopped — this falls back to the persisted
-    DB record. This keeps the unauthenticated route from ever waking or
-    recovering a sandbox (denial-of-wallet) from a UUID-only request.
+    Live bytes are read only from a session this worker already holds *and*
+    that still matches the row's binding; anything else — a replaced sandbox, a
+    stale ``running`` row whose sandbox auto-stopped, a cold worker — falls back
+    to the persisted DB record. This keeps the unauthenticated route from ever
+    waking or recovering a sandbox (denial-of-wallet) from a UUID-only request.
     """
     extension_mime = _guess_content_type(normalized_path)
 
-    # Live read only from an already-warm sandbox; short-circuit so the manager
-    # singleton is consulted only on the running path. A stale 'running' DB row
-    # whose Daytona sandbox auto-stopped has no warm session → DB fallback.
+    # Live read only from an already-warm sandbox, resolved in one shot so the
+    # handle is fenced against the row's binding: a session bound to a replaced
+    # sandbox must read as "not warm" here. Going through the acquisition path
+    # instead would retire that handle and re-attach — which is correct for an
+    # authenticated caller and exactly wrong for this route, since it starts or
+    # provisions a sandbox from a UUID-only request. A stale 'running' row whose
+    # sandbox auto-stopped has no warm session either → DB fallback.
     status = workspace.get("status")
-    warm = (
-        status == "running"
-        and WorkspaceManager.get_instance().has_ready_session(workspace_id)
+    session = (
+        WorkspaceManager.get_instance().get_session_if_ready(
+            workspace_id, expected_sandbox_id=workspace.get("sandbox_id")
+        )
+        if status == "running"
+        else None
     )
-    if not warm:
-        return await _db_fallback_bytes(workspace_id, normalized_path, extension_mime)
-
-    # Warm sandbox — read live bytes without any Daytona start/reconnect. If
-    # the session died between has_ready_session() above and here (TOCTOU),
-    # _acquire_sandbox raises 503; absorb it and fall back to the DB record so
-    # the route keeps its uniform-404 posture instead of leaking a 503 that
-    # would confirm the workspace UUID is valid.
-    try:
-        sandbox = await _acquire_sandbox(workspace_id, workspace.get("user_id") or "")
-    except HTTPException:
+    sandbox = getattr(session, "sandbox", None) if session else None
+    if sandbox is None:
         return await _db_fallback_bytes(workspace_id, normalized_path, extension_mime)
     candidate, error = sandbox.validate_and_normalize_path(normalized_path)
     if error:
         return None
     try:
         content = await sandbox.adownload_file_bytes(candidate)
-    except RuntimeError:
-        return None
+    except RuntimeError as e:
+        # Deliberate residual: an unreachable sandbox is indistinguishable from a
+        # missing file on this route. It is unauthenticated, so distinguishing
+        # them (503 vs 404) would confirm that a guessed workspace UUID is real.
+        # Fall back to the persisted copy first so the common case still serves.
+        # Warning, not debug: the response deliberately hides the cause, which
+        # makes this line the only place it survives.
+        logger.warning(
+            f"Sandbox read failed for workspace {workspace_id}; "
+            f"serving the persisted copy instead: {single_line(str(e))}"
+        )
+        return await _db_fallback_bytes(workspace_id, normalized_path, extension_mime)
     if content is None:
         return None
     client_path = _to_client_path(sandbox, candidate)

--- a/src/server/app/workspaces.py
+++ b/src/server/app/workspaces.py
@@ -51,6 +51,8 @@ from src.server.models.workspace import (
     WorkspaceSpecRequest,
     WorkspaceUpdate,
 )
+from ptc_agent.core.sandbox.runtime import SandboxGoneError, SandboxTransientError
+from src.server.utils.error_sanitization import sandbox_unreachable_detail
 from src.server.models.workspace_refresh import WorkspaceRefreshResponse
 from src.server.services.workspace_manager import WorkspaceManager
 from src.server.services.workspace_status_pubsub import subscribe_to_status
@@ -71,6 +73,13 @@ async def _workspace_action_errors(action: str, workspace_id: str):
     try:
         yield
     except HTTPException:
+        raise
+    except (SandboxGoneError, SandboxTransientError):
+        # Before the RuntimeError arm, which these subclass. An unreachable
+        # sandbox is not a bad request: letting it fall through answered 400
+        # with the provider's raw text, which both loses the 503 the file panel
+        # keys on and ships request URLs and SDK bodies to the client. Re-raise
+        # for the app-level handler that owns the wording and the sanitizing.
         raise
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
@@ -856,8 +865,16 @@ async def refresh_workspace(
         session = await manager.get_session_for_workspace(
             workspace_id, user_id=x_user_id
         )
+    except (SandboxGoneError, SandboxTransientError):
+        # Same reasoning as _workspace_action_errors above: re-raise for the
+        # app-level handler that owns both the wording and the sanitizing,
+        # rather than spelling a fourth variant of this 503 here.
+        raise
     except Exception as e:
-        raise HTTPException(status_code=503, detail=f"Sandbox not available: {e}")
+        # Everything else still answers 503, but never with the raw text: this
+        # is the same call _acquire_sandbox makes, and its exceptions quote
+        # provider URLs and sandbox ids.
+        raise HTTPException(status_code=503, detail=sandbox_unreachable_detail(e))
 
     sandbox = getattr(session, "sandbox", None)
     if sandbox is None:

--- a/src/server/database/workspace.py
+++ b/src/server/database/workspace.py
@@ -7,11 +7,13 @@ Each workspace has a 1:1 mapping with a Daytona sandbox.
 
 import logging
 import uuid
+from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 from psycopg.rows import dict_row
 
+from ptc_agent.core.sandbox.runtime import SandboxTransientError
 from src.server.database.pool import get_db_connection
 from src.server.services.workspace_status_pubsub import publish_status_change
 from src.server.utils.pg_sanitize import normalize_uuid
@@ -21,20 +23,35 @@ logger = logging.getLogger(__name__)
 # Deterministic namespace for flash workspace UUIDs
 FLASH_WORKSPACE_NAMESPACE = uuid.UUID("f1a50000-0000-5000-e000-f1a500000000")
 
-# Canonical base column list returned by workspace SELECT/RETURNING queries.
-# Hardcoded literals only (no user data) — safe to interpolate via f-string.
-# Column order and set MUST stay identical across every site; rows are consumed
-# by name via dict_row. `get_workspace` returns this plus `mcp_config_version`.
+# Canonical column list returned by EVERY workspace SELECT/RETURNING query, so
+# callers never have to ask which shape a given helper hands back. Hardcoded
+# literals only (no user data) — safe to interpolate via f-string. Rows are
+# consumed by name via dict_row.
 _WS_COLS = (
     "workspace_id, user_id, name, description, sandbox_id, status, created_at, "
     "updated_at, last_activity_at, stopped_at, config, artifacts, is_pinned, "
-    "sort_order, resource_tier, is_always_on, platform_secret_version"
+    "sort_order, resource_tier, is_always_on, platform_secret_version, "
+    "mcp_config_version"
 )
 
 # Scalar workspace columns that may be set via `_set_workspace_scalar`. The
 # column name is interpolated as a SQL literal (never a bound param), so it must
 # be whitelisted to keep the surface injection-free.
 _SETTABLE_SCALAR_COLUMNS = frozenset({"resource_tier", "is_always_on"})
+
+
+@asynccontextmanager
+async def _ws_cursor(conn=None):
+    """A ``dict_row`` cursor on *conn*, or on a freshly checked-out pooled one.
+
+    Every query here takes an optional connection so callers can compose several
+    writes into one transaction. ``get_db_connection`` owns that passthrough;
+    this only spares each query from writing out the cursor nesting and hoisting
+    its body into a closure to share it.
+    """
+    async with get_db_connection(conn) as owned:
+        async with owned.cursor(row_factory=dict_row) as cur:
+            yield cur
 
 
 def get_flash_workspace_id(user_id: str) -> str:
@@ -56,26 +73,18 @@ async def get_or_create_flash_workspace(
     workspace_id = get_flash_workspace_id(user_id)
     config_json = Json({"flash_mode": True})
 
-    async def _execute(cur):
-        await cur.execute(
-            f"""
-            INSERT INTO workspaces (workspace_id, user_id, name, description, config, status, is_pinned)
-            VALUES (%s, %s, %s, %s, %s, %s, TRUE)
-            ON CONFLICT (workspace_id) DO UPDATE SET updated_at = NOW(), is_pinned = TRUE
-            RETURNING {_WS_COLS}
-            """,
-            (workspace_id, user_id, "Flash", "Flash mode conversations", config_json, "flash"),
-        )
-        return await cur.fetchone()
-
     try:
-        if conn:
-            async with conn.cursor(row_factory=dict_row) as cur:
-                result = await _execute(cur)
-        else:
-            async with get_db_connection() as conn:
-                async with conn.cursor(row_factory=dict_row) as cur:
-                    result = await _execute(cur)
+        async with _ws_cursor(conn) as cur:
+            await cur.execute(
+                f"""
+                INSERT INTO workspaces (workspace_id, user_id, name, description, config, status, is_pinned)
+                VALUES (%s, %s, %s, %s, %s, %s, TRUE)
+                ON CONFLICT (workspace_id) DO UPDATE SET updated_at = NOW(), is_pinned = TRUE
+                RETURNING {_WS_COLS}
+                """,
+                (workspace_id, user_id, "Flash", "Flash mode conversations", config_json, "flash"),
+            )
+            result = await cur.fetchone()
 
         logger.info(f"Upserted flash workspace: {workspace_id} for user: {user_id}")
         return dict(result)
@@ -119,7 +128,7 @@ async def create_workspace(
     try:
         config_json = Json(config) if config else Json({})
 
-        async def _execute(cur):
+        async with _ws_cursor(conn) as cur:
             if workspace_id:
                 # Use specific workspace_id (for flash mode: workspace_id = thread_id)
                 await cur.execute(
@@ -140,15 +149,7 @@ async def create_workspace(
                     """,
                     (user_id, name, description, config_json, status),
                 )
-            return await cur.fetchone()
-
-        if conn:
-            async with conn.cursor(row_factory=dict_row) as cur:
-                result = await _execute(cur)
-        else:
-            async with get_db_connection() as conn:
-                async with conn.cursor(row_factory=dict_row) as cur:
-                    result = await _execute(cur)
+            result = await cur.fetchone()
 
         logger.info(f"Created workspace: {result['workspace_id']} for user: {user_id}")
         return dict(result)
@@ -181,24 +182,16 @@ async def get_workspace(
         return None
 
     try:
-        async def _execute(cur):
+        async with _ws_cursor(conn) as cur:
             await cur.execute(
                 f"""
-                SELECT {_WS_COLS}, mcp_config_version
+                SELECT {_WS_COLS}
                 FROM workspaces
                 WHERE workspace_id = %s AND status != 'deleted'
                 """,
                 (workspace_id,),
             )
-            return await cur.fetchone()
-
-        if conn:
-            async with conn.cursor(row_factory=dict_row) as cur:
-                result = await _execute(cur)
-        else:
-            async with get_db_connection() as conn:
-                async with conn.cursor(row_factory=dict_row) as cur:
-                    result = await _execute(cur)
+            result = await cur.fetchone()
 
         if result:
             return dict(result)
@@ -206,6 +199,38 @@ async def get_workspace(
 
     except Exception as e:
         logger.error(f"Error getting workspace {workspace_id}: {e}")
+        raise
+
+
+async def get_workspace_identity(workspace_id: str) -> Optional[Dict[str, Any]]:
+    """Read only ``status`` + ``sandbox_id`` — the durable identity of a workspace.
+
+    Deliberately narrow so the session-acquisition warm path can validate the
+    handle it is about to hand out on every request without pulling the JSONB
+    ``config``/``artifacts`` columns that make ``get_workspace`` expensive.
+    Unlike ``get_workspace`` this does NOT hide ``status='deleted'`` rows — a
+    caller validating a cached session needs to see the tombstone rather than an
+    ambiguous "not found".
+    """
+    workspace_id = normalize_uuid(workspace_id)
+    if workspace_id is None:
+        return None
+
+    try:
+        async with _ws_cursor() as cur:
+            await cur.execute(
+                """
+                SELECT status, sandbox_id
+                FROM workspaces
+                WHERE workspace_id = %s
+                """,
+                (workspace_id,),
+            )
+            result = await cur.fetchone()
+        return dict(result) if result else None
+
+    except Exception as e:
+        logger.error(f"Error reading identity for workspace {workspace_id}: {e}")
         raise
 
 
@@ -238,7 +263,16 @@ async def get_workspaces_for_user(
         # Exclude flash workspaces from gallery listings unless explicitly requested
         flash_filter = "" if include_flash else "AND status != 'flash'"
 
-        async def _execute(cur):
+        # Build ORDER BY based on sort mode
+        if sort_by == "activity":
+            order_clause = "is_pinned DESC, COALESCE(last_activity_at, updated_at) DESC"
+        elif sort_by == "name":
+            order_clause = "is_pinned DESC, name ASC"
+        else:
+            # 'custom' — manual sort order, then recency
+            order_clause = "is_pinned DESC, sort_order ASC, updated_at DESC"
+
+        async with _ws_cursor(conn) as cur:
             # Get total count
             await cur.execute(
                 f"""
@@ -250,15 +284,6 @@ async def get_workspaces_for_user(
             )
             count_result = await cur.fetchone()
             total = count_result["total"] if count_result else 0
-
-            # Build ORDER BY based on sort mode
-            if sort_by == "activity":
-                order_clause = "is_pinned DESC, COALESCE(last_activity_at, updated_at) DESC"
-            elif sort_by == "name":
-                order_clause = "is_pinned DESC, name ASC"
-            else:
-                # 'custom' — manual sort order, then recency
-                order_clause = "is_pinned DESC, sort_order ASC, updated_at DESC"
 
             # Get paginated results
             await cur.execute(
@@ -272,15 +297,7 @@ async def get_workspaces_for_user(
                 (user_id, limit, offset),
             )
             results = await cur.fetchall()
-            return [dict(r) for r in results], total
-
-        if conn:
-            async with conn.cursor(row_factory=dict_row) as cur:
-                return await _execute(cur)
-        else:
-            async with get_db_connection() as conn:
-                async with conn.cursor(row_factory=dict_row) as cur:
-                    return await _execute(cur)
+        return [dict(r) for r in results], total
 
     except Exception as e:
         logger.error(f"Error getting workspaces for user {user_id}: {e}")
@@ -341,7 +358,7 @@ async def update_workspace(
 
         update_clause = ", ".join(updates)
 
-        async def _execute(cur):
+        async with _ws_cursor(conn) as cur:
             await cur.execute(
                 f"""
                 UPDATE workspaces
@@ -351,15 +368,7 @@ async def update_workspace(
                 """,
                 params,
             )
-            return await cur.fetchone()
-
-        if conn:
-            async with conn.cursor(row_factory=dict_row) as cur:
-                result = await _execute(cur)
-        else:
-            async with get_db_connection() as conn:
-                async with conn.cursor(row_factory=dict_row) as cur:
-                    result = await _execute(cur)
+            result = await cur.fetchone()
 
         if result:
             logger.debug(f"Updated workspace: {workspace_id}")
@@ -374,71 +383,49 @@ async def update_workspace(
 async def update_workspace_status(
     workspace_id: str,
     status: str,
-    sandbox_id: Optional[str] = None,
     conn=None,
 ) -> Optional[Dict[str, Any]]:
     """
-    Update workspace status and optionally sandbox_id.
+    Move a workspace's status.
+
+    Never touches ``sandbox_id``: the durable workspace↔sandbox binding moves
+    only through ``try_bind_workspace_sandbox``'s compare-and-set, so a plain
+    status change can never silently rebind a workspace to a stale sandbox.
+
+    The ``status != 'deleted'`` guard is what stops a soft-deleted row from
+    being revived. Nothing in the codebase ever clears ``sandbox_id``, so a
+    deleted workspace still names a real sandbox; without the guard a racing
+    reaper flipping it back to 'running' would hand that sandbox out again.
 
     Args:
         workspace_id: Workspace UUID
         status: New status (creating, running, stopping, stopped, error, deleted)
-        sandbox_id: Optional sandbox ID to set
         conn: Optional database connection to reuse
 
     Returns:
-        Updated workspace record, or None if not found
+        Updated workspace record, or None if not found or already deleted
     """
     try:
         now = datetime.now(timezone.utc)
 
-        # Build update based on status
-        if sandbox_id is not None:
-            if status == "stopped":
-                query = f"""
-                    UPDATE workspaces
-                    SET status = %s, sandbox_id = %s, updated_at = %s, stopped_at = %s
-                    WHERE workspace_id = %s
-                    RETURNING {_WS_COLS}
-                """
-                params = (status, sandbox_id, now, now, workspace_id)
-            else:
-                query = f"""
-                    UPDATE workspaces
-                    SET status = %s, sandbox_id = %s, updated_at = %s
-                    WHERE workspace_id = %s
-                    RETURNING {_WS_COLS}
-                """
-                params = (status, sandbox_id, now, workspace_id)
-        else:
-            if status == "stopped":
-                query = f"""
-                    UPDATE workspaces
-                    SET status = %s, updated_at = %s, stopped_at = %s
-                    WHERE workspace_id = %s
-                    RETURNING {_WS_COLS}
-                """
-                params = (status, now, now, workspace_id)
-            else:
-                query = f"""
-                    UPDATE workspaces
-                    SET status = %s, updated_at = %s
-                    WHERE workspace_id = %s
-                    RETURNING {_WS_COLS}
-                """
-                params = (status, now, workspace_id)
+        # 'stopped' additionally stamps stopped_at; every other status is a
+        # plain status move.
+        stopped_at_clause = ", stopped_at = %s" if status == "stopped" else ""
+        query = f"""
+            UPDATE workspaces
+            SET status = %s, updated_at = %s{stopped_at_clause}
+            WHERE workspace_id = %s AND status != 'deleted'
+            RETURNING {_WS_COLS}
+        """
+        params = (
+            (status, now, now, workspace_id)
+            if status == "stopped"
+            else (status, now, workspace_id)
+        )
 
-        async def _execute(cur):
+        async with _ws_cursor(conn) as cur:
             await cur.execute(query, params)
-            return await cur.fetchone()
-
-        if conn:
-            async with conn.cursor(row_factory=dict_row) as cur:
-                result = await _execute(cur)
-        else:
-            async with get_db_connection() as conn:
-                async with conn.cursor(row_factory=dict_row) as cur:
-                    result = await _execute(cur)
+            result = await cur.fetchone()
 
         if result:
             logger.debug(f"Updated workspace {workspace_id} status to: {status}")
@@ -455,52 +442,175 @@ async def update_workspace_status(
         raise
 
 
-async def try_claim_workspace_for_start(
+class SandboxIdentityLostError(SandboxTransientError):
+    """Another provisioner won the race to bind this workspace's sandbox.
+
+    The loser owns a real, running sandbox that nothing points at — it must
+    delete its own and attach to the winner's, never retry the write.
+
+    Transient by inheritance, and deliberately so: losing this race is a
+    recoverable condition the caller should retry into, but no caller catches it
+    by name. As a bare ``RuntimeError`` it reached the client as a 500 and the
+    chat funnel did not recognise it as a sandbox condition at all.
+    """
+
+    def __init__(self, workspace_id: str, sandbox_id: str):
+        self.workspace_id = workspace_id
+        self.sandbox_id = sandbox_id
+        super().__init__(
+            f"Workspace {workspace_id} was bound to a different sandbox while "
+            f"{sandbox_id} was being provisioned"
+        )
+
+
+async def _try_claim_starting(
     workspace_id: str,
+    *,
+    from_status: str,
+    expected_sandbox_id: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
-    """Atomically claim a stopped workspace for a start transition.
+    """Cross-worker mutex for a ``<from_status>`` → ``starting`` transition.
 
-    Cross-worker mutex for the stopped → starting transition. Only the worker
-    whose UPDATE returns a row should proceed to restart the sandbox; losers
-    must wait for the winner to flip status to 'running' (or 'error').
+    Only the worker whose UPDATE returns a row owns the transition; losers wait
+    for it to reach 'running' (or 'error'). Owns its own connection so the
+    UPDATE commits before the publish — a caller-supplied transaction would let
+    ``publish_status_change`` wake SSE subscribers that then read the pre-claim
+    row.
 
-    Owns its own connection so the UPDATE is committed before the publish
-    fires — a caller-supplied transaction would let publish_status_change
-    wake SSE subscribers that then read the still-'stopped' row.
-
-    Returns:
-        The updated workspace row (status='starting') if claimed; None if
-        the workspace was not in 'stopped' state (already starting, running,
-        creating, error, deleted, or stopping).
+    ``expected_sandbox_id`` adds a compare-and-set so only the caller holding
+    the identity it intends to replace can claim it.
     """
     try:
         now = datetime.now(timezone.utc)
+        sandbox_guard = " AND sandbox_id = %s" if expected_sandbox_id else ""
         query = f"""
             UPDATE workspaces
             SET status = 'starting', updated_at = %s
-            WHERE workspace_id = %s AND status = 'stopped'
+            WHERE workspace_id = %s AND status = %s{sandbox_guard}
             RETURNING {_WS_COLS}
         """
-        params = (now, workspace_id)
+        params: Tuple[Any, ...] = (now, workspace_id, from_status)
+        if expected_sandbox_id:
+            params += (expected_sandbox_id,)
 
-        async with get_db_connection() as conn:
-            async with conn.cursor(row_factory=dict_row) as cur:
-                await cur.execute(query, params)
-                result = await cur.fetchone()
+        async with _ws_cursor() as cur:
+            await cur.execute(query, params)
+            result = await cur.fetchone()
 
-        if result:
-            logger.debug(f"Claimed workspace {workspace_id} for start (was stopped)")
-            # Notify so cross-worker /events subscribers learn about the
-            # stopped → starting flip without polling. The wait loop in
-            # WorkspaceManager doesn't need this (the loser path triggers
-            # only after the claim returns None), but the FE does.
-            await publish_status_change(workspace_id, "starting")
-            return dict(result)
-        return None
+        if result is None:
+            return None
+
+        logger.debug(
+            f"Claimed workspace {workspace_id} for start (was {from_status}"
+            + (f" on {expected_sandbox_id}" if expected_sandbox_id else "")
+            + ")"
+        )
+        # Cross-worker /events subscribers learn about the flip without
+        # polling. The WorkspaceManager wait loop doesn't need it (the loser
+        # path triggers only after the claim returns None), but the FE does.
+        await publish_status_change(workspace_id, "starting")
+        return dict(result)
 
     except Exception as e:
         logger.error(f"Error claiming workspace {workspace_id} for start: {e}")
         raise
+
+
+async def try_claim_workspace_for_start(
+    workspace_id: str,
+) -> Optional[Dict[str, Any]]:
+    """Claim a stopped workspace for a start transition.
+
+    Returns the claimed row (status='starting'), or None when the workspace was
+    not 'stopped' — already starting, running, creating, error, deleted or
+    stopping.
+    """
+    return await _try_claim_starting(workspace_id, from_status="stopped")
+
+
+async def try_claim_workspace_for_replacement(
+    workspace_id: str,
+    expected_sandbox_id: str,
+) -> Optional[Dict[str, Any]]:
+    """Claim a running workspace whose sandbox is about to be replaced.
+
+    Replacement (a tier change, a working-dir migration) deletes the sandbox and
+    builds a new one. Without a durable claim the row keeps saying
+    ``running``/<old id> across that window, so DB and cache *agree* on an
+    identity that is being destroyed — the one state no identity check can catch.
+    Claiming ``starting`` closes it with machinery that already exists: acquirers
+    seeing ``starting`` wait for the owner instead of racing to provision a
+    duplicate, and the stuck-start reaper is the existing backstop.
+
+    Returns the claimed row, or None if another worker already moved the
+    workspace off ``running``/*expected_sandbox_id*.
+    """
+    return await _try_claim_starting(
+        workspace_id, from_status="running", expected_sandbox_id=expected_sandbox_id
+    )
+
+
+async def try_bind_workspace_sandbox(
+    workspace_id: str,
+    *,
+    sandbox_id: str,
+    expected_previous_sandbox_id: Optional[str],
+    platform_secret_version: int,
+) -> Optional[Dict[str, Any]]:
+    """Atomically bind a freshly provisioned sandbox to a workspace and mark it running.
+
+    The only writer of ``workspaces.sandbox_id``. The compare-and-set is what
+    makes concurrent provisioning safe: without it two workers both "succeed",
+    one sandbox is left running with nothing pointing at it, and workers briefly
+    disagree about which identity is current. Returns None when another writer
+    got there first — the loser owns a real sandbox it must now delete.
+
+    ``platform_secret_version`` is always written, never preserved: it records
+    what THIS sandbox was certified against, and 0 means "never certified — may
+    hold plaintext env" (migration 021). Carrying a previous sandbox's
+    generation forward would leave a plaintext sandbox looking certified, and
+    the sweeper only visits rows behind the fleet generation.
+
+    The predicate fences lifecycle as well as identity. Matching on the sandbox
+    id alone is not enough: a stop and a recovery can race on the SAME id, and
+    since this statement unconditionally writes ``running`` the bind would
+    resurrect a workspace another worker had just stopped — leaving the row
+    ``stopped`` while its sandbox runs on and bills, or the reverse. Stopping
+    and stopped are named rather than a whitelist of bindable states because a
+    losing bind destroys its own sandbox: a whitelist that omitted some future
+    transitional state would fail legitimate provisions and churn sandboxes,
+    where this only ever refuses the two states a bind must never overwrite.
+    """
+    query = f"""
+        UPDATE workspaces
+        SET status = 'running',
+            sandbox_id = %s,
+            platform_secret_version = %s,
+            updated_at = NOW()
+        WHERE workspace_id = %s
+          AND status NOT IN ('deleted', 'stopping', 'stopped')
+          AND sandbox_id IS NOT DISTINCT FROM %s
+        RETURNING {_WS_COLS}
+    """
+
+    async with _ws_cursor() as cur:
+        await cur.execute(
+            query,
+            (
+                sandbox_id,
+                platform_secret_version,
+                workspace_id,
+                expected_previous_sandbox_id,
+            ),
+        )
+        result = await cur.fetchone()
+
+    if result is None:
+        return None
+    # Same broadcast obligation as update_workspace_status: this is what wakes
+    # cross-worker start waiters and /events subscribers.
+    await publish_status_change(workspace_id, "running")
+    return dict(result)
 
 
 async def _set_workspace_scalar(
@@ -521,7 +631,7 @@ async def _set_workspace_scalar(
     try:
         now = datetime.now(timezone.utc)
 
-        async def _execute(cur):
+        async with _ws_cursor(conn) as cur:
             await cur.execute(
                 f"""
                 UPDATE workspaces
@@ -531,15 +641,7 @@ async def _set_workspace_scalar(
                 """,
                 (value, now, workspace_id),
             )
-            return await cur.fetchone()
-
-        if conn:
-            async with conn.cursor(row_factory=dict_row) as cur:
-                result = await _execute(cur)
-        else:
-            async with get_db_connection() as conn:
-                async with conn.cursor(row_factory=dict_row) as cur:
-                    result = await _execute(cur)
+            result = await cur.fetchone()
 
         if result:
             logger.info(f"Set workspace {workspace_id} {column} to: {value}")
@@ -591,7 +693,7 @@ async def update_workspace_activity(
     try:
         now = datetime.now(timezone.utc)
 
-        async def _execute(cur):
+        async with _ws_cursor(conn) as cur:
             await cur.execute(
                 """
                 UPDATE workspaces
@@ -604,16 +706,6 @@ async def update_workspace_activity(
                 (now, now, workspace_id, now),
             )
             return cur.rowcount > 0
-
-        if conn:
-            async with conn.cursor(row_factory=dict_row) as cur:
-                result = await _execute(cur)
-        else:
-            async with get_db_connection() as conn:
-                async with conn.cursor(row_factory=dict_row) as cur:
-                    result = await _execute(cur)
-
-        return result
 
     except Exception as e:
         logger.error(f"Error updating workspace {workspace_id} activity: {e}")
@@ -637,7 +729,7 @@ async def delete_workspace(
         True if deleted, False if not found
     """
     try:
-        async def _execute(cur):
+        async with _ws_cursor(conn) as cur:
             if hard_delete:
                 await cur.execute(
                     """
@@ -657,20 +749,17 @@ async def delete_workspace(
                     """,
                     (datetime.now(timezone.utc), workspace_id),
                 )
-            return await cur.fetchone()
-
-        if conn:
-            async with conn.cursor(row_factory=dict_row) as cur:
-                result = await _execute(cur)
-        else:
-            async with get_db_connection() as conn:
-                async with conn.cursor(row_factory=dict_row) as cur:
-                    result = await _execute(cur)
+            result = await cur.fetchone()
 
         if result:
             logger.info(
                 f"{'Hard' if hard_delete else 'Soft'} deleted workspace: {workspace_id}"
             )
+            # Same broadcast obligation as every other status writer. Load-bearing
+            # since sessions validate against the durable status: without it a
+            # sibling worker keeps its cached handle until its next request, and
+            # /events subscribers never learn the workspace is gone.
+            await publish_status_change(workspace_id, "deleted")
             return True
         return False
 
@@ -696,16 +785,16 @@ async def batch_update_sort_order(
         return
 
     try:
-        async def _execute(cur):
-            # Build VALUES list for the update
-            values_parts = []
-            params: list = []
-            for ws_id, order in items:
-                values_parts.append("(%s, %s)")
-                params.extend([ws_id, order])
-            values_sql = ", ".join(values_parts)
-            params.append(user_id)
+        # Build VALUES list for the update
+        values_parts = []
+        params: list = []
+        for ws_id, order in items:
+            values_parts.append("(%s, %s)")
+            params.extend([ws_id, order])
+        values_sql = ", ".join(values_parts)
+        params.append(user_id)
 
+        async with _ws_cursor(conn) as cur:
             await cur.execute(
                 f"""
                 UPDATE workspaces w
@@ -715,15 +804,7 @@ async def batch_update_sort_order(
                 """,
                 params,
             )
-            return cur.rowcount
-
-        if conn:
-            async with conn.cursor(row_factory=dict_row) as cur:
-                updated = await _execute(cur)
-        else:
-            async with get_db_connection() as conn:
-                async with conn.cursor(row_factory=dict_row) as cur:
-                    updated = await _execute(cur)
+            updated = cur.rowcount
 
         if updated == 0:
             logger.warning(f"batch_update_sort_order: 0/{len(items)} rows updated for user {user_id}")
@@ -765,7 +846,7 @@ async def get_workspaces_by_status(
         List of workspace dicts
     """
     try:
-        async def _execute(cur):
+        async with _ws_cursor(conn) as cur:
             await cur.execute(
                 f"""
                 SELECT {_WS_COLS}
@@ -777,15 +858,7 @@ async def get_workspaces_by_status(
                 (status, limit),
             )
             results = await cur.fetchall()
-            return [dict(r) for r in results]
-
-        if conn:
-            async with conn.cursor(row_factory=dict_row) as cur:
-                return await _execute(cur)
-        else:
-            async with get_db_connection() as conn:
-                async with conn.cursor(row_factory=dict_row) as cur:
-                    return await _execute(cur)
+        return [dict(r) for r in results]
 
     except Exception as e:
         logger.error(f"Error getting workspaces by status {status}: {e}")

--- a/src/server/services/persistence/file.py
+++ b/src/server/services/persistence/file.py
@@ -18,6 +18,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from ptc_agent.core.paths import BACKUP_EXCLUDE_AGENT_SUBDIRS, BACKUP_EXCLUDE_DIRS, ALWAYS_HIDDEN_DIR_NAMES, HIDDEN_DIR_NAMES
+from ptc_agent.core.sandbox.runtime import SandboxGoneError, SandboxTransientError
 from src.server.database.workspace_file import (
     bulk_update_file_mtimes,
     bulk_upsert_files,
@@ -574,12 +575,22 @@ class FilePersistenceService:
         if not sandbox or not dirs:
             return
 
-        ok = await sandbox.acreate_directories(dirs)
-        if ok:
-            return
+        try:
+            if await sandbox.acreate_directories(dirs):
+                return
+            reason = "bulk mkdir reported failure"
+        except SandboxGoneError:
+            # Nothing to fall back to: per-dir creates would fail identically.
+            raise
+        except Exception as exc:
+            # The bulk call is an optimization, and its documented failure mode
+            # — one mkdir line too long for the shell — now normalizes to a
+            # typed transient instead of a False return. Falling back is still
+            # the right answer for it; only a gone sandbox is unrecoverable.
+            reason = str(exc)
 
         logger.debug(
-            f"Bulk mkdir unavailable or failed for {len(dirs)} dirs; "
+            f"Bulk mkdir unavailable or failed for {len(dirs)} dirs ({reason}); "
             "falling back to parallel per-dir creates."
         )
         sem = asyncio.Semaphore(16)
@@ -624,6 +635,13 @@ class FilePersistenceService:
             )
             await cls.restore_to_sandbox(workspace_id, sandbox)
 
+        except (SandboxGoneError, SandboxTransientError):
+            # Let a sandbox condition reach the caller as itself. The marker
+            # probe answering with a failure means we never learned whether the
+            # files are there, and flattening that into a generic warning here
+            # reads downstream as "checked, nothing to do" — which is how a
+            # recreated sandbox stays empty with no attributable reason.
+            raise
         except Exception as e:
             logger.warning(f"Error in maybe_restore for workspace {workspace_id}: {e}")
 

--- a/src/server/services/platform_secret_rollout.py
+++ b/src/server/services/platform_secret_rollout.py
@@ -253,50 +253,19 @@ async def list_workspaces_behind_platform_secret(
             return [dict(row) for row in await cur.fetchall()]
 
 
-async def certify_new_workspace_sandbox(
-    config: Any,
-    *,
-    workspace_id: str,
-    expected_previous_sandbox_id: str | None,
-    sandbox_id: str,
-    runtime: Any,
-) -> dict[str, Any] | None:
-    """Verify and atomically attach one newly created hosted sandbox."""
+async def certify_platform_secrets(config: Any, *, runtime: Any) -> int:
+    """Verify the placeholders landed in this sandbox; return the generation to stamp.
 
+    Returns 0 — the "never certified, may hold plaintext env" sentinel from
+    migration 021 — when no catalog is configured. A pure contributor: it writes
+    nothing and decides no control flow, so the workspace binding stays owned by
+    the caller that owns the sandbox.
+    """
     if not platform_secrets_active(config):
-        return None
+        return 0
     rollout_set = await get_platform_secret_rollouts()
-    await verify_runtime_platform_secrets(
-        runtime, expected=rollout_set.placeholders
-    )
-
-    async with get_db_connection() as conn:
-        async with conn.cursor(row_factory=dict_row) as cur:
-            await cur.execute(
-                """
-                UPDATE workspaces
-                SET status = 'running',
-                    sandbox_id = %s,
-                    platform_secret_version = %s,
-                    updated_at = NOW()
-                WHERE workspace_id = %s
-                  AND status != 'deleted'
-                  AND sandbox_id IS NOT DISTINCT FROM %s
-                RETURNING workspace_id
-                """,
-                (
-                    sandbox_id,
-                    rollout_set.generation,
-                    workspace_id,
-                    expected_previous_sandbox_id,
-                ),
-            )
-            row = await cur.fetchone()
-    if row is None:
-        raise RuntimeError("Workspace changed before platform Secret certification")
-    from src.server.database.workspace import get_workspace
-
-    return await get_workspace(workspace_id)
+    await verify_runtime_platform_secrets(runtime, expected=rollout_set.placeholders)
+    return rollout_set.generation
 
 
 async def stamp_workspace_platform_secret_version(

--- a/src/server/services/platform_secret_sweep.py
+++ b/src/server/services/platform_secret_sweep.py
@@ -272,22 +272,28 @@ class PlatformSecretSweeper:
         return True
 
     async def _drop_local_session(self, workspace_id: str) -> None:
-        """Best-effort eviction of this worker's cached session after a scrub.
+        """Best-effort retirement of this worker's cached session after a scrub.
 
-        The restart killed the session's exec processes; evicting makes the
-        next acquisition re-init instead of tripping a transient. Other
+        The restart killed the session's exec processes; retiring makes the
+        next acquisition re-attach instead of tripping a transient. Other
         workers' caches recover through the existing sandbox-transient paths,
         the same as any out-of-band sandbox restart.
+
+        Retirement, not destruction: the sandbox was just scrubbed and remains
+        the workspace's durable identity, so destroying it here would leave
+        Postgres pointing at a sandbox that no longer exists.
         """
         try:
             from src.server.services.workspace_manager import WorkspaceManager
 
             manager = WorkspaceManager._instance
             if manager is not None:
-                await manager.evict_session_if_present(workspace_id)
+                await manager.retire_session_if_present(
+                    workspace_id, reason="platform-secret scrub restart"
+                )
         except Exception:
             logger.warning(
-                "[PlatformSecretSweeper] local session eviction failed for "
+                "[PlatformSecretSweeper] local session retirement failed for "
                 f"workspace {workspace_id}",
                 exc_info=True,
             )

--- a/src/server/services/workspace_entitlements.py
+++ b/src/server/services/workspace_entitlements.py
@@ -20,6 +20,7 @@ from src.server.database.workspace import (
     get_workspace as db_get_workspace,
     set_workspace_always_on as db_set_workspace_always_on,
     set_workspace_resource_tier as db_set_workspace_resource_tier,
+    try_claim_workspace_for_replacement,
     update_workspace_status,
 )
 from src.server.database.workspace_file import (
@@ -288,39 +289,70 @@ class WorkspaceEntitlementsMixin:
                     # Recreate in place — mirrors the sandbox-migration path.
                     logger.info(f"Recreating workspace {workspace_id} at tier {tier!r}")
                     # Strict: the sandbox is about to be destroyed, so a missed
-                    # backup here is data loss, not a degraded sync.
-                    await self._backup_files_to_db(workspace_id, strict=True)
+                    # backup here is data loss, not a degraded sync. Pinned to the
+                    # locked sandbox id — a session bound to an already-superseded
+                    # sandbox would snapshot the wrong filesystem over the DB copy.
+                    await self._backup_files_to_db(
+                        workspace_id,
+                        strict=True,
+                        expected_sandbox_id=locked_sandbox_id,
+                    )
                     if is_downgrade:
-                        # Checked post-backup (fresh DB sizes), pre-teardown — the
-                        # live sandbox is untouched, so a failure aborts cleanly.
+                        # Checked post-backup (fresh DB sizes), pre-claim — the
+                        # live sandbox is untouched and the row still advertises
+                        # running/<old id>, so a rejection aborts cleanly instead
+                        # of stranding the workspace mid-replacement.
                         await self._assert_disk_fits(workspace_id, target_disk)
-                    # Tear the old sandbox down via the canonical teardown, then
-                    # force-evict the SessionManager entry: cleanup_session skips
-                    # its own pop when session.cleanup() raised, so the immediate
-                    # _recover_sandbox get_session below must not return the stale
-                    # broken session.
-                    await self._clear_session(workspace_id)
-                    SessionManager.remove_session(workspace_id)
-                    # Belt-and-braces: if cleanup raised before deleting the
-                    # sandbox, destroy it by id (mirrors the stopped path) so a
-                    # half-torn-down sandbox can't keep running and billing.
-                    try:
-                        await self._destroy_sandbox(locked_sandbox_id)
-                    except Exception as e:
-                        logger.debug(
-                            f"Old sandbox {locked_sandbox_id} already gone: {e}"
+                    # Durably fence the replacement BEFORE teardown. The lock above
+                    # is a per-process asyncio.Lock, so without this the row keeps
+                    # advertising running/<old id> while that sandbox is deleted —
+                    # and a request on another worker would attach to it, fail, and
+                    # race us into provisioning a duplicate.
+                    if not await try_claim_workspace_for_replacement(
+                        workspace_id, locked_sandbox_id
+                    ):
+                        raise RuntimeError(
+                            "Workspace changed while preparing the spec change; "
+                            "retry"
                         )
+                    # Everything past the claim runs under a compensator. The row
+                    # now reads 'starting' and only this task can release it;
+                    # leaving through any other exit strands the workspace
+                    # permanently unstartable, because the start path claims from
+                    # 'stopped', never from 'starting'. Scoping this to the
+                    # _recover_sandbox call alone left the teardown steps —
+                    # themselves failure-prone — outside the net.
                     try:
+                        # Tear the old sandbox down via the canonical teardown,
+                        # then force-evict the SessionManager entry:
+                        # cleanup_session skips its own pop when session.cleanup()
+                        # raised, so the _recover_sandbox below must not return
+                        # the stale broken session.
+                        await self._clear_session(workspace_id)
+                        SessionManager.remove_session(workspace_id)
+                        # Belt-and-braces: if cleanup raised before deleting the
+                        # sandbox, destroy it by id (mirrors the stopped path) so
+                        # a half-torn-down sandbox can't keep running.
+                        try:
+                            await self._destroy_sandbox(locked_sandbox_id)
+                        except Exception as e:
+                            logger.debug(
+                                f"Old sandbox {locked_sandbox_id} already gone: {e}"
+                            )
                         await self._recover_sandbox(
                             workspace_id, user_id, self.config.to_core_config()
                         )
-                    except Exception:
-                        # Old sandbox is already torn down but the files are
-                        # safely backed up — mark the row 'stopped' so the next
-                        # start self-heals (claim → restart → SandboxGone →
-                        # recover). 'error' would be terminal: the start path
-                        # refuses it outright. The outer except still reverts
-                        # the tier.
+                    except (Exception, asyncio.CancelledError):
+                        # Files are safely backed up — mark the row 'stopped' so
+                        # the next start self-heals (claim → restart →
+                        # SandboxGone → recover). 'error' would be terminal: the
+                        # start path refuses it outright. The outer except still
+                        # reverts the tier.
+                        #
+                        # CancelledError is caught explicitly because it is a
+                        # BaseException: a client disconnect or a shutdown
+                        # landing mid-replacement would otherwise skip this and
+                        # strand the row in 'starting', which no start can claim.
                         await update_workspace_status(
                             workspace_id=workspace_id, status="stopped"
                         )
@@ -344,7 +376,11 @@ class WorkspaceEntitlementsMixin:
                         f"Cannot change spec while workspace is {locked_status!r}; "
                         "wait for the current operation to finish"
                     )
-        except Exception:
+        except (Exception, asyncio.CancelledError):
+            # Same reason the inner handler names CancelledError: it is a
+            # BaseException, so a plain `except Exception` would let a
+            # cancellation land with the row already stamped at the new tier
+            # the recreate never reached.
             await db_set_workspace_resource_tier(workspace_id, current_tier_name)
             raise
 
@@ -446,8 +482,12 @@ class WorkspaceEntitlementsMixin:
 
         # Files only persist to the DB on stop/delete, so flush a running source
         # before the copy or the new workspace would miss in-sandbox changes.
+        # We already hold the row, so hand the durable id over rather than
+        # making the backup re-read it.
         if source["status"] == "running":
-            await self._backup_files_to_db(source_id)
+            await self._backup_files_to_db(
+                source_id, expected_sandbox_id=source.get("sandbox_id")
+            )
 
         source_tier = source.get("resource_tier") or "standard"
 

--- a/src/server/services/workspace_manager.py
+++ b/src/server/services/workspace_manager.py
@@ -44,7 +44,11 @@ from src.server.database.workspace import (
     create_workspace as db_create_workspace,
     delete_workspace as db_delete_workspace,
     get_workspace as db_get_workspace,
+    get_workspace_identity as db_get_workspace_identity,
     get_workspaces_by_status,
+    SandboxIdentityLostError,
+    try_bind_workspace_sandbox,
+    try_claim_workspace_for_replacement,
     try_claim_workspace_for_start,
     update_workspace_activity,
     update_workspace_status,
@@ -130,6 +134,11 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
 
         # Track last sync time per workspace for cooldown
         self._last_sync_at: Dict[str, float] = {}
+
+        # One provider kept solely to classify exceptions. Built on first use —
+        # constructing one opens an SDK client, so the alternative was leaking
+        # a client per failed teardown. See ``_is_sandbox_gone``.
+        self._error_classifier: Any = None
 
         # Strong refs to fire-and-forget background MCP discovery+re-sync tasks
         # (asyncio holds only weak refs to tasks). Discarded in each task's done
@@ -250,20 +259,168 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
         self._pending_lazy_sync.discard(workspace_id)
         self._pending_tier_recheck.discard(workspace_id)
 
-    async def evict_session_if_present(self, workspace_id: str) -> bool:
-        """Evict this worker's cached session so the next acquisition re-inits.
+    async def _take_valid_cached_session(
+        self, workspace_id: str, mark: Callable[[str], None]
+    ) -> "Session | None":
+        """This worker's cached session if it is safe to hand out, else None.
 
-        The public entry point for out-of-band invalidation (e.g. the
-        platform-secret sweeper after a scrub-restart kills the session's exec
-        processes). Returns False without locking when nothing is cached.
+        Answers only "is this handle still valid" — readiness and sync policy
+        stay with the caller. Validity means initialized, holding a sandbox, and
+        matching the durable binding in Postgres: workers are spawn-isolated
+        with no cross-worker invalidation, and every warm fast path returns
+        without reading the row, so one narrow ``status, sandbox_id`` query is
+        what makes the cache safe to trust. Invalid sessions are retired here,
+        which is non-destructive — the sandbox they named may still be live and
+        owned by someone else.
+        """
+        session = self._sessions.get(workspace_id)
+        if session is None:
+            return None
+
+        logger.debug(
+            f"Found cached session for {workspace_id}, "
+            f"initialized={session._initialized}, "
+            f"has_sandbox={session.sandbox is not None}"
+        )
+        if not session._initialized or not session.sandbox:
+            return None
+
+        _t0 = time.time()
+        identity = await db_get_workspace_identity(workspace_id)
+        identity_ms = (time.time() - _t0) * 1000
+        stale_reason = self._identity_is_stale(workspace_id, session, identity)
+        mark("identity_check")
+        # Recorded here rather than through the caller's phase dict: every warm
+        # path returns before that dict is emitted, so the one query this adds
+        # to the hot path would otherwise be permanently unmeasured.
+        safe_record(
+            session_acquire_phase_duration_ms,
+            identity_ms,
+            {"phase": "identity_check", "session_path": "warm"},
+        )
+        if stale_reason is None:
+            return session
+
+        # The reason goes in the message, not only in `extra`: the root
+        # formatter is a plain %-format, so extras never reach the log file. An
+        # unattributable warning is what let the original bug serve 404s
+        # indefinitely with nothing in the logs pointing at the stale handle.
+        logger.warning(
+            f"Cached session for {workspace_id} is stale "
+            f"({stale_reason}); retiring and re-attaching",
+            extra={"workspace_id": workspace_id, "reason": stale_reason},
+        )
+        await self._retire_session(workspace_id, session, reason=stale_reason)
+        safe_add(session_path_counter, 1, {"path": "stale_reattach"})
+        return None
+
+    async def retire_session_if_present(
+        self, workspace_id: str, *, reason: str
+    ) -> bool:
+        """Forget this worker's cached session without touching the sandbox.
+
+        The out-of-band invalidation entry point: the sandbox stays alive (it may
+        be owned by another worker or still be the workspace's durable identity),
+        only this process's handle is dropped so the next acquisition re-attaches.
+        Returns False without locking when nothing is cached.
         """
         if workspace_id not in self._sessions:
             return False
         async with self._acquire_workspace_lock(workspace_id):
-            if workspace_id not in self._sessions:
+            session = self._sessions.get(workspace_id)
+            if session is None:
                 return False
-            await self._clear_session(workspace_id)
+            await self._retire_session(workspace_id, session, reason=reason)
         return True
+
+    async def _retire_session(
+        self, workspace_id: str, session: "Session", *, reason: str
+    ) -> None:
+        """Drop a session from both process caches, leaving the sandbox alive.
+
+        Both caches must go: popping only ``self._sessions`` leaves
+        ``SessionManager.get_session`` handing back the same ``Session`` with
+        ``_initialized=True``, so the re-attach silently no-ops and the stale
+        handle survives. Provider/MCP resources are deliberately NOT closed —
+        ``PTCSandbox.close()`` closes the shared SDK HTTP client, which would
+        abort in-flight work (a running graph, a background subagent) still
+        holding this session. They are released when the last holder drops it.
+        """
+        self._cancel_mcp_discovery(workspace_id)
+        if self._sessions.get(workspace_id) is session:
+            self._sessions.pop(workspace_id, None)
+        if SessionManager.get_cached_session(workspace_id) is session:
+            SessionManager.remove_session(workspace_id)
+        self._pending_lazy_sync.discard(workspace_id)
+        self._pending_tier_recheck.discard(workspace_id)
+        self._phase2_events.pop(workspace_id, None)
+        self._last_sync_at.pop(workspace_id, None)
+        logger.info(
+            f"Retired cached session for {workspace_id} "
+            f"(sandbox {self._session_sandbox_id(session)} left intact): {reason}",
+            extra={
+                "workspace_id": workspace_id,
+                "reason": reason,
+                "sandbox_id": self._session_sandbox_id(session),
+            },
+        )
+
+    @staticmethod
+    def _session_sandbox_id(session: "Session | None") -> str | None:
+        """The sandbox identity a cached session is bound to, if any."""
+        sandbox = getattr(session, "sandbox", None) if session is not None else None
+        sandbox_id = getattr(sandbox, "sandbox_id", None) if sandbox else None
+        return str(sandbox_id) if sandbox_id else None
+
+    # Statuses in which a workspace legitimately serves a cached session.
+    # Everything else means the durable state has moved past the handle this
+    # worker holds. 'flash' is a permanent status, not a transient one.
+    _SESSION_SERVING_STATUSES = frozenset({"running", "flash"})
+
+    def _identity_is_stale(
+        self, workspace_id: str, session: "Session", identity: Dict[str, Any] | None
+    ) -> str | None:
+        """Return a reason string when a cached session must not be handed out.
+
+        Postgres owns the workspace↔sandbox binding; this worker's cache is only
+        a handle. Deliberately does *not* require both ids to be non-None — a
+        half-known binding is itself an inconsistency, and treating it as "can't
+        tell, assume fine" is exactly how a deleted sandbox goes on serving 404s
+        indefinitely, since nothing else ever revisits the handle.
+
+        Status matters as much as identity, because the two transitions that
+        *replace* a sandbox — the replacement claim and a stop — both leave
+        ``sandbox_id`` untouched. During those windows the ids still agree while
+        the sandbox they name is being torn down, so an id-only check sees
+        nothing wrong. Retiring instead sends the caller down the slow path,
+        which already knows how to wait for the new sandbox.
+        """
+        if identity is None:
+            return "workspace row is gone"
+        status = identity.get("status")
+        if status not in self._SESSION_SERVING_STATUSES:
+            # 'starting' is legitimate for the worker that owns an in-flight
+            # lazy init; for anyone else it means a replacement was claimed and
+            # our handle names a doomed sandbox. Ownership is the membership,
+            # not the sandbox's readiness: Phase 2 runs outside the lock, so the
+            # owner's sandbox goes ready while the row is still 'starting' and
+            # it has yet to promote. Reading that window as "someone else
+            # claimed it" retires the owner's own session, and _retire_session
+            # drops the very membership that both the promotion and its revert
+            # are gated on — wedging the row in 'starting' until the reaper.
+            initializing_here = (
+                status == "starting" and workspace_id in self._pending_lazy_sync
+            )
+            if not initializing_here:
+                return f"workspace status is {status!r}"
+        db_sandbox_id = identity.get("sandbox_id")
+        local_sandbox_id = self._session_sandbox_id(session)
+        if db_sandbox_id != local_sandbox_id:
+            return (
+                f"sandbox identity moved (db={db_sandbox_id}, "
+                f"local={local_sandbox_id})"
+            )
+        return None
 
     async def _apply_session_platform_secret(
         self,
@@ -323,15 +480,24 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
         Args:
             workspace_id: Workspace UUID.
             sandbox: Optional sandbox to push to directly.  When omitted the
-                sandbox is looked up from the session cache — this fails during
-                initial startup (session not cached yet), so callers that
-                already hold a sandbox reference should pass it explicitly.
+                sandbox is looked up from the session cache and identity-checked
+                against Postgres — that lookup finds nothing during initial
+                startup (session not cached yet), so callers that already hold a
+                sandbox reference should pass it explicitly.
             user_id: The workspace owner. Looked up from the workspace row
                 when omitted (one extra read).
         """
         if sandbox is None:
-            session = self._sessions.get(workspace_id)
-            if not session or not session.sandbox:
+            # Both cache-lookup callers are best-effort mutation fan-outs, so a
+            # superseded handle here writes the new secrets into a sandbox
+            # nothing points at while the live one keeps the old set — silently,
+            # since neither caller reports back. Declining leaves convergence to
+            # the version bump, which is what those callers already rely on.
+            identity = await db_get_workspace_identity(workspace_id)
+            session = self.get_session_if_ready(
+                workspace_id, expected_sandbox_id=(identity or {}).get("sandbox_id")
+            )
+            if session is None:
                 return
             sandbox = session.sandbox
 
@@ -806,16 +972,23 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
         -> ``session.initialize`` (sized to ``tier`` / ``auto_stop_minutes``) ->
         install the MCP composite -> sync assets -> cache -> optionally kick
         background discovery -> run ``post_init(session)`` (seed agent.md for
-        create, restore files for recover/duplicate) -> flip the row to running
-        -> record the sync. Returns ``(session, workspace_record)`` where the
-        record is the row returned by ``update_workspace_status``.
+        create, restore files for recover/duplicate) -> bind the sandbox and flip
+        the row to running -> record the sync. Returns
+        ``(session, workspace_record)`` where the record is the row returned by
+        the binding compare-and-set.
 
-        The session is cached BEFORE the discovery kick so the background task's
-        liveness gate (``self._sessions.get(workspace_id) is session``) passes;
-        ``ws_version=None`` forces a fresh MCP resolve. On any failure the
-        half-built session is torn down via ``_clear_session`` (identity-guarded
-        pop + Daytona delete) so a partial provision never orphans a billed
-        sandbox, and the exception re-raises for the caller to mark the row.
+        The session is published to ``self._sessions`` only AFTER ``post_init``
+        and the guarded DB identity write both succeed — a session visible while
+        its row still names the previous sandbox looks stale to every concurrent
+        acquisition, which would retire it mid-restore and (because retirement
+        pops ``SessionManager`` too) leave ``_clear_session`` unable to find the
+        sandbox to delete: an orphaned, still-billed sandbox. Discovery is kicked
+        after publication for the same reason — its liveness gate is
+        ``self._sessions.get(workspace_id) is session``. ``ws_version=None``
+        forces a fresh MCP resolve. On any failure the half-built session is torn
+        down via ``_clear_session`` (identity-guarded pop + Daytona delete) so a
+        partial provision never orphans a billed sandbox, and the exception
+        re-raises for the caller to mark the row.
         """
         if core_config is None:
             core_config = self.config.to_core_config()
@@ -841,20 +1014,6 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
                 workspace_id, user_id, session.sandbox, reusing_sandbox=False
             )
 
-            # Cache the session BEFORE kicking discovery: the background task's
-            # liveness gate (``self._sessions.get(workspace_id) is session``)
-            # would otherwise see no cached session and exit permanently.
-            self._sessions[workspace_id] = session
-
-            if kick_discovery and resolved_mcp is not None:
-                self._kick_mcp_discovery(
-                    workspace_id,
-                    user_id,
-                    session,
-                    self._servers_needing_discovery(session, resolved_mcp),
-                    session.mcp_config_version or 0,
-                )
-
             await post_init(session)
 
             sandbox_id = (
@@ -866,31 +1025,59 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
                 raise RuntimeError("Fresh sandbox is missing its runtime identity")
 
             from src.server.services.platform_secret_rollout import (
-                certify_new_workspace_sandbox,
+                certify_platform_secrets,
             )
 
-            workspace = await certify_new_workspace_sandbox(
-                core_config,
-                workspace_id=workspace_id,
-                expected_previous_sandbox_id=expected_previous_sandbox_id,
+            # Verify, then bind. Statement order is what enforces "no workspace
+            # points at an uncertified sandbox"; the secret module contributes a
+            # generation and owns nothing else.
+            secret_version = await certify_platform_secrets(
+                core_config, runtime=session.sandbox.runtime
+            )
+            workspace = await try_bind_workspace_sandbox(
+                workspace_id,
                 sandbox_id=sandbox_id,
-                runtime=session.sandbox.runtime,
+                expected_previous_sandbox_id=expected_previous_sandbox_id,
+                platform_secret_version=secret_version,
             )
             if workspace is None:
-                workspace = await update_workspace_status(
-                    workspace_id=workspace_id,
-                    status="running",
-                    sandbox_id=sandbox_id,
+                # Another provisioner bound this workspace first. The unwind below
+                # deletes the sandbox we just built — mandatory, since nothing
+                # references it and it would bill forever — and the caller's retry
+                # attaches to the winner. Never re-issue the write: that is how two
+                # provisioners both "win" and one sandbox leaks.
+                logger.warning(
+                    f"Lost the sandbox-identity race for {workspace_id}; "
+                    f"discarding our sandbox {sandbox_id}",
+                    extra={"workspace_id": workspace_id, "sandbox_id": sandbox_id},
+                )
+                raise SandboxIdentityLostError(workspace_id, sandbox_id)
+
+            # Certified: the row now names THIS sandbox, so publishing the session
+            # can no longer be read as stale by a concurrent acquisition.
+            self._sessions[workspace_id] = session
+
+            if kick_discovery and resolved_mcp is not None:
+                self._kick_mcp_discovery(
+                    workspace_id,
+                    user_id,
+                    session,
+                    self._servers_needing_discovery(session, resolved_mcp),
+                    session.mcp_config_version or 0,
                 )
 
             self._record_sync(workspace_id)
             return session, workspace
-        except Exception:
+        except (Exception, asyncio.CancelledError):
             # Unwind a half-built provision: cancel discovery, drop the broken
             # cached session (identity-guarded), and destroy the Daytona sandbox
             # created before the failure so a partial provision never leaves an
             # orphaned, still-billed sandbox. Re-raise for the caller to mark the
             # row (error) and/or revert side effects.
+            #
+            # Cancellation has to unwind too: it is a BaseException, and a client
+            # disconnecting mid-provision is exactly when a sandbox exists that
+            # no row will ever name.
             await self._clear_session(workspace_id, evict_session=session)
             raise
 
@@ -943,25 +1130,64 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
         return session
 
     async def _backup_files_to_db(
-        self, workspace_id: str, *, strict: bool = False
+        self,
+        workspace_id: str,
+        *,
+        strict: bool = False,
+        expected_sandbox_id: str | None = None,
+        session: Session | None = None,
     ) -> None:
         """Backup workspace files from sandbox to DB. Non-blocking on failure.
 
         ``strict=True`` raises instead of warning — for callers about to destroy
         the sandbox, where a missed backup is data loss rather than degraded sync.
+
+        The identity check is unconditional, and deliberately not opt-in:
+        ``sync_to_db`` *overwrites* the workspace's durable file copy, so running
+        it from a session bound to a superseded sandbox both misses the live
+        files and destroys the good copy. ``expected_sandbox_id`` is only an
+        optimization for callers that already hold the row; it is read from
+        Postgres otherwise.
         """
-        session = self._sessions.get(workspace_id)
+        # A caller that already holds the session must pass it: the cache is not
+        # populated until the end of a restart, so looking it up here would find
+        # nothing and fail a backup the caller could plainly have performed.
+        session = session or self._sessions.get(workspace_id)
         if not session or not getattr(session, "sandbox", None):
             if strict:
                 raise RuntimeError(
                     f"No attached session to back up workspace {workspace_id} from"
                 )
+            # Not silent: with N workers the request routinely lands on one that
+            # never held this workspace, and a non-strict caller may still tear
+            # the sandbox down afterwards. Whatever it holds unsynced is then
+            # gone, so the skip has to be attributable after the fact.
+            logger.warning(
+                f"Skipping file backup for {workspace_id}: no attached session "
+                "on this worker"
+            )
             return
+
+        if expected_sandbox_id is None:
+            identity = await db_get_workspace_identity(workspace_id)
+            expected_sandbox_id = (identity or {}).get("sandbox_id")
+
+        local_sandbox_id = self._session_sandbox_id(session)
+        if local_sandbox_id != expected_sandbox_id:
+            message = (
+                f"Refusing to back up workspace {workspace_id} from a stale "
+                f"session (attached={local_sandbox_id}, "
+                f"durable={expected_sandbox_id})"
+            )
+            if strict:
+                raise RuntimeError(message)
+            logger.warning(message)
+            return
+
         try:
             result = await FilePersistenceService.sync_to_db(
                 workspace_id, session.sandbox
             )
-            logger.debug(f"File backup completed for {workspace_id}: {result}")
         except Exception as e:
             if strict:
                 raise RuntimeError(
@@ -969,6 +1195,95 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
                     f"sandbox teardown: {e}"
                 ) from e
             logger.warning(f"File backup failed for {workspace_id}: {e}")
+            return
+
+        # ``sync_to_db`` is per-file best-effort: it counts failures instead of
+        # raising, so an exception is not the only way a backup can be
+        # incomplete. A strict caller is about to delete the sandbox, so a
+        # nonzero count is data loss and must abort the teardown.
+        errors = int((result or {}).get("errors") or 0)
+        if errors:
+            message = (
+                f"File backup for {workspace_id} left {errors} file(s) unsaved "
+                f"({result})"
+            )
+            if strict:
+                raise RuntimeError(f"{message}; aborting before sandbox teardown")
+            logger.warning(message)
+            return
+
+        logger.debug(f"File backup completed for {workspace_id}: {result}")
+
+    @asynccontextmanager
+    async def _detached_runtime(self, sandbox_id: str):
+        """Yield a runtime for a sandbox this worker holds no session for.
+
+        The durable ``sandbox_id`` is the authority, not the local cache, so
+        lifecycle operations have to be able to reach a sandbox this process
+        never attached to. Owns the provider for the duration — every caller
+        needs the same create/get/close dance, and leaking the provider leaks
+        the SDK's HTTP client.
+        """
+        from ptc_agent.core.sandbox.providers import create_provider
+
+        provider = create_provider(self.config.to_core_config())
+        try:
+            yield await provider.get(sandbox_id)
+        finally:
+            await provider.close()
+
+    def _is_sandbox_gone(self, exc: Exception) -> bool:
+        """Whether *exc* means the sandbox no longer exists (vs. a live failure).
+
+        Holds one lazily-built provider rather than making a fresh one per call.
+        ``classify_error`` only reads structured metadata off the exception, but
+        constructing a provider opens an SDK client, and this is a sync method,
+        so it cannot await a close — building one per call leaked a client on
+        every failed teardown.
+        """
+        from ptc_agent.core.sandbox.runtime import SandboxFailureKind
+
+        if isinstance(exc, SandboxGoneError):
+            return True
+        if self._error_classifier is None:
+            from ptc_agent.core.sandbox.providers import create_provider
+
+            self._error_classifier = create_provider(self.config.to_core_config())
+        return (
+            self._error_classifier.classify_error(exc)
+            is SandboxFailureKind.SANDBOX_GONE
+        )
+
+    async def _detached_sandbox_teardown(
+        self, workspace_id: str, sandbox_id: str, *, delete: bool
+    ) -> None:
+        """Stop or delete a sandbox this worker holds no session for.
+
+        The durable ``sandbox_id`` is the authority, not the local cache: acting
+        on the cache alone lets a request that lands on a session-less worker
+        flip the row to ``stopped``/``deleted`` while the sandbox keeps running.
+        """
+        action = "delete" if delete else "stop"
+        try:
+            async with self._detached_runtime(sandbox_id) as runtime:
+                await (runtime.delete() if delete else runtime.stop())
+            logger.info(
+                f"Tore down detached sandbox {sandbox_id} for {workspace_id} "
+                f"({action})",
+                extra={
+                    "workspace_id": workspace_id,
+                    "sandbox_id": sandbox_id,
+                    "action": action,
+                },
+            )
+        except Exception as exc:
+            if not self._is_sandbox_gone(exc):
+                raise
+            logger.info(
+                f"Detached sandbox {sandbox_id} for {workspace_id} is already "
+                f"gone; nothing to tear down",
+                extra={"workspace_id": workspace_id, "sandbox_id": sandbox_id},
+            )
 
     async def _restore_files(self, workspace_id: str, sandbox: Any) -> None:
         """Restore backed-up files from DB to sandbox. Non-blocking on failure."""
@@ -1068,6 +1383,7 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
         workspace: Dict[str, Any],
         *,
         expected_hash: str | None = None,
+        transition_already_owned: bool = False,
     ) -> Session | None:
         """Check if sandbox working directory matches config; migrate if not.
 
@@ -1077,6 +1393,11 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
         Args:
             expected_hash: Pre-computed config hash (avoids recomputation when
                 the caller already checked it, e.g. in ``_restart_workspace``).
+            transition_already_owned: The caller already holds this workspace's
+                lifecycle transition, so there is nothing left to fence. True on
+                the restart path, where the row is ``starting`` and claimed by
+                this task — a replacement claim starts from ``running`` and
+                could never succeed there.
         """
         if expected_hash is None:
             expected_hash = self._compute_sandbox_config_hash(self.config)
@@ -1104,33 +1425,78 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
             f"Migrating workspace {workspace_id} sandbox: {actual_wd} -> {expected_wd}"
         )
 
-        # 1. Backup files to DB (must succeed or we abort — data loss prevention)
+        old_sandbox_id = self._session_sandbox_id(session) or workspace.get("sandbox_id")
+
+        # 1. Backup files to DB (must succeed or we abort — data loss prevention).
+        # Strict, because step 2 deletes the sandbox. Migration is opportunistic,
+        # so an abort degrades to "reconnect on the old working dir", never to a
+        # failed request.
         try:
-            result = await FilePersistenceService.sync_to_db(
-                workspace_id, session.sandbox
+            await self._backup_files_to_db(
+                workspace_id,
+                strict=True,
+                expected_sandbox_id=old_sandbox_id,
+                session=session,
             )
-            logger.info(f"Pre-migration backup for {workspace_id}: {result}")
         except Exception:
             logger.error(
-                f"Migration aborted for {workspace_id}: file backup failed",
+                f"Migration aborted for {workspace_id}: pre-migration backup "
+                f"incomplete",
                 exc_info=True,
             )
             return None
 
-        # 2. Tear down old sandbox (delete, not just stop — we're replacing it)
-        self._sessions.pop(workspace_id, None)
-        try:
-            await SessionManager.cleanup_session(workspace_id)
-        except Exception as e:
-            # cleanup_session may fail after cleanup() but before del _sessions,
-            # leaving a stale entry.  Evict unconditionally so _recover_sandbox
-            # creates a fresh session.
-            SessionManager.remove_session(workspace_id)
-            logger.warning(f"Old sandbox cleanup failed for {workspace_id}: {e}")
+        # 2. Durably fence the replacement before teardown, then tear the old
+        # sandbox down (delete, not just stop — we're replacing it). Without the
+        # claim the row advertises running/<old id> while that sandbox is being
+        # deleted, so a request on another worker attaches to it and races us into
+        # provisioning a duplicate. Losing the claim means someone else already
+        # moved the workspace — leave the current session alone.
+        if not old_sandbox_id:
+            logger.warning(
+                f"Skipping migration for {workspace_id}: no sandbox to replace"
+            )
+            return None
+        if not transition_already_owned and not await try_claim_workspace_for_replacement(
+            workspace_id, old_sandbox_id
+        ):
+            logger.warning(
+                f"Skipping migration for {workspace_id}: could not claim the "
+                f"replacement (sandbox {old_sandbox_id})"
+            )
+            return None
 
-        # 3. Create fresh sandbox + restore files from DB
-        core_config = self.config.to_core_config()
-        new_session = await self._recover_sandbox(workspace_id, user_id, core_config)
+        # Everything past the claim runs under a compensator. The row now reads
+        # 'starting' and only this task can release it; returning or raising out
+        # of here without doing so leaves the workspace permanently unstartable,
+        # because the start path claims from 'stopped', never from 'starting'.
+        try:
+            self._sessions.pop(workspace_id, None)
+            try:
+                await SessionManager.cleanup_session(workspace_id)
+            except Exception as e:
+                # cleanup_session may fail after cleanup() but before del
+                # _sessions, leaving a stale entry.  Evict unconditionally so
+                # _recover_sandbox creates a fresh session.
+                SessionManager.remove_session(workspace_id)
+                logger.warning(f"Old sandbox cleanup failed for {workspace_id}: {e}")
+
+            # 3. Create fresh sandbox + restore files from DB
+            core_config = self.config.to_core_config()
+            new_session = await self._recover_sandbox(
+                workspace_id, user_id, core_config
+            )
+        except (Exception, asyncio.CancelledError):
+            # Files are backed up and the old sandbox is gone, so 'stopped' lets
+            # the next start self-heal. 'error' would be terminal — the start
+            # path refuses it outright.
+            #
+            # CancelledError is caught explicitly because it is a BaseException:
+            # a client disconnect or a shutdown landing mid-replacement would
+            # otherwise skip this and strand the row in 'starting', which no
+            # start can claim.
+            await update_workspace_status(workspace_id, "stopped")
+            raise
 
         # 4. Stamp DB so future reconnects skip migration.
         # Retry once on failure — an unstamped workspace would re-migrate every
@@ -1238,31 +1604,50 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
             return False
         return session.sandbox.is_ready()
 
-    def get_session_if_ready(self, workspace_id: str) -> "Session | None":
-        """Return the cached session iff it's ready, else None (no I/O, no wake).
+    def get_session_if_ready(
+        self, workspace_id: str, *, expected_sandbox_id: str | None
+    ) -> "Session | None":
+        """Return the cached session iff it's ready and bound to *expected_sandbox_id*.
 
         One-shot replacement for the ``has_ready_session()`` + ``_sessions.get()``
         pair so callers (e.g. the unauthenticated public serve routes) avoid the
         TOCTOU window between the two and don't reach into the private map.
+
+        Still no I/O and no wake — the unauthenticated routes must never let a
+        UUID-only request start a sandbox. The identity fence is free for them
+        because they already hold the ``workspaces`` row, and without it this is
+        a serving path that skips the check every other cache boundary makes:
+        a share link would keep answering from a replaced sandbox with the same
+        false "File not found" this change exists to remove. ``expected_sandbox_id``
+        is keyword-only and mandatory so a new caller cannot omit the fence.
+
+        A mismatch only declines to serve; retiring is the async acquisition
+        path's job, and these routes fall back to the persisted copy anyway.
         """
         session = self._sessions.get(workspace_id)
         if session is None or not session._initialized or not session.sandbox:
             return None
         if not session.sandbox.is_ready():
             return None
+        if self._session_sandbox_id(session) != expected_sandbox_id:
+            return None
         return session
 
-    def get_applied_mcp_config_version(self, workspace_id: str) -> int | None:
+    def get_applied_mcp_config_version(
+        self, workspace_id: str, *, expected_sandbox_id: str | None
+    ) -> int | None:
         """The MCP config version the warm session has applied (no I/O, no lock).
 
-        Returns None when no ready session exists — the config isn't loaded
-        anywhere live yet. The effective-list endpoint surfaces this so the UI
-        shows a version-accurate "applied / still applying" state instead of a
-        best-effort timer.
+        None means nothing is loaded live *that this worker can vouch for*: no
+        ready session, or one bound to a sandbox the workspace has since
+        replaced. The version is a claim about what a running sandbox holds, so
+        reporting a superseded session's would name a number no live sandbox has
+        applied — and the UI reads it as ground truth for "applied / still
+        applying".
         """
-        if not self.has_ready_session(workspace_id):
-            return None
-        session = self._sessions.get(workspace_id)
+        session = self.get_session_if_ready(
+            workspace_id, expected_sandbox_id=expected_sandbox_id
+        )
         return session.mcp_config_version if session is not None else None
 
     async def proactively_apply_mcp_config(
@@ -1381,18 +1766,10 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
         async with self._observed_lock(
             workspace_id, "workspace.session.acquire", cached_on_entry=_was_cached
         ):
-            # ── Fast path: check session cache before any DB call ──
-            if workspace_id in self._sessions:
-                session = self._sessions[workspace_id]
-                logger.debug(
-                    f"Found cached session for {workspace_id}, "
-                    f"initialized={session._initialized}, has_sandbox={session.sandbox is not None}"
-                )
-
-                if not session._initialized or not session.sandbox:
-                    # Session exists but not usable, fall through to status-based handling
-                    session = None
-                elif not session.sandbox.is_ready():
+            # ── Fast path: check session cache before any full-row DB call ──
+            session = await self._take_valid_cached_session(workspace_id, _mark)
+            if session is not None:
+                if not session.sandbox.is_ready():
                     if session.sandbox.has_failed():
                         # Lazy init completed with error — clear broken session
                         init_err = session.sandbox.init_error
@@ -2136,6 +2513,25 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
         session = SessionManager.get_session(workspace_id, core_config)
         did_init = False
 
+        # ``SessionManager`` outlives ``self._sessions`` on purpose (stop_workspace
+        # leaves its entry so a restart can reuse it), so an already-initialized
+        # session here may still be bound to a sandbox this workspace has since
+        # replaced. Re-initializing is skipped for such a session, so validate the
+        # binding first or the stale handle gets promoted straight back into cache.
+        if session._initialized:
+            stale_reason = self._identity_is_stale(
+                workspace_id, session, dict(workspace)
+            )
+            if stale_reason is not None:
+                logger.warning(
+                    f"Discarding stale SessionManager session for "
+                    f"{workspace_id} on attach ({stale_reason})",
+                    extra={"workspace_id": workspace_id, "reason": stale_reason},
+                )
+                await self._retire_session(workspace_id, session, reason=stale_reason)
+                safe_add(session_path_counter, 1, {"path": "stale_reattach"})
+                session = SessionManager.get_session(workspace_id, core_config)
+
         if not session._initialized:
             sandbox_id = workspace.get("sandbox_id")
             try:
@@ -2164,6 +2560,49 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
                 ws_version=int(workspace.get("platform_secret_version") or 0),
             )
             mark("platform_secret")
+
+            # ``initialize`` BUILDS a sandbox when the row names none, so this
+            # path can provision without ever having gone through provisioning.
+            # Binding it is not optional bookkeeping: the row is what every
+            # other worker validates against, so leaving it NULL means the
+            # identity check calls this session stale on the very next request,
+            # retires it, and builds another sandbox — a fresh billed sandbox
+            # per request, each one abandoned with the files still in it.
+            live_sandbox_id = self._session_sandbox_id(session)
+            if live_sandbox_id and live_sandbox_id != sandbox_id:
+                from src.server.services.platform_secret_rollout import (
+                    certify_platform_secrets,
+                )
+
+                # Certify before binding, for the same reason provisioning does:
+                # statement order is what keeps a workspace from ever pointing
+                # at an uncertified sandbox. The resync above is what makes the
+                # certification pass for a sandbox built on this path.
+                secret_version = await certify_platform_secrets(
+                    core_config, runtime=session.sandbox.runtime
+                )
+                bound = await try_bind_workspace_sandbox(
+                    workspace_id,
+                    sandbox_id=live_sandbox_id,
+                    expected_previous_sandbox_id=sandbox_id,
+                    platform_secret_version=secret_version,
+                )
+                if bound is None:
+                    # Another worker bound first. Ours is real and unreferenced,
+                    # so it must not survive; the caller's retry attaches to the
+                    # winner. Same contract as _provision_sandbox_session.
+                    logger.warning(
+                        f"Lost the sandbox-identity race for {workspace_id} on "
+                        f"attach; discarding our sandbox {live_sandbox_id}",
+                        extra={
+                            "workspace_id": workspace_id,
+                            "sandbox_id": live_sandbox_id,
+                        },
+                    )
+                    await self._clear_session(workspace_id, evict_session=session)
+                    raise SandboxIdentityLostError(workspace_id, live_sandbox_id)
+                workspace = bound
+                mark("bind_attached_sandbox")
 
             # Resolve + install the per-workspace composite before asset sync so
             # codegen uploads user-server wrappers. Cheap; discovery kicked in
@@ -2515,6 +2954,9 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
                     session,
                     workspace,
                     expected_hash=expected_hash,
+                    # This path owns the transition already: the row is
+                    # 'starting' and claimed by this task.
+                    transition_already_owned=True,
                 )
                 if migrated is not None:
                     return migrated
@@ -2598,16 +3040,52 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
             # sandbox so it can't run against a dead sandbox / write orphan rows.
             self._cancel_mcp_discovery(workspace_id)
 
+            durable_sandbox_id = workspace.get("sandbox_id")
+
             try:
                 # Backup files to DB before stopping sandbox
-                await self._backup_files_to_db(workspace_id)
+                await self._backup_files_to_db(
+                    workspace_id, expected_sandbox_id=durable_sandbox_id
+                )
 
-                # Stop the session (stops sandbox, preserves data)
+                # Stop the session (stops sandbox, preserves data). Only the
+                # session bound to the DURABLE sandbox may be stopped this way —
+                # any other cached session belongs to a superseded sandbox, and
+                # stopping it would leave the real one running while the row says
+                # 'stopped'. Same shape when this worker holds no session at all.
                 session = self._sessions.get(workspace_id)
-                if session:
+                attached_sandbox_id = self._session_sandbox_id(session)
+                if session is not None and attached_sandbox_id == durable_sandbox_id:
                     await session.stop()
                     # Remove from cache (will be recreated on restart)
                     del self._sessions[workspace_id]
+                else:
+                    if session is not None:
+                        await self._retire_session(
+                            workspace_id,
+                            session,
+                            reason=(
+                                "stop_workspace saw a session bound to "
+                                f"{attached_sandbox_id}, durable is "
+                                f"{durable_sandbox_id}"
+                            ),
+                        )
+                    if durable_sandbox_id:
+                        try:
+                            await self._detached_sandbox_teardown(
+                                workspace_id, durable_sandbox_id, delete=False
+                            )
+                        except Exception as e:
+                            # Best-effort on purpose: this except-block marks the
+                            # row 'error', which the start path refuses outright.
+                            # Bricking a workspace over a provider blip is worse
+                            # than a sandbox that Daytona's own auto-stop will
+                            # reap — unlike delete, stop has a safety net.
+                            logger.warning(
+                                f"Could not stop detached sandbox "
+                                f"{durable_sandbox_id} for {workspace_id}: {e}; "
+                                "marking stopped and leaving it to auto-stop"
+                            )
 
                 self._pending_lazy_sync.discard(workspace_id)
                 self._last_sync_at.pop(workspace_id, None)
@@ -2651,19 +3129,13 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
             if not sandbox_id:
                 raise RuntimeError("No sandbox associated with this workspace")
 
-            from ptc_agent.core.sandbox.providers import create_provider
-
-            provider = create_provider(self.config.to_core_config())
-            try:
-                runtime = await provider.get(sandbox_id)
+            async with self._detached_runtime(sandbox_id) as runtime:
                 if "archive" not in runtime.capabilities:
                     raise RuntimeError(
                         f"Provider does not support archiving "
                         f"(capabilities: {runtime.capabilities})"
                     )
                 await runtime.archive()
-            finally:
-                await provider.close()
 
             logger.info(f"Workspace {workspace_id} archived successfully")
             return workspace
@@ -2692,11 +3164,21 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
             # sandbox so it can't run against a dead sandbox / write orphan rows.
             self._cancel_mcp_discovery(workspace_id)
 
+            durable_sandbox_id = workspace.get("sandbox_id")
+
             try:
                 # Backup files to DB before deleting (if sandbox is accessible)
-                await self._backup_files_to_db(workspace_id)
+                await self._backup_files_to_db(
+                    workspace_id, expected_sandbox_id=durable_sandbox_id
+                )
 
-                # Remove from local cache (SessionManager.cleanup_session handles actual cleanup)
+                # ``cleanup_session`` only deletes the sandbox this process is
+                # attached to. When that is not the durable one — a stale handle,
+                # or no session on this worker at all — the real sandbox has to be
+                # deleted through the provider or it keeps running and billing
+                # behind a soft-deleted row.
+                session = self._sessions.get(workspace_id)
+                attached_sandbox_id = self._session_sandbox_id(session)
                 self._sessions.pop(workspace_id, None)
 
                 self._pending_lazy_sync.discard(workspace_id)
@@ -2707,6 +3189,11 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
                     await SessionManager.cleanup_session(workspace_id)
                 except Exception as e:
                     logger.warning(f"Error cleaning up from SessionManager: {e}")
+
+                if durable_sandbox_id and attached_sandbox_id != durable_sandbox_id:
+                    await self._detached_sandbox_teardown(
+                        workspace_id, durable_sandbox_id, delete=True
+                    )
 
                 # Soft delete in DB
                 await db_delete_workspace(workspace_id)

--- a/src/server/utils/error_sanitization.py
+++ b/src/server/utils/error_sanitization.py
@@ -32,3 +32,33 @@ def sanitize_error_text(text: str) -> str:
     text = _URL_KEY_QUERY_RE.sub(r"\1[REDACTED]", text)
     text = _SK_TOKEN_RE.sub("[REDACTED]", text)
     return _GOOGLE_KEY_RE.sub("[REDACTED]", text)
+
+
+def single_line(text: str) -> str:
+    """Escape CR/LF so untrusted text cannot forge log lines.
+
+    Provider exceptions quote response bodies verbatim, and a body the client
+    influenced can carry a newline followed by a convincing fake entry.
+    """
+    return text.replace("\r", "\\r").replace("\n", "\\n")
+
+
+# The file panel categorizes a 503 by matching this prefix, so every producer
+# must spell it identically or the same condition renders a different card.
+SANDBOX_UNREACHABLE_PREFIX = "Sandbox is not reachable: "
+
+
+def sandbox_unreachable_detail(exc: BaseException) -> str:
+    """Client-safe 503 detail for an unreachable sandbox.
+
+    Provider exceptions quote request URLs, sandbox ids and SDK response bodies,
+    none of which may cross to a client, so the raw text never reaches this
+    string and survives only in the server log. Reading "starting" back out of
+    the message is a protocol read rather than the message matching this module
+    otherwise avoids: the sandbox layer stamps that word deliberately as the
+    carrier for the in-flight case, and it is the one distinction the file panel
+    renders differently.
+    """
+    if "starting" in str(exc).lower():
+        return f"{SANDBOX_UNREACHABLE_PREFIX}the sandbox is still starting"
+    return f"{SANDBOX_UNREACHABLE_PREFIX}please retry in a moment"

--- a/tests/integration/test_message_hot_path.py
+++ b/tests/integration/test_message_hot_path.py
@@ -265,15 +265,22 @@ class TestColdWarmSessionPath:
 
         assert session1 is session2
 
-    async def test_warm_path_zero_db_queries(
+    async def test_warm_path_makes_only_the_narrow_identity_query(
         self, workspace_manager, running_workspace, metrics_collector
     ):
-        """Within sync cooldown, warm path makes zero db_get_workspace calls.
+        """Within sync cooldown, the warm path reads identity and nothing else.
 
         The cold path creates the session inline (Phase 1) and does NOT call
         _record_sync (Phase 2 is skipped).  The second call triggers Phase 2
-        which records the cooldown.  The THIRD call is the true warm path
-        that skips DB entirely.
+        which records the cooldown.  The THIRD call is the true warm path.
+
+        It is no longer zero queries: a cached sandbox handle cannot be served
+        without checking it against the durable binding, or a worker goes on
+        answering from a sandbox that was replaced. What the hot path must still
+        never do is pull the full row, which selects the JSONB config/artifacts
+        columns. Both halves are asserted, because patching only the full-row
+        helper would leave this passing no matter how many identity reads the
+        warm path grew.
         """
         ws_id = str(running_workspace["workspace_id"])
         user_id = running_workspace["user_id"]
@@ -284,20 +291,33 @@ class TestColdWarmSessionPath:
         # Call 2 — triggers Phase 2 re-sync, records cooldown via _record_sync
         await workspace_manager.get_session_for_workspace(ws_id, user_id=user_id)
 
-        # Call 3 (warm) — cooldown active, should skip DB entirely
-        with patch(
-            "src.server.services.workspace_manager.db_get_workspace",
-            new_callable=AsyncMock,
-        ) as mock_db:
+        # Call 3 (warm) — cooldown active
+        from src.server.services import workspace_manager as workspace_manager_module
+
+        real_identity = workspace_manager_module.db_get_workspace_identity
+        with (
+            patch(
+                "src.server.services.workspace_manager.db_get_workspace",
+                new_callable=AsyncMock,
+            ) as mock_full_row,
+            patch(
+                "src.server.services.workspace_manager.db_get_workspace_identity",
+                side_effect=real_identity,
+            ) as spy_identity,
+        ):
             async with metrics_collector.timed(
                 provider=_PROVIDER, category="session", operation="warm_zero_db",
-                test_name="warm_path_zero_db_queries",
+                test_name="warm_path_makes_only_the_narrow_identity_query",
             ):
                 session = await workspace_manager.get_session_for_workspace(
                     ws_id, user_id=user_id
                 )
 
-            mock_db.assert_not_called()
+            mock_full_row.assert_not_called()
+            assert spy_identity.call_count == 1, (
+                f"warm path made {spy_identity.call_count} identity queries, "
+                "expected exactly 1"
+            )
             assert session is not None
 
     async def test_sync_cooldown_respected(

--- a/tests/integration/test_platform_secret_rollout_db.py
+++ b/tests/integration/test_platform_secret_rollout_db.py
@@ -213,9 +213,9 @@ async def test_provider_change_is_an_identity_change(
 async def test_certification_attaches_a_verified_replacement(
     seed_workspace, patched_get_db_connection, db_conn
 ):
-    from src.server.services.platform_secret_rollout import (
-        certify_new_workspace_sandbox,
-    )
+    """Verify, then bind — the order that keeps an uncertified sandbox unbound."""
+    from src.server.database.workspace import try_bind_workspace_sandbox
+    from src.server.services.platform_secret_rollout import certify_platform_secrets
 
     rollout_set = await _register(
         _identity(secret_id="secret-1", placeholder="dtn_secret_one")
@@ -225,16 +225,38 @@ async def test_certification_attaches_a_verified_replacement(
     config = _capable_config()
     with pytest.MonkeyPatch.context() as monkeypatch:
         monkeypatch.setattr("src.config.env.HOST_MODE", "platform")
-        workspace = await certify_new_workspace_sandbox(
-            config,
-            workspace_id=workspace_id,
-            expected_previous_sandbox_id=None,
-            sandbox_id="replacement-sandbox",
-            runtime=_VerifiedRuntime("dtn_secret_one"),
+        version = await certify_platform_secrets(
+            config, runtime=_VerifiedRuntime("dtn_secret_one")
         )
+
+    assert version == rollout_set.generation
+    workspace = await try_bind_workspace_sandbox(
+        workspace_id,
+        sandbox_id="replacement-sandbox",
+        expected_previous_sandbox_id=None,
+        platform_secret_version=version,
+    )
 
     assert workspace["platform_secret_version"] == rollout_set.generation
     assert workspace["sandbox_id"] == "replacement-sandbox"
+
+
+async def test_certification_without_a_catalog_stamps_the_zero_sentinel(
+    seed_workspace, patched_get_db_connection
+):
+    """0 means "never certified — may hold plaintext env" (migration 021).
+
+    A no-catalog deployment must stamp it rather than carry the previous
+    sandbox's generation forward, which would leave a plaintext sandbox looking
+    certified and invisible to the sweeper.
+    """
+    from src.server.services.platform_secret_rollout import certify_platform_secrets
+
+    await _register(_identity(secret_id="secret-1", placeholder="dtn_secret_one"))
+    sandbox = type("Sandbox", (), {"provider": "daytona", "platform_secrets": ()})()
+    config = type("Config", (), {"sandbox": sandbox})()
+
+    assert await certify_platform_secrets(config, runtime=None) == 0
 
 
 async def test_stamp_cas_rejects_a_moved_workspace(
@@ -257,27 +279,81 @@ async def test_stamp_cas_rejects_a_moved_workspace(
         )
 
 
-async def test_certify_cas_rejects_a_concurrent_attachment(
+async def test_bind_cas_rejects_a_concurrent_attachment(
     seed_workspace, patched_get_db_connection
 ):
-    from src.server.services.platform_secret_rollout import (
-        certify_new_workspace_sandbox,
+    """A losing provisioner gets None, not the row — never a silent overwrite.
+
+    None is the signal to delete the sandbox it just built and re-attach to the
+    winner's; a last-writer-wins UPDATE here is how two workers both believe
+    they own the workspace and one sandbox is billed with nothing pointing at
+    it.
+    """
+    from src.server.database.workspace import (
+        get_workspace_identity,
+        try_bind_workspace_sandbox,
     )
 
-    await _register(_identity(secret_id="secret-1", placeholder="dtn_secret_one"))
     workspace_id = str(seed_workspace["workspace_id"])
+    await try_bind_workspace_sandbox(
+        workspace_id,
+        sandbox_id="winner-sandbox",
+        expected_previous_sandbox_id=None,
+        platform_secret_version=7,
+    )
 
-    config = _capable_config()
-    with pytest.MonkeyPatch.context() as monkeypatch:
-        monkeypatch.setattr("src.config.env.HOST_MODE", "platform")
-        with pytest.raises(RuntimeError, match="before platform Secret"):
-            await certify_new_workspace_sandbox(
-                config,
-                workspace_id=workspace_id,
-                expected_previous_sandbox_id="stale-previous-sandbox",
-                sandbox_id="replacement-sandbox",
-                runtime=_VerifiedRuntime("dtn_secret_one"),
-            )
+    lost = await try_bind_workspace_sandbox(
+        workspace_id,
+        sandbox_id="replacement-sandbox",
+        expected_previous_sandbox_id="stale-previous-sandbox",
+        platform_secret_version=9,
+    )
+
+    assert lost is None
+    identity = await get_workspace_identity(workspace_id)
+    assert identity["sandbox_id"] == "winner-sandbox"
+
+
+@pytest.mark.parametrize("stopped_status", ["stopping", "stopped"])
+async def test_bind_cas_refuses_to_resurrect_a_stopped_workspace(
+    seed_workspace, patched_get_db_connection, stopped_status
+):
+    """Identity matching alone would let a recovery undo a concurrent stop.
+
+    The dangerous race shares the sandbox id rather than changing it, so the
+    id-only predicate matched: worker B stops the workspace while worker A
+    recovers the SAME sandbox, and since this statement writes ``running``
+    unconditionally the bind resurrected the row. The outcome is a ``stopped``
+    row whose sandbox is still up and billing, or a workspace that restarts
+    itself after a user stopped it.
+    """
+    from src.server.database.workspace import (
+        get_workspace_identity,
+        try_bind_workspace_sandbox,
+        update_workspace_status,
+    )
+
+    workspace_id = str(seed_workspace["workspace_id"])
+    await try_bind_workspace_sandbox(
+        workspace_id,
+        sandbox_id="sb-old",
+        expected_previous_sandbox_id=None,
+        platform_secret_version=1,
+    )
+    await update_workspace_status(workspace_id=workspace_id, status=stopped_status)
+
+    # Same expected id: this is a recovery of the very sandbox being stopped.
+    lost = await try_bind_workspace_sandbox(
+        workspace_id,
+        sandbox_id="sb-new",
+        expected_previous_sandbox_id="sb-old",
+        platform_secret_version=2,
+    )
+
+    assert lost is None
+    identity = await get_workspace_identity(workspace_id)
+    assert identity["status"] == stopped_status
+    assert identity["sandbox_id"] == "sb-old"
 
 
 async def test_missing_rollout_row_fails_readiness(patched_get_db_connection):

--- a/tests/integration/test_workspace_lifecycle.py
+++ b/tests/integration/test_workspace_lifecycle.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import uuid
 
 import pytest
-import pytest_asyncio
 
 pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
 
@@ -138,19 +137,48 @@ class TestUpdateWorkspace:
         assert updated["status"] == "stopped"
         assert updated["stopped_at"] is not None
 
-    async def test_update_workspace_status_with_sandbox_id(
+    async def test_update_workspace_status_leaves_the_binding_alone(
         self, seed_workspace, patched_get_db_connection
     ):
-        from src.server.database.workspace import update_workspace_status
+        """A status move must never rebind the workspace to a sandbox.
+
+        ``try_bind_workspace_sandbox``'s compare-and-set is the sole writer of
+        ``sandbox_id``; if a plain status change could also write it, a worker
+        holding a superseded id could resurrect it.
+        """
+        from src.server.database.workspace import (
+            try_bind_workspace_sandbox,
+            update_workspace_status,
+        )
 
         ws_id = str(seed_workspace["workspace_id"])
-        updated = await update_workspace_status(
-            ws_id, "running", sandbox_id="sandbox-abc-123"
+        await try_bind_workspace_sandbox(
+            ws_id,
+            sandbox_id="sandbox-abc-123",
+            expected_previous_sandbox_id=None,
+            platform_secret_version=0,
         )
+
+        updated = await update_workspace_status(ws_id, "running")
 
         assert updated is not None
         assert updated["status"] == "running"
         assert updated["sandbox_id"] == "sandbox-abc-123"
+
+    async def test_update_workspace_status_cannot_revive_a_deleted_row(
+        self, seed_workspace, patched_get_db_connection
+    ):
+        """Soft-deleted is terminal: nothing clears ``sandbox_id`` on delete, so a
+        revived row would hand its still-named sandbox back out."""
+        from src.server.database.workspace import (
+            delete_workspace,
+            update_workspace_status,
+        )
+
+        ws_id = str(seed_workspace["workspace_id"])
+        await delete_workspace(ws_id)
+
+        assert await update_workspace_status(ws_id, "running") is None
 
     async def test_update_workspace_activity(
         self, seed_workspace, patched_get_db_connection

--- a/tests/unit/ptc_agent/agent/backends/test_sandbox_backend.py
+++ b/tests/unit/ptc_agent/agent/backends/test_sandbox_backend.py
@@ -23,6 +23,7 @@ from deepagents.backends.protocol import (
 )
 
 from ptc_agent.agent.backends.sandbox import SandboxBackend
+from ptc_agent.core.sandbox.runtime import SandboxTransientError
 
 
 # ---------------------------------------------------------------------------
@@ -295,6 +296,25 @@ class TestAedit:
         await backend.aedit("/f.py", "x", "y")
         cb.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_a_failed_readback_does_not_fail_a_committed_edit(self, sandbox):
+        """The read now raises where it used to return None.
+
+        The edit is already committed by the time the callback re-reads, so
+        letting a sandbox that died in between propagate would fail the whole
+        tool call over a snapshot the callback can do without.
+        """
+        sandbox.aedit_file_text.return_value = {"success": True, "occurrences": 2}
+        sandbox.aread_file_text.side_effect = SandboxTransientError("sandbox went away")
+        cb = MagicMock()
+        backend = SandboxBackend(sandbox, operation_callback=cb)
+
+        result = await backend.aedit("/f.py", "old", "new")
+
+        assert result.error is None
+        assert result.occurrences == 2
+        assert cb.call_args.args[0]["content"] is None
+
 
 class TestAdownloadAupload:
     """Protocol-surface batch file transfer methods."""
@@ -311,10 +331,15 @@ class TestAdownloadAupload:
         assert r.error == "file_not_found"
 
     @pytest.mark.asyncio
-    async def test_adownload_exception_maps_to_file_not_found(self, sandbox, backend):
+    async def test_adownload_exception_is_not_reported_as_not_found(
+        self, sandbox, backend
+    ):
+        """A transport failure must not read as "this file does not exist"."""
         sandbox.adownload_file_bytes.side_effect = RuntimeError("net")
         [r] = await backend.adownload_files(["/x.txt"])
-        assert r.error == "file_not_found"
+        assert r.error is not None
+        assert r.error != "file_not_found"
+        assert "net" in r.error
 
     @pytest.mark.asyncio
     async def test_adownload_mixed_batch_preserves_order(self, sandbox, backend):

--- a/tests/unit/ptc_agent/config/test_structlog_exception_rendering.py
+++ b/tests/unit/ptc_agent/config/test_structlog_exception_rendering.py
@@ -1,0 +1,54 @@
+"""Unit test for ``configure_structlog``'s exception rendering.
+
+structlog's ``ConsoleRenderer`` defaults to ``show_locals=True``, which writes
+every frame local into the log. Logs never pass through
+``src/server/utils/secret_redactor.py`` (that covers user-facing file content),
+so the default turns any ``exc_info=True`` in a frame holding a credential into
+a plaintext leak. Nothing fails if someone simplifies the renderer back to a
+bare ``ConsoleRenderer()``, which is why this is pinned.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+
+import pytest
+import structlog
+
+from ptc_agent.config.utils import configure_structlog
+
+_TOKEN = "gxsa_pinned_test_token_value"  # noqa: S105 — not a real credential
+
+
+@pytest.fixture(autouse=True)
+def _restore_structlog_defaults():
+    """``configure_structlog`` mutates global structlog state; undo it."""
+    yield
+    structlog.reset_defaults()
+
+
+def _emit_handled_exception() -> str:
+    """Log an exception from a frame whose locals hold a token; return the output."""
+    configure_structlog("INFO")
+    log = structlog.get_logger("test_structlog_exception_locals")
+    buf = io.StringIO()
+    try:
+        exec_command = f"curl -H 'Authorization: Bearer {_TOKEN}'"  # noqa: F841
+        raise RuntimeError("sandbox is gone")
+    except RuntimeError:
+        with contextlib.redirect_stdout(buf):
+            log.error("Failed to execute bash command", exc_info=True)
+    return buf.getvalue()
+
+
+def test_exception_rendering_omits_frame_locals():
+    output = _emit_handled_exception()
+
+    assert "Traceback" in output, "the traceback itself must still be rendered"
+    # The source line assigning exec_command is legitimately rendered as code
+    # context; what must never appear is the resolved runtime value.
+    assert _TOKEN not in output
+    # rich titles the panel " locals "; match with the spaces so a path or
+    # identifier that merely contains the word cannot satisfy the assertion.
+    assert " locals " not in output, "rich's locals panel must not be rendered"

--- a/tests/unit/ptc_agent/core/sandbox/test_error_state_is_recoverable.py
+++ b/tests/unit/ptc_agent/core/sandbox/test_error_state_is_recoverable.py
@@ -1,0 +1,151 @@
+"""An error-state sandbox is transient, because ``reconnect`` still revives it.
+
+``reconnect`` answers state ``error`` with a recovery ``start`` rather than
+giving up. If this module called that state absence instead, the caller would
+act on ``SandboxGoneError`` by building a replacement and restoring from the
+last backup, destroying a sandbox a ``start`` would have brought back and losing
+every write since that backup. The two paths have to agree on what is fatal.
+
+``reconnect`` used to disagree: it gave a sandbox about 20s to leave ``starting``
+(10s for ``stopping``) and then raised ``SandboxGoneError``, so a slow but live
+control-plane transition authorized a replacement. The last test here pins the
+two paths together, because the classifier agreeing with itself proves nothing
+about the function that actually destroys sandboxes.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from ptc_agent.config.core import (
+    CoreConfig,
+    DaytonaConfig,
+    FilesystemConfig,
+    LoggingConfig,
+    MCPConfig,
+    SandboxConfig,
+    SecurityConfig,
+)
+from ptc_agent.core.sandbox.files import _classify_by_liveness
+from ptc_agent.core.sandbox.ptc_sandbox import PTCSandbox
+from ptc_agent.core.sandbox.runtime import (
+    RuntimeState,
+    SandboxGoneError,
+    SandboxTransientError,
+)
+
+
+def _sandbox(state: RuntimeState):
+    """A sandbox whose liveness probe reports *state*.
+
+    Only the three attributes ``_classify_by_liveness`` reads, so nothing here
+    depends on a provider or a live runtime.
+    """
+
+    class _Runtime:
+        async def refresh_state(self):
+            return state
+
+    class _Provider:
+        def classify_error(self, exc):  # never reached: the probe succeeds
+            raise AssertionError("probe succeeded, so the error is not reclassified")
+
+    class _Sandbox:
+        runtime = _Runtime()
+        provider = _Provider()
+        sandbox_id = "sbx-test"
+
+    return _Sandbox()
+
+
+@pytest.mark.asyncio
+async def test_error_state_is_transient_not_gone():
+    result = await _classify_by_liveness(
+        _sandbox(RuntimeState.ERROR), RuntimeError("boom"), op="download_file", path="/a.txt"
+    )
+    assert isinstance(result, SandboxTransientError)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "state",
+    [
+        RuntimeState.RUNNING,
+        RuntimeState.STARTING,
+        RuntimeState.STOPPED,
+        RuntimeState.STOPPING,
+        RuntimeState.ARCHIVED,
+        RuntimeState.ERROR,
+    ],
+)
+async def test_liveness_probe_calls_every_recoverable_state_transient(state):
+    """What ``_classify_by_liveness`` alone decides, which is all this covers.
+
+    Deliberately not named for ``reconnect``: that function is a separate path
+    with its own verdict, pinned separately below. Parametrized rather than
+    asserted against the frozenset so a regression fails on behavior, not on a
+    container's contents.
+    """
+    result = await _classify_by_liveness(
+        _sandbox(state), RuntimeError("boom"), op="list_files", path="/"
+    )
+    assert isinstance(result, SandboxTransientError)
+    assert not isinstance(result, SandboxGoneError)
+
+
+def _config() -> CoreConfig:
+    return CoreConfig(
+        sandbox=SandboxConfig(daytona=DaytonaConfig(api_key="test-key")),
+        security=SecurityConfig(),
+        mcp=MCPConfig(),
+        logging=LoggingConfig(),
+        filesystem=FilesystemConfig(),
+    )
+
+
+def _stuck_provider(state: RuntimeState):
+    """A provider whose sandbox never leaves *state* but always answers."""
+
+    class _Runtime:
+        id = "sbx-stuck"
+
+        async def get_state(self):
+            return state
+
+    class _Provider:
+        async def get(self, sandbox_id, **kwargs):
+            return _Runtime()
+
+        def is_transient_error(self, exc):  # consulted by the retry wrapper
+            return False
+
+        def classify_error(self, exc):
+            raise AssertionError("provider.get succeeded; nothing to classify")
+
+    return _Provider()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "state, expected_word",
+    [(RuntimeState.STARTING, "starting"), (RuntimeState.STOPPING, "stopping")],
+)
+async def test_a_transition_that_times_out_is_transient_not_gone(state, expected_word):
+    """The path that actually destroys sandboxes, not the classifier beside it.
+
+    Reading the state back is positive evidence the sandbox exists, so a wait
+    that runs out is a retry. ``SandboxGoneError`` is the authorization to
+    replace, and its handlers in ``workspace_manager`` call ``_clear_session``
+    before recovering, which deletes the runtime — so raising it here destroyed
+    a live sandbox mid-boot and restored it from the last DB backup.
+    """
+    sandbox = PTCSandbox(_config(), None)
+    sandbox.provider = _stuck_provider(state)
+
+    # The waits are ~20s and ~10s of real sleeping; only the verdict is at issue.
+    with patch("asyncio.sleep", new=AsyncMock()):
+        with pytest.raises(SandboxTransientError) as excinfo:
+            await sandbox.reconnect("sbx-stuck")
+
+    assert not isinstance(excinfo.value, SandboxGoneError)
+    assert expected_word in str(excinfo.value).lower()

--- a/tests/unit/ptc_agent/core/sandbox/test_provider_absence_classification.py
+++ b/tests/unit/ptc_agent/core/sandbox/test_provider_absence_classification.py
@@ -1,0 +1,137 @@
+"""The base classifier must read ``FileNotFoundError`` as absence.
+
+``DaytonaProvider`` is the only provider whose SDK reports a machine-readable
+``FILE_NOT_FOUND``; every other provider raises Python's ``FileNotFoundError``
+and overrides ``classify_error`` not at all. Without a type-based absence signal
+on the base, an ordinary missing file falls through to ``UNKNOWN``, the liveness
+probe finds the sandbox perfectly alive, and the caller is handed a transient —
+so "this file isn't there" reaches the user as a 503 instead of a 404.
+
+Exercised against ``DockerProvider`` rather than a stub because it is the
+shipping provider that inherits the default, and the ordering below is only
+load-bearing given its real message-scanning ``is_transient_error``.
+
+``DaytonaProvider`` overrides ``classify_error`` outright rather than reusing
+that ordering, so the base tests say nothing about it and it is pinned
+separately at the bottom of this module.
+"""
+
+from daytona.common.errors import DaytonaNotFoundError
+
+from ptc_agent.core.sandbox.providers.daytona import DaytonaProvider
+from ptc_agent.core.sandbox.providers.docker import DockerProvider
+from ptc_agent.core.sandbox.runtime import SandboxFailureKind
+
+
+def _provider() -> DockerProvider:
+    """A provider bypassing ``__init__``.
+
+    Both methods under test read only the exception, so the docker client and
+    config a real one needs would be dead weight.
+    """
+    return DockerProvider.__new__(DockerProvider)
+
+
+def test_file_not_found_is_absence() -> None:
+    assert (
+        _provider().classify_error(FileNotFoundError("File not found: /data/report.csv"))
+        is SandboxFailureKind.PATH_ABSENT
+    )
+
+
+def test_absence_outranks_the_transient_message_scan() -> None:
+    """A filename is not a diagnosis.
+
+    ``is_transient_error`` matches "connection" anywhere in the message, so
+    checking it first would classify a file whose own path contains the word as
+    a connection fault — and that file could never be reported missing.
+    """
+    assert (
+        _provider().classify_error(
+            FileNotFoundError("File not found: /data/connection.log")
+        )
+        is SandboxFailureKind.PATH_ABSENT
+    )
+
+
+def test_a_real_transient_still_classifies_as_transient() -> None:
+    assert (
+        _provider().classify_error(RuntimeError("connection refused"))
+        is SandboxFailureKind.TRANSIENT
+    )
+
+
+def test_an_unclassifiable_failure_stays_unknown() -> None:
+    """``UNKNOWN`` is the honest answer, not a synonym for absent.
+
+    It routes to the liveness probe; collapsing it into ``PATH_ABSENT`` is the
+    conflation that reported live files as deleted.
+    """
+    assert (
+        _provider().classify_error(RuntimeError("something we have never seen"))
+        is SandboxFailureKind.UNKNOWN
+    )
+
+
+def _daytona() -> DaytonaProvider:
+    """A provider bypassing ``__init__`` — ``classify_error`` reads only *exc*."""
+    return DaytonaProvider.__new__(DaytonaProvider)
+
+
+def _miss(path: str) -> DaytonaNotFoundError:
+    """A per-path miss shaped exactly as the live API returns it.
+
+    Message and metadata transcribed from a probe against SDK 0.200.1: the
+    server echoes the requested path into the message, which is precisely what
+    makes the message scan dangerous here.
+    """
+    return DaytonaNotFoundError(
+        f"Failed to download file: file not found: {path}",
+        status_code=404,
+        error_code="FILE_NOT_FOUND",
+    )
+
+
+def test_daytona_file_not_found_is_absence() -> None:
+    assert (
+        _daytona().classify_error(_miss("/home/workspace/report.csv"))
+        is SandboxFailureKind.PATH_ABSENT
+    )
+
+
+def test_daytona_absence_outranks_the_transient_message_scan() -> None:
+    """The override had this backwards, and the path is in the message.
+
+    ``is_transient_daytona_error`` matches "timeout" as a bare substring, so
+    scanning first made a missing ``session_timeout.log`` a transient: a plain
+    404 surfaced as a 503 retry card for a file that was never coming back.
+    """
+    exc = _miss("/home/workspace/session_timeout.log")
+
+    from ptc_agent.core.sandbox.providers.daytona_secrets import (
+        is_transient_daytona_error,
+    )
+
+    # The scan really does fire; only the ordering keeps it from deciding.
+    assert is_transient_daytona_error(exc) is True
+    assert _daytona().classify_error(exc) is SandboxFailureKind.PATH_ABSENT
+
+
+def test_daytona_a_real_transient_still_classifies_as_transient() -> None:
+    """Carrying no error code, it must still reach the scan."""
+    assert (
+        _daytona().classify_error(RuntimeError("Read timed out"))
+        is SandboxFailureKind.TRANSIENT
+    )
+
+
+def test_daytona_a_missing_sandbox_is_still_gone() -> None:
+    """A sandbox-level 404 keeps authorizing replacement; only files moved."""
+    assert (
+        _daytona().classify_error(
+            DaytonaNotFoundError(
+                "Sandbox not found", status_code=404, error_code="NOT_FOUND"
+            )
+        )
+        is SandboxFailureKind.SANDBOX_GONE
+    )

--- a/tests/unit/ptc_agent/core/sandbox/test_reconnect_error_classification.py
+++ b/tests/unit/ptc_agent/core/sandbox/test_reconnect_error_classification.py
@@ -1,0 +1,76 @@
+"""Only a positively identified absence may come out of ``reconnect`` as Gone.
+
+``SandboxGoneError`` is not just a status code here — the manager answers it by
+provisioning a replacement and abandoning the sandbox it was holding. So the
+classification is an authorization decision, and ``SandboxFailureKind.UNKNOWN``
+(where a rotated or under-privileged provider key lands) must not reach it:
+declaring a live sandbox gone recreates it on every request and leaks the
+original each time.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ptc_agent.core.sandbox.ptc_sandbox import PTCSandbox
+from ptc_agent.core.sandbox.runtime import (
+    SandboxFailureKind,
+    SandboxGoneError,
+    SandboxTransientError,
+)
+
+
+def _sandbox(kind: SandboxFailureKind, failure: Exception) -> PTCSandbox:
+    """A PTCSandbox wired so ``provider.get`` fails and classifies as *kind*.
+
+    Bypasses __init__ on purpose: a real one needs a provider and a config, and
+    reconnect touches only the caches cleared below before it reaches the call
+    under test.
+    """
+    sandbox = PTCSandbox.__new__(PTCSandbox)
+    sandbox._bg_sessions = {}
+    sandbox._bg_trace_paths = {}
+    sandbox._preview_sessions = {}
+    sandbox._preview_link_cache = {}
+    sandbox.runtime = None
+    sandbox.provider = MagicMock()
+    sandbox.provider.get = MagicMock()
+    sandbox.provider.classify_error = MagicMock(return_value=kind)
+    sandbox._runtime_call = AsyncMock(side_effect=failure)
+    return sandbox
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kind",
+    [
+        SandboxFailureKind.UNKNOWN,
+        SandboxFailureKind.TRANSIENT,
+        SandboxFailureKind.PATH_ABSENT,
+    ],
+)
+async def test_only_sandbox_gone_authorizes_destructive_recovery(kind):
+    sandbox = _sandbox(kind, RuntimeError("boom"))
+
+    with pytest.raises(SandboxTransientError):
+        await sandbox.reconnect("sandbox-abc")
+
+
+@pytest.mark.asyncio
+async def test_confirmed_absence_still_raises_gone():
+    sandbox = _sandbox(SandboxFailureKind.SANDBOX_GONE, RuntimeError("404"))
+
+    with pytest.raises(SandboxGoneError):
+        await sandbox.reconnect("sandbox-abc")
+
+
+@pytest.mark.asyncio
+async def test_a_transient_error_is_never_upgraded_to_gone():
+    """``_runtime_call`` already raises typed transients out of its retry
+    envelope; those must pass through rather than be re-classified."""
+    sandbox = _sandbox(
+        SandboxFailureKind.UNKNOWN, SandboxTransientError("provider blip")
+    )
+
+    with pytest.raises(SandboxTransientError, match="provider blip"):
+        await sandbox.reconnect("sandbox-abc")

--- a/tests/unit/ptc_agent/core/sandbox/test_wait_ready_error_typing.py
+++ b/tests/unit/ptc_agent/core/sandbox/test_wait_ready_error_typing.py
@@ -1,0 +1,72 @@
+"""``_wait_ready`` must raise typed sandbox errors, never a bare ``RuntimeError``.
+
+It runs *before* the ``try`` that normalizes each file/exec operation's failures,
+so it is the one place an untyped error can escape every classifier downstream.
+The HTTP layer keys its 503 on ``SandboxGoneError``/``SandboxTransientError``, and
+the chat funnel keys "is this a sandbox condition" on the same pair — a bare
+``RuntimeError`` gets a 500 and the generic error card instead.
+"""
+
+import asyncio
+
+import pytest
+
+from ptc_agent.core.sandbox.ptc_sandbox import PTCSandbox
+from ptc_agent.core.sandbox.runtime import SandboxTransientError
+
+
+def _sandbox(*, ready_event, runtime=None, init_error=None) -> PTCSandbox:
+    """A PTCSandbox with only the fields ``_wait_ready`` reads.
+
+    Bypasses __init__ on purpose: constructing a real one needs a provider and a
+    config, none of which this code path touches.
+    """
+    sandbox = PTCSandbox.__new__(PTCSandbox)
+    sandbox._ready_event = ready_event
+    sandbox.runtime = runtime
+    sandbox._init_error = init_error
+    return sandbox
+
+
+@pytest.mark.asyncio
+async def test_no_runtime_without_lazy_init_is_transient():
+    with pytest.raises(SandboxTransientError, match="not initialized"):
+        await _sandbox(ready_event=None)._wait_ready()
+
+
+@pytest.mark.asyncio
+async def test_ready_runtime_without_lazy_init_passes():
+    await _sandbox(ready_event=None, runtime=object())._wait_ready()
+
+
+@pytest.mark.asyncio
+async def test_init_timeout_says_starting(monkeypatch):
+    """The file panel selects its "starting" card by finding that word in the
+    detail, so the genuinely-in-flight case has to keep saying it."""
+    never_set = asyncio.Event()
+    sandbox = _sandbox(ready_event=never_set)
+
+    async def _immediate_timeout(awaitable, timeout):
+        awaitable.close()
+        raise asyncio.TimeoutError
+
+    # monkeypatch, not a bare assignment: this replaces a stdlib symbol for
+    # everything running in the process, so the restore has to survive a
+    # failure raised before a finally would be reached.
+    monkeypatch.setattr(asyncio, "wait_for", _immediate_timeout)
+    with pytest.raises(SandboxTransientError, match="still starting"):
+        await sandbox._wait_ready()
+
+
+@pytest.mark.asyncio
+async def test_init_error_propagates_verbatim():
+    """Whatever init recorded is re-raised as-is — reconnect already normalized
+    it, so re-wrapping here would only bury the real cause."""
+    ready = asyncio.Event()
+    ready.set()
+    recorded = SandboxTransientError("Sandbox init was cancelled")
+
+    with pytest.raises(SandboxTransientError) as caught:
+        await _sandbox(ready_event=ready, init_error=recorded)._wait_ready()
+
+    assert caught.value is recorded

--- a/tests/unit/server/app/test_mcp_servers.py
+++ b/tests/unit/server/app/test_mcp_servers.py
@@ -34,6 +34,7 @@ def _ws(workspace_id=None, user_id=USER, status="running", **overrides):
         "user_id": user_id,
         "name": "Test Workspace",
         "status": status,
+        "sandbox_id": "sb-1",
         "config": None,
         "mcp_config_version": 3,
         **overrides,
@@ -266,7 +267,30 @@ async def test_list_surfaces_applied_config_version(client):
     assert body["config_version"] == 3
     # applied (2) < saved (3) ⇒ the UI reads "applying", not "synced".
     assert body["applied_config_version"] == 2
-    wm.get_applied_mcp_config_version.assert_called_once_with(ws["workspace_id"])
+    # Fenced on the row's binding: a version from a session holding a superseded
+    # sandbox is not something this worker can vouch for.
+    wm.get_applied_mcp_config_version.assert_called_once_with(
+        ws["workspace_id"], expected_sandbox_id="sb-1"
+    )
+
+
+def test_live_sandbox_declines_a_superseded_handle():
+    """Discovery probes a sandbox and persists the schemas under the workspace,
+    so a handle for a replaced sandbox would attribute a dead sandbox's toolset
+    to the live one. Declining leaves the rows ``pending``, which is recoverable.
+    """
+    from src.server.app.mcp_servers import _get_live_sandbox
+
+    ws = _ws(sandbox_id="sb-replaced")
+    wm = MagicMock()
+    wm.get_session_if_ready.return_value = None  # bound elsewhere ⇒ declined
+    with patch(
+        "src.server.app.mcp_servers.WorkspaceManager.get_instance", return_value=wm
+    ):
+        assert _get_live_sandbox(ws["workspace_id"], ws) is None
+    wm.get_session_if_ready.assert_called_once_with(
+        ws["workspace_id"], expected_sandbox_id="sb-replaced"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/server/app/test_workspace_file_serving.py
+++ b/tests/unit/server/app/test_workspace_file_serving.py
@@ -33,7 +33,6 @@ _VAULT_PATCH = "src.server.app.workspace_files.serve.get_vault_secrets_for_redac
 _DBWS_PATCH = "src.server.app.workspace_files.serve.db_get_workspace"
 _FP_PATCH = "src.server.app.workspace_files.serve.FilePersistenceService"
 _WD_PATCH = "src.server.app.workspace_files.serve._get_work_dir"
-_SANDBOX_PATCH = "src.server.app.workspace_files.serve._acquire_sandbox"
 _WSMGR_PATCH = "src.server.app.workspace_files.serve.WorkspaceManager"
 _RENDER_PATCH = "src.server.services.pdf_render.render_workspace_pdf"
 _PDF_INTERNAL_BASE = "http://127.0.0.1:8000"
@@ -54,11 +53,17 @@ def _assert_report_csp(csp: str) -> None:
     assert "https://fonts.gstatic.com" in csp
 
 
-def _warm_manager() -> MagicMock:
-    """A WorkspaceManager whose cached session reports ready (live-read path)."""
-    mgr = MagicMock()
-    mgr.get_instance.return_value.has_ready_session.return_value = True
-    return mgr
+def _warm(mock_mgr: MagicMock, sandbox: object | None) -> MagicMock:
+    """Point a patched WorkspaceManager's fenced lookup at *sandbox*.
+
+    ``None`` stands for every reason the route must not read live: no cached
+    session, one that isn't ready, or one bound to a sandbox the row has since
+    replaced. The route can't tell them apart and shouldn't — all three mean
+    "serve from the DB, wake nothing".
+    """
+    session = MagicMock(sandbox=sandbox) if sandbox is not None else None
+    mock_mgr.get_instance.return_value.get_session_if_ready.return_value = session
+    return mock_mgr
 
 
 def _workspace(status: str) -> dict:
@@ -277,75 +282,78 @@ async def test_db_fallback_unknown_extension_uses_db_mime(mock_ws, mock_fp, _wd,
 
 
 @pytest.mark.asyncio
-@patch(_WSMGR_PATCH, new=_warm_manager())
 @patch(_VAULT_PATCH, new_callable=AsyncMock, return_value={})
 @patch(_WD_PATCH, return_value="/home/workspace")
-@patch(_SANDBOX_PATCH, new_callable=AsyncMock)
+@patch(_WSMGR_PATCH)
 @patch(_DBWS_PATCH, new_callable=AsyncMock)
-async def test_running_workspace_serves_live_bytes(mock_ws, mock_sb, _wd, _vault):
+async def test_running_workspace_serves_live_bytes(mock_ws, mock_mgr, _wd, _vault):
     mock_ws.return_value = _workspace("running")
-    mock_sb.return_value = _running_sandbox(b"<html><body>live</body></html>")
+    _warm(mock_mgr, _running_sandbox(b"<html><body>live</body></html>"))
     resp = await serve_workspace_file(WS_ID, "results/x.html", inject_theme=False)
     assert resp.status_code == 200
     assert b"live" in resp.body
 
 
 @pytest.mark.asyncio
-@patch(_WSMGR_PATCH, new=_warm_manager())
 @patch(_VAULT_PATCH, new_callable=AsyncMock, return_value={})
 @patch(_WD_PATCH, return_value="/home/workspace")
-@patch(_SANDBOX_PATCH, new_callable=AsyncMock)
+@patch(_WSMGR_PATCH)
 @patch(_DBWS_PATCH, new_callable=AsyncMock)
-async def test_running_workspace_missing_file_returns_404(mock_ws, mock_sb, _wd, _vault):
+async def test_running_workspace_missing_file_returns_404(
+    mock_ws, mock_mgr, _wd, _vault
+):
     mock_ws.return_value = _workspace("running")
-    mock_sb.return_value = _running_sandbox(None)
+    _warm(mock_mgr, _running_sandbox(None))
     with pytest.raises(HTTPException) as exc:
         await serve_workspace_file(WS_ID, "results/x.html", inject_theme=False)
     assert exc.value.status_code == 404
 
 
 @pytest.mark.asyncio
-@patch(_WSMGR_PATCH)
 @patch(_FP_PATCH)
 @patch(_VAULT_PATCH, new_callable=AsyncMock, return_value={})
 @patch(_WD_PATCH, return_value="/home/workspace")
-@patch(_SANDBOX_PATCH, new_callable=AsyncMock)
+@patch(_WSMGR_PATCH)
 @patch(_DBWS_PATCH, new_callable=AsyncMock)
 async def test_running_db_row_but_cold_sandbox_uses_db_not_wake(
-    mock_ws, mock_sb, _wd, _vault, mock_fp, mock_mgr
+    mock_ws, mock_mgr, _wd, _vault, mock_fp
 ):
     # DB says 'running' but no warm session (Daytona auto-stopped). The serve
-    # route must read from the DB and never call _acquire_sandbox (which would
-    # trigger a paid Daytona start) — denial-of-wallet guard.
+    # route must read from the DB and never acquire a session, which would
+    # trigger a paid Daytona start — denial-of-wallet guard.
     mock_ws.return_value = _workspace("running")
-    mock_mgr.get_instance.return_value.has_ready_session.return_value = False
+    _warm(mock_mgr, None)
     mock_fp.get_file_content = AsyncMock(return_value=_db_text_record("from-db"))
     resp = await serve_workspace_file(WS_ID, "results/x.html", inject_theme=False)
     assert resp.status_code == 200
     assert b"from-db" in resp.body
-    mock_sb.assert_not_called()
+    mock_mgr.get_instance.return_value.get_session_for_workspace.assert_not_called()
 
 
 @pytest.mark.asyncio
-@patch(_WSMGR_PATCH, new=_warm_manager())
 @patch(_FP_PATCH)
 @patch(_VAULT_PATCH, new_callable=AsyncMock, return_value={})
 @patch(_WD_PATCH, return_value="/home/workspace")
-@patch(_SANDBOX_PATCH, new_callable=AsyncMock)
+@patch(_WSMGR_PATCH)
 @patch(_DBWS_PATCH, new_callable=AsyncMock)
-async def test_warm_session_dies_falls_back_to_db_not_503(
-    mock_ws, mock_sb, _wd, _vault, mock_fp
+async def test_superseded_handle_uses_db_and_never_wakes_a_sandbox(
+    mock_ws, mock_mgr, _wd, _vault, mock_fp
 ):
-    # TOCTOU: has_ready_session() reported warm, but the session died before
-    # _acquire_sandbox(), which then raises HTTPException(503). The serve route
-    # must absorb that and fall back to the DB record — never leak a 503, which
-    # would break the uniform-404 contract and confirm the UUID is valid.
+    # This worker holds a ready session, but for a sandbox the row has since
+    # replaced. The fenced lookup declines it, so the route serves the DB copy.
+    # Acquiring instead would retire the stale handle and re-attach — correct
+    # for an authenticated caller, and a paid sandbox start for a UUID-only one.
     mock_ws.return_value = _workspace("running")
-    mock_sb.side_effect = HTTPException(status_code=503, detail="Sandbox not ready")
+    mgr = mock_mgr.get_instance.return_value
+    mgr.get_session_if_ready.return_value = None
     mock_fp.get_file_content = AsyncMock(return_value=_db_text_record("from-db"))
     resp = await serve_workspace_file(WS_ID, "results/x.html", inject_theme=False)
     assert resp.status_code == 200
     assert b"from-db" in resp.body
+    mgr.get_session_if_ready.assert_called_once_with(
+        WS_ID, expected_sandbox_id="sb-existing"
+    )
+    mgr.get_session_for_workspace.assert_not_called()
 
 
 # --- CSP + cache headers present on every response ------------------------

--- a/tests/unit/server/database/test_workspace_db.py
+++ b/tests/unit/server/database/test_workspace_db.py
@@ -47,7 +47,10 @@ def ws_mock_db(mock_connection):
     """Patch get_db_connection in the workspace module (its import location)."""
 
     @asynccontextmanager
-    async def _fake():
+    async def _fake(conn=None):
+        if conn is not None:
+            yield conn
+            return
         yield mock_connection
 
     with patch(
@@ -284,21 +287,26 @@ async def test_update_workspace_status_stopped(ws_mock_db, mock_cursor):
 
 @pytest.mark.asyncio
 async def test_update_workspace_status_running(ws_mock_db, mock_cursor):
-    """update_workspace_status with non-stopped status omits stopped_at."""
+    """A status move omits stopped_at, and never touches sandbox_id.
+
+    The binding is owned solely by ``try_bind_workspace_sandbox``'s
+    compare-and-set; a status writer that could also rebind is how a workspace
+    ends up pointing at a sandbox that was already replaced.
+    """
     from src.server.database.workspace import update_workspace_status
 
     row = _workspace_row(status="running")
     mock_cursor.fetchone.return_value = row
 
-    result = await update_workspace_status("ws-1", "running", sandbox_id="sb-1")
+    result = await update_workspace_status("ws-1", "running")
 
     assert result["status"] == "running"
     sql = mock_cursor.execute.call_args[0][0]
-    assert "sandbox_id = %s" in sql
-    # stopped_at should NOT be in the SET clause (it does appear in RETURNING)
-    # Extract just the SET portion of the SQL
+    # stopped_at and sandbox_id should NOT be in the SET clause (both appear in
+    # RETURNING). Extract just the SET portion of the SQL.
     set_clause = sql.split("SET")[1].split("WHERE")[0]
     assert "stopped_at" not in set_clause
+    assert "sandbox_id" not in set_clause
 
 
 @pytest.mark.asyncio

--- a/tests/unit/server/services/conftest.py
+++ b/tests/unit/server/services/conftest.py
@@ -1,0 +1,36 @@
+"""Shared stubs for the workspace-identity fencing the manager tests exercise.
+
+Both workspace_manager suites patch the same two symbols. Kept here so a rename
+touches one copy, not two that had already drifted apart in their docstrings.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+
+def _patch_identity(workspace):
+    """Stub the narrow identity read every cached-session return validates against.
+
+    Returns the workspace's own status/sandbox_id, i.e. "the cache agrees with
+    Postgres" — the baseline the staleness tests deviate from deliberately.
+    """
+    return patch(
+        "src.server.services.workspace_manager.db_get_workspace_identity",
+        AsyncMock(
+            return_value={
+                "status": workspace["status"],
+                "sandbox_id": workspace["sandbox_id"],
+            }
+        ),
+    )
+
+
+def _patch_sandbox_bind(workspace):
+    """Stub the identity CAS that publishes a freshly provisioned sandbox.
+
+    Returning the row means "we won the race"; returning None means another
+    provisioner bound this workspace first.
+    """
+    return patch(
+        "src.server.services.workspace_manager.try_bind_workspace_sandbox",
+        AsyncMock(return_value=workspace),
+    )

--- a/tests/unit/server/services/test_workspace_manager.py
+++ b/tests/unit/server/services/test_workspace_manager.py
@@ -17,6 +17,7 @@ import pytest
 
 from ptc_agent.core.sandbox.runtime import SandboxGoneError
 from src.server.services.workspace_manager import WorkspaceManager
+from tests.unit.server.services.conftest import _patch_identity, _patch_sandbox_bind
 
 
 # ---------------------------------------------------------------------------
@@ -205,9 +206,10 @@ class TestCreateWorkspace:
         config = _make_config()
         wm = WorkspaceManager(config)
 
-        result = await wm.create_workspace(
-            user_id="user-1", name="Test", description="desc"
-        )
+        with _patch_sandbox_bind(updated_ws):
+            result = await wm.create_workspace(
+                user_id="user-1", name="Test", description="desc"
+            )
 
         assert result["status"] == "running"
         mock_db_create.assert_awaited_once()
@@ -266,7 +268,7 @@ class TestStopWorkspace:
     ):
         ws_id = str(uuid.uuid4())
         mock_db_get.return_value = _make_workspace(workspace_id=ws_id, status="running")
-        mock_file_svc.sync_to_db = AsyncMock()
+        mock_file_svc.sync_to_db = AsyncMock(return_value={"synced": 1, "errors": 0})
         stopped_ws = _make_workspace(workspace_id=ws_id, status="stopped")
         mock_update_status.return_value = stopped_ws
 
@@ -306,8 +308,122 @@ class TestStopWorkspace:
 
 
 # ---------------------------------------------------------------------------
+# _identity_is_stale
+# ---------------------------------------------------------------------------
+
+class TestIdentityIsStale:
+    """The predicate guarding every cached-session return.
+
+    Postgres owns the workspace↔sandbox binding; this worker's cache is only a
+    handle. Getting this wrong in either direction is expensive: too permissive
+    and a deleted sandbox keeps serving 404s, too strict and a live workspace
+    retires its session on every single request.
+    """
+
+    def setup_method(self):
+        WorkspaceManager.reset_instance()
+
+    def teardown_method(self):
+        WorkspaceManager.reset_instance()
+
+    @staticmethod
+    def _check(identity, *, local_id="sandbox-abc", ready=True, owns_lazy_init=False):
+        wm = WorkspaceManager(_make_config())
+        session = _make_mock_session()
+        session.sandbox.sandbox_id = local_id
+        session.sandbox.is_ready = MagicMock(return_value=ready)
+        if owns_lazy_init:
+            wm._pending_lazy_sync.add("ws-1")
+        return wm._identity_is_stale("ws-1", session, identity)
+
+    def test_agreeing_running_row_is_served(self):
+        assert self._check({"status": "running", "sandbox_id": "sandbox-abc"}) is None
+
+    def test_flash_is_a_permanent_serving_status(self):
+        """Flash workspaces are inserted at status='flash' and never leave it.
+
+        Treating it as transitional would retire and re-attach the session on
+        every request the assistant makes.
+        """
+        assert self._check({"status": "flash", "sandbox_id": "sandbox-abc"}) is None
+
+    def test_missing_row_is_stale(self):
+        assert "row is gone" in self._check(None)
+
+    def test_identity_moved_is_stale(self):
+        reason = self._check({"status": "running", "sandbox_id": "sandbox-new"})
+        assert "sandbox identity moved" in reason
+
+    @pytest.mark.parametrize("status", ["deleted", "error", "stopped", "stopping"])
+    def test_non_serving_status_is_stale_even_when_ids_agree(self, status):
+        """A stop leaves ``sandbox_id`` untouched, so the ids still agree while
+        the sandbox they name is being torn down — status is the only signal."""
+        reason = self._check({"status": status, "sandbox_id": "sandbox-abc"})
+        assert repr(status) in reason
+
+    def test_starting_without_owning_the_lazy_init_is_stale(self):
+        """'starting' on a worker that owns no lazy init means someone else
+        claimed this workspace for replacement — our handle names a doomed
+        sandbox. Readiness is irrelevant; ownership is the whole signal."""
+        reason = self._check({"status": "starting", "sandbox_id": "sandbox-abc"})
+        assert "'starting'" in reason
+
+    @pytest.mark.parametrize("ready", [False, True])
+    def test_starting_while_owning_the_lazy_init_is_served(self, ready):
+        """The worker running the lazy init sees its own claim, and keeps
+        seeing it after its sandbox goes ready.
+
+        Phase 2 runs outside the lock, so the owner's sandbox is ready for the
+        whole sync while the row is still 'starting'. Retiring there drops the
+        ``_pending_lazy_sync`` membership that gates both the promotion and its
+        revert, leaving the row wedged in 'starting' until the reaper.
+        """
+        assert (
+            self._check(
+                {"status": "starting", "sandbox_id": "sandbox-abc"},
+                ready=ready,
+                owns_lazy_init=True,
+            )
+            is None
+        )
+
+    @pytest.mark.parametrize(
+        "db_id,local_id", [("sandbox-abc", None), (None, "sandbox-abc"), (None, None)]
+    )
+    def test_half_known_binding_is_stale(self, db_id, local_id):
+        """A one-sided binding is itself an inconsistency. Treating it as
+        "can't tell, assume fine" is how a deleted sandbox goes on serving
+        indefinitely."""
+        reason = self._check(
+            {"status": "running", "sandbox_id": db_id}, local_id=local_id
+        )
+        if db_id == local_id:
+            assert reason is None
+        else:
+            assert "sandbox identity moved" in reason
+
+    def test_initialized_session_without_a_sandbox_is_stale(self):
+        """``SessionManager`` outlives ``self._sessions``, so an initialized
+        session with no sandbox can be handed back for a bound workspace."""
+        wm = WorkspaceManager(_make_config())
+        session = _make_mock_session(has_sandbox=False)
+        reason = wm._identity_is_stale(
+            "ws-1", session, {"status": "running", "sandbox_id": "sandbox-abc"}
+        )
+        assert "sandbox identity moved" in reason
+
+
+# ---------------------------------------------------------------------------
 # _backup_files_to_db strict mode
 # ---------------------------------------------------------------------------
+
+def _patch_backup_identity(sandbox_id="sandbox-abc"):
+    """Stub the durable-identity read ``_backup_files_to_db`` validates against."""
+    return patch(
+        "src.server.services.workspace_manager.db_get_workspace_identity",
+        AsyncMock(return_value={"status": "running", "sandbox_id": sandbox_id}),
+    )
+
 
 class TestBackupFilesStrict:
     """strict=True turns the best-effort backup into a hard precondition for
@@ -335,8 +451,9 @@ class TestBackupFilesStrict:
         wm._sessions[ws_id] = _make_mock_session()
         mock_file_svc.sync_to_db = AsyncMock(side_effect=OSError("disk detached"))
 
-        with pytest.raises(RuntimeError, match="aborting before sandbox teardown"):
-            await wm._backup_files_to_db(ws_id, strict=True)
+        with _patch_backup_identity():
+            with pytest.raises(RuntimeError, match="aborting before sandbox teardown"):
+                await wm._backup_files_to_db(ws_id, strict=True)
 
     @pytest.mark.asyncio
     @patch("src.server.services.workspace_manager.FilePersistenceService")
@@ -346,7 +463,66 @@ class TestBackupFilesStrict:
         wm._sessions[ws_id] = _make_mock_session()
         mock_file_svc.sync_to_db = AsyncMock(side_effect=OSError("disk detached"))
 
-        await wm._backup_files_to_db(ws_id)  # warns, does not raise
+        with _patch_backup_identity():
+            await wm._backup_files_to_db(ws_id)  # warns, does not raise
+
+    @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.FilePersistenceService")
+    async def test_strict_aborts_when_sync_leaves_files_unsaved(self, mock_file_svc):
+        """``sync_to_db`` counts per-file failures instead of raising, so a clean
+        return is not proof the backup is complete. The strict caller is about to
+        delete the sandbox, which makes a nonzero count unrecoverable data loss.
+        """
+        wm = WorkspaceManager(_make_config())
+        ws_id = str(uuid.uuid4())
+        wm._sessions[ws_id] = _make_mock_session()
+        mock_file_svc.sync_to_db = AsyncMock(
+            return_value={"synced": 3, "errors": 2}
+        )
+
+        with _patch_backup_identity():
+            with pytest.raises(RuntimeError, match="left 2 file\\(s\\) unsaved"):
+                await wm._backup_files_to_db(ws_id, strict=True)
+
+    @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.FilePersistenceService")
+    async def test_refuses_a_session_bound_to_a_superseded_sandbox(self, mock_file_svc):
+        """``sync_to_db`` OVERWRITES the workspace's durable file copy, so running
+        it from a stale handle destroys the good copy as well as missing the live
+        files. The check is unconditional: making it opt-in is what left two of
+        five call sites unprotected.
+        """
+        wm = WorkspaceManager(_make_config())
+        ws_id = str(uuid.uuid4())
+        wm._sessions[ws_id] = _make_mock_session()  # attached to 'sandbox-abc'
+        mock_file_svc.sync_to_db = AsyncMock(return_value={"synced": 1, "errors": 0})
+
+        with _patch_backup_identity(sandbox_id="sandbox-REPLACED"):
+            await wm._backup_files_to_db(ws_id)  # best-effort: warns, no raise
+            mock_file_svc.sync_to_db.assert_not_awaited()
+
+            with pytest.raises(RuntimeError, match="stale session"):
+                await wm._backup_files_to_db(ws_id, strict=True)
+            mock_file_svc.sync_to_db.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.FilePersistenceService")
+    async def test_caller_supplied_identity_skips_the_read(self, mock_file_svc):
+        """``expected_sandbox_id`` is an optimization for callers holding the row,
+        not the contract — the guard runs either way."""
+        wm = WorkspaceManager(_make_config())
+        ws_id = str(uuid.uuid4())
+        wm._sessions[ws_id] = _make_mock_session()
+        mock_file_svc.sync_to_db = AsyncMock(return_value={"synced": 1, "errors": 0})
+
+        identity = AsyncMock()
+        with patch(
+            "src.server.services.workspace_manager.db_get_workspace_identity", identity
+        ):
+            await wm._backup_files_to_db(ws_id, expected_sandbox_id="sandbox-abc")
+
+        identity.assert_not_awaited()
+        mock_file_svc.sync_to_db.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------
@@ -372,7 +548,7 @@ class TestDeleteWorkspace:
     ):
         ws_id = str(uuid.uuid4())
         mock_db_get.return_value = _make_workspace(workspace_id=ws_id, status="running")
-        mock_file_svc.sync_to_db = AsyncMock()
+        mock_file_svc.sync_to_db = AsyncMock(return_value={"synced": 1, "errors": 0})
         mock_sm.cleanup_session = AsyncMock()
 
         config = _make_config()
@@ -1003,7 +1179,8 @@ class TestSandboxRecovery:
         mock_session_mgr.get_session.return_value = new_session
         mock_session_mgr.cleanup_session = AsyncMock()
 
-        result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
+        with _patch_identity(workspace), _patch_sandbox_bind(workspace):
+            result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
 
         # Broken session should be proactively cleaned up (MCP + provider)
         mock_session_mgr.cleanup_session.assert_awaited_with(ws_id)
@@ -1037,7 +1214,8 @@ class TestSandboxRecovery:
         mock_session_mgr.get_session.return_value = new_session
         mock_session_mgr.cleanup_session = AsyncMock()
 
-        result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
+        with _patch_identity(workspace), _patch_sandbox_bind(workspace):
+            result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
 
         # Broken session proactively cleaned up (MCP + provider)
         mock_session_mgr.cleanup_session.assert_awaited_with(ws_id)
@@ -1088,7 +1266,8 @@ class TestSandboxRecovery:
         session = self._make_initializing_session()
         manager._sessions[ws_id] = session
 
-        result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
+        with _patch_identity(workspace):
+            result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
 
         # Same session returned, no recovery triggered
         assert result is session
@@ -1122,7 +1301,8 @@ class TestSandboxRecovery:
         mock_session_mgr.get_session.return_value = new_session
         mock_session_mgr.cleanup_session = AsyncMock()
 
-        result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
+        with _patch_identity(workspace), _patch_sandbox_bind(workspace):
+            result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
 
         # Recovery triggered
         mock_session_mgr.cleanup_session.assert_awaited_with(ws_id)
@@ -1165,7 +1345,8 @@ class TestSandboxRecovery:
 
         manager._acquire_workspace_lock = mock_acquire
 
-        result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
+        with _patch_identity(workspace):
+            result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
 
         # Should return the already-recovered session, not create a new one
         assert result is already_recovered
@@ -1186,7 +1367,8 @@ class TestSandboxRecovery:
         manager._sessions[ws_id] = session
         manager._last_sync_at = {}
 
-        result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
+        with _patch_identity(workspace):
+            result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
 
         # Same session returned (broken, but we don't know it's sandbox-gone)
         assert result is session
@@ -1218,7 +1400,8 @@ class TestSandboxRecovery:
         mock_session_mgr.get_session.side_effect = [failing_session, recovered_session]
         mock_session_mgr.cleanup_session = AsyncMock()
 
-        result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
+        with _patch_sandbox_bind(workspace):
+            result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
 
         # Recovery triggered
         mock_session_mgr.cleanup_session.assert_awaited_with(ws_id)
@@ -1272,7 +1455,11 @@ class TestSandboxRecovery:
             manager._pending_lazy_sync.add(ws_id)
             return session
 
-        with patch.object(manager, "_restart_workspace", side_effect=mock_restart):
+        with (
+            patch.object(manager, "_restart_workspace", side_effect=mock_restart),
+            _patch_identity(workspace),
+            _patch_sandbox_bind(workspace),
+        ):
             result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
 
         # Phase 2 caught SandboxGoneError and triggered recovery
@@ -1528,7 +1715,8 @@ class TestOnStateObservedForwarding:
         path to fire on the warm hit and must not leak into any init path."""
         manager = self._make_manager()
         ws_id = str(uuid.uuid4())
-        mock_get_ws.return_value = _make_workspace(workspace_id=ws_id, status="running")
+        workspace = _make_workspace(workspace_id=ws_id, status="running")
+        mock_get_ws.return_value = workspace
         cached = _make_mock_session(initialized=True)
         cached.sandbox.is_ready = MagicMock(return_value=True)
         cached.sandbox.has_failed = MagicMock(return_value=False)
@@ -1537,9 +1725,10 @@ class TestOnStateObservedForwarding:
         def sentinel(_s: str) -> None:
             return None
 
-        await manager.get_session_for_workspace(
-            ws_id, user_id="user-1", on_state_observed=sentinel
-        )
+        with _patch_identity(workspace):
+            await manager.get_session_for_workspace(
+                ws_id, user_id="user-1", on_state_observed=sentinel
+            )
 
         cached.initialize.assert_not_awaited()
         cached.initialize_lazy.assert_not_awaited()
@@ -1581,9 +1770,8 @@ class TestPhase2ErrorNarrowing:
         is called and the error propagates for handle_workflow_error to catch."""
         manager = self._make_manager()
         ws_id = str(uuid.uuid4())
-        mock_get_ws.return_value = _make_workspace(
-            workspace_id=ws_id, status="running"
-        )
+        workspace = _make_workspace(workspace_id=ws_id, status="running")
+        mock_get_ws.return_value = workspace
 
         session = _make_mock_session()
         session.sandbox.ensure_sandbox_ready = AsyncMock(
@@ -1594,7 +1782,7 @@ class TestPhase2ErrorNarrowing:
         manager._last_sync_at = {}
         mock_session_mgr.cleanup_session = AsyncMock()
 
-        with pytest.raises(SandboxTransientError):
+        with pytest.raises(SandboxTransientError), _patch_identity(workspace):
             await manager.get_session_for_workspace(ws_id, user_id="user-1")
 
         mock_session_mgr.cleanup_session.assert_awaited_with(ws_id)
@@ -1616,9 +1804,8 @@ class TestPhase2ErrorNarrowing:
         membership; the deferred-sync asset step is reached only on that path."""
         manager = self._make_manager()
         ws_id = str(uuid.uuid4())
-        mock_get_ws.return_value = _make_workspace(
-            workspace_id=ws_id, status="running"
-        )
+        workspace = _make_workspace(workspace_id=ws_id, status="running")
+        mock_get_ws.return_value = workspace
 
         session = _make_mock_session()
         session.sandbox.has_failed = MagicMock(return_value=False)
@@ -1634,7 +1821,7 @@ class TestPhase2ErrorNarrowing:
         manager._last_sync_at = {}
         mock_session_mgr.cleanup_session = AsyncMock()
 
-        with pytest.raises(SandboxTransientError):
+        with pytest.raises(SandboxTransientError), _patch_identity(workspace):
             await manager.get_session_for_workspace(ws_id, user_id="user-1")
 
         # Row reverted so cross-worker losers re-claim immediately instead of
@@ -1655,9 +1842,8 @@ class TestPhase2ErrorNarrowing:
         'log and retry next request' behavior. Do not broaden the clear."""
         manager = self._make_manager()
         ws_id = str(uuid.uuid4())
-        mock_get_ws.return_value = _make_workspace(
-            workspace_id=ws_id, status="running"
-        )
+        workspace = _make_workspace(workspace_id=ws_id, status="running")
+        mock_get_ws.return_value = workspace
 
         session = _make_mock_session()
         session.sandbox.ensure_sandbox_ready = AsyncMock(
@@ -1667,7 +1853,8 @@ class TestPhase2ErrorNarrowing:
         manager._last_sync_at = {}
         mock_session_mgr.cleanup_session = AsyncMock()
 
-        result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
+        with _patch_identity(workspace):
+            result = await manager.get_session_for_workspace(ws_id, user_id="user-1")
 
         assert result is session
         mock_session_mgr.cleanup_session.assert_not_awaited()
@@ -2076,7 +2263,44 @@ class TestStatusRoutesToDbFallback:
         source = inspect.getsource(public)
         # list/read/download each read the cached session through the single
         # no-wake accessor rather than acquiring (or waking) one.
-        assert source.count("get_session_if_ready(workspace_id)") >= 3
+        assert source.count("get_session_if_ready(") >= 3
+
+    def test_get_session_if_ready_declines_a_handle_bound_elsewhere(self):
+        """The no-wake accessor must refuse a session whose sandbox has moved.
+
+        This is the fence itself, as opposed to the source assertion below that
+        only proves the call sites pass an argument.
+        """
+        config = _make_config()
+        wm = WorkspaceManager(config)
+        wm._sessions["ws-1"] = _make_mock_session()  # bound to 'sandbox-abc'
+
+        assert (
+            wm.get_session_if_ready("ws-1", expected_sandbox_id="sandbox-abc")
+            is not None
+        )
+        # The workspace was rebound to a replacement sandbox.
+        assert wm.get_session_if_ready("ws-1", expected_sandbox_id="sandbox-xyz") is None
+        # A half-known binding is an inconsistency, not a licence to serve.
+        assert wm.get_session_if_ready("ws-1", expected_sandbox_id=None) is None
+
+    def test_public_routes_fence_the_cached_session_on_identity(self):
+        """Every public-route read of the cache must pass the row's sandbox id.
+
+        These routes are the one serving path that does no DB round-trip of its
+        own, so without the fence a replaced sandbox keeps answering share links
+        with the false "File not found" this change exists to remove. They
+        already hold the row, so the check is free — and it is only correct if
+        every call site passes it, which a source assertion is the cheapest way
+        to keep true.
+        """
+        from src.server.app import public
+        import inspect
+
+        source = inspect.getsource(public)
+        assert source.count("get_session_if_ready(") == source.count(
+            'expected_sandbox_id=workspace.get("sandbox_id")'
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -2771,9 +2995,10 @@ class TestRecoverSandboxEntitledTier:
         returns, not the raw persisted tier (a lapsed 'max' rebuilds at standard)."""
         manager = self._make_manager()
         ws_id = str(uuid.uuid4())
-        mock_get_ws.return_value = _make_workspace(
+        workspace = _make_workspace(
             workspace_id=ws_id, status="stopped", resource_tier="max"
         )
+        mock_get_ws.return_value = workspace
         session = _make_mock_session()
         mock_session_mgr.get_session.return_value = session
 
@@ -2783,7 +3008,8 @@ class TestRecoverSandboxEntitledTier:
         manager._sync_sandbox_assets = AsyncMock()
         manager._restore_files = AsyncMock()
 
-        result = await manager._recover_sandbox(ws_id, "user-1", MagicMock())
+        with _patch_sandbox_bind(workspace):
+            result = await manager._recover_sandbox(ws_id, "user-1", MagicMock())
 
         assert result is session
         manager._entitled_tier.assert_awaited_once()
@@ -2909,8 +3135,12 @@ class TestSetWorkspaceSpec:
     @patch("src.server.services.workspace_entitlements.update_workspace_status")
     @patch("src.server.services.workspace_entitlements.db_set_workspace_resource_tier")
     @patch("src.server.services.workspace_entitlements.db_get_workspace")
+    @patch(
+        "src.server.services.workspace_entitlements.try_claim_workspace_for_replacement",
+        new_callable=AsyncMock,
+    )
     async def test_running_recreate_failure_marks_stopped_and_reverts_tier(
-        self, mock_get_ws, mock_set_tier, mock_status, mock_session_mgr, mock_btm
+        self, mock_claim, mock_get_ws, mock_set_tier, mock_status, mock_session_mgr, mock_btm
     ):
         """A failed recreate flips the row to stopped (so the next start
         self-heals via claim -> restart -> SandboxGone -> recover) AND reverts
@@ -2918,6 +3148,7 @@ class TestSetWorkspaceSpec:
         manager = self._make_manager()
         ws = _make_workspace(status="running", sandbox_id="sb-1", resource_tier="standard")
         mock_get_ws.return_value = ws
+        mock_claim.return_value = ws
         mock_btm.get_instance.return_value.has_active_tasks_for_workspace = AsyncMock(
             return_value=False
         )
@@ -3107,14 +3338,15 @@ class TestDuplicateWorkspace:
         mock_get_ws.return_value = source
         new_id = str(uuid.uuid4())
         mock_create.return_value = {"workspace_id": new_id}
-        mock_status.return_value = _make_workspace(workspace_id=new_id, status="running")
+        running = _make_workspace(workspace_id=new_id, status="running")
         mock_assert_spec.return_value = None  # entitled
 
         session = _make_mock_session()
         mock_session_mgr.get_session.return_value = session
         self._install_create_path(manager, session)
 
-        result = await manager.duplicate_workspace(source["workspace_id"], "user-1")
+        with _patch_sandbox_bind(running) as mock_bind:
+            result = await manager.duplicate_workspace(source["workspace_id"], "user-1")
 
         # A duplicate is a new allocation → re-check the carried tier's entitlement.
         mock_assert_spec.assert_awaited_once_with("user-1", "max", current_tier="standard")
@@ -3124,9 +3356,15 @@ class TestDuplicateWorkspace:
         assert mock_create.call_args.kwargs["config"] == {"custom": "keep-me"}
         # Copy's sandbox built at the carried tier (hosted Daytona can't resize later).
         assert session.initialize.await_args.kwargs["tier"] == "max"
-        mock_status.assert_awaited_once_with(
-            workspace_id=new_id, status="running", sandbox_id="sandbox-abc"
+        # A brand-new row has no sandbox yet, so the CAS expects NULL — that is
+        # what stops a second provisioner from overwriting the winner's binding.
+        mock_bind.assert_awaited_once_with(
+            new_id,
+            sandbox_id="sandbox-abc",
+            expected_previous_sandbox_id=None,
+            platform_secret_version=0,
         )
+        mock_status.assert_not_awaited()
         assert result["status"] == "running"
 
     @pytest.mark.asyncio
@@ -3150,14 +3388,15 @@ class TestDuplicateWorkspace:
         mock_get_ws.return_value = source
         new_id = str(uuid.uuid4())
         mock_create.return_value = {"workspace_id": new_id}
-        mock_status.return_value = _make_workspace(workspace_id=new_id, status="running")
+        running = _make_workspace(workspace_id=new_id, status="running")
         mock_assert_spec.side_effect = HTTPException(403, detail="Requires scope: workspace:spec:performance")
 
         session = _make_mock_session()
         mock_session_mgr.get_session.return_value = session
         self._install_create_path(manager, session)
 
-        await manager.duplicate_workspace(source["workspace_id"], "user-1")
+        with _patch_sandbox_bind(running):
+            await manager.duplicate_workspace(source["workspace_id"], "user-1")
 
         # Fell back to standard → tier not carried, sandbox built at standard.
         mock_set_tier.assert_not_awaited()
@@ -3207,23 +3446,50 @@ class TestPlatformSecretWiring:
         WorkspaceManager.reset_instance()
 
     @pytest.mark.asyncio
-    async def test_evict_session_if_present(self):
-        # Public out-of-band invalidation (used by the sweeper after a scrub):
-        # evicts under the workspace lock when cached, no-ops otherwise.
+    async def test_retire_session_if_present_leaves_the_sandbox_alone(self):
+        # Retirement drops both caches without touching the sandbox — the
+        # primitive the sweeper needs after restarting a sandbox in place, and
+        # the one a stale-identity re-attach uses.
         manager = WorkspaceManager.get_instance(config=_make_config())
         session = _make_mock_session()
-        workspace_id = "ws-evict"
+        workspace_id = "ws-retire"
         manager._sessions[workspace_id] = session
+        manager._pending_lazy_sync.add(workspace_id)
+        manager._last_sync_at[workspace_id] = time.monotonic()
 
-        with patch(
-            "src.server.services.workspace_manager."
-            "SessionManager.cleanup_session",
-            AsyncMock(),
-        ) as cleanup:
-            assert await manager.evict_session_if_present(workspace_id) is True
-            cleanup.assert_awaited_once_with(workspace_id)
+        with (
+            patch(
+                "src.server.services.workspace_manager."
+                "SessionManager.cleanup_session",
+                AsyncMock(),
+            ) as cleanup,
+            patch(
+                "src.server.services.workspace_manager."
+                "SessionManager.get_cached_session",
+                MagicMock(return_value=session),
+            ),
+            patch(
+                "src.server.services.workspace_manager."
+                "SessionManager.remove_session",
+                MagicMock(),
+            ) as remove,
+        ):
+            assert await manager.retire_session_if_present(
+                workspace_id, reason="test"
+            ) is True
+            # Both caches dropped, so the next get_session builds a fresh
+            # Session instead of handing back this one with _initialized=True.
+            remove.assert_called_once_with(workspace_id)
             assert workspace_id not in manager._sessions
-            assert await manager.evict_session_if_present(workspace_id) is False
+            assert workspace_id not in manager._pending_lazy_sync
+            assert workspace_id not in manager._last_sync_at
+            # The sandbox is NOT destroyed.
+            cleanup.assert_not_awaited()
+            session.cleanup.assert_not_awaited()
+
+            assert await manager.retire_session_if_present(
+                workspace_id, reason="test"
+            ) is False
 
     @pytest.mark.asyncio
     async def test_hot_resync_failure_propagates_without_evicting_session(self):
@@ -3302,16 +3568,20 @@ class TestPlatformSecretWiring:
         assert kwargs["applied_generation"] is None
 
     @pytest.mark.asyncio
-    async def test_provision_falls_back_to_plain_running_when_certify_is_inert(
-        self,
-    ):
+    async def test_provision_binds_through_the_cas_in_every_deployment(self):
+        """The binding CAS is the only writer, platform Secrets or not.
+
+        It used to run only when platform Secrets were active; everywhere else
+        fell through to a last-writer-wins ``update_workspace_status``, so two
+        concurrent provisions both "won" and one sandbox was left billed with
+        nothing pointing at it.
+        """
         manager = WorkspaceManager.get_instance(config=_make_config())
         session = _make_mock_session()
         session.sandbox.runtime = MagicMock()
         workspace = _make_workspace()
         workspace_id = workspace["workspace_id"]
 
-        certify = AsyncMock(return_value=None)
         status = AsyncMock(return_value=workspace)
         with (
             patch.object(manager, "_mint_sandbox_tokens", AsyncMock(return_value={})),
@@ -3320,11 +3590,7 @@ class TestPlatformSecretWiring:
             ) as session_mgr,
             patch.object(manager, "_apply_session_mcp", AsyncMock(return_value=None)),
             patch.object(manager, "_sync_sandbox_assets", AsyncMock()),
-            patch(
-                "src.server.services.platform_secret_rollout."
-                "certify_new_workspace_sandbox",
-                certify,
-            ),
+            _patch_sandbox_bind(workspace) as bind,
             patch(
                 "src.server.services.workspace_manager.update_workspace_status",
                 status,
@@ -3337,11 +3603,54 @@ class TestPlatformSecretWiring:
                 ws_version=None,
                 kick_discovery=False,
                 post_init=AsyncMock(),
+                expected_previous_sandbox_id="sb-old",
             )
 
         assert result_session is session
         assert record is workspace
-        certify.assert_awaited_once()
-        status.assert_awaited_once_with(
-            workspace_id=workspace_id, status="running", sandbox_id="sandbox-abc"
+        # 0 is the "never certified — may hold plaintext env" sentinel from
+        # migration 021, which is exactly what a no-catalog deployment should
+        # stamp. It must be written, not left to COALESCE onto the previous
+        # sandbox's generation.
+        bind.assert_awaited_once_with(
+            workspace_id,
+            sandbox_id="sandbox-abc",
+            expected_previous_sandbox_id="sb-old",
+            platform_secret_version=0,
         )
+        status.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_provision_losing_the_identity_race_does_not_publish(self):
+        """A lost CAS must unwind, not fall back to an unguarded write.
+
+        Publishing anyway is how two workers end up believing they own the
+        workspace; the loser's sandbox is deleted by the caller's unwind.
+        """
+        from src.server.database.workspace import SandboxIdentityLostError
+
+        manager = WorkspaceManager.get_instance(config=_make_config())
+        session = _make_mock_session()
+        session.sandbox.runtime = MagicMock()
+        workspace_id = str(uuid.uuid4())
+
+        with (
+            patch.object(manager, "_mint_sandbox_tokens", AsyncMock(return_value={})),
+            patch(
+                "src.server.services.workspace_manager.SessionManager"
+            ) as session_mgr,
+            patch.object(manager, "_apply_session_mcp", AsyncMock(return_value=None)),
+            patch.object(manager, "_sync_sandbox_assets", AsyncMock()),
+            _patch_sandbox_bind(None),
+        ):
+            session_mgr.get_session.return_value = session
+            with pytest.raises(SandboxIdentityLostError):
+                await manager._provision_sandbox_session(
+                    workspace_id,
+                    "user-1",
+                    ws_version=None,
+                    kick_discovery=False,
+                    post_init=AsyncMock(),
+                )
+
+        assert workspace_id not in manager._sessions

--- a/tests/unit/server/services/test_workspace_manager_mcp.py
+++ b/tests/unit/server/services/test_workspace_manager_mcp.py
@@ -16,6 +16,7 @@ import pytest
 
 from src.server.services.workspace_manager import WorkspaceManager
 from tests.unit.server.mcp_builders import resolved_mcp
+from tests.unit.server.services.conftest import _patch_identity, _patch_sandbox_bind
 
 
 def _make_config():
@@ -56,6 +57,9 @@ def _make_session(*, version=None, summary=None):
     session.config = MagicMock()
     session.config.mcp = MagicMock(servers=[])
     session.sandbox = MagicMock()
+    # Must match _make_workspace's sandbox_id: every cached return validates the
+    # session's binding against the row before handing it out.
+    session.sandbox.sandbox_id = "sb-1"
     session.sandbox.is_ready = MagicMock(return_value=True)
     session.sandbox.has_failed = MagicMock(return_value=False)
     session.sandbox.ensure_sandbox_ready = AsyncMock()
@@ -97,23 +101,40 @@ class TestWarmCooldownNoQuery:
 
     @pytest.mark.asyncio
     @patch("src.server.services.workspace_manager.db_get_workspace", new_callable=AsyncMock)
-    async def test_warm_cooldown_zero_workspace_queries(self, mock_get_ws):
-        """A ready cached session inside the 30s cooldown returns WITHOUT any
-        db_get_workspace read — so the version check adds zero per-turn queries."""
+    async def test_warm_cooldown_reads_identity_only(self, mock_get_ws):
+        """A ready cached session inside the 30s cooldown returns after exactly one
+        narrow ``status, sandbox_id`` read — never the full row.
+
+        The identity read is not optional: workers are spawn-isolated, so a
+        cached handle can name a sandbox Postgres has already replaced and every
+        warm path returns without consulting the row. What the hot path must
+        keep avoiding is ``db_get_workspace``, which drags the JSONB ``config``
+        and ``artifacts`` columns along with it.
+        """
         wm = WorkspaceManager.get_instance(config=_make_config())
         ws_id = str(uuid.uuid4())
         session = _make_session(version=0, summary="cached")
         wm._sessions[ws_id] = session
         wm._record_sync(ws_id)  # cooldown active
 
+        identity = AsyncMock(
+            return_value={"status": "running", "sandbox_id": "sb-1"}
+        )
         # resolve must NOT be called within cooldown.
-        with patch(
-            "src.server.services.mcp_config.resolve_mcp_config",
-            new_callable=AsyncMock,
-        ) as mock_resolve:
+        with (
+            patch(
+                "src.server.services.mcp_config.resolve_mcp_config",
+                new_callable=AsyncMock,
+            ) as mock_resolve,
+            patch(
+                "src.server.services.workspace_manager.db_get_workspace_identity",
+                identity,
+            ),
+        ):
             result = await wm.get_session_for_workspace(ws_id, user_id="user-1")
 
         assert result is session
+        identity.assert_awaited_once_with(ws_id)
         mock_get_ws.assert_not_awaited()
         mock_resolve.assert_not_awaited()
 
@@ -592,7 +613,8 @@ class TestVersionDeltaBackgroundDiscovery:
         wm._sessions[ws_id] = session
         wm._last_sync_at = {}  # cooldown expired → slow path runs
 
-        mock_get_ws.return_value = _make_workspace(ws_id, mcp_config_version=5)
+        workspace = _make_workspace(ws_id, mcp_config_version=5)
+        mock_get_ws.return_value = workspace
 
         # Assert the resolve does NOT run while the per-workspace lock is held.
         lock_held_during_resolve = {"value": False}
@@ -622,7 +644,7 @@ class TestVersionDeltaBackgroundDiscovery:
         ), patch(
             "ptc_agent.agent.prompts.formatter.build_tool_summary_from_registry",
             return_value="NEW",
-        ):
+        ), _patch_identity(workspace):
             await wm.get_session_for_workspace(ws_id, user_id="user-1")
 
         mock_resolve.assert_awaited_once()
@@ -648,12 +670,22 @@ class TestAppliedVersionAndProactiveApply:
     def test_applied_version_none_without_session(self):
         """No warm session ⇒ the config isn't loaded anywhere live ⇒ None."""
         wm = WorkspaceManager.get_instance(config=_make_config())
-        assert wm.get_applied_mcp_config_version("ws-x") is None
+        assert (
+            wm.get_applied_mcp_config_version("ws-x", expected_sandbox_id="sb-1")
+            is None
+        )
 
     def test_applied_version_reads_warm_session(self):
         wm = WorkspaceManager.get_instance(config=_make_config())
         wm._sessions["ws"] = _make_session(version=7, summary="s")
-        assert wm.get_applied_mcp_config_version("ws") == 7
+        assert wm.get_applied_mcp_config_version("ws", expected_sandbox_id="sb-1") == 7
+
+    def test_applied_version_none_when_session_holds_a_superseded_sandbox(self):
+        """The version claims what a LIVE sandbox applied. A session bound to a
+        replaced sandbox can only name a number no live sandbox has."""
+        wm = WorkspaceManager.get_instance(config=_make_config())
+        wm._sessions["ws"] = _make_session(version=7, summary="s")
+        assert wm.get_applied_mcp_config_version("ws", expected_sandbox_id="sb-2") is None
 
     @pytest.mark.asyncio
     async def test_proactive_apply_warms_without_ready_session(self):
@@ -766,7 +798,8 @@ class TestDiscoveryKickSeesCachedSession:
 
         wm._kick_mcp_discovery = spy_kick
 
-        await wm._recover_sandbox(ws_id, "user-1", MagicMock())
+        with _patch_sandbox_bind(_make_workspace(ws_id)):
+            await wm._recover_sandbox(ws_id, "user-1", MagicMock())
 
         assert cached_at_kick["value"] is True
         assert wm._sessions.get(ws_id) is session
@@ -807,6 +840,84 @@ class TestDiscoveryKickSeesCachedSession:
         assert wm._sessions.get(ws_id) is session
 
     @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.SessionManager")
+    async def test_attach_binds_a_sandbox_it_had_to_build(self, mock_session_mgr):
+        """A row naming no sandbox must be bound to the one ``initialize`` builds.
+
+        ``session.initialize(sandbox_id=None)`` creates a sandbox, so this path
+        provisions without going through provisioning. If the binding is not
+        written back, the row still says NULL on the next request, the identity
+        check reads that as stale, retires the session, and builds another
+        sandbox — one billed sandbox per request, each abandoned with its files.
+        Regression: the identity fencing made this fatal rather than untidy.
+        """
+        wm = WorkspaceManager.get_instance(config=_make_config())
+        ws_id = str(uuid.uuid4())
+
+        session = _make_session(version=1, summary="s")
+        session._initialized = False
+        session.sandbox.sandbox_id = "sb-built-by-initialize"
+        session.initialize = AsyncMock()
+        mock_session_mgr.get_session.return_value = session
+
+        wm._apply_session_mcp = AsyncMock(return_value=_resolved(1))
+        wm._servers_needing_discovery = MagicMock(return_value=[])
+        wm._sync_sandbox_assets = AsyncMock()
+        wm._maybe_migrate_sandbox = AsyncMock(return_value=None)
+        wm._apply_session_platform_secret = AsyncMock()
+        wm._kick_mcp_discovery = MagicMock()
+
+        workspace = _make_workspace(ws_id, status="running", mcp_config_version=1)
+        workspace["sandbox_id"] = None
+        bound_row = dict(workspace, sandbox_id="sb-built-by-initialize")
+
+        with patch(
+            "src.server.services.workspace_manager.try_bind_workspace_sandbox",
+            AsyncMock(return_value=bound_row),
+        ) as mock_bind:
+            await wm._attach_running_session(
+                workspace, "user-1", None, lambda _stage: None
+            )
+
+        mock_bind.assert_awaited_once()
+        assert mock_bind.await_args.kwargs["sandbox_id"] == "sb-built-by-initialize"
+        # NULL-safe CAS: the fence is the value we read, so a concurrent binder
+        # that got there first makes this write lose rather than clobber.
+        assert mock_bind.await_args.kwargs["expected_previous_sandbox_id"] is None
+
+    @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.SessionManager")
+    async def test_attach_does_not_rebind_when_the_row_already_matches(
+        self, mock_session_mgr
+    ):
+        """Reattaching to the sandbox the row already names must not write."""
+        wm = WorkspaceManager.get_instance(config=_make_config())
+        ws_id = str(uuid.uuid4())
+
+        session = _make_session(version=1, summary="s")
+        session._initialized = False
+        session.initialize = AsyncMock()  # sandbox_id stays 'sb-1', as the row says
+        mock_session_mgr.get_session.return_value = session
+
+        wm._apply_session_mcp = AsyncMock(return_value=_resolved(1))
+        wm._servers_needing_discovery = MagicMock(return_value=[])
+        wm._sync_sandbox_assets = AsyncMock()
+        wm._maybe_migrate_sandbox = AsyncMock(return_value=None)
+        wm._apply_session_platform_secret = AsyncMock()
+        wm._kick_mcp_discovery = MagicMock()
+
+        workspace = _make_workspace(ws_id, status="running", mcp_config_version=1)
+        with patch(
+            "src.server.services.workspace_manager.try_bind_workspace_sandbox",
+            AsyncMock(),
+        ) as mock_bind:
+            await wm._attach_running_session(
+                workspace, "user-1", None, lambda _stage: None
+            )
+
+        mock_bind.assert_not_awaited()
+
+    @pytest.mark.asyncio
     @patch("src.server.services.workspace_manager.db_get_workspace", new_callable=AsyncMock)
     @patch("src.server.services.workspace_manager.update_workspace_status", new_callable=AsyncMock)
     @patch("src.server.services.workspace_manager.update_workspace_activity", new_callable=AsyncMock)
@@ -832,9 +943,13 @@ class TestDiscoveryKickSeesCachedSession:
         wm._restore_files = AsyncMock()
         wm._kick_mcp_discovery = MagicMock()
         wm._cancel_mcp_discovery = MagicMock()
-        mock_status.side_effect = RuntimeError("status write failed")
+        # The last step of a provision, i.e. genuinely after the kick.
+        wm._record_sync = MagicMock(side_effect=RuntimeError("sync stamp failed"))
 
-        with pytest.raises(RuntimeError, match="status write failed"):
+        with (
+            pytest.raises(RuntimeError, match="sync stamp failed"),
+            _patch_sandbox_bind(_make_workspace(ws_id)),
+        ):
             await wm._recover_sandbox(ws_id, "user-1", MagicMock())
 
         assert wm._sessions.get(ws_id) is None
@@ -936,8 +1051,9 @@ class TestSetWorkspaceSpecDiskGuard:
 
     @pytest.fixture(autouse=True)
     def _quiet_durable_probes(self):
-        """The spec-change activity guard also reads the run ledgers; keep
-        both quiet so these tests exercise only the disk-guard mechanics."""
+        """The spec-change activity guard also reads the run ledgers, and the
+        replacement is durably fenced before teardown; keep all three quiet so
+        these tests exercise only the disk-guard mechanics."""
         with (
             patch(
                 "src.server.database.runs.lifecycle.workspace_has_active_run",
@@ -947,7 +1063,13 @@ class TestSetWorkspaceSpecDiskGuard:
                 "src.server.database.runs.subagent_runs.count_open_runs_for_workspace",
                 new=AsyncMock(return_value=0),
             ),
+            patch(
+                "src.server.services.workspace_entitlements."
+                "try_claim_workspace_for_replacement",
+                new=AsyncMock(return_value={"status": "starting"}),
+            ) as claim,
         ):
+            self.claim = claim
             yield
 
     @staticmethod
@@ -985,6 +1107,9 @@ class TestSetWorkspaceSpecDiskGuard:
         wm._backup_files_to_db.assert_awaited_once()
         wm._recover_sandbox.assert_not_awaited()
         mock_session_mgr.cleanup_session.assert_not_called()
+        # Rejected before the replacement was claimed, so the row still
+        # advertises running/<old id> rather than being stranded at 'starting'.
+        self.claim.assert_not_awaited()
         # Tier set to target optimistically, then reverted to the original.
         assert mock_set_tier.await_args_list[0].args == (ws_id, "standard")
         assert mock_set_tier.await_args_list[-1].args == (ws_id, "max")

--- a/tests/unit/server/utils/test_sandbox_unreachable_detail.py
+++ b/tests/unit/server/utils/test_sandbox_unreachable_detail.py
@@ -1,0 +1,167 @@
+"""The 503 detail carries one bit to the UI and none of the provider's text.
+
+Two constraints meet in this string. The file panel picks its "still starting"
+card by finding that word, so the in-flight case has to keep saying it. But the
+exceptions behind these 503s quote provider URLs, sandbox ids and SDK response
+bodies, so the raw text must not cross to a client. A sanitizer that satisfies
+only the second constraint silently downgrades every "starting" card to
+"unavailable", which is why both are pinned together.
+"""
+
+import asyncio
+
+import pytest
+
+from ptc_agent.core.sandbox.runtime import SandboxGoneError, SandboxTransientError
+from src.server.app.workspaces import _workspace_action_errors
+from src.server.utils.error_sanitization import (
+    SANDBOX_UNREACHABLE_PREFIX,
+    sandbox_unreachable_detail,
+)
+
+
+_LEAK = (
+    "download_file failed on /a.txt: 500 from "
+    "https://provider.internal.example/api/sandbox/sbx-9f3c/files: "
+    "upstream said 'disk quota exceeded'"
+)
+
+
+def _async_return(value):
+    async def _inner(*args, **kwargs):
+        return value
+
+    return _inner
+
+
+def test_prefix_is_stable_for_every_exception_shape():
+    """Every route builds the same prefix or the panel renders a different card."""
+    for exc in (
+        SandboxTransientError("Sandbox is still starting: init timed out"),
+        SandboxGoneError("sbx-1", "deleted"),
+        RuntimeError("anything at all"),
+    ):
+        assert sandbox_unreachable_detail(exc).startswith(SANDBOX_UNREACHABLE_PREFIX)
+
+
+def test_the_workspace_action_routes_do_not_answer_400_with_raw_text():
+    """The real producer, not just the sanitizer in isolation.
+
+    ``SandboxGoneError``/``SandboxTransientError`` subclass ``RuntimeError`` so
+    that call sites map them to 503. This context manager also has a
+    ``RuntimeError`` arm, mapping to 400 with ``str(e)`` — so the same
+    inheritance that buys the 503 elsewhere bought a wrong status and a raw
+    provider string here. Asserting on the sanitizer alone never sees this.
+    """
+    leaky = SandboxTransientError(
+        "download_file failed: 500 from https://provider.internal.example/sbx-9f3c"
+    )
+
+    async def _run():
+        async with _workspace_action_errors("start", "ws-1"):
+            raise leaky
+
+    with pytest.raises(SandboxTransientError):
+        asyncio.run(_run())
+
+
+@pytest.mark.parametrize(
+    "raised, expect_reraise",
+    [
+        (SandboxTransientError(_LEAK), True),
+        (SandboxGoneError("sbx-9f3c", _LEAK), True),
+        (RuntimeError(_LEAK), False),
+    ],
+)
+def test_refresh_does_not_answer_with_the_provider_text(raised, expect_reraise):
+    """The one route the sanitization sweep missed.
+
+    ``refresh_workspace`` makes the same ``get_session_for_workspace`` call
+    ``_acquire_sandbox`` does, but kept a bare ``except Exception`` that
+    interpolated the exception into the 503 body. Typed errors now re-raise for
+    the app-level handler; anything else still answers 503, but sanitized.
+    """
+    from fastapi import HTTPException
+
+    from src.server.app import workspaces as workspaces_module
+
+    class _Manager:
+        async def get_session_for_workspace(self, workspace_id, user_id=None):
+            raise raised
+
+    monkey = pytest.MonkeyPatch()
+    monkey.setattr(
+        workspaces_module.WorkspaceManager, "get_instance", staticmethod(lambda: _Manager())
+    )
+    monkey.setattr(
+        workspaces_module, "db_get_workspace", _async_return({"user_id": "u-1"})
+    )
+    monkey.setattr(workspaces_module, "require_workspace_owner", lambda *a, **kw: None)
+    try:
+        with pytest.raises(Exception) as excinfo:
+            asyncio.run(workspaces_module.refresh_workspace("ws-1", "u-1"))
+    finally:
+        monkey.undo()
+
+    if expect_reraise:
+        assert excinfo.value is raised
+        return
+    assert isinstance(excinfo.value, HTTPException)
+    assert excinfo.value.status_code == 503
+    for leaked in ("provider.internal.example", "sbx-9f3c", "disk quota"):
+        assert leaked not in excinfo.value.detail
+
+
+def test_starting_survives_the_boundary():
+    detail = sandbox_unreachable_detail(
+        SandboxTransientError("Sandbox is still starting: initialization timed out after 300s")
+    )
+    assert "starting" in detail.lower()
+
+
+def test_provider_text_does_not_reach_the_client():
+    """The exact leak class: a URL, a host and a sandbox id in one SDK message."""
+    exc = SandboxTransientError(
+        "download_file failed on /a.txt: 500 from "
+        "https://provider.internal.example/api/sandbox/sbx-9f3c/files "
+        "(host=runner-07.pool.internal): upstream said 'disk quota exceeded'"
+    )
+    detail = sandbox_unreachable_detail(exc)
+    for leaked in ("provider.internal.example", "sbx-9f3c", "runner-07", "disk quota"):
+        assert leaked not in detail
+
+
+def test_a_gone_sandbox_does_not_claim_to_be_starting():
+    """Otherwise the panel offers a retry card for a sandbox that is never coming back."""
+    detail = sandbox_unreachable_detail(SandboxGoneError("sbx-1", "sandbox was deleted"))
+    assert "starting" not in detail.lower()
+
+
+def test_the_handler_logs_one_line_for_a_multiline_provider_body(monkeypatch):
+    """The text the client never sees still lands in the log, newlines and all.
+
+    The provider quotes response bodies verbatim, so a body the caller shaped
+    can close the line and open a convincing fake one. Driving the handler
+    rather than the escaper proves the escaping is actually wired into the
+    message, which is the part a helper-only assertion would miss.
+    """
+    from src.server.app import setup
+
+    forged = "download failed: 500 body=\n2026-08-15 [warning] sandbox verified clean"
+    captured: list[str] = []
+    monkeypatch.setattr(
+        setup.logger, "warning", lambda message, *a, **kw: captured.append(message)
+    )
+
+    class _Request:
+        url = type("U", (), {"path": "/api/v1/workspaces/ws-1/files"})()
+
+    response = asyncio.run(
+        setup._sandbox_unreachable_handler(_Request(), SandboxTransientError(forged))
+    )
+
+    assert response.status_code == 503
+    assert len(captured) == 1
+    assert "\n" not in captured[0] and "\r" not in captured[0]
+    # Escaped, not dropped: the diagnostic has to survive for the operator.
+    assert "sandbox verified clean" in captured[0]


### PR DESCRIPTION
## Summary

The File panel intermittently showed **"File not found — The file path may be incorrect, or the file has been deleted"** for files that exist. Two defects in series, both fixed here.

The backend runs `uvicorn --workers N` with `spawn` isolation, so `WorkspaceManager._sessions` is a per-process cache of sandbox handles with no cross-worker invalidation and **no sandbox-identity check**. When a sandbox was replaced, the worker that missed the change kept calling the dead one — observed reaching for a deleted sandbox for the better part of an hour after Postgres had moved on, across three separate requests. `sandbox_id_from_db` was already being read on the acquisition path; its only consumer was a `logger.debug`.

Underneath that, `adownload_file_bytes` returned `None` for both "file absent" and "sandbox unreachable", so the route turned a transport failure into a 404.

Postgres already owns the workspace↔sandbox binding. This makes the cache honour it: every cached-session return is now fenced against a narrow identity read, sandbox failures carry a type so an unreachable sandbox answers **503** instead of a false 404 or a raw 500, and the binding itself is written through a compare-and-set so concurrent provisioners cannot both claim a workspace.

## Why this way

**A pull check, not a Redis broadcast.** A "sandbox replaced" pub/sub channel was considered and rejected. Staleness only manifests on use, so a check at the point of use is what actually closes it; a channel plus a per-worker listener would add exactly the process-local subscriber state that `src/server/AGENTS.md:37` bans, and would still need this pull path as its durable fallback.

**A narrow identity read, not the full row.** `SELECT status, sandbox_id` rather than the existing full-row helper, which also drags in the JSON `config` and `artifacts` columns. `workspace_id` is the primary key, so this is a single-row index scan on a hot path. It does change a documented contract — `test_message_hot_path.py` asserted the warm path made **zero** DB queries — so that test was deliberately rewritten to assert zero *full-row* reads and exactly one narrow identity read. On the file panel the change is net cheaper: `list_workspace_files` lost a `ensure_sandbox_ready()` pre-flight, trading a control-plane round trip for a ~1ms indexed read.

**Status is checked, not just identity.** The two transitions that replace a sandbox — a replacement claim and a stop — both leave `sandbox_id` untouched. During those windows the ids still agree while the sandbox they name is being torn down, so an id-only check sees nothing wrong.

**Retirement is a distinct operation from destruction.** `evict_session_if_present` read like a cache eviction but reached `runtime.delete()`. Every invalidation added here uses a new `_retire_session` that drops both process caches and leaves the sandbox alive; the destructive sibling was renamed `retire_session_if_present`/`destroy` accordingly. This also fixes a live bug in the platform-secret sweeper, which intended a local eviction after restarting the *same* sandbox and was instead deleting the sandbox it had just scrubbed, leaving Postgres pointed at a dead id.

**Ambiguity raises rather than returning empty.** Absence is only reported when the provider positively says so, via structured `status_code`/`error_code` rather than message matching. A status-less failure is never read as "the file isn't there" — that conflation is the whole bug.

**Where the 404 is kept on purpose.** The unauthenticated share routes still collapse 503 into 404. Distinguishing them would confirm to an anonymous caller that a guessed workspace UUID is real. That is a deliberate residual, not an oversight, and it is commented as such at each site.

## How it works

**`workspace_manager.py`** carries the fence. `_take_valid_cached_session` performs the identity read and runs `_identity_is_stale`, which returns a reason string; a stale session is retired and the caller falls through to the slow path, counted as `stale_reattach` on `session_path_counter` so the fix is observable rather than showing up as a warm hit. `_retire_session` must pop **both** `_sessions` and `SessionManager` — popping only the first leaves `SessionManager.get_session` handing back the same `Session` with `_initialized=True`, so the re-attach silently no-ops.

One subtlety worth reading carefully: `'starting'` is a serving status **only for the worker that owns the in-flight lazy init**, and ownership is `_pending_lazy_sync` membership, not sandbox readiness. Phase 2 runs outside the per-workspace lock, so the owner's sandbox goes ready while the row is still `starting` and it has yet to promote. Treating that window as someone else's replacement claim retires the owner's own session, and retirement drops the membership that gates both the promotion and its revert — leaving the row wedged until the reaper.

**`database/workspace.py`** is now the only writer of `workspaces.sandbox_id`, through a NULL-safe `sandbox_id IS NOT DISTINCT FROM` compare-and-set. `update_workspace_status` lost its `sandbox_id` parameter entirely so status and binding cannot drift apart, and gained `AND status != 'deleted'` so a soft-deleted row cannot be revived. A losing provisioner raises `SandboxIdentityLostError`, destroys its own sandbox, and re-attaches to the winner. `_attach_running_session` goes through the same CAS: it *builds* a sandbox when the row names none, so before this it provisioned outside provisioning and never wrote the binding back — harmless before the fence, fatal after, since the still-NULL row read as stale on the very next request. One billed sandbox per request, each abandoned with its files.

**`core/sandbox/files.py`** normalises all 11 conflating helpers onto `SandboxGoneError`/`SandboxTransientError` (both `RuntimeError` subclasses). This matters because `DaytonaError` inherits plain `Exception`, so re-raising a raw SDK error would have produced a 500, not the 503 the callers expect. Six of the swallowing helpers used a bare `except Exception` that also caught the transient error, which is why the existing `except RuntimeError → 503` at the call site was dead code.

**`setup.py`** maps the typed errors to 503 at the ASGI boundary, rather than per route. One caveat that is easy to miss: this only reaches routes that let the exception escape the endpoint. The 64 routes wrapped in `@handle_api_exceptions` (`src/server/utils/api.py:166`) catch bare `Exception` *inside* the endpoint and re-raise as 500, so they never reach the handler. The sandbox-touching one is `POST /{workspace_id}/mcp/servers/{name}/discover`, which still answers 500. Left as a known residual rather than widening the decorator across all 64 routes in this PR.

## Overview

| | Files | Insertions | Deletions |
|---|---|---|---|
| Total | 36 | +2697 | −743 |
| **Net (excl. tests)** | **23** | **+1658** | **−582** |
| New files | 4 | +269 | — |

All four new files are tests. No migration is added and none is needed — every column the new SQL touches already exists, and `status='starting'` is permitted by the existing check constraint.

**By module**

*Session identity and lifecycle*
- `src/server/services/workspace_manager.py` (+689) — the fence, `_retire_session`, detached sandbox teardown, CAS binding, strict-backup gating
- `src/server/services/workspace_entitlements.py` (+90) — replacement claim around the tier change
- `src/server/services/platform_secret_sweep.py` (+16) — the sweeper's eviction becomes retirement
- `src/server/services/platform_secret_rollout.py` (+51) — the CAS becomes unconditional
- `src/server/database/workspace.py` (+485) — sole writer of the binding; `_ws_cursor` collapses per-query connection boilerplate

*Sandbox error typing*
- `src/ptc_agent/core/sandbox/files.py` (+257) — all 11 helpers, absence vs unreachable
- `src/ptc_agent/core/sandbox/ptc_sandbox.py` (+76), `runtime.py` (+40), `retry.py` (+18) — typed errors, retry rebinding, `SandboxGoneError` propagation, and the base absence classifier every non-Daytona provider inherits
- `src/ptc_agent/core/sandbox/providers/daytona.py` (+28), `daytona_secrets.py` (+47) — structured error classification
- `src/ptc_agent/core/session.py` (+9)

*HTTP surface*
- `src/server/app/setup.py` (+27) — one app-wide 503 handler
- `src/server/app/workspace_files/{crud,serve,_shared}.py` (+120) — correct 503s; serve keeps its uniform-404 posture
- `src/server/app/public.py` (+52), `mcp_servers.py` (+16) — fenced reads on the share and discovery paths
- `src/ptc_agent/agent/backends/sandbox.py` (+41) — the agent no longer reads a transport failure as `file_not_found`
- `src/ptc_agent/config/utils.py` (+13) — stop structlog writing frame locals into logs

*Enforcement*
- `scripts/multiworker_gate/gate.py` (+122), `README.md` (+19) — cell 18, the first workspace/sandbox cell in the gate

## Risk

**Unproven by tests, only by live runs.** These are the behaviours a reviewer should look hardest at, because no unit test establishes them:

- **`classify_error` is the hinge of the whole fix, and CI caught it breaking.** It was previously unpinned, and the sandbox integration job proved the gap reachable: only `DaytonaProvider` overrides it, so on every other provider a genuine missing file fell through to `UNKNOWN`, the liveness probe found the sandbox alive, and an ordinary 404 came back as a 503 — this branch's own thesis inverted. Fixed at the base classifier rather than in the test double, because `DockerProvider` ships with the identical gap. Now pinned by `test_provider_absence_classification.py`, and the pin is mutation-verified: reverting the fix turns 2 of its 4 cases red and reproduces the exact CI signature. The residual is narrower but real — Daytona's `FILE_NOT_FOUND`/404 split is still a vendor-shaped constant measured against the live SDK, and it can still drift silently.
- **`files.py` is +257 lines with no unit coverage.** Mutation-checked during review: inserting an early `return` into `_raise_normalized` — restoring the exact 404-for-a-live-file bug — leaves all 8640 tests green.
- **The warm-path fence itself is only pinned as a pure predicate.** Replacing the staleness call with `None` inside `_take_valid_cached_session` also leaves the suite green. Only the live gate cell catches it.
- **Detached teardown (`_detached_sandbox_teardown`, `_is_sandbox_gone`) has no test references at all** — and it is the multi-worker case the branch exists for: a delete or stop landing on a worker that holds no session. A regression leaks a running sandbox behind a soft-deleted row.

**Behaviour changes worth a second opinion:**

- **`delete_workspace` can now fail where it previously always succeeded.** The detached teardown re-raises anything not classified as gone, so a provider 429/5xx during delete returns 500 and leaves the row. Previously delete always soft-deleted.
- **A strict backup now aborts teardown on any nonzero per-file error count** — including a file that vanished between listing and download. That is the intended direction (it was silently destroying sandboxes after partial backups), but it means benign churn can now block a tier change.
- **The warm path depends on Postgres for the first time.** A pool exhaustion or failover that warm turns used to ride out now fails them. Deliberate — durable truth is the point — but it is a new failure mode.
- **The File panel's "starting" copy.** The panel selects its card by substring-matching the detail string, and most cases now produce a different one, so a momentarily-unreachable sandbox on a running workspace reads "Start the workspace to access files". The re-categorisation is correct; the copy needs a follow-up.
- **Mixed-version deploy.** During a rolling cutover an old worker still writes `sandbox_id` unconditionally and can clobber a CAS-fenced binding. Worth confirming the deploy order rather than assuming.
- **Automations now count a strike for a dead sandbox.** This is the one behaviour change created by meeting #350 on this branch. The chat funnel classifies `SandboxTransientError`/`SandboxGoneError` as recoverable infrastructure (`error_handling.py:76`), but the automation strike gate does not: it exempts only `isinstance(e, HTTPException) and status == 503` (`automation_executor.py:325`), and these propagate raw as `RuntimeError` subclasses. Before this branch those failures were largely silent, so they never reached the counter; now more of them will, and a persistently broken sandbox can auto-disable a user's automation. That may well be correct, but it is the same "our outage vs their fault" call #350 just made for the quota service and resolved the other way. Flagging it as a deliberate decision rather than letting it land by default.
- **Sandbox 503s miss #350's new message-lift.** `client.ts:63` lifts `detail.message` onto `error.message` only when `detail` is an object; every 503 here emits `detail` as a plain string, so axios call sites still show "Request failed with status code 503". The File panel is unaffected (it reads `response.data.detail` directly), but the codebase now carries three 503 discriminator conventions: `detail.type` (quota), `detail.code` (`threads/messaging.py:47`), and bare string (here). Worth unifying, not in this PR.

**Not covered:** three integration files were modified but are deselected by default and need live credentials, so CI is their first real run. The rendered File panel has not been driven in a browser — every 404→503 conversion was verified by status code. The live gate and E2E evidence below predates the rebase, but was gathered with `HOST_MODE=oss`, where the credit gate is skipped entirely — so #350 did not execute in that stack either before or after, and the evidence stands. The corollary is that the two changes have not met in *platform* mode locally; CI and the first platform-mode deploy are their first real contact.

## Test plan

- [x] Rebased onto `origin/main` including #350 (the quota-denial relay / fail-closed refactor). Zero file overlap, zero conflicts; all 12 commits replayed unchanged
- [x] Backend unit suite: **8655 passed, 0 failed** (post-rebase, includes #350's new quota tests and the 4 new absence-classification pins)
- [x] Sandbox integration suite (memory provider): the 3 CI failures pass. The 6 remaining local failures are environmental (`Conversation database pool is not open`) and were proven pre-existing by re-running with only the fix stashed
- [x] Frontend Vitest: **2942 passed** (271 files; no frontend file is touched by this branch)
- [x] `ruff check src/` clean
- [x] Multi-worker gate **9/9** against a real 4-worker stack, including new cell 18 — sandbox `a64062fb`→`09b1e674`, second worker converged to 200 with exact content, 1 stale detection
- [x] Live E2E, 4 workers: 174 reads across a replacement with zero 404s; 180 reads across stop/start; 100 reads against an agent-authored file; 3 concurrent-replacement rounds; 3 rounds of 6-way concurrent attach on a NULL binding — 8 loser sandboxes built, 8 confirmed gone, zero leaked
- [x] Session totals across the run: 26 stale detections (25 identity-moved, 1 status-stopped — both branches fired live), 16 CAS losers self-destructed, zero rows stuck in `starting`, zero running rows with a NULL binding
- [x] Integration tier (`-m integration`) — deselected by default, needs live DB + Redis + credentials
- [x] File panel driven in a browser


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of sandbox outages, replacements, and transient connection failures.
  * Prevented stale sandbox sessions from being used after workspace changes.
  * Added reliable fallback to saved workspace files when live sandbox access is unavailable.
  * Standardized unavailable-sandbox responses with clearer 404 and 503 behavior.
  * Improved file-operation error reporting and protected sensitive data in exception logs.
  * Improved workspace recovery and cleanup during replacement or cancellation.

* **Documentation**
  * Expanded multi-worker guidance and added sandbox replacement validation coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->