### PR TITLE
feat(desktop): save a report or a widget as a real PDF

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -68,6 +68,12 @@ jobs:
       matrix:
         os: [macos-14, windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
+    # Declared once for the whole job. It selects what gets built and, through
+    # electron-builder.yml's per-edition `directories.output`, where the
+    # artifacts land, so the steps below read it rather than spelling the edition
+    # again beside a path that has to agree with it.
+    env:
+      DESKTOP_EDITION: oss
     defaults:
       run:
         shell: bash
@@ -104,7 +110,6 @@ jobs:
 
       - name: Build
         env:
-          DESKTOP_EDITION: oss
           # electron-builder picks these up automatically. Absent, it produces an
           # unsigned build and says so, which is the current state.
           CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
@@ -122,20 +127,20 @@ jobs:
         if: matrix.os == 'macos-14'
         continue-on-error: true
         run: |
-          app=$(find dist -maxdepth 2 -name "*.app" -print -quit)
+          app=$(find "dist/$DESKTOP_EDITION" -maxdepth 2 -name "*.app" -print -quit)
           if [ -n "$app" ]; then codesign -dv "$app" 2>&1 | head -5 || echo "UNSIGNED"; fi
 
       - uses: actions/upload-artifact@v4
         with:
-          name: langalpha-desktop-oss-${{ matrix.os }}
+          name: langalpha-desktop-${{ env.DESKTOP_EDITION }}-${{ matrix.os }}
           retention-days: 14
           if-no-files-found: error
           path: |
-            desktop/dist/*.dmg
-            desktop/dist/*.zip
-            desktop/dist/*.exe
-            desktop/dist/*.AppImage
-            desktop/dist/*.deb
+            desktop/dist/${{ env.DESKTOP_EDITION }}/*.dmg
+            desktop/dist/${{ env.DESKTOP_EDITION }}/*.zip
+            desktop/dist/${{ env.DESKTOP_EDITION }}/*.exe
+            desktop/dist/${{ env.DESKTOP_EDITION }}/*.AppImage
+            desktop/dist/${{ env.DESKTOP_EDITION }}/*.deb
 
   release:
     needs: build

--- a/desktop/AGENTS.md
+++ b/desktop/AGENTS.md
@@ -44,7 +44,7 @@ whole story.
 pnpm start                       # run the shell from source (oss defaults → localhost:5173)
 pnpm test                        # node:test; pure logic only, no Electron runtime needed
 pnpm run preview                 # the shell against a web build that has not deployed yet
-pnpm run build                   # unpacked build into dist/, fastest way to check packaging
+pnpm run build                   # unpacked build into dist/<edition>/, fastest way to check packaging
 pnpm run dist                    # real installers (dmg + zip on macOS)
 
 DESKTOP_EDITION=saas \
@@ -86,7 +86,7 @@ the build it actually loads may not, which is the bug it exists to catch.
 **Say `pnpm run`, not `pnpm`, for anything that builds.** `pnpm <name>` falls back
 to a script only when pnpm has no command of that name, and the failure when it
 does is silent: this used to be `pnpm pack`, which quietly built a **tarball**
-instead, left the previous artifact in `dist/`, and exited 0. A verification run
+instead, left the previous artifact in the output tree, and exited 0. A verification run
 against that stale artifact is what caught it.
 
 **The `postinstall` line is load-bearing.** Electron 42 removed the package's own
@@ -142,6 +142,22 @@ is decided per package, so the origins are written from the environment at packa
 and deleted again on an `oss` build: a tree that previously built `saas` cannot bake
 those origins into an OSS package by accident.
 
+**Nor do the two share an output directory** (`directories.output: dist/${EDITION}`).
+The artifact filename carries the edition; nothing else written there does. The unpacked
+bundle is named from `productName`, so both `.app`s land under one `mac-arm64`, and the
+update manifests are `latest-mac.yml` and `latest.yml`, fixed names with no edition in
+them at all, so whichever edition builds second overwrites the first's. `scripts/build.mjs`
+then searches that same directory for what it just produced, which is where one tree
+turns into a signing check verifying the other edition's stale bundle and a no-feed build
+whose sweep strips the other edition's baked `app-update.yml`.
+
+Separate outputs do **not** make the two editions safe to build at the same time. Both
+still write `config/build.json` and `.electron-builder.resolved.yml`, one copy each at
+fixed paths, so two concurrent packages race over the origins and the identity and can
+produce a correctly named artifact carrying the other edition's configuration. Build them
+one after the other. For the same reason `scripts/make-release-index.mjs` takes one
+edition's output directory and refuses a parent holding several.
+
 ## Layout
 
 | File | Purpose |
@@ -152,7 +168,10 @@ those origins into an OSS package by accident.
 | `src/origins.js` | what counts as ours: **by origin, never by path** |
 | `src/oauth.js` | system-browser OAuth, intercepted (below) |
 | `src/deeplink.js` | `langalpha://` scheme, for magic links clicked with the app closed |
-| `src/preload.js` | the renderer bridge: version, platform, `setTheme`, `openExternal` |
+| `src/preload.js` | the renderer bridge: version, platform, `setTheme`, `openExternal`, `savePdf` |
+| `src/pdf.js` | renders the calling window to a PDF the user picks a home for; allowlists the options the page may set |
+| `src/downloads.js` | gives a download a visible ending, since a frameless window has no download shelf |
+| `src/notify.js` | the dock bounce that says a file landed |
 | `src/outage.js` | what replaces a blank window when the network does not answer |
 | `src/updater.js` | auto-update, gated on a feed actually existing |
 | `src/probe.js` | "is anything answering", shared by the picker and the outage page |

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -26,7 +26,16 @@ copyright: LangAlpha
 artifactName: LangAlpha-${EDITION}-${version}-${arch}.${ext}
 
 directories:
-  output: dist
+  # Per edition, because `artifactName` above is the only thing that carries one
+  # and it does not reach everything written here. The unpacked bundle is named
+  # from `productName`, so both editions' `.app`s land side by side under
+  # `mac-arm64`; the update manifests are `latest-mac.yml` and `latest.yml`,
+  # fixed names with no edition in them at all, so a second edition built into
+  # one tree silently overwrites the first's. Downstream of that, scripts/build.mjs
+  # searches this directory for what it just produced: sharing it means a signing
+  # check that verifies the other edition's stale bundle, and a no-feed build
+  # whose sweep strips the other edition's baked app-update.yml.
+  output: dist/${EDITION}
   buildResources: resources
 
 # The shell is a remote-URL wrapper: it carries no web bundle, so `files` is just

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langalpha-desktop",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "description": "Desktop shell for LangAlpha",
   "homepage": "https://langalpha.ai",

--- a/desktop/scripts/build.mjs
+++ b/desktop/scripts/build.mjs
@@ -77,7 +77,7 @@ if (feed) {
 // in place it would swallow a certificate the moment one exists and still exit
 // 0, so the presence of CSC_LINK is what takes the line back out.
 if (signing) {
-  replace(/^ {2}identity: null$/m, '  # identity resolved from CSC_LINK by scripts/build.mjs', 'identity: null')
+  replace(/^ {2}identity: null\r?$/m, '  # identity resolved from CSC_LINK by scripts/build.mjs', 'identity: null')
   console.log(`[build] signing enabled (${process.env.CSC_LINK ? 'CSC_LINK' : 'CSC_NAME'})`)
 }
 
@@ -104,27 +104,32 @@ if (edition !== 'oss') {
   replace(/^ {6}- langalpha-oss\r?$/m, `      - ${identity.scheme}`, 'protocol scheme')
 }
 
-// Always resolved, unlike the feed and signing edits: the filename carries the
-// edition on every build, so there is no configuration left that electron-builder
-// can consume as committed.
-// Anchored to the directive, not to the bare placeholder: the comment above it
-// in electron-builder.yml spells ${EDITION} too, and a non-global replace takes
-// the first match, so substituting into that prose left the real line alone and
-// failed at packaging with "macro EDITION is not defined". A function
-// replacement rather than a string keeps `$` in the edition from being read as
-// a capture reference.
-replace(/^(artifactName:.*?)\$\{EDITION\}/m, (_, pre) => pre + edition, 'artifactName ${EDITION} placeholder')
-
-// The precondition above is not enough on its own: it passed while the
-// substitution did nothing, because it matched the placeholder in the prose.
-// Check the postcondition on every line electron-builder will actually read,
-// so a second directive carrying the placeholder cannot slip through either.
-const unresolved = config
+// Always resolved, unlike the feed and signing edits: the artifact filename and
+// the output directory both carry the edition on every build, so there is no
+// configuration left that electron-builder can consume as committed.
+//
+// Every occurrence outside a comment, rather than one anchored to a directive by
+// name. The prose in electron-builder.yml spells ${EDITION} too, and an anchored
+// replace that took the first match once landed in that prose, left the real
+// line alone, and failed at packaging with "macro EDITION is not defined",
+// which is why the old form needed a second pass to check its own work. Covering
+// exactly the lines electron-builder reads leaves nothing for that pass to find,
+// and a new directive carrying the placeholder needs no marker added here.
+let substitutions = 0
+config = config
   .split('\n')
-  .filter((l) => !l.trimStart().startsWith('#') && l.includes('${EDITION}'))
-if (unresolved.length > 0) {
-  console.error('[build] ${EDITION} survived substitution on:')
-  for (const l of unresolved) console.error(`  ${l.trim()}`)
+  .map((line) =>
+    line.trimStart().startsWith('#')
+      ? line
+      // A function replacement, so a `$` in the edition is not read as a
+      // capture reference.
+      : line.replace(/\$\{EDITION\}/g, () => {
+        substitutions++
+        return edition
+      }))
+  .join('\n')
+if (substitutions === 0) {
+  console.error('[build] electron-builder.yml no longer spells ${EDITION} outside its comments')
   process.exit(1)
 }
 
@@ -147,6 +152,32 @@ for (const [line, what] of identityLines) {
 }
 console.log(`[build] identity: ${identity.productName} (${identity.appId}, ${identity.scheme}://)`)
 
+// Read back off the resolved config rather than rebuilt from `edition` here:
+// electron-builder writes wherever this line says, and everything below that
+// goes looking for what it produced has to ask the same line or drift from it
+// in silence. Drift does not announce itself: a sweep, a signing check and a
+// manifest check that all simply find nothing look exactly like a clean build.
+// One regex, so the key and its exact indent are stated once rather than as a
+// find predicate and a slice offset that have to agree. It also has to survive
+// the shapes YAML allows and this script does not write itself: a quoted value,
+// and a trailing comment, both of which a plain slice would carry into the path.
+const outputMatch = /^ {2}output:[ \t]*(?:"([^"]*)"|'([^']*)'|([^#\r\n]*))/m.exec(config)
+const outputDir = outputMatch && (outputMatch[1] ?? outputMatch[2] ?? outputMatch[3] ?? '').trim()
+if (!outputDir) {
+  console.error('[build] electron-builder.yml no longer has a `directories.output` line')
+  process.exit(1)
+}
+// The whole point of the per-edition tree, asserted where it is knowable. The
+// substitution count above is file-wide, so dropping ${EDITION} from this one
+// line while artifactName keeps its own leaves that count non-zero and both
+// editions building into one directory, which is the state this replaced.
+if (!outputDir.includes(edition)) {
+  console.error(`[build] directories.output resolved to '${outputDir}', which is not this edition's tree`)
+  process.exit(1)
+}
+const dist = path.resolve(root, outputDir)
+console.log(`[build] output: ${path.relative(root, dist)}`)
+
 writeFileSync(RESOLVED, config)
 args.push('--config', path.basename(RESOLVED))
 
@@ -167,7 +198,7 @@ const bin = existsSync(local) ? local : 'electron-builder'
 // while every installer already carries the old feed baked in. Those are the
 // artifacts that ship.
 if (!feed) {
-  for (const stale of findStaleFeeds(path.join(root, 'dist'))) {
+  for (const stale of findStaleFeeds(dist)) {
     rmSync(stale, { force: true })
     console.log(`[build] removed a previous build's feed: ${path.relative(root, stale)}`)
   }
@@ -180,8 +211,6 @@ if (result.error) {
   process.exit(1)
 }
 if (result.status !== 0) process.exit(result.status ?? 1)
-
-const dist = path.join(root, 'dist')
 
 // Same shape as the manifest guard: a certificate that produced an unsigned
 // artifact is a green build that Squirrel.Mac will refuse to install from, and
@@ -200,7 +229,7 @@ if (signing && process.platform === 'darwin') {
     if (check.status !== 0) {
       console.error(`[build] signing was requested but ${rel} is not validly signed`)
       console.error((check.stderr || '').trim())
-      console.error('[build] if that path is from an earlier build, clear dist/ and build again')
+      console.error(`[build] if that path is from an earlier build, clear ${path.relative(root, dist)}/ and build again`)
       process.exit(1)
     }
     console.log(`[build] signed and verified: ${rel}`)

--- a/desktop/scripts/make-release-index.mjs
+++ b/desktop/scripts/make-release-index.mjs
@@ -53,10 +53,22 @@ const files = readdirSync(dir, { recursive: true })
   .map((f) => path.basename(String(f)))
   .filter((f, i, all) => all.indexOf(f) === i)
 
+// One match per platform, or none. Two is not a tie to break: the scan is
+// recursive and flattened to basenames, so a directory holding more than one
+// candidate is either a previous version's artifacts left behind or a parent of
+// the per-edition output directories electron-builder now writes
+// (`dist/<edition>`, see electron-builder.yml). Picking the first in read order
+// publishes an index that names a build this release did not produce, which is
+// the one failure this file exists to prevent, and it does it silently.
 const artifacts = {}
 for (const [key, pattern] of PLATFORMS) {
-  const match = files.find((f) => pattern.test(f))
-  if (match) artifacts[key] = match
+  const matches = files.filter((f) => pattern.test(f))
+  if (matches.length > 1) {
+    console.error(`[index] ${matches.length} candidates for ${key} in ${dir}: ${matches.join(', ')}`)
+    console.error('[index] point this at one build\'s output directory, not a parent of several')
+    process.exit(1)
+  }
+  if (matches.length === 1) artifacts[key] = matches[0]
 }
 
 if (Object.keys(artifacts).length === 0) {

--- a/desktop/src/downloads.js
+++ b/desktop/src/downloads.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const { app, dialog } = require('electron')
+const notify = require('./notify')
+
+// Sessions, not windows: the app and the console share the default session, and
+// attaching twice would report every download twice. A WeakSet so a session that
+// goes away is not held alive by having been seen.
+const attached = new WeakSet()
+
+/**
+ * Give a download a visible ending.
+ *
+ * Electron already prompts for a location, so the missing half is what happens
+ * afterwards. A browser has a download shelf that reports progress, completion
+ * and failure; a shell with no chrome at all shows none of it, which leaves an
+ * interrupted transfer looking exactly like a finished one. The user's next move
+ * is to go hunting in Finder for a file that never arrived.
+ *
+ * Reports the two endings the user cannot otherwise see and stays silent on the
+ * third: a download they cancelled themselves needs no dialog telling them so.
+ */
+/**
+ * A filename fit to put inside a dialog that wears the app's own name.
+ *
+ * The name comes off the wire (Content-Disposition, or the page's own download
+ * attribute) and both macOS and Linux allow newlines in one. Interpolated
+ * whole, a name ending in a blank line and a sentence composes extra lines of
+ * text in a native dialog the user reads as the application speaking.
+ */
+function displayName(raw) {
+  return String(raw || 'the file').replace(/\s+/g, ' ').trim().slice(0, 80) || 'the file'
+}
+
+function attach(session) {
+  if (!session || attached.has(session)) return
+  attached.add(session)
+
+  session.on('will-download', (_event, item) => {
+    // Read now rather than in the handler below: after an interrupted transfer
+    // the item still answers, but this is the name the user was shown.
+    const name = displayName(item.getFilename())
+    console.log(`[download] started ${name}`)
+
+    item.once('done', (_doneEvent, state) => {
+      if (state === 'completed') {
+        console.log(`[download] completed ${name}`)
+        notify.fileLanded(item.getSavePath())
+        return
+      }
+      if (state === 'interrupted') {
+        console.log(`[download] interrupted ${name}`)
+        dialog.showErrorBox(
+          app.getName(),
+          `The download of ${name} did not finish.\n\nCheck your connection and try again.`,
+        )
+      }
+    })
+  })
+}
+
+module.exports = { attach }

--- a/desktop/src/main.js
+++ b/desktop/src/main.js
@@ -12,6 +12,8 @@ const deeplink = require('./deeplink')
 const theme = require('./theme')
 const updater = require('./updater')
 const outage = require('./outage')
+const pdf = require('./pdf')
+const downloads = require('./downloads')
 const { probe } = require('./probe')
 const { navigate } = require('./navigate')
 const { forDisplay } = require('./redact')
@@ -697,6 +699,8 @@ function registerIpc() {
   })
 
   ipcMain.handle('server:current', () => store.get('serverUrl'))
+
+  pdf.registerIpc()
 }
 
 // ---------------------------------------------------------------------------
@@ -807,6 +811,7 @@ app.on('web-contents-created', (_event, contents) => {
   // session with only the first set falls through to the defaults for the
   // second. Same answer from both, or the policy is only half a policy.
   contents.session.setPermissionCheckHandler((_wc, permission) => permitted(permission))
+  downloads.attach(contents.session)
 })
 
 // Exported for the tests: the verdict path that policy cannot own (it opens the

--- a/desktop/src/notify.js
+++ b/desktop/src/notify.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const { app } = require('electron')
+
+/**
+ * Tell the desktop a file just landed.
+ *
+ * The Downloads stack bounce: the platform's own "a file arrived" signal, and
+ * the only one that reports without taking focus from a window that may be
+ * mid-turn. Every route that writes a file for the user goes through here, so
+ * a saved PDF and a finished download announce themselves the same way.
+ *
+ * Silent everywhere else. Windows and Linux have no equivalent that does not
+ * interrupt, and an error box for a success is worse than saying nothing.
+ */
+function fileLanded(filePath) {
+  if (process.platform === 'darwin' && app.dock) app.dock.downloadFinished(filePath)
+}
+
+module.exports = { fileLanded }

--- a/desktop/src/pdf.js
+++ b/desktop/src/pdf.js
@@ -1,0 +1,204 @@
+'use strict'
+
+const fs = require('node:fs/promises')
+const path = require('node:path')
+const { app, dialog, ipcMain, BrowserWindow } = require('electron')
+const notify = require('./notify')
+
+// Electron's own enum. A name outside it throws inside printToPDF, and the
+// value arrives from a page loaded over the network, so it is checked here
+// rather than taken on trust.
+const PAGE_SIZES = new Set([
+  'A0', 'A1', 'A2', 'A3', 'A4', 'A5', 'A6', 'Legal', 'Letter', 'Tabloid', 'Ledger',
+])
+
+const MAX_STEM = 120
+
+const clamp = (value, lo, hi) => Math.min(hi, Math.max(lo, value))
+
+/**
+ * One export at a time, decided here rather than in the page.
+ *
+ * The page has a guard of its own, but that one is advice: this channel is
+ * reachable from any script the window is running, and every call renders a
+ * whole PDF and then parks on a modal dialog, so a loop of them stacks native
+ * dialogs and buffers with nothing to stop it.
+ *
+ * It is also what makes the background swap below safe. That reads the window's
+ * colour, stands white in for it and puts the original back; two renders
+ * overlapping would have the second read white as the original and restore it
+ * permanently, leaving the window on white paper for the rest of the session.
+ */
+let rendering = false
+
+/**
+ * Translate the page's request into printToPDF options.
+ *
+ * Allowlisted rather than forwarded: an unrecognised or out-of-range field is
+ * not ignored by Chromium, it throws, and the request arrives from a page
+ * loaded over the network. Every value the page can influence is matched
+ * against a known set or clamped, so a malformed request degrades to the
+ * defaults here instead of failing the export.
+ */
+function normalizeOptions(raw) {
+  const input = raw && typeof raw === 'object' ? raw : {}
+  const options = {
+    // The document's own `@page` rule is the layout its preview was measured
+    // from, so it outranks anything named here; `pageSize` below is only the
+    // answer for a document that declares none.
+    preferCSSPageSize: true,
+    printBackground: input.printBackground !== false,
+    // The two things a browser's print dialog cannot produce, and much of the
+    // reason this path exists: a tagged reading order and a real outline built
+    // from the heading tree. Both default on; a caller can still decline.
+    generateTaggedPDF: input.tagged !== false,
+    generateDocumentOutline: input.outline !== false,
+    landscape: input.landscape === true,
+  }
+  if (typeof input.pageSize === 'string' && PAGE_SIZES.has(input.pageSize)) {
+    options.pageSize = input.pageSize
+  }
+  if (typeof input.scale === 'number' && Number.isFinite(input.scale)) {
+    options.scale = clamp(input.scale, 0.1, 2)
+  }
+  if (typeof input.pageRanges === 'string' && /^[0-9,\s-]{1,64}$/.test(input.pageRanges)) {
+    options.pageRanges = input.pageRanges
+  }
+  return options
+}
+
+/**
+ * A filename safe to hand the save dialog as its opening suggestion.
+ *
+ * The name comes from a document title the agent wrote, so it is neither
+ * trusted nor tidy. Separators are replaced rather than stripped with
+ * `basename`: that makes the result something that cannot be a path at all,
+ * which is a stronger statement than removing the directory part, and it keeps
+ * the whole of an ordinary title. `basename` looked equivalent and was not:
+ * it turned "profit/loss review" into "loss review". The same replacement
+ * covers the characters that are legal on one desktop and rejected on another,
+ * so the same export does not fail only on Windows.
+ *
+ * The extension comes off before the leading run does, or a name of `.pdf`
+ * leaves `pdf` behind and saves as `pdf.pdf`.
+ */
+function safeFileName(raw) {
+  const cleaned = (typeof raw === 'string' ? raw : '')
+    .replace(/[\u0000-\u001f\u007f]/g, '')
+    .replace(/[\\/:*?"<>|]/g, '-')
+    .trim()
+  const stem = cleaned
+    .replace(/\.pdf$/i, '')
+    .replace(/^[-.\s]+/, '')
+    .slice(0, MAX_STEM)
+    .trim()
+  return `${stem || 'export'}.pdf`
+}
+
+/**
+ * Render the window's contents to PDF bytes, on white paper.
+ *
+ * printToPDF composites the page over the window's own background colour, which
+ * the shell sets from the theme (`theme.js`, #191919 in dark). Nothing paints
+ * the margin area (a page's canvas background does not reach it), so whatever
+ * is behind the window shows through, and every export from a dark window came
+ * out on dark paper with the text block floating in it. White for the duration
+ * of the render, put back immediately after.
+ */
+async function renderToBuffer(win, contents, options) {
+  const previous = win.getBackgroundColor()
+  win.setBackgroundColor('#ffffff')
+  try {
+    return await contents.printToPDF(options)
+  } finally {
+    // A long report can outlive its window. Restoring a colour on a window that
+    // is gone throws from a `finally`, which would replace whatever the render
+    // actually failed with by an unrelated 'Object has been destroyed'.
+    if (!win.isDestroyed()) win.setBackgroundColor(previous)
+  }
+}
+
+/**
+ * Render the calling window to a PDF the user picks a home for.
+ *
+ * Prints the sender's own contents, never markup passed in: the page cannot
+ * name a URL or hand over HTML, so this adds no way to render something the
+ * window was not already showing. Rendering happens before the dialog opens
+ * because `printToPDF` composes an off-screen print layout and leaves the
+ * visible window untouched, so the user never watches their page reflow.
+ *
+ * Answers with an outcome instead of throwing. A rejected `invoke` reaches the
+ * page as an opaque error it cannot tell from a shell too old to know this
+ * channel, and the caller's fallback to browser print depends on telling those
+ * apart. The saved path stays on this side; the page gets no filesystem detail.
+ */
+async function savePdf(event, request) {
+  const win = BrowserWindow.fromWebContents(event.sender)
+  if (!win || win.isDestroyed()) return { error: 'This window is closing.' }
+  // `canceled`, matching the page's own re-entry answer: nothing was exported,
+  // and the caller must not respond by opening a second dialog on top of the
+  // one already up.
+  if (rendering) return { canceled: true }
+  rendering = true
+
+  try {
+    let data
+    try {
+      data = await renderToBuffer(win, event.sender, normalizeOptions(request))
+    } catch (err) {
+      console.error(`[pdf] render failed: ${err.message}`)
+      return { error: `Could not render the PDF: ${err.message}` }
+    }
+
+    const suggestion = safeFileName(request && request.fileName)
+    let chosen
+    try {
+      // Inside the try for the same reason the render is: this function answers
+      // with an outcome, and a dialog that throws (a window closed while its
+      // sheet was up) would escape as a rejected `invoke`, which the page cannot
+      // tell from a shell too old to know the channel.
+      chosen = await dialog.showSaveDialog(win, {
+        defaultPath: path.join(app.getPath('downloads'), suggestion),
+        filters: [{ name: 'PDF', extensions: ['pdf'] }],
+      })
+    } catch (err) {
+      console.error(`[pdf] save dialog failed: ${err.message}`)
+      return { error: 'Could not open the save dialog.' }
+    }
+    if (chosen.canceled || !chosen.filePath) return { canceled: true }
+    const filePath = chosen.filePath
+
+    // Staged and renamed rather than written in place. `writeFile` truncates
+    // first, so a volume that filled or was pulled mid-write left a damaged file
+    // wearing a .pdf name exactly where the user asked for one, while the UI
+    // said the export had failed. Worse when they were saving over a previous
+    // export: the file destroyed that way was one they already had. A sibling
+    // keeps the rename on one filesystem, which is what makes it replace in one
+    // step.
+    const staged = `${filePath}.${process.pid}-${Date.now()}.part`
+    try {
+      await fs.writeFile(staged, data)
+      await fs.rename(staged, filePath)
+    } catch (err) {
+      // The code, never the message. Node puts the full path in `err.message`,
+      // and the page is remote: handing it back would publish the user's home
+      // directory and account name over the same channel this function's
+      // contract says keeps the path on this side.
+      console.error(`[pdf] write failed: ${err.message}`)
+      await fs.rm(staged, { force: true }).catch(() => {})
+      return { error: `Could not save the file (${err.code || 'unknown error'}).` }
+    }
+
+    notify.fileLanded(filePath)
+    console.log(`[pdf] saved ${suggestion} (${data.length} bytes)`)
+    return { saved: true }
+  } finally {
+    rendering = false
+  }
+}
+
+function registerIpc() {
+  ipcMain.handle('shell:save-pdf', savePdf)
+}
+
+module.exports = { registerIpc, savePdf, normalizeOptions, safeFileName, renderToBuffer }

--- a/desktop/src/preload.js
+++ b/desktop/src/preload.js
@@ -43,6 +43,14 @@ contextBridge.exposeInMainWorld('langalphaDesktop', {
 
   /** Open a URL in the user's real browser. */
   openExternal: (url) => ipcRenderer.invoke('shell:open-external', url),
+
+  /**
+   * Save this page as a PDF file, replacing the print dialog a browser has to
+   * fall back to. Answers `{ saved }`, `{ canceled }` or `{ error }` rather
+   * than rejecting, so a caller can tell a refusal apart from a shell too old
+   * to know the channel and keep its browser path for the second case.
+   */
+  savePdf: (options) => ipcRenderer.invoke('shell:save-pdf', options),
 })
 
 // The outage page is a local file loaded into this same window, so it shares

--- a/desktop/test/helpers.js
+++ b/desktop/test/helpers.js
@@ -32,6 +32,12 @@ const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'la-test-'))
 let online = true
 const setOnline = (value) => { online = value }
 
+// What the save dialog answers. Mutable for the same reason: a user who
+// dismissed the dialog and a user who chose a path are two different endings of
+// the PDF export, and neither is reachable without driving the dialog.
+let saveDialog = { canceled: true }
+const setSaveDialog = (value) => { saveDialog = value }
+
 // What Electron falls back to with no `productName`: the package.json `name`.
 // Nothing should ever run on it — main sets the edition's name before anything
 // asks where userData lives — so it is deliberately neither edition's.
@@ -75,8 +81,13 @@ const electronStub = {
   dialog: {
     showErrorBox: (title, content) => { errorBoxes.push({ title, content }) },
     showMessageBox: async () => ({ response: 0 }),
+    showSaveDialog: async () => saveDialog,
   },
-  BrowserWindow: { getAllWindows: () => [] },
+  // `fromWebContents` is how the PDF path finds the window it was asked from.
+  // The stub reads a back-reference the caller hangs on its own fake contents,
+  // rather than keeping a registry: the mapping is Electron's, not ours, and a
+  // registry here would be a second implementation of it.
+  BrowserWindow: { getAllWindows: () => [], fromWebContents: (wc) => (wc && wc.window) || null },
   Menu: { buildFromTemplate: (t) => t, setApplicationMenu: () => {} },
   ipcMain: { on: () => {}, handle: () => {} },
 }
@@ -125,6 +136,7 @@ function loadShell({ edition = 'oss', appOrigin, platformOrigin, serverUrl = nul
     deeplink: require(path.join(SRC, 'deeplink.js')),
     theme: require(path.join(SRC, 'theme.js')),
     outage: require(path.join(SRC, 'outage.js')),
+    pdf: require(path.join(SRC, 'pdf.js')),
     captive: require(path.join(SRC, 'captive.js')),
     main: require(path.join(SRC, 'main.js')),
   }
@@ -146,10 +158,21 @@ function loadEntryWith(buildConfig) {
   return { errorBoxes, exits }
 }
 
+/** Directories a test made and wants the shared teardown to take away again. */
+const TEMP_DIRS = []
+
+/** A temp directory this suite will not leave behind. */
+function tempDir(prefix) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix))
+  TEMP_DIRS.push(dir)
+  return dir
+}
+
 function cleanup() {
   if (STASHED_BUILD_CONFIG) fs.writeFileSync(BUILD_CONFIG, STASHED_BUILD_CONFIG)
   else fs.rmSync(BUILD_CONFIG, { force: true })
   fs.rmSync(userData, { recursive: true, force: true })
+  for (const dir of TEMP_DIRS) fs.rmSync(dir, { recursive: true, force: true })
 }
 
-module.exports = { loadShell, loadEntryWith, cleanup, opened, electronStub, setOnline }
+module.exports = { loadShell, loadEntryWith, cleanup, opened, electronStub, setOnline, setSaveDialog, tempDir }

--- a/desktop/test/shell.test.js
+++ b/desktop/test/shell.test.js
@@ -5,7 +5,7 @@ const assert = require('node:assert/strict')
 const fs = require('node:fs')
 const path = require('node:path')
 const { EventEmitter } = require('node:events')
-const { loadShell, loadEntryWith, cleanup, opened, setOnline, electronStub } = require('./helpers')
+const { loadShell, loadEntryWith, cleanup, opened, setOnline, setSaveDialog, tempDir, electronStub } = require('./helpers')
 
 after(cleanup)
 
@@ -1289,6 +1289,32 @@ describe('the two editions can sit on one machine', () => {
     assert.match(yml, /^artifactName: LangAlpha-\$\{EDITION\}/m)
     assert.ok(!/^artifactName:.*\$\{productName\}/m.test(yml), 'artifactName still interpolates productName')
   })
+
+  // The filename is not enough on its own. The unpacked bundle is named from
+  // productName and lands in a shared `mac-arm64`, and the update manifests are
+  // fixed names (`latest-mac.yml` carries no edition at all), so one output tree
+  // means the second edition to build overwrites the first's metadata.
+  test('neither edition builds into the other\'s output tree', () => {
+    assert.match(read('electron-builder.yml'), /^ {2}output: dist\/\$\{EDITION\}$/m)
+  })
+
+  // Everything build.mjs does after electron-builder returns, the stale-feed
+  // sweep and the signing verification and the manifest check, is a search of
+  // the output directory. A second, hardcoded copy of that path is how all three
+  // quietly become searches of an empty tree, which reads exactly like a clean
+  // build. It reads the directive back off the config it just resolved instead.
+  test('build.mjs looks for its own output where the config puts it', () => {
+    const build = read('scripts/build.mjs')
+    // The derivation, not the expression that parses it: how the line is found
+    // is this script's own business, but that the path comes from the config
+    // rather than from a second copy of it is the property.
+    assert.match(build, /output:\[ \\t\]\*/,
+      'build.mjs no longer reads directories.output out of the resolved config')
+    assert.match(build, /const dist = path\.resolve\(root, outputDir\)/,
+      'build.mjs no longer derives its output directory from that line')
+    assert.ok(!/path\.(join|resolve)\(root, 'dist'\)/.test(build),
+      'build.mjs also hardcodes the output directory somewhere')
+  })
 })
 
 // The window-chrome contract is four string literals spread across three files
@@ -1347,5 +1373,288 @@ describe('the window-chrome contract holds across the two processes', () => {
                          '../web/src/components/Sidebar/Sidebar.css']) {
       assert.ok(read(sheet).includes('html.desktop-mac'), sheet)
     }
+  })
+
+  // The fallback strip rests on two properties from two different mechanisms,
+  // and the browser suite can only see one of them. The region walk is settled
+  // by tree order; the click is settled by hit testing. `getComputedStyle`
+  // reports `no-drag` on a control the strip is swallowing whole, verified
+  // against a pre-fix document, so a check that reads the region calls the
+  // broken arrangement healthy. The e2e suite now hit-tests as well, and these
+  // two literals are what stands between either half and a silent revert.
+  test('the fallback drag strip declines the mouse and stays first in tree order', () => {
+    const indexHtml = read('../web/index.html')
+    // Regions are collected in layout-tree preorder and differenced in that
+    // order, so the app's `no-drag` controls only subtract from this strip while
+    // it comes first. z-index is not an input to that walk.
+    const strip = indexHtml.indexOf('<div id="window-drag"')
+    const root = indexHtml.indexOf('<div id="root"')
+    assert.ok(strip >= 0 && root >= 0, 'one of the two elements is missing')
+    assert.ok(strip < root, '#window-drag must precede #root, or the no-drag rule cannot reach it')
+    // And the other half, which is a different mechanism entirely: hit testing,
+    // where a fixed box beats every in-flow element that is not itself
+    // positioned. Without this the strip swallowed the clicks of every static
+    // control that scrolled under the titlebar, while those controls went on
+    // computing `no-drag` -- so nothing that reads the region could see it.
+    assert.match(indexHtml, /#window-drag \{[^}]*pointer-events: none;/,
+      '#window-drag takes pointer events, so it eats the clicks of whatever scrolls under it')
+  })
+
+  // What the strip cannot subtract is prose: `no-drag` covers controls, so a
+  // route that renders a document with no chrome of its own has its top line
+  // inside a drag region, where a press-and-drag moves the window instead of
+  // selecting the text. Terms and privacy are the two such documents this app
+  // ships, and the answer is that neither opens in the shell at all -- an
+  // anchor with a target reaches setWindowOpenHandler in src/main.js, which
+  // hands one of our own URLs to the system browser. A `<Link>` is a
+  // client-side navigation that never reaches that handler, and a plain `<a>`
+  // navigates this window; both put the document back under the titlebar, and
+  // both look correct in a browser.
+  test('a legal document is never opened inside the app window', () => {
+    const src = path.join(__dirname, '..', '..', 'web/src')
+    // The documents themselves are exempt, and by the same rule rather than as
+    // a hole in it: they only ever render in a browser tab, so a link between
+    // them is an ordinary in-tab navigation. The rule is about app surface.
+    const exempt = `pages${path.sep}Legal${path.sep}`
+    const offenders = []
+    for (const rel of fs.readdirSync(src, { recursive: true })) {
+      if (!/\.tsx$/.test(rel) || rel.includes('__tests__') || rel.includes(exempt)) continue
+      const text = fs.readFileSync(path.join(src, rel), 'utf8')
+      // `[^<>]` and not `[^>]`: the sign-in page passes its anchors as props to
+      // <Trans>, so a match that may cross a `<` swallows the outer element and
+      // reports the wrong tag.
+      for (const [tag] of text.matchAll(/<\w+\b[^<>]*?\b(?:to|href)=["'{]+\/(?:legal|privacy)\b[^<>]*>/g)) {
+        const external = tag.startsWith('<a') && tag.includes('target="_blank"')
+        if (!external) offenders.push(`${rel}: ${tag.replace(/\s+/g, ' ')}`)
+      }
+    }
+    assert.deepEqual(offenders, [],
+      'a legal page is reachable without leaving the app window:\n' + offenders.join('\n'))
+  })
+})
+
+// The one string this feature spans two processes on, spelled in exactly two
+// places with nothing that reads both. Drift does not fail anything: the page
+// sees a channel that never answers, decides the shell is too old to know it,
+// and falls back to browser print. That is precisely the pre-feature behaviour,
+// so the whole path silently reverts and the tests stay green — savePdf is
+// called directly everywhere below, and the ipcMain stub records nothing.
+describe('the PDF channel is the same one on both sides', () => {
+  const read = (rel) => fs.readFileSync(path.join(__dirname, '..', rel), 'utf8')
+
+  test('the channel main handles is the one preload invokes', () => {
+    assert.match(read('src/pdf.js'), /ipcMain\.handle\('shell:save-pdf'/)
+    assert.match(read('src/preload.js'), /ipcRenderer\.invoke\('shell:save-pdf'/)
+  })
+
+  test('the bridge key preload exposes is the one the web app feature-detects', () => {
+    assert.match(read('src/preload.js'), /^\s*savePdf: \(options\) =>/m)
+    assert.match(read('../web/src/lib/desktop.ts'), /^\s*savePdf\?\(options\?: SavePdfOptions\)/m)
+  })
+})
+
+// The three pure functions below stand between a page loaded over the network
+// and Chromium's printer. Every one of them exists because the input is not
+// trusted: the options come from the renderer, and the filename is a title an
+// agent wrote. A live run only ever exercises the well-formed case, so the
+// cases that matter here are the ones that must be REFUSED or repaired.
+describe('rendering a page to a PDF', () => {
+  let pdf
+  before(() => { ({ pdf } = loadShell({ edition: 'saas' })) })
+  after(() => setSaveDialog({ canceled: true }))
+
+  describe('what a page is allowed to ask for', () => {
+    test('a field Chromium has never heard of does not reach it', () => {
+      const options = pdf.normalizeOptions({ headerTemplate: '<img src=x>', displayHeaderFooter: true })
+      assert.equal('headerTemplate' in options, false)
+      assert.equal('displayHeaderFooter' in options, false)
+    })
+
+    test('a page size outside the enum is dropped, not passed through', () => {
+      // printToPDF throws on a name outside its own enum, and a throw here is
+      // an export the user simply does not get.
+      assert.equal('pageSize' in pdf.normalizeOptions({ pageSize: 'A4; DROP' }), false)
+      assert.equal('pageSize' in pdf.normalizeOptions({ pageSize: 'Poster' }), false)
+      assert.equal(pdf.normalizeOptions({ pageSize: 'Letter' }).pageSize, 'Letter')
+    })
+
+    test('an out-of-range scale is clamped rather than refused', () => {
+      assert.equal(pdf.normalizeOptions({ scale: 99 }).scale, 2)
+      assert.equal(pdf.normalizeOptions({ scale: 0 }).scale, 0.1)
+      assert.equal(pdf.normalizeOptions({ scale: 1.5 }).scale, 1.5)
+      // NaN and Infinity survive JSON round-trips through the widget layer.
+      assert.equal('scale' in pdf.normalizeOptions({ scale: NaN }), false)
+      assert.equal('scale' in pdf.normalizeOptions({ scale: Infinity }), false)
+    })
+
+    test('pageRanges has to look like a page range', () => {
+      assert.equal(pdf.normalizeOptions({ pageRanges: '1-3, 7' }).pageRanges, '1-3, 7')
+      assert.equal('pageRanges' in pdf.normalizeOptions({ pageRanges: 'all' }), false)
+      assert.equal('pageRanges' in pdf.normalizeOptions({ pageRanges: '1'.repeat(65) }), false)
+    })
+
+    test('the two things a print dialog cannot produce are on by default', () => {
+      // A tagged reading order and a real outline are much of the reason this
+      // path exists at all, so they are opt-out rather than opt-in.
+      const defaults = pdf.normalizeOptions({})
+      assert.equal(defaults.generateTaggedPDF, true)
+      assert.equal(defaults.generateDocumentOutline, true)
+      assert.equal(defaults.printBackground, true)
+      assert.equal(defaults.preferCSSPageSize, true)
+      const declined = pdf.normalizeOptions({ tagged: false, outline: false, printBackground: false })
+      assert.equal(declined.generateTaggedPDF, false)
+      assert.equal(declined.generateDocumentOutline, false)
+      assert.equal(declined.printBackground, false)
+    })
+
+    test('a request that is not an object at all still yields defaults', () => {
+      assert.equal(pdf.normalizeOptions(null).generateTaggedPDF, true)
+      assert.equal(pdf.normalizeOptions('A4').generateTaggedPDF, true)
+    })
+  })
+
+  describe('the name the save dialog opens on', () => {
+    test('a name cannot walk out of the folder it was offered in', () => {
+      // The suggestion is joined onto the downloads path, so a traversal here
+      // would open the dialog somewhere the user never asked for.
+      assert.equal(pdf.safeFileName('../../../etc/passwd'), 'etc-passwd.pdf')
+      assert.equal(pdf.safeFileName('/tmp/evil'), 'tmp-evil.pdf')
+    })
+
+    test('characters that are legal on one desktop and rejected on another go', () => {
+      // Otherwise the same export fails only on Windows, which is the kind of
+      // bug that gets found by a user rather than by us.
+      assert.equal(pdf.safeFileName('Q3: profit/loss <draft>'), 'Q3- profit-loss -draft-.pdf')
+      assert.equal(pdf.safeFileName('tab\there'), 'tabhere.pdf')
+    })
+
+    test('a name that survives to nothing still produces a file', () => {
+      assert.equal(pdf.safeFileName('...'), 'export.pdf')
+      assert.equal(pdf.safeFileName(''), 'export.pdf')
+      assert.equal(pdf.safeFileName(undefined), 'export.pdf')
+      assert.equal(pdf.safeFileName('.pdf'), 'export.pdf')
+    })
+
+    test('an agent-length title is cut to something every filesystem accepts', () => {
+      const name = pdf.safeFileName('x'.repeat(400))
+      assert.equal(name.length, 124)
+      assert.ok(name.endsWith('.pdf'))
+    })
+
+    test('the extension is not doubled on a name that already carries it', () => {
+      assert.equal(pdf.safeFileName('report.pdf'), 'report.pdf')
+      assert.equal(pdf.safeFileName('report.PDF'), 'report.pdf')
+    })
+  })
+
+  describe('what the render does to the window', () => {
+    const windowWithColor = (colors) => {
+      let current = '#191919'
+      return {
+        isDestroyed: () => false,
+        getBackgroundColor: () => current,
+        setBackgroundColor: (c) => { current = c; colors.push(c) },
+      }
+    }
+
+    test('the page is printed on white paper, not on the window ground', async () => {
+      // printToPDF composites over the window's own background, and nothing
+      // paints the margin area — so a dark window produced dark paper with the
+      // text block floating in it.
+      const colors = []
+      const win = windowWithColor(colors)
+      let duringRender = null
+      await pdf.renderToBuffer(win, {
+        printToPDF: async () => { duringRender = win.getBackgroundColor(); return Buffer.from('%PDF') },
+      }, {})
+      assert.equal(duringRender, '#ffffff')
+      assert.deepEqual(colors, ['#ffffff', '#191919'])
+    })
+
+    test('the window colour is put back even when the render throws', async () => {
+      const colors = []
+      await assert.rejects(pdf.renderToBuffer(windowWithColor(colors), {
+        printToPDF: async () => { throw new Error('boom') },
+      }, {}))
+      assert.deepEqual(colors, ['#ffffff', '#191919'])
+    })
+  })
+
+  // The web side branches on which of the three it got, and treats them
+  // differently on purpose: only `error` may fall back to browser print, because
+  // reopening a dialog the user just dismissed reads as the app ignoring them.
+  describe('the three answers a save can give', () => {
+    const senderFor = (printToPDF) => ({
+      printToPDF,
+      window: {
+        isDestroyed: () => false,
+        getBackgroundColor: () => '#191919',
+        setBackgroundColor: () => {},
+      },
+    })
+
+    test('a dismissed dialog is canceled, never an error', async () => {
+      setSaveDialog({ canceled: true })
+      const result = await pdf.savePdf({ sender: senderFor(async () => Buffer.from('%PDF')) }, {})
+      assert.deepEqual(result, { canceled: true })
+    })
+
+    test('a failed render answers with an error instead of rejecting', async () => {
+      // A rejected `invoke` reaches the page as an opaque error it cannot tell
+      // from a shell too old to know the channel, and the caller's fallback
+      // depends on telling those apart.
+      const result = await pdf.savePdf({ sender: senderFor(async () => { throw new Error('no printer') }) }, {})
+      assert.ok(result.error.includes('no printer'))
+      assert.equal('canceled' in result, false)
+    })
+
+    test('a chosen path gets the bytes, and the page is told only that it worked', async () => {
+      const target = path.join(tempDir('la-pdf-'), 'out.pdf')
+      setSaveDialog({ canceled: false, filePath: target })
+      const result = await pdf.savePdf(
+        { sender: senderFor(async () => Buffer.from('%PDF-1.7 body')) },
+        { fileName: 'Q3 review' },
+      )
+      assert.deepEqual(result, { saved: true })
+      assert.equal(fs.readFileSync(target, 'utf8'), '%PDF-1.7 body')
+      // No path in the answer: the page gets no filesystem detail back.
+      assert.equal('filePath' in result, false)
+    })
+
+    test('a window already closing answers rather than throwing on it', async () => {
+      const result = await pdf.savePdf({ sender: { printToPDF: async () => Buffer.from('x') } }, {})
+      assert.ok(result.error)
+    })
+
+    test('a failed write leaves the file the user was overwriting where it was', async () => {
+      // The destination is usually a previous export of the same report, so the
+      // in-place write had already truncated something the user owned by the
+      // time it failed, and the cleanup then removed what was left of it.
+      const target = path.join(tempDir('la-pdf-'), 'out.pdf')
+      fs.writeFileSync(target, 'the export from last week')
+      setSaveDialog({ canceled: false, filePath: target })
+      const fsp = require('node:fs/promises')
+      const real = fsp.writeFile
+      // Some of the bytes land before it fails, which is what a full volume
+      // actually does. Throwing without writing leaves no staged file at all,
+      // and the directory assertion below then passes on a cleanup that never
+      // ran, so removing it would not fail this test.
+      fsp.writeFile = async (to, bytes) => {
+        await real(to, bytes.subarray(0, 1))
+        const e = new Error('no space left')
+        e.code = 'ENOSPC'
+        throw e
+      }
+      let result
+      try {
+        result = await pdf.savePdf({ sender: senderFor(async () => Buffer.from('%PDF')) }, {})
+      } finally {
+        fsp.writeFile = real
+      }
+      assert.ok(result.error.includes('ENOSPC'))
+      assert.equal(fs.readFileSync(target, 'utf8'), 'the export from last week')
+      // And nothing half-written left beside it under a name nobody will explain.
+      assert.deepEqual(fs.readdirSync(path.dirname(target)), ['out.pdf'])
+    })
   })
 })

--- a/web/e2e/window-chrome.spec.js
+++ b/web/e2e/window-chrome.spec.js
@@ -24,6 +24,19 @@ const BUTTON_RECT = { w: 78, h: 38 };
 
 const SHELL_BRIDGE = { version: '0.0.0-e2e', platform: 'darwin', windowChrome: 'hidden' };
 
+// Every route that renders no chrome of its own, and so is left with the
+// fallback strip as its only drag region. Two suites below sweep it for two
+// different properties; a route added to one list and not the other would
+// quietly keep half its coverage.
+//
+// The two legal documents are here even though the shell no longer opens either
+// one (every link to them carries a target, so it reaches the system browser
+// instead). They stay because the reason they were exposed is the general one:
+// a route of prose has nothing in the `no-drag` list, so the strip covers its
+// top line. If one is ever linked back into the app window, this is what still
+// measures what that costs.
+const CHROMELESS_ROUTES = ['/setup/method', '/privacy', '/legal', '/s/no-such-token'];
+
 async function asDesktopShell(page, bridge = SHELL_BRIDGE) {
   await page.addInitScript((value) => {
     Object.defineProperty(window, 'langalphaDesktop', { value, configurable: true });
@@ -112,12 +125,12 @@ test.describe('desktop window chrome', () => {
     expect(await cornerOccupants(page)).toEqual([]);
   });
 
-  // The fixed strip in index.html exists for the window whose bundle never ran.
-  // It is `position: fixed` at z-index 9999 and 120px wide, so once the app IS
-  // up it also covers 40px of the main column past the 80px collapsed sidebar —
-  // and a control there cannot win its clicks back, because `no-drag` loses to a
-  // drag region painted over it. So it has to stand down once the sidebar
-  // renders the real one, and that handover is what this pins.
+  // The fixed strip in index.html exists for the window whose bundle never ran,
+  // and for every route that renders no chrome of its own. It spans the window
+  // and paints under #root, so the `no-drag` rule covers the controls inside it.
+  // It still has to stand down once the sidebar renders the real one: a page
+  // owning its top row should own all of it, and a plain div carrying an onClick
+  // is not in that rule's list. That handover is what this pins.
   test('the fallback drag strip stands down once the sidebar renders its own', async ({ page }) => {
     await asDesktopShell(page);
     await mockAPI(page);
@@ -141,7 +154,92 @@ test.describe('desktop window chrome', () => {
 
   // Everything outside the app shell. None of these reserve anything, so this
   // asserts the property directly rather than the mechanism.
-  for (const route of ['/setup/method', '/privacy', '/legal', '/s/no-such-token']) {
+  // The fallback spans the titlebar on every route that renders no chrome of its
+  // own, and it is the ONLY drag region those routes have. Two properties, both
+  // of which failed in production before this: it has to be wide enough to aim
+  // at (it was 120px, most of which the window buttons cover, so a drag landed
+  // on the page and selected text instead), and every control under it has to
+  // keep its own clicks. That second one takes two assertions, not one, because
+  // it takes two mechanisms: the drag region has to be subtracted (`no-drag` in
+  // chrome.css, which resolves in layout-tree order, so DOM position decides it
+  // and z-index does not), AND the strip has to stay out of the hit test, which
+  // it does by declining pointer events. Assert only the first and a strip that
+  // eats every click on the route still reports healthy.
+  //
+  // Not pinned here, because CDP-synthesized mouse events never reach the hit
+  // test that owns `-webkit-app-region`: that dragging the strip moves the
+  // window. This asserts the geometry and the computed regions that decide it.
+  // `/` is deliberately absent: signed in it IS the app shell, so the sidebar's
+  // strip retires this one, and the test above pins that handover instead.
+  for (const route of CHROMELESS_ROUTES) {
+    test(`the titlebar is draggable and its controls still click on ${route}`, async ({ page }) => {
+      await asDesktopShell(page);
+      await mockAPI(page);
+      await page.goto(route);
+      // The same precondition the corner test below uses, for the same reason:
+      // these routes are lazy, so `.page-loading` is absent before it mounts as
+      // well as after it goes, and the trapped-control sweep below has nothing
+      // to sweep on a document that never rendered.
+      await page.waitForFunction(
+        () => !document.querySelector('.page-loading') && document.body?.innerText.trim().length > 0,
+      );
+
+      const strip = await page.evaluate(() => {
+        const el = document.querySelector('#window-drag');
+        if (!el) return null;
+        const r = el.getBoundingClientRect();
+        const cs = getComputedStyle(el);
+        return { w: Math.round(r.width), h: Math.round(r.height), top: Math.round(r.top),
+          left: Math.round(r.left), region: cs.webkitAppRegion, display: cs.display };
+      });
+      expect(strip, `${route} has no #window-drag`).not.toBeNull();
+      expect(strip.display).toBe('block');
+      expect(strip.region).toBe('drag');
+      // Spans the window, flush to the corner the buttons float over.
+      expect(strip.top).toBe(0);
+      expect(strip.left).toBe(0);
+      expect(strip.w).toBe(page.viewportSize().width);
+      expect(strip.h).toBe(BUTTON_RECT.h);
+
+      // The strip must not be what the mouse lands on. This is a SEPARATE
+      // property from the drag region below, and the one that actually broke: a
+      // fixed element beats every in-flow element that is not itself positioned,
+      // so a statically positioned control scrolling under the titlebar had its
+      // clicks eaten while still computing `no-drag` -- the region was
+      // subtracted correctly, and the hit test took the click anyway. Asserting
+      // the region alone reports that arrangement as healthy.
+      const eaten = await page.evaluate((stripH) => {
+        const y = Math.round(stripH / 2);
+        const w = document.documentElement.clientWidth;
+        return [8, w * 0.25, w * 0.5, w * 0.75, w - 8]
+          .map((x) => document.elementFromPoint(Math.round(x), y))
+          .filter((el) => el && el.closest('#window-drag'))
+          .length;
+      }, BUTTON_RECT.h);
+      expect(eaten, `#window-drag is taking the mouse on ${route}`).toBe(0);
+
+      // Anything clickable the strip covers must have taken its region back. A
+      // control this misses is not merely awkward, it is UNCLICKABLE, and only
+      // in the desktop shell — ordinary browser QA never sees it.
+      const trapped = await page.evaluate((stripH) => {
+        const out = [];
+        const sel = 'a,button,input,textarea,select,label,summary,[role="button"],'
+          + '[role="tab"],[role="menuitem"],[role="option"],[role="switch"],[role="checkbox"]';
+        for (const el of document.querySelectorAll(sel)) {
+          const r = el.getBoundingClientRect();
+          if (r.width === 0 || r.height === 0) continue;
+          if (r.top >= stripH) continue;
+          if (getComputedStyle(el).webkitAppRegion !== 'no-drag') {
+            out.push(`<${el.tagName.toLowerCase()}> "${(el.innerText || el.getAttribute('aria-label') || '').trim().slice(0, 30)}"`);
+          }
+        }
+        return out;
+      }, BUTTON_RECT.h);
+      expect(trapped, `controls under the drag strip on ${route} that cannot be clicked`).toEqual([]);
+    });
+  }
+
+  for (const route of CHROMELESS_ROUTES) {
     test(`nothing paints under the window buttons on ${route}`, async ({ page }) => {
       await asDesktopShell(page);
       await mockAPI(page);

--- a/web/index.html
+++ b/web/index.html
@@ -272,17 +272,40 @@
          two reasons: it must exist on every route, including the ones with no
          sidebar (a login screen that reserves nothing tells the shell this build
          reserves nothing), and a window whose entry chunk never ran still has to
-         be movable. Wide enough to cover the buttons and no wider — the rest of
-         the top row holds real controls. */
-      #window-drag { display: none; position: fixed; top: 0; left: 0; width: 120px; height: 38px; z-index: 9999; -webkit-app-region: drag; }
+         be movable.
+
+         Spans the window, because this element is only ever *visible* on a page
+         that has no chrome of its own — the handover below retires it the moment
+         a real strip exists. Those are the login, legal and wizard routes, whose
+         top row is empty, so a titlebar's width of it is free. It was 120px on
+         the reasoning that the rest of the row holds controls, which is true of
+         the app and never true while this is on screen; the window buttons cover
+         most of that 120px, leaving a sliver nobody finds by aiming for it.
+
+         Two mechanisms decide what happens at the top of the window and they are
+         not the same one. Drag regions are collected from the layout tree in
+         preorder and differenced in that order, so the `no-drag` rule in
+         chrome.css, which already names every control in the app, subtracts them
+         from this strip whatever the stacking: z-index is not an input to it,
+         and this element sitting before #root is what puts the app's controls
+         later in that order. Ordinary clicks and text selection are decided by
+         hit testing instead, where a fixed element beats every in-flow element
+         that is not itself positioned, whatever the DOM order says. So the strip
+         declares the region and then takes itself out of hit testing entirely.
+         Without `pointer-events: none` it swallows the clicks of every statically
+         positioned control that scrolls under it, on exactly the chrome-less
+         routes it exists for, and the failure is invisible to the browser suite:
+         those controls still compute `no-drag`, because the region really was
+         subtracted. It was the hit test that ate them. */
+      #window-drag { display: none; position: fixed; top: 0; left: 0; width: 100%; height: 38px; z-index: 0; pointer-events: none; -webkit-app-region: drag; }
       html.desktop-mac #window-drag { display: block; }
-      /* ...and stands down the moment the sidebar renders its own strip. This
-         one is fixed and above everything, so while the app is up it also sits
-         on top of the main column: the collapsed sidebar is 80px and this is
-         120px, and a control in that 40px cannot take its clicks back — an
-         element's `no-drag` loses to a drag region painted over it. The handover
-         is `:has` rather than a class the app sets, because the condition IS the
-         real strip existing, and asking about it directly cannot drift. */
+      /* ...and stands down the moment the sidebar renders its own strip, which is
+         what keeps this from spanning a top row the app fills with its own
+         chrome. A plain div carrying an onClick is not in the `no-drag` list and
+         could not take its clicks back from underneath, so the app's own bars
+         stay the ones that decide. The handover is `:has` rather than a class
+         the app sets, because the condition IS the real strip existing, and
+         asking about it directly cannot drift. */
       html.desktop-mac:has(.sidebar-window-drag) #window-drag { display: none; }
     </style>
     <link rel="icon" type="image/svg+xml" href="/logo-favicon.svg" />

--- a/web/src/__tests__/e2eImportGraph.test.ts
+++ b/web/src/__tests__/e2eImportGraph.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, existsSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+const WEB = path.resolve(__dirname, '../..');
+const SRC = path.join(WEB, 'src');
+
+/**
+ * Playwright transforms a spec and everything it imports with its own pipeline,
+ * which has no CSS loader. So a spec that reaches app source pays for that
+ * module's whole import graph, and a stylesheet anywhere in it is a parse error
+ * that takes down the entire e2e run at collection, not one test.
+ *
+ * `printPageStyle.ts` reached `lib/shellPdf.ts`, which imports printExport.css
+ * for its side effect. That is why the page geometry lives alone in
+ * `lib/pageGeometry.ts` now, and why this walks the graph rather than pinning
+ * that one file: the next import added anywhere along the chain is what breaks
+ * it, and a red e2e job says only "Unexpected token".
+ */
+const EXTS = ['', '.ts', '.tsx', '.js', '.jsx', '/index.ts', '/index.tsx'];
+
+function resolveSpecifier(spec: string, fromFile: string): string | null {
+  let base: string;
+  if (spec.startsWith('@/')) base = path.join(SRC, spec.slice(2));
+  else if (spec.startsWith('.')) base = path.resolve(path.dirname(fromFile), spec);
+  else return null; // bare package: Playwright leaves node_modules alone
+  for (const ext of EXTS) {
+    const candidate = base + ext;
+    if (existsSync(candidate) && statSync(candidate).isFile()) return candidate;
+  }
+  return null;
+}
+
+// `export ... from` as well as `import`: a re-export is followed at transform
+// time exactly like an import, and reading only one of the two would let the
+// chain be rebuilt through the other with the guard still green.
+const SPECIFIER = /^\s*(?:import|export)\s[^'"]*?from\s*['"]([^'"]+)['"]|^\s*import\s*['"]([^'"]+)['"]/gm;
+
+function importsOf(file: string): string[] {
+  const text = readFileSync(file, 'utf8');
+  return [...text.matchAll(SPECIFIER)].map((m) => m[1] ?? m[2]);
+}
+
+describe('what an e2e spec drags in when it imports app source', () => {
+  it('never reaches a stylesheet', () => {
+    const specs = readdirSync(path.join(WEB, 'e2e'))
+      .filter((f) => f.endsWith('.spec.js'))
+      .map((f) => path.join(WEB, 'e2e', f));
+
+    const offenders: string[] = [];
+    const seen = new Set<string>();
+    const walk = (file: string, trail: string[]) => {
+      if (seen.has(file)) return;
+      seen.add(file);
+      for (const spec of importsOf(file)) {
+        if (/\.(css|scss|sass|less)$/.test(spec)) {
+          offenders.push([...trail, file, spec].map((p) => path.relative(WEB, p)).join(' -> '));
+          continue;
+        }
+        const next = resolveSpecifier(spec, file);
+        if (next) walk(next, [...trail, file]);
+      }
+    };
+    for (const spec of specs) walk(spec, []);
+
+    expect(specs.length).toBeGreaterThan(0);
+    expect(offenders).toEqual([]);
+  });
+});

--- a/web/src/lib/__tests__/shellPdf.test.ts
+++ b/web/src/lib/__tests__/shellPdf.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `desktop` is read once at module load, so every case here rebuilds the module
+ * graph with the bridge it wants present or absent.
+ */
+const load = async (savePdf?: unknown) => {
+  if (savePdf) {
+    window.langalphaDesktop = {
+      version: '0.1.2',
+      platform: 'darwin',
+      savePdf,
+    } as unknown as Window['langalphaDesktop'];
+  }
+  vi.resetModules();
+  return (await import('../shellPdf')).renderToPdf;
+};
+
+const root = () => document.getElementById('export-pdf-root');
+const pageStyle = () =>
+  [...document.head.querySelectorAll('style')].find((s) => s.textContent?.includes('@page'));
+
+afterEach(() => {
+  delete window.langalphaDesktop;
+  document.body.innerHTML = '';
+  document.head.querySelectorAll('style').forEach((s) => s.remove());
+  vi.resetModules();
+});
+
+describe('renderToPdf', () => {
+  it('answers null without a shell, and builds nothing', async () => {
+    const renderToPdf = await load();
+    const populate = vi.fn();
+
+    expect(await renderToPdf(populate, 'report')).toBeNull();
+    // The one case a caller must handle by falling back to browser print, so it
+    // has to be reachable without any of the work happening first.
+    expect(populate).not.toHaveBeenCalled();
+    expect(root()).toBeNull();
+  });
+
+  it('gives populate a mounted root and takes it away again', async () => {
+    let seen: { mounted: boolean; page: boolean } | null = null;
+    const savePdf = vi.fn(async () => ({ saved: true }));
+    const renderToPdf = await load(savePdf);
+
+    const result = await renderToPdf((el) => {
+      // The node has to be in the document while populate runs: a widget
+      // measures itself, and a detached element has no layout to measure.
+      seen = { mounted: el.isConnected && el.id === 'export-pdf-root', page: !!pageStyle() };
+    }, 'report');
+
+    expect(seen).toEqual({ mounted: true, page: true });
+    expect(savePdf).toHaveBeenCalledTimes(1);
+    expect(savePdf).toHaveBeenCalledWith({ fileName: 'report' });
+    expect(result).toEqual({ saved: true });
+    expect(root()).toBeNull();
+    expect(pageStyle()).toBeUndefined();
+  });
+
+  it('reports a shell that failed inside the channel as an error, not as no shell', async () => {
+    // The distinction the caller branches on: `error` may fall back to browser
+    // print, `null` means there was never a shell to ask.
+    const renderToPdf = await load(async () => {
+      throw new Error('no printer');
+    });
+
+    const result = await renderToPdf(() => {}, 'report');
+
+    expect(result).toEqual({ error: 'no printer' });
+  });
+
+  it('clears the document even when the render throws', async () => {
+    // #export-pdf-root left behind is not cosmetic: printExport.css drops every
+    // other body child at print media, so a leak turns the user's own Ctrl+P
+    // into a blank page for the rest of the session.
+    const renderToPdf = await load(async () => {
+      throw new Error('boom');
+    });
+
+    await renderToPdf(() => {}, 'report');
+
+    expect(root()).toBeNull();
+    expect(pageStyle()).toBeUndefined();
+  });
+
+  it('clears the document when populate itself throws', async () => {
+    const savePdf = vi.fn(async () => ({ saved: true }));
+    const renderToPdf = await load(savePdf);
+
+    const result = await renderToPdf(() => {
+      throw new Error('bad widget');
+    }, 'report');
+
+    expect(result).toEqual({ error: 'bad widget' });
+    expect(savePdf).not.toHaveBeenCalled();
+    expect(root()).toBeNull();
+    expect(pageStyle()).toBeUndefined();
+  });
+
+  it('answers a second export canceled rather than null while one is in flight', async () => {
+    // Two roots under one id would leave both in the print flow and put the
+    // content in the file twice. `canceled` and not `null`, because null sends
+    // the caller to browser print on top of the save dialog already open.
+    let release: (v: { saved: true }) => void = () => {};
+    const savePdf = vi.fn(() => new Promise<{ saved: true }>((r) => { release = r; }));
+    const renderToPdf = await load(savePdf);
+
+    const first = renderToPdf(() => {}, 'first');
+    const second = await renderToPdf(() => {}, 'second');
+
+    expect(second).toEqual({ canceled: true });
+    expect(savePdf).toHaveBeenCalledTimes(1);
+
+    release({ saved: true });
+    expect(await first).toEqual({ saved: true });
+
+    // And the guard releases, so the next export is not wedged.
+    release = () => {};
+    const third = renderToPdf(() => {}, 'third');
+    await Promise.resolve(); // past the `await populate`, so savePdf has been reached
+    expect(savePdf).toHaveBeenCalledTimes(2);
+    release({ saved: true });
+    await third;
+  });
+});

--- a/web/src/lib/desktop.ts
+++ b/web/src/lib/desktop.ts
@@ -10,6 +10,37 @@
  * itself and hands the code back through this app's own /callback route, so
  * sign-in needs no desktop-specific code on this side.
  */
+/** What the shell will accept for a PDF export; everything is optional. */
+export interface SavePdfOptions {
+  /** Suggested filename. The shell sanitizes it and appends `.pdf`. */
+  fileName?: string;
+  landscape?: boolean;
+  /** 0.1 to 2. Clamped by the shell rather than rejected. */
+  scale?: number;
+  pageSize?:
+    | 'A0' | 'A1' | 'A2' | 'A3' | 'A4' | 'A5' | 'A6'
+    | 'Legal' | 'Letter' | 'Tabloid' | 'Ledger';
+  /** Comma-separated 1-based pages or ranges, e.g. `1-3, 7`. */
+  pageRanges?: string;
+  /** Defaults to true; false drops backgrounds the way a browser does. */
+  printBackground?: boolean;
+  /** Tagged reading order, defaults to true. */
+  tagged?: boolean;
+  /** PDF outline built from the heading tree, defaults to true. */
+  outline?: boolean;
+}
+
+/**
+ * Deliberately three outcomes, not a boolean. A caller falls back to browser
+ * print when the method is absent, but must NOT fall back on `canceled`:
+ * reopening a print dialog the user just dismissed is the one response that
+ * reads as the app ignoring them.
+ */
+export type SavePdfResult =
+  | { saved: true }
+  | { canceled: true }
+  | { error: string };
+
 export interface DesktopBridge {
   readonly version: string;
   /** Node's process.platform: 'darwin' | 'win32' | 'linux'. */
@@ -25,6 +56,11 @@ export interface DesktopBridge {
   /** Tells the shell which theme the page settled on. Added in shell 0.1.0. */
   setTheme?(theme: 'light' | 'dark'): void;
   openExternal?(url: string): Promise<void>;
+  /**
+   * Render this page to a PDF and let the user choose where it lands, with no
+   * print dialog in between. Added in shell 0.1.2; feature-detect it.
+   */
+  savePdf?(options?: SavePdfOptions): Promise<SavePdfResult>;
 }
 
 declare global {

--- a/web/src/lib/pageGeometry.ts
+++ b/web/src/lib/pageGeometry.ts
@@ -1,0 +1,21 @@
+/**
+ * Page geometry, alone in a module so that importing it costs nothing else.
+ *
+ * It used to live in `shellPdf.ts`, which imports `printExport.css` for its side
+ * effect. `printPageStyle.ts` reads it from there, and `e2e/export-print-color-
+ * scheme.spec.js` reads that in turn under Playwright's own transform, which has
+ * no CSS loader: a stylesheet in the import graph took the whole e2e suite down
+ * at collection. Keep this file import-free.
+ */
+
+/**
+ * A4 with 15mm margins: the geometry every export in this app prints at.
+ *
+ * `!important` carries it. Paged.js writes an unconditioned `@page { margin: 0 }`
+ * into the head while a preview is up and it reaches print media too; in the page
+ * context an important declaration beats a plain one on either side of it, while
+ * two plain declarations fall back to source order, which is how an export once
+ * came out full-bleed. Paged.js never writes `!important`, so this holds wherever
+ * its styles land.
+ */
+export const A4_PAGE_RULE = '@page { size: A4 !important; margin: 15mm !important; }';

--- a/web/src/lib/shellPdf.ts
+++ b/web/src/lib/shellPdf.ts
@@ -1,0 +1,71 @@
+import { desktop, type SavePdfResult } from './desktop';
+import { A4_PAGE_RULE } from './pageGeometry';
+import '@/styles/printExport.css';
+
+/**
+ * Page geometry, appended for the render and taken away after.
+ *
+ * `@page` cannot be gated on a selector the way every rule in printExport.css is,
+ * so a stylesheet carrying it would set the paper size for the app's own Ctrl+P
+ * on a page the user never asked to export. Injecting it only while the render
+ * is in flight is what keeps it scoped.
+ */
+const PAGE_CSS = `@media print { ${A4_PAGE_RULE} }`;
+
+/** The id printExport.css keys every export rule on. */
+const ROOT_ID = 'export-pdf-root';
+
+/**
+ * The render root is a document-wide resource: two exports at once would put two
+ * nodes under the same id and the print rules would keep both in the flow, so the
+ * file comes out with the content twice. A module-level guard is the only scope
+ * that covers a widget export and a report export racing each other.
+ */
+let inFlight = false;
+
+/**
+ * Render a detached node tree to a PDF through the desktop shell.
+ *
+ * `printToPDF` renders the whole document and reflows it partway through, which
+ * unmounts React's own tree. So `populate` builds into a plain node owned here,
+ * parked off-screen, and removed afterwards, while the print rules drop every
+ * other body child out of the flow. It may be async: a widget has to measure
+ * itself before its box is the right height.
+ *
+ * Answers `null` when there is no shell channel at all, which is the one case a
+ * caller must handle by falling back to browser print. `canceled` is the user's
+ * own answer and must NOT fall back: reopening a print dialog on top of a save
+ * dialog they just dismissed is the one response that reads as the app ignoring
+ * them.
+ */
+export async function renderToPdf(
+  populate: (root: HTMLElement) => void | Promise<void>,
+  fileName: string,
+): Promise<SavePdfResult | null> {
+  const savePdf = desktop?.savePdf;
+  if (!savePdf) return null;
+  // Re-entry answers `canceled`, not `null`: nothing was exported, and the
+  // caller must not respond by opening a second dialog.
+  if (inFlight) return { canceled: true };
+  inFlight = true;
+
+  const page = document.createElement('style');
+  page.textContent = PAGE_CSS;
+  const root = document.createElement('div');
+  root.id = ROOT_ID;
+
+  try {
+    document.head.appendChild(page);
+    document.body.appendChild(root);
+    await populate(root);
+    return await savePdf({ fileName });
+  } catch (err) {
+    // A shell that knows the channel but fails inside it still leaves the user
+    // wanting a PDF, so this reports as an error rather than as "no shell".
+    return { error: err instanceof Error ? err.message : String(err) };
+  } finally {
+    root.remove();
+    page.remove();
+    inFlight = false;
+  }
+}

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -1632,6 +1632,7 @@
     "htmlSource": "Source",
     "pdfPrintHint": "Press Cmd/Ctrl-P to save the page as a PDF.",
     "pdfGenerating": "Generating PDF…",
+    "pdfFailed": "Could not save the PDF. Please try again.",
     "copyShareLink": "Copy link",
     "shareLinkCopied": "Shareable link copied to clipboard",
     "shareLinkFailed": "Couldn't copy the link",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -1631,6 +1631,7 @@
     "htmlSource": "源代码",
     "pdfPrintHint": "按 Cmd/Ctrl-P 将页面保存为 PDF。",
     "pdfGenerating": "正在生成 PDF…",
+    "pdfFailed": "无法保存 PDF，请重试。",
     "copyShareLink": "复制链接",
     "shareLinkCopied": "分享链接已复制到剪贴板",
     "shareLinkFailed": "无法复制链接",

--- a/web/src/pages/ChatAgent/components/ExportPreviewModal.css
+++ b/web/src/pages/ChatAgent/components/ExportPreviewModal.css
@@ -191,6 +191,10 @@
 }
 
 /* Hidden source element — keeps original content for react-to-print PDF export */
+/* `.export-pdf-host` is the live portal this modal renders the source into. Its
+   own rules, and how it interacts with the shell's detached copy, live in
+   styles/printExport.css alongside every other export rule. */
+
 .export-preview-source {
   position: absolute !important;
   top: 0 !important;
@@ -472,14 +476,23 @@
 /* react-to-print prints the hidden source div via the browser's native engine.
    These rules ensure the PDF has light-mode colors and proper typography. */
 @media print {
+  /* Must stay in step with `A4_PAGE_RULE` (lib/pageGeometry.ts), which is the same
+     geometry for the routes that can inject it. This copy covers the one that
+     cannot: a plain Cmd+P of this document while the preview is up. The
+     reasoning behind `!important` is on that constant. */
   @page {
-    size: A4;
-    margin: 15mm; /* Paged.js @page{margin:0} is scoped to media=screen during print */
+    size: A4 !important;
+    margin: 15mm !important;
   }
 
   /* Unclip ancestor chain — react-to-print iframe inherits parent stylesheets.
-     The matching `color-scheme: light` lives in the pageStyle prop, not here —
-     see the comment on useReactToPrint in ExportPreviewModal.tsx. */
+     `color-scheme: light` deliberately does not live here. This file is a lazy
+     chunk and a stylesheet is loaded for the life of the document, so a
+     declaration in it reaches every later print, the app's own Ctrl+P included.
+     Each route states it where it is already scoped: the pageStyle prop for the
+     iframe, which react-to-print inlines and which therefore arrives even when
+     the iframe's re-fetch of this file fails, and printExport.css's
+     `:has(#export-pdf-root)` block for the shell render. */
   html, body {
     height: auto !important;
     overflow: visible !important;

--- a/web/src/pages/ChatAgent/components/ExportPreviewModal.tsx
+++ b/web/src/pages/ChatAgent/components/ExportPreviewModal.tsx
@@ -11,6 +11,7 @@ import { useIsMobile } from '@/hooks/useIsMobile';
 import Markdown from './Markdown';
 import { stripLineNumbers } from './toolDisplayConfig';
 import { PRINT_PAGE_STYLE } from './printPageStyle';
+import { renderToPdf } from '@/lib/shellPdf';
 import './ExportPreviewModal.css';
 
 // ---------------------------------------------------------------------------
@@ -109,6 +110,8 @@ export default function ExportPreviewModal({
   const [error, setError] = useState<string | null>(null);
   const [pageCount, setPageCount] = useState(0);
   const [rendering, setRendering] = useState(false);
+  /** A save in flight, which is a different wait from `rendering` (the preview). */
+  const [saving, setSaving] = useState(false);
   const [previewZoom, setPreviewZoom] = useState(0.5);
   const previewZoomRef = useRef(previewZoom);
   previewZoomRef.current = previewZoom;
@@ -313,10 +316,62 @@ export default function ExportPreviewModal({
   // <link> that the iframe re-fetches — and react-to-print prints anyway if
   // that fetch fails, which would leave index.html's unscoped dark scheme in
   // force. Scoping it here also keeps it off the app's own Ctrl+P output.
+
+  // What the saved file is called, on both paths. `fileName` is the workspace
+  // path the panel selected, not a name: left whole, the shell would suggest
+  // `results-q3.md.pdf` for `results/q3.md`, since it flattens the separator
+  // rather than reading a path out of a name it was handed.
+  const pdfStem = useMemo(
+    () => (fileName.split('/').pop() || 'export').replace(/\.[^.]+$/, ''),
+    [fileName],
+  );
+
   const handlePrint = useReactToPrint({
     contentRef: printRef,
     pageStyle: PRINT_PAGE_STYLE,
+    // The browser print dialog names the file after `document.title`, which is
+    // the app's, so every report saved from a browser landed in the user's
+    // downloads as `LangAlpha.pdf`. react-to-print swaps the title in for the
+    // duration of the print and puts it back after.
+    documentTitle: pdfStem,
   });
+
+  // A desktop shell renders the PDF itself, which skips the print dialog and
+  // produces a tagged, outlined file that browser print cannot emit at all.
+  // Feature-detected per the bridge contract, because the shell updates on its
+  // own cadence and this app deploys continuously: an older shell simply has no
+  // savePdf and keeps the browser path below.
+  const handleSave = useCallback(async () => {
+    const source = printRef.current;
+    if (!source) {
+      handlePrint();
+      return;
+    }
+    // Cloning the whole rendered report and then reflowing the document to
+    // paper width is seconds of frozen tab on a long one. Without this the
+    // button stays live throughout, and a second click is swallowed by the
+    // re-entry guard in renderToPdf, which answers `canceled` and deliberately
+    // shows nothing: the control reads as dead rather than as busy.
+    setSaving(true);
+    try {
+      // printToPDF reflows the live document to the paper width before it takes
+      // its snapshot. The app re-renders at that width and the dialog unmounts,
+      // taking the portal below with it, so anything React owns is already gone
+      // when the snapshot happens — the file comes out correctly paginated and
+      // completely blank. A detached copy is not React's to remove and survives
+      // the reflow, which is why the export is cloned rather than printed in
+      // place. renderToPdf owns that node, the page geometry and the teardown.
+      const result = await renderToPdf((root) => {
+        root.appendChild(source.cloneNode(true));
+      }, pdfStem);
+
+      // No shell, or the shell failed inside the channel. A `canceled` result is
+      // the user's own answer and must not reopen a dialog they just dismissed.
+      if (!result || 'error' in result) handlePrint();
+    } finally {
+      setSaving(false);
+    }
+  }, [handlePrint, pdfStem]);
 
   // ---- CSS vars for source (used by react-to-print) ----
   const cssVars = useMemo(
@@ -449,11 +504,11 @@ export default function ExportPreviewModal({
   const saveBtn = (
     <button
       className="export-preview-save-btn"
-      onClick={() => handlePrint()}
-      disabled={rendering || typoPending}
-      style={rendering || typoPending ? { opacity: 0.6, cursor: 'wait' } : undefined}
+      onClick={() => void handleSave()}
+      disabled={rendering || typoPending || saving}
+      style={rendering || typoPending || saving ? { opacity: 0.6, cursor: 'wait' } : undefined}
     >
-      {t('filePanel.saveAsPdf')}
+      {saving ? t('filePanel.pdfGenerating') : t('filePanel.saveAsPdf')}
     </button>
   );
 
@@ -539,14 +594,27 @@ export default function ExportPreviewModal({
               ))}
             </div>
           )}
-          {/* Hidden source — used by react-to-print for PDF export */}
-          <div
-            ref={printRef}
-            className="markdown-print-content print-preview-active export-preview-source"
-            style={cssVars}
-          >
-            <Markdown variant="panel" content={displayContent} codeTheme="light" />
-          </div>
+          {/* Hidden source, portaled to <body> rather than left inside the
+              modal, and parked off-screen. This is what Paged.js clones for the
+              preview and what react-to-print copies into its iframe; the
+              desktop path clones it again into a detached `#export-pdf-root`
+              for the duration of the render (see handleSave). It carries no id
+              of its own: the print stylesheet keeps `#export-pdf-root` and
+              drops every other body child out of the flow, and an invisible app
+              still lays out — the first attempt at this produced a 57-page PDF
+              with the report buried in blank pages of chat. */}
+          {createPortal(
+            <div className="export-pdf-host">
+              <div
+                ref={printRef}
+                className="markdown-print-content print-preview-active export-preview-source"
+                style={cssVars}
+              >
+                <Markdown variant="panel" content={displayContent} codeTheme="light" />
+              </div>
+            </div>,
+            document.body,
+          )}
           {/* Paged.js renders paginated page sheets here */}
           <div ref={pagedContainerRef} className="export-preview-paged" />
         </>

--- a/web/src/pages/ChatAgent/components/__tests__/ExportPreviewModal.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/ExportPreviewModal.test.tsx
@@ -15,9 +15,24 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-vi.mock('react-to-print', () => ({
-  useReactToPrint: () => vi.fn(),
+// Hoisted, so the same handle the component calls is the one the assertions
+// read: `vi.mock` factories run before any module-level `const` in this file.
+const { printMock, renderToPdfMock, printOptions } = vi.hoisted(() => ({
+  printMock: vi.fn(),
+  // The options react-to-print was configured with, so the browser path's own
+  // filename is observable: the hook is mocked, so nothing else can see them.
+  printOptions: { current: null as { documentTitle?: string } | null },
+  renderToPdfMock: vi.fn(),
 }));
+
+vi.mock('react-to-print', () => ({
+  useReactToPrint: (options: { documentTitle?: string }) => {
+    printOptions.current = options;
+    return printMock;
+  },
+}));
+
+vi.mock('@/lib/shellPdf', () => ({ renderToPdf: renderToPdfMock }));
 
 // Render Dialog inline (no portal) so Testing Library can find its children.
 vi.mock('@/components/ui/dialog', () => ({
@@ -360,5 +375,79 @@ describe('ExportPreviewModal', () => {
     expect(presetSelect).toHaveValue('');
     // The "Custom" option text
     expect(screen.getByText('filePanel.custom')).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — the shell save path
+// ---------------------------------------------------------------------------
+
+// Four answers from the shell and only one of them means "print in the browser
+// instead". The rule is documented at both call sites and was pinned at
+// neither: narrowing the guard so a dismissed save dialog counts as a failure
+// reopens a dialog the user just closed, which is the one response that reads
+// as the app not listening.
+describe('ExportPreviewModal — save', () => {
+  const saveButton = () =>
+    screen.getByText('filePanel.saveAsPdf').closest('button') as HTMLButtonElement;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    renderToPdfMock.mockResolvedValue({ saved: true });
+  });
+
+  const outcomes: Array<[string, unknown, boolean]> = [
+    ['saved', { saved: true }, false],
+    ['canceled', { canceled: true }, false],
+    ['error', { error: 'no printer' }, true],
+    ['no shell at all (null)', null, true],
+  ];
+
+  for (const [label, answer, fallsBack] of outcomes) {
+    it(`${fallsBack ? 'falls back to browser print' : 'stays put'} on ${label}`, async () => {
+      renderToPdfMock.mockResolvedValue(answer);
+      renderModal();
+
+      fireEvent.click(saveButton());
+
+      await waitFor(() => expect(renderToPdfMock).toHaveBeenCalledTimes(1));
+      expect(renderToPdfMock).toHaveBeenCalledWith(expect.any(Function), 'report');
+      await waitFor(() => expect(printMock).toHaveBeenCalledTimes(fallsBack ? 1 : 0));
+    });
+  }
+
+  it('suggests a filename, not the workspace path it was handed', async () => {
+    // FilePanel passes the selected path as `fileName`, and the shell flattens a
+    // separator rather than reading a path out of a name: unstripped, the save
+    // dialog opened on `results-q3.md.pdf`. The served export already takes the
+    // basename and drops the extension, and this is the same answer.
+    renderToPdfMock.mockResolvedValue({ saved: true });
+    renderModal({ fileName: 'results/q3 report.md' });
+
+    fireEvent.click(saveButton());
+
+    await waitFor(() =>
+      expect(renderToPdfMock).toHaveBeenCalledWith(expect.any(Function), 'q3 report'),
+    );
+    // And the same name on the browser path, which takes it from `document.title`
+    // and so saved every report as the app's own name until this was passed.
+    expect(printOptions.current?.documentTitle).toBe('q3 report');
+  });
+
+  it('reports the wait on the button, because cloning a long report freezes the tab', async () => {
+    let release: (v: unknown) => void = () => {};
+    renderToPdfMock.mockReturnValue(new Promise((r) => { release = r; }));
+    renderModal();
+
+    fireEvent.click(saveButton());
+
+    // Without this the control stays live throughout and a second click is
+    // swallowed by the re-entry guard, which shows nothing: the button reads as
+    // dead rather than as busy.
+    await waitFor(() => expect(screen.getByText('filePanel.pdfGenerating')).toBeInTheDocument());
+    expect(screen.getByText('filePanel.pdfGenerating').closest('button')).toBeDisabled();
+
+    release({ saved: true });
+    await waitFor(() => expect(saveButton()).not.toBeDisabled());
   });
 });

--- a/web/src/pages/ChatAgent/components/printPageStyle.ts
+++ b/web/src/pages/ChatAgent/components/printPageStyle.ts
@@ -18,8 +18,10 @@
  * `hr`/`td`, which also reveals the table wrapper and row rules — those carry
  * only the var, so they were invisible in every export, not just the fallback.
  */
+import { A4_PAGE_RULE } from '@/lib/pageGeometry';
+
 export const PRINT_PAGE_STYLE = `
-  @page { size: A4 !important; margin: 15mm !important; }
+  ${A4_PAGE_RULE}
   html, body { color-scheme: light !important; background: #ffffff !important; }
   html {
     --color-text-primary: #1a1a1a !important;

--- a/web/src/pages/ChatAgent/components/viewers/InlineWidget.tsx
+++ b/web/src/pages/ChatAgent/components/viewers/InlineWidget.tsx
@@ -66,12 +66,12 @@ export default function InlineWidget({ html, title, onSendPrompt, data }: Inline
   // Live report wins; cached height bridges the load; 150px is the cold guess.
   const displayHeight = height ?? lastKnownHeights.get(heightKey) ?? null;
 
+  // One action set for both surfaces, built on the inline srcDoc. The fullscreen
+  // variant is display markup for the dialog it is shown in and nothing else:
+  // opening, downloading or printing it would hand the user a document carrying
+  // the dialog's own layout, and on paper the box is 680px wide and neither the
+  // column cap nor the magnification means anything.
   const actions = useHtmlActions({ mode: 'widget', srcDoc, fileName: title });
-  const fullscreenActions = useHtmlActions({
-    mode: 'widget',
-    srcDoc: fullscreenSrcDoc,
-    fileName: title,
-  });
 
   // No max-height cap — widgets span naturally to fit content (charts, tables,
   // dashboards). The agent controls HTML output and the skill doc guides it to
@@ -121,7 +121,7 @@ export default function InlineWidget({ html, title, onSendPrompt, data }: Inline
           onOpenChange={setFullscreen}
           title={title || 'Widget'}
           srcDoc={fullscreenSrcDoc}
-          actions={fullscreenActions}
+          actions={actions}
         />
       )}
     </div>

--- a/web/src/pages/ChatAgent/components/viewers/html/HtmlActionBar.tsx
+++ b/web/src/pages/ChatAgent/components/viewers/html/HtmlActionBar.tsx
@@ -5,7 +5,8 @@ import { cn } from '@/lib/utils';
 import './HtmlActionBar.css';
 
 interface HtmlActionBarProps {
-  onOpenInNewTab: () => void;
+  /** Omit where a second surface cannot be opened — see HtmlActions.openInNewTab. */
+  onOpenInNewTab?: () => void;
   /** Download/PDF live in a secondary "more" menu. Omit both on surfaces where
    *  they're owned elsewhere (the file toolbar defers to the panel header menu). */
   onDownload?: () => void;
@@ -57,15 +58,17 @@ export default function HtmlActionBar({
           {isFullscreen ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
         </button>
       )}
-      <button
-        type="button"
-        className="html-action-btn"
-        onClick={onOpenInNewTab}
-        title={t('filePanel.openInNewTab')}
-        aria-label={t('filePanel.openInNewTab')}
-      >
-        <ExternalLink className="h-4 w-4" />
-      </button>
+      {onOpenInNewTab && (
+        <button
+          type="button"
+          className="html-action-btn"
+          onClick={onOpenInNewTab}
+          title={t('filePanel.openInNewTab')}
+          aria-label={t('filePanel.openInNewTab')}
+        >
+          <ExternalLink className="h-4 w-4" />
+        </button>
+      )}
       {(onDownload || onExportPdf) && (
         <DropdownMenu modal={false}>
           <DropdownMenuTrigger asChild>

--- a/web/src/pages/ChatAgent/components/viewers/html/HtmlFullscreenModal.css
+++ b/web/src/pages/ChatAgent/components/viewers/html/HtmlFullscreenModal.css
@@ -27,6 +27,31 @@
   min-width: 0;
 }
 
+/* Breathing room between the widget and the dialog edge. Host-side rather
+   than inside the document, so it stays a constant inset instead of scaling
+   with the magnification below. Widgets only: a served file document brings
+   its own body margins and would double up. */
+.html-fullscreen-frame-pad {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  padding: 16px 24px 24px;
+}
+
+/* A widget is authored for the chat column, so the dialog magnifies it rather
+   than stretching it: at 1400px the extra width was dead space beside a 768px
+   layout. This is the whole mechanism — Chromium divides a child frame's layout
+   viewport by the zoom on its owner element, so the document lays out at about
+   the column width and renders larger, with no measurement and no script inside
+   it. It also cannot overflow: `flex: 1` resolves in this element's own
+   coordinate space, so the iframe box stays exactly as wide as the pad.
+
+   Widgets only. A served file document is a page in its own right, sized for
+   whatever viewport it gets. */
+.html-fullscreen-frame-pad > .html-fullscreen-frame {
+  zoom: 1.15;
+}
+
 .html-fullscreen-frame {
   flex: 1;
   min-height: 0;

--- a/web/src/pages/ChatAgent/components/viewers/html/HtmlFullscreenModal.tsx
+++ b/web/src/pages/ChatAgent/components/viewers/html/HtmlFullscreenModal.tsx
@@ -17,7 +17,11 @@ interface BaseProps {
 
 interface WidgetVariant extends BaseProps {
   variant: 'widget';
-  /** widget-fullscreen srcDoc. */
+  /**
+   * widget-fullscreen srcDoc: display markup for this dialog only. `actions`
+   * deliberately operates on the inline srcDoc, which is the widget as an
+   * artifact — see InlineWidget.
+   */
   srcDoc: string;
 }
 
@@ -59,7 +63,7 @@ export default function HtmlFullscreenModal(props: HtmlFullscreenModalProps) {
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         variant="centered"
-        className="html-fullscreen-modal !w-[95vw] !max-w-[1400px] !h-[90vh] !max-h-[90vh] !p-0 !overflow-hidden"
+        className={`html-fullscreen-modal !w-[95vw] !h-[90vh] !max-h-[90vh] !p-0 !overflow-hidden ${props.variant === 'widget' ? '!max-w-[940px]' : '!max-w-[1400px]'}`}
         aria-describedby={undefined}
       >
         <DialogTitle className="sr-only">{title}</DialogTitle>
@@ -90,13 +94,24 @@ export default function HtmlFullscreenModal(props: HtmlFullscreenModalProps) {
             // Popup tokens: agent-embedded links must open as REAL tabs (a
             // sandbox-inheriting tab has no cookies — bot checks break);
             // buildHtmlSrcDoc's click handler forces noopener.
-            <iframe
-              ref={iframeRef}
-              srcDoc={props.srcDoc}
-              sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
-              className="html-fullscreen-frame"
-              title={title || t('filePanel.fullscreen')}
-            />
+            <div className="html-fullscreen-frame-pad">
+              <iframe
+                ref={iframeRef}
+                srcDoc={props.srcDoc}
+                sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
+                className="html-fullscreen-frame"
+                title={title || t('filePanel.fullscreen')}
+                // The same push the served variant does, and needed for the same
+                // reason. A srcDoc bakes the theme in at build time, and this one
+                // is built once when the widget mounts inline, while the dialog
+                // creates a fresh document from it on every open. Between those
+                // two moments the user can change theme: the inline frame is
+                // patched live by the observer in useHtmlSandbox, but this frame
+                // did not exist to be patched, so it opens wearing whatever theme
+                // the thread was first rendered in.
+                onLoad={pushTheme}
+              />
+            </div>
           )}
         </div>
       </DialogContent>

--- a/web/src/pages/ChatAgent/components/viewers/html/__tests__/InlineWidget.test.tsx
+++ b/web/src/pages/ChatAgent/components/viewers/html/__tests__/InlineWidget.test.tsx
@@ -128,6 +128,27 @@ describe('InlineWidget — hover action bar + fullscreen', () => {
     expect(frame.getAttribute('srcdoc')).toContain('overflow: auto; height: 100%;');
   });
 
+  // The srcDoc bakes the theme in at build time and is built once, when the
+  // widget mounts inline; the dialog makes a fresh document from that same
+  // string on every open. A theme the user changed in between reaches the
+  // inline frame through useHtmlSandbox's observer, but this frame did not
+  // exist to be pushed to, so without a push on load it opens wearing the
+  // theme the thread was first rendered in.
+  it('pushes the live theme into the fullscreen document when it loads', () => {
+    render(<InlineWidget html="<div>hi</div>" title="My widget" />);
+    fireEvent.click(screen.getByLabelText('filePanel.fullscreen'));
+    const frame = document.querySelector('iframe.html-fullscreen-frame') as HTMLIFrameElement;
+    const postMessage = vi.fn();
+    Object.defineProperty(frame, 'contentWindow', { value: { postMessage }, configurable: true });
+    fireEvent.load(frame);
+    // '*' and not a real origin: the frame is sandboxed without
+    // allow-same-origin, so it has no origin that can be named.
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'widget:themeUpdate' }),
+      '*',
+    );
+  });
+
   it('opens a blob tab when open-in-new-tab is clicked', () => {
     render(<InlineWidget html="<div>hi</div>" />);
     fireEvent.click(screen.getByLabelText('filePanel.openInNewTab'));

--- a/web/src/pages/ChatAgent/components/viewers/html/__tests__/__fixtures__/widget-inline-nodata.srcdoc.html
+++ b/web/src/pages/ChatAgent/components/viewers/html/__tests__/__fixtures__/widget-inline-nodata.srcdoc.html
@@ -12,8 +12,13 @@ body > :first-child {
   border: none !important;
   border-radius: 0 !important;
   box-shadow: none !important;
-  margin: 0 !important;
+  margin: 0 auto !important;
 }
+
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--color-border-elevated); border-radius: 4px; }
+::-webkit-scrollbar-thumb:hover { background: var(--color-text-tertiary); }
 </style>
 <script>
 (function(){

--- a/web/src/pages/ChatAgent/components/viewers/html/__tests__/__fixtures__/widget-inline.srcdoc.html
+++ b/web/src/pages/ChatAgent/components/viewers/html/__tests__/__fixtures__/widget-inline.srcdoc.html
@@ -12,8 +12,13 @@ body > :first-child {
   border: none !important;
   border-radius: 0 !important;
   box-shadow: none !important;
-  margin: 0 !important;
+  margin: 0 auto !important;
 }
+
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--color-border-elevated); border-radius: 4px; }
+::-webkit-scrollbar-thumb:hover { background: var(--color-text-tertiary); }
 </style>
 <script>
 (function(){

--- a/web/src/pages/ChatAgent/components/viewers/html/__tests__/buildHtmlSrcDoc.test.ts
+++ b/web/src/pages/ChatAgent/components/viewers/html/__tests__/buildHtmlSrcDoc.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, afterEach } from 'vitest';
 
 import { buildHtmlSrcDoc } from '../buildHtmlSrcDoc';
-// Byte-exact srcDoc captured from the pre-refactor InlineWidget under jsdom
+// Byte-exact srcDoc for the inline variant, captured under jsdom
 // (getComputedStyle resolves themeCSS to '' there, so output is deterministic).
+// The inline document is the widget as an ARTIFACT: it is what gets downloaded,
+// opened in a tab and printed to PDF. So an unintended byte here is a real
+// regression in three places at once, and the fixture is the cheapest detector
+// there is. Regenerate it deliberately when the document is meant to change.
 import widgetInlineFixture from './__fixtures__/widget-inline.srcdoc.html?raw';
 import widgetInlineNodataFixture from './__fixtures__/widget-inline-nodata.srcdoc.html?raw';
 
@@ -10,12 +14,12 @@ import widgetInlineNodataFixture from './__fixtures__/widget-inline-nodata.srcdo
 const WITH_DATA = { html: '<div>hi</div>', data: { 'a.json': '{"x":1}' } };
 const NO_DATA = { html: '<p>no data</p>' };
 
-describe('buildHtmlSrcDoc — widget-inline byte compatibility', () => {
-  it('produces byte-identical srcDoc to the pre-refactor InlineWidget (with data)', () => {
+describe('buildHtmlSrcDoc — widget-inline document lock', () => {
+  it('emits the locked inline document (with data)', () => {
     expect(buildHtmlSrcDoc('widget-inline', WITH_DATA)).toBe(widgetInlineFixture);
   });
 
-  it('produces byte-identical srcDoc to the pre-refactor InlineWidget (no data)', () => {
+  it('emits the locked inline document (no data)', () => {
     expect(buildHtmlSrcDoc('widget-inline', NO_DATA)).toBe(widgetInlineNodataFixture);
   });
 
@@ -30,18 +34,51 @@ describe('buildHtmlSrcDoc — widget-fullscreen variant', () => {
   const inline = buildHtmlSrcDoc('widget-inline', WITH_DATA);
   const fullscreen = buildHtmlSrcDoc('widget-fullscreen', WITH_DATA);
 
-  it('differs from widget-inline only in the body rule and the seamless override', () => {
+  it('differs from widget-inline only in the body rule and the layout block', () => {
     expect(fullscreen).not.toBe(inline);
+    // The title's claim, proved rather than asserted by name. The variant reaches
+    // the template in exactly two adjacent places — the tail of the body rule and
+    // the layout block on the line after it — so blanking that one region makes
+    // the two documents identical. What this really pins is the inline fixture's
+    // reach: it is a byte lock, and it only stays one as long as the fullscreen
+    // variant cannot reach any of the bytes it locks.
+    const region = /background: transparent;[\s\S]*?\n::-webkit-scrollbar \{/;
+    const blank = (doc: string) => doc.replace(region, '\n::-webkit-scrollbar {');
+    expect(blank(fullscreen)).toBe(blank(inline));
   });
 
-  it('uses overflow:auto; height:100% on the body instead of overflow:hidden', () => {
+  it('scrolls rather than clipping, in either direction', () => {
+    // The cap in the layout block is what a widget is authored to, not a
+    // guarantee it obeys. `html` carries no overflow here, so the body's value
+    // propagates to the viewport: `overflow-x: hidden` clipped anything wider
+    // than the cap with no scrollbar to reach it by, in the one view whose job
+    // is showing the widget bigger.
     expect(fullscreen).toContain('overflow: auto; height: 100%;');
+    expect(fullscreen).not.toContain('overflow-x: hidden');
     expect(fullscreen).not.toContain('background: transparent; overflow: hidden; }');
   });
 
-  it('drops the seamless first-child override', () => {
-    expect(inline).toContain('body > :first-child {');
-    expect(fullscreen).not.toContain('body > :first-child {');
+  it('swaps the seamless reset for the column layout', () => {
+    // Both variants style the outermost element; they disagree about what for.
+    // Inline flattens it into the chat flow, fullscreen centres it.
+    expect(inline).toContain('margin: 0 auto !important;');
+    expect(inline).not.toContain('max-width: 768px;');
+    expect(fullscreen).toContain('max-width: 768px;');
+    expect(fullscreen).not.toContain('box-shadow: none !important;');
+  });
+
+  it('carries no sizing logic of its own, in either variant', () => {
+    // The magnification that fills the dialog is a `zoom` on the host iframe
+    // (HtmlFullscreenModal.css), because the host is what knows how much room
+    // there is. It lived in here once, measured from the document's own
+    // viewport, and the print root — a 680px box the same markup is rendered
+    // into — then shrank every exported widget to fit a number that meant
+    // nothing on paper. Nothing in the document may measure or scale itself.
+    for (const doc of [inline, fullscreen]) {
+      expect(doc).not.toContain('zoom');
+      expect(doc).not.toContain('clientWidth');
+      expect(doc).not.toContain('scrollbar-gutter');
+    }
   });
 
   it('keeps the CSP meta and the early/runtime scripts identical to the inline variant', () => {

--- a/web/src/pages/ChatAgent/components/viewers/html/__tests__/useHtmlActions.test.ts
+++ b/web/src/pages/ChatAgent/components/viewers/html/__tests__/useHtmlActions.test.ts
@@ -128,7 +128,7 @@ describe('useHtmlActions — widget mode', () => {
     const { result } = renderHook(() =>
       useHtmlActions({ mode: 'widget', srcDoc: WIDGET_SRCDOC, fileName: 'w.html' }),
     );
-    result.current.openInNewTab();
+    result.current.openInNewTab!();
     expect(createObjectURL).toHaveBeenCalledTimes(1);
     expect(open).toHaveBeenCalledWith('blob:widget-url', '_blank', 'noopener,noreferrer');
   });
@@ -151,14 +151,16 @@ describe('useHtmlActions — widget mode', () => {
     createSpy.mockRestore();
   });
 
-  it('opens a blob tab WITHOUT noopener so auto-print fires for PDF', () => {
+  it('opens a blob tab WITHOUT noopener so auto-print fires for PDF', async () => {
     vi.useFakeTimers();
     const print = vi.fn();
     open.mockReturnValue({ print, addEventListener: vi.fn() });
     const { result } = renderHook(() =>
       useHtmlActions({ mode: 'widget', srcDoc: WIDGET_SRCDOC }),
     );
-    result.current.exportPdf();
+    // Awaited: the shell is asked first now, so the fallback lands a microtask
+    // later even when there is no shell to ask.
+    await result.current.exportPdf();
     // No noopener — we need the window handle to drive print on a same-origin blob.
     expect(open).toHaveBeenCalledWith('blob:widget-url', '_blank');
     vi.advanceTimersByTime(800);
@@ -169,7 +171,7 @@ describe('useHtmlActions — widget mode', () => {
     const { result } = renderHook(() =>
       useHtmlActions({ mode: 'widget', srcDoc: WIDGET_SRCDOC }),
     );
-    result.current.openInNewTab();
+    result.current.openInNewTab!();
     expect(open).toHaveBeenCalledWith('blob:widget-url', '_blank', 'noopener,noreferrer');
   });
 });
@@ -224,7 +226,7 @@ describe('useHtmlActions — file mode', () => {
     const { result } = renderHook(() =>
       useHtmlActions({ mode: 'file', workspaceId: 'ws-1', filePath: 'results/report.html' }),
     );
-    result.current.openInNewTab();
+    result.current.openInNewTab!();
     expect(open).toHaveBeenCalledWith(
       '/api/v1/wsfiles/ws-1/results/report.html',
       '_blank',
@@ -436,7 +438,131 @@ describe('useHtmlActions — file mode', () => {
         servedUrl: served,
       }),
     );
-    result.current.openInNewTab();
+    result.current.openInNewTab!();
     expect(open).toHaveBeenCalledWith(served, '_blank', 'noopener,noreferrer');
+  });
+});
+
+// The shell answers every `window.open` by handing the URL to the OS browser,
+// which takes http/https/mailto and nothing else. A widget is a `blob:` that
+// belongs to the renderer that made it, so there is no fallback to offer and the
+// action is withheld rather than left as a button that does nothing. `desktop` is
+// read once at module load, so reaching this needs the module graph rebuilt.
+describe('useHtmlActions — inside the desktop shell', () => {
+  const saveWidgetPdf = vi.fn();
+  let open: ReturnType<typeof vi.fn>;
+
+  const install = async () => {
+    window.langalphaDesktop = { version: '0.1.2', platform: 'darwin', savePdf: vi.fn() };
+    vi.resetModules();
+    // `doMock` and not `vi.mock`: the latter is hoisted to the top of the file
+    // and would take the real module away from the widget test above, which
+    // exercises it for real to prove the no-shell path still reaches the tab.
+    vi.doMock('../widgetPdf', () => ({ saveWidgetPdf }));
+    return (await import('../useHtmlActions')).useHtmlActions;
+  };
+
+  beforeEach(() => {
+    toastMock.mockClear();
+    toastDismiss.mockClear();
+    open = vi.fn().mockReturnValue(null);
+    vi.stubGlobal('open', open);
+    vi.stubGlobal('URL', {
+      createObjectURL: vi.fn(() => 'blob:widget-url'),
+      revokeObjectURL: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    delete window.langalphaDesktop;
+    saveWidgetPdf.mockReset();
+    vi.doUnmock('../widgetPdf');
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it('withholds open-in-new-tab for a widget, whose blob the shell cannot open', async () => {
+    const hook = await install();
+    const { result } = renderHook(() => hook({ mode: 'widget', srcDoc: WIDGET_SRCDOC }));
+    expect(result.current.openInNewTab).toBeUndefined();
+  });
+
+  it('keeps it for a served file, whose URL opens in the real browser', async () => {
+    const hook = await install();
+    const { result } = renderHook(() =>
+      hook({ mode: 'file', workspaceId: 'ws-1', filePath: 'results/report.html' }),
+    );
+    expect(result.current.openInNewTab).toBeDefined();
+  });
+
+  // Three answers, three different responses, and only one of them is "print in
+  // the browser instead". The distinction is documented at both call sites and
+  // was pinned at neither: narrowing the guard to `'saved' in result` — which
+  // reads as a tidy-up — puts a print dialog on top of the save dialog the user
+  // just dismissed, and inside the shell that print dialog cannot even be
+  // reached, because the tab it wants to open is a `blob:` the shell refuses.
+  const outcomes: Array<[string, unknown, boolean]> = [
+    ['saved', { saved: true }, false],
+    ['canceled', { canceled: true }, false],
+    ['error', { error: 'no printer' }, false],
+    // `null` is covered on its own below: inside the shell it means the shell is
+    // too old, which is not the browser's fallback case.
+  ];
+
+  for (const [label, answer, fallsBack] of outcomes) {
+    it(`${fallsBack ? 'falls back to the browser' : 'stays put'} on ${label}`, async () => {
+      saveWidgetPdf.mockResolvedValue(answer);
+      const hook = await install();
+      const { result } = renderHook(() => hook({ mode: 'widget', srcDoc: WIDGET_SRCDOC }));
+
+      await result.current.exportPdf();
+
+      expect(saveWidgetPdf).toHaveBeenCalledWith(WIDGET_SRCDOC, 'widget');
+      expect(open).toHaveBeenCalledTimes(fallsBack ? 1 : 0);
+    });
+  }
+
+  it('says so on a shell too old to know the channel, rather than nothing at all', async () => {
+    // The blob tab is the browser's fallback and the shell refuses to open one,
+    // so falling through here is a button that does nothing and says nothing.
+    // Every install older than the one that added savePdf lands on this line.
+    saveWidgetPdf.mockResolvedValue(null);
+    const hook = await install();
+    const { result } = renderHook(() => hook({ mode: 'widget', srcDoc: WIDGET_SRCDOC }));
+
+    await result.current.exportPdf();
+
+    expect(open).not.toHaveBeenCalled();
+    expect(toastMock).toHaveBeenCalledWith({ description: 'filePanel.pdfFailed' });
+  });
+
+  it('shows the same generating toast the served export shows, and clears it', async () => {
+    // 700ms to 8s of measuring with no feedback reads as a broken button.
+    saveWidgetPdf.mockResolvedValue({ saved: true });
+    const hook = await install();
+    const { result } = renderHook(() => hook({ mode: 'widget', srcDoc: WIDGET_SRCDOC }));
+
+    await result.current.exportPdf();
+
+    expect(toastMock).toHaveBeenCalledWith({ description: 'filePanel.pdfGenerating' });
+    expect(toastDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('tells the user when the shell failed, and stays silent when they cancelled', async () => {
+    saveWidgetPdf.mockResolvedValue({ error: 'no printer' });
+    let hook = await install();
+    let view = renderHook(() => hook({ mode: 'widget', srcDoc: WIDGET_SRCDOC }));
+    await view.result.current.exportPdf();
+    expect(toastMock).toHaveBeenCalledWith({ description: 'filePanel.pdfFailed' });
+
+    toastMock.mockClear();
+    saveWidgetPdf.mockResolvedValue({ canceled: true });
+    hook = await install();
+    view = renderHook(() => hook({ mode: 'widget', srcDoc: WIDGET_SRCDOC }));
+    await view.result.current.exportPdf();
+    // Dismissing a save dialog is not an error, and reporting it as one is how
+    // an app tells the user it was not listening. The generating toast is still
+    // raised and dismissed, so this asks about the failure specifically.
+    expect(toastMock).not.toHaveBeenCalledWith({ description: 'filePanel.pdfFailed' });
   });
 });

--- a/web/src/pages/ChatAgent/components/viewers/html/buildHtmlSrcDoc.ts
+++ b/web/src/pages/ChatAgent/components/viewers/html/buildHtmlSrcDoc.ts
@@ -50,11 +50,51 @@ body > :first-child {
   border: none !important;
   border-radius: 0 !important;
   box-shadow: none !important;
-  margin: 0 !important;
+  margin: 0 auto !important;
 }`;
 
-export function resolveThemeVars(): string {
-  const style = getComputedStyle(document.documentElement);
+/**
+ * The widget is a separate document, so it inherits none of the app's chrome and
+ * draws the platform's default scrollbar: a bright slab against a dark surface.
+ * Applies to both variants — an inline widget with its own scrolling table shows
+ * the same one. Matches `styles/tokens.css`; keep them in step.
+ */
+const SCROLLBARS = `
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--color-border-elevated); border-radius: 4px; }
+::-webkit-scrollbar-thumb:hover { background: var(--color-text-tertiary); }`;
+
+/**
+ * Fullscreen caps at the chat column the widget was authored for and centres in
+ * whatever room is left, rather than stretching: a widget built for a 768px
+ * column has no layout to give at 1366px, so the extra width becomes dead space.
+ *
+ * The magnification that fills the dialog is NOT here. It is a `zoom` on the
+ * host iframe (HtmlFullscreenModal.css), which is the element that knows how
+ * much room there is; Chromium divides the child's layout viewport by it, so
+ * this stays plain layout with no measurement in it. Keeping it out of the
+ * document is also what stops it reaching the other boxes the same markup is
+ * rendered in, notably the 680px print root.
+ */
+const FULLSCREEN_LAYOUT = `
+body {
+  max-width: 768px;
+  margin-left: auto;
+  margin-right: auto;
+}
+body > :first-child {
+  margin-left: auto !important;
+  margin-right: auto !important;
+}`;
+
+/**
+ * `from` exists for the print path, which needs the light palette rather than
+ * the one the document is currently wearing (see widgetPdf.ts). Every other
+ * caller wants the live theme and passes nothing.
+ */
+export function resolveThemeVars(from: Element = document.documentElement): string {
+  const style = getComputedStyle(from);
   const vars = THEME_VARS.map((v) => {
     const val = style.getPropertyValue(v).trim();
     return val ? `${v}: ${val};` : '';
@@ -70,6 +110,31 @@ export function resolveThemeVars(): string {
   const scheme = style.colorScheme;
   return scheme && scheme !== 'normal' ? `color-scheme: ${scheme};\n  ${vars}` : vars;
 }
+
+/**
+ * What each variant asks of the document, so the template carries no branches.
+ *
+ * A widget is authored for the chat column, so neither variant stretches to fill
+ * a wider box and the inline one never scrolls at all. Fullscreen still caps at
+ * that column width, but it no longer clips what overflows it. `html` here
+ * carries no overflow of its own, so the body's value propagates to the
+ * viewport, and `overflow-x: hidden` there put a widget wider than the cap out
+ * of reach entirely rather than merely making it untidy. A widget that does not
+ * fit the column is a widget we did not author; a sideways scrollbar is the
+ * better way to be wrong about one.
+ */
+const VARIANTS: Record<HtmlSrcDocVariant, { bodyOverflow: string; layout: string }> = {
+  'widget-inline': {
+    // Seamless in the chat flow: the host sizes the iframe from the widget's
+    // own reported height, so the document never scrolls itself.
+    bodyOverflow: 'overflow: hidden;',
+    layout: SEAMLESS_OVERRIDE,
+  },
+  'widget-fullscreen': {
+    bodyOverflow: 'overflow: auto; height: 100%;',
+    layout: FULLSCREEN_LAYOUT,
+  },
+};
 
 export function buildHtmlSrcDoc(
   variant: HtmlSrcDocVariant,
@@ -138,14 +203,6 @@ export function buildHtmlSrcDoc(
 })();
 </script>\n`;
 
-  // Body overflow rule + seamless override differ between variants:
-  // - widget-inline: seamless (overflow hidden, first-child reset) for chat embedding.
-  // - widget-fullscreen: scrollable, fills the modal, no seamless reset.
-  const bodyOverflow = variant === 'widget-fullscreen'
-    ? 'overflow: auto; height: 100%;'
-    : 'overflow: hidden;';
-  const seamless = variant === 'widget-fullscreen' ? '' : `${SEAMLESS_OVERRIDE}\n`;
-
   return `<!DOCTYPE html><html><head>
 <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' cdnjs.cloudflare.com cdn.jsdelivr.net unpkg.com esm.sh; style-src 'unsafe-inline'; img-src data: blob:; font-src cdnjs.cloudflare.com cdn.jsdelivr.net; connect-src cdnjs.cloudflare.com cdn.jsdelivr.net unpkg.com esm.sh;">
 <style>
@@ -153,8 +210,9 @@ export function buildHtmlSrcDoc(
   ${themeCSS}
 }
 *, *::before, *::after { box-sizing: border-box; }
-body { margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: var(--color-text-primary); background: transparent; ${bodyOverflow} }
-${seamless}</style>
+body { margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: var(--color-text-primary); background: transparent; ${VARIANTS[variant].bodyOverflow} }
+${VARIANTS[variant].layout}\n${SCROLLBARS}
+</style>
 ${earlyScripts}${dataScript}<script>
 window.sendPrompt = function(text) {
   parent.postMessage({ type: 'widget:sendPrompt', text: String(text) }, '*');

--- a/web/src/pages/ChatAgent/components/viewers/html/useDirectLinkGuard.tsx
+++ b/web/src/pages/ChatAgent/components/viewers/html/useDirectLinkGuard.tsx
@@ -20,19 +20,22 @@ import {
  * user gesture and isn't blocked.
  *
  * Returns the click handler to wire to the button and the dialog node to render.
+ * An absent `open` (the surface has nowhere to open — see HtmlActions) answers
+ * with an absent handler, so the guard never has to be asked about it twice.
  */
-export function useDirectLinkGuard(open: () => void, guard: boolean) {
+export function useDirectLinkGuard(open: (() => void) | undefined, guard: boolean) {
   const { t } = useTranslation();
   const [confirming, setConfirming] = useState(false);
 
   const request = useCallback(() => {
+    if (!open) return;
     if (guard) setConfirming(true);
     else open();
   }, [guard, open]);
 
   const confirm = useCallback(() => {
     setConfirming(false);
-    open();
+    open?.();
   }, [open]);
 
   const dialog = (
@@ -69,5 +72,5 @@ export function useDirectLinkGuard(open: () => void, guard: boolean) {
     </Dialog>
   );
 
-  return { request, dialog };
+  return { request: open ? request : undefined, dialog };
 }

--- a/web/src/pages/ChatAgent/components/viewers/html/useHtmlActions.ts
+++ b/web/src/pages/ChatAgent/components/viewers/html/useHtmlActions.ts
@@ -1,7 +1,10 @@
-import { useCallback, useRef } from 'react';
+import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from '@/components/ui/use-toast';
+import { useStableHandler } from '@/hooks/useStableHandler';
+import { desktop } from '@/lib/desktop';
 import { buildWsfilesUrl, pdfQuery } from './wsfilesUrl';
+import { saveWidgetPdf } from './widgetPdf';
 
 interface WidgetModeOptions {
   mode: 'widget';
@@ -24,7 +27,16 @@ interface FileModeOptions {
 export type UseHtmlActionsOptions = WidgetModeOptions | FileModeOptions;
 
 export interface HtmlActions {
-  openInNewTab: () => void;
+  /**
+   * Absent where a second surface cannot be opened at all: a widget inside the
+   * desktop shell opens a `blob:` URL, and the shell answers every
+   * `window.open` by handing the URL to the OS browser instead, which takes
+   * http/https/mailto and nothing else. There is no fallback to offer — a blob
+   * belongs to the renderer that made it — so the action is withheld rather
+   * than left as a button that does nothing. A file surface is unaffected: its
+   * URL is served over http and opens in the real browser.
+   */
+  openInNewTab?: () => void;
   downloadHtml: () => void;
   exportPdf: () => void | Promise<void>;
 }
@@ -146,7 +158,11 @@ export function useHtmlActions(opts: UseHtmlActionsOptions): HtmlActions {
   // Server PDF renders take seconds; ignore re-entry while one is in flight.
   const pdfInFlight = useRef(false);
 
-  const openInNewTab = useCallback(() => {
+  // `useStableHandler`, not `useCallback`: every call site builds `opts` as a
+  // fresh object literal, so listing it as a dependency memoizes nothing. These
+  // are click handlers and never run during render, which is the hook's one
+  // precondition.
+  const openInNewTab = useStableHandler(() => {
     if (opts.mode === 'widget') {
       const blob = new Blob([opts.srcDoc], { type: 'text/html' });
       const url = URL.createObjectURL(blob);
@@ -157,9 +173,9 @@ export function useHtmlActions(opts: UseHtmlActionsOptions): HtmlActions {
       const url = opts.servedUrl ?? buildWsfilesUrl(opts.workspaceId, opts.filePath);
       window.open(url, '_blank', 'noopener,noreferrer');
     }
-  }, [opts]);
+  });
 
-  const downloadHtml = useCallback(() => {
+  const downloadHtml = useStableHandler(() => {
     if (opts.mode === 'widget') {
       const blob = new Blob([opts.srcDoc], { type: 'text/html' });
       const url = URL.createObjectURL(blob);
@@ -176,32 +192,60 @@ export function useHtmlActions(opts: UseHtmlActionsOptions): HtmlActions {
         console.error('[useHtmlActions] Download failed:', err),
       );
     }
-  }, [opts]);
+  });
 
-  const exportPdf = useCallback(async () => {
-    if (opts.mode === 'widget') {
-      const blob = new Blob([opts.srcDoc], { type: 'text/html' });
-      const url = URL.createObjectURL(blob);
-      // Same-origin blob tab: keep the handle (no noopener) so auto-print fires.
-      const win = window.open(url, '_blank');
-      if (win) {
-        const triggerPrint = () => {
-          try {
-            win.print();
-          } catch {
-            /* user can print manually */
-          }
-        };
-        win.addEventListener?.('load', triggerPrint);
-        setTimeout(triggerPrint, 800);
-      }
-      setTimeout(() => URL.revokeObjectURL(url), 60_000);
-      return;
-    }
-
+  const exportPdf = useStableHandler(async () => {
     if (pdfInFlight.current) return;
     pdfInFlight.current = true;
     try {
+      if (opts.mode === 'widget') {
+        // Measuring the widget and rendering it takes seconds, same as a server
+        // render, so it gets the same dismissible toast rather than a button
+        // that looks broken until a file dialog appears.
+        const pending = toast({ description: t('filePanel.pdfGenerating') });
+        let result;
+        try {
+          // The shell renders it directly. Not merely nicer than the blob tab
+          // below — that tab is one the shell refuses to open, so this is the
+          // only route a widget has there. A null answer means no shell at all,
+          // which is the only case that falls through.
+          result = await saveWidgetPdf(opts.srcDoc, opts.fileName || 'widget');
+        } finally {
+          pending.dismiss();
+        }
+        if (result) {
+          if ('error' in result) toast({ description: t('filePanel.pdfFailed') });
+          return;
+        }
+        // Null inside the shell does not mean "print in the browser instead", it
+        // means this shell is too old to know the channel. The fallback below is
+        // a blob: tab, which the shell hands to the OS browser and the OS browser
+        // will not open, so falling through here is a button that does nothing at
+        // all and says nothing either. Every install older than the one that
+        // added savePdf lands on exactly this line.
+        if (desktop) {
+          toast({ description: t('filePanel.pdfFailed') });
+          return;
+        }
+        const blob = new Blob([opts.srcDoc], { type: 'text/html' });
+        const url = URL.createObjectURL(blob);
+        // Same-origin blob tab: keep the handle (no noopener) so auto-print fires.
+        const win = window.open(url, '_blank');
+        if (win) {
+          const triggerPrint = () => {
+            try {
+              win.print();
+            } catch {
+              /* user can print manually */
+            }
+          };
+          win.addEventListener?.('load', triggerPrint);
+          setTimeout(triggerPrint, 800);
+        }
+        setTimeout(() => URL.revokeObjectURL(url), 60_000);
+        return;
+      }
+
       await exportServedPdf({
         workspaceId: opts.workspaceId,
         filePath: opts.filePath,
@@ -212,7 +256,11 @@ export function useHtmlActions(opts: UseHtmlActionsOptions): HtmlActions {
     } finally {
       pdfInFlight.current = false;
     }
-  }, [opts, t]);
+  });
 
-  return { openInNewTab, downloadHtml, exportPdf };
+  return {
+    openInNewTab: opts.mode === 'widget' && desktop ? undefined : openInNewTab,
+    downloadHtml,
+    exportPdf,
+  };
 }

--- a/web/src/pages/ChatAgent/components/viewers/html/widgetPdf.ts
+++ b/web/src/pages/ChatAgent/components/viewers/html/widgetPdf.ts
@@ -1,0 +1,145 @@
+import { renderToPdf } from '@/lib/shellPdf';
+import type { SavePdfResult } from '@/lib/desktop';
+import { resolveThemeVars } from './buildHtmlSrcDoc';
+
+/**
+ * How long to keep waiting for the widget to stop changing height.
+ *
+ * The srcDoc reports its height on DOMContentLoaded and then again at 100ms,
+ * 300ms, 800ms, 2s and 5s, because a widget that pulls a chart library off a CDN
+ * is not done when the document is. Settling on quiet rather than on a fixed
+ * delay keeps a simple widget fast and still gives a slow one its last report.
+ */
+const SETTLE_MS = 700;
+const MAX_WAIT_MS = 8000;
+/** Enough to be a legible page if the widget never reports at all. */
+const FALLBACK_HEIGHT_PX = 1000;
+
+/**
+ * Slack on the measured height.
+ *
+ * The box is the printed area — Chromium paginates what is inside an iframe but
+ * not past the bottom of the box — and the print pass lays the content out
+ * again, landing a hair taller than the measurement: different rasterization,
+ * and a page content box that is 180mm rather than exactly 680px. Measured
+ * without this, a widget lost its last element with no other symptom. Too tall
+ * only costs trailing white space; too short deletes content silently.
+ */
+const HEIGHT_SLACK = 1.02;
+const HEIGHT_SLACK_PX = 32;
+
+/**
+ * Roughly forty A4 pages at this width, and the point past which a number is
+ * not a widget that got long. The height is authored by the widget, so it is
+ * bounded here rather than trusted: an unbounded box is one Chromium's print
+ * service has to lay out and paginate.
+ */
+const MAX_HEIGHT_PX = 40_000;
+
+/**
+ * The light palette, read off a probe rather than off the live document.
+ *
+ * A srcDoc bakes its theme in as literal values when it is built, and the shell
+ * prints on white paper. So neither the baked theme nor the one the app happens
+ * to be wearing is the right answer: a widget authored while the app was dark
+ * otherwise lands as dark cards on a white sheet.
+ *
+ * `[data-theme="light"]` in styles/tokens.css is a bare attribute selector, so
+ * it applies to any element, not only the root. It has to be in the document to
+ * have a computed style at all, and `color-scheme` is inherited rather than
+ * declared per theme, so the probe states its own.
+ */
+function lightThemeCss(): string {
+  const probe = document.createElement('div');
+  probe.dataset.theme = 'light';
+  probe.style.cssText = 'position:fixed;left:-10000px;top:0;color-scheme:light';
+  document.body.appendChild(probe);
+  try {
+    return resolveThemeVars(probe);
+  } finally {
+    probe.remove();
+  }
+}
+
+/**
+ * Wait for the widget to settle, and answer with the height it needs.
+ *
+ * The iframe is sandboxed without `allow-same-origin`, so its document is an
+ * opaque origin this side cannot read: the height can only come from the
+ * `widget:resize` message the srcDoc already posts. Matched on `event.source`
+ * rather than the payload, because every widget on the page posts the same
+ * shape and the inline ones are still running.
+ */
+function measureHeight(frame: HTMLIFrameElement): Promise<number> {
+  return new Promise((resolve) => {
+    let height = 0;
+    let quiet: ReturnType<typeof setTimeout> | undefined;
+    let cap: ReturnType<typeof setTimeout> | undefined;
+
+    const finish = () => {
+      clearTimeout(quiet);
+      clearTimeout(cap);
+      window.removeEventListener('message', onMessage);
+      resolve(height || FALLBACK_HEIGHT_PX);
+    };
+
+    const onMessage = (event: MessageEvent) => {
+      if (event.source !== frame.contentWindow) return;
+      const data = event.data as { type?: string; height?: number } | null;
+      if (!data || data.type !== 'widget:resize') return;
+      // Bounded, not merely typed. The widget authors this number: `NaN` is a
+      // number and would poison `Math.max` for every later report, leaving the
+      // fallback height as the only outcome, and `Infinity` reaches the style
+      // as `Infinitypx`, which the parser drops so the box keeps whatever it
+      // had. Both of those clip content silently, which is the one failure
+      // mode this measurement exists to avoid.
+      const reported = data.height;
+      if (typeof reported !== 'number' || !Number.isFinite(reported) || reported <= 0) return;
+      height = Math.min(MAX_HEIGHT_PX, Math.max(height, reported));
+      clearTimeout(quiet);
+      quiet = setTimeout(finish, SETTLE_MS);
+    };
+
+    cap = setTimeout(finish, MAX_WAIT_MS);
+    window.addEventListener('message', onMessage);
+  });
+}
+
+/**
+ * Render a widget to a PDF through the desktop shell.
+ *
+ * A widget lives in a sandboxed iframe and the shell renders the window it is
+ * asked from, so the export is a second iframe carrying the same srcDoc. Its own
+ * iframe rather than the one on screen because the print reflow unmounts the
+ * modal around it, and its box has to be as tall as the content: Chromium
+ * paginates what is inside an iframe, but not past the bottom of the box.
+ *
+ * Takes the inline srcDoc, never the fullscreen one. The fullscreen variant is
+ * sized and magnified for the dialog it is displayed in (HtmlFullscreenModal.css);
+ * on paper that box is 680px wide and neither number means anything.
+ */
+export function saveWidgetPdf(srcDoc: string, fileName: string): Promise<SavePdfResult | null> {
+  return renderToPdf(async (root) => {
+    const frame = document.createElement('iframe');
+    // No popup tokens: nothing in a print copy is clickable, and the srcDoc's
+    // link handler would otherwise be able to open tabs from an offscreen node.
+    frame.setAttribute('sandbox', 'allow-scripts');
+    frame.style.cssText = 'display:block;width:100%;border:0';
+    frame.style.height = `${FALLBACK_HEIGHT_PX}px`;
+    // Before the append, so the listener is in place for the load it causes.
+    // The push is the same channel useHtmlSandbox uses on the frames that are
+    // on screen, and '*' for the same reason: sandboxed without
+    // allow-same-origin, this document has no origin that can be named.
+    frame.addEventListener('load', () => {
+      frame.contentWindow?.postMessage(
+        { type: 'widget:themeUpdate', css: lightThemeCss() },
+        '*',
+      );
+    });
+    frame.srcdoc = srcDoc;
+    root.appendChild(frame);
+
+    const measured = await measureHeight(frame);
+    frame.style.height = `${Math.ceil(measured * HEIGHT_SLACK) + HEIGHT_SLACK_PX}px`;
+  }, fileName);
+}

--- a/web/src/pages/Dashboard/widgets/framework/TradingViewSettingsFooter.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/TradingViewSettingsFooter.tsx
@@ -1,6 +1,5 @@
 import { useTranslation } from 'react-i18next';
 import { HelpCircle } from 'lucide-react';
-import { Link } from 'react-router-dom';
 
 /**
  * Shared attribution block at the bottom of every TradingView widget's
@@ -29,13 +28,18 @@ export function TradingViewSettingsFooter() {
         </a>
         .
       </span>
-      <Link
-        to="/legal"
+      {/* Same reason as the sign-in page's terms line: attribution is a document
+          about the product, so it opens in a browser rather than replacing the
+          dashboard, and the desktop shell sends it to the system browser. */}
+      <a
+        href="/legal"
+        target="_blank"
+        rel="noopener noreferrer"
         title={t('dashboard.widgets.tvFooter.legal')}
         style={{ color: 'var(--color-text-tertiary)', display: 'inline-flex' }}
       >
         <HelpCircle size={12} />
-      </Link>
+      </a>
     </div>
   );
 }

--- a/web/src/pages/Login/LoginPage.tsx
+++ b/web/src/pages/Login/LoginPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Link, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { Mail, Link2 } from 'lucide-react';
 import { Input } from '../../components/ui/input';
 import { useTranslation, Trans } from 'react-i18next';
@@ -526,9 +526,18 @@ function LoginPage() {
         )}
 
         <p className="login-page__legal">
+          {/* Deliberately anchors and not <Link>: these two are documents about
+              the product rather than app surface, and the desktop shell hands a
+              window.open of one of our own URLs to the system browser
+              (setWindowOpenHandler in desktop/src/main.js). Routing them through
+              a new window is what keeps a page of prose out of a frameless app
+              window, where the top of it sits under the titlebar drag region. */}
           <Trans
             i18nKey="auth.agreeToTerms"
-            components={{ 1: <Link to="/legal" />, 2: <Link to="/privacy" /> }}
+            components={{
+              1: <a href="/legal" target="_blank" rel="noopener noreferrer" />,
+              2: <a href="/privacy" target="_blank" rel="noopener noreferrer" />,
+            }}
           />
         </p>
         </div>

--- a/web/src/styles/printExport.css
+++ b/web/src/styles/printExport.css
@@ -1,0 +1,107 @@
+/* Every rule a PDF export needs, for both routes that produce one.
+ *
+ * `printToPDF` renders the whole document, so an export has to be the only thing
+ * left in the flow or the app paginates behind it as blank pages. Which node IS
+ * the export depends on the route:
+ *
+ *   .export-pdf-host   the live React portal, printed in place by the browser
+ *   #export-pdf-root   a detached copy the app builds, printed by the shell
+ *
+ * The shell route also reflows the live document partway through, which unmounts
+ * React's tree — so what it prints is a plain node the app parks off-screen and
+ * removes itself (see lib/shellPdf.ts). Both routes are here rather than in the
+ * surfaces that use them, because during a shell save BOTH nodes are in the body
+ * and only a single file can state which one wins.
+ */
+
+.export-pdf-host,
+#export-pdf-root {
+  position: fixed;
+  left: -10000px;
+  top: 0;
+  /* A4 content width: (210 - 2×15)mm × 96/25.4. Laid out at the width it will
+     be printed at, so a widget that reports its own height reports the right
+     one. */
+  width: 680px;
+}
+
+@media print {
+  /* Gated on an export node actually being present, so a plain Ctrl+P of the app
+     is left exactly as it was. The app is a fixed scroll box — `body { overflow:
+     hidden }` at viewport height — so without the unclip the document is one
+     screen tall and the export stops after a single page with the rest cut off.
+     index.html declares the app `dark`, and a dark scheme paints the UA's own
+     canvas under everything, page margins included; `background` alone does not
+     undo it. */
+  html:has(#export-pdf-root),
+  body:has(#export-pdf-root) {
+    height: auto !important;
+    overflow: visible !important;
+    position: static !important;
+    color-scheme: light !important;
+    background: #ffffff !important;
+    /* react-remove-scroll, under every Radix dialog, writes an inline
+       `padding-right` on <body> worth exactly one scrollbar so the page does not
+       shift when the dialog locks scrolling. Inline, so it survives into print,
+       where the report then lays out that much narrower than the width it was
+       measured and paginated at and sits off-centre inside the A4 margins. Only
+       reachable where scrollbars take space, which is most of the world outside
+       macOS defaults. */
+    padding: 0 !important;
+  }
+
+  /* Shell route. The live portal, if one exists, is just another body child to
+     drop: the snapshot is what gets printed. */
+  body:has(#export-pdf-root) > *:not(#export-pdf-root) {
+    display: none !important;
+  }
+
+  #export-pdf-root {
+    position: static !important;
+    left: auto !important;
+    width: 100% !important;
+    display: block !important;
+  }
+
+  /* Browser route, stated as the absence of a snapshot rather than left to
+     specificity to settle. The two modes are mutually exclusive by selector, so
+     neither rule set has to out-score the other and the report cannot land
+     twice. Neither matches inside react-to-print's iframe, which holds only the
+     source node. */
+  body:has(.export-pdf-host):not(:has(#export-pdf-root)) > *:not(.export-pdf-host) {
+    display: none !important;
+  }
+
+  body:has(.export-pdf-host):not(:has(#export-pdf-root)) .export-pdf-host {
+    position: static !important;
+    left: auto !important;
+    width: 100% !important;
+    display: block !important;
+  }
+
+  /* ExportPreviewModal.css carries an ungated `body * { visibility: hidden }`
+     and restores visibility only for `.markdown-print-content`. That is the
+     mechanism the react-to-print iframe relies on, so it has to stay, but a
+     stylesheet is loaded for the life of the document: once the user has opened
+     the export preview once, that rule applies to every later print. A report
+     export carries the class it names and survives; a widget export is an
+     iframe that does not, so it was hidden — display and width restored below,
+     visibility never, which prints a correctly paginated blank page.
+
+     Stated for both roots so neither depends on what the other stylesheet
+     happens to name. */
+  #export-pdf-root, #export-pdf-root *,
+  .export-pdf-host, .export-pdf-host * {
+    visibility: visible !important;
+  }
+
+  /* A widget prints as an iframe, and its box is the printed area: Chromium
+     paginates the content inside across pages, but only as far as the box
+     reaches. The height is set from the widget's own measurement before the
+     render (see widgetPdf.ts); this only stops a stylesheet from clipping it. */
+  #export-pdf-root iframe {
+    display: block !important;
+    width: 100% !important;
+    border: 0 !important;
+  }
+}


### PR DESCRIPTION
## Overview

| Category | Files | +LOC | −LOC |
|---|--:|--:|--:|
| Production | 31 | 1169 | 143 |
| Tests | 11 | 936 | 28 |
| **Total** | **42** | **2105** | **171** |

| Module | Files | +LOC | −LOC |
|---|--:|--:|--:|
| `web/src/pages/ChatAgent/` (viewers, export modal) | 11 | 467 | 87 |
| `desktop/src/` (shell) | 5 | 299 | 0 |
| `web/src/lib/` (bridge, render root, page geometry) | 3 | 128 | 0 |
| `web/src/styles/printExport.css` | 1 | 107 | 0 |
| `desktop/` build config, version, release workflow | 5 | 92 | 37 |
| `web/index.html` (window chrome) | 1 | 33 | 10 |
| `desktop/AGENTS.md` | 1 | 22 | 3 |
| sign-in + widget attribution (legal links) | 2 | 19 | 6 |
| i18n (`en-US`, `zh-CN`) | 2 | 2 | 0 |
| tests (unit, node, e2e) | 11 | 936 | 28 |

**What this introduces:** Save as PDF writes an actual PDF file in the desktop shell,
for an exported report and for a widget, instead of opening an OS print dialog.
Alongside it: the two editions stop building into each other's output tree, the
fullscreen widget dialog stops being its own artifact, the titlebar drag region covers
the whole titlebar on chrome-less routes, and the legal pages open in a browser.

## Commits

| | |
|---|---|
| `6048240d` | make the whole titlebar draggable on a page with no chrome |
| `545d8308` | open the legal pages in the browser instead of the app window |
| `fc0f099b` | give each edition its own output tree |
| `c1906234` | render the page to a PDF through the shell |
| `4847d576` | give the fullscreen widget one action set and its own column |
| `f00c87f7` | export a report or a widget to PDF through the desktop shell |

## The PDF path

One channel, `shell:save-pdf`. Main renders with `printToPDF`, opens a save dialog,
writes the bytes, and answers `{ saved }`, `{ canceled }` or `{ error }`. It never
rejects: a rejected `invoke` is indistinguishable from a shell too old to know the
channel, and that distinction is the whole fallback. Three answers rather than two
because a dismissed save dialog is the user's own answer, and treating it as failure
reopens a print dialog on top of the one they just closed.

`renderToPdf` (`web/src/lib/shellPdf.ts`) owns the render root. `printToPDF` reflows
the live document to paper width and React unmounts at that width partway through, so
a report is cloned into a detached node instead of printed in place. That was the
difference between a correctly paginated file and a correctly paginated blank one. A
module-level guard keeps the root a single resource. Both paths name the file
after the source document rather than the workspace path it was selected by, the
browser one through `documentTitle`, without which every report a user saved from a
browser landed in their downloads as the app's own name.

A widget has no served bytes to fetch, so `widgetPdf.ts` renders its srcDoc offscreen,
waits for the height it reports, sizes the box and hands that to the same root. It is
measured in the light palette over the existing `widget:themeUpdate` channel, since a
srcDoc bakes the theme in as literal CSS variables and would otherwise print dark on
white paper. Without a shell, `renderToPdf` answers `null` and both paths keep browser
print. Inside a shell with no `savePdf` that same `null` means the shell is too old,
and the widget path says so rather than falling through to a `blob:` tab the shell
hands to the OS browser and the OS browser refuses to open.

## Print CSS

`printExport.css` gates on `#export-pdf-root`: with the root present every other body
child leaves the flow, and with no root the app's own Ctrl+P is untouched. It also
restores `visibility`, which is not redundant. `ExportPreviewModal.css` carries an
ungated `@media print { body * { visibility: hidden } }`, and a stylesheet lives for
the life of the document, so once the export preview had been opened every later
widget export printed a correctly paginated blank page. The same block zeroes body
padding, which `react-remove-scroll` writes inline under every Radix dialog and which
survives into print.

`color-scheme: light` is stated once per route, each time where it is already scoped:
the `pageStyle` prop for react-to-print's iframe, which is inlined and so arrives even
when the iframe's re-fetch of the lazy chunk fails, and the `:has(#export-pdf-root)`
block for the shell render. It is deliberately not in `ExportPreviewModal.css`, whose
rules outlive the modal and would retint the app's own Ctrl+P.

## Editions and build output

Both editions built into `dist/`, and since the unpacked bundle is named from
`productName` and the update manifests are fixed names, the second build overwrote the
first's metadata. Output is now `dist/${EDITION}`, read back off the resolved config
rather than kept as a second copy of the path, and a resolved path that does not name
this edition is refused. `make-release-index.mjs` refuses two candidates for one
platform instead of publishing whichever it read first. Concurrent edition builds are
still unsafe (one `config/build.json` path) and `desktop/AGENTS.md` now says so.
Version moves to 0.1.2, which is what `savePdf` is documented against.

## Widget fullscreen

The dialog built a second action set on the srcDoc it renders, so downloading or
printing from fullscreen returned a document carrying the dialog's layout. Both
surfaces now share the actions built on the inline srcDoc, which is the widget as an
artifact. The dialog narrows to the widget's column instead of stretching to 1400 px,
and pushes the current theme on load, since its frame is created fresh on every open.

The column cap says what a widget is authored to, not what it obeys, so the document
scrolls rather than clips. `html` carries no overflow here, so the body's value
propagates to the viewport: `overflow-x: hidden` put anything wider than the cap out
of reach entirely. Measured at the dialog's width, a 1100 px table left 326 px off the
right edge that no gesture could reach.

## Window chrome

`#window-drag` goes from a 120 px stub to the full window width, most of the stub
having been covered by the window buttons themselves. Widening it exposed that the
strip rests on two mechanisms. Drag regions are collected in layout-tree preorder, so
`no-drag` in `chrome.css` subtracts the app's controls whatever the stacking; ordinary
clicks are settled by hit testing, where a fixed box beats every in-flow element that
is not positioned. A static control scrolling under the titlebar therefore had its
clicks eaten while still computing `no-drag`. The strip now declines pointer events,
and the e2e suite hit-tests as well as reading the region.

What `no-drag` cannot subtract is prose. Rather than teach the strip about running
text, the two pages made of it open in the browser: both links carry a target, which
reaches the shell's `setWindowOpenHandler` and is handed to the system browser. A
`<Link>` is the one thing that silently puts them back in the window and it looks
identical in a browser, so `shell.test.js` scans `web/src` for one.

## Risk

- **A widget export re-runs the original srcDoc.** Interactive state is not captured,
  and a CDN library is needed at export time. A widget whose library fails renders its
  error card, reports that height, and exports as a successful PDF of the error.
- **The settle window can close early.** Measuring waits 700 ms of quiet against a
  document reporting height at 100/300/800/2000/5000 ms, so a widget quiet after
  800 ms is measured at ~1.5 s. Waiting for the last checkpoint would make every
  widget export take 5.7 s.
- **Widget colours are only fixed in CSS.** A chart library that read
  `getComputedStyle` at DOMContentLoaded keeps the dark values it baked into a canvas.
- **No timeout on the shell render.** A `printToPDF` that never returns wedges exports
  for the session. Splitting the channel into render and save is the real fix.
- **A busy guard answers `canceled`,** so a cross-surface concurrent export is silent.
- **The drag region still covers prose,** though nothing renders prose under it now:
  the two documents open in a browser, onboarding's top band is padding above a logo,
  and nothing links to a `/s/<token>` URL. `chrome.css` ships an in-flow
  `.chrome-drag-strip` for a future one.
- **`safeFileName` is byte-naive:** 120 UTF-16 units, no bidi stripping, no Windows
  reserved names. Nothing is lost, since the dialog shows the name first.

## Verification

- Backend unit: 8836 passed, 1 xfailed. Web Vitest: 3026 across 278 files.
- Desktop `node:test`: 117. Playwright: 72, the whole suite.
- `tsc --noEmit` clean; `pnpm build` critical path 439.0 kB gz against a 450 kB ceiling.
- Every commit checks out green on its own: tsc, the desktop suite and Vitest pass at
  all six, Vitest growing 3003 to 3026 as tests land with their subjects.
- `pnpm lint`: 9 errors, all in gitignored `web/workers/verify.mjs`, not in this diff.

Mutation-checked by removing the fix and watching the new tests go red: the drag
strip's `pointer-events` (four e2e routes), the `canceled`-is-not-a-failure rule at
both call sites, the browser path's `documentTitle`, each half of the staged write
(the rename and the cleanup, separately), and the import-graph walk, which names the
whole chain back to the stylesheet.

Two claims were measured rather than reasoned about. Fullscreen overflow, in Chromium
at the dialog's width: `overflow-x: hidden` moved 0 px under a horizontal wheel with
the far edge 326 px off screen; `overflow: auto` moved 328 px and brought it on
screen. And the external-link path, in Electron wired the way `main.js` wires it: a
top-level `<a target="_blank">`, the same anchor inside a sandboxed widget iframe, and
a `window.open` from that iframe all reach `setWindowOpenHandler`, are denied, and
leave the window count at one.

Not verified: the drag itself, which needs a real Electron window. CDP-synthesized
mouse events never reach the region walk, so the suite asserts the two properties the
walk and the hit test depend on rather than the outcome.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ginlix-ai/codesmith/LangAlpha/pr/362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789844380&installation_model_id=432753&pr_number=362&repository=ginlix-ai%2FLangAlpha&return_to=https%3A%2F%2Fgithub.com%2Fginlix-ai%2FLangAlpha%2Fpull%2F362&signature=f84b408644965307b43fe8d449e43e6ee744f2665a9bb55892bd9517ac843923"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added desktop PDF export for chat content and interactive widgets, with safe filenames, progress feedback, cancellation handling, and browser-print fallback.
  * Added download completion notifications and clearer interruption messages.
  * Improved fullscreen widget presentation with larger, better-spaced content, theme synchronization, and scrollbar styling.

* **Bug Fixes**
  * Fixed macOS window dragging so controls remain clickable on chrome-less pages.
  * Improved edition-specific packaging reliability and prevented ambiguous release artifacts.
  * Legal and privacy links now open reliably in a new browser context.
  * Updated the desktop app to version 0.1.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
