### PR TITLE
feat(llms): add OrcaRouter as a named BYOK provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,7 @@ OPENAI_API_KEY=
 GEMINI_API_KEY=
 MINIMAX_API_KEY=
 ZAI_API_KEY=
+ORCAROUTER_API_KEY=
 
 # =============================================================================
 # Web Search — at least one recommended for search tools

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ LangAlpha runs on a provider-agnostic model layer that abstracts across multiple
 
 **Bring your own model** — Use your existing AI subscriptions and API keys directly. Connect ChatGPT or Claude subscriptions via OAuth (OpenAI Codex OAuth, Claude Code OAuth), use coding plans from Kimi (Moonshot), GLM (Zhipu), MiniMax, or Doubao (Volcengine), or supply your own API keys for any supported provider via BYOK. All keys are encrypted at rest via PostgreSQL pgcrypto (see [Security](#security)).
 
+**OrcaRouter gateway** — [OrcaRouter](https://www.orcarouter.ai) is supported as a named provider: set `ORCAROUTER_API_KEY` and pick one of the gateway models (`orcarouter/auto`, `orcarouter/fusion`, `orcarouter/fusion-flash`, `orcarouter/fusion-mini`) to route every request through OrcaRouter's smart-routing gateway. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
 **Model resilience** — automatic retries on transient errors, then failover to a configured fallback model. Reasoning effort (`low`/`medium`/`high`) is normalized across providers automatically.
 
 ### Programmatic Tool Calling (PTC) and Workspace Architecture

--- a/src/llms/manifest/models.json
+++ b/src/llms/manifest/models.json
@@ -380,6 +380,66 @@
       "text"
     ]
   },
+  "orcarouter/auto": {
+    "model_id": "orcarouter/auto",
+    "provider": "orcarouter",
+    "display_name": "OrcaRouter Auto",
+    "visible": true,
+    "speed": 3,
+    "intelligence": 5,
+    "context": 1000000,
+    "input_modalities": [
+      "text"
+    ],
+    "parameters": {
+      "max_tokens": 128000
+    }
+  },
+  "orcarouter/fusion": {
+    "model_id": "orcarouter/fusion",
+    "provider": "orcarouter",
+    "display_name": "OrcaRouter Fusion",
+    "visible": true,
+    "speed": 2,
+    "intelligence": 5,
+    "context": 1000000,
+    "input_modalities": [
+      "text"
+    ],
+    "parameters": {
+      "max_tokens": 128000
+    }
+  },
+  "orcarouter/fusion-flash": {
+    "model_id": "orcarouter/fusion-flash",
+    "provider": "orcarouter",
+    "display_name": "OrcaRouter Fusion Flash",
+    "visible": true,
+    "speed": 4,
+    "intelligence": 4,
+    "context": 200000,
+    "input_modalities": [
+      "text"
+    ],
+    "parameters": {
+      "max_tokens": 128000
+    }
+  },
+  "orcarouter/fusion-mini": {
+    "model_id": "orcarouter/fusion-mini",
+    "provider": "orcarouter",
+    "display_name": "OrcaRouter Fusion Mini",
+    "visible": true,
+    "speed": 4,
+    "intelligence": 3,
+    "context": 1000000,
+    "input_modalities": [
+      "text"
+    ],
+    "parameters": {
+      "max_tokens": 128000
+    }
+  },
   "deepseek-v4-pro": {
     "model_id": "deepseek-v4-pro",
     "provider": "deepseek",

--- a/src/llms/manifest/providers.json
+++ b/src/llms/manifest/providers.json
@@ -363,6 +363,64 @@
     ],
     "lm-studio": [],
     "openrouter": [],
+    "orcarouter": [
+      {
+        "id": "orcarouter/auto",
+        "name": "OrcaRouter Auto",
+        "is_reasoning": false,
+        "description": "OrcaRouter smart-routing gateway model — picks the best upstream for each request",
+        "context_window": 1000000,
+        "max_output": 128000,
+        "pricing": {
+          "input": 0.44,
+          "cached_input": 0.014,
+          "output": 1.32,
+          "unit": "per_1m_tokens"
+        }
+      },
+      {
+        "id": "orcarouter/fusion",
+        "name": "OrcaRouter Fusion",
+        "is_reasoning": false,
+        "description": "OrcaRouter gateway model with 1M context",
+        "context_window": 1000000,
+        "max_output": 128000,
+        "pricing": {
+          "input": 0.44,
+          "cached_input": 0.014,
+          "output": 1.32,
+          "unit": "per_1m_tokens"
+        }
+      },
+      {
+        "id": "orcarouter/fusion-flash",
+        "name": "OrcaRouter Fusion Flash",
+        "is_reasoning": false,
+        "description": "OrcaRouter gateway model with 200K context",
+        "context_window": 200000,
+        "max_output": 128000,
+        "pricing": {
+          "input": 0.44,
+          "cached_input": 0.014,
+          "output": 1.32,
+          "unit": "per_1m_tokens"
+        }
+      },
+      {
+        "id": "orcarouter/fusion-mini",
+        "name": "OrcaRouter Fusion Mini",
+        "is_reasoning": false,
+        "description": "OrcaRouter gateway model with 1M context",
+        "context_window": 1000000,
+        "max_output": 128000,
+        "pricing": {
+          "input": 0.44,
+          "cached_input": 0.014,
+          "output": 1.32,
+          "unit": "per_1m_tokens"
+        }
+      }
+    ],
     "deepseek": [
       {
         "id": "deepseek-v4-pro",
@@ -1227,6 +1285,14 @@
           "comment": "DeepInfra models accessed via OpenRouter with provider routing"
         }
       }
+    },
+    "orcarouter": {
+      "sdk": "openai",
+      "base_url": "https://api.orcarouter.ai/v1",
+      "env_key": "ORCAROUTER_API_KEY",
+      "access_type": "api_key",
+      "byok_eligible": true,
+      "display_name": "OrcaRouter"
     },
     "deepseek": {
       "sdk": "anthropic",

--- a/src/llms/token_counter.py
+++ b/src/llms/token_counter.py
@@ -447,7 +447,7 @@ class TokenUsageTracker:
 
                 for model in self.model_totals.keys():
                     # Try to find the model in config across all providers
-                    for provider in ['openai', 'anthropic', 'gemini', 'volcengine', 'openrouter', 'vllm']:
+                    for provider in ['openai', 'anthropic', 'gemini', 'volcengine', 'openrouter', 'orcarouter', 'vllm']:
                         model_info = config.get_model_info(provider, model)
                         if model_info and 'pricing' in model_info:
                             model_pricing_map[model] = model_info['pricing']

--- a/tests/unit/llms/test_orcarouter_provider.py
+++ b/tests/unit/llms/test_orcarouter_provider.py
@@ -1,0 +1,63 @@
+"""OrcaRouter provider contract — loads the REAL providers.json/models.json.
+
+Mirrors test_manifest_integrity.py: no mocking, exercises the actual manifest
+files on disk so a renamed or removed provider entry fails loudly.
+"""
+
+from src.llms.llm import LLM, ModelConfig
+from src.llms.pricing_utils import find_model_pricing
+
+ORCA_MODELS = [
+    "orcarouter/auto",
+    "orcarouter/fusion",
+    "orcarouter/fusion-flash",
+    "orcarouter/fusion-mini",
+]
+
+
+class TestOrcaRouterProvider:
+    def test_provider_defined_in_providers_json(self):
+        info = ModelConfig().get_provider_info("orcarouter")
+        assert info["sdk"] == "openai"
+        assert info["base_url"] == "https://api.orcarouter.ai/v1"
+        assert info["env_key"] == "ORCAROUTER_API_KEY"
+        assert info["access_type"] == "api_key"
+        assert info["byok_eligible"] is True
+        assert info["display_name"] == "OrcaRouter"
+
+    def test_provider_is_byok_eligible(self):
+        eligible = ModelConfig().get_byok_eligible_providers()
+        assert "orcarouter" in eligible
+
+    def test_every_orca_model_resolves_to_provider(self):
+        mc = ModelConfig()
+        for model in ORCA_MODELS:
+            cfg = mc.get_model_config(model)
+            assert cfg is not None, model
+            assert cfg["provider"] == "orcarouter"
+            assert cfg.get("visible") is True
+            assert "text" in cfg.get("input_modalities", [])
+
+    def test_orca_models_listed_in_configured_models(self):
+        from src.llms.llm import get_configured_llm_models
+
+        grouped = get_configured_llm_models()
+        assert sorted(grouped.get("orcarouter", [])) == sorted(ORCA_MODELS)
+
+    def test_each_orca_model_has_pricing(self):
+        for model in ORCA_MODELS:
+            pricing = find_model_pricing(model, provider="orcarouter")
+            assert pricing is not None, f"{model} missing pricing"
+            assert pricing["input"] > 0
+            assert pricing["output"] > 0
+
+    def test_llm_factory_builds_openai_client_for_orca(self):
+        from unittest.mock import patch
+
+        mc = ModelConfig()
+        with patch.object(LLM, "get_model_config", return_value=mc):
+            llm = LLM("orcarouter/auto")
+            assert llm.provider == "orcarouter"
+            assert llm.sdk == "openai"
+            assert llm.base_url == "https://api.orcarouter.ai/v1"
+            assert llm.model == "orcarouter/auto"

--- a/web/src/components/model/ProviderCard.tsx
+++ b/web/src/components/model/ProviderCard.tsx
@@ -55,6 +55,7 @@ const PROVIDER_COLORS: Record<string, string> = {
   "claude-oauth": "#D4A574",
   gemini: "#4285F4",
   openrouter: "#6366F1",
+  orcarouter: "#0284C7",
   "z-ai": "#3B82F6",
   "z-ai-coding": "#3B82F6",
   "z-ai-cn": "#3B82F6",


### PR DESCRIPTION
## Summary

Add **[OrcaRouter](https://www.orcarouter.ai)** as a first-class named BYOK provider in the model manifest, mirroring the existing manifest-driven wiring for OpenRouter/DeepSeek. Setting `ORCAROUTER_API_KEY` and picking one of the gateway models routes every request through OrcaRouter's smart-routing gateway.

## Changes

- `src/llms/manifest/providers.json` — declare the `orcarouter` provider (`sdk: openai`, `base_url: https://api.orcarouter.ai/v1`, `env_key: ORCAROUTER_API_KEY`, `byok_eligible: true`) and a `models.orcarouter` group with pricing for cost tracking.
- `src/llms/manifest/models.json` — four visible gateway models: `orcarouter/auto`, `orcarouter/fusion`, `orcarouter/fusion-flash`, `orcarouter/fusion-mini` (context/max_output metadata per the `/v1/models` live response).
- `src/llms/token_counter.py` — include `orcarouter` in the legacy pricing fallback list.
- `.env.example` — `ORCAROUTER_API_KEY`.
- `README.md` — document the OrcaRouter gateway option.
- `web/src/components/model/ProviderCard.tsx` — branded monogram color for `orcarouter`.
- `tests/unit/llms/test_orcarouter_provider.py` — locks the manifest contract (provider definition, BYOK eligibility, model resolution, pricing, factory wiring).

## Test Plan

- **L3 live**: all four gateway models answered `ORCA-LIVE-OK` through the real `LLM` factory path (sdk `openai`, base_url `https://api.orcarouter.ai/v1`).
- **Unit**: `607 passed` in `tests/unit/llms/` + `tests/unit/test_llm_constructor_boundary.py` (includes the 6 new OrcaRouter tests).
- **Full suite**: no regressions vs `main` — identical pre-existing environment failures (market-clock/YouTube/scrapling, unrelated to this change).

Disclosure: I'm an engineer on the OrcaRouter team.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ginlix-ai/codesmith/LangAlpha/pr/361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789821957&installation_model_id=432753&pr_number=361&repository=ginlix-ai%2FLangAlpha&return_to=https%3A%2F%2Fgithub.com%2Fginlix-ai%2FLangAlpha%2Fpull%2F361&signature=9f80ac815646308ad591cfffd669a1651cb05ba712dab92e807c28293562eb94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added OrcaRouter as an available LLM provider.
  - Added four models: Auto, Fusion, Fusion Flash, and Fusion Mini.
  - Added API key configuration and BYOK support.
  - Added model pricing and cost estimation support.
  - Added OrcaRouter branding in the provider interface.

- **Documentation**
  - Added setup and usage information for OrcaRouter, including supported models and security details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->