### PR TITLE
fix(mcp): mark Robinhood one connection per account

### DIFF
--- a/src/server/services/brokerages.py
+++ b/src/server/services/brokerages.py
@@ -64,6 +64,7 @@ BROKERAGES: tuple[Brokerage, ...] = (
             "instrument lookup, and order placement."
         ),
         native_callback_only=True,
+        exclusive_connection=True,
     ),
     Brokerage(
         name="ibkr",

--- a/tests/unit/server/app/test_mcp_catalog.py
+++ b/tests/unit/server/app/test_mcp_catalog.py
@@ -988,6 +988,11 @@ async def test_brokerages_are_offered_without_touching_the_database(client):
     assert by_name["robinhood"]["native_callback_only"] is True
     assert by_name["ibkr"]["exclusive_connection"] is True
     assert by_name["ibkr"]["label"] == "Interactive Brokers"
+    # The two quirks are independent, and Robinhood carries both. Asserted
+    # because it is the one row where a reader could take the first flag as the
+    # whole story, and because dropping this one silently costs the confirm
+    # that stands between a connect here and the user's other AI platform.
+    assert by_name["robinhood"]["exclusive_connection"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/server/services/test_mcp_oauth_connect.py
+++ b/tests/unit/server/services/test_mcp_oauth_connect.py
@@ -72,9 +72,11 @@ INFLIGHT_PREFIX = "mcp:oauth:inflight:"
 # and a sibling path is still that vendor.
 IBKR_URL = "https://api.ibkr.com/v1/api/mcp-public"
 IBKR_ALT_URL = "https://api.ibkr.com/v1/api/mcp-public/mine"
-# Shipped too, but with no exclusivity, so it is the control for every case
-# below rather than a second example of one.
-RH_URL = "https://agent.robinhood.com/mcp/trading"
+# A vendor we do not ship, which is the control for every case below rather
+# than a second example of one. Neither shipped brokerage can play the part --
+# both are one connection per account -- so the ordinary case has to come from
+# a host the registry has never heard of.
+ORDINARY_URL = "https://mcp.example.com/mcp"
 
 
 # ---------------------------------------------------------------------------
@@ -1084,16 +1086,16 @@ class TestExclusiveVendorScope:
     ):
         """The control, and the reason the scope is not simply the host.
 
-        Robinhood ships from the same registry and joins by host the same way.
-        Widening supersession to every shipped vendor would retire a connect for
-        no reason at all -- nothing about a second Robinhood row costs the first
-        one anything.
+        Two rows at one host join to one vendor exactly as the exclusive case
+        does, so the host alone cannot be what decides. Widening supersession to
+        every vendor would retire a connect for no reason at all -- nothing
+        about a second row here costs the first one anything.
         """
-        self._row(phase1, "robinhood", RH_URL)
-        self._row(phase1, "my_rh", RH_URL + "/mine")
+        self._row(phase1, "ordinary", ORDINARY_URL)
+        self._row(phase1, "my_ordinary", ORDINARY_URL + "/mine")
 
-        first = await start_connect(USER_ID, "robinhood")
-        await start_connect(USER_ID, "my_rh")
+        first = await start_connect(USER_ID, "ordinary")
+        await start_connect(USER_ID, "my_ordinary")
 
         assert f"{STATE_PREFIX}{first.state}" in redis.store
 


### PR DESCRIPTION
## Overview

| | Files | +/− |
|---|---|---|
| Production | 1 | +1 / −0 |
| Tests | 2 | +18 / −11 |
| **Total** | **3** | **+19 / −11** |

By module:

- `src/server/services/brokerages.py` — one flag on the Robinhood registry entry
- `tests/unit/server/app/test_mcp_catalog.py` — assert the flag reaches the wire
- `tests/unit/server/services/test_mcp_oauth_connect.py` — move the exclusivity control off Robinhood

This introduces nothing new. It corrects a registry entry so an existing mechanism, the one-connection-per-account handling already built for Interactive Brokers, actually runs for Robinhood.

## The bug

Robinhood permits a single connected AI platform per account and drops the previous grant when a new one lands, the same as Interactive Brokers. Its registry entry carried only `native_callback_only`, so `exclusive_connection` stayed False and four things that should have happened did not:

- **No confirmation before connecting.** `useMcpOauthActions.connect()` gates the confirm on `vendor.exclusive_connection`, so the user was never told the connect replaces whatever is connected now.
- **No warning on the row.** `VendorNotes` renders `plugins.brokerages.exclusiveNote` under the same flag.
- **A row-scoped inflight key.** `_inflight_scope` returns `vendor:<name>` for an exclusive vendor and the bare row name otherwise, so two Robinhood rows could each hold a live connect instead of the second superseding the first.
- **No displacement reconciliation.** `_drop_what_the_vendor_displaced` runs only for exclusive vendors. After a second Robinhood row took the first one's grant, our side went on reporting the first as connected until a turn actually called the broker and failed.

The flags are independent, which is how this was missed: Robinhood carries both, and the entry read as complete with one.

## The test change

`test_rows_at_an_ordinary_vendor_are_separate_connects` is the control for the exclusivity suite. It proves supersession is not simply keyed on host, and it used Robinhood as its non-exclusive example. With both shipped brokerages now exclusive, the control moves to a host the registry has never heard of. That is also the more durable shape: it no longer breaks when a brokerage's exclusivity changes.

## Verification

- Full unit suite: **9256 passed, 1 xfailed**
- `ruff check` clean on all three touched files

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ginlix-ai/codesmith/LangAlpha/pr/374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790589614&installation_model_id=432753&pr_number=374&repository=ginlix-ai%2FLangAlpha&return_to=https%3A%2F%2Fgithub.com%2Fginlix-ai%2FLangAlpha%2Fpull%2F374&signature=c84f8cae4c665680797e420104cf168d863e2a30cda78cfd907e3431e91798aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Robinhood connections now support exclusive access, allowing only one connected platform per account.
  * When a new Robinhood connection is granted, any previous connection is automatically replaced.
  * Existing connection behavior for other brokerage providers remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->