### PR TITLE
feat(mcp): ship moomoo as a brokerage connector

### DIFF
--- a/migrations/versions/032_free_moomoo_name.py
+++ b/migrations/versions/032_free_moomoo_name.py
@@ -34,9 +34,19 @@ depends_on = None
 # a user-tier row under exactly this name, and renaming it would break the thing
 # being shipped. A row at the vendor's own host is the connector and stays; a
 # plugin-owned row is never it, whatever it points at.
-_SHIPPED = """(VALUES
-    ('moomoo', 'https://mcp.moomoo.com/')
-) AS shipped(name, vendor_url)"""
+#
+# "The vendor's own host" is asked as a host test rather than 030's textual
+# prefix, because that is the question ``brokerage_for_url`` answers and the two
+# have to agree: whatever this leaves under the name is drawn as that vendor by
+# a page that joined on it. Parsing lowercases the host and drops the port, so
+# ``HTTPS://MCP.MOOMOO.COM:443/mcp`` is the connector, while a prefix reads it as
+# somebody else's server and renames it out from under a live connection. The
+# trailing anchor is what keeps this a host test rather than a longer prefix: an
+# address matches only where the host ends, so ``mcp.moomoo.com.evil.com`` is
+# still somebody else.
+_SHIPPED = r"""(VALUES
+    ('moomoo', '^https?://mcp\.moomoo\.com(:[0-9]+)?([/?#]|$)')
+) AS shipped(name, vendor_host)"""
 _RESERVED = "('moomoo')"
 
 
@@ -80,7 +90,7 @@ def upgrade() -> None:
           JOIN {_SHIPPED} ON shipped.name = u.name
          WHERE u.plugin_id IS NOT NULL
             OR u.url IS NULL
-            OR u.url NOT LIKE shipped.vendor_url || '%'
+            OR u.url !~* shipped.vendor_host
     """)
 
     op.execute("""

--- a/migrations/versions/032_free_moomoo_name.py
+++ b/migrations/versions/032_free_moomoo_name.py
@@ -42,12 +42,19 @@ _RESERVED = "('moomoo')"
 
 def upgrade() -> None:
     # --- user tier -------------------------------------------------------
+    # The scratch tables carry this revision in their names because ON COMMIT
+    # DROP means "at the end of the transaction", and alembic runs the whole
+    # upgrade in ONE transaction. A database coming from 029 or earlier still
+    # holds 030's identically-named tables when this runs, so the bare names
+    # abort every fresh install with "relation already exists". A migration
+    # that borrows this shape needs its own suffix, not this one.
+    #
     # The suffix is checked free against all three tables this rename writes a
     # name into, each of which has its own UNIQUE over it. The OAuth connection
     # is the one that can be holding a name nothing else holds, so it gets its
     # own check rather than riding on the server row's.
     op.execute(f"""
-        CREATE TEMP TABLE mcp_user_renames ON COMMIT DROP AS
+        CREATE TEMP TABLE mcp_user_renames_032 ON COMMIT DROP AS
         SELECT u.user_id,
                u.name AS old_name,
                CASE WHEN EXISTS (
@@ -78,19 +85,19 @@ def upgrade() -> None:
 
     op.execute("""
         UPDATE user_mcp_servers u SET name = r.new_name
-          FROM mcp_user_renames r
+          FROM mcp_user_renames_032 r
          WHERE u.user_id = r.user_id AND u.name = r.old_name
     """)
     # Moves with the row or the freed name inherits a live grant and the page
     # draws somebody else's server as a connected broker.
     op.execute("""
         UPDATE user_mcp_oauth_connections c SET server_name = r.new_name
-          FROM mcp_user_renames r
+          FROM mcp_user_renames_032 r
          WHERE c.user_id = r.user_id AND c.server_name = r.old_name
     """)
     op.execute("""
         UPDATE user_mcp_tool_schemas s SET server_name = r.new_name
-          FROM mcp_user_renames r
+          FROM mcp_user_renames_032 r
          WHERE s.user_id = r.user_id AND s.server_name = r.old_name
     """)
     # source='user' rows are tombstones naming an inherited user row that is
@@ -98,7 +105,7 @@ def upgrade() -> None:
     # brokerage the user connects later, in a workspace they never chose it for.
     op.execute("""
         UPDATE workspace_mcp_servers w SET name = r.new_name
-          FROM mcp_user_renames r, workspaces ws
+          FROM mcp_user_renames_032 r, workspaces ws
          WHERE w.workspace_id = ws.workspace_id
            AND ws.user_id = r.user_id
            AND w.source = 'user'
@@ -110,7 +117,7 @@ def upgrade() -> None:
     # so a workspace-local row under the name is always somebody's own server,
     # and always the one the resolver has already stopped running.
     op.execute(f"""
-        CREATE TEMP TABLE mcp_workspace_renames ON COMMIT DROP AS
+        CREATE TEMP TABLE mcp_workspace_renames_032 ON COMMIT DROP AS
         SELECT w.workspace_mcp_server_id,
                w.workspace_id,
                w.name AS old_name,
@@ -131,12 +138,12 @@ def upgrade() -> None:
     # (workspace_row_to_server_config), so the blob is left as it is.
     op.execute("""
         UPDATE workspace_mcp_servers w SET name = r.new_name
-          FROM mcp_workspace_renames r
+          FROM mcp_workspace_renames_032 r
          WHERE w.workspace_mcp_server_id = r.workspace_mcp_server_id
     """)
     op.execute("""
         UPDATE workspace_mcp_tool_schemas s SET server_name = r.new_name
-          FROM mcp_workspace_renames r
+          FROM mcp_workspace_renames_032 r
          WHERE s.workspace_id = r.workspace_id AND s.server_name = r.old_name
     """)
 
@@ -145,8 +152,8 @@ def upgrade() -> None:
     # name until something else happens to bump it.
     op.execute("""
         UPDATE workspaces ws SET mcp_config_version = ws.mcp_config_version + 1
-         WHERE ws.workspace_id IN (SELECT workspace_id FROM mcp_workspace_renames)
-            OR ws.user_id IN (SELECT user_id FROM mcp_user_renames)
+         WHERE ws.workspace_id IN (SELECT workspace_id FROM mcp_workspace_renames_032)
+            OR ws.user_id IN (SELECT user_id FROM mcp_user_renames_032)
     """)
 
 

--- a/migrations/versions/032_free_moomoo_name.py
+++ b/migrations/versions/032_free_moomoo_name.py
@@ -1,0 +1,157 @@
+"""Free the ``moomoo`` name for the brokerage connector shipped alongside it.
+
+The pass ``030_free_brokerage_names`` did for ``robinhood`` and ``ibkr``, done
+again for one more name. Its reasoning is unchanged and is not repeated here:
+a brokerage's name IS its identity, every surface joins a row to the shipped
+definition by name and then draws it wearing that vendor, and the write paths
+that now refuse the name cannot repair a row that was already sitting on it.
+
+What is worth saying is why this is a second migration rather than an edit to
+the first. 030 already ran everywhere, so amending it would repair no database
+that has one of these rows; and a migration is a record of what the schema
+needed on the day it ran, which is exactly why 030 pinned its names as literals
+instead of importing ``BROKERAGES``. Each brokerage added after it therefore
+brings its own pass, on the same shape, for its own name only.
+
+Revision ID: 032
+Revises: 031
+"""
+
+from alembic import op
+
+
+revision = "032"
+down_revision = "031"
+branch_labels = None
+depends_on = None
+
+# Pinned rather than imported, for the reason 030 gives: BROKERAGES is free to
+# grow after this runs, and a later entry is that entry's migration to write.
+#
+# The address exemption is 030's and matters more here, not less. On every
+# database where this feature already runs -- a dev stack, staging, anywhere the
+# connector was connected before the reservation reached it -- the connector IS
+# a user-tier row under exactly this name, and renaming it would break the thing
+# being shipped. A row at the vendor's own host is the connector and stays; a
+# plugin-owned row is never it, whatever it points at.
+_SHIPPED = """(VALUES
+    ('moomoo', 'https://mcp.moomoo.com/')
+) AS shipped(name, vendor_url)"""
+_RESERVED = "('moomoo')"
+
+
+def upgrade() -> None:
+    # --- user tier -------------------------------------------------------
+    # The suffix is checked free against all three tables this rename writes a
+    # name into, each of which has its own UNIQUE over it. The OAuth connection
+    # is the one that can be holding a name nothing else holds, so it gets its
+    # own check rather than riding on the server row's.
+    op.execute(f"""
+        CREATE TEMP TABLE mcp_user_renames ON COMMIT DROP AS
+        SELECT u.user_id,
+               u.name AS old_name,
+               CASE WHEN EXISTS (
+                        SELECT 1 FROM user_mcp_servers x
+                         WHERE x.user_id = u.user_id
+                           AND x.name = u.name || '_legacy'
+                    ) OR EXISTS (
+                        SELECT 1
+                          FROM workspace_mcp_servers w
+                          JOIN workspaces ws USING (workspace_id)
+                         WHERE ws.user_id = u.user_id
+                           AND w.name = u.name || '_legacy'
+                    ) OR EXISTS (
+                        SELECT 1 FROM user_mcp_oauth_connections c
+                         WHERE c.user_id = u.user_id
+                           AND c.server_name = u.name || '_legacy'
+                    )
+                    THEN u.name || '_legacy_'
+                         || replace(u.user_mcp_server_id::text, '-', '')
+                    ELSE u.name || '_legacy'
+               END AS new_name
+          FROM user_mcp_servers u
+          JOIN {_SHIPPED} ON shipped.name = u.name
+         WHERE u.plugin_id IS NOT NULL
+            OR u.url IS NULL
+            OR u.url NOT LIKE shipped.vendor_url || '%'
+    """)
+
+    op.execute("""
+        UPDATE user_mcp_servers u SET name = r.new_name
+          FROM mcp_user_renames r
+         WHERE u.user_id = r.user_id AND u.name = r.old_name
+    """)
+    # Moves with the row or the freed name inherits a live grant and the page
+    # draws somebody else's server as a connected broker.
+    op.execute("""
+        UPDATE user_mcp_oauth_connections c SET server_name = r.new_name
+          FROM mcp_user_renames r
+         WHERE c.user_id = r.user_id AND c.server_name = r.old_name
+    """)
+    op.execute("""
+        UPDATE user_mcp_tool_schemas s SET server_name = r.new_name
+          FROM mcp_user_renames r
+         WHERE s.user_id = r.user_id AND s.server_name = r.old_name
+    """)
+    # source='user' rows are tombstones naming an inherited user row that is
+    # switched off in this workspace. Left behind, one would switch off the
+    # brokerage the user connects later, in a workspace they never chose it for.
+    op.execute("""
+        UPDATE workspace_mcp_servers w SET name = r.new_name
+          FROM mcp_user_renames r, workspaces ws
+         WHERE w.workspace_id = ws.workspace_id
+           AND ws.user_id = r.user_id
+           AND w.source = 'user'
+           AND w.name = r.old_name
+    """)
+
+    # --- workspace tier --------------------------------------------------
+    # No address test: a brokerage connector only ever exists at the user tier,
+    # so a workspace-local row under the name is always somebody's own server,
+    # and always the one the resolver has already stopped running.
+    op.execute(f"""
+        CREATE TEMP TABLE mcp_workspace_renames ON COMMIT DROP AS
+        SELECT w.workspace_mcp_server_id,
+               w.workspace_id,
+               w.name AS old_name,
+               CASE WHEN EXISTS (
+                        SELECT 1 FROM workspace_mcp_servers x
+                         WHERE x.workspace_id = w.workspace_id
+                           AND x.name = w.name || '_local'
+                    )
+                    THEN w.name || '_local_'
+                         || replace(w.workspace_mcp_server_id::text, '-', '')
+                    ELSE w.name || '_local'
+               END AS new_name
+          FROM workspace_mcp_servers w
+         WHERE w.source = 'workspace' AND w.name IN {_RESERVED}
+    """)
+
+    # The name on the row wins over any name inside the config blob
+    # (workspace_row_to_server_config), so the blob is left as it is.
+    op.execute("""
+        UPDATE workspace_mcp_servers w SET name = r.new_name
+          FROM mcp_workspace_renames r
+         WHERE w.workspace_mcp_server_id = r.workspace_mcp_server_id
+    """)
+    op.execute("""
+        UPDATE workspace_mcp_tool_schemas s SET server_name = r.new_name
+          FROM mcp_workspace_renames r
+         WHERE s.workspace_id = r.workspace_id AND s.server_name = r.old_name
+    """)
+
+    # Every workspace whose effective set just changed, so a session holding the
+    # old version re-resolves instead of running the renamed row under its old
+    # name until something else happens to bump it.
+    op.execute("""
+        UPDATE workspaces ws SET mcp_config_version = ws.mcp_config_version + 1
+         WHERE ws.workspace_id IN (SELECT workspace_id FROM mcp_workspace_renames)
+            OR ws.user_id IN (SELECT user_id FROM mcp_user_renames)
+    """)
+
+
+def downgrade() -> None:
+    # Deliberately empty, as 030's is. A renamed row is indistinguishable from
+    # one a user named that way, and restoring the reserved name would re-create
+    # the collision this exists to clear, on a schema that still refuses it.
+    pass

--- a/src/server/database/mcp_servers.py
+++ b/src/server/database/mcp_servers.py
@@ -28,10 +28,20 @@ from src.server.database.pool import get_db_connection
 logger = logging.getLogger(__name__)
 
 # Hard cap on user-configured (source='workspace') servers per workspace.
-MAX_MCP_SERVERS_PER_WORKSPACE = 20
+#
+# The stingier of the two on purpose, because this one is the expensive one:
+# every row here is a server the agent actually runs, which is a discovery
+# round trip on each config change and, for stdio, a subprocess inside the
+# sandbox. Raising it spends startup latency, not storage.
+MAX_MCP_SERVERS_PER_WORKSPACE = 30
 
 # Hard cap on catalog templates per user.
-MAX_CATALOG_SERVERS_PER_USER = 50
+#
+# Roomier than the workspace cap because a catalog row is inert: it is an
+# address and a description until some workspace enables it, so the cost is a
+# row and a line on the settings page. A user collecting servers they have not
+# switched on is not costing a sandbox anything.
+MAX_CATALOG_SERVERS_PER_USER = 100
 
 # Mutable catalog columns, split by how a value binds. Anything outside the
 # union is rejected by ``update_catalog_server`` rather than silently dropped.

--- a/src/server/database/mcp_servers.py
+++ b/src/server/database/mcp_servers.py
@@ -37,10 +37,12 @@ MAX_MCP_SERVERS_PER_WORKSPACE = 30
 
 # Hard cap on catalog templates per user.
 #
-# Roomier than the workspace cap because a catalog row is inert: it is an
-# address and a description until some workspace enables it, so the cost is a
-# row and a line on the settings page. A user collecting servers they have not
-# switched on is not costing a sandbox anything.
+# Roomier than the workspace cap because a catalog row costs a row and a line
+# on the settings page until it is switched on. Enabling is what makes it live,
+# and it is not a per-workspace act: ``list_enabled_user_servers`` inherits
+# every enabled row into every one of the user's workspaces, where it pays for
+# discovery and, on stdio, a subprocess. So this bounds what may be COLLECTED,
+# and the ceiling on what runs is however many of them the user switches on.
 MAX_CATALOG_SERVERS_PER_USER = 100
 
 # Mutable catalog columns, split by how a value binds. Anything outside the

--- a/src/server/database/plugins.py
+++ b/src/server/database/plugins.py
@@ -23,9 +23,14 @@ from src.server.database.pool import get_db_connection
 
 logger = logging.getLogger(__name__)
 
-# Hard cap on installed plugins per user. Components additionally count
-# against their own per-user caps (50 servers, 50 skills).
-MAX_PLUGINS_PER_USER = 20
+# Hard cap on installed plugins per user. Components additionally count against
+# their own per-user caps (``MAX_CATALOG_SERVERS_PER_USER``,
+# ``MAX_SKILLS_PER_USER``), which are the caps that bound real resource use --
+# this one only bounds how many packages a user may hold.
+#
+# Named rather than restated, because the numbers here drifted out of date once
+# already: this comment claimed 50 skills long after that limit became 200.
+MAX_PLUGINS_PER_USER = 50
 
 _PLUGIN_COLUMNS = """
     user_plugin_id, user_id, name, version, source_type, source_ref,

--- a/src/server/services/brokerages.py
+++ b/src/server/services/brokerages.py
@@ -78,6 +78,19 @@ BROKERAGES: tuple[Brokerage, ...] = (
         ),
         exclusive_connection=True,
     ),
+    Brokerage(
+        name="moomoo",
+        label="moomoo",
+        url="https://mcp.moomoo.com/mcp",
+        site="moomoo.com",
+        description=(
+            "moomoo brokerage account: balances, positions, and order history, "
+            "real-time quotes and order book, option chains and volatility, "
+            "company fundamentals and analyst research, stock and IPO "
+            "screeners, and order placement. Covers US, Greater China, Japan "
+            "and Southeast Asia."
+        ),
+    ),
 )
 
 _BY_NAME: dict[str, Brokerage] = {b.name: b for b in BROKERAGES}

--- a/src/server/services/mcp_discovery.py
+++ b/src/server/services/mcp_discovery.py
@@ -30,8 +30,19 @@ logger = logging.getLogger(__name__)
 
 # Discovery-boundary caps for hostile/buggy servers (plan §6). The prompt-side
 # detailed-mode caps live in the formatter; these bound what we cache at all.
-MAX_TOOLS_PER_SERVER = 64
-MAX_SCHEMA_CHARS_PER_SERVER = 200_000
+#
+# So neither bounds prompt cost, which is what makes them cheap to raise: a
+# server over the formatter's caps renders as a summary either way, and what
+# these actually size is the cached JSON and the wrapper module a sandbox gets.
+#
+# Sized against what brokers and data vendors really ship, not a round number.
+# Going over is not graceful degradation -- the cut is by list position, so a
+# server one tool past the cap loses whichever capability it happened to
+# enumerate last. moomoo publishes 88 tools, and the old cap of 64 silently
+# took its entire paper-trading suite along with news, insider and short
+# interest data, none of which anything on screen could explain.
+MAX_TOOLS_PER_SERVER = 128
+MAX_SCHEMA_CHARS_PER_SERVER = 400_000
 
 
 def mcp_discovery_fingerprint(server: MCPServerConfig) -> str:

--- a/tests/unit/server/app/test_mcp_catalog.py
+++ b/tests/unit/server/app/test_mcp_catalog.py
@@ -984,7 +984,7 @@ async def test_brokerages_are_offered_without_touching_the_database(client):
     resp = await client.get("/api/v1/mcp/brokerages")
     assert resp.status_code == 200
     by_name = {b["name"]: b for b in resp.json()["brokerages"]}
-    assert set(by_name) == {"robinhood", "ibkr"}
+    assert set(by_name) == {"robinhood", "ibkr", "moomoo"}
     assert by_name["robinhood"]["native_callback_only"] is True
     assert by_name["ibkr"]["exclusive_connection"] is True
     assert by_name["ibkr"]["label"] == "Interactive Brokers"
@@ -993,6 +993,12 @@ async def test_brokerages_are_offered_without_touching_the_database(client):
     # whole story, and because dropping this one silently costs the confirm
     # that stands between a connect here and the user's other AI platform.
     assert by_name["robinhood"]["exclusive_connection"] is True
+    # A vendor whose authorization server takes the spec as written needs
+    # neither quirk, so the flags stay off and every surface treats it as the
+    # ordinary case. Asserted rather than left implicit: both defaults are
+    # False, so a flag set here by mistake would otherwise read as intent.
+    assert by_name["moomoo"]["native_callback_only"] is False
+    assert by_name["moomoo"]["exclusive_connection"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/server/app/test_mcp_catalog.py
+++ b/tests/unit/server/app/test_mcp_catalog.py
@@ -15,6 +15,7 @@ import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
+from src.server.database.mcp_servers import MAX_CATALOG_SERVERS_PER_USER
 from src.server.services.vault_invalidation import USER_TIER
 from tests.conftest import create_test_app
 
@@ -69,7 +70,9 @@ async def test_list_echoes_stored_maps_and_reports_max(client):
     body = resp.json()
     assert body["servers"][0]["headers"] == STORED_HEADERS
     assert body["servers"][0]["header_refs"] == ["API_KEY"]
-    assert body["max_servers"] == 50
+    # Bound to the constant, not its value: this asserts the cap reaches the
+    # wire, which is what the page needs, and stays true when the cap moves.
+    assert body["max_servers"] == MAX_CATALOG_SERVERS_PER_USER
 
 
 @pytest.mark.asyncio

--- a/tests/unit/server/app/test_mcp_servers.py
+++ b/tests/unit/server/app/test_mcp_servers.py
@@ -20,6 +20,7 @@ from httpx import ASGITransport, AsyncClient
 from ptc_agent.config.core import MCPServerConfig
 from src.server.app.mcp_servers import _derive_status
 from src.server.database.account_disables import AccountDisables
+from src.server.database.mcp_servers import MAX_MCP_SERVERS_PER_WORKSPACE
 from src.server.services.mcp_config import Origin
 from src.server.services.plugins.bundled import ComponentOwners
 from src.server.services.mcp_discovery import mcp_discovery_fingerprint
@@ -222,7 +223,7 @@ async def test_list_effective_servers_masks_and_decorates(client):
     body = resp.json()
     assert body["sandbox_running"] is True
     assert body["sandbox_warming"] is False  # already running ⇒ not warming
-    assert body["max_servers"] == 20
+    assert body["max_servers"] == MAX_MCP_SERVERS_PER_WORKSPACE
     assert body["config_version"] == 3
     by_name = {s["name"]: s for s in body["servers"]}
 


### PR DESCRIPTION
> Stacked on #374. Review that first; this PR's diff is against it.

## Overview

| | Files | +/− |
|---|---|---|
| Production | 5 | +203 / −7 |
| Tests | 2 | +13 / −3 |
| **Total** | **7** | **+216 / −10** |

By module:

| File | +/− | What |
|---|---|---|
| `migrations/versions/032_free_moomoo_name.py` | +157 | frees the `moomoo` catalog name |
| `src/server/services/brokerages.py` | +13 | the registry entry |
| `src/server/services/mcp_discovery.py` | +13 / −2 | `MAX_TOOLS_PER_SERVER` 64 → 128, `MAX_SCHEMA_CHARS_PER_SERVER` 200k → 400k |
| `src/server/database/mcp_servers.py` | +12 / −2 | catalog 50 → 100, per-workspace 20 → 30 |
| `src/server/database/plugins.py` | +8 / −3 | plugins 20 → 50 |
| tests | +13 / −3 | flags reach the wire; caps bound to their constants |

This introduces a third brokerage connector, and the cap headroom that shipping it turned out to require.

## The connector

moomoo is the first brokerage whose authorization server takes the OAuth spec as written. It does real dynamic client registration (distinct `client_id` per registration, `client_name` preserved, an RFC 7592 management URI) and accepts an ordinary `https` redirect URI at both registration and authorize. That matters because `_register_client` hard-raises on a server without real DCR, and because Robinhood allowlists only the RFC 8252 native-app profile — which is what `native_callback_only` exists to describe. moomoo needs neither quirk, so both flags stay off, and the tests assert that rather than leaving it implicit.

It also negotiates the session era (`mcp-session-id` on `initialize`), where Robinhood is legacy-only.

Verified end to end against a live account: `initialize`, `tools/list`, and read-only `tools/call` all return live data.

## Why the caps moved

moomoo publishes **88 tools**. The old `MAX_TOOLS_PER_SERVER = 64` silently dropped 24 of them, and the cut is by list position, so what went missing was arbitrary: the entire paper-trading suite, plus news, insider and short-interest data. Nothing on screen could have explained which capability had disappeared.

Neither discovery cap bounds prompt cost, which is what makes them cheap to raise. The prompt formatter has its own separate caps (`WORKSPACE_DETAILED_MAX_TOOLS`, `WORKSPACE_DETAILED_MAX_CHARS`), and a server this size renders as a summary either way. The two tests that asserted the old numbers now assert the constants, so the next change to a cap does not break them.

After the raise, live re-discovery returns **88 tools, 0 skipped**, at 101,569 characters against the new 400k ceiling.

The catalog, per-workspace and plugin counts move in the same commit for consistency. The asymmetry between them is deliberate and now commented: a workspace row costs a subprocess and a discovery round trip, while a catalog row is inert until enabled.

## The migration

`032` frees the `moomoo` catalog name the same way `030` freed `robinhood` and `ibkr`. Reserving a name only reaches writes, never rows already there, so without a companion migration the reservation would lock an existing row out of the only rule that could repair it. User-tier rows that are plugin-owned, have no URL, or point somewhere off the vendor's host are renamed aside; workspace-tier rows get `_local`. `downgrade()` is intentionally empty.

## Follow-up

Capability consent is the next change: hand-curated tool groups the user chooses from at connect time, filtered at the composite registry and enforced per call at the egress relay's `tool_allowlist`. Until it lands, connecting a brokerage grants the agent every tool the vendor publishes, which is the behaviour Robinhood and Interactive Brokers already have.

## Verification

- Full unit suite: **9256 passed, 1 xfailed**
- `ruff check` clean on all seven touched files
- Live discovery against a real moomoo account, before and after the cap change

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ginlix-ai/codesmith/LangAlpha/pr/375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790589799&installation_model_id=432753&pr_number=375&repository=ginlix-ai%2FLangAlpha&return_to=https%3A%2F%2Fgithub.com%2Fginlix-ai%2FLangAlpha%2Fpull%2F375&signature=1f6881262f35b13f7c069bdd5716a4da6830f550f6fbde508040029c0b8db9f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->