### PR TITLE
feat: sign in on any free port, drag any window, ring only for the keyboard

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -57,6 +57,13 @@ ascii liveness glyph. Never:
   only sanctioned edge markers are **nav selection** (sidebar rail edge,
   bottom-bar underline, watchlist active row).
 
+The rule governs the product's own surfaces. Illustrations that *depict* the
+product are not one of them: the onboarding intro panels draw a miniature of the
+app rather than being part of it, and they carry the accent structurally, in
+washes, glows and fills. A picture of a branded thing reads as brand, not as
+state. The alternative is a picture whose color has to be kept in step with the
+brand by hand, which is how that panel spent a rebrand still showing the old one.
+
 Semantic color (profit/loss/warning/danger) is separate from the accent and
 never substitutes for it.
 

--- a/desktop/AGENTS.md
+++ b/desktop/AGENTS.md
@@ -251,8 +251,22 @@ Three things are load-bearing:
 - **The exchange happens in the renderer, never in main.** The PKCE verifier lives in
   that renderer's cookie jar and never leaves it. That is also what makes the loopback
   hop safe: anything else listening on the port gets a code it cannot redeem.
-- **Only 8788/8789/8790 work.** Supabase matches `redirect_to` as an exact string, so
-  every port has to be in its Redirect URLs allowlist.
+- **The port comes from the OS, not from us.** `listen(0)` on loopback, which is what
+  RFC 8252 §7.3 tells an authorization server to expect from a native client, and the
+  only way to be sure of getting a port at all. Sign-in's `redirect_to` is still matched
+  against the Supabase Redirect URLs allowlist, so that entry has to be a port wildcard
+  (`http://127.0.0.1:*/callback`) for any of this to work. **That wildcard is wider than
+  a port.** Supabase's glob stops only at `.` and `/`, and `@` is neither, so the same
+  entry also matches `http://127.0.0.1:x@capture/callback`, a string whose real host is
+  `capture` rather than loopback. Reaching it takes a single-label hostname the user's own
+  resolver answers for, which is a narrower opening than the glob's shape suggests but not a
+  closed one: a search domain or a `hosts` entry can point `capture` at an address anywhere.
+  The allowlist is simply not doing the work it looks like it is doing. Whatever a Supabase
+  version happens to special-case about loopback literals is theirs to change, so do not
+  lean on it: the binding that actually holds is the PKCE verifier, which lives in the
+  renderer that minted it and cannot be redeemed anywhere else. A connector's authorization
+  server matches loopback as a pattern and adds no constraint, and this deployment's backend
+  accepts any loopback port at or above 1024 (`sanitize_loopback_redirect`).
 - **The interception mechanic is indirect.** `setWindowOpenHandler` returns `deny`, so
   `window.open` returns `null` and the SPA takes its existing popup-blocked fallback: a
   same-tab navigation to the authorize URL, which `will-navigate` then catches. If an

--- a/desktop/src/main.js
+++ b/desktop/src/main.js
@@ -815,8 +815,9 @@ app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') app.quit()
 })
 
-// Release the loopback port on the way out. A relaunch that finds 8788 still in
-// TIME_WAIT falls through to 8789, and only three ports are allowlisted.
+// Release the loopback port on the way out, and with it every flow still armed
+// on it. The port itself the OS reclaims either way; what this is for is the
+// flows, which would otherwise sit on timers in a process that is leaving.
 app.on('before-quit', () => {
   oauth.stopCallbackServer()
   updater.stop()

--- a/desktop/src/oauth.js
+++ b/desktop/src/oauth.js
@@ -38,11 +38,20 @@ const { forDisplay } = require('./redact')
 // redeemable by nothing on this machine at all.
 // ---------------------------------------------------------------------------
 
-// Every port here must be in the Supabase Redirect URLs allowlist, because
-// Supabase matches redirect_to as an exact string. A connector's AS is the
-// looser of the two, matching loopback as a pattern, so it takes what it is
-// given and adds no constraint of its own.
-const CALLBACK_PORTS = [8788, 8789, 8790]
+// The port is the operating system's to choose (RFC 8252 7.3: an authorization
+// server "MUST allow any port to be specified at the time of the request for
+// loopback IP redirect URIs"). Asking for a free one is what every native OAuth
+// client does, and it is the only way to be sure of getting one: three
+// hand-picked numbers were three chances for something else on the machine to
+// have taken them first, and when all three were gone the shell could not sign
+// anybody in until it was restarted.
+//
+// It costs a wildcard entry on the Supabase side, since sign-in's redirect_to is
+// matched against its Redirect URLs allowlist. A connector's authorization
+// server was never the constraint: it matches loopback as a pattern, and this
+// deployment's own backend allowlists any loopback port at or above 1024
+// (`sanitize_loopback_redirect`).
+const EPHEMERAL_PORT = 0
 // Matched to the backend's own STATE_TTL_SECONDS. A shell that gives up first
 // can only ever lose a flow the server would still have honoured, and brokerage
 // consent behind 2FA or an approval push routinely runs past five minutes.
@@ -145,7 +154,7 @@ function escapeHtml(value) {
  *
  * The provider returns by sending the user's browser to this URL, which every
  * browser labels `document`. Any other value is a page on the open web reaching
- * a loopback port as a subresource, and `<img src="http://127.0.0.1:8788/callback
+ * a loopback port as a subresource, and `<img src="http://127.0.0.1:<port>/callback
  * ?error=x">` is the whole attack: no-cors means the attacker never has to read
  * the reply, because the damage is the side effect. The flow is consumed and the
  * window that was signing in is driven to a failure it never had.
@@ -300,26 +309,41 @@ function connectorFlowFor(state) {
   return null
 }
 
-function startCallbackServer(i = 0) {
+// Bumped by every stop, so a bind that lands afterwards knows it was already
+// asked to go away. `stopCallbackServer` can only close a server it has, and a
+// start still in flight has none to hand it: the listener came up seconds later
+// with nothing waiting on it and nobody left to close it. No caller could reach
+// that until `begin` started one without awaiting it.
+let era = 0
+
+function startCallbackServer() {
+  const mine = era
   return new Promise((resolve) => {
-    if (i >= CALLBACK_PORTS.length) {
-      console.error('[auth] no free callback port in', CALLBACK_PORTS)
-      return resolve(null)
-    }
     const srv = http.createServer(handleCallback)
-    const nextPort = () => resolve(startCallbackServer(i + 1))
-    srv.once('error', nextPort)
-    srv.listen(CALLBACK_PORTS[i], '127.0.0.1', () => {
-      // Only a *bind* failure means "try the next port". Left attached, a later
-      // socket error would open a second listener and repoint `callbackPort`
-      // while the authorize URL already in the browser still names this one, so
-      // the provider's redirect arrives at a port nobody is reading.
-      srv.removeListener('error', nextPort)
+    const failed = (err) => {
+      // No fallback to try in the same attempt: the port is the OS's to pick, so
+      // there is no second number to reach for. The conditions that get here --
+      // no descriptors, no loopback to bind, a sandbox refusing the socket -- are
+      // the machine's rather than ours, which is why the retry belongs to the
+      // next caller (`ensureCallbackServer`) and not to a timer here.
+      console.error(`[auth] could not open a callback listener: ${err.code || err.message}`)
+      resolve(null)
+    }
+    srv.once('error', failed)
+    srv.listen(EPHEMERAL_PORT, '127.0.0.1', () => {
+      // Only a *bind* failure ends the attempt. Left attached, a later socket
+      // error would resolve this promise a second time and report a listener
+      // that is still up as never having opened.
+      srv.removeListener('error', failed)
       // Replaced, never just removed: a listening server with no 'error'
       // listener *throws* on the next socket error, which ends the app.
       srv.on('error', (err) => console.error(`[auth] callback server: ${err.code || err.message}`))
+      if (mine !== era) {
+        srv.close()
+        return resolve(null)
+      }
       server = srv
-      callbackPort = CALLBACK_PORTS[i]
+      callbackPort = srv.address().port
       console.log(`[auth] callback listening on http://127.0.0.1:${callbackPort}/callback`)
       resolve(callbackPort)
     })
@@ -329,11 +353,11 @@ function startCallbackServer(i = 0) {
 /**
  * The listening port, opening one now if the last attempt did not get one.
  *
- * Startup probes the three ports once, at the moment a crashed instance's socket
- * may still be in TIME_WAIT or a second copy may still be shutting down. That is
- * a transient condition, but the result was latched: `callbackPort` stayed null
- * for the life of the process and every connector flow in that session was
- * refused for a port that had since been free for hours.
+ * Startup opens the listener once, and a failure there used to be latched:
+ * `callbackPort` stayed null for the life of the process and every flow in that
+ * session was refused for a condition that may have cleared in seconds. Retrying
+ * on demand is cheap and costs one bind, so no caller has to inherit the state
+ * the app happened to boot into.
  */
 function ensureCallbackServer() {
   if (callbackPort) return Promise.resolve(callbackPort)
@@ -349,6 +373,7 @@ function ensureCallbackServer() {
  * for a code to arrive, so a flow left armed could only ever time out.
  */
 function stopCallbackServer() {
+  era += 1
   if (pending) {
     clearTimeout(pending.timer)
     pending = null
@@ -489,15 +514,24 @@ function begin(rawUrl, win) {
   // 'external', which opens the authorize URL in the system browser: the flow
   // then completes into a browser profile holding none of the PKCE verifier this
   // renderer just minted, so it cannot be redeemed and the window is never told
-  // why. Three ports is not a lot, and a preview plus a packaged app plus one
-  // other local service is enough to take them all. Claim it and say so.
+  // why. Claim it and say so.
+  //
+  // Reads the port rather than awaiting one: `decide` in main answers Electron's
+  // navigation handlers, which take a verdict in the same tick and no promise, so
+  // this flow is refused either way. Start the listener anyway and let it land
+  // after the refusal -- otherwise the boot failure stays latched for the life of
+  // the process exactly as it used to, and a user who only ever signs in never
+  // reaches the one path (`beginMcp`) that retries. What the message owes them is
+  // the way in that needs no listener at all; the click after it may well work.
   if (!callbackPort) {
     console.error('[auth] no loopback listener; refusing the flow rather than sending it somewhere it cannot finish')
+    ensureCallbackServer().catch(() => {})
     // Claimed either way: a window that closed under us still must not have its
     // authorize URL handed to a browser that cannot finish it.
     if (win.isDestroyed()) return true
     navigate(win, withParam(originalRedirect, 'error',
-      'Sign-in could not start: the local callback port is in use. Quit any other copy of LangAlpha and try again.'))
+      'Sign-in with a provider could not start: this machine would not give the app a local port '
+      + 'to listen on. Signing in with your email and password still works.'))
     return true
   }
 
@@ -685,5 +719,5 @@ function cancelMcp(win, flowId) {
 
 module.exports = {
   isAuthorizeUrl, begin, beginMcp, bindMcp, cancelMcp, startCallbackServer, stopCallbackServer,
-  isProviderNavigation, CALLBACK_PORTS, MCP_CALLBACK_PATH,
+  isProviderNavigation, MCP_CALLBACK_PATH,
 }

--- a/desktop/test/helpers.js
+++ b/desktop/test/helpers.js
@@ -102,6 +102,9 @@ Module._load = function (request, ...rest) {
  * Load the shell modules under a given edition. Config is read at require time,
  * so the cache has to be dropped between editions.
  */
+/** Every shell loaded here, so `cleanup` can close what each one opened. */
+const SHELLS = []
+
 function loadShell({ edition = 'oss', appOrigin, platformOrigin, serverUrl = null, loginPath, settings } = {}) {
   if (edition === 'saas') {
     fs.writeFileSync(BUILD_CONFIG, JSON.stringify({
@@ -127,7 +130,7 @@ function loadShell({ edition = 'oss', appOrigin, platformOrigin, serverUrl = nul
   const store = require(path.join(SRC, 'store.js'))
   if (serverUrl) store.set('serverUrl', serverUrl)
 
-  return {
+  const shell = {
     store,
     config: require(path.join(SRC, 'config.js')),
     origins: require(path.join(SRC, 'origins.js')),
@@ -140,6 +143,14 @@ function loadShell({ edition = 'oss', appOrigin, platformOrigin, serverUrl = nul
     captive: require(path.join(SRC, 'captive.js')),
     main: require(path.join(SRC, 'main.js')),
   }
+  // `oauth` is the one module here that can own an OS resource. A callback
+  // listener outlives the suite that opened it -- and a suite need not have
+  // asked for one, since a sign-in refused for want of a port starts one so the
+  // next attempt is not refused for a condition that already cleared. Left open,
+  // it holds the runner's event loop past the last test and the file is reported
+  // cancelled rather than passed.
+  SHELLS.push(shell.oauth)
+  return shell
 }
 
 /**
@@ -169,6 +180,7 @@ function tempDir(prefix) {
 }
 
 function cleanup() {
+  for (const oauth of SHELLS.splice(0)) oauth.stopCallbackServer()
   if (STASHED_BUILD_CONFIG) fs.writeFileSync(BUILD_CONFIG, STASHED_BUILD_CONFIG)
   else fs.rmSync(BUILD_CONFIG, { force: true })
   fs.rmSync(userData, { recursive: true, force: true })

--- a/desktop/test/shell.test.js
+++ b/desktop/test/shell.test.js
@@ -503,7 +503,7 @@ describe('interception, and what it refuses', () => {
   })
 
   // The loopback port is reachable from any page on the open web, not just from
-  // this machine: `<img src="http://127.0.0.1:8788/callback?error=x">` needs no
+  // this machine: `<img src="http://127.0.0.1:<port>/callback?error=x">` needs no
   // CORS, because the attacker never has to read the reply. The damage is the
   // side effect — the pending flow is consumed and the window signing in is
   // driven to a failure it never had. What separates that from the provider is
@@ -597,13 +597,25 @@ describe('interception, and what it refuses', () => {
     assert.equal(new URL(landed[1]).searchParams.get('code'), 'xyz')
   })
 
-  // The comment on CALLBACK_PORTS states a constraint that lives in someone
-  // else's dashboard: Supabase matches redirect_to as an exact string, so a port
-  // that is not on the Redirect URLs allowlist fails the exchange in production
-  // and only for the users whose earlier ports were already taken. The hardest
-  // possible thing to reproduce, so the list is pinned here instead.
-  test('the callback ports are the ones the provider allows', () => {
-    assert.deepEqual(oauth.CALLBACK_PORTS, [8788, 8789, 8790])
+  // The port is asked for, never chosen (RFC 8252 7.3), and the allowlist entry
+  // on the provider's side is a wildcard because of it. A hardcoded number would
+  // still pass every test above -- the listener works fine on any port -- and
+  // would fail in production only for the users whose machine already had that
+  // one taken, which is the hardest possible thing to reproduce. So the absence
+  // is asserted at the source, where reintroducing it is visible.
+  test('no callback port is hardcoded', () => {
+    const source = fs.readFileSync(path.join(__dirname, '..', 'src', 'oauth.js'), 'utf8')
+    assert.match(source, /\.listen\(EPHEMERAL_PORT, '127\.0\.0\.1'/)
+    assert.equal(/^const EPHEMERAL_PORT = 0$/m.test(source), true)
+    for (const line of source.split('\n')) {
+      assert.doesNotMatch(line, /\.listen\(\s*\d/, `a literal port reached listen(): ${line.trim()}`)
+    }
+  })
+
+  // And what it hands out is the port it actually got, which is the only way a
+  // caller can learn an OS-assigned one.
+  test('the port it reports is the one it bound', () => {
+    assert.ok(port >= 1024 && port <= 65535, `port ${port} is outside the usable range`)
   })
 
   // A code that arrives with nothing waiting is discarded, and the page written
@@ -696,10 +708,8 @@ describe('an MCP connector whose provider allows only a loopback callback', () =
   // degrade every desktop connect to the hosted callback silently, which for
   // the vendors this exists for is a dead end with no error to report.
   test('the URI it mints is one the backend will accept', async () => {
-    for (const p of oauth.CALLBACK_PORTS) {
-      assert.ok(p >= 1024, `port ${p} is below the backend's floor`)
-    }
     const u = new URL((await oauth.beginMcp(RETURN, windowStub([], PLUGINS))).redirectUri)
+    assert.ok(Number(u.port) >= 1024, `port ${u.port} is below the backend's floor`)
     assert.equal(u.protocol, 'http:')
     assert.equal(u.hostname, '127.0.0.1')
     assert.equal(u.pathname, oauth.MCP_CALLBACK_PATH)
@@ -1108,6 +1118,22 @@ describe('an authorize URL with nowhere to come back to', () => {
     assert.equal(landed.length, 1, 'the window has to be told')
     assert.equal(new URL(landed[0]).origin + new URL(landed[0]).pathname, 'https://app.example.com/auth/callback')
     assert.match(new URL(landed[0]).searchParams.get('error'), /port/)
+  })
+
+  // The refusal above is for this attempt, not for the session. Reading the port
+  // without ever starting one is what latched a failed boot bind for the life of
+  // the process: every sign-in refused for a condition that may have cleared in
+  // seconds, while the connector path next door recovered on its first retry.
+  test('and starts the listener the click after it will need', async () => {
+    opened.length = 0
+    // Nothing exposes the listener directly, so wait for the effect instead: a
+    // click that reaches the browser is a click that got a port.
+    for (let i = 0; i < 200 && opened.length === 0; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 10))
+      oauth.begin(authorize('https://app.example.com/auth/callback'), windowStub([]))
+    }
+    assert.equal(opened.length > 0, true, 'still refused; the failure is latched for the session')
+    assert.match(new URL(opened[0]).searchParams.get('redirect_to'), /^http:\/\/127\.0\.0\.1:\d+\/callback$/)
   })
 
   // The refusal is for flows that are ours. A crafted redirect_to is still not

--- a/web/e2e/account-menu.spec.js
+++ b/web/e2e/account-menu.spec.js
@@ -1,0 +1,68 @@
+/**
+ * The account panel is positioned against the account *row*, and that row is
+ * inset inside the sidebar's padding. So any width the panel names for itself
+ * lines up on one edge and misses on the other, and the miss is invisible in
+ * code review: `w-64` next to `align="start"` looks deliberate. It shipped that
+ * way, 17px wider than the row and hanging 7px off the sidebar entirely.
+ *
+ * Taking the width from the trigger fixes it by construction, and this is what
+ * keeps it fixed: the assertion is that the two edges agree, so it survives a
+ * change to --sidebar-width or to the panel's padding, neither of which a
+ * pinned pixel count would.
+ */
+import { test, expect, mockAPI } from './fixtures.js';
+
+/**
+ * How far each edge of the open panel sits from the same edge of the row.
+ *
+ * Polled rather than read once: the sidebar animates in, so for the first few
+ * frames the row is still travelling (left 4.8 on the way to 10) and Radix
+ * anchors to wherever it was when the panel mounted, then corrects. Asserting
+ * on the first paint measures the animation, not the alignment.
+ */
+const edgeGaps = (page) =>
+  page.evaluate(() => {
+    const row = document.querySelector('.sidebar-account-row');
+    const menu = document.querySelector('[role="menu"]');
+    if (!row || !menu) return null;
+    const r = row.getBoundingClientRect();
+    const m = menu.getBoundingClientRect();
+    return { left: Math.round(m.left - r.left), right: Math.round(m.right - r.right) };
+  });
+
+test.beforeEach(async ({ page }) => {
+  await mockAPI(page);
+  await page.goto('/dashboard');
+  await expect(page.locator('.sidebar-account-row')).toBeVisible();
+});
+
+// The row spells the account out, so it carries no fixed `aria-label` -- and
+// that means every descendant is exposed, the avatar included. The initials are
+// a picture of the name sitting beside them, so undecorated the row announces
+// the account twice over: "TU Test User".
+test('the row announces the account once, not once per rendering of it', async ({ page }) => {
+  await expect(page.locator('.sidebar-account-row')).toHaveAccessibleName('Test User');
+});
+
+test('the open panel lines up with the row it came from', async ({ page }) => {
+  await page.click('.sidebar-account-row');
+  await expect(page.locator('[role="menu"]')).toBeVisible();
+
+  // Both edges, not just the one align="start" already guaranteed. The right
+  // edge is the one that was wrong: +17 against the row, and 7px past the
+  // sidebar's own edge.
+  await expect.poll(() => edgeGaps(page)).toEqual({ left: 0, right: 0 });
+});
+
+test('the panel is not wider than its own content needs', async ({ page }) => {
+  await page.click('.sidebar-account-row');
+  await expect(page.locator('[role="menu"]')).toBeVisible();
+
+  // Inheriting a narrower width than before is only correct if nothing had to
+  // be cut to fit; a clipped label would make the alignment a bad trade.
+  const clipped = await page.evaluate(() => {
+    const m = document.querySelector('[role="menu"]');
+    return m.scrollWidth > m.clientWidth;
+  });
+  expect(clipped).toBe(false);
+});

--- a/web/e2e/auth-callback.spec.js
+++ b/web/e2e/auth-callback.spec.js
@@ -1,0 +1,68 @@
+/**
+ * The OAuth callback runs in one of two documents and cannot tell which from
+ * its own markup: the tab the user was already in, or the child window
+ * loginWithProvider opened. The success path has always branched on that. The
+ * failure path did not, and a popup that navigates itself back to the login
+ * route leaves a SECOND login page on screen, in a window the user now has to
+ * find and close, while the real one waits untouched in the opener.
+ *
+ * Both branches are swept because the two are one `window.opener` apart and the
+ * wrong one is invisible in ordinary browser QA -- a popup is exactly what a
+ * headed test run does not open for you.
+ */
+import { test, expect, mockAPI } from './fixtures.js';
+
+const DENIED = '/callback?error=access_denied&error_description=Sign-in%20was%20declined';
+
+/** Count window.close() calls without letting one actually close the page. */
+async function spyOnClose(page) {
+  await page.addInitScript(() => {
+    window.__closed = 0;
+    window.close = () => { window.__closed += 1; };
+  });
+}
+
+/** Present this document as the child window loginWithProvider opened. */
+async function asPopup(page) {
+  await page.addInitScript(() => {
+    Object.defineProperty(window, 'opener', { value: { name: 'opener' }, configurable: true });
+  });
+}
+
+test.describe('OAuth callback failure', () => {
+  test('in a popup, the way out closes the window instead of navigating it', async ({ page }) => {
+    await spyOnClose(page);
+    await asPopup(page);
+    await mockAPI(page);
+    await page.goto(DENIED);
+
+    await expect(page.getByText('Sign-in was declined')).toBeVisible();
+    // The other way this page reaches the failure UI is a timeout, eight seconds
+    // after it settled on "Signing you in" with nothing else on screen changing.
+    // Only a live region makes that swap audible, so the role is asserted on the
+    // branch a test can reach synchronously.
+    await expect(page.getByRole('alert')).toContainText('Sign-in was declined');
+    const button = page.getByRole('button');
+    // Not "Back to login": there is nothing behind this window to go back to.
+    await expect(button).toHaveText('Close');
+
+    await button.click();
+    expect(await page.evaluate(() => window.__closed)).toBe(1);
+    // The popup stayed on the callback rather than growing a second login page.
+    expect(new URL(page.url()).pathname).toBe('/callback');
+  });
+
+  test('in the top-level tab, the way out is still the login page', async ({ page }) => {
+    await spyOnClose(page);
+    await mockAPI(page);
+    await page.goto(DENIED);
+
+    await expect(page.getByText('Sign-in was declined')).toBeVisible();
+    const button = page.getByRole('button');
+    await expect(button).toHaveText('\u2190 Back to sign in');
+
+    await button.click();
+    await expect.poll(() => new URL(page.url()).pathname).not.toBe('/callback');
+    expect(await page.evaluate(() => window.__closed)).toBe(0);
+  });
+});

--- a/web/e2e/fixtures.js
+++ b/web/e2e/fixtures.js
@@ -47,6 +47,11 @@ export async function mockAPI(page, overrides = {}) {
     await page.route(
       (url) => pathRegex.test(url.pathname.replace('/api/v1', '')),
       async (route) => {
+        // A page navigation is never one of these calls. Some API paths are also
+        // app routes -- `/news/:id` is both -- and the predicate above sees only
+        // a pathname, so without this the document request for /news/1 is
+        // answered with the article JSON and the SPA never loads at all.
+        if (route.request().resourceType() === 'document') return route.fallback();
         const reqMethod = route.request().method();
         if (method !== '*' && reqMethod !== method) {
           return route.fallback();

--- a/web/e2e/focus-ring.spec.js
+++ b/web/e2e/focus-ring.spec.js
@@ -1,0 +1,80 @@
+/**
+ * A focus ring is the mouse cursor for someone navigating by keyboard, so it
+ * has to be there for them and absent for everyone else. Both halves break
+ * silently and neither is visible from inside a component.
+ *
+ * The half that broke: Radix hands focus back to the trigger when an overlay
+ * closes, and Chromium propagates :focus-visible across a programmatic focus
+ * move. So a menu opened and dismissed entirely with the mouse left its trigger
+ * ringed until the next click, on every dropdown in the app. Nothing about that
+ * is expressible in CSS, and a screenshot of the ring looks identical whether
+ * it was earned by a keystroke or not. This is the only place the difference
+ * can be measured.
+ *
+ * The other half is the one an over-eager fix takes out. Suppressing the
+ * restore unconditionally would pass every mouse assertion below and leave
+ * keyboard users pressing Escape into nowhere, so the keyboard cases are not
+ * balance: they are the thing most at risk.
+ */
+import { test, expect, mockAPI } from './fixtures.js';
+
+// The account button in the sidebar footer, chosen because it is a plain
+// DropdownMenu over the shared ui/ wrapper -- whatever is true here is true of
+// the other call sites, which is the point of fixing it in the wrapper.
+const ROW = '.sidebar-account-row';
+
+// Somewhere in the page body with nothing interactive under it.
+const EMPTY = { x: 760, y: 300 };
+
+/** Is a focus indicator actually painted on the element that holds focus? */
+async function ringed(page) {
+  return page.evaluate((sel) => {
+    const row = document.querySelector(sel);
+    if (!row) throw new Error('the account row is not on the page');
+    return document.activeElement === row && row.matches(':focus-visible');
+  }, ROW);
+}
+
+test.beforeEach(async ({ page }) => {
+  await mockAPI(page);
+  await page.goto('/dashboard');
+  await expect(page.locator(ROW)).toBeVisible();
+});
+
+test.describe('a flow driven entirely by the mouse', () => {
+  test('leaves no ring after choosing a menu item', async ({ page }) => {
+    await page.click(ROW);
+    // The regression lived here: this close returns focus to the trigger.
+    await page.locator('[role="menuitem"]').first().click();
+    await expect.poll(() => ringed(page)).toBe(false);
+  });
+
+  test('leaves no ring after dismissing the menu', async ({ page }) => {
+    await page.click(ROW);
+    await page.mouse.click(EMPTY.x, EMPTY.y);
+    await expect.poll(() => ringed(page)).toBe(false);
+  });
+
+  test('leaves no ring on the click that opened it', async ({ page }) => {
+    await page.click(ROW);
+    await page.click(ROW);
+    await expect.poll(() => ringed(page)).toBe(false);
+  });
+});
+
+test.describe('a keyboard user still gets an indicator', () => {
+  test('when focus lands on the row', async ({ page }) => {
+    await page.keyboard.press('Escape');
+    await page.locator(ROW).evaluate((el) => el.focus());
+    await expect.poll(() => ringed(page)).toBe(true);
+  });
+
+  test('when they open the menu and press Escape', async ({ page }) => {
+    await page.locator(ROW).evaluate((el) => el.focus());
+    await page.keyboard.press('Enter');
+    await expect(page.locator('[role="menuitem"]').first()).toBeVisible();
+    // Escape must put them back where they were, still able to see where.
+    await page.keyboard.press('Escape');
+    await expect.poll(() => ringed(page)).toBe(true);
+  });
+});

--- a/web/e2e/helpers/mockResponses.js
+++ b/web/e2e/helpers/mockResponses.js
@@ -40,6 +40,21 @@ export const defaultResponses = {
     },
   },
   'GET /workspaces': { workspaces: [], total: 0, limit: 20, offset: 0 },
+  // What ChatAgent fetches one path segment below /chat. Left unmocked these
+  // 404, and ThreadGallery's not-found effect navigates back to /chat -- so a
+  // test that names /chat/<id> silently measures the workspace gallery above it
+  // and passes. The id is fixed rather than echoed from the URL because nothing
+  // downstream compares the two; `status` is what decides the flash path.
+  'GET /workspaces/*': {
+    workspace_id: 'a0000001-0000-4000-8000-000000000001',
+    name: 'Research',
+    description: 'Main workspace',
+    status: 'ready',
+    config: {},
+    created_at: '2025-01-01T00:00:00Z',
+    updated_at: '2025-01-01T00:00:00Z',
+  },
+  'GET /threads': { threads: [], total: 0, limit: 20, offset: 0 },
   'POST /workspaces/flash': {
     workspace_id: 'ws-flash',
     name: 'Flash',
@@ -58,6 +73,21 @@ export const defaultResponses = {
   'GET /market-data/snapshots/indexes': { snapshots: [] },
   'GET /market-data/intraday/indexes/*': { data: [] },
   'GET /news': { results: [], count: 0, next_cursor: null },
+  // The article behind /news/:id. Unmocked, the detail page renders its
+  // "Article not found" branch, which has text and so satisfies every wait a
+  // test puts on it while measuring a page nobody meant to test.
+  'GET /news/*': {
+    id: 'news-1',
+    title: 'Markets Rally on Strong Earnings',
+    published_at: '2025-01-01T12:00:00Z',
+    author: 'Test Author',
+    source: { name: 'Reuters', favicon_url: '' },
+    image_url: '',
+    tickers: ['AAPL'],
+    description: 'A test article body.',
+    sentiments: [],
+    article_url: 'https://example.com/article',
+  },
   'GET /insights/today': { insights: [] },
   'GET /users/me/watchlists': {
     watchlists: [{ watchlist_id: 'wl-1', name: 'Default' }],

--- a/web/e2e/window-chrome.spec.js
+++ b/web/e2e/window-chrome.spec.js
@@ -37,6 +37,29 @@ const SHELL_BRIDGE = { version: '0.0.0-e2e', platform: 'darwin', windowChrome: '
 // measures what that costs.
 const CHROMELESS_ROUTES = ['/setup/method', '/privacy', '/legal', '/s/no-such-token'];
 
+// Any valid v4 UUID; nothing has to exist behind it for the thread gallery to
+// render its back-button row, which is the bar this suite measures.
+const E2E_WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
+
+// And every route that renders INSIDE the app shell. There the sidebar reserves
+// and drags its own column and the fallback strip has stood down, which leaves
+// the content column beside it entirely to the route: a route with no top bar of
+// its own to mark `data-chrome="drag"` owes the window a `.chrome-drag-strip`, or
+// nothing right of the sidebar moves the window at all. Four routes shipped
+// without one, and the shape of the miss is why this list is swept rather than
+// spot-checked -- see the test.
+//
+// `/chat` appears twice on purpose. One path segment later ChatAgent swaps the
+// workspace gallery for the thread gallery, a different component with a
+// different top row, so the bare route proves nothing about the one below it.
+// Any route whose component branches on a param owes this list both branches.
+//
+// The id has to be a well-formed UUID. ChatAgent runs the param through
+// isValidUuid and treats anything else as absent, so a readable placeholder
+// like `ws-e2e` silently lands back on the workspace gallery and the test
+// passes while measuring the route above the one it names.
+const APP_ROUTES = ['/dashboard', '/chat', `/chat/${E2E_WORKSPACE_ID}`, '/market', '/plugins', '/automations', '/settings', '/news/1'];
+
 async function asDesktopShell(page, bridge = SHELL_BRIDGE) {
   await page.addInitScript((value) => {
     Object.defineProperty(window, 'langalphaDesktop', { value, configurable: true });
@@ -263,6 +286,127 @@ test.describe('desktop window chrome', () => {
       expect(await cornerOccupants(page)).toEqual([]);
     });
   }
+
+  // Swept across the whole row rather than sampled in the middle, because both
+  // ways this fails leave the middle working. A strip dropped inside a page that
+  // carries the column's padding on its root starts BELOW the window's top edge
+  // and stops short of BOTH sides -- and the left shortfall lands exactly in the
+  // gap between this strip and the sidebar's own, which is where a drag aimed at
+  // "the empty bit at the top" tends to go. One sample at x=50% passes on all of
+  // it. A strip parked inside a scrolling page is the third shape: it rides the
+  // content out of view, so the titlebar works until the user scrolls.
+  for (const route of APP_ROUTES) {
+    test(`the top of the content column moves the window on ${route}`, async ({ page }) => {
+      await asDesktopShell(page);
+      await mockAPI(page);
+      await page.goto(route);
+      // The settled CONTENT COLUMN, and not merely a settled document. The
+      // sweeps above wait on `document.body`, which inside the app shell is
+      // satisfied by the sidebar alone -- and /chat opens behind a full-height
+      // curtain at opacity 0, so the row was swept while the route it belongs to
+      // had not painted, and every point read as dead. Waiting on `.main` waits
+      // for the column the assertion is about.
+      await page.waitForFunction(
+        () => !document.querySelector('.page-loading')
+          && document.querySelector('.app-main .main')?.innerText.trim().length > 0,
+      );
+
+      // Still the route this test names. A route whose data 404s can navigate
+      // itself somewhere else before the sweep runs -- /chat/<id> does exactly
+      // that, its not-found effect replacing the URL with /chat -- and the sweep
+      // then measures a page that was never in question and reports it under the
+      // name of the one that was. Mocks keep it here; this is what notices when
+      // they stop.
+      expect(new URL(page.url()).pathname).toBe(route);
+
+      const dead = await page.evaluate((stripH) => {
+        const main = document.querySelector('.app-main');
+        if (!main) return ['no .app-main'];
+        const box = main.getBoundingClientRect();
+        const y = Math.round(stripH / 2);
+        const out = [];
+        // The 24px stride can stop up to a stride short of the right edge, and a
+        // page that carries its padding on the root falls short by exactly that
+        // sort of distance. Sample the far edge outright rather than hoping the
+        // stride lands inside the gap.
+        const xs = [];
+        for (let x = Math.round(box.left) + 2; x < box.right - 2; x += 24) xs.push(x);
+        xs.push(Math.round(box.right) - 3);
+        for (const x of xs) {
+          const el = document.elementFromPoint(x, y);
+          let region = 'none';
+          for (let node = el; node; node = node.parentElement) {
+            const r = getComputedStyle(node).webkitAppRegion;
+            if (r === 'drag' || r === 'no-drag') { region = r; break; }
+          }
+          // `no-drag` is a control taking its own clicks back, which is the whole
+          // point of the rule in chrome.css and is expected wherever a route puts
+          // a real bar in the titlebar row. `none` is the row never having been a
+          // drag region at all, which is the bug.
+          if (region === 'none') {
+            out.push(`x=${x} <${el ? el.tagName.toLowerCase() : 'nothing'}` +
+              `${el && el.className ? ` class="${String(el.className).slice(0, 40)}"` : ''}>`);
+          }
+        }
+        return out;
+      }, BUTTON_RECT.h);
+
+      expect(dead, `dead points in the titlebar row on ${route}`).toEqual([]);
+    });
+  }
+
+  // The third shape, and the one the sweep above cannot see: a strip parked
+  // inside a page that scrolls sits in the right row at load and then rides the
+  // content out of view on the first wheel event, so the titlebar works until
+  // the user scrolls and the sweep passes the whole time. `/news/:id` is the
+  // long route -- an article -- and was exactly that until it grew a scroll port
+  // of its own.
+  test('the titlebar stays put once a long route is scrolled', async ({ page }) => {
+    await asDesktopShell(page);
+    await mockAPI(page, {
+      'GET /news/*': {
+        id: 'news-long',
+        title: 'Markets Rally on Strong Earnings',
+        published_at: '2025-01-01T12:00:00Z',
+        source: { name: 'Reuters', favicon_url: '' },
+        tickers: ['AAPL'],
+        // Long enough to overflow any window this suite runs in.
+        description: 'Lorem ipsum dolor sit amet. '.repeat(2000),
+        sentiments: [],
+        article_url: 'https://example.com/article',
+      },
+    });
+    await page.goto('/news/1');
+    await page.waitForFunction(
+      () => !document.querySelector('.page-loading')
+        && document.querySelector('.app-main .main')?.innerText.trim().length > 0,
+    );
+
+    // Whichever element ended up owning the overflow -- that is the question, so
+    // the test must not assume the answer.
+    const scrolled = await page.evaluate(() => {
+      let moved = 0;
+      for (const el of document.querySelectorAll('*')) {
+        if (el.scrollHeight > el.clientHeight + 4) {
+          el.scrollTop = el.scrollHeight;
+          if (el.scrollTop > 0) moved += 1;
+        }
+      }
+      return moved;
+    });
+    expect(scrolled, 'nothing scrolled; the article is not long enough to test').toBeGreaterThan(0);
+
+    const region = await page.evaluate((stripH) => {
+      const box = document.querySelector('.app-main').getBoundingClientRect();
+      const el = document.elementFromPoint(Math.round((box.left + box.right) / 2), Math.round(stripH / 2));
+      for (let node = el; node; node = node.parentElement) {
+        const r = getComputedStyle(node).webkitAppRegion;
+        if (r === 'drag' || r === 'no-drag') return r;
+      }
+      return `none <${el ? el.tagName.toLowerCase() : 'nothing'}>`;
+    }, BUTTON_RECT.h);
+    expect(region).toBe('drag');
+  });
 
   test('a pre-0.1.1 shell still gets the strip from the platform guess', async ({ page }) => {
     // The bridge without `windowChrome` is what an already-installed older shell

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -37,6 +37,30 @@
   box-sizing: border-box;
 }
 
+/* A route with no top bar of its own to mark `data-chrome="drag"` drops in a
+   `.chrome-drag-strip` (chrome.css) so the top of the content column can still
+   move the window. Two shapes, and which one a route needs is decided by
+   whether it scrolls:
+
+   A route that scrolls puts the strip ABOVE its scroll port (Plugins, Settings)
+   -- a strip inside one rides the content out of view, and a titlebar that
+   works only at scroll-top is the bug reported again. That shape needs nothing
+   from here: the strip is the first child of an unpadded column, so it already
+   starts at the window's top edge and runs the column's full width.
+
+   A route that does not scroll can keep its padding on the page root and drop
+   the strip straight in (Automations). There the padding is between the strip
+   and the two edges a drag aims for -- the window's top, and on the left the
+   band between this strip and the sidebar's own. Such a page publishes its
+   padding as `--page-inset`: the strip pulls back out of it and hands it back
+   below itself, so the strip is the titlebar and the padding still spaces the
+   content underneath. Unset, every margin here resolves to zero. */
+html.desktop-mac .chrome-drag-strip {
+  margin-top: calc(-1 * var(--page-inset, 0px));
+  margin-bottom: var(--page-inset, 0px);
+  margin-inline: calc(-1 * var(--page-inset, 0px));
+}
+
 @media (max-width: 767px) {
   .app-layout {
     height: 100vh;
@@ -62,5 +86,11 @@
      the shell's preload can produce, so mobile web is untouched. */
   html.desktop-mac .app-main {
     padding-top: 38px;
+  }
+
+  /* ...so a route's own strip stands down here. The rule above already reserved
+     the row for every one of them, and two reservations are 76px of nothing. */
+  html.desktop-mac .app-main .chrome-drag-strip {
+    display: none;
   }
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -31,20 +31,64 @@ const PrivacyPolicy = React.lazy(() => import('./pages/Legal/PrivacyPolicy'));
 const Legal = React.lazy(() => import('./pages/Legal/Legal'));
 const ResetPassword = React.lazy(() => import('./pages/Login/ResetPassword'));
 
+/** How long a callback may sit holding neither a session nor a stated reason
+ *  before it is called a failure. What it waits on is the `?code=` exchange the
+ *  Supabase client runs on load, which is the same wait AuthConfirm bounds. */
+const CALLBACK_TIMEOUT_MS = 8000;
+
 /**
- * Handles the OAuth redirect from Supabase. Two modes:
+ * The failure a callback arrived carrying, or null for none. Two writers put it
+ * in two places: Supabase reports a denied or expired authorization in the query
+ * under PKCE and in the hash under implicit, and the desktop shell writes its own
+ * prose into the query when it declines a flow it cannot finish (no free loopback
+ * port, a timeout, a second sign-in superseding this one) — this route is the
+ * only channel it has for saying so. Read during render, not from an effect: the
+ * Supabase client strips the URL as soon as it has consumed it.
+ */
+function callbackFailure(): string | null {
+  const query = new URLSearchParams(window.location.search);
+  const hash = new URLSearchParams(window.location.hash.slice(1));
+  const read = (key: string) => query.get(key) || hash.get(key);
+  return read('error_description') || read('error');
+}
+
+/**
+ * Handles the OAuth redirect from Supabase. Three modes:
  * - Popup (opened by loginWithProvider): broadcast to the opener and close.
  * - Top-level (fallback when the popup was blocked): navigate to /dashboard.
+ * - Failed: say why, and offer the way back. Waiting only on a session leaves
+ *   every flow that ends without one behind a message promising a sign-in that
+ *   is not coming, and no way out of the page but quitting.
  */
 function AuthCallback() {
   const { isLoggedIn } = useAuth();
   const navigate = useNavigate();
   const { t: tAuth } = useTranslation();
+  // Two failures with different standing. A stated one is somebody's answer --
+  // the provider denied it, or the shell could not finish it -- and it holds
+  // even if a session from an earlier sign-in is sitting in the cookie jar.
+  const [stated] = useState<string | null>(callbackFailure);
+  // A timeout is only us giving up on the wait. Nobody said no, so a session
+  // that lands on a slow connection after the deadline still wins the page;
+  // latching this into `stated` is what used to strand it behind an error.
+  const [timedOut, setTimedOut] = useState(false);
+  const failure = stated ?? (timedOut ? tAuth('auth.errors.generic') : null);
+
+  // Whether this document is the child window loginWithProvider opened. The
+  // failure UI needs it too, so it is read here rather than inside the effect:
+  // in a popup there is no back to go to, the page it would go back to is in
+  // the opener and still on screen.
+  const isPopup = typeof window !== 'undefined' && !!window.opener && window.opener !== window;
 
   useEffect(() => {
-    if (!isLoggedIn) return;
+    if (stated) return;
+    if (!isLoggedIn) {
+      // No session and nobody said why. Whatever dropped the flow is not going
+      // to report it later, so bound the wait instead of spinning on it.
+      const deadline = setTimeout(() => setTimedOut(true), CALLBACK_TIMEOUT_MS);
+      return () => clearTimeout(deadline);
+    }
 
-    const isPopup = typeof window !== 'undefined' && !!window.opener && window.opener !== window;
     if (isPopup) {
       try {
         const channel = new BroadcastChannel(AUTH_BROADCAST_CHANNEL);
@@ -66,7 +110,38 @@ function AuthCallback() {
       return;
     }
     navigate('/dashboard', { replace: true });
-  }, [isLoggedIn, navigate]);
+  }, [stated, isPopup, isLoggedIn, navigate]);
+
+  if (failure) {
+    return (
+      // A timeout swaps this in eight seconds after the page settled on
+      // "Signing you in", with nothing on screen changing that a screen reader
+      // would otherwise report. `alert` is what makes the swap audible, and it
+      // carries the button's label with it, so the way out is announced too.
+      <div
+        role="alert"
+        className="flex flex-col items-center justify-center gap-5 min-h-screen px-6 text-center"
+        style={{ backgroundColor: 'var(--color-bg-page)' }}
+      >
+        <p className="text-sm max-w-sm" style={{ color: 'var(--color-text-secondary)' }}>{failure}</p>
+        <button
+          type="button"
+          className="text-sm rounded-md px-3 py-1.5"
+          style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-default)' }}
+          onClick={() => {
+            // Navigating a popup would leave a second login page stranded in a
+            // window the user still has to find and close, while the real one
+            // waits untouched in the opener. Hand the window back instead --
+            // the opener holds no pending state, so it needs no telling.
+            if (isPopup) window.close();
+            else navigate(APP_ENTRY_PATH, { replace: true });
+          }}
+        >
+          {isPopup ? tAuth('common.close') : tAuth('auth.backToLogin')}
+        </button>
+      </div>
+    );
+  }
 
   return (
     <div className="flex items-center justify-center min-h-screen" style={{ backgroundColor: 'var(--color-bg-page)' }}>

--- a/web/src/components/Sidebar/AccountMenu.tsx
+++ b/web/src/components/Sidebar/AccountMenu.tsx
@@ -55,12 +55,19 @@ const AccountMenu: React.FC<AccountMenuProps> = ({ variant = 'rail' }) => {
   const initials = useMemo(() => {
     const source = displayName || email;
     if (!source) return '';
-    return source
+    const letters = source
       .split(/[\s@.]+/)
       .filter(Boolean)
       .slice(0, 2)
-      .map((s) => s[0]?.toUpperCase() ?? '')
+      // Array.from, not [0]: an emoji or an astral CJK character is two code
+      // units, and indexing takes half of one and renders it as U+FFFD.
+      .map((s) => Array.from(s)[0]?.toUpperCase() ?? '')
       .join('');
+    // Bound the characters, not the parts. Uppercasing can turn one code point
+    // into two ('ß' -> 'SS', 'fi' ligature -> 'FI'), so slicing the parts leaves
+    // the glyph count to the font: measured in Chromium, "ssner Muller" spelled
+    // with an eszett gives SSM at 28.6px inside a 28px disc and clips.
+    return Array.from(letters).slice(0, 2).join('');
   }, [displayName, email]);
 
   const [avatarError, setAvatarError] = useState(false);
@@ -74,13 +81,20 @@ const AccountMenu: React.FC<AccountMenuProps> = ({ variant = 'rail' }) => {
       <DropdownMenu open={open} onOpenChange={setOpen} modal={false}>
         <DropdownMenuTrigger asChild>
           {variant === 'row' ? (
+            // No aria-label here, unlike the collapsed trigger: this row spells
+            // the account out, so a fixed label would replace what is on screen
+            // with something less (WCAG 2.5.3). The plan reads out for the same
+            // reason -- it is a tier, and the rail is where it is stated.
             <button
               type="button"
-              aria-label={t('account.menuLabel', 'Account menu')}
               className="sidebar-account-row"
               data-active={isTriggerActive ? 'true' : undefined}
             >
-              <span className="sidebar-account-row-avatar">
+              {/* Decorative in this variant. Dropping the fixed `aria-label`
+                  exposed every descendant, and the initials are a picture of the
+                  name spelled out beside them: without this the row announces
+                  "JD John Doe Pro". */}
+              <span className="sidebar-account-row-avatar" aria-hidden="true">
                 {avatarUrl && !avatarError ? (
                   <img
                     src={avatarUrl}
@@ -98,7 +112,7 @@ const AccountMenu: React.FC<AccountMenuProps> = ({ variant = 'rail' }) => {
                 {displayName || email || t('account.menuLabel', 'Account menu')}
               </span>
               {planDisplayName && (
-                <span className="sidebar-account-row-plan" aria-hidden="true">
+                <span className="sidebar-account-row-plan">
                   {planDisplayName}
                 </span>
               )}
@@ -136,11 +150,21 @@ const AccountMenu: React.FC<AccountMenuProps> = ({ variant = 'rail' }) => {
           side={variant === 'row' ? 'top' : 'right'}
           align={variant === 'row' ? 'start' : 'end'}
           sideOffset={variant === 'row' ? 8 : 12}
-          className="w-64"
+          // Expanded, the panel is an extension of the row it came from, so it
+          // takes that row's width rather than a number of its own: the row is
+          // inset 10px inside the sidebar, so any fixed width lines up on the
+          // left (align="start") and misses on the right. Collapsed, the
+          // trigger is a 32px avatar and has no width worth inheriting.
+          className={variant === 'row' ? 'w-[var(--radix-dropdown-menu-trigger-width)]' : 'w-64'}
         >
-          {(displayName || email) && (
+          {/* The expanded trigger is a full row already carrying this avatar and
+              this name, so repeating them here stacks the same identity twice.
+              Collapsed, the trigger is a bare circle and this block is the only
+              place the account is named at all. The email is what neither
+              trigger shows, so the row variant keeps that line and nothing else. */}
+          {variant === 'rail' && (displayName || email) && (
             <>
-              <div className="flex items-center gap-2.5 px-3 py-2">
+              <div className="flex items-center gap-2.5 px-2.5 py-1.5">
                 <div
                   className="h-9 w-9 rounded-full flex items-center justify-center overflow-hidden flex-shrink-0"
                   style={{ backgroundColor: 'var(--color-accent-soft)' }}
@@ -194,16 +218,18 @@ const AccountMenu: React.FC<AccountMenuProps> = ({ variant = 'rail' }) => {
             </>
           )}
 
+          {variant === 'row' && email && (
+            <div
+              className="px-2.5 pt-1 pb-1.5 text-xs truncate"
+              style={{ color: 'var(--color-text-tertiary)' }}
+            >
+              {email}
+            </div>
+          )}
+
           {platformUrl && (
             <DropdownMenuItem asChild>
-              <a
-                href={platformUrl}
-                className="flex items-center gap-2"
-                style={{
-                  backgroundColor: 'var(--color-accent-soft)',
-                  border: '1px solid var(--color-accent-overlay)',
-                }}
-              >
+              <a href={platformUrl} className="flex items-center gap-2">
                 <CreditCard
                   className="h-4 w-4"
                   style={{ color: 'var(--color-accent-light)' }}
@@ -213,16 +239,11 @@ const AccountMenu: React.FC<AccountMenuProps> = ({ variant = 'rail' }) => {
                 </span>
                 <ChevronRight
                   className="h-3.5 w-3.5"
-                  style={{ color: 'var(--color-accent-light)' }}
+                  style={{ color: 'var(--color-text-tertiary)' }}
                 />
               </a>
             </DropdownMenuItem>
           )}
-
-          {/* Only divide when the Usage & Plan item above actually rendered;
-              OSS mode hides it (platformUrl === null) and an unconditional
-              separator would stack against the profile divider. */}
-          {platformUrl && <DropdownMenuSeparator />}
 
           <DropdownMenuItem onSelect={() => navigate('/settings')}>
             <Settings className="h-4 w-4" />

--- a/web/src/components/Sidebar/Sidebar.css
+++ b/web/src/components/Sidebar/Sidebar.css
@@ -190,7 +190,7 @@ html.desktop-mac .sidebar-window-drag {
   align-items: center;
   gap: 10px;
   width: 100%;
-  padding: 7px 9px;
+  padding: 5px 9px;
   border: none;
   border-radius: 6px;
   background: transparent;
@@ -308,7 +308,7 @@ html.desktop-mac .sidebar-window-drag {
   align-items: center;
   gap: 10px;
   width: 100%;
-  padding: 6px 8px;
+  padding: 5px 8px;
   border: none;
   border-radius: 8px;
   background: transparent;
@@ -320,9 +320,18 @@ html.desktop-mac .sidebar-window-drag {
   background: hsl(var(--sidebar-hover));
 }
 
+/* Inset, unlike the collapsed avatar's: the row is already full-bleed against
+   the panel, so an outset ring lands in the gutter and reads as a second border
+   on the sidebar itself. Drawn inside its own radius it stays a ring on one
+   control. */
+.sidebar-account-row:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px var(--color-focus-ring);
+}
+
 .sidebar-account-row-avatar {
-  width: 32px;
-  height: 32px;
+  width: 28px;
+  height: 28px;
   border-radius: 999px;
   background: var(--color-accent-soft);
   color: var(--color-accent-light);
@@ -354,6 +363,13 @@ html.desktop-mac .sidebar-window-drag {
   background: var(--color-accent-soft);
   color: var(--color-accent-light);
   flex-shrink: 0;
+  /* Bounded because the text is a backend value, not one of ours: the plan's
+     display name is free-form, and unbounded next to a shrinkable name this
+     pill wins the row and squeezes the account down to nothing. */
+  max-width: 7rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .sidebar-logo {
@@ -479,7 +495,7 @@ html.desktop-mac .sidebar-window-drag {
 
 .sidebar-account-trigger:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 2px var(--color-accent-overlay);
+  box-shadow: 0 0 0 2px var(--color-focus-ring);
 }
 
 .sidebar-account-trigger[data-active='true'] {

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -3,6 +3,7 @@ import * as DialogPrimitive from "@radix-ui/react-dialog"
 import { X } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import { lastInputWasPointer } from "@/lib/inputModality"
 import { useIsMobile } from "@/hooks/useIsMobile"
 import { useSwipeToDismiss } from "@/hooks/useSwipeToDismiss"
 
@@ -42,9 +43,23 @@ const DialogContent = React.forwardRef<
     /** 'default' = bottom-sheet on mobile, centered on desktop. 'centered' = always centered. */
     variant?: 'default' | 'centered';
   }
->(({ className, children, variant = 'default', ...props }, ref) => {
+>(({ className, children, variant = 'default', onCloseAutoFocus, ...props }, ref) => {
   const isMobile = useIsMobile();
   const swipeEnabled = isMobile && variant === 'default';
+
+  // Radix hands focus back to whatever opened the dialog so a keyboard user
+  // keeps their place. Chromium carries :focus-visible across that programmatic
+  // move, so a dialog opened and dismissed with the mouse leaves that control
+  // ringed until the next click. Skip the restore when no key was pressed:
+  // focus falls to <body>, which is where clicking anywhere else would have put
+  // it anyway. Held in one place because this component renders two Contents.
+  const closeAutoFocus = React.useCallback(
+    (event: Event) => {
+      onCloseAutoFocus?.(event);
+      if (!event.defaultPrevented && lastInputWasPointer()) event.preventDefault();
+    },
+    [onCloseAutoFocus],
+  );
 
   // Hidden close button ref — clicking it triggers Radix's onOpenChange(false)
   const closeRef = React.useRef<HTMLButtonElement>(null);
@@ -83,6 +98,7 @@ const DialogContent = React.forwardRef<
           aria-describedby={undefined}
           ref={containerRefCb}
           className={cn(DIALOG_MOBILE_SHEET_CLASSES, className)}
+          onCloseAutoFocus={closeAutoFocus}
           {...props}
         >
           {/* Drag handle */}
@@ -122,6 +138,7 @@ const DialogContent = React.forwardRef<
           DIALOG_CENTERED_CLASSES,
           className
         )}
+        onCloseAutoFocus={closeAutoFocus}
         {...props}>
         {children}
         <DialogPrimitive.Close

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
 
 import { cn } from "@/lib/utils"
+import { lastInputWasPointer } from "@/lib/inputModality"
 
 const DropdownMenu = DropdownMenuPrimitive.Root
 
@@ -14,12 +15,22 @@ const DropdownMenuContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content> & {
     container?: HTMLElement | null
   }
->(({ className, sideOffset = 4, collisionPadding = 8, container, ...props }, ref) => (
+>(({ className, sideOffset = 4, collisionPadding = 8, container, onCloseAutoFocus, ...props }, ref) => (
   <DropdownMenuPrimitive.Portal container={container ?? undefined}>
     <DropdownMenuPrimitive.Content
       ref={ref}
       sideOffset={sideOffset}
       collisionPadding={collisionPadding}
+      onCloseAutoFocus={(event) => {
+        onCloseAutoFocus?.(event)
+        // Radix hands focus back to the trigger on close so a keyboard user
+        // keeps their place. Chromium carries :focus-visible across that
+        // programmatic move, so a menu opened and dismissed with the mouse
+        // leaves the trigger ringed until the next click. Skip the restore
+        // when no key was pressed: focus falls to <body>, which is where
+        // clicking anywhere else would have put it anyway.
+        if (!event.defaultPrevented && lastInputWasPointer()) event.preventDefault()
+      }}
       className={cn(
         // Radix measures the space left to the collision boundary and publishes
         // it as --radix-…-available-height; capping there is what keeps a long

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -60,7 +60,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-default select-none items-center gap-2 rounded-sm px-3 py-2 text-sm outline-none transition-colors",
+      "relative flex w-full cursor-default select-none items-center gap-2 rounded-sm px-2.5 py-1.5 text-sm outline-none transition-colors",
       "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       itemVariants[variant],
       className
@@ -76,7 +76,7 @@ const DropdownMenuLabel = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.Label
     ref={ref}
-    className={cn("px-3 py-2 text-sm font-medium", className)}
+    className={cn("px-2.5 py-1.5 text-sm font-medium", className)}
     {...props}
   />
 ))
@@ -103,7 +103,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center gap-2 rounded-sm px-3 py-2 text-sm outline-none data-[highlighted]:bg-accent/15 data-[state=open]:bg-accent/15",
+      "flex cursor-default select-none items-center gap-2 rounded-sm px-2.5 py-1.5 text-sm outline-none data-[highlighted]:bg-accent/15 data-[state=open]:bg-accent/15",
       className
     )}
     {...props}

--- a/web/src/components/ui/input.tsx
+++ b/web/src/components/ui/input.tsx
@@ -6,7 +6,7 @@ const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLI
     <input
       type={type}
       className={cn(
-        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base sm:text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        "flex h-9 w-full rounded-md border border-input bg-background px-3 py-2 text-base sm:text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       ref={ref}

--- a/web/src/components/ui/popover.tsx
+++ b/web/src/components/ui/popover.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import * as PopoverPrimitive from "@radix-ui/react-popover"
 
 import { cn } from "@/lib/utils"
+import { lastInputWasPointer } from "@/lib/inputModality"
 
 const Popover = PopoverPrimitive.Root
 
@@ -12,12 +13,22 @@ const PopoverAnchor = PopoverPrimitive.Anchor
 const PopoverContent = React.forwardRef<
   React.ComponentRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+>(({ className, align = "center", sideOffset = 4, onCloseAutoFocus, ...props }, ref) => (
   <PopoverPrimitive.Portal>
     <PopoverPrimitive.Content
       ref={ref}
       align={align}
       sideOffset={sideOffset}
+      onCloseAutoFocus={(event) => {
+        onCloseAutoFocus?.(event)
+        // Radix hands focus back to the trigger on close so a keyboard user
+        // keeps their place. Chromium carries :focus-visible across that
+        // programmatic move, so a popover opened and dismissed with the mouse
+        // leaves the trigger ringed until the next click. Skip the restore
+        // when no key was pressed: focus falls to <body>, which is where
+        // clicking anywhere else would have put it anyway.
+        if (!event.defaultPrevented && lastInputWasPointer()) event.preventDefault()
+      }}
       className={cn(
         "z-[1030] w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -12,7 +12,7 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
       <div className={cn("relative", className)}>
         <select
           ref={ref}
-          className="w-full appearance-none rounded-md py-2 pl-3 pr-9 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50"
+          className="h-9 w-full appearance-none rounded-md py-0 pl-3 pr-9 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50"
           style={{
             backgroundColor: "var(--color-bg-card)",
             border: "1px solid var(--color-border-muted)",

--- a/web/src/lib/inputModality.ts
+++ b/web/src/lib/inputModality.ts
@@ -1,0 +1,32 @@
+/**
+ * Which input device the user last reached for.
+ *
+ * Chromium propagates `:focus-visible` across a *programmatic* focus move: an
+ * element focused by script inherits the state of the element focus came from.
+ * Radix overlays hand focus back to their trigger on close, so a menu opened
+ * and dismissed entirely with the mouse still lights that trigger's focus ring,
+ * and leaves it lit until the next click. Overlays consult this to skip the
+ * restore when no keyboard was involved.
+ */
+
+/** Held alone, a modifier is someone reaching for Cmd-Tab, not navigating. */
+const MODIFIERS = new Set(['Meta', 'Control', 'Alt', 'Shift']);
+
+let pointer = false;
+
+if (typeof window !== 'undefined') {
+  // Capture phase: a handler that stops propagation must not be able to hide
+  // the interaction from this.
+  window.addEventListener('pointerdown', () => { pointer = true; }, true);
+  window.addEventListener(
+    'keydown',
+    (event) => {
+      if (!MODIFIERS.has(event.key)) pointer = false;
+    },
+    true,
+  );
+}
+
+export function lastInputWasPointer(): boolean {
+  return pointer;
+}

--- a/web/src/lib/scrollMemory.ts
+++ b/web/src/lib/scrollMemory.ts
@@ -41,10 +41,12 @@ export const scrollMemory = {
 // Thread/route keys are per-account state — wipe on sign-out/account switch.
 registerAuthReset(() => scrollMemory.clear());
 
-// Restore retries: content below the fold often lands a few frames after the
-// route swap (lazy pages, query cache hydration). ~10 frames covers that
-// without fighting a user who has started scrolling (wheel/touch cancels).
-const RESTORE_RETRY_FRAMES = 10;
+// Restore retries: content below the fold lands after the route swap, and how
+// long after depends on where it comes from -- a lazy chunk or a warm query
+// cache is a few frames, a cold fetch is not. A frame budget was tuned for the
+// first and silently never restored the second, so the wait is a deadline
+// instead. A user who has started scrolling cancels it (wheel/touch).
+const RESTORE_WINDOW_MS = 1200;
 
 /**
  * Keyed scroll persistence for a container the caller owns. Saves scrollTop
@@ -63,12 +65,12 @@ export function useScrollMemory(ref: React.RefObject<HTMLElement | null>, key: s
     if (target === 0) return;
 
     let cancelled = false;
-    let attempts = 0;
+    const deadline = performance.now() + RESTORE_WINDOW_MS;
     const retry = () => {
       if (cancelled) return;
       if (el.scrollTop >= target - 4) return; // reached (content tall enough)
       el.scrollTop = target;
-      if (++attempts < RESTORE_RETRY_FRAMES) requestAnimationFrame(retry);
+      if (performance.now() < deadline) requestAnimationFrame(retry);
     };
     requestAnimationFrame(retry);
     const cancel = () => {

--- a/web/src/lib/scrollMemory.ts
+++ b/web/src/lib/scrollMemory.ts
@@ -41,12 +41,16 @@ export const scrollMemory = {
 // Thread/route keys are per-account state — wipe on sign-out/account switch.
 registerAuthReset(() => scrollMemory.clear());
 
-// Restore retries: content below the fold lands after the route swap, and how
-// long after depends on where it comes from -- a lazy chunk or a warm query
-// cache is a few frames, a cold fetch is not. A frame budget was tuned for the
-// first and silently never restored the second, so the wait is a deadline
-// instead. A user who has started scrolling cancels it (wheel/touch).
-const RESTORE_WINDOW_MS = 1200;
+// Restoring is content-dependent, not time-dependent: a saved offset only
+// becomes reachable once whatever fills the port has arrived, and how long that
+// takes is the network's business rather than a number this module can pick. A
+// frame budget tuned for a lazy chunk silently never restored a route whose body
+// comes from a fetch, and widening it into a deadline only moved the cliff out
+// to slower responses. So watch the port for content instead, and stop the
+// moment the offset lands or the user takes the scroll for themselves. The
+// bound below is a backstop for a port that never grows tall enough to hold the
+// offset, not the mechanism.
+const RESTORE_BACKSTOP_MS = 10_000;
 
 /**
  * Keyed scroll persistence for a container the caller owns. Saves scrollTop
@@ -64,25 +68,40 @@ export function useScrollMemory(ref: React.RefObject<HTMLElement | null>, key: s
     el.scrollTop = target;
     if (target === 0) return;
 
-    let cancelled = false;
-    const deadline = performance.now() + RESTORE_WINDOW_MS;
-    const retry = () => {
-      if (cancelled) return;
-      if (el.scrollTop >= target - 4) return; // reached (content tall enough)
+    // The offset this hook last wrote, so a scroll event can be attributed. Any
+    // other value means something else moved the port -- a wheel, a key, a drag
+    // on the scrollbar -- and where the user is now outranks where they were.
+    // Reading it back rather than assuming `target` matters while the content is
+    // still short: the write clamps to whatever the port can currently hold.
+    let written = el.scrollTop;
+    let stopped = false;
+    const stop = () => {
+      if (stopped) return;
+      stopped = true;
+      observer.disconnect();
+      clearTimeout(backstop);
+      el.removeEventListener('scroll', onScroll);
+    };
+    const attempt = () => {
+      if (stopped) return;
+      if (el.scrollTop >= target - 4) return stop(); // reached
       el.scrollTop = target;
-      if (performance.now() < deadline) requestAnimationFrame(retry);
+      written = el.scrollTop;
+      if (written >= target - 4) stop();
     };
-    requestAnimationFrame(retry);
-    const cancel = () => {
-      cancelled = true;
+    const onScroll = () => {
+      if (el.scrollTop !== written) stop();
     };
-    el.addEventListener('wheel', cancel, { passive: true });
-    el.addEventListener('touchstart', cancel, { passive: true });
-    return () => {
-      cancelled = true;
-      el.removeEventListener('wheel', cancel);
-      el.removeEventListener('touchstart', cancel);
-    };
+    // `subtree`, because the growth is inside the page the port wraps, not in
+    // the port itself -- whose own box is pinned by the column and so never
+    // resizes. `characterData`, because a route that renders its shell first and
+    // fills the text in later grows without adding a node.
+    const observer = new MutationObserver(attempt);
+    const backstop = setTimeout(stop, RESTORE_BACKSTOP_MS);
+    observer.observe(el, { childList: true, subtree: true, characterData: true });
+    el.addEventListener('scroll', onScroll, { passive: true });
+    requestAnimationFrame(attempt);
+    return stop;
   }, [ref, key]);
 
   useLayoutEffect(() => {

--- a/web/src/lib/scrollMemory.ts
+++ b/web/src/lib/scrollMemory.ts
@@ -41,17 +41,6 @@ export const scrollMemory = {
 // Thread/route keys are per-account state — wipe on sign-out/account switch.
 registerAuthReset(() => scrollMemory.clear());
 
-// Restoring is content-dependent, not time-dependent: a saved offset only
-// becomes reachable once whatever fills the port has arrived, and how long that
-// takes is the network's business rather than a number this module can pick. A
-// frame budget tuned for a lazy chunk silently never restored a route whose body
-// comes from a fetch, and widening it into a deadline only moved the cliff out
-// to slower responses. So watch the port for content instead, and stop the
-// moment the offset lands or the user takes the scroll for themselves. The
-// bound below is a backstop for a port that never grows tall enough to hold the
-// offset, not the mechanism.
-const RESTORE_BACKSTOP_MS = 10_000;
-
 /**
  * Keyed scroll persistence for a container the caller owns. Saves scrollTop
  * per key while the user scrolls; on key change restores the saved offset
@@ -67,39 +56,56 @@ export function useScrollMemory(ref: React.RefObject<HTMLElement | null>, key: s
     const target = typeof saved === 'number' ? saved : 0;
     el.scrollTop = target;
     if (target === 0) return;
+    // Already tall enough, which is the common case and needs nothing further.
+    // The write clamps to what the port can hold, so reading it back is the test.
+    if (el.scrollTop >= target - 4) return;
 
-    // The offset this hook last wrote, so a scroll event can be attributed. Any
-    // other value means something else moved the port -- a wheel, a key, a drag
-    // on the scrollbar -- and where the user is now outranks where they were.
-    // Reading it back rather than assuming `target` matters while the content is
-    // still short: the write clamps to whatever the port can currently hold.
+    // The offset this hook last wrote. Any other value in the port means
+    // something else moved it -- a wheel, a key, a drag on the scrollbar -- and
+    // where the user is now outranks where they were, so the restore stands
+    // down. The check belongs here, immediately before the write, and not in a
+    // `scroll` listener: a mutation callback is a microtask and the scroll event
+    // it would race is dispatched a frame later, so the write would land first
+    // and the listener would then compare the user's position against the value
+    // that had just overwritten it and find them equal. Read back rather than
+    // assumed to be `target`, since the write clamps to what the port can hold.
     let written = el.scrollTop;
     let stopped = false;
     const stop = () => {
       if (stopped) return;
       stopped = true;
       observer.disconnect();
-      clearTimeout(backstop);
-      el.removeEventListener('scroll', onScroll);
+      el.removeEventListener('load', attempt, true);
+      el.removeEventListener('wheel', stop);
+      el.removeEventListener('touchstart', stop);
     };
     const attempt = () => {
       if (stopped) return;
+      if (el.scrollTop !== written) return stop(); // the port moved, and not by us
       if (el.scrollTop >= target - 4) return stop(); // reached
       el.scrollTop = target;
       written = el.scrollTop;
       if (written >= target - 4) stop();
-    };
-    const onScroll = () => {
-      if (el.scrollTop !== written) stop();
     };
     // `subtree`, because the growth is inside the page the port wraps, not in
     // the port itself -- whose own box is pinned by the column and so never
     // resizes. `characterData`, because a route that renders its shell first and
     // fills the text in later grows without adding a node.
     const observer = new MutationObserver(attempt);
-    const backstop = setTimeout(stop, RESTORE_BACKSTOP_MS);
     observer.observe(el, { childList: true, subtree: true, characterData: true });
-    el.addEventListener('scroll', onScroll, { passive: true });
+    // An image or an iframe finishing its load grows the page without touching
+    // the DOM, so the observer above never hears about it. `load` does not
+    // bubble; capture is how a listener on the port sees a descendant's.
+    el.addEventListener('load', attempt, true);
+    // The two gestures that mean "move this port" even when it cannot move yet:
+    // a wheel or a swipe against a loading state too short to scroll leaves the
+    // offset untouched, so the guard in `attempt` has nothing to notice, and the
+    // article arriving a second later would snap the page out from under someone
+    // who had already started reading it. Keys are deliberately not here -- a
+    // keypress that scrolls is caught by the guard like any other movement, and
+    // one that does not is usually someone typing in a field on the page.
+    el.addEventListener('wheel', stop, { passive: true });
+    el.addEventListener('touchstart', stop, { passive: true });
     requestAnimationFrame(attempt);
     return stop;
   }, [ref, key]);

--- a/web/src/pages/Automations/Automations.css
+++ b/web/src/pages/Automations/Automations.css
@@ -1,8 +1,10 @@
 .automations-page {
+  /* Also read by the desktop shell's drag strip (App.css). */
+  --page-inset: clamp(16px, 3vw, 32px);
   display: flex;
   flex-direction: column;
   height: 100%;
-  padding: clamp(16px, 3vw, 32px) clamp(16px, 3vw, 32px);
+  padding: var(--page-inset) var(--page-inset);
   overflow: hidden;
 }
 

--- a/web/src/pages/Automations/Automations.tsx
+++ b/web/src/pages/Automations/Automations.tsx
@@ -117,6 +117,8 @@ export default function Automations() {
 
   return (
     <div className="automations-page">
+      {/* Doubles as the window titlebar in the desktop shell; inert elsewhere. */}
+      <div className="chrome-drag-strip" aria-hidden="true" />
       <div ref={topRef} />
       <AutomationsHeader automations={automations} />
 

--- a/web/src/pages/ChatAgent/components/NavigationPanel.css
+++ b/web/src/pages/ChatAgent/components/NavigationPanel.css
@@ -22,12 +22,12 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 6px 10px;
+  padding: 4px 10px;
   cursor: pointer;
   border-radius: 6px;
   margin: 1px 6px;
   transition: background-color 0.15s ease;
-  min-height: 32px;
+  min-height: 28px;
 }
 
 .nav-panel-row:hover {

--- a/web/src/pages/ChatAgent/components/ThreadGallery.tsx
+++ b/web/src/pages/ChatAgent/components/ThreadGallery.tsx
@@ -555,14 +555,20 @@ function ThreadGallery({ workspaceId, onBack, onThreadSelect }: ThreadGalleryPro
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center h-full">
-        <div className="flex flex-col items-center gap-4">
-          <span aria-hidden="true" className="flex-shrink-0">
-            <Loader size={32} className="text-[color:var(--color-accent-primary)]" />
-          </span>
-          <p className="text-sm" style={{ color: 'var(--color-text-tertiary)' }}>
-            {t('thread.loadingThreads')}
-          </p>
+      // A branch that replaces the whole route replaces its top bar too, so it
+      // owes the window a titlebar of its own -- otherwise the column beside the
+      // sidebar stops moving the window for as long as the fetch is in flight.
+      <div className="h-full flex flex-col">
+        <div className="chrome-drag-strip" aria-hidden="true" />
+        <div className="flex-1 min-h-0 flex items-center justify-center">
+          <div className="flex flex-col items-center gap-4">
+            <span aria-hidden="true" className="flex-shrink-0">
+              <Loader size={32} className="text-[color:var(--color-accent-primary)]" />
+            </span>
+            <p className="text-sm" style={{ color: 'var(--color-text-tertiary)' }}>
+              {t('thread.loadingThreads')}
+            </p>
+          </div>
         </div>
       </div>
     );
@@ -570,21 +576,24 @@ function ThreadGallery({ workspaceId, onBack, onThreadSelect }: ThreadGalleryPro
 
   if (error) {
     return (
-      <div className="flex items-center justify-center h-full">
-        <div className="flex flex-col items-center gap-4 max-w-md text-center px-4">
-          <p className="text-sm" style={{ color: 'var(--color-loss)' }}>
-            {error}
-          </p>
-          <button
-            onClick={() => queryClient.invalidateQueries({ queryKey: queryKeys.threads.byWorkspace(workspaceId) })}
-            className="px-4 py-2 rounded-md text-sm font-medium transition-opacity hover:opacity-90"
-            style={{
-              backgroundColor: 'var(--color-btn-primary-bg)',
-              color: 'var(--color-btn-primary-text)',
-            }}
-          >
-            {t('common.retry')}
-          </button>
+      <div className="h-full flex flex-col">
+        <div className="chrome-drag-strip" aria-hidden="true" />
+        <div className="flex-1 min-h-0 flex items-center justify-center">
+          <div className="flex flex-col items-center gap-4 max-w-md text-center px-4">
+            <p className="text-sm" style={{ color: 'var(--color-loss)' }}>
+              {error}
+            </p>
+            <button
+              onClick={() => queryClient.invalidateQueries({ queryKey: queryKeys.threads.byWorkspace(workspaceId) })}
+              className="px-4 py-2 rounded-md text-sm font-medium transition-opacity hover:opacity-90"
+              style={{
+                backgroundColor: 'var(--color-btn-primary-bg)',
+                color: 'var(--color-btn-primary-text)',
+              }}
+            >
+              {t('common.retry')}
+            </button>
+          </div>
         </div>
       </div>
     );
@@ -601,8 +610,11 @@ function ThreadGallery({ workspaceId, onBack, onThreadSelect }: ThreadGalleryPro
     >
       {/* Main Content Area */}
       <div className="flex-1 flex flex-col overflow-hidden">
-        {/* Back Button - Fixed at top left */}
-        <div className="flex-shrink-0 px-6 py-4 enter-fade-up">
+        {/* Back Button - Fixed at top left. Doubles as this route's drag region
+            in the desktop shell: it is the top bar the content column already
+            has, so it costs no layout, and the back button wins its own clicks
+            back through the `no-drag` list in chrome.css. */}
+        <div className="flex-shrink-0 px-6 py-4 enter-fade-up" data-chrome="drag">
           <button
             onClick={onBack}
             className="p-2 rounded-md transition-colors"

--- a/web/src/pages/ChatAgent/components/WorkspaceGallery.tsx
+++ b/web/src/pages/ChatAgent/components/WorkspaceGallery.tsx
@@ -706,14 +706,20 @@ function WorkspaceGallery({ onWorkspaceSelect, prefetchThreads }: WorkspaceGalle
 
   if (isWsLoading) {
     return (
-      <div className="flex items-center justify-center h-full">
-        <div className="flex flex-col items-center gap-4">
-          <span aria-hidden="true" className="flex-shrink-0">
-            <Loader size={32} className="text-[color:var(--color-accent-primary)]" />
-          </span>
-          <p className="text-sm" style={{ color: 'var(--color-text-tertiary)' }}>
-            {t('workspace.loadingWorkspaces')}
-          </p>
+      // A branch that replaces the whole route replaces its top bar too, so it
+      // owes the window a titlebar of its own -- otherwise the column beside the
+      // sidebar stops moving the window for as long as the fetch is in flight.
+      <div className="h-full flex flex-col">
+        <div className="chrome-drag-strip" aria-hidden="true" />
+        <div className="flex-1 min-h-0 flex items-center justify-center">
+          <div className="flex flex-col items-center gap-4">
+            <span aria-hidden="true" className="flex-shrink-0">
+              <Loader size={32} className="text-[color:var(--color-accent-primary)]" />
+            </span>
+            <p className="text-sm" style={{ color: 'var(--color-text-tertiary)' }}>
+              {t('workspace.loadingWorkspaces')}
+            </p>
+          </div>
         </div>
       </div>
     );
@@ -721,21 +727,24 @@ function WorkspaceGallery({ onWorkspaceSelect, prefetchThreads }: WorkspaceGalle
 
   if (wsError) {
     return (
-      <div className="flex items-center justify-center h-full">
-        <div className="flex flex-col items-center gap-4 max-w-md text-center px-4">
-          <p className="text-sm" style={{ color: 'var(--color-loss)' }}>
-            {t('workspace.failedLoadWorkspaces')}
-          </p>
-          <button
-            onClick={() => queryClient.invalidateQueries({ queryKey: queryKeys.workspaces.lists() })}
-            className="px-4 py-2 rounded-md text-sm font-medium transition-opacity hover:opacity-90"
-            style={{
-              backgroundColor: 'var(--color-btn-primary-bg)',
-              color: 'var(--color-btn-primary-text)',
-            }}
-          >
-            {t('common.retry')}
-          </button>
+      <div className="h-full flex flex-col">
+        <div className="chrome-drag-strip" aria-hidden="true" />
+        <div className="flex-1 min-h-0 flex items-center justify-center">
+          <div className="flex flex-col items-center gap-4 max-w-md text-center px-4">
+            <p className="text-sm" style={{ color: 'var(--color-loss)' }}>
+              {t('workspace.failedLoadWorkspaces')}
+            </p>
+            <button
+              onClick={() => queryClient.invalidateQueries({ queryKey: queryKeys.workspaces.lists() })}
+              className="px-4 py-2 rounded-md text-sm font-medium transition-opacity hover:opacity-90"
+              style={{
+                backgroundColor: 'var(--color-btn-primary-bg)',
+                color: 'var(--color-btn-primary-text)',
+              }}
+            >
+              {t('common.retry')}
+            </button>
+          </div>
         </div>
       </div>
     );
@@ -861,6 +870,10 @@ function WorkspaceGallery({ onWorkspaceSelect, prefetchThreads }: WorkspaceGalle
       className="h-full flex flex-col overflow-hidden"
       style={{ backgroundColor: 'var(--color-bg-page)' }}
     >
+      {/* Doubles as the window titlebar in the desktop shell; inert elsewhere.
+          The header below is centred and holds a title, so it is not the bar to
+          hand the window -- a drag region over prose is text you cannot select. */}
+      <div className="chrome-drag-strip" aria-hidden="true" />
       {/* Header (desktop only) */}
       <header className="hidden md:flex w-full h-24 items-end mx-auto max-w-4xl flex-shrink-0 px-8 enter-fade-up">
         <div className="flex w-full items-center justify-between gap-4">

--- a/web/src/pages/Detail/NewsDetailPage.tsx
+++ b/web/src/pages/Detail/NewsDetailPage.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { ArrowLeft, ExternalLink } from 'lucide-react';
 import { Loader } from '@/components/ui/loader';
+import { useScrollMemory } from '@/lib/scrollMemory';
 import { getNewsArticle } from '../Dashboard/utils/api';
 
 interface ArticleSentiment {
@@ -28,7 +29,41 @@ interface NewsArticle {
   article_url?: string;
 }
 
+/* Three exit paths render three different roots, and none of them is a bar the
+   window could be dragged by, so the titlebar is donated here instead of in each
+   one. Outside the article's own padding on purpose: it keeps the strip flush
+   with the top of the column and out of the column gap below it.
+
+   The article is long and this route brought no scroll port of its own, so it
+   was `.app-main` doing the scrolling -- with the strip inside it. That is the
+   third shape App.css warns about: the titlebar rides the content out of view
+   and stops working the moment the user scrolls. Give the page the column that
+   Settings and Plugins have, strip above and a scroll port below it. */
 function NewsDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const portRef = useRef<HTMLDivElement>(null);
+  // Owned here rather than left to the shell, now that the scrolling is. What
+  // `App.tsx` remembers is `.app-main`, which on this route no longer moves.
+  //
+  // The saved offset does not come back yet, and did not before this port
+  // existed either (measured both ways: 1200 out, 0 back). The restore runs on
+  // mount and gives up after ten frames, while the article arrives from a fetch
+  // in `NewsArticleView` some time after that, so there is nothing to scroll
+  // when the hook looks. Fixing that means teaching the hook to wait for content
+  // it does not own, which is every caller's problem and not this route's.
+  useScrollMemory(portRef, `page:news:${id ?? ''}`);
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="chrome-drag-strip" aria-hidden="true" />
+      <div ref={portRef} className="flex-1 min-h-0 overflow-y-auto">
+        <NewsArticleView />
+      </div>
+    </div>
+  );
+}
+
+function NewsArticleView() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const [article, setArticle] = useState<NewsArticle | null>(null);

--- a/web/src/pages/Detail/NewsDetailPage.tsx
+++ b/web/src/pages/Detail/NewsDetailPage.tsx
@@ -45,12 +45,9 @@ function NewsDetailPage() {
   // Owned here rather than left to the shell, now that the scrolling is. What
   // `App.tsx` remembers is `.app-main`, which on this route no longer moves.
   //
-  // The saved offset does not come back yet, and did not before this port
-  // existed either (measured both ways: 1200 out, 0 back). The restore runs on
-  // mount and gives up after ten frames, while the article arrives from a fetch
-  // in `NewsArticleView` some time after that, so there is nothing to scroll
-  // when the hook looks. Fixing that means teaching the hook to wait for content
-  // it does not own, which is every caller's problem and not this route's.
+  // The slowest caller the hook has, and the one that decided its shape: the
+  // article arrives from a fetch inside `NewsArticleView`, so the port is empty
+  // for as long as that takes and there is nothing to scroll until it lands.
   useScrollMemory(portRef, `page:news:${id ?? ''}`);
 
   return (

--- a/web/src/pages/Login/LoginPage.css
+++ b/web/src/pages/Login/LoginPage.css
@@ -110,6 +110,12 @@
 
 .login-page__input {
   width: 100%;
+  /* These are <Input>, so the shared primitive's height lands here too. This
+     surface sets its own type (1rem) and radius and wants the roomier box the
+     console does not; min-height rather than height so it holds whatever the
+     primitive's default becomes next. It is also what keeps the password
+     toggle's 44px touch target from overflowing the field it sits in. */
+  min-height: 2.5rem;
   padding: 0.75rem 1rem;
   font-size: 1rem;
   font-weight: 400;

--- a/web/src/pages/Onboarding/engine/introVisuals.tsx
+++ b/web/src/pages/Onboarding/engine/introVisuals.tsx
@@ -39,7 +39,7 @@ function Ln({ w, h = 3, c }: { w: string; h?: number; c?: string }) {
   );
 }
 
-function Tag({ children, color = 'var(--iv-blue)' }: { children: ReactNode; color?: string }) {
+function Tag({ children, color = 'var(--iv-accent)' }: { children: ReactNode; color?: string }) {
   return (
     <span
       className="w-fit shrink-0 rounded px-1 py-0.5 font-mono text-[0.5rem] leading-none"
@@ -88,7 +88,7 @@ function Frame({ children, topbar }: { children: ReactNode; topbar?: ReactNode }
           className="flex w-7 shrink-0 flex-col items-center gap-2 border-r py-2.5"
           style={{ borderColor: 'var(--iv-border)' }}
         >
-          <span className="h-2.5 w-2.5 rounded" style={{ background: 'var(--iv-blue)' }} />
+          <span className="h-2.5 w-2.5 rounded" style={{ background: 'var(--iv-accent)' }} />
           {[0, 1, 2].map((i) => (
             <span key={i} className="h-2.5 w-2.5 rounded" style={{ background: 'var(--iv-fill)' }} />
           ))}
@@ -123,7 +123,7 @@ function InputDock({ hot = false, delay, chip }: { hot?: boolean; delay?: number
         </span>
         <span
           className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full"
-          style={{ background: 'var(--iv-blue-deep)' }}
+          style={{ background: 'var(--iv-accent-deep)' }}
         >
           <ArrowUp className="h-2 w-2 text-white" />
         </span>
@@ -145,14 +145,14 @@ function WsCard({ hot = false, flash = false, delay }: { hot?: boolean; flash?: 
         flash
           ? {
               background:
-                'linear-gradient(135deg, rgba(90,130,216,0.22), rgba(90,130,216,0.08))',
-              borderColor: 'rgba(90,130,216,0.3)',
+                'linear-gradient(135deg, hsl(var(--primary) / 0.22), hsl(var(--primary) / 0.08))',
+              borderColor: 'hsl(var(--primary) / 0.3)',
             }
           : undefined
       }
     >
       <div className="flex items-center gap-1">
-        {flash && <Zap className="h-2 w-2 shrink-0" style={{ color: 'var(--iv-blue)' }} />}
+        {flash && <Zap className="h-2 w-2 shrink-0" style={{ color: 'var(--iv-accent)' }} />}
         <Ln w="52%" h={4} c="var(--iv-line-2)" />
       </div>
       <Ln w="88%" />
@@ -173,17 +173,17 @@ function TwoModes() {
       <div className="flex flex-1 gap-2">
         {/* Flash half: coordinating the desk, with quick answers on the side */}
         <Region hot delay={0.12} className="flex flex-1 flex-col gap-1.5 p-2">
-          <div className="flex items-center gap-1.5" style={{ color: 'var(--iv-blue)' }}>
+          <div className="flex items-center gap-1.5" style={{ color: 'var(--iv-accent)' }}>
             <Zap className="h-2.5 w-2.5" />
             <span className="font-mono text-[0.5rem]">Flash</span>
           </div>
           <OrchRow
-            icon={<Folder className="h-2 w-2 shrink-0" style={{ color: 'var(--iv-blue)' }} />}
+            icon={<Folder className="h-2 w-2 shrink-0" style={{ color: 'var(--iv-accent)' }} />}
             label="workspace created"
             delay={0.22}
           />
           <OrchRow
-            icon={<ChevronRight className="h-2 w-2 shrink-0" style={{ color: 'var(--iv-blue)' }} />}
+            icon={<ChevronRight className="h-2 w-2 shrink-0" style={{ color: 'var(--iv-accent)' }} />}
             label="dispatched to PTC"
             delay={0.3}
           />
@@ -231,7 +231,7 @@ function WorkspaceGrid() {
           <Ln w="22%" h={5} c="var(--iv-line-2)" />
           <span
             className="flex items-center gap-1 rounded px-1.5 py-1"
-            style={{ background: 'var(--iv-blue-deep)' }}
+            style={{ background: 'var(--iv-accent-deep)' }}
           >
             <Plus className="h-2 w-2 text-white" />
             <Ln w="30px" h={3} c="rgba(255,255,255,0.8)" />
@@ -342,7 +342,7 @@ function FlashAnswer() {
         <div className="intro-rv mr-24 flex justify-end" style={rv(0.12)}>
           <div
             className="rounded-md rounded-br-sm px-2 py-1.5"
-            style={{ background: 'rgba(90,130,216,0.22)' }}
+            style={{ background: 'hsl(var(--primary) / 0.22)' }}
           >
             <span
               className="block font-mono text-[0.5rem] leading-none"
@@ -353,22 +353,22 @@ function FlashAnswer() {
           </div>
         </div>
         <Region hot delay={0.2} className="flex flex-col gap-1.5 p-2">
-          <div className="flex items-center gap-1.5" style={{ color: 'var(--iv-blue)' }}>
+          <div className="flex items-center gap-1.5" style={{ color: 'var(--iv-accent)' }}>
             <Zap className="h-2.5 w-2.5" />
             <span className="font-mono text-[0.5rem]">flash · orchestrating</span>
           </div>
           <OrchRow
-            icon={<Folder className="h-2 w-2 shrink-0" style={{ color: 'var(--iv-blue)' }} />}
+            icon={<Folder className="h-2 w-2 shrink-0" style={{ color: 'var(--iv-accent)' }} />}
             label="workspace created · NVDA deep dive"
             delay={0.3}
           />
           <OrchRow
-            icon={<ChevronRight className="h-2 w-2 shrink-0" style={{ color: 'var(--iv-blue)' }} />}
+            icon={<ChevronRight className="h-2 w-2 shrink-0" style={{ color: 'var(--iv-accent)' }} />}
             label="task dispatched to PTC"
             delay={0.38}
           />
           <OrchRow
-            icon={<Clock className="h-2 w-2 shrink-0" style={{ color: 'var(--iv-blue)' }} />}
+            icon={<Clock className="h-2 w-2 shrink-0" style={{ color: 'var(--iv-accent)' }} />}
             label="automation · daily earnings brief"
             delay={0.46}
           />
@@ -377,7 +377,7 @@ function FlashAnswer() {
         <div className="intro-rv mr-24 flex justify-end" style={rv(0.54)}>
           <div
             className="rounded-md rounded-br-sm px-2 py-1.5"
-            style={{ background: 'rgba(90,130,216,0.22)' }}
+            style={{ background: 'hsl(var(--primary) / 0.22)' }}
           >
             <span
               className="block font-mono text-[0.5rem] leading-none"
@@ -388,7 +388,7 @@ function FlashAnswer() {
           </div>
         </div>
         <Region delay={0.62} className="flex flex-col gap-1.5 p-2">
-          <div className="flex items-center gap-1.5" style={{ color: 'var(--iv-blue)' }}>
+          <div className="flex items-center gap-1.5" style={{ color: 'var(--iv-accent)' }}>
             <Zap className="h-2.5 w-2.5" />
             <span className="font-mono text-[0.5rem]">flash · 0.9s</span>
           </div>
@@ -455,7 +455,7 @@ function PtcSandbox() {
                   style={{
                     ...rv(0.42 + i * 0.05),
                     height: `${h}%`,
-                    background: i === accent ? 'var(--iv-teal)' : 'rgba(90,130,216,0.7)',
+                    background: i === accent ? 'var(--iv-teal)' : 'hsl(var(--primary) / 0.7)',
                   }}
                 />
               ))}
@@ -537,7 +537,7 @@ function CreateWorkspace() {
               <Ln w="22%" h={5} c="var(--iv-line-2)" />
               <span
                 className="ml-auto mr-16 flex items-center gap-1 rounded px-1.5 py-1"
-                style={{ background: 'var(--iv-blue-deep)' }}
+                style={{ background: 'var(--iv-accent-deep)' }}
               >
                 <Plus className="h-2 w-2 text-white" />
                 <Ln w="30px" h={3} c="rgba(255,255,255,0.8)" />
@@ -617,7 +617,7 @@ function CreateWorkspace() {
               </span>
               <span
                 className="flex items-center px-2 py-1"
-                style={{ background: 'var(--iv-blue-deep)', borderRadius: 5 }}
+                style={{ background: 'var(--iv-accent-deep)', borderRadius: 5 }}
               >
                 <span className="font-mono text-[0.5rem] leading-none text-white">create</span>
               </span>
@@ -641,7 +641,7 @@ function PanelTabs({ active }: { active: 'files' | 'memory' | 'memos' }) {
           className="rounded px-1.5 py-0.5 font-mono text-[0.5rem] leading-none"
           style={
             t === active
-              ? { background: 'var(--iv-blue-deep)', color: '#fff' }
+              ? { background: 'var(--iv-accent-deep)', color: '#fff' }
               : { color: 'var(--iv-text-3)' }
           }
         >
@@ -761,7 +761,7 @@ function Memory() {
       tab="memory"
       bubble={
         <div className="intro-rv flex justify-end" style={rv(0.1)}>
-          <div className="rounded-md rounded-br-sm px-1.5 py-1" style={{ background: 'rgba(90,130,216,0.22)' }}>
+          <div className="rounded-md rounded-br-sm px-1.5 py-1" style={{ background: 'hsl(var(--primary) / 0.22)' }}>
             <span className="block font-mono text-[0.5rem] leading-none" style={{ color: 'var(--iv-text-2)' }}>
               remember this…
             </span>
@@ -797,7 +797,7 @@ function Memo() {
           </Region>
           {['76%', '60%'].map((w, i) => (
             <div key={i} className="intro-rv flex items-center gap-1.5" style={rv(0.42 + i * 0.1)}>
-              <span className="h-2 w-2 shrink-0 rounded-sm" style={{ background: 'var(--iv-blue)' }} />
+              <span className="h-2 w-2 shrink-0 rounded-sm" style={{ background: 'var(--iv-accent)' }} />
               <Ln w={w} />
               <span className="ml-auto">
                 <Tag color="var(--iv-teal)">ready</Tag>
@@ -902,7 +902,7 @@ function DashboardCustomize() {
             <span className="rounded px-1.5 py-0.5 font-mono text-[0.5rem]" style={{ color: 'var(--iv-text-3)' }}>
               Classic
             </span>
-            <span className="rounded px-1.5 py-0.5 font-mono text-[0.5rem] text-white" style={{ background: 'var(--iv-blue-deep)' }}>
+            <span className="rounded px-1.5 py-0.5 font-mono text-[0.5rem] text-white" style={{ background: 'var(--iv-accent-deep)' }}>
               Custom
             </span>
           </span>
@@ -955,8 +955,8 @@ function DashboardAttach() {
                 <Ln w="92%" />
                 <Ln w="64%" />
               </div>
-              <span className="relative flex h-5 w-5 shrink-0 items-center justify-center rounded-full" style={{ background: 'rgba(90,130,216,0.25)' }}>
-                <Paperclip className="h-2.5 w-2.5" style={{ color: 'var(--iv-blue)' }} />
+              <span className="relative flex h-5 w-5 shrink-0 items-center justify-center rounded-full" style={{ background: 'hsl(var(--primary) / 0.25)' }}>
+                <Paperclip className="h-2.5 w-2.5" style={{ color: 'var(--iv-accent)' }} />
                 <span className="intro-pulse intro-pulse--blue absolute -right-0.5 -top-0.5" style={{ width: 5, height: 5 }} />
               </span>
             </div>
@@ -971,9 +971,9 @@ function DashboardAttach() {
           delay={0.36}
           chip={
             /* right-aligned: this scene bleeds off the left edge */
-            <span className="ml-auto flex w-fit items-center gap-1 rounded px-1.5 py-0.5" style={{ background: 'rgba(90,130,216,0.2)' }}>
-              <Paperclip className="h-2 w-2" style={{ color: 'var(--iv-blue)' }} />
-              <span className="font-mono text-[0.5rem]" style={{ color: 'var(--iv-blue)' }}>
+            <span className="ml-auto flex w-fit items-center gap-1 rounded px-1.5 py-0.5" style={{ background: 'hsl(var(--primary) / 0.2)' }}>
+              <Paperclip className="h-2 w-2" style={{ color: 'var(--iv-accent)' }} />
+              <span className="font-mono text-[0.5rem]" style={{ color: 'var(--iv-accent)' }}>
                 attached
               </span>
             </span>

--- a/web/src/pages/Onboarding/engine/pageIntro.css
+++ b/web/src/pages/Onboarding/engine/pageIntro.css
@@ -1,16 +1,22 @@
 /*
- * Page-intro modal visual panel — blueprint style lifted from the
- * ginlix-platform landing page: blue radial glow, faint drafting grid, teal
- * pulse accents, mono-labelled product mockups. The panel follows the app
- * theme: near-black blueprint in dark mode, paper-light in light mode. All
- * surface/line colors below are tokens so the scenes render in both.
+ * Page-intro modal visual panel — blueprint style: accent radial glow, faint
+ * drafting grid, teal pulse accents, mono-labelled product mockups. The panel
+ * follows the app theme: near-black blueprint in dark mode, paper-light in
+ * light mode. All surface/line colors below are tokens so the scenes render
+ * in both.
+ *
+ * The structural accent is --primary itself, not a hex of its own. This panel
+ * shipped with a private copy of the brand color and quietly kept the old one
+ * through a rebrand; deriving it means that cannot happen twice, and it drops
+ * the per-theme override the hardcoded pair needed.
  */
 
 .intro-visual {
-  --iv-blue: #5a82d8;
-  --iv-blue-deep: #4161a4;
+  --iv-accent: hsl(var(--primary));
+  /* Both fills that use this carry a white glyph, so it has to stay dark
+     enough to hold one. Mixing toward black keeps it on the accent's hue. */
+  --iv-accent-deep: color-mix(in srgb, hsl(var(--primary)) 62%, #000);
   --iv-teal: #0fedbe;
-  --iv-amber: #ffc400;
   --iv-red: #ff6b6e;
   --iv-edge: rgba(232, 238, 248, 0.55);
   --iv-text: rgba(255, 255, 255, 0.86);
@@ -25,14 +31,14 @@
   --iv-grid: rgba(232, 238, 248, 0.05);
   --iv-mk-bg: rgba(10, 11, 14, 0.82);
   --iv-mk-border: rgba(255, 255, 255, 0.12);
-  --iv-mk-shadow: 0 16px 44px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(90, 130, 216, 0.07);
+  --iv-mk-shadow: 0 16px 44px rgba(0, 0, 0, 0.5), 0 0 0 1px hsl(var(--primary) / 0.07);
   --iv-region-bg: rgba(255, 255, 255, 0.03);
   --iv-ease: cubic-bezier(0.16, 1, 0.3, 1);
 
   position: relative;
   overflow: hidden;
   background:
-    radial-gradient(ellipse 95% 70% at 78% 12%, rgba(65, 97, 164, 0.4), transparent 70%),
+    radial-gradient(ellipse 95% 70% at 78% 12%, hsl(var(--primary) / 0.24), transparent 70%),
     radial-gradient(ellipse 70% 55% at 18% 112%, rgba(15, 237, 190, 0.1), transparent 70%),
     #060709;
   color: var(--iv-text);
@@ -41,7 +47,6 @@
 /* Light theme: paper panel, ink lines, accents darkened for contrast. */
 [data-theme='light'] .intro-visual {
   --iv-teal: #0a9f7c;
-  --iv-amber: #c27c00;
   --iv-red: #d8494c;
   --iv-text: rgba(18, 22, 30, 0.88);
   --iv-text-2: rgba(18, 22, 30, 0.62);
@@ -54,11 +59,11 @@
   --iv-grid: rgba(18, 22, 30, 0.05);
   --iv-mk-bg: rgba(255, 255, 255, 0.9);
   --iv-mk-border: rgba(18, 22, 30, 0.12);
-  --iv-mk-shadow: 0 16px 44px rgba(18, 22, 30, 0.14), 0 0 0 1px rgba(90, 130, 216, 0.08);
+  --iv-mk-shadow: 0 16px 44px rgba(18, 22, 30, 0.14), 0 0 0 1px hsl(var(--primary) / 0.08);
   --iv-region-bg: rgba(18, 22, 30, 0.03);
 
   background:
-    radial-gradient(ellipse 95% 70% at 78% 12%, rgba(90, 130, 216, 0.16), transparent 70%),
+    radial-gradient(ellipse 95% 70% at 78% 12%, hsl(var(--primary) / 0.16), transparent 70%),
     radial-gradient(ellipse 70% 55% at 18% 112%, rgba(10, 159, 124, 0.08), transparent 70%),
     #f4f1ea;
 }
@@ -104,8 +109,8 @@
 }
 
 .intro-mk--accent {
-  border-color: rgba(90, 130, 216, 0.55);
-  box-shadow: var(--iv-mk-shadow), 0 0 18px rgba(90, 130, 216, 0.28);
+  border-color: hsl(var(--primary) / 0.55);
+  box-shadow: var(--iv-mk-shadow), 0 0 18px hsl(var(--primary) / 0.28);
 }
 
 /* A region inside the zoomed-out page wireframe. Dim by default; `--hot`
@@ -117,9 +122,9 @@
 }
 
 .intro-region--hot {
-  border-color: rgba(90, 130, 216, 0.6);
-  background: rgba(90, 130, 216, 0.07);
-  box-shadow: 0 0 14px rgba(90, 130, 216, 0.22);
+  border-color: hsl(var(--primary) / 0.6);
+  background: hsl(var(--primary) / 0.07);
+  box-shadow: 0 0 14px hsl(var(--primary) / 0.22);
 }
 
 .intro-region--dashed {
@@ -187,8 +192,8 @@
 }
 
 .intro-pulse--blue {
-  background: var(--iv-blue);
-  box-shadow: 0 0 0 0 rgba(90, 130, 216, 0.6);
+  background: var(--iv-accent);
+  box-shadow: 0 0 0 0 hsl(var(--primary) / 0.6);
   animation-name: intro-pulse-blue;
 }
 
@@ -206,20 +211,20 @@
 
 @keyframes intro-pulse-blue {
   0% {
-    box-shadow: 0 0 0 0 rgba(90, 130, 216, 0.6);
+    box-shadow: 0 0 0 0 hsl(var(--primary) / 0.6);
   }
   70% {
-    box-shadow: 0 0 0 10px rgba(90, 130, 216, 0);
+    box-shadow: 0 0 0 10px hsl(var(--primary) / 0);
   }
   100% {
-    box-shadow: 0 0 0 0 rgba(90, 130, 216, 0);
+    box-shadow: 0 0 0 0 hsl(var(--primary) / 0);
   }
 }
 
 /* One-shot click ripple — fired by the scripted cursor in a scene. */
 .intro-click {
   border-radius: 50%;
-  border: 1.5px solid var(--iv-blue);
+  border: 1.5px solid var(--iv-accent);
   opacity: 0;
   animation: intro-click 0.55s var(--iv-ease) both;
   animation-delay: var(--rv, 0s);

--- a/web/src/pages/Plugins/Plugins.css
+++ b/web/src/pages/Plugins/Plugins.css
@@ -1,9 +1,19 @@
+/* The scroll port is a child rather than the root, so the desktop shell's drag
+   strip can sit above it and stay put while the page scrolls. Off the shell the
+   strip collapses to nothing and this is a plain full-height column. */
 .plugins-page {
   height: 100%;
-  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
   /* Ground behind the connector card grid — matches the Dashboard page root.
      Aliases bg-page in dark; a distinct lighter canvas in light mode. */
   background-color: var(--color-bg-canvas);
+}
+
+.plugins-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
   padding: clamp(16px, 3vw, 32px) clamp(16px, 3vw, 32px) 48px;
 }
 
@@ -17,7 +27,7 @@
 }
 
 @media (max-width: 767px) {
-  .plugins-page { padding: 16px 16px 48px; }
+  .plugins-scroll { padding: 16px 16px 48px; }
   .plugins-tab-bar { scrollbar-width: none; -ms-overflow-style: none; }
   .plugins-tab-bar::-webkit-scrollbar { display: none; }
 }

--- a/web/src/pages/Plugins/Plugins.tsx
+++ b/web/src/pages/Plugins/Plugins.tsx
@@ -144,83 +144,89 @@ function Plugins() {
   }, [searchParams]);
 
   return (
-    <div ref={pageRef} className="plugins-page">
-      <div className="plugins-container">
-        <div className="flex items-start justify-between gap-3 mb-6">
-          <div className="min-w-0">
-            <h2 className="text-xl font-semibold mb-1" style={{ color: 'var(--color-text-primary)' }}>
-              {t('plugins.title')}
-            </h2>
-            <p className="text-sm" style={{ color: 'var(--color-text-tertiary)' }}>
-              {t('plugins.description')}
-            </p>
+    <div className="plugins-page">
+      {/* Doubles as the window titlebar in the desktop shell; inert
+          elsewhere. Above the scroll port rather than inside it, so it stays
+          put once the page is scrolled. */}
+      <div className="chrome-drag-strip" aria-hidden="true" />
+      <div ref={pageRef} className="plugins-scroll">
+        <div className="plugins-container">
+          <div className="flex items-start justify-between gap-3 mb-6">
+            <div className="min-w-0">
+              <h2 className="text-xl font-semibold mb-1" style={{ color: 'var(--color-text-primary)' }}>
+                {t('plugins.title')}
+              </h2>
+              <p className="text-sm" style={{ color: 'var(--color-text-tertiary)' }}>
+                {t('plugins.description')}
+              </p>
+            </div>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-md transition-opacity hover:opacity-90 flex-shrink-0"
+                  style={{
+                    color: 'var(--color-btn-primary-text)',
+                    backgroundColor: 'var(--color-btn-primary-bg)',
+                  }}
+                >
+                  <Plus className="h-3 w-3" />
+                  {t('plugins.addMenu.add')}
+                  <ChevronDown className="h-3 w-3" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onSelect={() => requestAdd('plugin')}>
+                  {t('plugins.addMenu.installPlugin')}
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => requestAdd('server')}>
+                  {t('plugins.addMenu.addServer')}
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => requestAdd('import')}>
+                  {t('plugins.addMenu.importServers')}
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => requestAdd('skill')}>
+                  {t('plugins.addMenu.uploadSkill')}
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
+          <div className="flex gap-2 mb-6 border-b overflow-x-auto plugins-tab-bar" style={{ borderColor: 'var(--color-border-muted)' }}>
+            {TABS.map((tab) => (
               <button
+                key={tab}
                 type="button"
-                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-md transition-opacity hover:opacity-90 flex-shrink-0"
+                onClick={() => handleTabChange(tab)}
+                className="relative px-4 py-2 text-sm font-medium whitespace-nowrap flex-shrink-0 transition-colors"
                 style={{
-                  color: 'var(--color-btn-primary-text)',
-                  backgroundColor: 'var(--color-btn-primary-bg)',
+                  color: activeTab === tab ? 'var(--color-text-primary)' : 'var(--color-text-tertiary)',
                 }}
               >
-                <Plus className="h-3 w-3" />
-                {t('plugins.addMenu.add')}
-                <ChevronDown className="h-3 w-3" />
+                {t(TAB_LABEL_KEYS[tab])}
+                {activeTab === tab && (
+                  <motion.span
+                    layoutId="plugins-tab-underline"
+                    aria-hidden
+                    className="absolute inset-x-1 bottom-0 h-0.5 rounded-full"
+                    style={{ backgroundColor: 'var(--color-accent-primary)' }}
+                    transition={
+                      reducedMotion
+                        ? { duration: 0 }
+                        : { type: 'spring', stiffness: 500, damping: 40 }
+                    }
+                  />
+                )}
               </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem onSelect={() => requestAdd('plugin')}>
-                {t('plugins.addMenu.installPlugin')}
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => requestAdd('server')}>
-                {t('plugins.addMenu.addServer')}
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => requestAdd('import')}>
-                {t('plugins.addMenu.importServers')}
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => requestAdd('skill')}>
-                {t('plugins.addMenu.uploadSkill')}
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-        <div className="flex gap-2 mb-6 border-b overflow-x-auto plugins-tab-bar" style={{ borderColor: 'var(--color-border-muted)' }}>
-          {TABS.map((tab) => (
-            <button
-              key={tab}
-              type="button"
-              onClick={() => handleTabChange(tab)}
-              className="relative px-4 py-2 text-sm font-medium whitespace-nowrap flex-shrink-0 transition-colors"
-              style={{
-                color: activeTab === tab ? 'var(--color-text-primary)' : 'var(--color-text-tertiary)',
-              }}
-            >
-              {t(TAB_LABEL_KEYS[tab])}
-              {activeTab === tab && (
-                <motion.span
-                  layoutId="plugins-tab-underline"
-                  aria-hidden
-                  className="absolute inset-x-1 bottom-0 h-0.5 rounded-full"
-                  style={{ backgroundColor: 'var(--color-accent-primary)' }}
-                  transition={
-                    reducedMotion
-                      ? { duration: 0 }
-                      : { type: 'spring', stiffness: 500, damping: 40 }
-                  }
-                />
-              )}
-            </button>
-          ))}
-        </div>
+            ))}
+          </div>
 
-        <div className="plugins-content">
-          {activeTab === 'plugins' && <PluginsList />}
-          {activeTab === 'brokerages' && <Brokerages />}
-          {activeTab === 'mcp' && <McpServers />}
-          {activeTab === 'skills' && <SkillsList />}
-          {activeTab === 'secrets' && <PluginSecrets />}
+          <div className="plugins-content">
+            {activeTab === 'plugins' && <PluginsList />}
+            {activeTab === 'brokerages' && <Brokerages />}
+            {activeTab === 'mcp' && <McpServers />}
+            {activeTab === 'skills' && <SkillsList />}
+            {activeTab === 'secrets' && <PluginSecrets />}
+          </div>
         </div>
       </div>
     </div>

--- a/web/src/pages/Settings/Settings.css
+++ b/web/src/pages/Settings/Settings.css
@@ -26,3 +26,26 @@
   .settings-tab-bar { scrollbar-width: none; -ms-overflow-style: none; }
   .settings-tab-bar::-webkit-scrollbar { display: none; }
 }
+
+/* Settings rows that are neither a labeled field nor a section: a name on the
+   left, its control on the right. They used to be individually bordered cards,
+   which made three ordinary settings look like a different kind of thing from
+   the Timezone and Language fields directly above them. One hairline stack
+   instead, so the whole tab reads as a single list. */
+.settings-rows {
+  border-top: 1px solid var(--color-border-muted);
+  border-bottom: 1px solid var(--color-border-muted);
+}
+
+.settings-rows > * + * {
+  border-top: 1px solid var(--color-border-muted);
+}
+
+.settings-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 9px 2px;
+  min-height: 44px;
+}

--- a/web/src/pages/Settings/Settings.css
+++ b/web/src/pages/Settings/Settings.css
@@ -1,5 +1,13 @@
+/* Scroll port as a child, not the root -- see Plugins.css. */
 .settings-page {
   height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.settings-scroll {
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
   padding: clamp(16px, 3vw, 32px) clamp(16px, 3vw, 32px) 48px;
 }
@@ -14,7 +22,7 @@
 }
 
 @media (max-width: 767px) {
-  .settings-page { padding: 16px 16px 48px; }
+  .settings-scroll { padding: 16px 16px 48px; }
   .settings-tab-bar { scrollbar-width: none; -ms-overflow-style: none; }
   .settings-tab-bar::-webkit-scrollbar { display: none; }
 }

--- a/web/src/pages/Settings/Settings.tsx
+++ b/web/src/pages/Settings/Settings.tsx
@@ -38,72 +38,78 @@ function Settings() {
   }, [searchParams]);
 
   return (
-    <div ref={pageRef} className="settings-page">
-      <div className="settings-container">
-        <h2 className="text-xl font-semibold mb-6" style={{ color: 'var(--color-text-primary)' }}>{t('settings.title')}</h2>
-        <div className="flex gap-2 mb-6 border-b overflow-x-auto settings-tab-bar" style={{ borderColor: 'var(--color-border-muted)' }}>
-          <button
-            type="button"
-            onClick={() => handleTabChange('userInfo')}
-            className="px-4 py-2 text-sm font-medium whitespace-nowrap flex-shrink-0"
-            style={{
-              color: activeTab === 'userInfo' ? 'var(--color-text-primary)' : 'var(--color-text-tertiary)',
-              borderBottom: activeTab === 'userInfo' ? '2px solid var(--color-accent-primary)' : '2px solid transparent',
-            }}
-          >
-            {t('settings.userInfo')}
-          </button>
-          <button
-            type="button"
-            onClick={() => handleTabChange('preferences')}
-            className="px-4 py-2 text-sm font-medium whitespace-nowrap flex-shrink-0"
-            style={{
-              color: activeTab === 'preferences' ? 'var(--color-text-primary)' : 'var(--color-text-tertiary)',
-              borderBottom: activeTab === 'preferences' ? '2px solid var(--color-accent-primary)' : '2px solid transparent',
-            }}
-          >
-            {t('settings.preferences')}
-          </button>
-          <button
-            type="button"
-            onClick={() => handleTabChange('model')}
-            className="px-4 py-2 text-sm font-medium whitespace-nowrap flex-shrink-0"
-            style={{
-              color: activeTab === 'model' ? 'var(--color-text-primary)' : 'var(--color-text-tertiary)',
-              borderBottom: activeTab === 'model' ? '2px solid var(--color-accent-primary)' : '2px solid transparent',
-            }}
-          >
-            {t('settings.model')}
-          </button>
-          <button
-            type="button"
-            onClick={() => handleTabChange('experiments')}
-            className="px-4 py-2 text-sm font-medium whitespace-nowrap flex-shrink-0"
-            style={{
-              color: activeTab === 'experiments' ? 'var(--color-text-primary)' : 'var(--color-text-tertiary)',
-              borderBottom: activeTab === 'experiments' ? '2px solid var(--color-accent-primary)' : '2px solid transparent',
-            }}
-          >
-            {t('settings.experiments', 'Experiments')}
-          </button>
-        </div>
+    <div className="settings-page">
+      {/* Doubles as the window titlebar in the desktop shell; inert
+          elsewhere. Above the scroll port rather than inside it, so it stays
+          put once the page is scrolled. */}
+      <div className="chrome-drag-strip" aria-hidden="true" />
+      <div ref={pageRef} className="settings-scroll">
+        <div className="settings-container">
+          <h2 className="text-xl font-semibold mb-6" style={{ color: 'var(--color-text-primary)' }}>{t('settings.title')}</h2>
+          <div className="flex gap-2 mb-6 border-b overflow-x-auto settings-tab-bar" style={{ borderColor: 'var(--color-border-muted)' }}>
+            <button
+              type="button"
+              onClick={() => handleTabChange('userInfo')}
+              className="px-4 py-2 text-sm font-medium whitespace-nowrap flex-shrink-0"
+              style={{
+                color: activeTab === 'userInfo' ? 'var(--color-text-primary)' : 'var(--color-text-tertiary)',
+                borderBottom: activeTab === 'userInfo' ? '2px solid var(--color-accent-primary)' : '2px solid transparent',
+              }}
+            >
+              {t('settings.userInfo')}
+            </button>
+            <button
+              type="button"
+              onClick={() => handleTabChange('preferences')}
+              className="px-4 py-2 text-sm font-medium whitespace-nowrap flex-shrink-0"
+              style={{
+                color: activeTab === 'preferences' ? 'var(--color-text-primary)' : 'var(--color-text-tertiary)',
+                borderBottom: activeTab === 'preferences' ? '2px solid var(--color-accent-primary)' : '2px solid transparent',
+              }}
+            >
+              {t('settings.preferences')}
+            </button>
+            <button
+              type="button"
+              onClick={() => handleTabChange('model')}
+              className="px-4 py-2 text-sm font-medium whitespace-nowrap flex-shrink-0"
+              style={{
+                color: activeTab === 'model' ? 'var(--color-text-primary)' : 'var(--color-text-tertiary)',
+                borderBottom: activeTab === 'model' ? '2px solid var(--color-accent-primary)' : '2px solid transparent',
+              }}
+            >
+              {t('settings.model')}
+            </button>
+            <button
+              type="button"
+              onClick={() => handleTabChange('experiments')}
+              className="px-4 py-2 text-sm font-medium whitespace-nowrap flex-shrink-0"
+              style={{
+                color: activeTab === 'experiments' ? 'var(--color-text-primary)' : 'var(--color-text-tertiary)',
+                borderBottom: activeTab === 'experiments' ? '2px solid var(--color-accent-primary)' : '2px solid transparent',
+              }}
+            >
+              {t('settings.experiments', 'Experiments')}
+            </button>
+          </div>
 
-        <div className="settings-content">
-          {isLoading && (
-            <div className="flex items-center justify-center py-8">
-              <p className="text-sm" style={{ color: 'var(--color-text-primary)', opacity: 0.7 }}>{t('common.loading')}</p>
-            </div>
-          )}
+          <div className="settings-content">
+            {isLoading && (
+              <div className="flex items-center justify-center py-8">
+                <p className="text-sm" style={{ color: 'var(--color-text-primary)', opacity: 0.7 }}>{t('common.loading')}</p>
+              </div>
+            )}
 
-          {!isLoading && activeTab === 'userInfo' && <UserInfoTab />}
+            {!isLoading && activeTab === 'userInfo' && <UserInfoTab />}
 
-          {!isLoading && activeTab === 'preferences' && <PreferencesTab />}
+            {!isLoading && activeTab === 'preferences' && <PreferencesTab />}
 
-          {!isLoading && activeTab === 'model' && <ModelTab />}
+            {!isLoading && activeTab === 'model' && <ModelTab />}
 
-          {/* Text-heavy tab: cap the measure so descriptions stay readable
-              instead of spanning the full settings container. */}
-          {!isLoading && activeTab === 'experiments' && <ExperimentsTab />}
+            {/* Text-heavy tab: cap the measure so descriptions stay readable
+                instead of spanning the full settings container. */}
+            {!isLoading && activeTab === 'experiments' && <ExperimentsTab />}
+          </div>
         </div>
       </div>
     </div>

--- a/web/src/pages/Settings/panels/PreferencesTab.tsx
+++ b/web/src/pages/Settings/panels/PreferencesTab.tsx
@@ -118,19 +118,42 @@ export function PreferencesTab() {
     }
   };
 
+  // The visibility test and the renderer used to disagree about what "empty"
+  // means: the test counted keys, the renderer dropped nulls, empty strings and
+  // output_format. A group holding only those passed the test and drew a
+  // labelled empty box. Derive the rows once and let their count decide.
+  //
+  // A string of spaces is the same empty box with a different value in it: the
+  // row renders, the label renders, and the cell beside it is blank. These come
+  // from a free-text onboarding answer, so whitespace is what a user submits by
+  // holding the spacebar, not a shape only a fuzzer produces.
+  const renderableEntries = (data?: Record<string, unknown> | null) =>
+    Object.entries(data ?? {}).filter(
+      ([key, value]) =>
+        key !== 'output_format'
+        && value != null
+        && (typeof value !== 'string' || value.trim() !== ''),
+    );
+
+  const prefSections = [
+    { label: t('settings.riskTolerance'), entries: renderableEntries(preferences?.risk_preference) },
+    { label: t('settings.investmentStyle'), entries: renderableEntries(preferences?.investment_preference) },
+    { label: t('settings.agentSettings'), entries: renderableEntries(preferences?.agent_preference) },
+  ].filter((section) => section.entries.length > 0);
+
   return (
     <>
-    <div className="space-y-5">
+    <div className="space-y-4">
       {authUser?.onboarding_completed !== true && (
         <div
-          className="rounded-lg px-4 py-4 flex items-center justify-between gap-3"
+          className="rounded-lg p-3 flex items-center justify-between gap-3"
           style={{
             backgroundColor: 'hsl(var(--primary) / 0.08)',
             border: '1px solid hsl(var(--primary) / 0.2)',
           }}
         >
           <div>
-            <p className="text-sm font-medium" style={{ color: 'var(--color-text-primary)' }}>
+            <p className="text-[0.8125rem] font-medium" style={{ color: 'var(--color-text-primary)' }}>
               {t('settings.completeProfile')}
             </p>
             <p className="text-xs mt-0.5" style={{ color: 'var(--color-text-tertiary)' }}>
@@ -140,7 +163,7 @@ export function PreferencesTab() {
           <button
             type="button"
             onClick={handleStartOnboarding}
-            className="shrink-0 flex items-center gap-1.5 px-4 py-2 rounded-md text-sm font-medium transition-opacity hover:opacity-90"
+            className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-opacity hover:opacity-90"
             style={{
               backgroundColor: 'var(--color-btn-primary-bg)',
               color: 'var(--color-btn-primary-text)',
@@ -151,57 +174,11 @@ export function PreferencesTab() {
         </div>
       )}
 
-      <p className="text-xs" style={{ color: 'var(--color-text-tertiary)' }}>
-        {t('settings.preferencesDesc')}
-      </p>
-
-      <div
-        className="rounded-md px-4 py-4"
-        style={{ backgroundColor: 'var(--color-bg-card)', border: '1px solid var(--color-border-muted)' }}
-      >
-        <div className="flex items-center justify-between gap-3">
-          <div>
-            <p className="text-sm font-medium" style={{ color: 'var(--color-text-primary)' }}>
-              {t('onboarding.settings.sectionTitle')}
-            </p>
-            <p className="text-xs mt-0.5" style={{ color: 'var(--color-text-tertiary)' }}>
-              {t('onboarding.settings.description')}
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={() => {
-              if (resetOnboarding()) toast({ description: t('onboarding.settings.resetDone') });
-            }}
-            className="shrink-0 rounded text-xs font-medium transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-primary)]"
-            style={{ color: 'var(--color-text-tertiary)' }}
-          >
-            {t('onboarding.settings.reset')}
-          </button>
-        </div>
-        <div className="mt-3 flex flex-wrap gap-2">
-          <button
-            type="button"
-            onClick={() => {
-              if (replayGuides()) toast({ description: t('onboarding.settings.replayDone') });
-            }}
-            className="px-3 py-1.5 rounded-md text-xs font-medium transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-primary)]"
-            style={{ border: '1px solid var(--color-border-muted)', color: 'var(--color-text-secondary)' }}
-          >
-            {t('onboarding.settings.replayGuides')}
-          </button>
-        </div>
-      </div>
-
-      {preferences && (preferences.risk_preference || preferences.investment_preference || preferences.agent_preference) ? (
+      {prefSections.length > 0 ? (
         <div className="space-y-4">
-          {[
-            { label: t('settings.riskTolerance'), data: preferences.risk_preference },
-            { label: t('settings.investmentStyle'), data: preferences.investment_preference },
-            { label: t('settings.agentSettings'), data: preferences.agent_preference },
-          ].filter((item): item is { label: string; data: Record<string, unknown> } => !!item.data && Object.keys(item.data).length > 0).map(({ label, data }) => (
+          {prefSections.map(({ label, entries }) => (
             <div key={label}>
-              <label className="block text-sm font-medium mb-2" style={{ color: 'var(--color-text-primary)' }}>{label}</label>
+              <label className="block text-[0.8125rem] font-medium mb-1.5" style={{ color: 'var(--color-text-primary)' }}>{label}</label>
               <div
                 className="rounded-md px-3 py-2.5 text-sm space-y-1"
                 style={{
@@ -209,17 +186,15 @@ export function PreferencesTab() {
                   border: '1px solid var(--color-border-muted)',
                 }}
               >
-                {Object.entries(data).filter(([key]) => key !== 'output_format').map(([key, value]) => (
-                  value != null && value !== '' && (
-                    <div key={key} className="flex gap-2">
-                      <span className="shrink-0 font-medium" style={{ color: 'var(--color-text-secondary)' }}>
-                        {key.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())}:
-                      </span>
-                      <span style={{ color: 'var(--color-text-primary)', wordBreak: 'break-word' }}>
-                        {typeof value === 'object' ? JSON.stringify(value) : String(value)}
-                      </span>
-                    </div>
-                  )
+                {entries.map(([key, value]) => (
+                  <div key={key} className="flex gap-2">
+                    <span className="shrink-0 font-medium" style={{ color: 'var(--color-text-secondary)' }}>
+                      {key.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())}:
+                    </span>
+                    <span style={{ color: 'var(--color-text-primary)', wordBreak: 'break-word' }}>
+                      {typeof value === 'object' ? JSON.stringify(value) : String(value)}
+                    </span>
+                  </div>
                 ))}
               </div>
             </div>
@@ -227,7 +202,7 @@ export function PreferencesTab() {
         </div>
       ) : (
         <div
-          className="rounded-md px-4 py-6 text-center"
+          className="rounded-md px-3 py-5 text-center"
           style={{
             backgroundColor: 'var(--color-bg-card)',
             border: '1px solid var(--color-border-muted)',
@@ -245,14 +220,14 @@ export function PreferencesTab() {
         return (
           <div className="p-3 rounded-lg" style={{ backgroundColor: 'var(--color-bg-card)', border: '1px solid var(--color-border-muted)' }}>
             <div className="flex items-center justify-between gap-3">
-              <label className="text-sm font-medium" style={{ color: 'var(--color-text-primary)' }}>
+              <label className="text-[0.8125rem] font-medium" style={{ color: 'var(--color-text-primary)' }}>
                 {t('settings.outputFormat')}
               </label>
               <div className="inline-flex rounded-lg overflow-hidden" style={{ border: '1px solid var(--color-border-muted)' }}>
                 <button
                   type="button"
                   onClick={() => handleOutputFormatChange('markdown')}
-                  className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium transition-colors"
+                  className="flex items-center gap-1.5 px-2.5 py-1 text-[0.8125rem] font-medium transition-colors"
                   style={{
                     backgroundColor: outputFormat === 'markdown' ? 'var(--color-accent-soft)' : 'transparent',
                     color: outputFormat === 'markdown' ? 'var(--color-accent-primary)' : 'var(--color-text-tertiary)',
@@ -264,7 +239,7 @@ export function PreferencesTab() {
                 <button
                   type="button"
                   onClick={() => handleOutputFormatChange('html')}
-                  className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium transition-colors"
+                  className="flex items-center gap-1.5 px-2.5 py-1 text-[0.8125rem] font-medium transition-colors"
                   style={{
                     backgroundColor: outputFormat === 'html' ? 'var(--color-accent-soft)' : 'transparent',
                     color: outputFormat === 'html' ? 'var(--color-accent-primary)' : 'var(--color-text-tertiary)',
@@ -284,17 +259,61 @@ export function PreferencesTab() {
         );
       })()}
 
+      {/* Column until there is room for a row. The two actions are a fixed
+          ~259px whatever the viewport, so side-by-side on a phone leaves the
+          description about 46px to wrap into and it shreds into a 150px-tall
+          ribbon two characters wide. */}
+      <div
+        className="rounded-md p-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+        style={{ backgroundColor: 'var(--color-bg-card)', border: '1px solid var(--color-border-muted)' }}
+      >
+        <div className="min-w-0">
+          <p className="text-[0.8125rem] font-medium" style={{ color: 'var(--color-text-primary)' }}>
+            {t('onboarding.settings.sectionTitle')}
+          </p>
+          <p className="text-xs mt-0.5" style={{ color: 'var(--color-text-tertiary)' }}>
+            {t('onboarding.settings.description')}
+          </p>
+        </div>
+        <div className="shrink-0 flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={() => {
+              if (replayGuides()) toast({ description: t('onboarding.settings.replayDone') });
+            }}
+            className="px-2.5 py-1 rounded-md text-xs font-medium transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+            style={{ border: '1px solid var(--color-border-muted)', color: 'var(--color-text-secondary)' }}
+          >
+            {t('onboarding.settings.replayGuides')}
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              if (resetOnboarding()) toast({ description: t('onboarding.settings.resetDone') });
+            }}
+            className="px-2.5 py-1 rounded-md text-xs font-medium transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+            style={{ border: '1px solid var(--color-border-muted)', color: 'var(--color-text-tertiary)' }}
+          >
+            {t('onboarding.settings.reset')}
+          </button>
+        </div>
+      </div>
+
       {error && (
         <div className="p-3 rounded-md" style={{ backgroundColor: 'var(--color-loss-soft)', border: '1px solid var(--color-border-loss)' }}>
           <p className="text-sm" style={{ color: 'var(--color-loss)' }}>{error}</p>
         </div>
       )}
 
+      <p className="text-xs pt-1" style={{ color: 'var(--color-text-tertiary)' }}>
+        {t('settings.preferencesDesc')}
+      </p>
+
       <div className="flex gap-3 justify-between pt-4" style={{ borderTop: '1px solid var(--color-border-muted)' }}>
         <button
           type="button"
           onClick={() => setShowResetConfirm(true)}
-          className="flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium transition-colors"
+          className="flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium transition-colors"
           style={{ color: 'var(--color-loss)', backgroundColor: 'transparent', border: '1px solid var(--color-loss)' }}
         >
           <Trash2 className="h-4 w-4" /> {t('settings.resetPreferences')}
@@ -303,7 +322,7 @@ export function PreferencesTab() {
           <button
             type="button"
             onClick={handleModifyPreferences}
-            className="flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium transition-opacity hover:opacity-90"
+            className="flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium transition-opacity hover:opacity-90"
             style={{
               backgroundColor: 'var(--color-btn-primary-bg)',
               color: 'var(--color-btn-primary-text)',

--- a/web/src/pages/Settings/panels/UserInfoTab.tsx
+++ b/web/src/pages/Settings/panels/UserInfoTab.tsx
@@ -199,17 +199,17 @@ export function UserInfoTab() {
 
   return (
     <>
-    <div className="space-y-5">
-      <div className="flex items-center gap-4 mb-6 pb-6" style={{ borderBottom: '1px solid var(--color-border-muted)' }}>
+    <div className="space-y-4">
+      <div className="flex items-center gap-4 mb-5 pb-5" style={{ borderBottom: '1px solid var(--color-border-muted)' }}>
         <div
-          className="h-16 w-16 rounded-full flex items-center justify-center cursor-pointer overflow-hidden flex-shrink-0"
+          className="h-12 w-12 rounded-full flex items-center justify-center cursor-pointer overflow-hidden flex-shrink-0"
           style={{ backgroundColor: 'var(--color-accent-soft)' }}
           onClick={() => fileInputRef.current?.click()}
         >
           {avatarUrl ? (
             <img src={avatarUrl} alt="avatar" className="h-full w-full object-cover" onError={() => setAvatarUrl(null)} />
           ) : (
-            <User className="h-8 w-8" style={{ color: 'var(--color-accent-primary)' }} />
+            <User className="h-6 w-6" style={{ color: 'var(--color-accent-primary)' }} />
           )}
         </div>
         <div>
@@ -225,7 +225,7 @@ export function UserInfoTab() {
           <button
             type="button"
             onClick={() => setShowLogoutConfirm(true)}
-            className="flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium transition-colors"
+            className="flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium transition-colors"
             style={{ color: 'var(--color-loss)', backgroundColor: 'transparent', border: '1px solid var(--color-loss)' }}
           >
             <LogOut className="h-4 w-4" /> {t('settings.logout')}
@@ -234,7 +234,7 @@ export function UserInfoTab() {
       </div>
 
       <div>
-        <label className="block text-sm font-medium mb-2" style={{ color: 'var(--color-text-primary)' }}>{t('common.email')}</label>
+        <label className="block text-[0.8125rem] font-medium mb-1.5" style={{ color: 'var(--color-text-primary)' }}>{t('common.email')}</label>
         <Input
           type="email"
           value={authUser?.email || ''}
@@ -251,7 +251,7 @@ export function UserInfoTab() {
       </div>
 
       <div>
-        <label className="block text-sm font-medium mb-2" style={{ color: 'var(--color-text-primary)' }}>{t('common.name')}</label>
+        <label className="block text-[0.8125rem] font-medium mb-1.5" style={{ color: 'var(--color-text-primary)' }}>{t('common.name')}</label>
         <Input
           type="text"
           value={name}
@@ -268,7 +268,7 @@ export function UserInfoTab() {
       </div>
 
       <div>
-        <label className="block text-sm font-medium mb-2" style={{ color: 'var(--color-text-primary)' }}>{t('settings.timezone')}</label>
+        <label className="block text-[0.8125rem] font-medium mb-1.5" style={{ color: 'var(--color-text-primary)' }}>{t('settings.timezone')}</label>
         <Select
           value={timezone}
           onChange={(e) => handleTimezoneChange(e.target.value)}
@@ -288,7 +288,7 @@ export function UserInfoTab() {
       </div>
 
       <div>
-        <label className="block text-sm font-medium mb-2" style={{ color: 'var(--color-text-primary)' }}>{t('settings.locale')}</label>
+        <label className="block text-[0.8125rem] font-medium mb-1.5" style={{ color: 'var(--color-text-primary)' }}>{t('settings.locale')}</label>
         <Select
           value={locale}
           onChange={(e) => handleLocaleChange(e.target.value)}
@@ -299,16 +299,17 @@ export function UserInfoTab() {
         </Select>
       </div>
 
+      <div className="settings-rows">
       {/* Theme Toggle */}
-      <div className="flex items-center justify-between p-3 rounded-lg" style={{ backgroundColor: 'var(--color-bg-card)', border: '1px solid var(--color-border-muted)' }}>
+      <div className="settings-row">
         <div className="space-y-0.5">
-          <label className="text-sm font-medium" style={{ color: 'var(--color-text-primary)' }}>{t('settings.theme')}</label>
+          <label className="text-[0.8125rem] font-medium" style={{ color: 'var(--color-text-primary)' }}>{t('settings.theme')}</label>
         </div>
         <div className="inline-flex rounded-lg overflow-hidden" style={{ border: '1px solid var(--color-border-muted)' }}>
           <button
             type="button"
             onClick={() => setThemePref('dark')}
-            className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium transition-colors"
+            className="flex items-center gap-1.5 px-2.5 py-1 text-[0.8125rem] font-medium transition-colors"
             style={{
               backgroundColor: preference === 'dark' ? 'var(--color-accent-soft)' : 'transparent',
               color: preference === 'dark' ? 'var(--color-accent-primary)' : 'var(--color-text-tertiary)',
@@ -320,7 +321,7 @@ export function UserInfoTab() {
           <button
             type="button"
             onClick={() => setThemePref('light')}
-            className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium transition-colors"
+            className="flex items-center gap-1.5 px-2.5 py-1 text-[0.8125rem] font-medium transition-colors"
             style={{
               backgroundColor: preference === 'light' ? 'var(--color-accent-soft)' : 'transparent',
               color: preference === 'light' ? 'var(--color-accent-primary)' : 'var(--color-text-tertiary)',
@@ -332,7 +333,7 @@ export function UserInfoTab() {
           <button
             type="button"
             onClick={() => setThemePref('auto')}
-            className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium transition-colors"
+            className="flex items-center gap-1.5 px-2.5 py-1 text-[0.8125rem] font-medium transition-colors"
             style={{
               backgroundColor: preference === 'auto' ? 'var(--color-accent-soft)' : 'transparent',
               color: preference === 'auto' ? 'var(--color-accent-primary)' : 'var(--color-text-tertiary)',
@@ -345,9 +346,9 @@ export function UserInfoTab() {
       </div>
 
       {/* Font size — multiplies the browser's own font-size preference */}
-      <div className="flex items-center justify-between p-3 rounded-lg" style={{ backgroundColor: 'var(--color-bg-card)', border: '1px solid var(--color-border-muted)' }}>
+      <div className="settings-row">
         <div className="space-y-0.5">
-          <label className="text-sm font-medium" style={{ color: 'var(--color-text-primary)' }}>{t('settings.fontSize', 'Font size')}</label>
+          <label className="text-[0.8125rem] font-medium" style={{ color: 'var(--color-text-primary)' }}>{t('settings.fontSize', 'Font size')}</label>
         </div>
         <div className="inline-flex rounded-lg overflow-hidden" style={{ border: '1px solid var(--color-border-muted)' }}>
           {FONT_SCALES.map((s) => (
@@ -355,7 +356,7 @@ export function UserInfoTab() {
               key={s}
               type="button"
               onClick={() => { setFontScale(s); setFontScaleState(s); }}
-              className="px-2.5 py-1.5 text-sm font-medium transition-colors"
+              className="px-2 py-1 text-[0.8125rem] font-medium transition-colors"
               style={{
                 backgroundColor: fontScale === s ? 'var(--color-accent-soft)' : 'transparent',
                 color: fontScale === s ? 'var(--color-accent-primary)' : 'var(--color-text-tertiary)',
@@ -368,9 +369,9 @@ export function UserInfoTab() {
       </div>
 
       {/* Voice Input Toggle */}
-      <div className="flex items-center justify-between p-3 rounded-lg" style={{ backgroundColor: 'var(--color-bg-card)', border: '1px solid var(--color-border-muted)' }}>
+      <div className="settings-row">
         <div className="space-y-0.5">
-          <label className="text-sm font-medium" style={{ color: 'var(--color-text-primary)' }}>{t('settings.voiceInput')}</label>
+          <label className="text-[0.8125rem] font-medium" style={{ color: 'var(--color-text-primary)' }}>{t('settings.voiceInput')}</label>
           <p className="text-xs" style={{ color: 'var(--color-text-tertiary)' }}>{t('settings.voiceInputDesc')}</p>
         </div>
         <ToggleSwitch
@@ -378,6 +379,7 @@ export function UserInfoTab() {
           onChange={handleVoiceInputToggle}
           ariaLabel={t('settings.voiceInput')}
         />
+      </div>
       </div>
 
       {error && (

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -117,6 +117,10 @@ html {
   --color-accent-overlay: rgba(233, 149, 74, 0.75);
   --color-accent-gradient: linear-gradient(90deg, #E9954A 0%, #E9954A 100%);
 
+  /* Focus ring, for plain CSS files. Derived from --ring so Tailwind's
+     ring-ring and a hand-written box-shadow can never drift apart. */
+  --color-focus-ring: hsl(var(--ring));
+
   --color-slash-icon: rgb(233, 149, 74);
   --color-slash-pill-bg: rgba(233, 149, 74, 0.1);
   --color-slash-pill-border: rgba(233, 149, 74, 0.28);
@@ -199,8 +203,15 @@ html {
   --destructive-foreground: 0 0% 98%;
   --border: 0 0% 100% / 0.08;
   --input: 220 4% 14.5%;
-  /* Focus ring is NEUTRAL — the amber never rings a control (DESIGN.md). */
-  --ring: 0 0% 100% / 0.45;
+  /* Focus ring is the navy this product carried before the amber. Amber is the
+     active/selected language here, so a ring painted in it reads as "selected"
+     rather than "focused" — which is the whole reason the ring is not the brand
+     color (DESIGN.md). Lightness is set by the *lightest* surface a ring can
+     land on, not the page: at 52% it cleared 3:1 (WCAG 1.4.11) against the
+     sidebar and the cards but came to 2.98:1 on --color-bg-elevated, the menus
+     and tooltips. 55% lands at 3.35:1 there and higher everywhere else. Opaque
+     rather than a wash, so that margin does not move with the backdrop. */
+  --ring: 221 43% 55%;
   --radius: 0.5rem;
   --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.35), 0 4px 16px rgba(0, 0, 0, 0.25);
 
@@ -363,8 +374,8 @@ html {
   --destructive-foreground: 0 0% 100%;
   --border: 60 2% 12% / 0.09;
   --input: 60 4% 96.5%;
-  /* Focus ring is NEUTRAL — the amber never rings a control (DESIGN.md). */
-  --ring: 60 2% 12% / 0.4;
+  /* Same navy as dark, one step down: on paper the lighter face washes out. */
+  --ring: 221 43% 45%;
   /* Kept tight rather than dropped: floating overlays (AgentEventOverlay,
      SelectionCommentOverlay, JumpToLatestPill) rely on this to separate from
      a now-pure-white page — the workspace cards carry their own border. */


### PR DESCRIPTION
## Overview

Four things, all of them places where the app worked but did not behave the way the platform it runs on expects. Provider sign-in in the desktop shell could stop working until a restart because it had only three ports to choose from. Half the app's routes had no draggable titlebar, so a frameless window could not be moved from them. Every dropdown in the app left its trigger ringed after a mouse click, because a focus ring meant for keyboard users was being handed out to everyone. And the sidebar, Settings and Plugins carried three different ideas of how dense a row should be.

| Category | Files | +LOC | -LOC |
|---|---:|---:|---:|
| Modified | 26 | 651 | 351 |
| New | 1 | 32 | 0 |
| Tests | 4 | 223 | 11 |
| **Net (excl. tests)** | **27** | **662** | **351** |

**By module**

| Area | Files | Net | What changed |
|---|---:|---:|---|
| Desktop sign-in | `desktop/src/oauth.js`, `main.js`, `AGENTS.md` | +40 | The callback listener takes an OS-assigned port instead of one of three hardcoded ones |
| Window titlebar | `App.tsx`, `App.css`, four route roots + their CSS | +129 | Every app route now has a strip at the top of the content column that moves the window |
| Focus ring | `lib/inputModality.ts` (new), three `ui/` primitives, `tokens.css`, `Sidebar.css` | +82 | An overlay hands focus back to its trigger only when a key was involved |
| Density | `AccountMenu`, `Settings`, `PreferencesTab`, `UserInfoTab`, `Plugins`, `ui/input`, `ui/select` | +34 | One row scale across the sidebar, Settings and Plugins; scroll ports moved off the page roots |
| Onboarding panel | `introVisuals.tsx`, `pageIntro.css` | +5 | The intro panel derives its structural color from `--primary` instead of holding a private copy |
| E2E | three new specs | +202 | The focus ring, the account menu and the window chrome are each gated in a browser |

**What this introduces:** provider sign-in that does not depend on a port being free, a window you can move from anywhere, a focus ring that means what it says, and one row scale across the three surfaces people move between.

## Desktop sign-in: the port is the OS's to choose

The shell used to try 8788, then 8789, then 8790. Three numbers is not many. A preview build, a packaged app and one other local service is enough to take all three, and when that happened the shell could not sign anyone in until it was restarted, because the failure was latched for the life of the process.

It now asks for a free port with `listen(0)`, which is what RFC 8252 §7.3 tells an authorization server to expect from a native client, and it retries on demand instead of inheriting whatever state the app booted into. The bind is still to `127.0.0.1`, never a wildcard address.

This costs a wildcard entry on the sign-in provider's redirect allowlist, and `desktop/AGENTS.md` now says plainly what that entry does and does not buy. The glob stops at `.` and `/`, which means the wildcard spans more than a port number: `@` is neither separator, so the same entry also matches a string whose real host is not loopback at all. Reaching it needs a single-label hostname that resolves on the user's own machine, so it is not an opening from the open web, but the allowlist is not doing the work its shape suggests. What actually holds the flow together is the PKCE verifier, which lives in the renderer that minted it and can be redeemed nowhere else.

When no listener can be opened at all, the refusal message now names the way in that needs no listener, rather than telling the user to quit another copy of the app that may not exist.

## A titlebar on every route

A frameless window needs somewhere to grab. Routes with a top bar of their own mark it `data-chrome="drag"`; routes without one now drop in a `.chrome-drag-strip`, and which shape a route needs is decided by whether it scrolls.

A route that scrolls puts the strip above its scroll port. That is why Settings and Plugins moved their `overflow-y: auto` off the page root and onto a new `.settings-scroll` / `.plugins-scroll` child: a strip inside a scroll port rides the content out of view, and a titlebar that only works at scroll-top is the same bug reported again. `useScrollMemory` follows the port to its new element.

A route that does not scroll can keep its padding on the page root and drop the strip straight in. Automations publishes its padding as `--page-inset`; the strip pulls back out of it and hands it back below itself, so the strip reaches the window's top edge and the content underneath is still spaced. Unset, every margin in that rule resolves to zero, so nothing else has to know about it.

On mobile the shell already reserves the row for every route, so a route's own strip stands down there. Two reservations are 76px of nothing.

The OAuth callback route also learned to fail. It used to wait on a session and nothing else, so a flow that ended without one sat behind a message promising a sign-in that was not coming, with no way out but quitting. It now reads the failure the callback arrived carrying, in the query under PKCE and in the hash under implicit, bounds the wait at 8s when nobody said anything, and offers the way back.

## A focus ring that means what it says

Radix hands focus back to a trigger when an overlay closes, so a keyboard user keeps their place. Chromium propagates `:focus-visible` across that programmatic move, so a menu opened and dismissed entirely with the mouse left its trigger ringed until the next click, on every dropdown in the app.

`lib/inputModality.ts` records which device the user last reached for, from capture-phase listeners so a handler that stops propagation cannot hide the interaction. The dropdown, popover and dialog wrappers consult it and skip the restore when no key was pressed: focus falls to `<body>`, which is where clicking anywhere else would have put it anyway. A modifier held alone does not count, because that is someone reaching for Cmd-Tab.

Suppressing the restore unconditionally would pass every mouse assertion and leave keyboard users pressing Escape into nowhere, so `web/e2e/focus-ring.spec.js` asserts both directions.

The ring itself changed color. It was the neutral it inherited; it is now the navy this product carried before the amber, because amber is the active/selected language here and a ring painted in it reads as "selected" rather than "focused". Its lightness is set by the lightest surface a ring can land on: at 52% it cleared 3:1 against the sidebar and the cards but came to 2.98:1 on the elevated surface the menus and tooltips use, under what WCAG 1.4.11 asks of an indicator. 55% lands at 3.35:1 there and higher everywhere else.

## Density and identity

The sidebar account row, the Settings tabs and the Plugins header each had their own idea of a row. They now share one: 28px avatars, 5px row padding, a 36px shared input and select. Settings' three unlabelled toggles were individually bordered cards, which made ordinary settings look like a different kind of thing from the Timezone and Language fields right above them; they are one hairline stack now, so the tab reads as a single list. Plugins' four separate add buttons became one menu.

The expanded account panel used to repeat the avatar and name that its own trigger already shows. It now shows the email, which neither trigger does, and takes the trigger's width so it lines up on both edges instead of only the left.

The row also reads out correctly now. It carried a fixed "Account menu" label over text that already names the account, so a screen-reader user heard less than what was on screen, and the plan was hidden from assistive tech entirely. Both are gone. The plan pill is width-bounded because its text is a backend value with no length this app controls.

Initials take a code point rather than a code unit, so a name starting with an emoji or an astral CJK character no longer renders a replacement glyph. The count is bounded on the characters rather than on the name parts, which is a different bug in the same expression: uppercasing can turn one code point into two, so two parts could put four glyphs in a disc measured for two. Measured in Chromium against the real rule, an eszett name renders 28.6px inside the 28px disc and clips, while the four-glyph case happens to fit because those letters are narrow. Leaving that to the font is the defect; the widest two-glyph pair now measures 25.7px.

`PreferencesTab` had a real bug behind the reflow: the test deciding whether a preference group was visible counted keys, while the renderer dropped nulls, empty strings and `output_format`. A group holding only those passed the test and drew a labelled empty box. The rows are derived once now and their count decides.

## Verification

- `pnpm typecheck` exits 0.
- `pnpm test`: 296 files, 3238 tests passed.
- `pnpm test:e2e`: 86 passed, including the three new specs.
- `npm test` in `desktop/`: 148 passed.
- Reviewed against the installed Radix sources for the exact versions in use, not from memory.

## Known and deliberate

- The dialog wrapper's modality guard is currently inert: no dialog in the app renders a `DialogTrigger`, and Radix's own handler ends at the same place whichever branch runs. It is kept so the four `ui/` primitives state one rule, and it becomes live the moment a trigger is added. Removing it instead is a fair call.
- The onboarding intro panel now derives its structural color from `--primary`, which is the amber. That fixes real drift (the panel held a private copy of the brand color and kept the old one through a rebrand), but it puts amber into washes and glows that `DESIGN.md` reserves for annotation. Either the rule wants a carve-out for illustration panels, or the panel should derive from a non-accent token and stay blue.
- The sign-in callback attaches to a single pending flow without checking `state`, so two sign-ins started back to back collide, and any local process that finds the port can consume a pending flow. PKCE means it cannot redeem the code, so this is availability, not account takeover. Unchanged from before this branch, and the ephemeral port makes the port harder to find rather than easier.
- `focus-ring.spec.js` asserts `:focus-visible` and active focus, not painted pixels. It catches removal of the close guard, which is what it was written for; it would not catch a ring made transparent.
- Focus styles that set `outline: none` and paint a `box-shadow` instead are invisible in forced-colors mode. That pattern predates this branch and this adds one more instance of it; fixing it repo-wide needs a `forced-colors` query.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ginlix-ai/codesmith/LangAlpha/pr/371"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790408758&installation_model_id=432753&pr_number=371&repository=ginlix-ai%2FLangAlpha&return_to=https%3A%2F%2Fgithub.com%2Fginlix-ai%2FLangAlpha%2Fpull%2F371&signature=05d3e4125925d4c64a18ef0f211812c0259f42647e1dce054780e9877ae071d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - OAuth sign-in now uses dynamic local callback ports for improved reliability.
  - Desktop pages provide full-width window-drag areas.
  - OAuth callback failures offer clearer popup and sign-in actions.

- **Bug Fixes**
  - Improved focus-ring behavior after mouse interactions while preserving keyboard accessibility.
  - Fixed sidebar menu alignment, clipping, and accessibility details.
  - Improved scrolling on Settings, Plugins, and News pages.
  - Prevented authentication timeouts from overriding successful late sign-ins.

- **Style**
  - Refined account menus, settings layouts, form controls, spacing, and onboarding visuals.
  - Updated focus-ring colors for clearer visual feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->