### PR TITLE
fix(web): give every control one focus ring, charts included

### DIFF
--- a/web/e2e/focus-ring.spec.js
+++ b/web/e2e/focus-ring.spec.js
@@ -101,7 +101,6 @@ test.describe('a keyboard user still gets an indicator', () => {
  * under test is the stylesheet, and coupling it to market-data mocks would let
  * it pass vacuously the day that data stops arriving.
  */
-const SURFACE = '#chart-fixture';
 const BAR = '#chart-fixture rect';
 const BEFORE = '#before-fixture';
 const PLAIN = '#plain-fixture';

--- a/web/e2e/focus-ring.spec.js
+++ b/web/e2e/focus-ring.spec.js
@@ -78,3 +78,139 @@ test.describe('a keyboard user still gets an indicator', () => {
     await expect.poll(() => ringed(page)).toBe(true);
   });
 });
+
+/**
+ * The chart half. Inside an SVG, Chromium paints its own focus ring on plain
+ * :focus -- it does not gate that on :focus-visible the way it does for HTML.
+ * So a mouse click on a chart draws a ring where the same click on a button
+ * draws nothing, and no amount of :focus-visible styling reaches it.
+ *
+ * Which node the click lands on is the part that is easy to get wrong: recharts
+ * 3.8 stacks its z-index layers as `<g tabindex="-1">` inside the surface, so a
+ * click on a bar focuses the layer, not the surface. The rule covering that is
+ * one space in a selector (`svg :focus...`) and reads like a typo. It shipped
+ * missing once and took three rounds of screenshots to find, with the whole
+ * unit suite green throughout: jsdom does not paint UA outlines, so this is the
+ * only place the difference exists.
+ *
+ * The clicks below have to be real. A programmatic .focus() matches
+ * :focus-visible and is caught by the tabindex="-1" rule instead, which passes
+ * whether or not the rule under test is present.
+ *
+ * The fixture is hand-built rather than a rendered chart on purpose: what is
+ * under test is the stylesheet, and coupling it to market-data mocks would let
+ * it pass vacuously the day that data stops arriving.
+ */
+const SURFACE = '#chart-fixture';
+const BAR = '#chart-fixture rect';
+const BEFORE = '#before-fixture';
+const PLAIN = '#plain-fixture';
+
+// Where the fixture sits, so a click can be aimed at plot space with no bar
+// under it -- the other way a chart takes focus from the mouse.
+const CHART = { x: 600, y: 200, w: 200, h: 100 };
+const BAR_BOX = { x: 10, y: 10, w: 100, h: 40 };
+const EMPTY_PLOT = { x: CHART.x + CHART.w - 20, y: CHART.y + CHART.h - 20 };
+
+/** A recharts surface, reduced to the parts the focus rules actually select. */
+async function mountChartFixture(page, chart, bar) {
+  await page.evaluate(({ chart, bar }) => {
+    const NS = 'http://www.w3.org/2000/svg';
+    const fixed = (css) => `position:fixed;z-index:9999;${css}`;
+
+    // Tab lands here first, so the next Tab is a real keyboard entry into the
+    // chart rather than a programmatic focus that would prove nothing.
+    const before = document.createElement('button');
+    before.id = 'before-fixture';
+    before.type = 'button';
+    before.textContent = 'before';
+    before.setAttribute('style', fixed(`top:${chart.y - 40}px;left:${chart.x}px`));
+
+    const svg = document.createElementNS(NS, 'svg');
+    svg.id = 'chart-fixture';
+    svg.setAttribute('class', 'recharts-surface');
+    svg.setAttribute('role', 'application');
+    svg.setAttribute('tabindex', '0');
+    svg.setAttribute('style', fixed(`top:${chart.y}px;left:${chart.x}px;width:${chart.w}px;height:${chart.h}px`));
+
+    const layer = document.createElementNS(NS, 'g');
+    layer.setAttribute('class', 'recharts-zIndex-layer_300');
+    layer.setAttribute('tabindex', '-1');
+    const rect = document.createElementNS(NS, 'rect');
+    for (const [k, v] of [['x', bar.x], ['y', bar.y], ['width', bar.w], ['height', bar.h]]) {
+      rect.setAttribute(k, String(v));
+    }
+    rect.setAttribute('fill', 'currentColor');
+    layer.appendChild(rect);
+    svg.appendChild(layer);
+
+    // The control the chart surface has to agree with: one baseline rule
+    // serves both, and this is what proves it still does.
+    const plain = document.createElement('button');
+    plain.id = 'plain-fixture';
+    plain.type = 'button';
+    plain.textContent = 'reference';
+    plain.setAttribute('style', fixed(`top:${chart.y + chart.h + 20}px;left:${chart.x}px`));
+
+    document.body.append(before, svg, plain);
+  }, { chart, bar });
+}
+
+/** What is focused right now, and the outline actually computed on it. */
+async function focused(page) {
+  return page.evaluate(() => {
+    const el = document.activeElement;
+    const cs = getComputedStyle(el);
+    return {
+      tag: el.tagName,
+      tabindex: el.getAttribute('tabindex'),
+      style: cs.outlineStyle,
+      width: cs.outlineWidth,
+      color: cs.outlineColor,
+    };
+  });
+}
+
+test.describe('a chart clicked with the mouse', () => {
+  test.beforeEach(async ({ page }) => {
+    await mountChartFixture(page, CHART, BAR_BOX);
+  });
+
+  test('leaves no ring on the layer a click on a bar lands in', async ({ page }) => {
+    await page.locator(BAR).click();
+    const el = await focused(page);
+    // If this is the surface, the fixture stopped reproducing the real bug.
+    expect({ tag: el.tag, tabindex: el.tabindex }).toEqual({ tag: 'g', tabindex: '-1' });
+    // `auto` is the UA ring, in a blue this product uses nowhere.
+    expect(el.style).toBe('none');
+  });
+
+  test('leaves no ring on the surface a click on empty plot space lands in', async ({ page }) => {
+    await page.mouse.click(EMPTY_PLOT.x, EMPTY_PLOT.y);
+    const el = await focused(page);
+    expect(el.tag).toBe('svg');
+    expect(el.style).toBe('none');
+  });
+});
+
+test.describe('a chart reached by keyboard', () => {
+  test.beforeEach(async ({ page }) => {
+    await mountChartFixture(page, CHART, BAR_BOX);
+  });
+
+  test('is a visible tab stop wearing the same ring as every other control', async ({ page }) => {
+    await page.locator(BEFORE).focus();
+    await page.keyboard.press('Tab');
+
+    const surface = await focused(page);
+    expect(surface.tag).toBe('svg');
+    expect(surface.style).toBe('solid');
+
+    await page.locator(PLAIN).focus();
+    const plain = await focused(page);
+    expect(plain.style).toBe('solid');
+    // One baseline rule serves both; drift here means a chart grew its own.
+    expect(surface.color).toBe(plain.color);
+    expect(surface.width).toBe(plain.width);
+  });
+});

--- a/web/src/components/ui/ContextOverflowPill.css
+++ b/web/src/components/ui/ContextOverflowPill.css
@@ -31,11 +31,6 @@
     0 6px 12px -4px rgba(20, 20, 23, 0.10);
 }
 
-.context-overflow-pill:focus-visible {
-  outline: 2px solid var(--color-accent-primary, #b88a2c);
-  outline-offset: 2px;
-}
-
 .context-overflow-pill__count {
   font-weight: 600;
   font-variant-numeric: tabular-nums;

--- a/web/src/components/ui/animated-tabs.tsx
+++ b/web/src/components/ui/animated-tabs.tsx
@@ -41,7 +41,7 @@ export function AnimatedTabs({
             className={`
               relative rounded-md px-3 py-1.5 text-sm font-medium
               outline-none transition-colors cursor-pointer
-              focus-visible:ring-2 focus-visible:ring-[var(--color-accent-overlay)]
+              focus-visible:ring-2 focus-visible:ring-ring
               ${isActive ? "" : "hover:opacity-60"}
             `}
             style={{

--- a/web/src/components/ui/chat-input.modelMenu.tsx
+++ b/web/src/components/ui/chat-input.modelMenu.tsx
@@ -100,7 +100,7 @@ export function ChatInputModelMenu({
     <DropdownMenu modal={false} open={menuOpen} onOpenChange={(open) => { setMenuOpen(open); if (!open) setShowMoreModels(false); }}>
       <DropdownMenuTrigger asChild>
         <button
-          className={`model-selector-trigger ${TRIGGER_CLASS} cursor-pointer transition-colors outline-none`}
+          className={`model-selector-trigger ${TRIGGER_CLASS} cursor-pointer transition-colors`}
           onClick={(e) => e.stopPropagation()}
           type="button"
           title="Select model"

--- a/web/src/components/ui/chat-input.tsx
+++ b/web/src/components/ui/chat-input.tsx
@@ -724,7 +724,7 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
                 }
               }}
               placeholder={isListening ? "" : placeholder}
-              className={`font-content w-full bg-transparent border-0 outline-none text-[var(--color-text-primary)] ${isMobile ? 'text-base' : 'text-sm'} placeholder:text-[var(--color-text-tertiary)] resize-none overflow-y-auto leading-relaxed block transition-opacity duration-300 ${isListening ? 'opacity-20' : 'opacity-100'}`}
+       className={`font-content w-full bg-transparent border-0 text-[var(--color-text-primary)] ${isMobile ? 'text-base' : 'text-sm'} placeholder:text-[var(--color-text-tertiary)] resize-none overflow-y-auto leading-relaxed block transition-opacity duration-300 ${isListening ? 'opacity-20' : 'opacity-100'}`}
               rows={minRows}
               disabled={disabled}
               style={{ minHeight: `${minRows * 1.5}em` }}

--- a/web/src/components/ui/chat-input.tsx
+++ b/web/src/components/ui/chat-input.tsx
@@ -724,7 +724,7 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
                 }
               }}
               placeholder={isListening ? "" : placeholder}
-       className={`font-content w-full bg-transparent border-0 text-[var(--color-text-primary)] ${isMobile ? 'text-base' : 'text-sm'} placeholder:text-[var(--color-text-tertiary)] resize-none overflow-y-auto leading-relaxed block transition-opacity duration-300 ${isListening ? 'opacity-20' : 'opacity-100'}`}
+              className={`font-content w-full bg-transparent border-0 text-[var(--color-text-primary)] ${isMobile ? 'text-base' : 'text-sm'} placeholder:text-[var(--color-text-tertiary)] resize-none overflow-y-auto leading-relaxed block transition-opacity duration-300 ${isListening ? 'opacity-20' : 'opacity-100'}`}
               rows={minRows}
               disabled={disabled}
               style={{ minHeight: `${minRows * 1.5}em` }}

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -12,7 +12,7 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
       <div className={cn("relative", className)}>
         <select
           ref={ref}
-          className="h-9 w-full appearance-none rounded-md py-0 pl-3 pr-9 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50"
+     className="h-9 w-full appearance-none rounded-md py-0 pl-3 pr-9 text-sm disabled:cursor-not-allowed disabled:opacity-50"
           style={{
             backgroundColor: "var(--color-bg-card)",
             border: "1px solid var(--color-border-muted)",

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -12,7 +12,7 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
       <div className={cn("relative", className)}>
         <select
           ref={ref}
-     className="h-9 w-full appearance-none rounded-md py-0 pl-3 pr-9 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+          className="h-9 w-full appearance-none rounded-md py-0 pl-3 pr-9 text-sm disabled:cursor-not-allowed disabled:opacity-50"
           style={{
             backgroundColor: "var(--color-bg-card)",
             border: "1px solid var(--color-border-muted)",

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -36,11 +36,3 @@
   50% { transform: translate(0, -5px) scale(1.3) rotate(-180deg); border-radius: 100%; }
   75% { transform: translate(-3px, -3px) scale(0.9) rotate(-270deg); border-radius: 75%; }
 }
-
-/* Suppress focus outlines on chart containers (Recharts, lightweight-charts) */
-.recharts-responsive-container,
-.recharts-responsive-container *,
-.tv-lightweight-charts,
-.tv-lightweight-charts * {
-  outline: none !important;
-}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -7,6 +7,9 @@ import { AuthProvider } from './contexts/AuthContext'
 import App from './App'
 import './i18n'
 import './index.css'
+// Side-effect import: the modality listeners have to be running before the
+// first click, not from whichever overlay happens to load first.
+import './lib/inputModality'
 import { Toaster } from './components/ui/toaster'
 import { StaleBuildBoundary } from './components/StaleBuildBoundary'
 

--- a/web/src/pages/ChatAgent/components/ActivityBlock.css
+++ b/web/src/pages/ChatAgent/components/ActivityBlock.css
@@ -168,7 +168,7 @@
 }
 
 .titem-title-button:focus-visible {
-  outline: 2px solid var(--color-accent-primary);
+  outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
   border-radius: 2px;
 }
@@ -235,7 +235,7 @@
 }
 
 .obj:focus-visible {
-  outline: 2px solid var(--color-accent-primary);
+  outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
   border-radius: 2px;
 }

--- a/web/src/pages/ChatAgent/components/ActivityBlock.tsx
+++ b/web/src/pages/ChatAgent/components/ActivityBlock.tsx
@@ -308,7 +308,10 @@ const ActivityBlock = memo(function ActivityBlock({ items, preparingToolCall, is
         {hasCompleted && (
           <motion.div
             key="accordion-zone"
-            className="-mt-2"
+            /* The fold animates its height, so it has to clip -- and its only
+               child is a summary button flush against every edge, whose ring
+               the clip then eats. clips-focus-ring turns it inward. */
+            className="-mt-2 clips-focus-ring"
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: 'auto' }}
             transition={SPRING_FOLD}

--- a/web/src/pages/ChatAgent/components/ChatMinimap.css
+++ b/web/src/pages/ChatAgent/components/ChatMinimap.css
@@ -61,7 +61,7 @@
 /* The ring goes on the button, not the faded bar: an outline inherits the
    bar's opacity and a 22% ring is no focus indicator. */
 .chat-minimap-tick:focus-visible {
-  outline: 2px solid var(--color-accent-primary);
+  outline: 2px solid var(--color-focus-ring);
   outline-offset: 1px;
 }
 

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -1685,7 +1685,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
                             <button
                               type="button"
                               aria-label={t('chat.workspaceStateHelp')}
-                              className="inline-flex items-center justify-center rounded-full p-0.5 hover:opacity-80 focus:outline-none focus-visible:ring-1 focus-visible:ring-current"
+                              className="inline-flex items-center justify-center rounded-full p-0.5 hover:opacity-80 focus:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                               style={{ color: 'var(--color-text-quaternary)' }}
                             >
                               <Info className="h-3 w-3" />

--- a/web/src/pages/ChatAgent/components/CitationBubble.css
+++ b/web/src/pages/ChatAgent/components/CitationBubble.css
@@ -2,11 +2,6 @@
   background: var(--color-bg-input);
 }
 
-.cite-bubble-pill:focus-visible {
-  outline: 2px solid var(--color-accent-primary);
-  outline-offset: 2px;
-}
-
 .cite-bubble-card-title:hover {
   color: var(--color-accent-primary);
 }

--- a/web/src/pages/ChatAgent/components/ExportPreviewModal.css
+++ b/web/src/pages/ChatAgent/components/ExportPreviewModal.css
@@ -100,10 +100,6 @@
 .export-preview-save-btn:hover {
   opacity: 0.9;
 }
-.export-preview-save-btn:focus-visible {
-  outline: 2px solid var(--color-accent-primary);
-  outline-offset: 2px;
-}
 
 /* Preview area — gray canvas to show page sheets */
 .export-preview-content {
@@ -298,10 +294,6 @@
 }
 .export-preview-retry-btn:hover {
   background: var(--color-bg-hover);
-}
-.export-preview-retry-btn:focus-visible {
-  outline: 2px solid var(--color-accent-primary);
-  outline-offset: 2px;
 }
 .export-preview-anyway-btn {
   padding: 6px 16px;

--- a/web/src/pages/ChatAgent/components/JumpToLatestPill.css
+++ b/web/src/pages/ChatAgent/components/JumpToLatestPill.css
@@ -44,11 +44,6 @@
   border-color: var(--color-accent-primary);
 }
 
-.jump-to-latest-pill:focus-visible {
-  outline: 2px solid var(--color-accent-primary);
-  outline-offset: 2px;
-}
-
 .jump-to-latest-pill__count {
   /* Text-primary (not accent): the amber accent fails AA contrast on the
      light theme's white pill; bold tabular text-primary is legible in both

--- a/web/src/pages/ChatAgent/components/MarketWatchChip.tsx
+++ b/web/src/pages/ChatAgent/components/MarketWatchChip.tsx
@@ -53,7 +53,7 @@ export default function MarketWatchChip({ symbols, lastUpdate, onClick }: Market
         onClick={onClick}
         title={title}
         aria-label={t('chat.marketWatch.chipAction', { defaultValue: 'Open live market watch' })}
-        className="inline-flex items-center gap-2 self-start rounded-full px-3 py-1 text-xs cursor-pointer outline-none transition-colors bg-[var(--color-border-muted)] text-[var(--color-text-tertiary)] hover:bg-[var(--color-bg-elevated)] focus-visible:ring-2 focus-visible:ring-[var(--color-accent-primary)]"
+        className="inline-flex items-center gap-2 self-start rounded-full px-3 py-1 text-xs cursor-pointer outline-none transition-colors bg-[var(--color-border-muted)] text-[var(--color-text-tertiary)] hover:bg-[var(--color-bg-elevated)] focus-visible:ring-2 focus-visible:ring-ring"
       >
         {dot}
         <span role="status" aria-live="polite">

--- a/web/src/pages/ChatAgent/components/NavigationRows.tsx
+++ b/web/src/pages/ChatAgent/components/NavigationRows.tsx
@@ -493,7 +493,7 @@ export function WorkspaceTreeRow({
           {isRenaming ? (
             <input
               ref={rename.inputRef}
-              className="text-sm font-medium bg-transparent outline-none border-b flex-1 min-w-0"
+       className="text-sm font-medium bg-transparent border-b flex-1 min-w-0"
               style={{ color: 'var(--color-text-primary)', borderColor: 'var(--color-border-muted)' }}
               value={rename.value}
               onChange={(e) => rename.onChange(e.target.value)}

--- a/web/src/pages/ChatAgent/components/NavigationRows.tsx
+++ b/web/src/pages/ChatAgent/components/NavigationRows.tsx
@@ -493,7 +493,7 @@ export function WorkspaceTreeRow({
           {isRenaming ? (
             <input
               ref={rename.inputRef}
-       className="text-sm font-medium bg-transparent border-b flex-1 min-w-0"
+              className="text-sm font-medium bg-transparent border-b flex-1 min-w-0"
               style={{ color: 'var(--color-text-primary)', borderColor: 'var(--color-border-muted)' }}
               value={rename.value}
               onChange={(e) => rename.onChange(e.target.value)}

--- a/web/src/pages/ChatAgent/components/PTCAgentCard.tsx
+++ b/web/src/pages/ChatAgent/components/PTCAgentCard.tsx
@@ -361,7 +361,7 @@ function PTCAgentCard({ proposalData, onApprove, onReject, flashContext }: PTCAg
         role="switch"
         aria-checked={reportBack}
         aria-label={t('chat.ptcCard.reportBack')}
-        className="mt-3 flex w-full cursor-pointer items-center justify-between rounded-md pt-2.5 outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-primary)]"
+        className="mt-3 flex w-full cursor-pointer items-center justify-between rounded-md pt-2.5 outline-none focus-visible:ring-2 focus-visible:ring-ring"
         style={{ borderTop: '1px solid var(--color-border-muted)' }}
         onClick={(e: React.MouseEvent) => { e.stopPropagation(); setReportBack((v) => !v); }}
       >

--- a/web/src/pages/ChatAgent/components/SourcesPanel.tsx
+++ b/web/src/pages/ChatAgent/components/SourcesPanel.tsx
@@ -63,7 +63,7 @@ const CARD_CHROME =
   'flex items-center gap-2.5 rounded-lg border px-2.5 text-left outline-none cursor-pointer ' +
   'border-[var(--color-border-muted)] bg-[var(--color-bg-card)] ' +
   'hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] ' +
-  'focus-visible:ring-2 focus-visible:ring-[var(--color-accent-primary)]';
+  'focus-visible:ring-2 focus-visible:ring-ring';
 
 const TERTIARY = { color: 'var(--color-text-tertiary)' as const };
 
@@ -445,7 +445,7 @@ export default function SourcesPanel({
                 onClick={() => toggleGroup(group.type)}
                 aria-expanded={!collapsed}
                 aria-label={`${groupLabel} — ${t(collapsed ? 'chat.sources.expand' : 'chat.sources.collapse')}`}
-                className="mb-1.5 flex w-full items-center gap-2 rounded-md px-1 py-0.5 text-left outline-none transition-colors hover:bg-[var(--color-bg-subtle)] focus-visible:ring-2 focus-visible:ring-[var(--color-accent-primary)]"
+                className="mb-1.5 flex w-full items-center gap-2 rounded-md px-1 py-0.5 text-left outline-none transition-colors hover:bg-[var(--color-bg-subtle)] focus-visible:ring-2 focus-visible:ring-ring"
               >
                 {collapsed ? (
                   <ChevronRight className="h-3.5 w-3.5 flex-shrink-0" style={TERTIARY} />
@@ -939,7 +939,7 @@ function SourceDetailDialog({
           <button
             type="button"
             onClick={handleOpen}
-            className="group inline-flex w-fit items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium outline-none transition-all hover:gap-2 focus-visible:ring-2 focus-visible:ring-[var(--color-accent-primary)]"
+            className="group inline-flex w-fit items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium outline-none transition-all hover:gap-2 focus-visible:ring-2 focus-visible:ring-ring"
             style={{
               backgroundColor: 'var(--color-bg-elevated)',
               borderColor: 'var(--color-border-elevated)',

--- a/web/src/pages/ChatAgent/components/SubagentStatusBar.tsx
+++ b/web/src/pages/ChatAgent/components/SubagentStatusBar.tsx
@@ -283,7 +283,7 @@ function SubagentStatusBar({ agent, threadId, onInstructionSent }: SubagentStatu
             onKeyDown={handleKeyDown}
             placeholder={t('chat.subagentBar.inputPlaceholder')}
             disabled={sending}
-            className="flex-1 bg-transparent text-sm placeholder-foreground/30 outline-none"
+      className="flex-1 bg-transparent text-sm placeholder-foreground/30 "
             style={{ color: 'var(--color-text-primary)' }}
           />
           <div className="flex items-center gap-1">

--- a/web/src/pages/ChatAgent/components/SubagentStatusBar.tsx
+++ b/web/src/pages/ChatAgent/components/SubagentStatusBar.tsx
@@ -283,7 +283,7 @@ function SubagentStatusBar({ agent, threadId, onInstructionSent }: SubagentStatu
             onKeyDown={handleKeyDown}
             placeholder={t('chat.subagentBar.inputPlaceholder')}
             disabled={sending}
-      className="flex-1 bg-transparent text-sm placeholder-foreground/30 "
+            className="flex-1 bg-transparent text-sm placeholder-foreground/30"
             style={{ color: 'var(--color-text-primary)' }}
           />
           <div className="flex items-center gap-1">

--- a/web/src/pages/ChatAgent/components/ThumbDownModal.tsx
+++ b/web/src/pages/ChatAgent/components/ThumbDownModal.tsx
@@ -109,7 +109,7 @@ function ThumbDownModal({ isOpen, onSubmit, onCancel, onReportWithAgent }: Thumb
           onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setComment(e.target.value)}
           placeholder="Tell us more about the issue..."
           rows={3}
-     className="w-full rounded-lg px-3 py-2.5 text-sm resize-none mb-2"
+          className="w-full rounded-lg px-3 py-2.5 text-sm resize-none mb-2"
           style={{
             backgroundColor: 'var(--color-bg-page)',
             color: 'var(--color-text-primary)',

--- a/web/src/pages/ChatAgent/components/ThumbDownModal.tsx
+++ b/web/src/pages/ChatAgent/components/ThumbDownModal.tsx
@@ -109,7 +109,7 @@ function ThumbDownModal({ isOpen, onSubmit, onCancel, onReportWithAgent }: Thumb
           onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setComment(e.target.value)}
           placeholder="Tell us more about the issue..."
           rows={3}
-          className="w-full rounded-lg px-3 py-2.5 text-sm resize-none outline-none mb-2"
+     className="w-full rounded-lg px-3 py-2.5 text-sm resize-none mb-2"
           style={{
             backgroundColor: 'var(--color-bg-page)',
             color: 'var(--color-text-primary)',

--- a/web/src/pages/ChatAgent/components/UserQuestionCard.tsx
+++ b/web/src/pages/ChatAgent/components/UserQuestionCard.tsx
@@ -361,7 +361,7 @@ function UserQuestionCard({ questionData, onAnswer, onSkip }: UserQuestionCardPr
           value={otherText}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => setOtherText(e.target.value)}
           onKeyDown={handleOtherKeyDown}
-     className="flex-1 text-sm px-3 py-2 rounded-md transition-colors duration-200 focus:border-[var(--color-accent-overlay)]"
+          className="flex-1 text-sm px-3 py-2 rounded-md transition-colors duration-200 focus:border-[var(--color-accent-overlay)]"
           style={{
             backgroundColor: 'var(--color-border-muted)',
             border: '1px solid var(--color-border-muted)',

--- a/web/src/pages/ChatAgent/components/UserQuestionCard.tsx
+++ b/web/src/pages/ChatAgent/components/UserQuestionCard.tsx
@@ -361,7 +361,7 @@ function UserQuestionCard({ questionData, onAnswer, onSkip }: UserQuestionCardPr
           value={otherText}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => setOtherText(e.target.value)}
           onKeyDown={handleOtherKeyDown}
-          className="flex-1 text-sm px-3 py-2 rounded-md outline-none transition-colors duration-200 focus:border-[var(--color-accent-overlay)]"
+     className="flex-1 text-sm px-3 py-2 rounded-md transition-colors duration-200 focus:border-[var(--color-accent-overlay)]"
           style={{
             backgroundColor: 'var(--color-border-muted)',
             border: '1px solid var(--color-border-muted)',

--- a/web/src/pages/ChatAgent/components/WorkspaceGallery.tsx
+++ b/web/src/pages/ChatAgent/components/WorkspaceGallery.tsx
@@ -930,7 +930,7 @@ function WorkspaceGallery({ onWorkspaceSelect, prefetchThreads }: WorkspaceGalle
             >
               <Search className="h-5 w-5 flex-shrink-0" style={{ color: 'var(--color-text-tertiary)' }} />
               <input
-        className="w-full bg-transparent text-base sm:text-sm"
+                className="w-full bg-transparent text-base sm:text-sm"
                 style={{ color: 'var(--color-text-primary)' }}
                 placeholder={t('workspace.searchWorkspaces')}
                 value={searchQuery}

--- a/web/src/pages/ChatAgent/components/WorkspaceGallery.tsx
+++ b/web/src/pages/ChatAgent/components/WorkspaceGallery.tsx
@@ -930,7 +930,7 @@ function WorkspaceGallery({ onWorkspaceSelect, prefetchThreads }: WorkspaceGalle
             >
               <Search className="h-5 w-5 flex-shrink-0" style={{ color: 'var(--color-text-tertiary)' }} />
               <input
-                className="w-full bg-transparent outline-none text-base sm:text-sm"
+        className="w-full bg-transparent text-base sm:text-sm"
                 style={{ color: 'var(--color-text-primary)' }}
                 placeholder={t('workspace.searchWorkspaces')}
                 value={searchQuery}

--- a/web/src/pages/ChatAgent/components/charts/InlineArtifactCards.tsx
+++ b/web/src/pages/ChatAgent/components/charts/InlineArtifactCards.tsx
@@ -81,6 +81,14 @@ function abbreviateSector(name: string): string {
   return ABBREVIATIONS[name] || name;
 }
 
+/** Recharts makes its chart surface a tab stop -- `tabindex="0"`,
+ *  `role="application"` -- so arrow keys can walk a tooltip's active index.
+ *  Neither card below renders a <Tooltip>, so the stop navigates nothing: a
+ *  Tab press spent on a picture, announced to assistive tech as an
+ *  application. (The stray focus ring these charts used to draw came from
+ *  elsewhere and is fixed in styles/tokens.css, not by this flag.) */
+const NO_KEYBOARD_LAYER = false;
+
 /** Measures container width via ResizeObserver and passes it to children as a render prop.
  *  Replaces ResponsiveContainer to avoid the Recharts width(-1) warning on first render. */
 function MeasuredContainer({ height, children }: { height: number; children: (width: number) => React.ReactNode }): React.ReactElement {
@@ -165,7 +173,13 @@ export function InlineStockPriceCard({ artifact, onClick }: InlineCardProps): Re
       {/* Sparkline */}
       <MeasuredContainer height={isMobile ? 48 : 64}>
         {(w) => (
-          <AreaChart width={w} height={isMobile ? 48 : 64} data={sparkData} margin={{ top: 4, right: 2, bottom: 2, left: 2 }}>
+          <AreaChart
+            width={w}
+            height={isMobile ? 48 : 64}
+            data={sparkData}
+            margin={{ top: 4, right: 2, bottom: 2, left: 2 }}
+            accessibilityLayer={NO_KEYBOARD_LAYER}
+          >
             <defs>
               <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
                 <stop offset="0%" stopColor={color} stopOpacity={0.3} />
@@ -450,6 +464,7 @@ export function InlineSectorPerformanceCard({ artifact, onClick }: InlineCardPro
             data={chartData}
             layout="vertical"
             margin={{ left: 0, right: isMobile ? 40 : 50, top: 0, bottom: 0 }}
+            accessibilityLayer={NO_KEYBOARD_LAYER}
           >
             <XAxis type="number" hide />
             <YAxis

--- a/web/src/pages/ChatAgent/components/charts/MarketDataCharts.tsx
+++ b/web/src/pages/ChatAgent/components/charts/MarketDataCharts.tsx
@@ -445,7 +445,7 @@ export function StockPriceChart({ data }: DataProps): React.ReactElement {
         )}
         <OpenInMarketLink symbol={data.symbol as string} />
       </div>
-      <div ref={containerRef} className="[&_*]:outline-none" style={{ width: '100%', height: 360 }} />
+      <div ref={containerRef} style={{ width: '100%', height: 360 }} />
       <StockStatsCard stats={data.stats as Record<string, unknown> | undefined} />
     </div>
   );
@@ -1441,5 +1441,5 @@ function MiniCandlestick({ ohlcv, height = 180 }: MiniCandlestickProps): React.R
   }, [ohlcv, height, ct]);
 
   if (!ohlcv?.length) return null;
-  return <div ref={containerRef} className="[&_*]:outline-none" style={{ width: '100%', height }} />;
+  return <div ref={containerRef} style={{ width: '100%', height }} />;
 }

--- a/web/src/pages/ChatAgent/components/chatView/FallbackSuggestionPill.tsx
+++ b/web/src/pages/ChatAgent/components/chatView/FallbackSuggestionPill.tsx
@@ -55,7 +55,7 @@ export function FallbackSuggestionPill({
       <button
         type="button"
         onClick={() => onSwitchModel(fallbackSuggestion.toModel)}
-        className="text-xs font-medium whitespace-nowrap rounded-md px-2.5 py-1 flex-shrink-0 hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-primary)] focus-visible:ring-offset-1"
+        className="text-xs font-medium whitespace-nowrap rounded-md px-2.5 py-1 flex-shrink-0 hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
         style={{
           backgroundColor: 'var(--color-btn-primary-bg)',
           color: 'var(--color-btn-primary-text)',

--- a/web/src/pages/ChatAgent/components/mcp/McpImportModal.tsx
+++ b/web/src/pages/ChatAgent/components/mcp/McpImportModal.tsx
@@ -109,7 +109,7 @@ export function McpImportModal({ onClose, onImport, onImported }: McpImportModal
                 placeholder={PLACEHOLDER}
                 rows={12}
                 spellCheck={false}
-                className="w-full px-3 py-2 text-xs rounded-md bg-transparent outline-none font-mono resize-none"
+        className="w-full px-3 py-2 text-xs rounded-md bg-transparent font-mono resize-none"
                 style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
               />
               {text.trim() && (

--- a/web/src/pages/ChatAgent/components/mcp/McpImportModal.tsx
+++ b/web/src/pages/ChatAgent/components/mcp/McpImportModal.tsx
@@ -109,7 +109,7 @@ export function McpImportModal({ onClose, onImport, onImported }: McpImportModal
                 placeholder={PLACEHOLDER}
                 rows={12}
                 spellCheck={false}
-        className="w-full px-3 py-2 text-xs rounded-md bg-transparent font-mono resize-none"
+                className="w-full px-3 py-2 text-xs rounded-md bg-transparent font-mono resize-none"
                 style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
               />
               {text.trim() && (

--- a/web/src/pages/ChatAgent/components/mcp/McpServerModal.tsx
+++ b/web/src/pages/ChatAgent/components/mcp/McpServerModal.tsx
@@ -286,7 +286,7 @@ export function McpServerModal({
                     placeholder={'{ "mcpServers": { "my-server": { "command": "npx", "args": ["-y", "pkg"] } } }'}
                     rows={4}
                     spellCheck={false}
-          className="w-full px-2 py-1.5 text-[0.6875rem] rounded bg-transparent font-mono resize-none"
+                    className="w-full px-2 py-1.5 text-[0.6875rem] rounded bg-transparent font-mono resize-none"
                     style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
                   />
                   <div className="flex items-center gap-2">
@@ -324,7 +324,7 @@ export function McpServerModal({
               onChange={(e) => setName(e.target.value)}
               disabled={isEdit}
               placeholder="my_server"
-       className="w-full px-3 py-2 text-sm rounded-md bg-transparent font-mono disabled:opacity-60"
+              className="w-full px-3 py-2 text-sm rounded-md bg-transparent font-mono disabled:opacity-60"
               style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
               maxLength={64}
             />
@@ -367,7 +367,7 @@ export function McpServerModal({
                   spellCheck={false}
                   autoCapitalize="off"
                   autoCorrect="off"
-         className="w-full px-3 py-2 text-sm rounded-md "
+                  className="w-full px-3 py-2 text-sm rounded-md"
                   style={{
                     color: 'var(--color-text-primary)',
                     backgroundColor: 'var(--color-bg-card)',
@@ -405,7 +405,7 @@ export function McpServerModal({
                   value={url}
                   onChange={(e) => setUrl(e.target.value)}
                   placeholder="https://example.com/mcp"
-         className="w-full px-3 py-2 text-sm rounded-md bg-transparent "
+                  className="w-full px-3 py-2 text-sm rounded-md bg-transparent"
                   style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
                 />
                 <FieldError error={errorFor('url')} />
@@ -434,7 +434,7 @@ export function McpServerModal({
               onChange={(e) => setDescription(e.target.value)}
               placeholder="What this server does"
               rows={2}
-       className="w-full px-3 py-2 text-sm rounded-md bg-transparent resize-none"
+              className="w-full px-3 py-2 text-sm rounded-md bg-transparent resize-none"
               style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
               maxLength={512}
             />
@@ -450,7 +450,7 @@ export function McpServerModal({
               onChange={(e) => setInstruction(e.target.value)}
               placeholder="How the agent should use this server"
               rows={2}
-       className="w-full px-3 py-2 text-sm rounded-md bg-transparent resize-none"
+              className="w-full px-3 py-2 text-sm rounded-md bg-transparent resize-none"
               style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
               maxLength={1024}
             />
@@ -609,7 +609,7 @@ function ArgsEditor({ args, onChange }: { args: string[]; onChange: (a: string[]
             value={a}
             onChange={(e) => onChange(args.map((x, j) => (j === i ? e.target.value : x)))}
             placeholder="argument"
-      className="flex-1 px-2 py-1 text-xs rounded bg-transparent font-mono"
+            className="flex-1 px-2 py-1 text-xs rounded bg-transparent font-mono"
             style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
           />
           <button
@@ -659,7 +659,7 @@ function KeyValueEditor({ kvs, onChange, secretNames, createSecret, keyPlacehold
               value={kv.key}
               onChange={(e) => onChange(kvs.map((x, j) => (j === i ? { ...x, key: e.target.value } : x)))}
               placeholder={keyPlaceholder}
-       className="flex-1 px-2 py-1 text-xs rounded bg-transparent font-mono"
+              className="flex-1 px-2 py-1 text-xs rounded bg-transparent font-mono"
               style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
             />
             <button

--- a/web/src/pages/ChatAgent/components/mcp/McpServerModal.tsx
+++ b/web/src/pages/ChatAgent/components/mcp/McpServerModal.tsx
@@ -286,7 +286,7 @@ export function McpServerModal({
                     placeholder={'{ "mcpServers": { "my-server": { "command": "npx", "args": ["-y", "pkg"] } } }'}
                     rows={4}
                     spellCheck={false}
-                    className="w-full px-2 py-1.5 text-[0.6875rem] rounded bg-transparent outline-none font-mono resize-none"
+          className="w-full px-2 py-1.5 text-[0.6875rem] rounded bg-transparent font-mono resize-none"
                     style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
                   />
                   <div className="flex items-center gap-2">
@@ -324,7 +324,7 @@ export function McpServerModal({
               onChange={(e) => setName(e.target.value)}
               disabled={isEdit}
               placeholder="my_server"
-              className="w-full px-3 py-2 text-sm rounded-md bg-transparent outline-none font-mono disabled:opacity-60"
+       className="w-full px-3 py-2 text-sm rounded-md bg-transparent font-mono disabled:opacity-60"
               style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
               maxLength={64}
             />
@@ -367,7 +367,7 @@ export function McpServerModal({
                   spellCheck={false}
                   autoCapitalize="off"
                   autoCorrect="off"
-                  className="w-full px-3 py-2 text-sm rounded-md outline-none"
+         className="w-full px-3 py-2 text-sm rounded-md "
                   style={{
                     color: 'var(--color-text-primary)',
                     backgroundColor: 'var(--color-bg-card)',
@@ -405,7 +405,7 @@ export function McpServerModal({
                   value={url}
                   onChange={(e) => setUrl(e.target.value)}
                   placeholder="https://example.com/mcp"
-                  className="w-full px-3 py-2 text-sm rounded-md bg-transparent outline-none"
+         className="w-full px-3 py-2 text-sm rounded-md bg-transparent "
                   style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
                 />
                 <FieldError error={errorFor('url')} />
@@ -434,7 +434,7 @@ export function McpServerModal({
               onChange={(e) => setDescription(e.target.value)}
               placeholder="What this server does"
               rows={2}
-              className="w-full px-3 py-2 text-sm rounded-md bg-transparent outline-none resize-none"
+       className="w-full px-3 py-2 text-sm rounded-md bg-transparent resize-none"
               style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
               maxLength={512}
             />
@@ -450,7 +450,7 @@ export function McpServerModal({
               onChange={(e) => setInstruction(e.target.value)}
               placeholder="How the agent should use this server"
               rows={2}
-              className="w-full px-3 py-2 text-sm rounded-md bg-transparent outline-none resize-none"
+       className="w-full px-3 py-2 text-sm rounded-md bg-transparent resize-none"
               style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
               maxLength={1024}
             />
@@ -609,7 +609,7 @@ function ArgsEditor({ args, onChange }: { args: string[]; onChange: (a: string[]
             value={a}
             onChange={(e) => onChange(args.map((x, j) => (j === i ? e.target.value : x)))}
             placeholder="argument"
-            className="flex-1 px-2 py-1 text-xs rounded bg-transparent outline-none font-mono"
+      className="flex-1 px-2 py-1 text-xs rounded bg-transparent font-mono"
             style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
           />
           <button
@@ -659,7 +659,7 @@ function KeyValueEditor({ kvs, onChange, secretNames, createSecret, keyPlacehold
               value={kv.key}
               onChange={(e) => onChange(kvs.map((x, j) => (j === i ? { ...x, key: e.target.value } : x)))}
               placeholder={keyPlaceholder}
-              className="flex-1 px-2 py-1 text-xs rounded bg-transparent outline-none font-mono"
+       className="flex-1 px-2 py-1 text-xs rounded bg-transparent font-mono"
               style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
             />
             <button

--- a/web/src/pages/ChatAgent/components/mcp/VaultSecretPicker.tsx
+++ b/web/src/pages/ChatAgent/components/mcp/VaultSecretPicker.tsx
@@ -142,7 +142,7 @@ export function VaultSecretPicker({
                 value={newName}
                 onChange={(e) => setNewName(e.target.value.toUpperCase().replace(/[^A-Z0-9_]/g, '').replace(/^[0-9]+/, ''))}
                 placeholder="SECRET_NAME"
-        className="w-full px-2 py-1 text-xs rounded bg-transparent font-mono"
+                className="w-full px-2 py-1 text-xs rounded bg-transparent font-mono"
                 style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
                 maxLength={64}
               />
@@ -151,7 +151,7 @@ export function VaultSecretPicker({
                 value={newValue}
                 onChange={(e) => setNewValue(e.target.value)}
                 placeholder="Secret value"
-        className="w-full px-2 py-1 text-xs rounded bg-transparent "
+                className="w-full px-2 py-1 text-xs rounded bg-transparent"
                 style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
                 maxLength={4096}
               />
@@ -197,7 +197,7 @@ export function VaultSecretPicker({
           value={value}
           onChange={(e) => onChange(e.target.value)}
           placeholder="Literal value"
-     className="w-full px-2 py-1 text-xs rounded bg-transparent "
+          className="w-full px-2 py-1 text-xs rounded bg-transparent"
           style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
         />
       )}

--- a/web/src/pages/ChatAgent/components/mcp/VaultSecretPicker.tsx
+++ b/web/src/pages/ChatAgent/components/mcp/VaultSecretPicker.tsx
@@ -142,7 +142,7 @@ export function VaultSecretPicker({
                 value={newName}
                 onChange={(e) => setNewName(e.target.value.toUpperCase().replace(/[^A-Z0-9_]/g, '').replace(/^[0-9]+/, ''))}
                 placeholder="SECRET_NAME"
-                className="w-full px-2 py-1 text-xs rounded bg-transparent outline-none font-mono"
+        className="w-full px-2 py-1 text-xs rounded bg-transparent font-mono"
                 style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
                 maxLength={64}
               />
@@ -151,7 +151,7 @@ export function VaultSecretPicker({
                 value={newValue}
                 onChange={(e) => setNewValue(e.target.value)}
                 placeholder="Secret value"
-                className="w-full px-2 py-1 text-xs rounded bg-transparent outline-none"
+        className="w-full px-2 py-1 text-xs rounded bg-transparent "
                 style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
                 maxLength={4096}
               />
@@ -197,7 +197,7 @@ export function VaultSecretPicker({
           value={value}
           onChange={(e) => onChange(e.target.value)}
           placeholder="Literal value"
-          className="w-full px-2 py-1 text-xs rounded bg-transparent outline-none"
+     className="w-full px-2 py-1 text-xs rounded bg-transparent "
           style={{ color: 'var(--color-text-primary)', border: '1px solid var(--color-border-muted)' }}
         />
       )}

--- a/web/src/pages/ChatAgent/components/messageList/MessageBubble.tsx
+++ b/web/src/pages/ChatAgent/components/messageList/MessageBubble.tsx
@@ -225,7 +225,7 @@ export const MessageBubble = memo(function MessageBubble({ message, turnIndex, i
                   resizeTextarea();
                 }}
                 onKeyDown={handleEditKeyDown}
-                className="w-full bg-transparent text-sm resize-none outline-none leading-relaxed overflow-hidden"
+        className="w-full bg-transparent text-sm resize-none leading-relaxed overflow-hidden"
                 style={{ color: 'var(--color-text-primary)' }}
                 rows={1}
               />

--- a/web/src/pages/ChatAgent/components/messageList/MessageBubble.tsx
+++ b/web/src/pages/ChatAgent/components/messageList/MessageBubble.tsx
@@ -225,7 +225,7 @@ export const MessageBubble = memo(function MessageBubble({ message, turnIndex, i
                   resizeTextarea();
                 }}
                 onKeyDown={handleEditKeyDown}
-        className="w-full bg-transparent text-sm resize-none leading-relaxed overflow-hidden"
+                className="w-full bg-transparent text-sm resize-none leading-relaxed overflow-hidden"
                 style={{ color: 'var(--color-text-primary)' }}
                 rows={1}
               />

--- a/web/src/pages/ChatAgent/components/sandbox/PackagesTab.tsx
+++ b/web/src/pages/ChatAgent/components/sandbox/PackagesTab.tsx
@@ -64,7 +64,7 @@ export function PackagesTab({ workspaceId, packages, defaultPackages, onInstalle
           value={pkgSearch}
           onChange={e => setPkgSearch(e.target.value)}
           placeholder="Filter packages..."
-          className="w-full pl-9 pr-3 py-2 text-sm rounded-md bg-transparent outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--color-accent-primary)]"
+          className="w-full pl-9 pr-3 py-2 text-sm rounded-md bg-transparent outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring"
           style={{
             color: 'var(--color-text-primary)',
             border: '1px solid var(--color-border-muted)',
@@ -124,7 +124,7 @@ export function PackagesTab({ workspaceId, packages, defaultPackages, onInstalle
             onChange={e => setInstallInput(e.target.value)}
             placeholder="Package names (e.g. torch transformers>=4.0)"
             onKeyDown={e => e.key === 'Enter' && !installing && handleInstall()}
-            className="flex-1 px-3 py-2 text-sm rounded-md bg-transparent outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--color-accent-primary)]"
+            className="flex-1 px-3 py-2 text-sm rounded-md bg-transparent outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring"
             style={{
               color: 'var(--color-text-primary)',
               border: '1px solid var(--color-border-muted)',

--- a/web/src/pages/ChatAgent/components/vault/SecretEditor.tsx
+++ b/web/src/pages/ChatAgent/components/vault/SecretEditor.tsx
@@ -29,7 +29,7 @@ export const EMPTY_DRAFT: SecretDraft = {
 type DraftPatch = (patch: Partial<SecretDraft>) => void;
 
 const inputClass =
-  'w-full px-3 py-2 text-sm rounded-md bg-transparent outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--color-accent-primary)]';
+  'w-full px-3 py-2 text-sm rounded-md bg-transparent outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring';
 const inputStyle: React.CSSProperties = {
   color: 'var(--color-text-primary)',
   border: '1px solid var(--color-border-muted)',

--- a/web/src/pages/ChatAgent/components/viewers/HtmlViewer.css
+++ b/web/src/pages/ChatAgent/components/viewers/HtmlViewer.css
@@ -38,7 +38,7 @@
 }
 
 .html-viewer-tab:focus-visible {
-  outline: 2px solid var(--color-accent-primary);
+  outline: 2px solid var(--color-focus-ring);
   outline-offset: 1px;
 }
 

--- a/web/src/pages/ChatAgent/components/viewers/html/HtmlActionBar.css
+++ b/web/src/pages/ChatAgent/components/viewers/html/HtmlActionBar.css
@@ -23,7 +23,7 @@
 }
 
 .html-action-btn:focus-visible {
-  outline: 2px solid var(--color-accent-primary);
+  outline: 2px solid var(--color-focus-ring);
   outline-offset: 1px;
 }
 

--- a/web/src/pages/Dashboard/components/DashboardHeader.css
+++ b/web/src/pages/Dashboard/components/DashboardHeader.css
@@ -23,7 +23,6 @@
   height: 100%;
   padding: 0;
   font-size: 0.875rem;
-  outline: none;
   background: transparent;
 }
 

--- a/web/src/pages/Dashboard/components/IndexMovementCard.tsx
+++ b/web/src/pages/Dashboard/components/IndexMovementCard.tsx
@@ -101,7 +101,7 @@ function IndexCardContent({ index }: { index: IndexData }) {
       </div>
 
       {/* Sparkline chart */}
-      <div className="mt-2 px-1 pb-2 [&_*]:outline-none" style={{ height: 100 }}>
+      <div className="mt-2 px-1 pb-2" style={{ height: 100 }}>
         {chartData.length > 1 ? (
           <ResponsiveContainer width="100%" height={100}>
             <LineChart data={chartData}>
@@ -360,7 +360,7 @@ function IndexSkeleton({ count }: { count: number }) {
               </div>
             </div>
           </div>
-          <div className="mt-2 px-1 pb-2 [&_*]:outline-none" style={{ height: 100 }}>
+          <div className="mt-2 px-1 pb-2" style={{ height: 100 }}>
             <div
               className="w-full h-full rounded"
               style={{ backgroundColor: 'var(--color-border-default)', opacity: 0.3 }}

--- a/web/src/pages/Dashboard/components/NewsFeedCard.tsx
+++ b/web/src/pages/Dashboard/components/NewsFeedCard.tsx
@@ -345,7 +345,7 @@ function NewsFeedCard({
               placeholder={t('dashboard.newsFeedCard.tickerPlaceholder')}
               value={tickerFilter}
               onChange={(e) => setTickerFilter(e.target.value)}
-              className="flex-1 text-[0.6875rem] bg-transparent border-none outline-none min-w-0"
+       className="flex-1 text-[0.6875rem] bg-transparent border-none min-w-0"
               style={{ color: 'var(--color-text-primary)' }}
             />
             {tickerFilter && (

--- a/web/src/pages/Dashboard/components/NewsFeedCard.tsx
+++ b/web/src/pages/Dashboard/components/NewsFeedCard.tsx
@@ -345,7 +345,7 @@ function NewsFeedCard({
               placeholder={t('dashboard.newsFeedCard.tickerPlaceholder')}
               value={tickerFilter}
               onChange={(e) => setTickerFilter(e.target.value)}
-       className="flex-1 text-[0.6875rem] bg-transparent border-none min-w-0"
+              className="flex-1 text-[0.6875rem] bg-transparent border-none min-w-0"
               style={{ color: 'var(--color-text-primary)' }}
             />
             {tickerFilter && (

--- a/web/src/pages/Dashboard/widgets/definitions/ChartWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/ChartWidget.tsx
@@ -1196,7 +1196,7 @@ function ChartWidget({ instance, updateConfig }: WidgetRenderProps<ChartConfig>)
                   setSearchHits([]);
                 }
               }}
-       className="text-sm font-semibold tabular-nums bg-transparent border-b px-0 py-0 w-24"
+              className="text-sm font-semibold tabular-nums bg-transparent border-b px-0 py-0 w-24"
               style={{
                 color: 'var(--color-text-primary)',
                 borderColor: 'var(--color-accent-primary)',

--- a/web/src/pages/Dashboard/widgets/definitions/ChartWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/ChartWidget.tsx
@@ -1196,7 +1196,7 @@ function ChartWidget({ instance, updateConfig }: WidgetRenderProps<ChartConfig>)
                   setSearchHits([]);
                 }
               }}
-              className="text-sm font-semibold tabular-nums bg-transparent outline-none border-b px-0 py-0 w-24"
+       className="text-sm font-semibold tabular-nums bg-transparent border-b px-0 py-0 w-24"
               style={{
                 color: 'var(--color-text-primary)',
                 borderColor: 'var(--color-accent-primary)',

--- a/web/src/pages/Dashboard/widgets/definitions/ConversationWidget.css
+++ b/web/src/pages/Dashboard/widgets/definitions/ConversationWidget.css
@@ -175,7 +175,7 @@
 }
 
 .conversation-widget__chip:focus-visible {
-  outline: 2px solid var(--color-accent-primary);
+  outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
   border-color: var(--color-accent-overlay);
   color: var(--color-text-primary);

--- a/web/src/pages/Dashboard/widgets/framework/AddWidgetDialog.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/AddWidgetDialog.tsx
@@ -184,7 +184,7 @@ export function AddWidgetDialog({ open, onOpenChange, onAdd, existingWidgets }: 
               placeholder={t('dashboard.widgets.addDialog.searchPlaceholder')}
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-       className="flex-1 min-w-0 bg-transparent "
+              className="flex-1 min-w-0 bg-transparent"
               style={{ color: 'var(--color-text-primary)' }}
             />
           </label>

--- a/web/src/pages/Dashboard/widgets/framework/AddWidgetDialog.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/AddWidgetDialog.tsx
@@ -184,7 +184,7 @@ export function AddWidgetDialog({ open, onOpenChange, onAdd, existingWidgets }: 
               placeholder={t('dashboard.widgets.addDialog.searchPlaceholder')}
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="flex-1 min-w-0 bg-transparent outline-none"
+       className="flex-1 min-w-0 bg-transparent "
               style={{ color: 'var(--color-text-primary)' }}
             />
           </label>

--- a/web/src/pages/Dashboard/widgets/framework/TradingViewAttribution.css
+++ b/web/src/pages/Dashboard/widgets/framework/TradingViewAttribution.css
@@ -18,6 +18,6 @@
 }
 
 .tv-attribution:focus-visible {
-  outline: 2px solid var(--color-accent-primary);
+  outline: 2px solid var(--color-focus-ring);
   outline-offset: 1px;
 }

--- a/web/src/pages/Dashboard/widgets/framework/WidgetFrame.css
+++ b/web/src/pages/Dashboard/widgets/framework/WidgetFrame.css
@@ -74,7 +74,7 @@
 }
 
 .widget-frame__drag:focus-visible {
-  outline: 2px solid var(--color-accent-primary);
+  outline: 2px solid var(--color-focus-ring);
   outline-offset: 1px;
 }
 
@@ -122,7 +122,7 @@
 }
 
 .widget-frame__icon-btn:focus-visible {
-  outline: 2px solid var(--color-accent-primary);
+  outline: 2px solid var(--color-focus-ring);
   outline-offset: 1px;
 }
 
@@ -163,7 +163,7 @@
 }
 
 .widget-frame__menu-item:focus-visible {
-  outline: 2px solid var(--color-accent-primary);
+  outline: 2px solid var(--color-focus-ring);
   outline-offset: -2px;
   background-color: var(--color-bg-hover);
 }

--- a/web/src/pages/Dashboard/widgets/framework/settings/SettingsDoneButton.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/settings/SettingsDoneButton.tsx
@@ -21,7 +21,7 @@ export function SettingsDoneButton({ onClick, label }: Props) {
         style={{
           backgroundColor: 'var(--color-btn-primary-bg)',
           color: 'var(--color-btn-primary-text)',
-          outlineColor: 'var(--color-accent-primary)',
+          outlineColor: 'var(--color-focus-ring)',
         }}
       >
         {label ?? t('dashboard.widgets.settings.doneButton')}

--- a/web/src/pages/MarketView/components/AgentEventOverlay.css
+++ b/web/src/pages/MarketView/components/AgentEventOverlay.css
@@ -54,7 +54,7 @@
 }
 
 .agent-event-badge:focus-visible {
-  outline: 2px solid var(--color-accent-primary);
+  outline: 2px solid var(--color-focus-ring);
   outline-offset: 1px;
 }
 

--- a/web/src/pages/MarketView/components/MarketChart.tsx
+++ b/web/src/pages/MarketView/components/MarketChart.tsx
@@ -2374,7 +2374,7 @@ const MarketChart = React.memo(forwardRef<MarketChartHandle, MarketChartProps>((
 
           {/* ---- Bottom bar: viewing-window presets + venue clock (TradingView-style) ---- */}
           <div className="chart-bottom-bar">
-            <div className="chart-range-selector">
+            <div className="chart-range-selector clips-focus-ring">
               {RANGE_PRESETS.map((preset) => (
                 <button
                   key={preset.key}

--- a/web/src/pages/MarketView/components/MarketChatHistoryButton.tsx
+++ b/web/src/pages/MarketView/components/MarketChatHistoryButton.tsx
@@ -194,7 +194,7 @@ export default function MarketChatHistoryButton({
                 e.preventDefault();
                 e.stopPropagation();
               }}
-              className="inline-flex items-center justify-center h-4 w-4 rounded-full transition-opacity opacity-60 hover:opacity-100 focus:outline-none focus-visible:ring-1 focus-visible:ring-foreground/30"
+              className="inline-flex items-center justify-center h-4 w-4 rounded-full transition-opacity opacity-60 hover:opacity-100 focus:outline-none focus-visible:ring-1 focus-visible:ring-ring"
               style={{ color: 'var(--color-text-tertiary)' }}
             >
               <Info className="h-3 w-3" />

--- a/web/src/pages/MarketView/components/SelectionCommentOverlay.css
+++ b/web/src/pages/MarketView/components/SelectionCommentOverlay.css
@@ -70,7 +70,6 @@
 .selection-composer-input {
   appearance: none;
   border: none;
-  outline: none;
   background: transparent;
   width: 190px;
   max-width: 40vw;

--- a/web/src/pages/MarketView/components/SelectionCommentOverlay.css
+++ b/web/src/pages/MarketView/components/SelectionCommentOverlay.css
@@ -36,11 +36,6 @@
   filter: brightness(1.08);
 }
 
-.selection-pin:focus-visible {
-  outline: 2px solid var(--color-accent-primary);
-  outline-offset: 2px;
-}
-
 /* The pin embedded in the composer is a static marker, not a button. */
 .selection-pin--composer {
   position: static;
@@ -106,11 +101,6 @@
   filter: brightness(1.08);
 }
 
-.selection-composer-send:focus-visible {
-  outline: 2px solid var(--color-accent-primary);
-  outline-offset: 2px;
-}
-
 .selection-composer-cancel {
   flex-shrink: 0;
   display: inline-flex;
@@ -129,9 +119,4 @@
 .selection-composer-cancel:hover {
   color: var(--color-text-primary);
   background: var(--color-bg-hover);
-}
-
-.selection-composer-cancel:focus-visible {
-  outline: 2px solid var(--color-accent-primary);
-  outline-offset: 2px;
 }

--- a/web/src/pages/MarketView/components/SelectionCommentOverlay.tsx
+++ b/web/src/pages/MarketView/components/SelectionCommentOverlay.tsx
@@ -332,7 +332,7 @@ export const SelectionCommentOverlay = React.memo(function SelectionCommentOverl
           onPointerDown={(e) => e.stopPropagation()}
         >
           <span className="selection-pin selection-pin--composer">{composer.n}</span>
-          <div className="selection-composer-pill">
+          <div className="selection-composer-pill clips-focus-ring">
             <input
               ref={inputRef}
               className="selection-composer-input"

--- a/web/src/pages/Onboarding/engine/GettingStartedCard.tsx
+++ b/web/src/pages/Onboarding/engine/GettingStartedCard.tsx
@@ -55,7 +55,7 @@ export function GettingStartedCard() {
             type="button"
             onClick={dismiss}
             aria-label={t('onboarding.gettingStarted.dismiss', 'Hide guide')}
-            className="rounded-md p-1 transition-colors hover:bg-[var(--color-bg-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-primary)]"
+            className="rounded-md p-1 transition-colors hover:bg-[var(--color-bg-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             style={{ color: 'var(--color-text-tertiary)' }}
           >
             <X className="h-3.5 w-3.5" />
@@ -106,7 +106,7 @@ export function GettingStartedCard() {
                   navigate(def.to);
                 }
               }}
-              className="flex w-full items-start gap-3 rounded-lg p-2 text-left transition-colors enabled:hover:bg-[var(--color-bg-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-primary)]"
+              className="flex w-full items-start gap-3 rounded-lg p-2 text-left transition-colors enabled:hover:bg-[var(--color-bg-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
               <span
                 className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border"
@@ -171,7 +171,7 @@ export function GettingStartedCard() {
             <button
               type="button"
               onClick={() => setInterviewPromptOpen(false)}
-              className="rounded-lg border px-4 py-2 text-sm font-medium transition-colors hover:bg-[var(--color-bg-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-primary)]"
+              className="rounded-lg border px-4 py-2 text-sm font-medium transition-colors hover:bg-[var(--color-bg-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               style={{
                 borderColor: 'var(--color-border-default)',
                 color: 'var(--color-text-secondary)',
@@ -185,7 +185,7 @@ export function GettingStartedCard() {
                 setInterviewPromptOpen(false);
                 void navigateToPersonalization();
               }}
-              className="rounded-lg px-4 py-2 text-sm font-semibold transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-primary)] focus-visible:ring-offset-2"
+              className="rounded-lg px-4 py-2 text-sm font-semibold transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
               style={{
                 background: 'var(--color-btn-primary-bg)',
                 color: 'var(--color-btn-primary-text)',

--- a/web/src/pages/Onboarding/engine/PageIntroModal.tsx
+++ b/web/src/pages/Onboarding/engine/PageIntroModal.tsx
@@ -117,7 +117,7 @@ export function PageIntroModal({ intro, onClose }: { intro: PageIntroDef; onClos
                     aria-current={i === stepIdx ? 'step' : undefined}
                     onClick={() => goTo(i)}
                     className={cn(
-                      'h-1.5 rounded-full transition-all duration-300 hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-primary)] focus-visible:ring-offset-2',
+                      'h-1.5 rounded-full transition-all duration-300 hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
                       i === stepIdx ? 'w-6' : 'w-1.5'
                     )}
                     style={{
@@ -141,7 +141,7 @@ export function PageIntroModal({ intro, onClose }: { intro: PageIntroDef; onClos
                   <button
                     type="button"
                     onClick={() => goTo(stepIdx - 1)}
-                    className="rounded-lg border px-4 py-2.5 text-sm font-medium transition-colors hover:bg-[var(--color-bg-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-primary)]"
+                    className="rounded-lg border px-4 py-2.5 text-sm font-medium transition-colors hover:bg-[var(--color-bg-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                     style={{
                       borderColor: 'var(--color-border-default)',
                       color: 'var(--color-text-secondary)',
@@ -153,7 +153,7 @@ export function PageIntroModal({ intro, onClose }: { intro: PageIntroDef; onClos
                 <button
                   type="button"
                   onClick={() => (isLast ? onClose() : goTo(stepIdx + 1))}
-                  className="flex-1 rounded-lg px-4 py-2.5 text-sm font-semibold transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-primary)] focus-visible:ring-offset-2"
+                  className="flex-1 rounded-lg px-4 py-2.5 text-sm font-semibold transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                   style={{
                     background: 'var(--color-accent-primary)',
                     color: 'var(--color-text-on-accent)',

--- a/web/src/pages/Onboarding/engine/WhatsNewModal.tsx
+++ b/web/src/pages/Onboarding/engine/WhatsNewModal.tsx
@@ -79,7 +79,7 @@ export function WhatsNewModal({
           <button
             type="button"
             onClick={onAcknowledge}
-            className="rounded-md px-4 py-2 text-sm font-semibold transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-primary)] focus-visible:ring-offset-2"
+            className="rounded-md px-4 py-2 text-sm font-semibold transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             style={{ background: 'var(--color-accent-primary)', color: 'var(--color-text-on-accent)' }}
           >
             {t('onboarding.whatsNew.gotIt', 'Got it')}

--- a/web/src/pages/Plugins/Plugins.tsx
+++ b/web/src/pages/Plugins/Plugins.tsx
@@ -191,7 +191,7 @@ function Plugins() {
               </DropdownMenuContent>
             </DropdownMenu>
           </div>
-          <div className="flex gap-2 mb-6 border-b overflow-x-auto plugins-tab-bar" style={{ borderColor: 'var(--color-border-muted)' }}>
+          <div className="flex gap-2 mb-6 border-b overflow-x-auto plugins-tab-bar clips-focus-ring" style={{ borderColor: 'var(--color-border-muted)' }}>
             {TABS.map((tab) => (
               <button
                 key={tab}

--- a/web/src/pages/Plugins/components/ListControls.tsx
+++ b/web/src/pages/Plugins/components/ListControls.tsx
@@ -106,7 +106,7 @@ export function ListControls({
           placeholder={t('plugins.filter.placeholder')}
           aria-label={t('plugins.filter.placeholder')}
           spellCheck={false}
-     className="text-sm pl-9 pr-8 py-2 rounded-md w-full "
+          className="text-sm pl-9 pr-8 py-2 rounded-md w-full"
           style={{
             color: 'var(--color-text-primary)',
             backgroundColor: 'var(--color-bg-input)',

--- a/web/src/pages/Plugins/components/ListControls.tsx
+++ b/web/src/pages/Plugins/components/ListControls.tsx
@@ -106,7 +106,7 @@ export function ListControls({
           placeholder={t('plugins.filter.placeholder')}
           aria-label={t('plugins.filter.placeholder')}
           spellCheck={false}
-          className="text-sm pl-9 pr-8 py-2 rounded-md w-full outline-none"
+     className="text-sm pl-9 pr-8 py-2 rounded-md w-full "
           style={{
             color: 'var(--color-text-primary)',
             backgroundColor: 'var(--color-bg-input)',

--- a/web/src/pages/Plugins/components/PluginBindingsStep.tsx
+++ b/web/src/pages/Plugins/components/PluginBindingsStep.tsx
@@ -78,7 +78,7 @@ export function PluginBindingsStep({
               value={values[name] ?? ''}
               onChange={(e) => setValues({ ...values, [name]: e.target.value })}
               placeholder={t('plugins.install.bindingPlaceholder')}
-       className="text-xs px-2 py-1.5 rounded-md "
+              className="text-xs px-2 py-1.5 rounded-md"
               style={{
                 color: 'var(--color-text-primary)',
                 backgroundColor: 'var(--color-bg-input)',

--- a/web/src/pages/Plugins/components/PluginBindingsStep.tsx
+++ b/web/src/pages/Plugins/components/PluginBindingsStep.tsx
@@ -78,7 +78,7 @@ export function PluginBindingsStep({
               value={values[name] ?? ''}
               onChange={(e) => setValues({ ...values, [name]: e.target.value })}
               placeholder={t('plugins.install.bindingPlaceholder')}
-              className="text-xs px-2 py-1.5 rounded-md outline-none"
+       className="text-xs px-2 py-1.5 rounded-md "
               style={{
                 color: 'var(--color-text-primary)',
                 backgroundColor: 'var(--color-bg-input)',

--- a/web/src/pages/Plugins/components/PluginSourceStep.tsx
+++ b/web/src/pages/Plugins/components/PluginSourceStep.tsx
@@ -153,7 +153,7 @@ export function PluginSourceStep({
           }}
           placeholder="https://github.com/owner/repo"
           spellCheck={false}
-          className="text-xs px-2 py-1.5 rounded-md outline-none"
+     className="text-xs px-2 py-1.5 rounded-md "
           style={{
             color: 'var(--color-text-primary)',
             backgroundColor: 'var(--color-bg-input)',

--- a/web/src/pages/Plugins/components/PluginSourceStep.tsx
+++ b/web/src/pages/Plugins/components/PluginSourceStep.tsx
@@ -153,7 +153,7 @@ export function PluginSourceStep({
           }}
           placeholder="https://github.com/owner/repo"
           spellCheck={false}
-     className="text-xs px-2 py-1.5 rounded-md "
+          className="text-xs px-2 py-1.5 rounded-md"
           style={{
             color: 'var(--color-text-primary)',
             backgroundColor: 'var(--color-bg-input)',

--- a/web/src/pages/Plugins/components/SkillRow.tsx
+++ b/web/src/pages/Plugins/components/SkillRow.tsx
@@ -79,7 +79,7 @@ function CommandChip({
       onBlur={() => setEditing(false)}
       spellCheck={false}
       aria-label={t('plugins.skills.commandInputAria')}
-      className="text-[0.6875rem] px-1.5 py-0.5 rounded w-28 outline-none"
+   className="text-[0.6875rem] px-1.5 py-0.5 rounded w-28 "
       style={{
         color: 'var(--color-text-secondary)',
         backgroundColor: 'var(--color-bg-input)',

--- a/web/src/pages/Plugins/components/SkillRow.tsx
+++ b/web/src/pages/Plugins/components/SkillRow.tsx
@@ -79,7 +79,7 @@ function CommandChip({
       onBlur={() => setEditing(false)}
       spellCheck={false}
       aria-label={t('plugins.skills.commandInputAria')}
-   className="text-[0.6875rem] px-1.5 py-0.5 rounded w-28 "
+      className="text-[0.6875rem] px-1.5 py-0.5 rounded w-28"
       style={{
         color: 'var(--color-text-secondary)',
         backgroundColor: 'var(--color-bg-input)',

--- a/web/src/pages/Settings/Settings.tsx
+++ b/web/src/pages/Settings/Settings.tsx
@@ -46,7 +46,7 @@ function Settings() {
       <div ref={pageRef} className="settings-scroll">
         <div className="settings-container">
           <h2 className="text-xl font-semibold mb-6" style={{ color: 'var(--color-text-primary)' }}>{t('settings.title')}</h2>
-          <div className="flex gap-2 mb-6 border-b overflow-x-auto settings-tab-bar" style={{ borderColor: 'var(--color-border-muted)' }}>
+          <div className="flex gap-2 mb-6 border-b overflow-x-auto settings-tab-bar clips-focus-ring" style={{ borderColor: 'var(--color-border-muted)' }}>
             <button
               type="button"
               onClick={() => handleTabChange('userInfo')}

--- a/web/src/pages/Settings/panels/PreferencesTab.tsx
+++ b/web/src/pages/Settings/panels/PreferencesTab.tsx
@@ -223,7 +223,7 @@ export function PreferencesTab() {
               <label className="text-[0.8125rem] font-medium" style={{ color: 'var(--color-text-primary)' }}>
                 {t('settings.outputFormat')}
               </label>
-              <div className="inline-flex rounded-lg overflow-hidden" style={{ border: '1px solid var(--color-border-muted)' }}>
+              <div className="inline-flex rounded-lg overflow-hidden clips-focus-ring" style={{ border: '1px solid var(--color-border-muted)' }}>
                 <button
                   type="button"
                   onClick={() => handleOutputFormatChange('markdown')}

--- a/web/src/pages/Settings/panels/UserInfoTab.tsx
+++ b/web/src/pages/Settings/panels/UserInfoTab.tsx
@@ -305,7 +305,7 @@ export function UserInfoTab() {
         <div className="space-y-0.5">
           <label className="text-[0.8125rem] font-medium" style={{ color: 'var(--color-text-primary)' }}>{t('settings.theme')}</label>
         </div>
-        <div className="inline-flex rounded-lg overflow-hidden" style={{ border: '1px solid var(--color-border-muted)' }}>
+        <div className="inline-flex rounded-lg overflow-hidden clips-focus-ring" style={{ border: '1px solid var(--color-border-muted)' }}>
           <button
             type="button"
             onClick={() => setThemePref('dark')}
@@ -350,7 +350,7 @@ export function UserInfoTab() {
         <div className="space-y-0.5">
           <label className="text-[0.8125rem] font-medium" style={{ color: 'var(--color-text-primary)' }}>{t('settings.fontSize', 'Font size')}</label>
         </div>
-        <div className="inline-flex rounded-lg overflow-hidden" style={{ border: '1px solid var(--color-border-muted)' }}>
+        <div className="inline-flex rounded-lg overflow-hidden clips-focus-ring" style={{ border: '1px solid var(--color-border-muted)' }}>
           {FONT_SCALES.map((s) => (
             <button
               key={s}

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -421,6 +421,48 @@ html {
     margin: 0;
     padding: 0;
   }
+
+  /* The ring every control gets unless it draws its own. Without a baseline the
+     fallback is Chromium's -- `outline: auto` in a blue this product uses
+     nowhere -- and that was the ring on four out of five controls, the chat
+     transcript included. Lives in the base layer, so a component that does draw
+     its own still wins: a Tailwind `focus-visible:` utility by layer order, a
+     hand-written `.class:focus-visible` by specificity. */
+  :focus-visible {
+    outline: 2px solid var(--color-focus-ring);
+    outline-offset: 2px;
+  }
+
+  /* Inside an SVG, Chromium paints its own ring on plain :focus -- it does not
+     gate that on :focus-visible the way it does for HTML, so a mouse click on
+     a chart draws a ring where the same click on a button would not. Take the
+     non-keyboard half away and the pseudo-class above rings the surface on a
+     Tab, exactly like everything else.
+
+     The descendant half is what the visible bug was: recharts stacks its
+     z-index layers as `<g tabindex="-1">`, so a click landing on a bar focuses
+     that layer rather than the surface, which is why the stray ring hugged the
+     bars and left the axis labels outside them. */
+  svg:focus:not(:focus-visible),
+  svg :focus:not(:focus-visible) {
+    outline: none;
+  }
+
+  /* A box that clips -- a tab bar that scrolls sideways, a segmented control
+     rounding its children -- eats the outset ring off whichever child sits
+     flush against the clipped edge, and what is left renders as a bar down one
+     side. Mark the clipper and its children ring inward instead. */
+  .clips-focus-ring > :focus-visible {
+    outline-offset: -2px;
+  }
+
+  /* tabindex="-1" is not a tab stop -- it is a landing spot script moves focus
+     to so the next Tab starts there (dialog roots, scroll ports). Chromium
+     carries :focus-visible across that programmatic move (lib/inputModality.ts),
+     so without this the ring draws around an entire dialog. */
+  [tabindex="-1"]:focus-visible {
+    outline: none;
+  }
 }
 
 @layer utilities {


### PR DESCRIPTION
## Summary

Every focusable control in the app now draws the same focus ring, and charts stop drawing a stray one.

Before this, most controls had no ring rule of their own, so the fallback was Chromium's `outline: auto` in a blue the product uses nowhere. About 35 other sites hand-rolled their own ring in the amber accent. Charts drew a third thing: a UA ring that appeared on a mouse click and hugged the bars.

This adds one base-layer `:focus-visible` rule, repoints the hand-rolled rings at the shared focus token, and removes the `outline: none` suppressions that the old ring made necessary — both the blanket chart hacks and the per-control `outline-none` on 27 form fields that were left with no indicator at all.

## Why this way

**A base-layer rule, not a component-by-component sweep.** A ring is a property of "being focusable," not of any one button, and the app has far more focusable things than it has ring declarations. Putting the rule in `@layer base` means the default is correct and a component only writes CSS when it genuinely differs. Layer order does the rest: a Tailwind `focus-visible:` utility beats it by layer, a hand-written `.class:focus-visible` beats it by specificity. Nothing had to be coordinated.

**The base layer loses to `outline-none`, and that is why the sweep is part of this PR.** A Tailwind utility outranks `@layer base`, so a control carrying `outline-none` never saw the baseline. Twenty-seven form fields were in that state — the plugin search box, the vault inputs, the MCP server forms — showing nothing at all on Tab. The tempting fix is to raise the baseline above the utilities layer, but 33 other sites pair `outline-none` with their own `focus-visible:ring-*`, and a Tailwind ring is a box-shadow: those would draw an outline *and* a ring together. Deleting the utility is narrower and more honest, because it only ever existed to suppress the UA ring the baseline now replaces. Menu items, popover content and dialog roots keep theirs — Radix drives those with `data-[highlighted]`, and a ring around a whole popover is wrong, not missing.

**The chart fix took three attempts, and the first two were wrong about the cause.** The ring was invisible to Tab and only appeared on a click at a precise spot, which ruled out the surface being a tab stop — `accessibilityLayer={false}` removes that and changed nothing. recharts stacks twelve z-index layers inside each surface as `<g tabindex="-1">`. `tabindex="-1"` keeps them off the tab order but leaves them mouse-focusable, so a click landing on a bar focuses the *layer*, not the surface. That is why the ring hugged the bars and left the axis labels outside it.

The rule that covers it is one space in a selector:

```css
svg:focus:not(:focus-visible),
svg :focus:not(:focus-visible) { outline: none; }
```

**An earlier version of this coupled the CSS to an input-modality attribute stamped on the document**, on the premise that Chromium never matches `:focus-visible` on SVG. That premise was wrong — a real-Tab probe reports `:focus-visible` true on keyboard and false on mouse, exactly as for HTML. What Chromium actually does is paint its own ring on plain `:focus` for SVG without gating it. Once that was clear, `:not(:focus-visible)` expressed the whole thing and the modality plumbing deleted itself: no DOM attribute, no changes to `lib/inputModality.ts`, and no over-suppression of a keyboard-focused control inside a `<foreignObject>`.

**`outline-offset: -2px` for clipping containers, rather than dropping the offset globally.** A scrolling tab bar or a segmented control with `overflow: hidden` eats the outset ring off whichever child sits flush against the clipped edge, leaving a bar down one side. Six such containers are marked `clips-focus-ring` so their children ring inward. The alternative — no offset anywhere — costs the ring its separation from the control on the other several hundred sites to fix six.

## How it works

`web/src/styles/tokens.css` carries all four rules, each with the reason it exists:

- `:focus-visible` — the 2px token-colored baseline
- `svg:focus:not(:focus-visible), svg :focus:not(:focus-visible)` — the chart fix, surface and descendant
- `.clips-focus-ring > :focus-visible` — inward offset for clipping parents
- `[tabindex="-1"]:focus-visible` — suppresses the ring on script-managed landing spots (dialog roots, scroll ports), which Chromium otherwise rings across a programmatic focus move

`web/src/main.tsx` imports `lib/inputModality` eagerly. Its listeners have to be running before the first click rather than starting from whichever overlay happens to load first.

`InlineArtifactCards.tsx` sets `accessibilityLayer={false}` on two charts. That flag does **not** fix the ring — it removes a tab stop that navigates nothing, since neither card renders a `<Tooltip>` for arrow keys to drive, and drops a `role="application"` announcement on what is a picture. The comment says so explicitly, because the first version of it claimed the opposite.

## Overview

| | Files | +/− |
|---|---|---|
| Modified | 58 | +271 / −118 |
| New | 0 | — |
| **Net excl. tests** | **57** | **+135 / −118  (net +17)** |

| Module | Files | +/− | What |
|---|---|---|---|
| `styles/` | 1 | +42 / −0 | the four rules, and the reasoning for each |
| `ChatAgent/` | 17 | +37 / −37 | amber → focus token; `clips-focus-ring` on the accordion fold; chart flags |
| app shell + `ui/` | 5 | +5 / −15 | eager modality import; deleted the `index.css` chart-outline hack; `ring-ring` on tabs |
| `Dashboard/` | 5 | +8 / −8 | token sweep; removed two `[&_*]:outline-none` wrappers |
| `MarketView/` | 4 | +3 / −18 | token sweep; deleted duplicate ring blocks |
| `Onboarding/` | 3 | +8 / −8 | token sweep |
| `Settings/` | 3 | +4 / −4 | `clips-focus-ring` on the tab bar and two segmented controls |
| `Plugins/` | 1 | +1 / −1 | `clips-focus-ring` on the tab bar |
| form controls (18 files) | 18 | +27 / −27 | deleted the obsolete `outline-none` so the baseline reaches them |
| CSS gaps | 3 | +1 / −3 | the last two stylesheet `outline: none` suppressions |
| `e2e/` | 1 | +136 / −0 | chart regression lock |

## Risk

**Widest-blast-radius change in the diff is the base `:focus-visible` rule** — it applies to every focusable element in the app, including ones no one has looked at. A control that previously showed no ring at all now shows one. That is the intent, but it is a visual change on surfaces this PR never opened.

**Only three focus paths are pinned; the rest are verified by observation, not by test.** The e2e locks the two chart nodes a mouse can focus and the keyboard entry into a chart. Everything else rests on a live audit: 2391 elements scanned on the dashboard, zero UA rings, every keyboard stop ringed. That audit is a snapshot, not a gate.

**Two controls suppressed their outline from a stylesheet rather than a utility class** — the dashboard search box and the market comment composer — so the Tailwind sweep missed them. Both are closed here. The composer sits inside a tight rounded pill, so the pill is marked `clips-focus-ring` and its children ring inward rather than overlapping the pill border.


**The sweep is judged per element, not by pattern.** 27 removals, each on an `<input>`, `<textarea>` or `<select>`; menu items, popovers and dialog roots deliberately keep theirs. If one of those 27 was relying on `outline-none` for something other than ring suppression, this is where it would show.

**Three `outline: none` declarations are *added* in `tokens.css`.** Each is deliberate and commented, and each is narrowed by `:not(:focus-visible)` or a `tabindex="-1"` attribute selector so no keyboard-reachable control loses its ring. Worth a reviewer's eye anyway, since that property is usually a smell.

## Test plan

- [x] `pnpm test` — 3251 passed, 297 files, 0 failures
- [x] `pnpm test:e2e` — 94 passed (full suite); `focus-ring` 8/8
- [x] `pnpm typecheck` — 0 errors
- [x] Ablation-verified: each half of the SVG selector fails a distinct test when removed, and dropping `:not(:focus-visible)` fails the keyboard-parity test
- [x] Live check on the dashboard search box: `outline: solid 2px rgb(65, 97, 164)` on focus, and `borderWidth: 0px` confirms the adjacent `:focus { border-color }` rule was always dead
- [x] Live check on a swept control: the plugin search box computes `outline: solid 2px rgb(65, 97, 164)` on keyboard focus, where it computed nothing before
- [x] Live check on real charts: click on a bar focuses `g.recharts-zIndex-layer_300` with `outline: none`; Tab onto a chart gives `solid 2px` identical to a plain button

Tests added: 3 (the chart regression lock).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Standardized keyboard focus indicators across charts, controls, forms, dashboards, settings, onboarding, and market views.
  - Focus rings now use a consistent theme color and remain visible during keyboard navigation.
  - Improved focus-ring clipping within grouped controls and containers.
  - Removed styling that unintentionally hid focus outlines.
  - Mouse-focused chart elements no longer show unnecessary outlines, while keyboard focus remains clear.

- **Tests**
  - Added end-to-end coverage for chart focus-ring behavior during mouse and keyboard interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->