### PR TITLE
feat(web): rebuild the chat minimap as a tick rail with turn previews

### DIFF
--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -1240,6 +1240,10 @@
     "jumpToLatest": {
       "aria": "Scroll to latest message"
     },
+    "minimap": {
+      "untitledTurn": "Message without text",
+      "replyPending": "Working"
+    },
     "pills": {
       "plan": "Plan",
       "planTitle": "Plan mode — agent creates a plan for approval before executing",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -1240,6 +1240,10 @@
     "jumpToLatest": {
       "aria": "滚动到最新消息"
     },
+    "minimap": {
+      "untitledTurn": "无文字消息",
+      "replyPending": "处理中"
+    },
     "pills": {
       "plan": "计划",
       "planTitle": "计划模式 — 智能体先生成计划，经确认后再执行",

--- a/web/src/pages/ChatAgent/components/ChatMinimap.css
+++ b/web/src/pages/ChatAgent/components/ChatMinimap.css
@@ -8,30 +8,137 @@
   display: none;
 }
 
+/* The column itself is inert: only the tick rail takes the pointer, and the
+   rail is as narrow as the widest bar so it overlaps as little of the
+   transcript's right edge as possible. */
 .chat-minimap {
-  width: 32px;
   position: absolute;
   right: 12px;
   top: 0;
   bottom: 0;
   z-index: 20;
+  width: 32px;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
-  pointer-events: auto;
-  transition: width 200ms ease;
+  justify-content: center;
+  align-items: flex-end;
+  pointer-events: none;
 }
 
-.chat-minimap:hover {
-  width: 240px;
-}
-
-.chat-minimap-entries {
+/* Past the minimum tick pitch the rail scrolls itself rather than spilling
+   out of the column; its scrollbar stays hidden like the transcript's. The
+   vertical padding is mirrored by RAIL_PADDING_PX in the component. */
+.chat-minimap-rail {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  flex-shrink: 0;
+  max-height: 100%;
+  padding: 8px 0;
   overflow-y: auto;
   scrollbar-width: none;
-  -ms-overflow-style: none;
+  pointer-events: auto;
+}
+.chat-minimap-rail::-webkit-scrollbar {
+  display: none;
 }
 
-.chat-minimap-entries::-webkit-scrollbar {
-  display: none;
+.chat-minimap-tick {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: flex-end;
+  width: 32px;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  border-radius: 2px;
+  background: transparent;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* The ring goes on the button, not the faded bar: an outline inherits the
+   bar's opacity and a 22% ring is no focus indicator. */
+.chat-minimap-tick:focus-visible {
+  outline: 2px solid var(--color-accent-primary);
+  outline-offset: 1px;
+}
+
+/* Width and opacity come from the component as custom properties: the
+   rail magnifies around the hovered (else active) tick, so every bar is a
+   function of its distance to that focus. */
+.chat-minimap-tick > span {
+  display: block;
+  height: 2px;
+  border-radius: 1px;
+  width: var(--tick-w, 12px);
+  opacity: var(--tick-o, 0.22);
+  background: var(--color-text-primary);
+  transition:
+    width 180ms cubic-bezier(0.16, 1, 0.3, 1),
+    opacity 180ms ease;
+}
+
+/* Sized against the message area (an inline-size container) so a narrow
+   column keeps most of the transcript readable beside the card. */
+.chat-minimap-card {
+  position: absolute;
+  top: 0;
+  right: calc(100% + 4px);
+  width: min(300px, 40cqw);
+  padding: 10px 12px;
+  border-radius: var(--radius);
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border-muted);
+  box-shadow: var(--shadow-card);
+  color: var(--color-text-primary);
+  pointer-events: none;
+  animation: chat-minimap-card-enter 140ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  transition: top 140ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.chat-minimap-card-prompt {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: 1.35;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chat-minimap-card-reply {
+  margin-top: 4px;
+  font-size: 0.75rem;
+  line-height: 1.45;
+  color: var(--color-text-secondary);
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+}
+
+/* Liveness is the shared glyph plus a word, at the annotation scale the task
+   chips already use: the glyph takes the accent, the label rides along. */
+.chat-minimap-card-live {
+  margin-top: 7px;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 0.75rem;
+  color: var(--color-accent-primary);
+}
+
+@keyframes chat-minimap-card-enter {
+  from { opacity: 0; transform: translateX(4px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat-minimap-tick > span,
+  .chat-minimap-card {
+    transition: none;
+    animation: none;
+  }
 }

--- a/web/src/pages/ChatAgent/components/ChatMinimap.tsx
+++ b/web/src/pages/ChatAgent/components/ChatMinimap.tsx
@@ -1,303 +1,377 @@
-import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
+import { memo, useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Loader } from '@/components/ui/loader';
 import { useStableArray } from '@/hooks/useStableArray';
+import { isNearBottom } from '../utils/scrollHelpers';
+import { resolveScrollContent, resolveScrollViewport } from '../utils/scrollDom';
+import type { MessageRecord } from './messageList/types';
+import { buildEntries, entriesEqual } from './minimapEntries';
+import type { PinTarget } from './chatView/useChatScroll';
 import './ChatMinimap.css';
-
-type MessageRecord = Record<string, unknown>;
-
-interface UserEntry {
-  id: string;
-  preview: string;
-}
-
-function userEntriesEqual(prev: UserEntry[], next: UserEntry[]): boolean {
-  return (
-    next.length === prev.length &&
-    next.every((e, i) => e.id === prev[i].id && e.preview === prev[i].preview)
-  );
-}
 
 interface ChatMinimapProps {
   messages: MessageRecord[];
   scrollAreaRef: React.RefObject<HTMLDivElement | null>;
+  /** The newest prompt with no reply text yet shows a skeleton only while a turn is actually running. */
+  turnInFlight: boolean;
+  /** Navigation goes through the scroll controller so settle re-apply and streaming follow honour the landing. */
+  pinToMessage: (id: string, behavior?: 'auto' | 'smooth', isLatest?: boolean) => void;
+  /** Read to tell a landing the reader asked for from one they scrolled to; see the scrollspy. */
+  pinTargetRef: React.RefObject<PinTarget | null>;
 }
 
-function getScrollViewport(scrollAreaRef: React.RefObject<HTMLDivElement | null>): HTMLElement | null {
-  if (!scrollAreaRef.current) return null;
-  // ScrollArea is a custom wrapper: outer div (overflow-hidden) > inner div (overflow-auto).
-  // The inner div is the actual scrollable viewport we need for IntersectionObserver root.
+/** Same band the scroll controller's jump pill uses, so "at the bottom" agrees. */
+const NEAR_BOTTOM_PX = 120;
+/** A turn becomes active once its prompt crosses this line below the viewport top; on short viewports the line sits at a fraction of the height instead. */
+const ACTIVE_LINE_PX = 96;
+const ACTIVE_LINE_MAX_FRACTION = 0.3;
+/** Vertical pitch of one tick. It shrinks to fit the column; past the minimum the rail scrolls. */
+const PITCH_MAX = 16;
+const PITCH_MIN = 4;
+/** Rail padding, top plus bottom; must match the stylesheet. */
+const RAIL_PADDING_PX = 16;
+const CARD_MARGIN_PX = 8;
+/** Tick width / opacity by index distance to the focus (hovered, else active); the last bucket is the resting look. */
+const TICK_FALLOFF = [
+  { width: 28, opacity: 0.5 },
+  { width: 20, opacity: 0.36 },
+  { width: 15, opacity: 0.28 },
+  { width: 12, opacity: 0.22 },
+] as const;
+const ACTIVE_OPACITY = 0.92;
+
+function stableIds(prev: string[], next: string[]): boolean {
+  return next.length === prev.length && next.every((id, i) => id === prev[i]);
+}
+
+/** A mouse click focuses the button too; only keyboard focus should hold the card up after the pointer leaves. */
+function keyboardFocused(el: HTMLElement): boolean {
+  try {
+    return el.matches(':focus-visible');
+  } catch {
+    return true;
+  }
+}
+
+function prefersReducedMotion(): boolean {
+  return typeof window !== 'undefined' && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+}
+
+interface TickProps {
+  id: string;
+  label: string;
+  pitch: number;
+  width: number;
+  opacity: number;
+  active: boolean;
+  describedBy?: string;
+  onHover: (id: string) => void;
+  onFocus: (id: string) => void;
+  onBlur: (id: string) => void;
+  onActivate: (id: string) => void;
+}
+
+// Memoised so a streamed chunk (which rebuilds the entries) re-renders the
+// card, not every tick in the rail.
+const Tick = memo(function Tick({
+  id, label, pitch, width, opacity, active, describedBy, onHover, onFocus, onBlur, onActivate,
+}: TickProps) {
   return (
-    scrollAreaRef.current.querySelector<HTMLElement>('[data-radix-scroll-area-viewport]') ??
-    scrollAreaRef.current.querySelector<HTMLElement>('.overflow-auto') ??
-    scrollAreaRef.current
+    <button
+      type="button"
+      className="chat-minimap-tick"
+      data-minimap-id={id}
+      aria-label={label}
+      aria-current={active ? 'true' : undefined}
+      aria-describedby={describedBy}
+      style={{ height: pitch, ['--tick-w' as string]: `${width}px`, ['--tick-o' as string]: opacity }}
+      onMouseEnter={() => onHover(id)}
+      onFocus={(e) => {
+        if (keyboardFocused(e.currentTarget)) onFocus(id);
+      }}
+      onBlur={() => onBlur(id)}
+      onClick={() => onActivate(id)}
+    >
+      <span aria-hidden="true" />
+    </button>
   );
-}
+});
 
-export default function ChatMinimap({ messages, scrollAreaRef }: ChatMinimapProps) {
-  const [isHovered, setIsHovered] = useState(false);
-  const [visibleMessageId, setVisibleMessageId] = useState<string | null>(null);
-  const entriesRef = useRef<HTMLDivElement>(null);
+export default function ChatMinimap({ messages, scrollAreaRef, turnInFlight, pinToMessage, pinTargetRef }: ChatMinimapProps) {
+  const { t } = useTranslation();
+  const rootRef = useRef<HTMLDivElement>(null);
+  const railRef = useRef<HTMLDivElement>(null);
+  const cardRef = useRef<HTMLDivElement>(null);
+  const cardId = useId();
 
-  // Extract user messages with preview text. `messages` takes a fresh array
-  // identity on every streamed chunk, but user entries only change when a
-  // message is sent/edited — keep the previous array identity when the
-  // content is unchanged, so the observer/listener effects below don't tear
-  // down and rebuild on every chunk.
-  const userEntries: UserEntry[] = useStableArray(
-    useMemo(
-      () =>
-        (messages ?? [])
-          .filter((m) => (m.role as string) === 'user')
-          .map((m) => {
-            const content = (m.content as string) || '';
-            const preview = content.length > 60 ? content.slice(0, 60) + '...' : content;
-            return { id: m.id as string, preview };
-          }),
-      [messages],
-    ),
-    userEntriesEqual,
+  const entries = useStableArray(
+    useMemo(() => buildEntries(messages ?? [], turnInFlight), [messages, turnInFlight]),
+    entriesEqual,
+  );
+  // Ids alone drive the observers: the reply text changes on every streamed
+  // chunk, and the scroll bookkeeping must not tear down for that.
+  const ids = useStableArray(
+    useMemo(() => entries.map((e) => e.id), [entries]),
+    stableIds,
   );
 
-  // IntersectionObserver to track which user message is visible
+  const [activeId, setActiveId] = useState<string | null>(null);
+  // Pointer and keyboard each own a slot: leaving with the mouse must not
+  // dismiss the card a focused tick is showing.
+  const [hoverId, setHoverId] = useState<string | null>(null);
+  const [focusId, setFocusId] = useState<string | null>(null);
+  const [railHeight, setRailHeight] = useState(0);
+
+  // Scrollspy: the active turn is whichever one the reader pinned, else the
+  // last prompt above the reading line, else the final turn once they are at
+  // the bottom. Anchors are resolved once per id set and re-queried only if one
+  // leaves the DOM; a binary search over them keeps a frame to a handful of
+  // rect reads however long the thread.
   useEffect(() => {
-    const viewport = getScrollViewport(scrollAreaRef);
-    if (!viewport || userEntries.length === 0) return;
+    const viewport = resolveScrollViewport(scrollAreaRef.current);
+    if (!viewport || ids.length < 2) return;
+    let anchors: { index: number; el: HTMLElement }[] = [];
+    let raf = 0;
 
-    const userIds = new Set(userEntries.map((e) => e.id));
-    const visibleIds = new Map<string, number>(); // id -> top offset
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        for (const entry of entries) {
-          const id = (entry.target as HTMLElement).dataset.messageId;
-          if (!id || !userIds.has(id)) continue;
-          if (entry.isIntersecting) {
-            visibleIds.set(id, entry.boundingClientRect.top);
-          } else {
-            visibleIds.delete(id);
-          }
-        }
-        // Pick topmost visible user message
-        let topId: string | null = null;
-        let topY = Infinity;
-        for (const [id, y] of visibleIds) {
-          if (y < topY) {
-            topY = y;
-            topId = id;
-          }
-        }
-        setVisibleMessageId(topId);
-      },
-      { root: viewport, threshold: 0.1 }
-    );
-
-    const elements = viewport.querySelectorAll<HTMLElement>('[data-message-id]');
-    elements.forEach((el) => {
-      if (userIds.has(el.dataset.messageId ?? '')) {
-        observer.observe(el);
+    const resolveAnchors = () => {
+      const byId = new Map<string, HTMLElement>();
+      for (const el of viewport.querySelectorAll<HTMLElement>('[data-message-id]')) {
+        byId.set(el.dataset.messageId ?? '', el);
       }
-    });
-
-    return () => observer.disconnect();
-  }, [scrollAreaRef, userEntries]);
-
-  // Auto-scroll minimap entries to keep active entry visible
-  useEffect(() => {
-    if (!isHovered || !visibleMessageId || !entriesRef.current) return;
-    const active = entriesRef.current.querySelector<HTMLElement>(`[data-minimap-id="${visibleMessageId}"]`);
-    if (active) {
-      active.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
-    }
-  }, [visibleMessageId, isHovered]);
-
-  // Track whether user is scrolled to the bottom
-  const [isAtBottom, setIsAtBottom] = useState(true);
-
-  useEffect(() => {
-    const viewport = getScrollViewport(scrollAreaRef);
-    if (!viewport) return;
-    const check = () => {
-      const atBottom = viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight < 40;
-      setIsAtBottom(atBottom);
+      anchors = [];
+      ids.forEach((id, index) => {
+        const el = byId.get(id);
+        if (el) anchors.push({ index, el });
+      });
     };
-    check();
-    viewport.addEventListener('scroll', check, { passive: true });
-    return () => viewport.removeEventListener('scroll', check);
-  }, [scrollAreaRef, userEntries]);
-
-  const handleClick = useCallback(
-    (id: string) => {
-      const viewport = getScrollViewport(scrollAreaRef);
-      if (!viewport) return;
-      const el = viewport.querySelector<HTMLElement>(`[data-message-id="${id}"]`);
-      if (el) {
-        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    const compute = () => {
+      raf = 0;
+      // A held anchor is the reader's own answer to "which turn am I on", so it
+      // outranks anything read off the scroll position. Without this, landing on
+      // one of the last turns lights up the final tick instead of the one just
+      // clicked: the landing falls inside the bottom band below, and the rail
+      // then magnifies around the wrong neighbourhood.
+      const anchored = pinTargetRef.current?.mode === 'anchor' ? pinTargetRef.current.id : null;
+      if (anchored) {
+        setActiveId(anchored);
+        return;
       }
+      const metrics = { scrollTop: viewport.scrollTop, scrollHeight: viewport.scrollHeight, clientHeight: viewport.clientHeight };
+      // A transcript too short to scroll at all would otherwise read as "at the
+      // bottom" forever and pin the last tick. One that overflows by less than
+      // the band still has a real bottom the reader can reach, and there the
+      // band never opens, so recognise that case by position instead.
+      const range = metrics.scrollHeight - metrics.clientHeight;
+      const atBottom =
+        range > 0 &&
+        (range <= NEAR_BOTTOM_PX ? metrics.scrollTop >= range - 1 : isNearBottom(metrics, NEAR_BOTTOM_PX));
+      if (atBottom) {
+        setActiveId(ids[ids.length - 1]);
+        return;
+      }
+      if (anchors.length < ids.length || anchors.some((a) => !a.el.isConnected)) resolveAnchors();
+      const vpRect = viewport.getBoundingClientRect();
+      const line = vpRect.top + Math.min(ACTIVE_LINE_PX, vpRect.height * ACTIVE_LINE_MAX_FRACTION);
+      let lo = 0;
+      let hi = anchors.length - 1;
+      let hit = -1;
+      while (lo <= hi) {
+        const mid = (lo + hi) >> 1;
+        if (anchors[mid].el.getBoundingClientRect().top <= line) {
+          hit = mid;
+          lo = mid + 1;
+        } else {
+          hi = mid - 1;
+        }
+      }
+      setActiveId(hit >= 0 ? ids[anchors[hit].index] : ids[0]);
+    };
+    const schedule = () => {
+      if (!raf) raf = requestAnimationFrame(compute);
+    };
+
+    compute();
+    viewport.addEventListener('scroll', schedule, { passive: true });
+    // Content growth moves the anchors under a fixed scrollTop; a viewport
+    // resize (composer growing, window height) moves the reading line.
+    const resize = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(schedule) : null;
+    resize?.observe(resolveScrollContent(viewport));
+    resize?.observe(viewport);
+    return () => {
+      viewport.removeEventListener('scroll', schedule);
+      resize?.disconnect();
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, [scrollAreaRef, ids, pinTargetRef]);
+
+  // Keyed on the rail being mounted: the component renders nothing until the
+  // second turn exists, and an effect that ran only once would have found no
+  // element to observe.
+  const railMounted = entries.length >= 2;
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!railMounted || !root || typeof ResizeObserver === 'undefined') return;
+    const measure = () => setRailHeight(root.clientHeight);
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(root);
+    return () => observer.disconnect();
+  }, [railMounted]);
+
+  const pitch = useMemo(() => {
+    if (!railHeight || ids.length === 0) return PITCH_MAX;
+    const fit = Math.floor((railHeight - RAIL_PADDING_PX) / ids.length);
+    return Math.max(PITCH_MIN, Math.min(PITCH_MAX, fit));
+  }, [railHeight, ids.length]);
+
+  const shownId = hoverId ?? focusId;
+  const shownEntry = shownId ? entries.find((e) => e.id === shownId) ?? null : null;
+
+  // Keep the card centred on its tick, clamped to the column. Positioned
+  // imperatively: the first placement must not animate, or the card slides in
+  // from wherever the element mounted.
+  useLayoutEffect(() => {
+    const root = rootRef.current;
+    const rail = railRef.current;
+    const card = cardRef.current;
+    if (!shownEntry || !root || !rail || !card) return;
+    const tick = rail.children[ids.indexOf(shownEntry.id)] as HTMLElement | undefined;
+    if (!tick) return;
+    const place = () => {
+      const center = tick.offsetTop - rail.scrollTop + tick.offsetHeight / 2;
+      const maxTop = Math.max(CARD_MARGIN_PX, root.clientHeight - card.offsetHeight - CARD_MARGIN_PX);
+      card.style.top = `${Math.min(maxTop, Math.max(CARD_MARGIN_PX, center - card.offsetHeight / 2))}px`;
+    };
+    if (card.dataset.placed) {
+      place();
+    } else {
+      card.style.transition = 'none';
+      place();
+      void card.offsetHeight;
+      card.style.transition = '';
+      card.dataset.placed = '1';
+    }
+    // An overflowing rail scrolls under a card that is already up: a wheel over
+    // the rail, or the active tick being kept in view as the transcript streams.
+    // Neither touches a dependency here, so the card would keep its old offset
+    // and drift away from the tick it describes.
+    rail.addEventListener('scroll', place, { passive: true });
+    return () => rail.removeEventListener('scroll', place);
+  }, [shownEntry, ids, pitch, railHeight]);
+
+  // A rail long enough to scroll keeps the active tick in view. A resize is a
+  // trigger as much as a new active turn: the column shrinking re-pitches every
+  // tick under an unchanged scrollTop, which is how the tick this is meant to
+  // keep visible ends up outside the rail.
+  useEffect(() => {
+    const rail = railRef.current;
+    if (!rail || !activeId || rail.scrollHeight <= rail.clientHeight) return;
+    const tick = rail.children[ids.indexOf(activeId)] as HTMLElement | undefined;
+    if (!tick) return;
+    const top = tick.offsetTop - rail.offsetTop;
+    const bottom = top + tick.offsetHeight;
+    if (top < rail.scrollTop) rail.scrollTop = top;
+    else if (bottom > rail.scrollTop + rail.clientHeight) rail.scrollTop = bottom - rail.clientHeight;
+  }, [activeId, ids, pitch, railHeight]);
+
+  const hover = useCallback((id: string) => setHoverId(id), []);
+  const focus = useCallback((id: string) => {
+    // Keyboard focus is the newer interaction, and a pointer resting on another
+    // tick never fires mouseleave. Without dropping it here the card and the
+    // aria-describedby it carries would keep naming the hovered tick while the
+    // keyboard is somewhere else.
+    setHoverId(null);
+    setFocusId(id);
+  }, []);
+  const blur = useCallback((id: string) => setFocusId((cur) => (cur === id ? null : cur)), []);
+  const leave = useCallback(() => setHoverId(null), []);
+  const dismiss = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    // Escape closes the preview without moving focus, so a reader on a tick can
+    // see the transcript the card is covering. Only swallow the key when there
+    // was something to close.
+    if (e.key !== 'Escape' || !shownId) return;
+    e.stopPropagation();
+    setHoverId(null);
+    setFocusId(null);
+  }, [shownId]);
+  const activate = useCallback(
+    (id: string) => {
+      // A turn already as far up as the transcript goes lands clamped: the
+      // scroll never moves, so no scroll event arrives and the scrollspy, which
+      // only recomputes on one, would leave the click unanswered.
+      setActiveId(id);
+      // Whether this is the newest turn is the rail's to answer, and it decides
+      // whether the landing keeps following the stream.
+      pinToMessage(id, prefersReducedMotion() ? 'auto' : 'smooth', id === ids[ids.length - 1]);
+    },
+    [pinToMessage, ids],
+  );
+  // The rail sits over the transcript's right edge where the scrollbar used to
+  // be, so a wheel over it must still scroll the transcript unless the rail
+  // itself can spend the gesture. The transcript is a sibling, not an ancestor,
+  // so nothing chains to it once the rail hits an end: forward from there too.
+  const wheel = useCallback(
+    (e: React.WheelEvent<HTMLDivElement>) => {
+      const rail = e.currentTarget;
+      const slack = rail.scrollHeight - rail.clientHeight;
+      if (slack > 0 && (e.deltaY < 0 ? rail.scrollTop > 0 : rail.scrollTop < slack - 1)) return;
+      const viewport = resolveScrollViewport(scrollAreaRef.current);
+      if (!viewport) return;
+      // deltaY is pixels, lines or pages depending on the device. The last two
+      // are counts, so a one-page gesture forwarded raw moves one pixel.
+      const step = e.deltaMode === 1 ? 16 : e.deltaMode === 2 ? viewport.clientHeight : 1;
+      viewport.scrollBy({ top: e.deltaY * step });
     },
     [scrollAreaRef],
   );
 
-  const handleScrollToBottom = useCallback(() => {
-    const viewport = getScrollViewport(scrollAreaRef);
-    if (!viewport) return;
-    viewport.scrollTo({ top: viewport.scrollHeight, behavior: 'smooth' });
-  }, [scrollAreaRef]);
+  if (!railMounted) return null;
 
-  if (userEntries.length < 2) return null;
+  const focusIndex = ids.indexOf(shownEntry?.id ?? activeId ?? '');
+  const resting = TICK_FALLOFF.length - 1;
+  const fallbackLabel = t('chat.minimap.untitledTurn');
 
   return (
-    <div
-      className="chat-minimap"
-      /* width controlled by CSS :hover */
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
-    >
-      {/* Entries */}
-      <div
-        ref={entriesRef}
-        className="chat-minimap-entries"
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: isHovered ? 'stretch' : 'flex-end',
-          justifyContent: 'center',
-          flex: 1,
-          padding: isHovered ? '12px 16px 12px 12px' : '12px 16px',
-          gap: 4,
-        }}
-      >
-        {userEntries.map((entry) => {
-          const isActive = !isAtBottom && entry.id === visibleMessageId;
+    <div ref={rootRef} className="chat-minimap">
+      <div ref={railRef} className="chat-minimap-rail" onMouseLeave={leave} onWheel={wheel} onKeyDown={dismiss}>
+        {entries.map((entry, index) => {
+          const bucket = focusIndex < 0 ? resting : Math.min(Math.abs(index - focusIndex), resting);
+          const isActive = entry.id === activeId;
           return (
-            <button
+            <Tick
               key={entry.id}
-              data-minimap-id={entry.id}
-              onClick={() => handleClick(entry.id)}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: isHovered ? 'flex-start' : 'flex-end',
-                gap: 8,
-                padding: isHovered ? '4px 6px' : '2px 0',
-                borderRadius: 4,
-                border: 'none',
-                background: isHovered && isActive ? 'var(--color-bg-surface)' : 'transparent',
-                cursor: 'pointer',
-                width: '100%',
-                textAlign: 'left',
-                transition: 'background 150ms ease',
-              }}
-              onMouseEnter={(e) => {
-                if (isHovered && !isActive) {
-                  e.currentTarget.style.background = 'var(--color-bg-subtle)';
-                }
-              }}
-              onMouseLeave={(e) => {
-                if (!isActive) {
-                  e.currentTarget.style.background = 'transparent';
-                }
-              }}
-            >
-              {/* Text preview (only when expanded) */}
-              {isHovered && (
-                <span
-                  style={{
-                    flex: 1,
-                    minWidth: 0,
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap',
-                    fontSize: '0.75rem',
-                    lineHeight: '18px',
-                    color: isActive
-                      ? 'var(--color-text-primary)'
-                      : 'var(--color-text-tertiary)',
-                    fontWeight: isActive ? 500 : 400,
-                    transition: 'color 150ms ease',
-                    textAlign: 'right',
-                  }}
-                >
-                  {entry.preview}
-                </span>
-              )}
-
-              {/* Line indicator */}
-              <span
-                style={{
-                  display: 'block',
-                  flexShrink: 0,
-                  width: isActive ? 28 : 14,
-                  height: isActive ? 3 : 2,
-                  borderRadius: 2,
-                  background: 'var(--color-text-primary)',
-                  opacity: isActive ? 0.7 : 0.2,
-                  transition: 'width 150ms ease, height 150ms ease, opacity 150ms ease',
-                }}
-              />
-            </button>
+              id={entry.id}
+              label={entry.prompt || fallbackLabel}
+              pitch={pitch}
+              width={TICK_FALLOFF[bucket].width}
+              opacity={isActive ? ACTIVE_OPACITY : TICK_FALLOFF[bucket].opacity}
+              active={isActive}
+              describedBy={entry.id === shownEntry?.id ? cardId : undefined}
+              onHover={hover}
+              onFocus={focus}
+              onBlur={blur}
+              onActivate={activate}
+            />
           );
         })}
-
-        {/* Bottom — always present, scrolls to very end of chat */}
-        <button
-          onClick={handleScrollToBottom}
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: isHovered ? 'flex-start' : 'flex-end',
-            gap: 8,
-            padding: isHovered ? '4px 6px' : '2px 0',
-            marginTop: 4,
-            borderRadius: 4,
-            border: 'none',
-            background: isHovered && isAtBottom ? 'var(--color-bg-surface)' : 'transparent',
-            cursor: 'pointer',
-            width: '100%',
-            textAlign: 'left',
-            transition: 'background 150ms ease',
-          }}
-          onMouseEnter={(e) => {
-            if (isHovered && !isAtBottom) {
-              e.currentTarget.style.background = 'var(--color-bg-subtle)';
-            }
-          }}
-          onMouseLeave={(e) => {
-            if (!isAtBottom) {
-              e.currentTarget.style.background = 'transparent';
-            }
-          }}
-        >
-          {isHovered && (
-            <span
-              style={{
-                flex: 1,
-                minWidth: 0,
-                fontSize: '0.75rem',
-                lineHeight: '18px',
-                color: isAtBottom
-                  ? 'var(--color-text-primary)'
-                  : 'var(--color-text-tertiary)',
-                fontWeight: isAtBottom ? 500 : 400,
-                transition: 'color 150ms ease',
-                textAlign: 'right',
-              }}
-            >
-              Bottom
-            </span>
-          )}
-          <span
-            style={{
-              display: 'block',
-              flexShrink: 0,
-              width: isAtBottom ? 28 : 14,
-              height: isAtBottom ? 3 : 2,
-              borderRadius: 2,
-              background: 'var(--color-text-primary)',
-              opacity: isAtBottom ? 0.7 : 0.2,
-              transition: 'width 150ms ease, height 150ms ease, opacity 150ms ease',
-            }}
-          />
-        </button>
       </div>
+
+      {shownEntry && (
+        <div ref={cardRef} id={cardId} className="chat-minimap-card" role="tooltip">
+          <div className="chat-minimap-card-prompt">{shownEntry.prompt || fallbackLabel}</div>
+          {shownEntry.pending ? (
+            // The Loader carries the announcement (role="status" + label), so
+            // the visible word is decoration beside it rather than a second
+            // thing to read out.
+            <div className="chat-minimap-card-live">
+              <Loader size={11} label={t('chat.minimap.replyPending')} style={{ color: 'inherit' }} />
+              <span aria-hidden="true">{t('chat.minimap.replyPending')}</span>
+            </div>
+          ) : shownEntry.reply ? (
+            <div className="chat-minimap-card-reply">{shownEntry.reply}</div>
+          ) : null}
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -359,6 +359,8 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     isNearBottomRef,
     isSubagentNearBottomRef,
     restoredForThreadRef,
+    pinToMessage,
+    pinTargetRef,
   } = useChatScroll({
     activeAgentId,
     messages,
@@ -1575,10 +1577,13 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
                 </div>
               )}
               {/* Minimap TOC — desktop only, when no right panel open */}
-              {!isMobile && !rightPanelType && activeAgentId === 'main' && (
+              {isActive && !isMobile && !rightPanelType && activeAgentId === 'main' && (
                 <ChatMinimap
                   messages={messages as unknown as MessageRecord[]}
                   scrollAreaRef={scrollAreaRef}
+                  turnInFlight={isLoading}
+                  pinToMessage={pinToMessage}
+                  pinTargetRef={pinTargetRef}
                 />
               )}
               {/* Jump-to-latest pill — coexists with the minimap (centered vs

--- a/web/src/pages/ChatAgent/components/__tests__/minimapEntries.test.ts
+++ b/web/src/pages/ChatAgent/components/__tests__/minimapEntries.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest';
+import { buildEntries, plainText } from '../minimapEntries';
+import type { MessageRecord } from '../messageList/types';
+
+const user = (id: string, content: unknown, extra: Record<string, unknown> = {}): MessageRecord =>
+  ({ id, role: 'user', content, ...extra }) as MessageRecord;
+const assistant = (id: string, content: string, extra: Record<string, unknown> = {}): MessageRecord =>
+  ({ id, role: 'assistant', content, ...extra }) as MessageRecord;
+
+describe('buildEntries', () => {
+  it('folds every assistant bubble after a prompt into that turn', () => {
+    const entries = buildEntries(
+      [user('u1', 'First'), assistant('a1', 'Part one.'), assistant('a2', 'Part two.'), user('u2', 'Second'), assistant('a3', 'Reply.')],
+      false,
+    );
+    expect(entries.map((e) => [e.id, e.reply])).toEqual([
+      ['u1', 'Part one. Part two.'],
+      ['u2', 'Reply.'],
+    ]);
+  });
+
+  it('marks only the newest text-free turn pending, and only while a turn is in flight', () => {
+    const messages = [user('u1', 'Old'), assistant('a1', ''), user('u2', 'New')];
+    expect(buildEntries(messages, true).map((e) => e.pending)).toEqual([false, true]);
+    // A failed send leaves the same shape; it must not read as loading.
+    expect(buildEntries(messages, false).map((e) => e.pending)).toEqual([false, false]);
+    // A reply with text is never pending, even mid-stream.
+    expect(buildEntries([user('u1', 'Q'), assistant('a1', 'Tok', { isStreaming: true })], true)[0].pending).toBe(false);
+  });
+
+  it('reads text segments in transcript order, falling back to flat content', () => {
+    const segmented = assistant('a1', 'fallback', {
+      contentSegments: [
+        { type: 'text', order: 2, content: 'second' },
+        { type: 'tool_call', order: 1 },
+        { type: 'text', order: 0, content: 'first ' },
+      ],
+    });
+    expect(buildEntries([user('u1', 'Q'), segmented], false)[0].reply).toBe('first second');
+    expect(buildEntries([user('u1', 'Q'), assistant('a1', 'flat')], false)[0].reply).toBe('flat');
+  });
+
+  it('names an attachment-only prompt by its files and survives non-string content', () => {
+    const entries = buildEntries(
+      [
+        user('u1', '', { attachments: [{ name: 'q3.pdf', type: 'application/pdf' }] }),
+        assistant('a1', 'Reply.'),
+        user('u2', ['not', 'a', 'string']),
+      ],
+      false,
+    );
+    expect(entries.map((e) => e.prompt)).toEqual(['q3.pdf', '']);
+  });
+
+  it('names an attachment-only prompt from either attachment shape', () => {
+    // A live send stores the upload-time shape as-is, where the name is on the
+    // File; history reloads it into the flat shape.
+    const entries = buildEntries(
+      [
+        user('u1', '', { attachments: [{ file: { name: 'live.csv' }, dataUrl: 'x', type: 'text/csv' }] }),
+        assistant('a1', 'Reply.'),
+        user('u2', '', { attachments: [{ name: 'history.pdf', type: 'application/pdf' }] }),
+      ],
+      false,
+    );
+    expect(entries.map((e) => e.prompt)).toEqual(['live.csv', 'history.pdf']);
+  });
+
+  it('does not let a failed steering send absorb the next prompt', () => {
+    // A failed steer keeps its bubble, is stamped queueError and never gets an
+    // assistant, so merging it would hand the fresh prompt the failed id.
+    const entries = buildEntries(
+      [
+        user('u1', 'Q'),
+        assistant('a1', 'Reply.'),
+        user('s1', 'steer that failed', { queueError: 'Failed to send steering' }),
+        user('u2', 'fresh prompt'),
+        assistant('a2', 'Fresh reply.'),
+      ],
+      false,
+    );
+    expect(entries.map((e) => [e.id, e.prompt, e.reply])).toEqual([
+      ['u1', 'Q', 'Reply.'],
+      ['s1', 'steer that failed', ''],
+      ['u2', 'fresh prompt', 'Fresh reply.'],
+    ]);
+  });
+
+  it('splits a failed steer out of the batch it was queued alongside', () => {
+    // The continuation answers only what was delivered, so labelling it with an
+    // instruction the agent never received would misreport what it was asked.
+    const entries = buildEntries(
+      [
+        user('u1', 'Analyse AMD'),
+        assistant('a1', 'Working.'),
+        user('s1', 'use Q3 numbers'),
+        user('s2', 'and skip the charts', { queueError: 'Failed to send steering' }),
+        assistant('a2', 'Continuation.'),
+      ],
+      false,
+    );
+    expect(entries.map((e) => [e.id, e.prompt, e.reply])).toEqual([
+      ['u1', 'Analyse AMD', 'Working.'],
+      ['s1', 'use Q3 numbers', 'Continuation.'],
+      ['s2', 'and skip the charts', ''],
+    ]);
+  });
+
+  it('never shows a failed steer as pending, even while the parent turn runs', () => {
+    const entries = buildEntries(
+      [
+        user('u1', 'Analyse AMD'),
+        assistant('a1', 'Working.'),
+        user('s1', 'use Q3 numbers', { queueError: 'Failed to send steering' }),
+      ],
+      true,
+    );
+    expect(entries.map((e) => [e.id, e.pending])).toEqual([
+      ['u1', false],
+      ['s1', false],
+    ]);
+    // The turn that is genuinely still running keeps its skeleton.
+    const noReplyYet = buildEntries(
+      [user('u1', 'Analyse AMD'), user('s1', 'use Q3 numbers', { queueError: 'Failed to send steering' })],
+      true,
+    );
+    expect(noReplyYet.map((e) => [e.id, e.pending])).toEqual([
+      ['u1', true],
+      ['s1', false],
+    ]);
+  });
+
+  it('gives a drained steering batch one tick, anchored and labelled by the whole batch', () => {
+    // Everything queued during one tool call is delivered together and answered
+    // by a single continuation, so the prompts share a tick rather than leaving
+    // all but the last with an empty card.
+    const entries = buildEntries(
+      [
+        user('u1', 'Analyse AMD'),
+        assistant('a1', 'Working.'),
+        user('s1', 'use Q3 numbers'),
+        user('s2', 'and skip the charts'),
+        assistant('a2', 'Continuation.'),
+      ],
+      false,
+    );
+    expect(entries.map((e) => [e.id, e.prompt, e.reply])).toEqual([
+      ['u1', 'Analyse AMD', 'Working.'],
+      ['s1', 'use Q3 numbers · and skip the charts', 'Continuation.'],
+    ]);
+  });
+
+  it('keeps a lone steer on its own tick, and leaves an unanswered batch pending as one', () => {
+    // A single steer has an assistant bubble before it, so it still splits.
+    const lone = buildEntries(
+      [user('u1', 'Q'), assistant('a1', 'Part.'), user('s1', 'actually stop'), assistant('a2', 'OK.')],
+      false,
+    );
+    expect(lone.map((e) => e.id)).toEqual(['u1', 's1']);
+    // Mid-flight, a batch with no continuation yet is one pending entry.
+    const inFlight = buildEntries(
+      [user('u1', 'Q'), assistant('a1', 'Part.'), user('s1', 'one'), user('s2', 'two')],
+      true,
+    );
+    expect(inFlight.map((e) => [e.id, e.pending])).toEqual([
+      ['u1', false],
+      ['s1', true],
+    ]);
+  });
+});
+
+describe('plainText', () => {
+  it('prefers prose over fenced code, but keeps a code-only message readable', () => {
+    expect(plainText('Run this:\n```py\nprint(1)\n```\nthen check.')).toBe('Run this: then check.');
+    expect(plainText('```py\nprint(1)\n```')).toBe('print(1)');
+  });
+
+  it('strips markdown structure to one line', () => {
+    expect(plainText('# Title\n\n- **bold** item\n> quote [link](http://x)\n| a | b |')).toBe('Title bold item quote link a b');
+  });
+
+  it('unwraps matched delimiters but leaves literal punctuation alone', () => {
+    expect(plainText('*em* _also_ ~~gone~~ `code`')).toBe('em also gone code');
+    // Research prose the old character-class strip silently rewrote.
+    expect(plainText('BRK_B is A * B, about ~5% of AAPL_US')).toBe('BRK_B is A * B, about ~5% of AAPL_US');
+  });
+});

--- a/web/src/pages/ChatAgent/components/chatView/useChatScroll.ts
+++ b/web/src/pages/ChatAgent/components/chatView/useChatScroll.ts
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { isNearBottom } from '../../utils/scrollHelpers';
+import { findMessageElement, resolveScrollContent, resolveScrollViewport } from '../../utils/scrollDom';
 import { scrollMemory } from '@/lib/scrollMemory';
 
 // Scroll/pin tuning. Distance from the bottom (px) still counted as "at bottom";
@@ -9,10 +10,29 @@ const NEAR_BOTTOM_PX = 120;
 const SETTLE_QUIET_MS = 1500;
 const SETTLE_HARD_CAP_MS = 8000;
 const SCROLLEND_FALLBACK_MS = 600;
+// Gap left above a bubble the transcript is pinned to.
+const ANCHOR_OFFSET_PX = 16;
+
+/** scrollTop that puts bubble `id` just under the viewport top, or null once it is no longer in the transcript. */
+function anchorTop(c: HTMLElement, id: string): number | null {
+  const el = findMessageElement(c, id);
+  if (!el) return null;
+  return Math.max(0, c.scrollTop + el.getBoundingClientRect().top - c.getBoundingClientRect().top - ANCHOR_OFFSET_PX);
+}
 
 /** Chat transcript scroll controller + tab scroll memory (carved out of
  * ChatView, 5.9c): bottom pin with async-settle re-apply, streaming follow,
  * thread-entry restore, jump-to-latest pill, and per-tab scroll memory. */
+/**
+ * Pin controller state. 'bottom' follows the growing transcript end; 'offset'
+ * converges on a remembered mid-thread scrollTop that async content (charts,
+ * markdown, images) hasn't made reachable yet — same settle machinery,
+ * different target. 'anchor' holds a chosen bubble under the viewport top
+ * (minimap navigation), re-measured on every re-apply so media above it
+ * finishing layout can't shift the landing.
+ */
+export type PinTarget = { mode: 'bottom' } | { mode: 'offset'; top: number } | { mode: 'anchor'; id: string };
+
 export function useChatScroll({ activeAgentId, messages, isActive, isActiveRef, isLoadingHistory, currentThreadId, threadId }: {
   activeAgentId: string;
   messages: unknown[];
@@ -41,12 +61,10 @@ export function useChatScroll({ activeAgentId, messages, isActive, isActiveRef, 
   const skipSubagentAutoScrollRef = useRef(false);
 
   // Helper: get the scrollable container from a ScrollArea ref
-  const getScrollContainer = useCallback((ref: React.RefObject<HTMLDivElement | null>): HTMLElement | null => {
-    if (!ref?.current) return null;
-    return ref.current.querySelector('[data-radix-scroll-area-viewport]') ||
-           ref.current.querySelector('.overflow-auto') ||
-           ref.current;
-  }, []);
+  const getScrollContainer = useCallback(
+    (ref: React.RefObject<HTMLDivElement | null>): HTMLElement | null => resolveScrollViewport(ref?.current ?? null),
+    [],
+  );
 
   // Save scroll position of the currently active tab
   const saveScrollPosition = useCallback(() => {
@@ -92,13 +110,11 @@ export function useChatScroll({ activeAgentId, messages, isActive, isActiveRef, 
   const isNearBottomRef = useRef(true);
   const isSubagentNearBottomRef = useRef(true);
 
-  // Pin controller state. 'bottom' follows the growing transcript end;
-  // 'offset' converges on a remembered mid-thread scrollTop that async content
-  // (charts, markdown, images) hasn't made reachable yet — same settle
-  // machinery, different target.
-  type PinTarget = { mode: 'bottom' } | { mode: 'offset'; top: number };
   const pinTargetRef = useRef<PinTarget | null>(null);
   const programmaticScrollRef = useRef(false);
+  // Detaches the pending release of the current programmatic scroll (see
+  // withProgrammaticScroll); null when no release is pending.
+  const programmaticReleaseRef = useRef<(() => void) | null>(null);
   const settleQuietTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const settleHardCapRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reapplyRafRef = useRef<number | null>(null);
@@ -126,30 +142,54 @@ export function useChatScroll({ activeAgentId, messages, isActive, isActiveRef, 
     );
   }, []);
   // Wrap a programmatic scroll so the scroll listener doesn't mistake it for a
-  // user scroll (which cancels the pin). Smooth scrolls clear on `scrollend`
-  // (600ms fallback for engines without it); instant clears after the scroll
-  // event flushes (double rAF).
+  // user scroll (which cancels the pin). Smooth scrolls clear on `scrollend`,
+  // with a fallback that fires 600ms after the last scroll event: it measures
+  // quiet, not elapsed time, because a whole-thread smooth scroll runs longer
+  // than any fixed budget, and it still covers a scroll that never moves and
+  // so never ends. Instant scrolls clear after the scroll event flushes (double
+  // rAF). The flag is shared, so a newer scroll detaches the previous release
+  // first: a release firing mid-way through this scroll would hand its
+  // remaining scroll events to the user-scroll branch, which drops the pin
+  // the new scroll just set.
   const withProgrammaticScroll = useCallback(
     (fn: () => void, behavior: 'auto' | 'smooth' = 'auto') => {
+      programmaticReleaseRef.current?.();
       programmaticScrollRef.current = true;
       fn();
       if (behavior === 'smooth') {
         const c = getScrollContainer(scrollAreaRef);
-        let cleared = false;
-        const clear = () => {
-          if (cleared) return;
-          cleared = true;
+        let timer: ReturnType<typeof setTimeout> | null = null;
+        function detach() {
           c?.removeEventListener('scrollend', clear);
+          c?.removeEventListener('scroll', arm);
+          if (timer) clearTimeout(timer);
+          if (programmaticReleaseRef.current === detach) programmaticReleaseRef.current = null;
+        }
+        function clear() {
+          detach();
           programmaticScrollRef.current = false;
-        };
+        }
+        function arm() {
+          if (timer) clearTimeout(timer);
+          timer = setTimeout(clear, SCROLLEND_FALLBACK_MS);
+        }
         c?.addEventListener('scrollend', clear, { once: true });
-        setTimeout(clear, SCROLLEND_FALLBACK_MS);
+        c?.addEventListener('scroll', arm, { passive: true });
+        arm();
+        programmaticReleaseRef.current = detach;
       } else {
-        requestAnimationFrame(() =>
-          requestAnimationFrame(() => {
+        let inner = 0;
+        const outer = requestAnimationFrame(() => {
+          inner = requestAnimationFrame(() => {
+            programmaticReleaseRef.current = null;
             programmaticScrollRef.current = false;
-          }),
-        );
+          });
+        });
+        programmaticReleaseRef.current = () => {
+          cancelAnimationFrame(outer);
+          cancelAnimationFrame(inner);
+          programmaticReleaseRef.current = null;
+        };
       }
     },
     [getScrollContainer],
@@ -158,11 +198,7 @@ export function useChatScroll({ activeAgentId, messages, isActive, isActiveRef, 
   // The growing content node inside the fixed-height Radix viewport. The viewport
   // height is fixed (h-full); only its content grows as async media expands, so
   // that is what the ResizeObserver must watch.
-  const getScrollContent = useCallback(
-    (c: HTMLElement): HTMLElement =>
-      c.querySelector<HTMLElement>('.max-w-3xl') ?? (c.firstElementChild as HTMLElement) ?? c,
-    [],
-  );
+  const getScrollContent = useCallback((c: HTMLElement): HTMLElement => resolveScrollContent(c), []);
 
   const clearSettleTimers = useCallback(() => {
     if (settleQuietTimerRef.current) {
@@ -226,13 +262,47 @@ export function useChatScroll({ activeAgentId, messages, isActive, isActiveRef, 
       const c = getScrollContainer(scrollAreaRef);
       const target = pinTargetRef.current;
       if (!target || !c) return;
-      withProgrammaticScroll(
-        () => c.scrollTo({ top: target.mode === 'bottom' ? c.scrollHeight : target.top }),
-        'auto',
-      );
+      const top =
+        target.mode === 'bottom' ? c.scrollHeight : target.mode === 'offset' ? target.top : anchorTop(c, target.id);
+      if (top == null) {
+        // The anchored bubble left the transcript (edit / regenerate truncation).
+        pinTargetRef.current = null;
+        clearSettleTimers();
+        return;
+      }
+      withProgrammaticScroll(() => c.scrollTo({ top }), 'auto');
       armSettleTimers();
     });
-  }, [getScrollContainer, withProgrammaticScroll, armSettleTimers]);
+  }, [getScrollContainer, withProgrammaticScroll, armSettleTimers, clearSettleTimers]);
+
+  // Scroll a bubble under the viewport top and hold it there through the settle
+  // window. Anything short of the newest turn hands the user the jump pill and
+  // a false near-bottom, so a streaming follow can't yank them back down.
+  const pinToMessage = useCallback(
+    (id: string, behavior: 'auto' | 'smooth' = 'auto', isLatest = false) => {
+      const c = getScrollContainer(scrollAreaRef);
+      if (!c) return;
+      const top = anchorTop(c, id);
+      if (top == null) return;
+      if (streamFollowTimerRef.current) {
+        clearTimeout(streamFollowTimerRef.current);
+        streamFollowTimerRef.current = null;
+      }
+      pinTargetRef.current = { mode: 'anchor', id };
+      // A request past the maximum clamps, so any turn near enough to the end
+      // reads as "at the bottom" by position alone. Only the newest one really
+      // is: under an earlier turn the transcript still has room to grow, and
+      // calling that the bottom re-arms the follow that carries the reader off
+      // the turn they picked.
+      const landsAtBottom = isLatest && top >= Math.max(0, c.scrollHeight - c.clientHeight) - 1;
+      isNearBottomRef.current = landsAtBottom;
+      pillBaselineLenRef.current = messagesLenRef.current;
+      setPillState({ visible: !landsAtBottom, hasNew: false, newCount: 0 });
+      withProgrammaticScroll(() => c.scrollTo({ top, behavior }), behavior);
+      armSettleTimers();
+    },
+    [getScrollContainer, withProgrammaticScroll, armSettleTimers, setPillState],
+  );
 
   // Scroll listener + settle-aware ResizeObserver.
   // Re-attaches when activeAgentId changes (ScrollArea remounts on tab switch).
@@ -247,10 +317,21 @@ export function useChatScroll({ activeAgentId, messages, isActive, isActiveRef, 
     nearBottomRef.current = true;
 
     const handleScroll = () => {
-      nearBottomRef.current = isNearBottom(
-        { scrollTop: c.scrollTop, scrollHeight: c.scrollHeight, clientHeight: c.clientHeight },
-        NEAR_BOTTOM_PX,
-      );
+      // The band is how a *user* scroll re-joins the stream. An anchor pin's own
+      // scrolls must not get to answer it: pinToMessage already decided whether
+      // that landing is the bottom, knowing the one thing a position cannot tell
+      // it, which turn is the newest. A request past the maximum clamps, so a
+      // landing on an earlier turn near the end sits exactly at the maximum and
+      // reads as the bottom by any positional test. Letting it re-arm the follow
+      // is what walks the reader off the turn they picked once the settle window
+      // lets go.
+      const pinOwnsPosition = programmaticScrollRef.current && pinTargetRef.current?.mode === 'anchor';
+      if (!pinOwnsPosition) {
+        nearBottomRef.current = isNearBottom(
+          { scrollTop: c.scrollTop, scrollHeight: c.scrollHeight, clientHeight: c.clientHeight },
+          NEAR_BOTTOM_PX,
+        );
+      }
       if (!isMain) return;
       // Record every settle (user scrolls AND pins/follows) so the cross-unmount
       // store always reflects where the transcript actually is — a bottom pin
@@ -437,6 +518,8 @@ export function useChatScroll({ activeAgentId, messages, isActive, isActiveRef, 
     getScrollContainer,
     withProgrammaticScroll,
     pinToBottom,
+    pinToMessage,
+    pinTargetRef,
     saveScrollPosition,
     jumpPill,
     scrollPositionsRef,

--- a/web/src/pages/ChatAgent/components/messageList/MessageBubble.tsx
+++ b/web/src/pages/ChatAgent/components/messageList/MessageBubble.tsx
@@ -18,6 +18,7 @@ import { MessageContentSegments } from './MessageContentSegments';
 import { OverflowCollapse } from './OverflowCollapse';
 import { useMessageActions } from './MessageActionsContext';
 import { isSteeringUserMessage } from './messagePredicates';
+import { assistantText } from './messageText';
 import { EMPTY_OBJ } from './types';
 import type { ContentSegmentRecord, FeedbackResult, MessageRecord, ToolCallProcessRecord } from './types';
 
@@ -169,12 +170,7 @@ export const MessageBubble = memo(function MessageBubble({ message, turnIndex, i
   };
 
   const handleCopy = () => {
-    // Collect all text content from segments
-    const contentSegments = message.contentSegments as ContentSegmentRecord[] | undefined;
-    const text = contentSegments
-      ?.filter((s) => s.type === 'text')
-      .map((s) => s.content)
-      .join('') || (message.content as string) || '';
+    const text = assistantText(message);
     // Confirm only after the write lands (it can reject when the document
     // loses focus); rapid re-copies reset the shared timer instead of
     // stacking timers that would cut the newer indicator short.

--- a/web/src/pages/ChatAgent/components/messageList/messageText.ts
+++ b/web/src/pages/ChatAgent/components/messageList/messageText.ts
@@ -1,0 +1,12 @@
+import type { ContentSegmentRecord, MessageRecord } from './types';
+
+/** The reply's prose in transcript order. Segments can land out of order, so they are sorted by `order` the way the bubble renders them; a message with no text segments falls back to its flat `content`. Shared by copy and the minimap preview so both read the same text. */
+export function assistantText(message: MessageRecord): string {
+  const segments = message.contentSegments as ContentSegmentRecord[] | undefined;
+  const text = segments
+    ?.filter((s) => s.type === 'text')
+    .sort((a, b) => a.order - b.order)
+    .map((s) => s.content ?? '')
+    .join('');
+  return text || (typeof message.content === 'string' ? message.content : '');
+}

--- a/web/src/pages/ChatAgent/components/minimapEntries.ts
+++ b/web/src/pages/ChatAgent/components/minimapEntries.ts
@@ -1,0 +1,144 @@
+import type { Attachment } from '@/types/sse';
+import type { MessageRecord } from './messageList/types';
+import { assistantText } from './messageList/messageText';
+
+export interface TurnEntry {
+  id: string;
+  /** Empty when the send carried no text and no attachment names. */
+  prompt: string;
+  reply: string;
+  /** The newest turn is in flight and has produced no reply text yet. */
+  pending: boolean;
+}
+
+export const PROMPT_MAX = 140;
+export const REPLY_MAX = 280;
+// Raw markdown read per message before flattening. The card only ever shows
+// the head, so the tail never earns its regex passes; the slack covers markup
+// (fences, link targets) that is longer than the text it wraps.
+const RAW_SLACK = 4;
+
+// Flattened text per settled message. Settled messages keep their object
+// identity across streamed chunks (the store maps untouched entries through),
+// so a thread's history is flattened once, not once per token.
+const flatCache = new WeakMap<object, string>();
+
+function flatten(markdown: string): string {
+  return markdown
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, '')
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/^\s{0,3}(#{1,6}\s+|>\s?|[-*+]\s+|\d+\.\s+)/gm, '')
+    // Only a matched pair is formatting. Research prose is full of literal
+    // `*`, `_` and `~` (BRK_B, A * B, ~5%), and stripping them by character
+    // rewrites the sentence the preview exists to quote.
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
+    .replace(/__([^_]+)__/g, '$1')
+    .replace(/~~([^~]+)~~/g, '$1')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/(^|[\s(])([*_])(?=\S)([^*_]*?[^\s*_])\2(?=[\s).,;:!?]|$)/g, '$1$3')
+    .replace(/\|/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** One line of prose for the hover card. Fenced code is dropped in favour of the prose around it, unless the message is nothing but code, in which case the code text is the preview. */
+export function plainText(markdown: unknown): string {
+  if (typeof markdown !== 'string') return '';
+  const prose = flatten(markdown.replace(/```[\s\S]*?(```|$)/g, ' '));
+  return prose || flatten(markdown.replace(/```[^\n]*/g, ' '));
+}
+
+export function clip(text: string, max: number): string {
+  return text.length > max ? text.slice(0, max).trimEnd() + '…' : text;
+}
+
+// `raw` is a producer, not a string: a settled message must cost nothing on a
+// cache hit, and building the raw text at the call site would sort and join
+// every prior message's segments once per streamed chunk.
+function flatOf(message: MessageRecord, raw: () => string, max: number): string {
+  const settled = !message.isStreaming;
+  if (settled) {
+    const hit = flatCache.get(message);
+    if (hit !== undefined) return hit;
+  }
+  const flat = plainText(raw().slice(0, max * RAW_SLACK));
+  if (settled) flatCache.set(message, flat);
+  return flat;
+}
+
+function promptOf(message: MessageRecord): string {
+  const text = flatOf(message, () => (typeof message.content === 'string' ? message.content : ''), PROMPT_MAX);
+  if (text) return clip(text, PROMPT_MAX);
+  // Two shapes reach here: the history `Attachment` (name) and the upload-time
+  // `AttachmentMeta` a live send stores as-is (the name is on the File).
+  const attachments = message.attachments as (Attachment & { file?: { name?: string } })[] | undefined;
+  const names = (attachments ?? []).map((a) => a.name || a.file?.name || '').filter(Boolean);
+  return clip(names.join(', '), PROMPT_MAX);
+}
+
+export function entriesEqual(prev: TurnEntry[], next: TurnEntry[]): boolean {
+  return (
+    next.length === prev.length &&
+    next.every((e, i) => {
+      const p = prev[i];
+      return e.id === p.id && e.prompt === p.prompt && e.reply === p.reply && e.pending === p.pending;
+    })
+  );
+}
+
+/**
+ * One entry per prompt-and-reply pair. Consecutive user bubbles with no
+ * assistant between them are one entry: steering drains as a batch, so
+ * everything queued during a single tool call is delivered together and
+ * answered by one continuation. Splitting them would leave every prompt but
+ * the last showing a card with nothing under it, permanently.
+ *
+ * A send that failed is the exception at every step. It gets its own tick in
+ * transcript order, joins no batch and takes no follower, and never claims the
+ * continuation that lands under it: the agent was never given it, so a reply
+ * below it answers the last message that was actually delivered. It is never
+ * pending either, since the turn still running is the one above it.
+ */
+const failedSend = (m: MessageRecord): boolean => !!(m as { queueError?: unknown }).queueError;
+
+type Draft = { id: string; prompts: string[]; reply: string; answered: boolean; failed: boolean };
+
+export function buildEntries(messages: MessageRecord[], turnInFlight: boolean): TurnEntry[] {
+  const drafts: Draft[] = [];
+  // The delivered entry replies attach to, which a failed send in between does
+  // not displace.
+  let open: Draft | null = null;
+
+  for (const m of messages) {
+    if (m.role === 'user') {
+      if (failedSend(m)) {
+        drafts.push({ id: String(m.id), prompts: [promptOf(m)], reply: '', answered: false, failed: true });
+        continue;
+      }
+      // The batch keeps the first bubble's id, so its tick lands the reader at
+      // the top of what they said rather than in the middle of it.
+      if (open && !open.answered) {
+        open.prompts.push(promptOf(m));
+        continue;
+      }
+      open = { id: String(m.id), prompts: [promptOf(m)], reply: '', answered: false, failed: false };
+      drafts.push(open);
+    } else if (m.role === 'assistant' && open) {
+      open.answered = true;
+      open.reply += flatOf(m, () => assistantText(m), REPLY_MAX) + ' ';
+    }
+  }
+
+  const entries = drafts.map((d) => ({
+    id: d.id,
+    prompt: clip(d.prompts.filter(Boolean).join(' · '), PROMPT_MAX),
+    reply: clip(d.reply.trim(), REPLY_MAX),
+    pending: false,
+  }));
+  for (let i = drafts.length - 1; turnInFlight && i >= 0; i--) {
+    if (drafts[i].failed) continue;
+    if (entries[i].reply === '') entries[i].pending = true;
+    break;
+  }
+  return entries;
+}

--- a/web/src/pages/ChatAgent/hooks/utils/__tests__/historyEventHandlers.stopped.test.ts
+++ b/web/src/pages/ChatAgent/hooks/utils/__tests__/historyEventHandlers.stopped.test.ts
@@ -11,6 +11,7 @@
  * (driven by the `stopped` flag) — matching the live finalize.
  */
 import { describe, it, expect } from 'vitest';
+import type { PairState } from '../../../session/types';
 import {
   handleHistoryReasoningSignal,
   handleHistoryReasoningContent,
@@ -18,11 +19,6 @@ import {
 } from '../historyEventHandlers';
 import type { MessageRecord } from '../types';
 
-interface PairState {
-  contentOrderCounter: number;
-  reasoningId: string | null;
-  toolCallId: string | null;
-}
 
 function makeStore(initial: MessageRecord[]) {
   const store = { messages: initial.slice() };
@@ -50,7 +46,7 @@ describe('historyEventHandlers — stopped turn replay', () => {
         toolCallProcesses: {},
       },
     ]);
-    const pairState: PairState = { contentOrderCounter: 0, reasoningId: null, toolCallId: null };
+    const pairState: PairState = { contentOrderCounter: 0, reasoningId: null, toolCallId: null, steeringBatches: 0 };
 
     // Replay: reasoning starts, gets content, then the synthetic close events.
     handleHistoryReasoningSignal({ assistantMessageId, signalContent: 'start', pairIndex: 0, pairState, setMessages });
@@ -77,7 +73,7 @@ describe('historyEventHandlers — stopped turn replay', () => {
     const { store, setMessages } = makeStore([
       { id: assistantMessageId, role: 'assistant', content: 'done', isStreaming: false, reasoningProcesses: {} },
     ]);
-    const pairState: PairState = { contentOrderCounter: 0, reasoningId: null, toolCallId: null };
+    const pairState: PairState = { contentOrderCounter: 0, reasoningId: null, toolCallId: null, steeringBatches: 0 };
 
     handleHistoryTextContent({ assistantMessageId, content: '', finishReason: 'stop', pairState, setMessages });
 

--- a/web/src/pages/ChatAgent/hooks/utils/__tests__/htmlWidgetHandlers.test.ts
+++ b/web/src/pages/ChatAgent/hooks/utils/__tests__/htmlWidgetHandlers.test.ts
@@ -62,6 +62,7 @@ function makePairState(counterStart = 0) {
     contentOrderCounter: counterStart,
     reasoningId: null,
     toolCallId: null,
+    steeringBatches: 0,
   };
 }
 

--- a/web/src/pages/ChatAgent/hooks/utils/historyEventHandlers.ts
+++ b/web/src/pages/ChatAgent/hooks/utils/historyEventHandlers.ts
@@ -19,3 +19,4 @@ export {
   handleHistoryTodoUpdate,
   handleHistoryHtmlWidget,
 } from '../../session/history/historyHandlers';
+export type { PairState } from '../../session/types';

--- a/web/src/pages/ChatAgent/session/history/historyHandlers.ts
+++ b/web/src/pages/ChatAgent/session/history/historyHandlers.ts
@@ -8,15 +8,8 @@ import { isTaskAgentId } from '../../utils/agentId';
 import { deriveTaskSegment, applyTaskSegment, applyLaunchReply } from '../subagents/taskSegmentBuilder';
 import type { SubagentTaskRecord } from '@/types/chat';
 import type { MessageRecord, SetMessages, ToolCallRecord, ToolCallResultRecord, TodoPayload, HtmlWidgetData } from '../../hooks/utils/types';
+import type { PairState } from '../types';
 
-let _steeringIdCounter = 0;
-
-/** Per-pair mutable state tracked during history replay. */
-interface PairState {
-  contentOrderCounter: number;
-  reasoningId: string | null;
-  toolCallId: string | null;
-}
 
 /** Shape of an SSE history event. */
 interface HistoryEvent {
@@ -88,6 +81,7 @@ export function handleHistoryUserMessage({
           contentOrderCounter: 0,
           reasoningId: null,
           toolCallId: null,
+          steeringBatches: 0,
         });
       }
       // Map turn_index to the streaming assistant message ID
@@ -101,6 +95,7 @@ export function handleHistoryUserMessage({
       contentOrderCounter: 0,
       reasoningId: null,
       toolCallId: null,
+      steeringBatches: 0,
     });
 
     // Create user message bubble (skip for empty content, HITL resume pairs,
@@ -167,6 +162,7 @@ export function handleHistoryUserMessage({
         contentOrderCounter: 0,
         reasoningId: null,
         toolCallId: null,
+        steeringBatches: 0,
       });
     }
 
@@ -518,8 +514,11 @@ export function handleHistorySteeringDelivered({
   const { newMessagesStartIndexRef } = refs;
   const steeringMessages = (event.messages || []) as Array<Record<string, unknown>>;
 
-  // Create user message bubble(s) for each steering message
-  const batchId = ++_steeringIdCounter;
+  // Create user message bubble(s) for each steering message. The batch is
+  // numbered within its pair, never from a process-wide counter: ids that
+  // change on every replay make the same bubbles look new to every id-keyed
+  // consumer (scroll observers, the minimap) each time history reattaches.
+  const batchId = (pairStateByPair.get(pairIndex)?.steeringBatches ?? 0) + 1;
   for (let sIdx = 0; sIdx < steeringMessages.length; sIdx++) {
     const qMsg = steeringMessages[sIdx];
     if (!qMsg.content) continue;
@@ -551,6 +550,7 @@ export function handleHistorySteeringDelivered({
     contentOrderCounter: 0,
     reasoningId: null,
     toolCallId: null,
+    steeringBatches: batchId,
   });
 
   const assistantMessage: MessageRecord = {

--- a/web/src/pages/ChatAgent/session/types.ts
+++ b/web/src/pages/ChatAgent/session/types.ts
@@ -236,6 +236,8 @@ interface PairState {
   contentOrderCounter: number;
   reasoningId: string | null;
   toolCallId: string | null;
+  /** Steering batches delivered in this pair so far. It keys the ids of the bubbles a batch adds, so a replay mints the same ids as the last one. */
+  steeringBatches: number;
 }
 
 

--- a/web/src/pages/ChatAgent/utils/scrollDom.ts
+++ b/web/src/pages/ChatAgent/utils/scrollDom.ts
@@ -1,0 +1,28 @@
+// DOM lookups the transcript scroll code shares (the scroll controller and
+// the minimap must agree on what "the viewport" is).
+
+/** The ScrollArea wrapper is outer (overflow-hidden) > inner (overflow-auto); the inner div is the element that actually scrolls. */
+export function resolveScrollViewport(root: HTMLElement | null): HTMLElement | null {
+  if (!root) return null;
+  return (
+    root.querySelector<HTMLElement>('[data-radix-scroll-area-viewport]') ??
+    root.querySelector<HTMLElement>('.overflow-auto') ??
+    root
+  );
+}
+
+/** The growing content node inside the fixed-height viewport: the viewport itself never changes size as content lands, so this is what a ResizeObserver must watch. */
+export function resolveScrollContent(viewport: HTMLElement): HTMLElement {
+  return (
+    viewport.querySelector<HTMLElement>('.max-w-3xl') ??
+    (viewport.firstElementChild as HTMLElement | null) ??
+    viewport
+  );
+}
+
+export function findMessageElement(viewport: HTMLElement, id: string): HTMLElement | null {
+  for (const el of viewport.querySelectorAll<HTMLElement>('[data-message-id]')) {
+    if (el.dataset.messageId === id) return el;
+  }
+  return null;
+}

--- a/web/src/pages/SharedChat/SharedChatView.tsx
+++ b/web/src/pages/SharedChat/SharedChatView.tsx
@@ -24,6 +24,7 @@ import {
   handleHistoryTodoUpdate,
   handleHistoryTaskArtifactStatus,
 } from '../ChatAgent/hooks/utils/historyEventHandlers';
+import type { PairState } from '../ChatAgent/hooks/utils/historyEventHandlers';
 import {
   getSharedThread,
   replaySharedThread,
@@ -43,12 +44,6 @@ type MessageRecord = Record<string, unknown>;
 /** SetMessages type matching historyEventHandlers' signature */
 type SetMessages = (updater: (prev: MessageRecord[]) => MessageRecord[]) => void;
 
-/** PairState type matching historyEventHandlers' PairState */
-interface PairState {
-  contentOrderCounter: number;
-  reasoningId: string | null;
-  toolCallId: string | null;
-}
 
 function updateMessage(messages: MessageRecord[], messageId: string, updater: (m: MessageRecord) => MessageRecord): MessageRecord[] {
   return messages.map((m) => (m.id === messageId ? updater(m) : m));


### PR DESCRIPTION
## Summary

The chat transcript's right-edge minimap becomes a tick rail, inspired by the transcript minimap in OpenAI's Codex app, whose design this follows closely (credit to the Codex team): one thin bar per user prompt, magnified around the hovered or active turn, with a hover card that shows the prompt in bold and a muted preview of the reply (a skeleton while the turn is still in flight). Clicking a tick pins that bubble just under the viewport top and the scroll controller keeps it there through streaming and settle re-applies. A second commit fixes history replay minting new ids for steered bubbles on every reattach, which the minimap (and the existing scroll observers) surfaced as ticks that changed identity on each re-entry.

## Why this way

- The rail is a pure function of the message list: `buildEntries` folds each user bubble plus its following assistant bubbles into one `TurnEntry`, so the component never inspects streaming state beyond one `turnInFlight` flag. Steered turns fold into the prompt they steered rather than adding ticks.
- Reply previews are flattened markdown, cached per settled message object in a `WeakMap`. The store keeps untouched message identities across streamed chunks, so the cache stays warm for everything but the bubble currently streaming, and it flattens only a bounded prefix of the raw text.
- Clicking a tick goes through the scroll controller's new `anchor` pin mode instead of `scrollIntoView`. The existing `bottom` and `offset` modes re-apply on resize and settle; an anchor pin does the same for a message id, which is what stops the streaming follow effect from yanking the landing back down.
- A programmatic smooth scroll hides its own scroll events from the user-scroll branch behind a flag. That flag used to be released by a fixed 600ms timer, which a whole-thread smooth scroll outruns; the release now waits for 600ms of quiet since the last scroll event (still covering a scroll that never moves), and a newer programmatic scroll detaches the previous release before starting.
- The hover card is positioned imperatively from the tick's offset and placed once without a transition, so the first mount does not slide in from the previous position. Keyboard focus and mouse hover are separate slots; focus only holds the card when it is `:focus-visible`, so a mouse click does not leave a phantom card behind.
- Steering batch ids are numbered within their pair (`steeringBatches` on `PairState`) rather than from a process-wide counter, which is what made them replay-stable. `PairState` becomes one shared type instead of three local copies.

## How it works

- `ChatMinimap` builds entries, runs a rAF-throttled scrollspy over cached message anchors (binary search on `getBoundingClientRect().top`), and derives every tick's width and opacity from its distance to the focus index. The rail adapts its pitch between 16px and 4px and scrolls itself beyond that, with a wheel handler that forwards to the transcript whenever the rail cannot spend the gesture itself (no overflow, or already at the end the gesture points to).
- `useChatScroll` gains `pinToMessage(id, behavior)`: it sets an `anchor` pin, computes the landing top with a 16px offset, updates the jump-pill baseline, performs a programmatic scroll and arms the settle timers. `reapplyPin` recomputes the anchor top on resize and clears the pin when the message leaves the DOM.
- `scrollDom.ts` centralises viewport/content/message-element resolution so the hook and the minimap agree on which element is the real scroll viewport.
- `messageText.ts` extracts the assistant-text flattening that `MessageBubble`'s copy button already did, and the minimap reuses it.
- Replay: `handleHistorySteeringDelivered` reads `steeringBatches` from the pair state to number the batch, then records it back after the batch is applied.

## Overview

| | Files | Added | Removed |
|---|---|---|---|
| Modified | 13 | +531 | -333 |
| New | 4 | +207 | -0 |
| **Total** | **17** | **+738** | **-333** |
| Tests (3 files) | | +65 | -7 |
| **Net excl. tests** | **14** | **+673** | **-326** |

**Chat minimap (web/src/pages/ChatAgent/components)**
- new `minimapEntries.ts` (+106): pure entry builder, markdown flatten with per-message cache, prompt fallback to attachment names
- new `messageList/messageText.ts` (+12): assistant text from ordered segments with content fallback
- new `__tests__/minimapEntries.test.ts` (+61): folding, pending rules, segment order, flatten behaviour
- `ChatMinimap.tsx` (+274/-261): rewritten as the tick rail with scrollspy, hover card, adaptive pitch, keyboard support; wheel forwards to the transcript at the rail's ends
- `ChatMinimap.css` (+130/-11): rail, tick, card and skeleton styles on design tokens, reduced-motion block
- `ChatView.tsx` (+4/-1): passes `turnInFlight` and `pinToMessage`, gates the rail on the active instance
- `messageList/MessageBubble.tsx` (+2/-6): copy button uses the shared `assistantText`

**Scroll controller (web/src/pages/ChatAgent/components/chatView, utils)**
- `chatView/useChatScroll.ts` (+97/-31): `anchor` pin mode, `pinToMessage`, anchor re-apply and clearing; programmatic-scroll release is quiet-based and superseded by a newer scroll
- new `utils/scrollDom.ts` (+28): viewport, content and message-element resolvers shared by the hook and the minimap

**History replay (web/src/pages/ChatAgent/session, hooks)**
- `session/history/historyHandlers.ts` (+10/-10): per-pair steering batch numbering, shared `PairState`
- `session/types.ts` (+2): `steeringBatches` on `PairState`
- `hooks/utils/historyEventHandlers.ts` (+1): re-exports the shared `PairState`
- `hooks/utils/__tests__/historyEventHandlers.stopped.test.ts` (+3/-7), `__tests__/htmlWidgetHandlers.test.ts` (+1): fixtures carry the new field

**Shared chat (web/src/pages/SharedChat)**
- `SharedChatView.tsx` (+1/-6): drops its local `PairState` copy for the shared type

**Locales (web/src/locales)**
- `en-US.json`, `zh-CN.json` (+3 each): `chat.minimap.untitledTurn` label for prompts without text

What this introduces: a transcript overview users can hover to read what each turn asked and answered, and click to land on it, on threads of any length, in both themes, with keyboard access.

## Test plan

- [x] `pnpm typecheck` clean; `pnpm test` 297 files, 3244 tests green; ESLint 0 errors on `src/pages/ChatAgent`
- [x] `uv run pytest tests/unit/` 9255 passed, 1 xfailed; one order-dependent failure in `tests/unit/core/test_mcp_client_negotiation.py` passes alone and with its file, and the branch touches no backend file
- [x] Live in the dev stack: hover card and skeleton, tick magnification, click landing held at +16px during a streaming turn while `scrollHeight` grew, wheel over the rail scrolls the transcript, rail scrolls itself on a forced 40px column, keyboard focus shows the card only on `:focus-visible`, light and dark tokens
- [x] Live replay on a steered thread: bubble ids identical after reload and after leaving and re-entering the thread

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ginlix-ai/codesmith/LangAlpha/pr/372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790470770&installation_model_id=432753&pr_number=372&repository=ginlix-ai%2FLangAlpha&return_to=https%3A%2F%2Fgithub.com%2Fginlix-ai%2FLangAlpha%2Fpull%2F372&signature=46d26ad6fd561dd59520be953d0a7c36dbc7a61ef99bc63bbdaff570254abf08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a vertical chat minimap for navigating conversation turns.
  * Select minimap items to jump directly to messages.
  * Added previews, hover details, pending indicators, and attachment-only message support.
  * Added English and Simplified Chinese labels for text-free and pending messages.

* **Improvements**
  * Improved scrolling and minimap positioning during navigation.
  * Added keyboard focus states and reduced-motion support.
  * Improved handling of failed sends and grouped steering messages.

* **Bug Fixes**
  * Improved consistency when replaying conversation history and restoring message identifiers.
  * Preserved literal punctuation in minimap previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->