### PR TITLE
fix(prefs): stop an empty model catalog from wiping saved model preferences

### DIFF
--- a/src/server/services/llm/availability.py
+++ b/src/server/services/llm/availability.py
@@ -67,6 +67,16 @@ async def _cleanup_stale_model_preferences(user_id: str) -> list[tuple[str, str]
     pref = await get_model_preference(user_id)
 
     mc = LLMFactory.get_model_config()
+    # An empty manifest is a load failure, not a catalog of zero models. Every
+    # name would then read as stale and this function would delete the user's
+    # entire model preference set — irreversibly, since the deletes go straight
+    # to the merge-upsert with no copy kept.
+    if not mc.llm_config:
+        logger.warning(
+            f"[CHAT] Skipping stale-pref scrub for user={user_id}: model manifest is empty"
+        )
+        return []
+
     custom_models = {cm.get("name") for cm in (pref.get("custom_models") or [])}
     custom_providers = {cp.get("name") for cp in (pref.get("custom_providers") or [])}
 
@@ -125,14 +135,21 @@ def _raise_model_removed(
 
     other = sorted({name for _, name in removed if name != model_name})
     extra = f" Also cleared: {', '.join(other)}." if other else ""
+    # Only claim a clear when one happened. The caller passes an empty list for
+    # a model named in the request rather than saved, and the scrub also returns
+    # empty when it declines to run, so asserting the clear unconditionally
+    # tells the user their preference is gone while it is still stored.
+    cleared = (
+        "Your saved preference has been cleared — open Settings to pick a current model."
+        if removed
+        else "Open Settings to pick a current model."
+    )
 
     raise HTTPException(
         status_code=400,
         detail={
             "message": (
-                f"Model '{model_name}' is no longer available. "
-                "Your saved preference has been cleared — open Settings to pick a current model."
-                + extra
+                f"Model '{model_name}' is no longer available. " + cleared + extra
             ),
             "type": "model_removed",
             "link": {"url": "/settings?tab=model", "label": "Open Settings"},

--- a/tests/unit/server/services/llm/test_stale_pref_scrub_guard.py
+++ b/tests/unit/server/services/llm/test_stale_pref_scrub_guard.py
@@ -1,0 +1,63 @@
+"""The stale-model-preference scrubber must not act on an empty catalog.
+
+Regression: ``resolvable()`` asks the manifest whether a model name still
+exists. When the manifest fails to load, every name answers "no" and the
+scrubber deletes the user's whole model preference set through a merge-upsert
+that keeps no copy. There is no undo, so the guard is the fix.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.server.services.llm.availability import _cleanup_stale_model_preferences
+
+STORED_PREFS = {
+    "preferred_model": "some-model",
+    "preferred_flash_model": "some-flash",
+    "fetch_model": "some-fetch",
+    "compaction_model": "some-compaction",
+    "fallback_models": ["fallback-a", "fallback-b"],
+    "profiles": {"some-model": {"reasoning_effort": "high"}},
+}
+
+
+def _catalog(names):
+    mc = MagicMock()
+    mc.llm_config = {n: {"model_id": n} for n in names}
+    mc.get_model_config.side_effect = lambda n: mc.llm_config.get(n)
+    return mc
+
+
+async def _run(catalog_names):
+    upsert = AsyncMock()
+    with (
+        patch("src.llms.llm.LLM.get_model_config", return_value=_catalog(catalog_names)),
+        patch(
+            "src.server.services.llm.config.get_model_preference",
+            AsyncMock(return_value=dict(STORED_PREFS)),
+        ),
+        patch("src.server.database.user.invalidate_user_prefs_cache", AsyncMock()),
+        patch("src.server.database.user.upsert_user_preferences", upsert),
+        patch("ptc_agent.agent.graph.invalidate_user_profile_cache", AsyncMock()),
+    ):
+        removed = await _cleanup_stale_model_preferences("user-1")
+    return removed, upsert
+
+
+@pytest.mark.asyncio
+async def test_empty_manifest_scrubs_nothing_and_writes_nothing():
+    """The destructive case. An empty catalog means "not loaded", not "all gone"."""
+    removed, upsert = await _run([])
+    assert removed == []
+    upsert.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_loaded_manifest_still_scrubs_what_really_vanished():
+    """The guard must not disable the feature it is protecting."""
+    removed, upsert = await _run(["something-else"])
+    assert removed, "a populated catalog should still scrub names it does not contain"
+    upsert.assert_awaited_once()
+    written = upsert.await_args.kwargs["other_preference"]
+    assert written["preferred_model"] is None

--- a/web/src/pages/Settings/__tests__/Settings.searchProvider.test.tsx
+++ b/web/src/pages/Settings/__tests__/Settings.searchProvider.test.tsx
@@ -50,6 +50,12 @@ const h = vi.hoisted(() => {
     user: null as Record<string, unknown> | null,
     preferences: null as Record<string, unknown> | null,
     validModelNames: new Set<string>(),
+    // The untouched GET /api/v1/models payload. Distinct from validModelNames,
+    // which has the user's custom models folded in.
+    rawApiResponse: null as Record<string, unknown> | null,
+    // Pre-filter catalog + custom models — what exists, as opposed to what the
+    // user can currently reach.
+    rawModels: {} as Record<string, { models?: string[] }>,
     searchProviderCatalog: searchProviderCatalog as typeof searchProviderCatalog | null,
     fullCatalog: searchProviderCatalog,
   };
@@ -103,6 +109,8 @@ vi.mock('@/hooks/useAllModels', () => ({
     systemDefaults: { fallback_models: [] },
     // Stable Set ref — the stale-model cleanup effect keys on its identity.
     validModelNames: h.validModelNames,
+    rawModels: h.rawModels,
+    rawApiResponse: h.rawApiResponse,
     compactionProfiles: null,
     searchProviders: h.searchProviderCatalog,
     isLoading: false,
@@ -131,9 +139,17 @@ vi.mock('@/hooks/useDebouncedSave', () => ({
 // select lives outside this component, so a stub is safe. The button exposes
 // onPrimaryModelChange so tests can fire an unrelated model-pref save.
 vi.mock('@/components/model/ModelTierConfig', () => ({
-  ModelTierConfig: (props: { onPrimaryModelChange?: (v: string) => void }) => (
+  ModelTierConfig: (props: {
+    onPrimaryModelChange?: (v: string) => void;
+    advancedModels?: { fallbackModels?: string[] };
+  }) => (
     <div data-testid="model-tier-config-stub">
       <button onClick={() => props.onPrimaryModelChange?.('')}>stub-change-primary</button>
+      {/* Mirrors FallbackModelsPicker, which maps `selected` with no catalog
+          filter — so this shows the fallback list the panel actually holds. */}
+      <ul data-testid="fallback-chips">
+        {(props.advancedModels?.fallbackModels ?? []).map((m) => <li key={m}>{m}</li>)}
+      </ul>
     </div>
   ),
 }));
@@ -194,6 +210,8 @@ beforeEach(() => {
   h.accessTier = 1;
   h.otherPreference = {};
   h.validModelNames = new Set<string>();
+  h.rawModels = {};
+  h.rawApiResponse = null;
   h.searchProviderCatalog = h.fullCatalog;
   h.mutateAsync.mockClear();
   h.mutateAsync.mockResolvedValue({});
@@ -478,5 +496,150 @@ describe('Settings — Search Depth', () => {
     };
     expect(payload.other_preference).toMatchObject({ search_provider: 'serper' });
     expect('search_depth' in payload.other_preference).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: an unloaded model catalog must not erase saved model preferences
+// ---------------------------------------------------------------------------
+
+describe('Settings — model prefs survive an unloaded catalog', () => {
+  const STORED = {
+    preferred_model: 'some-model',
+    preferred_flash_model: 'some-flash',
+    compaction_model: 'some-compaction',
+    fetch_model: 'some-fetch',
+    fallback_models: ['fallback-a', 'fallback-b'],
+  };
+
+  it('keeps every model reference when validModelNames is empty', async () => {
+    // Every model field is filtered against the catalog. Empty used to mean
+    // "nothing is valid", so one unrelated save nulled the whole set at once.
+    h.platformMode = false;
+    h.otherPreference = { ...STORED };
+    h.validModelNames = new Set<string>();
+
+    setupAndRenderModelTab();
+
+    const select = await screen.findByRole('combobox', { name: 'Web Search Provider' });
+    await waitFor(() => expect(select).toHaveValue(''));
+    fireEvent.change(select, { target: { value: 'serper' } });
+
+    await waitFor(() => expect(h.mutateAsync).toHaveBeenCalled());
+    const payload = h.mutateAsync.mock.calls.at(-1)![0] as {
+      other_preference: Record<string, unknown>;
+    };
+    expect(payload.other_preference).toMatchObject({
+      preferred_model: 'some-model',
+      preferred_flash_model: 'some-flash',
+      compaction_model: 'some-compaction',
+      fetch_model: 'some-fetch',
+      fallback_models: ['fallback-a', 'fallback-b'],
+    });
+  });
+
+  it('still drops a genuinely stale model once the catalog has loaded', async () => {
+    h.platformMode = false;
+    h.otherPreference = { ...STORED };
+    h.validModelNames = new Set(['some-flash', 'fallback-a']);
+    h.rawModels = { anthropic: { models: ['some-flash', 'fallback-a'] } };
+    h.rawApiResponse = { models: { anthropic: { models: ['some-flash', 'fallback-a'] } } };
+
+    setupAndRenderModelTab();
+
+    const select = await screen.findByRole('combobox', { name: 'Web Search Provider' });
+    await waitFor(() => expect(select).toHaveValue(''));
+    fireEvent.change(select, { target: { value: 'serper' } });
+
+    await waitFor(() => expect(h.mutateAsync).toHaveBeenCalled());
+    const payload = h.mutateAsync.mock.calls.at(-1)![0] as {
+      other_preference: Record<string, unknown>;
+    };
+    expect(payload.other_preference).toMatchObject({
+      preferred_model: null,
+      preferred_flash_model: 'some-flash',
+      fallback_models: ['fallback-a'],
+    });
+  });
+
+  it('keeps them when only a custom model makes the model set non-empty', async () => {
+    // useAllModels folds custom models into validModelNames, so a user with one
+    // custom model has a non-empty set even while the server catalog is down.
+    // Gating on that set would let this exact case wipe every built-in.
+    h.platformMode = false;
+    h.otherPreference = { ...STORED };
+    h.validModelNames = new Set(['my-custom-model']);
+    h.rawModels = { 'my-provider': { models: ['my-custom-model'] } };
+    h.rawApiResponse = { models: {} };
+
+    setupAndRenderModelTab();
+
+    const select = await screen.findByRole('combobox', { name: 'Web Search Provider' });
+    await waitFor(() => expect(select).toHaveValue(''));
+    fireEvent.change(select, { target: { value: 'serper' } });
+
+    await waitFor(() => expect(h.mutateAsync).toHaveBeenCalled());
+    const payload = h.mutateAsync.mock.calls.at(-1)![0] as {
+      other_preference: Record<string, unknown>;
+    };
+    expect(payload.other_preference).toMatchObject({
+      preferred_model: 'some-model',
+      preferred_flash_model: 'some-flash',
+      compaction_model: 'some-compaction',
+      fetch_model: 'some-fetch',
+      fallback_models: ['fallback-a', 'fallback-b'],
+    });
+  });
+
+  it('keeps them when the catalog is loaded but access data is not', async () => {
+    // Platform mode with /api/auth/models slow or failed: buildVisibleModels
+    // falls back to the configured-provider filter, which admits nothing for a
+    // user with no BYOK keys, so validModelNames is empty while the catalog is
+    // fully loaded. That query is not in useAllModels' isLoading either, so
+    // there is no "still loading" signal to wait on.
+    h.platformMode = true;
+    h.otherPreference = { ...STORED };
+    h.validModelNames = new Set<string>();
+    h.rawModels = {
+      anthropic: { models: ['some-model', 'some-flash', 'some-compaction', 'some-fetch', 'fallback-a', 'fallback-b'] },
+    };
+    h.rawApiResponse = { models: { anthropic: { models: ['some-model', 'some-flash'] } } };
+
+    setupAndRenderModelTab();
+
+    const select = await screen.findByRole('combobox', { name: 'Web Search Provider' });
+    await waitFor(() => expect(select).toHaveValue(''));
+    fireEvent.change(select, { target: { value: 'serper' } });
+
+    await waitFor(() => expect(h.mutateAsync).toHaveBeenCalled());
+    const payload = h.mutateAsync.mock.calls.at(-1)![0] as {
+      other_preference: Record<string, unknown>;
+    };
+    expect(payload.other_preference).toMatchObject({
+      preferred_model: 'some-model',
+      preferred_flash_model: 'some-flash',
+      compaction_model: 'some-compaction',
+      fetch_model: 'some-fetch',
+      fallback_models: ['fallback-a', 'fallback-b'],
+    });
+  });
+
+  it('clears a stale fallback chip once the catalog has loaded', async () => {
+    // The fallback chips render straight from state — FallbackModelsPicker maps
+    // `selected` with no catalog filter, unlike the starred list. The load-time
+    // cleanup effect is the only thing that removes one, and it used to miss
+    // them entirely: loadModelTabData sets fallbackModels after an await, and
+    // the effect did not list it as a dependency.
+    h.platformMode = false;
+    h.otherPreference = { ...STORED, fallback_models: ['fallback-a', 'ghost-model'] };
+    h.validModelNames = new Set(['fallback-a']);
+    h.rawModels = { anthropic: { models: ['fallback-a'] } };
+    h.rawApiResponse = { models: { anthropic: { models: ['fallback-a'] } } };
+
+    setupAndRenderModelTab();
+
+    const chips = await screen.findByTestId('fallback-chips');
+    await waitFor(() => expect(chips).toHaveTextContent('fallback-a'));
+    await waitFor(() => expect(chips).not.toHaveTextContent('ghost-model'));
   });
 });

--- a/web/src/pages/Settings/panels/ModelTab.tsx
+++ b/web/src/pages/Settings/panels/ModelTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Search, Pin, Settings2 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { Select } from '@/components/ui/select';
@@ -24,7 +24,33 @@ export function ModelTab() {
   const { user: authUser } = useUser();
   const { preferences: prefsData } = usePreferences();
   const updatePrefsMutation = useUpdatePreferences();
-  const { models: visibleModels, modelAccessMap, systemDefaults: hookSystemDefaults, validModelNames, compactionProfiles, searchProviders, isLoading: isModelsLoading } = useAllModels();
+  const { models: visibleModels, modelAccessMap, systemDefaults: hookSystemDefaults, validModelNames, rawModels, compactionProfiles, searchProviders, isLoading: isModelsLoading, rawApiResponse } = useAllModels();
+
+  // Gate cleanup on the catalog itself, not on validModelNames: useAllModels
+  // folds the user's custom models into that set, so one custom model makes it
+  // non-empty while the server catalog is still unavailable, and every saved
+  // built-in would read as stale.
+  const catalogLoaded = useMemo(() => {
+    if (!rawApiResponse) return false;
+    const groups = (rawApiResponse.models ?? rawApiResponse) as Record<string, { models?: string[] } | undefined>;
+    return Object.values(groups).some(g => (g?.models?.length ?? 0) > 0);
+  }, [rawApiResponse]);
+
+  // Clean against existence, not access. validModelNames is what the user can
+  // reach right now: buildVisibleModels falls back to the configured-provider
+  // filter whenever the platform response is null, so a slow or failed
+  // /api/auth/models leaves it empty for a user with no BYOK keys, and its
+  // query is not part of useAllModels' isLoading. Cleaning against it would
+  // also delete a preference the moment a tier lapses or a key is removed, for
+  // a model that never went anywhere. rawModels is the pre-filter catalog plus
+  // the user's custom models, which is the question being asked.
+  const knownModelNames = useMemo(() => {
+    const names = new Set<string>();
+    for (const group of Object.values(rawModels)) {
+      for (const m of group.models ?? []) names.add(m);
+    }
+    return names;
+  }, [rawModels]);
   const { t } = useTranslation();
 
   // Model tab state
@@ -151,12 +177,19 @@ export function ModelTab() {
         if (p.use_response_api) entry.use_response_api = true;
         return entry;
       });
-    const cleanStarred = s.starredModels.filter(m => validModelNames.has(m));
-    const cleanFallback = s.fallbackModels.filter(m => validModelNames.has(m));
+    // An unloaded catalog is not a catalog of zero models. Validating against
+    // it would null preferred, flash, compaction, fetch, starred and fallback
+    // in a single write, with no undo. Keep the names untouched instead and let
+    // a later save do the cleanup once the catalog is in. Unrelated keys on
+    // this payload still save either way.
+    const known = (m: string) => !catalogLoaded || knownModelNames.has(m);
+
+    const cleanStarred = s.starredModels.filter(known);
+    const cleanFallback = s.fallbackModels.filter(known);
     const activeProviderKeys = new Set(s.byokProviders.filter(p => p.has_key).map(p => p.provider));
     const cleanCustomProviders = customProvidersList.filter(cp => activeProviderKeys.has(cp.name as string));
-    const cleanCustomModels = s.customModels.filter(cm => activeProviderKeys.has(cm.provider) || validModelNames.has(cm.name));
-    const cleanModelRef = (val: string) => validModelNames.has(val) ? val : null;
+    const cleanCustomModels = s.customModels.filter(cm => activeProviderKeys.has(cm.provider) || known(cm.name));
+    const cleanModelRef = (val: string) => known(val) ? val : null;
 
     await updatePrefsMutation.mutateAsync({
       other_preference: {
@@ -179,7 +212,7 @@ export function ModelTab() {
         ...(s.canCustomizeSearchDepth ? { search_depth: s.searchDepth || null } : {}),
       },
     });
-  }, [validModelNames, updatePrefsMutation]);
+  }, [knownModelNames, catalogLoaded, updatePrefsMutation]);
 
   const { trigger: triggerModelSaveRaw, flush: flushModelSave, status: modelSaveStatus } = useDebouncedSave(saveModelPrefs, 500);
   const triggerModelSave = useCallback(() => { dirtyRef.current = true; triggerModelSaveRaw(); }, [triggerModelSaveRaw]);
@@ -188,15 +221,19 @@ export function ModelTab() {
   // on unmount — flush a pending edit so it isn't silently lost.
   useEffect(() => () => { if (dirtyRef.current) flushModelSave(); }, [flushModelSave]);
 
-  // Auto-clean stale starred/fallback models on load
+  // Auto-clean stale starred/fallback models on load. starredModels and
+  // fallbackModels are in the deps because loadModelTabData sets them after an
+  // await: without them this only ran before the stored values arrived, and the
+  // fallback chips render straight from state (ModelTierConfig's
+  // FallbackModelsPicker maps `selected` unfiltered), so a model that no longer
+  // exists stayed on screen until the models query happened to refetch.
   useEffect(() => {
-    if (validModelNames.size === 0) return;
-    const cleanS = starredModels.filter(m => validModelNames.has(m));
+    if (!catalogLoaded) return;
+    const cleanS = starredModels.filter(m => knownModelNames.has(m));
     if (cleanS.length !== starredModels.length) setStarredModels(cleanS);
-    const cleanF = fallbackModels.filter(m => validModelNames.has(m));
+    const cleanF = fallbackModels.filter(m => knownModelNames.has(m));
     if (cleanF.length !== fallbackModels.length) setFallbackModels(cleanF);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [validModelNames]);
+  }, [knownModelNames, catalogLoaded, starredModels, fallbackModels]);
 
   return (
       <div className="space-y-6">


### PR DESCRIPTION
## Overview

| | Files | Insertions | Deletions |
|---|---:|---:|---:|
| Production | 2 | 70 | 16 |
| Tests | 3 | 227 | 1 |
| **Total** | **5** | **297** | **17** |

**By module**

| Module | File | What changed |
|---|---|---|
| `src/server/services/llm` | `availability.py` | the stale-preference scrub returns early when the model manifest is empty, and the removed-model error stops claiming a preference was cleared when none was |
| `web/src/pages/Settings/panels` | `ModelTab.tsx` | `saveModelPrefs` and the sibling auto-cleanup effect gate on the raw catalog rather than on the access-filtered `validModelNames`; the effect also gains the arrays it cleans as dependencies |

**What this introduces:** two guards against one bug class. An empty model catalog now reads as "not loaded" rather than "zero models exist", so neither the backend scrub nor the frontend save deletes a user's saved model preferences while the manifest is unavailable.

## The bug

Both sites treat an empty catalog as ground truth, so if the manifest fails to load every saved model name looks stale.

- **Backend.** `_cleanup_stale_model_preferences` deletes each unrecognised name. Those deletes go to a merge-upsert where `None` means "remove this key", so the whole preference set goes with no copy kept.
- **Frontend.** `saveModelPrefs` validates against `validModelNames`. Empty means `preferred_model`, `preferred_flash_model`, `compaction_model`, `fetch_model`, `starred_models` and `fallback_models` are all nulled in a single write. It is debounced and fires on any Model tab edit, including changing the search provider, and also flushes on unmount.

Neither has an undo. The sibling effect in `ModelTab.tsx` already carried a guard of the same shape, which is what made the omission visible — though that guard turned out to have the hole described below.

`validModelNames` is the wrong thing to ask, in two independent ways, both surfaced in review.

It is **not a loaded signal.** `useAllModels` folds the user's own custom models into it, so a user with one custom model has a non-empty set while the server catalog is still unavailable, and every saved built-in reads as stale.

It is **not an existence signal either.** `buildVisibleModels` branches on the platform access response and only the truthy side fails open: with `platform === null` it runs the configured-provider filter, which admits nothing for a user with no BYOK keys. Since `usePlatformModels` sets `retry: false`, a single failed `/api/auth/models` leaves that set empty for the whole session against a fully loaded catalog. Keying cleanup on access is wrong on its own terms too — a lapsed tier or a removed key would read as a deleted model.

A third problem sat in the same effect, found in review. It listed neither array it cleans as a dependency, so it only ever ran before `loadModelTabData`'s await resolved and never saw the stored values. That is invisible for starred models, which render filtered, but the fallback chips render straight from state — `FallbackModelsPicker` maps `selected` with no catalog filter — so a model that no longer existed stayed on screen until the models query happened to refetch. The deps are now exhaustive and the eslint-disable is gone.

So the two questions are now asked separately: `catalogLoaded`, from the raw `/api/v1/models` payload, for whether the catalog arrived at all; `knownModelNames`, from the pre-filter catalog plus custom models, for whether a name exists. This is what the backend already does — `mc.get_model_config(name)` reads the process-global manifest, never a per-user filtered view. Display filtering still uses `validModelNames`: a model the user cannot reach should not render, it should just not be deleted.

## Verification

Reproduced end to end against a running stack. Emptying `src/llms/manifest/models.json` makes `/api/v1/models` answer HTTP 200 with zero providers and zero models, which is exactly the condition both call sites were missing: a successful response carrying nothing.

With the manifest emptied, changing the Web Search Provider in Settings sent, on `main`, `preferred_model: null`, `preferred_flash_model: null`, `starred_models: null` and `fallback_models: []`, and the database confirmed the wipe. On this branch the same action sent every name intact.

Both review findings were covered the same way. One custom model with an empty catalog keeps every built-in; a loaded catalog with empty access data keeps every built-in. Each was confirmed by reverting the gate and watching that test alone fail, which is the only way to know it tests anything.

- Backend: scoped tests pass, `ruff check` clean.
- Frontend: 27 Settings tests pass, eslint and `tsc --noEmit` clean.

The frontend tests are a set on purpose: nothing is dropped while the catalog is empty; a genuinely stale name is still dropped once it has loaded; a custom model alone does not count as a loaded catalog; an empty access set does not count as an empty catalog; and a stale fallback chip does clear once the catalog is in. Without the second, this fix would be indistinguishable from deleting the cleanup.

## Follow-up, not in scope

The cleanup effect and `saveModelPrefs` now filter the same two arrays through the same predicate. One of them should own that, rather than both.

## Risk

Both paths now skip cleanup when the catalog is unavailable, so a genuinely stale name survives until the next save that happens with a loaded catalog. That is the intended trade: a delayed cleanup is recoverable, a deleted preference set is not.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ginlix-ai/codesmith/LangAlpha/pr/369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790282767&installation_model_id=432753&pr_number=369&repository=ginlix-ai%2FLangAlpha&return_to=https%3A%2F%2Fgithub.com%2Fginlix-ai%2FLangAlpha%2Fpull%2F369&signature=4d09523094615f443b531954410a74210f12254cb1305e34f1e55f8c50a21cb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved saved model preferences while the model catalog is unavailable or still loading.
  - Prevented valid model references from being removed when model data is incomplete.
  - Continued removing preferences for models no longer present after the catalog loads.
  - Improved guidance when a selected model is unavailable, without incorrectly indicating that a preference was deleted.

- **Tests**
  - Added coverage for catalog loading states, stale model cleanup, and fallback selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
