### PR TITLE
fix(egress): name a vendor redirect instead of relaying a bare 3xx

### DIFF
--- a/src/ptc_agent/core/sandbox/mcp_client_runtime.py
+++ b/src/ptc_agent/core/sandbox/mcp_client_runtime.py
@@ -1435,6 +1435,11 @@ def _discover_http(server_name: str) -> list:
     with httpx.Client(timeout=_HTTP_EXCHANGE_BUDGET) as client:
         deadline = time.monotonic() + _HTTP_EXCHANGE_BUDGET
         with client.stream("POST", url, json=req, headers=hdrs) as response:
+            # A relay rejection here would otherwise surface as a bare 502
+            # against the relay URL; decode it like the handshake path does.
+            _msg = _relay_error(response, server_name)
+            if _msg:
+                raise RuntimeError(_msg)
             response.raise_for_status()
             result = _parse_http_reply(response, req["id"], server_name, deadline)
     if "error" in result:

--- a/src/ptc_agent/core/sandbox/mcp_client_runtime.py
+++ b/src/ptc_agent/core/sandbox/mcp_client_runtime.py
@@ -307,6 +307,7 @@ _RELAY_ERROR_HINTS = {
     "refresh_in_progress": "the vendor token is being refreshed; retry in a few seconds",
     "destination_blocked": "the relay refused to dial this server's address",
     "upstream_unreachable": "the relay could not reach the vendor's server",
+    "vendor_redirect": "the vendor redirected this endpoint, so its URL has moved; update the server URL in Connectors",
     "limited_rate": "rate limit reached for this connection; retry shortly",
     "limited_concurrency": "too many concurrent calls for this connection; retry shortly",
     "relay_disabled": "the egress relay is disabled on this deployment",

--- a/src/server/services/egress/__init__.py
+++ b/src/server/services/egress/__init__.py
@@ -31,6 +31,7 @@ class RelayError(StrEnum):
     # open_upstream
     DESTINATION_BLOCKED = "destination_blocked"
     UPSTREAM_UNREACHABLE = "upstream_unreachable"
+    VENDOR_REDIRECT = "vendor_redirect"
     # the route's own budgets
     LIMITED_RATE = "limited_rate"
     LIMITED_CONCURRENCY = "limited_concurrency"

--- a/src/server/services/egress/relay.py
+++ b/src/server/services/egress/relay.py
@@ -213,7 +213,8 @@ async def open_upstream(
     prepared: PreparedRelay, incoming_headers: dict[str, str]
 ) -> httpx.Response:
     """Send the canonical body to the pinned destination; one 401 retry when
-    the stored bundle has visibly rotated since we read it."""
+    the stored bundle has visibly rotated since we read it. A vendor redirect
+    is refused rather than followed or relayed on."""
     destination = prepared.grant["destination_url"]
     try:
         target = await pin_public_url(destination, require_https=True)
@@ -243,13 +244,28 @@ async def open_upstream(
                 content=prepared.canonical.body,
                 extensions=extensions,
             )
-            return await client.send(request, stream=True)
+            response = await client.send(request, stream=True)
         except httpx.HTTPError as e:
             logger.warning(
                 "[egress_relay] upstream unreachable for connection %s: %s",
                 connection_id, e,
             )
             raise RelayRejection(502, RelayError.UPSTREAM_UNREACHABLE)
+        if response.has_redirect_location:
+            # Following the hop would carry the vendor bearer to whatever host
+            # the redirect names, but relaying the 3xx on is worse than useless:
+            # Location is not in RESPONSE_HEADER_ALLOWLIST, so the sandbox would
+            # raise a bare "redirect response" against the RELAY's own URL, with
+            # nothing pointing at the vendor. Name it as its own outcome instead.
+            # The target follows the destination-pin reason above and stays
+            # host-side, since the sandbox is never told the vendor's address.
+            await response.aclose()
+            logger.warning(
+                "[egress_relay] vendor redirected connection %s to %s",
+                connection_id, response.headers.get("location"),
+            )
+            raise RelayRejection(502, RelayError.VENDOR_REDIRECT)
+        return response
 
     response = await _send(headers)
     if response.status_code != 401:

--- a/src/server/services/egress/relay.py
+++ b/src/server/services/egress/relay.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from urllib.parse import urlsplit
 
 import httpx
 
@@ -209,6 +210,29 @@ def _vendor_headers(
     return headers
 
 
+def _is_vendor_redirect(status: int) -> bool:
+    # Every 3xx names elsewhere instead of answering, except 304, which is a
+    # real response (caching passthrough). Relaying any other 3xx is useless to
+    # the sandbox: Location is stripped by the response allowlist, so
+    # raise_for_status there yields a bare "Redirect response" against the
+    # relay's own URL. Deliberately the whole range rather than the
+    # hop-following five — location-less, deprecated (305), reserved (306),
+    # and future codes all land on that same bare error if passed through.
+    return 300 <= status <= 399 and status != 304
+
+
+def _redirect_host(location: str | None) -> str:
+    # A vendor Location is untrusted and may embed signed query parameters or
+    # userinfo; even the host-side log keeps only the hostname.
+    if not location:
+        return "<missing>"
+    try:
+        host = urlsplit(location).hostname
+    except ValueError:
+        return "<unparseable>"
+    return host or "<relative>"
+
+
 async def open_upstream(
     prepared: PreparedRelay, incoming_headers: dict[str, str]
 ) -> httpx.Response:
@@ -251,18 +275,19 @@ async def open_upstream(
                 connection_id, e,
             )
             raise RelayRejection(502, RelayError.UPSTREAM_UNREACHABLE)
-        if response.has_redirect_location:
+        if _is_vendor_redirect(response.status_code):
             # Following the hop would carry the vendor bearer to whatever host
             # the redirect names, but relaying the 3xx on is worse than useless:
             # Location is not in RESPONSE_HEADER_ALLOWLIST, so the sandbox would
             # raise a bare "redirect response" against the RELAY's own URL, with
-            # nothing pointing at the vendor. Name it as its own outcome instead.
-            # The target follows the destination-pin reason above and stays
-            # host-side, since the sandbox is never told the vendor's address.
+            # nothing pointing at the vendor. Name it as its own outcome
+            # instead. Only the target's host is kept even in the host-side
+            # log — a vendor Location can carry signed query parameters or
+            # userinfo, and the sandbox is never told any of it.
             await response.aclose()
             logger.warning(
-                "[egress_relay] vendor redirected connection %s to %s",
-                connection_id, response.headers.get("location"),
+                "[egress_relay] vendor redirected connection %s to host %s",
+                connection_id, _redirect_host(response.headers.get("location")),
             )
             raise RelayRejection(502, RelayError.VENDOR_REDIRECT)
         return response

--- a/tests/unit/server/app/test_egress_relay.py
+++ b/tests/unit/server/app/test_egress_relay.py
@@ -1055,6 +1055,77 @@ class TestVendor401Disambiguation:
 
 
 # ===========================================================================
+# 5b. Vendor redirects
+# ===========================================================================
+
+
+class TestVendorRedirects:
+    """A vendor 3xx has no safe passthrough: following it would carry the
+    bearer to the host the vendor names, and relaying it strips Location (not
+    allowlisted), leaving the sandbox to raise a bare redirect error against
+    the relay's own URL. It gets its own code instead."""
+
+    @pytest.mark.asyncio
+    async def test_a_redirect_is_named_rather_than_relayed_as_a_bare_3xx(
+        self, env, client
+    ):
+        env.set_vendor(
+            _vendor_json(status=307, headers={"location": f"https://{VENDOR_HOST}/mcp/"})
+        )
+
+        resp = await _post(client, token=_jwt())
+
+        assert resp.status_code == 502
+        assert _error(resp) == "vendor_redirect"
+
+    @pytest.mark.asyncio
+    async def test_the_redirect_target_stays_host_side(self, env, client):
+        # Same posture as destination_blocked: the sandbox is never told the
+        # vendor's address, so the code travels and the target does not.
+        env.set_vendor(
+            _vendor_json(
+                status=302, headers={"location": "https://elsewhere.example/mcp"}
+            )
+        )
+
+        resp = await _post(client, token=_jwt())
+
+        assert _error(resp) == "vendor_redirect"
+        assert "location" not in {k.lower() for k in resp.headers}
+        assert "elsewhere.example" not in resp.text
+        assert VENDOR_HOST not in resp.text
+
+    @pytest.mark.asyncio
+    async def test_a_redirect_on_the_401_retry_is_caught_too(self, env, client):
+        # The guard sits in the send helper, not on the first response: a
+        # rotated-bundle retry is a second chance for the vendor to redirect.
+        env.set_vendor(
+            _vendor_json(status=401),
+            _vendor_json(status=308, headers={"location": f"https://{VENDOR_HOST}/v2"}),
+        )
+        env.connection = AccessToken(
+            access_token=ROTATED_TOKEN, token_type="Bearer", generation=2
+        )
+
+        resp = await _post(client, token=_jwt())
+
+        assert resp.status_code == 502
+        assert _error(resp) == "vendor_redirect"
+        assert env.vendor.sends == 2
+
+    @pytest.mark.asyncio
+    async def test_a_3xx_without_a_location_is_not_a_redirect(self, env, client):
+        # Refusing on the status alone would swallow responses that carry no
+        # hop to follow; the passthrough contract still owns those.
+        env.set_vendor(_vendor_json(status=304))
+
+        resp = await _post(client, token=_jwt())
+
+        assert resp.status_code == 304
+        assert _error(resp) is None
+
+
+# ===========================================================================
 # 6. Streaming
 # ===========================================================================
 

--- a/tests/unit/server/app/test_egress_relay.py
+++ b/tests/unit/server/app/test_egress_relay.py
@@ -1114,15 +1114,63 @@ class TestVendorRedirects:
         assert env.vendor.sends == 2
 
     @pytest.mark.asyncio
-    async def test_a_3xx_without_a_location_is_not_a_redirect(self, env, client):
-        # Refusing on the status alone would swallow responses that carry no
-        # hop to follow; the passthrough contract still owns those.
+    async def test_a_304_is_not_a_redirect(self, env, client):
+        # 304 is the one 3xx that answers rather than names elsewhere; the
+        # passthrough contract still owns it.
         env.set_vendor(_vendor_json(status=304))
 
         resp = await _post(client, token=_jwt())
 
         assert resp.status_code == 304
         assert _error(resp) is None
+
+    @pytest.mark.asyncio
+    async def test_a_redirect_status_without_location_is_still_refused(
+        self, env, client
+    ):
+        # A 301 with no Location is malformed, but relaying it lands the
+        # sandbox on the same bare redirect error; the status alone decides.
+        env.set_vendor(_vendor_json(status=301))
+
+        resp = await _post(client, token=_jwt())
+
+        assert resp.status_code == 502
+        assert _error(resp) == "vendor_redirect"
+
+    @pytest.mark.asyncio
+    async def test_a_300_multiple_choices_is_refused_too(self, env, client):
+        # 300 may name a preferred target in Location; relayed with the header
+        # stripped it is just another bare redirect error in the sandbox.
+        env.set_vendor(
+            _vendor_json(
+                status=300, headers={"location": f"https://{VENDOR_HOST}/v2/mcp"}
+            )
+        )
+
+        resp = await _post(client, token=_jwt())
+
+        assert resp.status_code == 502
+        assert _error(resp) == "vendor_redirect"
+
+    @pytest.mark.asyncio
+    async def test_the_log_keeps_only_the_redirect_host(self, env, client, caplog):
+        # The Location value is vendor-controlled and can carry signed query
+        # parameters; even the host-side log must not retain them.
+        env.set_vendor(
+            _vendor_json(
+                status=302,
+                headers={"location": "https://elsewhere.example/hop?sig=SIGNEDSECRET"},
+            )
+        )
+
+        with caplog.at_level("WARNING", logger="src.server.services.egress.relay"):
+            resp = await _post(client, token=_jwt())
+
+        assert _error(resp) == "vendor_redirect"
+        log_text = "\n".join(r.getMessage() for r in caplog.records)
+        assert "elsewhere.example" in log_text
+        assert "SIGNEDSECRET" not in log_text
+        assert "/hop" not in log_text
 
 
 # ===========================================================================


### PR DESCRIPTION
## Overview

| Category | Files | +LOC | -LOC |
|---|---:|---:|---:|
| Modified (prod) | 3 | 50 | 2 |
| Tests | 1 | 119 | 0 |
| **Net (excl. tests)** | **3** | **+48** | |

By module:
- `src/server/services/egress/` (+44/-2): `relay.py` grows a redirect guard inside the send helper (`_is_vendor_redirect`: any 3xx except 304) plus host-only logging of the Location (`_redirect_host`); `__init__.py` adds `RelayError.VENDOR_REDIRECT`.
- `src/ptc_agent/core/sandbox/mcp_client_runtime.py` (+6): agent-facing hint for the new error code, and the discovery `tools/list` now decodes `X-Relay-Error` before `raise_for_status` like the handshake and tools/call paths (codegen version auto-derives, warm sandboxes resync on their own).

**What this introduces:** the egress relay now refuses a vendor 3xx as a named `X-Relay-Error: vendor_redirect` outcome instead of relaying a bare redirect status the sandbox cannot interpret. Two commits: the guard, then review hardening (host-only Location logging, classification widened to every 3xx except 304, discovery decode).

## Summary

A vendor 3xx had no safe outcome on the relay path:

- Following the hop is forbidden: the relay would carry the vendor bearer token to whatever host the redirect names.
- Passing the status through was worse than useless: `Location` is not in `RESPONSE_HEADER_ALLOWLIST`, so the sandbox raised a bare redirect error against the relay's own URL, with nothing pointing at the vendor.

The fix makes `open_upstream` refuse any redirect response as its own `RelayRejection(502, vendor_redirect)`. The guard lives inside the send helper so the 401-refresh-retry leg is covered too. The redirect target is logged host-side only, matching the destination-pin posture that keeps vendor addresses out of the sandbox. The agent now sees an actionable instruction ("the vendor redirected this endpoint, so its URL has moved; update the server URL in Connectors") instead of an httpx stack message.

## Verification

- Full default unit suite on the rebased branch: 8623 passed, 1 xfailed. The relay file's new cases cover refusal on the first send and the post-refresh retry, location-less redirects, 300 with a Location, 304 passthrough, host-only logging (signed query params never reach the log), and the named `X-Relay-Error` reaching the response.
- Motivating case: the Robinhood legacy MCP work, where vendor-side failures on the relay path were indistinguishable from relay failures until `X-Relay-Error` named them.
