### PR TITLE
fix(tracking): bill on the manifest key, honor DeepSeek peak hour rates

### DIFF
--- a/src/llms/llm.py
+++ b/src/llms/llm.py
@@ -500,6 +500,13 @@ class LLM:
         # runs inside ModelResilienceMiddleware sees a substituted client, so a
         # capability read has to come off the client in hand rather than off a
         # name captured when the stack was built.
+        # ``pricing_model_id``/``pricing_provider`` are the same identity a
+        # manifest lookup would yield, carried explicitly because a user-defined
+        # model's key is its display name and resolves to nothing. Their config
+        # names the id and provider outright, which is a better billing source
+        # than the vendor echo. ``provider_route`` cannot stand in: it qualifies
+        # off-manifest endpoints by base_url to keep reasoning lineage separate,
+        # so it identifies a trust boundary, not a set of rates.
         billing_type = self._resolve_billing_type()
         existing = client.metadata or {}
         client.metadata = {
@@ -507,6 +514,8 @@ class LLM:
             "billing_type": billing_type,
             "provider_route": self._provider_route(),
             "manifest_model": self.custom_model_name,
+            "pricing_model_id": self.model,
+            "pricing_provider": self.provider,
         }
 
         return client

--- a/src/llms/manifest/providers.json
+++ b/src/llms/manifest/providers.json
@@ -372,10 +372,25 @@
         "context_window": 1000000,
         "max_output": 384000,
         "pricing": {
-          "input": 0.435,
-          "cached_input": 0.003625,
-          "output": 0.87,
-          "unit": "per_1m_tokens"
+          "input": 1.32,
+          "cached_input": 0.044,
+          "output": 3.96,
+          "unit": "per_1m_tokens",
+          "peak_utc": [
+            [
+              1,
+              4
+            ],
+            [
+              6,
+              10
+            ]
+          ],
+          "off_peak": {
+            "input": 0.66,
+            "cached_input": 0.022,
+            "output": 1.98
+          }
         }
       },
       {
@@ -386,10 +401,25 @@
         "context_window": 1000000,
         "max_output": 384000,
         "pricing": {
-          "input": 0.14,
-          "cached_input": 0.0028,
-          "output": 0.28,
-          "unit": "per_1m_tokens"
+          "input": 0.44,
+          "cached_input": 0.014,
+          "output": 1.32,
+          "unit": "per_1m_tokens",
+          "peak_utc": [
+            [
+              1,
+              4
+            ],
+            [
+              6,
+              10
+            ]
+          ],
+          "off_peak": {
+            "input": 0.22,
+            "cached_input": 0.007,
+            "output": 0.66
+          }
         }
       }
     ],

--- a/src/llms/pricing_utils.py
+++ b/src/llms/pricing_utils.py
@@ -2,11 +2,21 @@
 Pricing calculation utilities for LLM token usage with support for both flat and tiered pricing.
 """
 
+from datetime import datetime, timezone
 from typing import Dict, Any, Optional, List, Tuple
 import logging
 import re
 
 logger = logging.getLogger(__name__)
+
+# Keys describing *when* a card applies rather than what it charges. Stripped
+# from the card handed to the engine so what gets priced, logged and snapshotted
+# is only the rates in force.
+_SCHEDULE_KEYS = ("peak_utc", "off_peak", "schedule_anchor")
+
+# An unstamped record's model name is the vendor's string; bound it before it
+# reaches a log line.
+_LOGGED_NAME_MAX_LEN = 120
 
 
 def extract_base_model(model_name: str) -> str:
@@ -57,21 +67,78 @@ def extract_base_model(model_name: str) -> str:
     return model_name
 
 
+def resolve_pricing_identity(
+    model_name: str, billing_type: str = "platform"
+) -> Tuple[Optional[str], str]:
+    """
+    Resolve a tracked model name to the (provider, pricing id) pair its rates live under.
+
+    A manifest key is tried before any model_id, and that ordering is the whole point:
+    keys are unique by construction, model_ids are not. Several keys share one id while
+    declaring providers whose rates genuinely differ (a region or plan variant against
+    its base), so a single scan matching keys and ids together would resolve a shared id
+    by whichever entry the manifest happens to list first.
+
+    For platform billing the provider is system_provider when present, since that is the
+    route whose rates the call actually costs. BYOK and OAuth resolve to the base provider,
+    which is the one the user pays directly.
+
+    Args:
+        model_name: Manifest key (preferred) or model_id from a usage record
+        billing_type: "platform", "byok", or "oauth"
+
+    Returns:
+        (provider, pricing_id). provider is None when the name is not in the manifest;
+        pricing_id falls back to model_name so the caller can still attempt a lookup.
+    """
+    from .llm import LLM
+
+    try:
+        config_data = LLM.get_model_config().llm_config  # models.json
+    except Exception as e:
+        logger.debug(f"Failed to load models.json for provider detection: {e}")
+        return None, model_name
+
+    if not config_data:
+        return None, model_name
+
+    def _provider_of(config: Dict[str, Any]) -> Optional[str]:
+        if billing_type == "platform":
+            return config.get("system_provider") or config.get("provider")
+        return config.get("provider")
+
+    model_name_lower = model_name.lower()
+
+    for custom_name, config in config_data.items():
+        if custom_name.lower() == model_name_lower:
+            provider = _provider_of(config)
+            pricing_id = config.get("model_id") or model_name
+            logger.debug(
+                f"Manifest key '{model_name}' (billing={billing_type}) "
+                f"-> provider={provider}, pricing id={pricing_id}"
+            )
+            return provider, pricing_id
+
+    for custom_name, config in config_data.items():
+        if config.get("model_id", "").lower() == model_name_lower:
+            provider = _provider_of(config)
+            logger.debug(
+                f"Model id '{model_name}' (billing={billing_type}) -> provider={provider} "
+                f"via key '{custom_name}'"
+            )
+            return provider, model_name
+
+    logger.debug(f"No provider found for model '{model_name}' in models.json")
+    return None, model_name
+
+
 def detect_provider_for_model(model_name: str, billing_type: str = "platform") -> Optional[str]:
     """
     Detect provider by reverse-looking up models.json, with billing-type awareness.
 
-    For platform billing, returns system_provider when available — that's the actual
-    routing provider whose rates determine credit costs. For BYOK/OAuth, returns the
-    base provider since the user pays that provider directly.
-
-    This handles mixed-billing conversations correctly: each per-call record carries
-    its own billing_type, so platform calls resolve to system_provider pricing while
-    BYOK calls in the same conversation resolve to base provider pricing.
-
-    Searches both:
-    - Custom model names (keys in models.json)
-    - model_id values (the actual model identifier sent to APIs)
+    Thin wrapper over resolve_pricing_identity for callers that only need the provider.
+    Prefer the resolver directly when the pricing id is needed too — a manifest key and
+    its model_id differ for most entries.
 
     Args:
         model_name: Model name from token usage (e.g., "MiniMax-M2", "gpt-5-0905")
@@ -88,38 +155,7 @@ def detect_provider_for_model(model_name: str, billing_type: str = "platform") -
         >>> detect_provider_for_model("gpt-5")
         "openai"
     """
-    from .llm import LLM
-
-    try:
-        model_config = LLM.get_model_config()
-        config_data = model_config.llm_config  # Load models.json
-    except Exception as e:
-        logger.debug(f"Failed to load models.json for provider detection: {e}")
-        return None
-
-    if not config_data:
-        return None
-
-    # Normalize for case-insensitive comparison
-    model_name_lower = model_name.lower()
-
-    # Search through all custom model configurations
-    for custom_name, config in config_data.items():
-        # Check 1: Match against custom name (the key in models.json)
-        # Check 2: Match against model_id field (case-insensitive)
-        model_id = config.get("model_id", "")
-        if custom_name.lower() == model_name_lower or model_id.lower() == model_name_lower:
-            if billing_type == "platform":
-                provider = config.get("system_provider") or config.get("provider")
-            else:
-                provider = config.get("provider")
-            if provider:
-                logger.debug(f"Provider detected for '{model_name}' (billing={billing_type}): {provider}")
-                return provider
-
-    # Not found in models.json
-    logger.debug(f"No provider found for model '{model_name}' in models.json")
-    return None
+    return resolve_pricing_identity(model_name, billing_type)[0]
 
 
 def find_model_pricing(model_name: str, provider: Optional[str] = None) -> Optional[Dict[str, Any]]:
@@ -247,35 +283,43 @@ def find_model_pricing(model_name: str, provider: Optional[str] = None) -> Optio
                         )
                         return model.get('pricing')
 
+    # On an unstamped record this name is the vendor's own string, which can carry
+    # newlines and forge a log record downstream, so every line below quotes and
+    # bounds it rather than interpolating it raw.
+    safe_name = f"{model_name[:_LOGGED_NAME_MAX_LEN]!r}"
+
     # STEP 3: Pattern-based fallback for version snapshots
     base_model = extract_base_model(model_name)
     if base_model != model_name:
         logger.info(
-            f"No exact match for '{model_name}', trying base model '{base_model}' "
+            f"No exact match for {safe_name}, trying base model '{base_model}' "
             f"(extracted via pattern matching)"
         )
         # Recursive lookup with base model (keep same provider context)
         pricing = find_model_pricing(base_model, provider)
         if pricing:
             logger.warning(
-                f"Using pricing for base model '{base_model}' for snapshot version '{model_name}'. "
-                f"This is a fallback strategy. Consider adding '{model_name}' as an alias in "
+                f"Using pricing for base model '{base_model}' for snapshot version {safe_name}. "
+                f"This is a fallback strategy. Consider adding that name as an alias in "
                 f"providers.json if this model is frequently used."
             )
             return pricing
         else:
             logger.debug(f"Base model '{base_model}' also not found in manifest")
 
-    # STEP 4: Not found - log comprehensive error
+    # STEP 4: Not found - log comprehensive error.
+    # Quoted and bounded: on an unstamped record this name is the vendor's own
+    # string, which can carry newlines and forge a log record downstream.
+    safe_name = f"{model_name[:_LOGGED_NAME_MAX_LEN]!r}"
     if provider:
         logger.warning(
-            f"No pricing found for model: {model_name} (provider: {provider}). "
+            f"No pricing found for model: {safe_name} (provider: {provider!r}). "
             f"Tried: exact ID match, alias match, base model '{base_model}'. "
             f"Please add this model to providers.json under provider '{provider}'."
         )
     else:
         logger.warning(
-            f"No pricing found for model: {model_name} (searched all providers). "
+            f"No pricing found for model: {safe_name} (searched all providers). "
             f"Tried: exact ID match, alias match, base model '{base_model}'. "
             f"Please add this model to providers.json."
         )
@@ -679,6 +723,129 @@ def get_output_cost(tokens: int, pricing: Dict[str, Any], input_tokens: int = 0)
         return (tokens / 1_000_000) * pricing['output']
 
     return 0.0
+
+
+def has_schedule(pricing: Optional[Dict[str, Any]]) -> bool:
+    """Whether this card's rate depends on when the call ran.
+
+    Either rate-bearing key arms the schedule. Keying on ``peak_utc`` alone would
+    let a card carrying only the ``off_peak`` discount read as unscheduled and
+    bill peak around the clock, silently and with nothing to log — the discount
+    block is the half a maintainer writes first.
+    """
+    return bool(pricing and (pricing.get("peak_utc") or pricing.get("off_peak")))
+
+
+def _usable_windows(pricing: Dict[str, Any]) -> List[Tuple[int, int]]:
+    """The peak windows this card can actually be evaluated against.
+
+    Every rejection is a manifest authoring error, so each one is logged rather
+    than raised: the callers of the pricing path wrap it in a blanket except that
+    turns any raise into a zero-cost turn for every model in it, not just this one.
+    A dropped window costs only its own card.
+    """
+    windows: List[Tuple[int, int]] = []
+    declared = pricing.get("peak_utc")
+    if declared and not isinstance(declared, (list, tuple)):
+        # The container is checked before the windows in it: a scalar would raise on
+        # the for statement itself, ahead of any per-window rule, and that raise
+        # escapes to the caller's blanket except and zeroes the turn. The list of
+        # windows is what this reads, so anything else says nothing about when peak is.
+        logger.warning(f"Ignoring unusable peak_utc container {declared!r}")
+        return windows
+
+    for window in declared or []:
+        if (
+            isinstance(window, (list, tuple))
+            and len(window) == 2
+            and all(isinstance(bound, int) for bound in window)
+            # A window that wraps midnight is inexpressible as one pair: no hour
+            # satisfies ``start <= hour < end`` when start > end, so it would read
+            # as "never peak" and bill the discount 24/7. Split it into two.
+            and 0 <= window[0] < window[1] <= 24
+        ):
+            windows.append((window[0], window[1]))
+        else:
+            logger.warning(f"Ignoring unusable peak_utc window {window!r}")
+    return windows
+
+
+def schedule_anchor(pricing: Optional[Dict[str, Any]]) -> str:
+    """Which end of the call picks the rate window: ``completion`` or ``request``.
+
+    A manifest field rather than a constant because no vendor publishes the rule.
+    DeepSeek documents the hours and says nothing about which end of a streamed
+    call decides, so this stays a one-line edit for when a vendor does.
+    """
+    return (pricing or {}).get("schedule_anchor", "completion")
+
+
+def parse_stamp(value: Optional[str]) -> Optional[datetime]:
+    """Read a per-call time stamp, defaulting a naive one to UTC.
+
+    Not a compatibility path: per-call records never leave the process that
+    wrote them, so a naive stamp cannot arrive here from an older build. The
+    default is kept because every bound it gets compared against is UTC, and
+    reading a naive stamp as local time would shift a call into the wrong rate
+    window on any host that is not.
+    """
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed.replace(tzinfo=timezone.utc) if parsed.tzinfo is None else parsed
+
+
+def resolve_schedule(
+    pricing: Dict[str, Any], at: Optional[datetime]
+) -> Tuple[Dict[str, Any], Optional[str]]:
+    """Pick the rate card in force at ``at``, for models on peak hour pricing.
+
+    The top level of the manifest entry holds the peak rates and ``off_peak``
+    carries only what differs. That way every reader predating this — the model
+    picker's price tier, the aggregate display path — keeps working untouched and
+    errs toward the higher rate rather than quietly quoting the cheaper one.
+
+    Returns the card and the window that chose it, or ``(pricing, None)`` for the
+    overwhelming majority of models, which have no schedule.
+    """
+    if not has_schedule(pricing):
+        return pricing, None
+
+    card = {k: v for k, v in pricing.items() if k not in _SCHEDULE_KEYS}
+    if at is None:
+        # No usable stamp: charge peak rather than guess downward.
+        return card, "peak"
+
+    # A shape test guards the committed manifest, but rates are hand-authored
+    # config and a deploy can carry an edit no test ran against, so the windows
+    # are validated where the money is decided rather than trusted.
+    windows = _usable_windows(pricing)
+    if not windows:
+        # Nothing left says when peak is, so nothing can place this call outside
+        # it. Same direction as the missing-stamp case: charge peak, don't guess
+        # downward off a card we just found unreadable.
+        logger.warning("No usable peak_utc window on a scheduled card, charging peak")
+        return card, "peak"
+
+    hour = at.astimezone(timezone.utc).hour
+    if any(start <= hour < end for start, end in windows):
+        return card, "peak"
+
+    off_peak = pricing.get("off_peak")
+    if off_peak and not isinstance(off_peak, dict):
+        # Same fail-high rule as an unusable window, and for the same reason: a card
+        # claiming a discount without saying what it is cannot price one, and letting
+        # dict.update raise here would escape into the caller's blanket except and
+        # zero the turn for every model in it. Absent is not malformed, so it keeps
+        # falling through to the peak rates under an off_peak label.
+        logger.warning(f"Ignoring unusable off_peak override {off_peak!r}, charging peak")
+        return card, "peak"
+
+    card.update(off_peak or {})
+    return card, "off_peak"
 
 
 def calculate_total_cost(

--- a/src/llms/pricing_utils.py
+++ b/src/llms/pricing_utils.py
@@ -308,9 +308,6 @@ def find_model_pricing(model_name: str, provider: Optional[str] = None) -> Optio
             logger.debug(f"Base model '{base_model}' also not found in manifest")
 
     # STEP 4: Not found - log comprehensive error.
-    # Quoted and bounded: on an unstamped record this name is the vendor's own
-    # string, which can carry newlines and forge a log record downstream.
-    safe_name = f"{model_name[:_LOGGED_NAME_MAX_LEN]!r}"
     if provider:
         logger.warning(
             f"No pricing found for model: {safe_name} (provider: {provider!r}). "
@@ -758,7 +755,12 @@ def _usable_windows(pricing: Dict[str, Any]) -> List[Tuple[int, int]]:
         if (
             isinstance(window, (list, tuple))
             and len(window) == 2
-            and all(isinstance(bound, int) for bound in window)
+            # ``type is int`` rather than isinstance: bool subclasses int, so a JSON
+            # ``true`` would pass as hour 1 and ``false`` as hour 0. Both then satisfy
+            # the range test and silently install a window nobody wrote -- and
+            # ``[0, true]`` reads as [0,1), handing out the discount for all 23 hours
+            # outside it, which is the one outcome this validation exists to forbid.
+            and all(type(bound) is int for bound in window)
             # A window that wraps midnight is inexpressible as one pair: no hour
             # satisfies ``start <= hour < end`` when start > end, so it would read
             # as "never peak" and bill the discount 24/7. Split it into two.

--- a/src/ptc_agent/agent/middleware/background_subagent/run_executor.py
+++ b/src/ptc_agent/agent/middleware/background_subagent/run_executor.py
@@ -87,7 +87,7 @@ def _merge_subagent_usage(
     the prior run's usage until cleanup drops it after a successful persist.
     """
     task.per_call_records = (task.per_call_records or []) + (
-        tracker.per_call_records or []
+        tracker.get_per_call_records()
     )
     for name, count in tool_tracker.get_summary().items():
         task.tool_usage[name] = task.tool_usage.get(name, 0) + count
@@ -275,7 +275,7 @@ async def _run_background_task(
             label,
             display_id=task.display_id,
             result_type=type(result).__name__,
-            token_records=len(tracker.per_call_records or []),
+            token_records=tracker.record_count(),
         )
         return {"success": True, "result": result}
     except asyncio.CancelledError:

--- a/src/server/handlers/chat/error_handling.py
+++ b/src/server/handlers/chat/error_handling.py
@@ -235,7 +235,9 @@ async def handle_workflow_error(
         abort the terminal transaction mid-flight."""
         if run_handle is None or run_handle.finalized:
             return False
-        records = token_callback.per_call_records if token_callback else None
+        # Snapshot under the tracker's lock — the error path fires while
+        # background subagent writers may still be appending.
+        records = token_callback.get_per_call_records() if token_callback else None
         tools = handler.get_tool_usage() if handler else None
         if not (run_handle.workspace_id and run_handle.user_id):
             records = None

--- a/src/server/services/persistence/usage.py
+++ b/src/server/services/persistence/usage.py
@@ -115,19 +115,17 @@ class UsagePersistenceService:
                 "per_call_costs": [...]
             }
         """
-        from src.utils.tracking.core import calculate_cost_from_per_call_records
+        from src.utils.tracking.core import (
+            calculate_cost_from_per_call_records,
+            empty_usage_payload,
+        )
 
         if not per_call_records:
             logger.debug("[UsagePersistence] No per-call records to track")
-            self._token_usage = {
-                "by_model": {},
-                "total_cost": 0.0,
-                "cost_breakdown": {
-                    "input_cost": 0.0,
-                    "output_cost": 0.0,
-                    "cached_cost": 0.0
-                }
-            }
+            # Shared with the pricing pass rather than hand-written: a duplicate
+            # literal drifts the moment a key is added, leaving a degraded row
+            # indistinguishable from one an older writer produced.
+            self._token_usage = empty_usage_payload()
             self._token_credits = Decimal("0.0")
             return self._token_usage
 
@@ -169,11 +167,9 @@ class UsagePersistenceService:
             # is_byok hint instead of deriving from _has_platform_calls (which
             # was never updated).
             self._token_credits = Decimal("0.0")
-            return {
-                "by_model": {},
-                "total_cost": 0.0,
-                "cost_breakdown": {"input_cost": 0.0, "output_cost": 0.0, "cached_cost": 0.0}
-            }
+            # Same shape as every other exit, built without touching the pricing
+            # pass that just raised.
+            return empty_usage_payload()
 
     # ========== Infrastructure Usage Tracking ==========
 

--- a/src/server/services/runs/sse_producer.py
+++ b/src/server/services/runs/sse_producer.py
@@ -953,22 +953,17 @@ class RunSSEProducer:
             try:
                 from src.server.services.persistence.usage import UsagePersistenceService
 
-                # Get token tracking from callback (already stored in self.token_callback)
+                # Snapshot under the tracker's lock: background subagent writers
+                # can still be appending records as the turn winds down.
                 per_call_records = None
                 if self.token_callback:
-                    per_call_records = self.token_callback.per_call_records
+                    per_call_records = self.token_callback.get_per_call_records()
 
                 # Get tool usage (non-destructive read, can be called multiple times)
                 tool_usage = self.get_tool_usage()
 
                 # Calculate credits if we have usage data
                 if per_call_records or tool_usage:
-                    # Calculate token usage for display
-                    token_usage = {}
-                    if per_call_records:
-                        from src.utils.tracking import calculate_cost_from_per_call_records
-                        token_usage = calculate_cost_from_per_call_records(per_call_records)
-
                     # Calculate total credits using same logic as persistence
                     credit_service = UsagePersistenceService(
                         thread_id=self.thread_id,
@@ -976,8 +971,12 @@ class RunSSEProducer:
                         user_id="temp"
                     )
 
+                    # One pricing pass, reused for the display payload. The
+                    # authoritative pass runs again at finalize (coordinator's
+                    # usage writer) against whatever records exist by then.
+                    token_usage = {}
                     if per_call_records:
-                        await credit_service.track_llm_usage(per_call_records)
+                        token_usage = await credit_service.track_llm_usage(per_call_records)
 
                     if tool_usage:
                         credit_service.record_tool_usage_batch(tool_usage)

--- a/src/server/utils/persistence_utils.py
+++ b/src/server/utils/persistence_utils.py
@@ -34,10 +34,12 @@ def get_token_usage_from_callback(
     per_call_records = None
     token_callback = metadata.get("token_callback")
 
-    if token_callback and hasattr(token_callback, "per_call_records"):
+    if token_callback and hasattr(token_callback, "get_per_call_records"):
         try:
             from src.utils.tracking import calculate_cost_from_per_call_records
-            per_call_records = token_callback.per_call_records
+            # Snapshot under the tracker's lock — this runs at interrupt, error
+            # and cancellation, where writers are still live by definition.
+            per_call_records = token_callback.get_per_call_records()
             token_usage = calculate_cost_from_per_call_records(per_call_records)
             logger.debug(
                 f"[WorkflowPersistence] Captured token usage at {context}: "

--- a/src/utils/tracking/__init__.py
+++ b/src/utils/tracking/__init__.py
@@ -18,7 +18,6 @@ from .core import (
     get_tracker,
     serialize_agent_message,
     renumber_agent_index,
-    add_cost_to_token_usage,
     calculate_cost_from_per_call_records,
 )
 
@@ -52,7 +51,6 @@ __all__ = [
     'get_tracker',
     'serialize_agent_message',
     'renumber_agent_index',
-    'add_cost_to_token_usage',
     'calculate_cost_from_per_call_records',
     # Decorators
     'track_messages',

--- a/src/utils/tracking/core.py
+++ b/src/utils/tracking/core.py
@@ -10,16 +10,32 @@ Provides:
 - Token usage and cost calculation utilities
 """
 
+import copy
 import logging
 import time
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from langchain_core.messages import AIMessage, ToolMessage
 
 logger = logging.getLogger(__name__)
+
+# An unstamped record's model name is the vendor's string; bound it before it
+# reaches a log line.
+_LOGGED_NAME_MAX_LEN = 120
+
+# Which key space ``by_model`` uses, read off the row rather than inferred from
+# created_at — during a blue/green drain both shapes are written concurrently,
+# which is exactly when a timestamp boundary stops working. Derived per payload
+# rather than fixed, because one turn can carry both a stamped client and a
+# consumer-supplied one and land two key spaces in the same dict. Nothing
+# consumes it yet; it is written now because a row that predates the marker can
+# never acquire one.
+KEY_SHAPE_MANIFEST = "manifest"
+KEY_SHAPE_VENDOR = "vendor"
+KEY_SHAPE_MIXED = "mixed"
 
 
 # ============================================================================
@@ -746,113 +762,75 @@ def renumber_agent_index(agent_execution_index: Dict[str, int]) -> Dict[str, int
 # Cost and Token Utilities
 # ============================================================================
 
-def add_cost_to_token_usage(token_usage: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+
+def _stamp_applied_rates(
+    entry: Dict[str, Any],
+    pricing: Optional[Dict[str, Any]],
+    window: Optional[str],
+    cost: float,
+    billing_type: str = "platform",
+    straddled: bool = False,
+) -> None:
+    """Record on the row itself which rate card this call was billed at.
+
+    A row holding only token counts is repriced by any later manifest edit, so a
+    rate change silently restates turns that were metered correctly at the time.
+    The resolved card is stored verbatim rather than summarized: a tiered or matrix
+    schedule does not reduce to a pair of numbers, and a summary would be the thing
+    that silently drifts.
+
+    Deduped by card rather than keyed by window, because ``by_model`` is keyed by
+    model and adding a second dimension to that key forks the key space again.
+    One entry is the normal case; a turn straddling a schedule boundary gets two.
     """
-    Add cost calculations to token usage data from UsageMetadataCallbackHandler.
+    if not pricing:
+        return
 
-    Reuses existing cost calculation utilities from src.llms.pricing_utils.
-    Supports model aliases, case-insensitive matching, and automatic provider detection.
+    rates = entry.setdefault("rates", [])
+    for applied in rates:
+        if (
+            applied.get("window") == window
+            and applied["billing_type"] == billing_type
+            and applied["pricing"] == pricing
+        ):
+            applied["call_count"] += 1
+            applied["cost"] += cost
+            if straddled:
+                applied["straddled_calls"] = applied.get("straddled_calls", 0) + 1
+            return
 
-    Args:
-        token_usage: Token usage dictionary from UsageMetadataCallbackHandler
-                    Format: {model_name: {input_tokens, output_tokens, input_token_details, ...}}
-
-    Returns:
-        Restructured token usage with cost information:
-        {
-            "by_model": {model_name: {input_tokens, output_tokens, ...}},
-            "total_cost": float,
-            "cost_breakdown": {input_cost, output_cost, cached_cost, ...}
-        }
-    """
-    from src.llms.pricing_utils import calculate_total_cost, find_model_pricing, detect_provider_for_model
-
-    if not token_usage:
-        return {
-            "by_model": {},
-            "total_cost": 0.0,
-            "cost_breakdown": {}
-        }
-
-    total_cost = 0.0
-    aggregated_breakdown = {
-        "input_cost": 0.0,
-        "output_cost": 0.0,
-        "cached_cost": 0.0,
-        "cache_storage_cost": 0.0,
-        "cache_5m_cost": 0.0,
-        "cache_1h_cost": 0.0
+    applied = {
+        "call_count": 1,
+        "cost": cost,
+        # by_model is keyed by model alone, so a model used both platform-routed
+        # and BYOK in one turn lands two genuinely different cards in one entry.
+        # Without this the platform-billed half is not recoverable from the row.
+        "billing_type": billing_type,
+        "pricing": copy.deepcopy(pricing),
     }
+    if window:
+        applied["window"] = window
+    if straddled:
+        applied["straddled_calls"] = 1
+    rates.append(applied)
 
-    # Calculate cost for each model
-    for model_name, usage in token_usage.items():
-        # Detect provider from llm_config.json for provider-aware pricing lookup
-        # This handles cases where the same model is offered by different providers
-        # with different pricing (e.g., GPT-4 via OpenAI vs Azure)
-        provider = detect_provider_for_model(model_name)
 
-        # Get pricing information using centralized lookup with provider context
-        # Supports: case-insensitive matching, aliases, version fallback
-        pricing = find_model_pricing(model_name, provider=provider)
-        if not pricing:
-            logger.debug(f"No pricing found for model: {model_name} (provider: {provider})")
-            continue
+def empty_usage_payload() -> Dict[str, Any]:
+    """The zero-usage row, in the same shape a priced turn produces.
 
-        # Skip cost calculation for subscription-priced models (coding plans)
-        if pricing.get("pricing_type") == "subscription":
-            logger.debug(f"Skipping cost calculation for subscription model: {model_name}")
-            continue
-
-        # Extract token counts
-        input_tokens = usage.get('input_tokens', 0)
-        output_tokens = usage.get('output_tokens', 0)
-
-        # Extract cache tokens from input_token_details via shared helper
-        cached_tokens = 0
-        cache_5m_tokens = 0
-        cache_1h_tokens = 0
-
-        if 'input_token_details' in usage:
-            from src.llms.token_counter import extract_cache_from_details
-            cache_info = extract_cache_from_details(usage['input_token_details'])
-            cached_tokens = cache_info.get('cached_tokens', 0)
-            cache_5m_tokens = cache_info.get('cache_5m_tokens', 0)
-            cache_1h_tokens = cache_info.get('cache_1h_tokens', 0)
-
-        # Calculate cost for this model using pricing utilities
-        cost_result = calculate_total_cost(
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
-            cached_tokens=cached_tokens,
-            cache_5m_tokens=cache_5m_tokens,
-            cache_1h_tokens=cache_1h_tokens,
-            pricing=pricing
-        )
-
-        total_cost += cost_result['total_cost']
-
-        # Aggregate breakdown across all models
-        breakdown = cost_result.get('breakdown', {})
-        if 'input' in breakdown:
-            aggregated_breakdown['input_cost'] += breakdown['input']['cost']
-        if 'cached_input' in breakdown:
-            aggregated_breakdown['cached_cost'] += breakdown['cached_input']['cost']
-        if 'output' in breakdown:
-            aggregated_breakdown['output_cost'] += breakdown['output']['cost']
-        if 'cache_storage' in breakdown:
-            aggregated_breakdown['cache_storage_cost'] += breakdown['cache_storage']['cost']
-        if 'cache_5m_creation' in breakdown:
-            aggregated_breakdown['cache_5m_cost'] += breakdown['cache_5m_creation']['cost']
-        if 'cache_1h_creation' in breakdown:
-            aggregated_breakdown['cache_1h_cost'] += breakdown['cache_1h_creation']['cost']
-
-    # Clean up zero-value breakdown entries
-    cost_breakdown = {k: v for k, v in aggregated_breakdown.items() if v > 0}
-
+    Kept separate from the pricing pass because the degraded exits that need it
+    run precisely when that pass has just raised, so they cannot call back into
+    it. Omitting a key here instead would make a row that failed to price
+    indistinguishable from one an older writer produced.
+    """
     return {
-        "by_model": token_usage,
-        "total_cost": total_cost,
-        "cost_breakdown": cost_breakdown
+        "by_model": {},
+        "model_key_shape": KEY_SHAPE_MANIFEST,
+        "total_cost": 0.0,
+        "platform_cost": 0.0,
+        # The populated path drops zero components, so an empty turn names none.
+        "cost_breakdown": {},
+        "per_call_costs": [],
     }
 
 
@@ -866,9 +844,8 @@ def calculate_cost_from_per_call_records(
     aggregating, enabling accurate pricing for models with tiered pricing, 2D matrix
     pricing, or input-dependent pricing.
 
-    Unlike add_cost_to_token_usage() which receives aggregated token counts,
-    this function receives per-call records from PerCallTokenTracker, allowing
-    accurate tiered pricing where rates vary based on token thresholds.
+    Pricing the aggregate instead would push two small calls into a tier neither
+    of them reached, so the records stay separate until after each is priced.
 
     Example:
         With tiered pricing (0-32k: $0.80, 32k-128k: $1.20):
@@ -879,13 +856,20 @@ def calculate_cost_from_per_call_records(
     Args:
         per_call_records: List of per-call token records from PerCallTokenTracker
                          Each record contains:
-                         - model_name: str
+                         - model_name: str (the billing key)
+                         - served_model: Optional[str] (vendor echo, never priced)
+                         - pricing_model_id / pricing_provider: Optional[str],
+                           used only when model_name is off-manifest
                          - usage: UsageMetadata dict
+                         - billing_type: str ("platform" / "byok" / "oauth")
                          - timestamp: str (ISO format)
                          - run_id: str
                          - parent_run_id: Optional[str]
 
     Returns:
+        The shape below is persisted verbatim into the ``token_usage`` JSON
+        column, so it is a stored contract rather than prose.
+
         {
             "by_model": {
                 model_name: {
@@ -895,9 +879,23 @@ def calculate_cost_from_per_call_records(
                     cached_tokens: int,
                     call_count: int,
                     total_cost: float,
+                    # Absent entirely when nothing was billed — an unpriced or
+                    # seat-priced model aggregates tokens but has no card:
+                    rates: [               # the card(s) actually billed, verbatim
+                        {
+                            call_count: int,
+                            cost: float,
+                            pricing: dict,
+                            window: str,           # omitted unless a schedule chose it
+                            straddled_calls: int,  # opened in the other window
+                        },
+                        ...
+                    ],
                 }
             },
+            "model_key_shape": str,   # which key space by_model uses
             "total_cost": float,
+            "platform_cost": float,
             "cost_breakdown": {
                 input_cost: float,
                 output_cost: float,
@@ -907,12 +905,18 @@ def calculate_cost_from_per_call_records(
             "per_call_costs": [
                 {
                     model_name: str,
+                    served_model: Optional[str],
                     input_tokens: int,
                     output_tokens: int,
                     cost: float,
                     breakdown: dict,
+                    billing_type: str,
                     timestamp: str,
                     run_id: str,
+                    # Peak hour models only, so every other call stays as it was:
+                    window: str,
+                    started_at: Optional[str],
+                    straddled: bool,   # omitted when the call sat in one window
                 },
                 ...
             ]
@@ -921,16 +925,15 @@ def calculate_cost_from_per_call_records(
     from src.llms.pricing_utils import (
         calculate_total_cost,
         find_model_pricing,
-        detect_provider_for_model
+        has_schedule,
+        parse_stamp,
+        resolve_pricing_identity,
+        resolve_schedule,
+        schedule_anchor,
     )
 
     if not per_call_records:
-        return {
-            "by_model": {},
-            "total_cost": 0.0,
-            "cost_breakdown": {},
-            "per_call_costs": []
-        }
+        return empty_usage_payload()
 
     total_cost = 0.0
     aggregated_breakdown = {
@@ -943,16 +946,99 @@ def calculate_cost_from_per_call_records(
     }
     per_call_costs = []
     by_model: Dict[str, Dict[str, Any]] = {}
+    Resolution = Tuple[Optional[str], str, Optional[Dict[str, Any]]]
+    resolved: Dict[Tuple[str, str, Optional[str], Optional[str]], Resolution] = {}
+
+    def _resolve(
+        model_name: str,
+        billing_type: str,
+        stamped_id: Optional[str],
+        stamped_provider: Optional[str],
+    ) -> Resolution:
+        """Resolve and price a model once per batch, not once per call.
+
+        A turn carries hundreds of records across a handful of models, and both
+        lookups walk the manifest and log on a miss. Memoizing turns the miss
+        into one warning per model per turn instead of one per call. The stamped
+        pair is part of the key because a fallback can swap the route mid-turn,
+        so two records can share a display name and still bill differently.
+        """
+        cache_key = (model_name, billing_type, stamped_id, stamped_provider)
+        if cache_key in resolved:
+            return resolved[cache_key]
+
+        if stamped_id:
+            # The client that issued the call is the authority on what it routed
+            # to, so its own stamp outranks a lookup by name. For a built-in the
+            # two agree — provider is already reassigned to system_provider on the
+            # platform route — but a user-defined model may deliberately shadow a
+            # built-in name to send it through a variant's key, and resolving that
+            # name against the manifest would price the model it replaced.
+            provider, pricing_id = stamped_provider, stamped_id
+        else:
+            # No stamp: a consumer-supplied client. Fall back to the manifest key
+            # the record carries — system_provider for platform billing, base
+            # provider for BYOK/OAuth.
+            provider, pricing_id = resolve_pricing_identity(
+                model_name, billing_type=billing_type
+            )
+
+        pricing = find_model_pricing(pricing_id, provider=provider)
+
+        if pricing is None:
+            # A miss on a platform call is a money event, not a reporting gap: the
+            # tokens still aggregate but contribute nothing to platform_cost, which
+            # is the figure the turn is billed on. find_model_pricing already warns
+            # on the lookup itself; this line adds the context that makes it actionable.
+            # !r on both names: an unstamped record carries the vendor's string,
+            # which can hold newlines and forge log records downstream. pricing_id
+            # needs the same treatment as model_name rather than less — on a
+            # manifest miss the resolver hands back the name it was given, so this
+            # is that same untrusted string a second time.
+            miss = (
+                f"No pricing found for model: {model_name[:_LOGGED_NAME_MAX_LEN]!r} "
+                f"(pricing id: {pricing_id[:_LOGGED_NAME_MAX_LEN]!r}, provider: {provider!r}), "
+                "recording tokens with zero cost"
+            )
+            if billing_type == "platform":
+                logger.warning(miss)
+            else:
+                logger.debug(miss)
+        elif pricing.get("pricing_type") == "subscription":
+            # Seat-priced plans meter tokens but bill nothing per token.
+            logger.debug(f"Subscription pricing for {model_name!r}, recording tokens with zero cost")
+            pricing = None
+
+        resolved[cache_key] = (provider, pricing_id, pricing)
+        return resolved[cache_key]
+
+    # A stamped client names its own key; an unstamped one leaves the vendor echo as
+    # the key. Counted so the marker describes the dict actually built rather than
+    # the one this writer intends.
+    #
+    # KEY_SHAPE_MANIFEST means the key came from our side, not that it is present in
+    # models.json: a user-defined model's key is its own alias, which is off-manifest
+    # by definition and still ours. A reader wanting manifest membership has to check
+    # the manifest; this marker only separates our keys from the vendor's.
+    stamped_records = 0
 
     # Process each call individually
     for record in per_call_records:
         model_name = record["model_name"]
         usage = record["usage"]
 
-        # Detect provider for pricing — uses system_provider for platform billing,
-        # base provider for BYOK/OAuth
         billing_type = record.get("billing_type", "platform")
-        provider = detect_provider_for_model(model_name, billing_type=billing_type)
+        stamped_id = record.get("pricing_model_id")
+        if stamped_id:
+            stamped_records += 1
+        # Only the priced card is needed here; the resolver logs the identity it
+        # used on a miss, which is the one place the other two matter.
+        _, _, pricing = _resolve(
+            model_name,
+            billing_type,
+            stamped_id,
+            record.get("pricing_provider"),
+        )
 
         # Extract token counts from this specific call
         input_tokens = usage.get('input_tokens', 0)
@@ -964,10 +1050,40 @@ def calculate_cost_from_per_call_records(
         cache_5m_tokens = usage.get('cache_5m_tokens', 0)
         cache_1h_tokens = usage.get('cache_1h_tokens', 0)
 
-        # Get pricing information — cost is 0 when pricing unavailable,
-        # but token counts are still aggregated so usage is never lost.
-        pricing = find_model_pricing(model_name, provider=provider)
-        if pricing:
+        # A model on peak hour pricing resolves per record, after the memoized
+        # lookup: the card depends on when this call ran, which the batch cannot
+        # share. Anchored on whichever end of the call the manifest names.
+        window = None
+        straddled = False
+        card = pricing
+        if has_schedule(pricing):
+            anchor = schedule_anchor(pricing)
+            billed_on = "started_at" if anchor == "request" else "timestamp"
+            other_end = "timestamp" if anchor == "request" else "started_at"
+            anchor_at = parse_stamp(record.get(billed_on))
+            other_at = parse_stamp(record.get(other_end))
+
+            # Records written before the start stamp existed carry only one end.
+            # The other end is a real observation of the same call, so it places
+            # the call far better than the no-stamp default of charging peak.
+            card, window = resolve_schedule(pricing, anchor_at or other_at)
+
+            # A streamed call can open in one window and close in another, and
+            # the whole call bills at one rate either way — the windows differ by
+            # 2x, so the unbilled end is the error. Recorded rather than acted on:
+            # no vendor says which end it charges, so the size of the disagreement
+            # has to be measurable before anyone can argue about it. Compares the
+            # two ends only, so a call crossing out of a window and back reads as
+            # unstraddled; that needs a call longer than the trough between two
+            # peak blocks, which is hours. Both ends have to be real: claiming a
+            # straddle off one stamp and one default would inflate the very count
+            # this exists to size, and every pre-branch record has one end.
+            if anchor_at is not None and other_at is not None:
+                straddled = resolve_schedule(pricing, other_at)[1] != window
+
+        # Cost is 0 when pricing is unavailable or seat-priced, but token counts
+        # are still aggregated so usage is never lost.
+        if card:
             # Calculate cost for THIS CALL ONLY (accurate tiered pricing)
             cost_result = calculate_total_cost(
                 input_tokens=input_tokens,
@@ -975,18 +1091,18 @@ def calculate_cost_from_per_call_records(
                 cached_tokens=cached_tokens,
                 cache_5m_tokens=cache_5m_tokens,
                 cache_1h_tokens=cache_1h_tokens,
-                pricing=pricing
+                pricing=card
             )
             call_cost = cost_result['total_cost']
             call_breakdown = cost_result.get('breakdown', {})
         else:
-            logger.debug(f"No pricing found for model: {model_name} (provider: {provider}), recording tokens with zero cost")
             call_cost = 0.0
             call_breakdown = {}
 
         # Store per-call cost record
-        per_call_costs.append({
+        call_cost_record = {
             "model_name": model_name,
+            "served_model": record.get("served_model"),
             "input_tokens": input_tokens,
             "output_tokens": output_tokens,
             "cached_tokens": cached_tokens,
@@ -996,7 +1112,15 @@ def calculate_cost_from_per_call_records(
             "timestamp": record.get("timestamp"),
             "run_id": record.get("run_id"),
             "parent_run_id": record.get("parent_run_id"),
-        })
+        }
+        if window:
+            # Only for models priced by the hour, so the row does not carry a
+            # window and a second stamp on every call of every other model.
+            call_cost_record["window"] = window
+            call_cost_record["started_at"] = record.get("started_at")
+            if straddled:
+                call_cost_record["straddled"] = True
+        per_call_costs.append(call_cost_record)
 
         # Aggregate total cost
         total_cost += call_cost
@@ -1032,6 +1156,9 @@ def calculate_cost_from_per_call_records(
         by_model[model_name]['cached_tokens'] += cached_tokens
         by_model[model_name]['call_count'] += 1
         by_model[model_name]['total_cost'] += call_cost
+        _stamp_applied_rates(
+            by_model[model_name], card, window, call_cost, billing_type, straddled
+        )
 
     # Clean up zero-value breakdown entries
     cost_breakdown = {k: v for k, v in aggregated_breakdown.items() if v > 0}
@@ -1042,8 +1169,16 @@ def calculate_cost_from_per_call_records(
         c["cost"] for c in per_call_costs if c.get("billing_type") == "platform"
     )
 
+    if stamped_records == len(per_call_records):
+        model_key_shape = KEY_SHAPE_MANIFEST
+    elif stamped_records == 0:
+        model_key_shape = KEY_SHAPE_VENDOR
+    else:
+        model_key_shape = KEY_SHAPE_MIXED
+
     return {
         "by_model": by_model,
+        "model_key_shape": model_key_shape,
         "total_cost": total_cost,
         "platform_cost": platform_cost,
         "cost_breakdown": cost_breakdown,
@@ -1059,6 +1194,5 @@ __all__ = [
     'ExecutionAnalyzer',
     'get_tracker',
     'serialize_agent_message',
-    'add_cost_to_token_usage',
     'calculate_cost_from_per_call_records',
 ]

--- a/src/utils/tracking/per_call_token_tracker.py
+++ b/src/utils/tracking/per_call_token_tracker.py
@@ -12,7 +12,7 @@ accurate pricing where rates vary based on token counts.
 
 import logging
 import threading
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
@@ -24,6 +24,52 @@ from langchain_core.outputs import ChatGeneration, LLMResult
 from src.llms.token_counter import extract_token_usage
 
 logger = logging.getLogger(__name__)
+
+# The vendor echo is stored per call and persisted into a JSON column, so it is
+# bounded before it lands. Long enough for any real model name plus a versioned
+# snapshot suffix; short enough that a repeated echo cannot amplify the row.
+_SERVED_MODEL_MAX_LEN = 256
+
+
+def _as_text(value: Any) -> Optional[str]:
+    """Keep a model field only when it is actually a string.
+
+    Guards both untrusted directions: the provider's echo and the run metadata a
+    caller can set. A non-string reaching the record becomes a dict key downstream
+    and raises where nothing can catch it usefully.
+    """
+    return value if isinstance(value, str) else None
+
+
+def collapse_repeated_name(name: str) -> str:
+    """Collapse a model name that streaming has written N times over.
+
+    langchain merges ``response_metadata`` across streamed chunks by concatenating
+    conflicting strings and does not exempt ``model_name``, so a provider repeating
+    the field on every chunk yields the name N times, which matches no pricing entry
+    and bills as zero. The shortest repeating unit wins: taking the longest would
+    return ``name * (N / smallest_prime_factor(N))`` and so only repair prime N,
+    while over-collapsing would need a real model name that is itself a perfect
+    repetition, which no manifest key or model_id is.
+    """
+    if not name:
+        return name
+    # Smallest rotation mapping the string onto itself, i.e. its shortest period,
+    # in one linear scan.
+    period = (name + name).find(name, 1)
+    if 0 < period < len(name) and len(name) % period == 0:
+        # Logged because the repair is not provably right: at this point a vendor model
+        # whose name is itself a perfect repetition is indistinguishable from a corrupted
+        # one, and no manifest key or model_id we ship is such a name. Not collapsing is
+        # the worse default, since the uncollapsed name matches no card and bills zero,
+        # so the substitution is made observable rather than avoided. served_model keeps
+        # the raw echo either way.
+        logger.warning(
+            f"Collapsed a repeated model name (x{len(name) // period}) to "
+            f"{name[:period][:_SERVED_MODEL_MAX_LEN]!r}"
+        )
+        return name[:period]
+    return name
 
 
 class PerCallTokenTracker(BaseCallbackHandler):
@@ -45,7 +91,11 @@ class PerCallTokenTracker(BaseCallbackHandler):
         >>> # Use in LangGraph workflow
         >>> result = workflow.invoke(input, config={"callbacks": [tracker]})
         >>> # Calculate accurate costs from per-call records
-        >>> costs = calculate_cost_from_per_call_records(tracker.per_call_records)
+        >>> costs = calculate_cost_from_per_call_records(tracker.get_per_call_records())
+
+    ``per_call_records`` is the private buffer; ``get_per_call_records()`` is the
+    reader-facing snapshot. Background subagents share one tracker, so anything
+    that iterates the buffer has to go through the accessor.
     """
 
     def __init__(self) -> None:
@@ -54,9 +104,12 @@ class PerCallTokenTracker(BaseCallbackHandler):
         self._lock = threading.Lock()
         self.per_call_records: List[Dict[str, Any]] = []
         self.usage_metadata: Dict[str, UsageMetadata] = {}
-        # Maps run_id → billing_type captured from LLM metadata in on_llm_start.
-        # Enables per-call billing attribution (byok / oauth / platform).
-        self._run_billing_type: Dict[UUID, str] = {}
+        # Maps run_id → what is only knowable at dispatch: the billing attribution
+        # stamped on the client that issued the call (see LLM.get_llm) — billing_type,
+        # the manifest key, the pricing id/provider that key resolves to — plus the
+        # request's start time. One dict rather than one per field so every terminal
+        # path drains the whole entry at once.
+        self._run_attribution: Dict[UUID, Dict[str, str]] = {}
 
     def on_llm_start(
         self,
@@ -69,10 +122,8 @@ class PerCallTokenTracker(BaseCallbackHandler):
         metadata: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> None:
-        """Capture billing_type from LLM metadata before the call runs."""
-        if metadata and "billing_type" in metadata:
-            with self._lock:
-                self._run_billing_type[run_id] = metadata["billing_type"]
+        """Capture billing attribution from LLM metadata before the call runs."""
+        self._capture_run_metadata(run_id, metadata)
 
     def on_chat_model_start(
         self,
@@ -85,10 +136,40 @@ class PerCallTokenTracker(BaseCallbackHandler):
         metadata: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> None:
-        """Capture billing_type from chat model metadata (preferred over on_llm_start)."""
-        if metadata and "billing_type" in metadata:
-            with self._lock:
-                self._run_billing_type[run_id] = metadata["billing_type"]
+        """Capture billing attribution from chat model metadata (preferred over on_llm_start)."""
+        self._capture_run_metadata(run_id, metadata)
+
+    _ATTRIBUTION_KEYS = ("billing_type", "manifest_model", "pricing_model_id", "pricing_provider")
+
+    def _capture_run_metadata(
+        self, run_id: UUID, metadata: Optional[Dict[str, Any]]
+    ) -> None:
+        """Stash the per-run billing attribution stamped on the client.
+
+        Read at start rather than at end because a fallback swaps the whole client
+        mid-turn; each attempt is its own run_id carrying its own stamp. The start
+        time is stamped even when the client carries none of that attribution: it
+        anchors peak hour pricing, which an unstamped client is equally subject
+        to, and a streamed call can open and close in different rate windows.
+        """
+        # Type-guarded like the vendor echo, and for a sharper reason: run metadata
+        # is not only ours. A consumer-supplied client, or any caller passing
+        # config={"metadata": ...}, can land a non-string here, and a non-string
+        # manifest_model becomes the billing key, poisons the record, and makes the
+        # turn's pricing pass raise on an unhashable key. Dropping it degrades to
+        # the echo, which is what an unstamped client already does.
+        captured = {
+            k: text
+            for k in self._ATTRIBUTION_KEYS
+            if metadata and (text := _as_text(metadata.get(k)))
+        }
+        with self._lock:
+            entry = self._run_attribution.setdefault(run_id, {})
+            entry.update(captured)
+            # First start wins: on_llm_start and on_chat_model_start are
+            # alternatives, but a handler that saw both would otherwise push the
+            # anchor later than the request actually went out.
+            entry.setdefault("started_at", datetime.now(timezone.utc).isoformat())
 
     def on_llm_end(
         self,
@@ -111,6 +192,12 @@ class PerCallTokenTracker(BaseCallbackHandler):
             parent_run_id: Identifier of the parent run (if nested)
             **kwargs: Additional callback arguments
         """
+        # Drain the run's attribution before any early return below can skip it.
+        # The entry is dead either way once the run ends, and four of the five
+        # exits here never reach the append.
+        with self._lock:
+            attribution = self._run_attribution.pop(run_id, {})
+
         if not response.generations or not response.generations[0]:
             return
 
@@ -128,12 +215,31 @@ class PerCallTokenTracker(BaseCallbackHandler):
         if not usage_metadata:
             return
 
-        # Extract model name from response metadata
-        model_name = message.response_metadata.get("model_name")
-        if not model_name:
-            # Fallback to model_name in response.llm_output if available
-            if response.llm_output:
-                model_name = response.llm_output.get("model_name")
+        # What the provider says it served. Useful on its own — it is how a silent
+        # substitution or an alias-to-snapshot resolution becomes visible — but it is
+        # the vendor's string, so it is not what we bill on. Bounded because it is
+        # upstream-controlled and lands in a JSON column: the same chunk-merge that
+        # motivates collapse_repeated_name makes its length scale with output tokens.
+        # Type-guarded because this is provider-parsed JSON, not our own value: a
+        # non-string here would raise inside the callback, and langchain swallows
+        # callback exceptions, so the call would complete having metered nothing.
+        served_model = _as_text(message.response_metadata.get("model_name"))
+        if not served_model and response.llm_output:
+            served_model = _as_text(response.llm_output.get("model_name"))
+
+        # Bill on our own key when we have one. Consumer-supplied clients carry no
+        # stamp, so the vendor echo is the fallback, with any streaming repetition
+        # collapsed before it reaches pricing. Collapse first, then bound: the
+        # repetition this repairs is longer than the cap, so cutting first would
+        # strand a name the repair would otherwise have recovered.
+        billing_type = attribution.get("billing_type", "platform")
+        model_name = attribution.get("manifest_model") or (
+            collapse_repeated_name(served_model)[:_SERVED_MODEL_MAX_LEN]
+            if served_model
+            else None
+        )
+        if served_model:
+            served_model = served_model[:_SERVED_MODEL_MAX_LEN]
 
         if not model_name:
             logger.warning(
@@ -143,15 +249,16 @@ class PerCallTokenTracker(BaseCallbackHandler):
             return
 
         with self._lock:
-            # Retrieve and consume billing_type captured in on_llm_start / on_chat_model_start
-            billing_type = self._run_billing_type.pop(run_id, "platform")
-
             # Store per-call record
             self.per_call_records.append({
                 "model_name": model_name,
+                "served_model": served_model,
+                "pricing_model_id": attribution.get("pricing_model_id"),
+                "pricing_provider": attribution.get("pricing_provider"),
                 "usage": usage_metadata,
                 "billing_type": billing_type,
-                "timestamp": datetime.now().isoformat(),
+                "started_at": attribution.get("started_at"),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
                 "run_id": str(run_id),
                 "parent_run_id": str(parent_run_id) if parent_run_id else None,
             })
@@ -172,9 +279,9 @@ class PerCallTokenTracker(BaseCallbackHandler):
         parent_run_id: Optional[UUID] = None,
         **kwargs: Any,
     ) -> None:
-        """Clean up billing_type entry when an LLM call errors out."""
+        """Clean up the per-run attribution when an LLM call errors out."""
         with self._lock:
-            self._run_billing_type.pop(run_id, None)
+            self._run_attribution.pop(run_id, None)
 
     def get_aggregated_usage(self) -> Dict[str, UsageMetadata]:
         """
@@ -190,19 +297,20 @@ class PerCallTokenTracker(BaseCallbackHandler):
             return self.usage_metadata.copy()
 
     def get_per_call_records(self) -> List[Dict[str, Any]]:
-        """
-        Get list of per-call token usage records.
+        """Snapshot of the per-call records, never the live buffer.
 
-        Returns:
-            List of dictionaries containing:
-            - model_name: str
-            - usage: UsageMetadata
-            - timestamp: str (ISO format)
-            - run_id: str
-            - parent_run_id: Optional[str]
+        Background subagents append to the same tracker while a turn winds down, so
+        every reader needs its own copy taken under the lock. In a record
+        ``model_name`` is the billing key and ``served_model`` the raw vendor echo,
+        diagnostic only and never priced; the append site documents the rest.
         """
         with self._lock:
             return self.per_call_records.copy()
+
+    def record_count(self) -> int:
+        """How many calls have been recorded, without copying the buffer."""
+        with self._lock:
+            return len(self.per_call_records)
 
     def reset(self) -> None:
         """
@@ -214,7 +322,7 @@ class PerCallTokenTracker(BaseCallbackHandler):
         with self._lock:
             self.per_call_records.clear()
             self.usage_metadata.clear()
-            self._run_billing_type.clear()
+            self._run_attribution.clear()
 
     def __repr__(self) -> str:
         """String representation showing number of calls and models tracked."""

--- a/src/utils/tracking/per_call_token_tracker.py
+++ b/src/utils/tracking/per_call_token_tracker.py
@@ -25,10 +25,11 @@ from src.llms.token_counter import extract_token_usage
 
 logger = logging.getLogger(__name__)
 
-# The vendor echo is stored per call and persisted into a JSON column, so it is
-# bounded before it lands. Long enough for any real model name plus a versioned
-# snapshot suffix; short enough that a repeated echo cannot amplify the row.
-_SERVED_MODEL_MAX_LEN = 256
+# Every model field is stored per call and persisted into a JSON column, so all of
+# them are bounded before they land. Long enough for any real model name plus a
+# versioned snapshot suffix (the longest identity we ship is 30 characters); short
+# enough that a repeated echo cannot amplify the row.
+_MODEL_FIELD_MAX_LEN = 256
 
 
 def _as_text(value: Any) -> Optional[str]:
@@ -39,6 +40,18 @@ def _as_text(value: Any) -> Optional[str]:
     and raises where nothing can catch it usefully.
     """
     return value if isinstance(value, str) else None
+
+
+def _as_identity(value: Any) -> Optional[str]:
+    """Keep a stamped billing identity only if it could plausibly be one.
+
+    Bounded like the vendor echo but rejected rather than truncated: a cut manifest
+    key matches no rate card and bills zero, which is the exact failure this
+    attribution exists to fix, whereas dropping it degrades to the echo and the
+    working fallback behind it.
+    """
+    text = _as_text(value)
+    return text if text and len(text) <= _MODEL_FIELD_MAX_LEN else None
 
 
 def collapse_repeated_name(name: str) -> str:
@@ -66,7 +79,7 @@ def collapse_repeated_name(name: str) -> str:
         # the raw echo either way.
         logger.warning(
             f"Collapsed a repeated model name (x{len(name) // period}) to "
-            f"{name[:period][:_SERVED_MODEL_MAX_LEN]!r}"
+            f"{name[:period][:_MODEL_FIELD_MAX_LEN]!r}"
         )
         return name[:period]
     return name
@@ -152,17 +165,27 @@ class PerCallTokenTracker(BaseCallbackHandler):
         anchors peak hour pricing, which an unstamped client is equally subject
         to, and a streamed call can open and close in different rate windows.
         """
-        # Type-guarded like the vendor echo, and for a sharper reason: run metadata
-        # is not only ours. A consumer-supplied client, or any caller passing
-        # config={"metadata": ...}, can land a non-string here, and a non-string
-        # manifest_model becomes the billing key, poisons the record, and makes the
-        # turn's pricing pass raise on an unhashable key. Dropping it degrades to
-        # the echo, which is what an unstamped client already does.
-        captured = {
-            k: text
-            for k in self._ATTRIBUTION_KEYS
-            if metadata and (text := _as_text(metadata.get(k)))
-        }
+        # Validated like the vendor echo, and for a sharper reason: run metadata is
+        # not only ours. A consumer-supplied client, or any caller passing
+        # config={"metadata": ...}, can land anything here, and a bad manifest_model
+        # becomes the billing key — a non-string poisons the record and makes the
+        # turn's pricing pass raise on an unhashable key, an unbounded one inflates
+        # every record and the row they persist to. Logged rather than dropped
+        # quietly: the fallback is the vendor echo, which is the very attribution
+        # this stamp exists to override.
+        captured: Dict[str, str] = {}
+        for key in self._ATTRIBUTION_KEYS:
+            raw = metadata.get(key) if metadata else None
+            if raw is None:
+                continue  # an unstamped client, not a malformed stamp
+            text = _as_identity(raw)
+            if text is None:
+                logger.warning(
+                    f"Ignoring unusable {key} stamp on run {run_id}; "
+                    "billing falls back to the provider echo"
+                )
+                continue
+            captured[key] = text
         with self._lock:
             entry = self._run_attribution.setdefault(run_id, {})
             entry.update(captured)
@@ -234,12 +257,12 @@ class PerCallTokenTracker(BaseCallbackHandler):
         # strand a name the repair would otherwise have recovered.
         billing_type = attribution.get("billing_type", "platform")
         model_name = attribution.get("manifest_model") or (
-            collapse_repeated_name(served_model)[:_SERVED_MODEL_MAX_LEN]
+            collapse_repeated_name(served_model)[:_MODEL_FIELD_MAX_LEN]
             if served_model
             else None
         )
         if served_model:
-            served_model = served_model[:_SERVED_MODEL_MAX_LEN]
+            served_model = served_model[:_MODEL_FIELD_MAX_LEN]
 
         if not model_name:
             logger.warning(
@@ -279,7 +302,6 @@ class PerCallTokenTracker(BaseCallbackHandler):
         parent_run_id: Optional[UUID] = None,
         **kwargs: Any,
     ) -> None:
-        """Clean up the per-run attribution when an LLM call errors out."""
         with self._lock:
             self._run_attribution.pop(run_id, None)
 

--- a/tests/unit/llms/test_manifest_integrity.py
+++ b/tests/unit/llms/test_manifest_integrity.py
@@ -230,7 +230,10 @@ class TestTimeOfDayPricing:
                     failures.append(f"{where}: window {window!r} is not a [start, end] pair")
                     continue
                 start, end = window
-                if not all(isinstance(h, int) for h in window):
+                # ``type is int`` rather than isinstance, matching the engine: bool
+                # subclasses int, so a JSON ``true``/``false`` bound would pass here
+                # and install an unintended window at runtime.
+                if not all(type(h) is int for h in window):
                     failures.append(f"{where}: window {window!r} has non-integer hours")
                 elif not 0 <= start < end <= 24:
                     failures.append(f"{where}: window {window!r} is not 0 <= start < end <= 24")

--- a/tests/unit/llms/test_manifest_integrity.py
+++ b/tests/unit/llms/test_manifest_integrity.py
@@ -13,6 +13,25 @@ from src.llms.llm import ModelConfig
 from src.llms.pricing_utils import find_model_pricing
 
 
+_SCHEDULE_KEYS = {"peak_utc", "off_peak", "schedule_anchor"}
+
+
+def _peak_hour_cards(manifest: dict) -> list[tuple[str, str, dict]]:
+    """Every pricing block whose rate depends on the hour the call ran.
+
+    Selected on any scheduling key, not on ``peak_utc`` alone: a card carrying the
+    discount without the window is exactly the authoring slip these checks exist
+    to catch, and keying on the window would let it skip every one of them.
+    """
+    return [
+        (provider, entry.get("id", "<no id>"), entry["pricing"])
+        for provider, entries in manifest.get("models", {}).items()
+        for entry in entries
+        if isinstance(entry.get("pricing"), dict)
+        and _SCHEDULE_KEYS & set(entry["pricing"])
+    ]
+
+
 def _scheduled_repricings(manifest: dict) -> list[tuple[str, str, object]]:
     # Keyed on presence, not truthiness: an empty or null block is malformed,
     # and dropping it here would quietly disarm the due-date alarm below.
@@ -179,4 +198,158 @@ class TestScheduledRepricing:
             + "\n".join(f"  - {o}" for o in overdue)
             + "\n\nFor each: move the scheduled_pricing rates into pricing, "
             "then delete the scheduled_pricing block."
+        )
+
+
+class TestTimeOfDayPricing:
+    """Cards priced by the hour, checked for shape rather than for rates.
+
+    The engine reads ``peak_utc`` to decide which card is in force and falls back
+    to the top level when ``off_peak`` omits a key. Both are silent failures: a
+    malformed window bills the wrong rate and a missing override bills the peak
+    one, and each looks identical to a correct turn in every log we keep.
+    """
+
+    @pytest.fixture
+    def manifest(self):
+        return ModelConfig().manifest
+
+    def test_peak_windows_are_well_formed(self, manifest):
+        failures: list[str] = []
+
+        for provider, model_id, pricing in _peak_hour_cards(manifest):
+            where = f"{provider}/{model_id}"
+            windows = pricing.get("peak_utc")
+
+            if not isinstance(windows, list) or not windows:
+                failures.append(f"{where}: peak_utc is {windows!r}, want a non-empty list")
+                continue
+
+            for window in windows:
+                if not (isinstance(window, list) and len(window) == 2):
+                    failures.append(f"{where}: window {window!r} is not a [start, end] pair")
+                    continue
+                start, end = window
+                if not all(isinstance(h, int) for h in window):
+                    failures.append(f"{where}: window {window!r} has non-integer hours")
+                elif not 0 <= start < end <= 24:
+                    failures.append(f"{where}: window {window!r} is not 0 <= start < end <= 24")
+
+        assert not failures, "Malformed peak_utc:\n" + "\n".join(f"  - {f}" for f in failures)
+
+    def test_peak_windows_do_not_overlap(self, manifest):
+        """Overlapping blocks make the schedule ambiguous to read, even though
+        the engine's any() would happen to resolve them to peak."""
+        failures: list[str] = []
+
+        for provider, model_id, pricing in _peak_hour_cards(manifest):
+            # Not indexed: the selector deliberately matches a card carrying only
+            # off_peak or schedule_anchor, and a KeyError here would replace the
+            # sibling test's named failure with a traceback that says nothing.
+            windows = sorted(
+                w
+                for w in (pricing.get("peak_utc") or [])
+                if isinstance(w, list) and len(w) == 2
+            )
+            for earlier, later in zip(windows, windows[1:]):
+                if later[0] < earlier[1]:
+                    failures.append(
+                        f"{provider}/{model_id}: {earlier} overlaps {later}"
+                    )
+
+        assert not failures, "Overlapping peak_utc:\n" + "\n".join(
+            f"  - {f}" for f in failures
+        )
+
+    def test_off_peak_only_overrides_rates_the_peak_card_already_names(self, manifest):
+        """A key present only in off_peak has nothing to fall back to, so the
+        peak window would bill it at zero."""
+        failures: list[str] = []
+
+        for provider, model_id, pricing in _peak_hour_cards(manifest):
+            off_peak = pricing.get("off_peak")
+            if not isinstance(off_peak, dict) or not off_peak:
+                failures.append(
+                    f"{provider}/{model_id}: off_peak is {off_peak!r}, want a non-empty object"
+                )
+                continue
+
+            orphans = sorted(set(off_peak) - set(pricing))
+            if orphans:
+                failures.append(
+                    f"{provider}/{model_id}: off_peak names {orphans} absent from the peak card"
+                )
+
+        assert not failures, "Malformed off_peak:\n" + "\n".join(
+            f"  - {f}" for f in failures
+        )
+
+    def test_off_peak_is_not_the_more_expensive_card(self, manifest):
+        """Catches a swapped paste, which the shape checks above cannot see.
+
+        Relational, so a repricing never churns it.
+        """
+        failures: list[str] = []
+
+        for provider, model_id, pricing in _peak_hour_cards(manifest):
+            off_peak = pricing.get("off_peak")
+            if not isinstance(off_peak, dict):
+                continue
+            for rate, off in off_peak.items():
+                peak = pricing.get(rate)
+                if isinstance(off, (int, float)) and isinstance(peak, (int, float)):
+                    if off > peak:
+                        failures.append(
+                            f"{provider}/{model_id}: off_peak {rate} {off} exceeds peak {peak}"
+                        )
+
+        assert not failures, "Inverted off_peak rates:\n" + "\n".join(
+            f"  - {f}" for f in failures
+        )
+
+    def test_every_off_peak_override_is_a_rate_the_engine_would_read(self, manifest):
+        """An override the engine never consults is worse than a missing one.
+
+        ``get_input_cost``/``get_output_cost`` resolve matrix before tiers before
+        flat rates, so a flat override on a card priced either of the other two
+        ways is dead: the call bills the peak rate while the stored snapshot
+        records ``window: off_peak``, corroborating a discount nobody got.
+        """
+        failures: list[str] = []
+
+        for provider, model_id, pricing in _peak_hour_cards(manifest):
+            off_peak = pricing.get("off_peak")
+            if not isinstance(off_peak, dict):
+                continue
+
+            shadowed: set[str] = set()
+            if pricing.get("pricing_mode") == "2d_matrix" and "matrix" in pricing:
+                shadowed |= {"input", "output", "cached_input"}
+            if "input_tiers" in pricing:
+                shadowed |= {"input", "cached_input"}
+            if "output_tiers" in pricing:
+                shadowed.add("output")
+
+            unreachable = sorted(shadowed & set(off_peak))
+            if unreachable:
+                failures.append(
+                    f"{provider}/{model_id}: off_peak overrides {unreachable}, "
+                    "which this card's pricing mode never reads"
+                )
+
+        assert not failures, "Unreachable off_peak overrides:\n" + "\n".join(
+            f"  - {f}" for f in failures
+        )
+
+    def test_the_schedule_anchor_is_one_the_engine_knows(self, manifest):
+        """An unrecognized value silently falls back to completion."""
+        failures = [
+            f"{provider}/{model_id}: schedule_anchor {pricing['schedule_anchor']!r}"
+            for provider, model_id, pricing in _peak_hour_cards(manifest)
+            if "schedule_anchor" in pricing
+            and pricing["schedule_anchor"] not in ("completion", "request")
+        ]
+
+        assert not failures, "Unknown schedule_anchor:\n" + "\n".join(
+            f"  - {f}" for f in failures
         )

--- a/tests/unit/llms/test_peak_hour_pricing.py
+++ b/tests/unit/llms/test_peak_hour_pricing.py
@@ -1,0 +1,219 @@
+"""Which rate card is in force at a given moment.
+
+Pinned against synthetic cards, never the shipped manifest. A vendor changing its
+hours should churn the manifest shape test and leave this contract alone, and
+asserting real rates here would turn every repricing into a test edit.
+
+The hazard this guards is quiet: a wrong window bills a real turn at the wrong
+rate and looks exactly like a correct one in every log we keep.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from src.llms.pricing_utils import (
+    has_schedule,
+    parse_stamp,
+    resolve_schedule,
+    schedule_anchor,
+)
+
+# Two peak blocks with a trough between them, which is the shape vendors
+# actually publish and the one a single (start, end) pair would get wrong.
+CARD = {
+    "input": 10.0,
+    "cached_input": 1.0,
+    "output": 40.0,
+    "unit": "per_1m_tokens",
+    "peak_utc": [[1, 4], [6, 10]],
+    "off_peak": {"input": 5.0, "cached_input": 0.5, "output": 20.0},
+}
+
+
+def _at(hour, minute=0, offset_hours=0):
+    return datetime(
+        2026, 1, 1, hour, minute, tzinfo=timezone(timedelta(hours=offset_hours))
+    )
+
+
+def _window(at):
+    return resolve_schedule(CARD, at)[1]
+
+
+class TestWindowBoundaries:
+    def test_a_peak_block_is_half_open(self):
+        """01:00 is peak and 04:00 is not, or an hour bills twice or never."""
+        assert _window(_at(0, 59)) == "off_peak"
+        assert _window(_at(1, 0)) == "peak"
+        assert _window(_at(3, 59)) == "peak"
+        assert _window(_at(4, 0)) == "off_peak"
+
+    def test_the_trough_between_two_peak_blocks_is_off_peak(self):
+        """A schedule read as one span from the first start to the last end
+        would bill these hours at double."""
+        assert _window(_at(4, 30)) == "off_peak"
+        assert _window(_at(5, 30)) == "off_peak"
+
+    def test_the_second_block_is_honored(self):
+        assert _window(_at(6, 0)) == "peak"
+        assert _window(_at(9, 59)) == "peak"
+        assert _window(_at(10, 0)) == "off_peak"
+
+    def test_the_hours_outside_every_block_are_off_peak(self):
+        for hour in (0, 11, 12, 18, 23):
+            assert _window(_at(hour)) == "off_peak", hour
+
+
+class TestTheStampIsReadAsUTC:
+    def test_a_non_utc_stamp_is_converted_not_truncated(self):
+        """Reading the local hour off the stamp would put this in off-peak."""
+        assert _at(11, 30, offset_hours=9).hour == 11
+        assert _window(_at(11, 30, offset_hours=9)) == "peak"  # 02:30 UTC
+
+    def test_a_naive_stamp_is_read_as_utc(self):
+        """Records written before the tz-aware writer carry no offset and came
+        from hosts running UTC. Any other reading reprices that history."""
+        assert _window(parse_stamp("2026-01-01T02:30:00")) == "peak"
+        assert _window(parse_stamp("2026-01-01T12:30:00")) == "off_peak"
+
+    def test_an_aware_stamp_keeps_its_offset(self):
+        assert _window(parse_stamp("2026-01-01T11:30:00+09:00")) == "peak"
+
+    def test_an_unreadable_stamp_is_no_stamp(self):
+        for junk in (None, "", "not-a-time", "2026-13-45T99:99:99"):
+            assert parse_stamp(junk) is None
+
+
+class TestTheCardHandedToTheEngine:
+    def test_the_schedule_keys_are_stripped(self):
+        """They describe when a card applies, not what it charges. Left in, they
+        reach the engine, the logs, and the snapshot stored on the usage row."""
+        for at in (_at(2), _at(12)):
+            card, _ = resolve_schedule(CARD, at)
+            assert not {"peak_utc", "off_peak", "schedule_anchor"} & set(card)
+
+    def test_off_peak_overrides_only_what_it_names(self):
+        """It carries the difference, so a key it omits still has to resolve."""
+        card, window = resolve_schedule(CARD, _at(12))
+        assert window == "off_peak"
+        assert card["input"] == 5.0
+        assert card["unit"] == "per_1m_tokens"
+
+    def test_peak_rates_live_at_the_top_level(self):
+        """Every reader predating schedules -- the price tier on the model
+        picker, the aggregate display path -- reads the top level untouched."""
+        card, window = resolve_schedule(CARD, _at(2))
+        assert window == "peak"
+        assert card["input"] == CARD["input"]
+        assert card["output"] == CARD["output"]
+
+    def test_the_source_card_is_never_mutated(self):
+        resolve_schedule(CARD, _at(12))
+        assert CARD["input"] == 10.0
+        assert "off_peak" in CARD
+
+
+class TestTheCommonPathIsUntouched:
+    def test_a_card_with_no_schedule_is_returned_as_is(self):
+        """Almost every model. Returning the same object keeps the check ahead
+        of the copy, so the overwhelming case pays nothing."""
+        flat = {"input": 3.0, "output": 15.0}
+        card, window = resolve_schedule(flat, _at(2))
+        assert card is flat
+        assert window is None
+
+    def test_has_schedule_is_false_for_the_ordinary_shapes(self):
+        assert not has_schedule(None)
+        assert not has_schedule({})
+        assert not has_schedule({"input": 3.0})
+        assert has_schedule(CARD)
+
+
+class TestTheAnchor:
+    def test_completion_is_the_default(self):
+        """No vendor documents which end of a streamed call picks the window, so
+        the default is the stamp we have always written."""
+        assert schedule_anchor(CARD) == "completion"
+        assert schedule_anchor(None) == "completion"
+
+    def test_the_manifest_can_name_the_other_end(self):
+        assert schedule_anchor({**CARD, "schedule_anchor": "request"}) == "request"
+
+
+class TestMissingTimeChargesPeak:
+    def test_no_stamp_resolves_to_peak(self):
+        """A record with no usable time still has to price. Guessing downward
+        would make an unparseable stamp a discount."""
+        card, window = resolve_schedule(CARD, None)
+        assert window == "peak"
+        assert card["input"] == CARD["input"]
+
+
+class TestAnUnreadableScheduleCannotDiscount:
+    """The committed manifest has a shape test, but a rate card is hand-authored
+    config that can change without one, so the engine validates its own windows.
+
+    Every case here is a card a maintainer can plausibly write. All of them must
+    land on peak: an unreadable window says nothing about where the call sat, and
+    the alternative is handing out a discount on the strength of a typo.
+    """
+
+    def test_a_discount_without_a_window_still_arms_the_schedule(self):
+        """The half a maintainer writes first. Keying has_schedule on peak_utc
+        alone would read this as an ordinary card and bill peak around the clock
+        with nothing logged, invisible to every check that selects on the window.
+        """
+        half_written = {"input": 10.0, "output": 40.0, "off_peak": {"input": 5.0}}
+        assert has_schedule(half_written)
+        card, window = resolve_schedule(half_written, _at(12))
+        assert window == "peak"
+        assert card["input"] == 10.0
+
+    def test_a_window_that_wraps_midnight_is_rejected_not_ignored(self):
+        """``[[22, 2]]`` is the natural way to write a 22:00-02:00 peak and no
+        hour satisfies it, so trusting it would bill the discount 24/7.
+        """
+        wrapping = {**CARD, "peak_utc": [[22, 2]]}
+        assert resolve_schedule(wrapping, _at(23))[1] == "peak"
+        assert resolve_schedule(wrapping, _at(12))[1] == "peak"
+
+    def test_a_malformed_window_prices_instead_of_raising(self):
+        """A raise here escapes into the caller's blanket except, which zeroes the
+        computed cost for every model in the turn, not just this one.
+        """
+        bad_windows = ([1, 4], [[1, "4"]], [[4, 1]], [["1", "4"]], [[1, 2, 3]], "1-4")
+        # A scalar is the container case, not a window case: it raises on the ``for``
+        # statement itself, ahead of every per-window rule. A string is iterable and so
+        # never exercised this.
+        bad_containers = (5, True, 1.5, {"start": 1})
+        for bad in bad_windows + bad_containers:
+            card, window = resolve_schedule({**CARD, "peak_utc": bad}, _at(12))
+            assert window == "peak", bad
+            assert card["input"] == 10.0, bad
+
+    def test_one_readable_window_survives_an_unreadable_sibling(self):
+        """Dropping the whole schedule would be a second failure on top of the
+        typo; the windows that still parse keep deciding.
+        """
+        mixed = {**CARD, "peak_utc": [[1, 4], "nonsense"]}
+        assert resolve_schedule(mixed, _at(2))[1] == "peak"
+        assert resolve_schedule(mixed, _at(12))[1] == "off_peak"
+
+    def test_a_malformed_off_peak_override_prices_instead_of_raising(self):
+        """The discount block is the other half of the card and was unguarded: a
+        truthy non-mapping reached dict.update and raised, which is the one
+        outcome the window validation above exists to prevent.
+        """
+        for bad in ("half price", ["input", 0.5], 0.5, [["input", 0.5]]):
+            card, window = resolve_schedule({**CARD, "off_peak": bad}, _at(12))
+            assert window == "peak", bad
+            assert card["input"] == 10.0, bad
+
+    def test_an_absent_off_peak_still_reads_as_off_peak(self):
+        """Absent is not malformed. A card with hours but no discount charges the
+        same rates outside them, and mislabelling that window as peak would make
+        every straddle comparison wrong.
+        """
+        no_discount = {k: v for k, v in CARD.items() if k != "off_peak"}
+        card, window = resolve_schedule(no_discount, _at(12))
+        assert window == "off_peak"
+        assert card["input"] == 10.0

--- a/tests/unit/llms/test_peak_hour_pricing.py
+++ b/tests/unit/llms/test_peak_hour_pricing.py
@@ -181,14 +181,21 @@ class TestAnUnreadableScheduleCannotDiscount:
         computed cost for every model in the turn, not just this one.
         """
         bad_windows = ([1, 4], [[1, "4"]], [[4, 1]], [["1", "4"]], [[1, 2, 3]], "1-4")
+        # bool subclasses int, so these read as hours 1 and 0 under an isinstance
+        # check and pass the range test. ``[[0, True]]`` is the one that costs money:
+        # it installs [0,1) and discounts the other 23 hours.
+        bad_bools = ([[True, 4]], [[False, 4]], [[0, True]], [[True, False]])
         # A scalar is the container case, not a window case: it raises on the ``for``
         # statement itself, ahead of every per-window rule. A string is iterable and so
         # never exercised this.
         bad_containers = (5, True, 1.5, {"start": 1})
-        for bad in bad_windows + bad_containers:
+        for bad in bad_windows + bad_bools + bad_containers:
             card, window = resolve_schedule({**CARD, "peak_utc": bad}, _at(12))
             assert window == "peak", bad
             assert card["input"] == 10.0, bad
+            # 02:00 is inside the card's real peak block, so a boolean bound that
+            # survived would show up here as an off_peak read rather than a no-op.
+            assert resolve_schedule({**CARD, "peak_utc": bad}, _at(2))[1] == "peak", bad
 
     def test_one_readable_window_survives_an_unreadable_sibling(self):
         """Dropping the whole schedule would be a second failure on top of the

--- a/tests/unit/llms/test_pricing_fallback.py
+++ b/tests/unit/llms/test_pricing_fallback.py
@@ -157,19 +157,25 @@ class TestPricingFallback:
             assert result_none is None
 
     def test_subscription_pricing_type_skips_cost_calc(self):
-        """Models with pricing_type='subscription' contribute zero cost."""
+        """Seat-priced models meter tokens but contribute zero cost.
+
+        Rates are non-zero on purpose: the guard must key off pricing_type, not
+        on the entry happening to carry zeros.
+        """
         subscription_pricing = {
             "pricing_type": "subscription",
-            "input": 0,
-            "output": 0,
+            "input": 3.0,
+            "output": 15.0,
         }
 
-        token_usage = {
-            "sub-model": {
-                "input_tokens": 5000,
-                "output_tokens": 2000,
+        records = [
+            {
+                "model_name": "sub-model",
+                "usage": {"input_tokens": 5000, "output_tokens": 2000},
+                "billing_type": "platform",
+                "run_id": "run-1",
             },
-        }
+        ]
 
         with (
             patch(
@@ -177,12 +183,15 @@ class TestPricingFallback:
                 return_value=subscription_pricing,
             ),
             patch(
-                "src.llms.pricing_utils.detect_provider_for_model",
-                return_value="some-provider",
+                "src.llms.pricing_utils.resolve_pricing_identity",
+                return_value=("some-provider", "sub-model"),
             ),
         ):
-            from src.utils.tracking.core import add_cost_to_token_usage
+            from src.utils.tracking.core import calculate_cost_from_per_call_records
 
-            result = add_cost_to_token_usage(token_usage)
+            result = calculate_cost_from_per_call_records(records)
 
         assert result["total_cost"] == 0.0
+        assert result["platform_cost"] == 0.0
+        # Usage is still metered even though it bills nothing.
+        assert result["by_model"]["sub-model"]["input_tokens"] == 5000

--- a/tests/unit/llms/test_pricing_identity.py
+++ b/tests/unit/llms/test_pricing_identity.py
@@ -1,0 +1,128 @@
+"""Pricing identity resolution: a manifest key must outrank a shared model_id.
+
+Model ids are not unique across the manifest. A region or plan variant shares its
+base model's id while declaring a different provider, and those providers carry
+different rates, so resolving by id alone decides pricing by manifest order.
+
+The pairs are discovered from the live manifest rather than named, so retiring a
+model churns the coverage instead of breaking the test. The ordering contract
+itself is pinned against a synthetic manifest, because shipped data is not a
+place to keep a regression: an entry that stops declaring ``system_provider``
+takes the assertion with it, and the test keeps passing on nothing.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from src.llms.llm import LLM
+from src.llms.pricing_utils import detect_provider_for_model, resolve_pricing_identity
+
+
+def _manifest():
+    return LLM.get_model_config().llm_config
+
+
+def _synthetic(entries):
+    """Patch a hand-built manifest in, so a branch is covered regardless of data."""
+    config = MagicMock()
+    config.llm_config = entries
+    return patch.object(LLM, "get_model_config", return_value=config)
+
+
+def _shared_id_pairs():
+    """Manifest keys grouped by the model_id they share, where providers differ."""
+    by_id = {}
+    for key, cfg in _manifest().items():
+        by_id.setdefault(cfg.get("model_id"), []).append(key)
+    manifest = _manifest()
+    return [
+        (model_id, keys)
+        for model_id, keys in by_id.items()
+        if len(keys) > 1 and len({manifest[k].get("provider") for k in keys}) > 1
+    ]
+
+
+class TestTheOrderingContract:
+    """Pinned against injected data, so shipped models can come and go."""
+
+    _TWO_KEYS_ONE_ID = {
+        "model-base": {"model_id": "shared-id", "provider": "provider-a"},
+        "model-regional": {"model_id": "shared-id", "provider": "provider-b"},
+    }
+
+    def test_a_key_outranks_another_entrys_matching_id(self):
+        """Resolving both in one pass would price by whichever is listed first."""
+        with _synthetic(self._TWO_KEYS_ONE_ID):
+            assert resolve_pricing_identity("model-regional", billing_type="byok") == (
+                "provider-b",
+                "shared-id",
+            )
+            assert resolve_pricing_identity("model-base", billing_type="byok") == (
+                "provider-a",
+                "shared-id",
+            )
+
+    def test_platform_billing_prefers_the_system_route(self):
+        """system_provider decides what the call costs, and an entry is free not to
+        declare one, so asserting against live data risks never running this at all."""
+        entries = {
+            "glm-x-cn": {
+                "model_id": "glm-x",
+                "provider": "z-ai",
+                "system_provider": "z-ai-dashscope",
+            }
+        }
+        with _synthetic(entries):
+            assert resolve_pricing_identity("glm-x-cn", billing_type="platform") == (
+                "z-ai-dashscope",
+                "glm-x",
+            )
+            for user_paid in ("byok", "oauth"):
+                assert resolve_pricing_identity("glm-x-cn", billing_type=user_paid) == (
+                    "z-ai",
+                    "glm-x",
+                )
+
+
+class TestResolvePricingIdentity:
+    def test_each_key_resolves_to_its_own_declared_provider(self):
+        manifest = _manifest()
+        for _model_id, keys in _shared_id_pairs():
+            for key in keys:
+                provider, _ = resolve_pricing_identity(key, billing_type="byok")
+                assert provider == manifest[key]["provider"], (
+                    f"{key} resolved to {provider}, not its declared "
+                    f"{manifest[key]['provider']}"
+                )
+
+    def test_a_key_resolves_to_the_id_its_rates_are_filed_under(self):
+        manifest = _manifest()
+        for key, cfg in manifest.items():
+            _, pricing_id = resolve_pricing_identity(key)
+            assert pricing_id == cfg["model_id"]
+
+    def test_platform_billing_prefers_the_system_route_in_shipped_data(self):
+        """Sweeps whatever the shipped manifest declares; asserts nothing about how much."""
+        manifest = _manifest()
+        for key, cfg in manifest.items():
+            if not cfg.get("system_provider"):
+                continue
+            provider, _ = resolve_pricing_identity(key, billing_type="platform")
+            assert provider == cfg["system_provider"]
+
+    def test_a_bare_model_id_still_resolves(self):
+        """Records written before keys were stamped carry the id, not the key."""
+        model_id = next(iter(_manifest().values()))["model_id"]
+        provider, pricing_id = resolve_pricing_identity(model_id, billing_type="byok")
+        assert provider is not None
+        assert pricing_id == model_id
+
+    def test_an_unknown_name_returns_no_provider_and_echoes_the_name(self):
+        provider, pricing_id = resolve_pricing_identity("not-a-real-model-xyz")
+        assert provider is None
+        assert pricing_id == "not-a-real-model-xyz"
+
+    def test_detect_provider_still_answers_for_its_callers(self):
+        key = next(iter(_manifest()))
+        assert detect_provider_for_model(key, billing_type="byok") == (
+            _manifest()[key]["provider"]
+        )

--- a/tests/unit/llms/test_prompt_cache_key.py
+++ b/tests/unit/llms/test_prompt_cache_key.py
@@ -38,6 +38,7 @@ def _make_llm(
     """
     llm = LLM.__new__(LLM)
     llm.sdk = sdk
+    llm.model = f"test-{sdk}-model-id"
     llm.provider = f"test-{sdk}"
     llm.provider_info = {"access_type": "platform"}
     llm.base_url = None

--- a/tests/unit/utils/tracking/test_model_name_attribution.py
+++ b/tests/unit/utils/tracking/test_model_name_attribution.py
@@ -169,6 +169,42 @@ class TestTrackerBillsOnTheManifestKey:
         # Every key that reaches pricing has to be usable as a dict key.
         assert isinstance(record["model_name"], str)
 
+    def test_an_overlong_stamp_is_rejected_rather_than_cut_to_fit(self):
+        """The stamp is bounded like the echo, but dropped instead of truncated.
+
+        Both land in a JSON column, so neither may be unbounded. Cutting a manifest
+        key to fit would leave a key matching no rate card, billing zero -- the exact
+        failure the stamp exists to prevent -- while dropping it degrades to the echo
+        and the working fallback behind it.
+        """
+        tracker = PerCallTokenTracker()
+        run_id = uuid4()
+        tracker.on_chat_model_start(
+            serialized={},
+            messages=[],
+            run_id=run_id,
+            metadata={"manifest_model": "glm-" + "5" * 9000, "pricing_provider": "z-ai"},
+        )
+        tracker.on_llm_end(_result("glm-5.2"), run_id=run_id)
+
+        record = tracker.get_per_call_records()[0]
+        assert record["model_name"] == "glm-5.2"
+        assert record["pricing_provider"] == "z-ai"
+
+    def test_a_stamp_at_the_bound_is_still_honored(self):
+        """The longest identity we ship is well under the cap, so the boundary is
+        inclusive and no real key can be near it."""
+        tracker = PerCallTokenTracker()
+        run_id = uuid4()
+        at_limit = "g" * 256
+        tracker.on_chat_model_start(
+            serialized={}, messages=[], run_id=run_id,
+            metadata={"manifest_model": at_limit},
+        )
+        tracker.on_llm_end(_result("glm-5.2"), run_id=run_id)
+
+        assert tracker.get_per_call_records()[0]["model_name"] == at_limit
+
     def test_a_non_string_echo_does_not_cost_the_call_its_metering(self):
         """``response_metadata`` is provider-parsed JSON, not a value we chose.
 

--- a/tests/unit/utils/tracking/test_model_name_attribution.py
+++ b/tests/unit/utils/tracking/test_model_name_attribution.py
@@ -1,0 +1,442 @@
+"""Billing keys on our manifest key, not on the name the provider echoes back.
+
+Two failures came out of trusting the echo. langchain concatenates conflicting
+strings when it merges streamed metadata, so a provider that repeats model_name on
+every finish_reason chunk yields the name written N times, which matches no pricing
+and bills as zero. And the echo is usually a bare model_id, which several manifest
+keys share while declaring providers whose rates differ.
+"""
+
+import logging
+from datetime import datetime
+from unittest.mock import patch
+from uuid import uuid4
+
+from langchain_core.messages import AIMessage, AIMessageChunk
+from langchain_core.outputs import ChatGeneration, LLMResult
+
+from src.utils.tracking.per_call_token_tracker import (
+    PerCallTokenTracker,
+    collapse_repeated_name,
+)
+
+PRICING_MODULE = "src.llms.pricing_utils"
+
+
+def _result(model_name):
+    msg = AIMessage(
+        content="ok",
+        response_metadata={"model_name": model_name},
+        usage_metadata={"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+    )
+    return LLMResult(generations=[[ChatGeneration(message=msg)]])
+
+
+class TestCollapseRepeatedName:
+    def test_a_doubled_name_collapses(self):
+        assert collapse_repeated_name("glm-5.2glm-5.2") == "glm-5.2"
+
+    def test_a_tripled_name_collapses(self):
+        name = "z-ai/glm-5.1-20260406"
+        assert collapse_repeated_name(name * 3) == name
+
+    def test_a_clean_name_is_untouched(self):
+        assert collapse_repeated_name("glm-5.2") == "glm-5.2"
+
+    def test_a_name_that_merely_repeats_a_fragment_is_untouched(self):
+        assert collapse_repeated_name("gpt-5-gpt-5-mini") == "gpt-5-gpt-5-mini"
+
+    def test_a_composite_repeat_count_collapses_all_the_way(self):
+        """Taking the longest unit would only ever repair a prime repeat count.
+
+        A four-chunk stream is the common case and would collapse to a still
+        unusable doubled name, which fails exactly the way the raw echo does.
+        """
+        assert collapse_repeated_name("glm-5.2" * 4) == "glm-5.2"
+        assert collapse_repeated_name("glm-5.2" * 6) == "glm-5.2"
+        assert collapse_repeated_name("glm-5.2" * 9) == "glm-5.2"
+        assert collapse_repeated_name("aaaa") == "a"
+
+    def test_an_empty_name_survives(self):
+        assert collapse_repeated_name("") == ""
+
+    def test_langchains_chunk_merge_is_what_doubles_the_name(self):
+        """Pins the upstream behavior this function exists for, rather than a
+        doubled literal we typed ourselves.
+
+        The repair is only correct while langchain keeps concatenating
+        conflicting model_name values across streamed chunks. If it ever joins
+        the exemption set, collapsing becomes dead code that can only damage a
+        legitimate name, and nothing else in this suite would notice.
+        """
+        chunk = AIMessageChunk(content="", response_metadata={"model_name": "glm-5.2"})
+        merged = chunk + chunk + chunk
+
+        assert merged.response_metadata["model_name"] == "glm-5.2" * 3
+        assert collapse_repeated_name(merged.response_metadata["model_name"]) == "glm-5.2"
+
+
+class TestTrackerBillsOnTheManifestKey:
+    def test_the_stamped_key_wins_over_the_echo(self):
+        tracker = PerCallTokenTracker()
+        run_id = uuid4()
+        tracker.on_chat_model_start(
+            serialized={},
+            messages=[],
+            run_id=run_id,
+            metadata={"billing_type": "byok", "manifest_model": "qwen3.8-max-intl"},
+        )
+        tracker.on_llm_end(_result("qwen3.8-max"), run_id=run_id)
+
+        record = tracker.get_per_call_records()[0]
+        assert record["model_name"] == "qwen3.8-max-intl"
+        assert record["served_model"] == "qwen3.8-max"
+
+    def test_the_stamp_survives_a_doubled_echo(self):
+        tracker = PerCallTokenTracker()
+        run_id = uuid4()
+        tracker.on_chat_model_start(
+            serialized={},
+            messages=[],
+            run_id=run_id,
+            metadata={"manifest_model": "glm-5.1-cn"},
+        )
+        tracker.on_llm_end(_result("glm-5.1glm-5.1"), run_id=run_id)
+
+        record = tracker.get_per_call_records()[0]
+        assert record["model_name"] == "glm-5.1-cn"
+        assert record["served_model"] == "glm-5.1glm-5.1"
+
+    def test_an_unstamped_client_falls_back_to_the_collapsed_echo(self):
+        """A consumer-supplied client (AgentConfig.create(llm=...)) carries no stamp."""
+        tracker = PerCallTokenTracker()
+        run_id = uuid4()
+        tracker.on_llm_end(_result("glm-5.2glm-5.2"), run_id=run_id)
+
+        record = tracker.get_per_call_records()[0]
+        assert record["model_name"] == "glm-5.2"
+        assert record["served_model"] == "glm-5.2glm-5.2"
+
+    def test_the_aggregate_buckets_under_the_same_key(self):
+        tracker = PerCallTokenTracker()
+        for echo in ("glm-5.2", "glm-5.2glm-5.2", "glm-5.2glm-5.2glm-5.2"):
+            tracker.on_llm_end(_result(echo), run_id=uuid4())
+
+        assert list(tracker.get_aggregated_usage()) == ["glm-5.2"]
+        assert len(tracker.get_per_call_records()) == 3
+
+    def test_a_failed_attempt_leaves_no_stamp_behind(self):
+        """Each fallback attempt is its own run_id; a dead one must not leak its key."""
+        tracker = PerCallTokenTracker()
+        run_id = uuid4()
+        tracker.on_chat_model_start(
+            serialized={},
+            messages=[],
+            run_id=run_id,
+            metadata={"manifest_model": "glm-5.1-cn"},
+        )
+        tracker.on_llm_error(RuntimeError("upstream 500"), run_id=run_id)
+        tracker.on_llm_end(_result("glm-5.2"), run_id=run_id)
+
+        assert tracker.get_per_call_records()[0]["model_name"] == "glm-5.2"
+
+    def test_a_non_string_stamp_degrades_to_the_echo_rather_than_poisoning_the_row(self):
+        """Run metadata is not only ours: a consumer-supplied client, or any caller
+        passing config={"metadata": ...}, can land a non-string here.
+
+        Unguarded it became the billing key, went into the record, and made the
+        turn's pricing pass raise on an unhashable dict key, zeroing every model in
+        the turn. Dropping it is the same degradation an unstamped client already
+        gets.
+        """
+        tracker = PerCallTokenTracker()
+        run_id = uuid4()
+        tracker.on_chat_model_start(
+            serialized={},
+            messages=[],
+            run_id=run_id,
+            metadata={
+                "billing_type": "platform",
+                "manifest_model": ["glm-5.1-cn"],
+                "pricing_model_id": {"id": "glm-5.1"},
+            },
+        )
+        tracker.on_llm_end(_result("glm-5.2"), run_id=run_id)
+
+        record = tracker.get_per_call_records()[0]
+        assert record["model_name"] == "glm-5.2"
+        assert record["pricing_model_id"] is None
+        # Every key that reaches pricing has to be usable as a dict key.
+        assert isinstance(record["model_name"], str)
+
+    def test_a_non_string_echo_does_not_cost_the_call_its_metering(self):
+        """``response_metadata`` is provider-parsed JSON, not a value we chose.
+
+        A non-string there used to raise inside the callback, and langchain
+        swallows callback exceptions, so the call would complete having metered
+        nothing at all — the stamped key it did not need the echo for included.
+        """
+        tracker = PerCallTokenTracker()
+        for echo in ({"id": "glm-5.2"}, 42, ["glm-5.2"], None):
+            run_id = uuid4()
+            tracker.on_chat_model_start(
+                serialized={},
+                messages=[],
+                run_id=run_id,
+                metadata={"manifest_model": "glm-5.1-cn"},
+            )
+            tracker.on_llm_end(_result(echo), run_id=run_id)
+
+        records = tracker.get_per_call_records()
+        assert len(records) == 4
+        assert {r["model_name"] for r in records} == {"glm-5.1-cn"}
+        assert {r["served_model"] for r in records} == {None}
+
+    def test_an_unstamped_non_string_echo_skips_rather_than_raises(self):
+        tracker = PerCallTokenTracker()
+        tracker.on_llm_end(_result({"id": "glm-5.2"}), run_id=uuid4())
+        assert tracker.get_per_call_records() == []
+
+    def test_the_echo_is_bounded_before_it_reaches_a_json_column(self):
+        """The chunk merge that motivates the collapse makes the echo's length
+        scale with output tokens, and a name that repairs to nothing still lands
+        in the row. Collapse runs first: the repetition is longer than the cap,
+        so cutting first would strand a name the repair would have recovered.
+        """
+        tracker = PerCallTokenTracker()
+        tracker.on_llm_end(_result("glm-5.2" * 5000), run_id=uuid4())
+        tracker.on_llm_end(_result("x" * 9000 + "!"), run_id=uuid4())
+
+        collapsible, unrepairable = tracker.get_per_call_records()
+        assert collapsible["model_name"] == "glm-5.2"
+        assert len(collapsible["served_model"]) == 256
+        assert len(unrepairable["model_name"]) == 256
+        assert len(unrepairable["served_model"]) == 256
+
+    def test_the_tracker_stamps_the_start_of_the_request(self):
+        """The producer half of the peak hour join. Every consumer test builds
+        this field by hand, so dropping it here would price every
+        schedule_anchor=request call at peak and make straddle detection report
+        zero forever, with both suites still green.
+        """
+        tracker = PerCallTokenTracker()
+        run_id = uuid4()
+        tracker.on_chat_model_start(
+            serialized={}, messages=[], run_id=run_id, metadata={"manifest_model": "glm-5.1-cn"}
+        )
+        tracker.on_llm_end(_result("glm-5.1"), run_id=run_id)
+
+        record = tracker.get_per_call_records()[0]
+        started = datetime.fromisoformat(record["started_at"])
+        ended = datetime.fromisoformat(record["timestamp"])
+        assert started.tzinfo is not None and ended.tzinfo is not None
+        assert started <= ended
+
+    def test_an_unstamped_client_is_still_anchored_in_time(self):
+        """Peak hour pricing applies to a consumer-supplied client too, so the
+        start stamp is written even when no billing attribution came with it.
+        """
+        tracker = PerCallTokenTracker()
+        run_id = uuid4()
+        tracker.on_chat_model_start(serialized={}, messages=[], run_id=run_id, metadata={})
+        tracker.on_llm_end(_result("glm-5.2"), run_id=run_id)
+
+        assert tracker.get_per_call_records()[0]["started_at"] is not None
+
+    def test_no_name_anywhere_still_skips_the_record(self):
+        tracker = PerCallTokenTracker()
+        msg = AIMessage(
+            content="ok",
+            response_metadata={},
+            usage_metadata={"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+        )
+        result = LLMResult(generations=[[ChatGeneration(message=msg)]])
+        tracker.on_llm_end(result, run_id=uuid4())
+
+        assert tracker.get_per_call_records() == []
+
+
+class TestPricingMissIsAudibleOnPlatformCalls:
+    """A miss contributes zero to platform_cost, the figure the turn is billed on."""
+
+    def _run(self, billing_type, caplog):
+        from src.utils.tracking.core import calculate_cost_from_per_call_records
+
+        record = {
+            "model_name": "not-a-real-model-xyz",
+            "served_model": "not-a-real-model-xyz",
+            "usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+            "billing_type": billing_type,
+            "timestamp": "2026-01-01T00:00:00",
+            "run_id": str(uuid4()),
+            "parent_run_id": None,
+        }
+        with patch(f"{PRICING_MODULE}.find_model_pricing", return_value=None):
+            with caplog.at_level(logging.WARNING, logger="src.utils.tracking.core"):
+                result = calculate_cost_from_per_call_records([record])
+        return result, caplog
+
+    def test_a_platform_miss_warns(self, caplog):
+        result, caplog = self._run("platform", caplog)
+        assert result["platform_cost"] == 0.0
+        assert any("No pricing found" in r.message for r in caplog.records)
+
+    def test_a_byok_miss_stays_quiet(self, caplog):
+        _result_, caplog = self._run("byok", caplog)
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+    def test_tokens_are_still_recorded_on_a_miss(self, caplog):
+        result, _ = self._run("platform", caplog)
+        assert result["by_model"]["not-a-real-model-xyz"]["total_tokens"] == 15
+
+
+class TestAnOffManifestStampStillPrices:
+    """A user-defined model's key is its display name, which is in no manifest.
+
+    Its config named the id and provider outright, so those are what the rates
+    are looked up under. Without this the whole custom-model path bills zero.
+    """
+
+    def _priced_with(self, record_extra):
+        from src.utils.tracking.core import calculate_cost_from_per_call_records
+
+        record = {
+            "model_name": "my-custom-alias",
+            "served_model": "gpt-5.5",
+            "usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+            "billing_type": "byok",
+            "timestamp": "2026-01-01T00:00:00",
+            "run_id": str(uuid4()),
+            "parent_run_id": None,
+            **record_extra,
+        }
+        seen = {}
+
+        def _capture(model_name, provider=None):
+            seen["model_name"], seen["provider"] = model_name, provider
+            return None
+
+        with patch(f"{PRICING_MODULE}.find_model_pricing", _capture):
+            calculate_cost_from_per_call_records([record])
+        return seen
+
+    def test_the_stamped_id_is_what_gets_priced(self):
+        seen = self._priced_with(
+            {"pricing_model_id": "gpt-5.5", "pricing_provider": "openai"}
+        )
+        assert seen == {"model_name": "gpt-5.5", "provider": "openai"}
+
+    def test_without_a_stamp_the_display_name_is_all_there_is(self):
+        """Pre-stamp records and consumer-supplied clients keep the old behavior."""
+        seen = self._priced_with({})
+        assert seen == {"model_name": "my-custom-alias", "provider": None}
+
+    def test_a_shadowing_custom_model_bills_on_its_own_route(self):
+        """A user may point a built-in's name at a different provider on purpose
+        (see resolve_model_source: a custom entry outranks a built-in of the same
+        name). Pricing that name off the manifest would charge the model it
+        replaced, so the client's own stamp outranks the same-named entry.
+        """
+        from src.llms.llm import LLM
+
+        key, cfg = next(iter(LLM.get_model_config().llm_config.items()))
+        seen = self._priced_with(
+            {
+                "model_name": key,
+                "pricing_model_id": "routed-elsewhere",
+                "pricing_provider": "some-variant",
+            }
+        )
+        assert seen == {"model_name": "routed-elsewhere", "provider": "some-variant"}
+        assert cfg["model_id"] != "routed-elsewhere"  # the entry it shadows
+
+    def test_a_built_in_prices_the_same_either_way(self):
+        """The stamp only changes the shadowed case: for a model we built from the
+        manifest, the stamped route is what a lookup by key would have produced.
+        """
+        from src.llms.pricing_utils import resolve_pricing_identity
+        from src.llms.llm import LLM
+
+        key, cfg = next(iter(LLM.get_model_config().llm_config.items()))
+        provider, pricing_id = resolve_pricing_identity(key, billing_type="byok")
+        seen = self._priced_with(
+            {
+                "model_name": key,
+                "pricing_model_id": pricing_id,
+                "pricing_provider": provider,
+                "billing_type": "byok",
+            }
+        )
+        assert seen == {"model_name": cfg["model_id"], "provider": cfg["provider"]}
+
+
+class TestTheStampSurvivesTheWire:
+    def test_a_real_invoke_carries_client_metadata_into_the_record(self, monkeypatch):
+        """Producer (LLM.get_llm stamps client.metadata) and consumer (this
+        tracker) are joined only by langchain's metadata merge. Nothing else in
+        the suite proves that join exists, and the whole fix rests on it.
+        """
+        from langchain_core.language_models.fake_chat_models import (
+            FakeMessagesListChatModel,
+        )
+
+        # A real invoke would otherwise reach for the tracing backend; the rest of
+        # this file never runs the chain, so nothing else disables it. The key is
+        # cleared as well as the flags because the tracer's background flush runs
+        # at interpreter exit, long after this test's assertions have passed.
+        for flag in ("LANGCHAIN_TRACING_V2", "LANGSMITH_TRACING", "LANGCHAIN_TRACING"):
+            monkeypatch.setenv(flag, "false")
+        for key in ("LANGCHAIN_API_KEY", "LANGSMITH_API_KEY"):
+            monkeypatch.delenv(key, raising=False)
+
+        msg = AIMessage(
+            content="ok",
+            response_metadata={"model_name": "glm-5.1glm-5.1"},
+            usage_metadata={"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+        )
+        llm = FakeMessagesListChatModel(responses=[msg])
+        llm.metadata = {
+            "billing_type": "byok",
+            "manifest_model": "glm-5.1-cn",
+            "pricing_model_id": "glm-5.1",
+            "pricing_provider": "z-ai",
+        }
+
+        tracker = PerCallTokenTracker()
+        llm.invoke("hi", config={"callbacks": [tracker]})
+
+        record = tracker.get_per_call_records()[0]
+        assert record["model_name"] == "glm-5.1-cn"
+        assert record["served_model"] == "glm-5.1glm-5.1"
+        assert record["billing_type"] == "byok"
+        assert record["pricing_model_id"] == "glm-5.1"
+
+
+class TestTheReaderGetsASnapshot:
+    def test_a_capture_does_not_grow_afterwards(self):
+        """The finalize paths capture while background subagent writers are still
+        appending. Handing out the live list is what they were changed for, so the
+        copy needs an assertion holding it in place."""
+        tracker = PerCallTokenTracker()
+        tracker.on_llm_end(_result("glm-5.2"), run_id=uuid4())
+
+        snapshot = tracker.get_per_call_records()
+        tracker.on_llm_end(_result("glm-5.2"), run_id=uuid4())
+
+        assert len(snapshot) == 1
+        assert len(tracker.get_per_call_records()) == 2
+
+    def test_the_attribution_drains_even_when_the_response_is_unusable(self):
+        """Four exits in on_llm_end return before the append; a run that takes one
+        still ends, so its entry must not outlive it."""
+        tracker = PerCallTokenTracker()
+        run_id = uuid4()
+        tracker.on_chat_model_start(
+            serialized={}, messages=[], run_id=run_id,
+            metadata={"manifest_model": "glm-5.1-cn"},
+        )
+
+        tracker.on_llm_end(LLMResult(generations=[]), run_id=run_id)
+
+        assert tracker._run_attribution == {}
+        assert tracker.get_per_call_records() == []

--- a/tests/unit/utils/tracking/test_per_call_token_tracker.py
+++ b/tests/unit/utils/tracking/test_per_call_token_tracker.py
@@ -141,9 +141,9 @@ class TestPerCallTokenTrackerBillingType:
         assert len(records) == 1
         assert records[0]["billing_type"] == "platform"
 
-    # -- on_llm_error cleans up _run_billing_type --
+    # -- on_llm_error cleans up the per-run attribution --
 
-    def test_on_llm_error_cleans_up_run_billing_type(self):
+    def test_on_llm_error_cleans_up_run_attribution(self):
         tracker = self._make_tracker()
         run_id = uuid4()
 
@@ -154,18 +154,18 @@ class TestPerCallTokenTrackerBillingType:
             metadata={"billing_type": "byok"},
         )
 
-        assert run_id in tracker._run_billing_type
+        assert run_id in tracker._run_attribution
 
         tracker.on_llm_error(
             error=RuntimeError("test error"),
             run_id=run_id,
         )
 
-        assert run_id not in tracker._run_billing_type
+        assert run_id not in tracker._run_attribution
 
-    # -- reset() clears _run_billing_type --
+    # -- reset() clears the per-run attribution --
 
-    def test_reset_clears_run_billing_type(self):
+    def test_reset_clears_run_attribution(self):
         tracker = self._make_tracker()
         run_id = uuid4()
 
@@ -176,11 +176,11 @@ class TestPerCallTokenTrackerBillingType:
             metadata={"billing_type": "byok"},
         )
 
-        assert len(tracker._run_billing_type) == 1
+        assert len(tracker._run_attribution) == 1
 
         tracker.reset()
 
-        assert len(tracker._run_billing_type) == 0
+        assert len(tracker._run_attribution) == 0
         assert len(tracker.per_call_records) == 0
         assert len(tracker.usage_metadata) == 0
 
@@ -226,8 +226,8 @@ class TestPerCallTokenTrackerBillingType:
         assert by_run[str(run_id_3)]["billing_type"] == "oauth"
         assert by_run[str(run_id_3)]["model_name"] == "model-c"
 
-        # All billing_type entries consumed
-        assert len(tracker._run_billing_type) == 0
+        # All attribution entries consumed
+        assert len(tracker._run_attribution) == 0
 
 
 # ===================================================================
@@ -245,7 +245,7 @@ class TestCalculateCostPlatformCost:
         with patch(
             f"{PRICING_MODULE}.find_model_pricing", return_value=_STUB_PRICING
         ), patch(
-            f"{PRICING_MODULE}.detect_provider_for_model", return_value="test"
+            f"{PRICING_MODULE}.resolve_pricing_identity", return_value=("test", "test-model")
         ), patch(
             f"{PRICING_MODULE}.calculate_total_cost",
             side_effect=lambda **kw: {

--- a/tests/unit/utils/tracking/test_rate_snapshot.py
+++ b/tests/unit/utils/tracking/test_rate_snapshot.py
@@ -1,0 +1,242 @@
+"""The usage row records the rate card it was billed at.
+
+A row holding only token counts and a total is repriced by any later manifest
+edit, so a rate change silently restates turns that were metered correctly at
+the time. These pin that the card travels with the row.
+
+Rates here are synthetic. Asserting shipped numbers would make every vendor
+repricing a test edit, which is the same churn the snapshot exists to absorb.
+"""
+
+from unittest.mock import patch
+from uuid import uuid4
+
+from src.utils.tracking.core import calculate_cost_from_per_call_records
+
+PRICING_MODULE = "src.llms.pricing_utils"
+
+FLAT = {"input": 10.0, "output": 40.0, "unit": "per_1m_tokens"}
+SCHEDULED = {
+    **FLAT,
+    "peak_utc": [[1, 4], [6, 10]],
+    "off_peak": {"input": 5.0, "output": 20.0},
+}
+
+
+def _record(model="a-model", at="2026-01-01T02:30:00+00:00", started_at=None):
+    return {
+        "model_name": model,
+        "served_model": model,
+        "usage": {"input_tokens": 1_000_000, "output_tokens": 0, "total_tokens": 1_000_000},
+        "billing_type": "platform",
+        "started_at": started_at or at,
+        "timestamp": at,
+        "run_id": str(uuid4()),
+        "parent_run_id": None,
+    }
+
+
+def _priced(records, pricing=FLAT):
+    with patch(f"{PRICING_MODULE}.find_model_pricing", return_value=pricing):
+        return calculate_cost_from_per_call_records(records)
+
+
+class TestTheCardTravelsWithTheRow:
+    def test_the_applied_rates_are_stored_verbatim(self):
+        rates = _priced([_record()])["by_model"]["a-model"]["rates"]
+        assert len(rates) == 1
+        assert rates[0]["pricing"] == FLAT
+
+    def test_a_snapshot_is_not_a_live_reference_to_the_manifest(self):
+        """Persisted rows must not alias a dict the manifest loader still owns."""
+        card = dict(FLAT)
+        rates = _priced([_record()], pricing=card)["by_model"]["a-model"]["rates"]
+        card["input"] = 999.0
+        assert rates[0]["pricing"]["input"] == FLAT["input"]
+
+    def test_repeated_calls_collapse_into_one_entry(self):
+        """One entry per distinct card, not per call: a long turn is hundreds of
+        calls and the row is already the widest thing we persist."""
+        result = _priced([_record(), _record(), _record()])
+        rates = result["by_model"]["a-model"]["rates"]
+        assert len(rates) == 1
+        assert rates[0]["call_count"] == 3
+        assert rates[0]["cost"] == result["by_model"]["a-model"]["total_cost"]
+
+    def test_an_unscheduled_card_carries_no_window(self):
+        rates = _priced([_record()])["by_model"]["a-model"]["rates"]
+        assert "window" not in rates[0]
+
+    def test_models_keep_their_own_cards(self):
+        result = _priced([_record("a-model"), _record("b-model")])
+        assert len(result["by_model"]["a-model"]["rates"]) == 1
+        assert len(result["by_model"]["b-model"]["rates"]) == 1
+
+    def test_an_unpriced_model_stamps_nothing(self):
+        """Tokens still aggregate on a miss; there is just no card to record."""
+        result = _priced([_record()], pricing=None)
+        entry = result["by_model"]["a-model"]
+        assert entry["total_tokens"] == 1_000_000
+        assert "rates" not in entry
+
+
+class TestATurnThatStraddlesAWindow:
+    def test_both_cards_are_recorded_and_sum_to_the_total(self):
+        result = _priced(
+            [
+                _record(at="2026-01-01T00:50:00+00:00"),  # off-peak
+                _record(at="2026-01-01T01:10:00+00:00"),  # peak
+            ],
+            pricing=SCHEDULED,
+        )
+        entry = result["by_model"]["a-model"]
+        rates = sorted(entry["rates"], key=lambda r: r["cost"])
+
+        assert [r["window"] for r in rates] == ["off_peak", "peak"]
+        assert sum(r["cost"] for r in rates) == entry["total_cost"]
+        assert sum(r["call_count"] for r in rates) == entry["call_count"]
+
+    def test_the_stored_cards_carry_the_rates_that_were_charged(self):
+        result = _priced(
+            [
+                _record(at="2026-01-01T00:50:00+00:00"),
+                _record(at="2026-01-01T01:10:00+00:00"),
+            ],
+            pricing=SCHEDULED,
+        )
+        by_window = {r["window"]: r["pricing"] for r in result["by_model"]["a-model"]["rates"]}
+        assert by_window["peak"]["input"] == SCHEDULED["input"]
+        assert by_window["off_peak"]["input"] == SCHEDULED["off_peak"]["input"]
+
+    def test_calls_in_one_window_stay_one_entry(self):
+        result = _priced(
+            [
+                _record(at="2026-01-01T01:10:00+00:00"),
+                _record(at="2026-01-01T02:10:00+00:00"),
+            ],
+            pricing=SCHEDULED,
+        )
+        assert len(result["by_model"]["a-model"]["rates"]) == 1
+
+
+class TestTheKeySpaceMarker:
+    """Says which namespace by_model is keyed in, so a reader can tell a row
+    written by this build from one written before it. Derived per payload rather
+    than asserted, because a turn can mix stamped and unstamped clients.
+    """
+
+    def _shape(self, records, pricing=FLAT):
+        return _priced(records, pricing=pricing)["model_key_shape"]
+
+    def test_every_stamped_record_reads_as_manifest(self):
+        stamped = _record()
+        stamped["pricing_model_id"] = "a-model-id"
+        stamped["pricing_provider"] = "a-provider"
+        assert self._shape([stamped, dict(stamped)]) == "manifest"
+
+    def test_no_stamp_anywhere_reads_as_vendor(self):
+        """A consumer-supplied client keys on the echo, which is a different
+        namespace even when the string happens to match."""
+        assert self._shape([_record(), _record()]) == "vendor"
+
+    def test_one_of_each_reads_as_mixed(self):
+        """A turn can swap clients mid-flight. Reporting either pure shape here
+        would tell a reader the whole row is safe to fold when half of it is not.
+        """
+        stamped = _record()
+        stamped["pricing_model_id"] = "a-model-id"
+        assert self._shape([stamped, _record()]) == "mixed"
+
+    def test_an_empty_turn_still_declares_a_shape(self):
+        """The degraded and no-usage paths return this payload too; a missing
+        marker there is indistinguishable from a row an older writer produced.
+        """
+        assert self._shape([]) == "manifest"
+
+
+class TestAStraddlingCallIsMarked:
+    """The two windows differ by 2x and the whole call bills at one of them, so
+    the unbilled end is the error. Nothing acts on this yet; it is recorded so
+    the exposure is a number before anyone argues about which end is right.
+    """
+
+    def _call(self, start, end):
+        return _record(started_at=f"2026-01-01T{start}+00:00", at=f"2026-01-01T{end}+00:00")
+
+    def test_a_call_crossing_into_peak_is_marked(self):
+        result = _priced([self._call("00:50:00", "01:10:00")], pricing=SCHEDULED)
+        call = result["per_call_costs"][0]
+        assert call["window"] == "peak"
+        assert call["straddled"] is True
+        assert result["by_model"]["a-model"]["rates"][0]["straddled_calls"] == 1
+
+    def test_a_call_crossing_out_of_peak_is_marked(self):
+        result = _priced([self._call("09:50:00", "10:10:00")], pricing=SCHEDULED)
+        assert result["per_call_costs"][0]["window"] == "off_peak"
+        assert result["per_call_costs"][0]["straddled"] is True
+
+    def test_a_call_inside_one_window_is_not_marked(self):
+        result = _priced([self._call("02:00:00", "02:05:00")], pricing=SCHEDULED)
+        assert "straddled" not in result["per_call_costs"][0]
+        assert "straddled_calls" not in result["by_model"]["a-model"]["rates"][0]
+
+    def test_a_record_with_no_start_claims_no_straddle(self):
+        """Absent evidence is not evidence of a crossing. Reading a missing
+        stamp as 'peak' would mark every legacy off-peak call as straddling."""
+        legacy = _record(at="2026-01-01T12:00:00+00:00")
+        del legacy["started_at"]
+        result = _priced([legacy], pricing=SCHEDULED)
+        assert result["per_call_costs"][0]["window"] == "off_peak"
+        assert "straddled" not in result["per_call_costs"][0]
+
+    def test_an_unscheduled_model_carries_no_window_fields(self):
+        """Every other model keeps the row shape it already had."""
+        call = _priced([_record()])["per_call_costs"][0]
+        assert not {"window", "started_at", "straddled"} & set(call)
+
+    def test_straddling_calls_accumulate_per_window(self):
+        result = _priced(
+            [
+                self._call("00:50:00", "01:10:00"),  # into peak, straddles
+                self._call("00:40:00", "01:20:00"),  # into peak, straddles
+                self._call("01:30:00", "01:35:00"),  # inside peak
+            ],
+            pricing=SCHEDULED,
+        )
+        peak = result["by_model"]["a-model"]["rates"][0]
+        assert peak["call_count"] == 3
+        assert peak["straddled_calls"] == 2
+
+
+class TestTheAnchorDecidesWhichStampIsRead:
+    _STRADDLE = {"started_at": "2026-01-01T00:50:00+00:00", "at": "2026-01-01T01:10:00+00:00"}
+
+    def test_completion_prices_on_the_end_of_the_call(self):
+        result = _priced([_record(**self._STRADDLE)], pricing=SCHEDULED)
+        assert result["by_model"]["a-model"]["rates"][0]["window"] == "peak"
+
+    def test_request_prices_on_the_start_of_the_call(self):
+        card = {**SCHEDULED, "schedule_anchor": "request"}
+        result = _priced([_record(**self._STRADDLE)], pricing=card)
+        assert result["by_model"]["a-model"]["rates"][0]["window"] == "off_peak"
+
+    def test_a_record_written_before_started_at_existed_still_prices(self):
+        """Rows already in Redis and the checkpointer have no start stamp."""
+        legacy = _record()
+        del legacy["started_at"]
+        card = {**SCHEDULED, "schedule_anchor": "request"}
+        result = _priced([legacy], pricing=card)
+        assert result["by_model"]["a-model"]["rates"][0]["window"] == "peak"
+
+    def test_a_missing_anchor_stamp_reads_the_other_end_before_defaulting(self):
+        """The stamp a legacy row does carry is a real observation of the same
+        call, so it places it. Dropping straight to the no-stamp peak default
+        would overcharge a row we can read, and then mark it straddled for
+        disagreeing with the default it was never compared against.
+        """
+        legacy = _record(at="2026-01-01T12:00:00+00:00")
+        del legacy["started_at"]
+        card = {**SCHEDULED, "schedule_anchor": "request"}
+        result = _priced([legacy], pricing=card)
+        assert result["by_model"]["a-model"]["rates"][0]["window"] == "off_peak"
+        assert "straddled" not in result["per_call_costs"][0]


### PR DESCRIPTION
## Overview

| Category              | Files | +LOC | −LOC |
|-----------------------|------:|-----:|-----:|
| Production (modified) |    11 |  691 |  246 |
| Tests (new files)     |     4 | 1031 |    0 |
| Tests (modified)      |     4 |  206 |   23 |
| **Net (excl. tests)** |**11** |**691**|**246**|
| Total                 |    19 | 1928 |  269 |

**`src/utils/tracking/` (+401 / −161)**
- `per_call_token_tracker.py` (+143 / −35): records the manifest key instead of the provider's echo, stamps both ends of the call, treats the echo as untrusted input.
- `core.py` (+258 / −124): resolves the pricing identity once per batch, stamps the applied rate card onto the usage row, derives the row's key shape from the records.
- `__init__.py` (0 / −2): drops a re-export with no callers left.

**`src/llms/` (+262 / −56)**
- `pricing_utils.py` (+215 / −48): adds `resolve_pricing_identity`, peak hour window resolution, and validation of the windows themselves.
- `manifest/providers.json` (+38 / −8): puts DeepSeek on its published peak/off-peak card.
- `llm.py` (+9): stamps the billing attribution on the client that will issue the call.

**`src/server/` (+26 / −27)**
- `services/persistence/usage.py` (+11 / −15): both degraded exits share one zero-usage payload with the pricing pass.
- `sse_producer.py`, `handlers/chat/error_handling.py`, `utils/persistence_utils.py`: read per-call records through the accessor instead of the live buffer.

**`src/ptc_agent/` (+2 / −2)**
- `background_subagent/run_executor.py`: asks the tracker for a count instead of copying the buffer to take a length.

**What this introduces:** usage rows are keyed and priced on our own manifest key rather than on whatever string the provider echoed back, and they carry the rate card that was actually applied, including which peak hour window it came from.

## What was wrong

A turn was priced by looking up `model_name` from each per-call record, and that name came from `response_metadata["model_name"]`, the vendor's echo.

1. **The echo is not a key we own.** It is usually a bare `model_id`, and several manifest keys share a `model_id` while declaring different providers and different rates (`glm-5.2-cn` and `glm-5.2`, `qwen3.8-max-intl` and `qwen3.8-max`). The lookup could land on the wrong card.
2. **Streaming can corrupt it.** langchain concatenates conflicting strings when it merges `response_metadata` across chunks, and `model_name` is not in its exemption set. A provider repeating the field on every chunk yields the name written N times, which matches no entry and prices as zero.
3. **DeepSeek has peak hour pricing** and we billed the peak rate around the clock.

## How it works

`LLM.get_llm()` stamps the manifest key and pricing identity onto the client's metadata. `on_chat_model_start` captures that stamp per `run_id` plus a start time. `on_llm_end` writes a record holding the manifest key, the vendor echo, the stamped identity and both time stamps. Pricing then resolves the identity once per batch and the rate window per record, and stores the applied card under `by_model[key].rates[]`.

- **Stamped at dispatch, because the client knows its own manifest key and the response does not.** A fallback swaps the client mid-turn, so the stamp is per `run_id` and each attempt carries its own. It has to outrank a lookup by name: a user-defined model can deliberately shadow a built-in's name (`classify_model` in `src/server/services/llm/config.py` gives the custom entry precedence), and pricing that name off the manifest would charge for the model it replaced.
- **The echo is kept as `served_model`, never priced.** It is the only way a silent substitution or an alias-to-snapshot resolution becomes visible after the fact.
- **Peak rates stay at the top level of the card, `off_peak` carries only the deltas.** Every reader that predates this keeps working untouched and errs toward the higher rate rather than quietly quoting the cheaper one.
- **Both ends of the call are stamped**, because a streamed call can open in one window and close in another and no vendor publishes which end it bills on. The disagreement is counted (`straddled`), not acted on. Which end decides is a manifest field (`schedule_anchor`), not a constant.

An unstamped client (a consumer-supplied `llm=`) still prices: it falls back to the echo, with any streaming repetition collapsed first.

## Risk

**The per-model key space changes.** `by_model` keys flip from the vendor echo to the manifest key, and 36 of the manifest's 60 keys differ from their `model_id`. Rows written before and after this deploy land in different buckets with no backfill, so every per-model rollup forks at the deploy boundary until history ages out. 20 `model_id`s are reachable under two or three manifest keys, so one physical model also splits by route where it previously merged. Rows carry a new `model_key_shape` marker naming the namespace used, but nothing reads it yet: it is the hook a future reader needs, not a mitigation.

**Repricing and the snapshot land together.** Rows written before this deploy carry no stored card, so they stay repriceable against a manifest that has already moved. Splitting the deploy (snapshot first, reprice after) closes that window.

**An unreadable schedule charges peak, deliberately.** A malformed or half-authored card logs and bills peak rather than raising, because raising escapes into the caller's blanket `except` and zeroes the cost for every model in the turn. The tradeoff is that a broken card overcharges instead of failing fast, with a warning on every priced call as the signal.

Smaller, and either accepted or pre-existing:
- The models-list `price` field is computed from the top-level card and never calls `resolve_schedule`, so the list quotes the peak rate all day for the two repriced DeepSeek entries. The wire carries no field saying the rate varies, so a client cannot render a range.
- `peak_utc` bounds are integer hours, so a half-hour vendor boundary cannot be expressed. DeepSeek's is on the hour. This is the cheapest moment to widen it.
- `billing_type` still defaults to `platform` for an unstamped client. That predates this change.
- Three automated-review findings were reproduced and fixed in place, all the same failure: one bad input raising out of the pricing pass and zeroing the whole turn. A truthy non-mapping `off_peak` reached `dict.update`; a non-iterable `peak_utc` raised on the `for` statement ahead of the per-window rules; a non-string stamp in run metadata became the billing key and made pricing raise on an unhashable key. All three are regression-tested.
- `collapse_repeated_name` cannot distinguish a corrupted name from a vendor model whose name is genuinely a perfect repetition. No manifest string is (0 of 191 checked), and not collapsing is the worse default since the uncollapsed name matches no card and bills zero, so the collapse now logs at WARNING with the repetition count and `served_model` keeps the raw echo. The substitution is observable rather than avoided.
- `model_key_shape: manifest` means the key came from our side, not that it is in `models.json`: a user-defined model's key is its own alias, off-manifest by definition and still ours. A reader wanting manifest membership has to check the manifest.

## Test plan

Verified end to end against a running backend and live provider calls, not only in unit tests.

- **Peak hour boundary.** The same call 63 seconds apart across 06:00 UTC: 05:59:02 billed `off_peak` (card 0.66/1.98, $0.00011154), 06:00:05 billed `peak` (card 1.32/3.96, $0.00020328). The arithmetic reconciles against the resolved card, so the discount is genuinely applied rather than the fail-high default coming back.
- **Billing key, on a real divergence.** A `gemini-3.1-pro` call echoed `gemini-3.1-pro-preview`; the record bills the manifest key and keeps the echo as `served_model`. A `glm-5.2-cn` client stamps `pricing_provider: z-ai-cn`, so it can no longer be priced off the separate `glm-5.2` entry.
- **Full request path.** A real turn over `POST /api/v1/threads/{id}/messages` persisted a row keyed on the manifest key with `model_key_shape: manifest` and a `rates[]` entry carrying the applied card and its window. All cost components reconcile, including cached input.
- **Per-call resolution.** A turn holding calls in both windows snapshots both cards; a single call spanning the boundary bills at one rate and is marked `straddled`.

One thing no test can settle: the provider returns no rate signal at either the body or header level, so `schedule_anchor` stays a documented default rather than something confirmable from the API.

`pytest tests/unit/` gives 8722 passed, 1 xfailed (a documented non-deterministic case in untouched code). `ruff check src/` clean. Frontend untouched. Each of the 5 commits was checked out and run independently: lint clean and suite green at every one.

91 tests added across 8 files, 4 of them new, covering the stamp beating the echo, langchain's chunk merge as the thing that doubles the name, the applied card travelling with the row, half-open window boundaries, every unreadable-schedule shape charging peak, and `off_peak` only overriding rates the peak card names. All pricing assertions use synthetic cards rather than the shipped manifest, so a vendor repricing churns the manifest shape test and leaves the behavior tests alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added time-based pricing for DeepSeek V4 Pro and V4 Flash, including UTC peak-hour windows and discounted off-peak rates.
  - Improved billing attribution with served model, provider, pricing identity, and applied rate details.
  - Enhanced handling of calls spanning different pricing periods.

- **Bug Fixes**
  - Improved usage tracking consistency during concurrent, failed, or interrupted requests.
  - Standardized empty usage results and safer handling of missing or malformed pricing data.
  - Improved model-name attribution and fallback behavior for unsupported or incomplete model information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->