### PR TITLE
fix(pricing): count DeepSeek peak days on the vendor clock, not UTC

### DIFF
--- a/src/llms/manifest/providers.json
+++ b/src/llms/manifest/providers.json
@@ -386,6 +386,14 @@
               10
             ]
           ],
+          "peak_days": [
+            1,
+            2,
+            3,
+            4,
+            5
+          ],
+          "peak_days_utc_offset": 8,
           "off_peak": {
             "input": 0.66,
             "cached_input": 0.022,
@@ -415,6 +423,14 @@
               10
             ]
           ],
+          "peak_days": [
+            1,
+            2,
+            3,
+            4,
+            5
+          ],
+          "peak_days_utc_offset": 8,
           "off_peak": {
             "input": 0.22,
             "cached_input": 0.007,

--- a/src/llms/pricing_utils.py
+++ b/src/llms/pricing_utils.py
@@ -2,7 +2,7 @@
 Pricing calculation utilities for LLM token usage with support for both flat and tiered pricing.
 """
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Dict, Any, Optional, List, Tuple
 import logging
 import re
@@ -12,7 +12,13 @@ logger = logging.getLogger(__name__)
 # Keys describing *when* a card applies rather than what it charges. Stripped
 # from the card handed to the engine so what gets priced, logged and snapshotted
 # is only the rates in force.
-_SCHEDULE_KEYS = ("peak_utc", "off_peak", "schedule_anchor")
+_SCHEDULE_KEYS = (
+    "peak_utc",
+    "off_peak",
+    "schedule_anchor",
+    "peak_days",
+    "peak_days_utc_offset",
+)
 
 # An unstamped record's model name is the vendor's string; bound it before it
 # reaches a log line.
@@ -772,6 +778,54 @@ def _usable_windows(pricing: Dict[str, Any]) -> List[Tuple[int, int]]:
     return windows
 
 
+def _usable_days(pricing: Dict[str, Any]) -> List[int]:
+    """The ISO weekdays this card's peak windows apply on, if it names any.
+
+    An empty list means the card places no day restriction, which is also where
+    every malformed value lands. That direction is deliberate and matches
+    ``_usable_windows``: no restriction leaves the hour windows charging peak,
+    and the rule here is to fail toward the higher rate rather than hand out a
+    discount off a card we just found unreadable.
+    """
+    declared = pricing.get("peak_days")
+    if declared is None:
+        return []
+    if not isinstance(declared, (list, tuple)) or not declared:
+        logger.warning(f"Ignoring unusable peak_days container {declared!r}")
+        return []
+    days: List[int] = []
+    for day in declared:
+        # ``type is int`` rather than isinstance, for the same reason as the
+        # window bounds: bool subclasses int, so a JSON ``true`` would install
+        # Monday and ``false`` would install nothing at all.
+        if type(day) is int and 1 <= day <= 7:
+            days.append(day)
+        else:
+            logger.warning(f"Ignoring unusable peak_days entry {day!r}")
+            return []
+    return days
+
+
+def _days_offset(pricing: Dict[str, Any]) -> int:
+    """Hours to shift UTC by before reading the weekday off the clock.
+
+    A vendor writes its schedule in one local calendar and publishes the hours
+    converted to UTC, which loses the day: DeepSeek's peak windows are Monday to
+    Friday *Beijing* time, and Beijing is eight hours ahead, so from 16:00Z
+    Friday it is already Saturday there and from 16:00Z Sunday it is already
+    Monday. Reading the day off UTC gets those sixteen hours a week wrong.
+
+    Zero -- read the day off UTC -- is the default and the landing place for a
+    malformed value, so a card that names days without naming a calendar still
+    restricts them rather than silently dropping the restriction.
+    """
+    declared = pricing.get("peak_days_utc_offset", 0)
+    if type(declared) is not int or not -14 <= declared <= 14:
+        logger.warning(f"Ignoring unusable peak_days_utc_offset {declared!r}")
+        return 0
+    return declared
+
+
 def schedule_anchor(pricing: Optional[Dict[str, Any]]) -> str:
     """Which end of the call picks the rate window: ``completion`` or ``request``.
 
@@ -832,8 +886,15 @@ def resolve_schedule(
         logger.warning("No usable peak_utc window on a scheduled card, charging peak")
         return card, "peak"
 
-    hour = at.astimezone(timezone.utc).hour
-    if any(start <= hour < end for start, end in windows):
+    # The windows are declared in UTC and read in UTC. Only the *day* is read
+    # on the vendor's own clock -- see ``_days_offset`` for why the two differ.
+    at_utc = at.astimezone(timezone.utc)
+    days = _usable_days(pricing)
+    on_a_peak_day = not days or (
+        at_utc.astimezone(timezone(timedelta(hours=_days_offset(pricing)))).isoweekday()
+        in days
+    )
+    if on_a_peak_day and any(start <= at_utc.hour < end for start, end in windows):
         return card, "peak"
 
     off_peak = pricing.get("off_peak")

--- a/tests/unit/llms/test_manifest_integrity.py
+++ b/tests/unit/llms/test_manifest_integrity.py
@@ -13,7 +13,13 @@ from src.llms.llm import ModelConfig
 from src.llms.pricing_utils import find_model_pricing
 
 
-_SCHEDULE_KEYS = {"peak_utc", "off_peak", "schedule_anchor"}
+_SCHEDULE_KEYS = {
+    "peak_utc",
+    "off_peak",
+    "schedule_anchor",
+    "peak_days",
+    "peak_days_utc_offset",
+}
 
 
 def _peak_hour_cards(manifest: dict) -> list[tuple[str, str, dict]]:
@@ -239,6 +245,42 @@ class TestTimeOfDayPricing:
                     failures.append(f"{where}: window {window!r} is not 0 <= start < end <= 24")
 
         assert not failures, "Malformed peak_utc:\n" + "\n".join(f"  - {f}" for f in failures)
+
+    def test_peak_day_restrictions_are_well_formed(self, manifest):
+        """A day list the engine cannot read is dropped, and the card then bills
+        peak on the days it meant to exclude -- the same silent overcharge the
+        window checks above guard, one axis over.
+        """
+        failures: list[str] = []
+
+        for provider, model_id, pricing in _peak_hour_cards(manifest):
+            where = f"{provider}/{model_id}"
+            days = pricing.get("peak_days")
+
+            if days is not None:
+                if not isinstance(days, list) or not days:
+                    failures.append(f"{where}: peak_days is {days!r}, want a non-empty list")
+                # ``type is int`` rather than isinstance, matching the engine: a
+                # JSON ``true`` would install Monday and ``false`` nothing at all.
+                elif not all(type(d) is int and 1 <= d <= 7 for d in days):
+                    failures.append(f"{where}: peak_days {days!r} are not ISO weekdays 1-7")
+                elif len(set(days)) != len(days):
+                    failures.append(f"{where}: peak_days {days!r} repeats a day")
+
+            offset = pricing.get("peak_days_utc_offset")
+            if offset is not None and (type(offset) is not int or not -14 <= offset <= 14):
+                failures.append(
+                    f"{where}: peak_days_utc_offset {offset!r} is not an hour offset in -14..14"
+                )
+            if offset is not None and days is None:
+                # The offset only ever shifts the clock the days are read on, so
+                # on its own it changes nothing and reads as a restriction that
+                # is not there.
+                failures.append(f"{where}: peak_days_utc_offset without peak_days")
+
+        assert not failures, "Malformed peak day rule:\n" + "\n".join(
+            f"  - {f}" for f in failures
+        )
 
     def test_peak_windows_do_not_overlap(self, manifest):
         """Overlapping blocks make the schedule ambiguous to read, even though

--- a/tests/unit/llms/test_peak_hour_pricing.py
+++ b/tests/unit/llms/test_peak_hour_pricing.py
@@ -224,3 +224,82 @@ class TestAnUnreadableScheduleCannotDiscount:
         card, window = resolve_schedule(no_discount, _at(12))
         assert window == "off_peak"
         assert card["input"] == 10.0
+
+
+# A card whose peak block reaches past 16:00 UTC, which is the only stretch of
+# the week where the UTC and Beijing calendars name different days. DeepSeek's
+# real windows both close before it, so a card built from the shipped manifest
+# cannot tell a UTC weekday from a Beijing one -- the two price identically at
+# all 168 hours. Synthetic, like every card in this file, so the contract is
+# pinned where it is visible rather than where today's rates happen to hide it.
+LATE_CARD = {
+    "input": 10.0,
+    "output": 40.0,
+    "unit": "per_1m_tokens",
+    "peak_utc": [[15, 20]],
+    "peak_days": [1, 2, 3, 4, 5],
+    "peak_days_utc_offset": 8,
+    "off_peak": {"input": 5.0, "output": 20.0},
+}
+
+WEEKDAY_CARD = {**CARD, "peak_days": [1, 2, 3, 4, 5], "peak_days_utc_offset": 8}
+
+
+def _on(year, month, day, hour, minute=0):
+    return datetime(year, month, day, hour, minute, tzinfo=timezone.utc)
+
+
+class TestPeakDays:
+    """A vendor that runs its peak windows on weekdays only.
+
+    Without a day axis the discount is billed at the peak rate for two days a
+    week, and every hour-based assertion above still passes.
+    """
+
+    def test_a_weekend_hour_inside_a_window_is_off_peak(self):
+        # 2026-01-03 is a Saturday, 02:00 UTC is inside the first block.
+        assert resolve_schedule(WEEKDAY_CARD, _on(2026, 1, 3, 2))[1] == "off_peak"
+        assert resolve_schedule(WEEKDAY_CARD, _on(2026, 1, 4, 7))[1] == "off_peak"
+
+    def test_the_same_hour_on_a_weekday_is_still_peak(self):
+        """The day rule must not leak into the days the windows do apply on."""
+        assert resolve_schedule(WEEKDAY_CARD, _on(2026, 1, 5, 2))[1] == "peak"
+        assert resolve_schedule(WEEKDAY_CARD, _on(2026, 1, 1, 7))[1] == "peak"
+
+    def test_a_card_without_peak_days_is_unrestricted(self):
+        """The overwhelming majority of scheduled cards name no days, and they
+        must keep billing peak on a Saturday inside a window."""
+        assert resolve_schedule(CARD, _on(2026, 1, 3, 2))[1] == "peak"
+
+    def test_the_day_is_read_on_the_vendors_clock_not_utc(self):
+        """16:00Z Friday is already Saturday in Beijing, and 16:00Z Sunday is
+        already Monday. Read off UTC, both land on the wrong rate."""
+        assert resolve_schedule(LATE_CARD, _on(2026, 1, 2, 15, 59))[1] == "peak"
+        assert resolve_schedule(LATE_CARD, _on(2026, 1, 2, 16, 0))[1] == "off_peak"
+        assert resolve_schedule(LATE_CARD, _on(2026, 1, 4, 15, 59))[1] == "off_peak"
+        assert resolve_schedule(LATE_CARD, _on(2026, 1, 4, 16, 0))[1] == "peak"
+
+    def test_days_without_an_offset_are_counted_in_utc(self):
+        """Zero is the default, so a card that names days without naming a
+        calendar still restricts them -- it does not lose the restriction."""
+        utc_card = {**CARD, "peak_days": [1, 2, 3, 4, 5]}
+        assert resolve_schedule(utc_card, _on(2026, 1, 3, 2))[1] == "off_peak"
+        assert resolve_schedule(utc_card, _on(2026, 1, 5, 2))[1] == "peak"
+
+    def test_an_unreadable_day_list_charges_peak_rather_than_discounting(self):
+        """Same direction as an unreadable window: never guess downward off a
+        card that was just found malformed."""
+        for broken in ([], "1-5", [0], [8], [True], [1, "2"], 5):
+            card = {**CARD, "peak_days": broken}
+            assert resolve_schedule(card, _on(2026, 1, 3, 2))[1] == "peak", broken
+
+    def test_an_unreadable_offset_falls_back_to_utc(self):
+        for broken in ("8", 99, True, None):
+            card = {**WEEKDAY_CARD, "peak_days_utc_offset": broken}
+            assert resolve_schedule(card, _on(2026, 1, 3, 2))[1] == "off_peak", broken
+
+    def test_the_day_keys_never_reach_the_rate_card(self):
+        """They describe when the card applies, not what it charges, so a
+        snapshot of the priced card must not carry them."""
+        card, _ = resolve_schedule(WEEKDAY_CARD, _on(2026, 1, 5, 2))
+        assert "peak_days" not in card and "peak_days_utc_offset" not in card


### PR DESCRIPTION
## Summary

DeepSeek's off-peak discount is published as a **weekday** rule on Beijing time, but the two DeepSeek cards in `providers.json` only carry the hour windows. A request that lands inside a peak window on a Beijing weekend is billed at full rate today, even though the vendor charges off-peak for it.

This adds an optional day restriction to the rate card and reads the day on the vendor's own clock. Windows stay declared and read in UTC — only the *day* is shifted, which is the only part the vendor states in local terms.

Worth flagging plainly: with the windows as published today, both readings of the calendar price **identically at all 168 hours of the week**, because the two peak windows sit clear of the hours where a UTC day and a Beijing day disagree. So no test written against the real windows can tell the two apart. That is exactly why the tests below use a synthetic `[[15, 20]]` card — it's the only window shape that makes the split visible, and it pins the rule before a future window edit walks into it silently.

## Changes

- `pricing_utils.py`: new `peak_days` (ISO 1–7) and `peak_days_utc_offset` on the rate card; `resolve_schedule` charges peak only when the instant is both in a window and on a peak day.
- Both keys added to `_SCHEDULE_KEYS`, so they're stripped from the priced card like the other scheduling keys and never reach a consumer as a rate.
- `providers.json`: `deepseek-v4-pro` and `deepseek-v4-flash` get `"peak_days": [1,2,3,4,5]`, `"peak_days_utc_offset": 8`.
- Validation fails **high**, not low: an unreadable day list drops the restriction entirely rather than dropping bad entries one by one. Dropping entries would narrow the peak days and hand out a discount nobody earned; dropping the restriction only ever charges the current, published rate. Same for a bad offset — it falls back to reading the day off UTC.
- `type(d) is int` rather than `isinstance`, because JSON `true` is an `int` in Python and would otherwise install Monday as a peak day.

## Test Plan

- `tests/unit/llms/test_peak_hour_pricing.py`: 8 new tests in `TestPeakDays`, including `test_the_day_is_read_on_the_vendors_clock_not_utc` — 2026-01-02 15:59Z is peak and 16:00Z is off-peak (UTC Friday becomes Beijing Saturday), 2026-01-04 16:00Z is peak again (UTC Sunday becomes Beijing Monday). Plus: a card with no `peak_days` stays unrestricted, days without an offset are counted in UTC, seven shapes of unreadable day list (`[]`, `"1-5"`, `[0]`, `[8]`, `[True]`, `[1,"2"]`, `5`) all charge peak, and neither key reaches the rate card.
- `tests/unit/llms/test_manifest_integrity.py`: shape check on the two new keys, and it rejects an offset declared without a day list — on its own it shifts a clock nothing reads, so it looks like a restriction that isn't there.
- Mutation-checked: removing the day condition from the peak branch reddens exactly the four day-axis tests (4 failed, 27 passed); restoring it gives 31 passed.

One caveat on how that was run: the full suite needs `langchain_openai` and `pytest_asyncio`, which I couldn't install here, so I ran the scheduling tests against `pricing_utils.py` loaded by path in isolation — 31 passed (your 23 plus my 8). The manifest-integrity check was validated by running its new assertion logic against the shipped `providers.json` directly. Both are worth a normal CI run before you take my word for them.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ginlix-ai/codesmith/LangAlpha/pr/365"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790049805&installation_model_id=432753&pr_number=365&repository=ginlix-ai%2FLangAlpha&return_to=https%3A%2F%2Fgithub.com%2Fginlix-ai%2FLangAlpha%2Fpull%2F365&signature=87ed95b5b5541140de11f6eb9b1cc79658293d11366f45d296e11979b2e3aa6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added weekday-aware peak pricing for DeepSeek V4 Pro and DeepSeek V4 Flash.
  * Peak pricing applies Monday through Friday based on vendor-local time (UTC+8).
  * Pricing schedules now support configurable weekday restrictions and timezone offsets.

* **Bug Fixes**
  * Improved handling of invalid pricing schedule settings, preventing incorrect peak-rate application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->