### PR TITLE
fix(desktop): declare homepage and author so the .deb builds

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.1",
   "private": true,
   "description": "Desktop shell for LangAlpha",
+  "homepage": "https://langalpha.ai",
+  "author": {
+    "name": "Ginlix AI",
+    "email": "contact@ginlix.ai"
+  },
   "main": "src/index.js",
   "packageManager": "pnpm@10.18.1",
   "scripts": {


### PR DESCRIPTION
## Overview

A one-file metadata fix that unblocks the Linux half of the desktop release. The `.deb`
target failed the entire `ubuntu-latest` job, and the `release` job needs all three
platforms, so no desktop release could ship at all.

| Category | Files | +LOC | -LOC |
|---|---:|---:|---:|
| Modified (`desktop/package.json`) | 1 | 5 | 0 |
| **Total** | **1** | **5** | **0** |

**What this introduces:** nothing new. It supplies metadata that Debian packaging has
always required and that `package.json` never carried.

## What was wrong

A Debian control file must declare a `Maintainer:`, and electron-builder's `FpmTarget`
derives it from `package.json`, which held only `name`, `version` and `description`:

```
building  target=AppImage  arch=x64  file=dist/LangAlpha-oss-0.1.1-x86_64.AppImage
building  target=deb       arch=x64
  ⨯ Please specify project homepage
    Please specify author 'email' in the application package.json
    It is required to set Linux .deb package maintainer
```

The AppImage does not need it, which is why one Linux target succeeded and the other
took the job down with it. The same gap was also producing an `author is missed in the
package.json` warning on the macOS and Windows builds, leaving their publisher metadata
blank.

## Why `package.json` and not `electron-builder.yml`

`electron-builder.yml` is where `appId`, `productName` and the URL scheme live
specifically because `scripts/build.mjs` swaps all three per edition, with a fail-loud
`replace()` if a marker goes missing. That split is what lets the two editions install
side by side, and `package.json` deliberately carries no `productName` so there is no
edition-blind third copy to win.

`homepage` and `author` are the same for both editions, so they carry none of that
identity and belong in `package.json`. Nothing about *which* app a build is comes from
this file.

## Verification

Two `workflow_dispatch` dry runs with `publish=false`, before and after:

| Run | macOS | Windows | Linux | |
|---|---|---|---|---|
| [32302538723](https://github.com/ginlix-ai/LangAlpha/actions/runs/32302538723) (before) | pass | pass | **fail** | died at `target=deb` |
| [32303566644](https://github.com/ginlix-ai/LangAlpha/actions/runs/32303566644) (after) | pass | pass | **pass** | emits `LangAlpha-oss-0.1.1-amd64.deb` |

The second run produces artifacts on all three platforms (macOS 462MB, Windows 374MB,
Linux 217MB) and correctly skips the `release` job. Desktop suite stays at 94/94.

## Not in scope

The Linux build also warns that `desktopName` is unset, so desktop environments may not
associate a running window with its `.desktop` entry (WM_CLASS). It is a warning on both
Linux targets, not a failure. Fixing it properly means `linux.desktopName` in
`electron-builder.yml` plus a fourth per-edition marker in `build.mjs`, since the name
differs between editions. That is a change to the identity machinery, not metadata, and
belongs on its own.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ginlix-ai/codesmith/LangAlpha/pr/358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789766913&installation_model_id=432753&pr_number=358&repository=ginlix-ai%2FLangAlpha&return_to=https%3A%2F%2Fgithub.com%2Fginlix-ai%2FLangAlpha%2Fpull%2F358&signature=51e5bde950eb89b38f020b4440516f1db66175567cc1879af27bd35a9ba4a9cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added project homepage and author contact metadata to improve package information and discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->