### PR TITLE
fix(web): stop submenus opening on top of their parent menu

### DIFF
--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -102,13 +102,18 @@ const DropdownMenuSubTrigger = React.forwardRef<
 ))
 DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName
 
+// Radix anchors a submenu to its trigger *row*, which the parent panel's
+// border + p-1 inset 5px from the panel edge — so the stock offset of 0 opens
+// the submenu 5px on top of the panel. Clear that, then add the same 4px gap
+// DropdownMenuContent leaves against its own trigger.
 const DropdownMenuSubContent = React.forwardRef<
   React.ComponentRef<typeof DropdownMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
->(({ className, collisionPadding = 8, ...props }, ref) => (
+>(({ className, sideOffset = 9, collisionPadding = 8, ...props }, ref) => (
   <DropdownMenuPrimitive.Portal>
     <DropdownMenuPrimitive.SubContent
       ref={ref}
+      sideOffset={sideOffset}
       collisionPadding={collisionPadding}
       className={cn(
         "z-[1030] min-w-[8rem] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg",


### PR DESCRIPTION
## Overview

| File | Files | Insertions | Deletions |
|---|---:|---:|---:|
| `web/src/components/ui/dropdown-menu.tsx` | 1 | 6 | 1 |

One file. No new files, no dependency, schema or config changes, no tests added.

**What this introduces:** a default gap between a submenu and the panel it opens from. Every submenu in the app previously rendered 5px on top of its parent panel; it now sits 4px clear, matching the gap a top level dropdown already leaves against its own trigger. The only API change is one more overridable prop default on an existing shared primitive.

## Why 9

Radix anchors a submenu to its **trigger row**, not to the panel that contains the row. The panel insets that row by 5px (`border` 1px plus `p-1` 4px), so at Radix's stock `sideOffset` of `0` the submenu lands 5px inside the panel's edge and covers it.

- **5px** cancels the inset
- **+4px** is the gap `DropdownMenuContent` already uses against its own trigger

So 9 is derived, not tuned, and the comment records the arithmetic for whoever changes `p-1` next. It goes on the shared primitive because the inset is a property of `DropdownMenuContent`, so all six submenu instances had the identical bug.

## Verification

Measured with `getBoundingClientRect()` on the "More models" submenu in the model picker. The before row is the real pre-fix code, swapped in by ablation from `origin/main`:

| Viewport | Side | Parent panel edge | Submenu before | after | Shift |
|---|---|---:|---:|---:|---:|
| 1512px | right | right 1156 | left 1151 (-5px) | left 1160 (+4px) | 9px |
| 900px | left | left 594 | right 599 (-5px) | right 590 (+4px) | 9px |

At 1512px the pre-fix submenu edge sits exactly on the trigger row's right edge (1151) and the panel edge exactly 5px outside it, which confirms each step of the reasoning rather than only the net result.

- **Hover traversal** across the new 9px dead gap, straight and diagonally toward a lower item: the submenu stays open and the destination item highlights. This was the main risk, since a submenu that closed mid-traversal would be worse than the bug being fixed.
- **Collision:** flips to the left side and stays fully on-screen where there is no room to the right; 104px of headroom where there is.
- `eslint` and `tsc --noEmit` clean.

The 4 vitest files referencing `dropdown-menu` pass (98 tests) but every one of them `vi.mock`s the module, so they do not cover this change. Nothing was added: the behaviour is geometric and jsdom does not lay out.

## Not covered

The other four call sites (`chat-input.toolbar.tsx`, `ScopeControl.tsx`, `BulkScopeMenu.tsx`, `FileHeaderActions.tsx`) were not opened, since the plugin surfaces need installed plugins this environment does not have. They render through the same primitive and none overrides `sideOffset`, so the same shift applies by construction. Touch and RTL untested.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ginlix-ai/codesmith/LangAlpha/pr/368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790280086&installation_model_id=432753&pr_number=368&repository=ginlix-ai%2FLangAlpha&return_to=https%3A%2F%2Fgithub.com%2Fginlix-ai%2FLangAlpha%2Fpull%2F368&signature=b302002d36d8ab0b1e3676a549dd0714e154ddc9d6b2724474831f740af59426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dropdown submenu positioning by adding spacing between the submenu and its parent menu.
  * Preserved collision padding to help keep submenus within the visible screen area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->